### PR TITLE
feat(desktop): live-session plumbing for code mode

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -1914,6 +1914,18 @@ export class ApiClient {
     );
   }
 
+  /**
+   * Redirect the in-flight turn. The route answers with an empty status;
+   * unsupported engines refuse with `steering_unavailable` rather than queue.
+   */
+  steerCodeSession(sessionId: string, message: string): Promise<void> {
+    return this.json(`/code/sessions/${encodeURIComponent(sessionId)}/steer`, {
+      method: "POST",
+      headers: this.headers(true),
+      body: JSON.stringify({ message }),
+    });
+  }
+
   interruptCodeSession(sessionId: string): Promise<void> {
     return this.json(`/code/sessions/${encodeURIComponent(sessionId)}/interrupt`, {
       method: "POST",

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
@@ -2,7 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 import type { Attention } from "../api/types";
-import { attentionLabel } from "./labels";
+import { attentionLabel, attentionTooltip } from "./labels";
 
 /**
  * Status affordance for a server-computed attention state.
@@ -22,6 +22,7 @@ export function AttentionBadge({
 }) {
   if (!attention || attention.state.type === "working") return null;
   const label = attentionLabel(attention);
+  const tooltip = attentionTooltip(attention);
   const tone = attentionTone(attention);
   if (compact) {
     return (
@@ -35,7 +36,7 @@ export function AttentionBadge({
           className,
         )}
         aria-label={label}
-        title={label}
+        title={tooltip}
         data-attention={attention.state.type}
       />
     );
@@ -54,7 +55,7 @@ export function AttentionBadge({
       size="sm"
       className={className}
       aria-label={label}
-      title={label}
+      title={tooltip}
       data-attention={attention.state.type}
     >
       {label}

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -5,8 +5,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CodeComposer } from "./CodeComposer";
 import { HttpError } from "../api/client";
+import { useUiStore } from "../UiStore";
+
 afterEach(() => {
   cleanup();
+  useUiStore.setState({ activeTurnSendMode: "queue" });
 });
 
 const QUEUED = {
@@ -48,9 +51,81 @@ describe("CodeComposer", () => {
 
     await waitFor(() => expect(onSend).toHaveBeenCalledWith("and run the tests"));
     expect(box).toHaveValue("");
-    expect(
-      await screen.findByText("Queued — runs after the current turn."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("1 follow-up queued")).toBeInTheDocument();
+  });
+
+  it("clears the queued pill when the next turn begins", async () => {
+    const onSend = vi.fn().mockResolvedValue(QUEUED);
+    const { rerender } = render(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        lastTurnBeganId="t1"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "and run the tests" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(await screen.findByText("1 follow-up queued")).toBeInTheDocument();
+
+    rerender(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        lastTurnBeganId="t2"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("1 follow-up queued")).toBeNull();
+  });
+
+  it("steers mid-turn when the harness supports it", async () => {
+    useUiStore.setState({ activeTurnSendMode: "steer" });
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onSend = vi.fn();
+    render(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        onSend={onSend}
+        onSteer={onSteer}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "try the other file" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(onSteer).toHaveBeenCalledWith("try the other file"),
+    );
+    expect(onSend).not.toHaveBeenCalled();
+    expect(await screen.findByText("Guidance sent")).toBeInTheDocument();
+  });
+
+  it("queues mid-turn when steering is unsupported", async () => {
+    useUiStore.setState({ activeTurnSendMode: "steer" });
+    const onSend = vi.fn().mockResolvedValue(QUEUED);
+    render(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "and run the tests" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("and run the tests"));
+    expect(await screen.findByText("1 follow-up queued")).toBeInTheDocument();
   });
 
   it("says the queue is full and keeps the draft", async () => {
@@ -74,9 +149,9 @@ describe("CodeComposer", () => {
       screen.getByRole("button", { name: "Queue message for after this response" }),
     );
 
-    expect(
-      await screen.findByText("A follow-up is already queued. Wait for it to run, or interrupt this turn."),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "A follow-up is already queued. Wait for it to run, or interrupt this turn.",
+    );
     expect(box).toHaveValue("and push it");
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -395,11 +395,11 @@ export function CodeComposer({
   }
 
   return (
-    <div className="shrink-0 px-[clamp(0.5rem,4%,5rem)] pb-2">
+    <div className="relative shrink-0 px-[clamp(0.5rem,4%,5rem)] pb-2">
       {showQueued && (
         <p
           role="status"
-          className="text-muted-foreground mx-auto max-w-3xl pb-1 text-xs"
+          className="text-muted-foreground pointer-events-none absolute inset-x-0 bottom-full mx-auto mb-1 max-w-3xl text-center text-[11px] [animation:code-reveal_140ms_ease-out] motion-reduce:animate-none"
         >
           1 follow-up queued
         </p>
@@ -452,7 +452,7 @@ export function CodeComposer({
       {notice && (
         <p
           role="alert"
-          className="text-destructive mx-auto max-w-3xl pt-1 text-xs"
+          className="text-critical-foreground mx-auto max-w-3xl pt-1 text-[11px]"
         >
           {notice.text}
         </p>

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -297,9 +297,13 @@ export function CodeComposer({
   model,
   modelOptions,
   sessionId,
+  history,
+  queued = false,
+  lastTurnBeganId,
   onModelChange,
   onModeChange,
   onSend,
+  onSteer,
   onInterrupt,
 }: {
   disabled?: boolean;
@@ -311,26 +315,42 @@ export function CodeComposer({
   model?: string;
   modelOptions?: readonly CodeModelOption[];
   sessionId?: string;
+  /** Prior user prompts, newest first, for Up/Down recall. */
+  history?: readonly string[];
+  /** A follow-up the pane is holding until the next turn begins. */
+  queued?: boolean;
+  /**
+   * The turn the journal last announced. A change drops the queued pill once
+   * the parked follow-up starts.
+   */
+  lastTurnBeganId?: string | null;
   onModelChange?: (model: string) => void;
   onModeChange?: (mode: CodePermissionMode) => void;
   onSend: (message: string) => Promise<CodeTurnSubmission | void> | void;
+  /**
+   * Redirect the in-flight turn. Absent when the harness cannot steer, so a
+   * mid-turn send stays on the queue path.
+   */
+  onSteer?: (message: string) => Promise<void>;
   onInterrupt: () => Promise<void> | void;
 }) {
   const [draft, setDraft] = useState("");
   const [selectedModel, setSelectedModel] = useState(model ?? "");
-  const [notice, setNotice] = useState<
-    { tone: "queued" | "error"; text: string } | null
-  >(null);
+  const [notice, setNotice] = useState<{ text: string } | null>(null);
+  const [followUpQueued, setFollowUpQueued] = useState(false);
+  const [steerPending, setSteerPending] = useState(false);
+  const [steerError, setSteerError] = useState<string | null>(null);
+  const [steerStatus, setSteerStatus] = useState<string | null>(null);
+  const canSteer = onSteer !== undefined;
+  const showQueued = queued || followUpQueued;
 
   useEffect(() => {
     if (model) setSelectedModel(model);
   }, [model]);
 
   useEffect(() => {
-    if (!running) {
-      setNotice((current) => (current?.tone === "queued" ? null : current));
-    }
-  }, [running]);
+    setFollowUpQueued(false);
+  }, [lastTurnBeganId]);
 
   async function submit() {
     const message = draft.trim();
@@ -340,14 +360,10 @@ export function CodeComposer({
     try {
       const outcome = await onSend(message);
       if (outcome && outcome.kind === "queued") {
-        setNotice({
-          tone: "queued",
-          text: "Queued — runs after the current turn.",
-        });
+        setFollowUpQueued(true);
       }
     } catch (err) {
       setNotice({
-        tone: "error",
         text:
           err instanceof HttpError && err.kind === "queue_full"
             ? "A follow-up is already queued. Wait for it to run, or interrupt this turn."
@@ -359,8 +375,35 @@ export function CodeComposer({
     }
   }
 
+  async function steer() {
+    const message = draft.trim();
+    if (!message || disabled || !onSteer) return;
+    setSteerPending(true);
+    setSteerError(null);
+    setSteerStatus("Sending guidance…");
+    setNotice(null);
+    try {
+      await onSteer(message);
+      setDraft("");
+      setSteerStatus("Guidance sent");
+    } catch (err) {
+      setSteerStatus(null);
+      setSteerError(err instanceof Error ? err.message : "Could not steer");
+    } finally {
+      setSteerPending(false);
+    }
+  }
+
   return (
     <div className="shrink-0 px-[clamp(0.5rem,4%,5rem)] pb-2">
+      {showQueued && (
+        <p
+          role="status"
+          className="text-muted-foreground mx-auto max-w-3xl pb-1 text-xs"
+        >
+          1 follow-up queued
+        </p>
+      )}
       <Composer
         activeTurnId={running ? "running" : null}
         busy={running}
@@ -368,6 +411,7 @@ export function CodeComposer({
         cancelPending={false}
         disabled={Boolean(disabled)}
         draft={draft}
+        history={history}
         modelMenu={
           harness && modelOptions && modelOptions.length > 0 ? (
             <HarnessModelMenu
@@ -389,26 +433,26 @@ export function CodeComposer({
             scopeKey={sessionId ?? "code-create"}
           />
         }
-        onDraftChange={setDraft}
+        onDraftChange={(value) => {
+          setSteerError(null);
+          setSteerStatus(null);
+          setDraft(value);
+        }}
         onSend={submit}
-        onSteer={submit}
+        onSteer={canSteer ? steer : submit}
         onQueue={submit}
         onStop={async () => {
           await onInterrupt();
         }}
         resetKey={sessionId ?? "code"}
-        steerError={null}
-        steerPending={false}
-        steerStatus={null}
+        steerError={canSteer ? steerError : null}
+        steerPending={canSteer ? steerPending : false}
+        steerStatus={canSteer ? steerStatus : null}
       />
       {notice && (
         <p
-          role="status"
-          className={
-            notice.tone === "error"
-              ? "text-destructive mx-auto max-w-3xl pt-1 text-xs"
-              : "text-muted-foreground mx-auto max-w-3xl pt-1 text-xs"
-          }
+          role="alert"
+          className="text-destructive mx-auto max-w-3xl pt-1 text-xs"
         >
           {notice.text}
         </p>

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -76,12 +76,7 @@ describe("seq cursor", () => {
   it("advances the cursor for unknown event kinds", () => {
     const { state, effects } = reduceCodeSessionEvent(
       initialCodeSessionState(),
-      framed(4, { type: "file_changed", path: "a.ts", kind: "modified", diffstat: {
-        files: 1,
-        insertions: 1,
-        deletions: 0,
-        truncated: false,
-      } }),
+      framed(4, { type: "future_kind" } as unknown as CodeEvent),
       deps(),
     );
     expect(state.lastSeq).toBe(4);
@@ -323,6 +318,81 @@ describe("hydration flag", () => {
     expect(settled.hydrated).toBe(true);
     expect(settled.items).toBe(withTurns.items);
     expect(markCodeSessionHydrated(settled)).toBe(settled);
+  });
+});
+
+describe("user_steered", () => {
+  it("appends a steer item on the active turn", () => {
+    const { state } = play([
+      { type: "turn_started", turn_id: "t1" },
+      { type: "user_steered", text: "use fixtures" },
+    ]);
+    expect(state.items.at(-1)).toMatchObject({
+      kind: "steer",
+      turnId: "t1",
+      text: "use fixtures",
+    });
+  });
+});
+
+describe("file_changed", () => {
+  it("aggregates per-turn file activity and bumps contentRevision", () => {
+    const { state } = play([
+      { type: "turn_started", turn_id: "t1" },
+      {
+        type: "file_changed",
+        path: "a.ts",
+        kind: "modified",
+        diffstat: { files: 1, insertions: 10, deletions: 2, truncated: false },
+      },
+      {
+        type: "file_changed",
+        path: "b.ts",
+        kind: "added",
+        diffstat: { files: 1, insertions: 32, deletions: 5, truncated: false },
+      },
+      {
+        type: "file_changed",
+        path: "a.ts",
+        kind: "modified",
+        diffstat: { files: 1, insertions: 12, deletions: 3, truncated: false },
+      },
+    ]);
+    expect(state.items.filter((item) => item.kind === "file_activity")).toHaveLength(
+      1,
+    );
+    expect(state.items.find((item) => item.kind === "file_activity")).toMatchObject({
+      kind: "file_activity",
+      turnId: "t1",
+      files: {
+        "a.ts": {
+          kind: "modified",
+          diffstat: { files: 1, insertions: 12, deletions: 3, truncated: false },
+        },
+        "b.ts": {
+          kind: "added",
+          diffstat: { files: 1, insertions: 32, deletions: 5, truncated: false },
+        },
+      },
+    });
+    expect(state.contentRevision).toBe(3);
+  });
+});
+
+describe("attention_changed", () => {
+  it("reduces into state.attention and does not add a transcript item", () => {
+    const { state } = play([
+      {
+        type: "attention_changed",
+        state: { type: "stalled", idle_secs: 90 },
+        source: "heuristic",
+      },
+    ]);
+    expect(state.attention).toEqual({
+      state: { type: "stalled", idle_secs: 90 },
+      source: "heuristic",
+    });
+    expect(state.items).toEqual([]);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -1,9 +1,11 @@
 import type {
+  Attention,
   CodeSessionLifecycle,
   CodeTurnSnapshot,
   CodeTurnStatus,
   CodeUsage,
   Diffstat,
+  FileChangeKind,
   HarnessKind,
   HarnessNoticeLevel,
   SequencedCodeEventFrame,
@@ -76,6 +78,18 @@ export type CodeTranscriptItem =
       id: string;
       approvalId: string;
       state: "pending" | "approved" | "denied";
+    }
+  | {
+      kind: "steer";
+      id: string;
+      turnId: string | null;
+      text: string;
+    }
+  | {
+      kind: "file_activity";
+      id: string;
+      turnId: string | null;
+      files: Record<string, { kind: FileChangeKind; diffstat: Diffstat }>;
     };
 
 export type CodeSessionState = {
@@ -110,6 +124,11 @@ export type CodeSessionState = {
    * as "your copy is stale", so they do not need their own polling.
    */
   contentRevision: number;
+  /**
+   * Latest `attention_changed` from the journal. Not a transcript item — the
+   * header badge reads this so a stall or a need-you does not grow the log.
+   */
+  attention: Attention | null;
 };
 
 export type CodeSessionEffect =
@@ -142,6 +161,7 @@ export function initialCodeSessionState(): CodeSessionState {
     lastUsage: null,
     lifecycle: null,
     contentRevision: 0,
+    attention: null,
   };
 }
 
@@ -151,6 +171,10 @@ export function userItemId(turnId: string): string {
 
 export function boundaryItemId(turnId: string): string {
   return `boundary:${turnId}`;
+}
+
+export function fileActivityItemId(turnId: string | null): string {
+  return turnId ? `files:${turnId}` : "files:open";
 }
 
 /**
@@ -443,6 +467,51 @@ export function reduceCodeSessionEvent(
       };
     }
 
+    case "user_steered": {
+      return {
+        state: {
+          ...state,
+          items: [
+            ...state.items,
+            {
+              kind: "steer",
+              id: deps.nextId(),
+              turnId: state.activeTurnId,
+              text: event.text,
+            },
+          ],
+        },
+        effects,
+      };
+    }
+
+    case "attention_changed": {
+      return {
+        state: {
+          ...state,
+          attention: { state: event.state, source: event.source },
+        },
+        effects,
+      };
+    }
+
+    case "file_changed": {
+      return {
+        state: {
+          ...state,
+          items: upsertFileActivity(
+            state.items,
+            state.activeTurnId,
+            event.path,
+            event.kind,
+            event.diffstat,
+          ),
+          contentRevision: state.contentRevision + 1,
+        },
+        effects,
+      };
+    }
+
     case "turn_completed":
     case "turn_failed":
     case "turn_interrupted": {
@@ -588,6 +657,40 @@ function applyDiffstat(
       ? { ...item, diffstat }
       : item,
   );
+}
+
+function upsertFileActivity(
+  items: CodeTranscriptItem[],
+  turnId: string | null,
+  path: string,
+  kind: FileChangeKind,
+  diffstat: Diffstat,
+): CodeTranscriptItem[] {
+  const id = fileActivityItemId(turnId);
+  const index = items.findIndex(
+    (item) => item.kind === "file_activity" && item.turnId === turnId,
+  );
+  if (index === -1) {
+    return [
+      ...items,
+      {
+        kind: "file_activity",
+        id,
+        turnId,
+        files: { [path]: { kind, diffstat } },
+      },
+    ];
+  }
+  const existing = items[index];
+  if (!existing || existing.kind !== "file_activity") return items;
+  return [
+    ...items.slice(0, index),
+    {
+      ...existing,
+      files: { ...existing.files, [path]: { kind, diffstat } },
+    },
+    ...items.slice(index + 1),
+  ];
 }
 
 function durationMs(

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -10,6 +10,9 @@ import { userItemId } from "./CodeSessionReducer";
 
 class FakeSocket {
   closed = false;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
   constructor(
     public readonly after: number,
     public readonly emit: (frame: SequencedCodeEventFrame) => void,
@@ -127,6 +130,29 @@ describe("CodeSessionRegistry", () => {
     expect(store.getState().items.find((item) => item.kind === "assistant")).toMatchObject({
       text: "README.md",
     });
+  });
+
+  it("records reconnecting from the controller", async () => {
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+
+    const store = acquireCodeSession("s1", openSocket);
+    expect(store.getState().connectionState).toBe("live");
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(store.getState().connectionState).toBe("live");
+    expect(sockets).toHaveLength(1);
+
+    sockets[0]?.onclose?.();
+    expect(store.getState().connectionState).toBe("reconnecting");
   });
 
   it("fills in the prompt of a turn the socket announces", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -88,7 +88,9 @@ export function acquireCodeSession(
         if (effect.type === "turn_began") fillPrompt(effect.turnId);
       }
     },
-    onConnectionState: () => {},
+    onConnectionState: (connectionState) => {
+      store.getState().setConnectionState(connectionState);
+    },
     hydrateTurns,
     onHydrate: (turns) => {
       store.getState().update((session) => hydrateCodeTurns(session, turns));

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { SequencedCodeEventFrame } from "../api/types";
+import type { CodeConnectionState } from "./CodeSessionController";
 import {
   initialCodeSessionState,
   reduceCodeSessionEvent,
@@ -15,8 +16,19 @@ import {
  * This is the chat session store factory generalized from one pinned instance
  * to N: the registry constructs one per open session, and nothing here is
  * app-global.
+ *
+ * `connectionState` sits beside the reducer so a reconnect does not replay as
+ * a journal event, and so the first paint can stay `live` instead of flashing
+ * a reconnect bar before the socket opens.
  */
 export type CodeSessionStore = CodeSessionState & {
+  connectionState: CodeConnectionState;
+  setConnectionState: (connectionState: CodeConnectionState) => void;
+  /**
+   * Turn id from the last `turn_began` effect. The pane watches this to drop
+   * a queued follow-up once the worker promotes it.
+   */
+  lastTurnBeganId: string | null;
   applyEvent: (
     framed: SequencedCodeEventFrame,
     deps: CodeSessionDeps,
@@ -28,28 +40,47 @@ export type CodeSessionStore = CodeSessionState & {
 export function createCodeSessionStore() {
   return create<CodeSessionStore>()((set, get) => ({
     ...initialCodeSessionState(),
+    connectionState: "live",
+    lastTurnBeganId: null,
+    setConnectionState: (connectionState) => set({ connectionState }),
     applyEvent: (framed, deps) => {
       const { state, effects } = reduceCodeSessionEvent(
         sessionOf(get()),
         framed,
         deps,
       );
-      set(state);
+      const began = effects.find((effect) => effect.type === "turn_began");
+      set(began ? { ...state, lastTurnBeganId: began.turnId } : state);
       return effects;
     },
     update: (change) => {
       set(change(sessionOf(get())));
     },
     reset: () => {
-      set(initialCodeSessionState());
+      set({
+        ...initialCodeSessionState(),
+        connectionState: "live",
+        lastTurnBeganId: null,
+      });
     },
   }));
 }
 
 function sessionOf(store: CodeSessionStore): CodeSessionState {
-  const { applyEvent, update, reset, ...session } = store;
+  const {
+    applyEvent,
+    update,
+    reset,
+    connectionState,
+    setConnectionState,
+    lastTurnBeganId,
+    ...session
+  } = store;
   void applyEvent;
   void update;
   void reset;
+  void connectionState;
+  void setConnectionState;
+  void lastTurnBeganId;
   return session;
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -1,5 +1,5 @@
 import { FileCode, FileSearch, Search, SquareTerminal, Wrench } from "lucide-react";
-import type { RefCallback } from "react";
+import { useState, type RefCallback } from "react";
 
 import type { CodeApprovalSnapshot, Diffstat, FileChangeKind, ToolDetail } from "../api/types";
 import { CodeApprovalCard } from "./CodeApprovalCard";
@@ -427,41 +427,72 @@ function FileActivityRow({
 }: {
   files: Record<string, { kind: FileChangeKind; diffstat: Diffstat }>;
 }) {
+  const [open, setOpen] = useState(false);
   const { count, insertions, deletions } = fileActivityTotals(files);
   const noun = count === 1 ? "file" : "files";
-  const summary = `${count} ${noun} changed · +${insertions} −${deletions}`;
   return (
-    <details className="text-muted-foreground max-w-prose text-xs">
-      <summary className="cursor-pointer">{summary}</summary>
-      <ul className="mt-1 flex flex-col gap-0.5">
-        {Object.entries(files).map(([path, file]) => (
-          <li key={path} className="flex items-baseline gap-2">
-            <span
-              className={cn(
-                "inline-flex size-4 shrink-0 items-center justify-center rounded-[3px] font-mono text-[10px] font-medium",
-                file.kind === "added" &&
-                  "bg-success-background text-success-foreground",
-                file.kind === "modified" &&
-                  "bg-info-background text-info-foreground",
-                file.kind === "deleted" &&
-                  "bg-critical-background text-critical-foreground",
-                file.kind === "renamed" &&
-                  "bg-warning-background text-warning-foreground",
-              )}
-              aria-label={file.kind}
-            >
-              {FILE_KIND_LETTER[file.kind]}
-            </span>
-            <code className="min-w-0 truncate" title={path}>
-              {path}
-            </code>
-            <span className="shrink-0 tabular-nums">
-              +{file.diffstat.insertions} −{file.diffstat.deletions}
-            </span>
-          </li>
-        ))}
-      </ul>
-    </details>
+    <div className="text-muted-foreground max-w-prose text-[11px]">
+      <button
+        type="button"
+        aria-expanded={open}
+        className="text-left"
+        onClick={() => setOpen((current) => !current)}
+      >
+        {count} {noun} changed ·{" "}
+        <span className="text-success-foreground-muted tabular-nums">
+          +{insertions}
+        </span>{" "}
+        <span className="text-critical-foreground-muted tabular-nums">
+          −{deletions}
+        </span>
+      </button>
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-[140ms] ease-out motion-reduce:transition-none",
+          open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <ul className="min-h-0 overflow-hidden">
+          {Object.entries(files).map(([path, file]) => (
+            <li key={path} className="flex items-baseline gap-2 pt-0.5">
+              <span
+                className={cn(
+                  "w-3 shrink-0 font-mono",
+                  file.kind === "added" && "text-success-foreground-muted",
+                  file.kind === "modified" && "text-info-foreground-muted",
+                  file.kind === "deleted" && "text-critical-foreground-muted",
+                  file.kind === "renamed" && "text-warning-foreground-muted",
+                )}
+                aria-label={file.kind}
+              >
+                {FILE_KIND_LETTER[file.kind]}
+              </span>
+              <PathLabel path={path} />
+              <span className="shrink-0 tabular-nums">
+                +{file.diffstat.insertions} −{file.diffstat.deletions}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function PathLabel({ path }: { path: string }) {
+  const slash = path.lastIndexOf("/");
+  if (slash < 0) {
+    return (
+      <span className="min-w-0 truncate font-mono" title={path}>
+        {path}
+      </span>
+    );
+  }
+  return (
+    <span className="flex min-w-0 font-mono" title={path}>
+      <span className="min-w-0 truncate">{path.slice(0, slash + 1)}</span>
+      <span className="shrink-0">{path.slice(slash + 1)}</span>
+    </span>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -1,7 +1,7 @@
 import { FileCode, FileSearch, Search, SquareTerminal, Wrench } from "lucide-react";
 import type { RefCallback } from "react";
 
-import type { CodeApprovalSnapshot, ToolDetail } from "../api/types";
+import type { CodeApprovalSnapshot, Diffstat, FileChangeKind, ToolDetail } from "../api/types";
 import { CodeApprovalCard } from "./CodeApprovalCard";
 import { Badge } from "@/components/ui/badge";
 import { AssistantMessageBody } from "@/AssistantMessageBody";
@@ -162,6 +162,10 @@ function itemSignature(
     case "assistant":
     case "reasoning":
       return String(item.streaming);
+    case "file_activity":
+      return fileActivitySignature(item.files);
+    case "steer":
+      return item.text;
     default:
       return item.kind;
   }
@@ -197,6 +201,20 @@ function TranscriptItem({
           anchorId={item.id}
         />
       );
+    case "steer":
+      return (
+        <UserMessage
+          text={item.text}
+          anchorId={item.id}
+          trailing={
+            <p className="text-muted-foreground mt-1 text-[11px]">
+              Steered mid-turn
+            </p>
+          }
+        />
+      );
+    case "file_activity":
+      return <FileActivityRow files={item.files} />;
     case "assistant":
       return (
         <article className="message message-assistant" aria-label="Assistant">
@@ -371,6 +389,80 @@ function toolDetailLine(detail: ToolDetail): string {
     case "other":
       return detail.summary;
   }
+}
+
+const FILE_KIND_LETTER: Record<FileChangeKind, string> = {
+  added: "A",
+  modified: "M",
+  deleted: "D",
+  renamed: "R",
+};
+
+function fileActivitySignature(
+  files: Record<string, { kind: FileChangeKind; diffstat: Diffstat }>,
+): string {
+  return Object.entries(files)
+    .map(
+      ([path, file]) =>
+        `${path}:${file.kind}:${file.diffstat.insertions}:${file.diffstat.deletions}`,
+    )
+    .join("|");
+}
+
+function fileActivityTotals(
+  files: Record<string, { kind: FileChangeKind; diffstat: Diffstat }>,
+): { count: number; insertions: number; deletions: number } {
+  let insertions = 0;
+  let deletions = 0;
+  const paths = Object.keys(files);
+  for (const file of Object.values(files)) {
+    insertions += file.diffstat.insertions;
+    deletions += file.diffstat.deletions;
+  }
+  return { count: paths.length, insertions, deletions };
+}
+
+function FileActivityRow({
+  files,
+}: {
+  files: Record<string, { kind: FileChangeKind; diffstat: Diffstat }>;
+}) {
+  const { count, insertions, deletions } = fileActivityTotals(files);
+  const noun = count === 1 ? "file" : "files";
+  const summary = `${count} ${noun} changed · +${insertions} −${deletions}`;
+  return (
+    <details className="text-muted-foreground max-w-prose text-xs">
+      <summary className="cursor-pointer">{summary}</summary>
+      <ul className="mt-1 flex flex-col gap-0.5">
+        {Object.entries(files).map(([path, file]) => (
+          <li key={path} className="flex items-baseline gap-2">
+            <span
+              className={cn(
+                "inline-flex size-4 shrink-0 items-center justify-center rounded-[3px] font-mono text-[10px] font-medium",
+                file.kind === "added" &&
+                  "bg-success-background text-success-foreground",
+                file.kind === "modified" &&
+                  "bg-info-background text-info-foreground",
+                file.kind === "deleted" &&
+                  "bg-critical-background text-critical-foreground",
+                file.kind === "renamed" &&
+                  "bg-warning-background text-warning-foreground",
+              )}
+              aria-label={file.kind}
+            >
+              {FILE_KIND_LETTER[file.kind]}
+            </span>
+            <code className="min-w-0 truncate" title={path}>
+              {path}
+            </code>
+            <span className="shrink-0 tabular-nums">
+              +{file.diffstat.insertions} −{file.diffstat.deletions}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
 }
 
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -643,15 +643,15 @@ function CodeSessionPane({
 
   return (
     <>
-      {connectionState === "reconnecting" && (
-        <div
-          role="status"
-          className="border-info-border bg-info-background text-info-foreground mx-4 mt-3 rounded-md border px-3 py-1.5 text-xs"
-        >
-          Reconnecting to the session…
-        </div>
-      )}
       <div className={cn("message-view", follow.fadeClass)}>
+        {connectionState === "reconnecting" && (
+          <p
+            role="status"
+            className="text-info-foreground-muted pointer-events-none absolute inset-x-0 top-2 z-[1] text-center text-[11px] [animation:code-reveal_140ms_ease-out] motion-reduce:animate-none"
+          >
+            Reconnecting to the session…
+          </p>
+        )}
         <CodeTranscript
           items={items}
           hydrated={hydrated}

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 
 import { archiveForceKind, type ApiClient } from "../api/client";
 import type {
+  Attention,
   CodeApprovalSnapshot,
   CodePermissionMode,
   CodeRepoSnapshot,
@@ -264,9 +265,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         <div className="flex items-center gap-2">
           {session && (
             <>
-              <AttentionBadge
-                compact
-                attention={digest?.attention ?? session.attention}
+              <SessionAttentionBadge
+                sessionId={session.id}
+                client={client}
+                fallback={digest?.attention ?? session.attention}
               />
               <PendingApprovalBadge sessionId={session.id} client={client} />
               <span className="text-muted-foreground text-xs">
@@ -407,6 +409,20 @@ function renderCodePanel(
   );
 }
 
+function SessionAttentionBadge({
+  sessionId,
+  client,
+  fallback,
+}: {
+  sessionId: string;
+  client: ApiClient;
+  fallback: Attention | undefined;
+}) {
+  const store = useRegisteredCodeSession(sessionId, client);
+  const live = store((state) => state.attention);
+  return <AttentionBadge compact attention={live ?? fallback} />;
+}
+
 function PendingApprovalBadge({
   sessionId,
   client,
@@ -477,6 +493,8 @@ function CodeSessionPane({
   const busy = store((state) => state.busy);
   const hydrated = store((state) => state.hydrated);
   const animateStreaming = store((state) => state.animateStreaming);
+  const connectionState = store((state) => state.connectionState);
+  const lastTurnBeganId = store((state) => state.lastTurnBeganId);
   // The reducer's own applied-event cursor is the activity signal the stall
   // timer wants: every delta, tool result, and boundary advances it.
   const lastSeq = store((state) => state.lastSeq);
@@ -487,6 +505,7 @@ function CodeSessionPane({
   );
   const [decidingId, setDecidingId] = useState<string | null>(null);
   const [approvalError, setApprovalError] = useState<string | undefined>();
+  const [queued, setQueued] = useState(false);
   // No `?? []` fallback here: a fresh array is a new snapshot every render,
   // and zustand v5 loops on referentially unstable snapshots.
   const cachedModels = useCodeCatalogStore(
@@ -550,6 +569,20 @@ function CodeSessionPane({
   const availableModes: CodePermissionMode[] = doctorEntry
     ? createPermissionModes(doctorEntry.caps)
     : ["plan", "ask", "auto", "allow"];
+  const steeringSupported = doctorEntry?.caps.mid_turn_steering === "supported";
+  const composerHistory = useMemo(
+    () =>
+      items
+        .flatMap((item) =>
+          item.kind === "user" && item.text.trim() ? [item.text] : [],
+        )
+        .reverse(),
+    [items],
+  );
+
+  useEffect(() => {
+    setQueued(false);
+  }, [lastTurnBeganId]);
 
   // `items` is a fresh array on every streamed delta, so keying the fetch on it
   // would list approvals again for every token of a turn. Only an approval
@@ -590,7 +623,14 @@ function CodeSessionPane({
     // message ran or queued, and it holds the draft when the server refuses.
     return submitAcceptedTurn(store.getState().update, () =>
       client.submitCodeTurn(session.id, message, model ?? undefined),
-    );
+    ).then((outcome) => {
+      if (outcome.kind === "queued") setQueued(true);
+      return outcome;
+    });
+  }
+
+  async function steer(message: string) {
+    await client.steerCodeSession(session.id, message);
   }
 
   async function interrupt() {
@@ -603,6 +643,14 @@ function CodeSessionPane({
 
   return (
     <>
+      {connectionState === "reconnecting" && (
+        <div
+          role="status"
+          className="border-info-border bg-info-background text-info-foreground mx-4 mt-3 rounded-md border px-3 py-1.5 text-xs"
+        >
+          Reconnecting to the session…
+        </div>
+      )}
       <div className={cn("message-view", follow.fadeClass)}>
         <CodeTranscript
           items={items}
@@ -659,10 +707,14 @@ function CodeSessionPane({
           model={model ?? undefined}
           modelOptions={modelOptions}
           sessionId={session.id}
+          history={composerHistory}
+          queued={queued}
+          lastTurnBeganId={lastTurnBeganId}
           onModelChange={
             harnessHonorsTurnModel(session.harness_kind) ? setModel : undefined
           }
           onSend={send}
+          onSteer={steeringSupported ? steer : undefined}
           onInterrupt={interrupt}
         />
       )}

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -329,3 +329,22 @@ export function attentionLabel(attention: Attention): string {
       return attention.state.note || "Pinned";
   }
 }
+
+/**
+ * Richer badge tooltip: idle seconds, how a need was detected, the pin note.
+ * The visible label stays short.
+ */
+export function attentionTooltip(attention: Attention): string {
+  switch (attention.state.type) {
+    case "stalled":
+      return `Stalled · idle ${attention.state.idle_secs}s`;
+    case "needs_you":
+      return `${attentionLabel(attention)} · ${attention.state.source}`;
+    case "manual":
+      return attention.state.note
+        ? `Pinned · ${attention.state.note}`
+        : "Pinned";
+    default:
+      return attentionLabel(attention);
+  }
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1304,6 +1304,28 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
       if (!state) return null;
       return { type: "attention_changed", state, source: value.source };
     }
+    case "file_changed": {
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "file_changed" }>>(value, [
+          "type",
+          "path",
+          "kind",
+          "diffstat",
+        ]) ||
+        typeof value.path !== "string" ||
+        !isMember(value.kind, FILE_CHANGE_KINDS)
+      ) {
+        return null;
+      }
+      const diffstat = parseDiffstat(value.diffstat);
+      if (!diffstat) return null;
+      return {
+        type: "file_changed",
+        path: value.path,
+        kind: value.kind,
+        diffstat,
+      };
+    }
     default:
       // Unknown kinds stay well-formed so a newer journal does not stall the
       // cursor. The reducer advances seq and paints nothing.

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -1029,6 +1029,15 @@ body {
   }
 }
 
+@keyframes code-reveal {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 /* ---------- Markdown ---------- */
 
 .message-markdown {


### PR DESCRIPTION
## Summary

Reconnect visibility, steering via the existing route, queued-turn affordance, and newly reduced journal events for code mode.

- `connectionState` lives on the session store (initial `live`) so a reconnect does not flash on mount. The registry now forwards the controller signal, and the pane shows a slim `role="status"` bar while reconnecting.
- The reducer now handles `user_steered` (steer item, rendered as a user message with a "Steered mid-turn" caption), `file_changed` (one aggregated `file_activity` row per turn, plus a `contentRevision` bump), and `attention_changed` (into `state.attention`, not the transcript). The header badge tooltip surfaces stalled idle seconds, NeedsYou source, and the manual note.
- A queued submit stays in pane state as a persistent "1 follow-up queued" pill above the composer and clears on the `turn_began` effect. Composer error notices use `role="alert"`.
- `ApiClient.steerCodeSession` posts `{ message }` to `POST /code/sessions/{id}/steer`. Steering is gated on doctor `mid_turn_steering === "supported"`; unsupported harnesses keep the current queue path. Composer history is the session's user items, newest first.

## Test plan

- Replaced the reducer's `file_changed`-as-unknown assertion with a genuine unknown kind, and added unit tests for steer items, file-activity aggregation + `contentRevision`, and attention state.
- Registry: connection-state case (starts `live`, becomes `reconnecting` on socket close).
- Composer: steer gating, queued pill, and `role="alert"` on send errors.
- No `api.test.ts` addition: `submitCodeTurn` / `interruptCodeSession` siblings are not covered there.

`pnpm vitest run src/code`, full `pnpm vitest run`, and `pnpm build` all passed locally.