### PR TITLE
test(release): accept JSON booleans when freezing in-flight notes

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1065,8 +1065,11 @@ test("release builds freeze a draft tag from the trusted main workflow", () => {
   assert.match(validateJob, /git merge-base --is-ancestor "\$RELEASE_SHA" origin\/main/);
   assert.match(validateJob, /release-snapshot\.json/);
   assert.match(validateJob, /Mark the in-flight draft as a prerelease/);
-  assert.match(validateJob, /-f draft=true/);
-  assert.match(validateJob, /-f prerelease=true/);
+  assert.match(
+    validateJob,
+    /(?:-f draft=true[\s\S]*-f prerelease=true|\{draft: true, prerelease: true\})/,
+  );
+  assert.match(validateJob, /Failed to keep release \$RELEASE_ID as a draft after marking it in-flight| -f draft=true/);
   assert.doesNotMatch(validateJob, /-f draft=false/);
   assert.match(release, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
 });


### PR DESCRIPTION
## Summary
Loosen the trusted release-policy assertions so an in-flight notes freeze may use either `gh -f draft=true` or a JSON body `{draft: true, prerelease: true}`.

This is the first half of the durable fix. `gh -f` stringifies booleans, and GitHub then publishes the in-flight release. The next PR will send JSON booleans and verify the object stayed a draft.

## Test plan
- [x] `node --test scripts/workflow-security.test.mjs`
- [ ] After this lands, follow with the workflow PATCH that uses `--input` JSON and asserts `.draft == true`
