### PR TITLE
fix(desktop): allow queueing follow-ups mid-turn and fix the permission control

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -119,8 +119,9 @@ import {
   parseCodeRepo,
   parseCodeSession,
   parseCodeSessionList,
-  parseCodeTurn,
   parseCodeTurnList,
+  parseCodeTurnSubmission,
+  type CodeTurnSubmission,
   parseCodeAction,
   parseCodeCommit,
   parseCodePush,
@@ -1860,12 +1861,20 @@ export class ApiClient {
     return requireParsed(parseCodeTurnList(body), "code session turns");
   }
 
+  /**
+   * Submit a turn, or park it behind the one in flight.
+   *
+   * The route answers 202 either way: a turn snapshot when the session was
+   * idle, a queue receipt when it was busy. Both are accepted work — treating
+   * the receipt as a malformed turn would report a failure for a message the
+   * server holds, and a retry would double-send.
+   */
   async submitCodeTurn(
     sessionId: string,
     message: string,
-  ): Promise<CodeTurnSnapshot> {
+  ): Promise<CodeTurnSubmission> {
     return requireParsed(
-      parseCodeTurn(
+      parseCodeTurnSubmission(
         await this.json(
           `/code/sessions/${encodeURIComponent(sessionId)}/turns`,
           {

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -114,6 +114,7 @@ import {
   type CodeSessionSnapshot as WireCodeSessionSnapshot,
   type CodeTurnId as WireCodeTurnId,
   type CodeTurnSnapshot as WireCodeTurnSnapshot,
+  type QueuedCodeTurn as WireQueuedCodeTurn,
   type CodeTurnStatus as WireCodeTurnStatus,
   type CodeUsage as WireCodeUsage,
   type CodeWorkspaceDiff as WireCodeWorkspaceDiff,
@@ -1000,6 +1001,8 @@ export type AttentionSource = WireAttentionSource;
 
 /** One user→engine cycle. */
 export type CodeTurnSnapshot = WireCodeTurnSnapshot;
+/** A follow-up parked while the session is busy; it has no turn row yet. */
+export type QueuedCodeTurn = WireQueuedCodeTurn;
 export type CodeTurnId = WireCodeTurnId;
 export type CodeTurnStatus = WireCodeTurnStatus;
 export type CodeUsage = WireCodeUsage;

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -3,36 +3,35 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CodeComposer } from "./CodeComposer";
+import { HttpError } from "../api/client";
 import { PERMISSION_MODE_UNAVAILABLE_REASON } from "./labels";
 
 afterEach(() => {
   cleanup();
 });
 
+const QUEUED = {
+  kind: "queued" as const,
+  queued: { session_id: "sess-1", message: "and run the tests", position: 1 },
+};
+
 describe("CodeComposer", () => {
-  it("enables Ask and Auto and reports the selected mode", () => {
-    const onPermissionMode = vi.fn();
+  it("states the session's mode without offering to change it", () => {
     render(
       <CodeComposer
         running={false}
         permissionMode="ask"
-        onPermissionMode={onPermissionMode}
         onSend={vi.fn()}
         onInterrupt={vi.fn()}
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Plan" })).toBeEnabled();
-    const ask = screen.getByRole("button", { name: "Ask" });
-    const auto = screen.getByRole("button", { name: "Auto" });
-    expect(ask).toBeEnabled();
-    expect(auto).toBeEnabled();
-    expect(ask).toHaveAttribute("aria-pressed", "true");
-    fireEvent.click(auto);
-    expect(onPermissionMode).toHaveBeenCalledWith("auto");
+    const modes = screen.getByTestId("permission-modes");
+    expect(modes).toHaveTextContent("Ask");
+    expect(modes.querySelector("button")).toBeNull();
   });
 
-  it("disables a mode the harness cannot honor", () => {
+  it("keeps an unavailable mode visible with the reason", () => {
     render(
       <CodeComposer
         running={false}
@@ -42,12 +41,57 @@ describe("CodeComposer", () => {
         onInterrupt={vi.fn()}
       />,
     );
-    const ask = screen.getByRole("button", { name: /Ask/ });
-    expect(ask).toBeDisabled();
-    expect(ask).toHaveAttribute(
-      "title",
-      `Ask: ${PERMISSION_MODE_UNAVAILABLE_REASON}`,
+    expect(screen.getByTitle(`Ask: ${PERMISSION_MODE_UNAVAILABLE_REASON}`)).toBeTruthy();
+  });
+
+  it("queues a follow-up written while a turn is running", async () => {
+    const onSend = vi.fn().mockResolvedValue(QUEUED);
+    render(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
     );
+
+    expect(screen.getByRole("button", { name: "Interrupt" })).toBeEnabled();
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "and run the tests" } });
+    expect(screen.getByRole("button", { name: "Queue" })).toBeEnabled();
+    fireEvent.keyDown(box, { key: "Enter" });
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("and run the tests"));
+    expect(box).toHaveValue("");
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "runs after the current turn",
+    );
+  });
+
+  it("says the queue is full and keeps the draft", async () => {
+    const onSend = vi
+      .fn()
+      .mockRejectedValue(
+        new HttpError(409, "409: a follow-up is already queued", "queue_full"),
+      );
+    render(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "and push it" } });
+    fireEvent.click(screen.getByRole("button", { name: "Queue" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "A follow-up is already queued",
+    );
+    expect(box).toHaveValue("and push it");
   });
 
   it("keeps the draft when send is refused", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1,10 +1,12 @@
-import { type KeyboardEvent, useState } from "react";
+import { type KeyboardEvent, useEffect, useState } from "react";
 import { Square } from "lucide-react";
 
 import type { CodePermissionMode } from "../api/types";
+import { HttpError } from "../api/client";
+import type { CodeTurnSubmission } from "./parsers";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { cn } from "@/lib/utils";
+import { cn, friendlyErrorMessage } from "@/lib/utils";
 import {
   PERMISSION_MODE_LABELS,
   PERMISSION_MODE_UNAVAILABLE_REASON,
@@ -14,12 +16,29 @@ import {
  * Trimmed composer for a code session: text, send, interrupt, and the
  * permission mode the session was created under.
  *
- * Ask is the default. Plan and Auto stay on the same scale. A mode the
- * current harness cannot honor is disabled with the refusal reason.
+ * A send while a turn is running parks the message in the session's single
+ * queue slot rather than being refused, so a follow-up can be written while
+ * the engine works. `PermissionModePicker` is the creation-time control —
+ * the session's own mode is stated, not offered, because it is fixed at
+ * launch.
  */
 
 const MODES: CodePermissionMode[] = ["plan", "ask", "auto"];
 
+const QUEUED_NOTE = "Queued — runs after the current turn.";
+
+/** Session-scoped copy for the one refusal the queue itself produces. */
+const QUEUE_FULL_NOTE =
+  "A follow-up is already queued. Wait for it to run, or interrupt this turn.";
+
+/**
+ * Pick the mode a session will be created under.
+ *
+ * Ask is the default. Plan and Auto stay on the same scale. A mode the
+ * chosen harness cannot honor is disabled with the refusal reason. This is a
+ * creation-time control: the new-workspace dialog and the start-session
+ * prompt use it, and an attached session shows `PermissionModeSummary`.
+ */
 export function PermissionModePicker({
   value,
   availableModes = MODES,
@@ -65,13 +84,63 @@ export function PermissionModePicker({
   );
 }
 
+/**
+ * The mode a live session is running under, stated rather than offered.
+ *
+ * The mode is composed into the engine's launch (decisions 0033 and 0038):
+ * there is no way to change it on a session that is already attached, so the
+ * composer reports it. Modes this harness cannot honor stay visible, dimmed
+ * with the reason, because that is part of what the session can do.
+ */
+export function PermissionModeSummary({
+  value,
+  availableModes = MODES,
+  unavailableReason = PERMISSION_MODE_UNAVAILABLE_REASON,
+}: {
+  value: CodePermissionMode;
+  availableModes?: readonly CodePermissionMode[];
+  unavailableReason?: string;
+}) {
+  return (
+    <div
+      className="text-muted-foreground flex flex-wrap items-center gap-1.5 text-xs"
+      data-testid="permission-modes"
+    >
+      <span>Mode</span>
+      {MODES.map((mode) => {
+        const available = availableModes.includes(mode);
+        const selected = value === mode;
+        return (
+          <span
+            key={mode}
+            title={
+              available
+                ? PERMISSION_MODE_LABELS[mode]
+                : `${PERMISSION_MODE_LABELS[mode]}: ${unavailableReason}`
+            }
+            className={cn(
+              "rounded-full px-2.5 py-0.5 font-medium",
+              selected && "border-foreground text-foreground border bg-muted",
+              !available && "opacity-50",
+            )}
+          >
+            {PERMISSION_MODE_LABELS[mode]}
+            {selected && <span className="sr-only"> (this session)</span>}
+            {!available && <span className="sr-only">{unavailableReason}</span>}
+          </span>
+        );
+      })}
+      <span>· set when the session started</span>
+    </div>
+  );
+}
+
 export function CodeComposer({
   disabled,
   running,
   permissionMode,
   availableModes = MODES,
   unavailableReason = PERMISSION_MODE_UNAVAILABLE_REASON,
-  onPermissionMode,
   onSend,
   onInterrupt,
 }: {
@@ -80,25 +149,39 @@ export function CodeComposer({
   permissionMode: CodePermissionMode;
   availableModes?: readonly CodePermissionMode[];
   unavailableReason?: string;
-  onPermissionMode?: (mode: CodePermissionMode) => void;
-  onSend: (message: string) => Promise<void> | void;
+  onSend: (message: string) => Promise<CodeTurnSubmission | void> | void;
   onInterrupt: () => Promise<void> | void;
 }) {
   const [draft, setDraft] = useState("");
-  const [sending, setSending] = useState(false);
-  const canSend = draft.trim().length > 0 && !disabled && !sending && !running;
+  const [notice, setNotice] = useState<
+    { tone: "queued" | "error"; text: string } | null
+  >(null);
+  const canSend = draft.trim().length > 0 && !disabled;
+
+  // The queue note describes the turn that was running when the message was
+  // parked; once that turn is done the note has nothing left to say.
+  useEffect(() => {
+    if (!running) {
+      setNotice((current) => (current?.tone === "queued" ? null : current));
+    }
+  }, [running]);
 
   async function send() {
     if (!canSend) return;
     const message = draft.trim();
-    setSending(true);
+    // A send that lands on an idle session is answered only when the turn
+    // ends, minutes later. Clearing now keeps the box usable for the
+    // follow-up that queueing exists to accept; a refusal puts the text back.
+    setDraft("");
+    setNotice(null);
     try {
-      await onSend(message);
-      setDraft("");
-    } catch {
-      // Leave the draft. A refused send has no turn to answer.
-    } finally {
-      setSending(false);
+      const outcome = await onSend(message);
+      if (outcome && outcome.kind === "queued") {
+        setNotice({ tone: "queued", text: QUEUED_NOTE });
+      }
+    } catch (err) {
+      setNotice({ tone: "error", text: sendRefusal(err) });
+      setDraft((current) => (current.length === 0 ? message : current));
     }
   }
 
@@ -117,12 +200,11 @@ export function CodeComposer({
   }
 
   return (
-    <div className="flex flex-col gap-2 border-t px-4 py-3">
-      <PermissionModePicker
+    <div className="flex shrink-0 flex-col gap-2 border-t px-4 py-3">
+      <PermissionModeSummary
         value={permissionMode}
         availableModes={availableModes}
         unavailableReason={unavailableReason}
-        onChange={onPermissionMode}
       />
       <div className="flex items-end gap-2">
         <Textarea
@@ -130,12 +212,15 @@ export function CodeComposer({
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={onKeyDown}
-          disabled={disabled || sending}
-          placeholder={running ? "Turn in progress…" : "Message the session"}
+          disabled={disabled}
+          placeholder={running ? "Queue a follow-up…" : "Message the session"}
           aria-label="Message"
           className="min-h-[2.75rem] resize-none"
         />
-        {running ? (
+        <Button type="button" size="sm" disabled={!canSend} onClick={() => void send()}>
+          {running ? "Queue" : "Send"}
+        </Button>
+        {running && (
           <Button
             type="button"
             variant="destructive"
@@ -146,12 +231,29 @@ export function CodeComposer({
             <Square />
             Interrupt
           </Button>
-        ) : (
-          <Button type="button" size="sm" disabled={!canSend} onClick={() => void send()}>
-            Send
-          </Button>
         )}
       </div>
+      {notice && (
+        <p
+          role="status"
+          className={cn(
+            "text-xs",
+            notice.tone === "error"
+              ? "text-destructive"
+              : "text-muted-foreground",
+          )}
+        >
+          {notice.text}
+        </p>
+      )}
     </div>
   );
+}
+
+/** The server's refusal, with the one queue-specific kind said in product terms. */
+function sendRefusal(error: unknown): string {
+  if (error instanceof HttpError && error.kind === "queue_full") {
+    return QUEUE_FULL_NOTE;
+  }
+  return friendlyErrorMessage(error, "Could not send that turn");
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -109,4 +109,51 @@ describe("CodeSessionRegistry", () => {
       text: "README.md",
     });
   });
+
+  it("fills in the prompt of a turn the socket announces", async () => {
+    // A queued follow-up is promoted by the worker, so the client never sees
+    // a turn snapshot for it; the same is true of any turn started elsewhere.
+    const sockets: FakeSocket[] = [];
+    const openSocket = (after: number, onFrame: (frame: SequencedCodeEventFrame) => void) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    let calls = 0;
+    const store = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now: () => "2026-08-15T12:00:02.500Z" },
+      async () => {
+        calls += 1;
+        return calls === 1
+          ? []
+          : [
+              {
+                id: "t2",
+                session_id: "s1",
+                ordinal: 2,
+                status: "running" as const,
+                user_input: "and run the tests",
+                started_at: "2026-08-15T12:00:03.000Z",
+              },
+            ];
+      },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    sockets[0]?.emit({ seq: 1, event: { type: "turn_started", turn_id: "t2" } });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(store.getState().items).toContainEqual({
+      kind: "user",
+      id: userItemId("t2"),
+      turnId: "t2",
+      text: "and run the tests",
+    });
+    expect(calls).toBe(2);
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -5,7 +5,11 @@ import {
   createCodeSessionStore,
   type CodeSessionStore,
 } from "./CodeSessionStore";
-import { hydrateCodeTurns, type CodeSessionDeps } from "./CodeSessionReducer";
+import {
+  applyAcceptedTurn,
+  hydrateCodeTurns,
+  type CodeSessionDeps,
+} from "./CodeSessionReducer";
 
 /**
  * Per-session stores and the sockets that feed them.
@@ -51,11 +55,37 @@ export function acquireCodeSession(
     return existing.store;
   }
   const store = createCodeSessionStore();
+  const fetchedPrompts = new Set<string>();
+  const fillPrompt = (turnId: string) => {
+    if (!hydrateTurns || fetchedPrompts.has(turnId)) return;
+    const state = store.getState();
+    if (
+      state.items.some((item) => item.kind === "user" && item.turnId === turnId)
+    ) {
+      return;
+    }
+    fetchedPrompts.add(turnId);
+    void hydrateTurns()
+      .then((turns) => {
+        const turn = turns.find((candidate) => candidate.id === turnId);
+        if (!turn) return;
+        store.getState().update((session) => applyAcceptedTurn(session, turn));
+      })
+      .catch(() => {
+        // The prompt lands on the next open. The turn itself still streams.
+      });
+  };
   const controller = new CodeSessionController({
     openSocket,
     getAfter: () => store.getState().lastSeq,
     onEvent: (frame) => {
-      store.getState().applyEvent(frame, deps);
+      // A turn the socket announces has no prompt bubble yet: submit answers
+      // only when the turn ends, and a queued follow-up is never answered
+      // with a turn at all. Pull the snapshot so the transcript shows what
+      // the engine is working on while it works.
+      for (const effect of store.getState().applyEvent(frame, deps)) {
+        if (effect.type === "turn_began") fillPrompt(effect.turnId);
+      }
     },
     onConnectionState: () => {},
     hydrateTurns,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
@@ -16,7 +16,10 @@ const TURN = {
 describe("submitAcceptedTurn", () => {
   it("inserts a turn-keyed user item only after the server accepts", async () => {
     const store = createCodeSessionStore();
-    await submitAcceptedTurn(store.getState().update, async () => TURN);
+    await submitAcceptedTurn(store.getState().update, async () => ({
+      kind: "ran" as const,
+      turn: TURN,
+    }));
     expect(store.getState().items).toEqual([
       {
         kind: "user",
@@ -44,7 +47,7 @@ describe("retry after a failed submit", () => {
     const submit = vi
       .fn()
       .mockRejectedValueOnce(new Error("offline"))
-      .mockResolvedValueOnce(TURN);
+      .mockResolvedValueOnce({ kind: "ran" as const, turn: TURN });
     await expect(
       submitAcceptedTurn(store.getState().update, submit),
     ).rejects.toThrow("offline");
@@ -90,8 +93,8 @@ describe("accepted turn after the socket already painted", () => {
       deps,
     );
     await submitAcceptedTurn(store.getState().update, async () => ({
-      ...TURN,
-      status: "completed",
+      kind: "ran" as const,
+      turn: { ...TURN, status: "completed" as const },
     }));
     expect(store.getState().items.map((item) => item.kind)).toEqual([
       "user",

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.ts
@@ -1,5 +1,5 @@
-import type { CodeTurnSnapshot } from "../api/types";
 import { applyAcceptedTurn, type CodeSessionState } from "./CodeSessionReducer";
+import type { CodeTurnSubmission } from "./parsers";
 
 /**
  * Insert a user turn only after the server accepts it.
@@ -8,12 +8,18 @@ import { applyAcceptedTurn, type CodeSessionState } from "./CodeSessionReducer";
  * stacks a duplicate on retry. Chat removes its optimistic item in the catch;
  * here the cheaper mirror is to wait for the accepted snapshot, which is also
  * the hydrate key.
+ *
+ * A queued follow-up has no turn row yet, so there is nothing to key an item
+ * on. Its bubble arrives when the worker promotes the slot and the session's
+ * `turn_started` event pulls the snapshot in.
  */
 export async function submitAcceptedTurn(
   update: (change: (session: CodeSessionState) => CodeSessionState) => void,
-  submit: () => Promise<CodeTurnSnapshot>,
-): Promise<CodeTurnSnapshot> {
-  const turn = await submit();
-  update((session) => applyAcceptedTurn(session, turn));
-  return turn;
+  submit: () => Promise<CodeTurnSubmission>,
+): Promise<CodeTurnSubmission> {
+  const outcome = await submit();
+  if (outcome.kind === "ran") {
+    update((session) => applyAcceptedTurn(session, outcome.turn));
+  }
+  return outcome;
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -584,14 +584,12 @@ function CodeSessionPane({
     };
   }, [client, session.id, approvalKey]);
 
-  async function send(message: string) {
-    try {
-      await submitAcceptedTurn(store.getState().update, () =>
-        client.submitCodeTurn(session.id, message),
-      );
-    } catch (err) {
-      toast.error(friendlyErrorMessage(err, "Could not send that turn"));
-    }
+  function send(message: string) {
+    // Outcome and refusal both belong to the composer: it says whether the
+    // message ran or queued, and it holds the draft when the server refuses.
+    return submitAcceptedTurn(store.getState().update, () =>
+      client.submitCodeTurn(session.id, message),
+    );
   }
 
   async function interrupt() {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -16,6 +16,7 @@ import {
   parseCodeTerminalRead,
   parseCodeTurn,
   parseCodeTurnList,
+  parseCodeTurnSubmission,
   parseCodeWorkspaceDiff,
   parseCodeWorkspaceFiles,
   parseCodeWorkspacePr,
@@ -84,6 +85,22 @@ describe("parseCodeTurnList", () => {
   it("rejects a non-array or a row the turn parser would drop", () => {
     expect(parseCodeTurnList({ turns: [TURN] })).toBeNull();
     expect(parseCodeTurnList([{ ...TURN, status: "paused" }])).toBeNull();
+  });
+});
+
+describe("parseCodeTurnSubmission", () => {
+  it("tells a turn that ran from a follow-up the server queued", () => {
+    // Both arrive as 202 on POST /code/sessions/{id}/turns. Reading the
+    // queue receipt as a malformed turn reports a failure for a message the
+    // server is holding, and the retry it invites double-sends.
+    expect(parseCodeTurnSubmission(TURN)).toEqual({ kind: "ran", turn: TURN });
+    const queued = {
+      session_id: "sess-1",
+      message: "and run the tests",
+      position: 1,
+    };
+    expect(parseCodeTurnSubmission(queued)).toEqual({ kind: "queued", queued });
+    expect(parseCodeTurnSubmission({ session_id: "sess-1" })).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -41,12 +41,14 @@ import type {
   CodeCloneDefaults,
   CodeCloneJobSnapshot,
   PullRequestDigest,
+  QueuedCodeTurn,
 } from "../api/types";
 import type {
   CodeEvent as WireCodeEvent,
   CodeRepoSnapshot as WireCodeRepoSnapshot,
   CodeSessionSnapshot as WireCodeSessionSnapshot,
   CodeTurnSnapshot as WireCodeTurnSnapshot,
+  QueuedCodeTurn as WireQueuedCodeTurn,
   CodeTerminalRead as WireCodeTerminalRead,
   CodeTerminalSnapshot as WireCodeTerminalSnapshot,
   CodeWorkspaceDiff as WireCodeWorkspaceDiff,
@@ -562,6 +564,43 @@ export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
     ...(diffstat ? { diffstat } : {}),
     ...(value.ended_at !== undefined ? { ended_at: value.ended_at } : {}),
   };
+}
+
+/**
+ * What `POST /code/sessions/{id}/turns` did with the message.
+ *
+ * The route answers 202 for both outcomes: a turn that ran, or a follow-up
+ * parked in the session's single queue slot while the current turn finishes.
+ * The two payloads share no required key, so the shape discriminates.
+ */
+export type CodeTurnSubmission =
+  | { kind: "ran"; turn: CodeTurnSnapshot }
+  | { kind: "queued"; queued: QueuedCodeTurn };
+
+export function parseQueuedCodeTurn(value: unknown): QueuedCodeTurn | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireQueuedCodeTurn>(value, ["session_id", "message", "position"]) ||
+    !nonEmpty(value.session_id) ||
+    typeof value.message !== "string" ||
+    !isFiniteNumber(value.position)
+  ) {
+    return null;
+  }
+  return {
+    session_id: value.session_id,
+    message: value.message,
+    position: value.position,
+  };
+}
+
+export function parseCodeTurnSubmission(
+  value: unknown,
+): CodeTurnSubmission | null {
+  const turn = parseCodeTurn(value);
+  if (turn) return { kind: "ran", turn };
+  const queued = parseQueuedCodeTurn(value);
+  return queued ? { kind: "queued", queued } : null;
 }
 
 export function parseCodeWorkspaceFiles(

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -236,6 +236,16 @@ purpose:
 - **Multiple sessions per workspace.** The data model keeps room for
   follow-up and successor sessions in one worktree; v1 runs one active
   session per workspace.
+- **Changing a session's permission mode after it starts.** The mode is
+  chosen at session creation, refused per harness capability there
+  ([record 33](decisions/0033-code-mode-approvals.md),
+  [record 38](decisions/0038-auto-is-a-declared-capability.md)), and composed
+  into the engine's launch; no adapter can renegotiate it on an attached
+  session. Changing it means tearing the engine down and relaunching it on a
+  resume ref — new semantics for spawn epochs, in-flight turns, and pending
+  approvals — so the composer states the session's mode rather than offering
+  it. Revisit when relaunch-on-resume is a proven path, or when a harness
+  protocol carries a mode change directly.
 - **An in-app code editor.** V1 reviews server-produced diffs and hands
   editing to the user's editor via the worktree path. An embedded editor is
   a heavyweight dependency with its own product surface; it needs demand


### PR DESCRIPTION
Two dead controls in the code-mode composer.

## Queueing was reachable only by race

The server has queued a mid-turn send since code mode landed: a submit on a busy session parks the message in the session's single slot and answers `202` with a queue receipt (`QueuedCodeTurn`) instead of a turn snapshot. The desktop could not get there. The composer swapped Send for Interrupt while a turn ran, and `parseCodeTurn` rejects anything that is not a turn snapshot — so if a queued receipt ever did arrive, the client reported "Could not send that turn" for a message the server was holding, and invited the retry that double-sends.

- The composer sends while a turn is running. The button reads **Queue**, Interrupt sits beside it, and Enter queues rather than silently doing nothing.
- `submitCodeTurn` returns a discriminated `CodeTurnSubmission` (`ran` | `queued`), matching what the CLI already accepts for the same route. Only a turn that ran inserts a transcript item — a queued follow-up has no turn row to key one on.
- A queued send says "Queued — runs after the current turn", cleared when that turn finishes. The queue's own refusal (`409 queue_full`) is stated in product terms instead of as a raw status line.

Two things surfaced while wiring it, both in the way of the feature:

- Submit answers only when the turn *ends*. The composer held the draft and disabled the textarea for the whole turn, which leaves nowhere to write the follow-up that queueing exists to accept. It now clears on send and puts the text back if the server refuses.
- The accepted snapshot was the only source of a prompt bubble, so a turn the client did not submit — every queued follow-up, and any turn started elsewhere — had no prompt in the transcript until the next open. The session registry now pulls the snapshot when the socket announces a turn it has no prompt for, once per turn.

## The permission control was inert

`PermissionModePicker` rendered pressable `aria-pressed` buttons in the composer, but nothing ever passed `onChange`, so clicking did nothing.

The mode is not changeable on a live session. It is composed into the engine's launch — argv flags per harness — and refused per capability at creation (decisions 0033 and 0038); `HarnessSession` has no seam for changing it, and doing so would mean engine relaunch semantics with resume refs, spawn epochs, and in-flight approvals to settle. That is a decision record, not a side effect of this fix. So the composer now *states* the session's mode (`PermissionModeSummary`) rather than offering it, keeping unavailable modes visible and dimmed with their reason. The picker is untouched where the choice is real: the new-workspace dialog and the start-session prompt.

**Follow-up:** changing permission mode mid-session is not implemented. It needs a decision on relaunch semantics first.

Also adds `shrink-0` to the composer root so a long draft cannot squeeze the transcript.

## Tests

- `CodeComposer.dom.test.tsx`: a follow-up typed during a running turn calls send and shows the queued affordance; `409 queue_full` surfaces its message and keeps the draft; the mode is stated with no pressable control. The old test asserting `onPermissionMode` fired on click is gone with the control it described — `StartSessionPrompt.dom.test.tsx` still covers the picker where it is interactive.
- `parsers.test.ts`: the two `202` shapes are told apart.
- `CodeSessionRegistry.test.ts`: a turn announced by the socket gets its prompt filled in.

`pnpm test` (1094 passing) and `pnpm build` pass. No Rust changes — the server side already worked. Not driven in the running app.

The parked scope is recorded in `docs/deferred.md` alongside the rest of what code mode leaves out.
