### PR TITLE
fix(server): record child pid after spawn and journal honest turn outcomes

### DIFF
--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -1,0 +1,157 @@
+//! Bookkeeping for adapters that run one engine child per turn.
+//!
+//! Two facts the session worker needs, and a pid read at turn boundaries
+//! cannot give it: the pid *while* the turn is in flight (that is the whole
+//! window a crash can orphan a child in), and how the child ended once it is
+//! gone (an EOF on stdout is not a completed turn).
+
+use std::process::ExitStatus;
+
+use tokio::sync::watch;
+
+use crate::TurnOutcome;
+
+/// Live pid of the child backing the current turn.
+///
+/// Every transition is published, so a watcher can persist the pid the moment
+/// the child exists rather than discovering it after the turn is over.
+#[derive(Debug)]
+pub struct ChildPid {
+    tx: watch::Sender<Option<i64>>,
+}
+
+impl Default for ChildPid {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChildPid {
+    /// A cell with no child recorded.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            tx: watch::Sender::new(None),
+        }
+    }
+
+    /// Publish the pid of a child that now exists. An absent or zero pid is
+    /// published as "no child": recovery must never probe an invented pid.
+    pub fn set(&self, pid: Option<u32>) {
+        let pid = pid.filter(|pid| *pid != 0).map(i64::from);
+        self.tx.send_replace(pid);
+    }
+
+    /// Publish that no child is running.
+    pub fn clear(&self) {
+        self.tx.send_replace(None);
+    }
+
+    /// The pid recorded right now, if any.
+    #[must_use]
+    pub fn get(&self) -> Option<i64> {
+        *self.tx.borrow()
+    }
+
+    /// Watch every transition, starting from the current value.
+    #[must_use]
+    pub fn subscribe(&self) -> watch::Receiver<Option<i64>> {
+        self.tx.subscribe()
+    }
+}
+
+/// Ask a child this session spawned to stop.
+///
+/// SIGINT only: the caller decides whether to escalate after its own grace
+/// period, and only ever against a pid recorded at spawn.
+pub fn signal_interrupt(pid: i64) {
+    #[cfg(unix)]
+    {
+        // SAFETY: the pid was recorded from a child we spawned this session.
+        let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+    }
+}
+
+/// Captured stderr carried on an incomplete turn, in bytes.
+const MAX_DETAIL_STDERR_BYTES: usize = 2 * 1_024;
+
+/// Classify how the child that ran one turn ended.
+///
+/// `saw_terminal` is whether the stream reported a terminal turn event.
+/// `status` is `None` when the exit could not be observed — a child another
+/// task already reaped, for instance.
+#[must_use]
+pub fn turn_outcome(status: Option<ExitStatus>, saw_terminal: bool, stderr: &str) -> TurnOutcome {
+    let failure = status.filter(|status| !status.success()).map(describe_exit);
+    if failure.is_none() && saw_terminal {
+        return TurnOutcome::Clean;
+    }
+    let mut detail =
+        failure.unwrap_or_else(|| "the engine exited without reporting a result".to_owned());
+    let tail = stderr_tail(stderr);
+    if !tail.is_empty() {
+        detail.push_str(": ");
+        detail.push_str(tail);
+    }
+    TurnOutcome::Incomplete { detail }
+}
+
+fn describe_exit(status: ExitStatus) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return format!("the engine was terminated by signal {signal}");
+        }
+    }
+    match status.code() {
+        Some(code) => format!("the engine exited with status {code}"),
+        None => "the engine exited abnormally".to_owned(),
+    }
+}
+
+/// The tail of captured stderr — the end carries the failure, the head
+/// carries startup chatter.
+fn stderr_tail(stderr: &str) -> &str {
+    let trimmed = stderr.trim();
+    if trimmed.len() <= MAX_DETAIL_STDERR_BYTES {
+        return trimmed;
+    }
+    let mut start = trimmed.len() - MAX_DETAIL_STDERR_BYTES;
+    while start < trimmed.len() && !trimmed.is_char_boundary(start) {
+        start += 1;
+    }
+    &trimmed[start..]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_stream_that_stopped_without_a_result_is_incomplete() {
+        // The defect this guards: EOF on stdout was read as a completed turn,
+        // so a killed or crashed child journaled as success.
+        let outcome = turn_outcome(None, false, "");
+        assert!(matches!(outcome, TurnOutcome::Incomplete { .. }));
+        assert_eq!(turn_outcome(None, true, ""), TurnOutcome::Clean);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_failed_exit_is_incomplete_even_after_a_terminal_event_and_carries_stderr() {
+        use std::os::unix::process::ExitStatusExt;
+        let outcome = turn_outcome(Some(ExitStatus::from_raw(3 << 8)), true, "  boom  ");
+        match outcome {
+            TurnOutcome::Incomplete { detail } => {
+                assert!(detail.contains("status 3"), "{detail}");
+                assert!(detail.ends_with("boom"), "{detail}");
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+}

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -1,22 +1,24 @@
 //! One print-mode child per turn.
 
-use std::process::Stdio;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::process::{ExitStatus, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
+use tokio::sync::watch;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
 use tracing::warn;
 
+use crate::child::{signal_interrupt, turn_outcome, ChildPid};
 use crate::claude::parse::ClaudeStreamParser;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::{
     filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
-    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput,
+    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -28,7 +30,10 @@ pub struct ClaudeSession {
     spec: SessionSpec,
     resume_ref: Mutex<Option<String>>,
     child: AsyncMutex<Option<Child>>,
-    child_pid: AtomicU32,
+    pid: ChildPid,
+    /// Exit status of a child [`HarnessSession::interrupt`] already reaped, so
+    /// `run_turn` can still report how the turn ended.
+    reaped: Mutex<Option<ExitStatus>>,
     /// Unrecognized events summed across every turn's parser: each turn is a
     /// fresh child, so the per-turn count alone would reset on every prompt.
     unrecognized: AtomicU64,
@@ -41,7 +46,8 @@ impl ClaudeSession {
             spec,
             resume_ref: Mutex::new(resume_ref),
             child: AsyncMutex::new(None),
-            child_pid: AtomicU32::new(0),
+            pid: ChildPid::new(),
+            reaped: Mutex::new(None),
             unrecognized: AtomicU64::new(0),
         }
     }
@@ -99,11 +105,23 @@ impl ClaudeSession {
         validate_launch_plan(&plan)?;
         Ok(plan)
     }
+
+    /// Drop a child this session is done with, leaving its exit status for
+    /// `run_turn` to report.
+    fn finish_child(
+        &self,
+        mut slot: tokio::sync::MutexGuard<'_, Option<Child>>,
+        status: Option<ExitStatus>,
+    ) {
+        *slot = None;
+        self.pid.clear();
+        *self.reaped.lock().expect("claude child exit") = status;
+    }
 }
 
 #[async_trait]
 impl HarnessSession for ClaudeSession {
-    async fn run_turn(&self, input: TurnInput) -> Result<(), HarnessError> {
+    async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
         let plan = self.compose_plan()?;
         let mut command = Command::new(&plan.argv[0]);
         command
@@ -133,8 +151,10 @@ impl HarnessSession for ClaudeSession {
             .stderr
             .take()
             .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
-        self.child_pid
-            .store(child.id().unwrap_or(0), Ordering::SeqCst);
+        self.reaped.lock().expect("claude child exit").take();
+        // Publish before the first await: the pid is what crash recovery
+        // probes, and the window it matters in opens here.
+        self.pid.set(child.id());
         *self.child.lock().await = Some(child);
 
         let prompt = input.text.clone();
@@ -149,6 +169,7 @@ impl HarnessSession for ClaudeSession {
         let mut lines = StreamLineBuffer::new();
         let mut reader = stdout;
         let mut chunk = vec![0_u8; budget.chunk_size];
+        let mut saw_terminal = false;
         loop {
             let mut chunks_this_tick = 0;
             let mut eof = false;
@@ -167,7 +188,8 @@ impl HarnessSession for ClaudeSession {
                             );
                         }
                         for line in tick.lines {
-                            emit_parsed(&self.spec, &mut parser, &self.resume_ref, &line).await;
+                            saw_terminal |=
+                                emit_parsed(&self.spec, &mut parser, &self.resume_ref, &line).await;
                         }
                     }
                 }
@@ -180,7 +202,7 @@ impl HarnessSession for ClaudeSession {
         }
         if !lines.pending().is_empty() {
             let pending = lines.pending().to_owned();
-            emit_parsed(&self.spec, &mut parser, &self.resume_ref, &pending).await;
+            saw_terminal |= emit_parsed(&self.spec, &mut parser, &self.resume_ref, &pending).await;
         }
         self.unrecognized
             .fetch_add(parser.unrecognized(), Ordering::SeqCst);
@@ -190,11 +212,14 @@ impl HarnessSession for ClaudeSession {
         if !stderr.is_empty() {
             warn!(bytes = stderr.len(), "engine stderr (capped)");
         }
-        if let Some(mut child) = self.child.lock().await.take() {
-            let _ = child.wait().await;
-        }
-        self.child_pid.store(0, Ordering::SeqCst);
-        Ok(())
+        // `interrupt` may already have reaped the child; it leaves the status
+        // behind so a stopped turn is still distinguishable from a finished one.
+        let status = match self.child.lock().await.take() {
+            Some(mut child) => child.wait().await.ok(),
+            None => self.reaped.lock().expect("claude child exit").take(),
+        };
+        self.pid.clear();
+        Ok(turn_outcome(status, saw_terminal, &stderr))
     }
 
     async fn decide(
@@ -214,8 +239,7 @@ impl HarnessSession for ClaudeSession {
     }
 
     async fn interrupt(&self) -> Result<(), HarnessError> {
-        let pid = self.child_pid.load(Ordering::SeqCst);
-        if pid != 0 {
+        if let Some(pid) = self.pid.get() {
             signal_interrupt(pid);
         }
         let mut slot = self.child.lock().await;
@@ -223,17 +247,18 @@ impl HarnessSession for ClaudeSession {
             return Ok(());
         };
         match timeout(INTERRUPT_GRACE, child.wait()).await {
-            Ok(Ok(_)) => {
-                *slot = None;
-                self.child_pid.store(0, Ordering::SeqCst);
+            Ok(Ok(status)) => {
+                self.finish_child(slot, Some(status));
                 Ok(())
             }
             Ok(Err(err)) => Err(err.into()),
             Err(_) => {
                 warn!("engine did not exit after SIGINT; killing");
+                // `kill` already reaps; `try_wait` reads the status it left
+                // without risking a second wait on a reaped child.
                 child.kill().await?;
-                *slot = None;
-                self.child_pid.store(0, Ordering::SeqCst);
+                let status = child.try_wait().ok().flatten();
+                self.finish_child(slot, status);
                 Ok(())
             }
         }
@@ -244,10 +269,11 @@ impl HarnessSession for ClaudeSession {
     }
 
     fn child_pid(&self) -> Option<i64> {
-        match self.child_pid.load(Ordering::SeqCst) {
-            0 => None,
-            pid => Some(i64::from(pid)),
-        }
+        self.pid.get()
+    }
+
+    fn child_pid_changes(&self) -> Option<watch::Receiver<Option<i64>>> {
+        Some(self.pid.subscribe())
     }
 
     fn unrecognized_events(&self) -> u64 {
@@ -262,12 +288,14 @@ impl HarnessSession for ClaudeSession {
     }
 }
 
+/// Emits one line's events, reporting whether any of them ended the turn.
 async fn emit_parsed(
     spec: &SessionSpec,
     parser: &mut ClaudeStreamParser,
     resume_ref: &Mutex<Option<String>>,
     line: &str,
-) {
+) -> bool {
+    let mut terminal = false;
     for event in parser.push_line(line) {
         if let HarnessEvent::SessionStarted {
             resume_ref: Some(resume),
@@ -276,8 +304,15 @@ async fn emit_parsed(
         {
             *resume_ref.lock().expect("claude resume") = Some(resume.clone());
         }
+        terminal |= matches!(
+            event,
+            HarnessEvent::TurnCompleted { .. }
+                | HarnessEvent::TurnFailed { .. }
+                | HarnessEvent::TurnInterrupted
+        );
         spec.sink.emit(event).await;
     }
+    terminal
 }
 
 async fn drain_capped<R>(mut reader: R, cap: usize) -> String
@@ -300,15 +335,68 @@ where
     String::from_utf8_lossy(&out).into_owned()
 }
 
-fn signal_interrupt(pid: u32) {
-    #[cfg(unix)]
-    {
-        let pid = pid as i32;
-        // SAFETY: the pid was recorded from a child we spawned this session.
-        let _ = unsafe { libc::kill(pid, libc::SIGINT) };
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::HarnessEventSink;
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::Arc;
+
+    struct Discard;
+
+    #[async_trait]
+    impl HarnessEventSink for Discard {
+        async fn emit(&self, _event: HarnessEvent) {}
     }
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
+
+    /// A failing engine is indistinguishable from a finished one on stdout
+    /// alone: both reach EOF. The exit status and stderr are the only signal
+    /// that the turn did not really complete, so they must leave the adapter.
+    #[tokio::test]
+    async fn a_failed_child_reports_its_exit_and_stderr_and_exposes_its_pid_while_it_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("engine.sh");
+        std::fs::write(
+            &binary,
+            "#!/bin/sh\nsleep 0.5\necho 'auth expired' >&2\nexit 3\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let session = ClaudeSession::new(SessionSpec {
+            worktree: dir.path().to_path_buf(),
+            permission_mode: CodePermissionMode::Plan,
+            resume_ref: None,
+            extra_argv: Vec::new(),
+            extra_env: Vec::new(),
+            env: Vec::new(),
+            approval: None,
+            binary,
+            sink: Arc::new(Discard),
+        });
+        assert!(
+            session.child_pid_changes().is_some(),
+            "an adapter with a per-turn child must stream its pid"
+        );
+
+        let run = session.run_turn(TurnInput {
+            text: "hello".into(),
+        });
+        let observe = async {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            session.child_pid()
+        };
+        let (outcome, mid_turn_pid) = tokio::join!(run, observe);
+        assert!(
+            mid_turn_pid.is_some(),
+            "the pid must be readable while the turn is in flight"
+        );
+        match outcome.expect("the adapter reports the exit rather than failing") {
+            TurnOutcome::Incomplete { detail } => {
+                assert!(detail.contains("status 3"), "{detail}");
+                assert!(detail.contains("auth expired"), "{detail}");
+            }
+            other => panic!("a child that exited 3 must not look clean: {other:?}"),
+        }
+        assert_eq!(session.child_pid(), None, "the pid is cleared on exit");
     }
 }

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -18,7 +18,7 @@ use crate::codex::parse::CodexStreamParser;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::{
     filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
-    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput,
+    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -340,7 +340,7 @@ impl CodexSession {
 
 #[async_trait]
 impl HarnessSession for CodexSession {
-    async fn run_turn(&self, input: TurnInput) -> Result<(), HarnessError> {
+    async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
         if self.child_pid.load(Ordering::SeqCst) == 0 {
             return Err(HarnessError::Other("engine child is not running".into()));
         }
@@ -357,7 +357,11 @@ impl HarnessSession for CodexSession {
             )
             .await?;
         let _ = id;
-        self.read_until_terminal_turn().await
+        // Long-lived child: its exit is a session-level failure, not a turn
+        // outcome, and `read_until_terminal_turn` already errors on a stream
+        // that ends without one.
+        self.read_until_terminal_turn().await?;
+        Ok(TurnOutcome::Clean)
     }
 
     async fn decide(

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -1,23 +1,25 @@
 //! One print-mode child per turn (`--prompt-file` + `--output-format streaming-json`).
 
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::process::{ExitStatus, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command};
+use tokio::sync::watch;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
 use tracing::warn;
 
+use crate::child::{signal_interrupt, turn_outcome, ChildPid};
 use crate::grok::parse::GrokStreamParser;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::{
     filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
-    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput,
+    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -30,7 +32,9 @@ pub struct GrokSession {
     resume_ref: Mutex<Option<String>>,
     version: String,
     child: AsyncMutex<Option<Child>>,
-    child_pid: AtomicU32,
+    pid: ChildPid,
+    /// Exit status of a child [`HarnessSession::interrupt`] already reaped.
+    reaped: Mutex<Option<ExitStatus>>,
     /// Unrecognized events summed across every turn's parser: each turn is a
     /// fresh child, so the per-turn count alone would reset on every prompt.
     unrecognized: AtomicU64,
@@ -44,7 +48,8 @@ impl GrokSession {
             resume_ref: Mutex::new(resume_ref),
             version,
             child: AsyncMutex::new(None),
-            child_pid: AtomicU32::new(0),
+            pid: ChildPid::new(),
+            reaped: Mutex::new(None),
             unrecognized: AtomicU64::new(0),
         }
     }
@@ -121,7 +126,7 @@ pub(crate) fn compose_print_plan(
 
 #[async_trait]
 impl HarnessSession for GrokSession {
-    async fn run_turn(&self, input: TurnInput) -> Result<(), HarnessError> {
+    async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
         refuse_unhonored_mode(self.spec.permission_mode)?;
         let prompt_file = write_prompt_file(&input.text)?;
         let plan = match self.compose_plan(&prompt_file) {
@@ -147,8 +152,7 @@ impl HarnessSession for GrokSession {
     }
 
     async fn interrupt(&self) -> Result<(), HarnessError> {
-        let pid = self.child_pid.load(Ordering::SeqCst);
-        if pid != 0 {
+        if let Some(pid) = self.pid.get() {
             signal_interrupt(pid);
         }
         let mut slot = self.child.lock().await;
@@ -156,17 +160,18 @@ impl HarnessSession for GrokSession {
             return Ok(());
         };
         match timeout(INTERRUPT_GRACE, child.wait()).await {
-            Ok(Ok(_)) => {
-                *slot = None;
-                self.child_pid.store(0, Ordering::SeqCst);
+            Ok(Ok(status)) => {
+                self.finish_child(slot, Some(status));
                 Ok(())
             }
             Ok(Err(err)) => Err(err.into()),
             Err(_) => {
                 warn!("engine did not exit after SIGINT; killing");
+                // `kill` already reaps; `try_wait` reads the status it left
+                // without risking a second wait on a reaped child.
                 child.kill().await?;
-                *slot = None;
-                self.child_pid.store(0, Ordering::SeqCst);
+                let status = child.try_wait().ok().flatten();
+                self.finish_child(slot, status);
                 Ok(())
             }
         }
@@ -177,10 +182,11 @@ impl HarnessSession for GrokSession {
     }
 
     fn child_pid(&self) -> Option<i64> {
-        match self.child_pid.load(Ordering::SeqCst) {
-            0 => None,
-            pid => Some(i64::from(pid)),
-        }
+        self.pid.get()
+    }
+
+    fn child_pid_changes(&self) -> Option<watch::Receiver<Option<i64>>> {
+        Some(self.pid.subscribe())
     }
 
     fn unrecognized_events(&self) -> u64 {
@@ -196,7 +202,19 @@ impl HarnessSession for GrokSession {
 }
 
 impl GrokSession {
-    async fn spawn_and_read(&self, plan: &LaunchPlan) -> Result<(), HarnessError> {
+    /// Drop a child this session is done with, leaving its exit status for
+    /// `spawn_and_read` to report.
+    fn finish_child(
+        &self,
+        mut slot: tokio::sync::MutexGuard<'_, Option<Child>>,
+        status: Option<ExitStatus>,
+    ) {
+        *slot = None;
+        self.pid.clear();
+        *self.reaped.lock().expect("grok child exit") = status;
+    }
+
+    async fn spawn_and_read(&self, plan: &LaunchPlan) -> Result<TurnOutcome, HarnessError> {
         let mut command = Command::new(&plan.argv[0]);
         command
             .args(&plan.argv[1..])
@@ -221,8 +239,10 @@ impl GrokSession {
             .stderr
             .take()
             .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
-        self.child_pid
-            .store(child.id().unwrap_or(0), Ordering::SeqCst);
+        self.reaped.lock().expect("grok child exit").take();
+        // Publish before the first await: the pid is what crash recovery
+        // probes, and the window it matters in opens here.
+        self.pid.set(child.id());
         *self.child.lock().await = Some(child);
 
         let stderr_task = tokio::spawn(async move { drain_capped(stderr, MAX_STDERR_BYTES).await });
@@ -271,9 +291,6 @@ impl GrokSession {
                 saw_terminal = true;
             }
         }
-        if !saw_terminal {
-            self.spec.sink.emit(HarnessEvent::TurnInterrupted).await;
-        }
         self.unrecognized
             .fetch_add(parser.unrecognized(), Ordering::SeqCst);
 
@@ -281,11 +298,14 @@ impl GrokSession {
         if !stderr.is_empty() {
             warn!(bytes = stderr.len(), "engine stderr (capped)");
         }
-        if let Some(mut child) = self.child.lock().await.take() {
-            let _ = child.wait().await;
-        }
-        self.child_pid.store(0, Ordering::SeqCst);
-        Ok(())
+        // `interrupt` may already have reaped the child; it leaves the status
+        // behind so a stopped turn is still distinguishable from a finished one.
+        let status = match self.child.lock().await.take() {
+            Some(mut child) => child.wait().await.ok(),
+            None => self.reaped.lock().expect("grok child exit").take(),
+        };
+        self.pid.clear();
+        Ok(turn_outcome(status, saw_terminal, &stderr))
     }
 }
 
@@ -343,17 +363,4 @@ where
         }
     }
     String::from_utf8_lossy(&out).into_owned()
-}
-
-fn signal_interrupt(pid: u32) {
-    #[cfg(unix)]
-    {
-        let pid = pid as i32;
-        // SAFETY: the pid was recorded from a child we spawned this session.
-        let _ = unsafe { libc::kill(pid, libc::SIGINT) };
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-    }
 }

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -21,6 +21,7 @@ use tidebreak_core::{
 };
 
 pub mod budget;
+pub mod child;
 pub mod claude;
 pub mod codex;
 pub mod grok;
@@ -30,6 +31,7 @@ pub mod probe;
 mod text;
 
 pub use budget::{BudgetTick, StreamBudget, StreamLineBuffer};
+pub use child::ChildPid;
 pub use launch::{validate_launch_plan, BypassFlagError, LaunchPlan};
 pub use probe::{
     filter_child_env, observe_version, probe_shell, resolve_binary, HostEnv, ProbeCapture,
@@ -165,6 +167,28 @@ pub struct TurnInput {
     pub text: String,
 }
 
+/// How the engine process behind one turn ended.
+///
+/// An adapter that runs one child per turn must report the child's exit here:
+/// stdout reaching EOF says only that the pipe closed, and a killed, crashed,
+/// or signed-out engine reaches EOF exactly like a finished one. The worker,
+/// not the adapter, decides how to close the turn — it is the side that knows
+/// whether the stop was asked for.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum TurnOutcome {
+    /// A terminal turn event arrived, and any per-turn child exited
+    /// successfully. Adapters with a long-lived child (or none) report this.
+    #[default]
+    Clean,
+    /// The engine ended without a terminal turn event, exited non-zero, or
+    /// was signaled.
+    Incomplete {
+        /// Bounded description — exit code or signal, plus captured stderr.
+        /// Safe to journal.
+        detail: String,
+    },
+}
+
 /// Completes a parked engine approval. Implemented by the server bridge so
 /// [`HarnessSession::decide`] can run while `run_turn` is blocked on the child.
 #[async_trait]
@@ -273,7 +297,12 @@ pub trait HarnessAdapter: Send + Sync {
 pub trait HarnessSession: Send + Sync {
     /// Feed one user turn; normalized events flow to the sink until a
     /// terminal turn event arrives.
-    async fn run_turn(&self, input: TurnInput) -> Result<(), HarnessError>;
+    ///
+    /// The returned [`TurnOutcome`] is how the *process* ended, which the
+    /// stream alone cannot say. Returning [`TurnOutcome::Clean`] for a child
+    /// that died is how an interrupted or crashed turn ends up journaled as a
+    /// success.
+    async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError>;
 
     /// Resolve a pending approval through the engine's native channel.
     async fn decide(
@@ -305,6 +334,18 @@ pub trait HarnessSession: Send + Sync {
     /// is `None`: an adapter that does not spawn a child, or has not spawned
     /// one yet, must not invent a pid.
     fn child_pid(&self) -> Option<i64> {
+        None
+    }
+
+    /// Every transition of [`Self::child_pid`], for a watcher that must
+    /// record the pid while a turn is in flight.
+    ///
+    /// An adapter that spawns a child *per turn* has no pid to report at turn
+    /// boundaries — which is precisely the window a crash orphans a child in.
+    /// Such adapters publish here the moment the child exists and clear it
+    /// when the child exits. The default is `None`: an adapter whose pid is
+    /// already stable across the session has nothing to stream.
+    fn child_pid_changes(&self) -> Option<tokio::sync::watch::Receiver<Option<i64>>> {
         None
     }
 

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -19,7 +19,7 @@ use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::opencode::parse::OpencodeStreamParser;
 use crate::{
     filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
-    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput,
+    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -399,7 +399,7 @@ impl OpencodeSession {
 
 #[async_trait]
 impl HarnessSession for OpencodeSession {
-    async fn run_turn(&self, input: TurnInput) -> Result<(), HarnessError> {
+    async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
         let session_id = self.resume_ref.lock().expect("opencode resume").clone();
         let Some(session_id) = session_id else {
             return Err(HarnessError::Other("session has no resume ref".into()));
@@ -417,7 +417,10 @@ impl HarnessSession for OpencodeSession {
         if status != 204 && !(200..300).contains(&status) {
             return Err(HarnessError::Other(format!("POST {path} status {status}")));
         }
-        self.read_until_terminal_turn().await
+        // Long-lived server child: its exit is a session-level failure, not a
+        // turn outcome.
+        self.read_until_terminal_turn().await?;
+        Ok(TurnOutcome::Clean)
     }
 
     async fn decide(

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -216,6 +216,7 @@ mod tests {
         Attention, CodePermissionMode, CodeRepo, CodeSessionId, CodeTurn, CodeTurnId,
         CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
     };
+    use tidebreak_harness::HarnessAdapter;
 
     fn now() -> chrono::DateTime<Utc> {
         Utc::now()
@@ -224,6 +225,35 @@ mod tests {
     async fn seeded_running(
         pid: Option<i64>,
     ) -> (tempfile::TempDir, DbStore, CodeSessionId, CodeTurnId) {
+        let (directory, store, session_id) =
+            seeded_session(pid, CodeSessionLifecycle::Running).await;
+        let turn_id = CodeTurnId::new();
+        insert_turn(
+            &store,
+            &CodeTurn {
+                id: turn_id,
+                session_id,
+                ordinal: 1,
+                status: CodeTurnStatus::Running,
+                user_input: "hello".into(),
+                user_input_blob_id: None,
+                checkpoint_ref: None,
+                diffstat: None,
+                usage: None,
+                narrative: None,
+                started_at: now(),
+                ended_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        (directory, store, session_id, turn_id)
+    }
+
+    async fn seeded_session(
+        pid: Option<i64>,
+        lifecycle: CodeSessionLifecycle,
+    ) -> (tempfile::TempDir, DbStore, CodeSessionId) {
         let directory = tempfile::tempdir().unwrap();
         let store = DbStore::connect(&format!(
             "sqlite://{}?mode=rwc",
@@ -276,7 +306,7 @@ mod tests {
                 harness_version: Some("2.1.233".into()),
                 harness_resume_ref: None,
                 permission_mode: CodePermissionMode::Plan,
-                lifecycle: CodeSessionLifecycle::Running,
+                lifecycle,
                 fence_reason: None,
                 child_pid: pid,
                 spawn_epoch: 1,
@@ -287,27 +317,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let turn_id = CodeTurnId::new();
-        insert_turn(
-            &store,
-            &CodeTurn {
-                id: turn_id,
-                session_id,
-                ordinal: 1,
-                status: CodeTurnStatus::Running,
-                user_input: "hello".into(),
-                user_input_blob_id: None,
-                checkpoint_ref: None,
-                diffstat: None,
-                usage: None,
-                narrative: None,
-                started_at: now(),
-                ended_at: None,
-            },
-        )
-        .await
-        .unwrap();
-        (directory, store, session_id, turn_id)
+        (directory, store, session_id)
     }
 
     #[tokio::test]
@@ -376,6 +386,96 @@ mod tests {
         let _ = signaled;
         let _ = decoy.kill();
         let _ = decoy.wait();
+    }
+
+    #[tokio::test]
+    async fn a_pid_the_worker_recorded_mid_turn_fences_recovery() {
+        // The fence is only as good as the pid in the row. Adapters that spawn
+        // one child per turn have no pid to report at turn boundaries, so this
+        // drives a real worker turn and reads back what the worker itself
+        // wrote — seeding a pid here would test nothing.
+        let (_dir, store, session_id) = seeded_session(None, CodeSessionLifecycle::Idle).await;
+        let store = Arc::new(store);
+        let bus = Arc::new(crate::code::bus::CodeEventBus::default());
+        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        let sink = crate::code::session_worker::sink_for(
+            store.clone(),
+            bus.clone(),
+            session_id,
+            session.spawn_epoch,
+            None,
+        );
+        let child_pid = i64::from(std::process::id());
+        let engine = crate::scripted_harness::ScriptedAdapter::new(vec![
+            tidebreak_harness::HarnessEvent::TurnStarted,
+            tidebreak_harness::HarnessEvent::AssistantDelta {
+                text: "working".into(),
+            },
+        ])
+        .with_child_pid(child_pid)
+        // Long enough that the turn is unambiguously still in flight while
+        // recovery runs; the test never waits for it.
+        .with_delay(std::time::Duration::from_secs(30))
+        .launch(tidebreak_harness::SessionSpec {
+            worktree: _dir.path().join("wt"),
+            permission_mode: CodePermissionMode::Plan,
+            resume_ref: None,
+            extra_argv: Vec::new(),
+            extra_env: Vec::new(),
+            env: Vec::new(),
+            approval: None,
+            binary: std::path::PathBuf::from("/scripted/engine"),
+            sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+        })
+        .await
+        .unwrap();
+        let handle = crate::code::session_worker::spawn_session_worker(
+            store.clone(),
+            bus.clone(),
+            session,
+            engine,
+            sink,
+        );
+        let (reply, _turn) = tokio::sync::oneshot::channel();
+        handle
+            .commands
+            .send(crate::code::session_worker::WorkerCommand::RunTurn {
+                message: "hello".into(),
+                reply,
+            })
+            .await
+            .unwrap();
+
+        let recorded = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let current = get_session(&store, session_id).await.unwrap().unwrap();
+                if let Some(pid) = current.child_pid {
+                    return pid;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the worker must record the pid while the turn is in flight");
+        assert_eq!(recorded, child_pid);
+
+        let probed = Arc::new(AtomicBool::new(false));
+        let flag = probed.clone();
+        let actions = recover_running_sessions_with(&store, &bus, move |pid| {
+            assert_eq!(pid, child_pid);
+            flag.store(true, Ordering::SeqCst);
+            PidLiveness::Alive
+        })
+        .await
+        .unwrap();
+        assert!(
+            probed.load(Ordering::SeqCst),
+            "recovery must probe the recorded pid rather than assume the engine died"
+        );
+        assert!(matches!(
+            actions.as_slice(),
+            [RecoveryAction::Fenced { .. }]
+        ));
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -7,13 +7,18 @@
 //! `run_turn` does not own the command loop. While a turn is in flight the
 //! worker keeps selecting on [`WorkerCommand`] so `decide` and `interrupt`
 //! reach the engine mid-turn — every adapter rides this, not just Claude.
+//! Applying a control command runs *alongside* the turn, never in front of
+//! it: an interrupt's grace period is exactly when the child's stdout most
+//! needs draining.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
-use tokio::sync::{mpsc, oneshot, Notify};
+use futures::future::BoxFuture;
+use futures::stream::{FuturesUnordered, StreamExt};
+use tokio::sync::{mpsc, oneshot, watch, Notify};
 use tracing::warn;
 
 use tidebreak_core::db::code::{
@@ -23,11 +28,11 @@ use tidebreak_core::db::code::{
 use tidebreak_core::{
     Attention, AttentionSource, BoundedError, CodeApproval, CodeApprovalId, CodeApprovalKind,
     CodeApprovalState, CodeEvent, CodeSession, CodeSessionId, CodeSessionLifecycle, CodeTurn,
-    CodeTurnId, CodeTurnStatus, DbStore,
+    CodeTurnId, CodeTurnStatus, DbStore, HarnessNoticeLevel,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent, HarnessEventSink,
-    HarnessSession, TurnInput,
+    HarnessSession, TurnInput, TurnOutcome,
 };
 
 use super::bus::CodeEventBus;
@@ -287,6 +292,26 @@ enum ControlFlow {
     Shutdown,
 }
 
+/// Stop the engine's current turn, discarding the adapter's error: the turn
+/// is ending either way, and the outcome is what the worker journals.
+async fn interrupt_engine(engine: &dyn HarnessSession) -> ControlFlow {
+    let _ = engine.interrupt().await;
+    ControlFlow::Continue
+}
+
+/// The next pid the adapter publishes, or a future that never resolves when
+/// the adapter has no per-turn child to report.
+async fn next_child_pid(changes: Option<&mut watch::Receiver<Option<i64>>>) -> Option<i64> {
+    // A dropped sender (or no sender at all) has nothing more to say.
+    let Some(changes) = changes else {
+        return std::future::pending().await;
+    };
+    if changes.changed().await.is_err() {
+        return std::future::pending().await;
+    }
+    *changes.borrow()
+}
+
 async fn apply_control(engine: &dyn HarnessSession, command: WorkerCommand) -> ControlFlow {
     match command {
         WorkerCommand::Decide {
@@ -407,23 +432,49 @@ async fn drive_turn(
 
     let run = engine.run_turn(TurnInput { text: message });
     tokio::pin!(run);
+    // Adapters that spawn one child per turn have no pid to report until the
+    // turn is under way. Record every transition as it happens: the session
+    // row's pid is what boot recovery probes, and a NULL pid there is read as
+    // "the engine is gone" — which would re-attach a worker to a worktree a
+    // live child is still writing to.
+    let mut pid_changes = engine.child_pid_changes();
+    // Control commands run concurrently with the turn. Awaiting one inline
+    // would stop draining the child's stdout — during an interrupt's grace
+    // period that is what turns a clean abort into a kill.
+    let mut controls: FuturesUnordered<BoxFuture<'_, ControlFlow>> = FuturesUnordered::new();
+    let mut interrupted = false;
+    let mut commands_closed = false;
     let run = loop {
         tokio::select! {
             result = &mut run => break result,
-            command = commands.recv() => match command {
+            Some(flow) = controls.next(), if !controls.is_empty() => {
+                if flow == ControlFlow::Shutdown {
+                    interrupted = true;
+                    controls.push(Box::pin(interrupt_engine(engine)));
+                }
+            }
+            pid = next_child_pid(pid_changes.as_mut()) => {
+                if session.child_pid != pid {
+                    session.child_pid = pid;
+                    let _ = save_session(db, session).await;
+                }
+            }
+            command = commands.recv(), if !commands_closed => match command {
                 Some(command) => {
-                    if apply_control(engine, command).await == ControlFlow::Shutdown {
-                        let _ = engine.interrupt().await;
-                        break run.await;
-                    }
+                    interrupted |= matches!(command, WorkerCommand::Interrupt { .. });
+                    controls.push(Box::pin(apply_control(engine, command)));
                 }
                 None => {
-                    let _ = engine.interrupt().await;
-                    break run.await;
+                    commands_closed = true;
+                    interrupted = true;
+                    controls.push(Box::pin(interrupt_engine(engine)));
                 }
             }
         }
     };
+    // A control command still in flight has a caller waiting on its reply.
+    // Dropping it here would answer them with a dead channel.
+    while controls.next().await.is_some() {}
 
     if let Some(pid) = engine.child_pid() {
         session.child_pid = Some(pid);
@@ -451,22 +502,52 @@ async fn drive_turn(
     }
 
     match run {
-        Ok(()) => {
-            if turn.status == CodeTurnStatus::Running {
-                turn.status = CodeTurnStatus::Completed;
-                turn.ended_at = Some(Utc::now());
-                let _ = save_turn(db, &turn).await;
+        Ok(outcome) => {
+            let detail = match outcome {
+                TurnOutcome::Clean => None,
+                TurnOutcome::Incomplete { detail } => Some(detail),
+            };
+            // An engine that died on us says why on stderr. That belongs in
+            // the journal, not only in a log line nobody reading the session
+            // will see. A stop the user asked for is not news.
+            if let (Some(detail), false) = (detail.as_ref(), interrupted) {
                 let _ = persist_and_publish(
                     db,
                     bus,
                     session.id,
                     session.spawn_epoch,
-                    CodeEvent::TurnCompleted {
-                        usage: turn.usage.clone().unwrap_or_default(),
-                        checkpoint: None,
+                    CodeEvent::HarnessNotice {
+                        level: HarnessNoticeLevel::Error,
+                        message: detail.clone(),
                     },
                 )
                 .await;
+            }
+            if turn.status == CodeTurnStatus::Running {
+                // The stream ended without closing the turn. Only the worker
+                // knows whether that was asked for.
+                let (status, event) = if interrupted {
+                    (CodeTurnStatus::Interrupted, CodeEvent::TurnInterrupted)
+                } else if let Some(detail) = detail {
+                    (
+                        CodeTurnStatus::Failed,
+                        CodeEvent::TurnFailed {
+                            error: BoundedError { message: detail },
+                        },
+                    )
+                } else {
+                    (
+                        CodeTurnStatus::Completed,
+                        CodeEvent::TurnCompleted {
+                            usage: turn.usage.clone().unwrap_or_default(),
+                            checkpoint: None,
+                        },
+                    )
+                };
+                turn.status = status;
+                turn.ended_at = Some(Utc::now());
+                let _ = save_turn(db, &turn).await;
+                let _ = persist_and_publish(db, bus, session.id, session.spawn_epoch, event).await;
             }
         }
         Err(err) => {

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -10,11 +10,13 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use tidebreak_core::{CapLevel, CodePermissionMode, HarnessCaps, HarnessKind};
+use tidebreak_harness::child::ChildPid;
 use tidebreak_harness::{
     ApprovalCompleter, ApprovalDecision, HarnessAdapter, HarnessApprovalRef, HarnessError,
     HarnessEvent, HarnessEventSink, HarnessProbe, HarnessSession, HostEnv, SessionSpec, TurnInput,
+    TurnOutcome,
 };
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{oneshot, watch, Mutex};
 
 /// Completer that records decisions and unparks a scripted turn.
 ///
@@ -78,6 +80,7 @@ pub(crate) struct ScriptedAdapter {
     auto_mode: CapLevel,
     child_pid: Option<i64>,
     unrecognized_per_turn: u64,
+    silent_interrupt: bool,
     approver: Arc<ScriptedApprover>,
 }
 
@@ -92,6 +95,7 @@ impl ScriptedAdapter {
             auto_mode: CapLevel::Unsupported,
             child_pid: None,
             unrecognized_per_turn: 0,
+            silent_interrupt: false,
             approver: Arc::new(ScriptedApprover::default()),
         }
     }
@@ -126,6 +130,8 @@ impl ScriptedAdapter {
         self
     }
 
+    /// Publish this pid for the duration of each turn, the way an adapter
+    /// that spawns one child per turn does.
     #[allow(dead_code)]
     pub(crate) fn with_child_pid(mut self, pid: i64) -> Self {
         self.child_pid = Some(pid);
@@ -136,6 +142,14 @@ impl ScriptedAdapter {
     /// scripted session reports this many unrecognized events per turn.
     pub(crate) fn with_unrecognized_per_turn(mut self, count: u64) -> Self {
         self.unrecognized_per_turn = count;
+        self
+    }
+
+    /// Model an engine that dies without saying anything — a SIGKILLed child
+    /// reaches EOF exactly like a finished one.
+    #[allow(dead_code)]
+    pub(crate) fn with_silent_interrupt(mut self) -> Self {
+        self.silent_interrupt = true;
         self
     }
 }
@@ -186,6 +200,8 @@ impl HarnessAdapter for ScriptedAdapter {
             delay: self.delay,
             mid_turn_steering: self.mid_turn_steering,
             child_pid: self.child_pid,
+            silent_interrupt: self.silent_interrupt,
+            pid: ChildPid::new(),
             interrupt: Arc::new(AtomicBool::new(false)),
             steered: Mutex::new(None),
             unrecognized: AtomicU64::new(0),
@@ -201,6 +217,8 @@ struct ScriptedSession {
     delay: Duration,
     mid_turn_steering: CapLevel,
     child_pid: Option<i64>,
+    silent_interrupt: bool,
+    pid: ChildPid,
     interrupt: Arc<AtomicBool>,
     steered: Mutex<Option<String>>,
     unrecognized: AtomicU64,
@@ -208,16 +226,12 @@ struct ScriptedSession {
     approver: Arc<ScriptedApprover>,
 }
 
-#[async_trait]
-impl HarnessSession for ScriptedSession {
-    async fn run_turn(&self, _input: TurnInput) -> Result<(), HarnessError> {
-        self.interrupt.store(false, Ordering::SeqCst);
-        self.unrecognized
-            .fetch_add(self.unrecognized_per_turn, Ordering::SeqCst);
+impl ScriptedSession {
+    /// Emit the script, stopping early when the worker interrupts.
+    async fn play_script(&self) -> TurnOutcome {
         for event in &self.events {
             if self.interrupt.load(Ordering::SeqCst) {
-                self.sink.emit(HarnessEvent::TurnInterrupted).await;
-                return Ok(());
+                return self.stopped().await;
             }
             if !self.delay.is_zero() {
                 tokio::time::sleep(self.delay).await;
@@ -245,13 +259,42 @@ impl HarnessSession for ScriptedSession {
                     | HarnessEvent::TurnFailed { .. }
                     | HarnessEvent::TurnInterrupted
             ) {
-                return Ok(());
+                return TurnOutcome::Clean;
             }
         }
         if self.interrupt.load(Ordering::SeqCst) {
-            self.sink.emit(HarnessEvent::TurnInterrupted).await;
+            return self.stopped().await;
         }
-        Ok(())
+        TurnOutcome::Clean
+    }
+
+    /// How a stopped engine ends: either it reports the abort on the stream,
+    /// or — `silent_interrupt` — it dies with nothing to say, which is what a
+    /// SIGKILLed child does.
+    async fn stopped(&self) -> TurnOutcome {
+        if self.silent_interrupt {
+            return TurnOutcome::Incomplete {
+                detail: "the engine was terminated by signal 9".into(),
+            };
+        }
+        self.sink.emit(HarnessEvent::TurnInterrupted).await;
+        TurnOutcome::Clean
+    }
+}
+
+#[async_trait]
+impl HarnessSession for ScriptedSession {
+    async fn run_turn(&self, _input: TurnInput) -> Result<TurnOutcome, HarnessError> {
+        self.interrupt.store(false, Ordering::SeqCst);
+        self.unrecognized
+            .fetch_add(self.unrecognized_per_turn, Ordering::SeqCst);
+        // A per-turn child exists only while the turn runs; publish it the way
+        // a real one does so the worker records the pid mid-turn.
+        self.pid
+            .set(self.child_pid.map(|pid| pid as u32).filter(|pid| *pid != 0));
+        let outcome = self.play_script().await;
+        self.pid.clear();
+        Ok(outcome)
     }
 
     async fn decide(
@@ -285,7 +328,11 @@ impl HarnessSession for ScriptedSession {
     }
 
     fn child_pid(&self) -> Option<i64> {
-        self.child_pid
+        self.pid.get()
+    }
+
+    fn child_pid_changes(&self) -> Option<watch::Receiver<Option<i64>>> {
+        Some(self.pid.subscribe())
     }
 
     fn unrecognized_events(&self) -> u64 {

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -686,6 +686,103 @@ async fn interrupt_stops_a_running_scripted_turn() {
     assert_eq!(interrupted.status(), reqwest::StatusCode::ACCEPTED);
     let turn = turn.unwrap();
     assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
+    assert_eq!(
+        turn_statuses(&client, addr, &token, &session).await,
+        ["interrupted"]
+    );
+}
+
+/// A killed engine reaches EOF exactly like a finished one. Reading that as
+/// success journaled a Stop — and an OOM kill, or a signed-out engine — as a
+/// completed turn with zero tokens.
+#[tokio::test]
+async fn an_engine_that_dies_without_saying_so_journals_an_interrupted_turn() {
+    let (router, token, _runtime, dir) = code_app_with(
+        ScriptedAdapter::new(vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::AssistantDelta {
+                text: "working".into(),
+            },
+            HarnessEvent::TurnCompleted {
+                usage: Default::default(),
+            },
+        ])
+        .with_delay(Duration::from_millis(80))
+        .with_silent_interrupt(),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    let turn_req = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "slow" }));
+    let interrupt = async {
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        client
+            .post(format!(
+                "http://{addr}/code/sessions/{}/interrupt",
+                json_id(&session)
+            ))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap()
+    };
+    let (turn, interrupted) = tokio::join!(turn_req.send(), interrupt);
+    assert_eq!(interrupted.status(), reqwest::StatusCode::ACCEPTED);
+    assert_eq!(turn.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+    assert_eq!(
+        turn_statuses(&client, addr, &token, &session).await,
+        ["interrupted"]
+    );
+}
+
+/// Turn statuses for a session, oldest first.
+async fn turn_statuses(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    session: &serde_json::Value,
+) -> Vec<String> {
+    let listed: Vec<serde_json::Value> = client
+        .get(format!(
+            "http://{addr}/code/sessions/{}/turns",
+            json_id(session)
+        ))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    listed
+        .iter()
+        .map(|turn| turn["status"].as_str().unwrap_or_default().to_owned())
+        .collect()
 }
 
 #[tokio::test]

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -154,15 +154,22 @@ pub trait HarnessAdapter: Send + Sync {
 }
 
 #[async_trait]
-pub trait HarnessSession: Send {
+pub trait HarnessSession: Send + Sync {
     /// Feed one user turn; normalized events flow to the sink until a
-    /// terminal turn event arrives.
-    async fn run_turn(&mut self, input: TurnInput) -> Result<(), HarnessError>;
+    /// terminal turn event arrives. The outcome reports how the engine
+    /// *process* ended — stdout reaching EOF is not a completed turn.
+    async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError>;
     /// Resolve a pending approval through the harness's native channel (0033).
-    async fn decide(&mut self, approval: HarnessApprovalRef,
+    async fn decide(&self, approval: HarnessApprovalRef,
                     decision: ApprovalDecision) -> Result<(), HarnessError>;
-    async fn interrupt(&mut self) -> Result<(), HarnessError>;
+    async fn interrupt(&self) -> Result<(), HarnessError>;
     fn resume_ref(&self) -> Option<String>;
+    /// Pid of a child this session spawned, and every transition of it. An
+    /// adapter with one child per turn publishes the pid the moment the child
+    /// exists: the session row's pid is what crash recovery probes (0032),
+    /// and it has to be there for the whole time a turn is in flight.
+    fn child_pid(&self) -> Option<i64>;
+    fn child_pid_changes(&self) -> Option<watch::Receiver<Option<i64>>>;
     /// Stream events this build could not map, counted since launch (0031).
     fn unrecognized_events(&self) -> u64;
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError>;


### PR DESCRIPTION
Three defects in the code-mode turn lifecycle, found reviewing what happens when a turn ends any way other than the happy path. They compound: the first hides a live engine from crash recovery, the second and third make a stopped or dead engine look like a successful turn.

## The orphan fence never covered per-turn-child adapters

The worker read `engine.child_pid()` *before* `run_turn` was constructed and cleared it after the turn returned. Claude and Grok spawn their child inside `run_turn`, so `code_session.child_pid` was NULL for the whole window a turn was in flight — precisely the window a crash can orphan a child in. Boot recovery then takes its "no recorded pid, treat as dead" branch and re-attaches a fresh worker to a worktree the still-running child is writing to, which is the failure the fence in ADR 0032 exists to prevent.

`HarnessSession` gains `child_pid_changes()`, a watch of the pid the adapter publishes the moment the child exists and clears when it exits. The worker selects on it alongside the turn and persists each transition to the session row. Adapters with a long-lived child (Codex, opencode) are unaffected — their pid is already stable across the session, and the default implementation returns `None`.

## Interrupts and dead children were journaled as completed turns

`run_turn` returned `Ok(())` at EOF and threw the child's exit status away. A SIGKILLed child never prints the `aborted_streaming` marker the Claude parser recognises, so the worker's fallback wrote `TurnCompleted` with default usage whenever the turn was still open. Stop produced a "completed, zero tokens" turn; an OOM kill, a panic, or an expired login produced exactly the same thing, with captured stderr going only to a `warn!`.

`run_turn` now returns a `TurnOutcome` describing how the process ended: `Clean`, or `Incomplete` with a bounded detail (exit code or signal, plus the tail of captured stderr). The worker decides the turn's fate, since it is the side that knows whether the stop was asked for — interrupt issued: interrupted; child died on its own: failed, with the stderr detail journaled as a `HarnessNotice` so the reason reaches the session and the UI rather than a log line. Grok's synthetic `TurnInterrupted` on a stream that just stopped is removed; that state is now reported through the outcome and classified honestly instead of always reading as "the user stopped it".

## Control commands starved stdout

`apply_control(...).await` ran inline inside the select arm, so nothing drained the child's stdout while an interrupt's two-second grace period ran. A chatty engine could not flush, the grace always expired, we escalated to SIGKILL, and the result line that would have said "aborted" was destroyed — which fed defect two. Control commands now run concurrently with the turn, and any still in flight are drained before the turn closes so their caller still gets a reply instead of a dropped channel.

## Tests

- `a_pid_the_worker_recorded_mid_turn_fences_recovery` drives a real worker turn and reads back the pid **the worker wrote**, then fences on it. The existing recovery tests hand-seed a pid into the row, so they pass with the fence completely broken.
- `an_engine_that_dies_without_saying_so_journals_an_interrupted_turn` — end to end over the routes, with a scripted engine that dies silently the way a killed child does; asserts the turn ends `interrupted`, not `completed`.
- An adapter test against a fake engine that sleeps, writes to stderr, and exits 3: the exit status and stderr have to leave the adapter, and the pid has to be readable while the turn runs.
- `interrupt_stops_a_running_scripted_turn` now asserts the turn's final status instead of only the two HTTP codes.
- Two small unit tests on the exit classifier (EOF without a result is not a completed turn; a failed exit carries its stderr).

## Notes

- `code/runtime.rs` is untouched.
- `docs/code-mode.md`'s trait sketch is updated to match the trait (it had also drifted to `&mut self` receivers).
- Verified with `cargo fmt --check`, `cargo clippy -p tidebreak-server -p tidebreak-harness --all-targets -- -D warnings`, `cargo check --workspace --all-targets --locked` (no lockfile movement), the full `tidebreak-harness` suite, and the `tidebreak-server` code-mode tests. Not verified against a real engine binary: the per-turn-child paths are exercised through a fake engine script and the scripted adapter, not Claude Code or Grok themselves.