### PR TITLE
feat(code): map Allow all onto each harness permission mode

### DIFF
--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -583,6 +583,7 @@ pub fn supported_caps_summary(caps: &HarnessCaps) -> String {
         ("steering", caps.mid_turn_steering),
         ("plan", caps.plan_mode),
         ("auto", caps.auto_mode),
+        ("allow", caps.allow_mode),
         ("reasoning", caps.reasoning_levels),
         ("file_events", caps.native_file_change_events),
         ("interrupt", caps.native_interrupt),

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -48,7 +48,7 @@ usage: tidebreak code doctor [--refresh]
        tidebreak code ws list [--repo <id|path>]
        tidebreak code ws show <id>
        tidebreak code ws archive <id> [--force]
-       tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto]
+       tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto|allow]
        tidebreak code session show <id>
        tidebreak code session reap <id>
        tidebreak code run (--session <id> | --ws <id>) [<message>]
@@ -799,6 +799,9 @@ async fn resolve_start_mode(
         }
         CodePermissionMode::Auto => Some(
             "starting in auto mode — this engine has no approval channel; every action proceeds without asking",
+        ),
+        CodePermissionMode::Allow => Some(
+            "starting in allow mode — this engine's permission system is off; every action runs without asking",
         ),
         CodePermissionMode::Ask => None,
     };
@@ -2189,7 +2192,7 @@ fn parse_harness(value: &str) -> std::result::Result<HarnessKind, String> {
 
 fn parse_mode(value: &str) -> std::result::Result<CodePermissionMode, String> {
     CodePermissionMode::from_str(value)
-        .ok_or_else(|| "--mode expects plan, ask, or auto".to_owned())
+        .ok_or_else(|| "--mode expects plan, ask, auto, or allow".to_owned())
 }
 
 fn parse_on_approval(value: &str) -> std::result::Result<OnApproval, String> {
@@ -2489,6 +2492,7 @@ mod tests {
                 mid_turn_steering: CapLevel::Unknown,
                 plan_mode,
                 auto_mode,
+                allow_mode: CapLevel::Unknown,
                 reasoning_levels: CapLevel::Unknown,
                 native_file_change_events: CapLevel::Unknown,
                 native_interrupt: CapLevel::Supported,

--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -137,7 +137,7 @@ usage: tidebreak serve
        tidebreak code ws list [--repo <id|path>]
        tidebreak code ws show <id>
        tidebreak code ws archive <id> [--force]
-       tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto]
+       tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto|allow]
        tidebreak code session show <id>
        tidebreak code session reap <id>
        tidebreak code run (--session <id> | --ws <id>) [<message>]

--- a/crates/tidebreak-core/src/code/caps.rs
+++ b/crates/tidebreak-core/src/code/caps.rs
@@ -68,6 +68,9 @@ pub struct HarnessCaps {
     /// approval cards; without it, Auto runs unsupervised and the product
     /// states so where the mode is chosen (decision 0038).
     pub auto_mode: CapLevel,
+    /// The engine has an allow-everything / bypass posture the adapter can
+    /// select. Composed only when the session is in Allow (decision 0039).
+    pub allow_mode: CapLevel,
     /// The engine accepts a reasoning-effort control.
     pub reasoning_levels: CapLevel,
     /// The engine emits native file-change events.
@@ -90,6 +93,7 @@ mod tests {
             mid_turn_steering: CapLevel::Unknown,
             plan_mode: CapLevel::Supported,
             auto_mode: CapLevel::Unknown,
+            allow_mode: CapLevel::Unknown,
             reasoning_levels: CapLevel::Unknown,
             native_file_change_events: CapLevel::Unknown,
             native_interrupt: CapLevel::Supported,

--- a/crates/tidebreak-core/src/code/permission.rs
+++ b/crates/tidebreak-core/src/code/permission.rs
@@ -1,10 +1,10 @@
 //! Permission modes for an external agent-engine session.
 //!
 //! Variant names match the chat product's [`crate::model::PermissionMode`]
-//! vocabulary (`Plan`, `Ask`, `Auto`) so a future unification is a merge, not
-//! a translation. There is no `Allow` here: a session that needs bypass
-//! behavior must choose it explicitly at the product layer, never as a
-//! composed default.
+//! vocabulary (`Plan`, `Ask`, `Auto`, `Allow`) so a future unification is a
+//! merge, not a translation. `Allow` is the explicit per-session bypass
+//! reserved by decision 0033 and named by decision 0039 — never a composed
+//! default.
 
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
@@ -29,11 +29,15 @@ pub enum CodePermissionMode {
     /// sensitive actions still escalate to approval. The adapter must select
     /// the engine's workspace-write posture, not a bypass flag.
     Auto,
+    /// The engine's allow-everything posture: its permission system is off.
+    /// The adapter must compose the engine's documented bypass — never as a
+    /// default, only when this mode is the session's explicit choice.
+    Allow,
 }
 
 impl CodePermissionMode {
     /// Every mode, in ascending order of autonomy.
-    pub const ALL: &'static [Self] = &[Self::Plan, Self::Ask, Self::Auto];
+    pub const ALL: &'static [Self] = &[Self::Plan, Self::Ask, Self::Auto, Self::Allow];
 
     /// The default for a new session.
     pub const DEFAULT: Self = Self::Ask;
@@ -45,6 +49,7 @@ impl CodePermissionMode {
             Self::Plan => "plan",
             Self::Ask => "ask",
             Self::Auto => "auto",
+            Self::Allow => "allow",
         }
     }
 
@@ -96,6 +101,10 @@ mod tests {
         assert_eq!(
             CodePermissionMode::Auto.as_str(),
             PermissionMode::Auto.as_str()
+        );
+        assert_eq!(
+            CodePermissionMode::Allow.as_str(),
+            PermissionMode::Allow.as_str()
         );
     }
 }

--- a/crates/tidebreak-core/src/db/migration/baseline/code.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/code.rs
@@ -147,7 +147,7 @@ pub(super) fn code_session_table() -> TableCreateStatement {
             Expr::col(CodeSession::Lifecycle)
                 .is_in(["created", "idle", "running", "fenced", "ended"]),
         )
-        .check(Expr::col(CodeSession::PermissionMode).is_in(["plan", "ask", "auto"]))
+        .check(Expr::col(CodeSession::PermissionMode).is_in(["plan", "ask", "auto", "allow"]))
         .check(Expr::col(CodeSession::SpawnEpoch).gte(0))
         .check(Expr::col(CodeSession::UnrecognizedEventCount).gte(0))
         .to_owned()

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -23,7 +23,7 @@ import {
  * launch.
  */
 
-const MODES: CodePermissionMode[] = ["plan", "ask", "auto"];
+const MODES: CodePermissionMode[] = ["plan", "ask", "auto", "allow"];
 
 const QUEUED_NOTE = "Queued — runs after the current turn.";
 
@@ -34,7 +34,7 @@ const QUEUE_FULL_NOTE =
 /**
  * Pick the mode a session will be created under.
  *
- * Ask is the default. Plan and Auto stay on the same scale. A mode the
+ * Ask is the default. Plan, Auto, and Allow stay on the same scale. A mode the
  * chosen harness cannot honor is disabled with the refusal reason. This is a
  * creation-time control: the new-workspace dialog and the start-session
  * prompt use it, and an attached session shows `PermissionModeSummary`.

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -590,7 +590,7 @@ function CodeSessionPane({
   // row yet, show everything and let the server refuse.
   const availableModes: CodePermissionMode[] = doctorEntry
     ? createPermissionModes(doctorEntry.caps)
-    : ["plan", "ask", "auto"];
+    : ["plan", "ask", "auto", "allow"];
 
   // `items` is a fresh array on every streamed delta, so keying the fetch on it
   // would list approvals again for every token of a turn. Only an approval

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -17,6 +17,7 @@ const CAPS = {
   mid_turn_steering: "unsupported",
   plan_mode: "supported",
   auto_mode: "supported",
+  allow_mode: "supported",
   reasoning_levels: "unknown",
   native_file_change_events: "unsupported",
   native_interrupt: "supported",

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -34,6 +34,7 @@ import {
   createPermissionModes,
   defaultCreatePermissionMode,
   harnessUnusableReason,
+  ALLOW_ALL_NOTE,
   UNSUPERVISED_AUTO_NOTE,
 } from "./labels";
 
@@ -209,6 +210,9 @@ export function NewWorkspaceDialog({
                   {UNSUPERVISED_AUTO_NOTE}
                 </p>
               )}
+            {postedMode === "allow" && (
+              <p className="text-warning-foreground text-xs">{ALLOW_ALL_NOTE}</p>
+            )}
           </div>
           <DialogFooter>
             <Button

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { HarnessDoctorEntry } from "../api/types";
 import { renderWithRouter } from "@/test/router";
-import { UNSUPERVISED_AUTO_NOTE } from "./labels";
+import { ALLOW_ALL_NOTE, UNSUPERVISED_AUTO_NOTE } from "./labels";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 
 afterEach(() => {
@@ -18,6 +18,7 @@ const CAPS = {
   mid_turn_steering: "unsupported",
   plan_mode: "supported",
   auto_mode: "supported",
+  allow_mode: "supported",
   reasoning_levels: "unknown",
   native_file_change_events: "unsupported",
   native_interrupt: "supported",
@@ -95,6 +96,7 @@ describe("StartSessionPrompt", () => {
           entry("grok", {
             plan_mode: "unsupported",
             structured_approvals: "unsupported",
+            allow_mode: "unsupported",
           }),
         ]}
         starting={false}
@@ -114,5 +116,26 @@ describe("StartSessionPrompt", () => {
     expect(screen.getByText(UNSUPERVISED_AUTO_NOTE)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Start session" }));
     expect(onStart).toHaveBeenCalledWith("grok", "auto");
+  });
+
+  it("states Allow all when that mode is chosen", async () => {
+    const user = userEvent.setup();
+    const onSelectMode = vi.fn();
+    await renderWithRouter(
+      <StartSessionPrompt
+        harnesses={[entry("claude_code", {})]}
+        starting={false}
+        selectedMode="allow"
+        onSelectMode={onSelectMode}
+        onStart={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Allow all" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText(ALLOW_ALL_NOTE)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Ask" }));
+    expect(onSelectMode).toHaveBeenCalledWith("ask");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -13,6 +13,7 @@ import {
   createPermissionModes,
   defaultCreatePermissionMode,
   harnessUnusableReason,
+  ALLOW_ALL_NOTE,
   UNSUPERVISED_AUTO_NOTE,
 } from "./labels";
 
@@ -66,6 +67,9 @@ export function StartSessionPrompt({
       />
       {mode === "auto" && selected && autoIsUnsupervised(selected.caps) && (
         <p className="text-warning-foreground text-xs">{UNSUPERVISED_AUTO_NOTE}</p>
+      )}
+      {mode === "allow" && (
+        <p className="text-warning-foreground text-xs">{ALLOW_ALL_NOTE}</p>
       )}
       <Button
         type="button"

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -12,8 +12,9 @@ function caps(
   plan_mode: ModeCaps["plan_mode"],
   structured_approvals: ModeCaps["structured_approvals"],
   auto_mode: ModeCaps["auto_mode"],
+  allow_mode: ModeCaps["allow_mode"] = "unsupported",
 ): ModeCaps {
-  return { plan_mode, structured_approvals, auto_mode };
+  return { plan_mode, structured_approvals, auto_mode, allow_mode };
 }
 
 describe("create-time permission mode", () => {
@@ -22,8 +23,8 @@ describe("create-time permission mode", () => {
       "ask",
     );
     expect(
-      createPermissionModes(caps("supported", "supported", "supported")),
-    ).toEqual(["plan", "ask", "auto"]);
+      createPermissionModes(caps("supported", "supported", "supported", "supported")),
+    ).toEqual(["plan", "ask", "auto", "allow"]);
   });
 
   it("falls back to Plan when structured approvals are not supported", () => {
@@ -41,6 +42,9 @@ describe("create-time permission mode", () => {
   it("offers only unsupervised Auto for a grok-shaped engine", () => {
     const grok = caps("unsupported", "unsupported", "supported");
     expect(createPermissionModes(grok)).toEqual(["auto"]);
+    expect(createPermissionModes(caps("unsupported", "unsupported", "supported", "supported"))).toEqual(
+      ["auto", "allow"],
+    );
     expect(defaultCreatePermissionMode(grok)).toBe("auto");
     expect(autoIsUnsupervised(grok)).toBe(true);
     // Supervised Auto rides the approval channel and needs no statement.

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -57,6 +57,7 @@ export const PERMISSION_MODE_LABELS: Record<CodePermissionMode, string> = {
   plan: "Plan",
   ask: "Ask",
   auto: "Auto",
+  allow: "Allow all",
 };
 
 /** Shown when the selected harness cannot honor Ask or Auto. */
@@ -67,10 +68,14 @@ export const PERMISSION_MODE_UNAVAILABLE_REASON =
 export const UNSUPERVISED_AUTO_NOTE =
   "This engine has no approval channel: in Auto, every action runs without asking.";
 
+/** Stated wherever Allow is offered (decision 0039). */
+export const ALLOW_ALL_NOTE =
+  "This engine's permission system is off: every action runs without asking.";
+
 /** The capability flags the mode policy reads. */
 export type ModeCaps = Pick<
   HarnessCaps,
-  "plan_mode" | "structured_approvals" | "auto_mode"
+  "plan_mode" | "structured_approvals" | "auto_mode" | "allow_mode"
 >;
 
 export function fenceReasonText(reason: FenceReason): string {
@@ -136,6 +141,7 @@ export function createPermissionModes(caps: ModeCaps): CodePermissionMode[] {
   if (caps.plan_mode === "supported") modes.push("plan");
   if (caps.structured_approvals === "supported") modes.push("ask");
   if (caps.auto_mode === "supported") modes.push("auto");
+  if (caps.allow_mode === "supported") modes.push("allow");
   return modes;
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -94,7 +94,7 @@ const HARNESS_TIERS = new Set<HarnessTier>([
   "best_effort",
 ]);
 const CAP_LEVELS = new Set<CapLevel>(["supported", "unsupported", "unknown"]);
-const PERMISSION_MODES = new Set<CodePermissionMode>(["plan", "ask", "auto"]);
+const PERMISSION_MODES = new Set<CodePermissionMode>(["plan", "ask", "auto", "allow"]);
 const SESSION_LIFECYCLES = new Set<CodeSessionLifecycle>([
   "created",
   "idle",
@@ -884,6 +884,7 @@ function parseHarnessCaps(value: unknown): HarnessCaps | null {
       "mid_turn_steering",
       "plan_mode",
       "auto_mode",
+      "allow_mode",
       "reasoning_levels",
       "native_file_change_events",
       "native_interrupt",
@@ -894,6 +895,7 @@ function parseHarnessCaps(value: unknown): HarnessCaps | null {
     !isMember(value.mid_turn_steering, CAP_LEVELS) ||
     !isMember(value.plan_mode, CAP_LEVELS) ||
     !isMember(value.auto_mode, CAP_LEVELS) ||
+    !isMember(value.allow_mode, CAP_LEVELS) ||
     !isMember(value.reasoning_levels, CAP_LEVELS) ||
     !isMember(value.native_file_change_events, CAP_LEVELS) ||
     !isMember(value.native_interrupt, CAP_LEVELS)
@@ -907,6 +909,7 @@ function parseHarnessCaps(value: unknown): HarnessCaps | null {
     mid_turn_steering: value.mid_turn_steering,
     plan_mode: value.plan_mode,
     auto_mode: value.auto_mode,
+    allow_mode: value.allow_mode,
     reasoning_levels: value.reasoning_levels,
     native_file_change_events: value.native_file_change_events,
     native_interrupt: value.native_interrupt,

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1121,7 +1121,7 @@ export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: n
  * Each adapter maps these onto the engine's native flags. A mode the
  * engine cannot honor is refused at session creation — never approximated.
  */
-export type CodePermissionMode = "plan" | "ask" | "auto";
+export type CodePermissionMode = "plan" | "ask" | "auto" | "allow";
 
 /**
  * Result of pushing the workspace branch.
@@ -1786,6 +1786,11 @@ plan_mode: CapLevel,
  * states so where the mode is chosen (decision 0038).
  */
 auto_mode: CapLevel, 
+/**
+ * The engine has an allow-everything / bypass posture the adapter can
+ * select. Composed only when the session is in Allow (decision 0039).
+ */
+allow_mode: CapLevel, 
 /**
  * The engine accepts a reasoning-effort control.
  */

--- a/crates/tidebreak-harness/fixtures/README.md
+++ b/crates/tidebreak-harness/fixtures/README.md
@@ -83,9 +83,9 @@ a new version.
 
 The capture bin writes the prompt to a file in the throwaway repo and tees
 stdout until the child exits. SIGINT on a live child produces a truncated
-stream with no `end` event (exit 130). `--always-approve`, `--yolo`, and
-`--permission-mode bypassPermissions` are denylisted and must not appear on
-a composed launch plan.
+stream with no `end` event (exit 130). `--yolo` and
+`--permission-mode bypassPermissions` are denylisted on Plan / Ask / Auto.
+Allow composes `--always-approve`.
 
 Re-capture the whole version directory when the engine version moves.
 

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/manifest.toml
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/manifest.toml
@@ -41,7 +41,7 @@ verified = [
   "prompt request shape: {tool_name, input, tool_use_id}",
   "prompt response: single MCP text block {behavior: allow} | {behavior: deny, message}",
   "deny message is the tool_result the model reads (non_execution_kind: permission-rule)",
-  "Ask maps to --permission-mode manual; Auto to acceptEdits; Plan to plan",
+  "Ask maps to --permission-mode manual; Auto to acceptEdits; Plan to plan; Allow to --dangerously-skip-permissions",
 ]
 not_verified = [
   "mid-turn steering input",

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/manifest.toml
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/manifest.toml
@@ -37,6 +37,7 @@ scenarios = [
 Plan = { sandbox = "read-only", approvalPolicy = "untrusted" }
 Ask = { sandbox = "workspace-write", approvalPolicy = "untrusted" }
 Auto = { sandbox = "workspace-write", approvalPolicy = "on-request" }
+Allow = { sandbox = "danger-full-access", approvalPolicy = "never" }
 
 [redaction]
 notes = """

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/manifest.toml
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/manifest.toml
@@ -40,10 +40,12 @@ scenarios = [
 # Plan: `--permission-mode plan` and `--sandbox read-only` both wrote
 # files in captured turns. `--deny Edit/Write/Bash` did refuse those
 # tools (see permission-denied) but is not composed as a Plan stand-in.
-# `--always-approve` / `--yolo` / `bypassPermissions` are denylisted.
+# `--yolo` / `bypassPermissions` stay denylisted on Auto. Allow composes
+# `--always-approve` as the explicit allow-everything setting.
 Plan = "refused"
 Ask = "refused"
 Auto = "default headless posture (no permission flags composed)"
+Allow = "--always-approve"
 
 [redaction]
 notes = """
@@ -64,7 +66,7 @@ verified = [
   "end.sessionId is the resume handle; --resume <id> reused that id",
   "SIGINT mid-turn: child exits, stream truncated, no end/error line",
   "unknown model: single {type:error,message} line, exit 1",
-  "--always-approve, --yolo, --dangerously-skip-permissions accepted by CLI; denylisted",
+  "--always-approve, --yolo, --dangerously-skip-permissions accepted by CLI; Allow maps to --always-approve",
   "--permission-mode plan wrote note.txt; --sandbox read-only wrote sandboxed.txt",
   "--deny Edit --deny Write --deny Bash failed write + run_terminal_command (Denied by permission policy)",
   "ACP: grok agent stdio initialize + session/new returned sessionId; no request_permission captured",

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/manifest.toml
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/manifest.toml
@@ -32,6 +32,7 @@ scenarios = [
 Plan = { agent = "plan" }
 Ask = { agent = "build", permission = [{ permission = "bash", pattern = "*", action = "ask" }, { permission = "edit", pattern = "*", action = "ask" }, { permission = "read", pattern = "*", action = "allow" }] }
 Auto = { agent = "build", permission = [{ permission = "edit", pattern = "*", action = "allow" }, { permission = "read", pattern = "*", action = "allow" }, { permission = "bash", pattern = "*", action = "ask" }] }
+Allow = { agent = "build", permission = [{ permission = "bash", pattern = "*", action = "allow" }, { permission = "edit", pattern = "*", action = "allow" }, { permission = "read", pattern = "*", action = "allow" }] }
 
 [redaction]
 notes = """

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -77,6 +77,13 @@ impl HarnessAdapter for ClaudeCodeAdapter {
             } else {
                 CapLevel::Unknown
             },
+            // `--dangerously-skip-permissions` is documented on 2.1.233;
+            // same version gate as the rest of the permission mapping.
+            allow_mode: if version_is_2_1_233(_probe.version.as_deref()) {
+                CapLevel::Supported
+            } else {
+                CapLevel::Unknown
+            },
             reasoning_levels: CapLevel::Unknown,
             native_file_change_events: CapLevel::Unknown,
             native_interrupt: CapLevel::Supported,
@@ -270,6 +277,8 @@ mod tests {
         assert_eq!(caps.streaming_deltas, CapLevel::Supported);
         assert_eq!(caps.native_interrupt, CapLevel::Supported);
         assert_eq!(caps.plan_mode, CapLevel::Supported);
+        assert_eq!(caps.auto_mode, CapLevel::Supported);
+        assert_eq!(caps.allow_mode, CapLevel::Supported);
         assert_eq!(caps.structured_approvals, CapLevel::Supported);
         assert_eq!(caps.mid_turn_steering, CapLevel::Unknown);
         assert_eq!(caps.reasoning_levels, CapLevel::Unknown);
@@ -287,5 +296,31 @@ mod tests {
             env: Vec::new(),
         });
         assert_eq!(caps.structured_approvals, CapLevel::Unknown);
+        assert_eq!(caps.allow_mode, CapLevel::Unknown);
+    }
+
+    #[test]
+    fn permission_mode_mapping_is_explicit() {
+        use crate::claude::session::permission_mode_flags;
+        use tidebreak_core::CodePermissionMode;
+        assert_eq!(
+            permission_mode_flags(CodePermissionMode::Plan),
+            ["--permission-mode", "plan"]
+        );
+        assert_eq!(
+            permission_mode_flags(CodePermissionMode::Ask),
+            ["--permission-mode", "manual"]
+        );
+        assert_eq!(
+            permission_mode_flags(CodePermissionMode::Auto),
+            ["--permission-mode", "acceptEdits"]
+        );
+        assert_eq!(
+            permission_mode_flags(CodePermissionMode::Allow),
+            [
+                "--dangerously-skip-permissions",
+                "--allow-dangerously-skip-permissions"
+            ]
+        );
     }
 }

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -15,7 +15,7 @@ use tracing::warn;
 
 use crate::child::{signal_interrupt, turn_outcome, ChildPid};
 use crate::claude::parse::ClaudeStreamParser;
-use crate::launch::{validate_launch_plan, LaunchPlan};
+use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
     filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
     HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
@@ -24,6 +24,37 @@ use tidebreak_core::CodePermissionMode;
 
 const INTERRUPT_GRACE: Duration = Duration::from_secs(2);
 const MAX_STDERR_BYTES: usize = 64 * 1_024;
+
+/// Per-mode flag mapping captured on 2.1.233:
+///   Plan  → --permission-mode plan        (mutations refused)
+///   Ask   → --permission-mode manual      (every tool parks on the prompt tool)
+///   Auto  → --permission-mode acceptEdits (workspace writes proceed; sensitive still parks)
+///   Allow → --dangerously-skip-permissions (engine permission system off)
+/// `--permission-mode auto` is the engine's classifier, not Auto.
+/// `--allow-dangerously-skip-permissions` is required for print mode to honor
+/// the skip flag.
+#[must_use]
+pub(crate) fn permission_mode_flags(mode: CodePermissionMode) -> Vec<String> {
+    match mode {
+        CodePermissionMode::Plan => vec!["--permission-mode".into(), "plan".into()],
+        CodePermissionMode::Ask => vec!["--permission-mode".into(), "manual".into()],
+        CodePermissionMode::Auto => vec!["--permission-mode".into(), "acceptEdits".into()],
+        CodePermissionMode::Allow => vec![
+            "--dangerously-skip-permissions".into(),
+            "--allow-dangerously-skip-permissions".into(),
+        ],
+    }
+}
+
+#[must_use]
+pub(crate) fn bypass_policy(mode: CodePermissionMode) -> BypassPolicy {
+    match mode {
+        CodePermissionMode::Allow => BypassPolicy::Permitted,
+        CodePermissionMode::Plan | CodePermissionMode::Ask | CodePermissionMode::Auto => {
+            BypassPolicy::Forbidden
+        }
+    }
+}
 
 /// Live Claude Code session: one child per [`HarnessSession::run_turn`].
 pub struct ClaudeSession {
@@ -63,27 +94,7 @@ impl ClaudeSession {
             "--verbose".into(),
             "--include-partial-messages".into(),
         ];
-        // Per-mode flag mapping captured on 2.1.233:
-        //   Plan → --permission-mode plan        (mutations refused)
-        //   Ask  → --permission-mode manual      (every tool parks on the prompt tool)
-        //   Auto → --permission-mode acceptEdits (workspace writes proceed; sensitive still parks)
-        // `--permission-mode auto` and `bypassPermissions` exist but are not
-        // these modes: `auto` is the engine's classifier, not Auto, and
-        // bypass is denylisted.
-        match self.spec.permission_mode {
-            CodePermissionMode::Plan => {
-                argv.push("--permission-mode".into());
-                argv.push("plan".into());
-            }
-            CodePermissionMode::Ask => {
-                argv.push("--permission-mode".into());
-                argv.push("manual".into());
-            }
-            CodePermissionMode::Auto => {
-                argv.push("--permission-mode".into());
-                argv.push("acceptEdits".into());
-            }
-        }
+        argv.extend(permission_mode_flags(self.spec.permission_mode));
         if let Some(channel) = &self.spec.approval {
             if let Some(flags) = crate::claude::approvals::launch_args_for_approval_channel(channel)
             {
@@ -102,7 +113,7 @@ impl ClaudeSession {
             cwd: self.spec.worktree.clone(),
             env,
         };
-        validate_launch_plan(&plan)?;
+        validate_launch_plan_with(&plan, bypass_policy(self.spec.permission_mode))?;
         Ok(plan)
     }
 

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -79,6 +79,8 @@ impl HarnessAdapter for CodexAdapter {
             // `thread/start` sandbox workspace-write + approvalPolicy
             // on-request; supervised by the captured approval channel.
             auto_mode: CapLevel::Supported,
+            // `thread/start` sandbox danger-full-access + approvalPolicy never.
+            allow_mode: CapLevel::Supported,
             reasoning_levels: CapLevel::Supported,
             native_file_change_events: CapLevel::Unknown,
             native_interrupt: CapLevel::Supported,
@@ -263,6 +265,8 @@ mod tests {
         assert_eq!(caps.structured_approvals, CapLevel::Supported);
         assert_eq!(caps.native_interrupt, CapLevel::Supported);
         assert_eq!(caps.plan_mode, CapLevel::Supported);
+        assert_eq!(caps.auto_mode, CapLevel::Supported);
+        assert_eq!(caps.allow_mode, CapLevel::Supported);
         assert_eq!(caps.reasoning_levels, CapLevel::Supported);
         assert_eq!(caps.mid_turn_steering, CapLevel::Unknown);
         assert_eq!(caps.native_file_change_events, CapLevel::Unknown);
@@ -281,10 +285,18 @@ mod tests {
             .argv
             .iter()
             .any(|arg| arg.contains("dangerously-bypass")));
-        for mode in CodePermissionMode::ALL {
-            let (sandbox, approval) = thread_start_policy(*mode);
+        for mode in [
+            CodePermissionMode::Plan,
+            CodePermissionMode::Ask,
+            CodePermissionMode::Auto,
+        ] {
+            let (sandbox, approval) = thread_start_policy(mode);
             assert_ne!(sandbox, "danger-full-access");
             assert_ne!(approval, "never");
         }
+        assert_eq!(
+            thread_start_policy(CodePermissionMode::Allow),
+            ("danger-full-access", "never")
+        );
     }
 }

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -143,6 +143,7 @@ pub(crate) fn thread_start_policy(mode: CodePermissionMode) -> (&'static str, &'
         CodePermissionMode::Plan => ("read-only", "untrusted"),
         CodePermissionMode::Ask => ("workspace-write", "untrusted"),
         CodePermissionMode::Auto => ("workspace-write", "on-request"),
+        CodePermissionMode::Allow => ("danger-full-access", "never"),
     }
 }
 
@@ -610,6 +611,10 @@ mod tests {
         assert_eq!(
             thread_start_policy(CodePermissionMode::Auto),
             ("workspace-write", "on-request")
+        );
+        assert_eq!(
+            thread_start_policy(CodePermissionMode::Allow),
+            ("danger-full-access", "never")
         );
         let _ = PathBuf::from("/workspace");
     }

--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -86,6 +86,8 @@ impl HarnessAdapter for GrokAdapter {
             // 1.0.4 (d846eb93). Unsupervised: nothing escalates, which the
             // product states where the mode is chosen (decision 0038).
             auto_mode: CapLevel::Supported,
+            // `--always-approve` accepted by the captured 1.0.4 CLI.
+            allow_mode: CapLevel::Supported,
             // `--reasoning-effort` is documented and was used on capture.
             reasoning_levels: CapLevel::Supported,
             native_file_change_events: CapLevel::Unknown,
@@ -276,13 +278,15 @@ mod tests {
         assert_eq!(caps.structured_approvals, CapLevel::Unsupported);
         assert_eq!(caps.plan_mode, CapLevel::Unsupported);
         assert_eq!(caps.auto_mode, CapLevel::Supported);
+        assert_eq!(caps.allow_mode, CapLevel::Supported);
         assert_eq!(caps.mid_turn_steering, CapLevel::Unsupported);
         assert_eq!(caps.native_file_change_events, CapLevel::Unknown);
     }
 
     #[test]
-    fn auto_is_honored_and_plan_and_ask_are_refused() {
+    fn auto_and_allow_are_honored_and_plan_and_ask_are_refused() {
         assert!(refuse_unhonored_mode(CodePermissionMode::Auto).is_ok());
+        assert!(refuse_unhonored_mode(CodePermissionMode::Allow).is_ok());
         for mode in [CodePermissionMode::Plan, CodePermissionMode::Ask] {
             let err = refuse_unhonored_mode(mode).unwrap_err();
             assert!(matches!(err, HarnessError::PermissionModeUnsupported(m) if m == mode));
@@ -290,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn launch_plan_never_includes_bypass_flags() {
+    fn auto_launch_plan_never_includes_bypass_flags() {
         let plan = compose_print_plan(
             Path::new("/usr/bin/grok"),
             &[],
@@ -298,6 +302,7 @@ mod tests {
             &[],
             None,
             Path::new("/tmp/prompt.txt"),
+            CodePermissionMode::Auto,
         )
         .unwrap();
         assert!(!plan.argv.iter().any(|arg| {
@@ -316,6 +321,21 @@ mod tests {
             Some("streaming-json")
         );
         assert!(!plan.argv.iter().any(|arg| arg.contains("hello from")));
+    }
+
+    #[test]
+    fn allow_launch_plan_composes_always_approve() {
+        let plan = compose_print_plan(
+            Path::new("/usr/bin/grok"),
+            &[],
+            Path::new("/workspace"),
+            &[],
+            None,
+            Path::new("/tmp/prompt.txt"),
+            CodePermissionMode::Allow,
+        )
+        .unwrap();
+        assert!(plan.argv.iter().any(|arg| arg == "--always-approve"));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -16,7 +16,7 @@ use tracing::warn;
 
 use crate::child::{signal_interrupt, turn_outcome, ChildPid};
 use crate::grok::parse::GrokStreamParser;
-use crate::launch::{validate_launch_plan, LaunchPlan};
+use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
     filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
     HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
@@ -62,26 +62,27 @@ impl GrokSession {
             &self.spec.extra_env,
             self.resume_ref.lock().expect("grok resume").as_deref(),
             prompt_file,
+            self.spec.permission_mode,
         )
     }
 }
 
-/// 1.0.4 honors Auto only, as its default headless posture.
+/// 1.0.4 honors Auto and Allow.
 ///
 /// Auto composes no permission flags: the default print-mode posture
 /// executes routine work unprompted (re-probed 2026-08-17 — a write tool
 /// ran without asking), which is exactly an unsupervised workspace-write
-/// auto. Ask needs a structured approval channel and headless
-/// `streaming-json` has none (`grok agent stdio` ACP was probed; no
-/// request/response pair was captured). Plan's `--permission-mode plan`
+/// auto. Allow composes `--always-approve`, the engine's documented
+/// allow-everything flag. Ask needs a structured approval channel and
+/// headless `streaming-json` has none (`grok agent stdio` ACP was probed;
+/// no request/response pair was captured). Plan's `--permission-mode plan`
 /// and `--sandbox read-only` both wrote files in captured and re-probed
-/// turns. Composing `--always-approve` / `--yolo` / `bypassPermissions`
-/// is forbidden. Composing `--deny` rules as a stand-in for Plan would
+/// turns. Composing `--deny` rules as a stand-in for Plan would
 /// approximate a posture the engine's own plan/read-only flags did not
 /// honor.
 pub(crate) fn refuse_unhonored_mode(mode: CodePermissionMode) -> Result<(), HarnessError> {
     match mode {
-        CodePermissionMode::Auto => Ok(()),
+        CodePermissionMode::Auto | CodePermissionMode::Allow => Ok(()),
         CodePermissionMode::Plan | CodePermissionMode::Ask => {
             Err(HarnessError::PermissionModeUnsupported(mode))
         }
@@ -97,6 +98,7 @@ pub(crate) fn compose_print_plan(
     extra_env: &[(String, String)],
     resume_ref: Option<&str>,
     prompt_file: &Path,
+    mode: CodePermissionMode,
 ) -> Result<LaunchPlan, HarnessError> {
     let mut argv = vec![
         binary.to_string_lossy().into_owned(),
@@ -108,6 +110,9 @@ pub(crate) fn compose_print_plan(
         cwd.to_string_lossy().into_owned(),
         "--no-auto-update".into(),
     ];
+    if mode == CodePermissionMode::Allow {
+        argv.push("--always-approve".into());
+    }
     if let Some(resume) = resume_ref {
         argv.push("--resume".into());
         argv.push(resume.to_owned());
@@ -115,12 +120,18 @@ pub(crate) fn compose_print_plan(
     argv.extend(extra_argv.iter().cloned());
     let mut env = extra_env.to_vec();
     env.retain(|(key, _)| !key.to_ascii_uppercase().starts_with("TIDEBREAK_") && key != "PWD");
+    let policy = match mode {
+        CodePermissionMode::Allow => BypassPolicy::Permitted,
+        CodePermissionMode::Plan | CodePermissionMode::Ask | CodePermissionMode::Auto => {
+            BypassPolicy::Forbidden
+        }
+    };
     let plan = LaunchPlan {
         argv,
         cwd: cwd.to_path_buf(),
         env,
     };
-    validate_launch_plan(&plan)?;
+    validate_launch_plan_with(&plan, policy)?;
     Ok(plan)
 }
 

--- a/crates/tidebreak-harness/src/launch.rs
+++ b/crates/tidebreak-harness/src/launch.rs
@@ -30,9 +30,30 @@ const DENIED_EXACT: &[&str] = &[
 /// Bypass mode values that can appear as a `--permission-mode` argument.
 const DENIED_VALUES: &[&str] = &["bypassPermissions"];
 
+/// Whether a composed launch plan may include the engine's bypass flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BypassPolicy {
+    /// Plan / Ask / Auto: no known bypass flag may appear, including extras.
+    Forbidden,
+    /// Allow: the adapter may compose the engine's documented bypass.
+    Permitted,
+}
+
 /// Reject a composed launch plan that includes a permission-bypass flag,
-/// including user-supplied extras.
+/// including user-supplied extras. Use [`validate_launch_plan_with`] when
+/// the session is in Allow.
 pub fn validate_launch_plan(plan: &LaunchPlan) -> Result<(), BypassFlagError> {
+    validate_launch_plan_with(plan, BypassPolicy::Forbidden)
+}
+
+/// Reject a composed launch plan under the given bypass policy.
+pub fn validate_launch_plan_with(
+    plan: &LaunchPlan,
+    policy: BypassPolicy,
+) -> Result<(), BypassFlagError> {
+    if policy == BypassPolicy::Permitted {
+        return Ok(());
+    }
     for arg in &plan.argv {
         if DENIED_VALUES.contains(&arg.as_str()) {
             return Err(BypassFlagError(arg.clone()));
@@ -118,6 +139,19 @@ mod tests {
         let err = validate_launch_plan(&plan(&["claude", "--dangerously-bypass-permissions"]))
             .unwrap_err();
         assert!(err.0.contains("dangerous"));
+    }
+
+    #[test]
+    fn allow_mode_may_compose_a_bypass_flag() {
+        validate_launch_plan_with(
+            &plan(&[
+                "claude",
+                "--dangerously-skip-permissions",
+                "--allow-dangerously-skip-permissions",
+            ]),
+            BypassPolicy::Permitted,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -32,7 +32,9 @@ mod text;
 
 pub use budget::{BudgetTick, StreamBudget, StreamLineBuffer};
 pub use child::ChildPid;
-pub use launch::{validate_launch_plan, BypassFlagError, LaunchPlan};
+pub use launch::{
+    validate_launch_plan, validate_launch_plan_with, BypassFlagError, BypassPolicy, LaunchPlan,
+};
 pub use probe::{
     filter_child_env, observe_version, probe_shell, resolve_binary, HostEnv, ProbeCapture,
     ProbeError,

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -81,6 +81,8 @@ impl HarnessAdapter for OpencodeAdapter {
             // Workspace-write ruleset with sensitive actions still asking
             // over the permission API; supervised Auto.
             auto_mode: CapLevel::Supported,
+            // build agent with every permission rule allow; not `--auto`.
+            allow_mode: CapLevel::Supported,
             reasoning_levels: CapLevel::Unknown,
             // session.diff was empty arrays; file.edited was not seen.
             native_file_change_events: CapLevel::Unknown,
@@ -273,6 +275,8 @@ mod tests {
         assert_eq!(caps.structured_approvals, CapLevel::Supported);
         assert_eq!(caps.native_interrupt, CapLevel::Supported);
         assert_eq!(caps.plan_mode, CapLevel::Supported);
+        assert_eq!(caps.auto_mode, CapLevel::Supported);
+        assert_eq!(caps.allow_mode, CapLevel::Supported);
         assert_eq!(caps.mid_turn_steering, CapLevel::Unknown);
         assert_eq!(caps.reasoning_levels, CapLevel::Unknown);
         assert_eq!(caps.native_file_change_events, CapLevel::Unknown);
@@ -292,10 +296,23 @@ mod tests {
             .argv
             .iter()
             .any(|arg| arg.contains("dangerous") || arg == "--auto"));
-        for mode in CodePermissionMode::ALL {
-            let body = session_create_body(*mode);
+        for mode in [
+            CodePermissionMode::Plan,
+            CodePermissionMode::Ask,
+            CodePermissionMode::Auto,
+        ] {
+            let body = session_create_body(mode);
             assert_ne!(body.get("agent").and_then(|v| v.as_str()), Some(""));
+            if let Some(rules) = body["permission"].as_array() {
+                assert!(
+                    !rules.iter().all(|rule| rule["action"] == "allow"),
+                    "{mode} must not allow every permission"
+                );
+            }
         }
+        let allow = session_create_body(CodePermissionMode::Allow);
+        let rules = allow["permission"].as_array().unwrap();
+        assert!(rules.iter().all(|rule| rule["action"] == "allow"));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -116,6 +116,14 @@ pub(crate) fn session_create_body(mode: CodePermissionMode) -> Value {
                 {"permission": "bash", "pattern": "*", "action": "ask"}
             ]
         }),
+        CodePermissionMode::Allow => json!({
+            "agent": "build",
+            "permission": [
+                {"permission": "bash", "pattern": "*", "action": "allow"},
+                {"permission": "edit", "pattern": "*", "action": "allow"},
+                {"permission": "read", "pattern": "*", "action": "allow"}
+            ]
+        }),
     }
 }
 
@@ -647,5 +655,12 @@ mod tests {
         assert!(rules
             .iter()
             .any(|rule| { rule["permission"] == "bash" && rule["action"] == "ask" }));
+        let allow = session_create_body(CodePermissionMode::Allow);
+        assert_eq!(allow["agent"], "build");
+        let rules = allow["permission"].as_array().unwrap();
+        assert!(rules.iter().all(|rule| rule["action"] == "allow"));
+        assert!(rules
+            .iter()
+            .any(|rule| { rule["permission"] == "bash" && rule["action"] == "allow" }));
     }
 }

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1252,6 +1252,7 @@ fn refuse_unhonored_mode(
         CodePermissionMode::Plan => caps.plan_mode == CapLevel::Supported,
         CodePermissionMode::Ask => caps.structured_approvals == CapLevel::Supported,
         CodePermissionMode::Auto => caps.auto_mode == CapLevel::Supported,
+        CodePermissionMode::Allow => caps.allow_mode == CapLevel::Supported,
     };
     if ok {
         return Ok(());
@@ -1265,6 +1266,10 @@ fn refuse_unhonored_mode(
         CodePermissionMode::Auto => format!(
             "{harness} cannot honor {mode}: an auto posture is {}",
             caps.auto_mode.as_str()
+        ),
+        CodePermissionMode::Allow => format!(
+            "{harness} cannot honor {mode}: an allow-all posture is {}",
+            caps.allow_mode.as_str()
         ),
     };
     Err(ServerError::unprocessable_kind(

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 28;
+const DESKTOP_SCHEMA_EPOCH: u32 = 29;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tidebreak_core::{CapLevel, CodePermissionMode, HarnessCaps, HarnessKind};
+use tidebreak_core::{CapLevel, HarnessCaps, HarnessKind};
 use tidebreak_harness::child::ChildPid;
 use tidebreak_harness::{
     ApprovalCompleter, ApprovalDecision, HarnessAdapter, HarnessApprovalRef, HarnessError,
@@ -78,6 +78,7 @@ pub(crate) struct ScriptedAdapter {
     mid_turn_steering: CapLevel,
     structured_approvals: CapLevel,
     auto_mode: CapLevel,
+    allow_mode: CapLevel,
     child_pid: Option<i64>,
     unrecognized_per_turn: u64,
     silent_interrupt: bool,
@@ -98,6 +99,7 @@ impl ScriptedAdapter {
             mid_turn_steering: CapLevel::Unsupported,
             structured_approvals: CapLevel::Unsupported,
             auto_mode: CapLevel::Unsupported,
+            allow_mode: CapLevel::Unsupported,
             child_pid: None,
             unrecognized_per_turn: 0,
             silent_interrupt: false,
@@ -143,6 +145,12 @@ impl ScriptedAdapter {
     /// for exercising the mode gate's per-flag refusals.
     pub(crate) fn with_auto_mode(mut self, level: CapLevel) -> Self {
         self.auto_mode = level;
+        self
+    }
+
+    /// Overrides the allow-everything posture independently of Auto.
+    pub(crate) fn with_allow_mode(mut self, level: CapLevel) -> Self {
+        self.allow_mode = level;
         self
     }
 
@@ -211,6 +219,7 @@ impl HarnessAdapter for ScriptedAdapter {
             mid_turn_steering: self.mid_turn_steering,
             plan_mode: CapLevel::Supported,
             auto_mode: self.auto_mode,
+            allow_mode: self.allow_mode,
             reasoning_levels: CapLevel::Unsupported,
             native_file_change_events: CapLevel::Unsupported,
             native_interrupt: CapLevel::Supported,
@@ -218,14 +227,6 @@ impl HarnessAdapter for ScriptedAdapter {
     }
 
     async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
-        if spec.permission_mode != CodePermissionMode::Plan
-            && spec.permission_mode != CodePermissionMode::Ask
-            && spec.permission_mode != CodePermissionMode::Auto
-        {
-            return Err(HarnessError::PermissionModeUnsupported(
-                spec.permission_mode,
-            ));
-        }
         self.launched_approvals
             .lock()
             .expect("scripted launches")

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -236,6 +236,66 @@ async fn auto_stands_on_its_own_capability_flag() {
     assert_eq!(session["permission_mode"], "auto");
 }
 
+/// Allow is gated by its own capability flag (decision 0039): an engine
+/// with Auto but no allow-all posture refuses Allow.
+#[tokio::test]
+async fn allow_stands_on_its_own_capability_flag() {
+    let adapter = ScriptedAdapter::new(plain_text_script())
+        .with_auto_mode(CapLevel::Supported)
+        .with_allow_mode(CapLevel::Unsupported);
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "allow",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "permission_mode_unavailable");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("allow-all posture"),
+        "{}",
+        body["message"]
+    );
+
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_allow_mode(CapLevel::Supported);
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "allow",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(session["permission_mode"], "allow");
+}
+
 #[tokio::test]
 async fn plan_is_the_only_session_mode_and_a_turn_journals_end_to_end() {
     let (router, token, _runtime, dir) = code_app(plain_text_script()).await;

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -2,17 +2,18 @@
 
 Status: implemented (first version). The decision records
 [`0030`](decisions/0030-code-mode-separate-surface.md) through
-[`0036`](decisions/0036-code-mode-auxiliary-terminals.md) carry the decisions
+[`0039`](decisions/0039-allow-is-a-first-class-code-permission-mode.md) carry the decisions
 and are accepted; this page carries the working design detail in one place.
 Where this page and a decision record disagree, the record wins. The first
 version ships the full surface described here — repos, workspaces, sessions,
 approvals, checkpoints and review, auxiliary terminals, the git/PR flow, the
 updates channel, and adapters for Claude Code (reference tier), Codex CLI,
-opencode, and Grok CLI (the last honors Auto only, as its default headless
-posture: its captured 1.0.4 plan and sandbox flags do not confine and it has
-no approval channel, so Auto runs unsupervised and the product says so where
+opencode, and Grok CLI (the last honors Auto and Allow: its captured 1.0.4 plan and sandbox flags do
+not confine and it has no approval channel, so Auto is the unsupervised
+default headless posture and Allow is `--always-approve`, both stated where
 the mode is chosen — see
-[`0038`](decisions/0038-auto-is-a-declared-capability.md)) — with the
+[`0038`](decisions/0038-auto-is-a-declared-capability.md) and
+[`0039`](decisions/0039-allow-is-a-first-class-code-permission-mode.md)) — with the
 deliberately parked scope recorded in [`docs/deferred.md`](deferred.md).
 
 Code mode is Tidebreak's second product surface: pick a local git repository,
@@ -49,7 +50,7 @@ crates/tidebreak-core/src/code/
   event.rs       CodeEvent, SequencedCodeEvent (conventions of src/event.rs)
   attention.rs   AttentionState, AttentionSource, should_replace
   caps.rs        HarnessCaps, CapLevel, HarnessTier
-  permission.rs  CodePermissionMode { Plan, Ask, Auto } and its per-mode contract
+  permission.rs  CodePermissionMode { Plan, Ask, Auto, Allow } and its per-mode contract
 
 crates/tidebreak-core/src/db/entities.rs      six new entities (below)
 crates/tidebreak-core/src/db/ops/code/        repo.rs, workspace.rs, session.rs,

--- a/docs/decisions/0039-allow-is-a-first-class-code-permission-mode.md
+++ b/docs/decisions/0039-allow-is-a-first-class-code-permission-mode.md
@@ -1,0 +1,106 @@
+# 39. Allow Is a First-Class Code Permission Mode
+
+- Status: Proposed
+- Date: 2026-08-17
+- Owners: code mode, approvals
+- Related: [`0033-code-mode-approvals.md`](0033-code-mode-approvals.md),
+  [`0038-auto-is-a-declared-capability.md`](0038-auto-is-a-declared-capability.md)
+
+## Context
+
+Chat already has four permission modes — `Plan`, `Ask`, `Auto`, `Allow` —
+in ascending autonomy. Code mode reused the first three and left `Allow`
+out: [`0033`](0033-code-mode-approvals.md) reserved bypass for "an explicit
+per-session choice that is rendered as prominently as the approvals it
+removes", and [`0038`](0038-auto-is-a-declared-capability.md) kept the
+bypass-flag denylist closed so unsupervised Auto would never be a flag we
+add.
+
+That split is now the product gap. Users who want the engine's own
+allow-everything posture have no first-class way to choose it. Each
+harness already has one:
+
+- Claude Code: `--dangerously-skip-permissions` (with
+  `--allow-dangerously-skip-permissions` so print mode will honor it)
+- Codex CLI: `thread/start` `sandbox=danger-full-access` +
+  `approvalPolicy=never`
+- opencode: the `build` agent with every permission rule `allow`
+- Grok CLI: `--always-approve` (accepted on the captured 1.0.4)
+
+0033 already forbids composing those as a default. It does not forbid
+mapping them onto a named mode the user picks.
+
+## Decision
+
+**`CodePermissionMode` gains `Allow`.** The token is `allow`, matching
+chat. The scale is `Plan < Ask < Auto < Allow`. Default stays `Ask`.
+
+**Each adapter maps every mode it can honor onto that engine's native
+setting.** The mapping is exhaustive and per-mode: a mode the engine cannot
+honor is still refused, never approximated. Allow is not "Auto plus a
+bypass flag we hope works"; it is the engine's documented allow-everything
+posture, composed only when the session is in Allow.
+
+**`Allow` is gated by its own capability flag.** `HarnessCaps` gains
+`allow_mode: CapLevel`. Session creation refuses Allow on that flag, the
+same way Plan / Ask / Auto each stand on their own. No mode is derived
+from another mode's flag.
+
+**The bypass denylist stays closed for every other mode.** Plan, Ask, and
+Auto launch plans — including user-supplied extra arguments — still fail
+the build if a known bypass flag appears. Allow is the one mode that may
+compose the engine's bypass. That is the explicit per-session choice 0033
+reserved; it is not a default, and it is stated where the mode is chosen.
+
+**Existing Auto mappings do not change.** Claude Auto is still
+`acceptEdits`. Codex Auto is still `workspace-write` + `on-request`.
+opencode Auto still allows edits and asks for bash. Grok Auto is still the
+default headless posture with no permission flags. Grok Allow is the
+distinct `--always-approve` flag; Auto and Allow are not collapsed.
+
+Deliberately excluded: changing a live session into Allow (still deferred
+with every other mid-session mode change); standing grants; Tidebreak-side
+sandboxing of an Allow session.
+
+## Alternatives Considered
+
+**Keep Allow out of code mode (do nothing).** Honest to 0038's closed
+denylist, but it leaves the chat vocabulary incomplete on the surface that
+actually drives foreign engines, and it forces anyone who wants bypass to
+smuggle it through extra argv — which the denylist then rejects.
+
+**Treat Grok's unsupervised Auto as Allow and hide Auto.** Rejected: Auto
+is the engine's default headless posture; Allow is an explicit bypass flag
+the CLI accepts. Collapsing them would approximate two settings as one.
+
+**Expose each engine's native mode names in the picker.** Rejected: the
+product vocabulary is Tidebreak's, and a future chat–code merge depends on
+the tokens staying shared. Native names belong in adapter mapping tables
+and doctor detail, not on the create control.
+
+## Consequences
+
+`HarnessCaps` changes shape again, which ripples through the wire
+snapshot, the generated renderer types, the CLI doctor summary, and every
+caps literal. The `code_session.permission_mode` check constraint grows
+`allow`, so the desktop schema epoch bumps in the same change.
+
+Allow sessions do not wire the approval channel. Surfaces that offer the
+mode must state that the engine's permission system is off.
+
+Revisit if a harness ships an allow-everything posture that is not a
+bypass flag (a first-class native mode with its own confinement story), or
+if usage shows Allow being chosen without the statement landing.
+
+## Validation
+
+- Per-adapter mapping tests: Allow composes the documented native setting;
+  Plan / Ask / Auto still do not contain a bypass flag.
+- A server mode-refusal test: Allow on an adapter with
+  `allow_mode: Unsupported` fails with the stated reason even when
+  `auto_mode: Supported` — the case a wrong implementation (deriving Allow
+  from Auto) would still pass.
+- UI: the mode list is computed from the four flags, and the Allow
+  statement renders exactly when Allow is the selected create mode.
+- The denylist test still fails a Plan / Ask / Auto plan that includes a
+  bypass flag, including via extra argv.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -239,7 +239,8 @@ purpose:
 - **Changing a session's permission mode after it starts.** The mode is
   chosen at session creation, refused per harness capability there
   ([record 33](decisions/0033-code-mode-approvals.md),
-  [record 38](decisions/0038-auto-is-a-declared-capability.md)), and composed
+  [record 38](decisions/0038-auto-is-a-declared-capability.md),
+  [record 39](decisions/0039-allow-is-a-first-class-code-permission-mode.md)), and composed
   into the engine's launch; no adapter can renegotiate it on an attached
   session. Changing it means tearing the engine down and relaunching it on a
   resume ref — new semantics for spawn epochs, in-flight turns, and pending


### PR DESCRIPTION
## Summary

Code mode only offered Plan, Ask, and Auto. Chat already has Allow, and every shipped harness already has an allow-everything posture. This adds `Allow` as a first-class session mode and maps it explicitly per engine.

- Claude Code → `--dangerously-skip-permissions` (plus `--allow-dangerously-skip-permissions` so print mode honors it)
- Codex CLI → `sandbox=danger-full-access`, `approvalPolicy=never`
- opencode → `build` with every permission rule `allow`
- Grok CLI → `--always-approve` (Plan and Ask stay refused)

`allow_mode` is its own capability flag, same as Auto. The bypass denylist still rejects those flags on Plan / Ask / Auto, including extra argv. Allow is the explicit per-session choice reserved by decision 0033, stated where the mode is chosen. Schema epoch 29 widens the `code_session.permission_mode` check constraint.

See [decision 0039](docs/decisions/0039-allow-is-a-first-class-code-permission-mode.md).

## Test plan

- [x] Adapter mapping tests: each Allow plan composes the documented native setting; Plan / Ask / Auto still contain no bypass flag
- [x] Server refuses Allow when `allow_mode` is unsupported even if `auto_mode` is supported
- [x] CLI default-mode test still defaults to Ask / Plan / Auto, never Allow
- [x] Clippy on the touched crates
- [ ] UI vitest (node_modules not installed in this worktree)
- [ ] Drive a session in Allow on Claude Code and confirm the skip flags land and no approval cards appear