### PR TITLE
refactor(desktop): extract shared transcript primitives from chat

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AssistantMessageBody.tsx
+++ b/crates/tidebreak-desktop/ui/src/AssistantMessageBody.tsx
@@ -1,0 +1,23 @@
+import { MessageMarkdown } from "./MessageMarkdown";
+import { useStreamingTypewriter } from "./useStreamingTypewriter";
+
+/**
+ * Assistant prose driven by the typewriter: while the bubble is the live
+ * streaming turn its text is typed in, and a settled or rehydrated message
+ * renders at once. Block-level memoization inside {@link MessageMarkdown} keeps
+ * each tick's re-parse confined to the trailing block.
+ */
+export function AssistantMessageBody({
+  text,
+  streaming,
+  containerRef,
+}: {
+  text: string;
+  streaming: boolean;
+  containerRef?: React.Ref<HTMLDivElement>;
+}) {
+  const displayed = useStreamingTypewriter(text, streaming);
+  return (
+    <MessageMarkdown containerRef={containerRef}>{displayed}</MessageMarkdown>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/ChatView.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.tsx
@@ -9,11 +9,8 @@ import {
 } from "react";
 import type { ApiClient, Chat } from "./api";
 import type { RendererTurnUsage } from "./generated/wire";
-import {
-  followScrollBehavior,
-  isNearBottom,
-  scrollToLatest,
-} from "./ChatScroll";
+import { followScrollBehavior } from "./ChatScroll";
+import { useTranscriptFollow } from "./useTranscriptFollow";
 import { useChatSessionStore } from "./ChatSessionStore";
 import {
   useComposerAttachments,
@@ -290,170 +287,37 @@ export function ChatView({
     [navigationSignature],
   );
 
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
   /** The composer's slot, which a pending question or plan card takes over. */
   const promptSlotRef = useRef<HTMLDivElement | null>(null);
-  const followsLatestRef = useRef(true);
-  const isProgrammaticRef = useRef(false);
-  const isSmoothScrollingRef = useRef(false);
-  const smoothScrollRequestedRef = useRef(false);
   const visibleContinuationCallIdsRef = useRef<Set<string>>(new Set());
-  const scrollObserverRef = useRef<ResizeObserver | null>(null);
-  const contentObserverRef = useRef<ResizeObserver | null>(null);
-  const [scrolledAway, setScrolledAway] = useState(false);
-  const [fadeClass, setFadeClass] = useState<string | null>(null);
+  const {
+    scrollRef: attachScrollRef,
+    contentRef: attachContentRef,
+    onScroll: handleScroll,
+    scrolledAway,
+    fadeClass,
+    scrollToBottom,
+    armFollow,
+    disarmFollow,
+    isFollowing,
+    scrollElement,
+    viewportRef,
+    beginProgrammaticScroll,
+    endProgrammaticScroll,
+    requestSmoothFollow,
+  } = useTranscriptFollow({ visible: transcriptVisible });
   // True once the reader has sent in this mounted session. Gates the turn pin so
   // a freshly loaded history reads normally, then the just-sent turn is held tall
   // enough to land near the top of the viewport.
   const [pinLastTurn, setPinLastTurn] = useState(false);
 
-  // Reflect where the scroll sits onto the edge-fade masks: fade the top once
-  // there is content above, the bottom while there is content below.
-  const updateEdges = useCallback(() => {
-    const scroll = scrollRef.current;
-    if (!scroll) return;
-    const fromTop = scroll.scrollTop > 0;
-    const fromBottom =
-      scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight > 1;
-    setFadeClass(
-      fromTop && fromBottom
-        ? "is-faded-both"
-        : fromTop
-          ? "is-faded-top"
-          : fromBottom
-            ? "is-faded-bottom"
-            : null,
-    );
-  }, []);
-
-  const instantScrollToBottom = useCallback(() => {
-    const scroll = scrollRef.current;
-    if (!scroll) return;
-    isProgrammaticRef.current = true;
-    setScrolledAway(false);
-    scrollToLatest(scroll, "auto");
-    requestAnimationFrame(() => {
-      isProgrammaticRef.current = false;
-    });
-  }, []);
-
-  const smoothScrollToBottom = useCallback(() => {
-    const scroll = scrollRef.current;
-    if (!scroll) return;
-    isSmoothScrollingRef.current = true;
-    isProgrammaticRef.current = true;
-    setScrolledAway(false);
-    scrollToLatest(scroll, followScrollBehavior(false));
-
-    const done = () => {
-      isSmoothScrollingRef.current = false;
-      isProgrammaticRef.current = false;
-      // Content may have grown while the animation was targeting an older
-      // bottom. Catch up once, without starting another animation.
-      if (followsLatestRef.current) instantScrollToBottom();
-    };
-    let timeout: ReturnType<typeof setTimeout>;
-    const onScrollEnd = () => {
-      clearTimeout(timeout);
-      done();
-    };
-    scroll.addEventListener("scrollend", onScrollEnd, { once: true });
-    timeout = setTimeout(() => {
-      scroll.removeEventListener("scrollend", onScrollEnd);
-      done();
-    }, 800);
-  }, [instantScrollToBottom]);
-
-  // Jump to the latest message. Marked programmatic so the resulting scroll
-  // events don't read as the reader deliberately scrolling away.
-  const scrollToBottom = useCallback(
-    (behavior: ScrollBehavior) => {
-      if (behavior === "smooth") smoothScrollToBottom();
-      else instantScrollToBottom();
-    },
-    [instantScrollToBottom, smoothScrollToBottom],
-  );
-
-  const enableFollow = useCallback(() => {
-    followsLatestRef.current = true;
-    instantScrollToBottom();
-  }, [instantScrollToBottom]);
-
-  const handleScroll = useCallback(() => {
-    updateEdges();
-    if (isProgrammaticRef.current) return;
-    const scroll = scrollRef.current;
-    if (!scroll) return;
-    const away = !isNearBottom(scroll);
-    setScrolledAway(away);
-    // Drifting away disarms follow; re-arming is deliberate (the button, or a
-    // send), never a side effect of scrolling back toward the bottom.
-    if (away && followsLatestRef.current) followsLatestRef.current = false;
-  }, [updateEdges]);
-
-  // Track the scroll viewport height in a CSS variable so a pinned turn can
-  // reserve roughly a screenful, and keep the edge fades honest across resizes.
-  const attachScrollRef = useCallback(
-    (element: HTMLDivElement | null) => {
-      scrollObserverRef.current?.disconnect();
-      scrollRef.current = element;
-      setScrollElement(element);
-      if (!element) return;
-      const observer = new ResizeObserver(() => {
-        element.style.setProperty(
-          "--transcript-viewport",
-          `${element.clientHeight}px`,
-        );
-        updateEdges();
-      });
-      observer.observe(element);
-      scrollObserverRef.current = observer;
-    },
-    [updateEdges],
-  );
-
-  // Follow asynchronous layout growth (image loads, markdown reflow) that no
-  // React state change announces, so a following reader stays pinned to the end.
-  const attachContentRef = useCallback(
-    (element: HTMLDivElement | null) => {
-      contentObserverRef.current?.disconnect();
-      if (!element) return;
-      const observer = new ResizeObserver(() => {
-        if (!transcriptVisible) return;
-        if (smoothScrollRequestedRef.current) {
-          smoothScrollRequestedRef.current = false;
-          scrollToBottom(followScrollBehavior(false));
-        } else if (
-          followsLatestRef.current &&
-          !isSmoothScrollingRef.current
-        ) {
-          scrollToBottom("auto");
-        }
-        const scroll = scrollRef.current;
-        if (scroll) setScrolledAway(!isNearBottom(scroll));
-        updateEdges();
-      });
-      observer.observe(element);
-      contentObserverRef.current = observer;
-    },
-    [transcriptVisible, scrollToBottom, updateEdges],
-  );
-
   // A conversation starts live at its tail. Streaming growth itself is handled
-  // only by the content ResizeObserver above; reacting to every message-array
-  // replacement as well makes token updates repeatedly restart scrolling and
-  // can fight a reader who is trying to move upward.
+  // only by the content ResizeObserver in the follow hook; reacting to every
+  // message-array replacement as well makes token updates repeatedly restart
+  // scrolling and can fight a reader who is trying to move upward.
   useEffect(() => {
-    enableFollow();
-  }, [chat.id, enableFollow]);
-
-  // The transcript can remain mounted while a neighboring panel takes the
-  // space. Restore a following reader to the tail when it becomes visible.
-  useEffect(() => {
-    if (transcriptVisible && followsLatestRef.current) scrollToBottom("auto");
-    updateEdges();
-  }, [transcriptVisible, scrollToBottom, updateEdges]);
+    armFollow();
+  }, [chat.id, armFollow]);
 
   useEffect(() => {
     const next = new Set([
@@ -466,11 +330,12 @@ export function ChatView({
     );
     visibleContinuationCallIdsRef.current = next;
     if (!gainedRequest) return;
-    if (followsLatestRef.current) scrollToBottom(followScrollBehavior(false));
+    if (isFollowing()) scrollToBottom(followScrollBehavior(false));
   }, [
     folderAccess.requests,
     outputWritebacks.requests,
     userQuestions.requests,
+    isFollowing,
     scrollToBottom,
   ]);
 
@@ -498,12 +363,11 @@ export function ChatView({
     };
     const attempt = () => {
       if (settled) return;
-      if (revealPendingCall(scrollRef.current, focusCallId)) {
+      if (revealPendingCall(viewportRef.current, focusCallId)) {
         // Arriving at a specific card means the reader is no longer following
         // the end of the transcript; letting follow stay armed would scroll them
         // straight back off it.
-        followsLatestRef.current = false;
-        setScrolledAway(true);
+        disarmFollow();
         clear();
         return;
       }
@@ -519,7 +383,14 @@ export function ChatView({
       window.clearInterval(timer);
       window.clearTimeout(deadline);
     };
-  }, [focusCallId, transcriptVisible, chat.id, navigate]);
+  }, [
+    focusCallId,
+    transcriptVisible,
+    chat.id,
+    disarmFollow,
+    navigate,
+    viewportRef,
+  ]);
 
   // The router's hash is already occupied by hash history, so a rail jump is
   // represented by `?at=`. Keeping it in the URL makes an anchored reload land
@@ -535,9 +406,8 @@ export function ChatView({
         (element) => element.dataset.transcriptAnchor === anchoredMessageId,
       );
       if (!target) return;
-      followsLatestRef.current = false;
-      setScrolledAway(true);
-      isProgrammaticRef.current = true;
+      disarmFollow();
+      beginProgrammaticScroll();
       const containerRect = scrollElement.getBoundingClientRect();
       const targetRect = target.getBoundingClientRect();
       scrollElement.scrollTo({
@@ -547,12 +417,18 @@ export function ChatView({
         ),
         behavior: "smooth",
       });
-      window.setTimeout(() => {
-        isProgrammaticRef.current = false;
-      }, 800);
+      window.setTimeout(endProgrammaticScroll, 800);
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [anchoredMessageId, messages, scrollElement, transcriptVisible]);
+  }, [
+    anchoredMessageId,
+    beginProgrammaticScroll,
+    disarmFollow,
+    endProgrammaticScroll,
+    messages,
+    scrollElement,
+    transcriptVisible,
+  ]);
 
   const jumpToMessage = useCallback(
     (anchorId: string) => {
@@ -581,9 +457,8 @@ export function ChatView({
         replace: true,
       });
     }
-    followsLatestRef.current = true;
-    scrollToBottom(followScrollBehavior(false));
-  }, [anchoredMessageId, chat.id, navigate, scrollToBottom]);
+    armFollow(followScrollBehavior(false));
+  }, [anchoredMessageId, armFollow, chat.id, navigate]);
 
   const handleSend = useCallback(async () => {
     setPinLastTurn(true);
@@ -598,10 +473,17 @@ export function ChatView({
         replace: true,
       });
     }
-    enableFollow();
-    smoothScrollRequestedRef.current = true;
+    armFollow();
+    requestSmoothFollow();
     await onSend();
-  }, [anchoredMessageId, chat.id, enableFollow, navigate, onSend]);
+  }, [
+    anchoredMessageId,
+    armFollow,
+    chat.id,
+    navigate,
+    onSend,
+    requestSmoothFollow,
+  ]);
 
   return (
     <section className="chat-pane">

--- a/crates/tidebreak-desktop/ui/src/MessageList.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo, useMemo, useRef } from "react";
+import { memo, useMemo, useRef } from "react";
 import { Wand2 } from "lucide-react";
 import type { ReactNode, Ref, RefCallback, UIEvent } from "react";
 import type {
@@ -26,6 +26,9 @@ import type {
 import { OutputWritebackCard } from "./OutputWritebackCard";
 import { MessageMarkdown } from "./MessageMarkdown";
 import { MessageFooter } from "./MessageFooter";
+import { AssistantMessageBody } from "./AssistantMessageBody";
+import { TranscriptSkeleton } from "./TranscriptSkeleton";
+import { UserMessage } from "./UserMessage";
 import { AssistantSources, type AssistantSource } from "./AssistantSources";
 import { ThinkingAccordion } from "./ThinkingAccordion";
 import { stripCitationDirectives } from "./citationDirectives";
@@ -61,8 +64,6 @@ import {
   turnFailureOffersRetry,
 } from "./TurnFailureNotice";
 import type { TurnFailureCategory } from "./generated/wire";
-import { useStreamingTypewriter } from "./useStreamingTypewriter";
-import { Skeleton } from "./components/ui/skeleton";
 import { ChangeSummaryCard } from "./ChangeSummaryCard";
 
 export type ChatMessage =
@@ -473,26 +474,6 @@ export function MessageList({
           </>
         )}
       </div>
-    </div>
-  );
-}
-
-/** Placeholder rows that echo the transcript's shape while history hydrates. */
-function TranscriptSkeleton() {
-  return (
-    <div className="flex w-full flex-col gap-4" aria-hidden="true">
-      {[0, 1, 2, 3].map((row) => (
-        <Fragment key={row}>
-          <Skeleton className="h-9 w-1/2 self-start rounded-xl" />
-          <div className="flex flex-col gap-2.5 py-2">
-            <Skeleton className="h-3 w-full" />
-            <Skeleton className="h-3 w-full" />
-            <Skeleton className="h-3 w-full" />
-            <Skeleton className="h-3 w-5/6" />
-            <Skeleton className="h-3 w-1/3" />
-          </div>
-        </Fragment>
-      ))}
     </div>
   );
 }
@@ -1043,27 +1024,6 @@ function surfacedCard(entry: ChatMessage, context: CardContext): ReactNode {
 }
 
 /**
- * Assistant prose driven by the typewriter: while the bubble is the live
- * streaming turn its text is typed in, and a settled or rehydrated message
- * renders at once. Block-level memoization inside {@link MessageMarkdown} keeps
- * each tick's re-parse confined to the trailing block.
- */
-function AssistantMessageBody({
-  text,
-  streaming,
-  containerRef,
-}: {
-  text: string;
-  streaming: boolean;
-  containerRef?: React.Ref<HTMLDivElement>;
-}) {
-  const displayed = useStreamingTypewriter(text, streaming);
-  return (
-    <MessageMarkdown containerRef={containerRef}>{displayed}</MessageMarkdown>
-  );
-}
-
-/**
  * The skills a durable user message named, read back from the transcript.
  *
  * Read-only by construction: the message has already been sent, so there is
@@ -1205,43 +1165,40 @@ function MessageBubbleImpl({
 
   if (message.role === "user") {
     return (
-      <div className="message-user-frame">
-        <article
-          className="message message-user"
-          aria-label="You"
-          data-transcript-anchor={message.id}
-        >
-          {message.images &&
-            message.images.length > 0 &&
-            imageClient &&
-            chatId &&
-            isolatedCard(
-              `${message.id}-images`,
-              message.images.map((image) => image.attachmentId).join(" "),
-              <TranscriptImageAttachments
-                client={imageClient}
-                chatId={chatId}
-                images={message.images}
-              />,
-            )}
-          {message.files &&
-            message.files.length > 0 &&
-            isolatedCard(
-              `${message.id}-files`,
-              message.files.map((file) => file.documentId).join(" "),
-              <TranscriptFileAttachments files={message.files} />,
-            )}
-          <MessageMarkdown>{message.text}</MessageMarkdown>
-          {message.invokedSkills && message.invokedSkills.length > 0 && (
+      <UserMessage
+        text={message.text}
+        createdAt={message.createdAt}
+        anchorId={message.id}
+        leading={
+          <>
+            {message.images &&
+              message.images.length > 0 &&
+              imageClient &&
+              chatId &&
+              isolatedCard(
+                `${message.id}-images`,
+                message.images.map((image) => image.attachmentId).join(" "),
+                <TranscriptImageAttachments
+                  client={imageClient}
+                  chatId={chatId}
+                  images={message.images}
+                />,
+              )}
+            {message.files &&
+              message.files.length > 0 &&
+              isolatedCard(
+                `${message.id}-files`,
+                message.files.map((file) => file.documentId).join(" "),
+                <TranscriptFileAttachments files={message.files} />,
+              )}
+          </>
+        }
+        trailing={
+          message.invokedSkills && message.invokedSkills.length > 0 ? (
             <TranscriptInvokedSkills skills={message.invokedSkills} />
-          )}
-        </article>
-        <MessageFooter
-          role="user"
-          text={message.text}
-          createdAt={message.createdAt}
-        />
-      </div>
+          ) : null
+        }
+      />
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -70,7 +70,15 @@ export function ToolCardShell({
             aria-hidden="true"
           />
           {icon}
-          <span className={cn("truncate", titleClassName)}>{title}</span>
+          {/* A truncated command is unreadable, and the card's body may not
+              repeat it. The native tooltip gives the whole line back to anyone
+              who hovers, for the titles that are plain text to begin with. */}
+          <span
+            className={cn("truncate", titleClassName)}
+            title={typeof title === "string" ? title : undefined}
+          >
+            {title}
+          </span>
         </span>
         {/* One end cluster: a fragment would become sibling flex children,
             so justify-between would split them and they would not share a

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.dom.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ToolOutputPreview } from "./ToolOutputPreview";
+
+const twelveLines = Array.from(
+  { length: 12 },
+  (_, index) => `line ${index + 1}`,
+).join("\n");
+
+afterEach(cleanup);
+
+describe("ToolOutputPreview", () => {
+  it("clamps long output and gives the rest back on request", async () => {
+    render(<ToolOutputPreview text={twelveLines} collapsedLines={8} />);
+
+    const body = screen.getByLabelText("Output");
+    expect(body.textContent).toContain("line 8");
+    expect(body.textContent).not.toContain("line 9");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show 4 more lines" }),
+    );
+
+    expect(screen.getByLabelText("Output").textContent).toContain("line 12");
+    expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
+  });
+
+  it("leaves short output whole, with the copy control still available", () => {
+    render(<ToolOutputPreview text={"one\ntwo"} />);
+
+    expect(screen.getByLabelText("Output").textContent).toBe("one\ntwo");
+    expect(screen.queryByRole("button", { name: /more line/ })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy output" })).toBeTruthy();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -1,0 +1,77 @@
+import { useId, useMemo, useState } from "react";
+
+import { ClipboardCopyButton } from "./ClipboardCopyButton";
+
+/** How much of a tool's output is worth showing before the reader asks. */
+export const DEFAULT_COLLAPSED_LINES = 8;
+
+type ToolOutputPreviewProps = {
+  /** What the tool printed, verbatim. */
+  text: string;
+  /** Lines shown before the expander takes over. */
+  collapsedLines?: number;
+  /** What this block is, for the copy control and assistive technology. */
+  label?: string;
+};
+
+/**
+ * A tool's output, clamped to the first few lines with the rest one click away.
+ *
+ * Output is the part of a transcript most likely to be enormous and least
+ * likely to be read in full, so the default is a glance: enough lines to see
+ * what happened, an honest count of what is hidden, and the whole text on the
+ * clipboard whether or not it is expanded. Clamping by line rather than by
+ * height keeps the count in the expander truthful — "show 40 more lines" that
+ * turns out to be four is worse than no count at all.
+ */
+export function ToolOutputPreview({
+  text,
+  collapsedLines = DEFAULT_COLLAPSED_LINES,
+  label = "Output",
+}: ToolOutputPreviewProps) {
+  const [expanded, setExpanded] = useState(false);
+  const bodyId = useId();
+  // A trailing newline is punctuation, not a line worth offering to expand.
+  const lines = useMemo(() => text.replace(/\n+$/, "").split("\n"), [text]);
+  const hiddenCount = Math.max(0, lines.length - collapsedLines);
+  const body =
+    hiddenCount > 0 && !expanded
+      ? lines.slice(0, collapsedLines).join("\n")
+      : lines.join("\n");
+
+  if (text.trim().length === 0) return null;
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <div className="group relative w-full">
+        <pre
+          id={bodyId}
+          aria-label={label}
+          className="bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-xs break-words whitespace-pre-wrap"
+        >
+          {body}
+        </pre>
+        <ClipboardCopyButton
+          value={text}
+          label={`Copy ${label.toLowerCase()}`}
+          copiedAnnouncement={`${label} copied to clipboard.`}
+          failedAnnouncement={`${label} could not be copied.`}
+          className="border-border bg-background text-muted-foreground hover:text-foreground absolute top-1 right-1 inline-flex items-center rounded-md border p-1 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
+        />
+      </div>
+      {hiddenCount > 0 && (
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
+          aria-expanded={expanded}
+          aria-controls={bodyId}
+          onClick={() => setExpanded((current) => !current)}
+        >
+          {expanded
+            ? "Show less"
+            : `Show ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/TranscriptSkeleton.tsx
+++ b/crates/tidebreak-desktop/ui/src/TranscriptSkeleton.tsx
@@ -1,0 +1,23 @@
+import { Fragment } from "react";
+
+import { Skeleton } from "./components/ui/skeleton";
+
+/** Placeholder rows that echo the transcript's shape while history hydrates. */
+export function TranscriptSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-4" aria-hidden="true">
+      {[0, 1, 2, 3].map((row) => (
+        <Fragment key={row}>
+          <Skeleton className="h-9 w-1/2 self-start rounded-xl" />
+          <div className="flex flex-col gap-2.5 py-2">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-5/6" />
+            <Skeleton className="h-3 w-1/3" />
+          </div>
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/UserMessage.tsx
+++ b/crates/tidebreak-desktop/ui/src/UserMessage.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+import { MessageMarkdown } from "./MessageMarkdown";
+import { MessageFooter } from "./MessageFooter";
+
+type UserMessageProps = {
+  /** What the reader sent, rendered as Markdown like the rest of the turn. */
+  text: string;
+  /** ISO timestamp behind the footer's relative time, when the mode has one. */
+  createdAt?: string;
+  /** Landing point for transcript-rail and deep-link jumps. */
+  anchorId?: string;
+  /** Rendered above the prose — chat puts its image and file attachments here. */
+  leading?: ReactNode;
+  /** Rendered below the prose — chat puts the skills the turn invoked here. */
+  trailing?: ReactNode;
+};
+
+/**
+ * One thing the reader said, in the frame every mode's transcript uses: the
+ * bubble carries the prose, the footer under it carries the timestamp.
+ *
+ * The slots exist because the frame is shared but its contents are not — chat
+ * hangs attachments and invoked skills off a user turn, and code mode has
+ * neither. Keeping the structure here rather than in each mode's transcript is
+ * what makes a user message read the same in both.
+ */
+export function UserMessage({
+  text,
+  createdAt,
+  anchorId,
+  leading,
+  trailing,
+}: UserMessageProps) {
+  return (
+    <div className="message-user-frame">
+      <article
+        className="message message-user"
+        aria-label="You"
+        data-transcript-anchor={anchorId}
+      >
+        {leading}
+        <MessageMarkdown>{text}</MessageMarkdown>
+        {trailing}
+      </article>
+      <MessageFooter role="user" text={text} createdAt={createdAt} />
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/useTranscriptFollow.ts
+++ b/crates/tidebreak-desktop/ui/src/useTranscriptFollow.ts
@@ -1,0 +1,254 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefCallback,
+  type RefObject,
+} from "react";
+
+import {
+  followScrollBehavior,
+  isNearBottom,
+  scrollToLatest,
+} from "./ChatScroll";
+
+export type TranscriptFollow = {
+  /** Attach to the scrolling viewport. */
+  scrollRef: RefCallback<HTMLDivElement>;
+  /** Attach to the growing content inside the viewport. */
+  contentRef: RefCallback<HTMLDivElement>;
+  /** Attach to the viewport's `onScroll`. */
+  onScroll: () => void;
+  /** Whether the reader has moved off the tail of the transcript. */
+  scrolledAway: boolean;
+  /** Which edges have more content beyond them, as a wrapper class. */
+  fadeClass: string | null;
+  /** Jump to the latest content, without arming follow. */
+  scrollToBottom: (behavior: ScrollBehavior) => void;
+  /** Follow the latest again, and go there. */
+  armFollow: (behavior?: ScrollBehavior) => void;
+  /** Stop following: the reader has been sent somewhere specific. */
+  disarmFollow: () => void;
+  /** Whether follow is armed, readable without a re-render. */
+  isFollowing: () => boolean;
+  /** The viewport element, once mounted, for consumers that re-render on it. */
+  scrollElement: HTMLDivElement | null;
+  /** The viewport, readable without a re-render. */
+  viewportRef: RefObject<HTMLDivElement | null>;
+  /** Suppress reader-intent handling while an imperative scroll runs. */
+  beginProgrammaticScroll: () => void;
+  endProgrammaticScroll: () => void;
+  /** Ease to the tail once the next content growth lands. */
+  requestSmoothFollow: () => void;
+};
+
+/**
+ * The transcript's scroll-follow machine: stay pinned to the newest content
+ * while the reader wants to be, get out of the way the moment they don't, and
+ * report where the scroll sits so the frame can fade its edges.
+ *
+ * Follow is armed deliberately — by opening a conversation, sending, or asking
+ * to return to the latest — and disarmed by drifting away from the tail. It is
+ * never re-armed by scrolling back down, because a reader who scrolled to read
+ * something is not asking to be dragged along by the next token.
+ *
+ * The edge fades are a class on the wrapper, painted as overlay
+ * pseudo-elements. Never move them to a `mask-image` on the scrolling layer:
+ * that is what WKWebView failed to repaint after the mount-time catch-up
+ * scroll, leaving a laid-out transcript blank (see `styles.css`).
+ */
+export function useTranscriptFollow({
+  visible = true,
+}: {
+  /** False while another surface covers the transcript's slot. */
+  visible?: boolean;
+} = {}): TranscriptFollow {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const followsLatestRef = useRef(true);
+  const isProgrammaticRef = useRef(false);
+  const isSmoothScrollingRef = useRef(false);
+  const smoothScrollRequestedRef = useRef(false);
+  const scrollObserverRef = useRef<ResizeObserver | null>(null);
+  const contentObserverRef = useRef<ResizeObserver | null>(null);
+  const [scrolledAway, setScrolledAway] = useState(false);
+  const [fadeClass, setFadeClass] = useState<string | null>(null);
+
+  // Reflect where the scroll sits onto the edge-fade masks: fade the top once
+  // there is content above, the bottom while there is content below.
+  const updateEdges = useCallback(() => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    const fromTop = scroll.scrollTop > 0;
+    const fromBottom =
+      scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight > 1;
+    setFadeClass(
+      fromTop && fromBottom
+        ? "is-faded-both"
+        : fromTop
+          ? "is-faded-top"
+          : fromBottom
+            ? "is-faded-bottom"
+            : null,
+    );
+  }, []);
+
+  const instantScrollToBottom = useCallback(() => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    isProgrammaticRef.current = true;
+    setScrolledAway(false);
+    scrollToLatest(scroll, "auto");
+    requestAnimationFrame(() => {
+      isProgrammaticRef.current = false;
+    });
+  }, []);
+
+  const smoothScrollToBottom = useCallback(() => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    isSmoothScrollingRef.current = true;
+    isProgrammaticRef.current = true;
+    setScrolledAway(false);
+    scrollToLatest(scroll, followScrollBehavior(false));
+
+    const done = () => {
+      isSmoothScrollingRef.current = false;
+      isProgrammaticRef.current = false;
+      // Content may have grown while the animation was targeting an older
+      // bottom. Catch up once, without starting another animation.
+      if (followsLatestRef.current) instantScrollToBottom();
+    };
+    let timeout: ReturnType<typeof setTimeout>;
+    const onScrollEnd = () => {
+      clearTimeout(timeout);
+      done();
+    };
+    scroll.addEventListener("scrollend", onScrollEnd, { once: true });
+    timeout = setTimeout(() => {
+      scroll.removeEventListener("scrollend", onScrollEnd);
+      done();
+    }, 800);
+  }, [instantScrollToBottom]);
+
+  // Jump to the latest message. Marked programmatic so the resulting scroll
+  // events don't read as the reader deliberately scrolling away.
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior) => {
+      if (behavior === "smooth") smoothScrollToBottom();
+      else instantScrollToBottom();
+    },
+    [instantScrollToBottom, smoothScrollToBottom],
+  );
+
+  const armFollow = useCallback(
+    (behavior: ScrollBehavior = "auto") => {
+      followsLatestRef.current = true;
+      scrollToBottom(behavior);
+    },
+    [scrollToBottom],
+  );
+
+  const disarmFollow = useCallback(() => {
+    followsLatestRef.current = false;
+    setScrolledAway(true);
+  }, []);
+
+  const isFollowing = useCallback(() => followsLatestRef.current, []);
+
+  const beginProgrammaticScroll = useCallback(() => {
+    isProgrammaticRef.current = true;
+  }, []);
+
+  const endProgrammaticScroll = useCallback(() => {
+    isProgrammaticRef.current = false;
+  }, []);
+
+  const requestSmoothFollow = useCallback(() => {
+    smoothScrollRequestedRef.current = true;
+  }, []);
+
+  const onScroll = useCallback(() => {
+    updateEdges();
+    if (isProgrammaticRef.current) return;
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    const away = !isNearBottom(scroll);
+    setScrolledAway(away);
+    // Drifting away disarms follow; re-arming is deliberate (the button, or a
+    // send), never a side effect of scrolling back toward the bottom.
+    if (away && followsLatestRef.current) followsLatestRef.current = false;
+  }, [updateEdges]);
+
+  // Track the scroll viewport height in a CSS variable so a pinned turn can
+  // reserve roughly a screenful, and keep the edge fades honest across resizes.
+  const attachScrollRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      scrollObserverRef.current?.disconnect();
+      scrollRef.current = element;
+      setScrollElement(element);
+      if (!element) return;
+      const observer = new ResizeObserver(() => {
+        element.style.setProperty(
+          "--transcript-viewport",
+          `${element.clientHeight}px`,
+        );
+        updateEdges();
+      });
+      observer.observe(element);
+      scrollObserverRef.current = observer;
+    },
+    [updateEdges],
+  );
+
+  // Follow asynchronous layout growth (image loads, markdown reflow) that no
+  // React state change announces, so a following reader stays pinned to the end.
+  const attachContentRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      contentObserverRef.current?.disconnect();
+      if (!element) return;
+      const observer = new ResizeObserver(() => {
+        if (!visible) return;
+        if (smoothScrollRequestedRef.current) {
+          smoothScrollRequestedRef.current = false;
+          scrollToBottom(followScrollBehavior(false));
+        } else if (followsLatestRef.current && !isSmoothScrollingRef.current) {
+          scrollToBottom("auto");
+        }
+        const scroll = scrollRef.current;
+        if (scroll) setScrolledAway(!isNearBottom(scroll));
+        updateEdges();
+      });
+      observer.observe(element);
+      contentObserverRef.current = observer;
+    },
+    [visible, scrollToBottom, updateEdges],
+  );
+
+  // The transcript can remain mounted while a neighboring panel takes the
+  // space. Restore a following reader to the tail when it becomes visible.
+  useEffect(() => {
+    if (visible && followsLatestRef.current) scrollToBottom("auto");
+    updateEdges();
+  }, [visible, scrollToBottom, updateEdges]);
+
+  return {
+    scrollRef: attachScrollRef,
+    contentRef: attachContentRef,
+    onScroll,
+    scrolledAway,
+    fadeClass,
+    scrollToBottom,
+    armFollow,
+    disarmFollow,
+    isFollowing,
+    scrollElement,
+    viewportRef: scrollRef,
+    beginProgrammaticScroll,
+    endProgrammaticScroll,
+    requestSmoothFollow,
+  };
+}


### PR DESCRIPTION
Groundwork for the code-mode transcript overhaul. ADR 0030 asks code mode to
share UI primitives with chat rather than grow a second implementation of the
same transcript, and today those primitives are private to `MessageList` and
`ChatView`. This moves them out. Chat is the only consumer in this change, and
the DOM it renders is unchanged — verified by rendering a user turn with
attachments and invoked skills before and after and diffing the markup.

## What moved

- `src/UserMessage.tsx` — the user branch of `MessageBubbleImpl`: the
  `.message-user-frame` wrapper, the `.message.message-user` article with its
  `aria-label` and transcript anchor, the Markdown body, and the footer. Chat's
  image and file attachments pass as `leading`, its invoked skills as
  `trailing`, because those are chat's and code mode has neither.
- `src/AssistantMessageBody.tsx` — moved verbatim from `MessageList.tsx`.
- `src/TranscriptSkeleton.tsx` — moved verbatim from `MessageList.tsx`.
- `src/useTranscriptFollow.ts` — `ChatView`'s scroll-follow machine, moved as
  it stood: `followsLatest` with drift-disarm, programmatic-scroll marking, the
  `scrollend` re-pin, the `--transcript-viewport` variable, the edge-fade class,
  and both ResizeObservers. It composes the pure helpers in `ChatScroll.ts`,
  which stays where it is. `ChatView` keeps the parts that are its own — the
  deep-link reveal, the `?at=` anchor jump, per-chat re-arming — and drives them
  through the hook's `armFollow` / `disarmFollow` / programmatic-scroll controls
  rather than reaching into refs.

The edge fades stay wrapper-overlay pseudo-elements (`.message-view::before` /
`::after`). No `mask-image` goes anywhere near the scrolling layer: masking a
composited scroll layer is what WKWebView occasionally failed to repaint after
the mount-time catch-up scroll, and `styles.css` says so at the rule.

## What is new

- `src/ToolOutputPreview.tsx` — a shared mono block clamped to the first lines
  of a tool's output, with an honest "Show N more lines" expander and a copy
  control revealed on hover or focus. Nothing adopts it yet; it lands here so
  the code transcript can stop rendering raw `pre` blocks in the next change.
- `ToolCardShell` gives a truncated title a native `title` attribute when the
  title is a string, so a long command is readable on hover. Chat benefits too.

## Tests

The existing chat DOM suite is the regression net and passes unchanged — no
test needed an import update. One new DOM test covers `ToolOutputPreview`
(clamp, expand, copy present). No tests were deleted.

`pnpm test` (1129 passing) and `pnpm build` are green locally.
