### PR TITLE
fix(server): re-start codex threads that never ran a turn, fence lost resumes

### DIFF
--- a/crates/tidebreak-core/src/code/attention.rs
+++ b/crates/tidebreak-core/src/code/attention.rs
@@ -57,7 +57,8 @@ impl AttentionSource {
     }
 }
 
-/// Why a session was fenced during crash recovery.
+/// Why a session is fenced: observed but not controlled, until an explicit
+/// user reap resolves it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum FenceReason {
@@ -66,6 +67,13 @@ pub enum FenceReason {
     /// A pid-reuse or probe ambiguity; safer to fence than to signal.
     ProbeAmbiguous {
         /// Bounded human-readable detail.
+        detail: String,
+    },
+    /// The engine no longer has the session this one resumed. The stored
+    /// resume ref is dropped when this is set, so a reap starts a fresh
+    /// engine session instead of resuming a ref that will fail again.
+    ResumeLost {
+        /// Bounded human-readable detail, as the engine reported it.
         detail: String,
     },
 }

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -77,6 +77,9 @@ export function fenceReasonText(reason: FenceReason): string {
   if (reason.type === "orphan_alive") {
     return "An engine process is still running from a previous session. Reap it before starting another turn.";
   }
+  if (reason.type === "resume_lost") {
+    return `The engine no longer has this session, so it cannot continue (${reason.detail}). Reap it to start a fresh engine session in this workspace; the transcript above is kept.`;
+  }
   return reason.detail;
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1262,6 +1262,9 @@ export function parseFenceReason(value: unknown): FenceReason | null {
   if (value.type === "probe_ambiguous" && typeof value.detail === "string") {
     return { type: "probe_ambiguous", detail: value.detail };
   }
+  if (value.type === "resume_lost" && typeof value.detail === "string") {
+    return { type: "resume_lost", detail: value.detail };
+  }
   return null;
 }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1646,11 +1646,16 @@ export type ExecFileRejectionReason = "stale" | "snapshot_unavailable" | "staged
 export type ExecFileUndoAvailability = "available" | "already_undone" | "stale" | "not_available";
 
 /**
- * Why a session was fenced during crash recovery.
+ * Why a session is fenced: observed but not controlled, until an explicit
+ * user reap resolves it.
  */
 export type FenceReason = { "type": "orphan_alive" } | { "type": "probe_ambiguous", 
 /**
  * Bounded human-readable detail.
+ */
+detail: string, } | { "type": "resume_lost", 
+/**
+ * Bounded human-readable detail, as the engine reported it.
  */
 detail: string, };
 

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -20,7 +20,7 @@ use crate::{
     filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
     HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
 };
-use tidebreak_core::CodePermissionMode;
+use tidebreak_core::{CodePermissionMode, MAX_NOTICE_CHARS};
 
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
 const MAX_STDERR_BYTES: usize = 64 * 1_024;
@@ -29,6 +29,13 @@ const MAX_STDERR_BYTES: usize = 64 * 1_024;
 pub struct CodexSession {
     spec: SessionSpec,
     resume_ref: Mutex<Option<String>>,
+    /// Whether a turn has actually run on this thread. Codex only writes the
+    /// thread's rollout once a turn starts, so a thread id from
+    /// `thread/start` alone is not resumable and must not be handed out as a
+    /// resume ref — see [`HarnessSession::resume_ref`] below.
+    thread_ran_a_turn: AtomicBool,
+    /// Detail from an engine error saying the resumed thread is gone.
+    resume_lost: Mutex<Option<String>>,
     child: AsyncMutex<Option<Child>>,
     child_pid: AtomicU32,
     stdin: Option<Arc<AsyncMutex<ChildStdin>>>,
@@ -50,6 +57,8 @@ impl CodexSession {
         Self {
             spec,
             resume_ref: Mutex::new(resume_ref),
+            thread_ran_a_turn: AtomicBool::new(false),
+            resume_lost: Mutex::new(None),
             child: AsyncMutex::new(None),
             child_pid: AtomicU32::new(0),
             stdin: None,
@@ -59,6 +68,11 @@ impl CodexSession {
             pending_approvals: Mutex::new(HashMap::new()),
             current_turn_id: Mutex::new(None),
         }
+    }
+
+    /// The detail of a lost resume observed on the stream, when any.
+    fn lost_resume(&self) -> Option<String> {
+        self.resume_lost.lock().expect("codex resume lost").clone()
     }
 
     fn next_rpc_id(&self) -> i64 {
@@ -210,6 +224,12 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<CodexSession, HarnessErr
         };
     let thread_req = session.request(method, params).await?;
     session.read_until_rpc(thread_req).await?;
+    if let Some(detail) = session.lost_resume() {
+        // The stored thread is gone on the engine side. Every turn on this
+        // child would fail identically, so fail the launch with a reason the
+        // caller can act on instead of attaching a session that cannot run.
+        return Err(HarnessError::ResumeLost(detail));
+    }
     Ok(session)
 }
 
@@ -308,6 +328,12 @@ impl CodexSession {
                 .and_then(Value::as_str)
             {
                 *self.current_turn_id.lock().expect("codex turn") = Some(turn_id.to_owned());
+                // The engine acknowledged a turn on this thread, so it has
+                // written the thread's rollout: the id is resumable now.
+                self.thread_ran_a_turn.store(true, Ordering::SeqCst);
+            }
+            if let Some(detail) = lost_resume_detail(&value) {
+                *self.resume_lost.lock().expect("codex resume lost") = Some(detail);
             }
         }
         let events = self.parser.lock().expect("codex parser").push_line(line);
@@ -360,7 +386,13 @@ impl HarnessSession for CodexSession {
         // Long-lived child: its exit is a session-level failure, not a turn
         // outcome, and `read_until_terminal_turn` already errors on a stream
         // that ends without one.
-        self.read_until_terminal_turn().await?;
+        let terminal = self.read_until_terminal_turn().await;
+        if let Some(detail) = self.lost_resume() {
+            // The thread this session attached to is gone. Report the lost
+            // resume rather than a turn failure the caller would retry.
+            return Err(HarnessError::ResumeLost(detail));
+        }
+        terminal?;
         Ok(TurnOutcome::Clean)
     }
 
@@ -443,7 +475,17 @@ impl HarnessSession for CodexSession {
     }
 
     fn resume_ref(&self) -> Option<String> {
-        self.resume_ref.lock().expect("codex resume").clone()
+        // Codex 0.147.0 does not persist a thread that never ran a turn:
+        // `thread/resume` on such an id answers "thread not found". Report a
+        // thread id only once a turn has run on it, so a session whose engine
+        // dies before its first turn re-attaches with a fresh `thread/start`
+        // instead of resuming a thread the engine never wrote. A ref this
+        // session was handed at launch is already persisted state and stays
+        // reported as is.
+        if self.thread_ran_a_turn.load(Ordering::SeqCst) {
+            return self.resume_ref.lock().expect("codex resume").clone();
+        }
+        self.spec.resume_ref.clone()
     }
 
     fn child_pid(&self) -> Option<i64> {
@@ -465,6 +507,20 @@ impl HarnessSession for CodexSession {
         }
         Ok(())
     }
+}
+
+/// Detail of a JSON-RPC error that says the thread we are on is gone.
+///
+/// Codex 0.147.0 answers `thread/resume` and `turn/start` for an unknown
+/// thread with `thread not found: <id>`. Matching the wording is deliberate:
+/// every other engine error is a turn failure, and only this one means the
+/// stored resume ref is dead.
+fn lost_resume_detail(value: &Value) -> Option<String> {
+    let message = value.pointer("/error/message").and_then(Value::as_str)?;
+    message
+        .to_ascii_lowercase()
+        .contains("thread not found")
+        .then(|| message.chars().take(MAX_NOTICE_CHARS).collect())
 }
 
 fn line_is_rpc_id(line: &str, rpc_id: i64) -> bool {
@@ -556,5 +612,144 @@ mod tests {
             ("workspace-write", "on-request")
         );
         let _ = PathBuf::from("/workspace");
+    }
+
+    /// A stand-in `codex app-server --stdio` that speaks just enough of the
+    /// 0.147.0 protocol to reproduce the resume hazard: it answers
+    /// `thread/resume` for an unknown thread the way codex does, and records
+    /// every method it was asked for so a test can assert what was on the
+    /// wire. Recorded shapes come from `fixtures/codex/0.147.0/`.
+    #[cfg(unix)]
+    const FAKE_APP_SERVER: &str = r#"#!/bin/sh
+while IFS= read -r line; do
+  id=${line#*\"id\":}
+  id=${id%%,*}
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf 'initialize\n' >>"$FAKE_CODEX_CALLS"
+      printf '{"id":%s,"result":{"userAgent":"fake/0.147.0"}}\n' "$id"
+      ;;
+    *'"method":"thread/start"'*)
+      printf 'thread/start\n' >>"$FAKE_CODEX_CALLS"
+      printf '{"id":%s,"result":{"thread":{"id":"THREAD-1","cliVersion":"0.147.0","turns":[]}}}\n' "$id"
+      ;;
+    *'"method":"thread/resume"'*)
+      printf 'thread/resume\n' >>"$FAKE_CODEX_CALLS"
+      printf '{"id":%s,"error":{"code":-32603,"message":"thread not found: STALE-THREAD"}}\n' "$id"
+      ;;
+    *'"method":"turn/start"'*)
+      printf 'turn/start\n' >>"$FAKE_CODEX_CALLS"
+      printf '{"id":%s,"result":{"turn":{"id":"TURN-1","status":"inProgress"}}}\n' "$id"
+      printf '{"method":"turn/completed","params":{"threadId":"THREAD-1","turn":{"id":"TURN-1","status":"completed"}}}\n'
+      ;;
+  esac
+done
+"#;
+
+    #[cfg(unix)]
+    fn write_fake_app_server(path: &std::path::Path) {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o755)
+            .open(path)
+            .unwrap();
+        file.write_all(FAKE_APP_SERVER.as_bytes()).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    #[cfg(unix)]
+    struct SilentSink;
+
+    #[cfg(unix)]
+    #[async_trait]
+    impl crate::HarnessEventSink for SilentSink {
+        async fn emit(&self, _event: HarnessEvent) {}
+    }
+
+    #[cfg(unix)]
+    fn spec_for(
+        dir: &std::path::Path,
+        binary: &std::path::Path,
+        resume_ref: Option<String>,
+    ) -> SessionSpec {
+        SessionSpec {
+            worktree: dir.to_path_buf(),
+            permission_mode: CodePermissionMode::Auto,
+            resume_ref,
+            extra_argv: Vec::new(),
+            extra_env: vec![(
+                "FAKE_CODEX_CALLS".into(),
+                dir.join("calls").to_string_lossy().into_owned(),
+            )],
+            env: Vec::new(),
+            approval: None,
+            binary: binary.to_path_buf(),
+            sink: Arc::new(SilentSink),
+        }
+    }
+
+    #[cfg(unix)]
+    fn calls(dir: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(dir.join("calls"))
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_owned)
+            .collect()
+    }
+
+    /// The wedge from the app-server dying before its first turn: codex never
+    /// persisted the thread, so a thread id that has run no turn must not be
+    /// reported as a resume ref. The next attach then starts a clean thread.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_thread_that_ran_no_turn_is_not_a_resume_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("codex");
+        write_fake_app_server(&binary);
+
+        let session = attach(spec_for(dir.path(), &binary, None)).await.unwrap();
+        assert_eq!(calls(dir.path()), ["initialize", "thread/start"]);
+        assert_eq!(
+            session.resume_ref(),
+            None,
+            "a thread with no turns is not resumable and must not be persisted"
+        );
+
+        session
+            .run_turn(TurnInput {
+                text: "first turn".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(session.resume_ref().as_deref(), Some("THREAD-1"));
+    }
+
+    /// A resume ref the engine no longer knows is a lost resume, not a turn
+    /// failure: the server fences on this rather than failing every turn.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_stale_resume_ref_reports_a_lost_resume() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("codex");
+        write_fake_app_server(&binary);
+
+        let attached = attach(spec_for(
+            dir.path(),
+            &binary,
+            Some("STALE-THREAD".to_owned()),
+        ))
+        .await;
+        let Err(err) = attached else {
+            panic!("attaching to an unknown thread must not succeed");
+        };
+        assert_eq!(calls(dir.path()), ["initialize", "thread/resume"]);
+        let HarnessError::ResumeLost(detail) = err else {
+            panic!("expected a lost resume, got {err}");
+        };
+        assert!(detail.contains("thread not found"), "detail: {detail}");
     }
 }

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -326,6 +326,10 @@ pub trait HarnessSession: Send + Sync {
     }
 
     /// Engine-native resume token, when the stream has reported one.
+    ///
+    /// Report a token only once it would actually resume: the caller persists
+    /// what this returns and hands it back on the next launch, so a token the
+    /// engine has not committed yet must stay unreported until it has.
     fn resume_ref(&self) -> Option<String>;
 
     /// Child pid recorded from a process this session spawned, when any.
@@ -392,6 +396,13 @@ pub enum HarnessError {
     /// The engine cannot honor the requested permission mode.
     #[error("permission mode {0} is not available on this engine")]
     PermissionModeUnsupported(CodePermissionMode),
+    /// The engine no longer knows the session this spec asked to resume.
+    ///
+    /// The stored resume ref is dead: retrying with it fails identically
+    /// forever, so the caller must drop it and start a fresh engine session
+    /// rather than treat this as one failed turn.
+    #[error("the engine no longer has this session: {0}")]
+    ResumeLost(String),
     /// I/O or spawn failure.
     #[error("engine io: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -252,6 +252,13 @@ impl OpencodeSession {
             let (status, body) = self
                 .http("GET", &path, &url, None, Some(query.as_slice()))
                 .await?;
+            if status == 404 {
+                // The server does not know this session any more: the stored
+                // ref is dead, not a transient failure.
+                return Err(HarnessError::ResumeLost(format!(
+                    "opencode has no session {resume}"
+                )));
+            }
             if !(200..300).contains(&status) {
                 return Err(HarnessError::Other(format!(
                     "resume GET {path} status {status}"

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -56,6 +56,35 @@ pub(crate) async fn recover_running_sessions_with(
     Ok(actions)
 }
 
+/// Fence a live session, the runtime counterpart of the boot-time fence.
+///
+/// A [`FenceReason::ResumeLost`] also drops the stored resume ref: the engine
+/// has already refused it, so the reap this fence asks for must re-attach
+/// with a fresh engine session rather than resume the same dead ref.
+pub(crate) async fn fence_session(
+    store: &DbStore,
+    bus: &CodeEventBus,
+    session: &mut CodeSession,
+    reason: FenceReason,
+) -> Result<(), tidebreak_core::AgentError> {
+    if matches!(reason, FenceReason::ResumeLost { .. }) {
+        session.harness_resume_ref = None;
+    }
+    session.lifecycle = CodeSessionLifecycle::Fenced;
+    session.fence_reason = Some(reason.clone());
+    session.child_pid = None;
+    replace_attention(
+        session,
+        Attention::new(
+            AttentionState::Fenced { reason },
+            AttentionSource::Lifecycle,
+        ),
+        false,
+    );
+    persist_session(store, bus, session).await?;
+    Ok(())
+}
+
 /// Resolve a fenced session after an explicit user reap. Never signals.
 pub(crate) async fn reap_session(
     store: &DbStore,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -18,11 +18,11 @@ use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
     CodeApprovalState, CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId,
     CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, DbStore,
-    Diffstat, HarnessKind, RepoId, WorkspaceId,
+    Diffstat, FenceReason, HarnessKind, RepoId, WorkspaceId,
 };
 use tidebreak_harness::{
     builtin_registry, AdapterRegistry, ApprovalChannelSpec, ApprovalDecision, HarnessAdapter,
-    HarnessEvent, HarnessEventSink, HarnessProbe, HostEnv, SessionSpec,
+    HarnessError, HarnessEvent, HarnessEventSink, HarnessProbe, HostEnv, SessionSpec,
 };
 
 use super::approval_bridge::ApprovalBridge;
@@ -981,10 +981,33 @@ impl CodeRuntime {
             binary,
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
         };
-        let engine = adapter.launch(spec).await.map_err(|err| {
-            ServerError::internal(format!("failed to launch engine session: {err}"))
-        })?;
         let mut attached = attached;
+        let engine = match adapter.launch(spec).await {
+            Ok(engine) => engine,
+            Err(HarnessError::ResumeLost(detail)) => {
+                // The engine refused the stored resume ref. Fence with a
+                // reason the UI can explain — the fence drops the dead ref, so
+                // a reap re-attaches with a fresh engine session.
+                recovery::fence_session(
+                    &self.db,
+                    &self.bus,
+                    &mut attached,
+                    FenceReason::ResumeLost {
+                        detail: detail.clone(),
+                    },
+                )
+                .await?;
+                return Err(ServerError::conflict_kind(
+                    "session_resume_lost",
+                    format!("the engine no longer has this session: {detail}"),
+                ));
+            }
+            Err(err) => {
+                return Err(ServerError::internal(format!(
+                    "failed to launch engine session: {err}"
+                )));
+            }
+        };
         attached.child_pid = engine.child_pid();
         if let Some(resume) = engine.resume_ref().or(session.harness_resume_ref.clone()) {
             attached.harness_resume_ref = Some(resume);

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -28,7 +28,7 @@ use tidebreak_core::db::code::{
 use tidebreak_core::{
     Attention, AttentionSource, BoundedError, CodeApproval, CodeApprovalId, CodeApprovalKind,
     CodeApprovalState, CodeEvent, CodeSession, CodeSessionId, CodeSessionLifecycle, CodeTurn,
-    CodeTurnId, CodeTurnStatus, DbStore, HarnessNoticeLevel,
+    CodeTurnId, CodeTurnStatus, DbStore, FenceReason, HarnessNoticeLevel,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent, HarnessEventSink,
@@ -569,6 +569,21 @@ async fn drive_turn(
                 .await;
             }
             if !session_was_ended(db, session).await {
+                if let HarnessError::ResumeLost(detail) = &err {
+                    // The engine has lost this session: every later turn would
+                    // fail the same way. Fence it so the user is offered a
+                    // reap instead of a session that is idle and broken.
+                    let _ = super::recovery::fence_session(
+                        db,
+                        bus,
+                        session,
+                        FenceReason::ResumeLost {
+                            detail: detail.clone(),
+                        },
+                    )
+                    .await;
+                    return Err(WorkerError::Failed(err.to_string()));
+                }
                 session.lifecycle = CodeSessionLifecycle::Idle;
                 super::attention::replace_attention(
                     session,

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -81,6 +81,7 @@ pub(crate) struct ScriptedAdapter {
     child_pid: Option<i64>,
     unrecognized_per_turn: u64,
     silent_interrupt: bool,
+    lost_resume: Option<String>,
     approver: Arc<ScriptedApprover>,
     probes: Arc<AtomicU64>,
     /// Approval endpoint each launch was handed, `None` when it was handed no
@@ -100,6 +101,7 @@ impl ScriptedAdapter {
             child_pid: None,
             unrecognized_per_turn: 0,
             silent_interrupt: false,
+            lost_resume: None,
             approver: Arc::new(ScriptedApprover::default()),
             probes: Arc::new(AtomicU64::new(0)),
             launched_approvals: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -120,6 +122,13 @@ impl ScriptedAdapter {
             .lock()
             .expect("scripted launches")
             .clone()
+    }
+
+    /// Fails every turn the way an engine does once it has lost the session
+    /// this one resumed: not a turn failure, a dead resume ref.
+    pub(crate) fn with_lost_resume(mut self, detail: &str) -> Self {
+        self.lost_resume = Some(detail.to_owned());
+        self
     }
 
     /// Sets the approval channel and, with it, the supervised auto posture —
@@ -233,6 +242,7 @@ impl HarnessAdapter for ScriptedAdapter {
             child_pid: self.child_pid,
             silent_interrupt: self.silent_interrupt,
             pid: ChildPid::new(),
+            lost_resume: self.lost_resume.clone(),
             interrupt: Arc::new(AtomicBool::new(false)),
             steered: Mutex::new(None),
             unrecognized: AtomicU64::new(0),
@@ -250,6 +260,7 @@ struct ScriptedSession {
     child_pid: Option<i64>,
     silent_interrupt: bool,
     pid: ChildPid,
+    lost_resume: Option<String>,
     interrupt: Arc<AtomicBool>,
     steered: Mutex<Option<String>>,
     unrecognized: AtomicU64,
@@ -316,6 +327,9 @@ impl ScriptedSession {
 #[async_trait]
 impl HarnessSession for ScriptedSession {
     async fn run_turn(&self, _input: TurnInput) -> Result<TurnOutcome, HarnessError> {
+        if let Some(detail) = &self.lost_resume {
+            return Err(HarnessError::ResumeLost(detail.clone()));
+        }
         self.interrupt.store(false, Ordering::SeqCst);
         self.unrecognized
             .fetch_add(self.unrecognized_per_turn, Ordering::SeqCst);

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -2661,6 +2661,94 @@ async fn unread_engine_events_accumulate_on_the_session_row_and_reach_the_doctor
     assert_eq!(report["harnesses"][0]["unrecognized_event_count"], 4);
 }
 
+/// A resume ref the engine has lost wedges the session otherwise: every turn
+/// fails identically, the session stays idle, and nothing offers a reap.
+#[tokio::test]
+async fn a_lost_resume_fences_the_session_instead_of_failing_every_turn() {
+    let adapter =
+        ScriptedAdapter::new(plain_text_script()).with_lost_resume("thread not found: dead-thread");
+    let (router, token, runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+
+    // The session carries a ref from an earlier engine process.
+    let mut row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+        .await
+        .unwrap()
+        .unwrap();
+    row.harness_resume_ref = Some("dead-thread".into());
+    assert!(tidebreak_core::db::code::save_session(&runtime.db, &row)
+        .await
+        .unwrap());
+
+    let failed = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "carry on" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(failed.status(), reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+
+    let listed = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let after = listed[0].clone();
+    assert_eq!(after["lifecycle"], "fenced");
+    assert_eq!(after["fence_reason"]["type"], "resume_lost");
+    assert_eq!(
+        after["fence_reason"]["detail"],
+        "thread not found: dead-thread"
+    );
+    assert_eq!(after["attention"]["state"]["type"], "fenced");
+    assert!(
+        after["harness_resume_ref"].is_null(),
+        "the fence must drop the dead ref so a reap starts a fresh session: {after}"
+    );
+
+    // Fenced, so the next turn is refused with the reap the UI offers rather
+    // than another identical failure.
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "again" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let refused_body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(refused_body["kind"], "session_fenced");
+}
+
 #[allow(dead_code)]
 fn _types(
     _id: WorkspaceId,

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -135,6 +135,16 @@ as `Interrupted` (journaled), session `Idle`, attention
 explicit reap. Never signal a pid not recorded at spawn; `EPERM` counts as
 alive.
 
+A resume ref is only worth persisting once it would actually resume:
+`HarnessSession::resume_ref` reports a token after the engine has committed
+it, not when the engine first names it. Codex, for instance, does not write a
+thread that has run no turn, so a thread id from `thread/start` alone stays
+unreported and a session whose engine dies before its first turn re-attaches
+with a fresh `thread/start`. When an engine does refuse a stored ref, the
+adapter reports `HarnessError::ResumeLost` and the session is
+`Fenced { ResumeLost }` — the fence drops the dead ref, so the reap it asks
+for starts a clean engine session instead of failing every turn identically.
+
 ## The adapter contract
 
 ```rust


### PR DESCRIPTION
A codex session whose `app-server` child died before its first turn completed
was left holding a thread id codex never persisted. Codex 0.147.0 does not write
a rollout for a thread that ran no turn, so every later `thread/resume` answered
`thread not found`, every turn failed identically, the session stayed `idle`,
and nothing offered a reap — with `session_exists` blocking a replacement, the
workspace was quietly unusable.

Both directions from the issue, which compose:

**Report a resume ref only once it would resume.** The codex adapter keeps the
thread id it needs for `turn/start`, but `HarnessSession::resume_ref` — the
value the server persists as `harness_resume_ref` — reports it only after the
engine has acknowledged a turn on that thread. A session whose engine dies
before its first turn therefore re-attaches with a clean `thread/start`; a
thread with no turns has no history to lose. A ref handed in at launch is
already persisted state and stays reported as is. The trait doc now states the
rule for every adapter.

**A refused resume is a lost resume, not a turn failure.** A JSON-RPC error
saying `thread not found`, on the resume handshake or on a turn, becomes
`HarnessError::ResumeLost`. The server fences the session with
`FenceReason::ResumeLost { detail }` instead of failing every turn forever, so
the workspace shows an explanation and the reap button. The fence drops the dead
ref, which is what makes the reap useful: it re-attaches with a fresh engine
session rather than resuming the same dead id. This is the honest fallback for
any stale ref, not only the premature-death case — a cleaned `~/.codex` lands
here too.

opencode has the same hazard in a milder form: it creates the session with
`POST /session`, which the server persists immediately, so a thread with no
turns still resumes — but a ref whose storage is gone answers `GET /session/{id}`
with 404 and wedged the same way. That 404 now maps to the same `ResumeLost`
path, which was a one-line change on the mechanism already being added.

Fencing gained a runtime counterpart (`recovery::fence_session`) beside the
boot-time one, and `FenceReason` gained a variant, so the desktop parser and
fence-reason label were extended and the generated wire types regenerated.

Tests: a codex adapter test drives a stand-in `app-server` and asserts that a
session which ran no turn reports no resume ref and put only `thread/start` on
the wire, and that it reports the thread id once a turn has run; a second
asserts a stale ref answers with a lost resume rather than attaching a session
that cannot run; a server test asserts a lost resume fences the session with the
explainable reason, drops the ref, and refuses the next turn with the reap the
UI offers, instead of leaving it idle and failing.

Not verified by running the desktop app against a real codex install; the
protocol shapes in the stand-in engine come from the checked-in
`fixtures/codex/0.147.0/` captures.

Closes #2151
