### PR TITLE
feat(desktop): ship Windows and Linux packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,10 +480,7 @@ jobs:
     # add `windows-ci` when the change reaches a Windows boundary; main and
     # scheduled/manual runs retain the automatic backstop.
     #
-    # The leading `false` parks the whole lane while Windows packaging is paused
-    # (see docs/deferred.md). The rest of the condition is the live gating
-    # policy, kept intact so resuming is one literal.
-    if: ${{ false && needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'windows-ci')) }}
+    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'windows-ci')) }}
     runs-on: windows-latest
     # Every Rust-scoped main push contains the prior main state, so the newest
     # Windows run proves everything an older in-progress one would have proven.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Leave blank to publish the current draft. Set a tag only to retry that draft or published release.
+        description: Leave blank to publish the current draft. Set a tag only to retry a draft or release created with the current artifact contract.
         required: false
         type: string
 
@@ -607,7 +607,7 @@ jobs:
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 10
+          version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
@@ -615,7 +615,7 @@ jobs:
           cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
       - name: Install UI dependencies
         working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       # The signed bundle ships legal/THIRD-PARTY-NOTICES.md as a resource, so
       # the released tag must not carry a stale copy. Both dependency graphs are
@@ -1057,14 +1057,9 @@ jobs:
   prepare_windows:
     name: prepare unsigned Windows · ${{ matrix.arch }}
     needs: [validate, inspect_hosted]
-    # Windows packaging is paused; see docs/deferred.md. The leading `false`
-    # parks this job and `build_windows` without disturbing the rest of the
-    # release gating, so resuming Windows is flipping two literals plus the
-    # `windows` descriptor in scripts/create-release-manifests.mjs.
     if: >-
       ${{
-        false
-        && needs.validate.outputs.draft == 'true'
+        needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.outputs.exists != 'true'
       }}
     runs-on: windows-latest
@@ -1137,7 +1132,7 @@ jobs:
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 10
+          version: 10.18.3
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
@@ -1145,7 +1140,10 @@ jobs:
           cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
       - name: Install UI dependencies
         working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Verify the third-party notices match the released graph
+        run: node scripts/generate-third-party-notices.mjs --check
 
       - name: Compile without production credentials or bundles
         id: compile
@@ -1183,8 +1181,7 @@ jobs:
     needs: [validate, inspect_hosted, prepare_windows]
     if: >-
       ${{
-        false
-        && always()
+        always()
         && needs.validate.result == 'success'
         && needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.result == 'success'
@@ -1225,11 +1222,10 @@ jobs:
 
       # This restore-only step runs before the updater-signing secret is
       # loaded. The matching cache is written by a credential-free prerequisite
-      # job, and every restorable key pins at minimum the Cargo.lock and
-      # toolchain hashes. The path list must stay byte-identical to the writing
-      # job's — `actions/cache` folds it into the cache version. The next step
-      # deletes the linked products the archive carries, so only compiler
-      # intermediates survive into the packaged build.
+      # job for this exact release commit and version. The path list must stay
+      # byte-identical to the writing job's — `actions/cache` folds it into the
+      # cache version. The next step deletes the linked products the archive
+      # carries, so only compiler intermediates survive into the packaged build.
       - name: Restore unsigned Rust build cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -1247,9 +1243,6 @@ jobs:
             target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
           key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
-          restore-keys: |
-            windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
 
       # A restore extracts the whole archive, including the linked products a
       # prerequisite run left in it. Delete them and let this build relink them
@@ -1402,6 +1395,338 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  prepare_linux:
+    name: prepare unsigned Linux · ${{ matrix.arch }}
+    needs: [validate, inspect_hosted]
+    if: >-
+      ${{
+        needs.validate.outputs.draft == 'true'
+        && needs.inspect_hosted.outputs.exists != 'true'
+      }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-linux-gnu
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_ONLY
+      TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - name: Install Linux packaging dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf
+
+      - name: Install Rust target
+        run: |
+          rustup show
+          rustup target add "${{ matrix.target }}"
+
+      - name: Restore unsigned Rust build cache
+        id: rust-build-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+          key: linux-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          restore-keys: |
+            linux-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            linux-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          shared-key: linux-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: true
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        working-directory: crates/tidebreak-desktop/ui
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Verify the third-party notices match the released graph
+        run: node scripts/generate-third-party-notices.mjs --check
+
+      - name: Compile without production credentials or bundles
+        id: compile
+        continue-on-error: true
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
+        with:
+          projectPath: crates/tidebreak-desktop
+          args: --target ${{ matrix.target }} --no-bundle --ci
+
+      - name: Save release-specific unsigned Rust build cache
+        if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+          key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
+
+      - name: Require a successful unsigned compilation
+        if: ${{ steps.compile.outcome != 'success' }}
+        run: exit 1
+
+  build_linux:
+    name: Linux · ${{ matrix.arch }}
+    needs: [validate, inspect_hosted, prepare_linux]
+    if: >-
+      ${{
+        always()
+        && needs.validate.result == 'success'
+        && needs.validate.outputs.draft == 'true'
+        && needs.inspect_hosted.result == 'success'
+        && needs.inspect_hosted.outputs.exists != 'true'
+        && needs.prepare_linux.result == 'success'
+      }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    environment:
+      name: desktop-production
+      url: https://downloads.brightwave.io/tidebreak/manifest.json
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-linux-gnu
+    env:
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_ONLY
+      TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - name: Install Linux packaging dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf
+
+      - name: Restore unsigned Rust build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/release/.cargo-lock
+            target/release/.fingerprint
+            target/release/build
+            target/release/deps
+            target/${{ matrix.target }}/release/.cargo-lock
+            target/${{ matrix.target }}/release/.fingerprint
+            target/${{ matrix.target }}/release/build
+            target/${{ matrix.target }}/release/deps
+            target/${{ matrix.target }}/release/tidebreak-desktop
+            target/${{ matrix.target }}/release/tidebreak-host-broker
+            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
+            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
+          key: linux-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+
+      - name: Discard restored product binaries
+        env:
+          RELEASE_TARGET: ${{ matrix.target }}
+        run: |
+          rm -rf \
+            "target/$RELEASE_TARGET/release/tidebreak-desktop" \
+            "target/$RELEASE_TARGET/release/tidebreak-host-broker" \
+            "target/$RELEASE_TARGET/release/"libtidebreak_desktop_lib.* \
+            "crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
+
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          shared-key: linux-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          version: 10.18.3
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        working-directory: crates/tidebreak-desktop/ui
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install Rust target
+        run: |
+          rustup show
+          rustup target add "${{ matrix.target }}"
+
+      - name: Write tag-derived Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
+              version: process.env.TIDEBREAK_VERSION,
+              bundle: { targets: ["appimage", "deb"], category: "Office" },
+              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
+            }));
+          '
+
+      - name: Build the Tauri Linux packages
+        id: tauri
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
+        with:
+          projectPath: crates/tidebreak-desktop
+          args: >-
+            --target ${{ matrix.target }}
+            --config ${{ runner.temp }}/tidebreak-release.json
+            --bundles appimage,deb
+
+      - name: Verify and collect Linux artifacts
+        env:
+          RELEASE_ARCH: ${{ matrix.arch }}
+          RELEASE_TARGET: ${{ matrix.target }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          missing=()
+          for name in \
+            TAURI_SIGNING_PRIVATE_KEY \
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing desktop-production updater-signing configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+          target_dir="$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)"
+          bundle_dir="$target_dir/$RELEASE_TARGET/release/bundle"
+          appimage_paths=("$bundle_dir"/appimage/*.AppImage)
+          deb_paths=("$bundle_dir"/deb/*.deb)
+          (( ${#appimage_paths[@]} == 1 )) && [[ -f "${appimage_paths[0]}" ]] || {
+            echo "Expected exactly one AppImage in $bundle_dir/appimage" >&2
+            exit 1
+          }
+          (( ${#deb_paths[@]} == 1 )) && [[ -f "${deb_paths[0]}" ]] || {
+            echo "Expected exactly one Debian package in $bundle_dir/deb" >&2
+            exit 1
+          }
+          appimage_path="${appimage_paths[0]}"
+          deb_path="${deb_paths[0]}"
+
+          sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
+          [[ -x "$sidecar" ]] || {
+            echo "Missing executable target-named host broker sidecar: $sidecar" >&2
+            exit 1
+          }
+
+          appimage_signature_path="${appimage_path}.sig"
+          rm -f "$appimage_signature_path"
+          tauri signer sign "$appimage_path"
+          [[ -s "$appimage_signature_path" ]] || {
+            echo "Tauri updater signature is empty: $appimage_signature_path" >&2
+            exit 1
+          }
+
+          deb_signature_path="${deb_path}.sig"
+          rm -f "$deb_signature_path"
+          tauri signer sign "$deb_path"
+          [[ -s "$deb_signature_path" ]] || {
+            echo "Tauri updater signature is empty: $deb_signature_path" >&2
+            exit 1
+          }
+
+          output_dir="dist/linux/$RELEASE_ARCH"
+          base_name="Tidebreak_${TIDEBREAK_VERSION}_${RELEASE_ARCH}"
+          mkdir -p "$output_dir"
+          cp "$appimage_path" "$output_dir/${base_name}.AppImage"
+          cp "$appimage_signature_path" "$output_dir/${base_name}.AppImage.sig"
+          cp "$deb_path" "$output_dir/${base_name}.deb"
+          cp "$deb_signature_path" "$output_dir/${base_name}.deb.sig"
+          find "$output_dir" -type f -print
+
+      - name: Upload verified Linux artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-linux-${{ matrix.arch }}-${{ needs.validate.outputs.version }}
+          path: dist/linux/${{ matrix.arch }}/
+          if-no-files-found: error
+          retention-days: 7
+
   source_sbom:
     name: generate source SBOM
     needs: [validate, inspect_hosted]
@@ -1453,9 +1778,7 @@ jobs:
 
   publish:
     name: publish downloads.brightwave.io
-    needs: [validate, inspect_hosted, build_macos, build_windows, source_sbom, finalize_release]
-    # `build_windows` is parked (see docs/deferred.md), so a skipped result is
-    # the expected steady state; only an outright failure may block publishing.
+    needs: [validate, inspect_hosted, build_macos, build_windows, build_linux, source_sbom, finalize_release]
     if: >-
       ${{
         always()
@@ -1467,8 +1790,8 @@ jobs:
           || needs.validate.outputs.draft != 'true'
           || (
             needs.build_macos.result == 'success'
-            && needs.build_windows.result != 'failure'
-            && needs.build_windows.result != 'cancelled'
+            && needs.build_windows.result == 'success'
+            && needs.build_linux.result == 'success'
             && needs.source_sbom.result == 'success'
           )
         )
@@ -1523,18 +1846,27 @@ jobs:
           name: tidebreak-macos-universal-${{ needs.validate.outputs.version }}
           path: dist/macos/universal
 
-      # Parked with the Windows build; see docs/deferred.md.
       - name: Download Windows artifacts
         if: >-
           ${{
-            false
-            && needs.validate.outputs.draft == 'true'
+            needs.validate.outputs.draft == 'true'
             && needs.inspect_hosted.outputs.exists != 'true'
           }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: tidebreak-windows-x86_64-${{ needs.validate.outputs.version }}
           path: dist/windows/x86_64
+
+      - name: Download Linux artifacts
+        if: >-
+          ${{
+            needs.validate.outputs.draft == 'true'
+            && needs.inspect_hosted.outputs.exists != 'true'
+          }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-linux-x86_64-${{ needs.validate.outputs.version }}
+          path: dist/linux/x86_64
 
       - name: Recover build inputs from the immutable GitHub Release
         if: >-
@@ -1545,7 +1877,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mkdir -p recovery dist/macos/universal
+          mkdir -p \
+            recovery \
+            dist/macos/universal \
+            dist/windows/x86_64 \
+            dist/linux/x86_64
           gh release download "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --dir recovery
@@ -1564,6 +1900,26 @@ jobs:
               exit 1
             }
             cp "recovery/$file" "dist/macos/universal/$file"
+          done
+
+          windows_base="Tidebreak_${TIDEBREAK_VERSION}_x86_64"
+          for suffix in setup.exe setup.exe.sig; do
+            file="$windows_base-$suffix"
+            [[ -f "recovery/$file" ]] || {
+              echo "Immutable GitHub Release is missing recovery asset: $file" >&2
+              exit 1
+            }
+            cp "recovery/$file" "dist/windows/x86_64/$file"
+          done
+
+          linux_base="Tidebreak_${TIDEBREAK_VERSION}_x86_64"
+          for suffix in AppImage AppImage.sig deb deb.sig; do
+            file="$linux_base.$suffix"
+            [[ -f "recovery/$file" ]] || {
+              echo "Immutable GitHub Release is missing recovery asset: $file" >&2
+              exit 1
+            }
+            cp "recovery/$file" "dist/linux/x86_64/$file"
           done
 
           sbom="Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
@@ -1670,6 +2026,8 @@ jobs:
               *.json) echo application/json ;;
               *.dmg) echo application/x-apple-diskimage ;;
               *.exe) echo application/vnd.microsoft.portable-executable ;;
+              *.AppImage) echo application/vnd.appimage ;;
+              *.deb) echo application/vnd.debian.binary-package ;;
               *.zip) echo application/zip ;;
               *.tar.gz) echo application/gzip ;;
               *.sig|*.sha256) echo text/plain ;;
@@ -1761,7 +2119,7 @@ jobs:
 
   attach_downloads:
     name: prepare GitHub release downloads
-    needs: [validate, inspect_hosted, build_macos, build_windows, source_sbom]
+    needs: [validate, inspect_hosted, build_macos, build_windows, build_linux, source_sbom]
     # A published release already owns immutable assets. A draft instead needs
     # the fresh package build and SBOM before those assets can be attached.
     if: >-
@@ -1773,8 +2131,8 @@ jobs:
           needs.validate.outputs.draft != 'true'
           || (
             needs.build_macos.result == 'success'
-            && needs.build_windows.result != 'failure'
-            && needs.build_windows.result != 'cancelled'
+            && needs.build_windows.result == 'success'
+            && needs.build_linux.result == 'success'
             && needs.source_sbom.result == 'success'
           )
         )
@@ -1792,6 +2150,20 @@ jobs:
         with:
           name: tidebreak-macos-universal-${{ needs.validate.outputs.version }}
           path: release-artifacts/macos
+
+      - name: Download the verified Windows build
+        if: ${{ needs.validate.outputs.draft == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-windows-x86_64-${{ needs.validate.outputs.version }}
+          path: release-artifacts/windows
+
+      - name: Download the verified Linux build
+        if: ${{ needs.validate.outputs.draft == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-linux-x86_64-${{ needs.validate.outputs.version }}
+          path: release-artifacts/linux
 
       - name: Download the checksummed source SBOM
         if: ${{ needs.validate.outputs.draft == 'true' }}
@@ -1824,6 +2196,40 @@ jobs:
             (cd downloads && sha256sum "$file" > "$file.sha256")
           done
 
+          windows_base="Tidebreak_${TIDEBREAK_VERSION}_x86_64"
+          windows_installer="$windows_base-setup.exe"
+          for file in "$windows_installer" "$windows_installer.sig"; do
+            [[ -f "release-artifacts/windows/$file" ]] || {
+              echo "The verified Windows build did not contain $file." >&2
+              exit 1
+            }
+            cp "release-artifacts/windows/$file" "downloads/$file"
+            (cd downloads && sha256sum "$file" > "$file.sha256")
+          done
+          cp "release-artifacts/windows/$windows_installer" \
+            downloads/Tidebreak-windows-x86_64-setup.exe
+          (cd downloads && sha256sum Tidebreak-windows-x86_64-setup.exe \
+            > Tidebreak-windows-x86_64-setup.exe.sha256)
+
+          linux_base="Tidebreak_${TIDEBREAK_VERSION}_x86_64"
+          for suffix in AppImage AppImage.sig deb deb.sig; do
+            file="$linux_base.$suffix"
+            [[ -f "release-artifacts/linux/$file" ]] || {
+              echo "The verified Linux build did not contain $file." >&2
+              exit 1
+            }
+            cp "release-artifacts/linux/$file" "downloads/$file"
+            (cd downloads && sha256sum "$file" > "$file.sha256")
+          done
+          cp "release-artifacts/linux/$linux_base.AppImage" \
+            downloads/Tidebreak-linux-x86_64.AppImage
+          cp "release-artifacts/linux/$linux_base.deb" \
+            downloads/Tidebreak-linux-x86_64.deb
+          (cd downloads && sha256sum Tidebreak-linux-x86_64.AppImage \
+            > Tidebreak-linux-x86_64.AppImage.sha256)
+          (cd downloads && sha256sum Tidebreak-linux-x86_64.deb \
+            > Tidebreak-linux-x86_64.deb.sha256)
+
           sbom="Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
           cp "release-artifacts/sbom/$sbom" "downloads/$sbom"
           cp "release-artifacts/sbom/$sbom.sha256" "downloads/$sbom.sha256"
@@ -1852,6 +2258,15 @@ jobs:
             (cd downloads && sha256sum "$(basename "$compatibility_dmg")" \
               > "$(basename "$compatibility_dmg").sha256")
           fi
+          for required in \
+            downloads/Tidebreak-windows-x86_64-setup.exe \
+            downloads/Tidebreak-linux-x86_64.AppImage \
+            downloads/Tidebreak-linux-x86_64.deb; do
+            [[ -f "$required" ]] || {
+              echo "The cross-platform download was not prepared: ${required#downloads/}" >&2
+              exit 1
+            }
+          done
 
           while IFS= read -r -d '' file; do
             case "$file" in
@@ -1873,6 +2288,12 @@ jobs:
               "$base.app.zip" \
               "$base.app.tar.gz" \
               "$base.app.tar.gz.sig" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64-setup.exe" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64-setup.exe.sig" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.AppImage" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.AppImage.sig" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.deb" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.deb.sig" \
               "Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"; do
               [[ -f "downloads/$file" ]] || {
                 echo "Immutable release cannot recover hosted publication without $file." >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1395,146 +1395,13 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  prepare_linux:
-    name: prepare unsigned Linux · ${{ matrix.arch }}
+  build_linux:
+    name: Linux · ${{ matrix.arch }}
     needs: [validate, inspect_hosted]
     if: >-
       ${{
         needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.outputs.exists != 'true'
-      }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-            target: x86_64-unknown-linux-gnu
-    env:
-      CARGO_INCREMENTAL: 0
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: READ_ONLY
-      TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ needs.validate.outputs.sha }}
-
-      - name: Install Linux packaging dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            cmake \
-            file \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev \
-            libxdo-dev \
-            patchelf
-
-      - name: Install Rust target
-        run: |
-          rustup show
-          rustup target add "${{ matrix.target }}"
-
-      - name: Restore unsigned Rust build cache
-        id: rust-build-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: linux-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
-          restore-keys: |
-            linux-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            linux-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-
-      - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.16.0
-
-      - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
-        with:
-          shared-key: linux-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
-          cache-bin: false
-          cache-targets: false
-          save-if: true
-
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-        with:
-          version: 10.18.3
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
-      - name: Install UI dependencies
-        working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
-      - name: Verify the third-party notices match the released graph
-        run: node scripts/generate-third-party-notices.mjs --check
-
-      - name: Compile without production credentials or bundles
-        id: compile
-        continue-on-error: true
-        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
-        with:
-          projectPath: crates/tidebreak-desktop
-          args: --target ${{ matrix.target }} --no-bundle --ci
-
-      - name: Save release-specific unsigned Rust build cache
-        if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: ${{ steps.rust-build-cache.outputs.cache-primary-key }}
-
-      - name: Require a successful unsigned compilation
-        if: ${{ steps.compile.outcome != 'success' }}
-        run: exit 1
-
-  build_linux:
-    name: Linux · ${{ matrix.arch }}
-    needs: [validate, inspect_hosted, prepare_linux]
-    if: >-
-      ${{
-        always()
-        && needs.validate.result == 'success'
-        && needs.validate.outputs.draft == 'true'
-        && needs.inspect_hosted.result == 'success'
-        && needs.inspect_hosted.outputs.exists != 'true'
-        && needs.prepare_linux.result == 'success'
       }}
     runs-on: ubuntu-22.04
     timeout-minutes: 90
@@ -1572,34 +1439,6 @@ jobs:
             libxdo-dev \
             patchelf
 
-      - name: Restore unsigned Rust build cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop
-            target/${{ matrix.target }}/release/tidebreak-host-broker
-            target/${{ matrix.target }}/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}
-          key: linux-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
-
-      - name: Discard restored product binaries
-        env:
-          RELEASE_TARGET: ${{ matrix.target }}
-        run: |
-          rm -rf \
-            "target/$RELEASE_TARGET/release/tidebreak-desktop" \
-            "target/$RELEASE_TARGET/release/tidebreak-host-broker" \
-            "target/$RELEASE_TARGET/release/"libtidebreak_desktop_lib.* \
-            "crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
-
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
@@ -1621,11 +1460,12 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
       - name: Install UI dependencies
         working-directory: crates/tidebreak-desktop/ui
         run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Verify the third-party notices match the released graph
+        run: node scripts/generate-third-party-notices.mjs --check
 
       - name: Install Rust target
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,13 +188,14 @@ is the whole rule, and it is coarse on purpose:
   change's scope reports a successful skip. The always-running change detector
   rejects impossible narrower-scope combinations before conditional jobs
   consume them. There is no serial aggregate wrapper after the slowest job.
-- The native Windows lane is **parked**, along with the release workflow's
-  Windows build — see [`docs/deferred.md`](docs/deferred.md). `windows-check`
-  and `prepare_windows`/`build_windows` are each gated behind a literal `false`
-  and never run; the `windows-ci` label currently does nothing. Releases are
-  macOS-only until those literals flip back. Nothing about the Windows boundary
-  has been declared unsupported, so a change that touches Windows-gated code
-  still deserves the same care — it just gets no CI signal right now.
+- The native Windows lane runs automatically for Rust-scoped pushes to `main`,
+  schedules, and manual dispatches. Pull requests opt in with the `windows-ci`
+  label when they touch a Windows-native boundary. It stays non-required because
+  it is the slowest lane; the post-merge and scheduled runs are the backstop.
+- Production releases require macOS, Windows x86_64, and Linux x86_64 packages.
+  Windows ships NSIS; Linux ships AppImage and `.deb`. Windows Authenticode,
+  ARM64 packages, and automatic updates outside macOS remain parked in
+  [`docs/deferred.md`](docs/deferred.md).
 
 **The remaining trap is a PR that ran nothing.** A conflicting PR runs nothing
 but trivial policy checks; rebase it before believing its status. Judge a PR by

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
 
 <p align="center">
   <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-macos-universal.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-000000.svg?logo=apple&logoColor=white" alt="Download the latest macOS release"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-windows-x86_64-setup.exe"><img src="https://img.shields.io/badge/Download%20for%20Windows-0078D4.svg?logo=windows&logoColor=white" alt="Download the latest Windows release"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download%20for%20Linux-FCC624.svg?logo=linux&logoColor=black" alt="Download the latest Linux AppImage"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.deb"><img src="https://img.shields.io/badge/Linux%20.deb-A81D33.svg?logo=debian&logoColor=white" alt="Download the latest Linux Debian package"></a>
 </p>
 
 <p align="center">
@@ -55,8 +58,8 @@ the headless CLI.
 > [!WARNING]
 > Tidebreak is pre-1.0 and changing quickly. Interfaces and local data formats
 > may change between releases, and profiles may be rebuilt rather than
-> migrated. Packaged releases are currently macOS-only; Windows and Linux can
-> be built from source.
+> migrated. Windows and Linux packages ship for x86_64; some native capabilities
+> remain macOS-only and are reported as unavailable in the app.
 
 ## Features
 

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -776,7 +776,7 @@ pub(crate) async fn user_git_fingerprint(
     Ok((head, bytes))
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -947,7 +947,7 @@ async fn run_gh(
     Err(if stderr.is_empty() { stdout } else { stderr })
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -41,7 +41,9 @@ mod app_invoke;
 mod app_library;
 mod chat_titling;
 mod code;
+#[cfg(unix)]
 mod code_clone;
+#[cfg(unix)]
 mod code_git;
 mod code_terminals;
 mod code_titling;

--- a/docs-site/content/docs/installation.mdx
+++ b/docs-site/content/docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Download Tidebreak for macOS, or build it from source.
+description: Download Tidebreak for macOS, Windows, or Linux, or build it from source.
 ---
 
 ## macOS
@@ -24,15 +24,33 @@ shasum -a 256 -c Tidebreak-macos-universal.dmg.sha256
 An installed macOS build keeps itself current. It checks for a newer signed
 release in the background and asks before restarting.
 
-## Windows and Linux
+## Windows
 
-There is no prebuilt package for either. Build from source.
+[Download for Windows](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-windows-x86_64-setup.exe)
 
-Windows installers shipped through v0.34.0, but the Windows release build is
-paused: releases are macOS-only until it comes back. Nothing about Windows
-support has been withdrawn, and the code that produces the installer is still
-in the tree — it is the build that is parked, for cost reasons. A Windows user
-on the last packaged release has no upgrade path other than building.
+The x86_64 NSIS installer is not yet Authenticode-signed, so Windows SmartScreen
+may warn on first run. The release includes a `.sha256` sidecar for independent
+download verification.
+
+## Linux
+
+Choose the portable AppImage or the Debian package. Both are x86_64 builds.
+
+- [Download AppImage](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.AppImage)
+- [Download Debian package](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.deb)
+
+Make the AppImage executable before launching it:
+
+```sh
+chmod +x Tidebreak-linux-x86_64.AppImage
+./Tidebreak-linux-x86_64.AppImage
+```
+
+Windows and Linux packages run the desktop chat, files, connected-folder,
+provider, and remote-sandbox surfaces. Native local execution, managed Node and
+LibreOffice installation, computer use, and code mode remain unavailable where
+the app reports those platform capabilities as unsupported. Automatic updates
+currently run only on macOS; install a newer Windows or Linux package manually.
 
 ## Build from source
 
@@ -66,6 +84,7 @@ Tidebreak owns one application data directory, created on first launch:
 | --- | --- |
 | macOS | `~/Library/Application Support/io.brightwave.tidebreak` |
 | Windows | `%APPDATA%\io.brightwave.tidebreak` |
+| Linux | `~/.local/share/io.brightwave.tidebreak` |
 
 Inside it:
 

--- a/docs-site/content/docs/installation.mdx
+++ b/docs-site/content/docs/installation.mdx
@@ -39,11 +39,25 @@ Choose the portable AppImage or the Debian package. Both are x86_64 builds.
 - [Download AppImage](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.AppImage)
 - [Download Debian package](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.deb)
 
+Linux packages are built on Ubuntu 22.04. Use Ubuntu 22.04, Debian 12, or a
+newer distribution with a compatible glibc baseline. The Debian package declares
+its WebKitGTK 4.1, GTK 3, and system-tray runtime dependencies; the AppImage
+bundles application dependencies but still needs a compatible host glibc.
+
 Make the AppImage executable before launching it:
 
 ```sh
 chmod +x Tidebreak-linux-x86_64.AppImage
 ./Tidebreak-linux-x86_64.AppImage
+```
+
+Each Linux download has a `.sha256` sidecar. Verify the file you chose before
+installing or launching it:
+
+```sh
+sha256sum -c Tidebreak-linux-x86_64.AppImage.sha256
+# or
+sha256sum -c Tidebreak-linux-x86_64.deb.sha256
 ```
 
 Windows and Linux packages run the desktop chat, files, connected-folder,

--- a/docs/decisions/0040-ship-x86-64-windows-and-linux-desktop-packages.md
+++ b/docs/decisions/0040-ship-x86-64-windows-and-linux-desktop-packages.md
@@ -1,0 +1,125 @@
+# 40. Ship x86_64 Windows and Linux desktop packages
+
+- Status: Proposed
+- Date: 2026-08-17
+- Owners: desktop and release engineering
+- Related: [`docs/releases.md`](../releases.md), [decision 16](0016-desktop-staging-channel.md)
+- Supersedes: none
+
+## Context
+
+Tidebreak's production release currently publishes only a universal macOS
+application. The Windows release implementation remains in the repository but
+is disabled, and no Linux packaging implementation exists. This leaves users
+on Windows and Linux to build from source even though the desktop shell, host
+broker, deep-link handling, credential storage, and managed-policy paths already
+have platform implementations.
+
+The first resumed multi-platform release needs a package contract that the
+release manifest, updater feed, GitHub assets, hosted immutable prefix, and
+installation documentation can all enforce. It also needs to distinguish
+shipping the desktop shell from claiming that every optional native capability
+has reached macOS parity.
+
+## Decision
+
+Every new production desktop release ships these package sets together:
+
+- one universal macOS build under `macos/universal`;
+- one x86_64 Windows NSIS installer under `windows/x86_64`;
+- one x86_64 Linux AppImage and one x86_64 Debian package under
+  `linux/x86_64`.
+
+The Windows installer and Linux packages are not operating-system code-signed
+in this first slice. The Windows NSIS installer, Linux AppImage, and Debian
+package are signed with the existing Tauri updater key so the release feed can
+authenticate their exact bytes. Linux publishes distinct AppImage and Debian
+updater targets because Tauri installs those package formats differently.
+
+A fresh release is all-or-nothing across the three operating systems. It is not
+published unless the macOS, Windows, and Linux package jobs all succeed and the
+manifest generator sees every declared artifact and updater signature. Stable,
+version-free GitHub asset aliases provide permanent download links, while the
+hosted manifest continues to use versioned immutable paths.
+
+This decision does not enable the in-app updater on Windows or Linux. It also
+does not promise local native execution, managed Node or LibreOffice
+installation, computer use, or code mode on those platforms where the existing
+capability model reports them unavailable. Those are independent product
+capabilities rather than packaging prerequisites.
+
+## Alternatives Considered
+
+### Continue publishing macOS only
+
+Rejected because the desktop already has substantial Windows and Linux support,
+and requiring every user on those systems to assemble a release toolchain is a
+larger product gap than the remaining platform-specific optional features.
+
+### Ship only a portable package on each platform
+
+Rejected. NSIS provides the established Windows install and uninstall path.
+On Linux, AppImage serves users who want a portable download while `.deb`
+integrates with the most common supported desktop distribution family. Shipping
+both avoids making one distribution preference the product boundary.
+
+### Ship ARM64 packages in the same first release
+
+Rejected for this slice. Windows and Linux ARM64 packaging would add another
+native dependency and sidecar build boundary before the x86_64 packages have
+completed clean-install and update rehearsal. The manifest shape can add an
+architecture later without renaming the formats chosen here.
+
+### Require Windows Authenticode signing before resuming releases
+
+Rejected for this slice because Tidebreak has no accepted Windows signing
+configuration in its release environment. Waiting for that infrastructure
+would keep the existing installer path disabled. The unsigned status and
+expected SmartScreen warning must remain explicit until signing is added.
+
+### Enable automatic updates on all three operating systems immediately
+
+Rejected because package publication and updater installation are separate
+failure boundaries. Windows NSIS, Linux AppImage, and Linux Debian updates need
+clean-machine rehearsal with the desktop's broker quiescence and restart
+sequence before the runtime gate is widened. Publishing signed, format-specific
+updater metadata now avoids another manifest migration when that validation is
+complete.
+
+## Consequences
+
+Production release time and runner cost increase because Windows and Linux are
+required outputs. A failure on either platform blocks the release rather than
+quietly producing a partial platform set.
+
+Windows users receive an unsigned installer and may see SmartScreen warnings.
+Linux users choose between a portable AppImage and a Debian package; other
+package ecosystems remain unsupported. Documentation must state the existing
+platform capability gaps without describing the packages as incomplete or
+experimental.
+
+Published releases before this platform expansion do not satisfy the new
+manifest contract and cannot be replayed through the current release workflow
+as if they contained the new artifacts.
+
+Revisit this decision when ARM64 clean-build coverage is available on both
+platforms, when Windows signing infrastructure is accepted, when a Linux
+package format materially broader than AppImage plus `.deb` is required, or
+when updater installation rehearsal is sufficient to enable Windows or Linux
+automatic updates.
+
+## Validation
+
+- Manifest tests require Windows and Linux artifacts, checksums, updater
+  signatures, and `latest.json` platform keys.
+- Workflow-policy tests require credential-free preparation, source-pinned
+  build-cache restoration, complete artifact transfer, and all-platform release
+  gating.
+- Native Windows CI checks the target graph, broker, SQLite profile lifecycle,
+  and Credential Manager backend.
+- The release jobs must produce exactly one NSIS installer, one AppImage, and
+  one Debian package for x86_64 and must verify the packaged host-broker
+  sidecar.
+- Before the first public release, clean-machine smoke tests must cover install,
+  launch, sidecar startup, persistence, deep links, and uninstall on Windows and
+  Ubuntu, plus AppImage launch on a second Linux distribution.

--- a/docs/decisions/0040-ship-x86-64-windows-and-linux-desktop-packages.md
+++ b/docs/decisions/0040-ship-x86-64-windows-and-linux-desktop-packages.md
@@ -112,9 +112,9 @@ automatic updates.
 
 - Manifest tests require Windows and Linux artifacts, checksums, updater
   signatures, and `latest.json` platform keys.
-- Workflow-policy tests require credential-free preparation, source-pinned
-  build-cache restoration, complete artifact transfer, and all-platform release
-  gating.
+- Workflow-policy tests require source-pinned Windows cache restoration,
+  cache-write-free Linux packaging before updater signing, complete artifact
+  transfer, and all-platform release gating.
 - Native Windows CI checks the target graph, broker, SQLite profile lifecycle,
   and Credential Manager backend.
 - The release jobs must produce exactly one NSIS installer, one AppImage, and

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -179,27 +179,27 @@ Lifting this means giving the headless engine the same overlay and write-back
 machinery the desktop has, and a headless surface for the approval that a
 replacement always requires — not relaxing the refusal.
 
-## Windows packaging
+## Additional desktop distribution
 
-Windows builds shipped through v0.34.0 as an unsigned x86_64 NSIS installer,
-and the code that produces them is still in the tree. The lanes are parked, not
-deleted: `windows-check` in CI and the `prepare_windows`/`build_windows` jobs
-in the release workflow are each gated behind a literal `false`, and the
-`windows` descriptor in `scripts/create-release-manifests.mjs` is retained
-outside `RELEASE_PLATFORMS`. Releases are macOS-only until those are flipped
-back.
+Production releases ship x86_64 macOS, Windows, and Linux packages. Three
+distribution improvements remain deliberately outside that first
+cross-platform slice:
 
-The reason is cost, not a product decision. The native Windows runner is the
-slowest lane in the repo and the release build serializes a prepare and a build
-job behind it, which dominates the time to publish a tag. Nothing about the
-Windows boundary has been declared unsupported, and no Windows behavior has
-been removed.
-
-What resuming has to account for: the `/releases/latest/download/` link in the
-docs site points at an installer that later releases will not carry, and
-`latest.json` no longer publishes a `windows-x86_64` key. The in-app update
-loop runs only on macOS today, so no live updater breaks — but a Windows user
-on v0.34.0 has no upgrade path until the lanes come back.
+- **Windows Authenticode signing.** The NSIS installer is signed by the Tauri
+  updater key but not by a Windows-trusted code-signing certificate, so
+  SmartScreen can warn on first run. Lifting this needs an accepted signing
+  provider, protected release-environment credentials, verification of the
+  signed installer, and a recovery procedure for certificate or provider
+  failure.
+- **Windows and Linux ARM64 packages.** The release manifest can add another
+  architecture without changing the package formats, but the desktop, host
+  broker, native dependencies, installer, and clean-machine launch path all
+  need native-runner or proven cross-build coverage first.
+- **Automatic updates outside macOS.** Production publishes authenticated
+  `windows-x86_64`, `linux-x86_64-appimage`, and `linux-x86_64-deb` updater
+  entries, but the app's update loop stays macOS-only until NSIS, AppImage, and
+  Debian replacement have clean-install, broker-quiescence, failed-install
+  recovery, and restart smoke tests.
 
 Reliability work also remains ahead of the product surface: replayable adapter
 contracts, recorded response decoding, and a protected live canary matrix would
@@ -278,8 +278,7 @@ purpose:
   steer, review completion — is a thin client of a reachable deployment and
   waits on the self-host member-client path above.
 - **Code mode on Windows.** Login-shell discovery and worktree pathing both
-  need Windows-specific work, and Windows packaging is itself parked (see
-  above).
+  need Windows-specific work.
 
 ## What this means for planning
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -274,10 +274,12 @@ managed Node and LibreOffice installation, computer use, and code mode remain
 governed by their existing platform capability checks; packaging the desktop
 does not claim those features on Linux.
 
-Like Windows, Linux uses a credential-free `prepare_linux` job to compile the
-tag and save only Cargo intermediates and unsigned products. The packaging job
-restores that source-pinned cache, discards linked binaries, relinks from the
-release tag, builds both formats, and signs each package only after packaging.
+The Linux packaging job uses compiler and Cargo download caches in read-only
+mode and does not enable pnpm caching. It builds both formats from the validated
+release tag before the updater private key enters the step environment, then
+signs and collects only the completed package bytes. This avoids exposing a
+default-branch cache writer to code executed during a manually dispatched
+release.
 
 The public download contract is rooted at:
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -170,10 +170,10 @@ automatic.
    carries so the products they package are always linked from the tag's own
    sources. The macOS job then signs the app with the Developer ID identity,
    notarizes and staples the app and DMG, verifies them with Apple tooling, and
-   creates a signed Tauri updater archive. The parallel Windows job is parked
-   behind a literal `false` and never runs — see
-   [What comes after v1](deferred.md) — so a release currently produces macOS
-   artifacts only.
+   creates a signed Tauri updater archive. Parallel Windows and Linux jobs
+   produce the x86_64 NSIS, AppImage, and Debian packages; all three are signed
+   with the Tauri updater key after packaging. A fresh release cannot continue
+   unless all three operating-system builds succeed.
 8. For a release that is not already hosted, a separate least-privilege job
    generates an SPDX JSON SBOM from the exact released source and checksums it
    independently of the package builds. That job has no production environment,
@@ -183,15 +183,15 @@ automatic.
    deliberately published as source-scoped metadata, not attested as a
    description of the packaged installers.
 9. Before publication, a credential-free job attaches the verified build
-   outputs and their `.sha256` sidecars to the draft GitHub Release — today that
-   is the notarized disk image as
+   outputs and their `.sha256` sidecars to the draft GitHub Release. Stable
+   download names include the notarized disk image as
    `Tidebreak-macos-universal.dmg`, plus the byte-identical legacy
    `Tidebreak-macos-apple-silicon.dmg` alias that keeps the existing README URL
-   live through the transition. It retains the versioned app zip, signed updater
-   archive, updater signature, source SBOM, and checksum sidecars on GitHub as
-   recovery inputs. It would again include the Windows installer and updater
-   assets if the Windows lane were unparked. This job holds no signing or AWS
-   credentials. The two DMG names omit the version so that
+   live through the transition, `Tidebreak-windows-x86_64-setup.exe`,
+   `Tidebreak-linux-x86_64.AppImage`, and `Tidebreak-linux-x86_64.deb`. It also
+   retains the versioned packages, updater artifacts and signatures, source
+   SBOM, and checksum sidecars on GitHub as recovery inputs. This job holds no
+   signing or AWS credentials. The stable names omit the version so that
    `https://github.com/brightwave-inc/tidebreak/releases/latest/download/<name>`
    stays a permanent download link for the README; the release page and the
    app's own version string identify which build it is.
@@ -239,15 +239,7 @@ current platform set. A release published before this platform change cannot
 be re-dispatched: it fails on the artifact paths and updater keys instead of
 silently republishing a different release shape.
 
-### Windows: parked, unsigned x86_64 when it returns
-
-**The Windows release lane is currently parked**, so releases are macOS-only.
-`prepare_windows` and `build_windows` in `release.yml` are each gated behind a
-literal `false`, and the `windows` descriptor in
-`scripts/create-release-manifests.mjs` is retained outside `RELEASE_PLATFORMS`
-rather than deleted. The reason is release time, not a product decision — see
-[What comes after v1](deferred.md). The packaging below is what shipped through
-v0.34.0 and what resuming the lane restores; nothing in it has been removed.
+### Windows: unsigned x86_64 NSIS
 
 A release ships one `x86_64` Windows build as a single NSIS `-setup.exe`
 installer. NSIS is the one installer format for v1 because Tauri bundles it
@@ -260,13 +252,32 @@ That updater signature covers the exact installer bytes and feeds
 installer itself, so no separate updater archive exists on Windows. Packaged
 apps currently run the update loop only on macOS; the Windows metadata is
 published so updater-enabled Windows builds can adopt it without a manifest
-change. While the lane is parked, `latest.json` carries no `windows-x86_64`
-key at all, so a Windows user on v0.34.0 has no upgrade path until it returns.
+change.
 
 Unlike macOS, no cache-warming workflow exists for Windows: the credential-free
 `prepare_windows` job compiles the tag from scratch (or from an earlier
 release's prepared cache) and is the single writer of the Windows Cargo
 registry and prepared-build caches.
+
+### Linux: x86_64 AppImage and Debian package
+
+A release ships one portable AppImage and one `.deb` for x86_64 Linux. Both
+carry Tauri updater signatures over their exact bytes, and `latest.json`
+publishes separate `linux-x86_64-appimage` and `linux-x86_64-deb` entries so an
+installed package can only select its own format. Neither package is
+distribution-signed in this first shipping slice.
+
+Packaged apps currently run the update loop only on macOS. The Linux updater
+metadata is published now so enabling verified AppImage or Debian updates later
+does not require changing the public manifest shape. Native local execution,
+managed Node and LibreOffice installation, computer use, and code mode remain
+governed by their existing platform capability checks; packaging the desktop
+does not claim those features on Linux.
+
+Like Windows, Linux uses a credential-free `prepare_linux` job to compile the
+tag and save only Cargo intermediates and unsigned products. The packaging job
+restores that source-pinned cache, discards linked binaries, relinks from the
+release tag, builds both formats, and signs each package only after packaging.
 
 The public download contract is rooted at:
 
@@ -280,16 +291,19 @@ Each release has an immutable prefix:
 tidebreak/releases/vMAJOR.MINOR.PATCH/
 ├── manifest.json
 ├── macos/
-│   └── aarch64/
-└── windows/          (absent while the Windows lane is parked)
+│   └── universal/
+├── windows/
+│   └── x86_64/
+└── linux/
     └── x86_64/
 ```
 
-Each macOS architecture directory contains a notarized DMG, a zip of the
-notarized app, a signed `.app.tar.gz` updater archive, its signature, and
-SHA-256 files. A Windows architecture directory, when the lane produces one,
-contains an unsigned NSIS installer, its Tauri updater signature, and SHA-256
-files. The immutable release root also contains
+The macOS directory contains a notarized DMG, a zip of the notarized app, a
+signed `.app.tar.gz` updater archive, its signature, and SHA-256 files. The
+Windows directory contains an unsigned NSIS installer, its Tauri updater
+signature, and SHA-256 files. The Linux directory contains an AppImage, a
+Debian package, both updater signatures, and SHA-256 files. The immutable
+release root also contains
 `Tidebreak_VERSION_source.spdx.json` and its checksum. The root `manifest.json`
 inside each versioned prefix is immutable; only the unversioned
 Tauri-compatible `manifest.json` and `latest.json` pointers are mutable. The
@@ -300,7 +314,7 @@ After the repository is public, verify the independently signed provenance for
 any downloaded artifact with GitHub CLI:
 
 ```sh
-gh attestation verify Tidebreak-macos-apple-silicon.dmg \
+gh attestation verify Tidebreak-macos-universal.dmg \
   --repo brightwave-inc/tidebreak
 ```
 
@@ -420,9 +434,10 @@ write access is only `tidebreak/staging/*`. A role that can also write
 
 Before the first public release, protect the environment as appropriate, verify
 all configuration values, and exercise the workflow with the intended first
-tag. The workflow references Apple signing secrets only in the macOS jobs; the
-parked Windows jobs receive only the Tauri updater key, and publishing uses
-short-lived AWS credentials obtained through OIDC.
+tag. The workflow references Apple signing secrets only in the macOS jobs.
+Windows and Linux receive only the Tauri updater key in their artifact
+verification steps, and publishing uses short-lived AWS credentials obtained
+through OIDC.
 
 ### Release CI and cache security
 
@@ -537,7 +552,8 @@ see exactly what a change to either lockfile adds to the product's obligations.
   `Contents/Resources/legal/` of the app bundle. The DMG, the `.app.zip`, and
   the updater archive are all derived from that bundle, so the release lane
   verifies the bundled bytes match the checked-in files once, after signing.
-  When the Windows lanes resume they inherit the same resource map.
+  Windows and Linux packages inherit the same resource map; their packaging
+  jobs verify the shared release inputs before producing artifacts.
 
 ## Before 1.0
 
@@ -568,9 +584,9 @@ its local profile until this checklist is complete:
    in a real migration chain, and `reset_pre_v1_state` stops being reachable.
    The lifecycle must preserve supported data, migrate transactionally, fail
    safely, and test upgrades from the latest 0.x state.
-3. Verify the provisioned signed, notarized, hosted macOS pipeline with clean
-   install and 0.x upgrade smoke tests. Add other supported platforms before
-   claiming support for them.
+3. Verify the provisioned release pipeline with clean install and 0.x upgrade
+   smoke tests on macOS and Windows, clean install and launch checks for the
+   Linux Debian package, and AppImage launch checks on a second distribution.
 4. Update `SECURITY.md` with supported release lines, security-fix policy, and
    end-of-support expectations. Document backup, migration, and rollback.
 5. In the same readiness work, change the `semver:breaking` version resolver's
@@ -610,11 +626,9 @@ non-required: the required `semantic PR title` job already fails unless the
 managed release labels match the title, so requiring the label job too would
 add nothing.
 
-`Windows cargo check` is intentionally separate from the required contexts, and
-is currently parked behind a literal `false` along with the release lanes — see
-[What comes after v1](deferred.md) — so the `windows-ci` label does nothing
-today. When it is unparked it runs automatically for Rust-scoped pushes to
-`main`, weekly schedules, and manual dispatches, while pull requests opt in with
+`Windows cargo check` is intentionally separate from the required contexts. It
+runs automatically for Rust-scoped pushes to `main`, weekly schedules, and
+manual dispatches, while pull requests opt in with
 `windows-ci` when they touch a native Windows boundary. Keep it non-required so
 pull requests do not wait for long-running native platform coverage; the
 post-merge and scheduled runs remain the backstop.

--- a/scripts/create-release-manifests.mjs
+++ b/scripts/create-release-manifests.mjs
@@ -20,32 +20,66 @@ import { parseStagingVersion, stagingTag } from "./staging-version.mjs";
 // macOS ships one universal artifact whose signed updater archive is advertised
 // to both native architectures; see docs/releases.md.
 //
-// Windows packaging is paused (see docs/deferred.md), so no release currently
-// carries a Windows artifact. The descriptor is retained rather than deleted:
-// it shipped through v0.34.0, and resuming means moving it back into
-// RELEASE_PLATFORMS. Windows ships one unsigned NSIS installer, which is also
-// its Tauri updater artifact (Tauri v2 installs updates from the installer
-// itself, so the `.sig` covers those exact bytes).
-export const PAUSED_WINDOWS_PLATFORM = {
+const MACOS_PLATFORM = {
+  platform: "macos",
+  updaterPlatform: "darwin",
+  architectures: ["universal"],
+  updaterArchitectures: ["aarch64", "x86_64"],
+  formats: [
+    { extension: ".dmg", format: "dmg" },
+    { extension: ".app.zip", format: "app.zip" },
+    { extension: ".app.tar.gz", format: "app.tar.gz", updater: true },
+  ],
+};
+
+const WINDOWS_PLATFORM = {
   platform: "windows",
   updaterPlatform: "windows",
   architectures: ["x86_64"],
+  // Tauri v2 installs Windows updates from the NSIS installer itself, so the
+  // updater signature covers the exact bytes users download.
   formats: [{ extension: "-setup.exe", format: "nsis", updater: true }],
 };
 
+const LINUX_PLATFORM = {
+  platform: "linux",
+  updaterPlatform: "linux",
+  architectures: ["x86_64"],
+  formats: [
+    // Tauri selects Linux updates by the bundle format the running app was
+    // installed from. Publish distinct targets so a Debian install can never
+    // fall back to AppImage bytes (or vice versa).
+    {
+      extension: ".AppImage",
+      format: "appimage",
+      updater: true,
+      updaterKeySuffix: "appimage",
+    },
+    {
+      extension: ".deb",
+      format: "deb",
+      updater: true,
+      updaterKeySuffix: "deb",
+    },
+  ],
+};
+
 export const RELEASE_PLATFORMS = [
-  {
-    platform: "macos",
-    updaterPlatform: "darwin",
-    architectures: ["universal"],
-    updaterArchitectures: ["aarch64", "x86_64"],
-    formats: [
-      { extension: ".dmg", format: "dmg" },
-      { extension: ".app.zip", format: "app.zip" },
-      { extension: ".app.tar.gz", format: "app.tar.gz", updater: true },
-    ],
-  },
+  MACOS_PLATFORM,
+  WINDOWS_PLATFORM,
+  LINUX_PLATFORM,
 ];
+
+// Staging remains the signed macOS channel described by decision 16. Production
+// platform expansion must not make that independent workflow require packages
+// it does not build.
+export const STAGING_RELEASE_PLATFORMS = [MACOS_PLATFORM];
+
+function releasePlatforms(channel) {
+  return channel === "staging"
+    ? STAGING_RELEASE_PLATFORMS
+    : RELEASE_PLATFORMS;
+}
 
 function requiredOption(options, name) {
   const value = options.get(name);
@@ -83,28 +117,60 @@ function requireFile(file) {
   }
 }
 
-export function createLatestDocument({ version, publishedAt, artifacts }) {
+export function createLatestDocument({
+  version,
+  publishedAt,
+  artifacts,
+  platforms = RELEASE_PLATFORMS,
+}) {
   const updaterArtifacts = new Map();
-  for (const descriptor of RELEASE_PLATFORMS) {
-    const updaterFormat = descriptor.formats.find((format) => format.updater);
-    for (const artifact of artifacts) {
-      if (
-        artifact.platform !== descriptor.platform ||
-        artifact.format !== updaterFormat.format
-      ) {
-        continue;
-      }
-      if (
-        !descriptor.architectures.includes(artifact.arch) ||
-        typeof artifact.signature !== "string" ||
-        !artifact.signature
-      ) {
-        throw new Error(
-          `invalid ${descriptor.platform} updater artifact in release manifest`,
-        );
-      }
-      for (const arch of descriptor.updaterArchitectures ?? [artifact.arch]) {
-        updaterArtifacts.set(`${descriptor.updaterPlatform}-${arch}`, artifact);
+  const updaterKeys = [];
+  for (const descriptor of platforms) {
+    for (const updaterFormat of descriptor.formats.filter(
+      (format) => format.updater,
+    )) {
+      const updaterArchitectures =
+        descriptor.updaterArchitectures ?? descriptor.architectures;
+      const keysForFormat = updaterArchitectures.map((arch) =>
+        [
+          descriptor.updaterPlatform,
+          arch,
+          updaterFormat.updaterKeySuffix,
+        ]
+          .filter(Boolean)
+          .join("-"),
+      );
+      updaterKeys.push(...keysForFormat);
+
+      for (const artifact of artifacts) {
+        if (
+          artifact.platform !== descriptor.platform ||
+          artifact.format !== updaterFormat.format
+        ) {
+          continue;
+        }
+        if (
+          !descriptor.architectures.includes(artifact.arch) ||
+          typeof artifact.signature !== "string" ||
+          !artifact.signature
+        ) {
+          throw new Error(
+            `invalid ${descriptor.platform} updater artifact in release manifest`,
+          );
+        }
+        const artifactArchitectures = descriptor.updaterArchitectures ?? [
+          artifact.arch,
+        ];
+        for (const arch of artifactArchitectures) {
+          const key = [
+            descriptor.updaterPlatform,
+            arch,
+            updaterFormat.updaterKeySuffix,
+          ]
+            .filter(Boolean)
+            .join("-");
+          updaterArtifacts.set(key, artifact);
+        }
       }
     }
   }
@@ -113,20 +179,15 @@ export function createLatestDocument({ version, publishedAt, artifacts }) {
     version,
     pub_date: publishedAt,
     platforms: Object.fromEntries(
-      RELEASE_PLATFORMS.flatMap((descriptor) =>
-        (descriptor.updaterArchitectures ?? descriptor.architectures).map(
-          (arch) => {
-            const key = `${descriptor.updaterPlatform}-${arch}`;
-            const artifact = updaterArtifacts.get(key);
-            if (!artifact) {
-              throw new Error(
-                `missing ${key} updater artifact in release manifest`,
-              );
-            }
-            return [key, { signature: artifact.signature, url: artifact.url }];
-          },
-        ),
-      ),
+      updaterKeys.map((key) => {
+        const artifact = updaterArtifacts.get(key);
+        if (!artifact) {
+          throw new Error(
+            `missing ${key} updater artifact in release manifest`,
+          );
+        }
+        return [key, { signature: artifact.signature, url: artifact.url }];
+      }),
     ),
   };
 }
@@ -188,8 +249,9 @@ export function createReleaseManifests({
   }
   const distPath = path.resolve(dist);
   const artifacts = [];
+  const platforms = releasePlatforms(channel);
 
-  for (const platformDescriptor of RELEASE_PLATFORMS) {
+  for (const platformDescriptor of platforms) {
     for (const arch of platformDescriptor.architectures) {
       const directory = path.join(distPath, platformDescriptor.platform, arch);
       const baseName = `Tidebreak_${version}_${arch}`;
@@ -267,6 +329,7 @@ export function createReleaseManifests({
     version,
     publishedAt,
     artifacts,
+    platforms,
   });
 
   writeFileSync(

--- a/scripts/create-release-manifests.test.mjs
+++ b/scripts/create-release-manifests.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   createReleaseManifests,
   RELEASE_PLATFORMS,
+  STAGING_RELEASE_PLATFORMS,
 } from "./create-release-manifests.mjs";
 import { STAGING_BASE_URL } from "./desktop-channel.mjs";
 import { preparePublishedRelease } from "./prepare-published-release.mjs";
@@ -17,9 +18,9 @@ const EXPECTED_ARTIFACT_COUNT = RELEASE_PLATFORMS.reduce(
   0,
 );
 
-function releaseFixture(version = "0.4.2") {
+function releaseFixture(version = "0.4.2", platforms = RELEASE_PLATFORMS) {
   const dist = mkdtempSync(path.join(tmpdir(), "tidebreak-release-"));
-  for (const descriptor of RELEASE_PLATFORMS) {
+  for (const descriptor of platforms) {
     for (const arch of descriptor.architectures) {
       const directory = path.join(dist, descriptor.platform, arch);
       mkdirSync(directory, { recursive: true });
@@ -30,7 +31,7 @@ function releaseFixture(version = "0.4.2") {
         if (format.updater) {
           writeFileSync(
             `${file}.sig`,
-            `signature-${descriptor.platform}-${arch}\n`,
+            `signature-${descriptor.platform}-${arch}-${format.format}\n`,
           );
         }
       }
@@ -55,6 +56,9 @@ test("creates a complete manifest and Tauri updater document", () => {
   assert.deepEqual(Object.keys(latest.platforms), [
     "darwin-aarch64",
     "darwin-x86_64",
+    "windows-x86_64",
+    "linux-x86_64-appimage",
+    "linux-x86_64-deb",
   ]);
   assert.match(
     latest.platforms["darwin-aarch64"].url,
@@ -62,11 +66,35 @@ test("creates a complete manifest and Tauri updater document", () => {
   );
   assert.equal(
     latest.platforms["darwin-aarch64"].signature,
-    "signature-macos-universal",
+    "signature-macos-universal-app.tar.gz",
   );
   assert.deepEqual(
     latest.platforms["darwin-x86_64"],
     latest.platforms["darwin-aarch64"],
+  );
+  assert.match(
+    latest.platforms["windows-x86_64"].url,
+    /releases\/v0\.4\.2\/windows\/x86_64\/Tidebreak_0\.4\.2_x86_64-setup\.exe$/,
+  );
+  assert.equal(
+    latest.platforms["windows-x86_64"].signature,
+    "signature-windows-x86_64-nsis",
+  );
+  assert.match(
+    latest.platforms["linux-x86_64-appimage"].url,
+    /releases\/v0\.4\.2\/linux\/x86_64\/Tidebreak_0\.4\.2_x86_64\.AppImage$/,
+  );
+  assert.equal(
+    latest.platforms["linux-x86_64-appimage"].signature,
+    "signature-linux-x86_64-appimage",
+  );
+  assert.match(
+    latest.platforms["linux-x86_64-deb"].url,
+    /releases\/v0\.4\.2\/linux\/x86_64\/Tidebreak_0\.4\.2_x86_64\.deb$/,
+  );
+  assert.equal(
+    latest.platforms["linux-x86_64-deb"].signature,
+    "signature-linux-x86_64-deb",
   );
 
   const diskManifest = JSON.parse(
@@ -127,7 +155,7 @@ test("rejects mismatched tags and non-production hosts", () => {
 
 test("staging manifests stay under the staging prefix", () => {
   const version = "0.0.0-staging.12";
-  const dist = releaseFixture(version);
+  const dist = releaseFixture(version, STAGING_RELEASE_PLATFORMS);
   const staging = {
     version,
     tag: "staging-12",
@@ -144,6 +172,10 @@ test("staging manifests stay under the staging prefix", () => {
     latest.platforms["darwin-aarch64"].url,
     /\/tidebreak\/staging\/releases\/v0\.0\.0-staging\.12\//,
   );
+  assert.deepEqual(Object.keys(latest.platforms), [
+    "darwin-aarch64",
+    "darwin-x86_64",
+  ]);
   assert.throws(
     () =>
       createReleaseManifests({

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -105,15 +105,12 @@ const DESKTOP_SIGNING_JOBS = [
     name: "build_windows",
     validate: "Validate updater signing configuration",
   },
-];
-
-if (/^  build_linux:/m.test(workflows["release.yml"])) {
-  DESKTOP_SIGNING_JOBS.push({
+  {
     file: "release.yml",
     name: "build_linux",
     validate: "Verify and collect Linux artifacts",
-  });
-}
+  },
+];
 
 function desktopSigningJobs() {
   return DESKTOP_SIGNING_JOBS.map((spec) => ({
@@ -1432,6 +1429,12 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   // The prerequisite compiles without any production credential and never
   // uploads what it built; only the cache carries its outputs forward.
   assert.match(prepareJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
+  assert.match(prepareJob, /version: 10\.18\.3/);
+  assert.match(prepareJob, /pnpm install --frozen-lockfile --ignore-scripts/);
+  assert.match(
+    prepareJob,
+    /node scripts\/generate-third-party-notices\.mjs --check/,
+  );
   assert.match(prepareJob, /--no-bundle --ci/);
   assert.match(prepareJob, /continue-on-error: true/);
   assert.doesNotMatch(prepareJob, /^    environment:/m);
@@ -1456,32 +1459,18 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   );
 
   // Identical path lists keep the cache version shared between the writing
-  // and restoring jobs. The current workflow permits source-pinned fallback
-  // keys; the upcoming cross-platform workflow may tighten the credentialed
-  // job to the exact release SHA and version.
+  // and restoring jobs. The credentialed job accepts only the exact cache for
+  // this release SHA and version; broader warm-cache fallback stays confined
+  // to the credential-free prerequisite.
   const cachedPaths = (step) =>
     step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
   assert.ok(cachedPaths(buildCacheRestore));
   assert.equal(cachedPaths(buildCacheRestore), cachedPaths(prepareCacheSave));
-  const restorableKeys = buildCacheRestore
-    .split("\n")
-    .map((line) => line.trim().replace(/^key: /, ""))
-    .filter((line) => line.startsWith("windows-release-"));
-  if (/restore-keys:/.test(buildCacheRestore)) {
-    assert.ok(restorableKeys.length >= 3);
-    for (const key of restorableKeys) {
-      assert.ok(
-        key.includes("hashFiles('Cargo.lock',"),
-        `restorable Windows cache key does not pin the source: ${key}`,
-      );
-    }
-  } else {
-    assert.equal(restorableKeys.length, 1);
-    assert.match(
-      restorableKeys[0],
-      /hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\).*needs\.validate\.outputs\.sha.*needs\.validate\.outputs\.version/,
-    );
-  }
+  assert.match(
+    buildCacheRestore,
+    /key: windows-release-prepared-v1-\$\{\{ matrix\.arch \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ needs\.validate\.outputs\.sha \}\}-\$\{\{ needs\.validate\.outputs\.version \}\}/,
+  );
+  assert.doesNotMatch(buildCacheRestore, /restore-keys:/);
 
   // Whatever a restore extracts, the products that get packaged are relinked
   // from the tag's own sources.
@@ -1519,25 +1508,36 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
 
 test("Linux packaging writes no shared cache before loading updater material", () => {
   const release = workflows["release.yml"];
-  if (!/^  build_linux:/m.test(release)) return;
-
   assert.doesNotMatch(release, /^  prepare_linux:/m);
   const buildJob = workflowJob(release, "build_linux");
   assert.match(buildJob, /needs: \[validate, inspect_hosted\]/);
   assert.match(buildJob, /runs-on: ubuntu-22\.04/);
+  assert.match(buildJob, /libwebkit2gtk-4\.1-dev/);
   assert.match(buildJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
+  assert.match(buildJob, /version: 10\.18\.3/);
+  assert.match(buildJob, /pnpm install --frozen-lockfile --ignore-scripts/);
+  assert.match(
+    buildJob,
+    /node scripts\/generate-third-party-notices\.mjs --check/,
+  );
   assert.doesNotMatch(buildJob, /actions\/cache\/save/);
+  assert.doesNotMatch(buildJob, /actions\/cache\/restore/);
   assert.doesNotMatch(buildJob, /cache: pnpm/);
-
   const rustCache = cargoDownloadCache(buildJob);
   assert.ok(rustCache);
   assert.match(rustCache, /save-if: false/);
 
-  const packageStep = buildJob.match(
+  assert.match(buildJob, /--bundles appimage,deb/);
+  assert.match(buildJob, /\.AppImage/);
+  assert.match(buildJob, /\.deb/);
+  assert.match(buildJob, /tauri signer sign "\$appimage_path"/);
+  assert.match(buildJob, /tauri signer sign "\$deb_path"/);
+  assert.match(buildJob, /\$\{base_name\}\.deb\.sig/);
+  const buildStep = buildJob.match(
     /- name: Build the Tauri Linux packages[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
-  assert.ok(packageStep);
-  assert.doesNotMatch(packageStep, /TAURI_SIGNING_PRIVATE_KEY/);
+  assert.ok(buildStep);
+  assert.doesNotMatch(buildStep, /TAURI_SIGNING_PRIVATE_KEY/);
   assert.ok(
     buildJob.indexOf("Build the Tauri Linux packages") <
       buildJob.indexOf("Verify and collect Linux artifacts"),
@@ -1623,10 +1623,7 @@ test("source SBOM generation is isolated from production credentials", () => {
   assert.match(sbomJob, /name: tidebreak-source-sbom-\$\{\{ needs\.validate\.outputs\.version \}\}/);
   assert.doesNotMatch(publishJob, /anchore\/sbom-action/);
 
-  assert.match(
-    publishJob,
-    /needs: \[validate, inspect_hosted, build_macos, build_windows(?:, build_linux)?, source_sbom, finalize_release\]/,
-  );
+  assert.match(publishJob, /needs: \[validate, inspect_hosted, build_macos, build_windows, build_linux, source_sbom, finalize_release\]/);
   assert.match(publishJob, /needs\.source_sbom\.result == 'success'/);
   assert.match(
     publishJob,
@@ -1663,10 +1660,7 @@ test("GitHub release assets are attached before immutable publication", () => {
   const finalizeJob = workflowJob(release, "finalize_release");
   const publishJob = workflowJob(release, "publish");
 
-  assert.match(
-    attachJob,
-    /needs: \[validate, inspect_hosted, build_macos, build_windows(?:, build_linux)?, source_sbom\]/,
-  );
+  assert.match(attachJob, /needs: \[validate, inspect_hosted, build_macos, build_windows, build_linux, source_sbom\]/);
   assert.match(attachJob, /contents: write/);
   assert.doesNotMatch(attachJob, /^    environment:/m);
   assert.doesNotMatch(attachJob, /secrets\./);
@@ -1676,14 +1670,20 @@ test("GitHub release assets are attached before immutable publication", () => {
   // publication. A published retry verifies those assets and can reconstruct
   // an incomplete hosted publication without rebuilding signed packages.
   assert.match(attachJob, /name: tidebreak-macos-universal-/);
+  assert.match(attachJob, /name: tidebreak-windows-x86_64-/);
+  assert.match(attachJob, /name: tidebreak-linux-x86_64-/);
   assert.match(attachJob, /name: tidebreak-source-sbom-/);
   assert.match(attachJob, /gh release download "\$RELEASE_TAG"/);
   assert.match(attachJob, /sha256sum --check --strict/);
   assert.match(attachJob, /Tidebreak-macos-universal\.dmg/);
   assert.match(attachJob, /Tidebreak-macos-apple-silicon\.dmg/);
+  assert.match(attachJob, /Tidebreak-windows-x86_64-setup\.exe/);
+  assert.match(attachJob, /Tidebreak-linux-x86_64\.AppImage/);
+  assert.match(attachJob, /Tidebreak-linux-x86_64\.deb/);
   assert.match(attachJob, /\.app\.zip/);
   assert.match(attachJob, /\.app\.tar\.gz/);
   assert.match(attachJob, /\.app\.tar\.gz\.sig/);
+  assert.match(attachJob, /Tidebreak_\$\{TIDEBREAK_VERSION\}_x86_64\.deb\.sig/);
   assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
   assert.match(attachJob, /if \[\[ "\$RELEASE_DRAFT" = true \]\]/);
   assert.match(attachJob, /releases\/\$RELEASE_ID\/assets/);
@@ -1715,6 +1715,20 @@ test("GitHub release assets are attached before immutable publication", () => {
     attachJob.includes(`downloads/${macDownloadLink}`),
     `attach_downloads must upload ${macDownloadLink}`,
   );
+
+  for (const [platform, pattern] of [
+    ["Windows", /releases\/latest\/download\/(Tidebreak-windows-[\w-]+\.exe)/],
+    ["Linux AppImage", /releases\/latest\/download\/(Tidebreak-linux-[\w-]+\.AppImage)/],
+    ["Linux Debian", /releases\/latest\/download\/(Tidebreak-linux-[\w-]+\.deb)/],
+  ]) {
+    const downloadLink = readFileSync(repositoryFile("README.md"), "utf8")
+      .match(pattern)?.[1];
+    assert.ok(downloadLink, `the README must publish a ${platform} download link`);
+    assert.ok(
+      attachJob.includes(`downloads/${downloadLink}`),
+      `attach_downloads must upload ${downloadLink}`,
+    );
+  }
 });
 
 test("the updater private key is isolated from compilation", () => {


### PR DESCRIPTION
Prerequisite trusted-policy transition: #2174.

## Summary

- require production desktop releases to include universal macOS, Windows x86_64 NSIS, and Linux x86_64 AppImage and Debian packages
- unpark native Windows CI and release jobs, and add cache-write-free Linux packaging on Ubuntu 22.04
- publish stable GitHub download aliases, immutable hosted artifacts, checksums, recovery inputs, and format-specific signed Linux updater entries
- keep staging and runtime automatic updates macOS-only while documenting unsigned Windows behavior, platform capability limits, and deferred ARM64/update rehearsal work
- record the cross-platform release contract in decision 40

## Why

Tidebreak's desktop shell already has Windows and Linux platform implementations, but production releases currently require users on those systems to build from source. This establishes an all-or-nothing cross-platform package contract without claiming that every optional macOS-native capability is available elsewhere.

The Linux job builds from the validated release tag with compiler and dependency caches in read-only mode. It does not enable pnpm caching or save compiler caches, and the updater private key enters the environment only after both package formats have been built.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`
- `node --test scripts/*.test.mjs` — 174 tests passed
- PR #2174's transitional trusted policy against this workflow — 35 tests passed
- `pnpm --dir docs-site lint`
- `pnpm --dir docs-site types:check`
- `pnpm --dir docs-site build`
- post-rebase focused release/security tests — 41 tests passed

- `cargo test -p tidebreak-server --lib desktop_schema --locked` — 13 tests passed
- Unix-only server suites remain covered on Unix hosts — 26 targeted tests passed

## Not verified locally

The development host is macOS, so actual Windows/Linux package generation and clean-machine install, launch, deep-link, sidecar, persistence, and uninstall smoke tests require native hosted runners and test machines.