### PR TITLE
feat: support code mode on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,15 @@ jobs:
       # native host, not a second copy of the workspace suite.
       - name: Host broker Windows tests
         run: cargo test -p tidebreak-host-broker --locked
+      # Code mode crosses Windows-native executable, environment, PowerShell,
+      # path-identity, and process-tree boundaries. A cross-target check cannot
+      # prove those behaviors; run the harness suite and the server's code-mode
+      # modules on NTFS with the Windows process APIs available.
+      - name: Code mode Windows lifecycle tests
+        run: |
+          cargo test -p tidebreak-code-execution --locked
+          cargo test -p tidebreak-harness --locked
+          cargo test -p tidebreak-server --lib code:: --locked
       # Boot-critical persistence, proven on the OS that ships it: the desktop
       # profile's SQLite open/migrate lifecycle (tidebreak-server's
       # desktop_schema module, including the Windows MoveFileExW marker swap)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7150,9 +7150,11 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.20",
+ "tidebreak-code-execution",
  "tidebreak-core",
  "tokio",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/tidebreak-code-execution/src/local.rs
+++ b/crates/tidebreak-code-execution/src/local.rs
@@ -867,8 +867,14 @@ fn finish_execution(path: &Path, receipt: &ExecutionReceipt) -> Result<(), CodeE
     sync_dir(parent).map_err(|_| CodeExecutionError::AmbiguousExecution)
 }
 
+#[cfg(unix)]
 fn sync_dir(path: &Path) -> std::io::Result<()> {
     fs::File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_dir(_path: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 fn secure_dir(path: &Path) -> Result<(), CodeExecutionError> {

--- a/crates/tidebreak-code-execution/src/managed_node.rs
+++ b/crates/tidebreak-code-execution/src/managed_node.rs
@@ -14,35 +14,57 @@ use serde::{Deserialize, Serialize};
 /// The exact Node version Tidebreak installs and trusts.
 pub const MANAGED_NODE_VERSION: &str = "20.20.2";
 
+// From the exact ZIP rows in Node's v20.20.2 SHASUMS256.txt. Keep the
+// filenames beside the tests below: the neighboring .7z, MSI, and standalone
+// node.exe rows are different artifacts with different digests.
+#[allow(dead_code)] // Each target uses only its own architecture; tests bind both names.
+const WINDOWS_ARM64_ZIP_SHA256: &str =
+    "d5c5b1d56f7f9469830eb1f57efeec0a6a9078c0a9e88cd5b4b4b48f46c22069";
+#[allow(dead_code)] // Each target uses only its own architecture; tests bind both names.
+const WINDOWS_X64_ZIP_SHA256: &str =
+    "dc3700fdd57a63eedb8fd7e3c7baaa32e6a740a1b904167ff4204bc68ed8bf77";
+
 /// The current platform's trusted managed-Node artifact identity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ManagedNodePin {
     pub version: &'static str,
-    pub tarball_sha256: &'static str,
+    pub artifact_sha256: &'static str,
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 static CURRENT_PIN: Option<ManagedNodePin> = Some(ManagedNodePin {
     version: MANAGED_NODE_VERSION,
-    tarball_sha256: "466e05f3477c20dfb723054dfebffe55bc74660ee77f612166fca121dacb65b6",
+    artifact_sha256: "466e05f3477c20dfb723054dfebffe55bc74660ee77f612166fca121dacb65b6",
 });
 
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 static CURRENT_PIN: Option<ManagedNodePin> = Some(ManagedNodePin {
     version: MANAGED_NODE_VERSION,
-    tarball_sha256: "8be6f5e4bb128c82774f8a0b8d7a1cc1365a7977d9657cece0ca647b3fe04e61",
+    artifact_sha256: "8be6f5e4bb128c82774f8a0b8d7a1cc1365a7977d9657cece0ca647b3fe04e61",
 });
 
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 static CURRENT_PIN: Option<ManagedNodePin> = Some(ManagedNodePin {
     version: MANAGED_NODE_VERSION,
-    tarball_sha256: "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d",
+    artifact_sha256: "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d",
 });
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 static CURRENT_PIN: Option<ManagedNodePin> = Some(ManagedNodePin {
     version: MANAGED_NODE_VERSION,
-    tarball_sha256: "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b",
+    artifact_sha256: "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b",
+});
+
+#[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+static CURRENT_PIN: Option<ManagedNodePin> = Some(ManagedNodePin {
+    version: MANAGED_NODE_VERSION,
+    artifact_sha256: WINDOWS_ARM64_ZIP_SHA256,
+});
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+static CURRENT_PIN: Option<ManagedNodePin> = Some(ManagedNodePin {
+    version: MANAGED_NODE_VERSION,
+    artifact_sha256: WINDOWS_X64_ZIP_SHA256,
 });
 
 #[cfg(not(any(
@@ -52,6 +74,10 @@ static CURRENT_PIN: Option<ManagedNodePin> = Some(ManagedNodePin {
     ),
     all(
         target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "x86_64")
+    ),
+    all(
+        target_os = "windows",
         any(target_arch = "aarch64", target_arch = "x86_64")
     )
 )))]
@@ -78,11 +104,65 @@ pub fn managed_node_marker_path(version_dir: &Path) -> PathBuf {
     version_dir.join("installed.json")
 }
 
+#[derive(Debug, Clone, Copy)]
+enum ManagedNodeLayout {
+    #[cfg_attr(windows, allow(dead_code))]
+    Unix,
+    #[cfg_attr(not(windows), allow(dead_code))]
+    Windows,
+}
+
+#[cfg(windows)]
+const CURRENT_LAYOUT: ManagedNodeLayout = ManagedNodeLayout::Windows;
+#[cfg(not(windows))]
+const CURRENT_LAYOUT: ManagedNodeLayout = ManagedNodeLayout::Unix;
+
+/// The managed Node interpreter for this platform's official archive layout.
+#[must_use]
+pub fn managed_node_executable(version_dir: &Path) -> PathBuf {
+    managed_node_executable_for_layout(version_dir, CURRENT_LAYOUT)
+}
+
+/// The managed npm executable or command shim for this platform's official
+/// archive layout.
+#[must_use]
+pub fn managed_npm_executable(version_dir: &Path) -> PathBuf {
+    managed_npm_executable_for_layout(version_dir, CURRENT_LAYOUT)
+}
+
+/// The directory to prepend to `PATH` for this platform's managed runtime.
+#[must_use]
+pub fn managed_node_path_dir(version_dir: &Path) -> PathBuf {
+    managed_node_path_dir_for_layout(version_dir, CURRENT_LAYOUT)
+}
+
+fn managed_node_executable_for_layout(version_dir: &Path, layout: ManagedNodeLayout) -> PathBuf {
+    match layout {
+        ManagedNodeLayout::Unix => version_dir.join("bin").join("node"),
+        ManagedNodeLayout::Windows => version_dir.join("node.exe"),
+    }
+}
+
+fn managed_npm_executable_for_layout(version_dir: &Path, layout: ManagedNodeLayout) -> PathBuf {
+    match layout {
+        ManagedNodeLayout::Unix => version_dir.join("bin").join("npm"),
+        ManagedNodeLayout::Windows => version_dir.join("npm.cmd"),
+    }
+}
+
+fn managed_node_path_dir_for_layout(version_dir: &Path, layout: ManagedNodeLayout) -> PathBuf {
+    match layout {
+        ManagedNodeLayout::Unix => version_dir.join("bin"),
+        ManagedNodeLayout::Windows => version_dir.to_path_buf(),
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct InstallMarker {
     version: String,
-    tarball_sha256: String,
+    #[serde(alias = "tarballSha256")]
+    artifact_sha256: String,
 }
 
 /// Serialize the marker for an artifact that has already passed digest
@@ -90,7 +170,7 @@ struct InstallMarker {
 pub fn managed_node_install_marker(pin: &ManagedNodePin) -> Result<Vec<u8>, serde_json::Error> {
     serde_json::to_vec_pretty(&InstallMarker {
         version: pin.version.to_owned(),
-        tarball_sha256: pin.tarball_sha256.to_owned(),
+        artifact_sha256: pin.artifact_sha256.to_owned(),
     })
 }
 
@@ -102,14 +182,23 @@ pub fn managed_node_root(data_dir: &Path) -> Option<PathBuf> {
 }
 
 fn managed_node_root_expecting(data_dir: &Path, pin: &ManagedNodePin) -> Option<PathBuf> {
+    managed_node_root_expecting_layout(data_dir, pin, CURRENT_LAYOUT)
+}
+
+fn managed_node_root_expecting_layout(
+    data_dir: &Path,
+    pin: &ManagedNodePin,
+    layout: ManagedNodeLayout,
+) -> Option<PathBuf> {
     let version_dir = managed_node_version_dir(data_dir);
     let marker = std::fs::read(managed_node_marker_path(&version_dir)).ok()?;
     let marker: InstallMarker = serde_json::from_slice(&marker).ok()?;
-    if marker.version != pin.version || marker.tarball_sha256 != pin.tarball_sha256 {
+    if marker.version != pin.version || marker.artifact_sha256 != pin.artifact_sha256 {
         return None;
     }
-    (version_dir.join("bin/node").is_file() && version_dir.join("bin/npm").is_file())
-        .then_some(version_dir)
+    (managed_node_executable_for_layout(&version_dir, layout).is_file()
+        && managed_npm_executable_for_layout(&version_dir, layout).is_file())
+    .then_some(version_dir)
 }
 
 #[cfg(test)]
@@ -120,23 +209,94 @@ mod tests {
     fn platform_pin_matches_shipped_desktop_hosts() {
         assert_eq!(
             current_managed_node_pin().is_some(),
-            cfg!(any(target_os = "macos", target_os = "linux"))
-                && cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
+            cfg!(any(
+                target_os = "macos",
+                target_os = "linux",
+                target_os = "windows"
+            )) && cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
         );
+    }
+
+    #[test]
+    fn windows_zip_pins_match_the_named_official_artifacts() {
+        assert_eq!(
+            ("node-v20.20.2-win-arm64.zip", WINDOWS_ARM64_ZIP_SHA256),
+            (
+                "node-v20.20.2-win-arm64.zip",
+                "d5c5b1d56f7f9469830eb1f57efeec0a6a9078c0a9e88cd5b4b4b48f46c22069"
+            )
+        );
+        assert_eq!(
+            ("node-v20.20.2-win-x64.zip", WINDOWS_X64_ZIP_SHA256),
+            (
+                "node-v20.20.2-win-x64.zip",
+                "dc3700fdd57a63eedb8fd7e3c7baaa32e6a740a1b904167ff4204bc68ed8bf77"
+            )
+        );
+    }
+
+    #[test]
+    fn official_archive_layouts_resolve_runtime_entrypoints() {
+        let root = Path::new("runtime");
+
+        assert_eq!(
+            managed_node_executable_for_layout(root, ManagedNodeLayout::Unix),
+            root.join("bin/node")
+        );
+        assert_eq!(
+            managed_npm_executable_for_layout(root, ManagedNodeLayout::Unix),
+            root.join("bin/npm")
+        );
+        assert_eq!(
+            managed_node_path_dir_for_layout(root, ManagedNodeLayout::Unix),
+            root.join("bin")
+        );
+
+        assert_eq!(
+            managed_node_executable_for_layout(root, ManagedNodeLayout::Windows),
+            root.join("node.exe")
+        );
+        assert_eq!(
+            managed_npm_executable_for_layout(root, ManagedNodeLayout::Windows),
+            root.join("npm.cmd")
+        );
+        assert_eq!(
+            managed_node_path_dir_for_layout(root, ManagedNodeLayout::Windows),
+            root
+        );
+    }
+
+    #[test]
+    fn marker_writes_platform_neutral_digest_and_reads_legacy_name() {
+        let expected = ManagedNodePin {
+            version: MANAGED_NODE_VERSION,
+            artifact_sha256: "digest",
+        };
+        let marker = managed_node_install_marker(&expected).expect("marker");
+        let marker_json: serde_json::Value = serde_json::from_slice(&marker).expect("json");
+        assert_eq!(marker_json["artifactSha256"], "digest");
+        assert!(marker_json.get("tarballSha256").is_none());
+
+        let legacy: InstallMarker =
+            serde_json::from_slice(br#"{"version":"20.20.2","tarballSha256":"digest"}"#)
+                .expect("legacy marker");
+        assert_eq!(legacy.artifact_sha256, "digest");
     }
 
     #[test]
     fn managed_runtime_resolves_only_with_a_matching_marker() {
         let expected = ManagedNodePin {
             version: MANAGED_NODE_VERSION,
-            tarball_sha256: "466e05f3477c20dfb723054dfebffe55bc74660ee77f612166fca121dacb65b6",
+            artifact_sha256: "466e05f3477c20dfb723054dfebffe55bc74660ee77f612166fca121dacb65b6",
         };
         let data_dir = tempfile::tempdir().expect("tempdir");
         let version_dir = managed_node_version_dir(data_dir.path());
-        let bin = version_dir.join("bin");
-        std::fs::create_dir_all(&bin).expect("bin");
-        std::fs::write(bin.join("node"), b"#!/bin/sh\n").expect("node");
-        std::fs::write(bin.join("npm"), b"#!/bin/sh\n").expect("npm");
+        let node = managed_node_executable(&version_dir);
+        let npm = managed_npm_executable(&version_dir);
+        std::fs::create_dir_all(node.parent().expect("node parent")).expect("node parent");
+        std::fs::create_dir_all(npm.parent().expect("npm parent")).expect("npm parent");
+        std::fs::write(node, b"node").expect("node");
+        std::fs::write(npm, b"npm").expect("npm");
 
         assert_eq!(
             managed_node_root_expecting(data_dir.path(), &expected),
@@ -144,7 +304,7 @@ mod tests {
         );
 
         let wrong = ManagedNodePin {
-            tarball_sha256: "0",
+            artifact_sha256: "0",
             ..expected
         };
         std::fs::write(
@@ -164,6 +324,48 @@ mod tests {
         .expect("write marker");
         assert_eq!(
             managed_node_root_expecting(data_dir.path(), &expected),
+            Some(version_dir)
+        );
+    }
+
+    #[test]
+    fn verifier_requires_the_selected_platform_layout() {
+        let expected = ManagedNodePin {
+            version: MANAGED_NODE_VERSION,
+            artifact_sha256: "digest",
+        };
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let version_dir = managed_node_version_dir(data_dir.path());
+        std::fs::create_dir_all(version_dir.join("bin")).expect("bin");
+        std::fs::write(version_dir.join("bin/node"), b"node").expect("unix node");
+        std::fs::write(version_dir.join("bin/npm"), b"npm").expect("unix npm");
+        std::fs::write(
+            managed_node_marker_path(&version_dir),
+            managed_node_install_marker(&expected).expect("marker"),
+        )
+        .expect("write marker");
+
+        assert_eq!(
+            managed_node_root_expecting_layout(data_dir.path(), &expected, ManagedNodeLayout::Unix),
+            Some(version_dir.clone())
+        );
+        assert_eq!(
+            managed_node_root_expecting_layout(
+                data_dir.path(),
+                &expected,
+                ManagedNodeLayout::Windows
+            ),
+            None
+        );
+
+        std::fs::write(version_dir.join("node.exe"), b"node").expect("windows node");
+        std::fs::write(version_dir.join("npm.cmd"), b"npm").expect("windows npm");
+        assert_eq!(
+            managed_node_root_expecting_layout(
+                data_dir.path(),
+                &expected,
+                ManagedNodeLayout::Windows
+            ),
             Some(version_dir)
         );
     }

--- a/crates/tidebreak-code-execution/src/plugins.rs
+++ b/crates/tidebreak-code-execution/src/plugins.rs
@@ -465,12 +465,7 @@ pub fn parse_plugin_manifest(
     if source.len() > crate::MAX_WORKSPACE_FILE_BYTES {
         return Err(invalid("manifest exceeds the workspace file limit"));
     }
-    let rest = source
-        .strip_prefix("---\n")
-        .ok_or_else(|| invalid("missing opening frontmatter fence"))?;
-    let (frontmatter, _body) = rest
-        .split_once("\n---\n")
-        .ok_or_else(|| invalid("missing closing frontmatter fence"))?;
+    let (frontmatter, _body) = crate::skills::split_frontmatter(source).map_err(invalid)?;
 
     let mut name = None;
     let mut display_name = None;

--- a/crates/tidebreak-code-execution/src/prompts.rs
+++ b/crates/tidebreak-code-execution/src/prompts.rs
@@ -111,12 +111,7 @@ pub fn parse_prompt_manifest(
     source: &str,
     origin: PromptOrigin,
 ) -> Result<LoadedPrompt, PromptParseError> {
-    let rest = source
-        .strip_prefix("---\n")
-        .ok_or_else(|| invalid("missing opening frontmatter fence"))?;
-    let (frontmatter, body) = rest
-        .split_once("\n---\n")
-        .ok_or_else(|| invalid("missing closing frontmatter fence"))?;
+    let (frontmatter, body) = crate::skills::split_frontmatter(source).map_err(invalid)?;
 
     let mut name = None;
     let mut description = None;

--- a/crates/tidebreak-code-execution/src/skills.rs
+++ b/crates/tidebreak-code-execution/src/skills.rs
@@ -259,12 +259,7 @@ pub fn parse_skill_manifest(
     if source.len() > crate::MAX_WORKSPACE_FILE_BYTES {
         return Err(invalid("manifest exceeds the workspace file limit"));
     }
-    let rest = source
-        .strip_prefix("---\n")
-        .ok_or_else(|| invalid("missing opening frontmatter fence"))?;
-    let (frontmatter, body) = rest
-        .split_once("\n---\n")
-        .ok_or_else(|| invalid("missing closing frontmatter fence"))?;
+    let (frontmatter, body) = split_frontmatter(source).map_err(invalid)?;
 
     let mut name = None;
     let mut description = None;
@@ -338,6 +333,18 @@ pub fn parse_skill_manifest(
         host_deps,
         origin,
     })
+}
+
+/// Split `---`-fenced YAML frontmatter. Windows checkouts and user files may
+/// use CRLF, so both fence encodings are accepted.
+pub(crate) fn split_frontmatter(source: &str) -> Result<(&str, &str), &'static str> {
+    let rest = source
+        .strip_prefix("---\r\n")
+        .or_else(|| source.strip_prefix("---\n"))
+        .ok_or("missing opening frontmatter fence")?;
+    rest.split_once("\r\n---\r\n")
+        .or_else(|| rest.split_once("\n---\n"))
+        .ok_or("missing closing frontmatter fence")
 }
 
 /// The three dependency lists one `deps` entry may declare.
@@ -670,6 +677,10 @@ Instructions live here.\n";
                 .python_deps,
             [""; 0]
         );
+
+        let crlf = VALID.replace('\n', "\r\n");
+        let package = parse_skill_manifest(&crlf, SkillOrigin::Builtin).unwrap();
+        assert_eq!(package.name, "pdf-documents");
     }
 
     /// The `host:` list is a closed vocabulary: `libreoffice` parses into its

--- a/crates/tidebreak-code-execution/tests/document_scripts.rs
+++ b/crates/tidebreak-code-execution/tests/document_scripts.rs
@@ -45,6 +45,30 @@ fn scripts_dir() -> PathBuf {
         .expect("document scripts directory exists")
 }
 
+fn compile_document_script(python: &Path, script: &Path, cache: &Path) -> std::io::Result<Output> {
+    let mut command = Command::new(python);
+    #[cfg(windows)]
+    {
+        // PYTHONPYCACHEPREFIX encodes `C:` as a `?` path component, which is
+        // not a legal Windows file name (WinError 123).
+        command
+            .args([
+                "-c",
+                "import py_compile, sys; py_compile.compile(sys.argv[1], cfile=sys.argv[2], doraise=True)",
+            ])
+            .arg(script)
+            .arg(cache.join(script.file_name().unwrap_or_default()).with_extension("pyc"));
+    }
+    #[cfg(not(windows))]
+    {
+        command
+            .args(["-m", "py_compile"])
+            .arg(script)
+            .env("PYTHONPYCACHEPREFIX", cache);
+    }
+    command.output()
+}
+
 fn run_missing_tool_case(python: &Path, script: &Path, input: &Path, needle: &str) -> Output {
     let output = Command::new(python)
         .arg("-S")
@@ -72,12 +96,8 @@ fn document_scripts_compile_and_expose_argparse_help() {
     let cache = tempfile::tempdir().unwrap();
     for script in PREVIEW_SCRIPTS.iter().chain(PACKAGE_SCRIPTS.iter()) {
         let path = directory.join(script);
-        let compiled = Command::new(&python)
-            .args(["-m", "py_compile"])
-            .arg(&path)
-            .env("PYTHONPYCACHEPREFIX", cache.path())
-            .output()
-            .expect("Python starts");
+        let compiled =
+            compile_document_script(&python, &path, cache.path()).expect("Python starts");
         assert!(
             compiled.status.success(),
             "{script} must compile: {}",

--- a/crates/tidebreak-desktop/src/node_install.rs
+++ b/crates/tidebreak-desktop/src/node_install.rs
@@ -12,7 +12,7 @@
 //!
 //! The version is pinned to match the container image's `node:20-bookworm-slim`
 //! so a skill behaves the same locally and in the cloud. The npm bundled in the
-//! official tarball is the npm the sandbox uses — there is no separate npm
+//! official archive is the npm the sandbox uses — there is no separate npm
 //! install to keep in step.
 //!
 //! Supply-chain posture, deliberately rigid, and the same as the managed
@@ -22,9 +22,10 @@
 //!
 //! - <https://nodejs.org/dist/v20.20.2/SHASUMS256.txt>
 //!
-//! macOS and Linux are supported on both shipped architectures. The local
-//! sandbox remains macOS-only, but code mode uses the same managed runtime to
-//! install and launch its pinned harness packages on Linux.
+//! macOS, Linux, and Windows are supported on both shipped architectures. The
+//! local sandbox remains macOS-only, but code mode uses the same managed
+//! runtime to install and launch its pinned harness packages on Linux and
+//! Windows.
 //!
 //! Gatekeeper: a download performed by this process carries no
 //! `com.apple.quarantine` attribute — quarantine is applied by applications
@@ -37,10 +38,10 @@
 //! hands us a quarantined file.
 //!
 //! Integrity at rest: the install directory carries an `installed.json` marker
-//! recording the version and the verified tarball digest. Resolution trusts the
-//! managed install only when the marker matches the constants pinned here — a
-//! marker for a different digest (a tampered or half-written install, or a
-//! stale layout after the pin moves) makes the managed copy invisible and a
+//! recording the version and the verified artifact digest. Resolution trusts
+//! the managed install only when the marker matches the constants pinned here
+//! — a marker for a different digest (a tampered or half-written install, or
+//! a stale layout after the pin moves) makes the managed copy invisible and a
 //! fresh install replaces it. The tree is not re-hashed per turn; the marker
 //! plus the `node` and `npm` entrypoints' presence is the check.
 //!
@@ -52,67 +53,112 @@
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 use std::time::Duration;
 
 use tauri::AppHandle;
 use tidebreak_code_execution::managed_node::{
-    current_managed_node_pin, managed_node_install_marker, managed_node_marker_path,
-    managed_node_root as verified_managed_node_root, managed_node_version_dir,
-    MANAGED_NODE_VERSION,
+    current_managed_node_pin, managed_node_executable, managed_node_install_marker,
+    managed_node_marker_path, managed_node_root as verified_managed_node_root,
+    managed_node_version_dir, managed_npm_executable, MANAGED_NODE_VERSION,
 };
 
 /// The exact Node version this build installs and trusts, matching the
 /// container image's `node:20-bookworm-slim`.
 pub(crate) const NODE_VERSION: &str = MANAGED_NODE_VERSION;
 
-/// The unpacked runtime is about 154 MB and the tarball about 40 MB; refuse to
+/// The unpacked runtime is about 154 MB and the archive about 40 MB; refuse to
 /// start on a disk with less headroom than that plus slack.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 const REQUIRED_FREE_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Official Node archives for the supported targets are below 55 MB. Bound
 /// the streamed response independently of Content-Length so a bad endpoint
 /// cannot fill the app-data volume before the digest check gets a vote.
-#[cfg(any(target_os = "macos", target_os = "linux", test))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows", test))]
 const MAX_ARCHIVE_BYTES: u64 = 128 * 1024 * 1024;
 
-#[cfg(any(target_os = "macos", target_os = "linux", test))]
+/// Bound decompressed output independently of the ZIP directory's declared
+/// sizes so a malformed archive cannot consume the app-data volume.
+#[cfg(any(target_os = "windows", test))]
+const MAX_UNPACKED_BYTES: u64 = 512 * 1024 * 1024;
+
+#[cfg(any(target_os = "windows", test))]
+const MAX_ARCHIVE_ENTRIES: usize = 100_000;
+
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows", test))]
 const DOWNLOAD_TOO_LARGE: &str = "The Node download was larger than expected and was discarded";
 
+#[derive(Clone, Copy)]
+enum ArchiveFormat {
+    #[cfg(any(target_os = "macos", target_os = "linux", test))]
+    TarGz,
+    #[cfg(any(target_os = "windows", test))]
+    Zip,
+}
+
 struct PinnedArtifact {
-    // Read only by the macOS/Linux install path; unsupported platforms carry
+    // Read only by the supported install path; unsupported platforms carry
     // the pinned shape (`PINNED = None`) without an installer to consume it.
-    #[cfg_attr(not(any(target_os = "macos", target_os = "linux")), allow(dead_code))]
+    #[cfg_attr(
+        not(any(target_os = "macos", target_os = "linux", target_os = "windows")),
+        allow(dead_code)
+    )]
     url: &'static str,
-    /// The single directory the official tarball unpacks into, which the
+    /// The single directory the official archive unpacks into, which the
     /// install moves into place as the version directory.
-    #[cfg_attr(not(any(target_os = "macos", target_os = "linux")), allow(dead_code))]
+    #[cfg_attr(
+        not(any(target_os = "macos", target_os = "linux", target_os = "windows")),
+        allow(dead_code)
+    )]
     archive_root: &'static str,
+    #[cfg_attr(
+        not(any(target_os = "macos", target_os = "linux", target_os = "windows")),
+        allow(dead_code)
+    )]
+    archive_format: ArchiveFormat,
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 static PINNED: Option<PinnedArtifact> = Some(PinnedArtifact {
     url: "https://nodejs.org/dist/v20.20.2/node-v20.20.2-darwin-arm64.tar.gz",
     archive_root: "node-v20.20.2-darwin-arm64",
+    archive_format: ArchiveFormat::TarGz,
 });
 
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 static PINNED: Option<PinnedArtifact> = Some(PinnedArtifact {
     url: "https://nodejs.org/dist/v20.20.2/node-v20.20.2-darwin-x64.tar.gz",
     archive_root: "node-v20.20.2-darwin-x64",
+    archive_format: ArchiveFormat::TarGz,
 });
 
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 static PINNED: Option<PinnedArtifact> = Some(PinnedArtifact {
     url: "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-arm64.tar.gz",
     archive_root: "node-v20.20.2-linux-arm64",
+    archive_format: ArchiveFormat::TarGz,
 });
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 static PINNED: Option<PinnedArtifact> = Some(PinnedArtifact {
     url: "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-x64.tar.gz",
     archive_root: "node-v20.20.2-linux-x64",
+    archive_format: ArchiveFormat::TarGz,
+});
+
+#[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+static PINNED: Option<PinnedArtifact> = Some(PinnedArtifact {
+    url: "https://nodejs.org/dist/v20.20.2/node-v20.20.2-win-arm64.zip",
+    archive_root: "node-v20.20.2-win-arm64",
+    archive_format: ArchiveFormat::Zip,
+});
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+static PINNED: Option<PinnedArtifact> = Some(PinnedArtifact {
+    url: "https://nodejs.org/dist/v20.20.2/node-v20.20.2-win-x64.zip",
+    archive_root: "node-v20.20.2-win-x64",
+    archive_format: ArchiveFormat::Zip,
 });
 
 #[cfg(not(any(
@@ -122,6 +168,10 @@ static PINNED: Option<PinnedArtifact> = Some(PinnedArtifact {
     ),
     all(
         target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "x86_64")
+    ),
+    all(
+        target_os = "windows",
         any(target_arch = "aarch64", target_arch = "x86_64")
     )
 )))]
@@ -147,7 +197,7 @@ fn managed_version_dir(data_dir: &Path) -> PathBuf {
     managed_node_version_dir(data_dir)
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 fn staging_dir(data_dir: &Path) -> PathBuf {
     data_dir.join("tools").join("node").join("staging")
 }
@@ -157,12 +207,12 @@ fn marker_path(version_dir: &Path) -> PathBuf {
 }
 
 fn managed_binary(version_dir: &Path) -> PathBuf {
-    version_dir.join("bin").join("node")
+    managed_node_executable(version_dir)
 }
 
 /// The managed Node runtime's root directory, if a verified install of the
-/// pinned artifact is present. This is the cheap at-rest check: marker matches
-/// the pin, and both `bin/node` and `bin/npm` exist.
+/// pinned artifact is present. This is the cheap at-rest check: the marker
+/// matches the pin and both platform entrypoints exist.
 pub(crate) fn managed_node_root(data_dir: &Path) -> Option<PathBuf> {
     verified_managed_node_root(data_dir)
 }
@@ -301,7 +351,7 @@ pub(crate) async fn status(app: &AppHandle) -> tidebreak_code_execution::HostToo
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 async fn run_install(data_dir: &Path) -> Result<(), String> {
     let pinned = PINNED
         .as_ref()
@@ -322,12 +372,12 @@ async fn run_install(data_dir: &Path) -> Result<(), String> {
     result
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 async fn run_install(_data_dir: &Path) -> Result<(), String> {
     Err("Automatic install is not supported on this platform".to_owned())
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 async fn install_into(
     data_dir: &Path,
     staging: &Path,
@@ -342,19 +392,26 @@ async fn install_into(
     )
     .await?;
 
-    let tarball = staging.join("node.tar.gz");
-    download(pinned.url, &tarball).await?;
+    let archive_path = match pinned.archive_format {
+        #[cfg(any(target_os = "macos", target_os = "linux", test))]
+        ArchiveFormat::TarGz => staging.join("node.tar.gz"),
+        #[cfg(any(target_os = "windows", test))]
+        ArchiveFormat::Zip => staging.join("node.zip"),
+    };
+    download(pinned.url, &archive_path).await?;
 
     // Verify against the pinned digest before touching the archive in any way.
     let digest = {
-        let tarball = tarball.clone();
-        tokio::task::spawn_blocking(move || crate::office_install::sha256_hex_of_file(&tarball))
-            .await
-            .map_err(|error| format!("Could not verify the download: {error}"))?
-            .map_err(|error| format!("Could not verify the download: {error}"))?
+        let archive_path = archive_path.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::office_install::sha256_hex_of_file(&archive_path)
+        })
+        .await
+        .map_err(|error| format!("Could not verify the download: {error}"))?
+        .map_err(|error| format!("Could not verify the download: {error}"))?
     };
-    if digest != managed_pin.tarball_sha256 {
-        let _ = tokio::fs::remove_file(&tarball).await;
+    if digest != managed_pin.artifact_sha256 {
+        let _ = tokio::fs::remove_file(&archive_path).await;
         return Err(
             "The downloaded Node did not match its published checksum, so it was discarded. \
              This can mean a corrupted download or a tampered one — try again later."
@@ -366,9 +423,9 @@ async fn install_into(
     tokio::fs::create_dir(&unpacked)
         .await
         .map_err(|error| format!("Could not prepare the install directory: {error}"))?;
-    unpack(&tarball, &unpacked).await?;
+    unpack(&archive_path, &unpacked, pinned.archive_format).await?;
     let extracted = unpacked.join(pinned.archive_root);
-    if !managed_binary(&extracted).is_file() {
+    if !managed_binary(&extracted).is_file() || !managed_npm_executable(&extracted).is_file() {
         return Err("The downloaded Node archive did not contain a runtime".to_owned());
     }
 
@@ -422,25 +479,26 @@ async fn install_into(
     Ok(())
 }
 
-/// Unpack the official tarball into `destination`.
+/// Unpack the official archive into `destination`.
 ///
-/// The in-process tar reader preserves the archive's `bin/npm` and `bin/npx`
-/// symlinks into `lib/node_modules/npm`, so the installed runtime does not
-/// depend on a system `tar` binary being present on the reader's machine.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-async fn unpack(tarball: &Path, destination: &Path) -> Result<(), String> {
-    let tarball = tarball.to_path_buf();
+/// Unix tarballs preserve the archive's `bin/npm` and `bin/npx` symlinks.
+/// Windows ZIPs are extracted through a bounded path validator that accepts
+/// only regular files and directories below `destination`.
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+async fn unpack(
+    archive_path: &Path,
+    destination: &Path,
+    format: ArchiveFormat,
+) -> Result<(), String> {
+    let archive_path = archive_path.to_path_buf();
     let destination = destination.to_path_buf();
     tokio::time::timeout(
         Duration::from_secs(300),
-        tokio::task::spawn_blocking(move || {
-            let file = std::fs::File::open(&tarball)
-                .map_err(|error| format!("Could not open the Node archive: {error}"))?;
-            let gzip = flate2::read::GzDecoder::new(file);
-            let mut archive = tar::Archive::new(gzip);
-            archive
-                .unpack(&destination)
-                .map_err(|error| format!("Could not unpack Node: {error}"))
+        tokio::task::spawn_blocking(move || match format {
+            #[cfg(any(target_os = "macos", target_os = "linux", test))]
+            ArchiveFormat::TarGz => unpack_tar_gz(&archive_path, &destination),
+            #[cfg(any(target_os = "windows", test))]
+            ArchiveFormat::Zip => unpack_zip(&archive_path, &destination),
         }),
     )
     .await
@@ -448,9 +506,164 @@ async fn unpack(tarball: &Path, destination: &Path) -> Result<(), String> {
     .map_err(|error| format!("Could not join the Node unpack task: {error}"))?
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux", test))]
+fn unpack_tar_gz(tarball: &Path, destination: &Path) -> Result<(), String> {
+    let file = std::fs::File::open(tarball)
+        .map_err(|error| format!("Could not open the Node archive: {error}"))?;
+    let gzip = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(gzip);
+    archive
+        .unpack(destination)
+        .map_err(|error| format!("Could not unpack Node: {error}"))
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn unpack_zip(archive_path: &Path, destination: &Path) -> Result<(), String> {
+    use std::io::{Read as _, Write as _};
+
+    let destination_metadata = std::fs::symlink_metadata(destination)
+        .map_err(|error| format!("Could not inspect the Node install directory: {error}"))?;
+    if !destination_metadata.is_dir() || destination_metadata.file_type().is_symlink() {
+        return Err("The Node install destination was not a real directory".to_owned());
+    }
+
+    let file = std::fs::File::open(archive_path)
+        .map_err(|error| format!("Could not open the Node archive: {error}"))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|error| format!("Could not read the Node ZIP archive: {error}"))?;
+    if archive.len() > MAX_ARCHIVE_ENTRIES {
+        return Err("The Node ZIP archive contained too many entries".to_owned());
+    }
+
+    let mut unpacked_bytes = 0_u64;
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| format!("Could not read the Node ZIP archive: {error}"))?;
+        if entry.encrypted() {
+            return Err("The Node ZIP archive contained an encrypted entry".to_owned());
+        }
+        if entry.is_symlink() || zip_entry_is_link_like(entry.unix_mode()) {
+            return Err("The Node ZIP archive contained a link-like entry".to_owned());
+        }
+
+        let relative = safe_zip_entry_path(entry.name())?;
+        let output_path = destination.join(&relative);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&output_path)
+                .map_err(|error| format!("Could not unpack Node: {error}"))?;
+            continue;
+        }
+        if !entry.is_file() {
+            return Err("The Node ZIP archive contained an unsupported entry type".to_owned());
+        }
+
+        let remaining = MAX_UNPACKED_BYTES
+            .checked_sub(unpacked_bytes)
+            .ok_or_else(|| "The Node ZIP archive expanded beyond its size limit".to_owned())?;
+        if entry.size() > remaining {
+            return Err("The Node ZIP archive expanded beyond its size limit".to_owned());
+        }
+        if let Some(parent) = output_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| format!("Could not unpack Node: {error}"))?;
+        }
+        let mut output = std::fs::File::create(&output_path)
+            .map_err(|error| format!("Could not unpack Node: {error}"))?;
+        let copied = std::io::copy(&mut entry.by_ref().take(remaining + 1), &mut output)
+            .map_err(|error| format!("Could not unpack Node: {error}"))?;
+        if copied > remaining {
+            return Err("The Node ZIP archive expanded beyond its size limit".to_owned());
+        }
+        output
+            .flush()
+            .map_err(|error| format!("Could not unpack Node: {error}"))?;
+        unpacked_bytes = unpacked_bytes
+            .checked_add(copied)
+            .ok_or_else(|| "The Node ZIP archive expanded beyond its size limit".to_owned())?;
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn safe_zip_entry_path(name: &str) -> Result<PathBuf, String> {
+    use std::path::Component;
+
+    let path_name = name.strip_suffix('/').unwrap_or(name);
+    if name.is_empty()
+        || name.starts_with('/')
+        || name.contains('\\')
+        || name.contains('\0')
+        || path_name.is_empty()
+        || path_name.split('/').any(windows_zip_segment_is_unsafe)
+    {
+        return Err("The Node ZIP archive contained an unsafe path".to_owned());
+    }
+
+    let path = Path::new(name);
+    if path
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err("The Node ZIP archive contained an unsafe path".to_owned());
+    }
+    Ok(path.to_path_buf())
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_zip_segment_is_unsafe(segment: &str) -> bool {
+    if segment.is_empty()
+        || segment == "."
+        || segment == ".."
+        || segment.ends_with(['.', ' '])
+        || segment
+            .chars()
+            .any(|character| character.is_control() || r#"<>:"|?*"#.contains(character))
+    {
+        return true;
+    }
+
+    let basename = segment.split('.').next().unwrap_or(segment);
+    matches!(
+        basename.to_ascii_uppercase().as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "CLOCK$"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    )
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn zip_entry_is_link_like(mode: Option<u32>) -> bool {
+    let Some(mode) = mode else {
+        return false;
+    };
+    let file_type = mode & 0o170_000;
+    file_type != 0 && file_type != 0o040_000 && file_type != 0o100_000
+}
+
 /// Stream the artifact to disk. Verification happens after, against the whole
 /// file.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 async fn download(url: &str, destination: &Path) -> Result<(), String> {
     use futures::StreamExt as _;
     use tokio::io::AsyncWriteExt as _;
@@ -496,7 +709,7 @@ async fn download(url: &str, destination: &Path) -> Result<(), String> {
 
 /// Account for one response chunk before it reaches disk. Content-Length is
 /// only a hint; this is the bound for chunked or dishonest responses.
-#[cfg(any(target_os = "macos", target_os = "linux", test))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows", test))]
 fn next_downloaded_size(downloaded: u64, chunk_bytes: usize) -> Result<u64, String> {
     let chunk_bytes = u64::try_from(chunk_bytes).map_err(|_| DOWNLOAD_TOO_LARGE.to_owned())?;
     let next = downloaded
@@ -566,7 +779,9 @@ mod tests {
 
         let destination = dir.path().join("unpacked");
         std::fs::create_dir(&destination).expect("destination");
-        unpack(&tarball, &destination).await.expect("unpack");
+        unpack(&tarball, &destination, ArchiveFormat::TarGz)
+            .await
+            .expect("unpack");
 
         let npm = destination.join("node-v0.0.0-test/bin/npm");
         assert!(std::fs::symlink_metadata(&npm)
@@ -583,5 +798,107 @@ mod tests {
             0,
             "the runtime remains executable"
         );
+    }
+
+    #[tokio::test]
+    async fn unpack_zip_extracts_the_windows_runtime_layout() {
+        use std::io::Write as _;
+        use zip::write::SimpleFileOptions;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive_path = dir.path().join("node.zip");
+        let file = std::fs::File::create(&archive_path).expect("zip");
+        let mut archive = zip::ZipWriter::new(file);
+        let options = SimpleFileOptions::default();
+        archive
+            .add_directory("node-v0.0.0-win-x64/", options)
+            .expect("root");
+        archive
+            .start_file("node-v0.0.0-win-x64/node.exe", options)
+            .expect("node entry");
+        archive.write_all(b"node").expect("node");
+        archive
+            .start_file("node-v0.0.0-win-x64/npm.cmd", options)
+            .expect("npm entry");
+        archive.write_all(b"@echo off\r\n").expect("npm");
+        archive
+            .start_file(
+                "node-v0.0.0-win-x64/node_modules/npm/bin/npm-cli.js",
+                options,
+            )
+            .expect("nested entry");
+        archive.write_all(b"// npm\n").expect("nested");
+        archive.finish().expect("finish zip");
+
+        let destination = dir.path().join("unpacked");
+        std::fs::create_dir(&destination).expect("destination");
+        unpack(&archive_path, &destination, ArchiveFormat::Zip)
+            .await
+            .expect("unpack");
+
+        let root = destination.join("node-v0.0.0-win-x64");
+        assert_eq!(std::fs::read(root.join("node.exe")).expect("node"), b"node");
+        assert_eq!(
+            std::fs::read(root.join("npm.cmd")).expect("npm"),
+            b"@echo off\r\n"
+        );
+        assert_eq!(
+            std::fs::read(root.join("node_modules/npm/bin/npm-cli.js")).expect("nested"),
+            b"// npm\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn unpack_zip_rejects_traversal_without_writing_outside_destination() {
+        use std::io::Write as _;
+        use zip::write::SimpleFileOptions;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive_path = dir.path().join("node.zip");
+        let file = std::fs::File::create(&archive_path).expect("zip");
+        let mut archive = zip::ZipWriter::new(file);
+        archive
+            .start_file("../escaped.txt", SimpleFileOptions::default())
+            .expect("traversal entry");
+        archive.write_all(b"escaped").expect("entry");
+        archive.finish().expect("finish zip");
+
+        let destination = dir.path().join("unpacked");
+        std::fs::create_dir(&destination).expect("destination");
+        let error = unpack(&archive_path, &destination, ArchiveFormat::Zip)
+            .await
+            .expect_err("traversal must fail");
+        assert!(error.contains("unsafe path"), "unexpected error: {error}");
+        assert!(!dir.path().join("escaped.txt").exists());
+    }
+
+    #[test]
+    fn zip_path_and_entry_validation_rejects_windows_escape_forms_and_links() {
+        for name in [
+            "../escape",
+            "/absolute",
+            "C:/absolute",
+            r"C:\absolute",
+            r"root\..\escape",
+            "root//file",
+            "root/./file",
+            "root/CON",
+            "root/NUL.txt",
+            "root/trailing. ",
+            "root/stream:name",
+        ] {
+            assert!(
+                safe_zip_entry_path(name).is_err(),
+                "unsafe path was accepted: {name}"
+            );
+        }
+        assert!(safe_zip_entry_path("node-v0.0.0-win-x64/node.exe").is_ok());
+        assert!(safe_zip_entry_path("node-v0.0.0-win-x64/").is_ok());
+
+        assert!(zip_entry_is_link_like(Some(0o120_777)));
+        assert!(zip_entry_is_link_like(Some(0o060_644)));
+        assert!(!zip_entry_is_link_like(Some(0o100_644)));
+        assert!(!zip_entry_is_link_like(Some(0o040_755)));
+        assert!(!zip_entry_is_link_like(None));
     }
 }

--- a/crates/tidebreak-desktop/src/office_install.rs
+++ b/crates/tidebreak-desktop/src/office_install.rs
@@ -703,10 +703,9 @@ pub(crate) async fn run_tool(
     Ok(())
 }
 
-/// Refuse to start a large install on a nearly full disk. `df` because the
-/// standard library has no free-space query and the callers are Unix-only.
-/// `shortfall` is the message the caller wants when the check fails, so each
-/// managed install names itself and its own size.
+/// Refuse to start a large install on a nearly full disk. `shortfall` is the
+/// message the caller wants when the check fails, so each managed install
+/// names itself and its own size.
 #[cfg(unix)]
 pub(crate) async fn ensure_free_disk(
     directory: &Path,
@@ -727,6 +726,38 @@ pub(crate) async fn ensure_free_disk(
         .and_then(|field| field.parse().ok())
         .ok_or_else(|| "Could not check free disk space".to_owned())?;
     if available_kib.saturating_mul(1024) < required {
+        return Err(shortfall.to_owned());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+pub(crate) async fn ensure_free_disk(
+    directory: &Path,
+    required: u64,
+    shortfall: &str,
+) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+
+    let mut directory = directory.as_os_str().encode_wide().collect::<Vec<_>>();
+    directory.push(0);
+    let mut available = 0_u64;
+    let status = unsafe {
+        GetDiskFreeSpaceExW(
+            directory.as_ptr(),
+            &mut available,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    if status == 0 {
+        return Err(format!(
+            "Could not check free disk space: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    if available < required {
         return Err(shortfall.to_owned());
     }
     Ok(())

--- a/crates/tidebreak-harness/Cargo.toml
+++ b/crates/tidebreak-harness/Cargo.toml
@@ -17,14 +17,20 @@ capture = []
 
 [dependencies]
 async-trait = { workspace = true }
-libc = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tidebreak-code-execution = { path = "../tidebreak-code-execution" }
 tidebreak-core = { path = "../tidebreak-core", default-features = false }
 tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "sync", "time"] }
 tracing = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -479,7 +479,7 @@ mod windows_tests {
                 "-NoProfile",
                 "-NonInteractive",
                 "-Command",
-                script,
+                script.as_str(),
             ])
             .stdin(Stdio::null())
             .stdout(Stdio::null())

--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -437,7 +437,7 @@ mod windows_tests {
 
     use tokio::process::Command;
     use tokio::time::{sleep, Instant};
-    use windows_sys::Win32::Foundation::{HANDLE, WAIT_OBJECT_0};
+    use windows_sys::Win32::Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
     use windows_sys::Win32::System::Threading::{
         OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
     };
@@ -487,6 +487,11 @@ mod windows_tests {
         let child = spawn_process_tree(&mut command).unwrap();
         let pid = wait_for_pid(&pid_file).await;
         let descendant = open_process(pid);
+        assert_eq!(
+            wait_status(&descendant, Duration::ZERO),
+            WAIT_TIMEOUT,
+            "descendant {pid} exited before ProcessTreeChild teardown"
+        );
         // The temp directory only carries the synchronization file. Keeping it
         // until the pid has been read avoids cleanup racing the parent write.
         drop(dir);
@@ -519,18 +524,22 @@ mod windows_tests {
     }
 
     fn assert_process_exits(process: OwnedHandle) {
-        // SAFETY: `process` is a live synchronization handle and remains owned
-        // for the duration of the bounded wait.
-        let result = unsafe {
-            WaitForSingleObject(
-                process.as_raw_handle() as HANDLE,
-                DESCENDANT_TIMEOUT.as_millis() as u32,
-            )
-        };
+        let result = wait_status(&process, DESCENDANT_TIMEOUT);
         assert_eq!(
             result, WAIT_OBJECT_0,
             "descendant remained alive after its ProcessTreeChild ended"
         );
+    }
+
+    fn wait_status(process: &OwnedHandle, timeout: Duration) -> u32 {
+        // SAFETY: `process` is a live synchronization handle and remains owned
+        // for the duration of the bounded wait.
+        unsafe {
+            WaitForSingleObject(
+                process.as_raw_handle() as HANDLE,
+                timeout.as_millis() as u32,
+            )
+        }
     }
 
     fn powershell_path() -> PathBuf {

--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -5,9 +5,14 @@
 //! window a crash can orphan a child in), and how the child ended once it is
 //! gone (an EOF on stdout is not a completed turn).
 
-use std::process::ExitStatus;
+use std::io;
+use std::process::{ExitStatus, Output};
+use std::time::Duration;
 
+use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 use tokio::sync::watch;
+#[cfg(unix)]
+use tokio::time::timeout;
 
 use crate::TurnOutcome;
 
@@ -60,19 +65,286 @@ impl ChildPid {
     }
 }
 
-/// Ask a child this session spawned to stop.
+/// One child and the operating-system process tree it owns.
 ///
-/// SIGINT only: the caller decides whether to escalate after its own grace
-/// period, and only ever against a pid recorded at spawn.
-pub fn signal_interrupt(pid: i64) {
-    #[cfg(unix)]
+/// Windows children are created suspended, assigned to a Job Object configured
+/// with `KILL_ON_JOB_CLOSE`, then resumed. That closes the usual spawn/assign
+/// race where a wrapper such as `npm.cmd` could create a descendant before it
+/// became part of the job. Dropping this value terminates the job tree.
+///
+/// Unix keeps Tokio's immediate-child kill-on-drop behavior. [`Self::interrupt`]
+/// sends SIGINT first and escalates after the caller's grace period.
+pub struct ProcessTreeChild {
+    child: Option<Child>,
+    #[cfg(windows)]
+    job: windows::Job,
+}
+
+/// Spawn `command` with process-tree ownership.
+///
+/// Callers may await [`ProcessTreeChild::wait_with_output`] inside a timeout:
+/// cancelling that future drops the owned child and terminates its Windows Job
+/// Object tree.
+pub fn spawn_process_tree(command: &mut Command) -> io::Result<ProcessTreeChild> {
+    command.kill_on_drop(true);
+    #[cfg(windows)]
     {
-        // SAFETY: the pid was recorded from a child we spawned this session.
-        let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
+        let job = windows::Job::new()?;
+        command.creation_flags(windows::CREATE_SUSPENDED_FLAG);
+        let mut child = command.spawn()?;
+        if let Err(err) = job.assign_and_resume(&child) {
+            let _ = child.start_kill();
+            return Err(err);
+        }
+        return Ok(ProcessTreeChild {
+            child: Some(child),
+            job,
+        });
     }
-    #[cfg(not(unix))]
+    #[cfg(not(windows))]
     {
-        let _ = pid;
+        Ok(ProcessTreeChild {
+            child: Some(command.spawn()?),
+        })
+    }
+}
+
+impl ProcessTreeChild {
+    fn child(&self) -> &Child {
+        self.child.as_ref().expect("process child is present")
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.child.as_mut().expect("process child is present")
+    }
+
+    /// Operating-system process id, when the child is still present.
+    #[must_use]
+    pub fn id(&self) -> Option<u32> {
+        self.child().id()
+    }
+
+    /// Take the child's piped stdin, when configured.
+    pub fn take_stdin(&mut self) -> Option<ChildStdin> {
+        self.child_mut().stdin.take()
+    }
+
+    /// Take the child's piped stdout, when configured.
+    pub fn take_stdout(&mut self) -> Option<ChildStdout> {
+        self.child_mut().stdout.take()
+    }
+
+    /// Take the child's piped stderr, when configured.
+    pub fn take_stderr(&mut self) -> Option<ChildStderr> {
+        self.child_mut().stderr.take()
+    }
+
+    /// Wait for the root child to exit.
+    pub async fn wait(&mut self) -> io::Result<ExitStatus> {
+        self.child_mut().wait().await
+    }
+
+    /// Read a completed root child's exit status without waiting.
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        self.child_mut().try_wait()
+    }
+
+    /// Wait for the root child and collect its configured stdout and stderr.
+    ///
+    /// Dropping this future before completion drops `self`, which terminates
+    /// the owned Windows process tree.
+    pub async fn wait_with_output(mut self) -> io::Result<Output> {
+        self.child
+            .take()
+            .expect("process child is present")
+            .wait_with_output()
+            .await
+    }
+
+    /// Ask the process to stop, escalating to tree termination after `grace`.
+    ///
+    /// Windows has no reliable console-control channel for GUI-spawned batch
+    /// shims, so interruption terminates the Job Object immediately. Unix
+    /// sends SIGINT to the root child first and preserves the existing grace
+    /// period before escalating.
+    pub async fn interrupt(&mut self, grace: Duration) -> io::Result<ExitStatus> {
+        #[cfg(unix)]
+        if let Some(pid) = self.id() {
+            // SAFETY: the pid belongs to the child held by this value.
+            let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
+            if let Ok(status) = timeout(grace, self.wait()).await {
+                return status;
+            }
+        }
+        #[cfg(not(unix))]
+        let _ = grace;
+
+        self.terminate().await
+    }
+
+    /// Terminate the entire owned tree and wait for the root child.
+    pub async fn terminate(&mut self) -> io::Result<ExitStatus> {
+        self.terminate_tree()?;
+        self.wait().await
+    }
+
+    fn terminate_tree(&mut self) -> io::Result<()> {
+        #[cfg(windows)]
+        {
+            self.job.terminate()
+        }
+        #[cfg(not(windows))]
+        {
+            self.child_mut().start_kill()
+        }
+    }
+}
+
+impl Drop for ProcessTreeChild {
+    fn drop(&mut self) {
+        if self.child.is_some() {
+            let _ = self.terminate_tree();
+        }
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::io;
+    use std::mem::size_of;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+    use std::ptr;
+
+    use tokio::process::Child;
+    use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+    };
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+    use windows_sys::Win32::System::Threading::{
+        OpenThread, ResumeThread, CREATE_SUSPENDED, THREAD_SUSPEND_RESUME,
+    };
+
+    pub(super) const CREATE_SUSPENDED_FLAG: u32 = CREATE_SUSPENDED;
+    const TERMINATED_EXIT_CODE: u32 = 1;
+
+    pub(super) struct Job {
+        handle: OwnedHandle,
+    }
+
+    impl Job {
+        pub(super) fn new() -> io::Result<Self> {
+            // SAFETY: null attributes and name create an unnamed job owned by
+            // the returned handle.
+            let raw = unsafe { CreateJobObjectW(ptr::null(), ptr::null()) };
+            let handle = owned_handle(raw)?;
+            let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            // SAFETY: `limits` has the exact layout and lifetime required for
+            // JobObjectExtendedLimitInformation.
+            let configured = unsafe {
+                SetInformationJobObject(
+                    handle.as_raw_handle() as HANDLE,
+                    JobObjectExtendedLimitInformation,
+                    ptr::from_ref(&limits).cast(),
+                    size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                )
+            };
+            if configured == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(Self { handle })
+        }
+
+        pub(super) fn assign_and_resume(&self, child: &Child) -> io::Result<()> {
+            let pid = child
+                .id()
+                .ok_or_else(|| io::Error::other("spawned child has no process id"))?;
+            let process = child
+                .raw_handle()
+                .ok_or_else(|| io::Error::other("spawned child has no process handle"))?;
+            // SAFETY: both handles are live and owned for at least this call.
+            let assigned = unsafe {
+                AssignProcessToJobObject(self.handle.as_raw_handle() as HANDLE, process as HANDLE)
+            };
+            if assigned == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            resume_process_threads(pid)
+        }
+
+        pub(super) fn terminate(&self) -> io::Result<()> {
+            // SAFETY: this value owns a live Job Object handle.
+            let terminated = unsafe {
+                TerminateJobObject(self.handle.as_raw_handle() as HANDLE, TERMINATED_EXIT_CODE)
+            };
+            if terminated == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        }
+    }
+
+    fn resume_process_threads(pid: u32) -> io::Result<()> {
+        // SAFETY: the returned snapshot handle is converted to OwnedHandle.
+        let raw_snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+        if raw_snapshot == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: INVALID_HANDLE_VALUE was rejected above.
+        let snapshot = unsafe { OwnedHandle::from_raw_handle(raw_snapshot.cast()) };
+        let mut entry = THREADENTRY32 {
+            dwSize: size_of::<THREADENTRY32>() as u32,
+            ..THREADENTRY32::default()
+        };
+        // SAFETY: `entry` points to writable storage of the documented size.
+        let mut has_entry = unsafe {
+            Thread32First(
+                snapshot.as_raw_handle() as HANDLE,
+                ptr::from_mut(&mut entry),
+            ) != 0
+        };
+        let mut resumed = false;
+        while has_entry {
+            if entry.th32OwnerProcessID == pid {
+                // SAFETY: the id came from a live system thread snapshot.
+                let raw_thread =
+                    unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID) };
+                if !raw_thread.is_null() {
+                    // SAFETY: non-null thread handle returned by OpenThread.
+                    let thread = unsafe { OwnedHandle::from_raw_handle(raw_thread.cast()) };
+                    // SAFETY: this child was created with CREATE_SUSPENDED, so
+                    // resuming its primary thread starts the assigned process.
+                    let previous = unsafe { ResumeThread(thread.as_raw_handle() as HANDLE) };
+                    if previous == u32::MAX {
+                        return Err(io::Error::last_os_error());
+                    }
+                    resumed = true;
+                }
+            }
+            // SAFETY: `entry` remains valid writable storage across calls.
+            has_entry = unsafe {
+                Thread32Next(
+                    snapshot.as_raw_handle() as HANDLE,
+                    ptr::from_mut(&mut entry),
+                ) != 0
+            };
+        }
+        resumed
+            .then_some(())
+            .ok_or_else(|| io::Error::other("spawned child had no resumable thread"))
+    }
+
+    fn owned_handle(raw: HANDLE) -> io::Result<OwnedHandle> {
+        if raw.is_null() || raw == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: the successful Win32 call transferred one owned handle.
+        Ok(unsafe { OwnedHandle::from_raw_handle(raw.cast()) })
     }
 }
 
@@ -153,5 +425,117 @@ mod tests {
             }
             other => panic!("{other:?}"),
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+    use std::path::{Path, PathBuf};
+    use std::process::Stdio;
+    use std::time::Duration;
+
+    use tokio::process::Command;
+    use tokio::time::{sleep, Instant};
+    use windows_sys::Win32::Foundation::{HANDLE, WAIT_OBJECT_0};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
+    };
+
+    use super::{spawn_process_tree, ProcessTreeChild};
+
+    const DESCENDANT_TIMEOUT: Duration = Duration::from_secs(10);
+
+    #[tokio::test]
+    async fn terminating_a_process_tree_kills_its_descendant() {
+        let (mut child, descendant) = spawn_powershell_tree().await;
+        child.terminate().await.unwrap();
+        assert_process_exits(descendant);
+    }
+
+    #[tokio::test]
+    async fn dropping_a_process_tree_kills_its_descendant() {
+        let (child, descendant) = spawn_powershell_tree().await;
+        drop(child);
+        assert_process_exits(descendant);
+    }
+
+    async fn spawn_powershell_tree() -> (ProcessTreeChild, OwnedHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("descendant.pid");
+        let powershell = powershell_path();
+        let script = "$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') \
+                      -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command',\
+                      'Start-Sleep -Seconds 120') -PassThru; \
+                      [IO.File]::WriteAllText($args[0], $child.Id.ToString()); \
+                      Wait-Process -Id $child.Id";
+        let mut command = Command::new(powershell);
+        command
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                script,
+            ])
+            .arg(&pid_file)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = spawn_process_tree(&mut command).unwrap();
+        let pid = wait_for_pid(&pid_file).await;
+        let descendant = open_process(pid);
+        // The temp directory only carries the synchronization file. Keeping it
+        // until the pid has been read avoids cleanup racing the parent write.
+        drop(dir);
+        (child, descendant)
+    }
+
+    async fn wait_for_pid(path: &Path) -> u32 {
+        let deadline = Instant::now() + DESCENDANT_TIMEOUT;
+        loop {
+            if let Ok(value) = tokio::fs::read_to_string(path).await {
+                if let Ok(pid) = value.trim().parse() {
+                    return pid;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "PowerShell descendant pid was not published within {DESCENDANT_TIMEOUT:?}"
+            );
+            sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    fn open_process(pid: u32) -> OwnedHandle {
+        // SAFETY: read/synchronization access is requested for the pid the
+        // test parent just created and published.
+        let raw = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, 0, pid) };
+        assert!(!raw.is_null(), "could not open descendant process {pid}");
+        // SAFETY: successful OpenProcess transfers one owned handle.
+        unsafe { OwnedHandle::from_raw_handle(raw.cast()) }
+    }
+
+    fn assert_process_exits(process: OwnedHandle) {
+        // SAFETY: `process` is a live synchronization handle and remains owned
+        // for the duration of the bounded wait.
+        let result = unsafe {
+            WaitForSingleObject(
+                process.as_raw_handle() as HANDLE,
+                DESCENDANT_TIMEOUT.as_millis() as u32,
+            )
+        };
+        assert_eq!(
+            result, WAIT_OBJECT_0,
+            "descendant remained alive after its ProcessTreeChild ended"
+        );
+    }
+
+    fn powershell_path() -> PathBuf {
+        PathBuf::from(std::env::var_os("SystemRoot").expect("SystemRoot is set on Windows"))
+            .join("System32")
+            .join("WindowsPowerShell")
+            .join("v1.0")
+            .join("powershell.exe")
     }
 }

--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -464,11 +464,14 @@ mod windows_tests {
         let dir = tempfile::tempdir().unwrap();
         let pid_file = dir.path().join("descendant.pid");
         let powershell = powershell_path();
-        let script = "$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') \
-                      -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command',\
-                      'Start-Sleep -Seconds 120') -PassThru; \
-                      [IO.File]::WriteAllText($args[0], $child.Id.ToString()); \
-                      Wait-Process -Id $child.Id";
+        let pid_literal = format!("'{}'", pid_file.to_string_lossy().replace('\'', "''"));
+        let script = format!(
+            "$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') \
+             -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command',\
+             'Start-Sleep -Seconds 120') -PassThru; \
+             [IO.File]::WriteAllText({pid_literal}, $child.Id.ToString(), [Text.UTF8Encoding]::new($false)); \
+             Wait-Process -Id $child.Id"
+        );
         let mut command = Command::new(powershell);
         command
             .args([
@@ -478,7 +481,6 @@ mod windows_tests {
                 "-Command",
                 script,
             ])
-            .arg(&pid_file)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
@@ -495,7 +497,7 @@ mod windows_tests {
         let deadline = Instant::now() + DESCENDANT_TIMEOUT;
         loop {
             if let Ok(value) = tokio::fs::read_to_string(path).await {
-                if let Ok(pid) = value.trim().parse() {
+                if let Ok(pid) = value.trim().trim_start_matches('\u{feff}').trim().parse() {
                     return pid;
                 }
             }

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -167,7 +167,8 @@ mod tests {
             });
             let actual = format!("{}\n", serde_json::to_string_pretty(&out.events).unwrap());
             assert_eq!(
-                expected, actual,
+                expected.replace("\r\n", "\n"),
+                actual,
                 "normalized sequence for {name} drifted from the fixture"
             );
         }

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -7,18 +7,18 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, Command};
+use tokio::process::Command;
 use tokio::sync::watch;
 use tokio::sync::Mutex as AsyncMutex;
-use tokio::time::timeout;
 use tracing::warn;
 
-use crate::child::{signal_interrupt, turn_outcome, ChildPid};
+use crate::child::{turn_outcome, ChildPid};
 use crate::claude::parse::ClaudeStreamParser;
 use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
-    filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
-    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
+    filter_child_env, spawn_process_tree, ApprovalDecision, HarnessApprovalRef, HarnessError,
+    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
+    TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -60,7 +60,7 @@ pub(crate) fn bypass_policy(mode: CodePermissionMode) -> BypassPolicy {
 pub struct ClaudeSession {
     spec: SessionSpec,
     resume_ref: Mutex<Option<String>>,
-    child: AsyncMutex<Option<Child>>,
+    child: AsyncMutex<Option<ProcessTreeChild>>,
     pid: ChildPid,
     /// Exit status of a child [`HarnessSession::interrupt`] already reaped, so
     /// `run_turn` can still report how the turn ended.
@@ -125,7 +125,7 @@ impl ClaudeSession {
     /// `run_turn` to report.
     fn finish_child(
         &self,
-        mut slot: tokio::sync::MutexGuard<'_, Option<Child>>,
+        mut slot: tokio::sync::MutexGuard<'_, Option<ProcessTreeChild>>,
         status: Option<ExitStatus>,
     ) {
         *slot = None;
@@ -145,7 +145,6 @@ impl HarnessSession for ClaudeSession {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
             .env_clear();
         for (key, value) in filter_child_env(self.spec.env.iter().cloned()) {
             command.env(key, value);
@@ -153,18 +152,15 @@ impl HarnessSession for ClaudeSession {
         for (key, value) in &plan.env {
             command.env(key, value);
         }
-        let mut child = command.spawn()?;
+        let mut child = spawn_process_tree(&mut command)?;
         let mut stdin = child
-            .stdin
-            .take()
+            .take_stdin()
             .ok_or_else(|| HarnessError::Other("engine child has no stdin".into()))?;
         let stdout = child
-            .stdout
-            .take()
+            .take_stdout()
             .ok_or_else(|| HarnessError::Other("engine child has no stdout".into()))?;
         let stderr = child
-            .stderr
-            .take()
+            .take_stderr()
             .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
         self.reaped.lock().expect("claude child exit").take();
         // Publish before the first await: the pid is what crash recovery
@@ -254,29 +250,13 @@ impl HarnessSession for ClaudeSession {
     }
 
     async fn interrupt(&self) -> Result<(), HarnessError> {
-        if let Some(pid) = self.pid.get() {
-            signal_interrupt(pid);
-        }
         let mut slot = self.child.lock().await;
         let Some(child) = slot.as_mut() else {
             return Ok(());
         };
-        match timeout(INTERRUPT_GRACE, child.wait()).await {
-            Ok(Ok(status)) => {
-                self.finish_child(slot, Some(status));
-                Ok(())
-            }
-            Ok(Err(err)) => Err(err.into()),
-            Err(_) => {
-                warn!("engine did not exit after SIGINT; killing");
-                // `kill` already reaps; `try_wait` reads the status it left
-                // without risking a second wait on a reaped child.
-                child.kill().await?;
-                let status = child.try_wait().ok().flatten();
-                self.finish_child(slot, status);
-                Ok(())
-            }
-        }
+        let status = child.interrupt(INTERRUPT_GRACE).await?;
+        self.finish_child(slot, Some(status));
+        Ok(())
     }
 
     fn resume_ref(&self) -> Option<String> {
@@ -297,7 +277,7 @@ impl HarnessSession for ClaudeSession {
 
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         if let Some(mut child) = self.child.lock().await.take() {
-            let _ = child.kill().await;
+            let _ = child.terminate().await;
         }
         Ok(())
     }

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -162,7 +162,8 @@ mod tests {
             });
             let actual = format!("{}\n", serde_json::to_string_pretty(&out.events).unwrap());
             assert_eq!(
-                expected, actual,
+                expected.replace("\r\n", "\n"),
+                actual,
                 "normalized sequence for {name} drifted from the fixture"
             );
         }

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -105,13 +105,16 @@ async fn observe_login(
         .args(["login", "status"])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
+        .stderr(Stdio::piped());
     command.env_clear();
     for (key, value) in crate::filter_child_env(env.iter().cloned()) {
         command.env(key, value);
     }
-    let output = timeout(AUTH_TIMEOUT, command.output()).await.ok()?.ok()?;
+    let child = crate::spawn_process_tree(&mut command).ok()?;
+    let output = timeout(AUTH_TIMEOUT, child.wait_with_output())
+        .await
+        .ok()?
+        .ok()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let line = stdout
         .lines()

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::process::{ChildStdin, ChildStdout, Command};
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
 use tracing::warn;
@@ -17,8 +17,9 @@ use tracing::warn;
 use crate::codex::parse::CodexStreamParser;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::{
-    filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
-    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
+    filter_child_env, spawn_process_tree, ApprovalDecision, HarnessApprovalRef, HarnessError,
+    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
+    TurnInput, TurnOutcome,
 };
 use tidebreak_core::{CodePermissionMode, MAX_NOTICE_CHARS};
 
@@ -36,7 +37,7 @@ pub struct CodexSession {
     thread_ran_a_turn: AtomicBool,
     /// Detail from an engine error saying the resumed thread is gone.
     resume_lost: Mutex<Option<String>>,
-    child: AsyncMutex<Option<Child>>,
+    child: AsyncMutex<Option<ProcessTreeChild>>,
     child_pid: AtomicU32,
     stdin: Option<Arc<AsyncMutex<ChildStdin>>>,
     stdout: Option<Arc<AsyncMutex<StdoutReader>>>,
@@ -163,7 +164,6 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<CodexSession, HarnessErr
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true)
         .env_clear();
     for (key, value) in filter_child_env(session.spec.env.iter().cloned()) {
         command.env(key, value);
@@ -171,18 +171,15 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<CodexSession, HarnessErr
     for (key, value) in &plan.env {
         command.env(key, value);
     }
-    let mut child = command.spawn()?;
+    let mut child = spawn_process_tree(&mut command)?;
     let stdin = child
-        .stdin
-        .take()
+        .take_stdin()
         .ok_or_else(|| HarnessError::Other("engine child has no stdin".into()))?;
     let stdout = child
-        .stdout
-        .take()
+        .take_stdout()
         .ok_or_else(|| HarnessError::Other("engine child has no stdout".into()))?;
     let stderr = child
-        .stderr
-        .take()
+        .take_stderr()
         .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
     session.stdin = Some(Arc::new(AsyncMutex::new(stdin)));
     session.stdout = Some(Arc::new(AsyncMutex::new(StdoutReader {
@@ -451,29 +448,14 @@ impl HarnessSession for CodexSession {
                 return Ok(());
             }
         }
-        let pid = self.child_pid.load(Ordering::SeqCst);
-        if pid != 0 {
-            signal_interrupt(pid);
-        }
         let mut slot = self.child.lock().await;
         let Some(child) = slot.as_mut() else {
             return Ok(());
         };
-        match timeout(Duration::from_secs(2), child.wait()).await {
-            Ok(Ok(_)) => {
-                *slot = None;
-                self.child_pid.store(0, Ordering::SeqCst);
-                Ok(())
-            }
-            Ok(Err(err)) => Err(err.into()),
-            Err(_) => {
-                warn!("engine did not exit after SIGINT; killing");
-                child.kill().await?;
-                *slot = None;
-                self.child_pid.store(0, Ordering::SeqCst);
-                Ok(())
-            }
-        }
+        child.interrupt(Duration::from_secs(2)).await?;
+        *slot = None;
+        self.child_pid.store(0, Ordering::SeqCst);
+        Ok(())
     }
 
     fn resume_ref(&self) -> Option<String> {
@@ -505,7 +487,7 @@ impl HarnessSession for CodexSession {
 
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         if let Some(mut child) = self.child.lock().await.take() {
-            let _ = child.kill().await;
+            let _ = child.terminate().await;
         }
         Ok(())
     }
@@ -554,19 +536,6 @@ where
         }
     }
     String::from_utf8_lossy(&out).into_owned()
-}
-
-fn signal_interrupt(pid: u32) {
-    #[cfg(unix)]
-    {
-        let pid = pid as i32;
-        // SAFETY: the pid was recorded from a child we spawned this session.
-        let _ = unsafe { libc::kill(pid, libc::SIGINT) };
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-    }
 }
 
 #[cfg(test)]

--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -179,7 +179,8 @@ mod tests {
             });
             let actual = format!("{}\n", serde_json::to_string_pretty(&out.events).unwrap());
             assert_eq!(
-                expected, actual,
+                expected.replace("\r\n", "\n"),
+                actual,
                 "normalized sequence for {name} drifted from the fixture"
             );
         }

--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -118,13 +118,16 @@ async fn observe_login(
         .args(["models"])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
+        .stderr(Stdio::piped());
     command.env_clear();
     for (key, value) in crate::filter_child_env(env.iter().cloned()) {
         command.env(key, value);
     }
-    let output = timeout(AUTH_TIMEOUT, command.output()).await.ok()?.ok()?;
+    let child = crate::spawn_process_tree(&mut command).ok()?;
+    let output = timeout(AUTH_TIMEOUT, child.wait_with_output())
+        .await
+        .ok()?
+        .ok()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     login_status_from_models(&stdout)
 }

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -8,18 +8,18 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use tokio::io::AsyncReadExt;
-use tokio::process::{Child, Command};
+use tokio::process::Command;
 use tokio::sync::watch;
 use tokio::sync::Mutex as AsyncMutex;
-use tokio::time::timeout;
 use tracing::warn;
 
-use crate::child::{signal_interrupt, turn_outcome, ChildPid};
+use crate::child::{turn_outcome, ChildPid};
 use crate::grok::parse::GrokStreamParser;
 use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
-    filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
-    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
+    filter_child_env, spawn_process_tree, ApprovalDecision, HarnessApprovalRef, HarnessError,
+    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
+    TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -31,7 +31,7 @@ pub struct GrokSession {
     spec: SessionSpec,
     resume_ref: Mutex<Option<String>>,
     version: String,
-    child: AsyncMutex<Option<Child>>,
+    child: AsyncMutex<Option<ProcessTreeChild>>,
     pid: ChildPid,
     /// Exit status of a child [`HarnessSession::interrupt`] already reaped.
     reaped: Mutex<Option<ExitStatus>>,
@@ -176,29 +176,13 @@ impl HarnessSession for GrokSession {
     }
 
     async fn interrupt(&self) -> Result<(), HarnessError> {
-        if let Some(pid) = self.pid.get() {
-            signal_interrupt(pid);
-        }
         let mut slot = self.child.lock().await;
         let Some(child) = slot.as_mut() else {
             return Ok(());
         };
-        match timeout(INTERRUPT_GRACE, child.wait()).await {
-            Ok(Ok(status)) => {
-                self.finish_child(slot, Some(status));
-                Ok(())
-            }
-            Ok(Err(err)) => Err(err.into()),
-            Err(_) => {
-                warn!("engine did not exit after SIGINT; killing");
-                // `kill` already reaps; `try_wait` reads the status it left
-                // without risking a second wait on a reaped child.
-                child.kill().await?;
-                let status = child.try_wait().ok().flatten();
-                self.finish_child(slot, status);
-                Ok(())
-            }
-        }
+        let status = child.interrupt(INTERRUPT_GRACE).await?;
+        self.finish_child(slot, Some(status));
+        Ok(())
     }
 
     fn resume_ref(&self) -> Option<String> {
@@ -219,7 +203,7 @@ impl HarnessSession for GrokSession {
 
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         if let Some(mut child) = self.child.lock().await.take() {
-            let _ = child.kill().await;
+            let _ = child.terminate().await;
         }
         Ok(())
     }
@@ -230,7 +214,7 @@ impl GrokSession {
     /// `spawn_and_read` to report.
     fn finish_child(
         &self,
-        mut slot: tokio::sync::MutexGuard<'_, Option<Child>>,
+        mut slot: tokio::sync::MutexGuard<'_, Option<ProcessTreeChild>>,
         status: Option<ExitStatus>,
     ) {
         *slot = None;
@@ -246,7 +230,6 @@ impl GrokSession {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
             .env_clear();
         for (key, value) in filter_child_env(self.spec.env.iter().cloned()) {
             command.env(key, value);
@@ -254,14 +237,12 @@ impl GrokSession {
         for (key, value) in &plan.env {
             command.env(key, value);
         }
-        let mut child = command.spawn()?;
+        let mut child = spawn_process_tree(&mut command)?;
         let stdout = child
-            .stdout
-            .take()
+            .take_stdout()
             .ok_or_else(|| HarnessError::Other("engine child has no stdout".into()))?;
         let stderr = child
-            .stderr
-            .take()
+            .take_stderr()
             .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
         self.reaped.lock().expect("grok child exit").take();
         // Publish before the first await: the pid is what crash recovery

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -32,7 +32,7 @@ pub mod probe;
 mod text;
 
 pub use budget::{BudgetTick, StreamBudget, StreamLineBuffer};
-pub use child::ChildPid;
+pub use child::{spawn_process_tree, ChildPid, ProcessTreeChild};
 pub use launch::{
     validate_launch_plan, validate_launch_plan_with, BypassFlagError, BypassPolicy, LaunchPlan,
 };

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -172,7 +172,8 @@ mod tests {
             });
             let actual = format!("{}\n", serde_json::to_string_pretty(&out.events).unwrap());
             assert_eq!(
-                expected, actual,
+                expected.replace("\r\n", "\n"),
+                actual,
                 "normalized sequence for {name} drifted from the fixture"
             );
         }

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -108,13 +108,16 @@ async fn observe_auth(
         .args(["auth", "list"])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
+        .stderr(Stdio::piped());
     command.env_clear();
     for (key, value) in crate::filter_child_env(env.iter().cloned()) {
         command.env(key, value);
     }
-    let output = timeout(AUTH_TIMEOUT, command.output()).await.ok()?.ok()?;
+    let child = crate::spawn_process_tree(&mut command).ok()?;
+    let output = timeout(AUTH_TIMEOUT, child.wait_with_output())
+        .await
+        .ok()?
+        .ok()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut last: Option<u64> = None;
     for line in stdout.lines() {

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -9,17 +9,17 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use tokio::io::AsyncReadExt;
-use tokio::process::{Child, Command};
+use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
-use tracing::warn;
 
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::opencode::parse::OpencodeStreamParser;
 use crate::{
-    filter_child_env, ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent,
-    HarnessSession, SessionSpec, StreamBudget, StreamLineBuffer, TurnInput, TurnOutcome,
+    filter_child_env, spawn_process_tree, ApprovalDecision, HarnessApprovalRef, HarnessError,
+    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
+    TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -31,7 +31,7 @@ const AUTO_FLAG: &str = "--auto";
 pub struct OpencodeSession {
     spec: SessionSpec,
     resume_ref: Mutex<Option<String>>,
-    child: AsyncMutex<Option<Child>>,
+    child: AsyncMutex<Option<ProcessTreeChild>>,
     child_pid: AtomicU32,
     base_url: String,
     client: reqwest::Client,
@@ -160,7 +160,6 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<OpencodeSession, Harness
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true)
         .env_clear();
     for (key, value) in filter_child_env(session.spec.env.iter().cloned()) {
         command.env(key, value);
@@ -168,14 +167,12 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<OpencodeSession, Harness
     for (key, value) in &plan.env {
         command.env(key, value);
     }
-    let mut child = command.spawn()?;
+    let mut child = spawn_process_tree(&mut command)?;
     let stdout = child
-        .stdout
-        .take()
+        .take_stdout()
         .ok_or_else(|| HarnessError::Other("engine child has no stdout".into()))?;
     let stderr = child
-        .stderr
-        .take()
+        .take_stderr()
         .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
     if let Some(pid) = child.id() {
         session.child_pid.store(pid, Ordering::SeqCst);
@@ -492,29 +489,14 @@ impl HarnessSession for OpencodeSession {
                 }
             }
         }
-        let pid = self.child_pid.load(Ordering::SeqCst);
-        if pid != 0 {
-            signal_interrupt(pid);
-        }
         let mut slot = self.child.lock().await;
         let Some(child) = slot.as_mut() else {
             return Ok(());
         };
-        match timeout(Duration::from_secs(2), child.wait()).await {
-            Ok(Ok(_)) => {
-                *slot = None;
-                self.child_pid.store(0, Ordering::SeqCst);
-                Ok(())
-            }
-            Ok(Err(err)) => Err(err.into()),
-            Err(_) => {
-                warn!("engine did not exit after SIGINT; killing");
-                child.kill().await?;
-                *slot = None;
-                self.child_pid.store(0, Ordering::SeqCst);
-                Ok(())
-            }
-        }
+        child.interrupt(Duration::from_secs(2)).await?;
+        *slot = None;
+        self.child_pid.store(0, Ordering::SeqCst);
+        Ok(())
     }
 
     fn resume_ref(&self) -> Option<String> {
@@ -534,7 +516,7 @@ impl HarnessSession for OpencodeSession {
 
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         if let Some(mut child) = self.child.lock().await.take() {
-            let _ = child.kill().await;
+            let _ = child.terminate().await;
         }
         Ok(())
     }
@@ -568,19 +550,6 @@ where
         }
     }
     String::from_utf8_lossy(&out).into_owned()
-}
-
-fn signal_interrupt(pid: u32) {
-    #[cfg(unix)]
-    {
-        let pid = pid as i32;
-        // SAFETY: the pid was recorded from a child we spawned this session.
-        let _ = unsafe { libc::kill(pid, libc::SIGINT) };
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-    }
 }
 
 #[cfg(test)]

--- a/crates/tidebreak-harness/src/pin.rs
+++ b/crates/tidebreak-harness/src/pin.rs
@@ -8,11 +8,14 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use tidebreak_code_execution::managed_node::{
+    managed_node_executable, managed_node_path_dir, managed_npm_executable,
+};
 use tidebreak_core::HarnessKind;
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use crate::is_absolute_executable;
+use crate::{is_absolute_executable, spawn_process_tree};
 
 const INSTALL_TIMEOUT: Duration = Duration::from_secs(180);
 
@@ -78,7 +81,12 @@ fn marker_path(dir: &Path) -> PathBuf {
 }
 
 fn binary_path(dir: &Path, pin: &HarnessPin) -> PathBuf {
-    dir.join("node_modules").join(".bin").join(pin.bin)
+    let name = if cfg!(windows) {
+        format!("{}.cmd", pin.bin)
+    } else {
+        pin.bin.to_owned()
+    };
+    dir.join("node_modules").join(".bin").join(name)
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -113,7 +121,7 @@ pub async fn ensure_installed(
     kind: HarnessKind,
     managed_node_root: Option<&Path>,
 ) -> Result<PathBuf, String> {
-    let node_bin = managed_node_bin(managed_node_root)
+    let node_root = verified_managed_node_root(managed_node_root)
         .ok_or_else(|| "install the managed Node runtime before pinning harnesses".to_owned())?;
     if let Some(existing) = managed_binary(data_dir, kind) {
         return Ok(existing);
@@ -124,7 +132,7 @@ pub async fn ensure_installed(
         .await
         .map_err(|err| format!("could not create harness install dir: {err}"))?;
     let spec = format!("{}@{}", pin.package, pin.version);
-    let mut command = Command::new(node_bin.join("npm"));
+    let mut command = Command::new(managed_npm_executable(node_root));
     command
         .args([
             "install",
@@ -135,12 +143,13 @@ pub async fn ensure_installed(
             &spec,
         ])
         .current_dir(&dir)
-        .env("PATH", prepend_path(&node_bin))
+        .env("PATH", prepend_path(&managed_node_path_dir(node_root)))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-    let output = timeout(INSTALL_TIMEOUT, command.output())
+        .stderr(Stdio::piped());
+    let child =
+        spawn_process_tree(&mut command).map_err(|err| format!("npm install {spec}: {err}"))?;
+    let output = timeout(INSTALL_TIMEOUT, child.wait_with_output())
         .await
         .map_err(|_| format!("npm install {spec} timed out"))?
         .map_err(|err| format!("npm install {spec}: {err}"))?;
@@ -169,14 +178,17 @@ pub async fn ensure_installed(
     })
 }
 
-/// `<verified-root>/bin` when both `node` and `npm` exist.
+/// The verified root when both platform-native Node and npm entrypoints exist.
 ///
-/// Official Node's `bin/npm` is `#!/usr/bin/env node`, so the sibling `node`
-/// must be first on the child PATH. GUI PATH is never consulted.
-fn managed_node_bin(managed_node_root: Option<&Path>) -> Option<PathBuf> {
-    let bin = managed_node_root?.join("bin");
-    (is_absolute_executable(&bin.join("node")) && is_absolute_executable(&bin.join("npm")))
-        .then_some(bin)
+/// Unix npm is a script that resolves `node` from PATH. Windows npm is a
+/// `.cmd` shim that first resolves the sibling `node.exe`. Both are validated
+/// here and the managed runtime directory is still placed first on PATH for
+/// the harness shims installed under `node_modules/.bin`.
+fn verified_managed_node_root(managed_node_root: Option<&Path>) -> Option<&Path> {
+    let root = managed_node_root?;
+    (is_absolute_executable(&managed_node_executable(root))
+        && is_absolute_executable(&managed_npm_executable(root)))
+    .then_some(root)
 }
 
 fn prepend_path(bin: &Path) -> std::ffi::OsString {
@@ -234,6 +246,16 @@ mod tests {
             managed_binary(tmp.path(), HarnessKind::ClaudeCode),
             Some(binary)
         );
+    }
+
+    #[test]
+    fn harness_binary_uses_the_platform_npm_shim_name() {
+        let pin = pin_for(HarnessKind::ClaudeCode).unwrap();
+        let path = binary_path(Path::new("install"), pin);
+        #[cfg(windows)]
+        assert_eq!(path.file_name().unwrap(), "claude.cmd");
+        #[cfg(not(windows))]
+        assert_eq!(path.file_name().unwrap(), "claude");
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -190,8 +190,8 @@ fn probe_windows_process_env(host: &HostEnv, name: &str) -> Result<ProbeCapture,
 
 #[cfg(windows)]
 fn resolve_windows_command(env: &[(OsString, OsString)], name: &str) -> Option<PathBuf> {
-    let path = env_value(env, "PATH")?;
-    let extensions = env_value(env, "PATHEXT")
+    let path = env_value(env, std::ffi::OsStr::new("PATH"))?;
+    let extensions = env_value(env, std::ffi::OsStr::new("PATHEXT"))
         .map(|value| {
             value
                 .to_string_lossy()

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -1179,7 +1179,14 @@ mod windows_tests {
         };
 
         let capture = probe_shell(&host, "claude").await.unwrap();
-        assert_eq!(capture.binary, shim);
+        assert!(
+            capture
+                .binary
+                .to_string_lossy()
+                .eq_ignore_ascii_case(&shim.to_string_lossy()),
+            "expected {shim:?}, got {:?}",
+            capture.binary
+        );
         assert_eq!(
             observe_version(&capture.binary, &capture.env)
                 .await

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -1,5 +1,4 @@
-//! Interactive-login-shell binary resolution, version detection, and
-//! environment capture.
+//! Host binary resolution, version detection, and environment capture.
 //!
 //! GUI processes on macOS do not inherit the user's shell PATH or profile
 //! environment. Resolution therefore asks `$SHELL -ilc '…'` — login *and*
@@ -7,16 +6,22 @@
 //! config commonly live — and accepts only an absolute, executable result.
 //! The same probe captures the shell's resolved environment so children
 //! run under that snapshot, not the GUI process env.
+//!
+//! A native Windows GUI process already receives the user's environment.
+//! Windows therefore captures that process environment directly, merges test
+//! or caller overrides case-insensitively, and resolves through `PATH` plus
+//! `PATHEXT` without running a shell profile script.
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use tidebreak_code_execution::managed_node::{managed_node_executable, managed_node_path_dir};
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use crate::is_absolute_executable;
+use crate::{is_absolute_executable, spawn_process_tree};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_STDERR_BYTES: usize = 4_096;
@@ -24,7 +29,7 @@ const MAX_STDERR_BYTES: usize = 4_096;
 /// Host environment used for discovery. Tests inject a shim shell and PATH.
 #[derive(Debug, Clone)]
 pub struct HostEnv {
-    /// Login shell. Defaults to `$SHELL`, then `/bin/sh`.
+    /// Login shell on Unix. Unused on Windows.
     pub shell: PathBuf,
     /// Extra environment for the probe child (typically a test PATH).
     pub env: Vec<(OsString, OsString)>,
@@ -32,8 +37,8 @@ pub struct HostEnv {
     pub clear_env: bool,
     /// App data directory. When set, probe prefers a pinned install under it.
     pub data_dir: Option<PathBuf>,
-    /// Host-verified managed Node root. Pinned npm harnesses need its `bin`
-    /// directory first on `PATH`; their entrypoints use `#!/usr/bin/env node`.
+    /// Host-verified managed Node root. Pinned npm harnesses need its runtime
+    /// directory first on `PATH`; their entrypoints resolve `node`/`node.exe`.
     pub managed_node_root: Option<PathBuf>,
 }
 
@@ -47,9 +52,12 @@ impl HostEnv {
     /// The current process's login shell.
     #[must_use]
     pub fn from_process() -> Self {
+        #[cfg(unix)]
         let shell = std::env::var_os("SHELL")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("/bin/sh"));
+        #[cfg(windows)]
+        let shell = PathBuf::new();
         Self {
             shell,
             env: Vec::new(),
@@ -112,7 +120,7 @@ pub async fn probe_shell(host: &HostEnv, name: &str) -> Result<ProbeCapture, Pro
                 let node = host
                     .managed_node_root
                     .as_deref()
-                    .map(|root| root.join("bin/node"));
+                    .map(managed_node_executable);
                 if !node.as_deref().is_some_and(crate::is_absolute_executable) {
                     return Err(ProbeError::NotFound(name.to_owned()));
                 }
@@ -124,41 +132,102 @@ pub async fn probe_shell(host: &HostEnv, name: &str) -> Result<ProbeCapture, Pro
             return Err(ProbeError::NotFound(name.to_owned()));
         }
     }
-    let token = sentinel_token();
-    let begin = format!("TIDEBREAK_PROBE_BEGIN_{token}");
-    let env_mark = format!("TIDEBREAK_PROBE_ENV_{token}");
-    let end = format!("TIDEBREAK_PROBE_END_{token}");
-    let script = format!(
-        "printf '%s\\n' '{begin}'; command -v {name} || true; printf '%s\\n' '{env_mark}'; \
-         if env -0 >/dev/null 2>&1; then env -0; else env; fi; printf '\\n%s\\n' '{end}'"
-    );
-    let output = run_interactive_login_shell(host, &script).await?;
-    let parsed =
-        parse_sentinel_output(&output.stdout, &begin, &env_mark, &end).ok_or_else(|| {
-            if output.stdout.trim().is_empty() && !output.status_ok {
-                ProbeError::NotFound(name.to_owned())
-            } else {
-                ProbeError::Shell("probe sentinels missing from shell output".into())
-            }
-        })?;
-    if parsed.path.is_empty() {
-        return Err(ProbeError::NotFound(name.to_owned()));
+    #[cfg(windows)]
+    {
+        probe_windows_process_env(host, name)
     }
-    let path = PathBuf::from(&parsed.path);
-    if !path.is_absolute() {
-        return Err(ProbeError::RelativePath {
-            name: name.to_owned(),
-            path: parsed.path,
-        });
+    #[cfg(not(windows))]
+    {
+        let token = sentinel_token();
+        let begin = format!("TIDEBREAK_PROBE_BEGIN_{token}");
+        let env_mark = format!("TIDEBREAK_PROBE_ENV_{token}");
+        let end = format!("TIDEBREAK_PROBE_END_{token}");
+        let script = format!(
+            "printf '%s\\n' '{begin}'; command -v {name} || true; printf '%s\\n' '{env_mark}'; \
+             if env -0 >/dev/null 2>&1; then env -0; else env; fi; printf '\\n%s\\n' '{end}'"
+        );
+        let output = run_interactive_login_shell(host, &script).await?;
+        let parsed =
+            parse_sentinel_output(&output.stdout, &begin, &env_mark, &end).ok_or_else(|| {
+                if output.stdout.trim().is_empty() && !output.status_ok {
+                    ProbeError::NotFound(name.to_owned())
+                } else {
+                    ProbeError::Shell("probe sentinels missing from shell output".into())
+                }
+            })?;
+        if parsed.path.is_empty() {
+            return Err(ProbeError::NotFound(name.to_owned()));
+        }
+        let path = PathBuf::from(&parsed.path);
+        if !path.is_absolute() {
+            return Err(ProbeError::RelativePath {
+                name: name.to_owned(),
+                path: parsed.path,
+            });
+        }
+        if !is_absolute_executable(&path) {
+            return Err(ProbeError::NotExecutable(path));
+        }
+        Ok(ProbeCapture {
+            binary: path,
+            env: parsed.env,
+            stderr: output.stderr,
+        })
     }
-    if !is_absolute_executable(&path) {
-        return Err(ProbeError::NotExecutable(path));
-    }
+}
+
+#[cfg(windows)]
+fn probe_windows_process_env(host: &HostEnv, name: &str) -> Result<ProbeCapture, ProbeError> {
+    let env = windows_process_env(host);
+    let path =
+        resolve_windows_command(&env, name).ok_or_else(|| ProbeError::NotFound(name.to_owned()))?;
     Ok(ProbeCapture {
         binary: path,
-        env: parsed.env,
-        stderr: output.stderr,
+        env,
+        stderr: String::new(),
     })
+}
+
+#[cfg(windows)]
+fn resolve_windows_command(env: &[(OsString, OsString)], name: &str) -> Option<PathBuf> {
+    let path = env_value(env, "PATH")?;
+    let extensions = env_value(env, "PATHEXT")
+        .map(|value| {
+            value
+                .to_string_lossy()
+                .split(';')
+                .filter(|extension| !extension.is_empty())
+                .map(|extension| {
+                    if extension.starts_with('.') {
+                        extension.to_owned()
+                    } else {
+                        format!(".{extension}")
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|extensions| !extensions.is_empty())
+        .unwrap_or_else(|| [".COM", ".EXE", ".BAT", ".CMD"].map(str::to_owned).to_vec());
+    let explicit_extension = Path::new(name).extension().is_some();
+    for dir in std::env::split_paths(path) {
+        if !dir.is_absolute() {
+            continue;
+        }
+        if explicit_extension {
+            let candidate = dir.join(name);
+            if is_absolute_executable(&candidate) {
+                return Some(candidate);
+            }
+            continue;
+        }
+        for extension in &extensions {
+            let candidate = dir.join(format!("{name}{extension}"));
+            if is_absolute_executable(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
 }
 
 fn kind_for_command(name: &str) -> Option<tidebreak_core::HarnessKind> {
@@ -196,16 +265,15 @@ fn prepend_managed_node_path(
     let Some(root) = managed_node_root else {
         return env;
     };
-    let bin = root.join("bin");
-    let prior = env
-        .iter()
-        .find(|(key, _)| key.to_string_lossy().eq_ignore_ascii_case("PATH"))
-        .map(|(_, value)| value.clone())
+    let runtime_dir = managed_node_path_dir(root);
+    let prior = env_value(&env, std::ffi::OsStr::new("PATH"))
+        .cloned()
         .unwrap_or_default();
-    env.retain(|(key, _)| !key.to_string_lossy().eq_ignore_ascii_case("PATH"));
-    let mut paths = vec![bin.clone()];
+    env.retain(|(key, _)| !env_key_eq(key, std::ffi::OsStr::new("PATH"), true));
+    let mut paths = vec![runtime_dir.clone()];
     paths.extend(std::env::split_paths(&prior));
-    let path = std::env::join_paths(paths).unwrap_or_else(|_| bin.into_os_string());
+    let path =
+        std::env::join_paths(paths).unwrap_or_else(|_| runtime_dir.as_os_str().to_os_string());
     env.push((OsString::from("PATH"), path));
     env
 }
@@ -215,18 +283,35 @@ fn process_env_without_tidebreak() -> Vec<(OsString, OsString)> {
 }
 
 async fn capture_shell_env(host: &HostEnv) -> Result<Vec<(OsString, OsString)>, ProbeError> {
-    let token = sentinel_token();
-    let begin = format!("TIDEBREAK_PROBE_BEGIN_{token}");
-    let env_mark = format!("TIDEBREAK_PROBE_ENV_{token}");
-    let end = format!("TIDEBREAK_PROBE_END_{token}");
-    let script = format!(
-        "printf '%s\\n' '{begin}'; printf '%s\\n' '{env_mark}'; \
-         if env -0 >/dev/null 2>&1; then env -0; else env; fi; printf '\\n%s\\n' '{end}'"
-    );
-    let output = run_interactive_login_shell(host, &script).await?;
-    let parsed = parse_sentinel_output(&output.stdout, &begin, &env_mark, &end)
-        .ok_or_else(|| ProbeError::Shell("probe sentinels missing from shell output".into()))?;
-    Ok(parsed.env)
+    #[cfg(windows)]
+    {
+        Ok(windows_process_env(host))
+    }
+    #[cfg(not(windows))]
+    {
+        let token = sentinel_token();
+        let begin = format!("TIDEBREAK_PROBE_BEGIN_{token}");
+        let env_mark = format!("TIDEBREAK_PROBE_ENV_{token}");
+        let end = format!("TIDEBREAK_PROBE_END_{token}");
+        let script = format!(
+            "printf '%s\\n' '{begin}'; printf '%s\\n' '{env_mark}'; \
+             if env -0 >/dev/null 2>&1; then env -0; else env; fi; printf '\\n%s\\n' '{end}'"
+        );
+        let output = run_interactive_login_shell(host, &script).await?;
+        let parsed = parse_sentinel_output(&output.stdout, &begin, &env_mark, &end)
+            .ok_or_else(|| ProbeError::Shell("probe sentinels missing from shell output".into()))?;
+        Ok(parsed.env)
+    }
+}
+
+#[cfg(windows)]
+fn windows_process_env(host: &HostEnv) -> Vec<(OsString, OsString)> {
+    let base = if host.clear_env {
+        Vec::new()
+    } else {
+        std::env::vars_os().collect()
+    };
+    filter_child_env(merge_environment(base, host.env.iter().cloned(), true))
 }
 
 /// Drop Tidebreak-prefixed variables from a captured shell snapshot.
@@ -237,14 +322,54 @@ where
     K: Into<OsString>,
     V: Into<OsString>,
 {
-    vars.into_iter()
-        .map(|(key, value)| (key.into(), value.into()))
-        .filter(|(key, _)| {
-            !key.to_string_lossy()
-                .to_ascii_uppercase()
-                .starts_with("TIDEBREAK_")
-        })
-        .collect()
+    let filtered = vars.into_iter().filter_map(|(key, value)| {
+        let key = key.into();
+        let name = key.to_string_lossy();
+        if name.is_empty()
+            || name.contains('=')
+            || name.to_ascii_uppercase().starts_with("TIDEBREAK_")
+        {
+            return None;
+        }
+        Some((key, value.into()))
+    });
+    merge_environment(Vec::new(), filtered, cfg!(windows))
+}
+
+fn merge_environment<I>(
+    mut base: Vec<(OsString, OsString)>,
+    overrides: I,
+    case_insensitive: bool,
+) -> Vec<(OsString, OsString)>
+where
+    I: IntoIterator<Item = (OsString, OsString)>,
+{
+    for (key, value) in overrides {
+        if let Some(index) = base
+            .iter()
+            .position(|(existing, _)| env_key_eq(existing, &key, case_insensitive))
+        {
+            base.remove(index);
+        }
+        base.push((key, value));
+    }
+    base
+}
+
+fn env_key_eq(left: &std::ffi::OsStr, right: &std::ffi::OsStr, case_insensitive: bool) -> bool {
+    if case_insensitive {
+        left.to_string_lossy()
+            .eq_ignore_ascii_case(&right.to_string_lossy())
+    } else {
+        left == right
+    }
+}
+
+fn env_value<'a>(env: &'a [(OsString, OsString)], key: &std::ffi::OsStr) -> Option<&'a OsString> {
+    env.iter()
+        .rev()
+        .find(|(candidate, _)| env_key_eq(candidate, key, cfg!(windows)))
+        .map(|(_, value)| value)
 }
 
 fn apply_captured_env(command: &mut Command, env: &[(std::ffi::OsString, std::ffi::OsString)]) {
@@ -265,10 +390,11 @@ pub async fn observe_version(
         .arg("--version")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
+        .stderr(Stdio::piped());
     apply_captured_env(&mut command, env);
-    let output = timeout(PROBE_TIMEOUT, command.output())
+    let child =
+        spawn_process_tree(&mut command).map_err(|err| ProbeError::Shell(err.to_string()))?;
+    let output = timeout(PROBE_TIMEOUT, child.wait_with_output())
         .await
         .map_err(|_| ProbeError::Shell("version probe timed out".into()))?
         .map_err(|err| ProbeError::Shell(err.to_string()))?;
@@ -307,10 +433,12 @@ pub async fn list_cli_models(
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
+        .stderr(Stdio::piped());
     apply_captured_env(&mut command, env);
-    let Ok(Ok(output)) = timeout(PROBE_TIMEOUT, command.output()).await else {
+    let Ok(child) = spawn_process_tree(&mut command) else {
+        return Vec::new();
+    };
+    let Ok(Ok(output)) = timeout(PROBE_TIMEOUT, child.wait_with_output()).await else {
         return Vec::new();
     };
     parse_cli_models(&String::from_utf8_lossy(&output.stdout), env)
@@ -335,7 +463,7 @@ pub fn infer_listed_default(
     ];
     let Some(current) = env.iter().find_map(|(key, value)| {
         let name = key.to_string_lossy();
-        if !KEYS.contains(&name.as_ref()) {
+        if !KEYS.iter().any(|key| name.eq_ignore_ascii_case(key)) {
             return None;
         }
         let id = value.to_string_lossy().trim().to_owned();
@@ -615,15 +743,16 @@ async fn run_interactive_login_shell(
         .arg(script)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
+        .stderr(Stdio::piped());
     if host.clear_env {
         command.env_clear();
     }
     for (key, value) in &host.env {
         command.env(key, value);
     }
-    let output = timeout(PROBE_TIMEOUT, command.output())
+    let child =
+        spawn_process_tree(&mut command).map_err(|err| ProbeError::Shell(err.to_string()))?;
+    let output = timeout(PROBE_TIMEOUT, child.wait_with_output())
         .await
         .map_err(|_| ProbeError::Shell("login shell timed out".into()))?
         .map_err(|err| ProbeError::Shell(err.to_string()))?;
@@ -637,7 +766,7 @@ async fn run_interactive_login_shell(
     })
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
@@ -992,5 +1121,80 @@ eval "$cmd"
             probe_shell(&host, "claude").await,
             Err(ProbeError::NotFound(name)) if name == "claude"
         ));
+    }
+}
+
+#[cfg(test)]
+mod environment_tests {
+    use super::*;
+
+    #[test]
+    fn case_insensitive_environment_merge_keeps_the_last_spelling_and_value() {
+        let merged = merge_environment(
+            vec![
+                (OsString::from("Path"), OsString::from("old")),
+                (OsString::from("KEEP"), OsString::from("yes")),
+            ],
+            [(OsString::from("PATH"), OsString::from("managed"))],
+            true,
+        );
+        assert_eq!(
+            merged,
+            vec![
+                (OsString::from("KEEP"), OsString::from("yes")),
+                (OsString::from("PATH"), OsString::from("managed")),
+            ]
+        );
+    }
+
+    #[test]
+    fn filter_rejects_case_varied_tidebreak_and_invalid_environment_keys() {
+        let filtered = filter_child_env([
+            ("tidebreak_secret", "nope"),
+            ("GOOD", "yes"),
+            ("BAD=KEY", "nope"),
+        ]);
+        assert_eq!(filtered, [(OsString::from("GOOD"), OsString::from("yes"))]);
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolves_cmd_shims_from_case_varied_path_and_pathext() {
+        let dir = tempfile::tempdir().unwrap();
+        let shim = dir.path().join("claude.cmd");
+        std::fs::write(&shim, "@echo 2.1.234\r\n").unwrap();
+        let host = HostEnv {
+            shell: PathBuf::new(),
+            env: vec![
+                (OsString::from("Path"), dir.path().as_os_str().to_owned()),
+                (OsString::from("pathext"), OsString::from(".CMD;.EXE")),
+            ],
+            clear_env: true,
+            data_dir: None,
+            managed_node_root: None,
+        };
+
+        let capture = probe_shell(&host, "claude").await.unwrap();
+        assert_eq!(capture.binary, shim);
+        assert_eq!(
+            capture
+                .env
+                .iter()
+                .filter(|(key, _)| key.to_string_lossy().eq_ignore_ascii_case("PATH"))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn from_process_captures_windows_environment_without_a_shell() {
+        let host = HostEnv::from_process();
+        assert!(host.shell.as_os_str().is_empty());
+        let captured = capture_shell_env(&host).await.unwrap();
+        assert!(env_value(&captured, std::ffi::OsStr::new("PATH")).is_some());
     }
 }

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -1163,7 +1163,7 @@ mod windows_tests {
     use super::*;
 
     #[tokio::test]
-    async fn resolves_cmd_shims_from_case_varied_path_and_pathext() {
+    async fn resolves_and_executes_cmd_shims_from_case_varied_path_and_pathext() {
         let dir = tempfile::tempdir().unwrap();
         let shim = dir.path().join("claude.cmd");
         std::fs::write(&shim, "@echo 2.1.234\r\n").unwrap();
@@ -1180,6 +1180,12 @@ mod windows_tests {
 
         let capture = probe_shell(&host, "claude").await.unwrap();
         assert_eq!(capture.binary, shim);
+        assert_eq!(
+            observe_version(&capture.binary, &capture.env)
+                .await
+                .unwrap(),
+            "2.1.234"
+        );
         assert_eq!(
             capture
                 .env

--- a/crates/tidebreak-host-broker/src/computer_use.rs
+++ b/crates/tidebreak-host-broker/src/computer_use.rs
@@ -883,24 +883,32 @@ mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
 
-    /// Write an executable `/bin/sh` script to a temp path and return it. The
-    /// body is the fake helper.
-    fn fake_helper(tag: &str, body: &str) -> PathBuf {
-        let path =
-            std::env::temp_dir().join(format!("tidebreak-cu-fake-{tag}-{}", std::process::id()));
+    struct FakeHelper {
+        _dir: tempfile::TempDir,
+        path: PathBuf,
+    }
+
+    /// Write an executable `/bin/sh` script in a uniquely owned temporary
+    /// directory. Keeping the directory alive prevents fixture paths from
+    /// colliding with concurrent or retried test processes.
+    fn fake_helper(tag: &str, body: &str) -> FakeHelper {
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("tidebreak-cu-fake-{tag}-"))
+            .tempdir()
+            .unwrap();
+        let path = dir.path().join("helper");
         std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
-        path
+        FakeHelper { _dir: dir, path }
     }
 
     #[test]
     fn parses_a_well_formed_ok_envelope() {
         let helper = fake_helper("ok", r#"cat >/dev/null; printf '{"ok":true,"result":[]}'"#);
-        let windows = HelperBackend::new(helper.clone())
+        let windows = HelperBackend::new(helper.path.clone())
             .list_windows(None)
             .unwrap();
         assert!(windows.is_empty());
-        let _ = std::fs::remove_file(&helper);
     }
 
     #[test]
@@ -909,11 +917,10 @@ mod tests {
             "perm",
             r#"cat >/dev/null; printf '{"ok":false,"code":"permission_denied","error":"nope"}'"#,
         );
-        let err = HelperBackend::new(helper.clone())
+        let err = HelperBackend::new(helper.path.clone())
             .list_windows(None)
             .unwrap_err();
         assert_eq!(err.kind, BackendErrorKind::PermissionDenied);
-        let _ = std::fs::remove_file(&helper);
     }
 
     #[test]
@@ -922,11 +929,10 @@ mod tests {
             "yield",
             r#"cat >/dev/null; printf '{"ok":false,"code":"yielded","error":"a system security dialog is in the foreground"}'"#,
         );
-        let err = HelperBackend::new(helper.clone())
+        let err = HelperBackend::new(helper.path.clone())
             .list_windows(None)
             .unwrap_err();
         assert_eq!(err.kind, BackendErrorKind::Yielded);
-        let _ = std::fs::remove_file(&helper);
     }
 
     #[test]
@@ -934,7 +940,7 @@ mod tests {
         // Sleeps far past the timeout; must be killed and reported promptly,
         // not block the broker.
         let helper = fake_helper("hang", "sleep 30");
-        let backend = HelperBackend::with_timeout(helper.clone(), Duration::from_millis(150));
+        let backend = HelperBackend::with_timeout(helper.path.clone(), Duration::from_millis(150));
         let start = Instant::now();
         let err = backend.list_windows(None).unwrap_err();
         assert_eq!(err.kind, BackendErrorKind::OperationFailed);
@@ -944,18 +950,16 @@ mod tests {
             "should return promptly after killing, took {:?}",
             start.elapsed()
         );
-        let _ = std::fs::remove_file(&helper);
     }
 
     #[test]
     fn empty_output_is_a_clean_error() {
         let helper = fake_helper("empty", "cat >/dev/null; exit 0");
-        let err = HelperBackend::new(helper.clone())
+        let err = HelperBackend::new(helper.path.clone())
             .list_windows(None)
             .unwrap_err();
         assert_eq!(err.kind, BackendErrorKind::OperationFailed);
         assert!(err.message.contains("no output"), "got: {}", err.message);
-        let _ = std::fs::remove_file(&helper);
     }
 
     #[test]
@@ -966,11 +970,10 @@ mod tests {
             "big",
             r#"cat >/dev/null; printf '{"ok":true,"result":"'; head -c 200000 /dev/zero | tr '\0' a; printf '"}'"#,
         );
-        let result = HelperBackend::new(helper.clone())
+        let result = HelperBackend::new(helper.path.clone())
             .run(serde_json::json!({ "op": "noop" }))
             .unwrap();
         assert!(result.is_string());
         assert_eq!(result.as_str().unwrap().len(), 200_000);
-        let _ = std::fs::remove_file(&helper);
     }
 }

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -103,7 +103,7 @@ portable-pty = "=0.9.0"
 libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
 # HKLM policy reads for the Windows managed-policy reader.
 winreg = "=0.56.0"
 

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -103,7 +103,7 @@ portable-pty = "=0.9.0"
 libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_SystemInformation", "Win32_System_Threading"] }
 # HKLM policy reads for the Windows managed-policy reader.
 winreg = "=0.56.0"
 

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -885,16 +885,42 @@ fn manual_pr_instructions(
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| generate_pr_body(&[], stat));
     format!(
-        "{header}\n\nCreate the pull request from a terminal:\n\n  cd {worktree}\n  git push -u origin {branch}\n  gh pr create --title {title} --body {body}\n",
+        "{header}\n\nCreate the pull request from a terminal:\n\n{commands}",
         header = gh.remediation,
-        worktree = worktree.display(),
-        title = shell_single_quote(&pr_title),
-        body = shell_single_quote(&pr_body),
+        commands = manual_pr_commands(worktree, branch, &pr_title, &pr_body),
     )
 }
 
+#[cfg(not(windows))]
+fn manual_pr_commands(worktree: &Path, branch: &str, title: &str, body: &str) -> String {
+    format!(
+        "  cd {worktree}\n  git push -u origin {branch}\n  gh pr create --title {title} --body {body}\n",
+        worktree = shell_single_quote(&worktree.to_string_lossy()),
+        branch = shell_single_quote(branch),
+        title = shell_single_quote(title),
+        body = shell_single_quote(body),
+    )
+}
+
+#[cfg(windows)]
+fn manual_pr_commands(worktree: &Path, branch: &str, title: &str, body: &str) -> String {
+    format!(
+        "  Set-Location -LiteralPath {worktree}\n  git push -u origin {branch}\n  gh pr create --title {title} --body {body}\n",
+        worktree = powershell_single_quote(&worktree.to_string_lossy()),
+        branch = powershell_single_quote(branch),
+        title = powershell_single_quote(title),
+        body = powershell_single_quote(body),
+    )
+}
+
+#[cfg(not(windows))]
 fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(windows)]
+fn powershell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 const PR_VIEW_FIELDS: &str = "number,url,state,title,isDraft,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRefName,baseRefName";
@@ -1072,15 +1098,69 @@ fn pr_number_from_url(url: &str) -> Option<u64> {
         .and_then(|value| value.parse().ok())
 }
 
+#[cfg(windows)]
 fn find_gh(search_path: Option<&str>) -> Option<PathBuf> {
     let path = search_path
-        .map(ToOwned::to_owned)
-        .or_else(|| std::env::var("PATH").ok())
+        .map(std::ffi::OsString::from)
+        .or_else(|| std::env::var_os("PATH"))
+        .unwrap_or_default();
+    find_windows_gh(&path, std::env::var_os("PATHEXT").as_deref())
+}
+
+#[cfg(not(windows))]
+fn find_gh(search_path: Option<&str>) -> Option<PathBuf> {
+    let path = search_path
+        .map(std::ffi::OsString::from)
+        .or_else(|| std::env::var_os("PATH"))
         .unwrap_or_default();
     for dir in std::env::split_paths(&path) {
         let candidate = dir.join("gh");
         if is_executable(&candidate) {
             return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn find_windows_gh(path: &std::ffi::OsStr, pathext: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
+    let configured = pathext
+        .map(|value| {
+            value
+                .to_string_lossy()
+                .split(';')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| {
+                    if value.starts_with('.') {
+                        value.to_owned()
+                    } else {
+                        format!(".{value}")
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|extensions| !extensions.is_empty())
+        .unwrap_or_else(|| [".COM", ".EXE", ".BAT", ".CMD"].map(str::to_owned).to_vec());
+    let mut extensions = vec![".EXE".to_owned()];
+    for extension in configured {
+        if !extensions
+            .iter()
+            .any(|known| known.eq_ignore_ascii_case(&extension))
+        {
+            extensions.push(extension);
+        }
+    }
+    for dir in std::env::split_paths(path) {
+        for extension in &extensions {
+            let candidate = dir.join(format!("gh{extension}"));
+            if is_executable(&candidate) {
+                return Some(candidate);
+            }
+        }
+        let extensionless = dir.join("gh");
+        if is_executable(&extensionless) {
+            return Some(extensionless);
         }
     }
     None
@@ -1878,6 +1958,45 @@ mod windows_tests {
     };
 
     const DESCENDANT_EXIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+    #[test]
+    fn github_cli_discovery_applies_windows_executable_extensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let gh = dir.path().join("gh.exe");
+        std::fs::write(&gh, b"synthetic executable").unwrap();
+        let search_path = std::env::join_paths([dir.path()]).unwrap();
+
+        assert_eq!(find_gh(search_path.to_str()), Some(gh));
+    }
+
+    #[test]
+    fn manual_pr_instructions_use_powershell_quoting() {
+        let gh = GhObservation {
+            found: false,
+            authenticated: None,
+            binary: None,
+            remediation: "install gh".into(),
+        };
+        let instructions = manual_pr_instructions(
+            Path::new(r"C:\Users\Jane Doe\repo"),
+            "tidebreak/jane's-fix",
+            "Jane's fix",
+            Some("It's ready"),
+            &Diffstat {
+                files: 1,
+                insertions: 2,
+                deletions: 0,
+                truncated: false,
+            },
+            &gh,
+        );
+
+        assert!(instructions.contains(r"Set-Location -LiteralPath 'C:\Users\Jane Doe\repo'"));
+        assert!(instructions.contains("git push -u origin 'tidebreak/jane''s-fix'"));
+        assert!(instructions.contains("--title 'Jane''s fix'"));
+        assert!(instructions.contains("--body 'It''s ready'"));
+        assert!(!instructions.contains("'\\''"));
+    }
 
     #[tokio::test]
     async fn quick_action_timeout_terminates_its_descendant() {

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1142,8 +1142,8 @@ fn find_windows_gh(path: &std::ffi::OsStr, pathext: Option<&std::ffi::OsStr>) ->
                 .collect::<Vec<_>>()
         })
         .filter(|extensions| !extensions.is_empty())
-        .unwrap_or_else(|| [".COM", ".EXE"].map(str::to_owned).to_vec());
-    let mut extensions = vec![".EXE".to_owned()];
+        .unwrap_or_else(|| [".COM", ".exe"].map(str::to_owned).to_vec());
+    let mut extensions = vec![".exe".to_owned()];
     for extension in configured {
         if !extensions
             .iter()
@@ -1964,6 +1964,16 @@ mod windows_tests {
 
     const DESCENDANT_EXIT_TIMEOUT: Duration = Duration::from_secs(10);
 
+    fn assert_windows_path_eq(actual: Option<PathBuf>, expected: &Path) {
+        let actual = actual.expect("expected an executable path");
+        assert!(
+            actual
+                .to_string_lossy()
+                .eq_ignore_ascii_case(&expected.to_string_lossy()),
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
     #[test]
     fn github_cli_discovery_applies_windows_executable_extensions() {
         let dir = tempfile::tempdir().unwrap();
@@ -1971,7 +1981,7 @@ mod windows_tests {
         std::fs::write(&gh, b"synthetic executable").unwrap();
         let search_path = std::env::join_paths([dir.path()]).unwrap();
 
-        assert_eq!(find_gh(search_path.to_str()), Some(gh));
+        assert_windows_path_eq(find_gh(search_path.to_str()), &gh);
     }
 
     #[test]
@@ -1983,9 +1993,9 @@ mod windows_tests {
         std::fs::write(&gh, b"synthetic executable").unwrap();
         let search_path = std::env::join_paths([unlaunchable.path(), installed.path()]).unwrap();
 
-        assert_eq!(
+        assert_windows_path_eq(
             find_windows_gh(&search_path, Some(OsStr::new(".PS1;.EXE"))),
-            Some(gh)
+            &gh,
         );
     }
 
@@ -1998,9 +2008,9 @@ mod windows_tests {
         std::fs::write(&gh, b"synthetic executable").unwrap();
         let search_path = std::env::join_paths([batch_shim.path(), installed.path()]).unwrap();
 
-        assert_eq!(
+        assert_windows_path_eq(
             find_windows_gh(&search_path, Some(OsStr::new(".CMD;.EXE"))),
-            Some(gh)
+            &gh,
         );
     }
 
@@ -2039,13 +2049,14 @@ mod windows_tests {
         let pid_file = dir.path().join("descendant.pid");
         let action = QuickAction {
             name: "process tree timeout".into(),
-            command: "$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') \
-                      -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command',\
-                      'Start-Sleep -Seconds 120') -PassThru; \
-                      $pidPath = Join-Path -Path (Get-Location) -ChildPath 'descendant.pid'; \
-                      [IO.File]::WriteAllText($pidPath, $child.Id.ToString()); \
-                      Wait-Process -Id $child.Id"
-                .into(),
+            command: format!(
+                "$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') \
+                 -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command',\
+                 'Start-Sleep -Seconds 120') -PassThru; \
+                 [IO.File]::WriteAllText({}, $child.Id.ToString(), [Text.UTF8Encoding]::new($false)); \
+                 Wait-Process -Id $child.Id",
+                powershell_single_quote(&pid_file.to_string_lossy())
+            ),
             auto_run_on_create: false,
         };
         let worktree = dir.path().to_path_buf();
@@ -2077,7 +2088,7 @@ mod windows_tests {
         let deadline = Instant::now() + ACTION_TIMEOUT - Duration::from_millis(500);
         loop {
             if let Ok(value) = tokio::fs::read_to_string(path).await {
-                if let Ok(pid) = value.trim().parse() {
+                if let Ok(pid) = value.trim().trim_start_matches('\u{feff}').trim().parse() {
                     return pid;
                 }
             }

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1866,3 +1866,91 @@ exit 3
         assert_eq!(url, "https://github.com/acme/demo.git");
     }
 }
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::*;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+    use tokio::time::{sleep, Instant};
+    use windows_sys::Win32::Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
+    };
+
+    const DESCENDANT_EXIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+    #[tokio::test]
+    async fn quick_action_timeout_terminates_its_descendant() {
+        let dir = tempfile::tempdir().unwrap();
+        let pid_file = dir.path().join("descendant.pid");
+        let action = QuickAction {
+            name: "process tree timeout".into(),
+            command: "$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') \
+                      -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command',\
+                      'Start-Sleep -Seconds 120') -PassThru; \
+                      $pidPath = Join-Path -Path (Get-Location) -ChildPath 'descendant.pid'; \
+                      [IO.File]::WriteAllText($pidPath, $child.Id.ToString()); \
+                      Wait-Process -Id $child.Id"
+                .into(),
+            auto_run_on_create: false,
+        };
+        let worktree = dir.path().to_path_buf();
+        let action_task = tokio::spawn(async move { run_action(&worktree, &action).await });
+
+        let pid = wait_for_pid(&pid_file, &action_task).await;
+        let descendant = open_process(pid);
+        assert_eq!(
+            wait_status(&descendant, Duration::ZERO),
+            WAIT_TIMEOUT,
+            "descendant {pid} exited before the quick-action timeout"
+        );
+        assert!(
+            !action_task.is_finished(),
+            "quick action ended before its descendant was opened"
+        );
+
+        let outcome = action_task.await.unwrap();
+        assert!(outcome.timed_out, "{outcome:?}");
+        assert!(!outcome.success, "{outcome:?}");
+        assert_eq!(
+            wait_status(&descendant, DESCENDANT_EXIT_TIMEOUT),
+            WAIT_OBJECT_0,
+            "descendant {pid} remained alive after quick-action job teardown"
+        );
+    }
+
+    async fn wait_for_pid(path: &Path, action: &tokio::task::JoinHandle<ActionOutcome>) -> u32 {
+        let deadline = Instant::now() + ACTION_TIMEOUT - Duration::from_millis(500);
+        loop {
+            if let Ok(value) = tokio::fs::read_to_string(path).await {
+                if let Ok(pid) = value.trim().parse() {
+                    return pid;
+                }
+            }
+            assert!(
+                !action.is_finished(),
+                "quick action ended before publishing its descendant pid"
+            );
+            assert!(
+                Instant::now() < deadline,
+                "descendant pid was not published before ACTION_TIMEOUT"
+            );
+            sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    fn open_process(pid: u32) -> OwnedHandle {
+        // SAFETY: synchronization access is requested for the descendant pid
+        // that the quick action just created and published.
+        let raw = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, 0, pid) };
+        assert!(!raw.is_null(), "could not open descendant process {pid}");
+        // SAFETY: successful OpenProcess transfers one owned handle.
+        unsafe { OwnedHandle::from_raw_handle(raw.cast()) }
+    }
+
+    fn wait_status(process: &OwnedHandle, limit: Duration) -> u32 {
+        // SAFETY: `process` is a live synchronization handle and remains owned
+        // for the duration of the bounded wait.
+        unsafe { WaitForSingleObject(process.as_raw_handle() as HANDLE, limit.as_millis() as u32) }
+    }
+}

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -2050,9 +2050,8 @@ mod windows_tests {
         let action = QuickAction {
             name: "process tree timeout".into(),
             command: format!(
-                "$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') \
-                 -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command',\
-                 'Start-Sleep -Seconds 120') -PassThru; \
+                "$child = Start-Process -FilePath (Join-Path $env:SystemRoot 'System32\\ping.exe') \
+                 -ArgumentList @('-t','127.0.0.1') -WindowStyle Hidden -PassThru; \
                  [IO.File]::WriteAllText({}, $child.Id.ToString(), [Text.UTF8Encoding]::new($false)); \
                  Wait-Process -Id $child.Id",
                 powershell_single_quote(&pid_file.to_string_lossy())
@@ -2085,7 +2084,7 @@ mod windows_tests {
     }
 
     async fn wait_for_pid(path: &Path, action: &tokio::task::JoinHandle<ActionOutcome>) -> u32 {
-        let deadline = Instant::now() + ACTION_TIMEOUT - Duration::from_millis(500);
+        let deadline = Instant::now() + ACTION_TIMEOUT + DESCENDANT_EXIT_TIMEOUT;
         loop {
             if let Ok(value) = tokio::fs::read_to_string(path).await {
                 if let Ok(pid) = value.trim().trim_start_matches('\u{feff}').trim().parse() {
@@ -2098,7 +2097,7 @@ mod windows_tests {
             );
             assert!(
                 Instant::now() < deadline,
-                "descendant pid was not published before ACTION_TIMEOUT"
+                "quick action exceeded its timeout without publishing its descendant pid"
             );
             sleep(Duration::from_millis(25)).await;
         }

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1131,11 +1131,12 @@ fn find_windows_gh(path: &std::ffi::OsStr, pathext: Option<&std::ffi::OsStr>) ->
                 .split(';')
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
-                .map(|value| {
+                .filter_map(|value| {
                     if value.starts_with('.') {
-                        value.to_owned()
+                        launchable_windows_extension(value).then(|| value.to_owned())
                     } else {
-                        format!(".{value}")
+                        let value = format!(".{value}");
+                        launchable_windows_extension(&value).then_some(value)
                     }
                 })
                 .collect::<Vec<_>>()
@@ -1164,6 +1165,13 @@ fn find_windows_gh(path: &std::ffi::OsStr, pathext: Option<&std::ffi::OsStr>) ->
         }
     }
     None
+}
+
+#[cfg(windows)]
+fn launchable_windows_extension(extension: &str) -> bool {
+    [".COM", ".EXE", ".BAT", ".CMD"]
+        .iter()
+        .any(|supported| extension.eq_ignore_ascii_case(supported))
 }
 
 fn is_executable(path: &Path) -> bool {
@@ -1950,6 +1958,7 @@ exit 3
 #[cfg(all(test, windows))]
 mod windows_tests {
     use super::*;
+    use std::ffi::OsStr;
     use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
     use tokio::time::{sleep, Instant};
     use windows_sys::Win32::Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
@@ -1967,6 +1976,21 @@ mod windows_tests {
         let search_path = std::env::join_paths([dir.path()]).unwrap();
 
         assert_eq!(find_gh(search_path.to_str()), Some(gh));
+    }
+
+    #[test]
+    fn github_cli_discovery_skips_unlaunchable_pathext_entries() {
+        let unlaunchable = tempfile::tempdir().unwrap();
+        std::fs::write(unlaunchable.path().join("gh.ps1"), b"Write-Output wrong").unwrap();
+        let installed = tempfile::tempdir().unwrap();
+        let gh = installed.path().join("gh.exe");
+        std::fs::write(&gh, b"synthetic executable").unwrap();
+        let search_path = std::env::join_paths([unlaunchable.path(), installed.path()]).unwrap();
+
+        assert_eq!(
+            find_windows_gh(&search_path, Some(OsStr::new(".PS1;.EXE"))),
+            Some(gh)
+        );
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1142,7 +1142,7 @@ fn find_windows_gh(path: &std::ffi::OsStr, pathext: Option<&std::ffi::OsStr>) ->
                 .collect::<Vec<_>>()
         })
         .filter(|extensions| !extensions.is_empty())
-        .unwrap_or_else(|| [".COM", ".EXE", ".BAT", ".CMD"].map(str::to_owned).to_vec());
+        .unwrap_or_else(|| [".COM", ".EXE"].map(str::to_owned).to_vec());
     let mut extensions = vec![".EXE".to_owned()];
     for extension in configured {
         if !extensions
@@ -1159,17 +1159,13 @@ fn find_windows_gh(path: &std::ffi::OsStr, pathext: Option<&std::ffi::OsStr>) ->
                 return Some(candidate);
             }
         }
-        let extensionless = dir.join("gh");
-        if is_executable(&extensionless) {
-            return Some(extensionless);
-        }
     }
     None
 }
 
 #[cfg(windows)]
 fn launchable_windows_extension(extension: &str) -> bool {
-    [".COM", ".EXE", ".BAT", ".CMD"]
+    [".COM", ".EXE"]
         .iter()
         .any(|supported| extension.eq_ignore_ascii_case(supported))
 }
@@ -1989,6 +1985,21 @@ mod windows_tests {
 
         assert_eq!(
             find_windows_gh(&search_path, Some(OsStr::new(".PS1;.EXE"))),
+            Some(gh)
+        );
+    }
+
+    #[test]
+    fn github_cli_discovery_skips_batch_shims_that_reject_multiline_bodies() {
+        let batch_shim = tempfile::tempdir().unwrap();
+        std::fs::write(batch_shim.path().join("gh.cmd"), b"@echo wrong\r\n").unwrap();
+        let installed = tempfile::tempdir().unwrap();
+        let gh = installed.path().join("gh.exe");
+        std::fs::write(&gh, b"synthetic executable").unwrap();
+        let search_path = std::env::join_paths([batch_shim.path(), installed.path()]).unwrap();
+
+        assert_eq!(
+            find_windows_gh(&search_path, Some(OsStr::new(".CMD;.EXE"))),
             Some(gh)
         );
     }

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -13,6 +13,8 @@ use tokio::time::timeout;
 
 use tidebreak_core::{Diffstat, PullRequestDigest, QuickAction, WorkspaceId};
 
+use super::setup_script::spawn_workspace_script;
+
 const GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const GIT_PUSH_TIMEOUT: Duration = Duration::from_secs(120);
 const GH_TIMEOUT: Duration = Duration::from_secs(30);
@@ -1113,18 +1115,7 @@ async fn run_action(worktree: &Path, action: &QuickAction) -> ActionOutcome {
             timed_out: false,
         };
     }
-    let shell = std::env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into());
-    let mut command = Command::new(shell);
-    command
-        .arg("-lc")
-        .arg(script)
-        .current_dir(worktree)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .env("GIT_TERMINAL_PROMPT", "0");
-    let child = match command.spawn() {
+    let child = match spawn_workspace_script(worktree, script) {
         Ok(child) => child,
         Err(err) => {
             return ActionOutcome {

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -1,10 +1,11 @@
 //! Boot recovery for sessions recorded as running.
 //!
-//! A recorded child pid is probed with signal 0 only. Dead → the open turn
-//! closes as Interrupted (journaled) and the session is Idle. Alive → the
-//! session is fenced until an explicit reap. A pid that was not recorded at
-//! spawn is never signaled.
+//! A recorded child pid is checked with the platform's non-mutating existence
+//! probe. Dead → the open turn closes as Interrupted (journaled) and the
+//! session is Idle. Alive → the session is fenced until an explicit reap. A
+//! pid that was not recorded at spawn is never probed or signaled.
 
+#[cfg(unix)]
 use std::io::ErrorKind;
 
 use chrono::Utc;
@@ -191,10 +192,12 @@ async fn interrupt_open_turn(
     Ok(())
 }
 
-/// Signal-0 probe of a pid that was recorded at spawn.
+/// Existence probe of a pid that was recorded at spawn.
 ///
-/// `EPERM` counts as alive. This function is the only place recovery sends a
-/// signal, and it sends only signal 0 (existence check).
+/// Unix uses signal 0 and counts `EPERM` as alive. Windows opens the process
+/// for limited query access and reads its exit code; access denial and other
+/// ambiguous failures count as alive so recovery fences rather than risks
+/// reusing an orphaned session.
 pub(crate) fn probe_recorded_pid(pid: i64) -> PidLiveness {
     if pid <= 0 {
         return PidLiveness::Dead;
@@ -225,7 +228,44 @@ pub(crate) fn probe_recorded_pid(pid: i64) -> PidLiveness {
             }
         }
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::{
+            CloseHandle, ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER, STILL_ACTIVE,
+        };
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        let Ok(pid) = u32::try_from(pid) else {
+            return PidLiveness::Dead;
+        };
+        // SAFETY: `pid` is a recorded numeric process id. The returned handle
+        // is checked for null and closed on every successful open.
+        let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if process.is_null() {
+            return match std::io::Error::last_os_error().raw_os_error() {
+                Some(code) if code as u32 == ERROR_ACCESS_DENIED => PidLiveness::Alive,
+                Some(code) if code as u32 == ERROR_INVALID_PARAMETER => PidLiveness::Dead,
+                _ => PidLiveness::Alive,
+            };
+        }
+        let mut exit_code = 0_u32;
+        // SAFETY: `process` is a live handle returned by `OpenProcess`, and
+        // `exit_code` points to writable storage for the duration of the call.
+        let queried = unsafe { GetExitCodeProcess(process, &mut exit_code) };
+        // SAFETY: ownership of the handle is local to this function and this
+        // is its single close, after the final query.
+        let _ = unsafe { CloseHandle(process) };
+        if queried == 0 {
+            PidLiveness::Alive
+        } else if exit_code == STILL_ACTIVE as u32 {
+            PidLiveness::Alive
+        } else {
+            PidLiveness::Dead
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = pid;
         PidLiveness::Alive
@@ -551,11 +591,31 @@ mod tests {
     }
 
     #[test]
-    fn probe_never_kills_and_treats_eperm_as_alive() {
-        // Our own pid is alive; signal 0 must not terminate us.
+    fn probe_recognizes_self_and_rejects_invalid_pids() {
+        // Our own pid is alive; the existence probe must not terminate us.
         let self_pid = i64::from(std::process::id());
         assert_eq!(probe_recorded_pid(self_pid), PidLiveness::Alive);
         assert_eq!(probe_recorded_pid(-1), PidLiveness::Dead);
         assert_eq!(probe_recorded_pid(0), PidLiveness::Dead);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_probe_distinguishes_a_live_process_from_an_exited_one() {
+        let mut child = std::process::Command::new("powershell.exe")
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Start-Sleep -Seconds 30",
+            ])
+            .spawn()
+            .expect("spawn live process");
+        let live_pid = i64::from(child.id());
+        assert_eq!(probe_recorded_pid(live_pid), PidLiveness::Alive);
+        child.kill().expect("terminate test process");
+        child.wait().expect("reap test process");
+        assert_eq!(probe_recorded_pid(live_pid), PidLiveness::Dead);
     }
 }

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -41,6 +41,8 @@ use super::session_worker::{
     attach_engine, journal_event, queue_follow_up, spawn_session_worker, WorkerCommand,
     WorkerError, WorkerHandle,
 };
+#[cfg(windows)]
+use super::worktree::repo_paths_equivalent;
 use super::worktree::{
     self, archive_blockers, branch_name, create_worktree, prune_worktrees, remove_worktree,
     run_archive_script, run_setup_script, slugify, validate_repo_path, worktree_dir, WorktreeError,
@@ -401,7 +403,17 @@ impl CodeRuntime {
     ) -> Result<CodeRepo, ServerError> {
         let validated = validate_repo_path(&root_path).await.map_err(map_worktree)?;
         let toplevel = validated.toplevel.display().to_string();
-        if let Some(existing) = get_repo_by_root_path(&self.db, &toplevel).await? {
+        let exact = get_repo_by_root_path(&self.db, &toplevel).await?;
+        #[cfg(windows)]
+        let existing = match exact {
+            Some(repo) => Some(repo),
+            None => list_repos(&self.db).await?.into_iter().find(|repo| {
+                repo_paths_equivalent(std::path::Path::new(&repo.root_path), &validated.toplevel)
+            }),
+        };
+        #[cfg(not(windows))]
+        let existing = exact;
+        if let Some(existing) = existing {
             return Err(ServerError::conflict_kind(
                 "repo_already_registered",
                 format!(

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -126,9 +126,8 @@ impl LiveSink {
             requested_at: Utc::now(),
             decided_at: None,
         };
-        if insert_approval(&self.db, &approval).await.is_err() {
-            return;
-        }
+        // Attention first: a client that can list the pending approval must
+        // already see NeedsYou.
         let _ = super::attention::apply_attention(
             &self.db,
             &self.bus,
@@ -137,6 +136,9 @@ impl LiveSink {
             false,
         )
         .await;
+        if insert_approval(&self.db, &approval).await.is_err() {
+            return;
+        }
         let _ = persist_and_publish(
             &self.db,
             &self.bus,

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -126,8 +126,9 @@ impl LiveSink {
             requested_at: Utc::now(),
             decided_at: None,
         };
-        // Attention first: a client that can list the pending approval must
-        // already see NeedsYou.
+        if insert_approval(&self.db, &approval).await.is_err() {
+            return;
+        }
         let _ = super::attention::apply_attention(
             &self.db,
             &self.bus,
@@ -136,9 +137,6 @@ impl LiveSink {
             false,
         )
         .await;
-        if insert_approval(&self.db, &approval).await.is_err() {
-            return;
-        }
         let _ = persist_and_publish(
             &self.db,
             &self.bus,

--- a/crates/tidebreak-server/src/code/setup_script.rs
+++ b/crates/tidebreak-server/src/code/setup_script.rs
@@ -3,10 +3,13 @@
 //! A failed hook preserves the checkout. The caller marks the workspace
 //! `SetupFailed` (or leaves archive uncommitted) rather than deleting work.
 
+use std::ffi::OsString;
+use std::io;
 use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
 
+use tidebreak_harness::ProcessTreeChild;
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -19,6 +22,18 @@ pub(crate) struct ScriptRun {
     pub status: Option<i32>,
     pub stdout: String,
     pub stderr: String,
+}
+
+/// Spawn a user-authored script in the platform-native non-interactive shell.
+///
+/// Process ownership stays centralized in `tidebreak-harness`, where Windows
+/// children are assigned to a Job Object before they can create descendants.
+pub(crate) fn spawn_workspace_script(
+    worktree: &Path,
+    script: &str,
+) -> io::Result<ProcessTreeChild> {
+    let mut command = workspace_script_command(worktree, script);
+    tidebreak_harness::spawn_process_tree(&mut command)
 }
 
 /// Run `script` inside `worktree` via the user's login shell.
@@ -38,19 +53,7 @@ pub(crate) async fn run_workspace_script(
             stderr: String::new(),
         });
     }
-    let shell = std::env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into());
-    let mut command = Command::new(shell);
-    command
-        .arg("-lc")
-        .arg(script)
-        .current_dir(worktree)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .env("GIT_TERMINAL_PROMPT", "0");
-    let child = command
-        .spawn()
+    let child = spawn_workspace_script(worktree, script)
         .map_err(|err| format!("failed to spawn workspace script: {err}"))?;
     let output = timeout(SCRIPT_TIMEOUT, child.wait_with_output())
         .await
@@ -64,6 +67,51 @@ pub(crate) async fn run_workspace_script(
     })
 }
 
+fn workspace_script_command(worktree: &Path, script: &str) -> Command {
+    let (program, args) = workspace_script_launcher(script, std::env::var_os("SHELL"));
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .current_dir(worktree)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("GIT_TERMINAL_PROMPT", "0");
+    command
+}
+
+fn workspace_script_launcher(
+    script: &str,
+    unix_shell: Option<OsString>,
+) -> (OsString, Vec<OsString>) {
+    #[cfg(windows)]
+    {
+        let _ = unix_shell;
+        let script = format!(
+            "$global:LASTEXITCODE = 0\n{script}\nif (-not $?) {{ if ($LASTEXITCODE -ne 0) {{ exit $LASTEXITCODE }}; exit 1 }}\nexit 0"
+        );
+        (
+            OsString::from("powershell.exe"),
+            [
+                OsString::from("-NoLogo"),
+                OsString::from("-NoProfile"),
+                OsString::from("-NonInteractive"),
+                OsString::from("-Command"),
+                OsString::from(script),
+            ]
+            .into_iter()
+            .collect(),
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        (
+            unix_shell.unwrap_or_else(|| OsString::from("/bin/sh")),
+            [OsString::from("-lc"), OsString::from(script)].into(),
+        )
+    }
+}
+
 fn bound_text(bytes: &[u8]) -> String {
     const MAX: usize = 4_096;
     let mut text = String::from_utf8_lossy(bytes).into_owned();
@@ -71,4 +119,58 @@ fn bound_text(bytes: &[u8]) -> String {
         text = text.chars().take(MAX).collect();
     }
     text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_scripts_preserve_the_configured_login_shell_contract() {
+        let (program, args) =
+            workspace_script_launcher("printf ready", Some(OsString::from("/custom/shell")));
+        assert_eq!(program, OsString::from("/custom/shell"));
+        assert_eq!(
+            args,
+            [OsString::from("-lc"), OsString::from("printf ready")]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_scripts_use_non_interactive_windows_powershell() {
+        let (program, args) = workspace_script_launcher(
+            "Write-Output ready",
+            Some(OsString::from("ignored-shell.exe")),
+        );
+        assert_eq!(program, OsString::from("powershell.exe"));
+        assert_eq!(
+            &args[..4],
+            ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
+        );
+        let command = args[4].to_string_lossy();
+        assert!(command.contains("Write-Output ready"));
+        assert!(command.contains("$LASTEXITCODE"));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn windows_powershell_runs_in_the_requested_worktree() {
+        let directory = tempfile::tempdir().expect("worktree");
+        let run = run_workspace_script(directory.path(), "(Get-Location).Path")
+            .await
+            .expect("run PowerShell");
+        assert!(run.success, "{}", run.stderr);
+        let reported = Path::new(run.stdout.trim())
+            .canonicalize()
+            .expect("reported worktree");
+        assert_eq!(reported, directory.path().canonicalize().unwrap());
+
+        let failed = run_workspace_script(directory.path(), "cmd.exe /c exit 7")
+            .await
+            .expect("run failing native command");
+        assert!(!failed.success);
+        assert_eq!(failed.status, Some(7));
+    }
 }

--- a/crates/tidebreak-server/src/code/setup_script.rs
+++ b/crates/tidebreak-server/src/code/setup_script.rs
@@ -6,8 +6,13 @@
 use std::ffi::OsString;
 use std::io;
 use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
+
+#[cfg(windows)]
+use std::os::windows::ffi::OsStringExt;
 
 use tidebreak_harness::ProcessTreeChild;
 use tokio::process::Command;
@@ -32,7 +37,7 @@ pub(crate) fn spawn_workspace_script(
     worktree: &Path,
     script: &str,
 ) -> io::Result<ProcessTreeChild> {
-    let mut command = workspace_script_command(worktree, script);
+    let mut command = workspace_script_command(worktree, script)?;
     tidebreak_harness::spawn_process_tree(&mut command)
 }
 
@@ -67,8 +72,8 @@ pub(crate) async fn run_workspace_script(
     })
 }
 
-fn workspace_script_command(worktree: &Path, script: &str) -> Command {
-    let (program, args) = workspace_script_launcher(script, std::env::var_os("SHELL"));
+fn workspace_script_command(worktree: &Path, script: &str) -> io::Result<Command> {
+    let (program, args) = workspace_script_launcher(script, std::env::var_os("SHELL"))?;
     let mut command = Command::new(program);
     command
         .args(args)
@@ -77,21 +82,21 @@ fn workspace_script_command(worktree: &Path, script: &str) -> Command {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .env("GIT_TERMINAL_PROMPT", "0");
-    command
+    Ok(command)
 }
 
 fn workspace_script_launcher(
     script: &str,
     unix_shell: Option<OsString>,
-) -> (OsString, Vec<OsString>) {
+) -> io::Result<(OsString, Vec<OsString>)> {
     #[cfg(windows)]
     {
         let _ = unix_shell;
         let script = format!(
             "$global:LASTEXITCODE = 0\n{script}\nif (-not $?) {{ if ($LASTEXITCODE -ne 0) {{ exit $LASTEXITCODE }}; exit 1 }}\nexit 0"
         );
-        (
-            OsString::from("powershell.exe"),
+        Ok((
+            system_windows_powershell()?.into_os_string(),
             [
                 OsString::from("-NoLogo"),
                 OsString::from("-NoProfile"),
@@ -101,14 +106,38 @@ fn workspace_script_launcher(
             ]
             .into_iter()
             .collect(),
-        )
+        ))
     }
     #[cfg(not(windows))]
     {
-        (
+        Ok((
             unix_shell.unwrap_or_else(|| OsString::from("/bin/sh")),
             [OsString::from("-lc"), OsString::from(script)].into(),
-        )
+        ))
+    }
+}
+
+#[cfg(windows)]
+fn system_windows_powershell() -> io::Result<PathBuf> {
+    use windows_sys::Win32::System::SystemInformation::GetSystemDirectoryW;
+
+    let mut buffer = vec![0_u16; 260];
+    loop {
+        // SAFETY: `buffer` is writable for the advertised number of UTF-16
+        // code units and remains alive for the duration of the call.
+        let length = unsafe { GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32) };
+        if length == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let length = length as usize;
+        if length < buffer.len() {
+            buffer.truncate(length);
+            return Ok(PathBuf::from(OsString::from_wide(&buffer))
+                .join("WindowsPowerShell")
+                .join("v1.0")
+                .join("powershell.exe"));
+        }
+        buffer.resize(length.saturating_add(1), 0);
     }
 }
 
@@ -129,7 +158,8 @@ mod tests {
     #[test]
     fn unix_scripts_preserve_the_configured_login_shell_contract() {
         let (program, args) =
-            workspace_script_launcher("printf ready", Some(OsString::from("/custom/shell")));
+            workspace_script_launcher("printf ready", Some(OsString::from("/custom/shell")))
+                .unwrap();
         assert_eq!(program, OsString::from("/custom/shell"));
         assert_eq!(
             args,
@@ -143,8 +173,13 @@ mod tests {
         let (program, args) = workspace_script_launcher(
             "Write-Output ready",
             Some(OsString::from("ignored-shell.exe")),
+        )
+        .unwrap();
+        assert_eq!(
+            program,
+            system_windows_powershell().unwrap().into_os_string()
         );
-        assert_eq!(program, OsString::from("powershell.exe"));
+        assert!(Path::new(&program).is_absolute());
         assert_eq!(
             &args[..4],
             ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
@@ -152,6 +187,23 @@ mod tests {
         let command = args[4].to_string_lossy();
         assert!(command.contains("Write-Output ready"));
         assert!(command.contains("$LASTEXITCODE"));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn windows_scripts_ignore_a_worktree_powershell_decoy() {
+        let directory = tempfile::tempdir().expect("worktree");
+        std::fs::write(
+            directory.path().join("powershell.exe"),
+            b"repository-controlled decoy",
+        )
+        .expect("write decoy executable");
+
+        let run = run_workspace_script(directory.path(), "Write-Output trusted")
+            .await
+            .expect("run trusted PowerShell");
+        assert!(run.success, "{}", run.stderr);
+        assert_eq!(run.stdout.trim(), "trusted");
     }
 
     #[cfg(windows)]

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -30,6 +30,85 @@ pub(crate) struct ValidatedRepo {
     pub toplevel: PathBuf,
 }
 
+/// Whether two canonical repository paths identify the same checkout.
+///
+/// Windows can present one path as a regular drive/UNC path or as the verbatim
+/// form returned by `canonicalize`. Repository identity is also
+/// case-insensitive there.
+#[cfg(windows)]
+pub(crate) fn repo_paths_equivalent(left: &Path, right: &Path) -> bool {
+    use windows_sys::Win32::Globalization::{CompareStringOrdinal, CSTR_EQUAL};
+
+    let left = windows_repo_path_identity(left);
+    let right = windows_repo_path_identity(right);
+    let (Ok(left_len), Ok(right_len)) = (i32::try_from(left.len()), i32::try_from(right.len()))
+    else {
+        return false;
+    };
+    // SAFETY: both pointers reference initialized UTF-16 buffers for the
+    // exact lengths passed. CompareStringOrdinal does not require NUL
+    // termination when explicit lengths are provided.
+    unsafe {
+        CompareStringOrdinal(left.as_ptr(), left_len, right.as_ptr(), right_len, 1) == CSTR_EQUAL
+    }
+}
+
+#[cfg(windows)]
+fn windows_repo_path_identity(path: &Path) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+
+    const VERBATIM: &[u16] = &[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16];
+    const VERBATIM_UNC: &[u16] = &[
+        b'\\' as u16,
+        b'\\' as u16,
+        b'?' as u16,
+        b'\\' as u16,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        b'\\' as u16,
+    ];
+
+    let mut value = path
+        .as_os_str()
+        .encode_wide()
+        .map(|unit| {
+            if unit == b'/' as u16 {
+                b'\\' as u16
+            } else {
+                unit
+            }
+        })
+        .collect::<Vec<_>>();
+    if wide_starts_with_ascii_case_insensitive(&value, VERBATIM_UNC) {
+        value.splice(..VERBATIM_UNC.len(), [b'\\' as u16, b'\\' as u16]);
+    } else if wide_starts_with_ascii_case_insensitive(&value, VERBATIM) {
+        value.drain(..VERBATIM.len());
+    }
+    while value.last() == Some(&(b'\\' as u16)) {
+        value.pop();
+    }
+    value
+}
+
+#[cfg(windows)]
+fn wide_starts_with_ascii_case_insensitive(value: &[u16], prefix: &[u16]) -> bool {
+    value.len() >= prefix.len()
+        && value
+            .iter()
+            .zip(prefix)
+            .all(|(left, right)| wide_ascii_upper(*left) == *right)
+}
+
+#[cfg(windows)]
+fn wide_ascii_upper(unit: u16) -> u16 {
+    if (b'a' as u16..=b'z' as u16).contains(&unit) {
+        unit - (b'a' - b'A') as u16
+    } else {
+        unit
+    }
+}
+
 /// Why a workspace archive needs an explicit `force`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ArchiveBlock {
@@ -610,5 +689,26 @@ mod tests {
         let slug = name.strip_prefix("tidebreak/").unwrap();
         assert!(slug.contains('-'), "{slug}");
         assert_eq!(slugify("Hello, World!"), "hello-world");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_repo_identity_ignores_case_and_verbatim_presentation() {
+        assert!(repo_paths_equivalent(
+            Path::new(r"C:\Users\Dev\Repo"),
+            Path::new(r"\\?\c:\users\dev\repo\")
+        ));
+        assert!(repo_paths_equivalent(
+            Path::new(r"\\Server\Share\Repo"),
+            Path::new(r"\\?\UNC\server\share\repo\")
+        ));
+        assert!(repo_paths_equivalent(
+            Path::new(r"\\Server\Share"),
+            Path::new(r"\\?\UNC\server\share\")
+        ));
+        assert!(!repo_paths_equivalent(
+            Path::new(r"\\Server\Share\Repo"),
+            Path::new(r"\\Server\Other\Repo")
+        ));
     }
 }

--- a/crates/tidebreak-server/src/plugin_install.rs
+++ b/crates/tidebreak-server/src/plugin_install.rs
@@ -1104,10 +1104,14 @@ fn category_name(category: PluginCategory) -> &'static str {
 }
 
 fn manifest_body(manifest: &str) -> &str {
-    manifest
-        .strip_prefix("---\n")
-        .and_then(|rest| rest.split_once("\n---\n"))
-        .map_or("", |(_, body)| body)
+    let rest = manifest
+        .strip_prefix("---\r\n")
+        .or_else(|| manifest.strip_prefix("---\n"));
+    rest.and_then(|rest| {
+        rest.split_once("\r\n---\r\n")
+            .or_else(|| rest.split_once("\n---\n"))
+    })
+    .map_or("", |(_, body)| body)
 }
 
 fn display_name(name: &str) -> String {

--- a/crates/tidebreak-server/src/routes/plugins.rs
+++ b/crates/tidebreak-server/src/routes/plugins.rs
@@ -308,11 +308,15 @@ pub async fn get_skill_instructions(
 /// parsed on the way in, so the split always succeeds; falling back to the
 /// whole source keeps a malformed one readable rather than blank.
 fn manifest_body(manifest: &str) -> &str {
-    manifest
-        .strip_prefix("---\n")
-        .and_then(|rest| rest.split_once("\n---\n"))
-        .map_or(manifest, |(_, body)| body)
-        .trim()
+    let rest = manifest
+        .strip_prefix("---\r\n")
+        .or_else(|| manifest.strip_prefix("---\n"));
+    rest.and_then(|rest| {
+        rest.split_once("\r\n---\r\n")
+            .or_else(|| rest.split_once("\n---\n"))
+    })
+    .map_or(manifest, |(_, body)| body)
+    .trim()
 }
 
 /// One prompt's insertable text, fetched when the user picks it.

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -2006,7 +2006,20 @@ async fn deny_feedback_reaches_the_scripted_engine() {
             assert_eq!(listed.status(), reqwest::StatusCode::OK);
             let body: Vec<serde_json::Value> = listed.json().await.unwrap();
             if let Some(row) = body.into_iter().next() {
-                return row;
+                let parsed: CodeSessionId = json_id(&session).parse().unwrap();
+                let session = tidebreak_core::db::code::get_session(&runtime.db, parsed)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                if matches!(
+                    session.attention.state,
+                    AttentionState::NeedsYou {
+                        source: AttentionSource::Structured,
+                        ..
+                    }
+                ) {
+                    return row;
+                }
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }

--- a/docs-site/content/docs/installation.mdx
+++ b/docs-site/content/docs/installation.mdx
@@ -64,14 +64,14 @@ sha256sum -c Tidebreak-linux-x86_64.deb.sha256
 ```
 
 Windows and Linux packages run the desktop chat, files, connected-folder,
-provider, and remote-sandbox surfaces. Linux also supports code mode with the
-same digest-verified managed Node runtime and pinned coding harnesses as macOS.
-Windows code mode remains unavailable. Native local execution, managed
-LibreOffice installation, and computer use remain unavailable on both Windows
-and Linux. Release builds check the signed updater feed in the background and
-ask before restarting into a newer package. Linux updates preserve the
-installed format: AppImage installs receive AppImage updates and Debian
-installs receive `.deb` updates.
+provider, remote-sandbox, and code-mode surfaces. Code mode uses the same
+digest-verified managed Node runtime and pinned coding harnesses as macOS,
+with PowerShell commands on Windows and POSIX shell commands on Linux. Native
+local execution, managed LibreOffice installation, and computer use remain
+unavailable on both Windows and Linux. Release builds check the signed updater
+feed in the background and ask before restarting into a newer package. Linux
+updates preserve the installed format: AppImage installs receive AppImage
+updates and Debian installs receive `.deb` updates.
 
 ## Build from source
 

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -347,11 +347,11 @@ live in a review sidebar).
 ## What v1 excludes
 
 Recorded in [`docs/deferred.md`](deferred.md): running a harness in a PTY;
-bundled or pinned harness binaries; checkpoint restore (the refs land in
-v1; the restore surface does not); multiple sessions per workspace;
+checkpoint restore (the refs land in v1; the restore surface does not);
+multiple sessions per workspace;
 an in-app code editor; chat–code convergence (the single-surface end
 state: one conversation concept with an optional workspace binding,
 engines behind the adapter contract, no user-facing mode choice); remote
 session execution (the same harness in a managed sandbox feeding the same
-journal); a supervision-first mobile client over the updates channel;
-a per-repo worktree-location override; Windows support for code mode.
+journal); a supervision-first mobile client over the updates channel; and a
+per-repo worktree-location override.

--- a/docs/decisions/0044-install-pinned-harnesses-on-linux.md
+++ b/docs/decisions/0044-install-pinned-harnesses-on-linux.md
@@ -1,6 +1,6 @@
 # 44. Install pinned coding harnesses on Linux
 
-- Status: Proposed
+- Status: Superseded by [decision 45](0045-run-code-mode-on-windows.md)
 - Date: 2026-08-18
 - Owners: code mode and desktop
 - Related: [decision 41](0041-pinned-harness-binaries.md),

--- a/docs/decisions/0045-run-code-mode-on-windows.md
+++ b/docs/decisions/0045-run-code-mode-on-windows.md
@@ -1,0 +1,172 @@
+# 45. Run code mode on Windows
+
+- Status: Proposed
+- Date: 2026-08-18
+- Owners: code mode and desktop
+- Related: [decision 32](0032-code-workspaces-worktrees-checkpoints.md),
+  [decision 34](0034-harness-discovery-credentials.md),
+  [decision 44](0044-install-pinned-harnesses-on-linux.md),
+  [`docs/code-mode.md`](../code-mode.md)
+- Supersedes: [decision 44](0044-install-pinned-harnesses-on-linux.md)
+
+## Context
+
+Decision 44 made the desktop provision one digest-verified Node runtime and
+made pinned harness probes and sessions use it on macOS and Linux. Windows
+desktop packages now ship for x86_64 and ARM64, but code mode remains disabled
+by several related Unix assumptions rather than by one capability gate.
+
+Official Windows Node distributions are ZIP archives whose `node.exe` and
+`npm.cmd` entrypoints live at the archive root. npm-installed harnesses expose
+Windows command shims under `node_modules/.bin`. Tidebreak's existing managed
+runtime verifier and harness launcher instead assume a `bin/node`, `bin/npm`,
+and extensionless harness entrypoint.
+
+The code-mode runtime also treats a POSIX login shell as the source of truth
+for the user's environment and invokes setup and quick-action scripts with
+`$SHELL -lc`. Windows desktop processes already receive the signed-in user's
+environment from the operating system, while neither PowerShell profiles nor
+`cmd.exe` startup files provide a stable machine-readable equivalent of
+`env -0`. Finally, interrupting only the immediate process is insufficient on
+Windows: launching a `.cmd` shim adds a command interpreter and Node child, and
+leaving either descendant alive breaks cancellation and restart recovery.
+
+Windows paths add a separate correctness boundary. Drive-letter paths are
+case-insensitive, UNC paths are valid repository roots, and canonicalization
+may add a verbatim path prefix. Persisted repository identities cannot depend
+on spelling differences that Windows treats as equal.
+
+## Decision
+
+The desktop-managed Node installer supports the shipped Windows x86_64 and
+ARM64 targets. It downloads the exact official ZIP for the existing Node pin,
+verifies the platform-specific SHA-256 before extraction, rejects archive
+entries that escape the staging directory, and installs the archive root under
+`tools/node/<version>/`. The shared managed-runtime contract describes the
+artifact digest and platform layout. Verification requires the platform's
+actual entrypoints: root-level `node.exe` and `npm.cmd` on Windows, and
+`bin/node` and `bin/npm` on macOS and Linux. No platform falls back to ambient
+Node.
+
+Pinned harness resolution is platform-aware. npm installation on Windows is
+invoked through the managed `npm.cmd`; a harness resolves to its generated
+`.cmd` shim, while Unix resolves the existing extensionless entrypoint. Every
+probe and live session receives the managed runtime directory first on
+`PATH`, and both paths retain marker-gated exact-version verification.
+
+Windows environment capture uses the current desktop/server process
+environment as the operating-system snapshot. It does not execute PowerShell
+profiles to synthesize another environment. Environment-key updates are
+case-insensitive so `Path` and `PATH` cannot become competing values. macOS and
+Linux retain login-shell capture.
+
+User-authored setup, archive, and quick-action scripts run with Windows
+PowerShell using non-profile, non-interactive flags. Tidebreak passes script
+text as one PowerShell command and does not reinterpret it as POSIX shell or
+`cmd.exe` syntax. Unix retains `$SHELL -lc`.
+
+Every spawned harness or user script is owned as a process tree. On Windows,
+Tidebreak creates the root process suspended, assigns it to a kill-on-close Job
+Object, and only then resumes it. Interruption, timeout, and owner drop
+terminate the job, including `.cmd`, Node, and tool descendants. Adapters do
+not carry independent Windows signal implementations. Unix retains the
+existing interrupt-and-escalate behavior.
+
+Repository validation continues to use canonical filesystem paths and
+argv-based Git commands. Windows repository identity comparisons normalize
+verbatim prefixes and compare case-insensitively without rejecting drive-letter
+or UNC roots. Tidebreak still creates worktrees under its data directory and
+does not introduce a user-selectable worktree location.
+
+This decision enables pinned local code-mode harnesses on Windows. It does not
+enable Tidebreak's native local execution sandbox, managed LibreOffice,
+computer use, or Windows Authenticode signing.
+
+## Alternatives Considered
+
+### Require users to install Node and harnesses globally
+
+Rejected. Ambient installs reintroduce version drift, make probes and sessions
+resolve different executables, and weaken the exact artifact contract already
+established on macOS and Linux.
+
+### Use `cmd.exe /c` for every Windows command
+
+Rejected. It is an implementation detail of npm-generated shims, but it is a
+poor contract for user scripts and provides no stable environment-capture
+protocol. PowerShell is the native user-script surface.
+
+### Load PowerShell profiles and parse the resulting environment
+
+Rejected. Profiles may prompt, print arbitrary data, mutate state, or never
+return. The desktop process already receives the signed-in user's environment;
+capturing it directly is deterministic and matches other native GUI software.
+
+### Assign a normally running child to a Job Object after spawn
+
+Rejected. A fast `.cmd` wrapper can create a Node descendant before assignment,
+allowing it to escape cancellation. Suspended creation makes ownership atomic
+from the child's perspective.
+
+### Kill only the spawned child process
+
+Rejected. npm shims and command interpreters create descendants. Killing only
+the child Tidebreak directly spawned can leave Node and tool subprocesses
+running against a supposedly interrupted worktree.
+
+### Compare persisted Windows paths as raw strings
+
+Rejected. Drive-letter case, separator spelling, and verbatim prefixes can
+describe the same path. Raw-string identity would permit duplicate repository
+registrations and make validation depend on presentation.
+
+### Keep Windows code mode unavailable
+
+Rejected once the native runtime, shell, process-tree, and path contracts are
+implemented and covered by Windows CI. The structured harness protocol and
+durable workspace model are otherwise platform-independent.
+
+## Consequences
+
+The managed Node contract gains explicit archive-layout and executable helpers
+instead of treating every artifact as a Unix tarball. The desktop installer
+must maintain a bounded ZIP extractor alongside the existing tar extractor.
+
+Windows interruption and timeout code depends on Job Objects and thread resume
+APIs. Spawn failures fail closed rather than launch an unowned process tree.
+Tests that spawn children must use the same ownership abstraction when they
+claim to cover production lifecycle behavior.
+
+Windows scripts use PowerShell syntax. Existing repositories whose setup
+commands are written only for POSIX shells need a platform-specific command or
+a cross-platform command they invoke from PowerShell; Tidebreak does not
+translate shell languages.
+
+Direct process-environment capture does not observe changes made only by a
+shell profile after Tidebreak starts. Users must restart Tidebreak after
+changing machine or user environment variables. This is more predictable than
+executing arbitrary profiles during every probe.
+
+Revisit this decision if Windows stops shipping Windows PowerShell by default,
+if a first-party process supervisor replaces local child ownership, or if code
+workspaces move outside the Tidebreak data directory and require a broader path
+authorization model.
+
+## Validation
+
+- Platform-pin tests require every shipped macOS, Linux, and Windows
+  architecture to select one artifact and the correct executable layout.
+- Archive tests exercise the real ZIP extractor and reject traversal,
+  absolute, reserved-name, and link-like entries before installation.
+- Harness tests require Windows managed npm and harness `.cmd` shims, exact
+  markers, and managed Node precedence on `PATH` for probes and sessions.
+- Environment tests require case-insensitive replacement of Windows keys and
+  prove that profile scripts are not executed for capture.
+- Script tests require PowerShell's non-profile, non-interactive invocation and
+  exercise success, failure, timeout, and descendant cleanup.
+- Worktree tests cover drive-letter, UNC, verbatim-prefix, and case-folded
+  duplicate behavior.
+- Native Windows CI runs managed-runtime, harness, and server code-mode suites.
+  It must exercise repository registration, worktree creation, setup and quick
+  actions, harness probe/launch, interruption, checkpointing, and restart
+  recovery. Cross-compilation alone does not satisfy this validation.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -215,9 +215,6 @@ purpose:
   existence would sap the pressure to keep adapters honest, and it forfeits
   approvals, resume, and durable history. Reconsider only if a harness's
   machine-readable surface proves genuinely unusable over time.
-- **Windows harness pins.** macOS and Linux are the supported install paths;
-  Windows remains coupled to the broader native code-mode work
-  ([record 44](decisions/0044-install-pinned-harnesses-on-linux.md)).
 - **Checkpoint restore.** Per-turn checkpoints land with v1 as hidden refs
   and power turn-scoped diffs; the surface that restores a workspace to an
   earlier checkpoint waits until review flows have settled.
@@ -265,9 +262,6 @@ purpose:
   fires off sessions and supervises them — approve, deny with feedback,
   steer, review completion — is a thin client of a reachable deployment and
   waits on the self-host member-client path above.
-- **Code mode on Windows.** Environment capture, setup and quick-action shell
-  semantics, npm command shims and process-tree cancellation, worktree path
-  validation, and native lifecycle tests all need Windows-specific work.
 
 ## What this means for planning
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -264,6 +264,13 @@ registry and prepared-build caches. The Windows ARM job keeps the
 restores only caches for the same commit SHA, so a failed MSVC CMake tree from
 an earlier attempt cannot be reused after that compiler switch.
 
+Windows code mode uses the desktop's digest-verified managed Node ZIP and
+pinned harness packages. Setup, archive, and quick-action commands run through
+Windows PowerShell, while harness and command descendants are owned as one
+process tree for interruption and timeout. Native local execution, managed
+LibreOffice installation, and computer use remain separate platform
+capabilities and are not implied by code-mode support.
+
 ### Linux: x86_64 and ARM64 AppImage and Debian packages
 
 A release ships one portable AppImage and one `.deb` for each of `x86_64` and


### PR DESCRIPTION
## Summary

- add digest-verified managed Node ZIPs for Windows x86_64 and ARM64, including bounded extraction and platform-specific `node.exe` / `npm.cmd` entrypoints
- make harness discovery, environment capture, npm installation, probes, and sessions work with Windows command shims and case-insensitive environment keys
- own spawned processes with suspended creation and kill-on-close Job Objects so interrupts, timeouts, and owner drops terminate descendants
- run setup, archive, and quick-action scripts through an absolute trusted Windows PowerShell path, and normalize Windows repository identities and PID recovery
- discover the native Windows GitHub CLI safely and render PowerShell-compatible manual PR instructions
- add native Windows code-mode CI coverage, decision record 0045, and user/release documentation

## Why

Code mode was available on macOS and Linux but remained blocked on Windows by Unix-specific runtime layouts, login-shell environment capture, process signaling, executable discovery, and path identity assumptions. This change defines and implements the Windows-native contracts while preserving the existing Unix behavior.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p tidebreak-code-execution --locked`
- `cargo test -p tidebreak-harness --locked`
- `cargo test -p tidebreak-desktop node_install::tests --lib --locked`
- `cargo test -p tidebreak-server --lib code:: --locked`
- `cargo clippy -p tidebreak-code-execution -p tidebreak-harness -p tidebreak-server --all-targets --locked -- -D warnings`
- workflow-security Node tests
- five adversarial review rounds across archive/supply-chain, process lifecycle, and Windows integration; all actionable P1/P2 findings were fixed and the final pass returned no P1/P2 findings

## Validation limits

- Native Windows-only tests could not run on the macOS development host. Cross-target checking reaches external `ring` C code and stops because the host lacks MSVC/Windows SDK headers. The `windows-ci` label enables the native Windows lane for this PR.
- The docs-site build was not run locally because its Node dependencies are not installed in this checkout.
