### PR TITLE
feat(desktop): redesign the code-mode sidebar into a command-center rail

### DIFF
--- a/crates/tidebreak-desktop/ui/package.json
+++ b/crates/tidebreak-desktop/ui/package.json
@@ -36,6 +36,7 @@
     "@hugeicons/react": "1.1.9",
     "@radix-ui/react-alert-dialog": "1.1.23",
     "@radix-ui/react-checkbox": "1.3.11",
+    "@radix-ui/react-context-menu": "2.3.7",
     "@radix-ui/react-dialog": "1.1.23",
     "@radix-ui/react-dropdown-menu": "2.1.24",
     "@radix-ui/react-popover": "1.1.23",

--- a/crates/tidebreak-desktop/ui/pnpm-lock.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: 1.3.11
         version: 1.3.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-context-menu':
+        specifier: 2.3.7
+        version: 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dialog':
         specifier: 1.1.23
         version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -949,6 +952,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.3.7':
+    resolution: {integrity: sha512-CtXP35dxaB5T3zXSd+E3uHe/QpXcpYnZmxp6OaIbfthtfW4wyb77M23BG+bwIJDtsMwEP/YssdsmNyZu7jhWew==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.2.2':
@@ -4494,6 +4510,19 @@ snapshots:
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@radix-ui/react-context-menu@2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-context@1.2.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -1820,6 +1820,22 @@ export class ApiClient {
     );
   }
 
+  async patchCodeWorkspace(
+    workspaceId: string,
+    body: { title: string },
+  ): Promise<CodeWorkspaceSnapshot> {
+    return requireParsed(
+      parseCodeWorkspace(
+        await this.json(`/code/workspaces/${encodeURIComponent(workspaceId)}`, {
+          method: "PATCH",
+          headers: this.headers(true),
+          body: JSON.stringify(body),
+        }),
+      ),
+      "code workspace",
+    );
+  }
+
   async archiveCodeWorkspace(
     workspaceId: string,
     force = false,

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { CodeWorkspaceSnapshot } from "../api/types";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+
+function workspace(
+  id: string,
+  createdAt: string,
+  title = id,
+): CodeWorkspaceSnapshot {
+  return {
+    id,
+    repo_id: "repo-1",
+    title,
+    worktree_path: `/tmp/app/.worktrees/${id}`,
+    branch_name: `tidebreak/${id}`,
+    base_ref: "main",
+    status: "active",
+    created_at: createdAt,
+  };
+}
+
+afterEach(() => {
+  useCodeCatalogStore.getState().reset();
+});
+
+describe("CodeCatalogStore.upsertWorkspace", () => {
+  it("selecting a workspace does not reorder the catalog", () => {
+    const first = workspace("ws-a", "2026-08-14T00:00:00.000Z");
+    const second = workspace("ws-b", "2026-08-16T00:00:00.000Z");
+    useCodeCatalogStore.setState({ workspaces: [first, second] });
+
+    useCodeCatalogStore.getState().upsertWorkspace({
+      ...second,
+      title: "viewed",
+    });
+
+    expect(
+      useCodeCatalogStore.getState().workspaces.map((item) => item.id),
+    ).toEqual(["ws-a", "ws-b"]);
+    expect(useCodeCatalogStore.getState().workspaces[1]?.title).toBe("viewed");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -151,12 +151,15 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     });
   },
   upsertWorkspace: (workspace) => {
-    set({
-      workspaces: [
-        workspace,
-        ...get().workspaces.filter((item) => item.id !== workspace.id),
-      ],
-    });
+    const current = get().workspaces;
+    const index = current.findIndex((item) => item.id === workspace.id);
+    if (index === -1) {
+      set({ workspaces: [...current, workspace] });
+      return;
+    }
+    const workspaces = current.slice();
+    workspaces[index] = workspace;
+    set({ workspaces });
   },
   reset: () => {
     set({

--- a/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
@@ -1,0 +1,49 @@
+import { FolderGit2, MessageSquare } from "lucide-react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+
+import { SegmentedControl } from "@/components/ui/segmented";
+import { useSidebarWidth } from "@/sidebar/primitives";
+import { isCodeRoute } from "./routes";
+
+type Mode = "chat" | "code";
+
+/**
+ * Chat / Code switch used at the top of both rails.
+ *
+ * One primitive, two hosts: the code rail always shows it, and the chat rail
+ * shows it only when the code-mode flag is on.
+ */
+export function CodeModeSwitch() {
+  const navigate = useNavigate();
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const isCompact = useSidebarWidth() === "compact";
+  const value: Mode = isCodeRoute(pathname) ? "code" : "chat";
+
+  return (
+    <div className="px-2">
+      <SegmentedControl
+        aria-label="App mode"
+        value={value}
+        compact={isCompact}
+        onValueChange={(next) => {
+          if (next === value) return;
+          void navigate({ to: next === "code" ? "/code" : "/" });
+        }}
+        options={[
+          {
+            value: "chat",
+            label: "Chat",
+            icon: <MessageSquare className="size-3.5 shrink-0" aria-hidden />,
+          },
+          {
+            value: "code",
+            label: "Code",
+            icon: <FolderGit2 className="size-3.5 shrink-0" aria-hidden />,
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -1,12 +1,17 @@
 // @vitest-environment jsdom
-import { cleanup, screen } from "@testing-library/react";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeSidebar } from "./CodeSidebar";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), message: vi.fn() },
+}));
 
 /**
  * ADR 0030: the code rail must render without initializing chat session
@@ -92,6 +97,7 @@ afterEach(() => {
   useCodeCatalogStore.getState().reset();
   disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
+  useCodeUiStore.setState({ workspaceSortMode: "by-repo" });
 });
 
 describe("CodeSidebar", () => {
@@ -103,10 +109,26 @@ describe("CodeSidebar", () => {
       { initialUrl: "/code" },
     );
 
-    expect(screen.getByRole("button", { name: "Chat" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Code" })).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup", { name: "App mode" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Chat" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Code" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "app" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Fix login" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "New workspace" })).toBeInTheDocument();
+  });
+
+  it("opens the workspace context menu with a destructive Archive item", async () => {
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const card = await screen.findByRole("button", { name: "Fix login" });
+    fireEvent.contextMenu(card);
+    const archive = await screen.findByRole("menuitem", { name: "Archive" });
+    expect(archive).toBeInTheDocument();
+    expect(archive.className).toContain("text-destructive");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -1,9 +1,24 @@
 import { useEffect } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { FolderGit2, GitBranch, MessageSquare, Plus } from "lucide-react";
+import {
+  ChevronRight,
+  CircleAlert,
+  FolderGit2,
+  GitPullRequest,
+  Plus,
+  SquareTerminal,
+} from "lucide-react";
 
 import { useApp } from "@/AppContext";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { cn } from "@/lib/utils";
+import { useLayoutState } from "@/panel/usePanelNav";
 import {
   SidebarButton,
   SidebarSectionTitle,
@@ -12,25 +27,38 @@ import {
 import { SidebarFrame } from "@/sidebar/SidebarFrame";
 import type {
   CodeSessionDigest,
+  CodeSessionSnapshot,
   CodeWorkspaceSnapshot,
   PullRequestDigest,
 } from "../api/types";
 import { AttentionBadge } from "./AttentionBadge";
+import { AddRepoPalette } from "./AddRepoPalette";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { CodeModeSwitch } from "./CodeModeSwitch";
 import { useCodeUiStore } from "./CodeUiStore";
 import { connectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
-import { AddRepoPalette } from "./AddRepoPalette";
+import { HARNESS_ICONS } from "./HarnessPicker";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import {
-  PR_CHIP_TONE_CLASSES,
-  groupWorkspacesByRepo,
+  useWorkspaceCardCommands,
+  workspaceCommands,
+  type WorkspaceCommand,
+} from "./workspaceActions";
+import {
+  arrangeWorkspaces,
+  formatCompactAge,
+  isSessionRowWorthy,
+  middleTruncate,
+  nextWorkspaceSortMode,
+  PR_ICON_TONE_CLASSES,
   prTone,
-  workspaceStateLabel,
+  repoAccentClass,
+  sessionRowLabel,
+  WORKSPACE_SORT_MODE_LABELS,
 } from "./workspaceCards";
 
 /**
- * The code-mode rail: repos, workspace cards grouped by repo, and the cheap
- * switch back to chat.
+ * The code-mode rail: repos, workspace cards, and the Chat/Code switch.
  *
  * Built on the same frame and primitives as the chat rail so the two modes
  * share chrome. It must not touch chat session stores — that separation is
@@ -50,6 +78,7 @@ export function CodeSidebar() {
   const isCompact = useSidebarWidth() === "compact";
   const repos = useCodeCatalogStore((state) => state.repos);
   const workspaces = useCodeCatalogStore((state) => state.workspaces);
+  const sessions = useCodeCatalogStore((state) => state.sessionsByWorkspace);
   const refresh = useCodeCatalogStore((state) => state.refresh);
   const digests = useCodeUpdatesStore((state) => state.byWorkspace);
   const newWorkspaceOpen = useCodeUiStore((state) => state.newWorkspaceOpen);
@@ -62,6 +91,16 @@ export function CodeSidebar() {
     (state) => state.setNewWorkspaceOpen,
   );
   const setAddRepoOpen = useCodeUiStore((state) => state.setAddRepoOpen);
+  const sortMode = useCodeUiStore((state) => state.workspaceSortMode);
+  const setSortMode = useCodeUiStore((state) => state.setWorkspaceSortMode);
+  const { run, dialogs } = useWorkspaceCardCommands();
+  const layout = useLayoutState();
+  const terminalOpen =
+    layout.tabs.some((tab) => tab.type === "terminal") &&
+    pathname.startsWith("/code/w/");
+  const viewedWorkspaceId = pathname.startsWith("/code/w/")
+    ? pathname.slice("/code/w/".length).split("/")[0]
+    : undefined;
 
   useEffect(() => {
     void refresh(client);
@@ -69,28 +108,12 @@ export function CodeSidebar() {
 
   useEffect(() => connectCodeUpdates(client), [client]);
 
-  const groups = groupWorkspacesByRepo(repos, workspaces);
+  const groups = arrangeWorkspaces(sortMode, repos, workspaces, digests);
+  const sortLabel = WORKSPACE_SORT_MODE_LABELS[sortMode];
 
   return (
     <SidebarFrame>
-      <div className="flex shrink-0 flex-col gap-0.5">
-        <SidebarButton
-          aria-label="Chat"
-          onClick={() => void navigate({ to: "/" })}
-        >
-          <MessageSquare />
-          <span>Chat</span>
-        </SidebarButton>
-        <SidebarButton
-          aria-current={pathname === "/code" ? "page" : undefined}
-          data-active={pathname === "/code" || undefined}
-          className="data-[active]:bg-muted"
-          onClick={() => void navigate({ to: "/code" })}
-        >
-          <FolderGit2 />
-          <span>Code</span>
-        </SidebarButton>
-      </div>
+      <CodeModeSwitch />
 
       {!isCompact && (
         <div className="flex items-center justify-between px-2">
@@ -140,16 +163,26 @@ export function CodeSidebar() {
       </div>
 
       {!isCompact && (
-        <div className="mt-3 flex items-center justify-between px-2">
+        <div className="mt-3 flex items-center justify-between gap-1 px-2">
           <SidebarSectionTitle className="px-0">Workspaces</SidebarSectionTitle>
-          <button
-            type="button"
-            className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-            aria-label="New workspace"
-            onClick={() => startNewWorkspace()}
-          >
-            <Plus size={14} />
-          </button>
+          <div className="flex items-center">
+            <button
+              type="button"
+              className="cursor-pointer rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label={`Sort workspaces: ${sortLabel}. Activate to cycle.`}
+              onClick={() => setSortMode(nextWorkspaceSortMode(sortMode))}
+            >
+              {sortLabel}
+            </button>
+            <button
+              type="button"
+              className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="New workspace"
+              onClick={() => startNewWorkspace()}
+            >
+              <Plus size={14} />
+            </button>
+          </div>
         </div>
       )}
       {isCompact && (
@@ -191,36 +224,60 @@ export function CodeSidebar() {
             })}
         {!isCompact &&
           groups.map((group) => (
-            <div
-              key={group.repo?.id ?? "unknown-repo"}
-              className="flex flex-col gap-0.5"
-            >
-              <div className="mt-1 truncate px-2 pt-1 pb-0.5 text-[11px] font-medium text-muted-foreground/90">
-                {group.repo?.display_name ?? "Other repos"}
-              </div>
-              {group.workspaces.map((workspace) => (
-                <WorkspaceCard
-                  key={workspace.id}
-                  workspace={workspace}
-                  digest={digests[workspace.id]}
-                  active={pathname === `/code/w/${workspace.id}`}
-                  onOpen={() =>
-                    void navigate({
-                      to: "/code/w/$workspaceId",
-                      params: { workspaceId: workspace.id },
-                    })
-                  }
-                />
-              ))}
+            <div key={group.key} className="flex flex-col gap-0.5">
+              {group.label && (
+                <div className="mt-1 truncate px-2 pt-1 pb-0.5 text-[11px] font-medium text-muted-foreground/90">
+                  {group.label}
+                </div>
+              )}
+              {group.workspaces.map((workspace) => {
+                const digest = digests[workspace.id];
+                const pr = digest?.pr_state ?? workspace.pr;
+                return (
+                  <WorkspaceCard
+                    key={workspace.id}
+                    workspace={workspace}
+                    digest={digest}
+                    session={sessions[workspace.id]}
+                    repoName={
+                      repos.find((repo) => repo.id === workspace.repo_id)
+                        ?.display_name ?? workspace.repo_id
+                    }
+                    active={pathname === `/code/w/${workspace.id}`}
+                    terminalOpen={
+                      terminalOpen && viewedWorkspaceId === workspace.id
+                    }
+                    commands={workspaceCommands({
+                      hasPr: Boolean(pr),
+                      archived: workspace.status === "archived",
+                    })}
+                    onOpen={() =>
+                      void navigate({
+                        to: "/code/w/$workspaceId",
+                        params: { workspaceId: workspace.id },
+                      })
+                    }
+                    onCommand={(command) =>
+                      run(command, {
+                        workspace,
+                        title: digest?.title ?? workspace.title,
+                        pr,
+                      })
+                    }
+                  />
+                );
+              })}
             </div>
           ))}
-        {!isCompact && groups.length === 0 && (
-          <p className="px-2 py-1 text-xs text-muted-foreground">
-            No workspaces yet
-          </p>
-        )}
+        {!isCompact &&
+          groups.every((group) => group.workspaces.length === 0) && (
+            <p className="px-2 py-1 text-xs text-muted-foreground">
+              No workspaces yet
+            </p>
+          )}
       </div>
 
+      {dialogs}
       <NewWorkspaceDialog
         open={newWorkspaceOpen}
         onOpenChange={setNewWorkspaceOpen}
@@ -233,75 +290,160 @@ export function CodeSidebar() {
 }
 
 /**
- * One workspace in the expanded rail: title, branch, and a status row with
- * the session state, the attention badge, and the PR chip. The accessible
- * name stays the title so the row reads like the flat list it replaced.
+ * One workspace on the expanded rail: title + attention, repo chip + branch,
+ * trailing glyphs, and a nested session row when something is live.
  */
 function WorkspaceCard({
   workspace,
   digest,
+  session,
+  repoName,
   active,
+  terminalOpen,
+  commands,
   onOpen,
+  onCommand,
 }: {
   workspace: CodeWorkspaceSnapshot;
   digest: CodeSessionDigest | undefined;
+  session: CodeSessionSnapshot | undefined;
+  repoName: string;
   active: boolean;
+  terminalOpen: boolean;
+  commands: WorkspaceCommand[];
   onOpen: () => void;
+  onCommand: (command: WorkspaceCommand["id"]) => void;
 }) {
   // The digest restates the title on every notice, so a background rename
   // lands here without a catalog refresh.
   const title = digest?.title ?? workspace.title;
-  const stateLabel = workspaceStateLabel(workspace.status, digest?.lifecycle);
-  // The catalog snapshot carries the PR too, so the chip survives the gap
-  // before the updates socket has restated its digest.
   const pr = digest?.pr_state ?? workspace.pr;
-  const hasAttention = digest && digest.attention.state.type !== "working";
+  const showSession = isSessionRowWorthy(digest);
+  const attentionTitle = cardTooltip(title, digest);
+  const branchShown = middleTruncate(workspace.branch_name, 22);
+  const HarnessIcon = session ? HARNESS_ICONS[session.harness_kind] : null;
+  const age = session?.created_at
+    ? formatCompactAge(session.created_at)
+    : null;
+
   return (
-    <button
-      type="button"
-      aria-label={title}
-      aria-current={active ? "page" : undefined}
-      data-active={active || undefined}
-      className="flex w-full cursor-pointer flex-col gap-0.5 rounded-md px-2 py-1.5 text-left ring-offset-background transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none data-[active]:bg-muted"
-      onClick={onOpen}
-    >
-      <span className="truncate text-sm font-[450]">{title}</span>
-      <span className="flex min-w-0 items-center gap-1 font-mono text-[11px] text-muted-foreground">
-        <GitBranch className="size-3 shrink-0" aria-hidden />
-        <span className="truncate">{workspace.branch_name}</span>
-      </span>
-      {(stateLabel || hasAttention || pr) && (
-        <span className="mt-0.5 flex min-w-0 items-center gap-1.5">
-          {stateLabel && (
-            <span className="text-[11px] text-muted-foreground">
-              {stateLabel}
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={title}
+          aria-current={active ? "page" : undefined}
+          data-active={active || undefined}
+          title={attentionTitle}
+          className="flex w-full cursor-pointer flex-col gap-0.5 rounded-md px-2 py-1.5 text-left ring-offset-background motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none data-[active]:bg-muted"
+          onClick={onOpen}
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <AttentionBadge attention={digest?.attention} compact />
+            <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium leading-5">
+              {title}
+            </span>
+            <span className="flex shrink-0 items-center gap-1">
+              {pr && <PrGlyph pr={pr} />}
+              {terminalOpen && (
+                <SquareTerminal
+                  className="size-3 text-muted-foreground"
+                  aria-label="Terminal open"
+                />
+              )}
+              {digest?.attention.state.type === "needs_you" &&
+                digest.attention.state.source === "structured" && (
+                  <CircleAlert
+                    className="size-3 text-critical"
+                    aria-label="Pending approval"
+                  />
+                )}
+            </span>
+          </span>
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="inline-flex min-w-0 max-w-[46%] items-center gap-1 text-[11px] text-muted-foreground">
+              <span
+                className={cn(
+                  "size-1.5 shrink-0 rounded-[2px]",
+                  repoAccentClass(workspace.repo_id),
+                )}
+                aria-hidden
+              />
+              <span className="truncate">{repoName}</span>
+            </span>
+            <span
+              className="min-w-0 flex-1 font-mono text-[11px] text-muted-foreground/90"
+              title={workspace.branch_name}
+            >
+              {branchShown}
+            </span>
+          </span>
+          {showSession && digest && (
+            <span className="mt-0.5 flex min-w-0 items-center gap-1.5 pl-0.5 text-[11px] text-muted-foreground">
+              <ChevronRight
+                className="size-3 shrink-0 opacity-50"
+                aria-hidden
+              />
+              {HarnessIcon && (
+                <HarnessIcon className="size-3 shrink-0" />
+              )}
+              <span className="truncate">{sessionRowLabel(digest)}</span>
+              {age && (
+                <span className="ml-auto shrink-0 tabular-nums">{age}</span>
+              )}
             </span>
           )}
-          <AttentionBadge
-            attention={digest?.attention}
-            className="min-w-0 overflow-hidden"
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        {commands.map((command) => (
+          <WorkspaceMenuItem
+            key={command.id}
+            command={command}
+            onSelect={() => onCommand(command.id)}
           />
-          <span className="grow" />
-          {pr && <PrChip pr={pr} />}
-        </span>
-      )}
-    </button>
+        ))}
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
-/** PR number pill, colored by the host state token. */
-function PrChip({ pr }: { pr: PullRequestDigest }) {
+function WorkspaceMenuItem({
+  command,
+  onSelect,
+}: {
+  command: WorkspaceCommand;
+  onSelect: () => void;
+}) {
+  return (
+    <>
+      {command.separated && <ContextMenuSeparator />}
+      <ContextMenuItem
+        variant={command.destructive ? "destructive" : "default"}
+        onSelect={onSelect}
+      >
+        {command.label}
+      </ContextMenuItem>
+    </>
+  );
+}
+
+/** PR-state mark. The number and title live on the tooltip. */
+function PrGlyph({ pr }: { pr: PullRequestDigest }) {
   const tone = prTone(pr);
   return (
-    <span
-      className={cn(
-        "inline-flex shrink-0 items-center rounded-full px-1.5 py-px text-[11px] font-medium",
-        PR_CHIP_TONE_CLASSES[tone],
-      )}
-      title={pr.title ? `#${pr.number} ${pr.title}` : `PR #${pr.number}`}
+    <GitPullRequest
+      className={cn("size-3", PR_ICON_TONE_CLASSES[tone])}
+      aria-label={pr.title ? `PR #${pr.number} ${pr.title}` : `PR #${pr.number}`}
       data-pr-state={tone}
-    >
-      #{pr.number}
-    </span>
+    />
   );
+}
+
+function cardTooltip(
+  title: string,
+  digest: CodeSessionDigest | undefined,
+): string {
+  if (!digest || digest.attention.state.type === "working") return title;
+  return `${title} · ${digest.attention.state.type === "needs_you" ? digest.attention.state.prompt || "Needs you" : sessionRowLabel(digest)}`;
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -2,9 +2,14 @@ import { create } from "zustand";
 
 import type { HarnessKind } from "../api/types";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import {
+  isWorkspaceSortMode,
+  type WorkspaceSortMode,
+} from "./workspaceCards";
 
 const REVIEW_SIDEBAR_OPEN_KEY = "tidebreak.code-review-sidebar-open";
 const LAST_CREATE_KEY = "tidebreak.code-last-create";
+const WORKSPACE_SORT_KEY = "tidebreak.code-workspace-sort";
 
 /** What the reader picked the last time they created a workspace. */
 export type CodeCreateDefaults = {
@@ -60,6 +65,24 @@ function storeReviewSidebarOpen(open: boolean): void {
   }
 }
 
+function readStoredWorkspaceSort(): WorkspaceSortMode {
+  try {
+    const raw = window.localStorage.getItem(WORKSPACE_SORT_KEY);
+    if (raw && isWorkspaceSortMode(raw)) return raw;
+  } catch {
+    // Preference persistence is best-effort.
+  }
+  return "by-repo";
+}
+
+function storeWorkspaceSort(mode: WorkspaceSortMode): void {
+  try {
+    window.localStorage.setItem(WORKSPACE_SORT_KEY, mode);
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
 /**
  * Code mode's dialog and chrome state, held outside the components that draw it.
  *
@@ -83,6 +106,7 @@ export type CodeUiStore = {
   newWorkspaceRepoId: string | undefined;
   addRepoOpen: boolean;
   reviewSidebarOpen: boolean;
+  workspaceSortMode: WorkspaceSortMode;
   lastCreate: CodeCreateDefaults | null;
   /**
    * Ask for a workspace, from a repo page or from anywhere in code mode.
@@ -96,6 +120,7 @@ export type CodeUiStore = {
   setAddRepoOpen: (open: boolean) => void;
   toggleReviewSidebar: () => void;
   setReviewSidebarOpen: (open: boolean) => void;
+  setWorkspaceSortMode: (mode: WorkspaceSortMode) => void;
   /** Record a successful create so the next dialog opens on the same choices. */
   rememberCreate: (defaults: CodeCreateDefaults) => void;
 };
@@ -105,6 +130,7 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   newWorkspaceRepoId: undefined,
   addRepoOpen: false,
   reviewSidebarOpen: readStoredReviewSidebarOpen(),
+  workspaceSortMode: readStoredWorkspaceSort(),
   lastCreate: readStoredCreateDefaults(),
   startNewWorkspace: (repoId) => {
     const { repos } = useCodeCatalogStore.getState();
@@ -129,6 +155,10 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   setReviewSidebarOpen: (open) => {
     storeReviewSidebarOpen(open);
     set({ reviewSidebarOpen: open });
+  },
+  setWorkspaceSortMode: (mode) => {
+    storeWorkspaceSort(mode);
+    set({ workspaceSortMode: mode });
   },
   rememberCreate: (defaults) => {
     storeCreateDefaults(defaults);

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
@@ -20,7 +20,7 @@ import {
   harnessUnusableReason,
 } from "./labels";
 
-const HARNESS_ICONS: Record<
+export const HARNESS_ICONS: Record<
   HarnessKind,
   ComponentType<{ className?: string }>
 > = {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -1,0 +1,288 @@
+import { useState, type ReactElement } from "react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+import { archiveForceKind, type ApiClient } from "../api/client";
+import type { CodeWorkspaceSnapshot, PullRequestDigest } from "../api/types";
+import { useApp } from "@/AppContext";
+import { copyPlainText } from "@/ClipboardCopyButton";
+import { useConfirm, type ConfirmOptions } from "@/components/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { openInBrowser } from "@/openInBrowser";
+import { EMPTY_LAYOUT } from "@/panel/panelTypes";
+import { searchFromLayout } from "@/panel/panelUrl";
+import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
+import { toggleTerminalLayout } from "./codeChrome";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+
+/**
+ * Workspace commands shared by the card context menu and, later, the
+ * workspace header overflow. One list, two surfaces.
+ */
+export type WorkspaceCommandId =
+  | "open"
+  | "new-session"
+  | "rename"
+  | "copy-branch"
+  | "copy-worktree"
+  | "open-pr"
+  | "toggle-terminal"
+  | "archive";
+
+export type WorkspaceCommand = {
+  id: WorkspaceCommandId;
+  label: string;
+  destructive?: boolean;
+  /** Draw a separator before this item. */
+  separated?: boolean;
+};
+
+export type WorkspaceCommandContext = {
+  workspace: CodeWorkspaceSnapshot;
+  title: string;
+  pr?: PullRequestDigest;
+};
+
+export function workspaceCommands(input: {
+  hasPr: boolean;
+  archived: boolean;
+}): WorkspaceCommand[] {
+  const items: WorkspaceCommand[] = [
+    { id: "open", label: "Open workspace" },
+    { id: "new-session", label: "New session" },
+    { id: "rename", label: "Rename…" },
+    { id: "copy-branch", label: "Copy branch name" },
+    { id: "copy-worktree", label: "Copy worktree path" },
+  ];
+  if (input.hasPr) {
+    items.push({ id: "open-pr", label: "Open pull request" });
+  }
+  items.push({ id: "toggle-terminal", label: "Toggle terminal" });
+  if (!input.archived) {
+    items.push({
+      id: "archive",
+      label: "Archive",
+      destructive: true,
+      separated: true,
+    });
+  }
+  return items;
+}
+
+export async function archiveWorkspaceWithConfirm(options: {
+  client: Pick<ApiClient, "archiveCodeWorkspace">;
+  workspaceId: string;
+  confirm: (options: ConfirmOptions) => Promise<boolean>;
+}): Promise<CodeWorkspaceSnapshot | null> {
+  const ok = await options.confirm({
+    title: "Archive this workspace?",
+    description:
+      "The worktree is removed. Commit, push, or create a pull request from the review sidebar first if you want to keep the work.",
+    confirmLabel: "Archive",
+    destructive: true,
+  });
+  if (!ok) return null;
+  try {
+    return await options.client.archiveCodeWorkspace(options.workspaceId, false);
+  } catch (error) {
+    if (!archiveForceKind(error)) throw error;
+    const forced = await options.confirm({
+      title: "Discard leftover work?",
+      description: `${error instanceof Error ? error.message : String(error)} Commit and push from the review sidebar, or discard.`,
+      confirmLabel: "Discard and archive",
+      destructive: true,
+    });
+    if (!forced) return null;
+    return await options.client.archiveCodeWorkspace(options.workspaceId, true);
+  }
+}
+
+export function useWorkspaceCardCommands(): {
+  run: (
+    command: WorkspaceCommandId,
+    context: WorkspaceCommandContext,
+  ) => void;
+  dialogs: ReactElement;
+} {
+  const { client } = useApp();
+  const navigate = useNavigate();
+  const { confirm, dialog } = useConfirm();
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const layout = useLayoutState();
+  const { setLayout } = usePanelNav();
+  const upsertWorkspace = useCodeCatalogStore((state) => state.upsertWorkspace);
+  const forgetWorkspaceSession = useCodeCatalogStore(
+    (state) => state.forgetWorkspaceSession,
+  );
+  const [rename, setRename] = useState<{ id: string; title: string } | null>(
+    null,
+  );
+  const [renameValue, setRenameValue] = useState("");
+  const [renaming, setRenaming] = useState(false);
+
+  function openWorkspace(workspaceId: string) {
+    void navigate({
+      to: "/code/w/$workspaceId",
+      params: { workspaceId },
+    });
+  }
+
+  async function runArchive(workspace: CodeWorkspaceSnapshot) {
+    try {
+      const archived = await archiveWorkspaceWithConfirm({
+        client,
+        workspaceId: workspace.id,
+        confirm,
+      });
+      if (!archived) return;
+      upsertWorkspace(archived);
+      forgetWorkspaceSession(archived.id);
+      toast.success("Workspace archived");
+      if (pathname === `/code/w/${archived.id}`) {
+        if (archived.repo_id) {
+          await navigate({
+            to: "/code/r/$repoId",
+            params: { repoId: archived.repo_id },
+            replace: true,
+          });
+        } else {
+          await navigate({ to: "/code", replace: true });
+        }
+      }
+    } catch (error) {
+      toast.error(friendlyErrorMessage(error, "Could not archive"));
+    }
+  }
+
+  async function submitRename() {
+    if (!rename) return;
+    const title = renameValue.trim();
+    if (title.length === 0) return;
+    setRenaming(true);
+    try {
+      const next = await client.patchCodeWorkspace(rename.id, { title });
+      upsertWorkspace(next);
+      toast.success("Workspace renamed");
+      setRename(null);
+    } catch (error) {
+      toast.error(friendlyErrorMessage(error, "Could not rename"));
+    } finally {
+      setRenaming(false);
+    }
+  }
+
+  function run(
+    command: WorkspaceCommandId,
+    context: WorkspaceCommandContext,
+  ): void {
+    switch (command) {
+      case "open":
+      case "new-session":
+        openWorkspace(context.workspace.id);
+        return;
+      case "rename":
+        setRenameValue(context.title);
+        setRename({ id: context.workspace.id, title: context.title });
+        return;
+      case "copy-branch":
+        void copyPlainText(context.workspace.branch_name)
+          .then(() => toast.success("Branch name copied"))
+          .catch(() => toast.error("Could not copy branch name"));
+        return;
+      case "copy-worktree":
+        void copyPlainText(context.workspace.worktree_path)
+          .then(() => toast.success("Worktree path copied"))
+          .catch(() => toast.error("Could not copy worktree path"));
+        return;
+      case "open-pr": {
+        const url = context.pr?.url;
+        if (!url) {
+          toast.error("No pull request URL");
+          return;
+        }
+        void openInBrowser(url);
+        return;
+      }
+      case "toggle-terminal": {
+        if (pathname === `/code/w/${context.workspace.id}`) {
+          setLayout(toggleTerminalLayout(layout));
+          return;
+        }
+        void navigate({
+          to: "/code/w/$workspaceId",
+          params: { workspaceId: context.workspace.id },
+          search: searchFromLayout(toggleTerminalLayout(EMPTY_LAYOUT)),
+        });
+        return;
+      }
+      case "archive":
+        void runArchive(context.workspace);
+        return;
+    }
+  }
+
+  const renameDialog = (
+    <Dialog
+      open={rename !== null}
+      onOpenChange={(open) => {
+        if (!open) setRename(null);
+      }}
+    >
+      <DialogContent className="max-w-sm" withCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Rename workspace</DialogTitle>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void submitRename();
+          }}
+        >
+          <Input
+            aria-label="Workspace title"
+            value={renameValue}
+            onChange={(event) => setRenameValue(event.target.value)}
+            autoFocus
+          />
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setRename(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={renaming || renameValue.trim().length === 0}
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+
+  return {
+    run,
+    dialogs: (
+      <>
+        {dialog}
+        {renameDialog}
+      </>
+    ),
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from "vitest";
 
-import type { CodeRepoSnapshot, CodeWorkspaceSnapshot } from "../api/types";
-import { groupWorkspacesByRepo, prChipTone } from "./workspaceCards";
+import type {
+  Attention,
+  CodeRepoSnapshot,
+  CodeSessionDigest,
+  CodeWorkspaceSnapshot,
+} from "../api/types";
+import {
+  arrangeWorkspaces,
+  formatCompactAge,
+  groupWorkspacesByRepo,
+  middleTruncate,
+  prChipTone,
+  workspaceStatusRank,
+} from "./workspaceCards";
 
 function repo(id: string): CodeRepoSnapshot {
   return {
@@ -19,6 +31,7 @@ function workspace(
   id: string,
   repoId: string,
   status: CodeWorkspaceSnapshot["status"] = "active",
+  createdAt = "2026-08-15T00:00:00.000Z",
 ): CodeWorkspaceSnapshot {
   return {
     id,
@@ -28,8 +41,31 @@ function workspace(
     branch_name: `tidebreak/${id}`,
     base_ref: "main",
     status,
-    created_at: "2026-08-15T00:00:00.000Z",
+    created_at: createdAt,
   };
+}
+
+const working: Attention = { state: { type: "working" }, source: "lifecycle" };
+
+function digest(
+  workspaceId: string,
+  overrides: Partial<CodeSessionDigest> = {},
+): CodeSessionDigest {
+  return {
+    workspace: workspaceId,
+    session: `sess-${workspaceId}`,
+    lifecycle: "idle",
+    attention: working,
+    title: workspaceId,
+    turn_count: 0,
+    ...overrides,
+  };
+}
+
+function idsOf(
+  groups: { workspaces: CodeWorkspaceSnapshot[] }[],
+): string[] {
+  return groups.flatMap((group) => group.workspaces.map((item) => item.id));
 }
 
 describe("groupWorkspacesByRepo", () => {
@@ -56,6 +92,152 @@ describe("groupWorkspacesByRepo", () => {
       [null, ["ws-orphan"]],
     ]);
   });
+
+  it("orders a repo's workspaces by created_at, not catalog array order", () => {
+    const groups = groupWorkspacesByRepo(
+      [repo("app")],
+      [
+        workspace("ws-new", "app", "active", "2026-08-17T00:00:00.000Z"),
+        workspace("ws-old", "app", "active", "2026-08-14T00:00:00.000Z"),
+      ],
+    );
+    expect(groups[0]?.workspaces.map((item) => item.id)).toEqual([
+      "ws-old",
+      "ws-new",
+    ]);
+  });
+});
+
+describe("arrangeWorkspaces", () => {
+  const repos = [repo("app"), repo("lib")];
+  const listed = [
+    workspace("ws-lib", "lib", "active", "2026-08-16T00:00:00.000Z"),
+    workspace("ws-app-new", "app", "active", "2026-08-17T00:00:00.000Z"),
+    workspace("ws-app-old", "app", "active", "2026-08-14T00:00:00.000Z"),
+    workspace("ws-archived", "app", "archived", "2026-08-13T00:00:00.000Z"),
+  ];
+
+  it("groups by repo in creation order within each repo", () => {
+    const groups = arrangeWorkspaces("by-repo", repos, listed, {});
+    expect(
+      groups.map((group) => [group.key, group.workspaces.map((item) => item.id)]),
+    ).toEqual([
+      ["app", ["ws-app-old", "ws-app-new"]],
+      ["lib", ["ws-lib"]],
+    ]);
+  });
+
+  it("groups by status rank and keeps created_at order inside a rank", () => {
+    const digests = {
+      "ws-app-old": digest("ws-app-old", {
+        attention: {
+          state: {
+            type: "needs_you",
+            prompt: "an approval is waiting",
+            source: "structured",
+          },
+          source: "structured",
+        },
+      }),
+      "ws-lib": digest("ws-lib", { lifecycle: "running" }),
+      "ws-app-new": digest("ws-app-new", {
+        pr_state: { number: 12, state: "open" },
+      }),
+    };
+    const groups = arrangeWorkspaces("by-status", repos, listed, digests);
+    expect(
+      groups.map((group) => [group.key, group.workspaces.map((item) => item.id)]),
+    ).toEqual([
+      ["needs_you", ["ws-app-old"]],
+      ["running", ["ws-lib"]],
+      ["pr_open", ["ws-app-new"]],
+      ["archived", ["ws-archived"]],
+    ]);
+  });
+
+  it("lists by created newest first and hides archived", () => {
+    const groups = arrangeWorkspaces("by-created", repos, listed, {});
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.label).toBeNull();
+    expect(groups[0]?.workspaces.map((item) => item.id)).toEqual([
+      "ws-app-new",
+      "ws-lib",
+      "ws-app-old",
+    ]);
+  });
+
+  it("selecting a workspace does not reorder", () => {
+    const original = [
+      workspace("ws-a", "app", "active", "2026-08-14T00:00:00.000Z"),
+      workspace("ws-b", "app", "active", "2026-08-16T00:00:00.000Z"),
+    ];
+    // The old catalog upsert prepended the viewed row. Presentation must
+    // ignore that and keep created_at order.
+    const afterSelect = [original[1]!, original[0]!];
+    const before = arrangeWorkspaces("by-repo", [repo("app")], original, {});
+    const after = arrangeWorkspaces("by-repo", [repo("app")], afterSelect, {});
+    expect(idsOf(after)).toEqual(idsOf(before));
+    expect(idsOf(after)).toEqual(["ws-a", "ws-b"]);
+
+    const digestBefore = {
+      "ws-b": digest("ws-b", { turn_count: 1 }),
+    };
+    const digestAfter = {
+      "ws-b": digest("ws-b", { turn_count: 9, title: "renamed" }),
+    };
+    expect(
+      idsOf(arrangeWorkspaces("by-created", [repo("app")], original, digestAfter)),
+    ).toEqual(
+      idsOf(arrangeWorkspaces("by-created", [repo("app")], original, digestBefore)),
+    );
+  });
+
+  it("moves a row under by-status only when the rank itself changes", () => {
+    const rows = [
+      workspace("ws-a", "app", "active", "2026-08-14T00:00:00.000Z"),
+      workspace("ws-b", "app", "active", "2026-08-16T00:00:00.000Z"),
+    ];
+    const idle = {
+      "ws-a": digest("ws-a"),
+      "ws-b": digest("ws-b"),
+    };
+    const bNeedsYou = {
+      ...idle,
+      "ws-b": digest("ws-b", {
+        attention: {
+          state: {
+            type: "needs_you",
+            prompt: "an approval is waiting",
+            source: "structured",
+          },
+          source: "structured",
+        },
+      }),
+    };
+    expect(idsOf(arrangeWorkspaces("by-status", [repo("app")], rows, idle))).toEqual([
+      "ws-b",
+      "ws-a",
+    ]);
+    expect(
+      idsOf(arrangeWorkspaces("by-status", [repo("app")], rows, bNeedsYou)),
+    ).toEqual(["ws-b", "ws-a"]);
+    expect(
+      arrangeWorkspaces("by-status", [repo("app")], rows, bNeedsYou).map(
+        (group) => group.key,
+      ),
+    ).toEqual(["needs_you", "idle"]);
+  });
+});
+
+describe("workspaceStatusRank", () => {
+  it("ranks archived last even when a digest is noisy", () => {
+    expect(
+      workspaceStatusRank(
+        workspace("ws-a", "app", "archived"),
+        digest("ws-a", { lifecycle: "running" }),
+      ),
+    ).toBe("archived");
+  });
 });
 
 describe("prChipTone", () => {
@@ -65,5 +247,25 @@ describe("prChipTone", () => {
     expect(prChipTone("Merged")).toBe("merged");
     expect(prChipTone("closed")).toBe("closed");
     expect(prChipTone("locked")).toBe("other");
+  });
+});
+
+describe("middleTruncate", () => {
+  it("keeps the head and tail when the name is long", () => {
+    expect(middleTruncate("tidebreak/fix-login-flow", 14)).toBe(
+      "tidebre…n-flow",
+    );
+    expect(middleTruncate("short", 14)).toBe("short");
+  });
+});
+
+describe("formatCompactAge", () => {
+  const now = Date.parse("2026-08-18T12:00:00.000Z");
+
+  it("renders now, minutes, hours, and days", () => {
+    expect(formatCompactAge("2026-08-18T11:59:40.000Z", now)).toBe("now");
+    expect(formatCompactAge("2026-08-18T11:48:00.000Z", now)).toBe("12m");
+    expect(formatCompactAge("2026-08-18T09:00:00.000Z", now)).toBe("3h");
+    expect(formatCompactAge("2026-08-16T12:00:00.000Z", now)).toBe("2d");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -1,10 +1,9 @@
 import type {
   CodeRepoSnapshot,
-  CodeSessionLifecycle,
+  CodeSessionDigest,
   CodeWorkspaceSnapshot,
-  CodeWorkspaceStatus,
 } from "../api/types";
-import { LIFECYCLE_LABELS, WORKSPACE_STATUS_LABELS } from "./labels";
+import { LIFECYCLE_LABELS } from "./labels";
 
 /**
  * Pure presentation logic for workspace cards: grouping by repo, the state
@@ -43,27 +42,255 @@ export function groupWorkspacesByRepo(
     const listed = byRepo.get(repo.id);
     if (!listed) continue;
     byRepo.delete(repo.id);
-    groups.push({ repo, workspaces: listed });
+    groups.push({ repo, workspaces: sortByCreated(listed, "asc") });
   }
-  const orphans = [...byRepo.values()].flat();
+  const orphans = sortByCreated([...byRepo.values()].flat(), "asc");
   if (orphans.length > 0) groups.push({ repo: null, workspaces: orphans });
   return groups;
 }
 
+export type WorkspaceSortMode = "by-repo" | "by-status" | "by-created";
+
+export const WORKSPACE_SORT_MODES: readonly WorkspaceSortMode[] = [
+  "by-repo",
+  "by-status",
+  "by-created",
+];
+
+export const WORKSPACE_SORT_MODE_LABELS: Record<WorkspaceSortMode, string> = {
+  "by-repo": "By repo",
+  "by-status": "By status",
+  "by-created": "By created",
+};
+
+export function isWorkspaceSortMode(value: string): value is WorkspaceSortMode {
+  return (WORKSPACE_SORT_MODES as readonly string[]).includes(value);
+}
+
+export function nextWorkspaceSortMode(
+  mode: WorkspaceSortMode,
+): WorkspaceSortMode {
+  const index = WORKSPACE_SORT_MODES.indexOf(mode);
+  return WORKSPACE_SORT_MODES[(index + 1) % WORKSPACE_SORT_MODES.length]!;
+}
+
+export type WorkspaceStatusRank =
+  | "needs_you"
+  | "running"
+  | "pr_open"
+  | "done_unreviewed"
+  | "idle"
+  | "archived";
+
+export const WORKSPACE_STATUS_RANK_ORDER: readonly WorkspaceStatusRank[] = [
+  "needs_you",
+  "running",
+  "pr_open",
+  "done_unreviewed",
+  "idle",
+  "archived",
+];
+
+export const WORKSPACE_STATUS_RANK_LABELS: Record<WorkspaceStatusRank, string> =
+  {
+    needs_you: "Needs you",
+    running: "Running",
+    pr_open: "PR open",
+    done_unreviewed: "Done",
+    idle: "Idle",
+    archived: "Archived",
+  };
+
 /**
- * The one state word a card shows: workspace setup states win, then the
- * session lifecycle. Null when the workspace is active with no session yet —
- * an empty label reads better than "Created" on every fresh card.
+ * Rank a workspace for the by-status rail. Needs-you wins, then a running
+ * engine, then an open PR, then done-unreviewed, then idle. Archived is last.
+ * A digest may change the rank; viewing or selecting never does.
  */
-export function workspaceStateLabel(
-  status: CodeWorkspaceStatus,
-  lifecycle: CodeSessionLifecycle | undefined,
-): string | null {
-  if (status === "creating" || status === "setup_failed") {
-    return WORKSPACE_STATUS_LABELS[status];
+export function workspaceStatusRank(
+  workspace: CodeWorkspaceSnapshot,
+  digest: CodeSessionDigest | undefined,
+): WorkspaceStatusRank {
+  if (workspace.status === "archived") return "archived";
+  if (digest?.attention.state.type === "needs_you") return "needs_you";
+  if (digest?.lifecycle === "running") return "running";
+  const pr = digest?.pr_state ?? workspace.pr;
+  if (pr) {
+    const tone = prTone(pr);
+    if (tone === "open" || tone === "draft") return "pr_open";
   }
-  if (!lifecycle) return null;
-  return LIFECYCLE_LABELS[lifecycle];
+  if (digest?.attention.state.type === "done_unreviewed") {
+    return "done_unreviewed";
+  }
+  return "idle";
+}
+
+export type StatusWorkspaceGroup = {
+  rank: WorkspaceStatusRank;
+  workspaces: CodeWorkspaceSnapshot[];
+};
+
+/**
+ * Group workspaces by status rank. Archived rows stay visible here so triage
+ * can scroll past live work to what has already been put away. Within a rank,
+ * newest created_at wins; id breaks ties.
+ */
+export function groupWorkspacesByStatus(
+  workspaces: readonly CodeWorkspaceSnapshot[],
+  digests: Readonly<Record<string, CodeSessionDigest | undefined>>,
+): StatusWorkspaceGroup[] {
+  const buckets = new Map<WorkspaceStatusRank, CodeWorkspaceSnapshot[]>();
+  for (const rank of WORKSPACE_STATUS_RANK_ORDER) buckets.set(rank, []);
+  for (const workspace of workspaces) {
+    const rank = workspaceStatusRank(workspace, digests[workspace.id]);
+    buckets.get(rank)?.push(workspace);
+  }
+  const groups: StatusWorkspaceGroup[] = [];
+  for (const rank of WORKSPACE_STATUS_RANK_ORDER) {
+    const listed = sortByCreated(buckets.get(rank) ?? [], "desc");
+    if (listed.length === 0) continue;
+    groups.push({ rank, workspaces: listed });
+  }
+  return groups;
+}
+
+/** Live workspaces, newest created_at first. Archived rows stay off this list. */
+export function listWorkspacesByCreated(
+  workspaces: readonly CodeWorkspaceSnapshot[],
+): CodeWorkspaceSnapshot[] {
+  return sortByCreated(
+    workspaces.filter((workspace) => workspace.status !== "archived"),
+    "desc",
+  );
+}
+
+export type ArrangedWorkspaceGroup = {
+  key: string;
+  label: string | null;
+  workspaces: CodeWorkspaceSnapshot[];
+};
+
+/**
+ * The one function the rail reads. Ordering is a pure function of created_at,
+ * repo catalog order, and status rank — never catalog array order or digest
+ * insertion order.
+ */
+export function arrangeWorkspaces(
+  mode: WorkspaceSortMode,
+  repos: readonly CodeRepoSnapshot[],
+  workspaces: readonly CodeWorkspaceSnapshot[],
+  digests: Readonly<Record<string, CodeSessionDigest | undefined>>,
+): ArrangedWorkspaceGroup[] {
+  if (mode === "by-created") {
+    return [
+      {
+        key: "created",
+        label: null,
+        workspaces: listWorkspacesByCreated(workspaces),
+      },
+    ];
+  }
+  if (mode === "by-status") {
+    return groupWorkspacesByStatus(workspaces, digests).map((group) => ({
+      key: group.rank,
+      label: WORKSPACE_STATUS_RANK_LABELS[group.rank],
+      workspaces: group.workspaces,
+    }));
+  }
+  return groupWorkspacesByRepo(repos, workspaces).map((group) => ({
+    key: group.repo?.id ?? "unknown-repo",
+    label: group.repo?.display_name ?? "Other repos",
+    workspaces: group.workspaces,
+  }));
+}
+
+function sortByCreated(
+  workspaces: readonly CodeWorkspaceSnapshot[],
+  direction: "asc" | "desc",
+): CodeWorkspaceSnapshot[] {
+  const sign = direction === "asc" ? 1 : -1;
+  return [...workspaces].sort((left, right) => {
+    const byTime = left.created_at.localeCompare(right.created_at);
+    if (byTime !== 0) return sign * byTime;
+    return sign * left.id.localeCompare(right.id);
+  });
+}
+
+/** True when the rail should draw the nested session row. */
+export function isSessionRowWorthy(
+  digest: CodeSessionDigest | undefined,
+): digest is CodeSessionDigest {
+  if (!digest) return false;
+  if (digest.lifecycle === "running" || digest.lifecycle === "fenced") {
+    return true;
+  }
+  const type = digest.attention.state.type;
+  return type === "needs_you" || type === "stalled";
+}
+
+/** Short lifecycle word for the nested session row. */
+export function sessionRowLabel(digest: CodeSessionDigest): string {
+  if (digest.attention.state.type === "needs_you") return "Needs you";
+  if (digest.lifecycle === "running") return "Running";
+  switch (digest.attention.state.type) {
+    case "stalled":
+      return "Stalled";
+    case "fenced":
+      return "Fenced";
+    case "done_unreviewed":
+      return "Done";
+    case "manual":
+      return "Pinned";
+    default:
+      return LIFECYCLE_LABELS[digest.lifecycle];
+  }
+}
+
+/**
+ * Keep the head and tail of a git name so the unique suffix survives a
+ * narrow rail. One ellipsis, never a CSS end-truncate on branches.
+ */
+export function middleTruncate(text: string, maxChars: number): string {
+  if (maxChars < 3 || text.length <= maxChars) return text;
+  const budget = maxChars - 1;
+  const head = Math.ceil(budget / 2);
+  const tail = Math.floor(budget / 2);
+  return `${text.slice(0, head)}…${text.slice(text.length - tail)}`;
+}
+
+/** Compact age for a session row: "now", "12m", "1h", "3d". */
+export function formatCompactAge(
+  iso: string,
+  nowMs: number = Date.now(),
+): string | null {
+  const then = Date.parse(iso);
+  if (!Number.isFinite(then)) return null;
+  const sec = Math.max(0, Math.floor((nowMs - then) / 1000));
+  if (sec < 45) return "now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hours = Math.floor(min / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+const REPO_ACCENT_CLASSES = [
+  "bg-sky-500/80",
+  "bg-teal-500/80",
+  "bg-amber-500/80",
+  "bg-rose-500/80",
+  "bg-indigo-500/80",
+  "bg-lime-600/80",
+] as const;
+
+/** Stable identity swatch for a repo chip. Not a status color. */
+export function repoAccentClass(id: string): string {
+  let hash = 0;
+  for (let index = 0; index < id.length; index += 1) {
+    hash = (hash * 31 + id.charCodeAt(index)) | 0;
+  }
+  const swatch =
+    REPO_ACCENT_CLASSES[Math.abs(hash) % REPO_ACCENT_CLASSES.length];
+  return swatch ?? REPO_ACCENT_CLASSES[0];
 }
 
 export type PrChipTone = "open" | "draft" | "merged" | "closed" | "other";

--- a/crates/tidebreak-desktop/ui/src/components/ui/context-menu.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/context-menu.tsx
@@ -1,0 +1,150 @@
+import * as React from "react";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { Check, ChevronRight } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const ContextMenu = ContextMenuPrimitive.Root;
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+const ContextMenuPortal = ContextMenuPrimitive.Portal;
+const ContextMenuSub = ContextMenuPrimitive.Sub;
+
+const menuContentMotion =
+  "motion-safe:data-[state=open]:animate-in motion-safe:data-[state=closed]:animate-out motion-safe:data-[state=closed]:fade-out-0 motion-safe:data-[state=open]:fade-in-0 motion-safe:data-[state=closed]:zoom-out-95 motion-safe:data-[state=open]:zoom-in-95 motion-safe:data-[side=bottom]:slide-in-from-top-2 motion-safe:data-[side=left]:slide-in-from-right-2 motion-safe:data-[side=right]:slide-in-from-left-2 motion-safe:data-[side=top]:slide-in-from-bottom-2 motion-safe:duration-150 motion-safe:ease-out";
+
+const ContextMenuContent = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "bg-popover text-popover-foreground z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
+        menuContentMotion,
+        className,
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const contextMenuItemVariants = cva(
+  "relative flex cursor-default items-center gap-4 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "focus:bg-accent focus:text-accent-foreground",
+        destructive: "text-destructive focus:bg-critical-background",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const ContextMenuItem = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> &
+    VariantProps<typeof contextMenuItemVariants>
+>(({ className, variant, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(contextMenuItemVariants({ variant }), className)}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("bg-muted -mx-1 my-1 h-px", className)}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    checked={checked}
+    className={cn(
+      "relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="size-4" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+));
+ContextMenuCheckboxItem.displayName =
+  ContextMenuPrimitive.CheckboxItem.displayName;
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "focus:bg-accent data-[state=open]:bg-accent flex cursor-default items-center gap-4 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </ContextMenuPrimitive.SubTrigger>
+));
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ComponentRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        "bg-popover text-popover-foreground z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
+        menuContentMotion,
+        className,
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuCheckboxItem,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+};

--- a/crates/tidebreak-desktop/ui/src/components/ui/segmented.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/segmented.dom.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { useState } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SegmentedControl } from "./segmented";
+
+afterEach(() => {
+  cleanup();
+});
+
+function Switch() {
+  const [value, setValue] = useState<"chat" | "code">("chat");
+  return (
+    <SegmentedControl
+      aria-label="App mode"
+      value={value}
+      onValueChange={setValue}
+      options={[
+        { value: "chat", label: "Chat" },
+        { value: "code", label: "Code" },
+      ]}
+    />
+  );
+}
+
+describe("SegmentedControl", () => {
+  it("moves the checked segment with arrow keys", async () => {
+    const user = userEvent.setup();
+    render(<Switch />);
+
+    const chat = screen.getByRole("radio", { name: "Chat" });
+    const code = screen.getByRole("radio", { name: "Code" });
+    expect(chat).toHaveAttribute("aria-checked", "true");
+    expect(code).toHaveAttribute("aria-checked", "false");
+
+    chat.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(code).toHaveAttribute("aria-checked", "true");
+    expect(code).toHaveFocus();
+
+    await user.keyboard("{ArrowLeft}");
+    expect(chat).toHaveAttribute("aria-checked", "true");
+    expect(chat).toHaveFocus();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/components/ui/segmented.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/segmented.tsx
@@ -1,0 +1,111 @@
+import {
+  useRef,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+export type SegmentedOption<T extends string> = {
+  value: T;
+  label: string;
+  icon?: ReactNode;
+};
+
+/**
+ * Two-or-more equal segments with radiogroup semantics.
+ *
+ * The active segment is filled. Arrow keys, Home, and End move the selection
+ * and the roving tabindex, matching a native radio group.
+ */
+export function SegmentedControl<T extends string>({
+  value,
+  onValueChange,
+  options,
+  "aria-label": ariaLabel,
+  compact = false,
+  className,
+}: {
+  value: T;
+  onValueChange: (value: T) => void;
+  options: readonly SegmentedOption<T>[];
+  "aria-label": string;
+  compact?: boolean;
+  className?: string;
+}) {
+  const refs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  function selectAt(index: number) {
+    const option = options[index];
+    if (!option) return;
+    onValueChange(option.value);
+    refs.current[index]?.focus();
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    const last = options.length - 1;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      selectAt(index === last ? 0 : index + 1);
+      return;
+    }
+    if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      selectAt(index === 0 ? last : index - 1);
+      return;
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      selectAt(0);
+      return;
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      selectAt(last);
+    }
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={cn(
+        "grid w-full gap-0.5 rounded-md bg-muted/70 p-0.5",
+        className,
+      )}
+      style={{ gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }}
+    >
+      {options.map((option, index) => {
+        const checked = option.value === value;
+        return (
+          <button
+            key={option.value}
+            ref={(node) => {
+              refs.current[index] = node;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={checked}
+            aria-label={option.label}
+            tabIndex={checked ? 0 : -1}
+            data-state={checked ? "on" : "off"}
+            className={cn(
+              "inline-flex min-w-0 cursor-pointer items-center justify-center gap-1.5 rounded-[5px] px-2 py-1 text-[12px] font-medium",
+              "ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none",
+              "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out",
+              checked
+                ? "bg-background text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+              compact && "px-1.5 [&_span]:hidden",
+            )}
+            onClick={() => onValueChange(option.value)}
+            onKeyDown={(event) => onKeyDown(event, index)}
+          >
+            {option.icon}
+            <span className="truncate">{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
@@ -1,11 +1,11 @@
 import { type ReactNode } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { FolderGit2, LayoutGrid, Puzzle, SquarePen } from "lucide-react";
+import { LayoutGrid, Puzzle, SquarePen } from "lucide-react";
 
 import type { Chat } from "@/api";
 import { useApp } from "@/AppContext";
 import { useChatListStore } from "@/ChatListStore";
-import { isCodeRoute } from "@/code/routes";
+import { CodeModeSwitch } from "@/code/CodeModeSwitch";
 import { useExperimentalFlags } from "@/experimental";
 import { ChatsSection } from "./ChatsSection";
 import { InboxButton } from "./InboxButton";
@@ -50,6 +50,8 @@ export function AppSidebar({ chat }: { chat?: Chat }) {
         </SidebarButton>
       )}
 
+      {codeModeEnabled && <CodeModeSwitch />}
+
       <div className="flex shrink-0 flex-col gap-0.5">
         <InboxButton />
 
@@ -67,16 +69,6 @@ export function AppSidebar({ chat }: { chat?: Chat }) {
           active={pathname === "/plugins" || pathname.startsWith("/plugins/")}
           onClick={() => void navigate({ to: "/plugins" })}
         />
-        {/* Experimental and opt-in: the rail lists Code only after the reader
-            enables it under Settings → Experimental. */}
-        {codeModeEnabled && (
-          <RouteButton
-            label="Code"
-            icon={<FolderGit2 />}
-            active={isCodeRoute(pathname)}
-            onClick={() => void navigate({ to: "/code" })}
-          />
-        )}
       </div>
 
       <ProjectsSection activeChatId={chat?.id} />

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -26,7 +26,7 @@ a stale one.
 ## Summary
 
 - Rust crates: 827
-- Desktop UI production packages: 499
+- Desktop UI production packages: 500
 - Distinct license texts: 569
 - Packages with no declared license: 0
 - Packages with a curated license: 28
@@ -5428,6 +5428,12 @@ License identifiers named across all declared expressions:
 - License text: `LICENSE` ([L-74144f6a3a6c](#l-74144f6a3a6c))
 
 ### @radix-ui/react-context 1.2.2
+
+- License: `MIT`
+- Repository: git+https://github.com/radix-ui/primitives.git
+- License text: `LICENSE` ([L-74144f6a3a6c](#l-74144f6a3a6c))
+
+### @radix-ui/react-context-menu 2.3.7
 
 - License: `MIT`
 - Repository: git+https://github.com/radix-ui/primitives.git


### PR DESCRIPTION
## Summary

Code mode's rail is now a dense command-center list: compact cards, a shared Chat/Code switch, and a right-click command list. Viewing a workspace no longer reshuffles the list.

## Card anatomy

Each expanded workspace card answers one question per mark. Compact mode keeps the existing flat buttons.

| Element | Need it answers |
| --- | --- |
| Attention dot on the title | Is this workspace asking for you? Failure is the same critical dot; the prompt lives in the tooltip. The old "the engine turn failed" text pill is gone. |
| Title at 13.5px medium | Which workspace is this? |
| Repo chip (swatch + name) | Which repository does this worktree belong to? The swatch is identity, not status. |
| Mono middle-truncated branch | Which branch? The tail of `tidebreak/…` stays readable. |
| PR glyph (`PR_ICON_TONE_CLASSES`) | Is there a pull request, and is it open, draft, merged, or closed? Number and title stay on the tooltip. |
| Terminal glyph | Is the terminal drawer open on the workspace you are viewing? |
| Pending-approval glyph | Is a structured approval waiting? Distinct from a lifecycle failure. |
| Nested session row | Is a session live? Harness mark + "Running" / "Needs you" + compact age from `created_at`. The chevron is reserved for later subagent nesting. |

Status color comes only from the semantic quads (and the existing merged purple on the PR icon). Reveals use 150ms ease-out and honor `prefers-reduced-motion`. Data updates do not animate. Every pointer control is a button, radio, or menu item.

## Sort modes

The Workspaces header cycles three persisted modes (`CodeUiStore` / localStorage):

- **By repo** — catalog repo order, `created_at` ascending inside each repo.
- **By status** — needs you → running → PR open → done-unreviewed → idle → archived. A digest may move a row only when the rank itself changes.
- **By created** — flat, newest first. Archived rows stay off this list.

## Reshuffle fix

Opening a workspace used to prepend it in `CodeCatalogStore.upsertWorkspace`. The rail also trusted that array order. Presentation now sorts only on `created_at`, repo catalog order, and status rank. `upsertWorkspace` updates in place. Tests pin "selecting a workspace does not reorder" at both the catalog and `arrangeWorkspaces` layers.

## Segmented Chat/Code switch

`components/ui/segmented.tsx` is a two-segment radiogroup (equal halves, filled active segment, arrow / Home / End keys). `CodeSidebar` always shows it. `AppSidebar` shows the same control when the code-mode flag is on, and drops the extra Code row so the switch is identical from both rails.

## New dependency

`@radix-ui/react-context-menu` `2.3.7` is exact-pinned in `ui/package.json` (`save-exact`). `pnpm-lock.yaml` updates in this commit. `Cargo.lock` is untouched.

The wrapper `components/ui/context-menu.tsx` mirrors `dropdown-menu.tsx`. A context menu is the right surface for a dense card that cannot host an overflow button without adding chrome. The action list is data in `workspaceCommands()` so a later header overflow can reuse it: Open workspace, New session, Rename… (`PATCH /code/workspaces/{id}` via new `ApiClient.patchCodeWorkspace`), Copy branch name, Copy worktree path, Open pull request (when a PR is present), Toggle terminal, Archive (destructive, separated).

## Tests

- `arrangeWorkspaces` grouping for all three modes, plus "selecting a workspace does not reorder".
- Catalog upsert no longer prepends on view.
- Context menu opens on `contextmenu`; Archive is present and `text-destructive`.
- Segmented control moves with arrow keys.

Replaced, not piled on:

- Code rail queries Chat/Code as radios in a radiogroup instead of stacked buttons.
- Removed `workspaceStateLabel` and the PR number pill from the rail (no remaining tests asserted that markup).

## Verification

- `pnpm vitest run src/code` (and the segmented / catalog additions)
- `pnpm vitest run`
- `pnpm build`