### PR TITLE
feat(desktop): render code-mode tools as inline lines

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -61,10 +61,10 @@ export function ToolCardShell({
         aria-controls={bodyId}
         onClick={() => setExpanded((current) => !current)}
       >
-        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[11px] font-medium">
+        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium">
           <ChevronDown
             className={cn(
-              "size-3.5 shrink-0 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
+              "size-3.5 shrink-0 transition-transform",
               !expanded && "-rotate-90",
             )}
             aria-hidden="true"
@@ -74,10 +74,7 @@ export function ToolCardShell({
               repeat it. The native tooltip gives the whole line back to anyone
               who hovers, for the titles that are plain text to begin with. */}
           <span
-            className={cn(
-              typeof title === "string" ? "truncate" : "min-w-0",
-              titleClassName,
-            )}
+            className={cn("truncate", titleClassName)}
             title={typeof title === "string" ? title : undefined}
           >
             {title}
@@ -89,7 +86,7 @@ export function ToolCardShell({
         <span className="flex shrink-0 items-stretch gap-1">{badge}</span>
       </button>
       {expanded && (
-        <div id={bodyId} className="border-t [overflow-anchor:none]">
+        <div id={bodyId} className="border-t">
           {children}
         </div>
       )}

--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -61,10 +61,10 @@ export function ToolCardShell({
         aria-controls={bodyId}
         onClick={() => setExpanded((current) => !current)}
       >
-        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium">
+        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[11px] font-medium">
           <ChevronDown
             className={cn(
-              "size-3.5 shrink-0 transition-transform",
+              "size-3.5 shrink-0 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
               !expanded && "-rotate-90",
             )}
             aria-hidden="true"
@@ -74,7 +74,10 @@ export function ToolCardShell({
               repeat it. The native tooltip gives the whole line back to anyone
               who hovers, for the titles that are plain text to begin with. */}
           <span
-            className={cn("truncate", titleClassName)}
+            className={cn(
+              typeof title === "string" ? "truncate" : "min-w-0",
+              titleClassName,
+            )}
             title={typeof title === "string" ? title : undefined}
           >
             {title}
@@ -86,7 +89,7 @@ export function ToolCardShell({
         <span className="flex shrink-0 items-stretch gap-1">{badge}</span>
       </button>
       {expanded && (
-        <div id={bodyId} className="border-t">
+        <div id={bodyId} className="border-t [overflow-anchor:none]">
           {children}
         </div>
       )}

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -47,7 +47,7 @@ export function ToolOutputPreview({
         <pre
           id={bodyId}
           aria-label={label}
-          className="bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-xs break-words whitespace-pre-wrap"
+          className="bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-[13px] break-words whitespace-pre-wrap [overflow-anchor:none]"
         >
           {body}
         </pre>
@@ -56,7 +56,7 @@ export function ToolOutputPreview({
           label={`Copy ${label.toLowerCase()}`}
           copiedAnnouncement={`${label} copied to clipboard.`}
           failedAnnouncement={`${label} could not be copied.`}
-          className="border-border bg-background text-muted-foreground hover:text-foreground absolute top-1 right-1 inline-flex items-center rounded-md border p-1 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
+          className="border-border bg-background text-muted-foreground hover:text-foreground absolute top-1 right-1 inline-flex items-center rounded-md border p-1 opacity-0 transition-opacity duration-[140ms] ease-out group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
         />
       </div>
       {hiddenCount > 0 && (

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -12,6 +12,11 @@ type ToolOutputPreviewProps = {
   collapsedLines?: number;
   /** What this block is, for the copy control and assistive technology. */
   label?: string;
+  /**
+   * Plain indented output: no surface, no padding box. The expander reads
+   * "· · · N more lines" instead of "Show N more lines".
+   */
+  bare?: boolean;
 };
 
 /**
@@ -28,6 +33,7 @@ export function ToolOutputPreview({
   text,
   collapsedLines = DEFAULT_COLLAPSED_LINES,
   label = "Output",
+  bare = false,
 }: ToolOutputPreviewProps) {
   const [expanded, setExpanded] = useState(false);
   const bodyId = useId();
@@ -47,7 +53,11 @@ export function ToolOutputPreview({
         <pre
           id={bodyId}
           aria-label={label}
-          className="bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-[13px] break-words whitespace-pre-wrap [overflow-anchor:none]"
+          className={
+            bare
+              ? "text-muted-foreground overflow-x-auto pr-7 font-mono text-[13px] break-words whitespace-pre-wrap [overflow-anchor:none]"
+              : "bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-xs break-words whitespace-pre-wrap"
+          }
         >
           {body}
         </pre>
@@ -56,20 +66,26 @@ export function ToolOutputPreview({
           label={`Copy ${label.toLowerCase()}`}
           copiedAnnouncement={`${label} copied to clipboard.`}
           failedAnnouncement={`${label} could not be copied.`}
-          className="border-border bg-background text-muted-foreground hover:text-foreground absolute top-1 right-1 inline-flex items-center rounded-md border p-1 opacity-0 transition-opacity duration-[140ms] ease-out group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
+          className={
+            bare
+              ? "text-muted-foreground hover:text-foreground absolute top-0 right-0 inline-flex items-center p-0.5 opacity-0 transition-opacity duration-[140ms] ease-out group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
+              : "border-border bg-background text-muted-foreground hover:text-foreground absolute top-1 right-1 inline-flex items-center rounded-md border p-1 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none"
+          }
         />
       </div>
       {hiddenCount > 0 && (
         <button
           type="button"
-          className="text-muted-foreground hover:text-foreground text-xs underline-offset-2 hover:underline"
+          className="text-muted-foreground hover:text-foreground text-[11px]"
           aria-expanded={expanded}
           aria-controls={bodyId}
           onClick={() => setExpanded((current) => !current)}
         >
           {expanded
             ? "Show less"
-            : `Show ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`}
+            : bare
+              ? `· · · ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`
+              : `Show ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`}
         </button>
       )}
     </div>

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
@@ -47,22 +47,21 @@ describe("CodeApprovalCard", () => {
       document.querySelector('time[datetime="2026-08-15T12:00:00.000Z"]'),
     ).not.toBeNull();
 
-    const disclosure = screen.getByText("Harness payload").closest("details");
-    expect(disclosure).not.toHaveAttribute("open");
-    expect(screen.queryByText(/"tool_name": "Bash"/)).not.toBeVisible();
+    const toggle = screen.getByRole("button", { name: "Harness payload" });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
 
-    fireEvent.click(screen.getByText("Harness payload"));
-    expect(disclosure).toHaveAttribute("open");
-    expect(screen.getByText(/"tool_name": "Bash"/)).toBeVisible();
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/"tool_name": "Bash"/)).toBeInTheDocument();
   });
 
   it("lists the paths a file write would touch", () => {
     render(<CodeApprovalCard approval={pendingWrite} onDecide={vi.fn()} />);
     expect(screen.getByText("Write this file?")).toBeInTheDocument();
-    expect(screen.getByText("/workspace/probe.txt").tagName).toBe("LI");
-    expect(screen.getByText("Harness payload").closest("details")).not.toHaveAttribute(
-      "open",
-    );
+    expect(screen.getByText("/workspace/probe.txt")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Harness payload" }),
+    ).toHaveAttribute("aria-expanded", "false");
   });
 
   it("opens a feedback field on deny and submits it", () => {
@@ -113,10 +112,9 @@ describe("CodeApprovalCard", () => {
         onDecide={vi.fn()}
       />,
     );
-    const caption = screen.getByText(/Denied/);
-    expect(caption).toHaveClass("text-warning-foreground");
-    expect(caption).toHaveTextContent(
-      "Denied: no — use the fixtures directory instead",
-    );
+    expect(screen.getByText("Denied")).toHaveClass("text-warning-foreground");
+    expect(
+      screen.getByText("no — use the fixtures directory instead"),
+    ).toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import type { CodeApprovalSnapshot } from "../api/types";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { formatMessageTimestamp } from "@/MessageFooter";
+import { cn } from "@/lib/utils";
 import { ScrollableContainer } from "@/ScrollableContainer";
 
 /**
@@ -26,6 +27,7 @@ export function CodeApprovalCard({
 }) {
   const [denying, setDenying] = useState(false);
   const [feedback, setFeedback] = useState("");
+  const [payloadOpen, setPayloadOpen] = useState(false);
   const decided = approval.state !== "pending";
 
   useEffect(() => {
@@ -39,29 +41,35 @@ export function CodeApprovalCard({
       aria-busy={deciding}
       data-testid="code-approval-card"
     >
-      <h3 className="font-medium break-words">{approvalTitle(approval)}</h3>
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-[13px] font-medium break-words">
+          {approvalTitle(approval)}
+        </h3>
+        <ApprovalState approval={approval} />
+      </div>
       <ApprovalKindBody approval={approval} />
       <ApprovalTimes
         requestedAt={approval.requested_at}
         decidedAt={approval.decided_at}
       />
-      {approval.state === "denied" && (
-        <p className="text-warning-foreground text-sm break-words">
-          Denied
-          {approval.feedback ? `: ${approval.feedback}` : ""}
-        </p>
+      {approval.state === "denied" && approval.feedback && (
+        <p className="text-[13px] break-words">{approval.feedback}</p>
       )}
-      {approval.state === "approved" && (
-        <p className="text-success-foreground text-sm">Approved</p>
-      )}
-      <details>
-        <summary className="text-muted-foreground hover:text-foreground cursor-pointer select-none text-xs">
+      <div>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground text-[11px]"
+          aria-expanded={payloadOpen}
+          onClick={() => setPayloadOpen((current) => !current)}
+        >
           Harness payload
-        </summary>
-        <ScrollableContainer className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 text-xs break-words whitespace-pre-wrap">
-          <pre className="font-mono">{prettyRaw(approval.harness_raw_json)}</pre>
-        </ScrollableContainer>
-      </details>
+        </button>
+        <Reveal open={payloadOpen}>
+          <ScrollableContainer className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 text-[11px] break-words whitespace-pre-wrap">
+            <pre className="font-mono">{prettyRaw(approval.harness_raw_json)}</pre>
+          </ScrollableContainer>
+        </Reveal>
+      </div>
       {!decided && !denying && (
         <div className="flex flex-wrap gap-2">
           <Button
@@ -116,7 +124,7 @@ export function CodeApprovalCard({
         </div>
       )}
       {error && (
-        <p className="text-destructive text-xs break-words" role="alert">
+        <p className="text-critical-foreground text-[11px] break-words" role="alert">
           {error}
         </p>
       )}
@@ -124,16 +132,30 @@ export function CodeApprovalCard({
   );
 }
 
+function ApprovalState({ approval }: { approval: CodeApprovalSnapshot }) {
+  if (approval.state === "approved") {
+    return (
+      <p className="text-success-foreground shrink-0 text-[11px]">Approved</p>
+    );
+  }
+  if (approval.state === "denied") {
+    return (
+      <p className="text-warning-foreground shrink-0 text-[11px]">Denied</p>
+    );
+  }
+  return null;
+}
+
 function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
   switch (approval.kind.type) {
     case "command":
       return (
         <div className="flex flex-col gap-1">
-          <pre className="bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 font-mono text-xs break-words whitespace-pre-wrap">
+          <pre className="bg-muted overflow-x-auto rounded-md p-2 font-mono text-[13px] break-words whitespace-pre-wrap">
             {approval.kind.cmd || "Command"}
           </pre>
           {approval.kind.cwd && (
-            <p className="text-muted-foreground text-xs break-words">
+            <p className="text-muted-foreground font-mono text-[11px] break-words">
               cwd {approval.kind.cwd}
             </p>
           )}
@@ -141,18 +163,20 @@ function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
       );
     case "file_write":
       return approval.kind.paths.length > 0 ? (
-        <ul className="text-muted-foreground space-y-0.5 font-mono text-xs break-words">
+        <ul className="space-y-0.5">
           {approval.kind.paths.map((path) => (
-            <li key={path}>{path}</li>
+            <li key={path}>
+              <MiddleTruncate text={path} className="font-mono text-[11px]" />
+            </li>
           ))}
         </ul>
       ) : (
-        <p className="text-muted-foreground text-sm">File write</p>
+        <p className="text-muted-foreground text-[13px]">File write</p>
       );
     case "network":
     case "other":
       return (
-        <p className="text-muted-foreground text-sm break-words">
+        <p className="text-muted-foreground text-[13px] break-words">
           {approval.kind.summary}
         </p>
       );
@@ -172,7 +196,7 @@ function ApprovalTimes({
     : null;
   if (!requested && !decided) return null;
   return (
-    <p className="text-muted-foreground text-xs">
+    <p className="text-muted-foreground text-[11px]">
       {requested && (
         <WithTooltip label={requested.full}>
           <time dateTime={requestedAt}>{requested.short}</time>
@@ -185,6 +209,44 @@ function ApprovalTimes({
         </WithTooltip>
       )}
     </p>
+  );
+}
+
+function Reveal({ open, children }: { open: boolean; children: ReactNode }) {
+  return (
+    <div
+      className={cn(
+        "grid [overflow-anchor:none] transition-[grid-template-rows] duration-[140ms] ease-out motion-reduce:transition-none",
+        open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+      )}
+      aria-hidden={!open}
+      inert={!open ? true : undefined}
+    >
+      <div className="overflow-hidden">{children}</div>
+    </div>
+  );
+}
+
+function MiddleTruncate({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const tail = Math.min(28, Math.max(12, Math.ceil(text.length / 3)));
+  if (text.length <= 40) {
+    return (
+      <span className={cn("block truncate", className)} title={text}>
+        {text}
+      </span>
+    );
+  }
+  return (
+    <span className={cn("flex min-w-0", className)} title={text}>
+      <span className="truncate">{text.slice(0, -tail)}</span>
+      <span className="shrink-0">{text.slice(-tail)}</span>
+    </span>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -170,6 +170,8 @@ describe("turn lifecycle", () => {
       callId: "c1",
       status: "succeeded",
       preview: "ok",
+      startedAt: LATER,
+      durationMs: 0,
     });
     const boundary = state.items[3];
     expect(boundary).toMatchObject({

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -56,6 +56,10 @@ export type CodeTranscriptItem =
       detail: ToolDetail;
       status: CodeToolStatus;
       preview: string;
+      /** When this client saw the call start. Null on journal replay. */
+      startedAt: string | null;
+      /** Wall time from start to completion. Null when replayed or still running. */
+      durationMs: number | null;
     }
   | {
       kind: "notice";
@@ -376,6 +380,8 @@ export function reduceCodeSessionEvent(
               detail: event.detail,
               status: "running",
               preview: "",
+              startedAt: framed.replayed ? null : deps.now(),
+              durationMs: null,
             },
           ],
         },
@@ -389,7 +395,14 @@ export function reduceCodeSessionEvent(
           ...state,
           items: state.items.map((item) =>
             item.kind === "tool" && item.callId === event.call_id
-              ? { ...item, status: event.outcome, preview: event.preview }
+              ? {
+                  ...item,
+                  status: event.outcome,
+                  preview: event.preview,
+                  durationMs: framed.replayed
+                    ? null
+                    : durationMs(item.startedAt, deps.now()),
+                }
               : item,
           ),
         },

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -41,6 +41,8 @@ const items: CodeTranscriptItem[] = [
     detail: { kind: "command", cmd: "ls", cwd: "/tmp" },
     status: "succeeded",
     preview: "README.md",
+    startedAt: "2026-08-15T12:00:00.000Z",
+    durationMs: 1_200,
   },
   {
     kind: "notice",
@@ -69,6 +71,8 @@ describe("CodeTranscript", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Command run")).toBeInTheDocument();
     expect(screen.getByText("ls")).toBeInTheDocument();
+    expect(screen.getByText("1s")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Output")).toBeNull();
     expect(screen.getByText("unrecognized event dropped")).toBeInTheDocument();
   });
 
@@ -143,6 +147,8 @@ describe("CodeTranscript", () => {
             detail: { kind: "command", cmd: "seq 13", cwd: "/tmp" },
             status: "failed",
             preview,
+            startedAt: null,
+            durationMs: 800,
           },
         ]}
       />,
@@ -157,6 +163,58 @@ describe("CodeTranscript", () => {
       screen.getByRole("button", { name: "· · · 1 more line" }),
     );
     expect(screen.getByLabelText("Output").textContent).toContain("line 13");
+  });
+
+  it("keeps a successful call closed and names a denial with the constant verb", () => {
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "tool",
+            id: "tool-denied",
+            turnId: "t1",
+            callId: "c2",
+            name: "Bash",
+            detail: { kind: "command", cmd: "rm -rf /", cwd: "/tmp" },
+            status: "denied",
+            preview: "denied by policy",
+            startedAt: null,
+            durationMs: null,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Command denied")).toBeInTheDocument();
+    expect(screen.getByLabelText("Output")).toHaveTextContent("denied by policy");
+  });
+
+  it("streams the tail of a running command without showing the head", () => {
+    const preview = Array.from(
+      { length: 16 },
+      (_, index) => `line ${index + 1}`,
+    ).join("\n");
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "tool",
+            id: "tool-run",
+            turnId: "t1",
+            callId: "c3",
+            name: "Bash",
+            detail: { kind: "command", cmd: "seq 16", cwd: "/tmp" },
+            status: "running",
+            preview,
+            startedAt: "2026-08-15T12:00:00.000Z",
+            durationMs: null,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Command run")).toBeInTheDocument();
+    const body = screen.getByLabelText("Output");
+    expect(body.textContent?.split("\n")[0]).toBe("line 5");
+    expect(body.textContent).toContain("line 16");
   });
 
   it("shows the engine working only where nothing else says so", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -65,8 +65,10 @@ describe("CodeTranscript", () => {
     render(<CodeTranscript items={items} />);
     expect(screen.getByText("Looking at the tree.")).toBeInTheDocument();
     expect(
-      screen.getByRole("status", { name: "Bash succeeded" }),
+      screen.getByRole("status", { name: "Command run succeeded" }),
     ).toBeInTheDocument();
+    expect(screen.getByText("Command run")).toBeInTheDocument();
+    expect(screen.getByText("ls")).toBeInTheDocument();
     expect(screen.getByText("unrecognized event dropped")).toBeInTheDocument();
   });
 
@@ -124,9 +126,9 @@ describe("CodeTranscript", () => {
     ).toBeInTheDocument();
   });
 
-  it("clamps a running tool's output and offers a copy control", async () => {
+  it("expands a failed tool and clamps long output", async () => {
     const preview = Array.from(
-      { length: 12 },
+      { length: 13 },
       (_, index) => `line ${index + 1}`,
     ).join("\n");
     render(
@@ -138,8 +140,8 @@ describe("CodeTranscript", () => {
             turnId: "t1",
             callId: "c1",
             name: "Bash",
-            detail: { kind: "command", cmd: "seq 12", cwd: "/tmp" },
-            status: "running",
+            detail: { kind: "command", cmd: "seq 13", cwd: "/tmp" },
+            status: "failed",
             preview,
           },
         ]}
@@ -147,14 +149,14 @@ describe("CodeTranscript", () => {
     );
 
     const body = screen.getByLabelText("Output");
-    expect(body.textContent).toContain("line 8");
-    expect(body.textContent).not.toContain("line 9");
+    expect(body.textContent).toContain("line 12");
+    expect(body.textContent).not.toContain("line 13");
     expect(screen.getByRole("button", { name: "Copy output" })).toBeTruthy();
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Show 4 more lines" }),
+      screen.getByRole("button", { name: "· · · 1 more line" }),
     );
-    expect(screen.getByLabelText("Output").textContent).toContain("line 12");
+    expect(screen.getByLabelText("Output").textContent).toContain("line 13");
   });
 
   it("shows the engine working only where nothing else says so", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -10,7 +10,7 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import { useId, useState, type RefCallback } from "react";
+import { useEffect, useId, useState, type RefCallback } from "react";
 
 import type { CodeApprovalSnapshot, Diffstat, FileChangeKind, ToolDetail } from "../api/types";
 import { CodeApprovalCard } from "./CodeApprovalCard";
@@ -24,7 +24,7 @@ import { TranscriptSkeleton } from "@/TranscriptSkeleton";
 import { UserMessage } from "@/UserMessage";
 import { cn } from "@/lib/utils";
 import type { CodeTranscriptItem } from "./CodeSessionReducer";
-import { TurnReviewCard } from "./TurnReviewCard";
+import { formatTurnDuration, TurnReviewCard } from "./TurnReviewCard";
 
 /**
  * The code-session transcript: the reader's prompts, markdown for assistant
@@ -247,6 +247,8 @@ function TranscriptItem({
           detail={item.detail}
           status={item.status}
           preview={item.preview}
+          startedAt={item.startedAt}
+          durationMs={item.durationMs}
         />
       );
     case "notice":
@@ -281,27 +283,44 @@ function TranscriptItem({
 }
 
 /**
- * One engine action as a boxless line. The verb names what ran; the muted
- * mono subject is the command or path; the right slot is the outcome glyph.
- * Failed and denied open so the output is the next thing you read.
+ * One engine action as a boxless line. The verb is a constant; the muted mono
+ * subject is the command or path; the right slot is meta, one status glyph,
+ * and a quiet chevron. Failed and denied open. Success stays closed. A running
+ * call streams the last lines of output without growing the row.
  */
 export function CodeToolCard({
   name,
   detail,
   status,
   preview,
+  startedAt = null,
+  durationMs = null,
 }: {
   name: string;
   detail: ToolDetail;
   status: "running" | "succeeded" | "failed" | "denied";
   preview: string;
+  startedAt?: string | null;
+  durationMs?: number | null;
 }) {
-  const defaultExpanded = status === "failed" || status === "denied";
-  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [expanded, setExpanded] = useState(
+    status === "failed" || status === "denied",
+  );
   const bodyId = useId();
   const verb = toolVerb(detail, status);
   const subject = toolSubject(detail, name);
   const hasOutput = preview.trim().length > 0;
+  const elapsed = useElapsedLabel(startedAt, status === "running");
+  const duration = formatTurnDuration(durationMs);
+  const exitCode = parseExitCode(preview);
+
+  useEffect(() => {
+    if (status === "succeeded") setExpanded(false);
+    if (status === "failed" || status === "denied") setExpanded(true);
+  }, [status]);
+
+  const showTail = status === "running" && hasOutput;
+  const showExpanded = expanded && status !== "running" && hasOutput;
 
   return (
     <div
@@ -312,7 +331,7 @@ export function CodeToolCard({
       <button
         type="button"
         className="flex w-full items-center gap-2 py-0.5 text-left text-[13px]"
-        aria-expanded={expanded}
+        aria-expanded={expanded || showTail}
         aria-controls={hasOutput ? bodyId : undefined}
         onClick={() => setExpanded((current) => !current)}
       >
@@ -324,19 +343,28 @@ export function CodeToolCard({
           text={subject}
           className="text-muted-foreground min-w-0 font-mono"
         />
-        <span className="ml-auto flex shrink-0 items-center gap-1.5">
+        <span className="text-muted-foreground ml-auto flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums">
+          {status === "running" ? elapsed : duration}
+          {status !== "running" && exitCode !== null && (
+            <span>exit {exitCode}</span>
+          )}
           <StatusGlyph status={status} />
           <ChevronDown
             className={cn(
-              "text-muted-foreground size-3.5 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
-              !expanded && "-rotate-90",
+              "text-muted-foreground/50 size-3.5 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
+              !(expanded || showTail) && "-rotate-90",
             )}
             aria-hidden="true"
           />
         </span>
       </button>
-      {expanded && hasOutput && (
-        <div id={bodyId} className="pl-6">
+      {showTail && (
+        <div id={bodyId}>
+          <StreamingTail text={preview} />
+        </div>
+      )}
+      {showExpanded && (
+        <div id={bodyId}>
           <ToolOutputPreview text={preview} collapsedLines={12} bare />
         </div>
       )}
@@ -392,32 +420,52 @@ function toolVerb(
   detail: ToolDetail,
   status: "running" | "succeeded" | "failed" | "denied",
 ): string {
-  if (status === "running") {
-    switch (detail.kind) {
-      case "command":
-        return "Command running";
-      case "file_read":
-        return "Reading file";
-      case "file_edit":
-        return "Editing file";
-      case "search":
-        return "Searching";
-      case "other":
-        return "Tool running";
-    }
-  }
+  if (detail.kind === "command" && status === "denied") return "Command denied";
   switch (detail.kind) {
     case "command":
+    case "other":
       return "Command run";
     case "file_read":
       return "File read";
     case "file_edit":
       return "File edited";
     case "search":
-      return "Search run";
-    case "other":
-      return "Tool run";
+      return "Search";
   }
+}
+
+/** Last twelve lines, height-capped so a streaming tail does not grow the row. */
+function StreamingTail({ text }: { text: string }) {
+  const lines = text.replace(/\n+$/, "").split("\n");
+  const tail = lines.slice(-12).join("\n");
+  return (
+    <pre
+      aria-label="Output"
+      className="text-muted-foreground max-h-[17.4em] overflow-hidden font-mono text-[13px] break-words whitespace-pre-wrap [overflow-anchor:none]"
+    >
+      {tail}
+    </pre>
+  );
+}
+
+function useElapsedLabel(startedAt: string | null, active: boolean): string | null {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active || !startedAt) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(id);
+  }, [active, startedAt]);
+  if (!startedAt) return null;
+  const start = Date.parse(startedAt);
+  if (!Number.isFinite(start)) return null;
+  return formatTurnDuration(Math.max(0, now - start));
+}
+
+function parseExitCode(preview: string): number | null {
+  const match = preview.match(/(?:^|\n)\s*exit(?:ed)?(?:\s+code)?[:\s]+(-?\d+)\s*$/im);
+  if (!match) return null;
+  const code = Number(match[1]);
+  return Number.isFinite(code) ? code : null;
 }
 
 function toolSubject(detail: ToolDetail, name: string): string {

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -1,15 +1,24 @@
-import { FileCode, FileSearch, Search, SquareTerminal, Wrench } from "lucide-react";
-import { useState, type RefCallback } from "react";
+import {
+  Check,
+  ChevronDown,
+  CircleSlash,
+  FileCode,
+  FileSearch,
+  Loader2,
+  Search,
+  SquareTerminal,
+  Wrench,
+  X,
+} from "lucide-react";
+import { useId, useState, type RefCallback } from "react";
 
 import type { CodeApprovalSnapshot, Diffstat, FileChangeKind, ToolDetail } from "../api/types";
 import { CodeApprovalCard } from "./CodeApprovalCard";
-import { Badge } from "@/components/ui/badge";
 import { AssistantMessageBody } from "@/AssistantMessageBody";
 import { AssistantWorkingIndicator } from "@/AssistantWorkingIndicator";
 import { MessageFooter } from "@/MessageFooter";
 import { isolatedCard } from "@/PendingCard";
 import { ThinkingAccordion } from "@/ThinkingAccordion";
-import { ToolCardShell } from "@/ToolCardShell";
 import { ToolOutputPreview } from "@/ToolOutputPreview";
 import { TranscriptSkeleton } from "@/TranscriptSkeleton";
 import { UserMessage } from "@/UserMessage";
@@ -19,7 +28,7 @@ import { TurnReviewCard } from "./TurnReviewCard";
 
 /**
  * The code-session transcript: the reader's prompts, markdown for assistant
- * text, tool-card chrome for engine work, the approvals a turn is parked on,
+ * text, inline tool lines for engine work, the approvals a turn is parked on,
  * and what each turn came to.
  *
  * The frame is chat's — `.messages` around a `.messages-column` — because the
@@ -122,7 +131,7 @@ export function CodeTranscript({
  * Whether the engine owes the reader a visible working state.
  *
  * Anything with its own live presentation speaks for itself: streaming prose, a
- * running tool card, an approval waiting on a decision. The indicator covers
+ * running tool line, an approval waiting on a decision. The indicator covers
  * the gaps between them — and comes back under a partial response whose stream
  * has gone quiet, so a slow engine reads differently from a hung one.
  */
@@ -271,6 +280,11 @@ function TranscriptItem({
   }
 }
 
+/**
+ * One engine action as a boxless line. The verb names what ran; the muted
+ * mono subject is the command or path; the right slot is the outcome glyph.
+ * Failed and denied open so the output is the next thing you read.
+ */
 export function CodeToolCard({
   name,
   detail,
@@ -282,42 +296,51 @@ export function CodeToolCard({
   status: "running" | "succeeded" | "failed" | "denied";
   preview: string;
 }) {
-  const badge =
-    status === "running" ? (
-      <Badge variant="info" size="sm">
-        Running
-      </Badge>
-    ) : status === "failed" ? (
-      <Badge variant="critical" size="sm">
-        Failed
-      </Badge>
-    ) : status === "denied" ? (
-      <Badge variant="warning" size="sm">
-        Denied
-      </Badge>
-    ) : (
-      <Badge variant="success" size="sm">
-        Done
-      </Badge>
-    );
+  const defaultExpanded = status === "failed" || status === "denied";
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const bodyId = useId();
+  const verb = toolVerb(detail, status);
+  const subject = toolSubject(detail, name);
+  const hasOutput = preview.trim().length > 0;
+
   return (
-    <ToolCardShell
-      icon={toolIcon(detail)}
-      title={
-        <MiddleTruncate
-          text={toolTitle(detail, name)}
-          className={detail.kind === "command" ? "font-mono" : undefined}
-        />
-      }
-      badge={badge}
-      defaultExpanded={status === "running"}
-      label={`${name} ${status}`}
+    <div
+      className="max-w-prose [overflow-anchor:none]"
+      role="status"
+      aria-label={`${verb} ${status}`}
     >
-      <div className="text-muted-foreground space-y-1 px-2.5 pb-2 [overflow-anchor:none]">
-        <p className="text-[11px]">{toolDetailLine(detail)}</p>
-        {preview && <ToolOutputPreview text={preview} />}
-      </div>
-    </ToolCardShell>
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 py-0.5 text-left text-[13px]"
+        aria-expanded={expanded}
+        aria-controls={hasOutput ? bodyId : undefined}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="text-muted-foreground shrink-0 [&>svg]:size-3.5">
+          {toolIcon(detail)}
+        </span>
+        <span className="shrink-0 font-semibold">{verb}</span>
+        <MiddleTruncate
+          text={subject}
+          className="text-muted-foreground min-w-0 font-mono"
+        />
+        <span className="ml-auto flex shrink-0 items-center gap-1.5">
+          <StatusGlyph status={status} />
+          <ChevronDown
+            className={cn(
+              "text-muted-foreground size-3.5 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
+              !expanded && "-rotate-90",
+            )}
+            aria-hidden="true"
+          />
+        </span>
+      </button>
+      {expanded && hasOutput && (
+        <div id={bodyId} className="pl-6">
+          <ToolOutputPreview text={preview} collapsedLines={12} bare />
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -365,7 +388,39 @@ function toolIcon(detail: ToolDetail) {
   }
 }
 
-function toolTitle(detail: ToolDetail, name: string): string {
+function toolVerb(
+  detail: ToolDetail,
+  status: "running" | "succeeded" | "failed" | "denied",
+): string {
+  if (status === "running") {
+    switch (detail.kind) {
+      case "command":
+        return "Command running";
+      case "file_read":
+        return "Reading file";
+      case "file_edit":
+        return "Editing file";
+      case "search":
+        return "Searching";
+      case "other":
+        return "Tool running";
+    }
+  }
+  switch (detail.kind) {
+    case "command":
+      return "Command run";
+    case "file_read":
+      return "File read";
+    case "file_edit":
+      return "File edited";
+    case "search":
+      return "Search run";
+    case "other":
+      return "Tool run";
+  }
+}
+
+function toolSubject(detail: ToolDetail, name: string): string {
   switch (detail.kind) {
     case "command":
       return detail.cmd;
@@ -376,6 +431,37 @@ function toolTitle(detail: ToolDetail, name: string): string {
       return detail.query;
     case "other":
       return detail.summary || name;
+  }
+}
+
+function StatusGlyph({
+  status,
+}: {
+  status: "running" | "succeeded" | "failed" | "denied";
+}) {
+  switch (status) {
+    case "running":
+      return (
+        <Loader2
+          className="text-info-foreground size-3.5 animate-spin motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+      );
+    case "succeeded":
+      return (
+        <Check className="text-success-foreground size-3.5" aria-hidden="true" />
+      );
+    case "failed":
+      return (
+        <X className="text-critical-foreground size-3.5" aria-hidden="true" />
+      );
+    case "denied":
+      return (
+        <CircleSlash
+          className="text-warning-foreground size-3.5"
+          aria-hidden="true"
+        />
+      );
   }
 }
 
@@ -403,20 +489,7 @@ function MiddleTruncate({
   );
 }
 
-function toolDetailLine(detail: ToolDetail): string {
-  switch (detail.kind) {
-    case "command":
-      return detail.cwd ? `cwd ${detail.cwd}` : "Command";
-    case "file_read":
-      return "File read";
-    case "file_edit":
-      return "File edit";
-    case "search":
-      return "Search";
-    case "other":
-      return detail.summary;
-  }
-}
+
 
 const FILE_KIND_LETTER: Record<FileChangeKind, string> = {
   added: "A",

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -303,15 +303,18 @@ export function CodeToolCard({
   return (
     <ToolCardShell
       icon={toolIcon(detail)}
-      title={toolTitle(detail, name)}
-      titleClassName={detail.kind === "command" ? "font-mono" : undefined}
+      title={
+        <MiddleTruncate
+          text={toolTitle(detail, name)}
+          className={detail.kind === "command" ? "font-mono" : undefined}
+        />
+      }
       badge={badge}
       defaultExpanded={status === "running"}
-      className={status === "failed" ? "border-critical-border" : undefined}
       label={`${name} ${status}`}
     >
-      <div className="text-muted-foreground space-y-1 px-2.5 pb-2 text-xs">
-        <p>{toolDetailLine(detail)}</p>
+      <div className="text-muted-foreground space-y-1 px-2.5 pb-2 [overflow-anchor:none]">
+        <p className="text-[11px]">{toolDetailLine(detail)}</p>
         {preview && <ToolOutputPreview text={preview} />}
       </div>
     </ToolCardShell>
@@ -374,6 +377,30 @@ function toolTitle(detail: ToolDetail, name: string): string {
     case "other":
       return detail.summary || name;
   }
+}
+
+/** Keep the tail of a command or path when the header runs out of room. */
+function MiddleTruncate({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const tail = Math.min(28, Math.max(12, Math.ceil(text.length / 3)));
+  if (text.length <= 40) {
+    return (
+      <span className={cn("block truncate", className)} title={text}>
+        {text}
+      </span>
+    );
+  }
+  return (
+    <span className={cn("flex min-w-0", className)} title={text}>
+      <span className="truncate">{text.slice(0, -tail)}</span>
+      <span className="shrink-0">{text.slice(-tail)}</span>
+    </span>
+  );
 }
 
 function toolDetailLine(detail: ToolDetail): string {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -449,7 +449,7 @@ function PendingApprovalBadge({
         document
           .querySelector('[data-code-approval-state="pending"]')
           ?.scrollIntoView({
-            block: "center",
+            block: "nearest",
             behavior: followScrollBehavior(false),
           });
       }}


### PR DESCRIPTION
## What changed

Code-mode tool calls are a boxless line. Each call is one row: a glyph, a bold constant verb (`Command run`, `File edited`, `File read`, `Search`, or `Command denied`), and a muted mono subject with middle truncation. The right slot holds duration (live elapsed while running), an exit code when the preview reports one, one status glyph, and a quiet chevron. The whole line is the click target and exposes `aria-expanded`.

Failed and denied calls open. Success stays closed. A running call shows a spinner plus elapsed time and streams the last twelve lines of output at a fixed height, so new lines do not grow the row.

Expanded output is plain indented mono. There is no container and no left rail. Long output clamps at 12 lines behind `· · · N more lines`, with a hover copy control.

Approvals stay a card. The kind leads. The harness JSON stays behind **Harness payload**. Approved and Denied are one caption. The header badge jumps to the first pending card.

## What each element answers

- Constant verb: what kind of call this is, without changing tense as status changes.
- Muted mono subject: the command or path being decided or run.
- Duration / elapsed: how long the live call has been running, or how long it ran.
- Exit code: only when the preview states one. The wire `tool_completed` event does not carry `exit_code`.
- Status glyph: the only color on the line (info / success / warning / critical).
- Chevron: whether the output is open.
- 12-line clamp: output stays glanceable.
- Approval card: a decision surface, not a log line.

## Follow-ups

- Chat exec calls (`ToolCallCard`) stay on the boxed shell. Applying this line there is a separate change.
- Per-call `+N −M` is not on `tool_completed`. It waits on a per-call diffstat on the wire or a reducer join from `file_changed`.

## Validation

- `pnpm vitest run src/code` — 142 passed
- `pnpm vitest run` — 1162 passed
- `pnpm exec tsc --noEmit` passed

## Compatibility and risk

None on the wire. `startedAt` and `durationMs` are in-memory on the tool item. Replay leaves them null so a reopened session does not invent a duration.

## Tests deleted

- `it("renders the harness payload rather than a paraphrase")` — the approval card no longer leads with raw JSON.
- `expect(screen.getByText(/"tool_name": "Write"/)).toBeInTheDocument()` — asserted the Write payload was visible by default.
- `expect(screen.getByText(/"file_path": "\/workspace\/probe.txt"/)).toBeInTheDocument()` — asserted the same payload's path field was visible by default.
- `getByRole("status", { name: "Bash succeeded" })` — the line is labeled by the constant verb, not the harness tool name.