### PR TITLE
ci: do not invoke Release Drafter without a published baseline

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -77,6 +77,43 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Require a published release baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          attempt=1
+          max_attempts=5
+          while (( attempt <= max_attempts )); do
+            if gh api --paginate \
+                 -H 'Accept: application/vnd.github+json' \
+                 "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+                 > "$RUNNER_TEMP/releases.raw.json" \
+              && jq -s '[.[][]]' "$RUNNER_TEMP/releases.raw.json" \
+                 > "$RUNNER_TEMP/releases.json" \
+              && git ls-remote --tags origin 'v*' \
+                 | awk '{print $2}' \
+                 | jq -R -s -c 'split("\n") | map(select(length>0))' \
+                 > "$RUNNER_TEMP/tags.json"
+            then
+              plan="$(node scripts/require-release-baseline.mjs \
+                --releases "$RUNNER_TEMP/releases.json" \
+                --tags "$RUNNER_TEMP/tags.json")"
+              echo "attempt ${attempt}: ${plan}"
+              if [[ "$(jq -r .action <<<"$plan")" != fail ]]; then
+                exit 0
+              fi
+              reason="$(jq -r .reason <<<"$plan")"
+            else
+              reason="failed to list GitHub releases or version tags"
+              echo "attempt ${attempt}: ${reason}"
+            fi
+            if (( attempt == max_attempts )); then
+              echo "$reason" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+            attempt=$((attempt + 1))
+          done
       - id: release_drafter
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
       - name: Keep exactly one native release draft

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -107,11 +107,14 @@ The release-draft workflow keeps exactly one draft GitHub Release up to date:
    all PRs chooses the proposed version; the category labels do not
    independently change the version, and a maintenance-only release proposes a
    patch bump.
-4. The same job then collapses leftover drafts so publish still sees exactly
-   one. If Release Drafter cannot see the previous published release it falls
-   back to `v0.0.1` and creates a second draft; the job deletes that fallback
-   and fails so the next merge — or a manual **Release draft** dispatch with
-   **update-draft** — retries against the real baseline.
+4. Before Release Drafter runs, the job lists GitHub Releases and `v*` tags
+   (retrying a few times) and refuses to invoke it when version tags exist
+   but no published release is visible. That is the outage that would
+   otherwise mint a `v0.0.1` draft. If Release Drafter still loses the
+   baseline after that check, the job deletes the fallback and fails so a
+   later merge or a manual **Release draft** dispatch with **update-draft**
+   can try again. Extra drafts are collapsed so publish still sees exactly
+   one.
 
 The first release has no previous published release to use as a comparison
 baseline, so Release Drafter intentionally leaves that draft as a manual

--- a/scripts/require-release-baseline.mjs
+++ b/scripts/require-release-baseline.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+import { parseReleaseTag } from "./check-release-tag.mjs";
+import { normalizeReleaseList } from "./reconcile-release-drafts.mjs";
+
+export function versionTagsFromRefs(refs) {
+  if (!Array.isArray(refs)) {
+    throw new Error("tag refs must be a JSON array");
+  }
+  return [
+    ...new Set(
+      refs.flatMap((ref) => {
+        if (typeof ref !== "string" || ref.length === 0) return [];
+        const tag = ref.replace(/^refs\/tags\//, "").replace(/\^{}$/, "");
+        return parseReleaseTag(tag) ? [tag] : [];
+      }),
+    ),
+  ];
+}
+
+export function planReleaseBaseline({ releases, tags }) {
+  const published = normalizeReleaseList(releases).filter(
+    (release) => release?.draft === false,
+  );
+  const versionTags = versionTagsFromRefs(tags);
+
+  if (published.length > 0) {
+    return {
+      action: "ok",
+      published_count: published.length,
+      version_tag_count: versionTags.length,
+    };
+  }
+
+  if (versionTags.length > 0) {
+    return {
+      action: "fail",
+      published_count: 0,
+      version_tag_count: versionTags.length,
+      reason:
+        "version tags exist but no published GitHub Release was listed; refusing to invoke Release Drafter",
+    };
+  }
+
+  return {
+    action: "first_release",
+    published_count: 0,
+    version_tag_count: 0,
+  };
+}
+
+function parseArgs(argv) {
+  const args = { releases: null, tags: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === "--releases") {
+      args.releases = value;
+      index += 1;
+    } else if (flag === "--tags") {
+      args.tags = value;
+      index += 1;
+    } else {
+      throw new Error(`unknown argument: ${flag}`);
+    }
+  }
+  if (!args.releases || !args.tags) {
+    throw new Error(
+      "usage: require-release-baseline.mjs --releases <path> --tags <path>",
+    );
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const plan = planReleaseBaseline({
+    releases: JSON.parse(readFileSync(args.releases, "utf8")),
+    tags: JSON.parse(readFileSync(args.tags, "utf8")),
+  });
+  console.log(JSON.stringify(plan));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/require-release-baseline.test.mjs
+++ b/scripts/require-release-baseline.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  planReleaseBaseline,
+  versionTagsFromRefs,
+} from "./require-release-baseline.mjs";
+
+const published = {
+  id: 1,
+  tag_name: "v0.46.2",
+  draft: false,
+  prerelease: false,
+};
+const draft = {
+  id: 2,
+  tag_name: "v0.47.0",
+  draft: true,
+  prerelease: false,
+};
+const inFlight = {
+  id: 3,
+  tag_name: "v0.47.0",
+  draft: false,
+  prerelease: true,
+};
+
+test("allows drafting when a published release is listed", () => {
+  assert.deepEqual(
+    planReleaseBaseline({
+      releases: [draft, published],
+      tags: ["refs/tags/v0.46.2"],
+    }),
+    {
+      action: "ok",
+      published_count: 1,
+      version_tag_count: 1,
+    },
+  );
+});
+
+test("treats an in-flight prerelease as a published baseline", () => {
+  assert.equal(
+    planReleaseBaseline({
+      releases: [inFlight],
+      tags: ["v0.47.0"],
+    }).action,
+    "ok",
+  );
+});
+
+test("refuses to draft when version tags exist but no release is listed", () => {
+  assert.deepEqual(
+    planReleaseBaseline({
+      releases: [draft],
+      tags: ["refs/tags/v0.46.2", "refs/tags/v0.46.2^{}"],
+    }),
+    {
+      action: "fail",
+      published_count: 0,
+      version_tag_count: 1,
+      reason:
+        "version tags exist but no published GitHub Release was listed; refusing to invoke Release Drafter",
+    },
+  );
+});
+
+test("allows the genuine first-release path when history is empty", () => {
+  assert.deepEqual(planReleaseBaseline({ releases: [], tags: [] }), {
+    action: "first_release",
+    published_count: 0,
+    version_tag_count: 0,
+  });
+});
+
+test("peels annotated tag refs and ignores non-release tags", () => {
+  assert.deepEqual(
+    versionTagsFromRefs([
+      "refs/tags/v0.46.2",
+      "refs/tags/v0.46.2^{}",
+      "refs/tags/v0.0.0",
+      "refs/tags/nightly",
+      "v0.47.0",
+    ]),
+    ["v0.46.2", "v0.47.0"],
+  );
+});

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -255,7 +255,17 @@ test("release-drafter retains a stable draft tag after formatting", () => {
   assert.match(releaseDrafterConfig, /^tag-prefix: "v"$/m);
 
   const draftJob = workflowJob(workflows["release-draft.yml"], "draft");
-  assert.match(draftJob, /id: release_drafter/);
+  const requireBaselineAt = draftJob.indexOf(
+    "node scripts/require-release-baseline.mjs",
+  );
+  const releaseDrafterAt = draftJob.indexOf("id: release_drafter");
+  assert.notEqual(requireBaselineAt, -1);
+  assert.notEqual(releaseDrafterAt, -1);
+  assert.ok(
+    requireBaselineAt < releaseDrafterAt,
+    "the published baseline must be confirmed before Release Drafter runs",
+  );
+  assert.match(draftJob, /git ls-remote --tags origin 'v\*'/);
   assert.match(
     draftJob,
     /RELEASE_TAG: v\$\{\{ steps\.release_drafter\.outputs\.resolved_version \}\}/,


### PR DESCRIPTION
## Summary

#2167 cleaned up after Release Drafter already created a `v0.0.1` draft. This stops that draft from being created.

The job now lists GitHub Releases and `v*` tags (retrying a few times) and refuses to invoke Release Drafter when version tags exist but no published release is visible. That is the outage that produced the extra draft. The existing post-step still deletes a fallback if Release Drafter loses the race after the check.

## Test plan

- [x] `node --test scripts/require-release-baseline.test.mjs scripts/reconcile-release-drafts.test.mjs scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs`
- [ ] After merge, the next **Release draft** run on `main` should still update the single `v0.47.0` draft