### PR TITLE
test(harness): stabilize Codex session tests against ETXTBSY

### DIFF
--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -654,17 +654,26 @@ done
 
     #[cfg(unix)]
     fn write_fake_app_server(path: &std::path::Path) {
+        // Write a sibling inode, fsync, then rename over `path` so execve
+        // never sees a file that still has a writer (Linux ETXTBSY).
         use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
+        let staging = path.with_extension("writing");
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
             .mode(0o755)
-            .open(path)
+            .open(&staging)
             .unwrap();
         file.write_all(FAKE_APP_SERVER.as_bytes()).unwrap();
         file.sync_all().unwrap();
+        drop(file);
+        std::fs::rename(&staging, path).unwrap();
+        if let Some(parent) = path.parent() {
+            let dir = std::fs::File::open(parent).unwrap();
+            dir.sync_all().unwrap();
+        }
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Why

CI on #2183 and #2181 failed in
`codex::session::tests::a_thread_that_ran_no_turn_is_not_a_resume_ref`
with `ETXTBSY` (`Text file busy`) when `attach` spawned the fake Codex
binary. Those failures are unrelated to the changes on those PRs.

The tests write that stand-in script in place and immediately exec it.
On Linux, especially overlayfs, `execve` can still see a writer on that
inode. The same helper also feeds
`a_stale_resume_ref_reports_a_lost_resume`.

## What changed

- write the fake `codex` script to a sibling inode
- fsync the file and the parent directory
- rename over the exec path so spawn never sees an open writer

This matches the existing `write_exec` helper in the probe tests.
Production `attach` is unchanged. The tests stay.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tidebreak-harness --lib --locked -- a_thread_that_ran_no_turn_is_not_a_resume_ref a_stale_resume_ref_reports_a_lost_resume`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to how the fake Codex binary is written before exec; no production harness or attach logic is modified.
> 
> **Overview**
> Fixes flaky Linux CI in Codex session tests where `attach` spawned a fake `codex` script immediately after writing it, triggering **ETXTBSY** (`Text file busy`) on overlayfs when `execve` still saw an open writer on the inode.
> 
> **`write_fake_app_server`** now mirrors the probe tests’ **`write_exec`** pattern: write the script to a sibling staging path (`*.writing`), fsync the file, rename into the exec path, then fsync the parent directory so spawn never execs a file that still has a writer.
> 
> Production **`attach`** behavior is unchanged; only test helpers for `a_thread_that_ran_no_turn_is_not_a_resume_ref` and `a_stale_resume_ref_reports_a_lost_resume` are affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e667fe44111d59a7074af91799fd42c296d7a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->