### PR TITLE
test(release): authorize ARM64 packages and cross-platform updates

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1511,7 +1511,17 @@ test("Linux packaging writes no shared cache before loading updater material", (
   assert.doesNotMatch(release, /^  prepare_linux:/m);
   const buildJob = workflowJob(release, "build_linux");
   assert.match(buildJob, /needs: \[validate, inspect_hosted\]/);
-  assert.match(buildJob, /runs-on: ubuntu-22\.04/);
+  // Current workflow pins the x86_64 job to ubuntu-22.04. The upcoming ARM64
+  // matrix keeps that runner and selects it through ${{ matrix.runner }}.
+  assert.match(buildJob, /ubuntu-22\.04/);
+  assert.match(
+    buildJob,
+    /runs-on: (?:ubuntu-22\.04|\$\{\{ matrix\.runner \}\})/,
+  );
+  if (/runner: ubuntu-22\.04-arm/.test(buildJob)) {
+    assert.match(buildJob, /target: x86_64-unknown-linux-gnu/);
+    assert.match(buildJob, /target: aarch64-unknown-linux-gnu/);
+  }
   assert.match(buildJob, /libwebkit2gtk-4\.1-dev/);
   assert.match(buildJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
   assert.match(buildJob, /version: 10\.18\.3/);
@@ -1683,7 +1693,22 @@ test("GitHub release assets are attached before immutable publication", () => {
   assert.match(attachJob, /\.app\.zip/);
   assert.match(attachJob, /\.app\.tar\.gz/);
   assert.match(attachJob, /\.app\.tar\.gz\.sig/);
-  assert.match(attachJob, /Tidebreak_\$\{TIDEBREAK_VERSION\}_x86_64\.deb\.sig/);
+  // Current publication lists the x86_64 Debian signature literally. The
+  // upcoming ARM64 graph may keep that literal or expand it through ${arch}.
+  assert.match(
+    attachJob,
+    /Tidebreak_\$\{TIDEBREAK_VERSION\}_(?:x86_64|\$\{arch\})\.deb\.sig/,
+  );
+  if (/name: tidebreak-windows-aarch64-/.test(attachJob)) {
+    assert.match(attachJob, /name: tidebreak-linux-aarch64-/);
+    assert.match(attachJob, /Tidebreak-windows-aarch64-setup\.exe/);
+    assert.match(attachJob, /Tidebreak-linux-aarch64\.AppImage/);
+    assert.match(attachJob, /Tidebreak-linux-aarch64\.deb/);
+    assert.match(
+      attachJob,
+      /Tidebreak_\$\{TIDEBREAK_VERSION\}_(?:aarch64|\$\{arch\})\.deb\.sig/,
+    );
+  }
   assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
   assert.match(attachJob, /if \[\[ "\$RELEASE_DRAFT" = true \]\]/);
   assert.match(attachJob, /releases\/\$RELEASE_ID\/assets/);
@@ -2100,10 +2125,20 @@ test("the packaged desktop activates the signed updater feed", () => {
     "updates must install behind the reversible broker barrier",
   );
   assert.match(desktopUpdater, /app\.restart\(\)/);
+  // Production updates stay off debug builds. Current main enables macOS
+  // only; the upcoming packaging change may also enable Windows and Linux
+  // in the same cfg! or a sibling one.
   assert.match(
     desktopUpdater,
-    /cfg!\(all\(not\(debug_assertions\), target_os = "macos"\)\)/,
+    /cfg!\(all\([\s\S]*not\(debug_assertions\),[\s\S]*target_os = "macos"[\s\S]*\)\)/,
   );
+  if (
+    /target_os = "windows"/.test(desktopUpdater) ||
+    /target_os = "linux"/.test(desktopUpdater)
+  ) {
+    assert.match(desktopUpdater, /target_os = "windows"/);
+    assert.match(desktopUpdater, /target_os = "linux"/);
+  }
   assert.match(
     desktopUpdater,
     /const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs\(15\)/,


### PR DESCRIPTION
## Summary

- authorize the current release workflow and the upcoming ARM64 Windows/Linux release graph in the trusted workflow policy
- allow Linux packaging to select `ubuntu-22.04` through `${{ matrix.runner }}` while keeping that runner as the x86_64 baseline
- allow immutable publication to attach native `aarch64` Windows and Linux assets
- allow the packaged updater to enable signed production updates on Windows and Linux as well as macOS

## Why

The release-policy CI job intentionally runs `main`'s trusted tests against pull-request workflow changes. PR #2182 cannot add ARM64 matrices or enable the signed updater on Windows and Linux until the trusted policy recognizes that graph. This is the same prerequisite-policy transition used for Windows/Linux packaging in #2174.

The transition keeps every current assertion active while admitting the stricter follow-up workflow. PR #2182 will tighten the tests to the final ARM64 and cross-platform-updater shape after this prerequisite lands.

## Validation

- `node --test scripts/workflow-security.test.mjs` — 35 tests passed against `main`
- `node --test scripts/workflow-security-mutations.test.mjs` — 43 tests passed against `main`
- the same trusted tests passed against #2182's files
- `git diff --check`

Prerequisite for #2182.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to trusted workflow policy matchers; no release workflow or application code is modified.
> 
> **Overview**
> Updates **`scripts/workflow-security.test.mjs`** so release-policy CI can pass on **`main`** today while also accepting the follow-up workflow from PR #2182 (ARM64 matrices and Windows/Linux production updaters).
> 
> **Linux `build_linux`** checks still require `ubuntu-22.04` and the existing packaging guards, but **`runs-on`** may be pinned literally or via **`${{ matrix.runner }}`**. When an ARM runner appears in the job, the test also expects both **`x86_64-unknown-linux-gnu`** and **`aarch64-unknown-linux-gnu`** matrix targets.
> 
> **`attach_downloads`** keeps current x86_64 asset names while allowing Debian signature paths to use **`${arch}`** instead of a fixed **`x86_64`**. If Windows ARM64 artifact names are present, it additionally requires matching Linux ARM64 packages and signatures.
> 
> **Packaged updater policy** still demands macOS in the production **`cfg!`**, with a looser matcher for nested **`all(...)`** blocks. If **`updater.rs`** mentions Windows or Linux, both **`target_os`** entries must appear—without requiring them on **`main`** until the packaging PR lands.
> 
> This is the same prerequisite pattern as #2174: current assertions stay active; stricter final shapes can tighten tests after this merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdb9025599865b20a25557d887d1ef68af06e1e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->