### PR TITLE
feat(desktop): default code sessions to Allow and speed up workspace creation

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -1,8 +1,44 @@
 import { create } from "zustand";
 
+import type { HarnessKind } from "../api/types";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 
 const REVIEW_SIDEBAR_OPEN_KEY = "tidebreak.code-review-sidebar-open";
+const LAST_CREATE_KEY = "tidebreak.code-last-create";
+
+/** What the reader picked the last time they created a workspace. */
+export type CodeCreateDefaults = {
+  repoId?: string;
+  harness?: HarnessKind;
+  model?: string;
+};
+
+function readStoredCreateDefaults(): CodeCreateDefaults | null {
+  try {
+    const raw = window.localStorage.getItem(LAST_CREATE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    const record = parsed as Record<string, unknown>;
+    const text = (value: unknown) =>
+      typeof value === "string" && value.length > 0 ? value : undefined;
+    return {
+      repoId: text(record.repoId),
+      harness: text(record.harness) as HarnessKind | undefined,
+      model: text(record.model),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function storeCreateDefaults(defaults: CodeCreateDefaults): void {
+  try {
+    window.localStorage.setItem(LAST_CREATE_KEY, JSON.stringify(defaults));
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
 
 function readStoredReviewSidebarOpen(): boolean {
   try {
@@ -35,6 +71,11 @@ function storeReviewSidebarOpen(open: boolean): void {
  *
  * The review rail is the same kind of chrome as the left sidebar: it is not
  * a URL, and a reload should not forget whether it was showing.
+ *
+ * `lastCreate` is the tie-breaker for the new-workspace dialog's defaults.
+ * The catalog answers "what did you work on last" for anyone with a
+ * workspace already; this covers the first run of a window and the reader
+ * whose newest workspace is not the one they want to repeat.
  */
 export type CodeUiStore = {
   newWorkspaceOpen: boolean;
@@ -42,6 +83,7 @@ export type CodeUiStore = {
   newWorkspaceRepoId: string | undefined;
   addRepoOpen: boolean;
   reviewSidebarOpen: boolean;
+  lastCreate: CodeCreateDefaults | null;
   /**
    * Ask for a workspace, from a repo page or from anywhere in code mode.
    *
@@ -54,6 +96,8 @@ export type CodeUiStore = {
   setAddRepoOpen: (open: boolean) => void;
   toggleReviewSidebar: () => void;
   setReviewSidebarOpen: (open: boolean) => void;
+  /** Record a successful create so the next dialog opens on the same choices. */
+  rememberCreate: (defaults: CodeCreateDefaults) => void;
 };
 
 export const useCodeUiStore = create<CodeUiStore>()((set) => ({
@@ -61,6 +105,7 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   newWorkspaceRepoId: undefined,
   addRepoOpen: false,
   reviewSidebarOpen: readStoredReviewSidebarOpen(),
+  lastCreate: readStoredCreateDefaults(),
   startNewWorkspace: (repoId) => {
     const { repos } = useCodeCatalogStore.getState();
     if (repos.length === 0) {
@@ -84,5 +129,9 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   setReviewSidebarOpen: (open) => {
     storeReviewSidebarOpen(open);
     set({ reviewSidebarOpen: open });
+  },
+  rememberCreate: (defaults) => {
+    storeCreateDefaults(defaults);
+    set({ lastCreate: defaults });
   },
 }));

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -58,6 +58,8 @@ describe("HarnessPicker", () => {
     const trigger = screen.getByRole("combobox", { name: "Harness" });
     expect(trigger).toHaveTextContent("Claude Code");
     await user.click(trigger);
+    // Ready rows carry the product name and nothing else: no vendor gloss.
+    expect(screen.getByRole("option", { name: "Codex CLI" })).toBeInTheDocument();
     expect(
       screen.getByRole("option", { name: /Not installed/ }),
     ).toHaveAttribute("aria-disabled", "true");

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/components/ui/select";
 import {
   HARNESS_LABELS,
-  HARNESS_SUBTITLES,
   harnessUnusableReason,
 } from "./labels";
 
@@ -32,12 +31,13 @@ const HARNESS_ICONS: Record<
 };
 
 /**
- * Branded harness dropdown: logo, product name, one-line subtitle per row.
+ * Branded harness dropdown: logo and product name per row.
  *
- * Ready rows are selectable. Unusable rows stay listed, disabled, with a
- * short reason in place of the subtitle; a quiet link to the doctor appears
- * under the control while any row is unusable. Versions and capability
- * flags stay off this surface.
+ * Ready rows are selectable and carry nothing but the name — a vendor gloss
+ * tells a reader picking an engine nothing they do not already know.
+ * Unusable rows stay listed, disabled, with the one reason they cannot be
+ * chosen; a quiet link to the doctor appears under the control while any row
+ * is unusable. Versions and capability flags stay off this surface.
  */
 export function HarnessPicker({
   harnesses,
@@ -89,9 +89,11 @@ export function HarnessPicker({
                     <span className="truncate font-medium">
                       {HARNESS_LABELS[entry.kind]}
                     </span>
-                    <span className="text-muted-foreground truncate text-xs">
-                      {reason ?? HARNESS_SUBTITLES[entry.kind]}
-                    </span>
+                    {reason && (
+                      <span className="text-muted-foreground truncate text-xs">
+                        {reason}
+                      </span>
+                    )}
                   </span>
                 </span>
               </SelectItem>

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import { renderWithRouter } from "@/test/router";
+import type {
+  CodeRepoSnapshot,
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+  HarnessDoctorEntry,
+  HarnessKind,
+} from "../api/types";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
+import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+
+afterEach(() => {
+  cleanup();
+  useCodeCatalogStore.getState().reset();
+  useCodeUiStore.setState({ lastCreate: null });
+});
+
+const CAPS = {
+  resume: "supported",
+  streaming_deltas: "supported",
+  mid_turn_steering: "unsupported",
+  plan_mode: "supported",
+  auto_mode: "supported",
+  allow_mode: "supported",
+  reasoning_levels: "unknown",
+  native_file_change_events: "unsupported",
+  native_interrupt: "supported",
+  structured_approvals: "supported",
+} as const;
+
+function harness(kind: HarnessKind): HarnessDoctorEntry {
+  return {
+    kind,
+    found: true,
+    tier: "reference",
+    caps: { ...CAPS },
+    remediation: "",
+    stderr: "",
+    unrecognized_event_count: 0,
+  } as HarnessDoctorEntry;
+}
+
+function repo(id: string, name: string): CodeRepoSnapshot {
+  return {
+    id,
+    root_path: `/tmp/${name}`,
+    display_name: name,
+    default_base_ref: "main",
+    branch_prefix: "tidebreak/",
+    quick_actions: [],
+    created_at: "2026-08-01T00:00:00.000Z",
+  } as CodeRepoSnapshot;
+}
+
+function workspace(id: string, repoId: string, createdAt: string) {
+  return {
+    id,
+    repo_id: repoId,
+    title: id,
+    worktree_path: `/tmp/wt/${id}`,
+    branch_name: `tidebreak/${id}`,
+    base_ref: "main",
+    status: "active",
+    created_at: createdAt,
+  } as CodeWorkspaceSnapshot;
+}
+
+function session(workspaceId: string, kind: HarnessKind, createdAt: string) {
+  return {
+    id: `sess-${workspaceId}`,
+    workspace_id: workspaceId,
+    harness_kind: kind,
+    permission_mode: "ask",
+    lifecycle: "idle",
+    attention: { state: { type: "working" }, source: "engine" },
+    unrecognized_event_count: 0,
+    created_at: createdAt,
+  } as unknown as CodeSessionSnapshot;
+}
+
+function app(client: Partial<AppContextValue["client"]>): AppContextValue {
+  return {
+    client: client as never,
+    models: [],
+    defaultModelKey: null,
+    providers: [],
+    refreshCatalog: async () => {},
+    refreshChats: async () => {},
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: { status: "idle", version: null, error: null, enabled: false },
+    updateUpToDate: false,
+    checkForUpdate: async () => ({
+      status: "idle",
+      version: null,
+      error: null,
+      enabled: false,
+    }),
+    restartForUpdate: async () => {},
+  } as AppContextValue;
+}
+
+describe("NewWorkspaceDialog", () => {
+  it("opens on the last repo, harness, and model, and creates on Cmd+Enter", async () => {
+    const repos = [repo("repo-old", "legacy"), repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      workspaces: [
+        workspace("ws-1", "repo-old", "2026-08-10T00:00:00.000Z"),
+        workspace("ws-2", "repo-new", "2026-08-17T00:00:00.000Z"),
+      ],
+      sessionsByWorkspace: {
+        "ws-1": session("ws-1", "claude_code", "2026-08-10T00:00:00.000Z"),
+        "ws-2": session("ws-2", "codex", "2026-08-17T00:00:00.000Z"),
+      },
+      doctor: {
+        harnesses: [harness("claude_code"), harness("codex")],
+        notices: [],
+      } as never,
+    });
+    const createCodeWorkspace = vi.fn(async () =>
+      workspace("ws-3", "repo-new", "2026-08-18T00:00:00.000Z"),
+    );
+    const createCodeSession = vi.fn(async () =>
+      session("ws-3", "codex", "2026-08-18T00:00:00.000Z"),
+    );
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace,
+          createCodeSession,
+          listCodeHarnessModels: vi.fn(async () => ({
+            kind: "codex" as const,
+            models: [{ id: "gpt-5.6-sol", label: "GPT 5.6 Sol", default: true }],
+          })),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const repoField = screen.getByRole("combobox", { name: "Repo" });
+    expect(repoField).toHaveTextContent("tidebreak");
+    expect(repoField).toHaveFocus();
+    expect(screen.getByRole("combobox", { name: "Harness" })).toHaveTextContent(
+      "Codex CLI",
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("combobox", { name: "Model" })).toHaveTextContent(
+        "GPT 5.6 Sol",
+      ),
+    );
+    // Allow is the default where the engine honors it, and it says so.
+    expect(
+      screen.getByRole("combobox", { name: "Permission mode" }),
+    ).toHaveTextContent("Allow all");
+    expect(
+      screen.getByText(/every action runs without asking/),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+    await waitFor(() =>
+      expect(createCodeWorkspace).toHaveBeenCalledWith({
+        repo_id: "repo-new",
+        title: undefined,
+        base_ref: "main",
+      }),
+    );
+    expect(createCodeSession).toHaveBeenCalledWith("ws-3", {
+      harness: "codex",
+      permission_mode: "allow",
+      model: "gpt-5.6-sol",
+    });
+    await waitFor(() =>
+      expect(useCodeUiStore.getState().lastCreate).toEqual({
+        repoId: "repo-new",
+        harness: "codex",
+        model: "gpt-5.6-sol",
+      }),
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
 import type {
   CodePermissionMode,
   CodeRepoSnapshot,
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+  HarnessDoctorEntry,
   HarnessKind,
 } from "../api/types";
 import { useApp } from "@/AppContext";
@@ -26,7 +29,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { friendlyErrorMessage } from "@/lib/utils";
+import { usesCommandModifier } from "@/ShellShortcuts";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
 import { HarnessPicker } from "./HarnessPicker";
 import {
   autoIsUnsupervised,
@@ -43,16 +48,47 @@ import {
 /**
  * Create a workspace and its first session, then open it.
  *
- * The title is optional: left blank, the server generates a two-word name and
- * later replaces it with one derived from the first turn, the same way chats
- * are named. Typing a title here is the way to opt out of that.
+ * Every field arrives answered, so the dialog is one keystroke deep: Cmd+Enter
+ * from anywhere in it creates with what is on screen. Repo, harness, and model
+ * open on what this reader used last — the catalog knows, and `lastCreate`
+ * covers a fresh window. The title is optional: left blank, the server
+ * generates a two-word name and later replaces it with one derived from the
+ * first turn, the same way chats are named.
  *
- * Permission mode defaults to Ask when the doctor reports structured
- * approvals, otherwise the most autonomous non-bypass mode the harness can
- * honor. Allow is never the create default.
+ * Permission mode defaults to the most autonomous posture the harness honors
+ * (decision 0039, amended). Whichever posture that is, the row states it.
  * The harness picker lists every doctor entry. Ready rows are selectable;
  * unusable ones stay visible and dimmed.
  */
+
+/** The repo this reader worked on last: newest workspace, then storage. */
+function recentRepoId(
+  repos: readonly CodeRepoSnapshot[],
+  workspaces: readonly CodeWorkspaceSnapshot[],
+  remembered: string | undefined,
+): string {
+  const known = (id: string | undefined) =>
+    id && repos.some((repo) => repo.id === id) ? id : undefined;
+  const newest = [...workspaces]
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))
+    .find((workspace) => known(workspace.repo_id));
+  return known(newest?.repo_id) ?? known(remembered) ?? repos[0]?.id ?? "";
+}
+
+/** The engine this reader started last, if it can still be started. */
+function recentHarness(
+  ready: readonly HarnessDoctorEntry[],
+  sessions: Record<string, CodeSessionSnapshot>,
+  remembered: HarnessKind | undefined,
+): HarnessKind | undefined {
+  const newest = Object.values(sessions).sort((a, b) =>
+    b.created_at.localeCompare(a.created_at),
+  )[0];
+  for (const kind of [newest?.harness_kind, remembered]) {
+    if (kind && ready.some((entry) => entry.kind === kind)) return kind;
+  }
+  return ready[0]?.kind;
+}
 
 export function NewWorkspaceDialog({
   open,
@@ -68,37 +104,56 @@ export function NewWorkspaceDialog({
   const navigate = useNavigate();
   const { client, models, defaultModelKey } = useApp();
   const doctor = useCodeCatalogStore((state) => state.doctor);
+  const sessions = useCodeCatalogStore((state) => state.sessionsByWorkspace);
   const upsertWorkspace = useCodeCatalogStore((state) => state.upsertWorkspace);
   const rememberSession = useCodeCatalogStore((state) => state.rememberSession);
   const ensureHarnessModels = useCodeCatalogStore(
     (state) => state.ensureHarnessModels,
   );
-  const [repoId, setRepoId] = useState(defaultRepoId ?? repos[0]?.id ?? "");
+  const lastCreate = useCodeUiStore((state) => state.lastCreate);
+  const rememberCreate = useCodeUiStore((state) => state.rememberCreate);
+  const [repoId, setRepoId] = useState("");
   const [title, setTitle] = useState("");
   const [baseRef, setBaseRef] = useState("");
-  const [harness, setHarness] = useState<HarnessKind>("claude_code");
+  const [pickedHarness, setPickedHarness] = useState<HarnessKind | null>(null);
   const [permissionMode, setPermissionMode] = useState<CodePermissionMode | null>(
     null,
   );
   const [creating, setCreating] = useState(false);
   const [model, setModel] = useState<string | undefined>();
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
+  const repoTrigger = useRef<HTMLButtonElement>(null);
+  const command = useMemo(() => usesCommandModifier(navigator.userAgent), []);
 
   const allHarnesses = doctor?.harnesses ?? [];
   const readyHarnesses = allHarnesses.filter(
     (entry) => !harnessUnusableReason(entry),
   );
+  // The doctor can land after the dialog opens, so the engine is derived
+  // rather than seeded: a pick wins, and until there is one the recent
+  // engine follows whatever the report says is ready.
+  const harness: HarnessKind =
+    (pickedHarness && readyHarnesses.some((e) => e.kind === pickedHarness)
+      ? pickedHarness
+      : undefined) ??
+    recentHarness(readyHarnesses, sessions, lastCreate?.harness) ??
+    "claude_code";
 
   useEffect(() => {
     if (!open) return;
-    setRepoId(defaultRepoId ?? repos[0]?.id ?? "");
+    const { workspaces: known } = useCodeCatalogStore.getState();
+    const nextRepo =
+      defaultRepoId ?? recentRepoId(repos, known, lastCreate?.repoId);
+    setRepoId(nextRepo);
     setTitle("");
-    const selected = repos.find((repo) => repo.id === (defaultRepoId ?? repos[0]?.id));
-    setBaseRef(selected?.default_base_ref ?? "");
-    setHarness(readyHarnesses[0]?.kind ?? "claude_code");
+    setBaseRef(
+      repos.find((repo) => repo.id === nextRepo)?.default_base_ref ?? "",
+    );
+    setPickedHarness(null);
     setPermissionMode(null);
     setModel(undefined);
-    // Reset against the dialog opening, not against doctor refreshes mid-open.
+    // Reset against the dialog opening, not against catalog refreshes
+    // mid-open — a workspace created elsewhere must not move this form.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, defaultRepoId, repos]);
 
@@ -118,33 +173,37 @@ export function NewWorkspaceDialog({
 
   useEffect(() => {
     if (!open || !harness) return;
+    // The reader's last model wins where it is still on offer; otherwise the
+    // catalog's default, then the first row.
+    const pick = (listed: CodeModelOption[]) => (current?: string) => {
+      for (const candidate of [current, lastCreate?.model]) {
+        if (candidate && listed.some((option) => option.id === candidate)) {
+          return candidate;
+        }
+      }
+      return listed.find((option) => option.default)?.id ?? listed[0]?.id;
+    };
     const gateway = gatewayCodeModels(models, harness, defaultModelKey);
     if (gateway.length > 0) {
       setModelOptions(gateway);
-      setModel((current) =>
-        current && gateway.some((option) => option.id === current)
-          ? current
-          : (gateway.find((option) => option.default)?.id ?? gateway[0]?.id),
-      );
+      setModel(pick(gateway));
       return;
     }
     let cancelled = false;
     void ensureHarnessModels(client, harness).then((listed) => {
       if (cancelled) return;
       setModelOptions(listed);
-      setModel((current) =>
-        current && listed.some((option) => option.id === current)
-          ? current
-          : (listed.find((option) => option.default)?.id ?? listed[0]?.id),
-      );
+      setModel(pick(listed));
     });
     return () => {
       cancelled = true;
     };
+    // `lastCreate` is a seed, not a subscription: re-running on it would
+    // undo a deliberate pick the moment another create records one.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, defaultModelKey, ensureHarnessModels, harness, models, open]);
 
-  async function submit(event: FormEvent) {
-    event.preventDefault();
+  async function create() {
     if (!canCreate) return;
     setCreating(true);
     try {
@@ -167,6 +226,7 @@ export function NewWorkspaceDialog({
         model: posted,
       });
       rememberSession(session);
+      rememberCreate({ repoId, harness, model: posted });
       onOpenChange(false);
       await navigate({
         to: "/code/w/$workspaceId",
@@ -179,9 +239,30 @@ export function NewWorkspaceDialog({
     }
   }
 
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    void create();
+  }
+
   return (
     <Dialog open={open} onOpenChange={creating ? undefined : onOpenChange}>
-      <DialogContent className="max-w-md gap-5 p-5" aria-busy={creating}>
+      <DialogContent
+        className="max-w-md gap-5 p-5"
+        aria-busy={creating}
+        onOpenAutoFocus={(event) => {
+          const trigger = repoTrigger.current;
+          if (!trigger || trigger.hasAttribute("disabled")) return;
+          event.preventDefault();
+          trigger.focus();
+        }}
+        onKeyDownCapture={(event) => {
+          // Cmd+Enter (Ctrl+Enter off macOS) creates with what is on screen,
+          // whichever field has focus. Plain Enter stays field-local.
+          if (event.key !== "Enter" || !(event.metaKey || event.ctrlKey)) return;
+          event.preventDefault();
+          void create();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>New workspace</DialogTitle>
           <DialogDescription>
@@ -200,7 +281,7 @@ export function NewWorkspaceDialog({
               }}
               disabled={creating || Boolean(defaultRepoId) || repos.length === 0}
             >
-              <SelectTrigger aria-label="Repo">
+              <SelectTrigger aria-label="Repo" ref={repoTrigger}>
                 <SelectValue placeholder="No repos" />
               </SelectTrigger>
               <SelectContent scrollButtons={false}>
@@ -219,7 +300,6 @@ export function NewWorkspaceDialog({
               onChange={(event) => setTitle(event.target.value)}
               disabled={creating}
               placeholder="Named automatically"
-              autoFocus
             />
           </label>
           <label className="flex flex-col gap-1 text-sm">
@@ -236,7 +316,7 @@ export function NewWorkspaceDialog({
             <HarnessPicker
               harnesses={allHarnesses}
               value={harness}
-              onChange={setHarness}
+              onChange={setPickedHarness}
               disabled={creating}
             />
           </div>
@@ -244,7 +324,13 @@ export function NewWorkspaceDialog({
             <span className="font-medium">Model</span>
             <Select
               value={model}
-              onValueChange={setModel}
+              // A model list that arrives after the first render lands its
+              // rows and its value in the same commit, and the select's
+              // hidden native input answers that with an empty change event.
+              // An empty id is never a model, so it is not a choice.
+              onValueChange={(next) => {
+                if (next) setModel(next);
+              }}
               disabled={creating || modelOptions.length === 0}
             >
               <SelectTrigger aria-label="Model">
@@ -307,6 +393,15 @@ export function NewWorkspaceDialog({
             </Button>
             <Button type="submit" disabled={!canCreate}>
               {creating ? "Creating…" : "Create"}
+              {!creating && (
+                <span
+                  className="ml-1 inline-flex items-center gap-0.5 text-2xs font-medium opacity-60"
+                  aria-hidden="true"
+                >
+                  <kbd className="font-sans">{command ? "⌘" : "Ctrl"}</kbd>
+                  <kbd className="font-sans">↩</kbd>
+                </span>
+              )}
             </Button>
           </DialogFooter>
         </form>

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -42,7 +42,7 @@ function entry(
 }
 
 describe("StartSessionPrompt", () => {
-  it("defaults to Ask and posts Ask when the doctor supports structured approvals", async () => {
+  it("defaults to the widest mode the engine honors, says so, and starts on Cmd+Enter", async () => {
     const user = userEvent.setup();
     const onStart = vi.fn();
     await renderWithRouter(
@@ -54,12 +54,16 @@ describe("StartSessionPrompt", () => {
         onStart={onStart}
       />,
     );
-    expect(screen.getByRole("button", { name: "Permissions: Ask" })).toBeInTheDocument();
-    await user.type(screen.getByRole("textbox", { name: "Message" }), "list the files");
-    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(
+      screen.getByRole("button", { name: "Permissions: Allow all" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(ALLOW_ALL_NOTE)).toBeInTheDocument();
+    const field = screen.getByRole("textbox", { name: "Message" });
+    await user.type(field, "list the files");
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
     expect(onStart).toHaveBeenCalledWith(
       "claude_code",
-      "ask",
+      "allow",
       "list the files",
       undefined,
     );
@@ -152,13 +156,13 @@ describe("StartSessionPrompt", () => {
     await user.click(screen.getByRole("button", { name: "Send message" }));
     expect(onStart).toHaveBeenCalledWith(
       "claude_code",
-      "ask",
+      "allow",
       "list the files",
       "claude-opus-5",
     );
   });
 
-  it("states Allow all when that mode is chosen", async () => {
+  it("narrows to a picked mode", async () => {
     const user = userEvent.setup();
     const onSelectMode = vi.fn();
     await renderWithRouter(
@@ -170,8 +174,6 @@ describe("StartSessionPrompt", () => {
         onStart={vi.fn()}
       />,
     );
-    expect(screen.getByRole("button", { name: "Permissions: Allow all" })).toBeInTheDocument();
-    expect(screen.getByText(ALLOW_ALL_NOTE)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Permissions: Allow all" }));
     await user.click(screen.getByRole("menuitem", { name: /Ask/ }));
     expect(onSelectMode).toHaveBeenCalledWith("ask");

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { ApiClient } from "../api/client";
 import type {
@@ -28,8 +28,12 @@ const NO_CATALOG_MODELS: ModelInfo[] = [];
  *
  * The harness dropdown defaults to the first ready engine; the mode list and
  * default follow the selected engine's own capability flags, so start always
- * posts a mode that engine can honor. Unsupervised Auto says so before the
- * session exists (decision 0038).
+ * posts a mode that engine can honor, and an unsupervised one says so before
+ * the session exists (decisions 0038, 0039).
+ *
+ * Cmd+Enter starts from anywhere on this surface, matching the new-workspace
+ * dialog. The draft lives in the composer, so the shortcut goes through the
+ * composer's own send button: one submit path, one set of disabled rules.
  */
 export function StartSessionPrompt({
   harnesses,
@@ -58,6 +62,7 @@ export function StartSessionPrompt({
   const [picked, setPicked] = useState<HarnessKind | null>(null);
   const [model, setModel] = useState<string | undefined>();
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
+  const root = useRef<HTMLDivElement>(null);
   const ensureHarnessModels = useCodeCatalogStore((state) => state.ensureHarnessModels);
   const ready = harnesses.filter((entry) => !harnessUnusableReason(entry));
   const selected =
@@ -106,7 +111,19 @@ export function StartSessionPrompt({
   }, [catalogModels, client, defaultModelKey, ensureHarnessModels, selectedKind]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div
+      ref={root}
+      className="flex min-h-0 flex-1 flex-col"
+      onKeyDownCapture={(event) => {
+        if (event.key !== "Enter" || !(event.metaKey || event.ctrlKey)) return;
+        const send = root.current?.querySelector<HTMLButtonElement>(
+          'button[aria-label="Send message"]',
+        );
+        if (!send || send.disabled) return;
+        event.preventDefault();
+        send.click();
+      }}
+    >
       <div className="flex flex-col gap-3 px-4 py-6">
         <p className="text-sm">Start a session on this workspace.</p>
         <HarnessPicker

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -20,16 +20,23 @@ function caps(
 }
 
 describe("create-time permission mode", () => {
-  it("defaults to Ask when the engine can honor it, never Allow", () => {
+  it("defaults to the most autonomous mode the engine honors", () => {
     expect(
       defaultCreatePermissionMode(caps("supported", "supported", "supported", "supported")),
-    ).toBe("ask");
+    ).toBe("allow");
     expect(
       createPermissionModes(caps("supported", "supported", "supported", "supported")),
     ).toEqual(["plan", "ask", "auto", "allow"]);
+    // Down the scale one flag at a time: Allow, then Auto, then Ask.
+    expect(
+      defaultCreatePermissionMode(caps("supported", "supported", "supported")),
+    ).toBe("auto");
+    expect(
+      defaultCreatePermissionMode(caps("supported", "supported", "unsupported")),
+    ).toBe("ask");
   });
 
-  it("falls back to Plan when structured approvals are not supported", () => {
+  it("falls back to Plan when no wider mode is supported", () => {
     expect(
       defaultCreatePermissionMode(caps("supported", "unsupported", "unsupported")),
     ).toBe("plan");
@@ -48,9 +55,6 @@ describe("create-time permission mode", () => {
       ["auto", "allow"],
     );
     expect(defaultCreatePermissionMode(grok)).toBe("auto");
-    expect(
-      defaultCreatePermissionMode(caps("unsupported", "unsupported", "supported", "supported")),
-    ).toBe("auto");
     expect(autoIsUnsupervised(grok)).toBe(true);
     // Supervised Auto rides the approval channel and needs no statement.
     expect(autoIsUnsupervised(caps("supported", "supported", "supported"))).toBe(

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -26,14 +26,6 @@ export const HARNESS_LABELS: Record<HarnessKind, string> = {
   grok: "Grok CLI",
 };
 
-/** One-line product gloss for the picker. Not how the adapter works. */
-export const HARNESS_SUBTITLES: Record<HarnessKind, string> = {
-  claude_code: "Anthropic's coding agent",
-  codex: "OpenAI's coding agent",
-  opencode: "Open-source coding agent",
-  grok: "xAI's coding agent",
-};
-
 export const HARNESS_TIER_LABELS: Record<HarnessTier, string> = {
   reference: "Reference",
   secondary: "Secondary",
@@ -127,14 +119,16 @@ export function autoIsUnsupervised(caps: ModeCaps): boolean {
 }
 
 /**
- * Create default: Ask when the engine can honor it. Otherwise the most
- * autonomous non-bypass posture it actually has. Allow is always opt-in
- * (decision 0033).
+ * Create default: the most autonomous posture the engine honors, walking
+ * Allow → Auto → Ask → Plan (decision 0039, amended 2026-08-18). Approving
+ * every step of a fresh session cost more than it caught, so create starts
+ * where the work runs. The mode is never silent: whichever surface offers it
+ * states the posture next to the control (decisions 0033, 0038).
  */
 export function defaultCreatePermissionMode(caps: ModeCaps): CodePermissionMode {
-  if (caps.structured_approvals === "supported") return "ask";
+  if (caps.allow_mode === "supported") return "allow";
   if (caps.auto_mode === "supported") return "auto";
-  if (caps.plan_mode === "supported") return "plan";
+  if (caps.structured_approvals === "supported") return "ask";
   return "plan";
 }
 

--- a/docs/decisions/0039-allow-is-a-first-class-code-permission-mode.md
+++ b/docs/decisions/0039-allow-is-a-first-class-code-permission-mode.md
@@ -1,6 +1,6 @@
 # 39. Allow Is a First-Class Code Permission Mode
 
-- Status: Proposed
+- Status: Proposed (amended 2026-08-18, see [Amendment](#amendment-2026-08-18))
 - Date: 2026-08-17
 - Owners: code mode, approvals
 - Related: [`0033-code-mode-approvals.md`](0033-code-mode-approvals.md),
@@ -104,3 +104,27 @@ if usage shows Allow being chosen without the statement landing.
   statement renders exactly when Allow is the selected create mode.
 - The denylist test still fails a Plan / Ask / Auto plan that includes a
   bypass flag, including via extra argv.
+
+## Amendment (2026-08-18)
+
+**The create default is now the most autonomous mode the engine honors**,
+walking `Allow → Auto → Ask → Plan` and stopping at the first flag that
+says `supported`. The rest of this record stands: the scale, the per-mode
+capability flags, the exhaustive adapter mapping, and the closed bypass
+denylist for every mode but Allow are unchanged.
+
+Why: supervision cost dominated the create flow. Every new session opened
+in Ask and then spent its first minutes on approvals for reads and edits
+inside a throwaway worktree — the confinement code mode already provides
+([`0032`](0032-code-workspaces-worktrees-checkpoints.md)). Choosing the
+posture per session stays available; it is no longer the price of starting.
+
+What does not change: the statement. Allow and unsupervised Auto still say
+what they are next to the control that selects them, and now that they can
+arrive by default, that statement renders on open rather than only after a
+deliberate pick.
+
+Revisit if an unsupervised default causes an incident — a session that
+damages something outside its worktree, or acts on a prompt the reader
+would have stopped at the approval — or if readers report not seeing the
+posture they were started in.


### PR DESCRIPTION
Opening a code workspace used to cost five decisions and a round of approvals before any work started. This makes the create flow one keystroke deep.

## Permission mode defaults to Allow

`defaultCreatePermissionMode` now walks the scale down from the top — Allow, then Auto, then Ask, then Plan — and stops at the first mode the harness's own capability flag says it honors. Nothing else about decision 0039 changes: the flags, the adapter mapping, and the closed bypass denylist for every mode but Allow all stand.

The statement rule stands too. Allow and unsupervised Auto still say what they are next to the control that selects them; now that they can arrive by default, that statement renders on open rather than only after a deliberate pick.

Decision 0039 recorded `Ask` as the default, so it carries a dated amendment (the record's status line points at it) covering the new default, why supervision cost dominated the create flow, and what would revisit it: an incident caused by an unsupervised default.

## The dialog remembers

`NewWorkspaceDialog` preselects the repo of the newest workspace in the catalog, the harness of the most recently started session, and the model through the existing default-model plumbing. A small `lastCreate` record in `CodeUiStore` (localStorage, like `reviewSidebarOpen`) is the tie-breaker for a fresh window, written after a successful create. Focus starts on the repo field.

## Cmd+Enter

Cmd+Enter (Ctrl+Enter off macOS) submits from anywhere in the dialog with the values on screen, disabled while creating and when there is no repo to create against. Plain Enter keeps its field-local behavior. The same binding starts the session from `StartSessionPrompt`, routed through the composer's own send button so it obeys one set of disabled rules. The Create button carries the keycap hint the project dialog already uses.

## Harness picker

Rows are logo and product name. The vendor blurbs ("Anthropic's coding agent", …) told a reader choosing an engine nothing they did not already know. The subtitle slot stays for the functional unusable-reason line on disabled rows.

## Fix found on the way

The model select's hidden native input answers an async model list — rows and value landing in the same commit — with an empty change event, which wiped the preselected model. An empty id is never a model, so it is no longer treated as a choice.

## Tests

Added one DOM test (`NewWorkspaceDialog.dom.test.tsx`): the dialog opens prefilled from a seeded catalog (most-recent repo and harness, listed default model, Allow stated) and Cmd+Enter posts those values.

Replaced, with the reason for each:

- `labels.test.ts` "defaults to Ask when the engine can honor it, never Allow" — asserted the superseded default; rewritten to walk the new scale one flag at a time.
- `labels.test.ts` grok case, the `defaultCreatePermissionMode(auto + allow) === "auto"` assertion — that combination now defaults to Allow, and the rewritten first test covers it.
- `StartSessionPrompt.dom.test.tsx` "defaults to Ask and posts Ask…" — same superseded default; replaced by one that asserts the Allow default, its statement, and the new Cmd+Enter start in a single run.
- `StartSessionPrompt.dom.test.tsx` "states Allow all when that mode is chosen" — its statement assertion is now duplicate coverage of the default; kept only the mode-menu wiring it uniquely covered.
- `HarnessPicker.dom.test.tsx` — extended the existing row test with an exact-name match, so a subtitle creeping back onto a ready row fails.

`pnpm vitest run` 1128 passed, `pnpm build` clean.