### PR TITLE
fix(server): persist and surface unrecognized harness events

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -216,6 +216,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                   client={client}
                 />
                 <PendingApprovalBadge sessionId={session.id} client={client} />
+                <UnrecognizedEventsBadge session={session} />
                 <SessionLifecycleBadge
                   session={session}
                   client={client}
@@ -496,6 +497,34 @@ function PendingApprovalBadge({
   return (
     <Badge variant="warning" size="sm" data-testid="pending-approval-badge">
       {pending} {pending === 1 ? "approval" : "approvals"}
+    </Badge>
+  );
+}
+
+/**
+ * The engine dropped part of its own stream. Saying so where the session is
+ * read is the point of counting it at all — a silently degraded transcript
+ * looks exactly like a complete one (decision 0031). The count comes from the
+ * session row, so it settles at the end of a turn rather than mid-stream.
+ */
+function UnrecognizedEventsBadge({
+  session,
+}: {
+  session: CodeSessionSnapshot;
+}) {
+  const dropped = session.unrecognized_event_count;
+  if (dropped <= 0) return null;
+  return (
+    <Badge
+      variant="warning"
+      size="sm"
+      data-testid="unrecognized-events-badge"
+      title={
+        `${dropped} engine ${dropped === 1 ? "event" : "events"} could not be read by this ` +
+        "build and are missing from the transcript. Check the harness doctor page."
+      }
+    >
+      {dropped} unread {dropped === 1 ? "event" : "events"}
     </Badge>
   );
 }

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -1,7 +1,7 @@
 //! One print-mode child per turn.
 
 use std::process::Stdio;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -29,6 +29,9 @@ pub struct ClaudeSession {
     resume_ref: Mutex<Option<String>>,
     child: AsyncMutex<Option<Child>>,
     child_pid: AtomicU32,
+    /// Unrecognized events summed across every turn's parser: each turn is a
+    /// fresh child, so the per-turn count alone would reset on every prompt.
+    unrecognized: AtomicU64,
 }
 
 impl ClaudeSession {
@@ -39,6 +42,7 @@ impl ClaudeSession {
             resume_ref: Mutex::new(resume_ref),
             child: AsyncMutex::new(None),
             child_pid: AtomicU32::new(0),
+            unrecognized: AtomicU64::new(0),
         }
     }
 
@@ -178,6 +182,8 @@ impl HarnessSession for ClaudeSession {
             let pending = lines.pending().to_owned();
             emit_parsed(&self.spec, &mut parser, &self.resume_ref, &pending).await;
         }
+        self.unrecognized
+            .fetch_add(parser.unrecognized(), Ordering::SeqCst);
 
         let _ = stdin_task.await;
         let stderr = stderr_task.await.unwrap_or_default();
@@ -242,6 +248,10 @@ impl HarnessSession for ClaudeSession {
             0 => None,
             pid => Some(i64::from(pid)),
         }
+    }
+
+    fn unrecognized_events(&self) -> u64 {
+        self.unrecognized.load(Ordering::SeqCst)
     }
 
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -291,6 +291,9 @@ impl CodexStreamParser {
             .and_then(Value::as_str)
             .unwrap_or("");
         match status {
+            "completed" => vec![HarnessEvent::TurnCompleted {
+                usage: self.last_usage.clone(),
+            }],
             "interrupted" => vec![HarnessEvent::TurnInterrupted],
             "failed" => {
                 let message = params
@@ -303,9 +306,29 @@ impl CodexStreamParser {
                     },
                 }]
             }
-            _ => vec![HarnessEvent::TurnCompleted {
-                usage: self.last_usage.clone(),
-            }],
+            // The manifest records the observed set as
+            // `completed | interrupted | failed`. A fourth value still ends
+            // the turn, so it closes as completed — but counted and stated,
+            // never folded in silently (decision 0031).
+            other => {
+                let label = if other.is_empty() { "missing" } else { other };
+                self.count_unrecognized(&format!("turn/completed/{label}"), params);
+                vec![
+                    HarnessEvent::HarnessNotice {
+                        level: HarnessNoticeLevel::Warning,
+                        message: bound(
+                            &format!(
+                                "the engine ended the turn with an unrecognized status \
+                                 ({label}); it was recorded as completed"
+                            ),
+                            MAX_NOTICE_CHARS,
+                        ),
+                    },
+                    HarnessEvent::TurnCompleted {
+                        usage: self.last_usage.clone(),
+                    },
+                ]
+            }
         }
     }
 
@@ -498,5 +521,27 @@ mod tests {
             Some(HarnessEvent::TurnCompleted { .. })
         ));
         assert_eq!(out.resume_ref.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn an_unknown_turn_status_is_counted_and_stated_before_the_turn_closes() {
+        // The turn still has to end — the plausible wrong implementation folds
+        // a fourth status into a plain completion and says nothing.
+        let input = r#"
+{"dir":"in","msg":{"method":"turn/completed","params":{"turn":{"status":"abandoned"}}}}
+"#;
+        let out = CodexStreamParser::parse_ndjson(input);
+        assert_eq!(out.unrecognized, 1);
+        assert!(matches!(
+            out.events.first(),
+            Some(HarnessEvent::HarnessNotice {
+                level: HarnessNoticeLevel::Warning,
+                ..
+            })
+        ));
+        assert!(matches!(
+            out.events.last(),
+            Some(HarnessEvent::TurnCompleted { .. })
+        ));
     }
 }

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -449,6 +449,12 @@ impl HarnessSession for CodexSession {
         }
     }
 
+    fn unrecognized_events(&self) -> u64 {
+        // One long-lived parser per session, so its own count is already
+        // cumulative.
+        self.parser.lock().expect("codex parser").unrecognized()
+    }
+
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         if let Some(mut child) = self.child.lock().await.take() {
             let _ = child.kill().await;

--- a/crates/tidebreak-harness/src/grok/parse.rs
+++ b/crates/tidebreak-harness/src/grok/parse.rs
@@ -8,8 +8,8 @@ use std::collections::HashSet;
 
 use serde_json::Value;
 use tidebreak_core::{
-    BoundedError, CodeUsage, HarnessKind, ToolDetail, ToolOutcome, MAX_EVENT_TEXT_CHARS,
-    MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS,
+    BoundedError, CodeUsage, HarnessKind, HarnessNoticeLevel, ToolDetail, ToolOutcome,
+    MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS,
 };
 
 use crate::HarnessEvent;
@@ -179,6 +179,10 @@ impl GrokStreamParser {
     }
 
     fn parse_tool_call_update(&mut self, value: &Value) -> Vec<HarnessEvent> {
+        // `status: null` is the documented progress frame — the manifest
+        // records the observed set as `null (progress) | completed | failed`.
+        // It carries no state we normalize, so dropping it is a deliberate
+        // no-op rather than an unrecognized event.
         let Some(status) = value.get("status").and_then(Value::as_str) else {
             return Vec::new();
         };
@@ -228,9 +232,31 @@ impl GrokStreamParser {
             .unwrap_or("");
         match stop {
             "cancelled" => events.push(HarnessEvent::TurnInterrupted),
-            _ => events.push(HarnessEvent::TurnCompleted {
+            "end_turn" => events.push(HarnessEvent::TurnCompleted {
                 usage: self.last_usage.clone(),
             }),
+            // A stop reason this build has never seen still ends the turn —
+            // the child has exited and something must close it out. Folding it
+            // into a plain completion without a word would be exactly the
+            // silent normalization decision 0031 forbids, so it is counted and
+            // stated before the turn closes.
+            other => {
+                let label = if other.is_empty() { "missing" } else { other };
+                self.count_unrecognized(&format!("end/stopReason/{label}"), value);
+                events.push(HarnessEvent::HarnessNotice {
+                    level: HarnessNoticeLevel::Warning,
+                    message: bound(
+                        &format!(
+                            "the engine ended the turn with an unrecognized stop reason \
+                             ({label}); it was recorded as completed"
+                        ),
+                        MAX_NOTICE_CHARS,
+                    ),
+                });
+                events.push(HarnessEvent::TurnCompleted {
+                    usage: self.last_usage.clone(),
+                });
+            }
         }
         events
     }
@@ -416,5 +442,30 @@ mod tests {
             Some(HarnessEvent::TurnCompleted { .. })
         ));
         assert_eq!(out.resume_ref.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn an_unknown_stop_reason_is_counted_and_stated_while_a_progress_frame_is_not() {
+        // `status: null` on tool_call_update is the manifest's documented
+        // progress frame: a deliberate no-op, not a drop. An unheard-of stop
+        // reason is the opposite — it still ends the turn, but it is counted.
+        let input = r#"
+{"type":"tool_call","toolCallId":"call-1","toolName":"read_file","rawInput":{}}
+{"type":"tool_call_update","toolCallId":"call-1","status":null}
+{"type":"end","stopReason":"budget_exhausted","sessionId":"abc"}
+"#;
+        let out = GrokStreamParser::parse_ndjson(input);
+        assert_eq!(out.unrecognized, 1);
+        assert!(out.events.iter().any(|event| matches!(
+            event,
+            HarnessEvent::HarnessNotice {
+                level: HarnessNoticeLevel::Warning,
+                ..
+            }
+        )));
+        assert!(matches!(
+            out.events.last(),
+            Some(HarnessEvent::TurnCompleted { .. })
+        ));
     }
 }

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -31,6 +31,9 @@ pub struct GrokSession {
     version: String,
     child: AsyncMutex<Option<Child>>,
     child_pid: AtomicU32,
+    /// Unrecognized events summed across every turn's parser: each turn is a
+    /// fresh child, so the per-turn count alone would reset on every prompt.
+    unrecognized: AtomicU64,
 }
 
 impl GrokSession {
@@ -42,6 +45,7 @@ impl GrokSession {
             version,
             child: AsyncMutex::new(None),
             child_pid: AtomicU32::new(0),
+            unrecognized: AtomicU64::new(0),
         }
     }
 
@@ -179,6 +183,10 @@ impl HarnessSession for GrokSession {
         }
     }
 
+    fn unrecognized_events(&self) -> u64 {
+        self.unrecognized.load(Ordering::SeqCst)
+    }
+
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         if let Some(mut child) = self.child.lock().await.take() {
             let _ = child.kill().await;
@@ -266,6 +274,8 @@ impl GrokSession {
         if !saw_terminal {
             self.spec.sink.emit(HarnessEvent::TurnInterrupted).await;
         }
+        self.unrecognized
+            .fetch_add(parser.unrecognized(), Ordering::SeqCst);
 
         let stderr = stderr_task.await.unwrap_or_default();
         if !stderr.is_empty() {

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -307,6 +307,15 @@ pub trait HarnessSession: Send + Sync {
         None
     }
 
+    /// How many stream events this session could not map to a
+    /// [`HarnessEvent`], counted since it was launched.
+    ///
+    /// Monotonic for the life of the session; the worker flushes the delta
+    /// onto the session row after each turn so the count survives a restart.
+    /// Deliberately has no default: an adapter that dropped part of a stream
+    /// must say so rather than inherit a silent zero (decision 0031).
+    fn unrecognized_events(&self) -> u64;
+
     /// Tear the session down.
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError>;
 }

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -498,6 +498,12 @@ impl HarnessSession for OpencodeSession {
         (pid != 0).then_some(i64::from(pid))
     }
 
+    fn unrecognized_events(&self) -> u64 {
+        // One long-lived parser per session, so its own count is already
+        // cumulative.
+        self.parser.lock().expect("opencode parser").unrecognized()
+    }
+
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         if let Some(mut child) = self.child.lock().await.take() {
             let _ = child.kill().await;

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -8,6 +8,7 @@
 //! worker keeps selecting on [`WorkerCommand`] so `decide` and `interrupt`
 //! reach the engine mid-turn — every adapter rides this, not just Claude.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -70,11 +71,24 @@ pub(crate) struct LiveSink {
     session_id: CodeSessionId,
     spawn_epoch: i64,
     turn_id: std::sync::Mutex<Option<CodeTurnId>>,
+    /// Engine-lifetime unrecognized count already folded onto the session row.
+    ///
+    /// The engine's own count is cumulative for as long as it is attached, and
+    /// the sink is created once per attachment, so the two share a lifetime.
+    flushed_unrecognized: AtomicU64,
 }
 
 impl LiveSink {
     pub(crate) fn set_turn(&self, turn_id: CodeTurnId) {
         *self.turn_id.lock().expect("code sink turn") = Some(turn_id);
+    }
+
+    /// How many unrecognized events the engine has counted since the last
+    /// flush. Reporting a total below the watermark (an engine that reset its
+    /// own counter) yields zero rather than a negative correction.
+    fn take_unrecognized_delta(&self, total: u64) -> u64 {
+        let flushed = self.flushed_unrecognized.swap(total, Ordering::SeqCst);
+        total.saturating_sub(flushed)
     }
 
     async fn record_approval(
@@ -419,6 +433,15 @@ async fn drive_turn(
     if let Some(resume) = engine.resume_ref() {
         session.harness_resume_ref = Some(resume);
     }
+    // End of turn is where the parser's unrecognized count becomes durable.
+    // The engine reports a running total, so only the delta since the last
+    // flush is added — the row accumulates across engine restarts.
+    let dropped = sink.take_unrecognized_delta(engine.unrecognized_events());
+    if dropped > 0 {
+        session.unrecognized_event_count = session
+            .unrecognized_event_count
+            .saturating_add(i64::try_from(dropped).unwrap_or(i64::MAX));
+    }
 
     // Re-read the turn: the sink may have already closed it.
     if let Ok(Some(updated)) = get_open_turn(db, session.id).await {
@@ -585,6 +608,7 @@ pub(crate) fn sink_for(
         session_id,
         spawn_epoch,
         turn_id: std::sync::Mutex::new(turn_id),
+        flushed_unrecognized: AtomicU64::new(0),
     })
 }
 

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -77,6 +77,7 @@ pub(crate) struct ScriptedAdapter {
     structured_approvals: CapLevel,
     auto_mode: CapLevel,
     child_pid: Option<i64>,
+    unrecognized_per_turn: u64,
     approver: Arc<ScriptedApprover>,
 }
 
@@ -90,6 +91,7 @@ impl ScriptedAdapter {
             structured_approvals: CapLevel::Unsupported,
             auto_mode: CapLevel::Unsupported,
             child_pid: None,
+            unrecognized_per_turn: 0,
             approver: Arc::new(ScriptedApprover::default()),
         }
     }
@@ -127,6 +129,13 @@ impl ScriptedAdapter {
     #[allow(dead_code)]
     pub(crate) fn with_child_pid(mut self, pid: i64) -> Self {
         self.child_pid = Some(pid);
+        self
+    }
+
+    /// Stands in for a parser that could not map part of the stream: the
+    /// scripted session reports this many unrecognized events per turn.
+    pub(crate) fn with_unrecognized_per_turn(mut self, count: u64) -> Self {
+        self.unrecognized_per_turn = count;
         self
     }
 }
@@ -180,6 +189,7 @@ impl HarnessAdapter for ScriptedAdapter {
             interrupt: Arc::new(AtomicBool::new(false)),
             steered: Mutex::new(None),
             unrecognized: AtomicU64::new(0),
+            unrecognized_per_turn: self.unrecognized_per_turn,
             approver: self.approver.clone(),
         }))
     }
@@ -194,6 +204,7 @@ struct ScriptedSession {
     interrupt: Arc<AtomicBool>,
     steered: Mutex<Option<String>>,
     unrecognized: AtomicU64,
+    unrecognized_per_turn: u64,
     approver: Arc<ScriptedApprover>,
 }
 
@@ -201,6 +212,8 @@ struct ScriptedSession {
 impl HarnessSession for ScriptedSession {
     async fn run_turn(&self, _input: TurnInput) -> Result<(), HarnessError> {
         self.interrupt.store(false, Ordering::SeqCst);
+        self.unrecognized
+            .fetch_add(self.unrecognized_per_turn, Ordering::SeqCst);
         for event in &self.events {
             if self.interrupt.load(Ordering::SeqCst) {
                 self.sink.emit(HarnessEvent::TurnInterrupted).await;
@@ -275,8 +288,11 @@ impl HarnessSession for ScriptedSession {
         self.child_pid
     }
 
+    fn unrecognized_events(&self) -> u64 {
+        self.unrecognized.load(Ordering::SeqCst)
+    }
+
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
-        let _ = self.unrecognized;
         Ok(())
     }
 }

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -2400,6 +2400,80 @@ async fn doctor_lists_the_scripted_adapter() {
     assert_eq!(report["harnesses"][0]["found"], true);
 }
 
+/// Decision 0031's honesty mechanism, end to end: a parser that could not read
+/// part of a stream must leave a durable, readable count behind. A build that
+/// counts drops but never persists them is indistinguishable from one that
+/// drops silently, which is the failure the record exists to prevent.
+#[tokio::test]
+async fn unread_engine_events_accumulate_on_the_session_row_and_reach_the_doctor() {
+    let (router, token, _runtime, dir) =
+        code_app_with(ScriptedAdapter::new(plain_text_script()).with_unrecognized_per_turn(2))
+            .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(session["unrecognized_event_count"], 0);
+
+    for message in ["hello", "again"] {
+        let turn = client
+            .post(format!(
+                "http://{addr}/code/sessions/{}/turns",
+                json_id(&session)
+            ))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({ "message": message }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
+    }
+
+    // Both turns, not just the last: the row accumulates rather than being
+    // overwritten with whatever the newest turn happened to see.
+    let listed = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .unwrap();
+    assert_eq!(listed[0]["unrecognized_event_count"], 4);
+
+    let report = client
+        .get(format!("http://{addr}/code/harnesses"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(report["harnesses"][0]["unrecognized_event_count"], 4);
+}
+
 #[allow(dead_code)]
 fn _types(
     _id: WorkspaceId,

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -163,9 +163,18 @@ pub trait HarnessSession: Send {
                     decision: ApprovalDecision) -> Result<(), HarnessError>;
     async fn interrupt(&mut self) -> Result<(), HarnessError>;
     fn resume_ref(&self) -> Option<String>;
+    /// Stream events this build could not map, counted since launch (0031).
+    fn unrecognized_events(&self) -> u64;
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError>;
 }
 ```
+
+The session worker folds the unrecognized count onto `code_session`
+(`unrecognized_event_count`) at the end of every turn, adding the delta
+since the last flush so the row accumulates across engine restarts. The
+workspace header shows it per session and the doctor page sums it per
+harness: a stream this build only partly understood has to say so, because
+a partly-read transcript is otherwise indistinguishable from a complete one.
 
 Process models the trait absorbs:
 


### PR DESCRIPTION
Decision [0031](docs/decisions/0031-harness-adapter-boundary.md) makes
unrecognized-event counting the honesty mechanism for harness protocol
drift: an unknown newer CLI "runs in best-effort mode with unrecognized-event
*counting* — a counter surfaced in the session UI and the harness doctor
page — never silent dropping."

The counting half shipped; the surfacing half never connected. All four
parsers increment a counter, but nothing called `unrecognized()`.
`code_session.unrecognized_event_count` was `Set(0)` at creation and never
written again, so the doctor summed zeros and the badge in `DoctorList`
could not appear under any circumstances. A build that counts drops and
then discards the count is indistinguishable from one that drops silently,
which is precisely the failure the record exists to prevent.

## What changed

**The count becomes durable.** `HarnessSession` gains
`unrecognized_events() -> u64`, the running total since launch. It has no
default: an adapter that dropped part of a stream has to answer, the same
reason `HarnessCaps` has no `Default`. Claude and Grok build a fresh parser
per turn (one child per turn), so they accumulate into an atomic; Codex and
opencode hold one parser for the session and report it directly.

The session worker flushes the delta onto the session row at the end of a
turn, next to where it already records the child pid and resume ref. The
watermark lives on the per-attachment `LiveSink`, so the row accumulates
across engine restarts rather than being overwritten by whatever the newest
turn saw.

**Two silent drops now count.** An `end` frame with an unrecognized
`stopReason` (Grok) and a `turn/completed` with an unrecognized status
(Codex) were folded into `TurnCompleted`. Both manifests record the exact
observed sets — `completed | interrupted | failed` for Codex — so a fourth
value is real drift. The turn still has to close, so it still completes,
but the event is counted and a warning notice is emitted first.

**One drop stays a drop, deliberately.** Grok's `tool_call_update` with no
`status` is not drift: `fixtures/grok/1.0.4/manifest.toml` records the
observed set as `null (progress) | completed | failed`. It carries nothing
we normalize, so it is now an explicitly commented no-op rather than an
unexplained early return.

**Surfacing.** The doctor endpoint already summed the column per harness and
needed no change — it just had nothing but zeros to sum. The workspace
header gains a small warning badge when a session's count is nonzero.
`CodeSessionSnapshot` already carried `unrecognized_event_count` over the
wire, so no wire type or generated binding changed.

## Tests

- `unread_engine_events_accumulate_on_the_session_row_and_reach_the_doctor`
  drives two real turns against a scripted engine that reports unmapped
  events, then asserts the count on the session snapshot and in the doctor
  report. Two turns rather than one because "increment" vs "overwrite" is
  the mistake worth pinning.
- One parser test each for the stop-status and turn-status paths, asserting
  the notice precedes the terminal event. The Grok test covers the progress
  frame in the same stream, so a future change that folds it back into the
  unrecognized path fails here.

No existing fixture expectations moved: every captured stream uses a known
stop reason and status.

## Follow-ups

- 0031 also asks for raw unrecognized payloads in a size-capped per-session
  debug log for later fixture capture. They currently go to `tracing::debug`
  with a 512-byte cap, which is not per-session and not retrievable from the
  product. A real debug log is more than a small addition and is left out
  here; the counter visibility is the point of this change.
- Grok counts `available_commands` as unrecognized (known frame, no mapping),
  so a healthy Grok session shows a nonzero count. That is defensible — it is
  a real drop — but it makes the badge less of a signal for that harness.
  Worth deciding separately whether "known but unmapped" deserves its own
  count.
