### PR TITLE
feat(desktop): tighten code-mode card visual language

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -61,10 +61,10 @@ export function ToolCardShell({
         aria-controls={bodyId}
         onClick={() => setExpanded((current) => !current)}
       >
-        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium">
+        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[11px] font-medium">
           <ChevronDown
             className={cn(
-              "size-3.5 shrink-0 transition-transform",
+              "size-3.5 shrink-0 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
               !expanded && "-rotate-90",
             )}
             aria-hidden="true"
@@ -74,7 +74,10 @@ export function ToolCardShell({
               repeat it. The native tooltip gives the whole line back to anyone
               who hovers, for the titles that are plain text to begin with. */}
           <span
-            className={cn("truncate", titleClassName)}
+            className={cn(
+              typeof title === "string" ? "truncate" : "min-w-0",
+              titleClassName,
+            )}
             title={typeof title === "string" ? title : undefined}
           >
             {title}
@@ -86,7 +89,7 @@ export function ToolCardShell({
         <span className="flex shrink-0 items-stretch gap-1">{badge}</span>
       </button>
       {expanded && (
-        <div id={bodyId} className="border-t">
+        <div id={bodyId} className="border-t [overflow-anchor:none]">
           {children}
         </div>
       )}

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -47,7 +47,7 @@ export function ToolOutputPreview({
         <pre
           id={bodyId}
           aria-label={label}
-          className="bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-xs break-words whitespace-pre-wrap"
+          className="bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-[13px] break-words whitespace-pre-wrap [overflow-anchor:none]"
         >
           {body}
         </pre>
@@ -56,7 +56,7 @@ export function ToolOutputPreview({
           label={`Copy ${label.toLowerCase()}`}
           copiedAnnouncement={`${label} copied to clipboard.`}
           failedAnnouncement={`${label} could not be copied.`}
-          className="border-border bg-background text-muted-foreground hover:text-foreground absolute top-1 right-1 inline-flex items-center rounded-md border p-1 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
+          className="border-border bg-background text-muted-foreground hover:text-foreground absolute top-1 right-1 inline-flex items-center rounded-md border p-1 opacity-0 transition-opacity duration-[140ms] ease-out group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
         />
       </div>
       {hiddenCount > 0 && (

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
@@ -47,22 +47,21 @@ describe("CodeApprovalCard", () => {
       document.querySelector('time[datetime="2026-08-15T12:00:00.000Z"]'),
     ).not.toBeNull();
 
-    const disclosure = screen.getByText("Harness payload").closest("details");
-    expect(disclosure).not.toHaveAttribute("open");
-    expect(screen.queryByText(/"tool_name": "Bash"/)).not.toBeVisible();
+    const toggle = screen.getByRole("button", { name: "Harness payload" });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
 
-    fireEvent.click(screen.getByText("Harness payload"));
-    expect(disclosure).toHaveAttribute("open");
-    expect(screen.getByText(/"tool_name": "Bash"/)).toBeVisible();
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/"tool_name": "Bash"/)).toBeInTheDocument();
   });
 
   it("lists the paths a file write would touch", () => {
     render(<CodeApprovalCard approval={pendingWrite} onDecide={vi.fn()} />);
     expect(screen.getByText("Write this file?")).toBeInTheDocument();
-    expect(screen.getByText("/workspace/probe.txt").tagName).toBe("LI");
-    expect(screen.getByText("Harness payload").closest("details")).not.toHaveAttribute(
-      "open",
-    );
+    expect(screen.getByText("/workspace/probe.txt")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Harness payload" }),
+    ).toHaveAttribute("aria-expanded", "false");
   });
 
   it("opens a feedback field on deny and submits it", () => {
@@ -113,10 +112,9 @@ describe("CodeApprovalCard", () => {
         onDecide={vi.fn()}
       />,
     );
-    const caption = screen.getByText(/Denied/);
-    expect(caption).toHaveClass("text-warning-foreground");
-    expect(caption).toHaveTextContent(
-      "Denied: no — use the fixtures directory instead",
-    );
+    expect(screen.getByText("Denied")).toHaveClass("text-warning-foreground");
+    expect(
+      screen.getByText("no — use the fixtures directory instead"),
+    ).toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import type { CodeApprovalSnapshot } from "../api/types";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { formatMessageTimestamp } from "@/MessageFooter";
+import { cn } from "@/lib/utils";
 import { ScrollableContainer } from "@/ScrollableContainer";
 
 /**
@@ -26,6 +27,7 @@ export function CodeApprovalCard({
 }) {
   const [denying, setDenying] = useState(false);
   const [feedback, setFeedback] = useState("");
+  const [payloadOpen, setPayloadOpen] = useState(false);
   const decided = approval.state !== "pending";
 
   useEffect(() => {
@@ -39,29 +41,35 @@ export function CodeApprovalCard({
       aria-busy={deciding}
       data-testid="code-approval-card"
     >
-      <h3 className="font-medium break-words">{approvalTitle(approval)}</h3>
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-[13px] font-medium break-words">
+          {approvalTitle(approval)}
+        </h3>
+        <ApprovalState approval={approval} />
+      </div>
       <ApprovalKindBody approval={approval} />
       <ApprovalTimes
         requestedAt={approval.requested_at}
         decidedAt={approval.decided_at}
       />
-      {approval.state === "denied" && (
-        <p className="text-warning-foreground text-sm break-words">
-          Denied
-          {approval.feedback ? `: ${approval.feedback}` : ""}
-        </p>
+      {approval.state === "denied" && approval.feedback && (
+        <p className="text-[13px] break-words">{approval.feedback}</p>
       )}
-      {approval.state === "approved" && (
-        <p className="text-success-foreground text-sm">Approved</p>
-      )}
-      <details>
-        <summary className="text-muted-foreground hover:text-foreground cursor-pointer select-none text-xs">
+      <div>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground text-[11px]"
+          aria-expanded={payloadOpen}
+          onClick={() => setPayloadOpen((current) => !current)}
+        >
           Harness payload
-        </summary>
-        <ScrollableContainer className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 text-xs break-words whitespace-pre-wrap">
-          <pre className="font-mono">{prettyRaw(approval.harness_raw_json)}</pre>
-        </ScrollableContainer>
-      </details>
+        </button>
+        <Reveal open={payloadOpen}>
+          <ScrollableContainer className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 text-[11px] break-words whitespace-pre-wrap">
+            <pre className="font-mono">{prettyRaw(approval.harness_raw_json)}</pre>
+          </ScrollableContainer>
+        </Reveal>
+      </div>
       {!decided && !denying && (
         <div className="flex flex-wrap gap-2">
           <Button
@@ -116,7 +124,7 @@ export function CodeApprovalCard({
         </div>
       )}
       {error && (
-        <p className="text-destructive text-xs break-words" role="alert">
+        <p className="text-critical-foreground text-[11px] break-words" role="alert">
           {error}
         </p>
       )}
@@ -124,16 +132,30 @@ export function CodeApprovalCard({
   );
 }
 
+function ApprovalState({ approval }: { approval: CodeApprovalSnapshot }) {
+  if (approval.state === "approved") {
+    return (
+      <p className="text-success-foreground shrink-0 text-[11px]">Approved</p>
+    );
+  }
+  if (approval.state === "denied") {
+    return (
+      <p className="text-warning-foreground shrink-0 text-[11px]">Denied</p>
+    );
+  }
+  return null;
+}
+
 function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
   switch (approval.kind.type) {
     case "command":
       return (
         <div className="flex flex-col gap-1">
-          <pre className="bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 font-mono text-xs break-words whitespace-pre-wrap">
+          <pre className="bg-muted overflow-x-auto rounded-md p-2 font-mono text-[13px] break-words whitespace-pre-wrap">
             {approval.kind.cmd || "Command"}
           </pre>
           {approval.kind.cwd && (
-            <p className="text-muted-foreground text-xs break-words">
+            <p className="text-muted-foreground font-mono text-[11px] break-words">
               cwd {approval.kind.cwd}
             </p>
           )}
@@ -141,18 +163,20 @@ function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
       );
     case "file_write":
       return approval.kind.paths.length > 0 ? (
-        <ul className="text-muted-foreground space-y-0.5 font-mono text-xs break-words">
+        <ul className="space-y-0.5">
           {approval.kind.paths.map((path) => (
-            <li key={path}>{path}</li>
+            <li key={path}>
+              <MiddleTruncate text={path} className="font-mono text-[11px]" />
+            </li>
           ))}
         </ul>
       ) : (
-        <p className="text-muted-foreground text-sm">File write</p>
+        <p className="text-muted-foreground text-[13px]">File write</p>
       );
     case "network":
     case "other":
       return (
-        <p className="text-muted-foreground text-sm break-words">
+        <p className="text-muted-foreground text-[13px] break-words">
           {approval.kind.summary}
         </p>
       );
@@ -172,7 +196,7 @@ function ApprovalTimes({
     : null;
   if (!requested && !decided) return null;
   return (
-    <p className="text-muted-foreground text-xs">
+    <p className="text-muted-foreground text-[11px]">
       {requested && (
         <WithTooltip label={requested.full}>
           <time dateTime={requestedAt}>{requested.short}</time>
@@ -185,6 +209,44 @@ function ApprovalTimes({
         </WithTooltip>
       )}
     </p>
+  );
+}
+
+function Reveal({ open, children }: { open: boolean; children: ReactNode }) {
+  return (
+    <div
+      className={cn(
+        "grid [overflow-anchor:none] transition-[grid-template-rows] duration-[140ms] ease-out motion-reduce:transition-none",
+        open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+      )}
+      aria-hidden={!open}
+      inert={!open ? true : undefined}
+    >
+      <div className="overflow-hidden">{children}</div>
+    </div>
+  );
+}
+
+function MiddleTruncate({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const tail = Math.min(28, Math.max(12, Math.ceil(text.length / 3)));
+  if (text.length <= 40) {
+    return (
+      <span className={cn("block truncate", className)} title={text}>
+        {text}
+      </span>
+    );
+  }
+  return (
+    <span className={cn("flex min-w-0", className)} title={text}>
+      <span className="truncate">{text.slice(0, -tail)}</span>
+      <span className="shrink-0">{text.slice(-tail)}</span>
+    </span>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -285,15 +285,18 @@ export function CodeToolCard({
   return (
     <ToolCardShell
       icon={toolIcon(detail)}
-      title={toolTitle(detail, name)}
-      titleClassName={detail.kind === "command" ? "font-mono" : undefined}
+      title={
+        <MiddleTruncate
+          text={toolTitle(detail, name)}
+          className={detail.kind === "command" ? "font-mono" : undefined}
+        />
+      }
       badge={badge}
       defaultExpanded={status === "running"}
-      className={status === "failed" ? "border-critical-border" : undefined}
       label={`${name} ${status}`}
     >
-      <div className="text-muted-foreground space-y-1 px-2.5 pb-2 text-xs">
-        <p>{toolDetailLine(detail)}</p>
+      <div className="text-muted-foreground space-y-1 px-2.5 pb-2 [overflow-anchor:none]">
+        <p className="text-[11px]">{toolDetailLine(detail)}</p>
         {preview && <ToolOutputPreview text={preview} />}
       </div>
     </ToolCardShell>
@@ -356,6 +359,30 @@ function toolTitle(detail: ToolDetail, name: string): string {
     case "other":
       return detail.summary || name;
   }
+}
+
+/** Keep the tail of a command or path when the header runs out of room. */
+function MiddleTruncate({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const tail = Math.min(28, Math.max(12, Math.ceil(text.length / 3)));
+  if (text.length <= 40) {
+    return (
+      <span className={cn("block truncate", className)} title={text}>
+        {text}
+      </span>
+    );
+  }
+  return (
+    <span className={cn("flex min-w-0", className)} title={text}>
+      <span className="truncate">{text.slice(0, -tail)}</span>
+      <span className="shrink-0">{text.slice(-tail)}</span>
+    </span>
+  );
 }
 
 function toolDetailLine(detail: ToolDetail): string {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -433,7 +433,7 @@ function PendingApprovalBadge({
         document
           .querySelector('[data-code-approval-state="pending"]')
           ?.scrollIntoView({
-            block: "center",
+            block: "nearest",
             behavior: followScrollBehavior(false),
           });
       }}


### PR DESCRIPTION
## What changed

A pass over #2198 against the code-mode visual bar. The first PR shipped the hierarchy; this one removes the extra signals and puts the remaining elements on one type ramp.

**Removed**
- Failed-tool `border-critical-border`. The Failed badge is already the status. A tint on the same fact is a second signal.
- A second decided caption under the body. Approved / Denied now sits once, as 11px meta beside the title, in the success or warning quad. Denial feedback stays as uncolored body copy so it is not a second warning.
- Native `<details>` for the harness payload. It popped open. The payload is now a button plus a 140ms ease-out height reveal that respects `prefers-reduced-motion`.

**What each remaining element answers**
- Title: the question being asked.
- Kind body (mono command + cwd, path list, or network summary): the thing being decided, in the engine's own terms.
- Timestamps: when it was requested, and when it was decided. 11px meta, no status color.
- Harness payload disclosure: ADR 0033 honesty. The raw request is still there; it is not the first thing you read.
- Approve / Deny: the decision. Unchanged.
- Tool badge: the only status color on a tool card (info / success / warning / critical).
- `ToolOutputPreview` clamp, expander, and copy: long output stays glanceable and copyable.
- Middle-truncation on commands and paths: the tail is what you need when the line runs out of room.
- Header pending-approval button: jump to the first parked card. Scrolls with `block: nearest` so it does not yank the transcript.

**Motion and layout**
- Reveals (payload, chevron, copy hover) are 140ms ease-out and `motion-reduce:transition-none`.
- Expanding a tool body sets `overflow-anchor: none` so the browser does not steal the scroll.
- Status updates do not retint or rebadge the same fact. Running stays `defaultExpanded`; completing does not collapse.

**Type**
- 13px body (title, command, network summary, feedback).
- 11px meta (cwd, timestamps, state caption, payload, tool header, detail line).
- Mono for command, path, cwd, and output.

## Validation

- `pnpm exec tsc --noEmit` passed
- `pnpm vitest run src/code` passed
- `pnpm vitest run` — 1141 passed

## Compatibility and risk

None. No persisted or wire-format change. Follow-up to #2198.

## Tests deleted

None in this pass. The #2198 deletions stand. Assertions now target `aria-expanded` on the payload button instead of a `<details open>` attribute, matching the disclosure that no longer pops.