### PR TITLE
fix(server): keep Ended from being overwritten by the outgoing worker

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -1,5 +1,6 @@
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, Condition, EntityTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait,
 };
 
 use crate::code::{
@@ -142,18 +143,19 @@ pub async fn list_sessions_by_lifecycle(
 
 /// Persist mutable session fields. `id`, `workspace_id`, and `created_at` stay as stored.
 ///
-/// The write is fenced on `spawn_epoch`, the same way journal appends are: a
-/// caller holding an epoch older than the stored row is a superseded worker
-/// unwinding, and its write is dropped rather than allowed to regress the row.
-/// Without the fence such a worker writes its own epoch back over a newer
-/// spawn's — un-fencing itself, making the live worker the stale one, and
-/// silently dropping everything the live worker appends afterwards. The same
-/// fence keeps a superseded worker from regressing lifecycle, attention, or
-/// the recorded child pid.
-///
-/// Returns `false` when nothing was written: either the row is gone or the
-/// caller has been superseded.
+/// `spawn_epoch` must be non-decreasing, and `Ended` is terminal: a caller
+/// that is not `Ended` cannot overwrite that lifecycle. Returns `false` when
+/// nothing was written.
 pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool> {
+    let mut predicate = Condition::all()
+        .add(entities::code_session::Column::Id.eq(session.id.0))
+        .add(entities::code_session::Column::SpawnEpoch.lte(session.spawn_epoch));
+    if session.lifecycle != CodeSessionLifecycle::Ended {
+        predicate = predicate.add(
+            entities::code_session::Column::Lifecycle
+                .ne(CodeSessionLifecycle::Ended.as_str().to_owned()),
+        );
+    }
     let result = entities::code_session::Entity::update_many()
         .col_expr(
             entities::code_session::Column::HarnessKind,
@@ -202,8 +204,7 @@ pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool
             entities::code_session::Column::UnrecognizedEventCount,
             sea_orm::sea_query::Expr::value(session.unrecognized_event_count),
         )
-        .filter(entities::code_session::Column::Id.eq(session.id.0))
-        .filter(entities::code_session::Column::SpawnEpoch.lte(session.spawn_epoch))
+        .filter(predicate)
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
@@ -213,9 +214,11 @@ pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool
         if let Some(current) = get_session(store, session.id).await? {
             tracing::warn!(
                 session = %session.id,
-                attempted = session.spawn_epoch,
-                current = current.spawn_epoch,
-                "dropping a session write from a superseded code-session worker"
+                attempted_epoch = session.spawn_epoch,
+                current_epoch = current.spawn_epoch,
+                attempted_lifecycle = session.lifecycle.as_str(),
+                current_lifecycle = current.lifecycle.as_str(),
+                "dropping a session write from a superseded or ended code-session row"
             );
         }
         return Ok(false);

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -216,6 +216,36 @@ async fn a_superseded_worker_cannot_regress_the_session_row() {
         .unwrap();
 }
 
+/// Archive marks the row Ended without bumping spawn_epoch. A same-epoch
+/// worker persist of Running or Idle must not revive it, or a late write
+/// leaves an archived workspace with a live-looking session (and pid).
+#[tokio::test]
+async fn an_ended_session_cannot_be_revived_by_a_same_epoch_persist() {
+    let (_dir, store, session_id, _) = seeded_session().await;
+    let mut ended = get_session(&store, session_id).await.unwrap().unwrap();
+    ended.lifecycle = CodeSessionLifecycle::Ended;
+    ended.child_pid = None;
+    assert!(save_session(&store, &ended).await.unwrap());
+
+    let mut running = ended.clone();
+    running.lifecycle = CodeSessionLifecycle::Running;
+    running.child_pid = Some(4242);
+    assert!(!save_session(&store, &running).await.unwrap());
+
+    let mut idle = ended.clone();
+    idle.lifecycle = CodeSessionLifecycle::Idle;
+    idle.child_pid = Some(7);
+    assert!(!save_session(&store, &idle).await.unwrap());
+
+    let row = get_session(&store, session_id).await.unwrap().unwrap();
+    assert_eq!(row.lifecycle, CodeSessionLifecycle::Ended);
+    assert_eq!(row.child_pid, None);
+    assert_eq!(row.spawn_epoch, 0);
+
+    // Re-asserting Ended at the same epoch is how archive writes after the wait.
+    assert!(save_session(&store, &ended).await.unwrap());
+}
+
 #[tokio::test]
 async fn journal_rejects_stale_spawn_epoch() {
     let (_dir, store, session_id, _) = seeded_session().await;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -938,23 +938,27 @@ impl CodeRuntime {
             if let Some(handle) = handle {
                 Self::shut_down_worker(session.id, handle).await;
             }
+            // The outgoing worker still holds this epoch, so a persist during
+            // the wait can overwrite Ended. Re-assert from a fresh load.
+            let mut current = self.get_session(session.id).await?;
+            current.lifecycle = CodeSessionLifecycle::Ended;
+            current.child_pid = None;
+            current.fence_reason = None;
+            if !super::attention::persist_session(&self.db, &self.bus, &current).await? {
+                return Err(ServerError::conflict_kind(
+                    "session_not_ended",
+                    "the session did not stay ended after the worker stopped",
+                ));
+            }
         }
         Ok(())
     }
 
-    /// Ask a superseded worker to stop, and wait for it to finish unwinding.
-    ///
-    /// The worker drops its command receiver as its last act — after the engine
-    /// is shut down and its final writes have landed — so the sender seeing the
-    /// receiver close is exactly "the worker is gone". One `Shutdown` is enough:
-    /// an idle worker leaves the loop on it, and a worker mid-turn interrupts
-    /// the turn and then leaves at the top of the next iteration because the
-    /// caller marked the session ended first. Resending would only replay
-    /// `interrupt` into an engine that is already stopping.
-    ///
-    /// The wait is bounded so an engine that never returns cannot hold an
-    /// archive or a reap open; the epoch fence on the session row keeps a late
-    /// writer harmless either way.
+    /// Ask a superseded worker to stop, and wait for its command receiver to
+    /// close — that is the last thing the worker does. One `Shutdown` is
+    /// enough; resending would only replay `interrupt` into an engine that is
+    /// already stopping. The wait is bounded so a wedged engine cannot hold
+    /// an archive or a reap open.
     async fn shut_down_worker(id: CodeSessionId, handle: WorkerHandle) {
         const GRACE: std::time::Duration = std::time::Duration::from_secs(5);
         let commands = handle.commands.clone();


### PR DESCRIPTION
Follow-up to #2160. That PR fenced `save_session` on `spawn_epoch` so a superseded worker could not regress the row, and it waited for the outgoing worker during archive/reap. The wait is still same-epoch: archive never bumps `spawn_epoch`, so the worker that is shutting down can persist `Running` or `Idle` (and a pid) over `Ended` while `end_workspace_sessions` waits. The archived workspace then looks live.

`save_session` now treats `Ended` as terminal. A persist that is not itself `Ended` cannot overwrite that lifecycle, even at the same epoch. `end_workspace_sessions` reloads the row after the wait and re-asserts `Ended` (clearing pid and fence) so a late write cannot stick. Re-asserting `Ended` at the same epoch still succeeds; the epoch fence is unchanged.

`an_ended_session_cannot_be_revived_by_a_same_epoch_persist` covers the CAS: same-epoch `Running`/`Idle` writes are rejected, the row stays `Ended` with no pid, and a same-epoch `Ended` persist still lands.

Verified locally: `cargo fmt --all -- --check` and `cargo test -p tidebreak-core --lib an_ended_session_cannot_be_revived`.