### PR TITLE
ci: keep a single release draft after a lost baseline

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -79,6 +79,30 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - id: release_drafter
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
+      - name: Keep exactly one native release draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.release_drafter.outputs.id }}
+          RESOLVED_VERSION: ${{ steps.release_drafter.outputs.resolved_version }}
+        run: |
+          gh api --paginate \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" | \
+            jq -s '[.[][]]' > "$RUNNER_TEMP/releases.json"
+          plan="$(node scripts/reconcile-release-drafts.mjs \
+            --releases "$RUNNER_TEMP/releases.json" \
+            --resolved-version "$RESOLVED_VERSION" \
+            --release-id "$RELEASE_ID")"
+          echo "$plan"
+          while IFS= read -r id; do
+            gh api --method DELETE \
+              "repos/$GITHUB_REPOSITORY/releases/$id" >/dev/null
+            echo "Deleted extra draft $id"
+          done < <(jq -r '.delete_ids[]' <<<"$plan")
+          if [[ "$(jq -r .action <<<"$plan")" = fail ]]; then
+            jq -r .reason <<<"$plan" >&2
+            exit 1
+          fi
       - name: Group release notes by Conventional Commit scope
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -107,6 +107,11 @@ The release-draft workflow keeps exactly one draft GitHub Release up to date:
    all PRs chooses the proposed version; the category labels do not
    independently change the version, and a maintenance-only release proposes a
    patch bump.
+4. The same job then collapses leftover drafts so publish still sees exactly
+   one. If Release Drafter cannot see the previous published release it falls
+   back to `v0.0.1` and creates a second draft; the job deletes that fallback
+   and fails so the next merge — or a manual **Release draft** dispatch with
+   **update-draft** — retries against the real baseline.
 
 The first release has no previous published release to use as a comparison
 baseline, so Release Drafter intentionally leaves that draft as a manual

--- a/scripts/reconcile-release-drafts.mjs
+++ b/scripts/reconcile-release-drafts.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const FIRST_RELEASE_VERSION = "0.0.1";
+
+function requirePositiveInteger(value, label) {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`invalid ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+export function normalizeReleaseList(input) {
+  if (!Array.isArray(input)) {
+    throw new Error("releases must be a JSON array");
+  }
+  return input.flatMap((entry) => {
+    if (Array.isArray(entry)) return entry;
+    return [entry];
+  });
+}
+
+export function planDraftReconciliation({
+  releases,
+  resolvedVersion,
+  releaseId,
+}) {
+  if (typeof resolvedVersion !== "string" || resolvedVersion.length === 0) {
+    throw new Error("resolved version is required");
+  }
+
+  const resolvedReleaseId = requirePositiveInteger(releaseId, "release id");
+  const allReleases = normalizeReleaseList(releases);
+  const drafts = allReleases.filter(
+    (release) => release?.draft === true && release?.prerelease === false,
+  );
+  const published = allReleases.filter((release) => release?.draft === false);
+
+  const lostBaseline =
+    resolvedVersion === FIRST_RELEASE_VERSION && published.length > 0;
+  if (lostBaseline) {
+    return {
+      action: "fail",
+      keep_id:
+        drafts.find((draft) => draft.tag_name !== `v${FIRST_RELEASE_VERSION}`)
+          ?.id ?? null,
+      delete_ids: drafts
+        .filter((draft) => draft.tag_name === `v${FIRST_RELEASE_VERSION}`)
+        .map((draft) => draft.id),
+      reason:
+        "Release Drafter resolved v0.0.1 even though published releases exist",
+    };
+  }
+
+  const keep = drafts.find((draft) => draft.id === resolvedReleaseId);
+  if (!keep) {
+    throw new Error(
+      `Release Drafter reported release ${resolvedReleaseId} but it is not a non-prerelease draft`,
+    );
+  }
+
+  const deleteIds = drafts
+    .filter((draft) => draft.id !== keep.id)
+    .map((draft) => draft.id);
+  return {
+    action: "ok",
+    keep_id: keep.id,
+    delete_ids: deleteIds,
+    reason:
+      deleteIds.length === 0
+        ? `kept the single draft ${keep.tag_name}`
+        : `kept ${keep.tag_name} and removed ${deleteIds.length} extra draft(s)`,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    releases: null,
+    resolvedVersion: null,
+    releaseId: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === "--releases") {
+      args.releases = value;
+      index += 1;
+    } else if (flag === "--resolved-version") {
+      args.resolvedVersion = value;
+      index += 1;
+    } else if (flag === "--release-id") {
+      args.releaseId = value;
+      index += 1;
+    } else {
+      throw new Error(`unknown argument: ${flag}`);
+    }
+  }
+  if (!args.releases || !args.resolvedVersion || !args.releaseId) {
+    throw new Error(
+      "usage: reconcile-release-drafts.mjs --releases <path> --resolved-version <version> --release-id <id>",
+    );
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const plan = planDraftReconciliation({
+    releases: JSON.parse(readFileSync(args.releases, "utf8")),
+    resolvedVersion: args.resolvedVersion,
+    releaseId: args.releaseId,
+  });
+  console.log(JSON.stringify(plan));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/reconcile-release-drafts.test.mjs
+++ b/scripts/reconcile-release-drafts.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeReleaseList,
+  planDraftReconciliation,
+} from "./reconcile-release-drafts.mjs";
+
+const published = {
+  id: 1,
+  tag_name: "v0.46.2",
+  draft: false,
+  prerelease: false,
+};
+const currentDraft = {
+  id: 20,
+  tag_name: "v0.47.0",
+  draft: true,
+  prerelease: false,
+};
+const staleDraft = {
+  id: 10,
+  tag_name: "v0.47.0",
+  draft: true,
+  prerelease: false,
+};
+const firstReleaseDraft = {
+  id: 30,
+  tag_name: "v0.0.1",
+  draft: true,
+  prerelease: false,
+};
+const inFlight = {
+  id: 40,
+  tag_name: "v0.47.0",
+  draft: false,
+  prerelease: true,
+};
+
+test("keeps the single next-version draft", () => {
+  assert.deepEqual(
+    planDraftReconciliation({
+      releases: [currentDraft, published],
+      resolvedVersion: "0.47.0",
+      releaseId: 20,
+    }),
+    {
+      action: "ok",
+      keep_id: 20,
+      delete_ids: [],
+      reason: "kept the single draft v0.47.0",
+    },
+  );
+});
+
+test("removes extra drafts after a successful draft update", () => {
+  assert.deepEqual(
+    planDraftReconciliation({
+      releases: [currentDraft, firstReleaseDraft, staleDraft, published],
+      resolvedVersion: "0.47.0",
+      releaseId: 20,
+    }),
+    {
+      action: "ok",
+      keep_id: 20,
+      delete_ids: [30, 10],
+      reason: "kept v0.47.0 and removed 2 extra draft(s)",
+    },
+  );
+});
+
+test("rejects a lost baseline and deletes only the v0.0.1 drafts", () => {
+  assert.deepEqual(
+    planDraftReconciliation({
+      releases: [firstReleaseDraft, currentDraft, published],
+      resolvedVersion: "0.0.1",
+      releaseId: 30,
+    }),
+    {
+      action: "fail",
+      keep_id: 20,
+      delete_ids: [30],
+      reason:
+        "Release Drafter resolved v0.0.1 even though published releases exist",
+    },
+  );
+});
+
+test("allows the genuine first-release v0.0.1 draft", () => {
+  assert.deepEqual(
+    planDraftReconciliation({
+      releases: [firstReleaseDraft],
+      resolvedVersion: "0.0.1",
+      releaseId: 30,
+    }),
+    {
+      action: "ok",
+      keep_id: 30,
+      delete_ids: [],
+      reason: "kept the single draft v0.0.1",
+    },
+  );
+});
+
+test("ignores an in-flight prerelease when collapsing drafts", () => {
+  const nextDraft = {
+    id: 50,
+    tag_name: "v0.48.0",
+    draft: true,
+    prerelease: false,
+  };
+  assert.deepEqual(
+    planDraftReconciliation({
+      releases: [nextDraft, inFlight, published],
+      resolvedVersion: "0.48.0",
+      releaseId: 50,
+    }),
+    {
+      action: "ok",
+      keep_id: 50,
+      delete_ids: [],
+      reason: "kept the single draft v0.48.0",
+    },
+  );
+});
+
+test("flattens paginated GitHub release pages", () => {
+  assert.deepEqual(normalizeReleaseList([[currentDraft], [published]]), [
+    currentDraft,
+    published,
+  ]);
+});
+
+test("rejects a Release Drafter id that is not a live draft", () => {
+  assert.throws(
+    () =>
+      planDraftReconciliation({
+        releases: [published],
+        resolvedVersion: "0.47.0",
+        releaseId: 20,
+      }),
+    /not a non-prerelease draft/,
+  );
+});

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -264,6 +264,10 @@ test("release-drafter retains a stable draft tag after formatting", () => {
     draftJob,
     /\{tag_name: \$tag, body: \$body\}/,
   );
+  assert.match(draftJob, /node scripts\/reconcile-release-drafts\.mjs/);
+  assert.match(draftJob, /Keep exactly one native release draft/);
+  assert.match(draftJob, /\.delete_ids\[\]/);
+  assert.match(draftJob, /jq -r \.action/);
 });
 
 test("workflow container images are pinned by digest", () => {


### PR DESCRIPTION
## Summary

Release Drafter lost the published `v0.46.2` baseline during a GitHub API blip and created a `v0.0.1` draft. Later runs then flipped among three drafts (`v0.47.0`, `v0.0.1`, and a stale earlier `v0.47.0`), which blocked **Publish desktop release** — that workflow requires exactly one non-prerelease draft.

- Deleted the extra live drafts. The remaining draft is the current `Tidebreak v0.47.0`.
- After each draft update, collapse leftover drafts and fail if Release Drafter resolved `v0.0.1` while published releases exist, so the next merge retries against the real baseline.

## Test plan

- [x] `node --test scripts/reconcile-release-drafts.test.mjs scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs`
- [x] Confirmed a single remaining draft: `v0.47.0` (`371806714`)
- [ ] After merge, the next **Release draft** run on `main` should keep that one draft