### PR TITLE
fix(release): keep in-flight notes as a draft prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,20 +123,20 @@ jobs:
             echo "tag=$RELEASE_TAG"
             echo "version=${RELEASE_TAG#v}"
           } >> "$GITHUB_OUTPUT"
-      - name: Convert the draft to a prerelease while it builds
+      - name: Mark the in-flight draft as a prerelease
         if: ${{ steps.release.outputs.draft == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ steps.release.outputs.release_id }}
         run: |
-          # A draft keeps collecting release notes from new merges while the
-          # build runs, making the live draft drift away from the frozen notes.
-          # Mark the in-flight release as a prerelease so Release Drafter treats
-          # it as already-published and starts the next draft for any PRs that
-          # merge during this build.
+          # Keep the frozen notes on this draft, but do not publish it yet.
+          # Publishing here makes GitHub treat the release as immutable, so
+          # later asset uploads fail. Release Drafter only updates
+          # non-prerelease drafts, so this shape freezes the notes and
+          # lets the next merge start a new draft.
           gh api --method PATCH \
             "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
-            -f draft=false \
+            -f draft=true \
             -f prerelease=true \
             >/dev/null
       - name: Require a commit from main

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -145,9 +145,11 @@ automatic.
    tag on a retry. It snapshots the draft metadata so a later merge cannot
    change the notes or proposed version while the build is running, and pins
    every later job to the frozen commit SHA. Immediately after the snapshot, the
-   draft becomes a GitHub prerelease. This lets Release Drafter start the next
-   draft for any PRs that merge during the build, instead of appending them to
-   the in-flight release.
+   draft is marked as a prerelease but stays a draft so assets can still be
+   attached. Release Drafter only updates non-prerelease drafts, so later
+   merges start a new notes draft instead of appending to the in-flight
+   release. The GitHub Release is published only after those assets are
+   attached.
 5. In parallel with the desktop build, the documentation builder checks out
    that validated SHA and builds `docs-site/` as a static export under `/docs`.
    Publication waits until the GitHub Release itself has been published. It

--- a/scripts/reconcile-release-drafts.test.mjs
+++ b/scripts/reconcile-release-drafts.test.mjs
@@ -124,6 +124,34 @@ test("ignores an in-flight prerelease when collapsing drafts", () => {
   );
 });
 
+test("ignores an in-flight draft prerelease when collapsing drafts", () => {
+  const nextDraft = {
+    id: 50,
+    tag_name: "v0.51.0",
+    draft: true,
+    prerelease: false,
+  };
+  const inFlightDraft = {
+    id: 60,
+    tag_name: "v0.50.0",
+    draft: true,
+    prerelease: true,
+  };
+  assert.deepEqual(
+    planDraftReconciliation({
+      releases: [nextDraft, inFlightDraft, published],
+      resolvedVersion: "0.51.0",
+      releaseId: 50,
+    }),
+    {
+      action: "ok",
+      keep_id: 50,
+      delete_ids: [],
+      reason: "kept the single draft v0.51.0",
+    },
+  );
+});
+
 test("flattens paginated GitHub release pages", () => {
   assert.deepEqual(normalizeReleaseList([[currentDraft], [published]]), [
     currentDraft,

--- a/scripts/require-release-baseline.test.mjs
+++ b/scripts/require-release-baseline.test.mjs
@@ -49,6 +49,23 @@ test("treats an in-flight prerelease as a published baseline", () => {
   );
 });
 
+test("does not treat a draft prerelease as a published baseline", () => {
+  assert.equal(
+    planReleaseBaseline({
+      releases: [
+        {
+          id: 4,
+          tag_name: "v0.51.0",
+          draft: true,
+          prerelease: true,
+        },
+      ],
+      tags: ["v0.47.0"],
+    }).action,
+    "fail",
+  );
+});
+
 test("refuses to draft when version tags exist but no release is listed", () => {
   assert.deepEqual(
     planReleaseBaseline({

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1064,6 +1064,10 @@ test("release builds freeze a draft tag from the trusted main workflow", () => {
   assert.match(validateJob, /repos\/\$GITHUB_REPOSITORY\/git\/refs/);
   assert.match(validateJob, /git merge-base --is-ancestor "\$RELEASE_SHA" origin\/main/);
   assert.match(validateJob, /release-snapshot\.json/);
+  assert.match(validateJob, /Mark the in-flight draft as a prerelease/);
+  assert.match(validateJob, /-f draft=true/);
+  assert.match(validateJob, /-f prerelease=true/);
+  assert.doesNotMatch(validateJob, /-f draft=false/);
   assert.match(release, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
 });
 


### PR DESCRIPTION
## Summary
Keep the in-flight desktop release as a **draft prerelease** until assets attach.

The previous freeze published the notes immediately (`draft=false`, `prerelease=true`). That did stop Release Drafter from appending later merges, but GitHub then locked the release as immutable before `gh release upload` ran. Turning the repo setting off does not unlock an already-immutable release, which is why `v0.48.0`–`v0.50.0` stayed empty.

This change still freezes the notes: Release Drafter only updates non-prerelease drafts. The in-flight object stays unpublished so assets can attach, then finalize publishes it after the upload.

## Root cause
`.github/workflows/release.yml` validate PATCHed the snapshot to a published prerelease. GitHub immutable releases then rejected later asset uploads with `HTTP 422: Cannot upload assets to an immutable release.`

## What this does not do
- It does not retry or rewrite the empty immutable prereleases `v0.48.0`, `v0.49.0`, `v0.49.1`, or `v0.50.0`.
- After this lands, the next ship should be the existing `v0.51.0` notes draft.

## Test plan
- [x] `node --test scripts/workflow-security.test.mjs scripts/reconcile-release-drafts.test.mjs scripts/require-release-baseline.test.mjs`
- [ ] After merge, dispatch **Publish desktop release** from `main` with a blank tag so it takes `v0.51.0`
- [ ] Confirm validate marks that release `draft=true, prerelease=true` and does **not** publish it
- [ ] Confirm attach can `gh release upload`
- [ ] Confirm Linux ARM still has `xdg-mime` and Windows ARM still uses clang-cl
