### PR TITLE
docs: add code mode to the README features table

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ the headless CLI.
 | **Execution** | Native macOS sandbox, local Docker, E2B, or Daytona. Per-chat network policy. Background agents one level deep. Built-in or configured web search (Exa, Tavily, Brave, SearXNG). Computer use: screen capture and consent-gated control of native apps. |
 | **Permissions** | Plan, Ask, Auto, or Allow all, per chat. Folder access is per capability from a native picker. Standing grants are revocable. Overwrite of a connected file always asks. |
 | **Extensions** | Built-in skills for Word, PDF, PowerPoint, spreadsheets, and charts; add your own. MCP servers over stdio or HTTP. REST APIs from an OpenAPI document, for local apps. Ask once for a mini-app and keep it in the sidebar. |
+| **Code mode** | Experimental. A second surface that drives coding agents (Claude Code, Codex CLI, opencode, Grok CLI) in isolated git worktrees: native approvals, per-turn diffs, and a reviewable change flow. |
 
 ## Run from source
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@
 Tidebreak is a local-first desktop agent for work that ends in a file, not just
 a chat response. It can read attached documents, work in explicitly connected
 folders, run code in a sandbox, search the web, delegate parallel jobs, and
-publish anything it creates as a versioned output.
+publish anything it creates as a versioned output. An experimental code mode
+turns the same supervision onto software work: it drives coding agents such as
+Claude Code in isolated git worktrees, with native approvals and per-turn
+diffs.
 
 You choose the model route: Anthropic, OpenAI, Google, xAI, OpenRouter, a local
 Ollama daemon, or another OpenAI-compatible endpoint. Conversations can switch

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ the headless CLI.
 > [!WARNING]
 > Tidebreak is pre-1.0 and changing quickly. Interfaces and local data formats
 > may change between releases, and profiles may be rebuilt rather than
-> migrated. Windows and Linux packages ship for x86_64; some native capabilities
+> migrated. Windows and Linux packages ship for x86_64, with ARM64 builds on
+> the way; some native capabilities
 > remain macOS-only and are reported as unavailable in the app.
 
 ## Features


### PR DESCRIPTION
Code mode shipped as an experimental surface (decision records 0030-0036, implementation PRs #2124/#2125/#2142 and follow-ups) but the README features table doesn't mention it.

Adds one row: experimental, drives coding agents (Claude Code, Codex CLI, opencode, Grok CLI) in isolated git worktrees, with native approvals, per-turn diffs, and a reviewable change flow. Harness list matches the adapters documented in docs/code-mode.md.

Docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, security, or data-handling changes.
> 
> **Overview**
> Updates the **README** so shipped **code mode** is visible in the product overview, not only in maintainer docs.
> 
> The opening paragraph now describes experimental code mode: supervision over software work via coding agents (e.g. Claude Code) in isolated git worktrees, with native approvals and per-turn diffs. The **Features** table adds a **Code mode** row aligned with `docs/code-mode.md`—experimental second surface, harnesses (Claude Code, Codex CLI, opencode, Grok CLI), worktrees, approvals, diffs, and a reviewable change flow.
> 
> The pre-1.0 **WARNING** also notes that Windows and Linux packages are x86_64 today, with **ARM64 builds on the way**, alongside the existing macOS-only capability caveat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 702066b6c98a08667dcdbf5840c65db8f1468a91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->