### PR TITLE
test(server): stabilize the cancellation usage-accounting test

### DIFF
--- a/crates/tidebreak-server/src/sandbox_container_run/tests.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run/tests.rs
@@ -3779,7 +3779,9 @@ async fn a_noop_heartbeat_does_not_revoke_a_live_container_drive() {
 /// immutable cancelled result.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn attached_cancellation_accounts_usage_observed_before_reverse_stream_drop() {
-    tokio::time::timeout(Duration::from_secs(30), async {
+    // Above the sum of the inner waits, so a slow provision surfaces their
+    // diagnostics instead of the outer guard's bare Elapsed.
+    tokio::time::timeout(Duration::from_secs(120), async {
         let (_dir, store, chat) = store().await;
         let run_id = admit_container_run(&store, chat.id, "account before cancellation").await;
 
@@ -3802,10 +3804,16 @@ async fn attached_cancellation_accounts_usage_observed_before_reverse_stream_dro
             store.clone(),
             backend.clone(),
             Arc::new(UsageThenPendingResolver(provider.clone())),
+            // Cancellation quiescing and usage accounting are under test, not
+            // lease or fence timing. The quiet cadence keeps the fence from
+            // writing every 250 ms against the fixture database's single
+            // writer, and the long lease removes the 2-second expiry that a
+            // stalled heartbeat could cross under suite contention. The
+            // heartbeat stays sub-second so nothing riding a periodic tick
+            // waits a quiet period.
             SandboxContainerRunConfig {
-                lease: Duration::from_secs(2),
-                heartbeat: Duration::from_millis(100),
-                ..fast_config()
+                heartbeat: Duration::from_millis(250),
+                ..quiet_drive_config()
             },
         ));
         let drive = tokio::spawn({
@@ -3824,7 +3832,7 @@ async fn attached_cancellation_accounts_usage_observed_before_reverse_stream_dro
             .unwrap()
             .expect("the cancellation request lands");
 
-        let outcome = match tokio::time::timeout(Duration::from_secs(15), drive).await {
+        let outcome = match tokio::time::timeout(Duration::from_secs(30), drive).await {
             Ok(joined) => joined
                 .expect("the drive task finished")
                 .expect("driving succeeds")


### PR DESCRIPTION
`attached_cancellation_accounts_usage_observed_before_reverse_stream_drop` flaked on this PR's own CI run by exhausting its 30-second outer guard with a bare `Elapsed` — the stall predates the inner waits, whose own bounds (a 30-second flag wait, a 15-second join) could never surface their diagnostics under a 30-second outer limit. Same parallel-suite SQLite contention class as #2178 and #2181.

Cancellation quiescing and usage accounting are under test, not lease or fence timing:

- The quiet cadence stops the 250 ms durable fence writing against the fixture database's single writer for the whole gated window.
- The long lease removes the 2-second expiry a stalled heartbeat could cross under load; nothing asserted the short lease.
- The heartbeat stays sub-second (250 ms) so nothing riding a periodic tick waits out a quiet period.
- The outer guard rises to 120 seconds, above the sum of the inner waits, and the join keeps its diagnostic panic at 30 seconds.

Assertions are unchanged.

This PR originally also stabilized the heartbeat lease test; #2181 landed on the same test first and has the floor, so that half was dropped here — the two PRs are now disjoint and complementary.

## Validation

- `cargo fmt --all -- --check`
- 10/10 repeated `sandbox_container_run` module iterations at `--test-threads 4`
- `cargo test -p tidebreak-server --lib --locked` — 973 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and configuration changes in integration tests; no production code paths modified.
> 
> **Overview**
> Stabilizes **`attached_cancellation_accounts_usage_observed_before_reverse_stream_drop`** against parallel-suite SQLite contention—the same flake class as recent sandbox container run test fixes.
> 
> The runner now uses **`quiet_drive_config()`** with a **250 ms** heartbeat instead of **`fast_config()`**’s short lease and **250 ms** durable fence, so cancellation quiescing and usage accounting stay under test without hammering the fixture DB’s single writer or racing lease expiry under load. The outer test timeout rises to **120 s** (above inner waits so diagnostics surface), and the drive **join** timeout rises to **30 s** with the existing diagnostic panic unchanged.
> 
> **Assertions are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e266358bf20d68d95bb08777646691feee56d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->