### PR TITLE
feat(desktop): render code-mode turn outcomes and adopt shared transcript primitives

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -26,6 +26,12 @@ export type CodeSessionControllerOptions = {
    */
   hydrateTurns?: () => Promise<CodeTurnSnapshot[]>;
   onHydrate?: (turns: CodeTurnSnapshot[]) => void;
+  /**
+   * The snapshot settled, whether it arrived or failed. The transcript hangs
+   * its skeleton on this rather than on `onHydrate`, so a session whose history
+   * could not be read still reaches a state the reader can send from.
+   */
+  onHydrateSettled?: () => void;
 };
 
 /**
@@ -69,6 +75,7 @@ export class CodeSessionController {
         if (this.disposed) return;
       }
     }
+    this.options.onHydrateSettled?.();
     this.connect();
   }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -4,6 +4,7 @@ import {
   applyAcceptedTurn,
   hydrateCodeTurns,
   initialCodeSessionState,
+  markCodeSessionHydrated,
   reduceCodeSessionEvent,
   userItemId,
   type CodeSessionDeps,
@@ -218,6 +219,7 @@ describe("hydrate then replay", () => {
       id: userItemId("t1"),
       turnId: "t1",
       text: "list the files",
+      createdAt: NOW,
     });
     expect(hydrated.items[1]).toMatchObject({
       kind: "turn_boundary",
@@ -241,6 +243,7 @@ describe("hydrate then replay", () => {
       kind: "user",
       turnId: "t1",
       text: "list the files",
+      createdAt: NOW,
     });
     expect(
       replayed.state.items.filter((item) => item.kind === "turn_boundary"),
@@ -287,6 +290,7 @@ describe("hydrate then replay", () => {
       kind: "user",
       turnId: "t1",
       text: "list the files",
+      createdAt: NOW,
     });
   });
 
@@ -301,5 +305,39 @@ describe("hydrate then replay", () => {
     ]);
     expect(again.items.filter((item) => item.kind === "user")).toHaveLength(1);
     expect(again.items[0]?.id).toBe(userItemId("t1"));
+    expect(again.items[0]).toMatchObject({ createdAt: NOW });
+  });
+});
+
+describe("hydration flag", () => {
+  it("starts unset and flips only when the snapshot settles", () => {
+    const initial = initialCodeSessionState();
+    expect(initial.hydrated).toBe(false);
+
+    // Applying turns is not settlement: a snapshot that never arrives still
+    // has to flip, so the flag is not a side effect of hydrateCodeTurns.
+    const withTurns = hydrateCodeTurns(initial, [SNAPSHOT_TURN]);
+    expect(withTurns.hydrated).toBe(false);
+
+    const settled = markCodeSessionHydrated(withTurns);
+    expect(settled.hydrated).toBe(true);
+    expect(settled.items).toBe(withTurns.items);
+    expect(markCodeSessionHydrated(settled)).toBe(settled);
+  });
+});
+
+describe("user item createdAt", () => {
+  it("carries the turn's started_at on accept and hydrate", () => {
+    const accepted = applyAcceptedTurn(initialCodeSessionState(), SNAPSHOT_TURN);
+    expect(accepted.items[0]).toMatchObject({
+      kind: "user",
+      createdAt: NOW,
+    });
+
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [SNAPSHOT_TURN]);
+    expect(hydrated.items[0]).toMatchObject({
+      kind: "user",
+      createdAt: NOW,
+    });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -28,6 +28,8 @@ export type CodeTranscriptItem =
       id: string;
       turnId: string;
       text: string;
+      /** When the server accepted the turn, for the message footer's time. */
+      createdAt: string;
     }
   | {
       kind: "assistant";
@@ -81,6 +83,15 @@ export type CodeSessionState = {
   lastSeq: number;
   /** Whether new stream presentation should animate rather than catch up. */
   animateStreaming: boolean;
+  /**
+   * Whether the durable turn snapshot has settled, either way.
+   *
+   * A session that has not hydrated yet is transiently empty, which reads
+   * exactly like a session with nothing in it. The transcript shows a skeleton
+   * until this flips, so an existing session does not flash its empty state
+   * before its history lands.
+   */
+  hydrated: boolean;
   items: CodeTranscriptItem[];
   busy: boolean;
   activeTurnId: string | null;
@@ -119,6 +130,7 @@ export function initialCodeSessionState(): CodeSessionState {
   return {
     lastSeq: 0,
     animateStreaming: true,
+    hydrated: false,
     items: [],
     busy: false,
     activeTurnId: null,
@@ -142,6 +154,19 @@ export function boundaryItemId(turnId: string): string {
 }
 
 /**
+ * The durable snapshot has settled, whether it arrived or failed.
+ *
+ * The skeleton comes down either way: a snapshot that could not be read leaves
+ * an empty transcript the reader can send into, not a placeholder that never
+ * resolves.
+ */
+export function markCodeSessionHydrated(
+  state: CodeSessionState,
+): CodeSessionState {
+  return state.hydrated ? state : { ...state, hydrated: true };
+}
+
+/**
  * Record a turn the server accepted. Create and hydrate share this so a
  * reopen and a live send produce the same turn-keyed user item.
  */
@@ -154,6 +179,9 @@ export function applyAcceptedTurn(
     id: userItemId(turn.id),
     turnId: turn.id,
     text: turn.user_input,
+    // Every accepted turn carries its own start, live or replayed, so the
+    // prompt's timestamp never depends on when this client happened to see it.
+    createdAt: turn.started_at,
   };
   const hasUser = state.items.some(
     (item) => item.kind === "user" && item.turnId === turn.id,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -24,6 +24,24 @@ afterEach(() => {
 });
 
 describe("CodeSessionRegistry", () => {
+  it("marks the session hydrated even when the snapshot cannot be read", async () => {
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => new FakeSocket(after, onFrame) as unknown as WebSocket;
+
+    const store = acquireCodeSession("s1", openSocket, undefined, async () => {
+      throw new Error("offline");
+    });
+    expect(store.getState().hydrated).toBe(false);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    // The skeleton has to come down either way: a snapshot that never arrives
+    // must leave a transcript the reader can send into.
+    expect(store.getState().hydrated).toBe(true);
+  });
+
   it("shares one store across two acquires and closes the socket on last release", () => {
     const sockets: FakeSocket[] = [];
     const openSocket = (after: number, onFrame: (frame: SequencedCodeEventFrame) => void) => {
@@ -83,6 +101,7 @@ describe("CodeSessionRegistry", () => {
       id: userItemId("t1"),
       turnId: "t1",
       text: "list the files",
+      createdAt: "2026-08-15T12:00:00.000Z",
     });
     expect(sockets[0]?.after).toBe(0);
 
@@ -153,6 +172,7 @@ describe("CodeSessionRegistry", () => {
       id: userItemId("t2"),
       turnId: "t2",
       text: "and run the tests",
+      createdAt: "2026-08-15T12:00:03.000Z",
     });
     expect(calls).toBe(2);
   });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -8,6 +8,7 @@ import {
 import {
   applyAcceptedTurn,
   hydrateCodeTurns,
+  markCodeSessionHydrated,
   type CodeSessionDeps,
 } from "./CodeSessionReducer";
 
@@ -91,6 +92,9 @@ export function acquireCodeSession(
     hydrateTurns,
     onHydrate: (turns) => {
       store.getState().update((session) => hydrateCodeTurns(session, turns));
+    },
+    onHydrateSettled: () => {
+      store.getState().update(markCodeSessionHydrated);
     },
   });
   registry.set(sessionId, { store, controller, refCount: 1 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
@@ -26,6 +26,7 @@ describe("submitAcceptedTurn", () => {
         id: userItemId("turn-1"),
         turnId: "turn-1",
         text: "list the files",
+        createdAt: "2026-08-15T12:00:00.000Z",
       },
     ]);
   });

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { CodeTranscript } from "./CodeTranscript";
@@ -9,8 +9,21 @@ afterEach(() => {
   cleanup();
 });
 
+const USAGE = {
+  input_tokens: 12_400,
+  output_tokens: 3_100,
+  cache_read_input_tokens: 900,
+  cache_creation_input_tokens: 40,
+};
+
 const items: CodeTranscriptItem[] = [
-  { kind: "user", id: "u1", turnId: "t1", text: "list the files" },
+  {
+    kind: "user",
+    id: "u1",
+    turnId: "t1",
+    text: "list the **files**",
+    createdAt: "2026-08-15T12:00:00.000Z",
+  },
   {
     kind: "assistant",
     id: "a1",
@@ -39,25 +52,95 @@ const items: CodeTranscriptItem[] = [
     id: "b1",
     turnId: "t1",
     status: "completed",
-    durationMs: 1500,
-    usage: {
-      input_tokens: 12,
-      output_tokens: 3,
-      cache_read_input_tokens: 0,
-      cache_creation_input_tokens: 0,
-    },
+    durationMs: 134_000,
+    usage: USAGE,
     error: null,
-    diffstat: null,
+    diffstat: { files: 2, insertions: 42, deletions: 7, truncated: false },
   },
 ];
 
 describe("CodeTranscript", () => {
   it("renders assistant text, a tool card, and a harness notice", () => {
     render(<CodeTranscript items={items} />);
-    expect(screen.getByText("list the files")).toBeInTheDocument();
     expect(screen.getByText("Looking at the tree.")).toBeInTheDocument();
-    expect(screen.getByRole("status", { name: "Bash succeeded" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: "Bash succeeded" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("unrecognized event dropped")).toBeInTheDocument();
-    expect(screen.queryByText("Turn completed")).toBeNull();
+  });
+
+  it("renders the prompt as markdown with a timestamped footer", () => {
+    render(<CodeTranscript items={items} />);
+    const prompt = screen.getByRole("article", { name: "You" });
+    expect(within(prompt).getByText("files").tagName).toBe("STRONG");
+    expect(
+      screen.getByText((_, element) => element?.tagName === "TIME"),
+    ).toHaveAttribute("datetime", "2026-08-15T12:00:00.000Z");
+  });
+
+  it("closes a completed turn with its duration, diffstat, and usage", () => {
+    render(<CodeTranscript items={items} />);
+    const seam = screen.getByRole("group", { name: "Turn finished" });
+    expect(within(seam).getByText("· 2m 14s")).toBeInTheDocument();
+    expect(within(seam).getByText(/2 files \+42 −7/)).toBeInTheDocument();
+    expect(within(seam).getByText("12k in / 3k out")).toBeInTheDocument();
+  });
+
+  it("says why a failed turn failed", () => {
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "turn_boundary",
+            id: "b2",
+            turnId: "t2",
+            status: "failed",
+            durationMs: 4_000,
+            usage: null,
+            error: "claude exited with status 1",
+            diffstat: null,
+          },
+        ]}
+      />,
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Turn failed");
+    expect(alert).toHaveTextContent("claude exited with status 1");
+    expect(alert).toHaveTextContent("4s");
+  });
+
+  it("holds the transcript's shape until the session hydrates", () => {
+    const { container, rerender } = render(
+      <CodeTranscript items={[]} hydrated={false} />,
+    );
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+    expect(screen.queryByText("Send a message to start a turn.")).toBeNull();
+
+    rerender(<CodeTranscript items={[]} hydrated />);
+    expect(container.querySelector(".animate-pulse")).toBeNull();
+    expect(
+      screen.getByText("Send a message to start a turn."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the engine working only where nothing else says so", () => {
+    const { rerender } = render(<CodeTranscript items={items} busy />);
+    expect(screen.getByText("Working")).toBeInTheDocument();
+
+    rerender(
+      <CodeTranscript
+        items={[
+          {
+            kind: "assistant",
+            id: "a2",
+            turnId: "t1",
+            text: "Reading",
+            streaming: true,
+          },
+        ]}
+        busy
+      />,
+    );
+    expect(screen.queryByText("Working")).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -1,20 +1,30 @@
 import { FileCode, FileSearch, Search, SquareTerminal, Wrench } from "lucide-react";
+import type { RefCallback } from "react";
 
 import type { CodeApprovalSnapshot, ToolDetail } from "../api/types";
 import { CodeApprovalCard } from "./CodeApprovalCard";
 import { Badge } from "@/components/ui/badge";
-import { MessageMarkdown } from "@/MessageMarkdown";
+import { AssistantMessageBody } from "@/AssistantMessageBody";
+import { AssistantWorkingIndicator } from "@/AssistantWorkingIndicator";
+import { MessageFooter } from "@/MessageFooter";
+import { isolatedCard } from "@/PendingCard";
 import { ThinkingAccordion } from "@/ThinkingAccordion";
 import { ToolCardShell } from "@/ToolCardShell";
+import { TranscriptSkeleton } from "@/TranscriptSkeleton";
+import { UserMessage } from "@/UserMessage";
 import { cn } from "@/lib/utils";
 import type { CodeTranscriptItem } from "./CodeSessionReducer";
+import { TurnReviewCard } from "./TurnReviewCard";
 
 /**
- * The code-session transcript: markdown for assistant text, tool-card chrome
- * for engine work, and visible harness notices.
+ * The code-session transcript: the reader's prompts, markdown for assistant
+ * text, tool-card chrome for engine work, the approvals a turn is parked on,
+ * and what each turn came to.
  *
- * Approvals stay out of this surface. Completed-turn review chrome lives in
- * the inspector, not in the transcript.
+ * The frame is chat's — `.messages` around a `.messages-column` — because the
+ * two modes are one product and a transcript that scrolls, follows, and spaces
+ * itself differently in each reads as two (decision 0030). What differs is what
+ * goes in the column, not the column.
  */
 
 export function CodeTranscript({
@@ -23,6 +33,14 @@ export function CodeTranscript({
   decidingId,
   approvalError,
   onDecide,
+  hydrated = true,
+  busy = false,
+  streamStalled = false,
+  animateStreaming = true,
+  onOpenTurnDiff,
+  scrollRef,
+  contentRef,
+  onScroll,
 }: {
   items: CodeTranscriptItem[];
   approvals?: Record<string, CodeApprovalSnapshot>;
@@ -33,44 +51,132 @@ export function CodeTranscript({
     decision: "approve" | "deny",
     feedback?: string,
   ) => void;
+  /** False until the durable turn snapshot settles; drives the skeleton. */
+  hydrated?: boolean;
+  /** A turn is open, so the engine owes the reader something. */
+  busy?: boolean;
+  /** The open turn's stream has gone quiet — see `useStreamStalled`. */
+  streamStalled?: boolean;
+  /** False while replaying, so a reopened session does not retype itself. */
+  animateStreaming?: boolean;
+  /** Scope the review sidebar to one turn's changes. */
+  onOpenTurnDiff?: (turnId: string) => void;
+  scrollRef?: RefCallback<HTMLDivElement>;
+  contentRef?: RefCallback<HTMLDivElement>;
+  onScroll?: () => void;
 }) {
+  // Only greet a session that is genuinely empty. A session still reading its
+  // turns is transiently empty too, and inviting the reader to start a turn
+  // there would flash over history that is about to arrive.
   if (items.length === 0) {
     return (
-      <p className="text-muted-foreground px-4 py-8 text-sm">
-        Send a message to start a turn.
-      </p>
+      <div className="messages is-empty" ref={scrollRef} onScroll={onScroll}>
+        {hydrated ? (
+          <p className="text-muted-foreground text-sm">
+            Send a message to start a turn.
+          </p>
+        ) : (
+          <div className="messages-column">
+            <TranscriptSkeleton />
+          </div>
+        )}
+      </div>
     );
   }
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-4 py-4">
-      {items.map((item) => (
-        <TranscriptItem
-          key={item.id}
-          item={item}
-          approval={
-            item.kind === "approval" ? approvals[item.approvalId] : undefined
-          }
-          deciding={item.kind === "approval" && decidingId === item.approvalId}
-          approvalError={
-            item.kind === "approval" && decidingId === item.approvalId
-              ? approvalError
-              : undefined
-          }
-          onDecide={onDecide}
-        />
-      ))}
+    <div className="messages" ref={scrollRef} onScroll={onScroll}>
+      <div className="messages-column" ref={contentRef}>
+        {items.map((item) =>
+          isolatedCard(
+            item.id,
+            itemSignature(item, decidingId, approvalError),
+            <TranscriptItem
+              item={item}
+              animateStreaming={animateStreaming}
+              approval={
+                item.kind === "approval" ? approvals[item.approvalId] : undefined
+              }
+              deciding={
+                item.kind === "approval" && decidingId === item.approvalId
+              }
+              approvalError={
+                item.kind === "approval" && decidingId === item.approvalId
+                  ? approvalError
+                  : undefined
+              }
+              onDecide={onDecide}
+              onOpenTurnDiff={onOpenTurnDiff}
+            />,
+          ),
+        )}
+        {shouldShowCodeWorking(items, busy, streamStalled) && (
+          <AssistantWorkingIndicator />
+        )}
+      </div>
     </div>
   );
 }
 
+/**
+ * Whether the engine owes the reader a visible working state.
+ *
+ * Anything with its own live presentation speaks for itself: streaming prose, a
+ * running tool card, an approval waiting on a decision. The indicator covers
+ * the gaps between them — and comes back under a partial response whose stream
+ * has gone quiet, so a slow engine reads differently from a hung one.
+ */
+export function shouldShowCodeWorking(
+  items: readonly CodeTranscriptItem[],
+  busy: boolean,
+  streamStalled = false,
+): boolean {
+  if (!busy) return false;
+  const last = items[items.length - 1];
+  if (!last) return true;
+  if (last.kind === "assistant" || last.kind === "reasoning") {
+    return last.streaming ? streamStalled : true;
+  }
+  if (last.kind === "tool") return last.status !== "running";
+  if (last.kind === "approval") return last.state !== "pending";
+  return true;
+}
+
+/**
+ * The data a row draws on, reduced to what decides whether it can render, so a
+ * row that threw on a half-written result is retried when the result lands
+ * rather than staying broken for the life of the transcript.
+ */
+function itemSignature(
+  item: CodeTranscriptItem,
+  decidingId?: string | null,
+  approvalError?: string,
+): string {
+  switch (item.kind) {
+    case "tool":
+      return `${item.status}:${item.preview.length}`;
+    case "approval":
+      return `${item.state}:${decidingId === item.approvalId}:${approvalError ?? ""}`;
+    case "turn_boundary":
+      return `${item.status}:${item.diffstat?.files ?? -1}`;
+    case "assistant":
+    case "reasoning":
+      return String(item.streaming);
+    default:
+      return item.kind;
+  }
+}
+
 function TranscriptItem({
   item,
+  animateStreaming,
   approval,
   deciding,
   approvalError,
   onDecide,
+  onOpenTurnDiff,
 }: {
   item: CodeTranscriptItem;
+  animateStreaming: boolean;
   approval?: CodeApprovalSnapshot;
   deciding?: boolean;
   approvalError?: string;
@@ -79,19 +185,30 @@ function TranscriptItem({
     decision: "approve" | "deny",
     feedback?: string,
   ) => void;
+  onOpenTurnDiff?: (turnId: string) => void;
 }) {
   switch (item.kind) {
     case "user":
       return (
-        <div className="ml-auto max-w-prose rounded-lg bg-muted px-3 py-2 text-sm">
-          {item.text}
-        </div>
+        <UserMessage
+          text={item.text}
+          createdAt={item.createdAt}
+          anchorId={item.id}
+        />
       );
     case "assistant":
       return (
-        <div className="max-w-prose text-sm">
-          <MessageMarkdown>{item.text}</MessageMarkdown>
-        </div>
+        <article className="message message-assistant" aria-label="Assistant">
+          <AssistantMessageBody
+            text={item.text}
+            streaming={item.streaming && animateStreaming}
+          />
+          <MessageFooter
+            role="assistant"
+            text={item.text}
+            settled={!item.streaming}
+          />
+        </article>
       );
     case "reasoning":
       return <ThinkingAccordion text={item.text} streaming={item.streaming} />;
@@ -125,7 +242,7 @@ function TranscriptItem({
         />
       );
     case "turn_boundary":
-      return null;
+      return <TurnReviewCard turn={item} onOpenTurnDiff={onOpenTurnDiff} />;
   }
 }
 
@@ -190,7 +307,9 @@ export function HarnessNotice({
     level === "error" ? "critical" : level === "warning" ? "warning" : "info";
   return (
     <div
-      role="status"
+      // An error is the reason the turn is not going anywhere, so it interrupts
+      // the reader. A warning or an aside is announced when they get to it.
+      role={level === "error" ? "alert" : "status"}
       className={cn(
         "max-w-prose rounded-md border px-3 py-2 text-sm",
         tone === "critical" &&

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -14,6 +14,7 @@ import {
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { PanelSearch } from "@/panel/panelUrl";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { resetCodeSessionRegistry } from "./CodeSessionRegistry";
 import { useCodeUiStore } from "./CodeUiStore";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeWorkspacePage } from "./CodeWorkspacePage";
@@ -75,10 +76,47 @@ const REPO = {
   created_at: "2026-08-15T00:00:00.000Z",
 };
 
+const SESSION = {
+  id: "sess-1",
+  workspace_id: "ws-1",
+  harness_kind: "claude_code" as const,
+  permission_mode: "ask" as const,
+  lifecycle: "idle" as const,
+  attention: {
+    state: { type: "done_unreviewed" as const },
+    source: "lifecycle" as const,
+  },
+  unrecognized_event_count: 0,
+  created_at: "2026-08-15T00:00:00.000Z",
+};
+
+const TURN = {
+  id: "turn-1",
+  session_id: "sess-1",
+  ordinal: 1,
+  status: "completed" as const,
+  user_input: "list the files",
+  started_at: "2026-08-15T00:00:00.000Z",
+  ended_at: "2026-08-15T00:02:14.000Z",
+  diffstat: { files: 2, insertions: 42, deletions: 7, truncated: false },
+};
+
 function makeClient() {
   return {
     getCodeWorkspace: vi.fn(async () => WORKSPACE),
-    listCodeWorkspaceSessions: vi.fn(async () => []),
+    listCodeWorkspaceSessions: vi.fn(
+      async (): Promise<(typeof SESSION)[]> => [],
+    ),
+    listCodeSessionTurns: vi.fn(async () => [TURN]),
+    listCodeApprovals: vi.fn(async () => []),
+    openCodeEvents: vi.fn(
+      () =>
+        ({
+          close() {},
+          addEventListener() {},
+          removeEventListener() {},
+        }) as unknown as WebSocket,
+    ),
     getCodeRepo: vi.fn(async () => REPO),
     archiveCodeWorkspace: vi.fn(async () => ({
       ...WORKSPACE,
@@ -243,6 +281,7 @@ async function mountWorkspace(
 
 afterEach(() => {
   cleanup();
+  resetCodeSessionRegistry();
   useCodeCatalogStore.getState().reset();
   disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
@@ -250,6 +289,26 @@ afterEach(() => {
 });
 
 describe("CodeWorkspacePage", () => {
+  it("gives the transcript chat's scrolling frame and closes the turn it hydrated", async () => {
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    const { container } = await mountWorkspace(client);
+
+    expect(
+      await screen.findByRole("article", { name: "You" }),
+    ).toHaveTextContent("list the files");
+
+    const view = container.querySelector(".message-view");
+    expect(view).not.toBeNull();
+    // The transcript, not the panel slot, is the scroller: the pane claims its
+    // own height, so `.messages` is what overflows.
+    expect(view?.querySelector(".messages > .messages-column")).not.toBeNull();
+
+    const seam = await screen.findByRole("group", { name: "Turn finished" });
+    expect(seam).toHaveTextContent("2m 14s");
+    expect(seam).toHaveTextContent("2 files +42 −7");
+  });
+
   it("leaves the archived workspace for its repo", async () => {
     const client = makeClient();
     const { router } = await mountWorkspace(client);

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { SquareTerminal } from "lucide-react";
+import { ArrowDown, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
 import { archiveForceKind, type ApiClient } from "../api/client";
@@ -22,7 +22,10 @@ import { PanelLayout } from "@/panel/PanelLayout";
 import type { PanelContent } from "@/panel/panelTypes";
 import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
 import { RouteFrame } from "@/RouteFrame";
-import { friendlyErrorMessage } from "@/lib/utils";
+import { followScrollBehavior } from "@/ChatScroll";
+import { useStreamStalled } from "@/useStreamStalled";
+import { useTranscriptFollow } from "@/useTranscriptFollow";
+import { cn, friendlyErrorMessage } from "@/lib/utils";
 import {
   SHELL_SHORTCUTS,
   shortcutKeycaps,
@@ -440,16 +443,30 @@ function CodeSessionPane({
   catalogModels,
   defaultModelKey,
   disabled,
+  onOpenTurnDiff,
 }: {
   session: CodeSessionSnapshot;
   client: ApiClient;
   catalogModels: ModelInfo[];
   defaultModelKey: string | null;
   disabled: boolean;
+  /**
+   * Scope the review sidebar to one turn's changes, from a turn's diffstat.
+   * Left unset until the inspector can hold a scope; the diffstat reads as a
+   * plain count meanwhile rather than a control that does nothing.
+   */
+  onOpenTurnDiff?: (turnId: string) => void;
 }) {
+  const follow = useTranscriptFollow();
   const store = useRegisteredCodeSession(session.id, client);
   const items = store((state) => state.items);
   const busy = store((state) => state.busy);
+  const hydrated = store((state) => state.hydrated);
+  const animateStreaming = store((state) => state.animateStreaming);
+  // The reducer's own applied-event cursor is the activity signal the stall
+  // timer wants: every delta, tool result, and boundary advances it.
+  const lastSeq = store((state) => state.lastSeq);
+  const streamStalled = useStreamStalled(busy, lastSeq);
   const lifecycle = store((state) => state.lifecycle) ?? session.lifecycle;
   const [approvals, setApprovals] = useState<Record<string, CodeApprovalSnapshot>>(
     {},
@@ -483,7 +500,9 @@ function CodeSessionPane({
     if (gatewayCodeModels(catalogModels, session.harness_kind, defaultModelKey).length > 0) {
       return;
     }
-    if (cachedModels && cachedModels.length > 0) return;
+    // An empty list is a finished fetch: this engine advertised no models.
+    // Treating [] as "not yet loaded" remembers a new [] forever.
+    if (cachedModels !== undefined) return;
     let cancelled = false;
     void client.listCodeHarnessModels(session.harness_kind).then(
       (listed) => {
@@ -549,6 +568,10 @@ function CodeSessionPane({
   }, [client, session.id, approvalKey]);
 
   function send(message: string) {
+    // Sending is a deliberate return to the tail: whatever the reader was
+    // reading, they now want to watch their own turn run.
+    follow.armFollow();
+    follow.requestSmoothFollow();
     // Outcome and refusal both belong to the composer: it says whether the
     // message ran or queued, and it holds the draft when the server refuses.
     return submitAcceptedTurn(store.getState().update, () =>
@@ -566,12 +589,20 @@ function CodeSessionPane({
 
   return (
     <>
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className={cn("message-view", follow.fadeClass)}>
         <CodeTranscript
           items={items}
+          hydrated={hydrated}
+          busy={busy}
+          streamStalled={streamStalled}
+          animateStreaming={animateStreaming}
           approvals={approvals}
           decidingId={decidingId}
           approvalError={approvalError}
+          onOpenTurnDiff={onOpenTurnDiff}
+          scrollRef={follow.scrollRef}
+          contentRef={follow.contentRef}
+          onScroll={follow.onScroll}
           onDecide={async (approvalId, decision, feedback) => {
             setDecidingId(approvalId);
             setApprovalError(undefined);
@@ -590,6 +621,19 @@ function CodeSessionPane({
             }
           }}
         />
+        <button
+          type="button"
+          className={cn(
+            "border-border text-foreground bg-background pointer-events-none absolute bottom-3 left-1/2 z-[1] inline-flex -translate-x-1/2 items-center justify-center rounded-full border p-2 opacity-0 shadow transition-[opacity,background-color] duration-150 ease-in-out hover:bg-accent motion-reduce:transition-none",
+            follow.scrolledAway && "pointer-events-auto opacity-100",
+          )}
+          aria-label="Scroll to latest"
+          aria-hidden={!follow.scrolledAway}
+          tabIndex={follow.scrolledAway ? 0 : -1}
+          onClick={() => follow.armFollow(followScrollBehavior(false))}
+        >
+          <ArrowDown size={16} />
+        </button>
       </div>
       {lifecycle !== "ended" && (
         <CodeComposer

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -1,5 +1,169 @@
-import type { Diffstat } from "../api/types";
+import type { ReactNode } from "react";
+import { Check, CircleSlash, TriangleAlert } from "lucide-react";
+
+import type { CodeUsage, Diffstat } from "../api/types";
 import { Badge } from "@/components/ui/badge";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { formatTokenCount } from "@/ContextUsage";
+import { cn } from "@/lib/utils";
+import type { CodeTranscriptItem } from "./CodeSessionReducer";
+
+/**
+ * What a turn came to, at the seam where it ended.
+ *
+ * The reducer has carried the status, the duration, the usage, the failure
+ * message, and the diffstat since code mode shipped, and the transcript threw
+ * all of it away. A turn that failed showed the reader nothing at all, which is
+ * the one outcome that must never be silent.
+ *
+ * The three outcomes are deliberately not the same weight. A completed turn is
+ * a quiet rule between exchanges — the work above it is the content, and a
+ * heavy card there would compete with it. A failed turn is a critical block,
+ * because it is the reason nothing further happened. An interrupted turn sits
+ * between: warning-toned, one line, no alarm.
+ */
+
+type TurnBoundary = Extract<CodeTranscriptItem, { kind: "turn_boundary" }>;
+
+export function TurnReviewCard({
+  turn,
+  narrative,
+  onOpenTurnDiff,
+}: {
+  turn: TurnBoundary;
+  /**
+   * The engine's own account of what it did this turn.
+   *
+   * No event carries one yet — this is the slot it lands in when one does, so
+   * the summary is a documented gap rather than something invented from the
+   * transcript.
+   */
+  narrative?: ReactNode;
+  /** Scope the review sidebar to this turn's changes. */
+  onOpenTurnDiff?: (turnId: string) => void;
+}) {
+  const duration = formatTurnDuration(turn.durationMs);
+  const diffstat = turn.diffstat && (
+    <TurnDiffstat
+      stat={turn.diffstat}
+      turnId={turn.turnId}
+      onOpenTurnDiff={onOpenTurnDiff}
+    />
+  );
+
+  if (turn.status === "failed") {
+    return (
+      <div
+        role="alert"
+        className="border-critical-border bg-critical-background text-critical-foreground flex flex-col gap-1.5 rounded-md border px-3 py-2 text-sm"
+      >
+        <p className="flex items-center gap-1.5 font-medium">
+          <TriangleAlert size={14} aria-hidden="true" />
+          Turn failed
+          {duration && <span className="font-normal">· {duration}</span>}
+        </p>
+        <p>{turn.error ?? "The engine stopped without saying why."}</p>
+        {narrative}
+        {diffstat && <div className="flex items-center gap-2">{diffstat}</div>}
+      </div>
+    );
+  }
+
+  if (turn.status === "interrupted") {
+    return (
+      <SeamRow label="Turn interrupted" tone="warning">
+        <CircleSlash size={13} aria-hidden="true" />
+        <span>Turn interrupted</span>
+        {duration && <span>· {duration}</span>}
+        {narrative}
+        {diffstat}
+      </SeamRow>
+    );
+  }
+
+  return (
+    <SeamRow label="Turn finished" tone="quiet">
+      <Check size={13} aria-hidden="true" />
+      <span>Turn finished</span>
+      {duration && <span>· {duration}</span>}
+      {narrative}
+      {diffstat}
+      <TurnUsage usage={turn.usage} />
+    </SeamRow>
+  );
+}
+
+/** The seam itself: a rule the turn ends on, and the facts sitting on it. */
+function SeamRow({
+  label,
+  tone,
+  children,
+}: {
+  label: string;
+  tone: "quiet" | "warning";
+  children: ReactNode;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 border-t pt-2 text-xs",
+        tone === "warning" ? "text-warning-foreground" : "text-muted-foreground",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The turn's token cost at the scale people quote it, with the exact counts —
+ * cache reads and writes included — behind the tooltip.
+ */
+function TurnUsage({ usage }: { usage: CodeUsage | null }) {
+  if (!usage) return null;
+  const summary = `${formatTokenCount(usage.input_tokens)} in / ${formatTokenCount(usage.output_tokens)} out`;
+  const detail = [
+    `${usage.input_tokens.toLocaleString()} input`,
+    `${usage.output_tokens.toLocaleString()} output`,
+    `${usage.cache_read_input_tokens.toLocaleString()} cache read`,
+    `${usage.cache_creation_input_tokens.toLocaleString()} cache write`,
+  ].join(" · ");
+  return (
+    <WithTooltip label={detail}>
+      <span className="ml-auto tabular-nums">{summary}</span>
+    </WithTooltip>
+  );
+}
+
+/**
+ * The turn's changes, as a control rather than a label.
+ *
+ * Whether it opens anything is the host's call: without a handler the numbers
+ * still read, so the seam never depends on a surface that is not mounted.
+ */
+function TurnDiffstat({
+  stat,
+  turnId,
+  onOpenTurnDiff,
+}: {
+  stat: Diffstat;
+  turnId: string | null;
+  onOpenTurnDiff?: (turnId: string) => void;
+}) {
+  if (!onOpenTurnDiff || !turnId) return <DiffstatBadge stat={stat} />;
+  return (
+    <button
+      type="button"
+      className="focus-visible:ring-ring rounded-full focus-visible:ring-2 focus-visible:outline-none"
+      aria-label="Review this turn's changes"
+      onClick={() => onOpenTurnDiff(turnId)}
+    >
+      <DiffstatBadge stat={stat} />
+    </button>
+  );
+}
 
 export function DiffstatBadge({ stat }: { stat: Diffstat }) {
   return (
@@ -9,4 +173,15 @@ export function DiffstatBadge({ stat }: { stat: Diffstat }) {
       {stat.truncated ? " · truncated" : ""}
     </Badge>
   );
+}
+
+/** How long the turn ran, at the precision the seam can carry. */
+export function formatTurnDuration(ms: number | null): string | null {
+  if (ms === null || !Number.isFinite(ms) || ms < 0) return null;
+  const seconds = Math.round(ms / 1_000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
 }


### PR DESCRIPTION
## What changed

Code-mode turn boundaries now render. A completed turn closes with a quiet seam that shows duration, a `DiffstatBadge`, and a token summary. A failed turn is a critical `role=alert` block that shows the engine error — previously `TurnReviewCard` returned `null`, so a failed turn showed nothing. An interrupted turn is a warning one-liner.

The transcript adopts the shared chat primitives from #2192, per [ADR 0030](docs/decisions/0030-code-mode-separate-surface.md) convergence: `UserMessage`, `AssistantMessageBody`, and `TranscriptSkeleton` from `src/`. The pane uses `useTranscriptFollow` so code mode scrolls, fades, and returns to the tail the same way chat does. A session shows a skeleton until the durable snapshot settles (`hydrated` on the reducer, `onHydrateSettled` on the controller), including when the snapshot cannot be read, so an existing session does not flash its empty state. Streaming uses `AssistantWorkingIndicator` in the gaps between live cards, and each row is wrapped in `isolatedCard` so one throw does not take the transcript with it. User items carry `createdAt` from the turn's `started_at` so the footer timestamp is the server's, not the client's.

A session whose harness reports zero models no longer refetches `listCodeHarnessModels` forever. An empty remembered list is a finished fetch.

## Validation

- `pnpm vitest run src/code` — 117 passed
- `pnpm vitest run` — 1136 passed (one `ManagedGate` pairing-nudge case failed once under load and passed on retry; unrelated to this change)
- `pnpm build` — `tsc` and Vite production build passed

## Compatibility and risk

None. No persisted or wire-format change. The reducer already carried turn status, duration, usage, error, and diffstat; this change only renders them. `createdAt` is new on the in-memory user item and is filled from `turn.started_at`.

## Tests deleted

- `expect(screen.getByText("list the files")).toBeInTheDocument()` — asserted the old plain-div user bubble; the prompt is now a `UserMessage` article with markdown and a timestamped footer.
- `expect(screen.queryByText("Turn completed")).toBeNull()` — asserted that a turn boundary renders nothing; that silent boundary is the bug this PR removes.