### PR TITLE
fix(release): retry newly created draft lookup

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -122,24 +122,46 @@ jobs:
           RELEASE_ID: ${{ steps.release_drafter.outputs.id }}
           RESOLVED_VERSION: ${{ steps.release_drafter.outputs.resolved_version }}
         run: |
-          gh api --paginate \
-            -H 'Accept: application/vnd.github+json' \
-            "repos/$GITHUB_REPOSITORY/releases?per_page=100" | \
-            jq -s '[.[][]]' > "$RUNNER_TEMP/releases.json"
-          plan="$(node scripts/reconcile-release-drafts.mjs \
-            --releases "$RUNNER_TEMP/releases.json" \
-            --resolved-version "$RESOLVED_VERSION" \
-            --release-id "$RELEASE_ID")"
-          echo "$plan"
-          while IFS= read -r id; do
-            gh api --method DELETE \
-              "repos/$GITHUB_REPOSITORY/releases/$id" >/dev/null
-            echo "Deleted extra draft $id"
-          done < <(jq -r '.delete_ids[]' <<<"$plan")
-          if [[ "$(jq -r .action <<<"$plan")" = fail ]]; then
-            jq -r .reason <<<"$plan" >&2
-            exit 1
-          fi
+          attempt=1
+          max_attempts=5
+          while (( attempt <= max_attempts )); do
+            if gh api --paginate \
+                 -H 'Accept: application/vnd.github+json' \
+                 "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+                 > "$RUNNER_TEMP/releases.raw.json" \
+              && jq -s '[.[][]]' "$RUNNER_TEMP/releases.raw.json" \
+                 > "$RUNNER_TEMP/releases.json"
+            then
+              plan="$(node scripts/reconcile-release-drafts.mjs \
+                --releases "$RUNNER_TEMP/releases.json" \
+                --resolved-version "$RESOLVED_VERSION" \
+                --release-id "$RELEASE_ID")"
+              echo "attempt ${attempt}: ${plan}"
+              action="$(jq -r .action <<<"$plan")"
+              if [[ "$action" != retry ]]; then
+                while IFS= read -r id; do
+                  gh api --method DELETE \
+                    "repos/$GITHUB_REPOSITORY/releases/$id" >/dev/null
+                  echo "Deleted extra draft $id"
+                done < <(jq -r '.delete_ids[]' <<<"$plan")
+                if [[ "$action" = fail ]]; then
+                  jq -r .reason <<<"$plan" >&2
+                  exit 1
+                fi
+                exit 0
+              fi
+              reason="$(jq -r .reason <<<"$plan")"
+            else
+              reason="failed to list GitHub releases"
+              echo "attempt ${attempt}: ${reason}"
+            fi
+            if (( attempt == max_attempts )); then
+              echo "$reason" >&2
+              exit 1
+            fi
+            sleep $((attempt * 5))
+            attempt=$((attempt + 1))
+          done
       - name: Group release notes by Conventional Commit scope
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/reconcile-release-drafts.mjs
+++ b/scripts/reconcile-release-drafts.mjs
@@ -57,6 +57,17 @@ export function planDraftReconciliation({
 
   const keep = drafts.find((draft) => draft.id === resolvedReleaseId);
   if (!keep) {
+    const reportedRelease = allReleases.find(
+      (release) => release?.id === resolvedReleaseId,
+    );
+    if (!reportedRelease) {
+      return {
+        action: "retry",
+        keep_id: null,
+        delete_ids: [],
+        reason: `Release Drafter reported release ${resolvedReleaseId}, but the releases list does not include it yet`,
+      };
+    }
     throw new Error(
       `Release Drafter reported release ${resolvedReleaseId} but it is not a non-prerelease draft`,
     );

--- a/scripts/reconcile-release-drafts.test.mjs
+++ b/scripts/reconcile-release-drafts.test.mjs
@@ -131,11 +131,28 @@ test("flattens paginated GitHub release pages", () => {
   ]);
 });
 
-test("rejects a Release Drafter id that is not a live draft", () => {
+test("retries when GitHub has not listed the new Release Drafter id yet", () => {
+  assert.deepEqual(
+    planDraftReconciliation({
+      releases: [published],
+      resolvedVersion: "0.47.0",
+      releaseId: 20,
+    }),
+    {
+      action: "retry",
+      keep_id: null,
+      delete_ids: [],
+      reason:
+        "Release Drafter reported release 20, but the releases list does not include it yet",
+    },
+  );
+});
+
+test("rejects a Release Drafter id that is listed but is not a live draft", () => {
   assert.throws(
     () =>
       planDraftReconciliation({
-        releases: [published],
+        releases: [{ ...inFlight, id: 20 }, published],
         resolvedVersion: "0.47.0",
         releaseId: 20,
       }),

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -281,6 +281,8 @@ test("release-drafter retains a stable draft tag after formatting", () => {
   );
   assert.match(draftJob, /node scripts\/reconcile-release-drafts\.mjs/);
   assert.match(draftJob, /Keep exactly one native release draft/);
+  assert.match(draftJob, /max_attempts=5/);
+  assert.match(draftJob, /\[\[ "\$action" != retry \]\]/);
   assert.match(draftJob, /\.delete_ids\[\]/);
   assert.match(draftJob, /jq -r \.action/);
 });


### PR DESCRIPTION
## What changed

- treat a just-created Release Drafter ID that is temporarily absent from the releases list as retryable
- retry release-list reconciliation with bounded backoff before failing
- keep failing immediately when the reported release is visible but is not a normal draft
- add regression and workflow-policy coverage for the retry path

## Root cause

The failed `v0.48.0` publish left that release as an in-flight prerelease, so Release Drafter correctly created the next `v0.48.1` draft. The action returned the new release ID before GitHub's paginated releases-list endpoint included it. Reconciliation interpreted that transient omission as a permanent invariant violation and failed the release-draft workflow.

## Validation

- `node --test scripts/*.test.mjs`
- `actionlint .github/workflows/release-draft.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only GitHub Actions release-draft automation and reconciliation scripts; no runtime product or auth paths.
> 
> **Overview**
> Fixes **release-draft** failures when Release Drafter returns a new release ID before GitHub’s paginated releases API lists that release.
> 
> **`planDraftReconciliation`** now returns **`action: "retry"`** when the reported ID is missing from the fetched list (transient lag). It still **throws** if the ID appears but is not a normal non-prerelease draft.
> 
> The **“Keep exactly one native release draft”** workflow step mirrors the baseline step: up to **5 attempts**, paginated fetch + `jq` flattening, bounded backoff (`attempt * 5` seconds), then fail with the last reason. Deletes extra drafts only when the plan is not `retry`.
> 
> Tests cover the retry path, the “listed but wrong kind” path, and workflow policy checks for `max_attempts=5` and retry handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5fc8fa2d161503748a96435b503c82015ec3690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->