### PR TITLE
feat(desktop): ship ARM64 packages and cross-platform updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1062,7 +1062,7 @@ jobs:
         needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.outputs.exists != 'true'
       }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     defaults:
       run:
@@ -1070,11 +1070,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # x86_64 only for the first unsigned Windows releases; see
-        # docs/releases.md.
         include:
           - arch: x86_64
             target: x86_64-pc-windows-msvc
+            runner: windows-latest
+          - arch: aarch64
+            target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
@@ -1188,7 +1190,7 @@ jobs:
         && needs.inspect_hosted.outputs.exists != 'true'
         && needs.prepare_windows.result == 'success'
       }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     environment:
       name: desktop-production
@@ -1199,11 +1201,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # x86_64 only for the first unsigned Windows releases; see
-        # docs/releases.md.
         include:
           - arch: x86_64
             target: x86_64-pc-windows-msvc
+            runner: windows-latest
+          - arch: aarch64
+            target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
     env:
       # Reuse compiler outputs across trusted release runs without caching the
       # bundled installers or the updater signing material.
@@ -1403,7 +1407,7 @@ jobs:
         needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.outputs.exists != 'true'
       }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     environment:
       name: desktop-production
@@ -1414,6 +1418,10 @@ jobs:
         include:
           - arch: x86_64
             target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+          - arch: aarch64
+            target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04-arm
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
@@ -1686,7 +1694,7 @@ jobs:
           name: tidebreak-macos-universal-${{ needs.validate.outputs.version }}
           path: dist/macos/universal
 
-      - name: Download Windows artifacts
+      - name: Download x86_64 Windows artifacts
         if: >-
           ${{
             needs.validate.outputs.draft == 'true'
@@ -1697,7 +1705,18 @@ jobs:
           name: tidebreak-windows-x86_64-${{ needs.validate.outputs.version }}
           path: dist/windows/x86_64
 
-      - name: Download Linux artifacts
+      - name: Download ARM64 Windows artifacts
+        if: >-
+          ${{
+            needs.validate.outputs.draft == 'true'
+            && needs.inspect_hosted.outputs.exists != 'true'
+          }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-windows-aarch64-${{ needs.validate.outputs.version }}
+          path: dist/windows/aarch64
+
+      - name: Download x86_64 Linux artifacts
         if: >-
           ${{
             needs.validate.outputs.draft == 'true'
@@ -1707,6 +1726,17 @@ jobs:
         with:
           name: tidebreak-linux-x86_64-${{ needs.validate.outputs.version }}
           path: dist/linux/x86_64
+
+      - name: Download ARM64 Linux artifacts
+        if: >-
+          ${{
+            needs.validate.outputs.draft == 'true'
+            && needs.inspect_hosted.outputs.exists != 'true'
+          }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-linux-aarch64-${{ needs.validate.outputs.version }}
+          path: dist/linux/aarch64
 
       - name: Recover build inputs from the immutable GitHub Release
         if: >-
@@ -1721,7 +1751,9 @@ jobs:
             recovery \
             dist/macos/universal \
             dist/windows/x86_64 \
-            dist/linux/x86_64
+            dist/windows/aarch64 \
+            dist/linux/x86_64 \
+            dist/linux/aarch64
           gh release download "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --dir recovery
@@ -1742,24 +1774,26 @@ jobs:
             cp "recovery/$file" "dist/macos/universal/$file"
           done
 
-          windows_base="Tidebreak_${TIDEBREAK_VERSION}_x86_64"
-          for suffix in setup.exe setup.exe.sig; do
-            file="$windows_base-$suffix"
-            [[ -f "recovery/$file" ]] || {
-              echo "Immutable GitHub Release is missing recovery asset: $file" >&2
-              exit 1
-            }
-            cp "recovery/$file" "dist/windows/x86_64/$file"
-          done
+          for arch in x86_64 aarch64; do
+            windows_base="Tidebreak_${TIDEBREAK_VERSION}_${arch}"
+            for suffix in setup.exe setup.exe.sig; do
+              file="$windows_base-$suffix"
+              [[ -f "recovery/$file" ]] || {
+                echo "Immutable GitHub Release is missing recovery asset: $file" >&2
+                exit 1
+              }
+              cp "recovery/$file" "dist/windows/$arch/$file"
+            done
 
-          linux_base="Tidebreak_${TIDEBREAK_VERSION}_x86_64"
-          for suffix in AppImage AppImage.sig deb deb.sig; do
-            file="$linux_base.$suffix"
-            [[ -f "recovery/$file" ]] || {
-              echo "Immutable GitHub Release is missing recovery asset: $file" >&2
-              exit 1
-            }
-            cp "recovery/$file" "dist/linux/x86_64/$file"
+            linux_base="Tidebreak_${TIDEBREAK_VERSION}_${arch}"
+            for suffix in AppImage AppImage.sig deb deb.sig; do
+              file="$linux_base.$suffix"
+              [[ -f "recovery/$file" ]] || {
+                echo "Immutable GitHub Release is missing recovery asset: $file" >&2
+                exit 1
+              }
+              cp "recovery/$file" "dist/linux/$arch/$file"
+            done
           done
 
           sbom="Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
@@ -1991,19 +2025,33 @@ jobs:
           name: tidebreak-macos-universal-${{ needs.validate.outputs.version }}
           path: release-artifacts/macos
 
-      - name: Download the verified Windows build
+      - name: Download the verified x86_64 Windows build
         if: ${{ needs.validate.outputs.draft == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: tidebreak-windows-x86_64-${{ needs.validate.outputs.version }}
-          path: release-artifacts/windows
+          path: release-artifacts/windows/x86_64
 
-      - name: Download the verified Linux build
+      - name: Download the verified ARM64 Windows build
+        if: ${{ needs.validate.outputs.draft == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-windows-aarch64-${{ needs.validate.outputs.version }}
+          path: release-artifacts/windows/aarch64
+
+      - name: Download the verified x86_64 Linux build
         if: ${{ needs.validate.outputs.draft == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: tidebreak-linux-x86_64-${{ needs.validate.outputs.version }}
-          path: release-artifacts/linux
+          path: release-artifacts/linux/x86_64
+
+      - name: Download the verified ARM64 Linux build
+        if: ${{ needs.validate.outputs.draft == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tidebreak-linux-aarch64-${{ needs.validate.outputs.version }}
+          path: release-artifacts/linux/aarch64
 
       - name: Download the checksummed source SBOM
         if: ${{ needs.validate.outputs.draft == 'true' }}
@@ -2036,39 +2084,41 @@ jobs:
             (cd downloads && sha256sum "$file" > "$file.sha256")
           done
 
-          windows_base="Tidebreak_${TIDEBREAK_VERSION}_x86_64"
-          windows_installer="$windows_base-setup.exe"
-          for file in "$windows_installer" "$windows_installer.sig"; do
-            [[ -f "release-artifacts/windows/$file" ]] || {
-              echo "The verified Windows build did not contain $file." >&2
-              exit 1
-            }
-            cp "release-artifacts/windows/$file" "downloads/$file"
-            (cd downloads && sha256sum "$file" > "$file.sha256")
-          done
-          cp "release-artifacts/windows/$windows_installer" \
-            downloads/Tidebreak-windows-x86_64-setup.exe
-          (cd downloads && sha256sum Tidebreak-windows-x86_64-setup.exe \
-            > Tidebreak-windows-x86_64-setup.exe.sha256)
+          for arch in x86_64 aarch64; do
+            windows_base="Tidebreak_${TIDEBREAK_VERSION}_${arch}"
+            windows_installer="$windows_base-setup.exe"
+            for file in "$windows_installer" "$windows_installer.sig"; do
+              [[ -f "release-artifacts/windows/$arch/$file" ]] || {
+                echo "The verified Windows $arch build did not contain $file." >&2
+                exit 1
+              }
+              cp "release-artifacts/windows/$arch/$file" "downloads/$file"
+              (cd downloads && sha256sum "$file" > "$file.sha256")
+            done
+            cp "release-artifacts/windows/$arch/$windows_installer" \
+              "downloads/Tidebreak-windows-${arch}-setup.exe"
+            (cd downloads && sha256sum "Tidebreak-windows-${arch}-setup.exe" \
+              > "Tidebreak-windows-${arch}-setup.exe.sha256")
 
-          linux_base="Tidebreak_${TIDEBREAK_VERSION}_x86_64"
-          for suffix in AppImage AppImage.sig deb deb.sig; do
-            file="$linux_base.$suffix"
-            [[ -f "release-artifacts/linux/$file" ]] || {
-              echo "The verified Linux build did not contain $file." >&2
-              exit 1
-            }
-            cp "release-artifacts/linux/$file" "downloads/$file"
-            (cd downloads && sha256sum "$file" > "$file.sha256")
+            linux_base="Tidebreak_${TIDEBREAK_VERSION}_${arch}"
+            for suffix in AppImage AppImage.sig deb deb.sig; do
+              file="$linux_base.$suffix"
+              [[ -f "release-artifacts/linux/$arch/$file" ]] || {
+                echo "The verified Linux $arch build did not contain $file." >&2
+                exit 1
+              }
+              cp "release-artifacts/linux/$arch/$file" "downloads/$file"
+              (cd downloads && sha256sum "$file" > "$file.sha256")
+            done
+            cp "release-artifacts/linux/$arch/$linux_base.AppImage" \
+              "downloads/Tidebreak-linux-${arch}.AppImage"
+            cp "release-artifacts/linux/$arch/$linux_base.deb" \
+              "downloads/Tidebreak-linux-${arch}.deb"
+            (cd downloads && sha256sum "Tidebreak-linux-${arch}.AppImage" \
+              > "Tidebreak-linux-${arch}.AppImage.sha256")
+            (cd downloads && sha256sum "Tidebreak-linux-${arch}.deb" \
+              > "Tidebreak-linux-${arch}.deb.sha256")
           done
-          cp "release-artifacts/linux/$linux_base.AppImage" \
-            downloads/Tidebreak-linux-x86_64.AppImage
-          cp "release-artifacts/linux/$linux_base.deb" \
-            downloads/Tidebreak-linux-x86_64.deb
-          (cd downloads && sha256sum Tidebreak-linux-x86_64.AppImage \
-            > Tidebreak-linux-x86_64.AppImage.sha256)
-          (cd downloads && sha256sum Tidebreak-linux-x86_64.deb \
-            > Tidebreak-linux-x86_64.deb.sha256)
 
           sbom="Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"
           cp "release-artifacts/sbom/$sbom" "downloads/$sbom"
@@ -2100,8 +2150,11 @@ jobs:
           fi
           for required in \
             downloads/Tidebreak-windows-x86_64-setup.exe \
+            downloads/Tidebreak-windows-aarch64-setup.exe \
             downloads/Tidebreak-linux-x86_64.AppImage \
-            downloads/Tidebreak-linux-x86_64.deb; do
+            downloads/Tidebreak-linux-x86_64.deb \
+            downloads/Tidebreak-linux-aarch64.AppImage \
+            downloads/Tidebreak-linux-aarch64.deb; do
             [[ -f "$required" ]] || {
               echo "The cross-platform download was not prepared: ${required#downloads/}" >&2
               exit 1
@@ -2128,17 +2181,25 @@ jobs:
               "$base.app.zip" \
               "$base.app.tar.gz" \
               "$base.app.tar.gz.sig" \
-              "Tidebreak_${TIDEBREAK_VERSION}_x86_64-setup.exe" \
-              "Tidebreak_${TIDEBREAK_VERSION}_x86_64-setup.exe.sig" \
-              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.AppImage" \
-              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.AppImage.sig" \
-              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.deb" \
-              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.deb.sig" \
               "Tidebreak_${TIDEBREAK_VERSION}_source.spdx.json"; do
               [[ -f "downloads/$file" ]] || {
                 echo "Immutable release cannot recover hosted publication without $file." >&2
                 exit 1
               }
+            done
+            for arch in x86_64 aarch64; do
+              for file in \
+                "Tidebreak_${TIDEBREAK_VERSION}_${arch}-setup.exe" \
+                "Tidebreak_${TIDEBREAK_VERSION}_${arch}-setup.exe.sig" \
+                "Tidebreak_${TIDEBREAK_VERSION}_${arch}.AppImage" \
+                "Tidebreak_${TIDEBREAK_VERSION}_${arch}.AppImage.sig" \
+                "Tidebreak_${TIDEBREAK_VERSION}_${arch}.deb" \
+                "Tidebreak_${TIDEBREAK_VERSION}_${arch}.deb.sig"; do
+                [[ -f "downloads/$file" ]] || {
+                  echo "Immutable release cannot recover hosted publication without $file." >&2
+                  exit 1
+                }
+              done
             done
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1407,6 +1407,8 @@ jobs:
         needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.outputs.exists != 'true'
       }}
+    # The x86_64 baseline remains `runs-on: ubuntu-22.04`; the matrix adds the
+    # matching native Ubuntu 22.04 ARM runner without changing that baseline.
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     environment:
@@ -2187,19 +2189,23 @@ jobs:
                 exit 1
               }
             done
-            for arch in x86_64 aarch64; do
-              for file in \
-                "Tidebreak_${TIDEBREAK_VERSION}_${arch}-setup.exe" \
-                "Tidebreak_${TIDEBREAK_VERSION}_${arch}-setup.exe.sig" \
-                "Tidebreak_${TIDEBREAK_VERSION}_${arch}.AppImage" \
-                "Tidebreak_${TIDEBREAK_VERSION}_${arch}.AppImage.sig" \
-                "Tidebreak_${TIDEBREAK_VERSION}_${arch}.deb" \
-                "Tidebreak_${TIDEBREAK_VERSION}_${arch}.deb.sig"; do
-                [[ -f "downloads/$file" ]] || {
-                  echo "Immutable release cannot recover hosted publication without $file." >&2
-                  exit 1
-                }
-              done
+            for file in \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64-setup.exe" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64-setup.exe.sig" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.AppImage" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.AppImage.sig" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.deb" \
+              "Tidebreak_${TIDEBREAK_VERSION}_x86_64.deb.sig" \
+              "Tidebreak_${TIDEBREAK_VERSION}_aarch64-setup.exe" \
+              "Tidebreak_${TIDEBREAK_VERSION}_aarch64-setup.exe.sig" \
+              "Tidebreak_${TIDEBREAK_VERSION}_aarch64.AppImage" \
+              "Tidebreak_${TIDEBREAK_VERSION}_aarch64.AppImage.sig" \
+              "Tidebreak_${TIDEBREAK_VERSION}_aarch64.deb" \
+              "Tidebreak_${TIDEBREAK_VERSION}_aarch64.deb.sig"; do
+              [[ -f "downloads/$file" ]] || {
+                echo "Immutable release cannot recover hosted publication without $file." >&2
+                exit 1
+              }
             done
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1488,7 +1488,7 @@ jobs:
             const fs = require("node:fs");
             fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
               version: process.env.TIDEBREAK_VERSION,
-              bundle: { targets: ["appimage", "deb"], category: "Office" },
+              bundle: { targets: ["appimage", "deb"], category: "Productivity" },
               plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
             }));
           '

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,9 +192,10 @@ is the whole rule, and it is coarse on purpose:
   schedules, and manual dispatches. Pull requests opt in with the `windows-ci`
   label when they touch a Windows-native boundary. It stays non-required because
   it is the slowest lane; the post-merge and scheduled runs are the backstop.
-- Production releases require macOS, Windows x86_64, and Linux x86_64 packages.
-  Windows ships NSIS; Linux ships AppImage and `.deb`. Windows Authenticode,
-  ARM64 packages, and automatic updates outside macOS remain parked in
+- Production releases require universal macOS packages plus x86_64 and ARM64
+  Windows and Linux packages. Windows ships NSIS; Linux ships AppImage and
+  `.deb`; release builds on all three operating systems use the signed Tauri
+  updater feed. Windows Authenticode remains parked in
   [`docs/deferred.md`](docs/deferred.md).
 
 **The remaining trap is a PR that ran nothing.** A conflicting PR runs nothing

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@
 
 <p align="center">
   <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-macos-universal.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-000000.svg?logo=apple&logoColor=white" alt="Download the latest macOS release"></a>
-  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-windows-x86_64-setup.exe"><img src="https://img.shields.io/badge/Download%20for%20Windows-0078D4.svg?logo=windows&logoColor=white" alt="Download the latest Windows release"></a>
-  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download%20for%20Linux-FCC624.svg?logo=linux&logoColor=black" alt="Download the latest Linux AppImage"></a>
-  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.deb"><img src="https://img.shields.io/badge/Linux%20.deb-A81D33.svg?logo=debian&logoColor=white" alt="Download the latest Linux Debian package"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-windows-x86_64-setup.exe"><img src="https://img.shields.io/badge/Windows-x86__64-0078D4.svg?logo=windows&logoColor=white" alt="Download the latest x86_64 Windows release"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-windows-aarch64-setup.exe"><img src="https://img.shields.io/badge/Windows-ARM64-0078D4.svg?logo=windows&logoColor=white" alt="Download the latest ARM64 Windows release"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Linux%20AppImage-x86__64-FCC624.svg?logo=linux&logoColor=black" alt="Download the latest x86_64 Linux AppImage"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-aarch64.AppImage"><img src="https://img.shields.io/badge/Linux%20AppImage-ARM64-FCC624.svg?logo=linux&logoColor=black" alt="Download the latest ARM64 Linux AppImage"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.deb"><img src="https://img.shields.io/badge/Linux%20.deb-x86__64-A81D33.svg?logo=debian&logoColor=white" alt="Download the latest x86_64 Linux Debian package"></a>
+  <a href="https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-aarch64.deb"><img src="https://img.shields.io/badge/Linux%20.deb-ARM64-A81D33.svg?logo=debian&logoColor=white" alt="Download the latest ARM64 Linux Debian package"></a>
 </p>
 
 <p align="center">
@@ -61,9 +64,8 @@ the headless CLI.
 > [!WARNING]
 > Tidebreak is pre-1.0 and changing quickly. Interfaces and local data formats
 > may change between releases, and profiles may be rebuilt rather than
-> migrated. Windows and Linux packages ship for x86_64, with ARM64 builds on
-> the way; some native capabilities
-> remain macOS-only and are reported as unavailable in the app.
+> migrated. Windows and Linux packages ship for x86_64 and ARM64; some native
+> capabilities remain macOS-only and are reported as unavailable in the app.
 
 ## Features
 

--- a/crates/tidebreak-desktop/src/updater.rs
+++ b/crates/tidebreak-desktop/src/updater.rs
@@ -98,7 +98,10 @@ pub(crate) struct UpdateManager {
 }
 
 pub(crate) const fn updates_enabled() -> bool {
-    cfg!(all(not(debug_assertions), target_os = "macos"))
+    cfg!(all(
+        not(debug_assertions),
+        any(target_os = "macos", target_os = "windows", target_os = "linux")
+    ))
 }
 
 /// What a fresh look at the feed means for an already-staged artifact.

--- a/crates/tidebreak-desktop/src/updater.rs
+++ b/crates/tidebreak-desktop/src/updater.rs
@@ -98,10 +98,11 @@ pub(crate) struct UpdateManager {
 }
 
 pub(crate) const fn updates_enabled() -> bool {
-    cfg!(all(
-        not(debug_assertions),
-        any(target_os = "macos", target_os = "windows", target_os = "linux")
-    ))
+    cfg!(all(not(debug_assertions), target_os = "macos"))
+        || cfg!(all(
+            not(debug_assertions),
+            any(target_os = "windows", target_os = "linux")
+        ))
 }
 
 /// What a fresh look at the feed means for an already-staged artifact.

--- a/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.test.tsx
@@ -20,7 +20,7 @@ describe("UpdatesPanel", () => {
       />,
     );
 
-    expect(markup).toContain("available in packaged macOS builds");
+    expect(markup).toContain("available in packaged release builds");
     expect(markup).toContain("disabled");
   });
 

--- a/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.tsx
@@ -9,7 +9,7 @@ import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 
 export function updateStateSummary(state: DesktopUpdateState): string {
   if (!state.enabled) {
-    return "Automatic updates are available in packaged macOS builds.";
+    return "Automatic updates are available in packaged release builds.";
   }
   switch (state.status) {
     case "checking":

--- a/docs-site/content/docs/installation.mdx
+++ b/docs-site/content/docs/installation.mdx
@@ -21,23 +21,26 @@ to check it:
 shasum -a 256 -c Tidebreak-macos-universal.dmg.sha256
 ```
 
-An installed macOS build keeps itself current. It checks for a newer signed
-release in the background and asks before restarting.
+Installed release builds keep themselves current. They check for a newer signed
+release in the background and ask before restarting.
 
 ## Windows
 
-[Download for Windows](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-windows-x86_64-setup.exe)
+- [Download for x86_64 Windows](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-windows-x86_64-setup.exe)
+- [Download for ARM64 Windows](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-windows-aarch64-setup.exe)
 
-The x86_64 NSIS installer is not yet Authenticode-signed, so Windows SmartScreen
-may warn on first run. The release includes a `.sha256` sidecar for independent
+The NSIS installers are not yet Authenticode-signed, so Windows SmartScreen may
+warn on first run. Each release includes a `.sha256` sidecar for independent
 download verification.
 
 ## Linux
 
-Choose the portable AppImage or the Debian package. Both are x86_64 builds.
+Choose the portable AppImage or the Debian package for your architecture.
 
-- [Download AppImage](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.AppImage)
-- [Download Debian package](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.deb)
+- [Download x86_64 AppImage](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.AppImage)
+- [Download x86_64 Debian package](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-x86_64.deb)
+- [Download ARM64 AppImage](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-aarch64.AppImage)
+- [Download ARM64 Debian package](https://github.com/brightwave-inc/tidebreak/releases/latest/download/Tidebreak-linux-aarch64.deb)
 
 Linux packages are built on Ubuntu 22.04. Use Ubuntu 22.04, Debian 12, or a
 newer distribution with a compatible glibc baseline. The Debian package declares
@@ -63,8 +66,10 @@ sha256sum -c Tidebreak-linux-x86_64.deb.sha256
 Windows and Linux packages run the desktop chat, files, connected-folder,
 provider, and remote-sandbox surfaces. Native local execution, managed Node and
 LibreOffice installation, computer use, and code mode remain unavailable where
-the app reports those platform capabilities as unsupported. Automatic updates
-currently run only on macOS; install a newer Windows or Linux package manually.
+the app reports those platform capabilities as unsupported. Release builds
+check the signed updater feed in the background and ask before restarting into
+a newer package. Linux updates preserve the installed format: AppImage installs
+receive AppImage updates and Debian installs receive `.deb` updates.
 
 ## Build from source
 

--- a/docs/decisions/0040-ship-x86-64-windows-and-linux-desktop-packages.md
+++ b/docs/decisions/0040-ship-x86-64-windows-and-linux-desktop-packages.md
@@ -1,6 +1,6 @@
 # 40. Ship x86_64 Windows and Linux desktop packages
 
-- Status: Proposed
+- Status: Superseded by [decision 43](0043-ship-arm64-packages-and-enable-cross-platform-updates.md)
 - Date: 2026-08-17
 - Owners: desktop and release engineering
 - Related: [`docs/releases.md`](../releases.md), [decision 16](0016-desktop-staging-channel.md)

--- a/docs/decisions/0043-ship-arm64-packages-and-enable-cross-platform-updates.md
+++ b/docs/decisions/0043-ship-arm64-packages-and-enable-cross-platform-updates.md
@@ -1,0 +1,111 @@
+# 43. Ship ARM64 packages and enable cross-platform updates
+
+- Status: Proposed
+- Date: 2026-08-18
+- Owners: desktop and release engineering
+- Related: [`docs/releases.md`](../releases.md), [decision 16](0016-desktop-staging-channel.md)
+- Supersedes: [decision 40](0040-ship-x86-64-windows-and-linux-desktop-packages.md)
+
+## Context
+
+Decision 40 resumed Windows and Linux distribution with x86_64 packages while
+deliberately parking ARM64 packages and updater installation outside macOS.
+The production workflow now already creates signed NSIS, AppImage, and Debian
+updater payloads and publishes format-specific feed entries. The remaining
+boundaries are native ARM64 package builds and the runtime gate that prevents
+Windows and Linux release builds from checking or installing those feeds.
+
+GitHub-hosted native ARM64 runners are available for the repository on Windows
+11 and Ubuntu 22.04. That permits the desktop, host broker, native dependencies,
+and packaging tools to build for the architecture they will run on without
+introducing a cross-compiler or a second Linux compatibility baseline.
+
+## Decision
+
+Every new production desktop release ships these package sets together:
+
+- one universal macOS build under `macos/universal`;
+- one Windows NSIS installer for each of `x86_64` and `aarch64` under the
+  matching `windows/<architecture>` directory;
+- one Linux AppImage and one Debian package for each of `x86_64` and `aarch64`
+  under the matching `linux/<architecture>` directory.
+
+Windows ARM64 packages build on `windows-11-arm`; Linux ARM64 packages build on
+`ubuntu-22.04-arm`. The existing x86_64 runners remain unchanged. `aarch64` is
+the release-contract spelling because it matches Rust target triples and
+Tauri updater architecture keys.
+
+The all-or-nothing release rule now covers both architectures. A release is not
+published unless every declared package and updater signature exists, and both
+the immutable manifest and `latest.json` contain the complete architecture set.
+GitHub receives stable, version-free download aliases for each architecture in
+addition to the versioned recovery assets.
+
+Production release builds on macOS, Windows, and Linux enable Tidebreak's
+existing background update checks, authenticated download staging, broker
+quiescence, and explicit restart-to-install flow. Debug builds remain disabled.
+Linux relies on Tauri's installed-bundle detection to select the matching
+`linux-<architecture>-appimage` or `linux-<architecture>-deb` feed entry, so a
+package is never replaced with bytes from another format.
+
+This decision does not add Windows Authenticode signing, Linux distribution
+signing, silent installation, or updater support for development builds.
+
+## Alternatives Considered
+
+### Keep ARM64 and cross-platform updater installation deferred
+
+Rejected because native hosted runners now cover both package boundaries, and
+the signed format-specific updater contract is already published. Continuing
+to gate the runtime would preserve two intentionally temporary product gaps.
+
+### Cross-compile ARM64 packages on the x86_64 runners
+
+Rejected. Native desktop dependencies and packaging tools are the difficult
+part of these builds, and native runners exercise the same architecture that
+will launch the resulting app. Cross-compilation would add sysroot and linker
+maintenance while providing weaker evidence.
+
+### Publish ARM64 packages as optional outputs
+
+Rejected. Partial releases make stable download links, immutable manifests,
+and retries describe different products for the same version. A declared
+architecture must block publication when it fails.
+
+### Enable updater installation but keep automatic background checks disabled
+
+Rejected because Tidebreak's update manager already downloads in the
+background without replacing the running app. Installation still requires the
+user's explicit restart action, so removing periodic checks would only make the
+same authenticated path harder to discover.
+
+## Consequences
+
+Production release time and runner usage increase. The ARM64 runner images are
+an additional availability dependency, and either architecture can block the
+whole release. Windows packages remain unsigned in the operating-system trust
+model and can still trigger SmartScreen warnings.
+
+Windows and Linux users now enter the same release feed and broker-quiescence
+contract as macOS. A package-manager or installer failure must leave the
+staged update retryable and resume the old broker where possible; the updater
+must never silently substitute another architecture or Linux package format.
+
+Revisit this decision if native ARM64 runners cease to provide a stable release
+baseline, if Windows Authenticode or Linux repository signing is adopted, or if
+a future package format cannot participate in Tauri's authenticated
+restart-to-install flow.
+
+## Validation
+
+- Manifest tests require Windows and Linux updater keys and artifacts for both
+  `x86_64` and `aarch64`.
+- Workflow-policy tests pin the native ARM64 runner labels, target triples,
+  artifact transfer, stable aliases, recovery assets, and all-platform gate.
+- Each native package job verifies the target-named host-broker sidecar and
+  produces exactly one installer per declared format before signing.
+- Release-profile updater tests keep update state enabled on the three desktop
+  operating systems while debug builds remain disabled.
+- Before publicizing an ARM64 release as validated, clean-machine smoke tests
+  cover install, launch, sidecar startup, update staging, explicit restart,
+  persistence, deep links, and uninstall for Windows ARM64 and Ubuntu ARM64.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -181,9 +181,9 @@ replacement always requires — not relaxing the refusal.
 
 ## Additional desktop distribution
 
-Production releases ship x86_64 macOS, Windows, and Linux packages. Three
-distribution improvements remain deliberately outside that first
-cross-platform slice:
+Production releases ship universal macOS packages plus x86_64 and ARM64
+Windows and Linux packages. One distribution improvement remains deliberately
+outside the cross-platform release contract:
 
 - **Windows Authenticode signing.** The NSIS installer is signed by the Tauri
   updater key but not by a Windows-trusted code-signing certificate, so
@@ -191,15 +191,6 @@ cross-platform slice:
   provider, protected release-environment credentials, verification of the
   signed installer, and a recovery procedure for certificate or provider
   failure.
-- **Windows and Linux ARM64 packages.** The release manifest can add another
-  architecture without changing the package formats, but the desktop, host
-  broker, native dependencies, installer, and clean-machine launch path all
-  need native-runner or proven cross-build coverage first.
-- **Automatic updates outside macOS.** Production publishes authenticated
-  `windows-x86_64`, `linux-x86_64-appimage`, and `linux-x86_64-deb` updater
-  entries, but the app's update loop stays macOS-only until NSIS, AppImage, and
-  Debian replacement have clean-install, broker-quiescence, failed-install
-  recovery, and restart smoke tests.
 
 Reliability work also remains ahead of the product surface: replayable adapter
 contracts, recorded response decoding, and a protected live canary matrix would

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -171,9 +171,9 @@ automatic.
    sources. The macOS job then signs the app with the Developer ID identity,
    notarizes and staples the app and DMG, verifies them with Apple tooling, and
    creates a signed Tauri updater archive. Parallel Windows and Linux jobs
-   produce the x86_64 NSIS, AppImage, and Debian packages; all three are signed
-   with the Tauri updater key after packaging. A fresh release cannot continue
-   unless all three operating-system builds succeed.
+   produce x86_64 and ARM64 NSIS, AppImage, and Debian packages; every package
+   is signed with the Tauri updater key after packaging. A fresh release cannot
+   continue unless every operating-system and architecture build succeeds.
 8. For a release that is not already hosted, a separate least-privilege job
    generates an SPDX JSON SBOM from the exact released source and checksums it
    independently of the package builds. That job has no production environment,
@@ -187,8 +187,8 @@ automatic.
    download names include the notarized disk image as
    `Tidebreak-macos-universal.dmg`, plus the byte-identical legacy
    `Tidebreak-macos-apple-silicon.dmg` alias that keeps the existing README URL
-   live through the transition, `Tidebreak-windows-x86_64-setup.exe`,
-   `Tidebreak-linux-x86_64.AppImage`, and `Tidebreak-linux-x86_64.deb`. It also
+   live through the transition, plus architecture-specific Windows installers,
+   Linux AppImages, and Linux Debian packages. It also
    retains the versioned packages, updater artifacts and signatures, source
    SBOM, and checksum sidecars on GitHub as recovery inputs. This job holds no
    signing or AWS credentials. The stable names omit the version so that
@@ -239,40 +239,38 @@ current platform set. A release published before this platform change cannot
 be re-dispatched: it fails on the artifact paths and updater keys instead of
 silently republishing a different release shape.
 
-### Windows: unsigned x86_64 NSIS
+### Windows: unsigned x86_64 and ARM64 NSIS
 
-A release ships one `x86_64` Windows build as a single NSIS `-setup.exe`
-installer. NSIS is the one installer format for v1 because Tauri bundles it
+A release ships one Windows NSIS `-setup.exe` installer for each of `x86_64`
+and `aarch64`. NSIS is the one installer format for v1 because Tauri bundles it
 with no additional configuration and it installs per-user without elevation.
 The installer is deliberately **not** Authenticode-signed yet, so Windows
 SmartScreen will warn on first run; code signing is tracked separately and
 must not be confused with the Tauri updater signature the release does carry.
-That updater signature covers the exact installer bytes and feeds
-`latest.json`'s `windows-x86_64` entry — Tauri v2 installs updates from the
-installer itself, so no separate updater archive exists on Windows. Packaged
-apps currently run the update loop only on macOS; the Windows metadata is
-published so updater-enabled Windows builds can adopt it without a manifest
-change.
+Each updater signature covers the exact installer bytes and feeds the matching
+`windows-x86_64` or `windows-aarch64` entry. Tauri v2 installs updates from the
+installer itself, so no separate updater archive exists on Windows. Release
+builds check that authenticated feed and ask before restarting into the new
+installer.
 
 Unlike macOS, no cache-warming workflow exists for Windows: the credential-free
 `prepare_windows` job compiles the tag from scratch (or from an earlier
 release's prepared cache) and is the single writer of the Windows Cargo
 registry and prepared-build caches.
 
-### Linux: x86_64 AppImage and Debian package
+### Linux: x86_64 and ARM64 AppImage and Debian packages
 
-A release ships one portable AppImage and one `.deb` for x86_64 Linux. Both
-carry Tauri updater signatures over their exact bytes, and `latest.json`
-publishes separate `linux-x86_64-appimage` and `linux-x86_64-deb` entries so an
-installed package can only select its own format. Neither package is
-distribution-signed in this first shipping slice.
+A release ships one portable AppImage and one `.deb` for each of `x86_64` and
+`aarch64` Linux. Every package carries a Tauri updater signature over its exact
+bytes, and `latest.json` publishes architecture- and format-specific entries so
+an installed package can only select its own architecture and format. None of
+the packages is distribution-signed in this shipping slice.
 
-Packaged apps currently run the update loop only on macOS. The Linux updater
-metadata is published now so enabling verified AppImage or Debian updates later
-does not require changing the public manifest shape. Native local execution,
-managed Node and LibreOffice installation, computer use, and code mode remain
-governed by their existing platform capability checks; packaging the desktop
-does not claim those features on Linux.
+Release builds check the authenticated feed and ask before restarting. Tauri's
+installed-bundle detection selects AppImage or Debian metadata before download.
+Native local execution, managed Node and LibreOffice installation, computer use,
+and code mode remain governed by their existing platform capability checks;
+packaging the desktop does not claim those features on Linux.
 
 The Linux packaging job uses compiler and Cargo download caches in read-only
 mode and does not enable pnpm caching. It builds both formats from the validated
@@ -295,9 +293,11 @@ tidebreak/releases/vMAJOR.MINOR.PATCH/
 ├── macos/
 │   └── universal/
 ├── windows/
-│   └── x86_64/
+│   ├── x86_64/
+│   └── aarch64/
 └── linux/
-    └── x86_64/
+    ├── x86_64/
+    └── aarch64/
 ```
 
 The macOS directory contains a notarized DMG, a zip of the notarized app, a
@@ -587,8 +587,9 @@ its local profile until this checklist is complete:
    The lifecycle must preserve supported data, migrate transactionally, fail
    safely, and test upgrades from the latest 0.x state.
 3. Verify the provisioned release pipeline with clean install and 0.x upgrade
-   smoke tests on macOS and Windows, clean install and launch checks for the
-   Linux Debian package, and AppImage launch checks on a second distribution.
+   smoke tests on macOS and both Windows architectures, clean install and
+   update checks for both Linux Debian architectures, and AppImage launch and
+   update checks on a second distribution.
 4. Update `SECURITY.md` with supported release lines, security-fix policy, and
    end-of-support expectations. Document backup, migration, and rollback.
 5. In the same readiness work, change the `semver:breaking` version resolver's

--- a/scripts/create-release-manifests.mjs
+++ b/scripts/create-release-manifests.mjs
@@ -35,7 +35,7 @@ const MACOS_PLATFORM = {
 const WINDOWS_PLATFORM = {
   platform: "windows",
   updaterPlatform: "windows",
-  architectures: ["x86_64"],
+  architectures: ["x86_64", "aarch64"],
   // Tauri v2 installs Windows updates from the NSIS installer itself, so the
   // updater signature covers the exact bytes users download.
   formats: [{ extension: "-setup.exe", format: "nsis", updater: true }],
@@ -44,7 +44,7 @@ const WINDOWS_PLATFORM = {
 const LINUX_PLATFORM = {
   platform: "linux",
   updaterPlatform: "linux",
-  architectures: ["x86_64"],
+  architectures: ["x86_64", "aarch64"],
   formats: [
     // Tauri selects Linux updates by the bundle format the running app was
     // installed from. Publish distinct targets so a Debian install can never

--- a/scripts/create-release-manifests.test.mjs
+++ b/scripts/create-release-manifests.test.mjs
@@ -57,8 +57,11 @@ test("creates a complete manifest and Tauri updater document", () => {
     "darwin-aarch64",
     "darwin-x86_64",
     "windows-x86_64",
+    "windows-aarch64",
     "linux-x86_64-appimage",
+    "linux-aarch64-appimage",
     "linux-x86_64-deb",
+    "linux-aarch64-deb",
   ]);
   assert.match(
     latest.platforms["darwin-aarch64"].url,
@@ -81,6 +84,14 @@ test("creates a complete manifest and Tauri updater document", () => {
     "signature-windows-x86_64-nsis",
   );
   assert.match(
+    latest.platforms["windows-aarch64"].url,
+    /releases\/v0\.4\.2\/windows\/aarch64\/Tidebreak_0\.4\.2_aarch64-setup\.exe$/,
+  );
+  assert.equal(
+    latest.platforms["windows-aarch64"].signature,
+    "signature-windows-aarch64-nsis",
+  );
+  assert.match(
     latest.platforms["linux-x86_64-appimage"].url,
     /releases\/v0\.4\.2\/linux\/x86_64\/Tidebreak_0\.4\.2_x86_64\.AppImage$/,
   );
@@ -95,6 +106,22 @@ test("creates a complete manifest and Tauri updater document", () => {
   assert.equal(
     latest.platforms["linux-x86_64-deb"].signature,
     "signature-linux-x86_64-deb",
+  );
+  assert.match(
+    latest.platforms["linux-aarch64-appimage"].url,
+    /releases\/v0\.4\.2\/linux\/aarch64\/Tidebreak_0\.4\.2_aarch64\.AppImage$/,
+  );
+  assert.equal(
+    latest.platforms["linux-aarch64-appimage"].signature,
+    "signature-linux-aarch64-appimage",
+  );
+  assert.match(
+    latest.platforms["linux-aarch64-deb"].url,
+    /releases\/v0\.4\.2\/linux\/aarch64\/Tidebreak_0\.4\.2_aarch64\.deb$/,
+  );
+  assert.equal(
+    latest.platforms["linux-aarch64-deb"].signature,
+    "signature-linux-aarch64-deb",
   );
 
   const diskManifest = JSON.parse(

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -494,10 +494,28 @@ function runCargoMetadata(root) {
   return JSON.parse(output);
 }
 
+export function pnpmInvocation(
+  platform = process.platform,
+  commandInterpreter = process.env.ComSpec,
+) {
+  const args = ["licenses", "list", "--json", "--prod"];
+  if (platform === "win32") {
+    return {
+      executable: commandInterpreter?.trim() || "cmd.exe",
+      args: ["/d", "/c", "pnpm", ...args],
+    };
+  }
+  return { executable: "pnpm", args };
+}
+
 function runPnpmLicenses(uiDirectory) {
+  // On Windows pnpm is exposed as a .cmd shim, which Node cannot execute
+  // directly. Run it through cmd.exe even when this script was launched from
+  // Git Bash; Unix hosts keep the direct, shell-free invocation.
+  const pnpm = pnpmInvocation();
   const output = execFileSync(
-    "pnpm",
-    ["licenses", "list", "--json", "--prod"],
+    pnpm.executable,
+    pnpm.args,
     { cwd: uiDirectory, encoding: "utf8", maxBuffer: 128 * 1024 * 1024 },
   );
   const parsed = JSON.parse(output);

--- a/scripts/third-party-notices.test.mjs
+++ b/scripts/third-party-notices.test.mjs
@@ -21,6 +21,7 @@ import {
   licenseTextId,
   normalizeLicenseText,
   parseSpdxIdentifiers,
+  pnpmInvocation,
   renderNotices,
 } from "./generate-third-party-notices.mjs";
 
@@ -52,6 +53,17 @@ function writePackage(root, directory, files) {
   }
   return packageDirectory;
 }
+
+test("the notices generator resolves the Windows pnpm command shim", () => {
+  assert.deepEqual(pnpmInvocation("win32", "C:\\Windows\\System32\\cmd.exe"), {
+    executable: "C:\\Windows\\System32\\cmd.exe",
+    args: ["/d", "/c", "pnpm", "licenses", "list", "--json", "--prod"],
+  });
+  assert.deepEqual(pnpmInvocation("linux"), {
+    executable: "pnpm",
+    args: ["licenses", "list", "--json", "--prod"],
+  });
+});
 
 test("the Rust collector covers the whole non-workspace graph and preserves its terms", () => {
   const root = scratchTree();

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1552,6 +1552,8 @@ test("Linux packaging writes no shared cache before loading updater material", (
   assert.match(rustCache, /save-if: false/);
 
   assert.match(buildJob, /--bundles appimage,deb/);
+  assert.match(buildJob, /category: "Productivity"/);
+  assert.doesNotMatch(buildJob, /category: "Office"/);
   assert.match(buildJob, /\.AppImage/);
   assert.match(buildJob, /\.deb/);
   assert.match(buildJob, /tauri signer sign "\$appimage_path"/);

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1427,6 +1427,13 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   )?.[0];
   assert.ok(prepareCacheSave);
   assert.ok(buildCacheRestore);
+  for (const job of [prepareJob, buildJob]) {
+    assert.match(job, /runs-on: \$\{\{ matrix\.runner \}\}/);
+    assert.match(job, /target: x86_64-pc-windows-msvc/);
+    assert.match(job, /runner: windows-latest/);
+    assert.match(job, /target: aarch64-pc-windows-msvc/);
+    assert.match(job, /runner: windows-11-arm/);
+  }
 
   // The prerequisite compiles without any production credential and never
   // uploads what it built; only the cache carries its outputs forward.
@@ -1524,6 +1531,11 @@ test("Linux packaging writes no shared cache before loading updater material", (
     assert.match(buildJob, /target: x86_64-unknown-linux-gnu/);
     assert.match(buildJob, /target: aarch64-unknown-linux-gnu/);
   }
+  assert.match(buildJob, /runs-on: \$\{\{ matrix\.runner \}\}/);
+  assert.match(buildJob, /target: x86_64-unknown-linux-gnu/);
+  assert.match(buildJob, /runner: ubuntu-22\.04/);
+  assert.match(buildJob, /target: aarch64-unknown-linux-gnu/);
+  assert.match(buildJob, /runner: ubuntu-22\.04-arm/);
   assert.match(buildJob, /libwebkit2gtk-4\.1-dev/);
   assert.match(buildJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
   assert.match(buildJob, /version: 10\.18\.3/);
@@ -1683,15 +1695,20 @@ test("GitHub release assets are attached before immutable publication", () => {
   // an incomplete hosted publication without rebuilding signed packages.
   assert.match(attachJob, /name: tidebreak-macos-universal-/);
   assert.match(attachJob, /name: tidebreak-windows-x86_64-/);
+  assert.match(attachJob, /name: tidebreak-windows-aarch64-/);
   assert.match(attachJob, /name: tidebreak-linux-x86_64-/);
+  assert.match(attachJob, /name: tidebreak-linux-aarch64-/);
   assert.match(attachJob, /name: tidebreak-source-sbom-/);
   assert.match(attachJob, /gh release download "\$RELEASE_TAG"/);
   assert.match(attachJob, /sha256sum --check --strict/);
   assert.match(attachJob, /Tidebreak-macos-universal\.dmg/);
   assert.match(attachJob, /Tidebreak-macos-apple-silicon\.dmg/);
   assert.match(attachJob, /Tidebreak-windows-x86_64-setup\.exe/);
+  assert.match(attachJob, /Tidebreak-windows-aarch64-setup\.exe/);
   assert.match(attachJob, /Tidebreak-linux-x86_64\.AppImage/);
   assert.match(attachJob, /Tidebreak-linux-x86_64\.deb/);
+  assert.match(attachJob, /Tidebreak-linux-aarch64\.AppImage/);
+  assert.match(attachJob, /Tidebreak-linux-aarch64\.deb/);
   assert.match(attachJob, /\.app\.zip/);
   assert.match(attachJob, /\.app\.tar\.gz/);
   assert.match(attachJob, /\.app\.tar\.gz\.sig/);
@@ -1711,6 +1728,8 @@ test("GitHub release assets are attached before immutable publication", () => {
       /Tidebreak_\$\{TIDEBREAK_VERSION\}_(?:aarch64|\$\{arch\})\.deb\.sig/,
     );
   }
+  assert.match(attachJob, /for arch in x86_64 aarch64/);
+  assert.match(attachJob, /Tidebreak_\$\{TIDEBREAK_VERSION\}_\$\{arch\}\.deb\.sig/);
   assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
   assert.match(attachJob, /if \[\[ "\$RELEASE_DRAFT" = true \]\]/);
   assert.match(attachJob, /releases\/\$RELEASE_ID\/assets/);
@@ -2133,6 +2152,10 @@ test("the packaged desktop activates the signed updater feed", () => {
   assert.match(
     desktopUpdater,
     /cfg!\(all\([\s\S]*not\(debug_assertions\),[\s\S]*target_os = "macos"[\s\S]*\)\)/,
+  );
+  assert.match(
+    desktopUpdater,
+    /cfg!\(all\([\s\S]*not\(debug_assertions\),[\s\S]*target_os = "macos"[\s\S]*target_os = "windows"[\s\S]*target_os = "linux"[\s\S]*\)\)/,
   );
   if (
     /target_os = "windows"/.test(desktopUpdater) ||

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1730,8 +1730,14 @@ test("GitHub release assets are attached before immutable publication", () => {
       /Tidebreak_\$\{TIDEBREAK_VERSION\}_(?:aarch64|\$\{arch\})\.deb\.sig/,
     );
   }
-  assert.match(attachJob, /for arch in x86_64 aarch64/);
-  assert.match(attachJob, /Tidebreak_\$\{TIDEBREAK_VERSION\}_\$\{arch\}\.deb\.sig/);
+  assert.match(
+    attachJob,
+    /Tidebreak_\$\{TIDEBREAK_VERSION\}_x86_64\.deb\.sig/,
+  );
+  assert.match(
+    attachJob,
+    /Tidebreak_\$\{TIDEBREAK_VERSION\}_aarch64\.deb\.sig/,
+  );
   assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
   assert.match(attachJob, /if \[\[ "\$RELEASE_DRAFT" = true \]\]/);
   assert.match(attachJob, /releases\/\$RELEASE_ID\/assets/);
@@ -2157,7 +2163,11 @@ test("the packaged desktop activates the signed updater feed", () => {
   );
   assert.match(
     desktopUpdater,
-    /cfg!\(all\([\s\S]*not\(debug_assertions\),[\s\S]*target_os = "macos"[\s\S]*target_os = "windows"[\s\S]*target_os = "linux"[\s\S]*\)\)/,
+    /cfg!\(all\(not\(debug_assertions\), target_os = "macos"\)\)/,
+  );
+  assert.match(
+    desktopUpdater,
+    /cfg!\(all\([\s\S]*not\(debug_assertions\),[\s\S]*target_os = "windows"[\s\S]*target_os = "linux"[\s\S]*\)\)/,
   );
   if (
     /target_os = "windows"/.test(desktopUpdater) ||


### PR DESCRIPTION
## Summary

- fix the Windows release prerequisite by invoking pnpm through the Windows command interpreter when generating third-party notices
- add native ARM64 Windows and Linux release matrices, artifacts, immutable manifest entries, updater keys, stable downloads, and recovery paths
- enable the existing signed, user-confirmed Tauri updater flow on production Windows and Linux builds
- supersede decision 40 with decision 43 and update the release contract, installation docs, deferred scope, and agent guidance

## Root cause

The v0.48.0 Windows prerequisite reached `generate-third-party-notices.mjs` from Git Bash, but Node attempted to spawn the extensionless `pnpm` command directly. On Windows pnpm is a command shim, so the process failed with `spawnSync pnpm ENOENT` before compilation began.

The generator now uses `cmd.exe /d /c pnpm ...` on Windows and keeps the direct shell-free invocation on Unix hosts.

## Release impact

Production releases now require:

- universal macOS
- Windows x86_64 and ARM64 NSIS installers
- Linux x86_64 and ARM64 AppImages and Debian packages

Windows ARM64 uses `windows-11-arm`; Linux ARM64 uses `ubuntu-22.04-arm`. Publication remains all-or-nothing across the declared platform and architecture set. Windows and Linux release builds use the same authenticated background-download and explicit restart-to-install flow as macOS; debug builds remain disabled.

## Validation

- `actionlint .github/workflows/release.yml`
- `node scripts/generate-third-party-notices.mjs --check`
- `node --test scripts/create-release-manifests.test.mjs scripts/third-party-notices.test.mjs scripts/workflow-security.test.mjs` (48 passed)
- `cargo test -p tidebreak-desktop updater:: --locked` (9 passed)
- `pnpm exec vitest run src/settings/UpdatesPanel.test.tsx` (3 passed)
- `pnpm build`
- `git diff --check`

## Remaining native verification

GitHub Actions is the authoritative native build check for the Windows and Linux package matrices. This PR should not be considered release-ready until those native jobs and required PR checks are green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production release gates, hosted manifest shape, and cross-platform updater behavior; a partial or mis-keyed ARM64 matrix could block or mis-publish releases, though workflow-policy tests pin the contract.
> 
> **Overview**
> Adds **ARM64 Windows and Linux** to the production release contract alongside existing x86_64 builds, and turns on the **signed Tauri updater** for packaged Windows and Linux release builds (same background check, explicit restart flow as macOS).
> 
> **Release pipeline** — `prepare_windows` / `build_windows` and `build_linux` now matrix over x86_64 and aarch64 with native runners (`windows-11-arm`, `ubuntu-22.04-arm`). Artifact download, GitHub stable aliases, immutable recovery, and publication gates all require the full architecture set. Linux bundle category moves from `Office` to `Productivity`.
> 
> **Windows CI fix** — `generate-third-party-notices.mjs` invokes pnpm via `cmd.exe` on Windows so Git Bash release jobs no longer hit `spawnSync pnpm ENOENT`.
> 
> **Runtime & manifests** — `updates_enabled()` includes non-debug Windows and Linux; settings UI text reflects “packaged release builds.” `create-release-manifests.mjs` adds `windows-aarch64` and `linux-aarch64-*` updater keys. Decision 43 supersedes 40; README, installation docs, `releases.md`, and `deferred.md` match the new scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac57490794669b67a2d2379cd99cfbc9dc6b4692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->