### PR TITLE
feat(desktop): finish the code workspace chrome and composer effort control

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -31,6 +31,25 @@ describe("CodeComposer", () => {
     expect(screen.getByRole("button", { name: "Permissions: Ask" })).toBeInTheDocument();
   });
 
+  it("explains why the session permission mode cannot change", async () => {
+    const user = userEvent.setup();
+    render(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Permissions: Ask" });
+    expect(trigger).toBeDisabled();
+    await user.hover(trigger.parentElement!);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Set when the session started — start a new session to change it",
+    );
+  });
+
   it("queues a follow-up written while a turn is running", async () => {
     const onSend = vi.fn().mockResolvedValue(QUEUED);
     render(

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -27,6 +27,7 @@ import {
   groupCodeModelOptions,
   type CodeModelOption,
   PERMISSION_MODE_UNAVAILABLE_REASON,
+  SESSION_PERMISSION_MODE_LOCKED,
 } from "./labels";
 
 const MODES: CodePermissionMode[] = ["plan", "ask", "auto", "allow"];
@@ -43,11 +44,12 @@ export function PermissionModePicker({
   onChange?: (mode: CodePermissionMode) => void;
   scopeKey?: string;
 }) {
-  return (
+  const locked = !onChange;
+  const menu = (
     <PermissionModeMenu
       scopeKey={scopeKey}
       value={value}
-      disabled={!onChange}
+      disabled={locked}
       onChange={async (mode: PermissionMode) => {
         if (!availableModes.includes(mode)) {
           throw new Error(PERMISSION_MODE_UNAVAILABLE_REASON);
@@ -55,6 +57,16 @@ export function PermissionModePicker({
         onChange?.(mode);
       }}
     />
+  );
+  if (!locked) return menu;
+  // Disabled buttons drop pointer events, so the tooltip has to sit on a
+  // wrapper the reader can still hover and focus.
+  return (
+    <WithTooltip label={SESSION_PERMISSION_MODE_LOCKED}>
+      <span className="inline-flex">
+        {menu}
+      </span>
+    </WithTooltip>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -250,6 +250,10 @@ export function CodeSidebar() {
                     commands={workspaceCommands({
                       hasPr: Boolean(pr),
                       archived: workspace.status === "archived",
+                      hasSession: Boolean(sessions[workspace.id]),
+                      attentionPinned:
+                        (digest?.attention ?? sessions[workspace.id]?.attention)
+                          ?.state.type === "manual",
                     })}
                     onOpen={() =>
                       void navigate({
@@ -262,6 +266,7 @@ export function CodeSidebar() {
                         workspace,
                         title: digest?.title ?? workspace.title,
                         pr,
+                        session: sessions[workspace.id],
                       })
                     }
                   />

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -13,6 +13,7 @@ import {
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { PanelSearch } from "@/panel/panelUrl";
+import { toast } from "sonner";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { resetCodeSessionRegistry } from "./CodeSessionRegistry";
 import { useCodeUiStore } from "./CodeUiStore";
@@ -72,7 +73,7 @@ const REPO = {
   display_name: "app",
   default_base_ref: "main",
   branch_prefix: "tidebreak",
-  quick_actions: [],
+  quick_actions: [] as { name: string; command: string; auto_run_on_create: boolean }[],
   created_at: "2026-08-15T00:00:00.000Z",
 };
 
@@ -121,6 +122,20 @@ function makeClient() {
     archiveCodeWorkspace: vi.fn(async () => ({
       ...WORKSPACE,
       status: "archived" as const,
+    })),
+    patchCodeWorkspace: vi.fn(async (id: string, body: { title: string }) => ({
+      ...WORKSPACE,
+      id,
+      title: body.title,
+    })),
+    setCodeAttention: vi.fn(async () => SESSION),
+    runCodeWorkspaceAction: vi.fn(async () => ({
+      name: "lint",
+      success: false,
+      exit_code: 1,
+      stdout: "oops",
+      stderr: "failed",
+      timed_out: false,
     })),
     getCodeWorkspacePr: vi.fn(async () => ({
       dirty: false,
@@ -309,6 +324,83 @@ describe("CodeWorkspacePage", () => {
     expect(seam).toHaveTextContent("2 files +42 −7");
   });
 
+  it("shows header skeleton bars instead of Workspace and a repo UUID", async () => {
+    const client = makeClient();
+    client.getCodeWorkspace.mockImplementation(() => new Promise(() => {}));
+    await mountWorkspace(client);
+
+    expect(screen.getByTestId("workspace-header-skeleton")).toBeInTheDocument();
+    expect(screen.queryByText("Workspace")).not.toBeInTheDocument();
+    expect(screen.queryByText("repo-1")).not.toBeInTheDocument();
+  });
+
+  it("marks unread engine events with a warning dot", async () => {
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([
+      { ...SESSION, unrecognized_event_count: 3 },
+    ]);
+    await mountWorkspace(client);
+
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("unrecognized-event-dot")).toHaveAttribute(
+      "aria-label",
+      "3 unread engine events",
+    );
+  });
+
+  it("toggles the review sidebar from the header control", async () => {
+    const client = makeClient();
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("code-inspector")).toBeInTheDocument();
+    expect(useCodeUiStore.getState().reviewSidebarOpen).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: "Review sidebar" }));
+
+    expect(useCodeUiStore.getState().reviewSidebarOpen).toBe(false);
+    expect(screen.queryByTestId("code-inspector")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a quick-action exit code on the result toast", async () => {
+    const client = makeClient();
+    client.getCodeRepo.mockResolvedValue({
+      ...REPO,
+      quick_actions: [
+        { name: "lint", command: "pnpm lint", auto_run_on_create: false },
+      ],
+    });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Fix login/ })).toHaveTextContent(
+        "app",
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Run: lint" }));
+
+    await waitFor(() =>
+      expect(client.runCodeWorkspaceAction).toHaveBeenCalledWith("ws-1", "lint"),
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      "lint exited 1",
+      expect.objectContaining({
+        action: expect.objectContaining({ label: "View output" }),
+      }),
+    );
+  });
+
   it("leaves the archived workspace for its repo", async () => {
     const client = makeClient();
     const { router } = await mountWorkspace(client);
@@ -318,7 +410,8 @@ describe("CodeWorkspacePage", () => {
       await screen.findByRole("heading", { name: /Fix login/ }),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Archive" }));
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Archive" }));
     const confirmation = await screen.findByRole("alertdialog");
     await user.click(
       within(confirmation).getByRole("button", { name: "Archive" }),

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
-import { ArrowDown, SquareTerminal } from "lucide-react";
+import { ArrowDown, PanelRight, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
-import { archiveForceKind, type ApiClient } from "../api/client";
+import type { ApiClient } from "../api/client";
 import type {
   Attention,
   CodeApprovalSnapshot,
@@ -15,9 +14,10 @@ import type {
   ModelInfo,
 } from "../api/types";
 import { useApp } from "@/AppContext";
+import { copyPlainText, scheduleCopyStateReset } from "@/ClipboardCopyButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { useConfirm } from "@/components/ConfirmDialog";
+import { Skeleton } from "@/components/ui/skeleton";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { PanelLayout } from "@/panel/PanelLayout";
 import type { PanelContent } from "@/panel/panelTypes";
@@ -58,13 +58,19 @@ import { TerminalDrawer } from "./TerminalDrawer";
 import { TerminalPane } from "./TerminalPane";
 import { useCodeContentRevision } from "./useLiveContent";
 import {
+  WorkspaceOverflowMenu,
+  useWorkspaceCardCommands,
+  workspaceHeaderCommands,
+} from "./workspaceActions";
+import { middleTruncate } from "./workspaceCards";
+import {
   createPermissionModes,
   fenceReasonText,
   gatewayCodeModels,
   harnessCodeModels,
   harnessHonorsTurnModel,
-  HARNESS_LABELS,
   LIFECYCLE_LABELS,
+  sessionLifecycleTooltip,
 } from "./labels";
 
 /**
@@ -87,13 +93,13 @@ export function CodeWorkspacePage({ workspaceId }: { workspaceId: string }) {
 
 function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const { client, models, defaultModelKey } = useApp();
-  const { confirm, dialog } = useConfirm();
-  const navigate = useNavigate();
   const catalog = useCodeCatalogStore();
+  const { run, dialogs } = useWorkspaceCardCommands();
   const layout = useLayoutState();
   const { setLayout } = usePanelNav();
   const chrome = splitCodeChromeLayout(layout);
   const reviewSidebarOpen = useCodeUiStore((state) => state.reviewSidebarOpen);
+  const toggleReviewSidebar = useCodeUiStore((state) => state.toggleReviewSidebar);
   const shortcutHints = useCodeShortcutHints();
   const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(null);
   const [repo, setRepo] = useState<CodeRepoSnapshot | null>(null);
@@ -101,11 +107,15 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     catalog.sessionsByWorkspace[workspaceId] ?? null,
   );
   const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
   const [starting, setStarting] = useState(false);
   const [createMode, setCreateMode] = useState<CodePermissionMode | null>(null);
   const digest = useCodeUpdatesStore((state) => state.byWorkspace[workspaceId]);
   const setViewedWorkspace = useCodeUpdatesStore((state) => state.setViewedWorkspace);
   const contentRevision = useCodeContentRevision(session?.id ?? null, client);
+  const rememberedSession = useCodeCatalogStore(
+    (state) => state.sessionsByWorkspace[workspaceId] ?? null,
+  );
 
   useEffect(() => {
     setViewedWorkspace(workspaceId);
@@ -113,7 +123,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   }, [setViewedWorkspace, workspaceId]);
 
   useEffect(() => {
+    if (rememberedSession) setSession(rememberedSession);
+  }, [rememberedSession]);
+
+  useEffect(() => {
     let cancelled = false;
+    setError(null);
     void (async () => {
       try {
         const [next, sessions] = await Promise.all([
@@ -142,7 +157,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     return () => {
       cancelled = true;
     };
-  }, [client, workspaceId]);
+  }, [client, workspaceId, reloadToken]);
 
   async function startSession(
     harness: HarnessKind,
@@ -185,81 +200,46 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     }
   }
 
-  async function archive() {
-    if (!workspace) return;
-    const ok = await confirm({
-      title: "Archive this workspace?",
-      description:
-        "The worktree is removed. Commit, push, or create a pull request from the review sidebar first if you want to keep the work.",
-      confirmLabel: "Archive",
-      destructive: true,
-    });
-    if (!ok) return;
-    try {
-      await archiveWorkspace(client, workspace.id, false);
-    } catch (err) {
-      if (archiveForceKind(err)) {
-        const forced = await confirm({
-          title: "Discard leftover work?",
-          description: `${err instanceof Error ? err.message : String(err)} Commit and push from the review sidebar, or discard.`,
-          confirmLabel: "Discard and archive",
-          destructive: true,
-        });
-        if (!forced) return;
-        try {
-          await archiveWorkspace(client, workspace.id, true);
-        } catch (forceErr) {
-          toast.error(friendlyErrorMessage(forceErr, "Could not archive"));
-        }
-        return;
-      }
-      toast.error(friendlyErrorMessage(err, "Could not archive"));
-    }
-  }
-
-  async function archiveWorkspace(
-    api: ApiClient,
-    id: string,
-    force: boolean,
-  ) {
-    const archived = await api.archiveCodeWorkspace(id, force);
-    // The archived row stays in the catalog — the rail filters archived
-    // workspaces out and the repo page lists them with their status — but the
-    // session it held is gone with the worktree.
-    catalog.upsertWorkspace(archived);
-    catalog.forgetWorkspaceSession(id);
-    setWorkspace(archived);
-    toast.success("Workspace archived");
-    // This page is addressed by the workspace that was just archived, so
-    // staying here leaves the reader on a dead worktree. The repo lists it
-    // again, archived and labelled.
-    if (archived.repo_id) {
-      await navigate({
-        to: "/code/r/$repoId",
-        params: { repoId: archived.repo_id },
-        replace: true,
-      });
-    } else {
-      await navigate({ to: "/code", replace: true });
-    }
-  }
-
   const fenced =
     session?.lifecycle === "fenced" || session?.fence_reason !== undefined;
   const doctorHarnesses = catalog.doctor?.harnesses ?? [];
+  const title = digest?.title ?? workspace?.title;
+  const repoName = repo?.display_name;
+  const headerCommands = workspace
+    ? workspaceHeaderCommands({
+        archived: workspace.status === "archived",
+        hasSession: Boolean(session),
+        attentionPinned:
+          (digest?.attention ?? session?.attention)?.state.type === "manual",
+        quickActions: repo?.quick_actions ?? [],
+      })
+    : [];
 
   return (
     <>
-      {dialog}
+      {dialogs}
       <header className="flex h-12 shrink-0 items-center justify-between gap-3 border-b px-4">
         <div className="min-w-0">
-          <h1 className="flex min-w-0 items-baseline gap-2 text-sm font-medium">
-            <span className="truncate">
-              {digest?.title ?? workspace?.title ?? "Workspace"}
-            </span>
-            <span className="text-muted-foreground truncate text-xs font-normal">
-              {repo?.display_name ?? workspace?.repo_id}
-            </span>
+          <h1 className="flex min-w-0 items-center gap-2 text-sm font-medium">
+            {title ? (
+              <span className="truncate">{title}</span>
+            ) : error ? null : (
+              <span
+                data-testid="workspace-header-skeleton"
+                className="flex min-w-0 items-center gap-2"
+              >
+                <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-3 w-16" />
+              </span>
+            )}
+            {repoName && (
+              <span className="text-muted-foreground truncate text-xs font-normal">
+                {repoName}
+              </span>
+            )}
+            {workspace && (
+              <WorktreePathChip path={workspace.worktree_path} />
+            )}
           </h1>
         </div>
         <div className="flex items-center gap-2">
@@ -271,11 +251,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                 fallback={digest?.attention ?? session.attention}
               />
               <PendingApprovalBadge sessionId={session.id} client={client} />
-              <span className="text-muted-foreground text-xs">
-                {LIFECYCLE_LABELS[digest?.lifecycle ?? session.lifecycle]}
-                {" · "}
-                {HARNESS_LABELS[session.harness_kind]}
-              </span>
+              <SessionLifecycleMark
+                lifecycle={digest?.lifecycle ?? session.lifecycle}
+                harness={session.harness_kind}
+                version={session.harness_version}
+                unrecognizedEventCount={session.unrecognized_event_count}
+              />
             </>
           )}
           <WithTooltip
@@ -296,14 +277,53 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
               <SquareTerminal />
             </Button>
           </WithTooltip>
-          {workspace && workspace.status !== "archived" && (
-            <Button type="button" variant="ghost" size="xs" onClick={() => void archive()}>
-              Archive
+          <WithTooltip
+            label={
+              reviewSidebarOpen
+                ? `Hide review sidebar ${shortcutHints.review}`
+                : `Review sidebar ${shortcutHints.review}`
+            }
+          >
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-pressed={reviewSidebarOpen}
+              aria-label="Review sidebar"
+              onClick={() => toggleReviewSidebar()}
+            >
+              <PanelRight />
             </Button>
+          </WithTooltip>
+          {workspace && (
+            <WorkspaceOverflowMenu
+              commands={headerCommands}
+              onCommand={(command) =>
+                run(command.id, {
+                  workspace,
+                  title: title ?? workspace.title,
+                  session: session ?? undefined,
+                  actionName: command.actionName,
+                })
+              }
+            />
           )}
         </div>
       </header>
-      {error && <p className="text-critical px-4 py-2 text-sm">{error}</p>}
+      {error ? (
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-4">
+          <p className="text-muted-foreground max-w-sm text-center text-sm">
+            {error}
+          </p>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => setReloadToken((token) => token + 1)}
+          >
+            Retry
+          </Button>
+        </div>
+      ) : (
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           <PanelLayout
@@ -376,15 +396,17 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           />
         )}
       </div>
+      )}
     </>
   );
 }
 
-function useCodeShortcutHints(): { terminal: string } {
+function useCodeShortcutHints(): { terminal: string; review: string } {
   return useMemo(() => {
     const command = usesCommandModifier(navigator.userAgent);
     return {
       terminal: shortcutHint("toggle-code-terminal", command),
+      review: shortcutHint("toggle-code-review", command),
     };
   }, []);
 }
@@ -421,6 +443,96 @@ function SessionAttentionBadge({
   const store = useRegisteredCodeSession(sessionId, client);
   const live = store((state) => state.attention);
   return <AttentionBadge compact attention={live ?? fallback} />;
+}
+
+/**
+ * The engine dropped part of its own stream. Saying so where the session is
+ * read is the point of counting it at all — a silently degraded transcript
+ * looks exactly like a complete one (decision 0031). The count comes from the
+ * session row, so it settles at the end of a turn rather than mid-stream.
+ */
+function SessionLifecycleMark({
+  lifecycle,
+  harness,
+  version,
+  unrecognizedEventCount,
+}: {
+  lifecycle: CodeSessionSnapshot["lifecycle"];
+  harness: CodeSessionSnapshot["harness_kind"];
+  version?: string;
+  unrecognizedEventCount: number;
+}) {
+  const tooltip = sessionLifecycleTooltip({
+    lifecycle,
+    harness,
+    version,
+    unrecognizedEventCount,
+  });
+  return (
+    <WithTooltip label={tooltip}>
+      <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
+        {unrecognizedEventCount > 0 && (
+          <span
+            data-testid="unrecognized-event-dot"
+            className="bg-warning-foreground-muted inline-block size-2 shrink-0 rounded-full"
+            aria-label={`${unrecognizedEventCount} unread engine ${unrecognizedEventCount === 1 ? "event" : "events"}`}
+          />
+        )}
+        <span>{LIFECYCLE_LABELS[lifecycle]}</span>
+      </span>
+    </WithTooltip>
+  );
+}
+
+function WorktreePathChip({ path }: { path: string }) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
+    "idle",
+  );
+
+  useEffect(() => {
+    if (copyState === "idle") return;
+    return scheduleCopyStateReset(() => setCopyState("idle"));
+  }, [copyState]);
+
+  async function onCopy() {
+    try {
+      await copyPlainText(path);
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+  }
+
+  const label =
+    copyState === "copied"
+      ? "Copied"
+      : copyState === "failed"
+        ? "Copy failed"
+        : path;
+
+  return (
+    <>
+      <WithTooltip label={label}>
+        <button
+          type="button"
+          className="text-muted-foreground hover:bg-muted hover:text-foreground max-w-44 shrink truncate rounded-md px-1.5 py-0.5 font-mono text-[11px] motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out"
+          aria-label={
+            copyState === "idle" ? `Copy worktree path ${path}` : label
+          }
+          onClick={() => void onCopy()}
+        >
+          {middleTruncate(path, 28)}
+        </button>
+      </WithTooltip>
+      <span className="sr-only" role="status" aria-live="polite">
+        {copyState === "copied"
+          ? "Worktree path copied to clipboard."
+          : copyState === "failed"
+            ? "Worktree path could not be copied."
+            : ""}
+      </span>
+    </>
+  );
 }
 
 function PendingApprovalBadge({
@@ -461,12 +573,6 @@ function PendingApprovalBadge({
   );
 }
 
-/**
- * The engine dropped part of its own stream. Saying so where the session is
- * read is the point of counting it at all — a silently degraded transcript
- * looks exactly like a complete one (decision 0031). The count comes from the
- * session row, so it settles at the end of a turn rather than mid-stream.
- */
 function CodeSessionPane({
   session,
   client,

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -8,6 +8,7 @@ import {
   gatewayCodeModels,
   groupCodeModelOptions,
   harnessUnusableReason,
+  sessionLifecycleTooltip,
 } from "./labels";
 
 function caps(
@@ -18,6 +19,30 @@ function caps(
 ): ModeCaps {
   return { plan_mode, structured_approvals, auto_mode, allow_mode };
 }
+
+describe("sessionLifecycleTooltip", () => {
+  it("joins the harness version and unread engine events", () => {
+    expect(
+      sessionLifecycleTooltip({
+        lifecycle: "idle",
+        harness: "claude_code",
+        version: "2.1.233",
+        unrecognizedEventCount: 3,
+      }),
+    ).toBe(
+      "Idle · Claude Code 2.1.233 · 3 unread engine events — transcript may be incomplete",
+    );
+    expect(
+      sessionLifecycleTooltip({
+        lifecycle: "running",
+        harness: "codex",
+        unrecognizedEventCount: 1,
+      }),
+    ).toBe(
+      "Running · Codex CLI · 1 unread engine event — transcript may be incomplete",
+    );
+  });
+});
 
 describe("create-time permission mode", () => {
   it("defaults to the most autonomous mode the engine honors", () => {

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -41,6 +41,30 @@ export const LIFECYCLE_LABELS: Record<CodeSessionLifecycle, string> = {
   ended: "Ended",
 };
 
+/**
+ * Lifecycle cluster tooltip: posture, harness + version, and unread engine
+ * events when the journal dropped frames (decision 0031).
+ */
+export function sessionLifecycleTooltip(input: {
+  lifecycle: CodeSessionLifecycle;
+  harness: HarnessKind;
+  version?: string;
+  unrecognizedEventCount: number;
+}): string {
+  const harness = input.version
+    ? `${HARNESS_LABELS[input.harness]} ${input.version}`
+    : HARNESS_LABELS[input.harness];
+  const parts = [LIFECYCLE_LABELS[input.lifecycle], harness];
+  if (input.unrecognizedEventCount > 0) {
+    const count = input.unrecognizedEventCount;
+    const noun = count === 1 ? "event" : "events";
+    parts.push(
+      `${count} unread engine ${noun} — transcript may be incomplete`,
+    );
+  }
+  return parts.join(" · ");
+}
+
 export const WORKSPACE_STATUS_LABELS: Record<CodeWorkspaceStatus, string> = {
   creating: "Creating",
   setup_failed: "Setup failed",
@@ -58,6 +82,10 @@ export const PERMISSION_MODE_LABELS: Record<CodePermissionMode, string> = {
 /** Shown when the selected harness cannot honor Ask or Auto. */
 export const PERMISSION_MODE_UNAVAILABLE_REASON =
   "this harness cannot honor that mode";
+
+/** Mid-session picker: there is no PATCH permission-mode route. */
+export const SESSION_PERMISSION_MODE_LOCKED =
+  "Set when the session started — start a new session to change it";
 
 /** Stated wherever unsupervised Auto is offered (decision 0038). */
 export const UNSUPERVISED_AUTO_NOTE =

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -1,9 +1,15 @@
 import { useState, type ReactElement } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { MoreHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
 import { archiveForceKind, type ApiClient } from "../api/client";
-import type { CodeWorkspaceSnapshot, PullRequestDigest } from "../api/types";
+import type {
+  CodeActionSnapshot,
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+  PullRequestDigest,
+} from "../api/types";
 import { useApp } from "@/AppContext";
 import { copyPlainText } from "@/ClipboardCopyButton";
 import { useConfirm, type ConfirmOptions } from "@/components/ConfirmDialog";
@@ -15,7 +21,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { ToolOutputPreview } from "@/ToolOutputPreview";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { openInBrowser } from "@/openInBrowser";
 import { EMPTY_LAYOUT } from "@/panel/panelTypes";
@@ -25,8 +39,8 @@ import { toggleTerminalLayout } from "./codeChrome";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 
 /**
- * Workspace commands shared by the card context menu and, later, the
- * workspace header overflow. One list, two surfaces.
+ * Workspace commands shared by the card context menu and the workspace
+ * header overflow. One list, two surfaces.
  */
 export type WorkspaceCommandId =
   | "open"
@@ -36,6 +50,9 @@ export type WorkspaceCommandId =
   | "copy-worktree"
   | "open-pr"
   | "toggle-terminal"
+  | "pin-attention"
+  | "clear-attention"
+  | "run-quick-action"
   | "archive";
 
 export type WorkspaceCommand = {
@@ -44,17 +61,23 @@ export type WorkspaceCommand = {
   destructive?: boolean;
   /** Draw a separator before this item. */
   separated?: boolean;
+  /** Set when `id` is `run-quick-action`. */
+  actionName?: string;
 };
 
 export type WorkspaceCommandContext = {
   workspace: CodeWorkspaceSnapshot;
   title: string;
   pr?: PullRequestDigest;
+  session?: CodeSessionSnapshot;
+  actionName?: string;
 };
 
 export function workspaceCommands(input: {
   hasPr: boolean;
   archived: boolean;
+  hasSession?: boolean;
+  attentionPinned?: boolean;
 }): WorkspaceCommand[] {
   const items: WorkspaceCommand[] = [
     { id: "open", label: "Open workspace" },
@@ -67,6 +90,13 @@ export function workspaceCommands(input: {
     items.push({ id: "open-pr", label: "Open pull request" });
   }
   items.push({ id: "toggle-terminal", label: "Toggle terminal" });
+  if (input.hasSession) {
+    items.push(
+      input.attentionPinned
+        ? { id: "clear-attention", label: "Clear attention" }
+        : { id: "pin-attention", label: "Pin attention" },
+    );
+  }
   if (!input.archived) {
     items.push({
       id: "archive",
@@ -76,6 +106,95 @@ export function workspaceCommands(input: {
     });
   }
   return items;
+}
+
+/**
+ * Header overflow: rename, pin/clear, repo quick actions, then archive.
+ * Card-only items (open, copy, terminal) stay off this surface.
+ */
+export function workspaceHeaderCommands(input: {
+  archived: boolean;
+  hasSession: boolean;
+  attentionPinned: boolean;
+  quickActions: readonly { name: string }[];
+}): WorkspaceCommand[] {
+  const items: WorkspaceCommand[] = [{ id: "rename", label: "Rename…" }];
+  if (input.hasSession) {
+    items.push(
+      input.attentionPinned
+        ? { id: "clear-attention", label: "Clear attention" }
+        : { id: "pin-attention", label: "Pin attention" },
+    );
+  }
+  if (!input.archived) {
+    for (const action of input.quickActions) {
+      items.push({
+        id: "run-quick-action",
+        label: `Run: ${action.name}`,
+        actionName: action.name,
+      });
+    }
+    items.push({
+      id: "archive",
+      label: "Archive",
+      destructive: true,
+      separated: true,
+    });
+  }
+  return items;
+}
+
+export function WorkspaceOverflowMenu({
+  commands,
+  onCommand,
+}: {
+  commands: readonly WorkspaceCommand[];
+  onCommand: (command: WorkspaceCommand) => void;
+}) {
+  if (commands.length === 0) return null;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Workspace actions"
+        >
+          <MoreHorizontal />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {commands.map((command) => (
+          <WorkspaceOverflowItem
+            key={`${command.id}:${command.actionName ?? ""}`}
+            command={command}
+            onSelect={() => onCommand(command)}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function WorkspaceOverflowItem({
+  command,
+  onSelect,
+}: {
+  command: WorkspaceCommand;
+  onSelect: () => void;
+}) {
+  return (
+    <>
+      {command.separated && <DropdownMenuSeparator />}
+      <DropdownMenuItem
+        variant={command.destructive ? "destructive" : "default"}
+        onSelect={onSelect}
+      >
+        {command.label}
+      </DropdownMenuItem>
+    </>
+  );
 }
 
 export async function archiveWorkspaceWithConfirm(options: {
@@ -122,6 +241,7 @@ export function useWorkspaceCardCommands(): {
   const layout = useLayoutState();
   const { setLayout } = usePanelNav();
   const upsertWorkspace = useCodeCatalogStore((state) => state.upsertWorkspace);
+  const rememberSession = useCodeCatalogStore((state) => state.rememberSession);
   const forgetWorkspaceSession = useCodeCatalogStore(
     (state) => state.forgetWorkspaceSession,
   );
@@ -130,6 +250,9 @@ export function useWorkspaceCardCommands(): {
   );
   const [renameValue, setRenameValue] = useState("");
   const [renaming, setRenaming] = useState(false);
+  const [actionOutput, setActionOutput] = useState<CodeActionSnapshot | null>(
+    null,
+  );
 
   function openWorkspace(workspaceId: string) {
     void navigate({
@@ -226,6 +349,54 @@ export function useWorkspaceCardCommands(): {
         });
         return;
       }
+      case "pin-attention": {
+        if (!context.session) return;
+        void client
+          .setCodeAttention(context.session.id, { note: "Pinned" })
+          .then((next) => {
+            rememberSession(next);
+            toast.success("Attention pinned");
+          })
+          .catch((error) =>
+            toast.error(friendlyErrorMessage(error, "Could not pin attention")),
+          );
+        return;
+      }
+      case "clear-attention": {
+        if (!context.session) return;
+        void client
+          .setCodeAttention(context.session.id, { clear: true })
+          .then((next) => {
+            rememberSession(next);
+            toast.success("Attention cleared");
+          })
+          .catch((error) =>
+            toast.error(
+              friendlyErrorMessage(error, "Could not clear attention"),
+            ),
+          );
+        return;
+      }
+      case "run-quick-action": {
+        const name = context.actionName;
+        if (!name) return;
+        void client
+          .runCodeWorkspaceAction(context.workspace.id, name)
+          .then((result) => {
+            const detail = quickActionToast(result);
+            const show = result.success && !result.timed_out ? toast.success : toast.error;
+            show(detail, {
+              action: {
+                label: "View output",
+                onClick: () => setActionOutput(result),
+              },
+            });
+          })
+          .catch((error) =>
+            toast.error(friendlyErrorMessage(error, "Could not run that action")),
+          );
+        return;
+      }
       case "archive":
         void runArchive(context.workspace);
         return;
@@ -276,13 +447,47 @@ export function useWorkspaceCardCommands(): {
     </Dialog>
   );
 
+  const outputDialog = (
+    <Dialog
+      open={actionOutput !== null}
+      onOpenChange={(open) => {
+        if (!open) setActionOutput(null);
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {actionOutput
+              ? `${actionOutput.name} · ${quickActionToast(actionOutput)}`
+              : "Action output"}
+          </DialogTitle>
+        </DialogHeader>
+        {actionOutput && (
+          <div className="flex flex-col gap-3">
+            <ToolOutputPreview text={actionOutput.stdout} label="stdout" />
+            <ToolOutputPreview text={actionOutput.stderr} label="stderr" />
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+
   return {
     run,
     dialogs: (
       <>
         {dialog}
         {renameDialog}
+        {outputDialog}
       </>
     ),
   };
+}
+
+export function quickActionToast(result: CodeActionSnapshot): string {
+  if (result.timed_out) return `${result.name} timed out`;
+  if (result.exit_code !== undefined) {
+    return `${result.name} exited ${result.exit_code}`;
+  }
+  return result.success ? `${result.name} finished` : `${result.name} failed`;
 }


### PR DESCRIPTION
## Summary

Finish the code workspace header and mid-session composer chrome. Each new mark answers one question. Nothing here is decorative.

## What each element answers

| Element | Need it answers |
| --- | --- |
| Header skeleton bars | Is this page still loading? The old fallback printed `Workspace` and the raw repo id, which reads as a finished title. Two bars hold the title and repo slots until those strings exist. |
| Centered error + **Retry** | Did the loader fail, and can you try again? A permanent `p` was a dead end. Retry re-runs the same load. |
| Warning dot on the lifecycle cluster | Did the engine drop journal frames? `unrecognized_event_count > 0` is a warning-quad dot, not a text pill. The count and "transcript may be incomplete" live in the lifecycle tooltip (decision 0031). The stray comment that used to sit on `CodeSessionPane` now lives on this mark. |
| Mono worktree-path chip | Which directory is this session in? Middle-truncated so the tail stays readable. Click copies, using the same copy-state pattern as `ClipboardCopyButton`. Reveal / open-in-editor needs a host capability and is a follow-up. |
| Review-sidebar toggle | Is the inspector open? `PanelRight`, `aria-pressed`, tooltip with the `⌘I` keycap. Same one-keystroke rule as the terminal (`⌘J`). |
| Harness version in the lifecycle tooltip | Which engine build is this session? Visible chrome stays `Idle`; the tooltip adds `Claude Code 2.1.233`. |
| Overflow `...` menu | Where do rename, pin/clear, quick actions, and archive live? The bare **Archive** button was one action pretending to be the whole menu. Archive is last, destructive, and separated. |
| Disabled permission-mode tooltip | Why can you not change the mode mid-session? There is no `POST /code/sessions/{id}/permission-mode` route. The trigger is wrapped so a disabled button can still host the tooltip. |

Status color comes only from the semantic quads. Reveals use 150ms ease-out and honor `prefers-reduced-motion`. Data updates do not animate.

## Shared command list

`origin/thet/code-sidebar-command-center` already landed as #2202, including `ApiClient.patchCodeWorkspace`. This PR extends that exportable list rather than adding a second copy:

- `workspaceCommands()` — card context menu. Adds pin/clear when a session is present.
- `workspaceHeaderCommands()` — header overflow: Rename…, pin/clear, `Run: <name>` per repo `quick_actions`, Archive last.
- `useWorkspaceCardCommands()` runs both surfaces. A quick-action toast is success or error from the exit code, with **View output** opening stdout/stderr in `ToolOutputPreview`.

## Reasoning effort (PR 4b)

Read first: `POST /code/sessions/{id}/turns` (`SubmitTurnBody` in `routes/code/types.rs`) accepts only `message` and `model` (`deny_unknown_fields`). `TurnInput` is `{ text, model }`. Claude, Codex, and Grok adapters pass a model flag only. Grok advertises `reasoning_levels: supported` and documents `--reasoning-effort`, but `compose_print_plan` does not compose that flag.

Nothing on the wire can carry effort today. Shipping a gated selector would be dead UI, so this PR does not add the control. A later ADR can add a turn field (or an honest adapter argv) before the composer offers one.

## Follow-ups

- Host capability to reveal the worktree or open it in an editor.
- Turn-payload field (or adapter argv) for reasoning effort, then the composer control.

## Tests

Replaced, not piled on:

- Header loading asserts skeleton bars and the absence of the literal `Workspace` / repo-id fallback.
- `unrecognized_event_count > 0` asserts the warning dot.
- Review-sidebar toggle flips `CodeUiStore.reviewSidebarOpen`.
- Quick action `lint` surfaces `lint exited 1` on an error toast with **View output**.
- Archive still leaves for the repo page, now through the overflow menu.
- Composer: disabled permission trigger is hoverable and states why.

No effort-control test: the control is not shipped.

## Validation

- `pnpm vitest run src/code` — 148 passed
- `pnpm vitest run` — 1166 passed
- `pnpm build` — `tsc` and Vite production build passed