### PR TITLE
feat(desktop): theme the code terminal from app tokens and add keyboard resize

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -10,6 +10,7 @@ import {
 const REVIEW_SIDEBAR_OPEN_KEY = "tidebreak.code-review-sidebar-open";
 const LAST_CREATE_KEY = "tidebreak.code-last-create";
 const WORKSPACE_SORT_KEY = "tidebreak.code-workspace-sort";
+const TERMINAL_DRAWER_HEIGHTS_KEY = "tidebreak.code-terminal-drawer-heights";
 
 /** What the reader picked the last time they created a workspace. */
 export type CodeCreateDefaults = {
@@ -83,6 +84,37 @@ function storeWorkspaceSort(mode: WorkspaceSortMode): void {
   }
 }
 
+function readStoredTerminalDrawerHeights(): Record<string, number> {
+  try {
+    const raw = window.localStorage.getItem(TERMINAL_DRAWER_HEIGHTS_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const heights: Record<string, number> = {};
+    for (const [workspaceId, value] of Object.entries(
+      parsed as Record<string, unknown>,
+    )) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        heights[workspaceId] = value;
+      }
+    }
+    return heights;
+  } catch {
+    return {};
+  }
+}
+
+function storeTerminalDrawerHeights(heights: Record<string, number>): void {
+  try {
+    window.localStorage.setItem(
+      TERMINAL_DRAWER_HEIGHTS_KEY,
+      JSON.stringify(heights),
+    );
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
 /**
  * Code mode's dialog and chrome state, held outside the components that draw it.
  *
@@ -93,7 +125,8 @@ function storeWorkspaceSort(mode: WorkspaceSortMode): void {
  * button that opens it.
  *
  * The review rail is the same kind of chrome as the left sidebar: it is not
- * a URL, and a reload should not forget whether it was showing.
+ * a URL, and a reload should not forget whether it was showing. Terminal
+ * drawer height is the same kind of chrome, remembered per workspace.
  *
  * `lastCreate` is the tie-breaker for the new-workspace dialog's defaults.
  * The catalog answers "what did you work on last" for anyone with a
@@ -108,6 +141,8 @@ export type CodeUiStore = {
   reviewSidebarOpen: boolean;
   workspaceSortMode: WorkspaceSortMode;
   lastCreate: CodeCreateDefaults | null;
+  /** Per-workspace terminal drawer height, remembered across reloads. */
+  terminalDrawerHeights: Record<string, number>;
   /**
    * Ask for a workspace, from a repo page or from anywhere in code mode.
    *
@@ -123,6 +158,7 @@ export type CodeUiStore = {
   setWorkspaceSortMode: (mode: WorkspaceSortMode) => void;
   /** Record a successful create so the next dialog opens on the same choices. */
   rememberCreate: (defaults: CodeCreateDefaults) => void;
+  setTerminalDrawerHeight: (workspaceId: string, height: number) => void;
 };
 
 export const useCodeUiStore = create<CodeUiStore>()((set) => ({
@@ -132,6 +168,7 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   reviewSidebarOpen: readStoredReviewSidebarOpen(),
   workspaceSortMode: readStoredWorkspaceSort(),
   lastCreate: readStoredCreateDefaults(),
+  terminalDrawerHeights: readStoredTerminalDrawerHeights(),
   startNewWorkspace: (repoId) => {
     const { repos } = useCodeCatalogStore.getState();
     if (repos.length === 0) {
@@ -163,5 +200,15 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   rememberCreate: (defaults) => {
     storeCreateDefaults(defaults);
     set({ lastCreate: defaults });
+  },
+  setTerminalDrawerHeight: (workspaceId, height) => {
+    set((state) => {
+      const terminalDrawerHeights = {
+        ...state.terminalDrawerHeights,
+        [workspaceId]: height,
+      };
+      storeTerminalDrawerHeights(terminalDrawerHeights);
+      return { terminalDrawerHeights };
+    });
   },
 }));

--- a/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.dom.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useCodeUiStore } from "./CodeUiStore";
+import {
+  DEFAULT_TERMINAL_DRAWER_HEIGHT,
+  TerminalDrawer,
+} from "./TerminalDrawer";
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    options = {};
+    write(_data: string, cb?: () => void) {
+      cb?.();
+    }
+    loadAddon() {}
+    open() {}
+    dispose() {}
+    onData() {
+      return { dispose() {} };
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}));
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+const HEIGHTS_KEY = "tidebreak.code-terminal-drawer-heights";
+
+const client = {
+  listCodeTerminals: vi.fn().mockResolvedValue([]),
+  createCodeTerminal: vi.fn().mockResolvedValue({
+    id: "term-1",
+    workspace_id: "ws-1",
+    cols: 80,
+    rows: 24,
+    ended: false,
+    created_at: "2026-08-15T12:00:00.000Z",
+  }),
+  readCodeTerminal: vi.fn().mockResolvedValue({
+    id: "term-1",
+    workspace_id: "ws-1",
+    bytes: "",
+    cursor: 0,
+    overflow: false,
+    truncated: false,
+    ended: false,
+  }),
+  writeCodeTerminal: vi.fn(),
+  resizeCodeTerminal: vi.fn(),
+};
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.removeItem(HEIGHTS_KEY);
+  useCodeUiStore.setState({ terminalDrawerHeights: {} });
+});
+
+describe("TerminalDrawer", () => {
+  it("resizes from the keyboard and persists the height per workspace", async () => {
+    const user = userEvent.setup();
+    render(
+      <TerminalDrawer
+        client={client as never}
+        workspaceId="ws-1"
+        onClose={() => {}}
+      />,
+    );
+
+    const separator = screen.getByRole("separator", { name: "Resize terminal" });
+    expect(separator).toHaveAttribute(
+      "aria-valuenow",
+      String(DEFAULT_TERMINAL_DRAWER_HEIGHT),
+    );
+    expect(separator).toHaveAttribute("tabindex", "0");
+
+    separator.focus();
+    await user.keyboard("{ArrowUp}");
+
+    const taller = DEFAULT_TERMINAL_DRAWER_HEIGHT + 32;
+    expect(separator).toHaveAttribute("aria-valuenow", String(taller));
+    expect(useCodeUiStore.getState().terminalDrawerHeights["ws-1"]).toBe(taller);
+    expect(window.localStorage.getItem(HEIGHTS_KEY)).toBe(
+      JSON.stringify({ "ws-1": taller }),
+    );
+
+    await user.keyboard("{ArrowDown}");
+    expect(separator).toHaveAttribute(
+      "aria-valuenow",
+      String(DEFAULT_TERMINAL_DRAWER_HEIGHT),
+    );
+  });
+
+  it("restores the persisted height for the workspace", () => {
+    window.localStorage.setItem(
+      HEIGHTS_KEY,
+      JSON.stringify({ "ws-1": 336, "ws-2": 176 }),
+    );
+    useCodeUiStore.setState({
+      terminalDrawerHeights: { "ws-1": 336, "ws-2": 176 },
+    });
+
+    render(
+      <TerminalDrawer
+        client={client as never}
+        workspaceId="ws-1"
+        onClose={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByRole("separator", { name: "Resize terminal" }),
+    ).toHaveAttribute("aria-valuenow", "336");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.tsx
@@ -4,18 +4,24 @@ import { SquareTerminal, X } from "lucide-react";
 import type { ApiClient } from "../api/client";
 import { Button } from "@/components/ui/button";
 import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useCodeUiStore } from "./CodeUiStore";
 import { TerminalPane } from "./TerminalPane";
 
-const DEFAULT_HEIGHT = 240;
-const MIN_HEIGHT = 140;
-const MAX_HEIGHT = 560;
+export const DEFAULT_TERMINAL_DRAWER_HEIGHT = 240;
+export const MIN_TERMINAL_DRAWER_HEIGHT = 140;
+export const MAX_TERMINAL_DRAWER_HEIGHT = 560;
+const HEIGHT_STEP = 32;
+const REVEAL_MS = 140;
+
+type RevealPhase = "pre" | "in" | "open" | "out";
 
 /**
  * Auxiliary shell as a bottom drawer under the conversation.
  *
- * The PTY is the same ephemeral surface as before; only where it sits
- * changed. Height is local to this mount — a reload starts at the default
- * again, which matches terminals that do not survive a restart.
+ * Height is remembered per workspace so a reopen matches the last size.
+ * Open and close clip the reserved band in 140ms; the xterm host stays at
+ * that height so streamed output does not reflow the transcript.
  */
 export function TerminalDrawer({
   client,
@@ -28,15 +34,27 @@ export function TerminalDrawer({
   shortcutHint?: string;
   onClose: () => void;
 }) {
-  const [height, setHeight] = useState(DEFAULT_HEIGHT);
+  const storedHeight = useCodeUiStore(
+    (state) => state.terminalDrawerHeights[workspaceId],
+  );
+  const setTerminalDrawerHeight = useCodeUiStore(
+    (state) => state.setTerminalDrawerHeight,
+  );
+  const height = clampDrawerHeight(
+    storedHeight ?? DEFAULT_TERMINAL_DRAWER_HEIGHT,
+  );
   const dragRef = useRef<{ startY: number; startHeight: number } | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
+  const [phase, setPhase] = useState<RevealPhase>(() =>
+    prefersReducedMotion() ? "open" : "pre",
+  );
 
   useEffect(() => {
     function onMove(event: PointerEvent) {
       const drag = dragRef.current;
       if (!drag) return;
       const next = drag.startHeight + (drag.startY - event.clientY);
-      setHeight(Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, next)));
+      setTerminalDrawerHeight(workspaceId, clampDrawerHeight(next));
     }
     function onUp() {
       dragRef.current = null;
@@ -47,43 +65,115 @@ export function TerminalDrawer({
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
     };
+  }, [setTerminalDrawerHeight, workspaceId]);
+
+  useEffect(() => {
+    if (phase !== "pre") return;
+    const frame = requestAnimationFrame(() => setPhase("in"));
+    return () => cancelAnimationFrame(frame);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== "in") return;
+    const timer = window.setTimeout(() => setPhase("open"), REVEAL_MS);
+    return () => window.clearTimeout(timer);
+  }, [phase]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current != null) {
+        window.clearTimeout(closeTimerRef.current);
+      }
+    };
   }, []);
+
+  function applyHeight(next: number) {
+    setTerminalDrawerHeight(workspaceId, clampDrawerHeight(next));
+  }
+
+  function hide() {
+    if (prefersReducedMotion() || phase === "pre") {
+      onClose();
+      return;
+    }
+    setPhase("out");
+    closeTimerRef.current = window.setTimeout(onClose, REVEAL_MS);
+  }
+
+  const expanded = phase === "in" || phase === "open";
+  const transitioning = phase !== "open";
 
   return (
     <aside
-      className="flex shrink-0 flex-col overflow-hidden border-t"
-      style={{ height }}
+      className={cn(
+        "shrink-0 overflow-hidden border-t",
+        transitioning &&
+          "transition-[max-height] duration-[140ms] ease-out motion-reduce:transition-none",
+      )}
+      style={{ maxHeight: expanded ? height : 0 }}
       aria-label="Terminal"
       data-testid="terminal-drawer"
     >
-      <div
-        role="separator"
-        aria-orientation="horizontal"
-        aria-label="Resize terminal"
-        className="hover:bg-muted flex h-1.5 shrink-0 cursor-ns-resize items-center justify-center"
-        onPointerDown={(event) => {
-          event.preventDefault();
-          dragRef.current = { startY: event.clientY, startHeight: height };
-        }}
-      >
-        <span className="bg-border h-0.5 w-8 rounded-full" />
-      </div>
-      <header className="flex h-8 shrink-0 items-center gap-2 px-3">
-        <SquareTerminal className="text-muted-foreground size-3.5 shrink-0" />
-        <h2 className="min-w-0 flex-1 truncate text-xs font-medium">Terminal</h2>
-        <WithTooltip label={shortcutHint ? `Hide terminal ${shortcutHint}` : "Hide terminal"}>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label="Hide terminal"
-            onClick={onClose}
+      <div className="flex flex-col overflow-hidden" style={{ height }}>
+        <div
+          role="separator"
+          tabIndex={0}
+          aria-orientation="horizontal"
+          aria-label="Resize terminal"
+          aria-valuemin={MIN_TERMINAL_DRAWER_HEIGHT}
+          aria-valuemax={MAX_TERMINAL_DRAWER_HEIGHT}
+          aria-valuenow={height}
+          className="hover:bg-muted focus-visible:bg-muted flex h-1.5 shrink-0 cursor-ns-resize items-center justify-center focus-visible:outline-none"
+          onPointerDown={(event) => {
+            event.preventDefault();
+            dragRef.current = { startY: event.clientY, startHeight: height };
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "ArrowUp") {
+              event.preventDefault();
+              applyHeight(height + HEIGHT_STEP);
+            } else if (event.key === "ArrowDown") {
+              event.preventDefault();
+              applyHeight(height - HEIGHT_STEP);
+            }
+          }}
+        >
+          <span className="bg-border h-0.5 w-8 rounded-full" />
+        </div>
+        <header className="flex h-8 shrink-0 items-center gap-2 px-3">
+          <SquareTerminal className="text-muted-foreground size-3.5 shrink-0" />
+          <h2 className="min-w-0 flex-1 truncate text-xs font-medium">Terminal</h2>
+          <WithTooltip
+            label={shortcutHint ? `Hide terminal ${shortcutHint}` : "Hide terminal"}
           >
-            <X />
-          </Button>
-        </WithTooltip>
-      </header>
-      <TerminalPane client={client} workspaceId={workspaceId} hideHeader />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Hide terminal"
+              onClick={hide}
+            >
+              <X />
+            </Button>
+          </WithTooltip>
+        </header>
+        <TerminalPane client={client} workspaceId={workspaceId} hideHeader />
+      </div>
     </aside>
+  );
+}
+
+export function clampDrawerHeight(value: number): number {
+  return Math.min(
+    MAX_TERMINAL_DRAWER_HEIGHT,
+    Math.max(MIN_TERMINAL_DRAWER_HEIGHT, Math.round(value)),
+  );
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
@@ -5,14 +5,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { TerminalPane } from "./TerminalPane";
 
 const written: string[] = [];
-const terminals: Array<{ disposed: boolean; write: (data: string, cb?: () => void) => void }> =
-  [];
+const terminals: Array<{
+  disposed: boolean;
+  options: { theme?: Record<string, string> };
+  write: (data: string, cb?: () => void) => void;
+}> = [];
 
 vi.mock("@xterm/xterm", () => ({
   Terminal: class MockTerminal {
     cols = 80;
     rows = 24;
     disposed = false;
+    options: { theme?: Record<string, string> };
     write(data: string, cb?: () => void) {
       written.push(data);
       cb?.();
@@ -25,7 +29,8 @@ vi.mock("@xterm/xterm", () => ({
     onData() {
       return { dispose() {} };
     }
-    constructor() {
+    constructor(options?: { theme?: Record<string, string> }) {
+      this.options = { ...options };
       terminals.push(this);
     }
   },
@@ -43,6 +48,8 @@ afterEach(() => {
   cleanup();
   written.length = 0;
   terminals.length = 0;
+  vi.restoreAllMocks();
+  document.documentElement.classList.remove("dark");
 });
 
 function encode(text: string): string {
@@ -151,5 +158,97 @@ describe("TerminalPane", () => {
     expect(await screen.findByTestId("terminal-ended")).toHaveTextContent(
       "Shell ended.",
     );
+  });
+
+  it("builds the xterm theme from CSS tokens and reapplies it when the root class flips", async () => {
+    const light: Record<string, string> = {
+      "--background": "#fafafa",
+      "--foreground": "#18181b",
+      "--muted-foreground": "#71717a",
+      "--success": "#16a34a",
+      "--success-foreground": "#14532d",
+      "--warning": "#ca8a04",
+      "--warning-foreground": "#713f12",
+      "--critical": "#dc2626",
+      "--critical-foreground": "#7f1d1d",
+      "--info": "#2563eb",
+      "--info-foreground": "#1e3a8a",
+    };
+    const dark: Record<string, string> = {
+      "--background": "#18181b",
+      "--foreground": "#e4e4e7",
+      "--muted-foreground": "#a1a1aa",
+      "--success": "#4ade80",
+      "--success-foreground": "#bbf7d0",
+      "--warning": "#facc15",
+      "--warning-foreground": "#fef08a",
+      "--critical": "#f87171",
+      "--critical-foreground": "#fecaca",
+      "--info": "#60a5fa",
+      "--info-foreground": "#bfdbfe",
+    };
+    const original = window.getComputedStyle;
+    vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
+      if (element === document.documentElement) {
+        const tokens = document.documentElement.classList.contains("dark")
+          ? dark
+          : light;
+        return {
+          getPropertyValue: (name: string) => tokens[name] ?? "",
+        } as CSSStyleDeclaration;
+      }
+      return original.call(window, element);
+    });
+
+    const client = {
+      listCodeTerminals: vi.fn().mockResolvedValue([]),
+      createCodeTerminal: vi.fn().mockResolvedValue({
+        id: "term-1",
+        workspace_id: "ws-1",
+        cols: 80,
+        rows: 24,
+        ended: false,
+        created_at: "2026-08-15T12:00:00.000Z",
+      }),
+      readCodeTerminal: vi.fn().mockResolvedValue({
+        id: "term-1",
+        workspace_id: "ws-1",
+        bytes: "",
+        cursor: 0,
+        overflow: false,
+        truncated: false,
+        ended: false,
+      }),
+      writeCodeTerminal: vi.fn(),
+      resizeCodeTerminal: vi.fn(),
+    };
+
+    document.documentElement.classList.remove("dark");
+    render(<TerminalPane client={client} workspaceId="ws-1" />);
+    await waitFor(() => expect(client.createCodeTerminal).toHaveBeenCalled());
+
+    expect(screen.getByTestId("terminal-host")).toHaveAttribute(
+      "aria-label",
+      "Terminal output",
+    );
+    expect(terminals[0]?.options.theme).toMatchObject({
+      background: "#fafafa",
+      foreground: "#18181b",
+      red: "#dc2626",
+      green: "#16a34a",
+      yellow: "#ca8a04",
+      blue: "#2563eb",
+    });
+
+    document.documentElement.classList.add("dark");
+    await waitFor(() =>
+      expect(terminals[0]?.options.theme).toMatchObject({
+        background: "#18181b",
+        foreground: "#e4e4e7",
+        red: "#f87171",
+        green: "#4ade80",
+      }),
+    );
+    document.documentElement.classList.remove("dark");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -17,6 +17,148 @@ const STALL_MS = 3_000;
 const TRUNCATION_TEXT = "[output truncated]";
 
 /**
+ * xterm theme built from the live CSS tokens on `:root`.
+ *
+ * Status quads supply the ANSI hues. Magenta has no token of its own, so it
+ * reuses the critical foreground; cyan reuses info.
+ */
+export type XtermTheme = {
+  background: string;
+  foreground: string;
+  cursor: string;
+  cursorAccent: string;
+  black: string;
+  red: string;
+  green: string;
+  yellow: string;
+  blue: string;
+  magenta: string;
+  cyan: string;
+  white: string;
+  brightBlack: string;
+  brightRed: string;
+  brightGreen: string;
+  brightYellow: string;
+  brightBlue: string;
+  brightMagenta: string;
+  brightCyan: string;
+  brightWhite: string;
+};
+
+export function readXtermTheme(
+  style: CSSStyleDeclaration = getComputedStyle(document.documentElement),
+): XtermTheme {
+  const token = (name: string, fallback: string) =>
+    resolveCssColor(style.getPropertyValue(name).trim() || fallback);
+
+  const background = token("--background", "#18181b");
+  const foreground = token("--foreground", "#e4e4e7");
+  const muted = token("--muted-foreground", "#71717a");
+  const success = token("--success", "#22c55e");
+  const successFg = token("--success-foreground", "#86efac");
+  const warning = token("--warning", "#eab308");
+  const warningFg = token("--warning-foreground", "#fde047");
+  const critical = token("--critical", "#ef4444");
+  const criticalFg = token("--critical-foreground", "#fca5a5");
+  const info = token("--info", "#3b82f6");
+  const infoFg = token("--info-foreground", "#93c5fd");
+
+  return {
+    background,
+    foreground,
+    cursor: foreground,
+    cursorAccent: background,
+    black: muted,
+    red: critical,
+    green: success,
+    yellow: warning,
+    blue: info,
+    magenta: criticalFg,
+    cyan: infoFg,
+    white: foreground,
+    brightBlack: muted,
+    brightRed: criticalFg,
+    brightGreen: successFg,
+    brightYellow: warningFg,
+    brightBlue: infoFg,
+    brightMagenta: criticalFg,
+    brightCyan: infoFg,
+    brightWhite: foreground,
+  };
+}
+
+/**
+ * Turn a CSS color (including `oklch(...)`) into something the xterm canvas
+ * renderer can paint. A live element's computed `color` is the first try;
+ * a 1×1 canvas `fillStyle` assignment is the fallback.
+ */
+export function resolveCssColor(value: string): string {
+  if (!value) return value;
+  const already = normalizeCssColor(value);
+  if (already) return already;
+  const computed = resolveViaComputedStyle(value);
+  if (computed) return computed;
+  const painted = resolveViaCanvas(value);
+  if (painted) return painted;
+  return value;
+}
+
+function resolveViaComputedStyle(value: string): string | null {
+  if (typeof document === "undefined") return null;
+  const probe = document.createElement("span");
+  probe.style.color = value;
+  document.documentElement.appendChild(probe);
+  const computed = getComputedStyle(probe).color.trim();
+  probe.remove();
+  return normalizeCssColor(computed);
+}
+
+function resolveViaCanvas(value: string): string | null {
+  if (typeof document === "undefined") return null;
+  const canvas = document.createElement("canvas");
+  canvas.width = 1;
+  canvas.height = 1;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.fillStyle = "#010101";
+  ctx.fillStyle = value;
+  const filled = String(ctx.fillStyle);
+  if (filled === "#010101") return null;
+  const fromFill = normalizeCssColor(filled);
+  if (fromFill) return fromFill;
+  // Modern syntax such as oklch() survives as the fillStyle string in
+  // Chromium. Paint a pixel and read it back so xterm always gets #rrggbb.
+  ctx.fillRect(0, 0, 1, 1);
+  const pixel = ctx.getImageData(0, 0, 1, 1).data;
+  if (pixel[3] === 0) return null;
+  return toHex(String(pixel[0]), String(pixel[1]), String(pixel[2]));
+}
+
+function normalizeCssColor(color: string): string | null {
+  if (!color) return null;
+  if (color.startsWith("#") && (color.length === 7 || color.length === 4)) {
+    return color;
+  }
+  const comma = color.match(
+    /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*[\d.]+\s*)?\)$/i,
+  );
+  if (comma) return toHex(comma[1], comma[2], comma[3]);
+  const space = color.match(
+    /^rgba?\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*[\d.%]+\s*)?\)$/i,
+  );
+  if (space) return toHex(space[1], space[2], space[3]);
+  return null;
+}
+
+function toHex(r: string, g: string, b: string): string {
+  const byte = (part: string) =>
+    Math.max(0, Math.min(255, Math.round(Number(part))))
+      .toString(16)
+      .padStart(2, "0");
+  return `#${byte(r)}${byte(g)}${byte(b)}`;
+}
+
+/**
  * Ephemeral renderer over the cursor-pull terminal API.
  *
  * Created on open, disposed on close. Reopening re-fetches recent ring bytes
@@ -61,11 +203,7 @@ export function TerminalPane({
       convertEol: true,
       fontSize: 13,
       cursorBlink: true,
-      theme: {
-        background: "#18181b",
-        foreground: "#e4e4e7",
-        cursor: "#e4e4e7",
-      },
+      theme: readXtermTheme(),
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
@@ -111,7 +249,14 @@ export function TerminalPane({
       typeof ResizeObserver === "undefined" ? null : new ResizeObserver(onResize);
     observer?.observe(host);
 
+    const root = document.documentElement;
+    const themeObserver = new MutationObserver(() => {
+      term.options.theme = readXtermTheme();
+    });
+    themeObserver.observe(root, { attributes: true, attributeFilter: ["class"] });
+
     return () => {
+      themeObserver.disconnect();
       window.removeEventListener("resize", onResize);
       observer?.disconnect();
       host.removeEventListener("keydown", onKeyDownCapture, true);
@@ -254,7 +399,12 @@ export function TerminalPane({
         </div>
       )}
       {error && <p className="text-critical px-3 py-2 text-sm">{error}</p>}
-      <div ref={hostRef} className="min-h-0 flex-1" data-testid="terminal-host" />
+      <div
+        ref={hostRef}
+        className="min-h-0 flex-1"
+        data-testid="terminal-host"
+        aria-label="Terminal output"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The code-mode terminal now follows the app theme and is resizable from the keyboard.

xterm used hardcoded zinc hex values, so the pane stayed dark-zinc in light mode and ignored theme flips. The drawer height lived in `useState` and reset on every remount, and the separator was pointer-only.

## Theme

`readXtermTheme()` reads `--background`, `--foreground`, `--muted-foreground`, and the status quads from `getComputedStyle(document.documentElement)`. ANSI red/green/yellow/blue come from `--critical` / `--success` / `--warning` / `--info`. Magenta has no token, so it reuses the critical foreground; cyan reuses info.

A `MutationObserver` on `document.documentElement`'s `class` reapplies `terminal.options.theme` when `theme.ts` toggles `.dark`.

### oklch in the xterm renderer

Headless Chrome 151 (macOS) accepts `oklch(...)` as a canvas `fillStyle` and paints the correct pixel. `getComputedStyle` still returns the `oklch(...)` string, not `rgb()`. xterm's parser uses that same canvas path, so oklch would work in this Chromium. WKWebView was not available in this checkout.

`resolveCssColor()` still converts tokens to `#rrggbb` before they reach xterm: hex and `rgb()` pass through, other functions go through a live element's computed `color`, then a 1×1 canvas `fillStyle` plus `getImageData` when the fill style stays an `oklch(...)` string. That keeps the renderer on hex if a WebKit build rejects oklch.

## Drawer

The separator is focusable (`tabIndex={0}`) with `role="separator"` and `aria-valuenow` / `min` / `max`. ArrowUp / ArrowDown change height by 32px. Height is stored per workspace in `CodeUiStore` (`tidebreak.code-terminal-drawer-heights` in localStorage).

Open and close clip the reserved band with a 140ms ease-out `max-height` transition. The inner xterm host keeps a fixed height so streamed output does not reflow. `prefers-reduced-motion` skips the reveal.

## Chrome added

| Element | Need it answers |
| --- | --- |
| Focusable resize separator | Keyboard-first: the pointer drag already existed; ArrowUp / ArrowDown is the key path. |
| `aria-label` on the xterm host | The host is an unlabeled region once the drawer header names the surface. |

No second accent, gradient, or shadow. Status color comes only from the existing quads.

## Tests

- Theme derives from stubbed CSS variables and updates when the root class flips (`TerminalPane.dom.test.tsx`).
- Keyboard resize changes `aria-valuenow` and persists per workspace (`TerminalDrawer.dom.test.tsx`).

`pnpm vitest run src/code`, full `pnpm vitest run`, and `pnpm build` passed locally after rebasing onto `origin/main`.