### PR TITLE
fix(server): stop reading merge stderr naming an author as a sign-out

### DIFF
--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -399,7 +399,15 @@ pub(crate) async fn merge_pull_request(
 pub(crate) fn classify_merge_error(err: String) -> GhError {
     let bounded = bound_text(&err);
     let lower = bounded.to_ascii_lowercase();
-    if lower.contains("not logged") || lower.contains("not signed") || lower.contains("auth") {
+    // Sign-out markers must be specific: a bare `auth` substring also matches
+    // host messages that name the pull request author, which would send a
+    // blocked merge to the sign-in remediation instead.
+    if lower.contains("not logged")
+        || lower.contains("not signed")
+        || lower.contains("authenticat")
+        || lower.contains("gh auth login")
+        || lower.contains("http 401")
+    {
         return GhError::GhSignedOut {
             instructions: "gh is installed but not signed in. Run `gh auth login` in a terminal, then try again. Tidebreak does not store GitHub credentials.".into(),
         };
@@ -1694,6 +1702,8 @@ exit 3
             "GraphQL: Pull request is not mergeable (mergePullRequest)",
             "X this branch has merge conflicts with the base branch",
             "X 2 reviews are required by reviewers with write access",
+            // "author" contains "auth"; the sign-out markers must not eat it.
+            "X review is required from someone other than the pull request author",
         ] {
             assert!(
                 matches!(
@@ -1706,6 +1716,10 @@ exit 3
         assert!(matches!(
             classify_merge_error("HTTP 401: authentication required".into()),
             GhError::GhSignedOut { .. }
+        ));
+        assert!(matches!(
+            classify_merge_error("the author of this pull request cannot approve it".into(),),
+            GhError::User(_)
         ));
         assert!(matches!(
             classify_merge_error("something else entirely".into()),


### PR DESCRIPTION
The merge-error classifier treated any stderr containing the bare substring `auth` as gh being signed out. `author` contains `auth`, so a blocked merge whose host message names the pull request author ("review is required from someone other than the pull request author") was misrouted to the sign-in remediation, hiding the real reason.

The sign-out branch now matches specific markers only — `not logged`, `not signed`, `authenticat…`, `gh auth login`, `HTTP 401` — and the classifier test pins an author-naming blocked message to `MergeBlocked` and an author-naming unknown message to the `User` fallthrough.

Follow-up to the non-blocking review note on #2176.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to merge stderr string matching and unit tests; no auth flow or merge execution changes.
> 
> **Overview**
> **Merge error classification** no longer treats any stderr containing `auth` as “gh signed out.” Host messages that mention the pull request **author** (e.g. review rules naming the author) were misclassified as sign-in remediation instead of the real merge block reason.
> 
> Sign-out detection in `classify_merge_error` now uses specific markers only: `not logged`, `not signed`, `authenticat…`, `gh auth login`, and `HTTP 401`. Tests pin an author-related blocked message to `MergeBlocked` and a generic author-related message to the `User` fallthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80a9e41216d217da1f1dbc3863808770baf88170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->