### PR TITLE
fix(desktop): keep review strip indexes independent of the terminal drawer

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.dom.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SHELL_SHORTCUTS,
+  useShellShortcuts,
+  usesCommandModifier,
+  type ShellShortcutAction,
+  type ShellShortcutHandlers,
+} from "./ShellShortcuts";
+import { TerminalPane } from "./code/TerminalPane";
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    write(_data: string, cb?: () => void) {
+      cb?.();
+    }
+    loadAddon() {}
+    open() {}
+    dispose() {}
+    onData() {
+      return { dispose() {} };
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}));
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+afterEach(cleanup);
+
+function noopHandlers(
+  overrides: Partial<ShellShortcutHandlers> = {},
+): ShellShortcutHandlers {
+  const handlers = {} as ShellShortcutHandlers;
+  for (const def of SHELL_SHORTCUTS) {
+    handlers[def.id] = () => {};
+  }
+  return { ...handlers, ...overrides };
+}
+
+function Harness({
+  handlers,
+}: {
+  handlers: ShellShortcutHandlers;
+}) {
+  useShellShortcuts(handlers, () => "code");
+  const client = {
+    listCodeTerminals: vi.fn().mockResolvedValue([]),
+    createCodeTerminal: vi.fn().mockResolvedValue({
+      id: "term-1",
+      workspace_id: "ws-1",
+      cols: 80,
+      rows: 24,
+      ended: false,
+      created_at: "2026-08-15T12:00:00.000Z",
+    }),
+    readCodeTerminal: vi.fn().mockResolvedValue({
+      id: "term-1",
+      workspace_id: "ws-1",
+      bytes: "",
+      cursor: 0,
+      overflow: false,
+      truncated: false,
+      ended: false,
+    }),
+    writeCodeTerminal: vi.fn().mockResolvedValue(undefined),
+    resizeCodeTerminal: vi.fn().mockResolvedValue({
+      id: "term-1",
+      workspace_id: "ws-1",
+      cols: 80,
+      rows: 24,
+      ended: false,
+      created_at: "2026-08-15T12:00:00.000Z",
+    }),
+  };
+  return <TerminalPane client={client} workspaceId="ws-1" />;
+}
+
+function chord(action: Extract<ShellShortcutAction, "toggle-code-terminal" | "toggle-code-review">) {
+  const command = usesCommandModifier(navigator.userAgent);
+  return new KeyboardEvent("keydown", {
+    key: action === "toggle-code-terminal" ? "j" : "i",
+    code: action === "toggle-code-terminal" ? "KeyJ" : "KeyI",
+    metaKey: command,
+    ctrlKey: !command,
+    bubbles: true,
+    cancelable: true,
+  });
+}
+
+describe("shell shortcut delivery", () => {
+  it("fires Cmd+J and Cmd+I while the terminal host is focused", () => {
+    const fired: ShellShortcutAction[] = [];
+    render(
+      <Harness
+        handlers={noopHandlers({
+          "toggle-code-terminal": () => fired.push("toggle-code-terminal"),
+          "toggle-code-review": () => fired.push("toggle-code-review"),
+        })}
+      />,
+    );
+
+    const host = screen.getByTestId("terminal-host");
+    host.dispatchEvent(chord("toggle-code-terminal"));
+    host.dispatchEvent(chord("toggle-code-review"));
+
+    expect(fired).toEqual(["toggle-code-terminal", "toggle-code-review"]);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -403,6 +403,9 @@ export type ShellShortcutHandlers = Record<ShellShortcutAction, () => void>;
  * `mode` is a getter for the same reason, and because the mode is read from the
  * route: asking for it at keydown keeps the shell out of a re-render on every
  * navigation.
+ *
+ * Capture, not bubble: a focused PTY (and anything else that stops a keydown
+ * from bubbling) would otherwise swallow Cmd+J / Cmd+I before this ran.
  */
 export function useShellShortcuts(
   handlers: ShellShortcutHandlers,
@@ -427,7 +430,7 @@ export function useShellShortcuts(
       event.preventDefault();
       handlersRef.current[def.id]();
     }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
   }, []);
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -109,6 +109,16 @@ function makeClient() {
           removeEventListener() {},
         }) as unknown as WebSocket,
     ),
+    listCodeWorkspaceFiles: vi.fn(async () => ({
+      files: [],
+      truncated: false,
+      stat: { files: 0, insertions: 0, deletions: 0, truncated: false },
+    })),
+    getCodeWorkspaceDiff: vi.fn(async () => ({
+      diff: "",
+      truncated: false,
+      stat: { files: 0, insertions: 0, deletions: 0, truncated: false },
+    })),
     listCodeTerminals: vi.fn(async () => []),
     createCodeTerminal: vi.fn(async () => ({
       id: "term-1",
@@ -178,7 +188,10 @@ function appContext(client: ReturnType<typeof makeClient>): AppContextValue {
  * marker instead, so an assertion can tell the two apart the way the running
  * app does.
  */
-async function mountWorkspace(client: ReturnType<typeof makeClient>) {
+async function mountWorkspace(
+  client: ReturnType<typeof makeClient>,
+  initialUrl = "/code/w/ws-1",
+) {
   const rootRoute = createRootRoute();
   const codeRoute = createRoute({
     getParentRoute: () => rootRoute,
@@ -217,7 +230,7 @@ async function mountWorkspace(client: ReturnType<typeof makeClient>) {
       codeRepoRoute,
       codeWorkspaceRoute,
     ]),
-    history: createMemoryHistory({ initialEntries: ["/code/w/ws-1"] }),
+    history: createMemoryHistory({ initialEntries: [initialUrl] }),
   });
   await router.load();
   const result = render(<RouterProvider router={router as never} />);
@@ -282,5 +295,75 @@ describe("CodeWorkspacePage", () => {
 
     await user.click(screen.getByRole("button", { name: "Hide review sidebar" }));
     expect(screen.queryByTestId("code-inspector")).not.toBeInTheDocument();
+  });
+
+  it("selects and closes the strip tab even when the terminal sits between them", async () => {
+    const client = makeClient();
+    const { router } = await mountWorkspace(
+      client,
+      "/code/w/ws-1?tabs=files,terminal,diff",
+    );
+    const user = userEvent.setup();
+
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Files" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.queryByRole("tab", { name: /Terminal/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Diff" }));
+    await waitFor(() =>
+      expect(router.state.location.search).toEqual({
+        tabs: "files,terminal,diff",
+        active: "diff",
+      }),
+    );
+    expect(screen.getByRole("tab", { name: "Diff" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(await screen.findByRole("heading", { name: "Diff" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close Diff" }));
+    await waitFor(() =>
+      expect(router.state.location.search).toEqual({ tabs: "files,terminal" }),
+    );
+    expect(screen.getByTestId("terminal-drawer")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Files" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.queryByRole("tab", { name: "Diff" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the visible files tab selected when the terminal drawer opens", async () => {
+    const client = makeClient();
+    const { router } = await mountWorkspace(client, "/code/w/ws-1?tabs=files,diff");
+    const user = userEvent.setup();
+
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Files" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Terminal" }));
+
+    await waitFor(() =>
+      expect(router.state.location.search).toEqual({
+        tabs: "files,diff,terminal",
+      }),
+    );
+    expect(screen.getByRole("tab", { name: "Files" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("heading", { name: "Changed files" })).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-drawer")).toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -31,7 +31,12 @@ import {
   type ShellShortcutAction,
 } from "@/ShellShortcuts";
 import { AttentionBadge } from "./AttentionBadge";
-import { splitCodeChromeLayout } from "./codeChrome";
+import {
+  closeCodeChromeTab,
+  focusCodeChromeTab,
+  splitCodeChromeLayout,
+  toggleTerminalLayout,
+} from "./codeChrome";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { CodeInspector } from "./CodeInspector";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
@@ -82,7 +87,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const navigate = useNavigate();
   const catalog = useCodeCatalogStore();
   const layout = useLayoutState();
-  const { openPanel, closeTab } = usePanelNav();
+  const { openPanel, closeTab, setLayout } = usePanelNav();
   const chrome = splitCodeChromeLayout(layout);
   const reviewSidebarOpen = useCodeUiStore((state) => state.reviewSidebarOpen);
   const toggleReviewSidebar = useCodeUiStore((state) => state.toggleReviewSidebar);
@@ -294,10 +299,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                 variant="ghost"
                 size="xs"
                 aria-pressed={chrome.terminal !== null}
-                onClick={() => {
-                  if (chrome.terminal) closeTab(chrome.terminal);
-                  else openPanel({ type: "terminal" });
-                }}
+                onClick={() => setLayout(toggleTerminalLayout(layout))}
               >
                 <SquareTerminal />
                 Terminal
@@ -361,6 +363,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           <PanelLayout
             layout={chrome.panels}
             framed={false}
+            onFocusTab={(index) => setLayout(focusCodeChromeTab(layout, index))}
+            onCloseTab={(index) => setLayout(closeCodeChromeTab(layout, index))}
             renderChat={(visible) => (
               // The panel slot this sits in is a plain block, so nothing stretches
               // the pane to the slot's height — `flex-1` resolves to nothing and

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -92,7 +92,8 @@ export function TerminalPane({
         mode: "code",
       });
       if (!def) return;
-      // Let the window listener fire the app shortcut; keep it out of xterm.
+      // The shell listener is on window capture, so it has already fired.
+      // Stopping here keeps the chord out of xterm.
       event.stopPropagation();
     }
     host.addEventListener("keydown", onKeyDownCapture, true);

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
@@ -1,7 +1,22 @@
 import { describe, expect, it } from "vitest";
 
 import { EMPTY_LAYOUT } from "@/panel/panelTypes";
-import { splitCodeChromeLayout, toggleTerminalLayout } from "./codeChrome";
+import {
+  closeCodeChromeTab,
+  focusCodeChromeTab,
+  splitCodeChromeLayout,
+  toggleTerminalLayout,
+} from "./codeChrome";
+
+const filesTerminalDiff = {
+  tabs: [
+    { type: "files" as const },
+    { type: "terminal" as const },
+    { type: "diff" as const },
+  ],
+  activeIndex: 0,
+  fullscreen: false,
+};
 
 describe("code chrome layout", () => {
   it("keeps files and diff in the side region and lifts the terminal out", () => {
@@ -23,6 +38,10 @@ describe("code chrome layout", () => {
       },
       terminal: { type: "terminal" },
     });
+  });
+
+  it("keeps the visible side tab when the URL did not name the terminal", () => {
+    expect(splitCodeChromeLayout(filesTerminalDiff).panels.activeIndex).toBe(0);
   });
 
   it("leaves a terminal-only layout as the conversation plus a drawer", () => {
@@ -52,5 +71,42 @@ describe("code chrome layout", () => {
     expect(toggleTerminalLayout(toggleTerminalLayout(EMPTY_LAYOUT))).toEqual(
       EMPTY_LAYOUT,
     );
+  });
+
+  it("leaves the visible files or diff tab selected when the drawer opens", () => {
+    const layout = {
+      tabs: [{ type: "files" as const }, { type: "diff" as const }],
+      activeIndex: 0,
+      fullscreen: false,
+    };
+
+    const opened = toggleTerminalLayout(layout);
+    expect(opened).toEqual({
+      tabs: [{ type: "files" }, { type: "diff" }, { type: "terminal" }],
+      activeIndex: 0,
+      fullscreen: false,
+    });
+    expect(splitCodeChromeLayout(opened).panels.activeIndex).toBe(0);
+  });
+
+  it("focuses and closes a strip tab without treating the terminal as a strip index", () => {
+    expect(focusCodeChromeTab(filesTerminalDiff, 1)).toEqual({
+      ...filesTerminalDiff,
+      activeIndex: 2,
+    });
+    expect(closeCodeChromeTab(filesTerminalDiff, 1)).toEqual({
+      tabs: [{ type: "files" }, { type: "terminal" }],
+      activeIndex: 0,
+      fullscreen: false,
+    });
+    // Closing the showing Diff tab must land on Files, not the drawer
+    // sitting between them in the URL.
+    expect(
+      closeCodeChromeTab({ ...filesTerminalDiff, activeIndex: 2 }, 1),
+    ).toEqual({
+      tabs: [{ type: "files" }, { type: "terminal" }],
+      activeIndex: 0,
+      fullscreen: false,
+    });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -1,4 +1,9 @@
-import { EMPTY_LAYOUT, type LayoutState, type PanelContent } from "@/panel/panelTypes";
+import {
+  EMPTY_LAYOUT,
+  panelKey,
+  type LayoutState,
+  type PanelContent,
+} from "@/panel/panelTypes";
 
 /**
  * Split a workspace layout into the panels that sit beside the conversation
@@ -28,6 +33,8 @@ export function splitCodeChromeLayout(layout: LayoutState): {
   let activeIndex = layout.activeIndex;
   if (terminalIndex < activeIndex) activeIndex -= 1;
   else if (terminalIndex === activeIndex) {
+    // The URL named the drawer. Pick a remaining side tab rather than
+    // leaving the strip pointing at a hole.
     activeIndex = Math.min(terminalIndex, tabs.length - 1);
   }
 
@@ -41,14 +48,80 @@ export function splitCodeChromeLayout(layout: LayoutState): {
   };
 }
 
+/**
+ * URL-tab index of the side-region tab at `stripIndex`.
+ *
+ * The strip is the URL tabs with the terminal removed, so a click or close
+ * on the strip has to skip over the drawer rather than treat it as a neighbour.
+ */
+function codeChromeUrlIndex(layout: LayoutState, stripIndex: number): number {
+  if (stripIndex < 0) return -1;
+  let remaining = stripIndex;
+  for (let index = 0; index < layout.tabs.length; index += 1) {
+    if (layout.tabs[index]?.type === "terminal") continue;
+    if (remaining === 0) return index;
+    remaining -= 1;
+  }
+  return -1;
+}
+
+/** Bring the side-region tab at `stripIndex` forward, leaving the drawer in place. */
+export function focusCodeChromeTab(layout: LayoutState, stripIndex: number): LayoutState {
+  const urlIndex = codeChromeUrlIndex(layout, stripIndex);
+  if (urlIndex < 0 || urlIndex === layout.activeIndex) return layout;
+  return { ...layout, activeIndex: urlIndex };
+}
+
+/** Close the side-region tab at `stripIndex` and keep the terminal in the URL. */
+export function closeCodeChromeTab(layout: LayoutState, stripIndex: number): LayoutState {
+  const { panels, terminal } = splitCodeChromeLayout(layout);
+  const nextPanels = closeLayoutTab(panels, stripIndex);
+  return mergeTerminalLayout(nextPanels, terminal);
+}
+
+function closeLayoutTab(layout: LayoutState, index: number): LayoutState {
+  if (index < 0 || index >= layout.tabs.length) return layout;
+  const tabs = layout.tabs.filter((_, at) => at !== index);
+  if (tabs.length === 0) return EMPTY_LAYOUT;
+  let activeIndex = layout.activeIndex;
+  if (index < activeIndex) activeIndex -= 1;
+  else if (index === activeIndex) activeIndex = index - 1;
+  return {
+    ...layout,
+    tabs,
+    activeIndex: Math.min(Math.max(activeIndex, 0), tabs.length - 1),
+  };
+}
+
+function mergeTerminalLayout(
+  panels: LayoutState,
+  terminal: Extract<PanelContent, { type: "terminal" }> | null,
+): LayoutState {
+  if (!terminal) return panels;
+  if (panels.tabs.length === 0) {
+    return { tabs: [terminal], activeIndex: 0, fullscreen: false };
+  }
+  const tabs = [...panels.tabs, terminal];
+  const active = panels.tabs[panels.activeIndex];
+  const activeIndex = active
+    ? tabs.findIndex((tab) => panelKey(tab) === panelKey(active))
+    : 0;
+  return {
+    ...panels,
+    tabs,
+    activeIndex: Math.max(0, activeIndex),
+  };
+}
+
 /** Open the terminal drawer, or close it if it is already in the layout. */
 export function toggleTerminalLayout(layout: LayoutState): LayoutState {
   const index = layout.tabs.findIndex((tab) => tab.type === "terminal");
   if (index === -1) {
+    // Leave the still-visible side tab selected. splitCodeChromeLayout remaps
+    // only when a reload or shared link actually named the terminal.
     return {
       ...layout,
       tabs: [...layout.tabs, { type: "terminal" }],
-      activeIndex: layout.tabs.length,
     };
   }
 

--- a/crates/tidebreak-desktop/ui/src/panel/PanelLayout.tsx
+++ b/crates/tidebreak-desktop/ui/src/panel/PanelLayout.tsx
@@ -34,6 +34,8 @@ export function PanelLayout({
   renderChat,
   renderPanel,
   framed = true,
+  onFocusTab,
+  onCloseTab,
 }: {
   layout: LayoutState;
   /** Name tabs after the things they show; see {@link PanelTabs}. */
@@ -52,10 +54,34 @@ export function PanelLayout({
    * turns it off so the group is only the split.
    */
   framed?: boolean;
+  /**
+   * The strip indexes the layout passed in, which a host may have filtered.
+   * Override these when that layout is not the URL's tab list.
+   */
+  onFocusTab?: (index: number) => void;
+  onCloseTab?: (index: number) => void;
 }) {
   const groupRef = useRef<ImperativePanelGroupHandle>(null);
   const [dragging, setDragging] = useState(false);
   const { focusTab, closeTab } = usePanelNav();
+
+  function handleSelect(index: number) {
+    if (onFocusTab) {
+      onFocusTab(index);
+      return;
+    }
+    const panel = layout.tabs[index];
+    if (panel) focusTab(panel);
+  }
+
+  function handleClose(index: number) {
+    if (onCloseTab) {
+      onCloseTab(index);
+      return;
+    }
+    const panel = layout.tabs[index];
+    if (panel) closeTab(panel);
+  }
 
   const hasTabs = layout.tabs.length > 0;
   const fullscreen = hasTabs && layout.fullscreen;
@@ -114,8 +140,8 @@ export function PanelLayout({
                 tabs={layout.tabs}
                 activeIndex={layout.activeIndex}
                 labelFor={tabLabel}
-                onSelect={focusTab}
-                onClose={closeTab}
+                onSelect={handleSelect}
+                onClose={handleClose}
               />
             </div>
             <div className="flex min-h-0 flex-1 flex-col">{renderPanel(panel)}</div>

--- a/crates/tidebreak-desktop/ui/src/panel/usePanelNav.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/usePanelNav.ts
@@ -57,6 +57,11 @@ export function usePanelNav() {
   return {
     layout,
 
+    /** Replace the URL layout wholesale. Used when a host remaps a split. */
+    setLayout(next: LayoutState) {
+      go(next);
+    },
+
     /**
      * Show `panel` in the region beside the conversation.
      *
@@ -108,7 +113,8 @@ export function usePanelNav() {
     },
 
     /** Bring one of the open tabs forward. */
-    focusTab(index: number) {
+    focusTab(target: PanelContent | number) {
+      const index = typeof target === "number" ? target : indexOf(target);
       if (index < 0 || index >= layout.tabs.length || index === layout.activeIndex) return;
       go({ ...layout, activeIndex: index });
     },


### PR DESCRIPTION
Follow-up to #2171. Three bugs that landed with the review sidebar:

1. **Tab strip indexed the unsplit URL layout.** `PanelLayout` received the filtered files/diff tabs but called `focusTab` / `closeTab` against the URL, so Files then Terminal then Diff made clicking or closing Diff select or remove the terminal.
2. **Opening the drawer remapped the visible files/diff tab.** `toggleTerminalLayout` / `openPanel({ type: "terminal" })` made the terminal the active tab; `splitCodeChromeLayout` then remapped that onto another side tab. With Files showing, opening Terminal left Diff selected, and closing the drawer did not restore Files.
3. **Cmd+J / Cmd+I were dead while the PTY was focused.** `TerminalPane` captured the chord and `stopPropagation()`'d it so xterm would not eat it, which also stopped the window bubble listener in `useShellShortcuts`.

The strip now focuses and closes against the filtered tabs and re-merges the terminal into the URL. Opening the drawer leaves the still-visible side tab selected; remapping happens only when the URL actually named the terminal. The shell shortcut listener registers on window capture so a focused PTY cannot swallow the chords.

## Tests

- Strip click/close with the terminal in the middle of the URL tabs
- Opening the terminal drawer keeps the previously visible files/diff tab
- Cmd+J / Cmd+I still fire while the terminal host is focused