### PR TITLE
feat(desktop): put code-mode git review in a sidebar

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -301,6 +301,7 @@ beforeEach(() => {
     newWorkspaceOpen: false,
     newWorkspaceRepoId: undefined,
     addRepoOpen: false,
+    reviewSidebarOpen: true,
   });
   usePendingPrompts.setState({ chatId: null, userQuestions: [], folderAccess: [] });
   // The stores outlive a test file's renders, so a chat list left behind would

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -22,8 +22,14 @@ import {
   prependReplacementChat,
 } from "./ChatDeletion";
 import { useChatListStore } from "./ChatListStore";
+import { toggleTerminalLayout } from "./code/codeChrome";
 import { useCodeUiStore } from "./code/CodeUiStore";
-import { codeRepoIdFromPath, shellShortcutMode } from "./code/routes";
+import {
+  codeRepoIdFromPath,
+  codeWorkspaceIdFromPath,
+  shellShortcutMode,
+} from "./code/routes";
+import { layoutFromSearch, searchFromLayout, type PanelSearch } from "./panel/panelUrl";
 import { useExperimentalFlags } from "./experimental";
 import { connectOutputs } from "./deliverables";
 import { useProjectListStore } from "./ProjectListStore";
@@ -173,6 +179,20 @@ export function AppShell() {
       useCodeUiStore
         .getState()
         .startNewWorkspace(codeRepoIdFromPath(pathname));
+    },
+    "toggle-code-review": () => {
+      useCodeUiStore.getState().toggleReviewSidebar();
+    },
+    "toggle-code-terminal": () => {
+      const { pathname, search } = router.state.location;
+      const workspaceId = codeWorkspaceIdFromPath(pathname);
+      if (!workspaceId) return;
+      const next = toggleTerminalLayout(layoutFromSearch(search as PanelSearch));
+      void navigate({
+        to: "/code/w/$workspaceId",
+        params: { workspaceId },
+        search: searchFromLayout(next),
+      });
     },
     "focus-composer": focusComposer,
     "zoom-in": zoom.zoomIn,

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
@@ -78,6 +78,30 @@ describe("shell shortcut resolution", () => {
     expect(resolveShellShortcut(cmdN, context({ mode: "code" }))?.id).toBe(
       "code-new-workspace",
     );
+    expect(
+      resolveShellShortcut(
+        keyEvent({ key: "i", code: "KeyI" }),
+        context({ mode: "code" }),
+      )?.id,
+    ).toBe("toggle-code-review");
+    expect(
+      resolveShellShortcut(
+        keyEvent({ key: "j", code: "KeyJ" }),
+        context({ mode: "code" }),
+      )?.id,
+    ).toBe("toggle-code-terminal");
+    expect(
+      resolveShellShortcut(
+        keyEvent({ key: "i", code: "KeyI" }),
+        context({ mode: "chat" }),
+      ),
+    ).toBeNull();
+    expect(
+      resolveShellShortcut(
+        keyEvent({ key: "j", code: "KeyJ" }),
+        context({ mode: "chat" }),
+      ),
+    ).toBeNull();
     // Unscoped shortcuts are the frame's and act the same on both sides.
     expect(
       resolveShellShortcut(keyEvent({}), context({ mode: "code" }))?.id,

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -14,6 +14,8 @@ export type ShellShortcutAction =
   | "toggle-sidebar"
   | "new-chat"
   | "code-new-workspace"
+  | "toggle-code-review"
+  | "toggle-code-terminal"
   | "focus-composer"
   | "zoom-in"
   | "zoom-out"
@@ -147,6 +149,24 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     codes: ["KeyN"],
     mod: true,
     description: "New workspace",
+    group: "Code",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "toggle-code-review",
+    codes: ["KeyI"],
+    mod: true,
+    description: "Show or hide the review sidebar",
+    group: "Code",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "toggle-code-terminal",
+    codes: ["KeyJ"],
+    mod: true,
+    description: "Show or hide the terminal",
     group: "Code",
     scope: "code",
     allowInEditable: true,

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -1,0 +1,135 @@
+import { GitPullRequest, MessageSquare, X } from "lucide-react";
+
+import type { ApiClient } from "../api/client";
+import type {
+  CodeWorkspaceSnapshot,
+  PullRequestDigest,
+} from "../api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { openExternal } from "@/host";
+import { PrCard } from "./PrCard";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+
+/**
+ * Workspace review rail: git sync, pull-request state, and comments.
+ *
+ * The conversation stays the center of the workspace. Commit, push, the PR,
+ * and review discussion live here so they are always one chord away without
+ * sitting on top of the transcript.
+ */
+export function CodeInspector({
+  client,
+  workspaceId,
+  workspace,
+  contentRevision,
+  shortcutHint,
+  onClose,
+}: {
+  client: ApiClient;
+  workspaceId: string;
+  workspace: CodeWorkspaceSnapshot | null;
+  contentRevision: number;
+  shortcutHint?: string;
+  onClose: () => void;
+}) {
+  const digest = useCodeUpdatesStore((state) => state.byWorkspace[workspaceId]);
+  const pr = digest?.pr_state ?? workspace?.pr;
+  const active = workspace?.status !== "archived";
+
+  return (
+    <aside
+      className="flex w-80 shrink-0 flex-col overflow-hidden border-l"
+      aria-label="Review"
+      data-testid="code-inspector"
+    >
+      <header className="flex h-10 shrink-0 items-center gap-2 border-b px-3">
+        <GitPullRequest className="text-muted-foreground size-3.5 shrink-0" />
+        <h2 className="min-w-0 flex-1 truncate text-sm font-medium">Review</h2>
+        <WithTooltip label={shortcutHint ? `Hide sidebar ${shortcutHint}` : "Hide sidebar"}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Hide review sidebar"
+            onClick={onClose}
+          >
+            <X />
+          </Button>
+        </WithTooltip>
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-3 py-3">
+        {active && (
+          <PrCard
+            client={client}
+            workspaceId={workspaceId}
+            contentRevision={contentRevision}
+            framed={false}
+          />
+        )}
+        <ReviewComments pr={pr} />
+      </div>
+    </aside>
+  );
+}
+
+function ReviewComments({ pr }: { pr?: PullRequestDigest }) {
+  return (
+    <section className="flex flex-col gap-2" aria-label="Comments">
+      <header className="flex items-center gap-2">
+        <MessageSquare className="text-muted-foreground size-3.5 shrink-0" />
+        <h3 className="text-sm font-medium">Comments</h3>
+      </header>
+      {pr ? (
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge variant={prStateVariant(pr.state)} size="sm">
+              #{pr.number} {pr.state}
+            </Badge>
+            {pr.checks_summary && (
+              <Badge variant={checksVariant(pr.checks_summary)} size="sm">
+                {pr.checks_summary}
+              </Badge>
+            )}
+          </div>
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            Review comments live on the pull request. Open it to read and reply.
+          </p>
+          {pr.url && (
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              className="self-start"
+              onClick={() => void openExternal(pr.url!).catch(() => undefined)}
+            >
+              Open pull request
+            </Button>
+          )}
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-xs leading-relaxed">
+          Comments and review discussion show up here once this workspace has a
+          pull request.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function prStateVariant(state: string): "success" | "warning" | "critical" | "info" | "outline" {
+  const token = state.toLowerCase();
+  if (token === "open") return "success";
+  if (token === "merged") return "info";
+  if (token === "closed") return "critical";
+  return "outline";
+}
+
+function checksVariant(summary: string): "success" | "warning" | "critical" | "info" | "outline" {
+  const lower = summary.toLowerCase();
+  if (/\b[1-9]\d* failing/.test(lower)) return "critical";
+  if (/\b[1-9]\d* pending/.test(lower)) return "warning";
+  if (/\b[1-9]\d* passing/.test(lower) || lower.includes("passing")) return "success";
+  return "outline";
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -2,20 +2,46 @@ import { create } from "zustand";
 
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 
+const REVIEW_SIDEBAR_OPEN_KEY = "tidebreak.code-review-sidebar-open";
+
+function readStoredReviewSidebarOpen(): boolean {
+  try {
+    const raw = window.localStorage.getItem(REVIEW_SIDEBAR_OPEN_KEY);
+    // Git, the pull request, and comments live here now — open until the
+    // reader hides the rail, then remember that.
+    if (raw == null) return true;
+    return raw === "true";
+  } catch {
+    return true;
+  }
+}
+
+function storeReviewSidebarOpen(open: boolean): void {
+  try {
+    window.localStorage.setItem(REVIEW_SIDEBAR_OPEN_KEY, String(open));
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
 /**
- * Code mode's dialog state, held outside the components that draw it.
+ * Code mode's dialog and chrome state, held outside the components that draw it.
  *
  * The new-workspace flow is reachable from three places — the rail, a repo
  * page, and Cmd+N — and only one of them is a component the shell can see. A
  * store lets the shortcut open the dialog without the shell importing code
  * mode's surfaces, and keeps a single dialog instance rather than one per
  * button that opens it.
+ *
+ * The review rail is the same kind of chrome as the left sidebar: it is not
+ * a URL, and a reload should not forget whether it was showing.
  */
 export type CodeUiStore = {
   newWorkspaceOpen: boolean;
   /** The repo the dialog opens locked to, when it was opened from one. */
   newWorkspaceRepoId: string | undefined;
   addRepoOpen: boolean;
+  reviewSidebarOpen: boolean;
   /**
    * Ask for a workspace, from a repo page or from anywhere in code mode.
    *
@@ -26,12 +52,15 @@ export type CodeUiStore = {
   startNewWorkspace: (repoId?: string) => void;
   setNewWorkspaceOpen: (open: boolean) => void;
   setAddRepoOpen: (open: boolean) => void;
+  toggleReviewSidebar: () => void;
+  setReviewSidebarOpen: (open: boolean) => void;
 };
 
 export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   newWorkspaceOpen: false,
   newWorkspaceRepoId: undefined,
   addRepoOpen: false,
+  reviewSidebarOpen: readStoredReviewSidebarOpen(),
   startNewWorkspace: (repoId) => {
     const { repos } = useCodeCatalogStore.getState();
     if (repos.length === 0) {
@@ -46,4 +75,14 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   },
   setNewWorkspaceOpen: (open) => set({ newWorkspaceOpen: open }),
   setAddRepoOpen: (open) => set({ addRepoOpen: open }),
+  toggleReviewSidebar: () =>
+    set((state) => {
+      const reviewSidebarOpen = !state.reviewSidebarOpen;
+      storeReviewSidebarOpen(reviewSidebarOpen);
+      return { reviewSidebarOpen };
+    }),
+  setReviewSidebarOpen: (open) => {
+    storeReviewSidebarOpen(open);
+    set({ reviewSidebarOpen: open });
+  },
 }));

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -14,8 +14,33 @@ import {
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { PanelSearch } from "@/panel/panelUrl";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeWorkspacePage } from "./CodeWorkspacePage";
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    write(_data: string, cb?: () => void) {
+      cb?.();
+    }
+    loadAddon() {}
+    open() {}
+    dispose() {}
+    onData() {
+      return { dispose() {} };
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}));
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), message: vi.fn() },
@@ -84,6 +109,33 @@ function makeClient() {
           removeEventListener() {},
         }) as unknown as WebSocket,
     ),
+    listCodeTerminals: vi.fn(async () => []),
+    createCodeTerminal: vi.fn(async () => ({
+      id: "term-1",
+      workspace_id: "ws-1",
+      cols: 80,
+      rows: 24,
+      ended: false,
+      created_at: "2026-08-15T00:00:00.000Z",
+    })),
+    readCodeTerminal: vi.fn(async () => ({
+      id: "term-1",
+      workspace_id: "ws-1",
+      bytes: "",
+      cursor: 0,
+      overflow: false,
+      truncated: false,
+      ended: false,
+    })),
+    writeCodeTerminal: vi.fn(async () => undefined),
+    resizeCodeTerminal: vi.fn(async () => ({
+      id: "term-1",
+      workspace_id: "ws-1",
+      cols: 80,
+      rows: 24,
+      ended: false,
+      created_at: "2026-08-15T00:00:00.000Z",
+    })),
   };
 }
 
@@ -177,6 +229,7 @@ afterEach(() => {
   useCodeCatalogStore.getState().reset();
   disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
+  useCodeUiStore.setState({ reviewSidebarOpen: true });
 });
 
 describe("CodeWorkspacePage", () => {
@@ -186,7 +239,7 @@ describe("CodeWorkspacePage", () => {
     const user = userEvent.setup();
 
     expect(
-      await screen.findByRole("heading", { name: "Fix login" }),
+      await screen.findByRole("heading", { name: /Fix login/ }),
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Archive" }));
@@ -200,7 +253,34 @@ describe("CodeWorkspacePage", () => {
     );
     expect(client.archiveCodeWorkspace).toHaveBeenCalledWith("ws-1", false);
     expect(
-      screen.queryByRole("heading", { name: "Fix login" }),
+      screen.queryByRole("heading", { name: /Fix login/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps git and comments in the review sidebar, and opens the terminal as a drawer", async () => {
+    const client = makeClient();
+    const { router } = await mountWorkspace(client);
+    const user = userEvent.setup();
+
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+
+    const inspector = screen.getByTestId("code-inspector");
+    expect(
+      within(inspector).getByRole("region", { name: "Pull request" }),
+    ).toBeInTheDocument();
+    expect(
+      within(inspector).getByRole("region", { name: "Comments" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Terminal" }));
+
+    expect(await screen.findByTestId("terminal-drawer")).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: /Terminal/i })).not.toBeInTheDocument();
+    expect(router.state.location.search).toMatchObject({ tabs: "terminal" });
+
+    await user.click(screen.getByRole("button", { name: "Hide review sidebar" }));
+    expect(screen.queryByTestId("code-inspector")).not.toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { FileCode, Files, FolderOpen, SquareTerminal } from "lucide-react";
+import { FileCode, Files, FolderOpen, GitPullRequest, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
 import { archiveForceKind, type ApiClient } from "../api/client";
@@ -17,18 +17,27 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ClipboardCopyButton } from "@/ClipboardCopyButton";
 import { useConfirm } from "@/components/ConfirmDialog";
+import { WithTooltip } from "@/components/ui/tooltip";
 import { openExternal } from "@/host";
 import { PanelLayout } from "@/panel/PanelLayout";
 import type { PanelContent } from "@/panel/panelTypes";
 import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
 import { RouteFrame } from "@/RouteFrame";
 import { friendlyErrorMessage } from "@/lib/utils";
+import {
+  SHELL_SHORTCUTS,
+  shortcutKeycaps,
+  usesCommandModifier,
+  type ShellShortcutAction,
+} from "@/ShellShortcuts";
 import { AttentionBadge } from "./AttentionBadge";
+import { splitCodeChromeLayout } from "./codeChrome";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { CodeInspector } from "./CodeInspector";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { useCodeUiStore } from "./CodeUiStore";
 import { liveCodeSession } from "./parsers";
 import { CodeComposer } from "./CodeComposer";
-import { PrCard } from "./PrCard";
 import {
   acquireCodeSessionFromClient,
   releaseCodeSession,
@@ -39,6 +48,7 @@ import { CodeTranscript } from "./CodeTranscript";
 import { DiffPanel } from "./DiffPanel";
 import { FilesPanel } from "./FilesPanel";
 import { StartSessionPrompt } from "./StartSessionPrompt";
+import { TerminalDrawer } from "./TerminalDrawer";
 import { TerminalPane } from "./TerminalPane";
 import { useCodeContentRevision } from "./useLiveContent";
 import {
@@ -72,7 +82,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const navigate = useNavigate();
   const catalog = useCodeCatalogStore();
   const layout = useLayoutState();
-  const { openPanel } = usePanelNav();
+  const { openPanel, closeTab } = usePanelNav();
+  const chrome = splitCodeChromeLayout(layout);
+  const reviewSidebarOpen = useCodeUiStore((state) => state.reviewSidebarOpen);
+  const toggleReviewSidebar = useCodeUiStore((state) => state.toggleReviewSidebar);
+  const setReviewSidebarOpen = useCodeUiStore((state) => state.setReviewSidebarOpen);
+  const shortcutHints = useCodeShortcutHints();
   const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(null);
   const [repo, setRepo] = useState<CodeRepoSnapshot | null>(null);
   const [session, setSession] = useState<CodeSessionSnapshot | null>(
@@ -154,7 +169,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     const ok = await confirm({
       title: "Archive this workspace?",
       description:
-        "The worktree is removed. Commit, push, or create a pull request from the card on this page first if you want to keep the work.",
+        "The worktree is removed. Commit, push, or create a pull request from the review sidebar first if you want to keep the work.",
       confirmLabel: "Archive",
       destructive: true,
     });
@@ -165,7 +180,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       if (archiveForceKind(err)) {
         const forced = await confirm({
           title: "Discard leftover work?",
-          description: `${err instanceof Error ? err.message : String(err)} Commit and push from the pull-request card on this page, or discard.`,
+          description: `${err instanceof Error ? err.message : String(err)} Commit and push from the review sidebar, or discard.`,
           confirmLabel: "Discard and archive",
           destructive: true,
         });
@@ -218,11 +233,17 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       <header className="flex shrink-0 flex-col gap-2 border-b px-4 py-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="min-w-0">
-            <h1 className="truncate text-lg font-medium">
-              {digest?.title ?? workspace?.title ?? "Workspace"}
+            <h1 className="flex min-w-0 items-center gap-1.5 text-sm font-medium">
+              <span className="text-muted-foreground truncate">
+                {repo?.display_name ?? workspace?.repo_id ?? "Repo"}
+              </span>
+              <span className="text-muted-foreground/70 shrink-0">/</span>
+              <span className="truncate">
+                {digest?.title ?? workspace?.title ?? "Workspace"}
+              </span>
             </h1>
             <p className="text-muted-foreground truncate text-xs">
-              {repo?.display_name ?? workspace?.repo_id} · {workspace?.branch_name}
+              {workspace?.branch_name}
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -261,15 +282,45 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
               <FileCode />
               Diff
             </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              onClick={() => openPanel({ type: "terminal" })}
+            <WithTooltip
+              label={
+                chrome.terminal
+                  ? `Hide terminal ${shortcutHints.terminal}`
+                  : `Terminal ${shortcutHints.terminal}`
+              }
             >
-              <SquareTerminal />
-              Terminal
-            </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                aria-pressed={chrome.terminal !== null}
+                onClick={() => {
+                  if (chrome.terminal) closeTab(chrome.terminal);
+                  else openPanel({ type: "terminal" });
+                }}
+              >
+                <SquareTerminal />
+                Terminal
+              </Button>
+            </WithTooltip>
+            <WithTooltip
+              label={
+                reviewSidebarOpen
+                  ? `Hide review sidebar ${shortcutHints.review}`
+                  : `Review sidebar ${shortcutHints.review}`
+              }
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                aria-pressed={reviewSidebarOpen}
+                onClick={() => toggleReviewSidebar()}
+              >
+                <GitPullRequest />
+                Review
+              </Button>
+            </WithTooltip>
             {workspace && workspace.status !== "archived" && (
               <Button type="button" variant="ghost" size="xs" onClick={() => void archive()}>
                 Archive
@@ -305,60 +356,89 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         )}
       </header>
       {error && <p className="text-critical px-4 py-2 text-sm">{error}</p>}
-      <PanelLayout
-        layout={layout}
-        renderChat={(visible) => (
-          // The panel slot this sits in is a plain block, so nothing stretches
-          // the pane to the slot's height — `flex-1` resolves to nothing and
-          // the transcript never becomes a scroller. It claims the height
-          // itself, the same way `.chat-pane` does.
-          <div
-            className="flex h-full min-h-0 flex-col overflow-hidden"
-            hidden={!visible}
-          >
-            {workspace && workspace.status !== "archived" && (
-              <div className="px-4 pt-3">
-                <PrCard
-                  client={client}
-                  workspaceId={workspace.id}
-                  contentRevision={contentRevision}
-                />
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          <PanelLayout
+            layout={chrome.panels}
+            framed={false}
+            renderChat={(visible) => (
+              // The panel slot this sits in is a plain block, so nothing stretches
+              // the pane to the slot's height — `flex-1` resolves to nothing and
+              // the transcript never becomes a scroller. It claims the height
+              // itself, the same way `.chat-pane` does.
+              <div
+                className="flex h-full min-h-0 flex-col overflow-hidden"
+                hidden={!visible}
+              >
+                {fenced && session?.fence_reason && (
+                  <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
+                    <p>{fenceReasonText(session.fence_reason)}</p>
+                    <Button type="button" size="sm" className="self-start" onClick={() => void reap()}>
+                      Reap
+                    </Button>
+                  </div>
+                )}
+                {!session && workspace?.status === "active" && (
+                  <StartSessionPrompt
+                    harnesses={doctorHarnesses}
+                    starting={starting}
+                    selectedMode={createMode}
+                    onSelectMode={setCreateMode}
+                    onStart={(harness, mode) => void startSession(harness, mode)}
+                  />
+                )}
+                {session && (
+                  <CodeSessionPane
+                    key={session.id}
+                    session={session}
+                    client={client}
+                    disabled={fenced || workspace?.status !== "active"}
+                    onOpenTurnDiff={(turnId) => openPanel({ type: "diff", turnId })}
+                  />
+                )}
               </div>
             )}
-            {fenced && session?.fence_reason && (
-              <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
-                <p>{fenceReasonText(session.fence_reason)}</p>
-                <Button type="button" size="sm" className="self-start" onClick={() => void reap()}>
-                  Reap
-                </Button>
-              </div>
-            )}
-            {!session && workspace?.status === "active" && (
-              <StartSessionPrompt
-                harnesses={doctorHarnesses}
-                starting={starting}
-                selectedMode={createMode}
-                onSelectMode={setCreateMode}
-                onStart={(harness, mode) => void startSession(harness, mode)}
-              />
-            )}
-            {session && (
-              <CodeSessionPane
-                key={session.id}
-                session={session}
-                client={client}
-                disabled={fenced || workspace?.status !== "active"}
-                onOpenTurnDiff={(turnId) => openPanel({ type: "diff", turnId })}
-              />
-            )}
-          </div>
+            renderPanel={(panel) =>
+              renderCodePanel(panel, client, workspaceId, openPanel, contentRevision)
+            }
+          />
+          {chrome.terminal && (
+            <TerminalDrawer
+              client={client}
+              workspaceId={workspaceId}
+              shortcutHint={shortcutHints.terminal}
+              onClose={() => closeTab(chrome.terminal!)}
+            />
+          )}
+        </div>
+        {reviewSidebarOpen && (
+          <CodeInspector
+            client={client}
+            workspaceId={workspaceId}
+            workspace={workspace}
+            contentRevision={contentRevision}
+            shortcutHint={shortcutHints.review}
+            onClose={() => setReviewSidebarOpen(false)}
+          />
         )}
-        renderPanel={(panel) =>
-          renderCodePanel(panel, client, workspaceId, openPanel, contentRevision)
-        }
-      />
+      </div>
     </>
   );
+}
+
+function useCodeShortcutHints(): { review: string; terminal: string } {
+  return useMemo(() => {
+    const command = usesCommandModifier(navigator.userAgent);
+    return {
+      review: shortcutHint("toggle-code-review", command),
+      terminal: shortcutHint("toggle-code-terminal", command),
+    };
+  }, []);
+}
+
+function shortcutHint(id: ShellShortcutAction, command: boolean): string {
+  const def = SHELL_SHORTCUTS.find((item) => item.id === id);
+  return def ? shortcutKeycaps(def, command).join("") : "";
 }
 
 function renderCodePanel(

--- a/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
@@ -29,6 +29,7 @@ export function PrCard({
   client,
   workspaceId,
   contentRevision = 0,
+  framed = true,
 }: {
   client: Pick<
     ApiClient,
@@ -40,6 +41,8 @@ export function PrCard({
   workspaceId: string;
   /** Bumped by the session journal when the worktree may have moved. */
   contentRevision?: number;
+  /** When false, drop the card chrome — the host already frames this. */
+  framed?: boolean;
 }) {
   const [message, setMessage] = useState("");
   const [busy, setBusy] = useState<"commit" | "push" | "pr" | null>(null);
@@ -133,6 +136,7 @@ export function PrCard({
       message={message}
       busy={busy}
       refreshing={refreshing}
+      framed={framed}
       onMessageChange={setMessage}
       onCommit={() => void commit()}
       onPush={() => void push()}
@@ -148,6 +152,7 @@ export function PrCardView({
   message,
   busy,
   refreshing = false,
+  framed = true,
   onMessageChange,
   onCommit,
   onPush,
@@ -159,6 +164,7 @@ export function PrCardView({
   message: string;
   busy: "commit" | "push" | "pr" | null;
   refreshing?: boolean;
+  framed?: boolean;
   onMessageChange: (value: string) => void;
   onCommit: () => void;
   onPush: () => void;
@@ -181,7 +187,11 @@ export function PrCardView({
 
   return (
     <section
-      className="border-border bg-card flex flex-col gap-3 rounded-lg border px-3 py-3"
+      className={
+        framed
+          ? "border-border bg-card flex flex-col gap-3 rounded-lg border px-3 py-3"
+          : "flex flex-col gap-3"
+      }
       aria-label="Pull request"
     >
       <header className="flex flex-wrap items-center justify-between gap-2">

--- a/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+import { SquareTerminal, X } from "lucide-react";
+
+import type { ApiClient } from "../api/client";
+import { Button } from "@/components/ui/button";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { TerminalPane } from "./TerminalPane";
+
+const DEFAULT_HEIGHT = 240;
+const MIN_HEIGHT = 140;
+const MAX_HEIGHT = 560;
+
+/**
+ * Auxiliary shell as a bottom drawer under the conversation.
+ *
+ * The PTY is the same ephemeral surface as before; only where it sits
+ * changed. Height is local to this mount — a reload starts at the default
+ * again, which matches terminals that do not survive a restart.
+ */
+export function TerminalDrawer({
+  client,
+  workspaceId,
+  shortcutHint,
+  onClose,
+}: {
+  client: ApiClient;
+  workspaceId: string;
+  shortcutHint?: string;
+  onClose: () => void;
+}) {
+  const [height, setHeight] = useState(DEFAULT_HEIGHT);
+  const dragRef = useRef<{ startY: number; startHeight: number } | null>(null);
+
+  useEffect(() => {
+    function onMove(event: PointerEvent) {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const next = drag.startHeight + (drag.startY - event.clientY);
+      setHeight(Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, next)));
+    }
+    function onUp() {
+      dragRef.current = null;
+    }
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+  }, []);
+
+  return (
+    <aside
+      className="flex shrink-0 flex-col overflow-hidden border-t"
+      style={{ height }}
+      aria-label="Terminal"
+      data-testid="terminal-drawer"
+    >
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize terminal"
+        className="hover:bg-muted flex h-1.5 shrink-0 cursor-ns-resize items-center justify-center"
+        onPointerDown={(event) => {
+          event.preventDefault();
+          dragRef.current = { startY: event.clientY, startHeight: height };
+        }}
+      >
+        <span className="bg-border h-0.5 w-8 rounded-full" />
+      </div>
+      <header className="flex h-8 shrink-0 items-center gap-2 px-3">
+        <SquareTerminal className="text-muted-foreground size-3.5 shrink-0" />
+        <h2 className="min-w-0 flex-1 truncate text-xs font-medium">Terminal</h2>
+        <WithTooltip label={shortcutHint ? `Hide terminal ${shortcutHint}` : "Hide terminal"}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Hide terminal"
+            onClick={onClose}
+          >
+            <X />
+          </Button>
+        </WithTooltip>
+      </header>
+      <TerminalPane client={client} workspaceId={workspaceId} hideHeader />
+    </aside>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -26,6 +26,7 @@ const TRUNCATION_TEXT = "[output truncated]";
 export function TerminalPane({
   client,
   workspaceId,
+  hideHeader = false,
 }: {
   client: Pick<
     ApiClient,
@@ -36,6 +37,8 @@ export function TerminalPane({
     | "resizeCodeTerminal"
   >;
   workspaceId: string;
+  /** The drawer already names this surface. */
+  hideHeader?: boolean;
 }) {
   const hostRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -103,9 +106,13 @@ export function TerminalPane({
       }
     };
     window.addEventListener("resize", onResize);
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(onResize);
+    observer?.observe(host);
 
     return () => {
       window.removeEventListener("resize", onResize);
+      observer?.disconnect();
       host.removeEventListener("keydown", onKeyDownCapture, true);
       dataSub.dispose();
       term.dispose();
@@ -222,9 +229,11 @@ export function TerminalPane({
       className="flex min-h-0 flex-1 flex-col overflow-hidden"
       data-testid="terminal-pane"
     >
-      <header className="flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2">
-        <h2 className="text-sm font-medium">Terminal</h2>
-      </header>
+      {!hideHeader && (
+        <header className="flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2">
+          <h2 className="text-sm font-medium">Terminal</h2>
+        </header>
+      )}
       {overflow && (
         <p className="text-muted-foreground px-3 py-2 text-xs" data-testid="terminal-truncated">
           Output was truncated.

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { EMPTY_LAYOUT } from "@/panel/panelTypes";
+import { splitCodeChromeLayout, toggleTerminalLayout } from "./codeChrome";
+
+describe("code chrome layout", () => {
+  it("keeps files and diff in the side region and lifts the terminal out", () => {
+    const layout = {
+      tabs: [
+        { type: "files" as const },
+        { type: "terminal" as const },
+        { type: "diff" as const },
+      ],
+      activeIndex: 1,
+      fullscreen: false,
+    };
+
+    expect(splitCodeChromeLayout(layout)).toEqual({
+      panels: {
+        tabs: [{ type: "files" }, { type: "diff" }],
+        activeIndex: 1,
+        fullscreen: false,
+      },
+      terminal: { type: "terminal" },
+    });
+  });
+
+  it("leaves a terminal-only layout as the conversation plus a drawer", () => {
+    expect(
+      splitCodeChromeLayout({
+        tabs: [{ type: "terminal" }],
+        activeIndex: 0,
+        fullscreen: true,
+      }),
+    ).toEqual({
+      panels: EMPTY_LAYOUT,
+      terminal: { type: "terminal" },
+    });
+  });
+
+  it("opens and closes the terminal without dropping the other tabs", () => {
+    const withFiles = {
+      tabs: [{ type: "files" as const }],
+      activeIndex: 0,
+      fullscreen: false,
+    };
+
+    const opened = toggleTerminalLayout(withFiles);
+    expect(opened.tabs).toEqual([{ type: "files" }, { type: "terminal" }]);
+    expect(toggleTerminalLayout(opened)).toEqual(withFiles);
+    expect(toggleTerminalLayout(EMPTY_LAYOUT).tabs).toEqual([{ type: "terminal" }]);
+    expect(toggleTerminalLayout(toggleTerminalLayout(EMPTY_LAYOUT))).toEqual(
+      EMPTY_LAYOUT,
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -1,0 +1,69 @@
+import { EMPTY_LAYOUT, type LayoutState, type PanelContent } from "@/panel/panelTypes";
+
+/**
+ * Split a workspace layout into the panels that sit beside the conversation
+ * and the terminal, which the workspace draws as a bottom drawer instead.
+ *
+ * The terminal stays in the URL so a reload or a shared link still opens it.
+ * Only the rendering changes: it is not a tab in the side region.
+ */
+export function splitCodeChromeLayout(layout: LayoutState): {
+  panels: LayoutState;
+  terminal: Extract<PanelContent, { type: "terminal" }> | null;
+} {
+  const terminalIndex = layout.tabs.findIndex((tab) => tab.type === "terminal");
+  if (terminalIndex === -1) {
+    return { panels: layout, terminal: null };
+  }
+
+  const terminal = layout.tabs[terminalIndex] as Extract<
+    PanelContent,
+    { type: "terminal" }
+  >;
+  const tabs = layout.tabs.filter((_, index) => index !== terminalIndex);
+  if (tabs.length === 0) {
+    return { panels: EMPTY_LAYOUT, terminal };
+  }
+
+  let activeIndex = layout.activeIndex;
+  if (terminalIndex < activeIndex) activeIndex -= 1;
+  else if (terminalIndex === activeIndex) {
+    activeIndex = Math.min(terminalIndex, tabs.length - 1);
+  }
+
+  return {
+    panels: {
+      tabs,
+      activeIndex: Math.max(0, Math.min(activeIndex, tabs.length - 1)),
+      fullscreen: layout.fullscreen,
+    },
+    terminal,
+  };
+}
+
+/** Open the terminal drawer, or close it if it is already in the layout. */
+export function toggleTerminalLayout(layout: LayoutState): LayoutState {
+  const index = layout.tabs.findIndex((tab) => tab.type === "terminal");
+  if (index === -1) {
+    return {
+      ...layout,
+      tabs: [...layout.tabs, { type: "terminal" }],
+      activeIndex: layout.tabs.length,
+    };
+  }
+
+  const tabs = layout.tabs.filter((_, at) => at !== index);
+  if (tabs.length === 0) return EMPTY_LAYOUT;
+
+  let activeIndex = layout.activeIndex;
+  if (index < activeIndex) activeIndex -= 1;
+  else if (index === activeIndex) {
+    activeIndex = Math.min(index, tabs.length - 1);
+  }
+  return {
+    ...layout,
+    tabs,
+    activeIndex: Math.max(0, Math.min(activeIndex, tabs.length - 1)),
+    fullscreen: layout.fullscreen && tabs.length > 0,
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/routes.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/routes.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { codeRepoIdFromPath, isCodeRoute, shellShortcutMode } from "./routes";
+import {
+  codeRepoIdFromPath,
+  codeWorkspaceIdFromPath,
+  isCodeRoute,
+  shellShortcutMode,
+} from "./routes";
 
 describe("code routes", () => {
   it("reads mode and repo from the path the reader is on", () => {
@@ -16,5 +21,9 @@ describe("code routes", () => {
     expect(codeRepoIdFromPath("/code/r/repo-1")).toBe("repo-1");
     expect(codeRepoIdFromPath("/code/w/ws-1")).toBeUndefined();
     expect(codeRepoIdFromPath("/code")).toBeUndefined();
+
+    expect(codeWorkspaceIdFromPath("/code/w/ws-1")).toBe("ws-1");
+    expect(codeWorkspaceIdFromPath("/code/r/repo-1")).toBeUndefined();
+    expect(codeWorkspaceIdFromPath("/code")).toBeUndefined();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/routes.ts
+++ b/crates/tidebreak-desktop/ui/src/code/routes.ts
@@ -29,3 +29,15 @@ export function codeRepoIdFromPath(pathname: string): string | undefined {
   const match = /^\/code\/r\/([^/]+)$/.exec(pathname);
   return match?.[1];
 }
+
+/**
+ * The workspace a path is showing, when it is showing one.
+ *
+ * The terminal drawer and review-sidebar shortcuts only mean something on a
+ * workspace, so the shell reads the id from here the same way Cmd+N reads
+ * the repo.
+ */
+export function codeWorkspaceIdFromPath(pathname: string): string | undefined {
+  const match = /^\/code\/w\/([^/]+)$/.exec(pathname);
+  return match?.[1];
+}

--- a/crates/tidebreak-desktop/ui/src/panel/PanelLayout.tsx
+++ b/crates/tidebreak-desktop/ui/src/panel/PanelLayout.tsx
@@ -33,6 +33,7 @@ export function PanelLayout({
   tabLabel,
   renderChat,
   renderPanel,
+  framed = true,
 }: {
   layout: LayoutState;
   /** Name tabs after the things they show; see {@link PanelTabs}. */
@@ -45,6 +46,12 @@ export function PanelLayout({
   renderChat: (visible: boolean) => ReactNode;
   /** Only the tab showing is rendered; the rest are addresses, not mounts. */
   renderPanel: (panel: PanelContent) => ReactNode;
+  /**
+   * The card chrome. Chat relies on this group being the card. A host that
+   * already frames the workspace — header, review rail, terminal drawer —
+   * turns it off so the group is only the split.
+   */
+  framed?: boolean;
 }) {
   const groupRef = useRef<ImperativePanelGroupHandle>(null);
   const [dragging, setDragging] = useState(false);
@@ -76,7 +83,8 @@ export function PanelLayout({
         // min-w-0 stops the group's content-driven min-content width from
         // pushing the row wider than its flex basis, which is what let panel
         // content squeeze the sidebar rail beside it.
-        "content-container min-h-0 w-full max-w-full min-w-0 flex-1 overflow-clip",
+        "min-h-0 w-full max-w-full min-w-0 flex-1 overflow-clip",
+        framed && "content-container",
       )}
       data-dragging={dragging || undefined}
     >

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -295,8 +295,9 @@ boundary applies to `gh` exactly as to harnesses). Absent or signed-out
 Routes (code-defined, hash history, in `ui/src/router.tsx`): `/code` (repo
 rail, doctor-driven empty state), `/code/r/$repoId` (workspace list,
 new-workspace flow, repo settings), `/code/w/$workspaceId` (the main
-surface; files, diff, and terminal open through the existing panel system —
-new `PanelContent` variants).
+surface; files and diff open through the existing panel system; the
+terminal opens as a bottom drawer; git, pull-request state, and comments
+live in a review sidebar).
 
 `ui/src/code/`:
 
@@ -316,11 +317,12 @@ new `PanelContent` variants).
   code-mode `ToolDetail` renderer; new `CodeApprovalCard` (chat's approval
   visual language, deny opens a feedback field), `TurnReviewCard`
   (diffstat, duration, async narrative slot), `CodeComposer` (text,
-  permission-mode selector, interrupt), `PrCard` (status-quad chips),
+  permission-mode selector, interrupt), `PrCard` (status-quad chips, hosted
+  in the review sidebar), `CodeInspector` (git sync, PR state, comments),
   `DiffPanel`/`FilesPanel` (server-produced unified diffs styled with the
   semantic status tokens; per-file grouping; per-turn anchoring),
-  `TerminalPane` (ephemeral renderer over the cursor-read API; replays
-  recent bytes on mount; chunked writes on a frame budget).
+  `TerminalDrawer`/`TerminalPane` (ephemeral renderer over the cursor-read
+  API; replays recent bytes on mount; chunked writes on a frame budget).
 - Settings: one new section, "Coding harnesses" — the doctor.
 - Wire: generated types plus hand-written validators in
   `ui/src/code/parsers.ts`, per [`docs/wire-types.md`](wire-types.md).


### PR DESCRIPTION
## What

Code-mode workspaces now keep the conversation in the center and move git work off it.

- **Review sidebar** (⌘I / Ctrl+I): commit, push, PR create, PR state, and a comments section. Preference is remembered.
- **Terminal drawer** (⌘J / Ctrl+J): the auxiliary shell opens under the conversation instead of as a side-panel tab. Existing `?tabs=terminal` links still open it.
- Files and diff stay in the existing side-panel region.

The comments section is the home for review discussion. There is still no comments API, so a PR links out and an empty workspace says comments appear after one exists.

## Why

Git sync and PR state were sitting on top of the transcript. The conversation should stay readable; review belongs in chrome that can be toggled.

## Tests

- Shortcut table: ⌘I / ⌘J fire only in code mode
- Layout helper: terminal is lifted out of the side region
- Workspace page: PR/comments render in the review rail; Terminal opens a drawer, not a tab