### PR TITLE
fix(release): unblock Windows and Linux ARM packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1447,7 +1447,8 @@ jobs:
             libssl-dev \
             libwebkit2gtk-4.1-dev \
             libxdo-dev \
-            patchelf
+            patchelf \
+            xdg-utils
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -551,7 +551,7 @@ export function generateNotices({ root = repositoryRoot } = {}) {
   });
 }
 
-function firstDifference(expected, actual) {
+export function firstDifference(expected, actual) {
   const expectedLines = expected.split("\n");
   const actualLines = actual.split("\n");
   const limit = Math.max(expectedLines.length, actualLines.length);
@@ -589,14 +589,13 @@ function main(argv) {
     );
   }
   const current = readFileSync(target, "utf8");
-  if (
-    normalizeNoticesForComparison(current) ===
-    normalizeNoticesForComparison(generated)
-  ) {
+  const comparableCurrent = normalizeNoticesForComparison(current);
+  const comparableGenerated = normalizeNoticesForComparison(generated);
+  if (comparableCurrent === comparableGenerated) {
     console.log(`${NOTICES_RELATIVE_PATH} is up to date`);
     return;
   }
-  const difference = firstDifference(current, generated);
+  const difference = firstDifference(comparableCurrent, comparableGenerated);
   throw new Error(
     `${NOTICES_RELATIVE_PATH} is stale; run \`${REGENERATE_COMMAND}\`\n` +
       `first difference at line ${difference.line}\n` +

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -116,6 +116,14 @@ export function normalizeLicenseText(raw) {
     .replace(/\s+$/, "");
 }
 
+export function normalizeNoticesForComparison(raw) {
+  // Git may materialize text files with CRLF on Windows. The generated notices
+  // deliberately use LF for deterministic repository bytes, but a check of an
+  // otherwise identical checkout must not fail solely because of Git's local
+  // line-ending conversion.
+  return raw.replace(/\r\n?/g, "\n");
+}
+
 export function licenseTextId(normalizedText) {
   const digest = createHash("sha256").update(normalizedText, "utf8").digest("hex");
   return `L-${digest.slice(0, 12)}`;
@@ -581,7 +589,10 @@ function main(argv) {
     );
   }
   const current = readFileSync(target, "utf8");
-  if (current === generated) {
+  if (
+    normalizeNoticesForComparison(current) ===
+    normalizeNoticesForComparison(generated)
+  ) {
     console.log(`${NOTICES_RELATIVE_PATH} is up to date`);
     return;
   }

--- a/scripts/third-party-notices.test.mjs
+++ b/scripts/third-party-notices.test.mjs
@@ -20,6 +20,7 @@ import {
   collectRustPackages,
   licenseTextId,
   normalizeLicenseText,
+  normalizeNoticesForComparison,
   parseSpdxIdentifiers,
   pnpmInvocation,
   renderNotices,
@@ -63,6 +64,14 @@ test("the notices generator resolves the Windows pnpm command shim", () => {
     executable: "pnpm",
     args: ["licenses", "list", "--json", "--prod"],
   });
+});
+
+test("the notices check ignores Git's Windows line-ending conversion", () => {
+  const notices = "# Third-party notices\n\nGenerated terms.\n";
+  assert.equal(
+    normalizeNoticesForComparison(notices.replaceAll("\n", "\r\n")),
+    normalizeNoticesForComparison(notices),
+  );
 });
 
 test("the Rust collector covers the whole non-workspace graph and preserves its terms", () => {

--- a/scripts/third-party-notices.test.mjs
+++ b/scripts/third-party-notices.test.mjs
@@ -18,6 +18,7 @@ import {
   REGENERATE_COMMAND,
   collectNodePackages,
   collectRustPackages,
+  firstDifference,
   licenseTextId,
   normalizeLicenseText,
   normalizeNoticesForComparison,
@@ -71,6 +72,17 @@ test("the notices check ignores Git's Windows line-ending conversion", () => {
   assert.equal(
     normalizeNoticesForComparison(notices.replaceAll("\n", "\r\n")),
     normalizeNoticesForComparison(notices),
+  );
+
+  const staleWindowsNotices = notices
+    .replace("Generated terms.", "Stale terms.")
+    .replaceAll("\n", "\r\n");
+  assert.deepEqual(
+    firstDifference(
+      normalizeNoticesForComparison(staleWindowsNotices),
+      normalizeNoticesForComparison(notices),
+    ),
+    { line: 3, expected: "Stale terms.", actual: "Generated terms." },
   );
 });
 

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1537,6 +1537,11 @@ test("Linux packaging writes no shared cache before loading updater material", (
   assert.match(buildJob, /target: aarch64-unknown-linux-gnu/);
   assert.match(buildJob, /runner: ubuntu-22\.04-arm/);
   assert.match(buildJob, /libwebkit2gtk-4\.1-dev/);
+  assert.match(
+    buildJob,
+    /xdg-utils/,
+    "AppImage packaging must install the xdg-mime provider on every runner",
+  );
   assert.match(buildJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
   assert.match(buildJob, /version: 10\.18\.3/);
   assert.match(buildJob, /pnpm install --frozen-lockfile --ignore-scripts/);


### PR DESCRIPTION
Fixes the release blockers exposed while publishing v0.49.0.

- compares third-party notices with normalized checkout line endings, so Windows CRLF materialization does not create a false stale-file failure
- uses the same normalized text for accurate first-difference diagnostics
- explicitly installs xdg-utils so Tauri AppImage packaging has xdg-mime on the Ubuntu ARM runner
- adds regression coverage for both release contracts

Observed failures:
- Windows x86_64 and ARM64: identical notices rejected solely due to CRLF
- Linux ARM64: application compiled, then AppImage bundling failed because /usr/bin/xdg-mime was absent

Validation:
- node --test scripts/workflow-security.test.mjs scripts/third-party-notices.test.mjs
- node scripts/generate-third-party-notices.mjs --check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release CI and notice-check behavior only; no changes to auth, signing, or runtime application logic.
> 
> **Overview**
> Fixes **false stale-file failures** on Windows release builds when Git materializes `THIRD-PARTY-NOTICES.md` with CRLF while the generator still writes LF. The `--check` path now compares through `normalizeNoticesForComparison` (CRLF→LF only for comparison); generated bytes stay LF. Stale diffs still use the normalized comparison via exported `firstDifference`, with a regression test for CRLF checkouts.
> 
> **Linux release** `build_linux` apt deps add **`xdg-utils`** so AppImage packaging has the xdg-mime provider on x86_64 and ARM runners; workflow-security tests assert that package is installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48a3779b4fe1c6d6a4b2fa8348e9835a4f2e8e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->