### PR TITLE
feat(desktop): redesign code-mode tool and approval cards

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
@@ -9,31 +9,65 @@ afterEach(() => {
   cleanup();
 });
 
-const pending: CodeApprovalSnapshot = {
+const pendingCommand: CodeApprovalSnapshot = {
   id: "appr-1",
   session_id: "sess-1",
   turn_id: "turn-1",
-  kind: { type: "file_write", paths: ["/workspace/probe.txt"] },
+  kind: { type: "command", cmd: "rm -rf /tmp/scratch", cwd: "/workspace" },
   harness_raw_json: JSON.stringify({
-    tool_name: "Write",
-    input: { file_path: "/workspace/probe.txt", content: "hello" },
+    tool_name: "Bash",
+    command: "rm -rf /tmp/scratch",
     tool_use_id: "toolu_1",
   }),
   state: "pending",
   requested_at: "2026-08-15T12:00:00.000Z",
 };
 
+const pendingWrite: CodeApprovalSnapshot = {
+  id: "appr-2",
+  session_id: "sess-1",
+  turn_id: "turn-1",
+  kind: { type: "file_write", paths: ["/workspace/probe.txt"] },
+  harness_raw_json: JSON.stringify({
+    tool_name: "Write",
+    input: { file_path: "/workspace/probe.txt", content: "hello" },
+    tool_use_id: "toolu_2",
+  }),
+  state: "pending",
+  requested_at: "2026-08-15T12:00:00.000Z",
+};
+
 describe("CodeApprovalCard", () => {
-  it("renders the harness payload rather than a paraphrase", () => {
-    render(<CodeApprovalCard approval={pending} onDecide={vi.fn()} />);
+  it("leads with the command and keeps the harness payload collapsed", () => {
+    render(<CodeApprovalCard approval={pendingCommand} onDecide={vi.fn()} />);
+    expect(screen.getByText("Run this command?")).toBeInTheDocument();
+    expect(screen.getByText("rm -rf /tmp/scratch").tagName).toBe("PRE");
+    expect(screen.getByText("cwd /workspace")).toBeInTheDocument();
+    expect(
+      document.querySelector('time[datetime="2026-08-15T12:00:00.000Z"]'),
+    ).not.toBeNull();
+
+    const disclosure = screen.getByText("Harness payload").closest("details");
+    expect(disclosure).not.toHaveAttribute("open");
+    expect(screen.queryByText(/"tool_name": "Bash"/)).not.toBeVisible();
+
+    fireEvent.click(screen.getByText("Harness payload"));
+    expect(disclosure).toHaveAttribute("open");
+    expect(screen.getByText(/"tool_name": "Bash"/)).toBeVisible();
+  });
+
+  it("lists the paths a file write would touch", () => {
+    render(<CodeApprovalCard approval={pendingWrite} onDecide={vi.fn()} />);
     expect(screen.getByText("Write this file?")).toBeInTheDocument();
-    expect(screen.getByText(/"tool_name": "Write"/)).toBeInTheDocument();
-    expect(screen.getByText(/"file_path": "\/workspace\/probe.txt"/)).toBeInTheDocument();
+    expect(screen.getByText("/workspace/probe.txt").tagName).toBe("LI");
+    expect(screen.getByText("Harness payload").closest("details")).not.toHaveAttribute(
+      "open",
+    );
   });
 
   it("opens a feedback field on deny and submits it", () => {
     const onDecide = vi.fn();
-    render(<CodeApprovalCard approval={pending} onDecide={onDecide} />);
+    render(<CodeApprovalCard approval={pendingCommand} onDecide={onDecide} />);
     fireEvent.click(screen.getByRole("button", { name: "Deny" }));
     const box = screen.getByRole("textbox", { name: "Denial feedback" });
     fireEvent.change(box, {
@@ -43,6 +77,46 @@ describe("CodeApprovalCard", () => {
     expect(onDecide).toHaveBeenCalledWith(
       "deny",
       "no — use the fixtures directory instead",
+    );
+  });
+
+  it("tones an approved card as success and stamps both times", () => {
+    render(
+      <CodeApprovalCard
+        approval={{
+          ...pendingCommand,
+          state: "approved",
+          decided_at: "2026-08-15T12:05:00.000Z",
+        }}
+        onDecide={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Approved")).toHaveClass("text-success-foreground");
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+    expect(
+      document.querySelector('time[datetime="2026-08-15T12:00:00.000Z"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector('time[datetime="2026-08-15T12:05:00.000Z"]'),
+    ).not.toBeNull();
+  });
+
+  it("tones a denial as a warning and shows the feedback", () => {
+    render(
+      <CodeApprovalCard
+        approval={{
+          ...pendingCommand,
+          state: "denied",
+          feedback: "no — use the fixtures directory instead",
+          decided_at: "2026-08-15T12:05:00.000Z",
+        }}
+        onDecide={vi.fn()}
+      />,
+    );
+    const caption = screen.getByText(/Denied/);
+    expect(caption).toHaveClass("text-warning-foreground");
+    expect(caption).toHaveTextContent(
+      "Denied: no — use the fixtures directory instead",
     );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -3,11 +3,15 @@ import { useEffect, useState } from "react";
 import type { CodeApprovalSnapshot } from "../api/types";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { formatMessageTimestamp } from "@/MessageFooter";
 import { ScrollableContainer } from "@/ScrollableContainer";
 
 /**
- * Parked engine approval. The card shows the harness payload, not a
- * Tidebreak paraphrase; deny opens a feedback field the model will see.
+ * Parked engine approval. The normalized kind leads so the reader can decide;
+ * the harness payload stays behind a disclosure so the card does not paraphrase
+ * what the engine asked (decision 0033). Deny opens a feedback field the model
+ * will see.
  */
 export function CodeApprovalCard({
   approval,
@@ -36,20 +40,28 @@ export function CodeApprovalCard({
       data-testid="code-approval-card"
     >
       <h3 className="font-medium break-words">{approvalTitle(approval)}</h3>
-      <p className="text-muted-foreground text-sm break-words">
-        {approvalSummary(approval)}
-      </p>
-      <ScrollableContainer className="bg-muted text-muted-foreground max-h-48 rounded-md p-3 text-xs break-words whitespace-pre-wrap">
-        <pre className="font-mono">{prettyRaw(approval.harness_raw_json)}</pre>
-      </ScrollableContainer>
-      {approval.state === "denied" && approval.feedback && (
-        <p className="text-muted-foreground text-sm">
-          Denied: {approval.feedback}
+      <ApprovalKindBody approval={approval} />
+      <ApprovalTimes
+        requestedAt={approval.requested_at}
+        decidedAt={approval.decided_at}
+      />
+      {approval.state === "denied" && (
+        <p className="text-warning-foreground text-sm break-words">
+          Denied
+          {approval.feedback ? `: ${approval.feedback}` : ""}
         </p>
       )}
       {approval.state === "approved" && (
-        <p className="text-muted-foreground text-sm">Approved</p>
+        <p className="text-success-foreground text-sm">Approved</p>
       )}
+      <details>
+        <summary className="text-muted-foreground hover:text-foreground cursor-pointer select-none text-xs">
+          Harness payload
+        </summary>
+        <ScrollableContainer className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 text-xs break-words whitespace-pre-wrap">
+          <pre className="font-mono">{prettyRaw(approval.harness_raw_json)}</pre>
+        </ScrollableContainer>
+      </details>
       {!decided && !denying && (
         <div className="flex flex-wrap gap-2">
           <Button
@@ -112,6 +124,70 @@ export function CodeApprovalCard({
   );
 }
 
+function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
+  switch (approval.kind.type) {
+    case "command":
+      return (
+        <div className="flex flex-col gap-1">
+          <pre className="bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 font-mono text-xs break-words whitespace-pre-wrap">
+            {approval.kind.cmd || "Command"}
+          </pre>
+          {approval.kind.cwd && (
+            <p className="text-muted-foreground text-xs break-words">
+              cwd {approval.kind.cwd}
+            </p>
+          )}
+        </div>
+      );
+    case "file_write":
+      return approval.kind.paths.length > 0 ? (
+        <ul className="text-muted-foreground space-y-0.5 font-mono text-xs break-words">
+          {approval.kind.paths.map((path) => (
+            <li key={path}>{path}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-muted-foreground text-sm">File write</p>
+      );
+    case "network":
+    case "other":
+      return (
+        <p className="text-muted-foreground text-sm break-words">
+          {approval.kind.summary}
+        </p>
+      );
+  }
+}
+
+function ApprovalTimes({
+  requestedAt,
+  decidedAt,
+}: {
+  requestedAt: string;
+  decidedAt?: string;
+}) {
+  const requested = formatMessageTimestamp(requestedAt, new Date());
+  const decided = decidedAt
+    ? formatMessageTimestamp(decidedAt, new Date())
+    : null;
+  if (!requested && !decided) return null;
+  return (
+    <p className="text-muted-foreground text-xs">
+      {requested && (
+        <WithTooltip label={requested.full}>
+          <time dateTime={requestedAt}>{requested.short}</time>
+        </WithTooltip>
+      )}
+      {requested && decided && decidedAt && " · "}
+      {decided && decidedAt && (
+        <WithTooltip label={decided.full}>
+          <time dateTime={decidedAt}>{decided.short}</time>
+        </WithTooltip>
+      )}
+    </p>
+  );
+}
+
 function approvalTitle(approval: CodeApprovalSnapshot): string {
   switch (approval.kind.type) {
     case "file_write":
@@ -122,19 +198,6 @@ function approvalTitle(approval: CodeApprovalSnapshot): string {
       return "Allow this network access?";
     default:
       return "Allow this?";
-  }
-}
-
-function approvalSummary(approval: CodeApprovalSnapshot): string {
-  switch (approval.kind.type) {
-    case "file_write":
-      return approval.kind.paths.join(", ") || "File write";
-    case "command":
-      return approval.kind.cmd || "Command";
-    case "network":
-      return approval.kind.summary;
-    default:
-      return approval.kind.summary;
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { CodeTranscript } from "./CodeTranscript";
@@ -121,6 +122,39 @@ describe("CodeTranscript", () => {
     expect(
       screen.getByText("Send a message to start a turn."),
     ).toBeInTheDocument();
+  });
+
+  it("clamps a running tool's output and offers a copy control", async () => {
+    const preview = Array.from(
+      { length: 12 },
+      (_, index) => `line ${index + 1}`,
+    ).join("\n");
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "tool",
+            id: "tool-long",
+            turnId: "t1",
+            callId: "c1",
+            name: "Bash",
+            detail: { kind: "command", cmd: "seq 12", cwd: "/tmp" },
+            status: "running",
+            preview,
+          },
+        ]}
+      />,
+    );
+
+    const body = screen.getByLabelText("Output");
+    expect(body.textContent).toContain("line 8");
+    expect(body.textContent).not.toContain("line 9");
+    expect(screen.getByRole("button", { name: "Copy output" })).toBeTruthy();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show 4 more lines" }),
+    );
+    expect(screen.getByLabelText("Output").textContent).toContain("line 12");
   });
 
   it("shows the engine working only where nothing else says so", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -10,6 +10,7 @@ import { MessageFooter } from "@/MessageFooter";
 import { isolatedCard } from "@/PendingCard";
 import { ThinkingAccordion } from "@/ThinkingAccordion";
 import { ToolCardShell } from "@/ToolCardShell";
+import { ToolOutputPreview } from "@/ToolOutputPreview";
 import { TranscriptSkeleton } from "@/TranscriptSkeleton";
 import { UserMessage } from "@/UserMessage";
 import { cn } from "@/lib/utils";
@@ -223,15 +224,12 @@ function TranscriptItem({
       );
     case "notice":
       return <HarnessNotice level={item.level} message={item.message} />;
-    case "approval":
-      if (!approval) {
-        return (
-          <p className="text-muted-foreground text-sm" role="status">
-            Loading approval…
-          </p>
-        );
-      }
-      return (
+    case "approval": {
+      const card = !approval ? (
+        <p className="text-muted-foreground text-sm" role="status">
+          Loading approval…
+        </p>
+      ) : (
         <CodeApprovalCard
           approval={approval}
           deciding={deciding}
@@ -241,6 +239,15 @@ function TranscriptItem({
           }
         />
       );
+      return (
+        <div
+          data-code-approval-id={item.approvalId}
+          data-code-approval-state={item.state}
+        >
+          {card}
+        </div>
+      );
+    }
     case "turn_boundary":
       return <TurnReviewCard turn={item} onOpenTurnDiff={onOpenTurnDiff} />;
   }
@@ -282,15 +289,12 @@ export function CodeToolCard({
       titleClassName={detail.kind === "command" ? "font-mono" : undefined}
       badge={badge}
       defaultExpanded={status === "running"}
+      className={status === "failed" ? "border-critical-border" : undefined}
       label={`${name} ${status}`}
     >
       <div className="text-muted-foreground space-y-1 px-2.5 pb-2 text-xs">
         <p>{toolDetailLine(detail)}</p>
-        {preview && (
-          <pre className="bg-muted max-h-40 overflow-auto rounded-md p-2 font-mono whitespace-pre-wrap">
-            {preview}
-          </pre>
-        )}
+        {preview && <ToolOutputPreview text={preview} />}
       </div>
     </ToolCardShell>
   );

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -425,9 +425,23 @@ function PendingApprovalBadge({
   );
   if (pending === 0) return null;
   return (
-    <Badge variant="warning" size="sm" data-testid="pending-approval-badge">
-      {pending} {pending === 1 ? "approval" : "approvals"}
-    </Badge>
+    <button
+      type="button"
+      data-testid="pending-approval-badge"
+      className="cursor-pointer rounded-full border-0 bg-transparent p-0"
+      onClick={() => {
+        document
+          .querySelector('[data-code-approval-state="pending"]')
+          ?.scrollIntoView({
+            block: "center",
+            behavior: followScrollBehavior(false),
+          });
+      }}
+    >
+      <Badge variant="warning" size="sm">
+        {pending} {pending === 1 ? "approval" : "approvals"}
+      </Badge>
+    </button>
   );
 }
 


### PR DESCRIPTION
## What changed

An approval now leads with the normalized kind, not the harness JSON. A command shows the command in a mono block with a cwd caption. A file write lists the paths. A network request shows the summary. `requested_at` is stamped with `formatMessageTimestamp`; a decided card also stamps `decided_at`. Approved is a success caption. Denied is a warning caption and still shows the feedback.

The raw harness payload stays available behind a collapsed **Harness payload** disclosure, using the same `ScrollableContainer` as before. That keeps [ADR 0033](docs/decisions/0033-code-mode-approvals.md) honesty — the engine's request is still there, it just does not occupy the card before the reader can decide. Approve, Deny, and deny-feedback are unchanged. The card stays inside the `isolatedCard` row PR 2 added.

Tool cards drop the raw `max-h-40` `<pre>` for `ToolOutputPreview`: a clamped mono block, a Show-N-more expander, and a hover copy button. The cwd/detail line stays. Failed tools get a `border-critical-border` tint. Running tools stay expanded by default.

The header pending-approval badge is a button. It scrolls the first `[data-code-approval-state="pending"]` card into view. The workspace page diff is limited to `PendingApprovalBadge` so it does not collide with other work on that file.

## Validation

- `pnpm vitest run src/code` — 122 passed
- `pnpm vitest run` — 1141 passed
- `pnpm build` — `tsc` and Vite production build passed

## Compatibility and risk

None. No persisted or wire-format change. The approval snapshot already carried `kind`, `requested_at`, `decided_at`, and `harness_raw_json`; this change only changes what the card puts first.

## Tests deleted

- `it("renders the harness payload rather than a paraphrase")` — the card no longer leads with the raw JSON.
- `expect(screen.getByText(/"tool_name": "Write"/)).toBeInTheDocument()` — asserted the Write payload was visible by default.
- `expect(screen.getByText(/"file_path": "\/workspace\/probe.txt"/)).toBeInTheDocument()` — asserted the same payload's path field was visible by default.

Replaced by tests that the command (or path list) leads, the disclosure starts closed, deny-feedback still submits, and both timestamps render.