### PR TITLE
fix(release): compile Windows ARM whisper.cpp with clang-cl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1110,10 +1110,9 @@ jobs:
             target/${{ matrix.target }}/release/tidebreak-host-broker.exe
             target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
-          key: windows-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
-            windows-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            windows-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -1280,7 +1279,7 @@ jobs:
             target/${{ matrix.target }}/release/tidebreak-host-broker.exe
             target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
-          key: windows-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
 
       # A restore extracts the whole archive, including the linked products a
       # prerequisite run left in it. Delete them and let this build relink them

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1173,6 +1173,9 @@ jobs:
           fi
           clang_cl="$(cygpath -m "$clang_cl")"
           {
+            echo "CC=$clang_cl"
+            echo "CXX=$clang_cl"
+            echo "CXXFLAGS=/EHsc"
             echo "CMAKE_GENERATOR=Ninja"
             echo "CMAKE_C_COMPILER=$clang_cl"
             echo "CMAKE_CXX_COMPILER=$clang_cl"
@@ -1380,6 +1383,9 @@ jobs:
           fi
           clang_cl="$(cygpath -m "$clang_cl")"
           {
+            echo "CC=$clang_cl"
+            echo "CXX=$clang_cl"
+            echo "CXXFLAGS=/EHsc"
             echo "CMAKE_GENERATOR=Ninja"
             echo "CMAKE_C_COMPILER=$clang_cl"
             echo "CMAKE_CXX_COMPILER=$clang_cl"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1110,10 +1110,10 @@ jobs:
             target/${{ matrix.target }}/release/tidebreak-host-broker.exe
             target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
-          key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          key: windows-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
-            windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            windows-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            windows-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -1146,6 +1146,40 @@ jobs:
 
       - name: Verify the third-party notices match the released graph
         run: node scripts/generate-third-party-notices.mjs --check
+
+      # whisper.cpp refuses MSVC on ARM. The cmake crate honors CMAKE_GENERATOR
+      # from the environment but not CMAKE_GENERATOR_TOOLSET, so Ninja plus
+      # clang-cl is the reliable way to keep aarch64-pc-windows-msvc while
+      # compiling the native C/C++ with Clang.
+      - name: Use clang-cl for Windows ARM native code
+        if: ${{ matrix.arch == 'aarch64' }}
+        run: |
+          clang_cl=""
+          for candidate in \
+            "$(command -v clang-cl || true)" \
+            "/c/Program Files/LLVM/bin/clang-cl.exe" \
+            "/c/Program Files/LLVM/bin/clang-cl"; do
+            if [[ -n "$candidate" && -x "$candidate" ]]; then
+              clang_cl="$candidate"
+              break
+            fi
+          done
+          if [[ -z "$clang_cl" ]]; then
+            echo "clang-cl is required to compile whisper.cpp on Windows ARM" >&2
+            exit 1
+          fi
+          if ! command -v ninja >/dev/null; then
+            echo "ninja is required to compile whisper.cpp on Windows ARM" >&2
+            exit 1
+          fi
+          clang_cl="$(cygpath -m "$clang_cl")"
+          {
+            echo "CMAKE_GENERATOR=Ninja"
+            echo "CMAKE_C_COMPILER=$clang_cl"
+            echo "CMAKE_CXX_COMPILER=$clang_cl"
+            echo "CMAKE_ASM_COMPILER=$clang_cl"
+          } >> "$GITHUB_ENV"
+          echo "Using $clang_cl with Ninja for Windows ARM native code"
 
       - name: Compile without production credentials or bundles
         id: compile
@@ -1246,7 +1280,7 @@ jobs:
             target/${{ matrix.target }}/release/tidebreak-host-broker.exe
             target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
             crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
-          key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          key: windows-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
 
       # A restore extracts the whole archive, including the linked products a
       # prerequisite run left in it. Delete them and let this build relink them
@@ -1319,6 +1353,40 @@ jobs:
         run: |
           rustup show
           rustup target add "${{ matrix.target }}"
+
+      # whisper.cpp refuses MSVC on ARM. The cmake crate honors CMAKE_GENERATOR
+      # from the environment but not CMAKE_GENERATOR_TOOLSET, so Ninja plus
+      # clang-cl is the reliable way to keep aarch64-pc-windows-msvc while
+      # compiling the native C/C++ with Clang.
+      - name: Use clang-cl for Windows ARM native code
+        if: ${{ matrix.arch == 'aarch64' }}
+        run: |
+          clang_cl=""
+          for candidate in \
+            "$(command -v clang-cl || true)" \
+            "/c/Program Files/LLVM/bin/clang-cl.exe" \
+            "/c/Program Files/LLVM/bin/clang-cl"; do
+            if [[ -n "$candidate" && -x "$candidate" ]]; then
+              clang_cl="$candidate"
+              break
+            fi
+          done
+          if [[ -z "$clang_cl" ]]; then
+            echo "clang-cl is required to compile whisper.cpp on Windows ARM" >&2
+            exit 1
+          fi
+          if ! command -v ninja >/dev/null; then
+            echo "ninja is required to compile whisper.cpp on Windows ARM" >&2
+            exit 1
+          fi
+          clang_cl="$(cygpath -m "$clang_cl")"
+          {
+            echo "CMAKE_GENERATOR=Ninja"
+            echo "CMAKE_C_COMPILER=$clang_cl"
+            echo "CMAKE_CXX_COMPILER=$clang_cl"
+            echo "CMAKE_ASM_COMPILER=$clang_cl"
+          } >> "$GITHUB_ENV"
+          echo "Using $clang_cl with Ninja for Windows ARM native code"
 
       - name: Write tag-derived Tauri configuration
         env:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -256,7 +256,11 @@ installer.
 Unlike macOS, no cache-warming workflow exists for Windows: the credential-free
 `prepare_windows` job compiles the tag from scratch (or from an earlier
 release's prepared cache) and is the single writer of the Windows Cargo
-registry and prepared-build caches.
+registry and prepared-build caches. The Windows ARM job keeps the
+`aarch64-pc-windows-msvc` Rust target and compiles whisper.cpp with Ninja plus
+`clang-cl`, because ggml refuses MSVC on ARM. The prepared-build cache key
+includes a version prefix so a failed MSVC CMake tree cannot be reused after
+that compiler switch.
 
 ### Linux: x86_64 and ARM64 AppImage and Debian packages
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -258,9 +258,9 @@ Unlike macOS, no cache-warming workflow exists for Windows: the credential-free
 release's prepared cache) and is the single writer of the Windows Cargo
 registry and prepared-build caches. The Windows ARM job keeps the
 `aarch64-pc-windows-msvc` Rust target and compiles whisper.cpp with Ninja plus
-`clang-cl`, because ggml refuses MSVC on ARM. The prepared-build cache key
-includes a version prefix so a failed MSVC CMake tree cannot be reused after
-that compiler switch.
+`clang-cl`, because ggml refuses MSVC on ARM. The credential-free prepare job
+restores only caches for the same commit SHA, so a failed MSVC CMake tree from
+an earlier attempt cannot be reused after that compiler switch.
 
 ### Linux: x86_64 and ARM64 AppImage and Debian packages
 

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1433,7 +1433,26 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
     assert.match(job, /runner: windows-latest/);
     assert.match(job, /target: aarch64-pc-windows-msvc/);
     assert.match(job, /runner: windows-11-arm/);
+    // whisper.cpp refuses MSVC on ARM. Force Ninja + clang-cl only on the
+    // ARM matrix entry so x86_64 keeps the Visual Studio generator.
+    assert.match(job, /if: \$\{\{ matrix\.arch == 'aarch64' \}\}/);
+    assert.match(job, /CMAKE_GENERATOR=Ninja/);
+    assert.match(job, /CMAKE_C_COMPILER=/);
+    assert.match(job, /CMAKE_CXX_COMPILER=/);
+    assert.match(job, /CMAKE_ASM_COMPILER=/);
+    assert.match(job, /clang-cl/);
+    assert.match(job, /command -v ninja/);
   }
+  assert.ok(
+    prepareJob.indexOf("Use clang-cl for Windows ARM native code") <
+      prepareJob.indexOf("Compile without production credentials or bundles"),
+    "Windows ARM clang-cl must be configured before the unsigned compile",
+  );
+  assert.ok(
+    buildJob.indexOf("Use clang-cl for Windows ARM native code") <
+      buildJob.indexOf("Build the Tauri app without Windows code signing"),
+    "Windows ARM clang-cl must be configured before the packaged build",
+  );
 
   // The prerequisite compiles without any production credential and never
   // uploads what it built; only the cache carries its outputs forward.
@@ -1477,7 +1496,7 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   assert.equal(cachedPaths(buildCacheRestore), cachedPaths(prepareCacheSave));
   assert.match(
     buildCacheRestore,
-    /key: windows-release-prepared-v1-\$\{\{ matrix\.arch \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ needs\.validate\.outputs\.sha \}\}-\$\{\{ needs\.validate\.outputs\.version \}\}/,
+    /key: windows-release-prepared-v2-\$\{\{ matrix\.arch \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ needs\.validate\.outputs\.sha \}\}-\$\{\{ needs\.validate\.outputs\.version \}\}/,
   );
   assert.doesNotMatch(buildCacheRestore, /restore-keys:/);
 

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1440,6 +1440,9 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
     assert.match(job, /CMAKE_C_COMPILER=/);
     assert.match(job, /CMAKE_CXX_COMPILER=/);
     assert.match(job, /CMAKE_ASM_COMPILER=/);
+    assert.match(job, /echo "CC=\$clang_cl"/);
+    assert.match(job, /echo "CXX=\$clang_cl"/);
+    assert.match(job, /CXXFLAGS=\/EHsc/);
     assert.match(job, /clang-cl/);
     assert.match(job, /command -v ninja/);
   }

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1496,7 +1496,7 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   assert.equal(cachedPaths(buildCacheRestore), cachedPaths(prepareCacheSave));
   assert.match(
     buildCacheRestore,
-    /key: windows-release-prepared-v2-\$\{\{ matrix\.arch \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ needs\.validate\.outputs\.sha \}\}-\$\{\{ needs\.validate\.outputs\.version \}\}/,
+    /key: windows-release-prepared-v1-\$\{\{ matrix\.arch \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ needs\.validate\.outputs\.sha \}\}-\$\{\{ needs\.validate\.outputs\.version \}\}/,
   );
   assert.doesNotMatch(buildCacheRestore, /restore-keys:/);
 


### PR DESCRIPTION
Windows ARM release jobs fail in whisper.cpp because ggml refuses MSVC on ARM:

```
CMake Error at ggml/src/ggml-cpu/CMakeLists.txt:109 (message):
  MSVC is not supported for ARM, use clang
```

The cmake crate honors `CMAKE_GENERATOR` from the environment but not `CMAKE_GENERATOR_TOOLSET`, so forcing Visual Studio's ClangCL toolset is not reliable. This keeps `aarch64-pc-windows-msvc` for Rust and points native C/C++ at Ninja plus the runner's `clang-cl` on both `prepare_windows` and `build_windows`.

The trusted release-policy job still asserts the existing `v1` prepared-cache name, so that key stays. The credential-free prepare job no longer restores lockfile-only Windows caches, which keeps a failed MSVC CMake tree from an earlier SHA out of the next compile.

Linux ARM `xdg-utils` already landed in #2186 and is unchanged here.

Validated with `node --test scripts/workflow-security.test.mjs`.
After this merges, dispatch the next draft release (`v0.49.2` or whatever Release Drafter created). Do not rewrite `v0.48.0`, `v0.49.0`, or `v0.49.1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI/release workflow paths for Windows ARM desktop builds; misconfigured clang-cl or cache behavior could block ARM releases without affecting runtime auth or data handling on shipped apps.
> 
> **Overview**
> Windows ARM release jobs were failing because **ggml/whisper.cpp refuses MSVC on ARM**. This PR keeps Rust on `aarch64-pc-windows-msvc` and, only for the **aarch64** matrix entry in **`prepare_windows`** and **`build_windows`**, configures native C/C++ via **Ninja** and **`clang-cl`** (`CMAKE_GENERATOR`, `CMAKE_C/CXX/ASM_COMPILER` on `GITHUB_ENV`), with hard failures if `clang-cl` or `ninja` are missing.
> 
> On **`prepare_windows`**, a **broader prepared-build cache restore key** (without the release commit SHA) is removed so a **failed MSVC CMake tree** from an earlier attempt cannot be reused after switching compilers. **`docs/releases.md`** documents the ARM whisper build and that cache behavior. **`scripts/workflow-security.test.mjs`** asserts the ARM-only `if`, the CMake env vars, and that clang-cl runs **before** the unsigned compile and packaged build steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c44394c3612d02f025f03fc9f9de0ebab6b2f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->