### PR TITLE
test(server): stabilize container worker service test

### DIFF
--- a/crates/tidebreak-server/src/sandbox_container_run/tests.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run/tests.rs
@@ -1407,7 +1407,7 @@ async fn wait_until_lease_expired(store: &Arc<dyn Store>, run_id: AgentRunId) {
 /// sandbox agent over loopback to its committed result.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn container_worker_service_drives_queued_work_over_loopback() {
-    tokio::time::timeout(Duration::from_secs(30), async {
+    tokio::time::timeout(Duration::from_secs(60), async {
         let (_dir, store, chat) = store().await;
         let run_id = admit_container_run(&store, chat.id, "driven by the service").await;
         let backend = MockBackend::spawning();
@@ -1419,8 +1419,16 @@ async fn container_worker_service_drives_queued_work_over_loopback() {
             Arc::new(Notify::new()),
             Arc::new(SandboxSteerGuard::default()),
             true,
-            fast_config(),
-            fast_worker_config(),
+            // This test proves service discovery and drive completion, not the
+            // heartbeat/fence cadence. Avoid making the real-agent path fight
+            // the parallel suite for SQLite's single writer.
+            quiet_drive_config(),
+            SandboxContainerRunWorkerConfig {
+                // One lane is sufficient for the singular queued run and
+                // avoids a second poller contending on the same fixture store.
+                max_concurrency: 1,
+                ..fast_worker_config()
+            },
         )
         .expect("the explicitly enabled service is constructed");
         let task = tokio::spawn(worker.run());
@@ -1435,7 +1443,7 @@ async fn container_worker_service_drives_queued_work_over_loopback() {
         // discharged; the runner-level tests pin the exactly-once destroy on
         // the drive path, where nothing else is sweeping.
         wait_until(
-            Duration::from_secs(25),
+            Duration::from_secs(45),
             "the service drive completed and discharged teardown",
             || async {
                 let run = store.get_agent_run(run_id).await.unwrap().unwrap();
@@ -1460,7 +1468,7 @@ async fn container_worker_service_drives_queued_work_over_loopback() {
         assert_eq!(backend.provisions.load(Ordering::SeqCst), 1);
     })
     .await
-    .expect("service drive completed within its time bound");
+    .expect("service drive completed within its 60-second hang guard");
 }
 
 /// A teardown created after the service's startup pass is completed by a later


### PR DESCRIPTION
## Why

The August 18, 2026 `main` CI run failed in `sandbox_container_run::tests::container_worker_service_drives_queued_work_over_loopback` after the test exhausted its 30-second outer timeout. The same path completes in roughly 0.1 seconds in isolation, and 968 sibling tests passed in the failed run, identifying this as parallel-suite contention rather than a product regression.

The test was still using the aggressive 250 ms durable-fence cadence and two service drive lanes even though it only proves discovery and completion of one queued run. Under the full parallel suite, those extra pollers and writes contend for the fixture SQLite database's single writer and can consume the hang guard.

## What changed

- use the existing quiet drive cadence because this test does not assert heartbeat or fence timing
- run one service drive lane for the singular queued fixture
- retain periodic maintenance and the state-based completion assertion
- give the integration-heavy path a 60-second outer hang guard and a 45-second diagnostic state wait

No production code changed and no tests were removed.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p tidebreak-server --all-targets --locked -- -D warnings`
- `cargo test -p tidebreak-server --locked sandbox_container_run -- --test-threads 4 --skip docker`
- 20/20 repeated container-run module iterations at `--test-threads 4`
- `cargo test -p tidebreak-server --lib --locked` — 969 passed, 3 ignored

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test configuration and timeouts in one integration test; no production code changes.
> 
> **Overview**
> **Stabilizes** `container_worker_service_drives_queued_work_over_loopback`, which was timing out under full parallel CI while passing quickly in isolation.
> 
> The worker is configured with the existing **`quiet_drive_config`** (slower heartbeat/fence cadence) and **`max_concurrency: 1`** so the test does not assert timing behavior and reduces SQLite single-writer contention from extra pollers and aggressive 250 ms fences. Outer hang guard moves to **60s** and the state **`wait_until`** to **45s**; completion assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e11e0291bee0098df5cd4a764a71873edd674bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->