### PR TITLE
feat(code): add a PR review surface, vendor-split model pickers, and workspace cards

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -384,6 +384,81 @@ pub struct PullRequestDigest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub checks: Option<Vec<PullRequestCheck>>,
+    /// True when the host reports the PR as a draft.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub draft: Option<bool>,
+    /// True when the host reports the PR merged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub merged: Option<bool>,
+    /// Lowercased host review decision (approved, changes_requested, review_required).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub review_decision: Option<String>,
+    /// Lowercased host mergeability (mergeable, conflicting, unknown).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub mergeable: Option<String>,
+    /// Lowercased host merge-state status (clean, blocked, behind, dirty, …).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub merge_state_status: Option<String>,
+    /// Head branch name on the host.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub head_branch: Option<String>,
+    /// Base branch name on the host.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub base_branch: Option<String>,
+    /// True when auto-merge is enabled on the host.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub auto_merge_enabled: Option<bool>,
+}
+
+/// One pull-request comment: an issue comment, a review body, or an inline
+/// review comment. Never persisted; fetched live from the host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct PullRequestComment {
+    /// Where on the PR the comment lives.
+    pub kind: PullRequestCommentKind,
+    /// Author login, when the host reported one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub author: Option<String>,
+    /// Host creation timestamp, verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub created_at: Option<String>,
+    /// Comment body, markdown as the host stores it.
+    pub body: String,
+    /// Lowercased review verdict (approved, changes_requested, commented), on
+    /// review bodies only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub review_state: Option<String>,
+    /// File path, on inline review comments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub path: Option<String>,
+    /// Line number, on inline review comments when the host reports one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub line: Option<u64>,
+}
+
+/// Which surface of the PR a comment belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum PullRequestCommentKind {
+    /// Conversation-tab issue comment.
+    Issue,
+    /// Review submission body.
+    Review,
+    /// Inline review comment on a file.
+    Inline,
 }
 
 /// Best-effort classification of what an approval is asking.

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -146,10 +146,10 @@ pub use code::{
     CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionLifecycle,
     CodeTerminalId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeUsage, CodeWorkspace,
     CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps, HarnessKind,
-    HarnessNoticeLevel, HarnessTier, PullRequestCheck, PullRequestCheckBucket, PullRequestDigest,
-    QuickAction, RepoId, SequencedCodeEvent, ToolDetail, ToolOutcome, WorkspaceId,
-    MAX_ATTENTION_NOTE, MAX_ATTENTION_PROMPT, MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS,
-    MAX_PREVIEW_CHARS, MAX_TOOL_SUMMARY_CHARS,
+    HarnessNoticeLevel, HarnessTier, PullRequestCheck, PullRequestCheckBucket, PullRequestComment,
+    PullRequestCommentKind, PullRequestDigest, QuickAction, RepoId, SequencedCodeEvent, ToolDetail,
+    ToolOutcome, WorkspaceId, MAX_ATTENTION_NOTE, MAX_ATTENTION_PROMPT, MAX_EVENT_TEXT_CHARS,
+    MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS, MAX_TOOL_SUMMARY_CHARS,
 };
 pub use compaction::{
     CompactionPolicy, CompactionSelection, CompactionSourceBoundary, CompactionTokenBounds,

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -854,8 +854,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         );
       case "agent":
         return <BackgroundAgentPanel chatId={chatId} runId={panel.runId} />;
-      case "files":
-      case "diff":
       case "terminal":
         return null;
     }

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
@@ -120,7 +120,7 @@ it("searches every visible provider when typing with the picker open", async () 
   expect(onChange).toHaveBeenCalledWith("openai::gpt-5");
 });
 
-it("uses the generic gateway mark for a mixed gateway rail", async () => {
+it("splits a mixed gateway catalog into vendor tabs", async () => {
   const gatewayModels: ModelInfo[] = [
     {
       ...MODELS[0],
@@ -134,6 +134,14 @@ it("uses the generic gateway mark for a mixed gateway rail", async () => {
       provider: "model_gateway",
       vendor: "openai",
     },
+    {
+      ...MODELS[2],
+      key: "model_gateway::mystery-model",
+      id: "mystery-model",
+      display_name: "Mystery Model",
+      provider: "model_gateway",
+      vendor: null,
+    },
   ];
   render(
     <ModelMenu
@@ -146,7 +154,20 @@ it("uses the generic gateway mark for a mixed gateway rail", async () => {
 
   const user = userEvent.setup();
   await user.click(screen.getByRole("button", { name: "Model: Claude Sonnet 4" }));
+
+  // One tab per vendor, opened on the selected model's vendor; only the
+  // unrecognizable row keeps the generic gateway tab.
+  const anthropicTab = screen.getByRole("tab", { name: "Anthropic" });
+  expect(anthropicTab).toHaveAttribute("aria-selected", "true");
+  expect(anthropicTab.querySelector("svg[fill='#D97757']")).not.toBeNull();
+  expect(screen.getByRole("menuitem", { name: "Claude Sonnet 4" })).toBeTruthy();
+  expect(screen.queryByRole("menuitem", { name: "GPT-5" })).toBeNull();
+
+  await user.click(screen.getByRole("tab", { name: "OpenAI" }));
+  expect(screen.getByRole("menuitem", { name: "GPT-5" })).toBeTruthy();
+
   const gatewayTab = screen.getByRole("tab", { name: "Model Gateway" });
   expect(gatewayTab.querySelector(".lucide-network")).not.toBeNull();
-  expect(gatewayTab.querySelector("svg[fill='#D97757']")).toBeNull();
+  await user.click(gatewayTab);
+  expect(screen.getByRole("menuitem", { name: "Mystery Model" })).toBeTruthy();
 });

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.test.tsx
@@ -6,7 +6,7 @@ import {
   ModelMenu,
   ModelToolCapabilityChip,
   notConnectedProviders,
-  pickerProviderForSelection,
+  pickerGroupForSelection,
   pickerRailEntries,
   reasoningEffortOptions,
   visibleModelGroups,
@@ -203,6 +203,42 @@ describe("visibleModelGroups", () => {
       HAIKU.key,
     ]);
   });
+
+  it("splits a gateway catalog into vendor groups", () => {
+    const viaGateway = (key: ModelInfo["key"], id: string, vendor: ModelInfo["vendor"]) => ({
+      ...MODELS[0],
+      key,
+      id,
+      provider: "model_gateway" as const,
+      vendor,
+    });
+    const groups = visibleModelGroups(
+      [
+        viaGateway("model_gateway::deepseek-v4", "deepseek-v4", null),
+        viaGateway("model_gateway::claude-sonnet-4", "claude-sonnet-4", "anthropic"),
+        viaGateway("model_gateway::gpt-5", "gpt-5", "openai"),
+        viaGateway("model_gateway::glm-5.2", "glm-5.2", null),
+        viaGateway("model_gateway::mystery-model", "mystery-model", null),
+      ],
+      null,
+    );
+    expect(groups.map((group) => [group.id, group.label])).toEqual([
+      ["model_gateway/openai", "OpenAI"],
+      ["model_gateway/anthropic", "Anthropic"],
+      ["model_gateway/deepseek", "DeepSeek"],
+      ["model_gateway/glm", "Z.ai"],
+      ["model_gateway", "Model Gateway"],
+    ]);
+    expect(
+      groups.map((group) => group.models.map((model) => model.id)),
+    ).toEqual([
+      ["gpt-5"],
+      ["claude-sonnet-4"],
+      ["deepseek-v4"],
+      ["glm-5.2"],
+      ["mystery-model"],
+    ]);
+  });
 });
 
 describe("matchingModels", () => {
@@ -315,29 +351,81 @@ describe("pickerRailEntries", () => {
       ["openrouter", false],
     ]);
   });
+
+  it("gives each gateway vendor group its own rail tab", () => {
+    const viaGateway = (key: ModelInfo["key"], id: string, vendor: ModelInfo["vendor"]) => ({
+      ...MODELS[0],
+      key,
+      id,
+      provider: "model_gateway" as const,
+      vendor,
+    });
+    const rail = pickerRailEntries(
+      [
+        viaGateway("model_gateway::claude-sonnet-4", "claude-sonnet-4", "anthropic"),
+        viaGateway("model_gateway::gpt-5", "gpt-5", "openai"),
+        viaGateway("model_gateway::deepseek-v4", "deepseek-v4", null),
+      ],
+      [],
+      null,
+    );
+    expect(rail.map((entry) => [entry.id, entry.connected])).toEqual([
+      ["model_gateway/openai", true],
+      ["model_gateway/anthropic", true],
+      ["model_gateway/deepseek", true],
+    ]);
+  });
+
+  it("does not offer setup for a provider a gateway group already serves", () => {
+    const directClaude: ModelInfo = {
+      ...MODELS[0],
+      available: false,
+    };
+    const gatewayClaude: ModelInfo = {
+      ...MODELS[0],
+      key: "model_gateway::claude-sonnet-4",
+      provider: "model_gateway",
+      vendor: "anthropic",
+    };
+    const rail = pickerRailEntries([directClaude, gatewayClaude], [], null);
+    expect(rail.map((entry) => entry.id)).toEqual(["model_gateway/anthropic"]);
+  });
 });
 
-describe("pickerProviderForSelection", () => {
-  const groups = [
-    { provider: "openai" as const },
-    { provider: "anthropic" as const },
-  ];
+describe("pickerGroupForSelection", () => {
+  const groups = [{ id: "openai" }, { id: "anthropic" }];
 
-  it("opens on the selected model's provider", () => {
+  it("opens on the selected model's group", () => {
+    expect(pickerGroupForSelection(groups, MODELS[0])).toBe("anthropic");
+  });
+
+  it("opens on a gateway model's vendor group", () => {
+    const gatewayClaude: ModelInfo = {
+      ...MODELS[0],
+      key: "model_gateway::claude-sonnet-4",
+      provider: "model_gateway",
+      vendor: "anthropic",
+    };
     expect(
-      pickerProviderForSelection(groups, { provider: "anthropic" }),
-    ).toBe("anthropic");
+      pickerGroupForSelection(
+        [{ id: "model_gateway/anthropic" }, { id: "model_gateway/openai" }],
+        gatewayClaude,
+      ),
+    ).toBe("model_gateway/anthropic");
   });
 
   it("falls back to the first visible group", () => {
-    expect(pickerProviderForSelection(groups, null)).toBe("openai");
+    expect(pickerGroupForSelection(groups, null)).toBe("openai");
     expect(
-      pickerProviderForSelection(groups, { provider: "gemini" }),
+      pickerGroupForSelection(groups, {
+        ...MODELS[0],
+        provider: "gemini",
+      }),
     ).toBe("openai");
   });
 
   it("is null when nothing is listed", () => {
-    expect(pickerProviderForSelection([], { provider: "openai" })).toBeNull();
+    expect(pickerGroupForSelection([], MODELS[0])).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
@@ -21,6 +21,7 @@ import {
   providerLabel,
 } from "./ModelSelection";
 import { useManagedPolicy } from "./managedPolicy";
+import { familyForModelId, MODEL_ID_FAMILIES } from "./modelFamilies";
 import { Button } from "@/components/ui/button";
 import { ProviderIcon } from "./ProviderIcons";
 import {
@@ -80,62 +81,142 @@ export function ModelToolCapabilityChip({ model }: { model: ModelInfo }) {
   );
 }
 
-/** Catalog rows by provider, in {@link PROVIDER_ORDER}, then the rest as found. */
-function groupByProvider(
-  models: readonly ModelInfo[],
-): { provider: ProviderKind; models: ModelInfo[] }[] {
-  const byProvider = new Map<ProviderKind, ModelInfo[]>();
+/** How a rail tab or group header is drawn: a mark and a name. */
+type GroupBadge = {
+  label: string;
+  iconProvider: ProviderKind;
+  iconModelId?: string;
+};
+
+/**
+ * One section of the picker: a serving provider, or one vendor's slice of a
+ * gateway catalog. `id` is the rail identity; `provider` stays the route that
+ * serves the rows, which routing and policy still key on.
+ */
+export type CatalogGroup = GroupBadge & {
+  id: string;
+  provider: ProviderKind;
+  models: ModelInfo[];
+};
+
+/**
+ * Which group a row belongs to.
+ *
+ * Direct providers group as themselves. A gateway catalog is mixed, so its
+ * rows split by the vendor the row is branded with — the curated `vendor`
+ * when the server matched one, else the open-model family its id names —
+ * and only rows with neither stay under the generic gateway tab.
+ */
+function groupBadgeForModel(model: ModelInfo): GroupBadge & { id: string } {
+  if (model.provider !== "model_gateway") {
+    return {
+      id: model.provider,
+      label: providerLabel(model.provider),
+      iconProvider: model.provider,
+    };
+  }
+  const family = familyForModelId(model.id);
+  if (family) {
+    return {
+      id: `model_gateway/${family.match}`,
+      label: family.label,
+      iconProvider: "model_gateway",
+      iconModelId: family.match,
+    };
+  }
+  if (model.vendor) {
+    return {
+      id: `model_gateway/${model.vendor}`,
+      label: providerLabel(model.vendor),
+      iconProvider: model.vendor,
+    };
+  }
+  return {
+    id: "model_gateway",
+    label: providerLabel("model_gateway"),
+    iconProvider: "model_gateway",
+  };
+}
+
+/** Rank vendors inside a gateway catalog: known vendors first, then families. */
+const GATEWAY_GROUP_ORDER: readonly string[] = [
+  ...PROVIDER_ORDER.map((provider) => `model_gateway/${provider}`),
+  ...MODEL_ID_FAMILIES.map((family) => `model_gateway/${family.match}`),
+  "model_gateway",
+];
+
+/**
+ * Catalog rows grouped for the rail: providers in {@link PROVIDER_ORDER},
+ * then the rest as found — except a gateway catalog, whose groups sort by
+ * {@link GATEWAY_GROUP_ORDER} so the split does not reshuffle with the
+ * catalog.
+ */
+function groupCatalog(models: readonly ModelInfo[]): CatalogGroup[] {
+  const byId = new Map<string, CatalogGroup>();
   for (const model of models) {
-    const list = byProvider.get(model.provider);
-    if (list) list.push(model);
-    else byProvider.set(model.provider, [model]);
+    const badge = groupBadgeForModel(model);
+    const existing = byId.get(badge.id);
+    if (existing) existing.models.push(model);
+    else byId.set(badge.id, { ...badge, provider: model.provider, models: [model] });
   }
 
-  const groups: { provider: ProviderKind; models: ModelInfo[] }[] = [];
+  const groups: CatalogGroup[] = [];
   for (const provider of PROVIDER_ORDER) {
-    const found = byProvider.get(provider);
+    const found = byId.get(provider);
     if (found) {
-      groups.push({ provider, models: found });
-      byProvider.delete(provider);
+      groups.push(found);
+      byId.delete(provider);
     }
   }
-  for (const [provider, found] of byProvider) {
-    groups.push({ provider, models: found });
-  }
+  const rest = [...byId.values()];
+  const gatewayRank = (group: CatalogGroup) => {
+    const rank = GATEWAY_GROUP_ORDER.indexOf(group.id);
+    return rank === -1 ? GATEWAY_GROUP_ORDER.length : rank;
+  };
+  groups.push(...rest.filter((group) => group.provider !== "model_gateway"));
+  groups.push(
+    ...rest
+      .filter((group) => group.provider === "model_gateway")
+      .sort((a, b) => gatewayRank(a) - gatewayRank(b)),
+  );
   return groups;
 }
 
 /**
- * Which provider rail the picker should open on.
+ * Which rail tab the picker should open on.
  *
- * Prefers the provider of the model that will run, then the first group the
+ * Prefers the group of the model that will run, then the first group the
  * menu actually shows. `null` only when there is no group at all.
  */
-export function pickerProviderForSelection(
-  groups: readonly { provider: ProviderKind }[],
-  selected: Pick<ModelInfo, "provider"> | null,
-): ProviderKind | null {
+export function pickerGroupForSelection(
+  groups: readonly { id: string }[],
+  selected: ModelInfo | null,
+): string | null {
   if (selected) {
-    const match = groups.find((group) => group.provider === selected.provider);
-    if (match) return match.provider;
+    const id = groupBadgeForModel(selected).id;
+    const match = groups.find((group) => group.id === id);
+    if (match) return match.id;
   }
-  return groups[0]?.provider ?? null;
+  return groups[0]?.id ?? null;
 }
 
-/** One icon on the picker rail: connected providers and ones still to set up. */
-export type PickerRailEntry = {
+/** One icon on the picker rail: connected groups and providers still to set up. */
+export type PickerRailEntry = GroupBadge & {
+  id: string;
   provider: ProviderKind;
   connected: boolean;
   modelCount: number;
 };
 
 /**
- * Every provider the catalog knows, in {@link PROVIDER_ORDER}.
+ * Every group the catalog knows, in {@link PROVIDER_ORDER}.
  *
  * Connected groups (something can run) sit with the unconfigured ones so the
  * rail is a map of the catalog rather than only what this install already
  * unlocked. The gateway stays off the unconfigured side: it has no key to
- * paste. A managed profile only lists what can already run.
+ * paste. A managed profile only lists what can already run. A provider whose
+ * vendor a gateway group already serves is not offered for setup — its models
+ * can run through the gateway.
  */
 export function pickerRailEntries(
   models: readonly ModelInfo[],
@@ -143,43 +224,63 @@ export function pickerRailEntries(
   selectedKey: string | null,
   managed: boolean = false,
 ): PickerRailEntry[] {
-  const connected = visibleModelGroups(models, selectedKey).map(
-    (group) => ({
-      provider: group.provider,
-      connected: true,
-      modelCount: group.models.length,
-    }),
+  const connected: PickerRailEntry[] = visibleModelGroups(
+    models,
+    selectedKey,
+  ).map((group) => ({
+    id: group.id,
+    provider: group.provider,
+    label: group.label,
+    iconProvider: group.iconProvider,
+    iconModelId: group.iconModelId,
+    connected: true,
+    modelCount: group.models.length,
+  }));
+  const seen = new Set(
+    connected.flatMap((entry) => [
+      entry.id,
+      // A gateway vendor group covers the direct provider it mirrors.
+      ...(entry.id.startsWith("model_gateway/")
+        ? [entry.id.slice("model_gateway/".length)]
+        : []),
+    ]),
   );
-  const seen = new Set(connected.map((entry) => entry.provider));
-  const unconfigured = notConnectedProviders(models, providers, managed)
+  const unconfigured: PickerRailEntry[] = notConnectedProviders(
+    models,
+    providers,
+    managed,
+  )
     .filter((entry) => !seen.has(entry.provider))
     .map((entry) => ({
+      id: entry.provider,
       provider: entry.provider,
+      label: providerLabel(entry.provider),
+      iconProvider: entry.provider,
       connected: false,
       modelCount: entry.modelCount,
     }));
 
-  const byProvider = new Map<ProviderKind, PickerRailEntry>();
+  const byId = new Map<string, PickerRailEntry>();
   for (const entry of [...connected, ...unconfigured]) {
-    byProvider.set(entry.provider, entry);
+    byId.set(entry.id, entry);
   }
 
   const ordered: PickerRailEntry[] = [];
   for (const provider of PROVIDER_ORDER) {
-    const found = byProvider.get(provider);
+    const found = byId.get(provider);
     if (found) {
       ordered.push(found);
-      byProvider.delete(provider);
+      byId.delete(provider);
     }
   }
-  for (const found of byProvider.values()) {
+  for (const found of byId.values()) {
     ordered.push(found);
   }
   return ordered;
 }
 
 /**
- * The groups the composer picker shows: every catalog row for a provider
+ * The groups the composer picker shows: every catalog row for a group
  * that can run something, plus the group holding the current selection even
  * when that row cannot run. A provider with nothing usable is a rail icon
  * that offers setup, not an empty model list.
@@ -187,8 +288,8 @@ export function pickerRailEntries(
 export function visibleModelGroups(
   models: readonly ModelInfo[],
   selectedKey: string | null,
-): { provider: ProviderKind; models: ModelInfo[] }[] {
-  return groupByProvider(models).flatMap((group) => {
+): CatalogGroup[] {
+  return groupCatalog(models).flatMap((group) => {
     if (group.models.some((model) => model.available)) return [group];
     if (selectedKey === null) return [];
 
@@ -240,7 +341,7 @@ export function notConnectedProviders(
 ): { provider: ProviderKind; modelCount: number }[] {
   if (managed) return [];
   const status = new Map(providers.map((info) => [info.kind, info]));
-  return groupByProvider(models)
+  return groupCatalog(models)
     .filter((group) => {
       if (group.provider === "model_gateway") return false;
       // Anything that can already run is connected however it got there.
@@ -351,13 +452,13 @@ export function ModelMenu({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const searchInput = useRef<HTMLInputElement>(null);
-  const [activeProvider, setActiveProvider] = useState<ProviderKind | null>(
-    () => pickerProviderForSelection(rail, known ?? usableDefault),
+  const [activeGroupId, setActiveGroupId] = useState<string | null>(
+    () => pickerGroupForSelection(rail, known ?? usableDefault),
   );
   const activeRail =
-    rail.find((entry) => entry.provider === activeProvider) ?? rail[0] ?? null;
+    rail.find((entry) => entry.id === activeGroupId) ?? rail[0] ?? null;
   const activeGroup =
-    groups.find((group) => group.provider === activeRail?.provider) ?? null;
+    groups.find((group) => group.id === activeRail?.id) ?? null;
   const showProviderRail = rail.length > 0;
   const searchResults = matchingModels(groups, query);
   const searching = query.length > 0;
@@ -365,8 +466,8 @@ export function ModelMenu({
   function openMenu(next: boolean) {
     if (next) {
       setQuery("");
-      setActiveProvider(
-        pickerProviderForSelection(rail, known ?? usableDefault),
+      setActiveGroupId(
+        pickerGroupForSelection(rail, known ?? usableDefault),
       );
     }
     setOpen(next);
@@ -457,39 +558,31 @@ export function ModelMenu({
             aria-label="Providers"
           >
             {rail.map((entry) => {
-              const selected = activeRail?.provider === entry.provider;
+              const selected = activeRail?.id === entry.id;
+              const railLabel = entry.connected
+                ? entry.label
+                : `Connect ${entry.label}`;
               return (
-                <WithTooltip
-                  key={entry.provider}
-                  label={
-                    entry.connected
-                      ? providerLabel(entry.provider)
-                      : `Connect ${providerLabel(entry.provider)}`
-                  }
-                  side="right"
-                >
+                <WithTooltip key={entry.id} label={railLabel} side="right">
                   <button
                     type="button"
                     role="tab"
                     aria-selected={selected}
-                    aria-label={
-                      entry.connected
-                        ? providerLabel(entry.provider)
-                        : `Connect ${providerLabel(entry.provider)}`
-                    }
+                    aria-label={railLabel}
                     className={cn(
                       "relative flex size-9 items-center justify-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring",
                       selected ? "bg-accent" : "hover:bg-accent/60",
                       !entry.connected && "opacity-45 hover:opacity-80",
                     )}
-                    onClick={() => setActiveProvider(entry.provider)}
+                    onClick={() => setActiveGroupId(entry.id)}
                   >
                     <ProviderIcon
-                      // A rail tab represents the route serving the group,
-                      // not whichever upstream vendor happened to be first.
-                      // Gateway catalogs are mixed, so their tab must stay the
-                      // generic gateway mark while rows retain vendor marks.
-                      provider={entry.provider}
+                      // A rail tab wears the mark of its group: a vendor's
+                      // slice of a gateway catalog gets the vendor mark, and
+                      // only gateway rows with no recognizable vendor keep
+                      // the generic gateway mark.
+                      provider={entry.iconProvider}
+                      modelId={entry.iconModelId}
                       className="size-4"
                     />
                     {selected && (
@@ -534,12 +627,13 @@ export function ModelMenu({
             <div>
               <div className="flex flex-col items-start gap-3 px-2 py-3">
                 <ProviderIcon
-                  provider={activeRail.provider}
+                  provider={activeRail.iconProvider}
+                  modelId={activeRail.iconModelId}
                   className="size-5"
                 />
                 <div className="space-y-1">
                   <p className="text-sm font-medium">
-                    Connect {providerLabel(activeRail.provider)}
+                    Connect {activeRail.label}
                   </p>
                   <p className="text-muted-foreground text-xs leading-relaxed">
                     {activeRail.modelCount}{" "}

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -90,6 +90,8 @@ import {
   type CodeWorkspaceDiff,
   type CodeWorkspaceFiles,
   type CodeWorkspacePrSnapshot,
+  type CodePrCommentsSnapshot,
+  type CodePrMergeMethod,
   type CodeWorkspaceSnapshot,
   type CodeCloneDefaults,
   type CodeCloneJobSnapshot,
@@ -132,6 +134,7 @@ import {
   parseCodeWorkspaceDiff,
   parseCodeWorkspaceFiles,
   parseCodeWorkspacePr,
+  parseCodePrComments,
   parseHarnessModelList,
   parseHarnessDoctorReport,
   parseSequencedCodeEvent,
@@ -1992,6 +1995,58 @@ export class ApiClient {
         await this.json(`/code/workspaces/${encodeURIComponent(workspaceId)}/pr`, {
           headers: this.headers(),
         }),
+      ),
+      "code pull request",
+    );
+  }
+
+  /** Force a fresh host read, bypassing the server's short PR cache. */
+  async refreshCodeWorkspacePr(
+    workspaceId: string,
+  ): Promise<CodeWorkspacePrSnapshot> {
+    return requireParsed(
+      parseCodeWorkspacePr(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/refresh`,
+          { method: "POST", headers: this.headers() },
+        ),
+      ),
+      "code pull request",
+    );
+  }
+
+  async getCodePrComments(
+    workspaceId: string,
+  ): Promise<CodePrCommentsSnapshot> {
+    return requireParsed(
+      parseCodePrComments(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/comments`,
+          { headers: this.headers() },
+        ),
+      ),
+      "code pull request comments",
+    );
+  }
+
+  /**
+   * User-initiated merge. auto=true arms host auto-merge instead of merging
+   * immediately. Returns the post-merge snapshot.
+   */
+  async mergeCodePr(
+    workspaceId: string,
+    body: { method: CodePrMergeMethod; auto?: boolean },
+  ): Promise<CodeWorkspacePrSnapshot> {
+    return requireParsed(
+      parseCodeWorkspacePr(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/merge`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+            body: JSON.stringify({ method: body.method, auto: body.auto ?? false }),
+          },
+        ),
       ),
       "code pull request",
     );

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -132,6 +132,11 @@ import {
   type PullRequestDigest as WirePullRequestDigest,
   type PullRequestCheck as WirePullRequestCheck,
   type PullRequestCheckBucket as WirePullRequestCheckBucket,
+  type PullRequestComment as WirePullRequestComment,
+  type PullRequestCommentKind as WirePullRequestCommentKind,
+  type CodePrCommentsSnapshot as WireCodePrCommentsSnapshot,
+  type CodePrMergeMethod as WireCodePrMergeMethod,
+  type MergeCodePrBody as WireMergeCodePrBody,
   type CodeTerminalRead as WireCodeTerminalRead,
   type CodeTerminalSnapshot as WireCodeTerminalSnapshot,
   type CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
@@ -1020,6 +1025,13 @@ export type CodeActionSnapshot = WireCodeActionSnapshot;
 export type PullRequestDigest = WirePullRequestDigest;
 export type PullRequestCheck = WirePullRequestCheck;
 export type PullRequestCheckBucket = WirePullRequestCheckBucket;
+export type PullRequestComment = WirePullRequestComment;
+export type PullRequestCommentKind = WirePullRequestCommentKind;
+/** The PR conversation, read live from the host and never persisted. */
+export type CodePrCommentsSnapshot = WireCodePrCommentsSnapshot;
+export type CodePrMergeMethod = WireCodePrMergeMethod;
+/** Body of POST /code/workspaces/{id}/pr/merge. */
+export type MergeCodePrBody = WireMergeCodePrBody;
 export type CodeTerminalSnapshot = WireCodeTerminalSnapshot;
 export type CodeTerminalRead = WireCodeTerminalRead;
 export type CodeTerminalActivityNotice = WireCodeTerminalActivityNotice;

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 import { Check, ChevronDown, Search } from "lucide-react";
 
 import type { CodePermissionMode, HarnessKind, PermissionMode } from "../api/types";
@@ -9,6 +9,7 @@ import {
   ClaudeIcon,
   OpenAIIcon,
   OpenCodeIcon,
+  ProviderIcon,
   XaiIcon,
 } from "../ProviderIcons";
 import { Button } from "@/components/ui/button";
@@ -18,8 +19,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 import type { CodeTurnSubmission } from "./parsers";
 import {
+  codeModelVendor,
+  groupCodeModelOptions,
   type CodeModelOption,
   PERMISSION_MODE_UNAVAILABLE_REASON,
 } from "./labels";
@@ -63,6 +68,34 @@ const HARNESS_ICONS: Record<
   grok: XaiIcon,
 };
 
+/** The mark for one picker row: its vendor, or the engine's own mark. */
+function CodeModelMark({
+  harness,
+  option,
+  className,
+}: {
+  harness: HarnessKind;
+  option: CodeModelOption;
+  className?: string;
+}) {
+  const vendor = codeModelVendor(option);
+  if (vendor) {
+    return (
+      <ProviderIcon provider={vendor} modelId={option.id} className={className} />
+    );
+  }
+  const Icon = HARNESS_ICONS[harness];
+  return <Icon className={className} />;
+}
+
+/**
+ * Per-session model selector for the code composer.
+ *
+ * Mirrors the chat picker: a vendor rail on the left, search on top, one
+ * row per model. The rows are confined to what the engine can drive, so a
+ * Claude Code session only ever offers Claude models while vendor-neutral
+ * engines group a mixed catalog by vendor.
+ */
 export function HarnessModelMenu({
   harness,
   options,
@@ -81,24 +114,65 @@ export function HarnessModelMenu({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const searchInput = useRef<HTMLInputElement>(null);
+  const groups = useMemo(() => groupCodeModelOptions(options), [options]);
+  const currentGroupId =
+    groups.find((group) =>
+      group.options.some((option) => option.id === current?.id),
+    )?.id ?? null;
+  const [activeGroupId, setActiveGroupId] = useState<string | null>(
+    currentGroupId,
+  );
+  const activeGroup =
+    groups.find((group) => group.id === activeGroupId) ?? groups[0] ?? null;
+  const searching = query.trim().length > 0;
   const matches = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    if (!needle) return options;
-    return options.filter(
-      (option) =>
-        option.label.toLowerCase().includes(needle) ||
-        option.id.toLowerCase().includes(needle) ||
-        option.source.toLowerCase().includes(needle),
-    );
-  }, [options, query]);
+    if (!needle) return [];
+    return groups
+      .flatMap((group) => group.options)
+      .filter(
+        (option) =>
+          option.label.toLowerCase().includes(needle) ||
+          option.id.toLowerCase().includes(needle) ||
+          option.source.toLowerCase().includes(needle),
+      );
+  }, [groups, query]);
+  const visible = searching ? matches : (activeGroup?.options ?? []);
   if (!current) return null;
-  const Icon = HARNESS_ICONS[harness];
+
+  function modelRow(option: CodeModelOption, index: number) {
+    const selected = option.id === current?.id;
+    return (
+      <DropdownMenuItem
+        key={`${option.source}:${option.id}`}
+        onSelect={() => onChange?.(option.id)}
+        className="flex items-center gap-2"
+      >
+        <CodeModelMark
+          harness={harness}
+          option={option}
+          className="size-4 shrink-0"
+        />
+        <span className="min-w-0 flex-1 truncate text-sm">{option.label}</span>
+        {index < 9 && (
+          <span className="text-muted-foreground rounded-md border px-1.5 py-0.5 font-mono text-[10px]">
+            ⌘{index + 1}
+          </span>
+        )}
+        {selected && <Check className="ml-auto size-4 shrink-0" />}
+      </DropdownMenuItem>
+    );
+  }
+
   return (
     <DropdownMenu
       open={open}
       onOpenChange={(next) => {
         setOpen(next);
-        if (next) setQuery("");
+        if (next) {
+          setQuery("");
+          setActiveGroupId(currentGroupId);
+        }
       }}
     >
       <DropdownMenuTrigger asChild>
@@ -113,7 +187,11 @@ export function HarnessModelMenu({
               : `Model: ${current.label} (set when this session started)`
           }
         >
-          <Icon className="size-4 shrink-0" />
+          <CodeModelMark
+            harness={harness}
+            option={current}
+            className="size-4 shrink-0"
+          />
           <span className="truncate">{current.label}</span>
           <ChevronDown className="size-4 opacity-50" />
         </Button>
@@ -121,10 +199,11 @@ export function HarnessModelMenu({
       <DropdownMenuContent
         align="start"
         side="top"
-        className="w-80 p-0"
+        collisionPadding={12}
+        className="model-menu-content w-80 p-0"
         onKeyDownCapture={(event) => {
           if ((event.metaKey || event.ctrlKey) && event.key >= "1" && event.key <= "9") {
-            const option = matches[Number(event.key) - 1];
+            const option = visible[Number(event.key) - 1];
             if (option) {
               event.preventDefault();
               onChange?.(option.id);
@@ -140,50 +219,69 @@ export function HarnessModelMenu({
           requestAnimationFrame(() => searchInput.current?.focus());
         }}
       >
-        <div className="border-border border-b p-1.5">
-          <label className="bg-muted/40 focus-within:ring-ring flex h-8 items-center gap-2 rounded-md px-2 focus-within:ring-2">
-            <Search className="text-muted-foreground size-3.5 shrink-0" />
-            <input
-              ref={searchInput}
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              onKeyDown={(event) => event.stopPropagation()}
-              placeholder="Search models"
-              aria-label="Search models"
-              className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm outline-none"
-            />
-          </label>
-        </div>
-        <div className="flex max-h-72 flex-col gap-0.5 overflow-y-auto p-1">
-          {matches.map((option, index) => {
-            const selected = option.id === current.id;
-            return (
-              <DropdownMenuItem
-                key={`${option.source}:${option.id}`}
-                onSelect={() => onChange?.(option.id)}
-                className="flex items-center gap-2 py-2"
-              >
-                <span className="flex min-w-0 flex-1 flex-col">
-                  <span className="truncate">{option.label}</span>
-                  <span className="text-muted-foreground truncate text-[11px]">
-                    {option.source}
-                  </span>
-                </span>
-                {index < 9 && (
-                  <span className="text-muted-foreground rounded-md border px-1.5 py-0.5 font-mono text-[10px]">
-                    ⌘{index + 1}
-                  </span>
-                )}
-                {selected && <Check className="size-4 shrink-0" />}
-              </DropdownMenuItem>
-            );
-          })}
-          {matches.length === 0 && (
-            <p className="text-muted-foreground px-2 py-3 text-sm">
-              No models match that search.
-            </p>
-          )}
+        {groups.length > 0 && (
+          <div
+            className="flex min-h-0 w-11 shrink-0 flex-col gap-1 overflow-y-auto border-r border-border bg-muted/30 p-1"
+            role="tablist"
+            aria-label="Vendors"
+          >
+            {groups.map((group) => {
+              const selected = activeGroup?.id === group.id;
+              return (
+                <WithTooltip key={group.id} label={group.label} side="right">
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={selected}
+                    aria-label={group.label}
+                    className={cn(
+                      "relative flex size-9 items-center justify-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      selected ? "bg-accent" : "hover:bg-accent/60",
+                    )}
+                    onClick={() => setActiveGroupId(group.id)}
+                  >
+                    <ProviderIcon
+                      provider={group.iconProvider}
+                      modelId={group.iconModelId}
+                      className="size-4"
+                    />
+                    {selected && (
+                      <span
+                        aria-hidden
+                        className="absolute -right-1 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-l-full bg-primary"
+                      />
+                    )}
+                  </button>
+                </WithTooltip>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="border-border border-b p-1.5">
+            <label className="bg-muted/40 focus-within:ring-ring flex h-8 items-center gap-2 rounded-md px-2 focus-within:ring-2">
+              <Search className="text-muted-foreground size-3.5 shrink-0" />
+              <input
+                ref={searchInput}
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={(event) => event.stopPropagation()}
+                placeholder="Search models"
+                aria-label="Search models"
+                className="placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm outline-none"
+              />
+            </label>
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-1">
+            {visible.map((option, index) => modelRow(option, index))}
+            {visible.length === 0 && (
+              <p className="text-muted-foreground px-2 py-3 text-sm">
+                No models match that search.
+              </p>
+            )}
+          </div>
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import type { ApiClient } from "../api/client";
+import type { CodeWorkspaceSnapshot, PullRequestDigest } from "../api/types";
+import { CodeInspector } from "./CodeInspector";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+
+afterEach(() => {
+  cleanup();
+  useCodeUpdatesStore.getState().reset();
+  vi.clearAllMocks();
+});
+
+const WORKSPACE: CodeWorkspaceSnapshot = {
+  id: "ws-1",
+  repo_id: "repo-1",
+  title: "Fix login",
+  branch_name: "tidebreak/fix-login",
+  status: "active",
+  created_at: "2026-08-01T00:00:00Z",
+} as never;
+
+const PR: PullRequestDigest = {
+  number: 41,
+  state: "open",
+  title: "Fix login flow",
+  url: "https://github.com/acme/app/pull/41",
+  draft: true,
+  review_decision: "changes_requested",
+  head_branch: "tidebreak/fix-login",
+  base_branch: "main",
+  checks: [
+    { name: "ci / rust", bucket: "pass" },
+    { name: "ci / ui", bucket: "pending" },
+  ],
+} as never;
+
+function makeClient(): Pick<
+  ApiClient,
+  | "getCodePrComments"
+  | "refreshCodeWorkspacePr"
+  | "mergeCodePr"
+  | "getCodeWorkspaceDiff"
+  | "listCodeWorkspaceFiles"
+  | "getCodeWorkspacePr"
+> {
+  return {
+    getCodePrComments: vi.fn().mockResolvedValue({
+      number: 41,
+      comments: [
+        {
+          kind: "inline",
+          author: "reviewer",
+          body: "Rename this.",
+          path: "src/login.rs",
+          line: 12,
+          created_at: "2026-08-02T10:00:00Z",
+        },
+      ],
+    }),
+    refreshCodeWorkspacePr: vi.fn(),
+    mergeCodePr: vi.fn(),
+    getCodeWorkspaceDiff: vi.fn().mockResolvedValue({ diff: "" }),
+    listCodeWorkspaceFiles: vi.fn().mockResolvedValue({ files: [] }),
+    getCodeWorkspacePr: vi.fn().mockResolvedValue(null),
+  };
+}
+
+it("shows PR state, checks, comments, and holds merge for a draft", async () => {
+  const client = makeClient();
+  render(
+    <CodeInspector
+      client={client as never}
+      workspaceId="ws-1"
+      workspace={{ ...WORKSPACE, pr: PR } as never}
+      contentRevision={0}
+    />,
+  );
+
+  screen.getByRole("button", { name: "Pull request" }).click();
+  await screen.findByText("Fix login flow");
+
+  // Draft wins over the open state token, and holds the merge buttons.
+  expect(screen.getByText("Draft")).toBeInTheDocument();
+  expect(screen.getByText("Changes requested")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
+  expect(
+    screen.getByRole("button", { name: "Enable auto-merge" }),
+  ).toBeDisabled();
+
+  // Checks render individually with their buckets counted.
+  expect(screen.getByText("1 passing")).toBeInTheDocument();
+  expect(screen.getByText("1 pending")).toBeInTheDocument();
+  expect(screen.getByText("ci / rust")).toBeInTheDocument();
+
+  // Comments load on open, with the inline anchor visible.
+  await waitFor(() =>
+    expect(screen.getByText("Rename this.")).toBeInTheDocument(),
+  );
+  expect(screen.getByText("src/login.rs:12")).toBeInTheDocument();
+  expect(client.getCodePrComments).toHaveBeenCalledWith("ws-1");
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -1,35 +1,53 @@
-import { useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import {
   Check,
   CircleDashed,
   ExternalLink,
-  FileCode,
   Files,
+  GitBranch,
+  GitMerge,
   GitPullRequest,
+  MessageSquare,
+  RefreshCw,
   X,
 } from "lucide-react";
+import { toast } from "sonner";
 
-import type { ApiClient } from "../api/client";
+import { HttpError, type ApiClient } from "../api/client";
 import type {
+  CodePrMergeMethod,
   CodeWorkspaceSnapshot,
   PullRequestCheck,
+  PullRequestComment,
   PullRequestDigest,
 } from "../api/types";
 import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { useConfirm } from "@/components/ConfirmDialog";
+import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { openExternal } from "@/host";
 import { DiffPanel } from "./DiffPanel";
 import { FilesPanel } from "./FilesPanel";
 import { PrCard } from "./PrCard";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
 
-type InspectorTab = "files" | "diff" | "pr";
+type InspectorTab = "files" | "source" | "pr";
 
 /**
- * Right workspace rail: Files, Diff, and PR as icon tabs.
+ * Right workspace rail: Files, Source control, and Pull request as icon tabs.
  *
- * Files is the changed-file list. Diff is the worktree patch, and that
- * is where commit and push live. PR stays empty until a pull request exists.
+ * Files is the changed-file list. Source control is the worktree patch plus
+ * commit, push, and PR creation. Pull request carries the PR's own life:
+ * status, checks, and review comments once one exists.
  */
 export function CodeInspector({
   client,
@@ -50,7 +68,7 @@ export function CodeInspector({
 
   function openFile(next: string) {
     setFile(next);
-    setTab("diff");
+    setTab("source");
   }
 
   return (
@@ -68,11 +86,11 @@ export function CodeInspector({
           <Files className="size-3.5" />
         </TabButton>
         <TabButton
-          label="Diff"
-          current={tab === "diff"}
-          onClick={() => setTab("diff")}
+          label="Source control"
+          current={tab === "source"}
+          onClick={() => setTab("source")}
         >
-          <FileCode className="size-3.5" />
+          <GitBranch className="size-3.5" />
         </TabButton>
         <TabButton
           label="Pull request"
@@ -80,7 +98,10 @@ export function CodeInspector({
           onClick={() => setTab("pr")}
         >
           <GitPullRequest
-            className={cn("size-3.5", prIconClass(pr?.state))}
+            className={cn(
+              "size-3.5",
+              pr ? PR_ICON_TONE_CLASSES[prTone(pr)] : undefined,
+            )}
           />
         </TabButton>
       </header>
@@ -94,16 +115,10 @@ export function CodeInspector({
             onOpenFile={openFile}
           />
         )}
-        {tab === "diff" && (
+        {tab === "source" && (
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            <DiffPanel
-              client={client}
-              workspaceId={workspaceId}
-              file={file}
-              contentRevision={contentRevision}
-            />
             {active && (
-              <div className="border-t px-3 py-3">
+              <div className="border-b px-3 py-3">
                 <PrCard
                   client={client}
                   workspaceId={workspaceId}
@@ -112,10 +127,21 @@ export function CodeInspector({
                 />
               </div>
             )}
+            <DiffPanel
+              client={client}
+              workspaceId={workspaceId}
+              file={file}
+              contentRevision={contentRevision}
+            />
           </div>
         )}
         {tab === "pr" && (
-          <PrTab pr={pr} branch={workspace?.branch_name} />
+          <PrTab
+            client={client}
+            workspaceId={workspaceId}
+            pr={pr}
+            branch={workspace?.branch_name}
+          />
         )}
       </div>
     </aside>
@@ -150,34 +176,118 @@ function TabButton({
   );
 }
 
+/**
+ * The pull request's own life: status, checks, review comments, and the two
+ * user-initiated ways to land it. The digest arrives over the updates socket,
+ * so actions only have to hit the server — the fresh state restates itself.
+ */
 function PrTab({
+  client,
+  workspaceId,
   pr,
   branch,
 }: {
+  client: ApiClient;
+  workspaceId: string;
   pr?: PullRequestDigest;
   branch?: string;
 }) {
+  const { confirm, dialog } = useConfirm();
+  const [refreshing, setRefreshing] = useState(false);
+  const [merging, setMerging] = useState<"merge" | "auto" | null>(null);
+  const [method, setMethod] = useState<CodePrMergeMethod>("squash");
+  const [mergeError, setMergeError] = useState<string | null>(null);
+  const [comments, setComments] = useState<PullRequestComment[] | null>(null);
+  const [commentsError, setCommentsError] = useState<string | null>(null);
+  const prNumber = pr?.number;
+
+  const loadComments = useCallback(async () => {
+    if (prNumber === undefined) return;
+    try {
+      const snapshot = await client.getCodePrComments(workspaceId);
+      setComments(snapshot.comments);
+      setCommentsError(null);
+    } catch (err) {
+      setCommentsError(
+        friendlyErrorMessage(err, "Could not load review comments"),
+      );
+    }
+  }, [client, prNumber, workspaceId]);
+
+  useEffect(() => {
+    setComments(null);
+    setCommentsError(null);
+    if (prNumber === undefined) return;
+    void loadComments();
+  }, [loadComments, prNumber]);
+
+  async function refresh() {
+    setRefreshing(true);
+    try {
+      await client.refreshCodeWorkspacePr(workspaceId);
+      await loadComments();
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not refresh the pull request"));
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  async function merge(auto: boolean) {
+    if (!pr) return;
+    if (!auto) {
+      const ok = await confirm({
+        title: `Merge #${pr.number}?`,
+        description: `The pull request is ${method === "squash" ? "squash-merged" : method === "rebase" ? "rebased and merged" : "merged"} into ${pr.base_branch ?? "its base branch"} on GitHub.`,
+        confirmLabel: "Merge",
+      });
+      if (!ok) return;
+    }
+    setMerging(auto ? "auto" : "merge");
+    setMergeError(null);
+    try {
+      await client.mergeCodePr(workspaceId, { method, auto });
+      toast.success(auto ? "Auto-merge enabled" : "Merged");
+    } catch (err) {
+      if (err instanceof HttpError && err.kind === "pr_not_mergeable") {
+        setMergeError(err.message);
+      } else {
+        toast.error(friendlyErrorMessage(err, "Could not merge"));
+      }
+    } finally {
+      setMerging(null);
+    }
+  }
+
   if (!pr) {
     return (
       <div className="text-muted-foreground flex flex-col gap-2 px-4 py-8 text-sm">
         <p className="text-foreground font-medium">No pull request yet</p>
         <p className="text-xs leading-relaxed">
-          This tab stays quiet until one exists. Commit and push live with the
-          diff, not here. When a PR is opened, status, checks, and review
-          comments land in this column.
+          This tab stays quiet until one exists. Commit, push, and Create PR
+          live in Source control. When a PR is opened, its status, checks, and
+          review comments land in this column.
         </p>
       </div>
     );
   }
 
+  const tone = prTone(pr);
   const counts = checkCounts(pr);
+  const open = tone === "open" || tone === "draft";
+  const branchLine =
+    pr.head_branch && pr.base_branch
+      ? `${pr.head_branch} → ${pr.base_branch}`
+      : (branch ?? null);
+
   return (
-    <div className="flex flex-col gap-4 overflow-y-auto px-3 py-3">
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-3 py-3">
+      {dialog}
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <GitPullRequest
-              className={cn("size-4 shrink-0", prIconClass(pr.state))}
+              className={cn("size-4 shrink-0", PR_ICON_TONE_CLASSES[tone])}
             />
             {pr.url ? (
               <a
@@ -198,14 +308,200 @@ function PrTab({
           </div>
           <p className="text-muted-foreground mt-1 truncate text-xs">
             #{pr.number}
-            {branch ? ` · ${branch}` : ""}
+            {branchLine ? ` · ${branchLine}` : ""}
           </p>
         </div>
-        <Badge variant={prStateVariant(pr.state)} size="sm">
-          {pr.state}
-        </Badge>
+        <div className="flex shrink-0 items-center gap-1">
+          <Badge variant={prStateVariant(tone)} size="sm">
+            {prToneLabel(pr)}
+          </Badge>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Refresh pull request"
+            disabled={refreshing}
+            onClick={() => void refresh()}
+          >
+            {refreshing ? <Spinner aria-hidden /> : <RefreshCw />}
+          </Button>
+        </div>
       </div>
+
+      <div className="flex flex-wrap items-center gap-1">
+        <ReviewDecisionBadge decision={pr.review_decision} />
+        {pr.auto_merge_enabled && (
+          <Badge variant="info" size="sm">
+            Auto-merge on
+          </Badge>
+        )}
+      </div>
+
       <CheckList checks={pr.checks ?? []} counts={counts} />
+
+      {open && (
+        <div className="flex flex-col gap-2 border-t pt-3">
+          <div className="flex items-center gap-2">
+            <GitMerge className="text-muted-foreground size-3.5 shrink-0" />
+            <Select
+              value={method}
+              onValueChange={(next) => setMethod(next as CodePrMergeMethod)}
+              disabled={merging !== null}
+            >
+              <SelectTrigger
+                className="h-7 flex-1 text-xs"
+                aria-label="Merge method"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="squash">Squash and merge</SelectItem>
+                <SelectItem value="merge">Merge commit</SelectItem>
+                <SelectItem value="rebase">Rebase and merge</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              disabled={merging !== null || tone === "draft"}
+              onClick={() => void merge(false)}
+            >
+              {merging === "merge" ? <Spinner aria-hidden /> : null}
+              Merge
+            </Button>
+            {!pr.auto_merge_enabled && (
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                disabled={merging !== null || tone === "draft"}
+                onClick={() => void merge(true)}
+              >
+                {merging === "auto" ? <Spinner aria-hidden /> : null}
+                Enable auto-merge
+              </Button>
+            )}
+          </div>
+          {tone === "draft" && (
+            <p className="text-muted-foreground text-xs">
+              Mark the pull request ready for review on GitHub to merge it.
+            </p>
+          )}
+          {mergeError && (
+            <p className="text-critical text-xs" role="alert">
+              {mergeError}
+            </p>
+          )}
+        </div>
+      )}
+
+      <CommentsSection
+        comments={comments}
+        error={commentsError}
+        onRetry={() => void loadComments()}
+      />
+    </div>
+  );
+}
+
+function ReviewDecisionBadge({ decision }: { decision?: string }) {
+  if (!decision) return null;
+  if (decision === "approved") {
+    return (
+      <Badge variant="success" size="sm">
+        Approved
+      </Badge>
+    );
+  }
+  if (decision === "changes_requested") {
+    return (
+      <Badge variant="critical" size="sm">
+        Changes requested
+      </Badge>
+    );
+  }
+  if (decision === "review_required") {
+    return (
+      <Badge variant="outline" size="sm">
+        Review required
+      </Badge>
+    );
+  }
+  return null;
+}
+
+/** Review conversation, newest last, in the order the server sorted it. */
+function CommentsSection({
+  comments,
+  error,
+  onRetry,
+}: {
+  comments: PullRequestComment[] | null;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 border-t pt-3">
+      <div className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+        <MessageSquare className="size-3.5" />
+        Comments
+        {comments && comments.length > 0 && <span>({comments.length})</span>}
+      </div>
+      {error && (
+        <div className="flex flex-col items-start gap-1">
+          <p className="text-critical text-xs">{error}</p>
+          <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+            Retry
+          </Button>
+        </div>
+      )}
+      {!error && comments === null && (
+        <p className="text-muted-foreground text-xs">Loading…</p>
+      )}
+      {!error && comments && comments.length === 0 && (
+        <p className="text-muted-foreground text-xs">No comments yet.</p>
+      )}
+      {!error &&
+        comments?.map((comment, index) => (
+          <CommentRow key={index} comment={comment} />
+        ))}
+    </div>
+  );
+}
+
+function CommentRow({ comment }: { comment: PullRequestComment }) {
+  const when = comment.created_at
+    ? new Date(comment.created_at).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : null;
+  return (
+    <div className="border-border flex flex-col gap-1 rounded-md border px-2 py-1.5">
+      <div className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[11px]">
+        <span className="text-foreground shrink-0 font-medium">
+          {comment.author ?? "Unknown"}
+        </span>
+        {comment.kind === "review" && comment.review_state && (
+          <span className="shrink-0 capitalize">
+            {comment.review_state.replaceAll("_", " ")}
+          </span>
+        )}
+        {comment.kind === "inline" && comment.path && (
+          <span className="truncate font-mono">
+            {comment.path}
+            {comment.line !== undefined ? `:${comment.line}` : ""}
+          </span>
+        )}
+        {when && <span className="ml-auto shrink-0">{when}</span>}
+      </div>
+      <p className="text-xs leading-relaxed whitespace-pre-wrap">
+        {comment.body}
+      </p>
     </div>
   );
 }
@@ -332,18 +628,11 @@ function checkCounts(pr: PullRequestDigest): {
   return { passing, pending, failing };
 }
 
-function prIconClass(state?: string): string {
-  const token = state?.toLowerCase();
-  if (token === "open") return "text-success";
-  if (token === "merged") return "text-info";
-  if (token === "closed") return "text-critical";
-  return "text-muted-foreground";
-}
-
-function prStateVariant(state: string): "success" | "critical" | "info" | "outline" {
-  const token = state.toLowerCase();
-  if (token === "open") return "success";
-  if (token === "merged") return "info";
-  if (token === "closed") return "critical";
+function prStateVariant(
+  tone: ReturnType<typeof prTone>,
+): "success" | "critical" | "info" | "outline" {
+  if (tone === "open") return "success";
+  if (tone === "merged") return "info";
+  if (tone === "closed") return "critical";
   return "outline";
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -1,24 +1,36 @@
 import { useEffect } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { FolderGit2, MessageSquare, Plus } from "lucide-react";
+import { FolderGit2, GitBranch, MessageSquare, Plus } from "lucide-react";
 
 import { useApp } from "@/AppContext";
+import { cn } from "@/lib/utils";
 import {
   SidebarButton,
   SidebarSectionTitle,
   useSidebarWidth,
 } from "@/sidebar/primitives";
 import { SidebarFrame } from "@/sidebar/SidebarFrame";
+import type {
+  CodeSessionDigest,
+  CodeWorkspaceSnapshot,
+  PullRequestDigest,
+} from "../api/types";
 import { AttentionBadge } from "./AttentionBadge";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
 import { connectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { AddRepoPalette } from "./AddRepoPalette";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import {
+  PR_CHIP_TONE_CLASSES,
+  groupWorkspacesByRepo,
+  prTone,
+  workspaceStateLabel,
+} from "./workspaceCards";
 
 /**
- * The code-mode rail: repos, recent workspaces, and the cheap switch back to
- * chat.
+ * The code-mode rail: repos, workspace cards grouped by repo, and the cheap
+ * switch back to chat.
  *
  * Built on the same frame and primitives as the chat rail so the two modes
  * share chrome. It must not touch chat session stores — that separation is
@@ -57,9 +69,7 @@ export function CodeSidebar() {
 
   useEffect(() => connectCodeUpdates(client), [client]);
 
-  const recent = workspaces
-    .filter((workspace) => workspace.status !== "archived")
-    .slice(0, 12);
+  const groups = groupWorkspacesByRepo(repos, workspaces);
 
   return (
     <SidebarFrame>
@@ -152,30 +162,63 @@ export function CodeSidebar() {
         </SidebarButton>
       )}
       <div className="flex min-h-0 flex-col gap-0.5">
-        {recent.map((workspace) => {
-          const active = pathname === `/code/w/${workspace.id}`;
-          const digest = digests[workspace.id];
-          return (
-            <SidebarButton
-              key={workspace.id}
-              aria-current={active ? "page" : undefined}
-              data-active={active || undefined}
-              className="data-[active]:bg-muted"
-              onClick={() =>
-                void navigate({
-                  to: "/code/w/$workspaceId",
-                  params: { workspaceId: workspace.id },
-                })
-              }
+        {isCompact &&
+          groups
+            .flatMap((group) => group.workspaces)
+            .map((workspace) => {
+              const active = pathname === `/code/w/${workspace.id}`;
+              const digest = digests[workspace.id];
+              return (
+                <SidebarButton
+                  key={workspace.id}
+                  aria-current={active ? "page" : undefined}
+                  data-active={active || undefined}
+                  className="data-[active]:bg-muted"
+                  onClick={() =>
+                    void navigate({
+                      to: "/code/w/$workspaceId",
+                      params: { workspaceId: workspace.id },
+                    })
+                  }
+                >
+                  <FolderGit2 />
+                  {/* The digest restates the title on every notice, so a
+                      background rename lands here without a catalog refresh. */}
+                  <span>{digest?.title ?? workspace.title}</span>
+                  <AttentionBadge attention={digest?.attention} compact />
+                </SidebarButton>
+              );
+            })}
+        {!isCompact &&
+          groups.map((group) => (
+            <div
+              key={group.repo?.id ?? "unknown-repo"}
+              className="flex flex-col gap-0.5"
             >
-              <FolderGit2 />
-              {/* The digest restates the title on every notice, so a
-                  background rename lands here without a catalog refresh. */}
-              <span>{digest?.title ?? workspace.title}</span>
-              <AttentionBadge attention={digest?.attention} compact />
-            </SidebarButton>
-          );
-        })}
+              <div className="mt-1 truncate px-2 pt-1 pb-0.5 text-[11px] font-medium text-muted-foreground/90">
+                {group.repo?.display_name ?? "Other repos"}
+              </div>
+              {group.workspaces.map((workspace) => (
+                <WorkspaceCard
+                  key={workspace.id}
+                  workspace={workspace}
+                  digest={digests[workspace.id]}
+                  active={pathname === `/code/w/${workspace.id}`}
+                  onOpen={() =>
+                    void navigate({
+                      to: "/code/w/$workspaceId",
+                      params: { workspaceId: workspace.id },
+                    })
+                  }
+                />
+              ))}
+            </div>
+          ))}
+        {!isCompact && groups.length === 0 && (
+          <p className="px-2 py-1 text-xs text-muted-foreground">
+            No workspaces yet
+          </p>
+        )}
       </div>
 
       <NewWorkspaceDialog
@@ -186,5 +229,79 @@ export function CodeSidebar() {
       />
       <AddRepoPalette open={addRepoOpen} onOpenChange={setAddRepoOpen} />
     </SidebarFrame>
+  );
+}
+
+/**
+ * One workspace in the expanded rail: title, branch, and a status row with
+ * the session state, the attention badge, and the PR chip. The accessible
+ * name stays the title so the row reads like the flat list it replaced.
+ */
+function WorkspaceCard({
+  workspace,
+  digest,
+  active,
+  onOpen,
+}: {
+  workspace: CodeWorkspaceSnapshot;
+  digest: CodeSessionDigest | undefined;
+  active: boolean;
+  onOpen: () => void;
+}) {
+  // The digest restates the title on every notice, so a background rename
+  // lands here without a catalog refresh.
+  const title = digest?.title ?? workspace.title;
+  const stateLabel = workspaceStateLabel(workspace.status, digest?.lifecycle);
+  // The catalog snapshot carries the PR too, so the chip survives the gap
+  // before the updates socket has restated its digest.
+  const pr = digest?.pr_state ?? workspace.pr;
+  const hasAttention = digest && digest.attention.state.type !== "working";
+  return (
+    <button
+      type="button"
+      aria-label={title}
+      aria-current={active ? "page" : undefined}
+      data-active={active || undefined}
+      className="flex w-full cursor-pointer flex-col gap-0.5 rounded-md px-2 py-1.5 text-left ring-offset-background transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none data-[active]:bg-muted"
+      onClick={onOpen}
+    >
+      <span className="truncate text-sm font-[450]">{title}</span>
+      <span className="flex min-w-0 items-center gap-1 font-mono text-[11px] text-muted-foreground">
+        <GitBranch className="size-3 shrink-0" aria-hidden />
+        <span className="truncate">{workspace.branch_name}</span>
+      </span>
+      {(stateLabel || hasAttention || pr) && (
+        <span className="mt-0.5 flex min-w-0 items-center gap-1.5">
+          {stateLabel && (
+            <span className="text-[11px] text-muted-foreground">
+              {stateLabel}
+            </span>
+          )}
+          <AttentionBadge
+            attention={digest?.attention}
+            className="min-w-0 overflow-hidden"
+          />
+          <span className="grow" />
+          {pr && <PrChip pr={pr} />}
+        </span>
+      )}
+    </button>
+  );
+}
+
+/** PR number pill, colored by the host state token. */
+function PrChip({ pr }: { pr: PullRequestDigest }) {
+  const tone = prTone(pr);
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-full px-1.5 py-px text-[11px] font-medium",
+        PR_CHIP_TONE_CLASSES[tone],
+      )}
+      title={pr.title ? `#${pr.number} ${pr.title}` : `PR #${pr.number}`}
+      data-pr-state={tone}
+    >
+      #{pr.number}
+    </span>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -456,8 +456,10 @@ function CodeSessionPane({
   );
   const [decidingId, setDecidingId] = useState<string | null>(null);
   const [approvalError, setApprovalError] = useState<string | undefined>();
+  // No `?? []` fallback here: a fresh array is a new snapshot every render,
+  // and zustand v5 loops on referentially unstable snapshots.
   const cachedModels = useCodeCatalogStore(
-    (state) => state.modelsByHarness[session.harness_kind] ?? [],
+    (state) => state.modelsByHarness[session.harness_kind],
   );
   const rememberHarnessModels = useCodeCatalogStore(
     (state) => state.rememberHarnessModels,
@@ -468,7 +470,7 @@ function CodeSessionPane({
       session.harness_kind,
       defaultModelKey,
     );
-    return gateway.length > 0 ? gateway : cachedModels;
+    return gateway.length > 0 ? gateway : (cachedModels ?? []);
   }, [cachedModels, catalogModels, defaultModelKey, session.harness_kind]);
   const inferred = modelOptions.find((option) => option.default)?.id;
   const [model, setModel] = useState(session.model ?? inferred);
@@ -481,7 +483,7 @@ function CodeSessionPane({
     if (gatewayCodeModels(catalogModels, session.harness_kind, defaultModelKey).length > 0) {
       return;
     }
-    if (cachedModels.length > 0) return;
+    if (cachedModels && cachedModels.length > 0) return;
     let cancelled = false;
     void client.listCodeHarnessModels(session.harness_kind).then(
       (listed) => {
@@ -497,7 +499,7 @@ function CodeSessionPane({
       cancelled = true;
     };
   }, [
-    cachedModels.length,
+    cachedModels,
     catalogModels,
     client,
     defaultModelKey,

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
@@ -19,14 +19,10 @@ const foldersTerminalAgents = {
 };
 
 describe("code chrome layout", () => {
-  it("lifts the terminal out and drops files/diff so they stay in the inspector", () => {
+  it("lifts the terminal out of the side region into the drawer", () => {
     const layout = {
-      tabs: [
-        { type: "files" as const },
-        { type: "terminal" as const },
-        { type: "diff" as const },
-      ],
-      activeIndex: 1,
+      tabs: [{ type: "terminal" as const }],
+      activeIndex: 0,
       fullscreen: false,
     };
 

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -11,9 +11,6 @@ import {
  *
  * The terminal stays in the URL so a reload or a shared link still opens it.
  * Only the rendering changes: it is not a tab in the side region.
- *
- * Files and Diff live in the inspector. A stale URL tab would duplicate
- * them in the conversation region, so they are stripped here too.
  */
 export function splitCodeChromeLayout(layout: LayoutState): {
   panels: LayoutState;
@@ -22,14 +19,14 @@ export function splitCodeChromeLayout(layout: LayoutState): {
   const terminal = layout.tabs.find((tab) => tab.type === "terminal") as
     | Extract<PanelContent, { type: "terminal" }>
     | undefined;
-  const tabs = layout.tabs.filter((tab) => !isInspectorOrDrawerTab(tab));
+  const tabs = layout.tabs.filter((tab) => !isDrawerTab(tab));
   if (tabs.length === 0) {
     return { panels: EMPTY_LAYOUT, terminal: terminal ?? null };
   }
 
   const active = layout.tabs[layout.activeIndex];
   let activeIndex = 0;
-  if (active && !isInspectorOrDrawerTab(active)) {
+  if (active && !isDrawerTab(active)) {
     const found = tabs.findIndex((tab) => panelKey(tab) === panelKey(active));
     if (found >= 0) activeIndex = found;
   }
@@ -44,23 +41,22 @@ export function splitCodeChromeLayout(layout: LayoutState): {
   };
 }
 
-function isInspectorOrDrawerTab(tab: PanelContent): boolean {
-  return tab.type === "files" || tab.type === "diff" || tab.type === "terminal";
+function isDrawerTab(tab: PanelContent): boolean {
+  return tab.type === "terminal";
 }
 
 /**
  * URL-tab index of the side-region tab at `stripIndex`.
  *
- * The strip is the URL tabs with the terminal, files, and diff removed, so a
- * click or close on the strip has to skip those rather than treat them as
- * neighbours.
+ * The strip is the URL tabs with the terminal removed, so a click or close on
+ * the strip has to skip it rather than treat it as a neighbour.
  */
 function codeChromeUrlIndex(layout: LayoutState, stripIndex: number): number {
   if (stripIndex < 0) return -1;
   let remaining = stripIndex;
   for (let index = 0; index < layout.tabs.length; index += 1) {
     const tab = layout.tabs[index];
-    if (!tab || isInspectorOrDrawerTab(tab)) continue;
+    if (!tab || isDrawerTab(tab)) continue;
     if (remaining === 0) return index;
     remaining -= 1;
   }

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -6,6 +6,7 @@ import {
   createPermissionModes,
   defaultCreatePermissionMode,
   gatewayCodeModels,
+  groupCodeModelOptions,
   harnessUnusableReason,
 } from "./labels";
 
@@ -140,8 +141,58 @@ describe("gatewayCodeModels", () => {
         id: "claude-opus-5",
         label: "Claude Opus 5",
         source: "Claude Code · model-gateway",
+        vendor: "anthropic",
         default: true,
       },
+    ]);
+  });
+
+  it("confines a mixed gateway catalog to the harness's vendor", () => {
+    const gatewayModel = (id: string, vendor: string | null) =>
+      ({
+        key: `model_gateway::${id}`,
+        id,
+        display_name: id,
+        provider: "model_gateway",
+        vendor,
+        available: true,
+      }) as never;
+    const catalog = [
+      gatewayModel("claude-opus-5", "anthropic"),
+      gatewayModel("gpt-5.6-sol", "openai"),
+      gatewayModel("deepseek-v4-pro", null),
+      gatewayModel("grok-4.5", "xai"),
+    ];
+    expect(
+      gatewayCodeModels(catalog, "claude_code").map((option) => option.id),
+    ).toEqual(["claude-opus-5"]);
+    expect(
+      gatewayCodeModels(catalog, "codex").map((option) => option.id),
+    ).toEqual(["gpt-5.6-sol"]);
+    // opencode is vendor-neutral: the whole catalog stays.
+    expect(gatewayCodeModels(catalog, "opencode")).toHaveLength(4);
+  });
+});
+
+describe("groupCodeModelOptions", () => {
+  it("groups rows by vendor and family, in the rail's fixed order", () => {
+    const option = (id: string, vendor: string | null = null) => ({
+      id,
+      label: id,
+      source: "opencode",
+      vendor: vendor as never,
+    });
+    const groups = groupCodeModelOptions([
+      option("deepseek-v4-pro"),
+      option("claude-opus-5", "anthropic"),
+      option("gpt-5.6-sol"),
+      option("mystery-model"),
+    ]);
+    expect(groups.map((group) => [group.id, group.label])).toEqual([
+      ["openai", "OpenAI"],
+      ["anthropic", "Anthropic"],
+      ["deepseek", "DeepSeek"],
+      ["other", "Other"],
     ]);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -8,7 +8,9 @@ import type {
   HarnessKind,
   HarnessTier,
   ModelInfo,
+  ProviderKind,
 } from "../api/types";
+import { familyForModelId, vendorForModelId } from "../modelFamilies";
 
 /**
  * Display names for the code-mode vocabulary.
@@ -155,22 +157,58 @@ export type CodeModelOption = {
   id: string;
   label: string;
   source: string;
+  /** The vendor the id is branded as, for icons and grouping. */
+  vendor?: ProviderKind | null;
   default?: boolean;
 };
 
-/** Gateway models the picker may offer when this profile is on model-gateway. */
+/**
+ * The vendors a harness can actually drive, or `null` for any. This confines
+ * a mixed catalog (a gateway's) to what the engine accepts: Claude Code only
+ * takes Claude models, Codex only OpenAI's, Grok only xAI's; opencode is
+ * vendor-neutral.
+ */
+export const HARNESS_VENDORS: Record<
+  HarnessKind,
+  readonly ProviderKind[] | null
+> = {
+  claude_code: ["anthropic"],
+  codex: ["openai"],
+  grok: ["xai"],
+  opencode: null,
+};
+
+/** The vendor a picker row is branded as: curated match first, then the id. */
+export function codeModelVendor(option: {
+  id: string;
+  vendor?: ProviderKind | null;
+}): ProviderKind | null {
+  return option.vendor ?? vendorForModelId(option.id);
+}
+
+/**
+ * Gateway models the picker may offer when this profile is on model-gateway,
+ * confined to the vendors the harness can drive.
+ */
 export function gatewayCodeModels(
   models: readonly ModelInfo[],
   kind: HarnessKind,
   defaultKey?: string | null,
 ): CodeModelOption[] {
   const source = `${HARNESS_LABELS[kind]} · model-gateway`;
+  const allowed = HARNESS_VENDORS[kind];
   return models
     .filter((model) => model.provider === "model_gateway" && model.available)
+    .filter((model) => {
+      if (!allowed) return true;
+      const vendor = model.vendor ?? vendorForModelId(model.id);
+      return vendor !== null && allowed.includes(vendor);
+    })
     .map((model) => ({
       id: model.id,
       label: model.display_name,
       source,
+      vendor: model.vendor ?? vendorForModelId(model.id),
       default: defaultKey === model.key || defaultKey === model.id,
     }));
 }
@@ -184,8 +222,91 @@ export function harnessCodeModels(
     id: option.id,
     label: prettyCodeModelLabel(option.label || option.id),
     source,
+    vendor: vendorForModelId(option.id),
     default: option.default,
   }));
+}
+
+/** One rail section of the code-mode picker: a vendor and its rows. */
+export type CodeModelGroup = {
+  id: string;
+  label: string;
+  iconProvider: ProviderKind;
+  iconModelId?: string;
+  options: CodeModelOption[];
+};
+
+/** Vendors in the rail's fixed order, matching the chat picker's. */
+const CODE_VENDOR_ORDER: readonly ProviderKind[] = [
+  "openai",
+  "anthropic",
+  "xai",
+  "gemini",
+];
+
+const VENDOR_LABELS: Partial<Record<ProviderKind, string>> = {
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  xai: "xAI",
+  gemini: "Google Gemini",
+};
+
+/**
+ * Group picker rows by vendor the way the chat picker groups a catalog:
+ * first-party vendors in a fixed order, then open-model families, then
+ * anything unrecognizable under "Other". One group per vendor present.
+ */
+export function groupCodeModelOptions(
+  options: readonly CodeModelOption[],
+): CodeModelGroup[] {
+  const byId = new Map<string, CodeModelGroup>();
+  const add = (
+    badge: Omit<CodeModelGroup, "options">,
+    option: CodeModelOption,
+  ) => {
+    const existing = byId.get(badge.id);
+    if (existing) existing.options.push(option);
+    else byId.set(badge.id, { ...badge, options: [option] });
+  };
+  for (const option of options) {
+    const family = familyForModelId(option.id);
+    if (family) {
+      add(
+        {
+          id: family.match,
+          label: family.label,
+          iconProvider: "model_gateway",
+          iconModelId: family.match,
+        },
+        option,
+      );
+      continue;
+    }
+    const vendor = codeModelVendor(option);
+    if (vendor) {
+      add(
+        {
+          id: vendor,
+          label: VENDOR_LABELS[vendor] ?? vendor,
+          iconProvider: vendor,
+        },
+        option,
+      );
+      continue;
+    }
+    add(
+      { id: "other", label: "Other", iconProvider: "openai_compatible" },
+      option,
+    );
+  }
+
+  const rank = (group: CodeModelGroup): number => {
+    const vendor = CODE_VENDOR_ORDER.indexOf(group.id as ProviderKind);
+    if (vendor !== -1) return vendor;
+    if (group.id === "other") return Number.MAX_SAFE_INTEGER;
+    return CODE_VENDOR_ORDER.length;
+  };
+  return [...byId.values()].sort((a, b) => rank(a) - rank(b));
 }
 
 export function prettyCodeModelLabel(id: string): string {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -20,6 +20,7 @@ import {
   parseCodeWorkspaceDiff,
   parseCodeWorkspaceFiles,
   parseCodeWorkspacePr,
+  parseCodePrComments,
 } from "./parsers";
 
 const SESSION = {
@@ -223,11 +224,27 @@ describe("parseCodeWorkspacePr", () => {
       url: "https://github.com/example/demo/pull/12",
       state: "open",
       checks_summary: "1 passing, 0 pending, 0 failing",
+      draft: false,
+      merged: false,
+      review_decision: "changes_requested",
+      mergeable: "mergeable",
+      merge_state_status: "blocked",
+      head_branch: "tidebreak/first-change",
+      base_branch: "main",
+      auto_merge_enabled: true,
     },
   };
 
   it("accepts GET /code/workspaces/{id}/pr", () => {
     expect(parseCodeWorkspacePr(pr)).toEqual(pr);
+  });
+
+  it("accepts a digest without the merge-status fields", () => {
+    const sparse = {
+      ...pr,
+      pr: { number: 12, state: "open" },
+    };
+    expect(parseCodeWorkspacePr(sparse)).toEqual(sparse);
   });
 
   it("accepts the gh-absent remediation state", () => {
@@ -245,6 +262,60 @@ describe("parseCodeWorkspacePr", () => {
 
   it("rejects a missing boolean", () => {
     expect(parseCodeWorkspacePr({ ...pr, dirty: "yes" })).toBeNull();
+  });
+
+  it("rejects a mistyped merge-status field", () => {
+    expect(
+      parseCodeWorkspacePr({ ...pr, pr: { ...pr.pr, draft: "yes" } }),
+    ).toBeNull();
+  });
+});
+
+describe("parseCodePrComments", () => {
+  it("accepts GET /code/workspaces/{id}/pr/comments", () => {
+    const comments = {
+      number: 12,
+      comments: [
+        {
+          kind: "issue",
+          author: "alice",
+          created_at: "2026-08-16T10:00:00Z",
+          body: "looks close",
+        },
+        {
+          kind: "review",
+          author: "bob",
+          created_at: "2026-08-16T11:00:00Z",
+          body: "please split this",
+          review_state: "changes_requested",
+        },
+        {
+          kind: "inline",
+          author: "bob",
+          created_at: "2026-08-16T12:00:00Z",
+          body: "rename this",
+          path: "src/lib.rs",
+          line: 42,
+        },
+      ],
+    };
+    expect(parseCodePrComments(comments)).toEqual(comments);
+    expect(parseCodePrComments({ number: 12, comments: [] })).toEqual({
+      number: 12,
+      comments: [],
+    });
+  });
+
+  it("rejects an unknown kind or a mistyped line", () => {
+    const one = (comment: object) => ({ number: 12, comments: [comment] });
+    expect(
+      parseCodePrComments(one({ kind: "thread", body: "hi" })),
+    ).toBeNull();
+    expect(
+      parseCodePrComments(
+        one({ kind: "inline", body: "hi", line: "forty-two" }),
+      ),
+    ).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -41,6 +41,9 @@ import type {
   CodeCloneDefaults,
   CodeCloneJobSnapshot,
   PullRequestDigest,
+  PullRequestComment,
+  PullRequestCommentKind,
+  CodePrCommentsSnapshot,
   QueuedCodeTurn,
 } from "../api/types";
 import type {
@@ -61,6 +64,8 @@ import type {
   CodeFileChange as WireCodeFileChange,
   Diffstat as WireDiffstat,
   PullRequestDigest as WirePullRequestDigest,
+  PullRequestComment as WirePullRequestComment,
+  CodePrCommentsSnapshot as WireCodePrCommentsSnapshot,
   HarnessCaps as WireHarnessCaps,
   HarnessDoctorEntry as WireHarnessDoctorEntry,
   HarnessDoctorReport as WireHarnessDoctorReport,
@@ -314,6 +319,10 @@ export function parseCodeWorkspace(
 export function parsePullRequestDigest(
   value: unknown,
 ): NonNullable<CodeWorkspaceSnapshot["pr"]> | null {
+  const optionalStringField = (field: unknown) =>
+    field === undefined || field === null || typeof field === "string";
+  const optionalBooleanField = (field: unknown) =>
+    field === undefined || field === null || typeof field === "boolean";
   if (
     !isRecord(value) ||
     !onlyKeys<WirePullRequestDigest>(value, [
@@ -323,14 +332,28 @@ export function parsePullRequestDigest(
       "title",
       "checks_summary",
       "checks",
+      "draft",
+      "merged",
+      "review_decision",
+      "mergeable",
+      "merge_state_status",
+      "head_branch",
+      "base_branch",
+      "auto_merge_enabled",
     ]) ||
     !isFiniteNumber(value.number) ||
     !nonEmpty(value.state) ||
-    (value.url !== undefined && value.url !== null && typeof value.url !== "string") ||
-    (value.title !== undefined && value.title !== null && typeof value.title !== "string") ||
-    (value.checks_summary !== undefined &&
-      value.checks_summary !== null &&
-      typeof value.checks_summary !== "string")
+    !optionalStringField(value.url) ||
+    !optionalStringField(value.title) ||
+    !optionalStringField(value.checks_summary) ||
+    !optionalStringField(value.review_decision) ||
+    !optionalStringField(value.mergeable) ||
+    !optionalStringField(value.merge_state_status) ||
+    !optionalStringField(value.head_branch) ||
+    !optionalStringField(value.base_branch) ||
+    !optionalBooleanField(value.draft) ||
+    !optionalBooleanField(value.merged) ||
+    !optionalBooleanField(value.auto_merge_enabled)
   ) {
     return null;
   }
@@ -343,6 +366,18 @@ export function parsePullRequestDigest(
     ...(value.title ? { title: value.title } : {}),
     ...(value.checks_summary ? { checks_summary: value.checks_summary } : {}),
     ...(checks && checks.length > 0 ? { checks } : {}),
+    ...(typeof value.draft === "boolean" ? { draft: value.draft } : {}),
+    ...(typeof value.merged === "boolean" ? { merged: value.merged } : {}),
+    ...(value.review_decision ? { review_decision: value.review_decision } : {}),
+    ...(value.mergeable ? { mergeable: value.mergeable } : {}),
+    ...(value.merge_state_status
+      ? { merge_state_status: value.merge_state_status }
+      : {}),
+    ...(value.head_branch ? { head_branch: value.head_branch } : {}),
+    ...(value.base_branch ? { base_branch: value.base_branch } : {}),
+    ...(typeof value.auto_merge_enabled === "boolean"
+      ? { auto_merge_enabled: value.auto_merge_enabled }
+      : {}),
   };
 }
 
@@ -420,6 +455,69 @@ export function parseCodeWorkspacePr(
     parsed.pr = pr;
   }
   return parsed;
+}
+
+const PR_COMMENT_KINDS = new Set<PullRequestCommentKind>([
+  "issue",
+  "review",
+  "inline",
+]);
+
+export function parseCodePrComments(
+  value: unknown,
+): CodePrCommentsSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodePrCommentsSnapshot>(value, ["number", "comments"]) ||
+    !isFiniteNumber(value.number) ||
+    !Array.isArray(value.comments)
+  ) {
+    return null;
+  }
+  const comments: PullRequestComment[] = [];
+  for (const item of value.comments) {
+    const comment = parsePullRequestComment(item);
+    if (!comment) return null;
+    comments.push(comment);
+  }
+  return { number: value.number, comments };
+}
+
+function parsePullRequestComment(value: unknown): PullRequestComment | null {
+  const optionalStringField = (field: unknown) =>
+    field === undefined || field === null || typeof field === "string";
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WirePullRequestComment>(value, [
+      "kind",
+      "author",
+      "created_at",
+      "body",
+      "review_state",
+      "path",
+      "line",
+    ]) ||
+    !isMember(value.kind, PR_COMMENT_KINDS) ||
+    typeof value.body !== "string" ||
+    !optionalStringField(value.author) ||
+    !optionalStringField(value.created_at) ||
+    !optionalStringField(value.review_state) ||
+    !optionalStringField(value.path) ||
+    (value.line !== undefined &&
+      value.line !== null &&
+      !isFiniteNumber(value.line))
+  ) {
+    return null;
+  }
+  return {
+    kind: value.kind,
+    body: value.body,
+    ...(value.author ? { author: value.author } : {}),
+    ...(value.created_at ? { created_at: value.created_at } : {}),
+    ...(value.review_state ? { review_state: value.review_state } : {}),
+    ...(value.path ? { path: value.path } : {}),
+    ...(isFiniteNumber(value.line) ? { line: value.line } : {}),
+  };
 }
 
 export function parseCodeCommit(value: unknown): CodeCommitSnapshot | null {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import type { CodeRepoSnapshot, CodeWorkspaceSnapshot } from "../api/types";
+import { groupWorkspacesByRepo, prChipTone } from "./workspaceCards";
+
+function repo(id: string): CodeRepoSnapshot {
+  return {
+    id,
+    root_path: `/tmp/${id}`,
+    display_name: id,
+    default_base_ref: "main",
+    branch_prefix: "tidebreak",
+    quick_actions: [],
+    created_at: "2026-08-15T00:00:00.000Z",
+  };
+}
+
+function workspace(
+  id: string,
+  repoId: string,
+  status: CodeWorkspaceSnapshot["status"] = "active",
+): CodeWorkspaceSnapshot {
+  return {
+    id,
+    repo_id: repoId,
+    title: id,
+    worktree_path: `/tmp/${repoId}/.worktrees/${id}`,
+    branch_name: `tidebreak/${id}`,
+    base_ref: "main",
+    status,
+    created_at: "2026-08-15T00:00:00.000Z",
+  };
+}
+
+describe("groupWorkspacesByRepo", () => {
+  it("groups in repo order, drops archived, and keeps orphans visible", () => {
+    const groups = groupWorkspacesByRepo(
+      [repo("app"), repo("lib"), repo("empty")],
+      [
+        workspace("ws-lib", "lib"),
+        workspace("ws-app-1", "app"),
+        workspace("ws-archived", "app", "archived"),
+        workspace("ws-app-2", "app"),
+        workspace("ws-orphan", "gone"),
+      ],
+    );
+
+    expect(
+      groups.map((group) => [
+        group.repo?.id ?? null,
+        group.workspaces.map((item) => item.id),
+      ]),
+    ).toEqual([
+      ["app", ["ws-app-1", "ws-app-2"]],
+      ["lib", ["ws-lib"]],
+      [null, ["ws-orphan"]],
+    ]);
+  });
+});
+
+describe("prChipTone", () => {
+  it("maps host state tokens case-insensitively and defaults unknowns", () => {
+    expect(prChipTone("OPEN")).toBe("open");
+    expect(prChipTone("draft")).toBe("draft");
+    expect(prChipTone("Merged")).toBe("merged");
+    expect(prChipTone("closed")).toBe("closed");
+    expect(prChipTone("locked")).toBe("other");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -1,0 +1,127 @@
+import type {
+  CodeRepoSnapshot,
+  CodeSessionLifecycle,
+  CodeWorkspaceSnapshot,
+  CodeWorkspaceStatus,
+} from "../api/types";
+import { LIFECYCLE_LABELS, WORKSPACE_STATUS_LABELS } from "./labels";
+
+/**
+ * Pure presentation logic for workspace cards: grouping by repo, the state
+ * line, and PR chip tones. The rail renders from these; list pages can reuse
+ * them.
+ */
+
+export type WorkspaceGroup = {
+  /** Null collects workspaces whose repo is missing from the catalog. */
+  repo: CodeRepoSnapshot | null;
+  workspaces: CodeWorkspaceSnapshot[];
+};
+
+/**
+ * Group unarchived workspaces under their repo, in catalog repo order.
+ * Repos without live workspaces get no group. Workspaces whose repo the
+ * catalog does not know land in a trailing null-repo group rather than
+ * disappearing.
+ */
+export function groupWorkspacesByRepo(
+  repos: readonly CodeRepoSnapshot[],
+  workspaces: readonly CodeWorkspaceSnapshot[],
+): WorkspaceGroup[] {
+  const byRepo = new Map<string, CodeWorkspaceSnapshot[]>();
+  for (const workspace of workspaces) {
+    if (workspace.status === "archived") continue;
+    const listed = byRepo.get(workspace.repo_id);
+    if (listed) {
+      listed.push(workspace);
+    } else {
+      byRepo.set(workspace.repo_id, [workspace]);
+    }
+  }
+  const groups: WorkspaceGroup[] = [];
+  for (const repo of repos) {
+    const listed = byRepo.get(repo.id);
+    if (!listed) continue;
+    byRepo.delete(repo.id);
+    groups.push({ repo, workspaces: listed });
+  }
+  const orphans = [...byRepo.values()].flat();
+  if (orphans.length > 0) groups.push({ repo: null, workspaces: orphans });
+  return groups;
+}
+
+/**
+ * The one state word a card shows: workspace setup states win, then the
+ * session lifecycle. Null when the workspace is active with no session yet —
+ * an empty label reads better than "Created" on every fresh card.
+ */
+export function workspaceStateLabel(
+  status: CodeWorkspaceStatus,
+  lifecycle: CodeSessionLifecycle | undefined,
+): string | null {
+  if (status === "creating" || status === "setup_failed") {
+    return WORKSPACE_STATUS_LABELS[status];
+  }
+  if (!lifecycle) return null;
+  return LIFECYCLE_LABELS[lifecycle];
+}
+
+export type PrChipTone = "open" | "draft" | "merged" | "closed" | "other";
+
+/** Host state token → chip tone. Unknown tokens stay neutral. */
+export function prChipTone(state: string): PrChipTone {
+  const token = state.trim().toLowerCase();
+  if (token === "open") return "open";
+  if (token === "draft") return "draft";
+  if (token === "merged") return "merged";
+  if (token === "closed") return "closed";
+  return "other";
+}
+
+/**
+ * The tone for a whole digest: the draft flag wins over the state token,
+ * since gh reports a draft PR's state as plain "open".
+ */
+export function prTone(pr: { state: string; draft?: boolean }): PrChipTone {
+  const tone = prChipTone(pr.state);
+  return tone === "open" && pr.draft ? "draft" : tone;
+}
+
+/** The word a badge shows for a tone; unknown tones show the raw token. */
+export function prToneLabel(
+  pr: { state: string; draft?: boolean },
+): string {
+  switch (prTone(pr)) {
+    case "open":
+      return "Open";
+    case "draft":
+      return "Draft";
+    case "merged":
+      return "Merged";
+    case "closed":
+      return "Closed";
+    case "other":
+      return pr.state;
+  }
+}
+
+/** Icon (text) classes per tone, for the PR mark itself. */
+export const PR_ICON_TONE_CLASSES: Record<PrChipTone, string> = {
+  open: "text-success",
+  draft: "text-muted-foreground",
+  merged: "text-purple-600 dark:text-purple-400",
+  closed: "text-critical",
+  other: "text-muted-foreground",
+};
+
+/**
+ * Chip classes per tone. Open, draft, and closed ride the semantic theme
+ * tokens; merged has no token, so it pins GitHub's purple in both themes.
+ */
+export const PR_CHIP_TONE_CLASSES: Record<PrChipTone, string> = {
+  open: "bg-success-background text-success-foreground-muted",
+  draft: "bg-muted text-muted-foreground",
+  merged: "bg-purple-100 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300",
+  closed: "bg-critical-background text-critical-foreground-muted",
+  other: "bg-muted text-muted-foreground",
+};

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1124,6 +1124,26 @@ export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: n
 export type CodePermissionMode = "plan" | "ask" | "auto" | "allow";
 
 /**
+ * `GET /code/workspaces/{id}/pr/comments`: the PR conversation, read live
+ * from the host and never persisted.
+ */
+export type CodePrCommentsSnapshot = { 
+/**
+ * PR number the comments belong to.
+ */
+number: number, 
+/**
+ * Issue comments, review bodies, and inline review comments, ordered by
+ * creation time.
+ */
+comments: Array<PullRequestComment>, };
+
+/**
+ * Merge strategy for a user-initiated PR merge.
+ */
+export type CodePrMergeMethod = "squash" | "merge" | "rebase";
+
+/**
  * Result of pushing the workspace branch.
  */
 export type CodePushSnapshot = { branch: string, remote: string, };
@@ -1203,7 +1223,12 @@ export type CodeUpdateNotice = { "type": "snapshot",
 /**
  * One row per live session.
  */
-sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, pr_state?: PullRequestDigest, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, };
+sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, 
+/**
+ * Boxed to keep the notice enum's variants near one size; the wire
+ * shape is unchanged.
+ */
+pr_state?: PullRequestDigest, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, };
 
 /**
  * Token accounting as reported by the engine. Missing fields stay zero.
@@ -2124,6 +2149,15 @@ export type McpServersInfo = { servers: Array<McpServerInfo>, };
 export type McpViewSession = { frame_path: string, };
 
 /**
+ * Body of `POST /code/workspaces/{id}/pr/merge`.
+ */
+export type MergeCodePrBody = { method: CodePrMergeMethod, 
+/**
+ * True arms host auto-merge instead of merging immediately.
+ */
+auto: boolean, };
+
+/**
  * Identifies a persisted message within a chat.
  */
 export type MessageId = string;
@@ -2653,6 +2687,46 @@ url?: string, };
 export type PullRequestCheckBucket = "pass" | "pending" | "fail";
 
 /**
+ * One pull-request comment: an issue comment, a review body, or an inline
+ * review comment. Never persisted; fetched live from the host.
+ */
+export type PullRequestComment = { 
+/**
+ * Where on the PR the comment lives.
+ */
+kind: PullRequestCommentKind, 
+/**
+ * Author login, when the host reported one.
+ */
+author?: string, 
+/**
+ * Host creation timestamp, verbatim.
+ */
+created_at?: string, 
+/**
+ * Comment body, markdown as the host stores it.
+ */
+body: string, 
+/**
+ * Lowercased review verdict (approved, changes_requested, commented), on
+ * review bodies only.
+ */
+review_state?: string, 
+/**
+ * File path, on inline review comments.
+ */
+path?: string, 
+/**
+ * Line number, on inline review comments when the host reports one.
+ */
+line?: number, };
+
+/**
+ * Which surface of the PR a comment belongs to.
+ */
+export type PullRequestCommentKind = "issue" | "review" | "inline";
+
+/**
  * Bounded pull-request digest stored on a workspace.
  */
 export type PullRequestDigest = { 
@@ -2679,7 +2753,39 @@ checks_summary?: string | null,
 /**
  * Individual checks, when the host reported any.
  */
-checks?: Array<PullRequestCheck>, };
+checks?: Array<PullRequestCheck>, 
+/**
+ * True when the host reports the PR as a draft.
+ */
+draft?: boolean, 
+/**
+ * True when the host reports the PR merged.
+ */
+merged?: boolean, 
+/**
+ * Lowercased host review decision (approved, changes_requested, review_required).
+ */
+review_decision?: string, 
+/**
+ * Lowercased host mergeability (mergeable, conflicting, unknown).
+ */
+mergeable?: string, 
+/**
+ * Lowercased host merge-state status (clean, blocked, behind, dirty, …).
+ */
+merge_state_status?: string, 
+/**
+ * Head branch name on the host.
+ */
+head_branch?: string, 
+/**
+ * Base branch name on the host.
+ */
+base_branch?: string, 
+/**
+ * True when auto-merge is enabled on the host.
+ */
+auto_merge_enabled?: boolean, };
 
 /**
  * A follow-up parked while the session is already running a turn.

--- a/crates/tidebreak-desktop/ui/src/modelFamilies.ts
+++ b/crates/tidebreak-desktop/ui/src/modelFamilies.ts
@@ -1,0 +1,51 @@
+import type { ProviderKind } from "./api";
+
+/**
+ * Vendor identity derived from a model id, shared by the chat picker and the
+ * code-mode picker so a model reads as the same vendor everywhere.
+ */
+
+/**
+ * Open-model families recognizable from a model id, mirroring the id
+ * heuristics `ProviderIcon` brands rows with. `match` doubles as the
+ * `modelId` an icon renders the family mark for.
+ */
+export const MODEL_ID_FAMILIES: { match: string; label: string }[] = [
+  { match: "deepseek", label: "DeepSeek" },
+  { match: "glm", label: "Z.ai" },
+  { match: "kimi", label: "Moonshot AI" },
+  { match: "minimax", label: "MiniMax" },
+  { match: "qwen", label: "Qwen" },
+  { match: "nemotron", label: "NVIDIA" },
+  { match: "gemma", label: "Gemma" },
+];
+
+/**
+ * First-party vendors recognizable from a model id alone. Used where a
+ * catalog carries bare ids with no vendor field — a harness's own model
+ * list, or a gateway row the server matched no curated model for.
+ */
+const VENDOR_ID_PATTERNS: { match: RegExp; vendor: ProviderKind }[] = [
+  { match: /claude|sonnet|opus|haiku/, vendor: "anthropic" },
+  { match: /gpt|codex|^o\d/, vendor: "openai" },
+  { match: /grok/, vendor: "xai" },
+  { match: /gemini/, vendor: "gemini" },
+];
+
+/** The first-party vendor a bare model id names, or `null`. */
+export function vendorForModelId(id: string): ProviderKind | null {
+  const leaf = (id.split("/").pop() ?? id).toLocaleLowerCase();
+  return (
+    VENDOR_ID_PATTERNS.find((entry) => entry.match.test(leaf))?.vendor ?? null
+  );
+}
+
+/** The open-model family a model id names, or `null`. */
+export function familyForModelId(
+  id: string,
+): { match: string; label: string } | null {
+  const needle = id.toLocaleLowerCase();
+  return (
+    MODEL_ID_FAMILIES.find((entry) => needle.includes(entry.match)) ?? null
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
@@ -1,4 +1,4 @@
-import { Bot, FileCode, FileText, Files, FolderOpen, Package, Shield, SquareTerminal, X } from "lucide-react";
+import { Bot, FileText, FolderOpen, Package, Shield, SquareTerminal, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { panelKey, type PanelContent } from "./panelTypes";
@@ -25,10 +25,6 @@ function panelTabFallbackLabel(panel: PanelContent): string {
       return "Agents";
     case "agent":
       return "Agent";
-    case "files":
-      return "Files";
-    case "diff":
-      return "Diff";
     case "terminal":
       return "Terminal";
   }
@@ -48,10 +44,6 @@ function PanelTabIcon({ panel }: { panel: PanelContent }) {
     case "agents":
     case "agent":
       return <Bot className={className} />;
-    case "files":
-      return <Files className={className} />;
-    case "diff":
-      return <FileCode className={className} />;
     case "terminal":
       return <SquareTerminal className={className} />;
   }

--- a/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
@@ -23,10 +23,6 @@ export type PanelContent =
   | { type: "agents" }
   /** One background agent run, opened from the agents table or the transcript. */
   | { type: "agent"; runId: string }
-  /** Changed files in a code-mode workspace; `turnId` filters to one turn. */
-  | { type: "files"; turnId?: string }
-  /** Server-produced unified diff; `turnId`/`file` anchor within the tab. */
-  | { type: "diff"; turnId?: string; file?: string }
   /** Auxiliary workspace shell; `terminalId` pins a live PTY when known. */
   | { type: "terminal"; terminalId?: string };
 

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
@@ -14,13 +14,6 @@ describe("panel URLs", () => {
     expect(parsePanelSegment("permissions")).toEqual({ type: "permissions" });
     expect(parsePanelSegment("agents")).toEqual({ type: "agents" });
     expect(parsePanelSegment("agent.run-1")).toEqual({ type: "agent", runId: "run-1" });
-    expect(parsePanelSegment("files")).toEqual({ type: "files" });
-    expect(parsePanelSegment("files.turn-1")).toEqual({ type: "files", turnId: "turn-1" });
-    expect(parsePanelSegment("diff.t.turn-1.f.src%2Flib.rs")).toEqual({
-      type: "diff",
-      turnId: "turn-1",
-      file: "src/lib.rs",
-    });
     expect(parsePanelSegment("terminal")).toEqual({ type: "terminal" });
     expect(parsePanelSegment("terminal.term-1")).toEqual({
       type: "terminal",
@@ -40,6 +33,15 @@ describe("panel URLs", () => {
     expect(parsePanelSegment("apps")).toBeNull();
     expect(parsePanelSegment("apps.app-1")).toBeNull();
     expect(parsePanelSegment("plugins.documents")).toBeNull();
+  });
+
+  // Files and Diff moved into the workspace inspector; links that still name
+  // them as tabs fall back to the conversation alone.
+  it("no longer reads the retired files and diff panels", () => {
+    expect(parsePanelSegment("files")).toBeNull();
+    expect(parsePanelSegment("files.turn-1")).toBeNull();
+    expect(parsePanelSegment("diff")).toBeNull();
+    expect(parsePanelSegment("diff.t.turn-1.f.src%2Flib.rs")).toBeNull();
   });
 
   // The conversation holds its own region now; a URL still naming it as a
@@ -74,11 +76,6 @@ describe("panel URLs", () => {
       { type: "permissions" },
       { type: "agents" },
       { type: "agent", runId: "run-1" },
-      { type: "files" },
-      { type: "files", turnId: "turn-1" },
-      { type: "diff" },
-      { type: "diff", turnId: "turn-1" },
-      { type: "diff", turnId: "turn-1", file: "src/lib.rs" },
       { type: "terminal" },
       { type: "terminal", terminalId: "term-1" },
     ] as const) {

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
@@ -48,54 +48,15 @@ export function parsePanelSegment(segment: string): PanelContent | null {
     case "agent":
       // A run id is the whole address; there is no id-less run panel.
       return id ? { type: "agent", runId: id } : null;
-    case "files":
-      return parseFilesTarget(id);
-    case "diff":
-      return parseDiffTarget(id);
     case "terminal":
       return id ? { type: "terminal", terminalId: id } : { type: "terminal" };
     default:
       // `apps` and `plugins` were panel segments before the libraries became
-      // routes of their own; those links fall back to the conversation alone.
+      // routes of their own, and `files`/`diff` before those surfaces moved
+      // into the workspace inspector; those links fall back to the
+      // conversation alone.
       return null;
   }
-}
-
-function parseFilesTarget(id: string): PanelContent | null {
-  if (!id) return { type: "files" };
-  if (id.includes(".")) return null;
-  return { type: "files", turnId: id };
-}
-
-function parseDiffTarget(id: string): PanelContent | null {
-  if (!id) return { type: "diff" };
-  const parts = id.split(".");
-  let turnId: string | undefined;
-  let file: string | undefined;
-  let index = 0;
-  while (index < parts.length) {
-    const token = parts[index];
-    if (token === "t" && parts[index + 1]) {
-      turnId = parts[index + 1];
-      index += 2;
-      continue;
-    }
-    if (token === "f" && parts[index + 1]) {
-      try {
-        file = decodeURIComponent(parts.slice(index + 1).join("."));
-      } catch {
-        return null;
-      }
-      if (!file) return null;
-      break;
-    }
-    return null;
-  }
-  return {
-    type: "diff",
-    ...(turnId ? { turnId } : {}),
-    ...(file ? { file } : {}),
-  };
 }
 
 function parseDocumentTarget(id: string): PanelContent | null {
@@ -127,14 +88,6 @@ export function encodePanelSegment(panel: PanelContent): string {
       return "agents";
     case "agent":
       return `agent.${panel.runId}`;
-    case "files":
-      return panel.turnId ? `files.${panel.turnId}` : "files";
-    case "diff": {
-      const parts = ["diff"];
-      if (panel.turnId) parts.push("t", panel.turnId);
-      if (panel.file) parts.push("f", encodeURIComponent(panel.file));
-      return parts.join(".");
-    }
     case "terminal":
       return panel.terminalId ? `terminal.${panel.terminalId}` : "terminal";
   }

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -253,7 +253,7 @@ pub(crate) async fn note_activity(
 
 pub(crate) async fn emit_digest(db: &DbStore, bus: &CodeEventBus, session: &CodeSession) {
     match build_digest(db, session).await {
-        Ok(digest) => bus.publish_update(CodeLiveUpdate::Digest(digest)),
+        Ok(digest) => bus.publish_update(CodeLiveUpdate::Digest(Box::new(digest))),
         Err(err) => warn!(
             session = %session.id,
             error = %err,

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -46,8 +46,9 @@ pub(crate) struct CloneProgress {
 /// One unsequenced notice on the install-wide updates channel.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum CodeLiveUpdate {
-    /// Cheap per-session digest, computed from rows.
-    Digest(SessionDigest),
+    /// Cheap per-session digest, computed from rows. Boxed: the PR digest
+    /// makes it much larger than the clone-progress variant.
+    Digest(Box<SessionDigest>),
     /// Clone job progress. Not restated on connect.
     CloneProgress(CloneProgress),
 }

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -71,6 +71,8 @@ pub(crate) enum GhError {
     #[error("{instructions}")]
     GhSignedOut { instructions: String },
     #[error("{0}")]
+    MergeBlocked(String),
+    #[error("{0}")]
     User(String),
     #[error("{0}")]
     Internal(String),
@@ -337,9 +339,252 @@ pub(crate) async fn create_pull_request(
         title: None,
         checks_summary: None,
         checks: None,
+        draft: None,
+        merged: None,
+        review_decision: None,
+        mergeable: None,
+        merge_state_status: None,
+        head_branch: None,
+        base_branch: None,
+        auto_merge_enabled: None,
     };
     cache.put(workspace_id, digest.clone());
     Ok(digest)
+}
+
+/// Merge strategy for the user-initiated merge operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MergeMethod {
+    Squash,
+    Merge,
+    Rebase,
+}
+
+impl MergeMethod {
+    fn flag(self) -> &'static str {
+        match self {
+            Self::Squash => "--squash",
+            Self::Merge => "--merge",
+            Self::Rebase => "--rebase",
+        }
+    }
+}
+
+/// Merge the workspace PR, or enable auto-merge on it. This is the only path
+/// allowed to run `gh pr merge`, and it exists solely for the user-initiated
+/// merge endpoint — agent and automation paths go through [`run_gh`], which
+/// refuses merge argv outright.
+pub(crate) async fn merge_pull_request(
+    worktree: &Path,
+    workspace_id: WorkspaceId,
+    method: MergeMethod,
+    auto: bool,
+    cache: &PrDigestCache,
+    gh_search_path: Option<&str>,
+) -> Result<(), GhError> {
+    let gh = observe_gh(gh_search_path).await;
+    let binary = require_gh_binary(&gh)?;
+    let mut args = vec!["pr", "merge", method.flag()];
+    if auto {
+        args.push("--auto");
+    }
+    run_gh_user_merge(worktree, &binary, &args, GH_TIMEOUT)
+        .await
+        .map_err(classify_merge_error)?;
+    cache.invalidate(workspace_id);
+    Ok(())
+}
+
+/// Turn a `gh pr merge` failure into something the PR card can show.
+pub(crate) fn classify_merge_error(err: String) -> GhError {
+    let bounded = bound_text(&err);
+    let lower = bounded.to_ascii_lowercase();
+    if lower.contains("not logged") || lower.contains("not signed") || lower.contains("auth") {
+        return GhError::GhSignedOut {
+            instructions: "gh is installed but not signed in. Run `gh auth login` in a terminal, then try again. Tidebreak does not store GitHub credentials.".into(),
+        };
+    }
+    if lower.contains("not mergeable")
+        || lower.contains("merge conflict")
+        || lower.contains("branch protection")
+        || lower.contains("protected branch")
+        || lower.contains("base branch policy")
+        || lower.contains("required status check")
+        || lower.contains("review is required")
+        || lower.contains("reviews are required")
+        || lower.contains("draft")
+        || lower.contains("already been merged")
+        || lower.contains("clean status")
+    {
+        return GhError::MergeBlocked(format!("the pull request cannot be merged: {bounded}"));
+    }
+    GhError::User(format!("gh pr merge failed: {bounded}"))
+}
+
+/// PR comments read live from the host. Never persisted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PrComments {
+    pub number: u64,
+    pub comments: Vec<tidebreak_core::PullRequestComment>,
+}
+
+/// Load issue comments, review bodies, and inline review comments for the
+/// workspace PR. Inline comments come from the REST endpoint because
+/// `gh pr view --json` does not carry file/line positions.
+pub(crate) async fn load_pr_comments(
+    worktree: &Path,
+    gh_search_path: Option<&str>,
+) -> Result<PrComments, GhError> {
+    let gh = observe_gh(gh_search_path).await;
+    let binary = require_gh_binary(&gh)?;
+    let view = run_gh(
+        worktree,
+        &binary,
+        &["pr", "view", "--json", "number,comments,reviews"],
+        GH_TIMEOUT,
+    )
+    .await
+    .map_err(|err| GhError::user(format!("could not read PR comments: {err}")))?;
+    let (number, mut comments) = parse_pr_view_comments(&view);
+    let Some(number) = number else {
+        return Err(GhError::user(
+            "no pull request found for this branch".to_owned(),
+        ));
+    };
+    let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{number}/comments");
+    // Inline comments are additive: a failed REST read still returns the
+    // conversation-tab comments rather than failing the whole request.
+    if let Ok(json) = run_gh(worktree, &binary, &["api", &endpoint], GH_TIMEOUT).await {
+        comments.extend(parse_review_comments(&json));
+    }
+    comments.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    Ok(PrComments { number, comments })
+}
+
+fn require_gh_binary(gh: &GhObservation) -> Result<PathBuf, GhError> {
+    if !gh.found {
+        return Err(GhError::GhAbsent {
+            instructions: gh.remediation.clone(),
+        });
+    }
+    if gh.authenticated != Some(true) {
+        return Err(GhError::GhSignedOut {
+            instructions: gh.remediation.clone(),
+        });
+    }
+    gh.binary.clone().ok_or_else(|| GhError::GhAbsent {
+        instructions: gh.remediation.clone(),
+    })
+}
+
+/// Parse `gh pr view --json number,comments,reviews`: issue comments plus
+/// review bodies. Missing or malformed entries are skipped, never fatal.
+pub(crate) fn parse_pr_view_comments(
+    json: &str,
+) -> (Option<u64>, Vec<tidebreak_core::PullRequestComment>) {
+    use tidebreak_core::{PullRequestComment, PullRequestCommentKind};
+
+    let parsed: serde_json::Value = serde_json::from_str(json).unwrap_or(serde_json::Value::Null);
+    let number = parsed.get("number").and_then(|value| value.as_u64());
+    let mut comments = Vec::new();
+    let text = |value: &serde_json::Value, key: &str| {
+        value
+            .get(key)
+            .and_then(|inner| inner.as_str())
+            .filter(|inner| !inner.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    let login = |value: &serde_json::Value| {
+        value
+            .get("author")
+            .and_then(|author| author.get("login"))
+            .and_then(|inner| inner.as_str())
+            .filter(|inner| !inner.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    for item in parsed
+        .get("comments")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+    {
+        let Some(body) = text(item, "body") else {
+            continue;
+        };
+        comments.push(PullRequestComment {
+            kind: PullRequestCommentKind::Issue,
+            author: login(item),
+            created_at: text(item, "createdAt"),
+            body,
+            review_state: None,
+            path: None,
+            line: None,
+        });
+    }
+    for item in parsed
+        .get("reviews")
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+    {
+        // A review submitted without a body (a bare approve) carries nothing
+        // to read; the decision already rides the digest.
+        let Some(body) = text(item, "body") else {
+            continue;
+        };
+        comments.push(PullRequestComment {
+            kind: PullRequestCommentKind::Review,
+            author: login(item),
+            created_at: text(item, "submittedAt").or_else(|| text(item, "createdAt")),
+            body,
+            review_state: text(item, "state").map(|state| state.to_ascii_lowercase()),
+            path: None,
+            line: None,
+        });
+    }
+    (number, comments)
+}
+
+/// Parse the REST `pulls/{n}/comments` array: inline review comments with
+/// file path and line. Missing fields are tolerated.
+pub(crate) fn parse_review_comments(json: &str) -> Vec<tidebreak_core::PullRequestComment> {
+    use tidebreak_core::{PullRequestComment, PullRequestCommentKind};
+
+    let parsed: serde_json::Value = serde_json::from_str(json).unwrap_or(serde_json::Value::Null);
+    let mut comments = Vec::new();
+    for item in parsed.as_array().into_iter().flatten() {
+        let Some(body) = item
+            .get("body")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        let text = |key: &str| {
+            item.get(key)
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        };
+        comments.push(PullRequestComment {
+            kind: PullRequestCommentKind::Inline,
+            author: item
+                .get("user")
+                .and_then(|user| user.get("login"))
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
+            created_at: text("created_at"),
+            body: body.to_owned(),
+            review_state: None,
+            path: text("path"),
+            line: item
+                .get("line")
+                .and_then(|value| value.as_u64())
+                .or_else(|| item.get("original_line").and_then(|value| value.as_u64())),
+        });
+    }
+    comments
 }
 
 /// Run one named quick action in the worktree. Output is not journaled.
@@ -642,6 +887,8 @@ fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
+const PR_VIEW_FIELDS: &str = "number,url,state,title,isDraft,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRefName,baseRefName";
+
 async fn load_pr_digest(
     worktree: &Path,
     gh: &GhObservation,
@@ -653,18 +900,25 @@ async fn load_pr_digest(
     let view = run_gh(
         worktree,
         binary,
-        &["pr", "view", "--json", "number,url,state,title"],
+        &["pr", "view", "--json", PR_VIEW_FIELDS],
         GH_TIMEOUT,
     )
     .await;
     let Ok(json) = view else {
         return Ok(None);
     };
-    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap_or(serde_json::Value::Null);
-    let number = parsed.get("number").and_then(|value| value.as_u64());
-    let Some(number) = number else {
-        return Ok(None);
-    };
+    let checks_table = run_gh(worktree, binary, &["pr", "checks"], GH_TIMEOUT)
+        .await
+        .unwrap_or_default();
+    Ok(digest_from_view_json(&json, &checks_table))
+}
+
+/// Parse one `gh pr view --json` payload plus a `gh pr checks` table into the
+/// stored digest. Every field beyond the number is optional and tolerated
+/// missing.
+pub(crate) fn digest_from_view_json(json: &str, checks_table: &str) -> Option<PullRequestDigest> {
+    let parsed: serde_json::Value = serde_json::from_str(json).unwrap_or(serde_json::Value::Null);
+    let number = parsed.get("number").and_then(|value| value.as_u64())?;
     let url = parsed
         .get("url")
         .and_then(|value| value.as_str())
@@ -681,13 +935,27 @@ async fn load_pr_digest(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
-    let checks_table = run_gh(worktree, binary, &["pr", "checks"], GH_TIMEOUT)
-        .await
-        .unwrap_or_default();
-    let checks = parse_pr_checks(&checks_table);
-    Ok(Some(PullRequestDigest {
+    let checks = parse_pr_checks(checks_table);
+    let lower_token = |key: &str| {
+        parsed
+            .get(key)
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_ascii_lowercase)
+    };
+    let branch = |key: &str| {
+        parsed
+            .get(key)
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    Some(PullRequestDigest {
         number,
         url,
+        merged: Some(state == "merged"),
         state,
         title,
         checks_summary: summarize_checks(&checks),
@@ -696,7 +964,18 @@ async fn load_pr_digest(
         } else {
             Some(checks)
         },
-    }))
+        draft: parsed.get("isDraft").and_then(|value| value.as_bool()),
+        review_decision: lower_token("reviewDecision"),
+        mergeable: lower_token("mergeable"),
+        merge_state_status: lower_token("mergeStateStatus"),
+        head_branch: branch("headRefName"),
+        base_branch: branch("baseRefName"),
+        auto_merge_enabled: Some(
+            parsed
+                .get("autoMergeRequest")
+                .is_some_and(|value| !value.is_null()),
+        ),
+    })
 }
 
 pub(crate) fn parse_pr_checks(output: &str) -> Vec<tidebreak_core::PullRequestCheck> {
@@ -960,6 +1239,11 @@ async fn git(cwd: &Path, args: &[&str], limit: Duration) -> Result<String, Strin
     }
 }
 
+/// General `gh` runner for creation, status, and comment reads — every
+/// agent-driven or automated path. It hard-refuses merge and auto-merge
+/// arguments so no automation path can ever merge a PR; the one allowed merge
+/// entry point is [`run_gh_user_merge`], reachable only from the dedicated
+/// user-initiated merge operation. GraphQL is refused on every runner.
 async fn run_gh(
     cwd: &Path,
     binary: &Path,
@@ -973,6 +1257,33 @@ async fn run_gh(
     {
         return Err("refusing to run a merge or GraphQL gh command".into());
     }
+    spawn_gh(cwd, binary, args, limit).await
+}
+
+/// Runner reserved for the user-initiated merge endpoint. It runs only
+/// `gh pr merge …` argv — anything else, including GraphQL, is refused — so
+/// the ability to merge stays scoped to the one operation the user asks for.
+async fn run_gh_user_merge(
+    cwd: &Path,
+    binary: &Path,
+    args: &[&str],
+    limit: Duration,
+) -> Result<String, String> {
+    if args.len() < 2 || args[0] != "pr" || args[1] != "merge" {
+        return Err("the merge runner only runs gh pr merge".into());
+    }
+    if args.contains(&"graphql") {
+        return Err("refusing to run a GraphQL gh command".into());
+    }
+    spawn_gh(cwd, binary, args, limit).await
+}
+
+async fn spawn_gh(
+    cwd: &Path,
+    binary: &Path,
+    args: &[&str],
+    limit: Duration,
+) -> Result<String, String> {
     let mut command = Command::new(binary);
     command
         .args(args)
@@ -1288,9 +1599,212 @@ exit 3
         assert!(!logged.contains("--base origin/main"), "{logged}");
         assert!(logged.contains("pr view"), "{logged}");
         assert!(logged.contains("pr checks"), "{logged}");
-        assert!(!logged.contains("merge"), "{logged}");
+        // The view field list legitimately names mergeable/autoMergeRequest;
+        // what may never appear is a merge invocation or flag.
+        assert!(!logged.contains("pr merge"), "{logged}");
+        assert!(!logged.contains("--merge"), "{logged}");
         assert!(!logged.contains("--auto"), "{logged}");
         assert!(!logged.contains("graphql"), "{logged}");
+
+        // The general runner refuses merge argv before spawning anything —
+        // creation and status paths cannot merge even if handed the argv.
+        for argv in [
+            &["pr", "merge", "--squash"][..],
+            &["pr", "merge", "--auto", "--squash"][..],
+            &["api", "graphql"][..],
+        ] {
+            let refused = run_gh(&work, &shim_dir.path().join("gh"), argv, GH_TIMEOUT)
+                .await
+                .unwrap_err();
+            assert!(refused.contains("refusing"), "{argv:?}: {refused}");
+        }
+        let after = std::fs::read_to_string(&log).unwrap();
+        assert_eq!(logged, after, "a refused command must never reach gh");
+    }
+
+    #[tokio::test]
+    async fn only_the_user_merge_runner_may_merge_and_it_runs_nothing_else() {
+        let shim_dir = TempDir::new().unwrap();
+        let log = shim_dir.path().join("log");
+        write_executable(
+            &shim_dir.path().join("gh"),
+            &format!(
+                r#"#!/bin/sh
+echo "$@" >> {log}
+if [ "$1" = auth ]; then exit 0; fi
+if [ "$1" = pr ] && [ "$2" = merge ]; then exit 0; fi
+echo unexpected "$@" >&2
+exit 3
+"#,
+                log = log.display()
+            ),
+        );
+        let binary = shim_dir.path().join("gh");
+        let dir = TempDir::new().unwrap();
+
+        // The merge runner refuses everything that is not `gh pr merge`,
+        // GraphQL included.
+        for argv in [
+            &["pr", "view"][..],
+            &["pr", "create"][..],
+            &["api", "graphql"][..],
+            &["pr", "merge", "graphql"][..],
+        ] {
+            let refused = run_gh_user_merge(dir.path(), &binary, argv, GH_TIMEOUT)
+                .await
+                .unwrap_err();
+            assert!(
+                refused.contains("only runs gh pr merge") || refused.contains("refusing"),
+                "{argv:?}: {refused}"
+            );
+        }
+        assert!(!log.exists(), "a refused argv must never spawn gh");
+
+        // The dedicated merge operation is the one path that runs it.
+        let cache = PrDigestCache::default();
+        merge_pull_request(
+            dir.path(),
+            WorkspaceId::new(),
+            MergeMethod::Squash,
+            false,
+            &cache,
+            Some(shim_dir.path().to_str().unwrap()),
+        )
+        .await
+        .unwrap();
+        merge_pull_request(
+            dir.path(),
+            WorkspaceId::new(),
+            MergeMethod::Merge,
+            true,
+            &cache,
+            Some(shim_dir.path().to_str().unwrap()),
+        )
+        .await
+        .unwrap();
+        let logged = std::fs::read_to_string(&log).unwrap();
+        assert!(logged.contains("pr merge --squash"), "{logged}");
+        assert!(logged.contains("pr merge --merge --auto"), "{logged}");
+    }
+
+    #[test]
+    fn merge_failures_map_to_blocked_signed_out_or_user() {
+        for blocked in [
+            "X Pull request #12 is not mergeable: the base branch policy prohibits the merge.",
+            "GraphQL: Pull request is not mergeable (mergePullRequest)",
+            "X this branch has merge conflicts with the base branch",
+            "X 2 reviews are required by reviewers with write access",
+        ] {
+            assert!(
+                matches!(
+                    classify_merge_error(blocked.into()),
+                    GhError::MergeBlocked(_)
+                ),
+                "expected MergeBlocked for {blocked}"
+            );
+        }
+        assert!(matches!(
+            classify_merge_error("HTTP 401: authentication required".into()),
+            GhError::GhSignedOut { .. }
+        ));
+        assert!(matches!(
+            classify_merge_error("something else entirely".into()),
+            GhError::User(_)
+        ));
+    }
+
+    #[test]
+    fn rich_pr_view_json_maps_to_digest() {
+        let json = r#"{
+            "number": 12,
+            "url": "https://github.com/example/demo/pull/12",
+            "state": "OPEN",
+            "title": "feat: first change",
+            "isDraft": true,
+            "reviewDecision": "CHANGES_REQUESTED",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "BLOCKED",
+            "autoMergeRequest": {"enabledAt": "2026-08-17T00:00:00Z"},
+            "headRefName": "tidebreak/first-change",
+            "baseRefName": "main"
+        }"#;
+        let digest = digest_from_view_json(json, "lint\tpass\t1s\n").unwrap();
+        assert_eq!(digest.number, 12);
+        assert_eq!(digest.state, "open");
+        assert_eq!(digest.draft, Some(true));
+        assert_eq!(digest.merged, Some(false));
+        assert_eq!(digest.review_decision.as_deref(), Some("changes_requested"));
+        assert_eq!(digest.mergeable.as_deref(), Some("mergeable"));
+        assert_eq!(digest.merge_state_status.as_deref(), Some("blocked"));
+        assert_eq!(
+            digest.head_branch.as_deref(),
+            Some("tidebreak/first-change")
+        );
+        assert_eq!(digest.base_branch.as_deref(), Some("main"));
+        assert_eq!(digest.auto_merge_enabled, Some(true));
+        assert_eq!(
+            digest.checks_summary.as_deref(),
+            Some("1 passing, 0 pending, 0 failing")
+        );
+
+        // Older gh output without the extra fields still yields a digest, and
+        // a merged state is reflected in both `state` and `merged`.
+        let sparse = digest_from_view_json(
+            r#"{"number": 7, "state": "MERGED", "autoMergeRequest": null}"#,
+            "",
+        )
+        .unwrap();
+        assert_eq!(sparse.state, "merged");
+        assert_eq!(sparse.merged, Some(true));
+        assert_eq!(sparse.draft, None);
+        assert_eq!(sparse.review_decision, None);
+        assert_eq!(sparse.auto_merge_enabled, Some(false));
+        assert!(digest_from_view_json("not json", "").is_none());
+    }
+
+    #[test]
+    fn pr_comments_parse_issue_review_and_inline_shapes() {
+        use tidebreak_core::PullRequestCommentKind;
+
+        let view = r#"{
+            "number": 12,
+            "comments": [
+                {"author": {"login": "alice"}, "createdAt": "2026-08-16T10:00:00Z", "body": "looks close"},
+                {"body": ""}
+            ],
+            "reviews": [
+                {"author": {"login": "bob"}, "state": "CHANGES_REQUESTED", "submittedAt": "2026-08-16T11:00:00Z", "body": "please split this"},
+                {"author": {"login": "carol"}, "state": "APPROVED", "body": ""}
+            ]
+        }"#;
+        let (number, comments) = parse_pr_view_comments(view);
+        assert_eq!(number, Some(12));
+        assert_eq!(comments.len(), 2, "empty bodies are dropped: {comments:?}");
+        assert_eq!(comments[0].kind, PullRequestCommentKind::Issue);
+        assert_eq!(comments[0].author.as_deref(), Some("alice"));
+        assert_eq!(comments[0].body, "looks close");
+        assert_eq!(comments[1].kind, PullRequestCommentKind::Review);
+        assert_eq!(
+            comments[1].review_state.as_deref(),
+            Some("changes_requested")
+        );
+        assert_eq!(
+            comments[1].created_at.as_deref(),
+            Some("2026-08-16T11:00:00Z")
+        );
+
+        let rest = r#"[
+            {"user": {"login": "bob"}, "created_at": "2026-08-16T12:00:00Z", "body": "rename this", "path": "src/lib.rs", "line": 42},
+            {"user": {"login": "bob"}, "body": "outdated hunk", "path": "src/old.rs", "line": null, "original_line": 7},
+            {"body": ""}
+        ]"#;
+        let inline = parse_review_comments(rest);
+        assert_eq!(inline.len(), 2);
+        assert_eq!(inline[0].kind, PullRequestCommentKind::Inline);
+        assert_eq!(inline[0].path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(inline[0].line, Some(42));
+        assert_eq!(inline[1].line, Some(7), "falls back to original_line");
+        assert_eq!(parse_review_comments("surprise!").len(), 0);
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -601,6 +601,54 @@ impl CodeRuntime {
         Ok(status)
     }
 
+    /// Force a fresh host read: drop the digest cache entry, then take the
+    /// normal status path.
+    pub(crate) async fn refresh_workspace_pr(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        self.pr_cache.invalidate(id);
+        self.workspace_pr(id).await
+    }
+
+    pub(crate) async fn workspace_pr_comments(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<gh::PrComments, ServerError> {
+        let workspace = self.get_workspace(id).await?;
+        let gh_path = self.gh_search_path_owned();
+        gh::load_pr_comments(
+            std::path::Path::new(&workspace.worktree_path),
+            gh_path.as_deref(),
+        )
+        .await
+        .map_err(map_gh)
+    }
+
+    /// User-initiated merge (or auto-merge arming) of the workspace PR, then a
+    /// fresh status read so the caller and the updates channel both see the
+    /// result. This is the only route to `gh pr merge`.
+    pub(crate) async fn merge_workspace_pr(
+        &self,
+        id: WorkspaceId,
+        method: gh::MergeMethod,
+        auto: bool,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        let workspace = self.require_live_workspace(id).await?;
+        let gh_path = self.gh_search_path_owned();
+        gh::merge_pull_request(
+            std::path::Path::new(&workspace.worktree_path),
+            workspace.id,
+            method,
+            auto,
+            &self.pr_cache,
+            gh_path.as_deref(),
+        )
+        .await
+        .map_err(map_gh)?;
+        self.workspace_pr(id).await
+    }
+
     pub(crate) async fn create_workspace_pr(
         &self,
         id: WorkspaceId,
@@ -1372,6 +1420,7 @@ fn map_gh(err: GhError) -> ServerError {
         GhError::GhSignedOut { instructions } => {
             ServerError::conflict_kind("gh_signed_out", instructions)
         }
+        GhError::MergeBlocked(message) => ServerError::conflict_kind("pr_not_mergeable", message),
         GhError::User(message) => {
             if message.contains("no quick action") {
                 ServerError::not_found(message)

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -746,6 +746,18 @@ pub fn app(state: AppState) -> Router {
             get(routes::code::get_workspace_pr),
         )
         .route(
+            "/code/workspaces/{id}/pr/refresh",
+            post(routes::code::refresh_workspace_pr),
+        )
+        .route(
+            "/code/workspaces/{id}/pr/comments",
+            get(routes::code::get_workspace_pr_comments),
+        )
+        .route(
+            "/code/workspaces/{id}/pr/merge",
+            post(routes::code::merge_workspace_pr),
+        )
+        .route(
             "/code/workspaces/{id}/actions/{name}",
             post(routes::code::run_workspace_action),
         )

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -10,10 +10,11 @@ use crate::state::AppState;
 
 use super::require_code;
 use super::types::{
-    CodeActionSnapshot, CodeCommitSnapshot, CodePushSnapshot, CodeWorkspacePrSnapshot,
-    CommitWorkspaceBody, CreatePullRequestBody,
+    CodeActionSnapshot, CodeCommitSnapshot, CodePrCommentsSnapshot, CodePrMergeMethod,
+    CodePushSnapshot, CodeWorkspacePrSnapshot, CommitWorkspaceBody, CreatePullRequestBody,
+    MergeCodePrBody,
 };
-use crate::code::gh::{ActionOutcome, CommitOutcome, PushOutcome, WorkspaceGitStatus};
+use crate::code::gh::{ActionOutcome, CommitOutcome, MergeMethod, PushOutcome, WorkspaceGitStatus};
 use tidebreak_core::WorkspaceId;
 
 pub async fn commit_workspace(
@@ -52,6 +53,43 @@ pub async fn get_workspace_pr(
 ) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
     Ok(Json(pr_snapshot(
         require_code(&state)?.workspace_pr(id).await?,
+    )))
+}
+
+pub async fn refresh_workspace_pr(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
+    Ok(Json(pr_snapshot(
+        require_code(&state)?.refresh_workspace_pr(id).await?,
+    )))
+}
+
+pub async fn get_workspace_pr_comments(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodePrCommentsSnapshot>, ServerError> {
+    let comments = require_code(&state)?.workspace_pr_comments(id).await?;
+    Ok(Json(CodePrCommentsSnapshot {
+        number: comments.number,
+        comments: comments.comments,
+    }))
+}
+
+pub async fn merge_workspace_pr(
+    State(state): State<AppState>,
+    Path(id): Path<WorkspaceId>,
+    Json(body): Json<MergeCodePrBody>,
+) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
+    let method = match body.method {
+        CodePrMergeMethod::Squash => MergeMethod::Squash,
+        CodePrMergeMethod::Merge => MergeMethod::Merge,
+        CodePrMergeMethod::Rebase => MergeMethod::Rebase,
+    };
+    Ok(Json(pr_snapshot(
+        require_code(&state)?
+            .merge_workspace_pr(id, method, body.auto)
+            .await?,
     )))
 }
 

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -14,7 +14,8 @@ mod workspaces;
 pub(crate) use crate::code::approval_bridge::approval_prompt;
 pub(crate) use approvals::{decide_approval, list_approvals};
 pub(crate) use git::{
-    commit_workspace, create_pull_request, get_workspace_pr, push_workspace, run_workspace_action,
+    commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,
+    merge_workspace_pr, push_workspace, refresh_workspace_pr, run_workspace_action,
 };
 pub(crate) use harnesses::{list_harness_models, list_harnesses, refresh_harnesses};
 pub(crate) use repos::{
@@ -33,11 +34,12 @@ pub(crate) use terminals::{
 #[allow(unused_imports)]
 pub(crate) use types::{
     CodeActionSnapshot, CodeApprovalDecisionBody, CodeApprovalSnapshot, CodeCloneDefaults,
-    CodeCloneJobSnapshot, CodeCommitSnapshot, CodeFileChange, CodePushSnapshot, CodeRepoSnapshot,
-    CodeSessionDigest, CodeSessionSnapshot, CodeTerminalActivityNotice, CodeTerminalRead,
-    CodeTerminalSnapshot, CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceDiff,
-    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSnapshot, HarnessDoctorReport,
-    HarnessModelList, QueuedCodeTurn, SequencedCodeEventFrame,
+    CodeCloneJobSnapshot, CodeCommitSnapshot, CodeFileChange, CodePrCommentsSnapshot,
+    CodePushSnapshot, CodeRepoSnapshot, CodeSessionDigest, CodeSessionSnapshot,
+    CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTurnSnapshot,
+    CodeUpdateNotice, CodeWorkspaceDiff, CodeWorkspaceFiles, CodeWorkspacePrSnapshot,
+    CodeWorkspaceSnapshot, HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
+    SequencedCodeEventFrame,
 };
 pub(crate) use updates::code_updates;
 pub(crate) use workspaces::{

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -371,6 +371,36 @@ pub struct CodeWorkspacePrSnapshot {
     pub remediation: String,
 }
 
+/// Body of `POST /code/workspaces/{id}/pr/merge`.
+#[derive(Debug, Deserialize, Serialize, TS)]
+#[serde(deny_unknown_fields)]
+pub struct MergeCodePrBody {
+    pub method: CodePrMergeMethod,
+    /// True arms host auto-merge instead of merging immediately.
+    #[serde(default)]
+    pub auto: bool,
+}
+
+/// Merge strategy for a user-initiated PR merge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum CodePrMergeMethod {
+    Squash,
+    Merge,
+    Rebase,
+}
+
+/// `GET /code/workspaces/{id}/pr/comments`: the PR conversation, read live
+/// from the host and never persisted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodePrCommentsSnapshot {
+    /// PR number the comments belong to.
+    pub number: u64,
+    /// Issue comments, review bodies, and inline review comments, ordered by
+    /// creation time.
+    pub comments: Vec<tidebreak_core::PullRequestComment>,
+}
+
 /// Bounded output of one named quick action. Never journaled.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub struct CodeActionSnapshot {
@@ -634,9 +664,11 @@ pub enum CodeUpdateNotice {
         attention: Attention,
         title: String,
         turn_count: i64,
+        /// Boxed to keep the notice enum's variants near one size; the wire
+        /// shape is unchanged.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
-        pr_state: Option<PullRequestDigest>,
+        pr_state: Option<Box<PullRequestDigest>>,
     },
     /// Coalesced terminal activity. Not restated on connect.
     TerminalActivity {
@@ -681,7 +713,7 @@ impl CodeUpdateNotice {
             attention: wire.attention,
             title: wire.title,
             turn_count: wire.turn_count,
-            pr_state: wire.pr_state,
+            pr_state: wire.pr_state.map(Box::new),
         }
     }
 }

--- a/crates/tidebreak-server/src/routes/code/updates.rs
+++ b/crates/tidebreak-server/src/routes/code/updates.rs
@@ -53,7 +53,7 @@ async fn stream_updates(mut socket: WebSocket, state: AppState) {
             },
             update = live.recv() => match update {
                 Ok(CodeLiveUpdate::Digest(digest)) => {
-                    if send_notice(&mut socket, &CodeUpdateNotice::digest(digest))
+                    if send_notice(&mut socket, &CodeUpdateNotice::digest(*digest))
                         .await
                         .is_err()
                     {

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -325,7 +325,11 @@ exit 3
     );
     assert!(logged.contains("pr view"), "{logged}");
     assert!(logged.contains("pr checks"), "{logged}");
-    assert!(!logged.contains("merge"), "{logged}");
+    // The view field list legitimately names mergeable/autoMergeRequest; a
+    // merge invocation or flag may never appear on the create/status path.
+    assert!(!logged.contains("pr merge"), "{logged}");
+    assert!(!logged.contains("--merge"), "{logged}");
+    assert!(!logged.contains("--auto"), "{logged}");
     assert!(!logged.contains("graphql"), "{logged}");
 }
 

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -427,6 +427,12 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodeCommitSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodePushSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeWorkspacePrSnapshot>(&cfg, &mut out);
+        // Its own endpoint root: the PR conversation is fetched per request
+        // rather than embedded in the digest.
+        generate::collect_from::<crate::routes::code::CodePrCommentsSnapshot>(&cfg, &mut out);
+        // The merge request body, so the renderer sends exactly the accepted
+        // method vocabulary.
+        generate::collect_from::<crate::routes::code::MergeCodePrBody>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeActionSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeCloneJobSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeCloneDefaults>(&cfg, &mut out);

--- a/docs/decisions/0042-user-initiated-pr-merge.md
+++ b/docs/decisions/0042-user-initiated-pr-merge.md
@@ -1,0 +1,70 @@
+# 42. User-Initiated PR Merge Through a Dedicated Endpoint
+
+- Status: Accepted
+- Date: 2026-08-17
+- Owners: code mode, git/gh integration
+- Related: [`0032-code-workspaces-worktrees-checkpoints.md`](0032-code-workspaces-worktrees-checkpoints.md),
+  [`0035-code-mode-wire-contract.md`](0035-code-mode-wire-contract.md)
+
+## Context
+
+Tidebreak's `gh` runner (`crates/tidebreak-server/src/code/gh.rs`) refused any
+argv containing `merge`, `--merge`, `--auto`, or `graphql`, so nothing in the
+app — agent, automation, or user — could merge a pull request. That total ban
+was deliberate: PR creation and status reads run on behalf of agent-driven
+flows, and an agent must never be able to land its own work.
+
+The desktop PR card now needs a merge button and an auto-merge toggle. Merging
+is a user decision, not an agent capability, so the question is where the
+ability to run `gh pr merge` may live without weakening the agent-path
+refusal.
+
+## Decision
+
+Merging happens only through `POST /code/workspaces/{id}/pr/merge`, a
+user-initiated endpoint. Its handler is the single caller of
+`merge_pull_request`, which drives `run_gh_user_merge` — a runner that
+executes only `pr merge …` argv and refuses everything else.
+
+The general runner (`run_gh`), used by every creation, status, and comment
+path, keeps its hard refusal of `merge`, `--merge`, and `--auto`. The
+`graphql` refusal stays absolute on both runners: no Tidebreak path runs
+GraphQL `gh` commands.
+
+Excluded on purpose: no agent-callable merge tool, no auto-merge armed by any
+background or automation flow, and no configuration that widens the merge
+runner beyond `pr merge`.
+
+## Alternatives Considered
+
+- **Keep the total ban.** Safest, but it pushes the user to a terminal for the
+  last step of a flow the app otherwise carries end to end, and the ban's
+  purpose was to constrain agents, not users.
+- **Let agents merge behind an approval prompt.** Rejected: merging publishes
+  reviewed work to a shared branch, and an approval card is too easy to
+  confirm reflexively. The blast radius of a wrong merge is a shared `main`,
+  not a local worktree.
+- **One runner with a boolean "allow merge" flag.** Rejected: a flag on the
+  shared runner spreads through call sites and one mistaken `true` silently
+  re-arms merging on an agent path. A separate, narrowly named function makes
+  misuse visible in review and pinnable in tests.
+
+## Consequences
+
+Every future `gh` capability must choose a runner, which keeps the
+merge boundary explicit. The merge endpoint maps host refusals to a
+structured `pr_not_mergeable` error so the UI can render them.
+
+Revisit if merging ever needs to ride an automation flow (for example,
+"auto-merge when checks pass" driven by Tidebreak rather than by GitHub's own
+auto-merge), or if the harness boundary gains a first-party review/merge
+delegation with its own authorization story.
+
+## Validation
+
+`code::gh` tests pin both sides: the creation/status test asserts the general
+runner refuses merge argv before spawning, and the merge-runner test asserts
+it refuses everything except `pr merge` (GraphQL included) while the dedicated
+operation runs `pr merge --squash` / `--merge --auto`. A wrong implementation
+that merged through the general runner, or ran arbitrary commands through the
+merge runner, fails those tests.


### PR DESCRIPTION
Reworks the code-mode review surfaces and the model pickers, and fixes an infinite render loop.

## Right sidebar: Files, Source control, Pull request

- The former Diff tab is now **Source control**: the commit/push/Create PR card on top, the worktree diff below.
- The **Pull request** tab carries the PR's own life instead of bare status: state-colored mark and badge (draft-aware), head → base branches, review decision, individual checks with pass/pending/fail counts and links, auto-loaded issue/review/inline comments, a refresh action, and user-initiated merge (squash/merge/rebase, immediate or auto-merge).
- New server routes back it: `POST …/pr/refresh`, `GET …/pr/comments`, `POST …/pr/merge`, all over `gh`. One richer `gh pr view` read fills the digest (draft, merged, review decision, mergeability, branches, auto-merge), serialized as optional fields so old persisted digests still parse.
- **Merge stays off-limits to automation.** The general `gh` runner still refuses `merge`/`--auto`/`graphql` before spawning; a dedicated runner accepts nothing but `pr merge` argv and is reachable only from the user-initiated merge route. See `docs/decisions/0042-user-initiated-pr-merge.md`. An unmergeable PR maps to a structured `pr_not_mergeable` 409.
- The dead `files`/`diff` panel tabs (type, icon, URL grammar, but no renderer anywhere) are removed; stale URLs naming them fall back to the conversation alone.

## Model pickers

- A model-gateway catalog now splits by vendor like a multi-provider install: one rail tab per vendor (curated `vendor` first, then the open-model family the id names), instead of one flat list under a generic gateway tab. Only unrecognizable rows keep the gateway tab, and a "Connect X" setup row is suppressed when a gateway group already serves that vendor.
- The code composer picker is rebuilt on the chat picker's two-pane layout (vendor rail, search, ⌘1–9 kept), and a mixed catalog is confined to what the engine can drive: Claude Code → Anthropic only, Codex → OpenAI, Grok → xAI, opencode neutral.

## Workspace rail

- Workspaces render as cards — digest title, branch, session state, attention badge, PR chip colored by state (draft-aware) — grouped under repo headers, scrolling instead of capping at 12. The pure logic lives in `workspaceCards.ts` for reuse by list pages.

## Fix

- The workspace page selected `modelsByHarness[kind] ?? []` from the catalog store; the fresh array is an unstable zustand v5 snapshot and looped renders ("Maximum update depth exceeded") whenever a workspace opened without a gateway.

## Tests

- New: gateway split and rail grouping (unit + dom), harness vendor confinement, code-option grouping, PR-tab dom test (state/checks/comments/draft-holds-merge), gh merge-guard shape (`only_the_user_merge_runner_may_merge_and_it_runs_nothing_else`, `merge_failures_map_to_blocked_signed_out_or_user`), rich `gh pr view` mapping, comment parsing, digest parser fixtures.
- Updated rather than removed: the codeChrome test dropped its files/diff fixtures for the removed tab types; panelUrl round-trip cases for those types became explicit "no longer reads" rejections; `create_pr_uses_view_and_checks_and_never_merges` now pins refusal on the general runner with tightened substrings (the view field list legitimately contains "mergeable").

## Not verified live

`gh pr merge`, comment pagination past the first page, and `{owner}/{repo}` substitution in `gh api` were exercised against shims and fixtures, not a live PR. Worth a real-PR pass after merge.