### PR TITLE
test(server): stabilize container heartbeat lease test

### DIFF
--- a/crates/tidebreak-server/src/sandbox_container_run/tests.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run/tests.rs
@@ -2070,7 +2070,7 @@ async fn recovered_drive_keeps_failed_provider_attempts_in_the_spend_budget() {
 /// move forward before the model call is released.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn heartbeats_the_lease_so_a_long_run_is_not_reaped() {
-    tokio::time::timeout(Duration::from_secs(60), async {
+    tokio::time::timeout(Duration::from_secs(120), async {
         let (_dir, store, chat) = store().await;
         let run_id = admit_container_run(&store, chat.id, "takes a while").await;
 
@@ -2081,7 +2081,8 @@ async fn heartbeats_the_lease_so_a_long_run_is_not_reaped() {
         // the container is driving — so a short lease expires under CI
         // contention before the first tick and this loop never observes an
         // extension. A short heartbeat still proves the expiry moved without
-        // sleeping through a full lease period.
+        // sleeping through a full lease period. The durable fence is not under
+        // test here; a quiet interval avoids extra SQLite writes during setup.
         let provider = Arc::new(ScriptedProvider::gated(
             vec![
                 "use-tool:write_file:{\"path\":\"note.txt\",\"content\":\"a b\"}".to_owned(),
@@ -2096,7 +2097,9 @@ async fn heartbeats_the_lease_so_a_long_run_is_not_reaped() {
             backend.clone(),
             resolver,
             SandboxContainerRunConfig {
+                lease: Duration::from_secs(120),
                 heartbeat: Duration::from_millis(100),
+                durable_fence_interval: Duration::from_secs(30),
                 ..fast_config()
             },
         ));
@@ -2106,7 +2109,7 @@ async fn heartbeats_the_lease_so_a_long_run_is_not_reaped() {
             async move { runner.drive(run_id).await }
         });
         wait_until(
-            Duration::from_secs(45),
+            Duration::from_secs(60),
             "the first model call started",
             || async {
                 if gate.entered() {
@@ -2130,7 +2133,7 @@ async fn heartbeats_the_lease_so_a_long_run_is_not_reaped() {
             .expect("a claimed run has a lease expiry");
 
         wait_until(
-            Duration::from_secs(10),
+            Duration::from_secs(20),
             "the live drive completed at least one heartbeat",
             || async {
                 let ticks = runner.heartbeat_ticks();
@@ -2158,17 +2161,27 @@ async fn heartbeats_the_lease_so_a_long_run_is_not_reaped() {
 
         gate.release();
 
-        let outcome = drive
-            .await
-            .unwrap()
-            .expect("driving succeeds")
-            .expect("the container run is claimable");
+        let outcome = match tokio::time::timeout(Duration::from_secs(45), drive).await {
+            Ok(joined) => joined
+                .expect("the drive task finished")
+                .expect("driving succeeds")
+                .expect("the container run is claimable"),
+            Err(_) => {
+                panic!(
+                    "drive still outstanding after the observed heartbeat; provisions={} destroys={} provider_calls={} heartbeats={}",
+                    backend.provisions.load(Ordering::SeqCst),
+                    backend.destroys.load(Ordering::SeqCst),
+                    provider.calls.load(Ordering::SeqCst),
+                    runner.heartbeat_ticks(),
+                );
+            }
+        };
         // The run completed normally rather than being reaped out from under the
         // still-working container.
         assert_eq!(outcome, SandboxContainerRunOutcome::Completed(run_id));
     })
     .await
-    .expect("test completed within its time bound");
+    .expect("heartbeat lease proof completed within its 120-second hang guard");
 }
 
 /// A container run is exempt from the in-process lease reaper: its lease


### PR DESCRIPTION
## Why

The August 18, 2026 CI run on #2177 failed in
`sandbox_container_run::tests::heartbeats_the_lease_so_a_long_run_is_not_reaped`
after the test exhausted its 60-second outer timeout. The same path
completes in roughly 0.2 seconds in isolation, and 972 sibling tests
passed in the failed run, identifying this as parallel-suite SQLite
contention rather than a product regression.

This is the same class of flake #2178 fixed for
`container_worker_service_drives_queued_work_over_loopback`. Unlike that
test, this one *does* prove the attached heartbeat: the run must stay
`running` and its lease expiry must move forward while the model call is
held. The 100 ms heartbeat stays so the proof does not sleep through a
full lease period.

The 250 ms durable fence is not under test. Under the full parallel
suite those extra writes contend for the fixture SQLite database's
single writer. Setup can then consume most of the hang guard before
post-release completion has time to finish, and the outer expect reports
only `Elapsed(())`.

## What changed

- keep the 100 ms attached heartbeat and the state assertions that the
  lease moved, the run stayed live, and the drive completed
- use a 120-second lease and a quiet 30-second fence so provision and
  attach do not fight the suite for SQLite's writer or expire before the
  first tick
- give the integration-heavy path a 120-second outer hang guard, a
  60-second wait for the first model call, and a 20-second wait for the
  observed heartbeat
- if the drive is still outstanding after release, print provision,
  destroy, provider-call, and heartbeat counts instead of a bare elapsed
  expect

No production code changed and no tests were removed.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p tidebreak-server --all-targets --locked -- -D warnings`
- `cargo test -p tidebreak-server --lib --locked sandbox_container_run -- --test-threads 4 --skip docker`
- 10/10 repeated focused runs of
  `heartbeats_the_lease_so_a_long_run_is_not_reaped`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and configuration in one integration test; no server or driver behavior changes.
> 
> **Overview**
> CI flake in **`heartbeats_the_lease_so_a_long_run_is_not_reaped`**: the 60s outer hang guard could expire under parallel **`sandbox_container_run`** SQLite writer contention while provision/attach ran, even though the heartbeat proof itself is fast in isolation.
> 
> The test still holds the first model step on a gate and asserts the run stays **`running`** and **`lease_expires_at`** moves after at least one observed heartbeat tick. It now uses a **120s lease**, keeps the **100ms** heartbeat, and sets **`durable_fence_interval` to 30s** so setup does not fight the suite for extra durable writes (the fence is not what this test proves). Waits are lengthened (**60s** for first model call, **20s** for heartbeat), the outer guard is **120s**, and if the drive task is still outstanding after release it panics with provision/destroy/provider/heartbeat counts instead of a bare elapsed timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d9eda44d64fbbb11f20df91a9ddf05b281a2bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->