### PR TITLE
fix(server): cache harness probes and restore approval channels on recovery

### DIFF
--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -22,7 +22,7 @@ use tidebreak_core::{
 };
 use tidebreak_harness::{
     builtin_registry, AdapterRegistry, ApprovalChannelSpec, ApprovalDecision, HarnessAdapter,
-    HarnessEvent, HarnessEventSink, HostEnv, SessionSpec,
+    HarnessEvent, HarnessEventSink, HarnessProbe, HostEnv, SessionSpec,
 };
 
 use super::approval_bridge::ApprovalBridge;
@@ -63,6 +63,8 @@ pub(crate) struct CodeRuntime {
     pub approvals: Arc<ApprovalBridge>,
     host: HostEnv,
     loopback_base: Mutex<Option<String>>,
+    /// Memoized harness probes, one per kind. See [`CodeRuntime::probe`].
+    probes: Mutex<HashMap<HarnessKind, HarnessProbe>>,
     workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
     pr_cache: PrDigestCache,
     pub(crate) clone_jobs: CloneJobs,
@@ -88,6 +90,7 @@ impl CodeRuntime {
             approvals: ApprovalBridge::new(),
             host: HostEnv::from_process(),
             loopback_base: Mutex::new(None),
+            probes: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
             clone_jobs: CloneJobs::default(),
@@ -100,9 +103,30 @@ impl CodeRuntime {
     }
 
     /// Bound after listen so Claude can be pointed at the loopback MCP route.
-    pub(crate) fn set_loopback_base(&self, base: String) {
+    fn set_loopback_base(&self, base: String) {
         *self.loopback_base.lock().expect("loopback base") =
             Some(base.trim_end_matches('/').into());
+    }
+
+    /// Boot: publish the bound loopback base now, and hand back the recovery
+    /// pass to run.
+    ///
+    /// The two steps are one call because their order is load-bearing. Every
+    /// worker recovery re-attaches mints its approval MCP endpoint from this
+    /// base ([`Self::approval_channel`]), so recovering before the bound
+    /// address is known restores Ask- and Auto-mode sessions with no approval
+    /// channel at all — silently, since the channel is an `Option`. Recovery
+    /// comes back as a future rather than running here so the boot path can
+    /// keep it off the bind critical path; the base is published before that
+    /// future exists, so a session created while recovery is still in flight
+    /// is wired exactly like a recovered one.
+    pub(crate) fn start(
+        self: &Arc<Self>,
+        loopback_base: String,
+    ) -> impl std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> {
+        self.set_loopback_base(loopback_base);
+        let runtime = self.clone();
+        async move { runtime.recover().await }
     }
 
     #[cfg(any(test, feature = "scripted-harness"))]
@@ -119,6 +143,7 @@ impl CodeRuntime {
             approvals: ApprovalBridge::new(),
             host: HostEnv::from_process(),
             loopback_base: Mutex::new(None),
+            probes: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
             clone_jobs: CloneJobs::default(),
@@ -148,29 +173,71 @@ impl CodeRuntime {
         }
         // Recovery only mutates rows. Re-attach a worker for every session
         // that is still usable so submit_turn is not stuck after a restart.
-        for session in list_sessions(&self.db).await? {
-            if matches!(
-                session.lifecycle,
-                CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
-            ) {
-                continue;
-            }
-            if self
-                .workers
-                .lock()
-                .expect("code workers")
-                .contains_key(&session.id)
-            {
-                continue;
-            }
+        // Concurrently: each attach launches an engine child, so a serial pass
+        // charged app launch the sum of every restored session.
+        let resumable: Vec<CodeSession> = list_sessions(&self.db)
+            .await?
+            .into_iter()
+            .filter(|session| {
+                !matches!(
+                    session.lifecycle,
+                    CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+                ) && !self
+                    .workers
+                    .lock()
+                    .expect("code workers")
+                    .contains_key(&session.id)
+            })
+            .collect();
+        futures::future::join_all(resumable.into_iter().map(|session| async move {
             if let Err(error) = self.attach_and_spawn_worker(session).await {
                 tracing::warn!(
                     "code-mode: could not resume a recovered session worker: {}",
                     error.message()
                 );
             }
-        }
+        }))
+        .await;
         Ok(actions)
+    }
+
+    /// The probe for `adapter`, resolved once and memoized.
+    ///
+    /// Decision 0034 makes discovery a cached read rather than a per-request
+    /// one: a cold probe asks the user's shell in interactive login mode and
+    /// then runs a version and an authentication observation, which is seconds
+    /// of subprocess per harness. Re-probing is on demand — the doctor's
+    /// refresh calls [`Self::invalidate_probes`] — so a harness installed
+    /// while the app is running is picked up by the button that exists to say
+    /// so, not by paying for it on every code-mode navigation.
+    ///
+    /// The cache fills lazily. Nothing warms it at boot: recovery already
+    /// probes the kinds that have live sessions on its way to re-attaching
+    /// them, and warming the rest would spend four login shells on harnesses
+    /// this launch may never touch.
+    pub(crate) async fn probe(&self, adapter: &dyn HarnessAdapter) -> HarnessProbe {
+        let kind = adapter.kind();
+        let cached = self
+            .probes
+            .lock()
+            .expect("harness probes")
+            .get(&kind)
+            .cloned();
+        if let Some(probe) = cached {
+            return probe;
+        }
+        let probe = adapter.probe(&self.host).await;
+        self.probes
+            .lock()
+            .expect("harness probes")
+            .insert(kind, probe.clone());
+        probe
+    }
+
+    /// Drop every memoized probe so the next read is cold. The doctor's
+    /// refresh is the on-demand re-probe decision 0034 describes.
+    pub(crate) fn invalidate_probes(&self) {
+        self.probes.lock().expect("harness probes").clear();
     }
 
     pub(crate) fn adapter(
@@ -595,7 +662,7 @@ impl CodeRuntime {
             ));
         }
         let adapter = self.adapter(harness)?;
-        let probe = adapter.probe(&self.host).await;
+        let probe = self.probe(adapter.as_ref()).await;
         if !probe.found {
             return Err(ServerError::unprocessable_kind(
                 "harness_not_found",
@@ -870,7 +937,9 @@ impl CodeRuntime {
     ) -> Result<CodeSession, ServerError> {
         let workspace = self.get_workspace(session.workspace_id).await?;
         let adapter = self.adapter(session.harness_kind)?;
-        let probe = adapter.probe(&self.host).await;
+        // Cached, so the probe `create_session` already paid for is not paid
+        // again on the way into the worker.
+        let probe = self.probe(adapter.as_ref()).await;
         if !probe.found {
             return Err(ServerError::unprocessable_kind(
                 "harness_not_found",

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1382,9 +1382,8 @@ async fn bind_inner(
     }
     state.host_folders = host_folders;
     let code = Arc::new(code::CodeRuntime::new(db, state.config.data_dir.clone()));
-    if let Err(error) = code.recover().await {
-        tracing::warn!("code-mode recovery: {}", error.message());
-    }
+    // Recovery runs after the bind, below: the workers it re-attaches need the
+    // bound loopback address to reach their approval endpoint.
     state.code = Some(code.clone());
     // Before `initialize`: a boot-file or persisted replacement derives the
     // plugin slice in the same pass, so bundled servers come up with
@@ -1537,7 +1536,20 @@ async fn bind_inner(
     let local_addr = listener
         .local_addr()
         .map_err(|e| AgentError::config(format!("no local address: {e}")))?;
-    code.set_loopback_base(format!("http://{local_addr}"));
+    // Publish the loopback base and take the code-mode recovery pass, then run
+    // it in the background. It has to come after the bind — a session
+    // re-attached before the address is known comes back with no approval
+    // endpoint — and it should not gate launch, because it relaunches an
+    // engine child per restored session. The trade is a brief window where a
+    // restored session is listed but its worker is not attached yet, and a
+    // turn submitted into it is refused with `session_worker_missing`; before,
+    // the same wait was spent with the port closed and the app unusable.
+    let code_recovery = code.start(format!("http://{local_addr}"));
+    tokio::spawn(async move {
+        if let Err(error) = code_recovery.await {
+            tracing::warn!("code-mode recovery: {}", error.message());
+        }
+    });
     // Publish before workers start answering so an attach racing boot sees a
     // file that matches the bound address. It carries the primary bearer and
     // the narrow local-import capability, never the executor credential. See

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -7,58 +7,65 @@ use crate::state::AppState;
 use super::require_code;
 use super::types::{HarnessDoctorEntry, HarnessDoctorReport};
 use tidebreak_core::HarnessKind;
-use tidebreak_harness::HostEnv;
 
+/// The doctor surface, served from the memoized probes (decision 0034).
 pub async fn list_harnesses(
     State(state): State<AppState>,
 ) -> Result<Json<HarnessDoctorReport>, ServerError> {
     Ok(Json(doctor(&state).await?))
 }
 
+/// The explicit re-probe decision 0034 puts behind the doctor's refresh: drop
+/// the memoized probes, then report what a cold read finds. This is how a
+/// harness installed or signed into while the app runs becomes visible.
 pub async fn refresh_harnesses(
     State(state): State<AppState>,
 ) -> Result<Json<HarnessDoctorReport>, ServerError> {
+    require_code(&state)?.invalidate_probes();
     Ok(Json(doctor(&state).await?))
 }
 
 async fn doctor(state: &AppState) -> Result<HarnessDoctorReport, ServerError> {
     let runtime = require_code(state)?;
     let sessions = runtime.list_sessions().await?;
-    let host = HostEnv::from_process();
-    let mut harnesses = Vec::new();
-    for kind in HarnessKind::ALL {
-        let Some(adapter) = runtime.adapters.get(*kind) else {
-            continue;
-        };
-        let probe = adapter.probe(&host).await;
-        let caps = adapter.capabilities(&probe);
-        let unrecognized_event_count = sessions
-            .iter()
-            .filter(|session| session.harness_kind == *kind)
-            .map(|session| session.unrecognized_event_count)
-            .sum();
-        let remediation = if !probe.found {
-            format!("install {kind} so it is on your login-shell PATH, then refresh")
-        } else if probe.authenticated == Some(false) {
-            format!("sign in to {kind} in your own terminal, then refresh")
-        } else {
-            String::new()
-        };
-        harnesses.push(HarnessDoctorEntry {
-            kind: *kind,
-            found: probe.found,
-            path: probe
-                .binary_path
-                .as_ref()
-                .map(|path| path.display().to_string()),
-            version: probe.version,
-            tier: kind.tier(),
-            caps,
-            authenticated: probe.authenticated,
-            remediation,
-            stderr: probe.stderr,
-            unrecognized_event_count,
-        });
-    }
+    let sessions = &sessions;
+    // Probe the kinds concurrently. A cold probe is a login shell plus a
+    // version and an authentication subprocess, so a serial walk over the
+    // harnesses is most of what this route costs on a cache miss.
+    let harnesses = futures::future::join_all(HarnessKind::ALL.iter().filter_map(|kind| {
+        let adapter = runtime.adapters.get(*kind)?;
+        Some(async move {
+            let probe = runtime.probe(adapter.as_ref()).await;
+            let caps = adapter.capabilities(&probe);
+            let unrecognized_event_count = sessions
+                .iter()
+                .filter(|session| session.harness_kind == *kind)
+                .map(|session| session.unrecognized_event_count)
+                .sum();
+            let remediation = if !probe.found {
+                format!("install {kind} so it is on your login-shell PATH, then refresh")
+            } else if probe.authenticated == Some(false) {
+                format!("sign in to {kind} in your own terminal, then refresh")
+            } else {
+                String::new()
+            };
+            HarnessDoctorEntry {
+                kind: *kind,
+                found: probe.found,
+                path: probe
+                    .binary_path
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                version: probe.version,
+                tier: kind.tier(),
+                caps,
+                authenticated: probe.authenticated,
+                remediation,
+                stderr: probe.stderr,
+                unrecognized_event_count,
+            }
+        })
+    }))
+    .await;
     Ok(HarnessDoctorReport { harnesses })
 }

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -78,6 +78,10 @@ pub(crate) struct ScriptedAdapter {
     auto_mode: CapLevel,
     child_pid: Option<i64>,
     approver: Arc<ScriptedApprover>,
+    probes: Arc<AtomicU64>,
+    /// Approval endpoint each launch was handed, `None` when it was handed no
+    /// channel at all. Lets a test see how a session was wired.
+    launched_approvals: Arc<std::sync::Mutex<Vec<Option<String>>>>,
 }
 
 impl ScriptedAdapter {
@@ -91,7 +95,25 @@ impl ScriptedAdapter {
             auto_mode: CapLevel::Unsupported,
             child_pid: None,
             approver: Arc::new(ScriptedApprover::default()),
+            probes: Arc::new(AtomicU64::new(0)),
+            launched_approvals: Arc::new(std::sync::Mutex::new(Vec::new())),
         }
+    }
+
+    /// How many times this adapter has been probed. The runtime memoizes
+    /// probes, so this is how a test sees a cache hit from a cold read.
+    #[allow(dead_code)]
+    pub(crate) fn probe_count(&self) -> u64 {
+        self.probes.load(Ordering::SeqCst)
+    }
+
+    /// The approval endpoint each launched session was given, in order.
+    #[allow(dead_code)]
+    pub(crate) fn launched_approvals(&self) -> Vec<Option<String>> {
+        self.launched_approvals
+            .lock()
+            .expect("scripted launches")
+            .clone()
     }
 
     /// Sets the approval channel and, with it, the supervised auto posture —
@@ -138,6 +160,7 @@ impl HarnessAdapter for ScriptedAdapter {
     }
 
     async fn probe(&self, _host: &HostEnv) -> HarnessProbe {
+        self.probes.fetch_add(1, Ordering::SeqCst);
         HarnessProbe {
             found: true,
             binary_path: Some(PathBuf::from("/scripted/engine")),
@@ -171,6 +194,14 @@ impl HarnessAdapter for ScriptedAdapter {
                 spec.permission_mode,
             ));
         }
+        self.launched_approvals
+            .lock()
+            .expect("scripted launches")
+            .push(
+                spec.approval
+                    .as_ref()
+                    .map(|channel| channel.mcp_endpoint_url.clone()),
+            );
         Ok(Box::new(ScriptedSession {
             sink: spec.sink,
             events: self.events.clone(),

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -2383,11 +2383,17 @@ async fn next_json(
     }
 }
 
+/// The doctor serves memoized probes, and refresh is the on-demand re-probe
+/// (decision 0034). A cold probe spends an interactive login shell plus a
+/// version and an authentication subprocess per harness, and the code-mode
+/// surface reads this route on every navigation.
 #[tokio::test]
-async fn doctor_lists_the_scripted_adapter() {
-    let (router, token, _runtime, _dir) = code_app(plain_text_script()).await;
+async fn the_doctor_caches_probes_and_refresh_re_probes() {
+    let adapter = ScriptedAdapter::new(plain_text_script());
+    let (router, token, _runtime, _dir) = code_app_with(adapter.clone()).await;
     let addr = serve(router).await;
-    let report = reqwest::Client::new()
+    let client = reqwest::Client::new();
+    let report = client
         .get(format!("http://{addr}/code/harnesses"))
         .bearer_auth(&token)
         .send()
@@ -2398,6 +2404,90 @@ async fn doctor_lists_the_scripted_adapter() {
         .unwrap();
     assert_eq!(report["harnesses"][0]["kind"], "claude_code");
     assert_eq!(report["harnesses"][0]["found"], true);
+
+    let again = client
+        .get(format!("http://{addr}/code/harnesses"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(again["harnesses"][0]["found"], true);
+    assert_eq!(
+        adapter.probe_count(),
+        1,
+        "a second doctor read must be served from the cache"
+    );
+
+    let refreshed = client
+        .post(format!("http://{addr}/code/harnesses/refresh"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(refreshed["harnesses"][0]["found"], true);
+    assert_eq!(
+        adapter.probe_count(),
+        2,
+        "refresh must re-probe rather than repeat the cached answer"
+    );
+}
+
+/// A session restored at boot comes back supervised. Recovery re-attaches its
+/// worker, and that worker's approval endpoint is minted from the bound
+/// loopback address — so recovery has to run after the address is published.
+/// The other order silently restores Ask- and Auto-mode sessions with no
+/// approval channel: an engine that can never ask.
+#[tokio::test]
+async fn a_recovered_session_keeps_its_approval_channel() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script()).with_approvals(CapLevel::Supported),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "ask",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_approvals(CapLevel::Supported);
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(adapter.clone()));
+    let restarted = Arc::new(CodeRuntime::with_registry(
+        runtime.db.clone(),
+        dir.path().to_path_buf(),
+        registry,
+    ));
+    restarted
+        .start("http://127.0.0.1:4242".into())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        adapter.launched_approvals(),
+        vec![Some(
+            "http://127.0.0.1:4242/code/mcp/approval-prompt".to_owned()
+        )],
+        "recovery must re-attach the session with a live approval endpoint"
+    );
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## The correctness bug

Boot recovery ran before the server bound its port, and the loopback base every approval MCP endpoint is built from was published *after* the bind. Recovery therefore re-attached every restored session while that base was still unset, and `approval_channel` returns an `Option` — so each Ask- and Auto-mode session restored at boot came back with **no approval endpoint at all**. The engine could never ask, and nothing in the journal said why.

Publishing the base and running recovery are now a single call, `CodeRuntime::start`. It sets the base synchronously and hands the recovery pass back as a future, so the order is no longer something a boot-sequence edit can get wrong: `set_loopback_base` is private, and a session created while recovery is still in flight is wired exactly like a recovered one.

## Getting recovery off the launch path

The boot path now runs that recovery future in a background task after the bind. Recovery relaunches an engine child per restored session, so launch no longer waits on the sum of them, and the per-session re-attach inside recovery is concurrent rather than serial.

The trade: for a short window a restored session is listed before its worker is attached, and a turn submitted into it is refused with `session_worker_missing`. Previously that same wait was spent with the port closed and the app unusable, so this is a strictly earlier-usable boot, not a new stall.

## The probe cache decision 0034 already specified

`docs/decisions/0034-harness-discovery-credentials.md` says the probe "is bounded … and cached; re-probe is on demand from the doctor surface". It was not cached. A cold probe spawns an interactive login shell (`$SHELL -ilc`) plus a version and an authentication subprocess — measured at roughly 1.5s per harness — and `GET /code/harnesses` walked all four serially, about 7s per call, on every code-mode navigation. `refresh_harnesses` was byte-identical to `list_harnesses`, so the refresh button meant nothing.

- Probes are memoized per `HarnessKind` on `CodeRuntime`.
- The doctor serves the cache, and probes concurrently on a miss (~7s to ~2s cold, instant warm).
- `POST /code/harnesses/refresh` is now the invalidate-and-re-probe path — the on-demand re-probe 0034 describes, and how a harness installed or signed into mid-session becomes visible.
- A session start probes at most once: `create_session` and `attach_and_spawn_worker` previously probed the same harness back to back and now read the same memoized result.

**Population policy:** lazily, not warmed at boot. Recovery already probes the kinds that have live sessions on its way to re-attaching them, so those fill for free and off the launch path; warming the rest would spend four login shells on harnesses a launch may never touch. One consequence worth naming: the probe also carries the shell environment harness children run under, so that snapshot is now captured once per refresh rather than once per launch — which is what 0034 asks for, but it does mean a profile edit needs a refresh to take effect.

## Tests

- `a_recovered_session_keeps_its_approval_channel` — the reproduction. It asserts a recovered session's worker was launched with an approval endpoint minted from the bound address; inverting the publish/recover order makes it fail with `[None]`.
- `the_doctor_caches_probes_and_refresh_re_probes` — a second doctor read must not re-probe, and refresh must. This replaces `doctor_lists_the_scripted_adapter`, whose assertions it keeps, rather than adding a test alongside it.
- The scripted adapter gained a probe counter and a record of the approval channel each launch was handed; both are test-only observation, no behavior.

Concurrency itself is not tested — it has no observable contract beyond being faster.

## Verified

`cargo fmt --check`, `cargo clippy -p tidebreak-server --all-targets -D warnings`, `cargo test -p tidebreak-server --locked --lib code::` (76 pass) and the `listener` integration test. Not verified by driving the app: the launch-latency and approval-channel improvements are argued from the code paths and the per-probe timings above, not from a running desktop build.
