### PR TITLE
feat(desktop): make the code inspector resizable with per-turn diff scoping

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -1,15 +1,18 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";
 
 import type { ApiClient } from "../api/client";
 import type { CodeWorkspaceSnapshot, PullRequestDigest } from "../api/types";
-import { CodeInspector } from "./CodeInspector";
+import { CodeInspector, inspectorTurnLabel } from "./CodeInspector";
+import { useCodeUiStore } from "./CodeUiStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 
 afterEach(() => {
   cleanup();
   useCodeUpdatesStore.getState().reset();
+  useCodeUiStore.setState({ inspectorScope: null });
   vi.clearAllMocks();
 });
 
@@ -62,8 +65,16 @@ function makeClient(): Pick<
     }),
     refreshCodeWorkspacePr: vi.fn(),
     mergeCodePr: vi.fn(),
-    getCodeWorkspaceDiff: vi.fn().mockResolvedValue({ diff: "" }),
-    listCodeWorkspaceFiles: vi.fn().mockResolvedValue({ files: [] }),
+    getCodeWorkspaceDiff: vi.fn().mockResolvedValue({
+      diff: "",
+      truncated: false,
+      stat: { files: 0, insertions: 0, deletions: 0, truncated: false },
+    }),
+    listCodeWorkspaceFiles: vi.fn().mockResolvedValue({
+      files: [],
+      truncated: false,
+      stat: { files: 0, insertions: 0, deletions: 0, truncated: false },
+    }),
     getCodeWorkspacePr: vi.fn().mockResolvedValue(null),
   };
 }
@@ -79,7 +90,7 @@ it("shows PR state, checks, comments, and holds merge for a draft", async () => 
     />,
   );
 
-  screen.getByRole("button", { name: "Pull request" }).click();
+  await userEvent.setup().click(screen.getByRole("tab", { name: "Pull request" }));
   await screen.findByText("Fix login flow");
 
   // Draft wins over the open state token, and holds the merge buttons.
@@ -101,4 +112,52 @@ it("shows PR state, checks, comments, and holds merge for a draft", async () => 
   );
   expect(screen.getByText("src/login.rs:12")).toBeInTheDocument();
   expect(client.getCodePrComments).toHaveBeenCalledWith("ws-1");
+});
+
+it("exposes a tablist and passes the scoped turn into files and source", async () => {
+  const client = makeClient();
+  useCodeUiStore.setState({
+    inspectorScope: { turnId: "turn-1", label: "Turn 4" },
+  });
+  render(
+    <CodeInspector
+      client={client as never}
+      workspaceId="ws-1"
+      workspace={WORKSPACE}
+      contentRevision={0}
+    />,
+  );
+
+  expect(screen.getByRole("tablist")).toBeInTheDocument();
+  expect(screen.getByRole("tab", { name: "Source control" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  expect(
+    screen.getByRole("button", { name: "Clear Turn 4 scope" }),
+  ).toBeInTheDocument();
+
+  await waitFor(() =>
+    expect(client.getCodeWorkspaceDiff).toHaveBeenCalledWith("ws-1", {
+      turn: "turn-1",
+      file: undefined,
+    }),
+  );
+
+  await userEvent.setup().click(screen.getByRole("tab", { name: "Files" }));
+  await waitFor(() =>
+    expect(client.listCodeWorkspaceFiles).toHaveBeenCalledWith("ws-1", "turn-1"),
+  );
+});
+
+it("labels a turn by its ordinal among user items", () => {
+  expect(
+    inspectorTurnLabel(
+      [
+        { kind: "user", id: "u1", turnId: "t-a", text: "one", createdAt: "" },
+        { kind: "user", id: "u2", turnId: "t-b", text: "two", createdAt: "" },
+      ],
+      "t-b",
+    ),
+  ).toBe("Turn 2");
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -31,9 +31,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { WithTooltip } from "@/components/ui/tooltip";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { openExternal } from "@/host";
+import type { CodeTranscriptItem } from "./CodeSessionReducer";
+import { useCodeUiStore } from "./CodeUiStore";
 import { DiffPanel } from "./DiffPanel";
 import { FilesPanel } from "./FilesPanel";
 import { PrCard } from "./PrCard";
@@ -41,6 +45,9 @@ import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
 
 type InspectorTab = "files" | "source" | "pr";
+
+const TAB_TRIGGER_CLASS =
+  "text-muted-foreground hover:text-foreground grid size-8 place-items-center rounded-lg px-0 py-0 data-[state=active]:bg-muted data-[state=active]:text-foreground";
 
 /**
  * Right workspace rail: Files, Source control, and Pull request as icon tabs.
@@ -62,9 +69,18 @@ export function CodeInspector({
 }) {
   const digest = useCodeUpdatesStore((state) => state.byWorkspace[workspaceId]);
   const pr = digest?.pr_state ?? workspace?.pr;
-  const [tab, setTab] = useState<InspectorTab>("files");
+  const scope = useCodeUiStore((state) => state.inspectorScope);
+  const setInspectorScope = useCodeUiStore((state) => state.setInspectorScope);
+  const [tab, setTab] = useState<InspectorTab>(scope ? "source" : "files");
   const [file, setFile] = useState<string | undefined>();
   const active = workspace?.status !== "archived";
+  const turnId = scope?.turnId;
+
+  useEffect(() => {
+    if (!scope) return;
+    setTab("source");
+    setFile(undefined);
+  }, [scope]);
 
   function openFile(next: string) {
     setFile(next);
@@ -73,49 +89,60 @@ export function CodeInspector({
 
   return (
     <aside
-      className="flex w-80 shrink-0 flex-col overflow-hidden border-l"
+      className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden"
       aria-label="Workspace surfaces"
       data-testid="code-inspector"
     >
-      <header className="flex h-12 shrink-0 items-center gap-1 border-b px-2">
-        <TabButton
-          label="Files"
-          current={tab === "files"}
-          onClick={() => setTab("files")}
+      <Tabs
+        value={tab}
+        onValueChange={(next) => setTab(next as InspectorTab)}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
+        <header className="flex h-12 shrink-0 items-center gap-1 border-b px-2">
+          <TabsList className="h-auto justify-start gap-0.5 bg-transparent p-0">
+            <InspectorTabTrigger value="files" label="Files">
+              <Files className="size-3.5" />
+            </InspectorTabTrigger>
+            <InspectorTabTrigger value="source" label="Source control">
+              <GitBranch className="size-3.5" />
+            </InspectorTabTrigger>
+            <InspectorTabTrigger value="pr" label="Pull request">
+              <GitPullRequest
+                className={cn(
+                  "size-3.5",
+                  pr ? PR_ICON_TONE_CLASSES[prTone(pr)] : undefined,
+                )}
+              />
+            </InspectorTabTrigger>
+          </TabsList>
+          {scope && (
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground ml-auto truncate rounded-full border px-2 py-0.5 font-mono text-[11px]"
+              aria-label={`Clear ${scope.label} scope`}
+              onClick={() => setInspectorScope(null)}
+            >
+              {scope.label} ×
+            </button>
+          )}
+        </header>
+        <TabsContent
+          value="files"
+          className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
         >
-          <Files className="size-3.5" />
-        </TabButton>
-        <TabButton
-          label="Source control"
-          current={tab === "source"}
-          onClick={() => setTab("source")}
-        >
-          <GitBranch className="size-3.5" />
-        </TabButton>
-        <TabButton
-          label="Pull request"
-          current={tab === "pr"}
-          onClick={() => setTab("pr")}
-        >
-          <GitPullRequest
-            className={cn(
-              "size-3.5",
-              pr ? PR_ICON_TONE_CLASSES[prTone(pr)] : undefined,
-            )}
-          />
-        </TabButton>
-      </header>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {tab === "files" && (
           <FilesPanel
             client={client}
             workspaceId={workspaceId}
+            turnId={turnId}
             contentRevision={contentRevision}
             selected={file}
             onOpenFile={openFile}
           />
-        )}
-        {tab === "source" && (
+        </TabsContent>
+        <TabsContent
+          value="source"
+          className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
             {active && (
               <div className="border-b px-3 py-3">
@@ -130,50 +157,66 @@ export function CodeInspector({
             <DiffPanel
               client={client}
               workspaceId={workspaceId}
+              turnId={turnId}
+              turnLabel={scope?.label}
               file={file}
               contentRevision={contentRevision}
             />
           </div>
-        )}
-        {tab === "pr" && (
+        </TabsContent>
+        <TabsContent
+          value="pr"
+          className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
           <PrTab
             client={client}
             workspaceId={workspaceId}
             pr={pr}
             branch={workspace?.branch_name}
           />
-        )}
-      </div>
+        </TabsContent>
+      </Tabs>
     </aside>
   );
 }
 
-function TabButton({
+function InspectorTabTrigger({
+  value,
   label,
-  current,
-  onClick,
   children,
 }: {
+  value: InspectorTab;
   label: string;
-  current: boolean;
-  onClick: () => void;
   children: ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      title={label}
-      aria-label={label}
-      aria-current={current}
-      onClick={onClick}
-      className={cn(
-        "text-muted-foreground hover:text-foreground grid size-8 place-items-center rounded-lg",
-        current && "bg-muted text-foreground",
-      )}
-    >
-      {children}
-    </button>
+    <WithTooltip label={label}>
+      <TabsTrigger
+        value={value}
+        aria-label={label}
+        className={TAB_TRIGGER_CLASS}
+      >
+        {children}
+      </TabsTrigger>
+    </WithTooltip>
   );
+}
+
+/**
+ * Ordinal label for a turn id, from the transcript's user items in order.
+ * The inspector never shows a raw turn UUID.
+ */
+export function inspectorTurnLabel(
+  items: readonly CodeTranscriptItem[],
+  turnId: string,
+): string {
+  let ordinal = 0;
+  for (const item of items) {
+    if (item.kind !== "user") continue;
+    ordinal += 1;
+    if (item.turnId === turnId) return `Turn ${ordinal}`;
+  }
+  return "This turn";
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -19,6 +19,12 @@ export type CodeCreateDefaults = {
   model?: string;
 };
 
+/** Inspector filter for one turn's files and diff. `label` is the ordinal, never the id. */
+export type InspectorScope = {
+  turnId: string;
+  label: string;
+};
+
 function readStoredCreateDefaults(): CodeCreateDefaults | null {
   try {
     const raw = window.localStorage.getItem(LAST_CREATE_KEY);
@@ -139,6 +145,8 @@ export type CodeUiStore = {
   newWorkspaceRepoId: string | undefined;
   addRepoOpen: boolean;
   reviewSidebarOpen: boolean;
+  /** Files and diff scoped to one turn, or the whole worktree when null. */
+  inspectorScope: InspectorScope | null;
   workspaceSortMode: WorkspaceSortMode;
   lastCreate: CodeCreateDefaults | null;
   /** Per-workspace terminal drawer height, remembered across reloads. */
@@ -155,6 +163,7 @@ export type CodeUiStore = {
   setAddRepoOpen: (open: boolean) => void;
   toggleReviewSidebar: () => void;
   setReviewSidebarOpen: (open: boolean) => void;
+  setInspectorScope: (scope: InspectorScope | null) => void;
   setWorkspaceSortMode: (mode: WorkspaceSortMode) => void;
   /** Record a successful create so the next dialog opens on the same choices. */
   rememberCreate: (defaults: CodeCreateDefaults) => void;
@@ -166,6 +175,7 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   newWorkspaceRepoId: undefined,
   addRepoOpen: false,
   reviewSidebarOpen: readStoredReviewSidebarOpen(),
+  inspectorScope: null,
   workspaceSortMode: readStoredWorkspaceSort(),
   lastCreate: readStoredCreateDefaults(),
   terminalDrawerHeights: readStoredTerminalDrawerHeights(),
@@ -193,6 +203,7 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
     storeReviewSidebarOpen(open);
     set({ reviewSidebarOpen: open });
   },
+  setInspectorScope: (inspectorScope) => set({ inspectorScope }),
   setWorkspaceSortMode: (mode) => {
     storeWorkspaceSort(mode);
     set({ workspaceSortMode: mode });

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -300,7 +300,7 @@ afterEach(() => {
   useCodeCatalogStore.getState().reset();
   disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
-  useCodeUiStore.setState({ reviewSidebarOpen: true });
+  useCodeUiStore.setState({ reviewSidebarOpen: true, inspectorScope: null });
 });
 
 describe("CodeWorkspacePage", () => {
@@ -437,10 +437,10 @@ describe("CodeWorkspacePage", () => {
 
     const inspector = screen.getByTestId("code-inspector");
     expect(
-      within(inspector).getByRole("button", { name: "Files" }),
+      within(inspector).getByRole("tab", { name: "Files" }),
     ).toBeInTheDocument();
     expect(
-      within(inspector).getByRole("button", { name: "Pull request" }),
+      within(inspector).getByRole("tab", { name: "Pull request" }),
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Terminal" }));
@@ -449,7 +449,7 @@ describe("CodeWorkspacePage", () => {
     expect(screen.queryByRole("tab", { name: /Terminal/i })).not.toBeInTheDocument();
     expect(router.state.location.search).toMatchObject({ tabs: "terminal" });
 
-    await user.click(screen.getByRole("button", { name: "Pull request" }));
+    await user.click(screen.getByRole("tab", { name: "Pull request" }));
     expect(within(inspector).getByText("No pull request yet")).toBeInTheDocument();
   });
 
@@ -463,7 +463,9 @@ describe("CodeWorkspacePage", () => {
     expect(
       await screen.findByRole("heading", { name: /Fix login/ }),
     ).toBeInTheDocument();
-    expect(screen.queryByRole("tab", { name: "Files" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("tablist", { name: "Open panels" }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Diff" })).not.toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: /Terminal/i })).not.toBeInTheDocument();
     expect(screen.getByTestId("terminal-drawer")).toBeInTheDocument();
@@ -473,7 +475,7 @@ describe("CodeWorkspacePage", () => {
 
     const inspector = screen.getByTestId("code-inspector");
     expect(
-      within(inspector).getByRole("button", { name: "Files" }),
+      within(inspector).getByRole("tab", { name: "Files" }),
     ).toBeInTheDocument();
   });
 
@@ -491,13 +493,40 @@ describe("CodeWorkspacePage", () => {
     await waitFor(() =>
       expect(router.state.location.search).toMatchObject({ tabs: "terminal" }),
     );
-    expect(screen.queryByRole("tab", { name: "Files" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("tablist", { name: "Open panels" }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Diff" })).not.toBeInTheDocument();
     expect(screen.getByTestId("terminal-drawer")).toBeInTheDocument();
     expect(
-      within(screen.getByTestId("code-inspector")).getByRole("button", {
+      within(screen.getByTestId("code-inspector")).getByRole("tab", {
         name: "Files",
       }),
     ).toBeInTheDocument();
+  });
+
+  it("scopes the inspector to a turn from the review seam", async () => {
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Review this turn's changes" }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Clear Turn 1 scope" }),
+    ).toHaveTextContent("Turn 1 ×");
+    expect(screen.getByRole("tab", { name: "Source control" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await waitFor(() =>
+      expect(client.getCodeWorkspaceDiff).toHaveBeenCalledWith("ws-1", {
+        turn: "turn-1",
+        file: undefined,
+      }),
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -17,6 +17,11 @@ import { useApp } from "@/AppContext";
 import { copyPlainText, scheduleCopyStateReset } from "@/ClipboardCopyButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { PanelLayout } from "@/panel/PanelLayout";
@@ -41,7 +46,7 @@ import {
   toggleTerminalLayout,
 } from "./codeChrome";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
-import { CodeInspector } from "./CodeInspector";
+import { CodeInspector, inspectorTurnLabel } from "./CodeInspector";
 import { useCodeUiStore } from "./CodeUiStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { liveCodeSession } from "./parsers";
@@ -100,6 +105,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const chrome = splitCodeChromeLayout(layout);
   const reviewSidebarOpen = useCodeUiStore((state) => state.reviewSidebarOpen);
   const toggleReviewSidebar = useCodeUiStore((state) => state.toggleReviewSidebar);
+  const setReviewSidebarOpen = useCodeUiStore(
+    (state) => state.setReviewSidebarOpen,
+  );
+  const setInspectorScope = useCodeUiStore((state) => state.setInspectorScope);
   const shortcutHints = useCodeShortcutHints();
   const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(null);
   const [repo, setRepo] = useState<CodeRepoSnapshot | null>(null);
@@ -125,6 +134,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   useEffect(() => {
     if (rememberedSession) setSession(rememberedSession);
   }, [rememberedSession]);
+
+  useEffect(() => {
+    return () => {
+      useCodeUiStore.getState().setInspectorScope(null);
+    };
+  }, [workspaceId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -214,6 +229,84 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         quickActions: repo?.quick_actions ?? [],
       })
     : [];
+
+  function openTurnDiff(turnId: string) {
+    const items = session
+      ? acquireCodeSessionFromClient(session.id, client).getState().items
+      : [];
+    if (session) releaseCodeSession(session.id);
+    setInspectorScope({
+      turnId,
+      label: inspectorTurnLabel(items, turnId),
+    });
+    setReviewSidebarOpen(true);
+  }
+
+  const workspaceMain = (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <PanelLayout
+        layout={chrome.panels}
+        framed={false}
+        onFocusTab={(index) => setLayout(focusCodeChromeTab(layout, index))}
+        onCloseTab={(index) => setLayout(closeCodeChromeTab(layout, index))}
+        renderChat={(visible) => (
+          // The panel slot this sits in is a plain block, so nothing stretches
+          // the pane to the slot's height — `flex-1` resolves to nothing and
+          // the transcript never becomes a scroller. It claims the height
+          // itself, the same way `.chat-pane` does.
+          <div
+            className="flex h-full min-h-0 flex-col overflow-hidden"
+            hidden={!visible}
+          >
+            {fenced && session?.fence_reason && (
+              <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
+                <p>{fenceReasonText(session.fence_reason)}</p>
+                <Button type="button" size="sm" className="self-start" onClick={() => void reap()}>
+                  Reap
+                </Button>
+              </div>
+            )}
+            {!session && workspace?.status === "active" && (
+              <StartSessionPrompt
+                harnesses={doctorHarnesses}
+                starting={starting}
+                selectedMode={createMode}
+                onSelectMode={setCreateMode}
+                client={client}
+                catalogModels={models}
+                defaultModelKey={defaultModelKey}
+                onStart={(harness, mode, message, model) =>
+                  startSession(harness, mode, message, model)
+                }
+              />
+            )}
+            {session && (
+              <CodeSessionPane
+                key={session.id}
+                session={session}
+                client={client}
+                catalogModels={models}
+                defaultModelKey={defaultModelKey}
+                disabled={fenced || workspace?.status !== "active"}
+                onOpenTurnDiff={openTurnDiff}
+              />
+            )}
+          </div>
+        )}
+        renderPanel={(panel) =>
+          renderCodePanel(panel, client, workspaceId)
+        }
+      />
+      {chrome.terminal && (
+        <TerminalDrawer
+          client={client}
+          workspaceId={workspaceId}
+          shortcutHint={shortcutHints.terminal}
+          onClose={() => setLayout(toggleTerminalLayout(layout))}
+        />
+      )}
+    </div>
+  );
 
   return (
     <>
@@ -323,79 +416,28 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             Retry
           </Button>
         </div>
-      ) : (
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-          <PanelLayout
-            layout={chrome.panels}
-            framed={false}
-            onFocusTab={(index) => setLayout(focusCodeChromeTab(layout, index))}
-            onCloseTab={(index) => setLayout(closeCodeChromeTab(layout, index))}
-            renderChat={(visible) => (
-              // The panel slot this sits in is a plain block, so nothing stretches
-              // the pane to the slot's height — `flex-1` resolves to nothing and
-              // the transcript never becomes a scroller. It claims the height
-              // itself, the same way `.chat-pane` does.
-              <div
-                className="flex h-full min-h-0 flex-col overflow-hidden"
-                hidden={!visible}
-              >
-                {fenced && session?.fence_reason && (
-                  <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
-                    <p>{fenceReasonText(session.fence_reason)}</p>
-                    <Button type="button" size="sm" className="self-start" onClick={() => void reap()}>
-                      Reap
-                    </Button>
-                  </div>
-                )}
-                {!session && workspace?.status === "active" && (
-                  <StartSessionPrompt
-                    harnesses={doctorHarnesses}
-                    starting={starting}
-                    selectedMode={createMode}
-                    onSelectMode={setCreateMode}
-                    client={client}
-                    catalogModels={models}
-                    defaultModelKey={defaultModelKey}
-                    onStart={(harness, mode, message, model) =>
-                      startSession(harness, mode, message, model)
-                    }
-                  />
-                )}
-                {session && (
-                  <CodeSessionPane
-                    key={session.id}
-                    session={session}
-                    client={client}
-                    catalogModels={models}
-                    defaultModelKey={defaultModelKey}
-                    disabled={fenced || workspace?.status !== "active"}
-                  />
-                )}
-              </div>
-            )}
-            renderPanel={(panel) =>
-              renderCodePanel(panel, client, workspaceId)
-            }
-          />
-          {chrome.terminal && (
-            <TerminalDrawer
+      ) : reviewSidebarOpen ? (
+        <ResizablePanelGroup
+          autoSaveId="code-inspector"
+          direction="horizontal"
+          className="min-h-0 flex-1"
+        >
+          <ResizablePanel defaultSize={72} minSize={36} className="min-w-0">
+            {workspaceMain}
+          </ResizablePanel>
+          <ResizableHandle />
+          <ResizablePanel defaultSize={28} minSize={18} className="min-w-0">
+            <CodeInspector
+              key={workspaceId}
               client={client}
               workspaceId={workspaceId}
-              shortcutHint={shortcutHints.terminal}
-              onClose={() => setLayout(toggleTerminalLayout(layout))}
+              workspace={workspace}
+              contentRevision={contentRevision}
             />
-          )}
-        </div>
-        {reviewSidebarOpen && (
-          <CodeInspector
-            client={client}
-            workspaceId={workspaceId}
-            workspace={workspace}
-            contentRevision={contentRevision}
-          />
-        )}
-      </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      ) : (
+        <div className="flex min-h-0 flex-1 overflow-hidden">{workspaceMain}</div>
       )}
     </>
   );
@@ -586,11 +628,7 @@ function CodeSessionPane({
   catalogModels: ModelInfo[];
   defaultModelKey: string | null;
   disabled: boolean;
-  /**
-   * Scope the review sidebar to one turn's changes, from a turn's diffstat.
-   * Left unset until the inspector can hold a scope; the diffstat reads as a
-   * plain count meanwhile rather than a control that does nothing.
-   */
+  /** Scope the review sidebar to one turn's changes, from a turn's diffstat. */
   onOpenTurnDiff?: (turnId: string) => void;
 }) {
   const follow = useTranscriptFollow();

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { DiffPanel, groupUnifiedDiff } from "./DiffPanel";
+import {
+  DIFF_COLLAPSE_LINE_THRESHOLD,
+  DiffPanel,
+  groupUnifiedDiff,
+} from "./DiffPanel";
 
 afterEach(() => {
   cleanup();
@@ -17,7 +22,7 @@ const DIFF = `diff --git a/src/lib.rs b/src/lib.rs
 `;
 
 describe("DiffPanel", () => {
-  it("renders a grouped unified diff and a truncation notice", async () => {
+  it("renders gutters, a grouped unified diff, and a truncation notice", async () => {
     const client = {
       getCodeWorkspaceDiff: vi.fn().mockResolvedValue({
         diff: DIFF,
@@ -32,11 +37,35 @@ describe("DiffPanel", () => {
         client={client}
         workspaceId="ws-1"
         turnId="turn-1"
+        turnLabel="Turn 4"
         file="src/lib.rs"
       />,
     );
-    expect(await screen.findByText("src/lib.rs")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "src/lib.rs" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Turn 4")).not.toBeInTheDocument();
     expect(screen.getByText("+new")).toBeInTheDocument();
+
+    const added = screen.getByText("+new").parentElement;
+    expect(added?.querySelector('[data-diff-gutter="old"]')?.textContent).toBe(
+      "",
+    );
+    expect(added?.querySelector('[data-diff-gutter="new"]')?.textContent).toBe(
+      "1",
+    );
+    expect(added?.querySelector('[data-diff-gutter="new"]')).toHaveClass(
+      "select-none",
+    );
+
+    const removed = screen.getByText("-old").parentElement;
+    expect(removed?.querySelector('[data-diff-gutter="old"]')?.textContent).toBe(
+      "1",
+    );
+    expect(removed?.querySelector('[data-diff-gutter="new"]')?.textContent).toBe(
+      "",
+    );
+
     expect(
       screen.getByText("This diff was truncated. Open a single file for the rest."),
     ).toBeInTheDocument();
@@ -44,6 +73,30 @@ describe("DiffPanel", () => {
       turn: "turn-1",
       file: "src/lib.rs",
     });
+  });
+
+  it("collapses a long file behind Show diff", async () => {
+    const body = Array.from(
+      { length: DIFF_COLLAPSE_LINE_THRESHOLD + 1 },
+      (_, index) => `+line ${index}`,
+    ).join("\n");
+    const client = {
+      getCodeWorkspaceDiff: vi.fn().mockResolvedValue({
+        diff: `diff --git a/big.ts b/big.ts\n--- a/big.ts\n+++ b/big.ts\n@@ -1,1 +1,401 @@\n${body}\n`,
+        truncated: false,
+        stat: { files: 1, insertions: 401, deletions: 0, truncated: false },
+      }),
+    };
+    render(<DiffPanel client={client} workspaceId="ws-1" />);
+    expect(await screen.findByText("big.ts")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show diff" })).toBeInTheDocument();
+    expect(screen.queryByText("+line 0")).not.toBeInTheDocument();
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Show diff" }));
+    expect(screen.getByText("+line 0")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Show diff" }),
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -53,5 +106,63 @@ describe("groupUnifiedDiff", () => {
       "diff --git a/a.txt b/a.txt\n+one\ndiff --git a/b.txt b/b.txt\n+two\n",
     );
     expect(groups.map((group) => group.path)).toEqual(["a.txt", "b.txt"]);
+  });
+
+  it("assigns old and new line numbers from a hunk header", () => {
+    const [group] = groupUnifiedDiff(`diff --git a/a.ts b/a.ts
+--- a/a.ts
++++ b/a.ts
+@@ -10,3 +10,4 @@
+ context
+-removed
++added
++also
+ context
+`);
+    expect(group?.lines.filter((line) => line.kind !== "meta")).toEqual([
+      { kind: "hunk", oldNo: null, newNo: null, text: "@@ -10,3 +10,4 @@" },
+      { kind: "context", oldNo: 10, newNo: 10, text: " context" },
+      { kind: "del", oldNo: 11, newNo: null, text: "-removed" },
+      { kind: "add", oldNo: null, newNo: 11, text: "+added" },
+      { kind: "add", oldNo: null, newNo: 12, text: "+also" },
+      { kind: "context", oldNo: 12, newNo: 13, text: " context" },
+    ]);
+  });
+
+  it("treats rename and file-mode lines as meta without line numbers", () => {
+    const [group] = groupUnifiedDiff(`diff --git a/old.txt b/new.txt
+similarity index 90%
+rename from old.txt
+rename to new.txt
+--- a/old.txt
++++ b/new.txt
+@@ -1 +1 @@
+-old
++new
+`);
+    expect(group?.path).toBe("new.txt");
+    const meta = group?.lines.filter((line) => line.kind === "meta") ?? [];
+    expect(meta.map((line) => line.text)).toEqual([
+      "similarity index 90%",
+      "rename from old.txt",
+      "rename to new.txt",
+      "--- a/old.txt",
+      "+++ b/new.txt",
+    ]);
+    expect(meta.every((line) => line.oldNo === null && line.newNo === null)).toBe(
+      true,
+    );
+    expect(group?.lines.find((line) => line.kind === "del")).toEqual({
+      kind: "del",
+      oldNo: 1,
+      newNo: null,
+      text: "-old",
+    });
+    expect(group?.lines.find((line) => line.kind === "add")).toEqual({
+      kind: "add",
+      oldNo: null,
+      newNo: 1,
+      text: "+new",
+    });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { ChevronRight } from "lucide-react";
 
 import type { ApiClient } from "../api/client";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -7,20 +8,43 @@ import { cn } from "@/lib/utils";
 import { DiffstatBadge } from "./TurnReviewCard";
 import { useLiveResource } from "./useLiveContent";
 
+/** Files longer than this start collapsed behind "Show diff". */
+export const DIFF_COLLAPSE_LINE_THRESHOLD = 400;
+
+export type DiffLineKind = "add" | "del" | "context" | "hunk" | "meta";
+
+export type DiffLine = {
+  kind: DiffLineKind;
+  oldNo: number | null;
+  newNo: number | null;
+  text: string;
+};
+
+export type DiffFileGroup = {
+  path: string;
+  lines: DiffLine[];
+};
+
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
 /**
  * Server-produced unified diff, grouped per file and tinted with the
- * semantic status tokens. No client-side diff library.
+ * semantic status tokens. No client-side highlighting: fragments misparse,
+ * fight the add/del tints, and cost a pass we do not need.
  */
 export function DiffPanel({
   client,
   workspaceId,
   turnId,
+  turnLabel,
   file,
   contentRevision = 0,
 }: {
   client: Pick<ApiClient, "getCodeWorkspaceDiff">;
   workspaceId: string;
   turnId?: string;
+  /** Ordinal label for the scoped turn. Never a raw id. */
+  turnLabel?: string;
   file?: string;
   contentRevision?: number;
 }) {
@@ -44,13 +68,19 @@ export function DiffPanel({
     [payload],
   );
 
+  const scopeCaption = file
+    ? file
+    : turnId
+      ? (turnLabel ?? "This turn")
+      : "Workspace vs base";
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <header className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b px-3 py-2">
         <div className="min-w-0">
           <h2 className="text-sm font-medium">Diff</h2>
-          <p className="text-muted-foreground truncate text-xs">
-            {file ?? (turnId ? `Turn ${turnId}` : "Workspace vs base")}
+          <p className="text-muted-foreground truncate font-mono text-[11px]">
+            {scopeCaption}
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -64,7 +94,7 @@ export function DiffPanel({
           This diff was truncated. Open a single file for the rest.
         </p>
       )}
-      <div className="min-h-0 flex-1 overflow-auto">
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {!payload && !error && (
           <div className="flex flex-col gap-2 px-3 py-3" aria-hidden="true">
             <Skeleton className="h-3 w-1/3" />
@@ -73,30 +103,7 @@ export function DiffPanel({
           </div>
         )}
         {groups.map((group) => (
-          <section key={group.path} className="border-b last:border-b-0">
-            <h3 className="text-muted-foreground truncate px-3 py-1.5 font-mono text-xs">
-              {group.path}
-            </h3>
-            <pre className="py-1 font-mono text-[11px] leading-5">
-              {group.lines.map((line, index) => (
-                <span
-                  key={`${group.path}:${index}`}
-                  className={cn(
-                    "block min-h-4 px-3",
-                    line.startsWith("+") &&
-                      !line.startsWith("+++") &&
-                      "text-success bg-success/10",
-                    line.startsWith("-") &&
-                      !line.startsWith("---") &&
-                      "text-critical bg-critical/10",
-                    line.startsWith("@@") && "text-muted-foreground",
-                  )}
-                >
-                  {line || " "}
-                </span>
-              ))}
-            </pre>
-          </section>
+          <FileDiffSection key={group.path} group={group} />
         ))}
         {payload && groups.length === 0 && !error && (
           <p className="text-muted-foreground px-3 py-6 text-sm">No diff.</p>
@@ -106,21 +113,175 @@ export function DiffPanel({
   );
 }
 
-export function groupUnifiedDiff(diff: string): { path: string; lines: string[] }[] {
-  const groups: { path: string; lines: string[] }[] = [];
-  let current: { path: string; lines: string[] } | null = null;
+function FileDiffSection({ group }: { group: DiffFileGroup }) {
+  const large = group.lines.length > DIFF_COLLAPSE_LINE_THRESHOLD;
+  const [expanded, setExpanded] = useState(!large);
+  const { insertions, deletions } = fileDiffstat(group.lines);
+
+  return (
+    <section className="border-b last:border-b-0">
+      <header className="bg-background sticky top-0 z-10">
+        <button
+          type="button"
+          className="hover:bg-muted/40 flex w-full items-center gap-1.5 px-3 py-1.5 text-left"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((current) => !current)}
+        >
+          <ChevronRight
+            className={cn(
+              "text-muted-foreground size-3 shrink-0 transition-transform duration-150 ease-out motion-reduce:transition-none",
+              expanded && "rotate-90",
+            )}
+            aria-hidden="true"
+          />
+          <h3 className="text-muted-foreground min-w-0 flex-1 truncate font-mono text-xs">
+            {group.path}
+          </h3>
+          <span className="shrink-0 font-mono text-[11px] tabular-nums">
+            <span className="text-success">+{insertions}</span>{" "}
+            <span className="text-critical">−{deletions}</span>
+          </span>
+        </button>
+      </header>
+      {expanded ? (
+        <pre className="overflow-x-auto py-1 font-mono text-[11px] leading-5">
+          {group.lines.map((line, index) => (
+            <DiffLineRow
+              key={`${group.path}:${index}`}
+              line={line}
+            />
+          ))}
+        </pre>
+      ) : large ? (
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground px-3 py-2 text-xs"
+          onClick={() => setExpanded(true)}
+        >
+          Show diff
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+function DiffLineRow({ line }: { line: DiffLine }) {
+  return (
+    <span
+      className={cn(
+        "flex min-h-4 min-w-max",
+        line.kind === "add" && "text-success bg-success/10",
+        line.kind === "del" && "text-critical bg-critical/10",
+        (line.kind === "hunk" || line.kind === "meta") && "text-muted-foreground",
+      )}
+    >
+      <span
+        className="text-muted-foreground w-[3.25ch] shrink-0 select-none text-right text-[11px] tabular-nums"
+        data-diff-gutter="old"
+      >
+        {line.oldNo ?? ""}
+      </span>
+      <span
+        className="text-muted-foreground w-[3.25ch] shrink-0 select-none pr-2 text-right text-[11px] tabular-nums"
+        data-diff-gutter="new"
+      >
+        {line.newNo ?? ""}
+      </span>
+      <span className="px-1 whitespace-pre">{line.text || " "}</span>
+    </span>
+  );
+}
+
+function fileDiffstat(lines: readonly DiffLine[]): {
+  insertions: number;
+  deletions: number;
+} {
+  let insertions = 0;
+  let deletions = 0;
+  for (const line of lines) {
+    if (line.kind === "add") insertions += 1;
+    else if (line.kind === "del") deletions += 1;
+  }
+  return { insertions, deletions };
+}
+
+/**
+ * Split a unified diff into per-file groups of structured lines.
+ *
+ * Hunk headers drive the old/new counters. Rename and other git headers stay
+ * `meta` so they never steal a gutter number from the patch they describe.
+ */
+export function groupUnifiedDiff(diff: string): DiffFileGroup[] {
+  const groups: DiffFileGroup[] = [];
+  let current: DiffFileGroup | null = null;
+  let oldCursor = 0;
+  let newCursor = 0;
+  let inHunk = false;
+
+  function ensureGroup(path: string): DiffFileGroup {
+    if (current) return current;
+    current = { path, lines: [] };
+    groups.push(current);
+    return current;
+  }
+
   for (const line of diff.split("\n")) {
     const file = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
     if (file) {
       current = { path: file[2] ?? file[1] ?? "file", lines: [] };
       groups.push(current);
+      oldCursor = 0;
+      newCursor = 0;
+      inHunk = false;
       continue;
     }
-    if (!current) {
-      current = { path: "file", lines: [] };
-      groups.push(current);
+
+    if (line.length === 0) continue;
+
+    const group = ensureGroup("file");
+    const hunk = HUNK_HEADER.exec(line);
+    if (hunk) {
+      oldCursor = Number(hunk[1]);
+      newCursor = Number(hunk[3]);
+      inHunk = true;
+      group.lines.push({ kind: "hunk", oldNo: null, newNo: null, text: line });
+      continue;
     }
-    current.lines.push(line);
+
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      group.lines.push({
+        kind: "add",
+        oldNo: null,
+        newNo: inHunk ? newCursor : null,
+        text: line,
+      });
+      if (inHunk) newCursor += 1;
+      continue;
+    }
+    if (line.startsWith("-") && !line.startsWith("---")) {
+      group.lines.push({
+        kind: "del",
+        oldNo: inHunk ? oldCursor : null,
+        newNo: null,
+        text: line,
+      });
+      if (inHunk) oldCursor += 1;
+      continue;
+    }
+    if (inHunk && line.startsWith(" ")) {
+      group.lines.push({
+        kind: "context",
+        oldNo: oldCursor,
+        newNo: newCursor,
+        text: line,
+      });
+      oldCursor += 1;
+      newCursor += 1;
+      continue;
+    }
+
+    group.lines.push({ kind: "meta", oldNo: null, newNo: null, text: line });
   }
+
   return groups.filter((group) => group.lines.length > 0 || groups.length === 1);
 }

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
@@ -42,8 +42,46 @@ describe("FilesPanel", () => {
     );
     expect(await screen.findByText("src/lib.rs")).toBeInTheDocument();
     expect(screen.getByText("new.txt")).toBeInTheDocument();
+    expect(screen.getByLabelText("modified")).toHaveTextContent("M");
+    expect(screen.getByLabelText("added")).toHaveTextContent("A");
+    expect(screen.getByText("+3")).toHaveClass("text-success");
+    expect(screen.getByText("−1")).toHaveClass("text-critical");
+    expect(screen.getByText("+1")).toHaveClass("text-success");
+
+    const selected = screen.getByRole("button", { name: /src\/lib\.rs/ });
+    expect(selected).not.toHaveAttribute("aria-current");
     await userEvent.setup().click(screen.getByText("src/lib.rs"));
     expect(onOpenFile).toHaveBeenCalledWith("src/lib.rs");
     expect(client.listCodeWorkspaceFiles).toHaveBeenCalledWith("ws-1", "turn-1");
+  });
+
+  it("marks the selected row with aria-current", async () => {
+    const client = {
+      listCodeWorkspaceFiles: vi.fn().mockResolvedValue({
+        files: [
+          {
+            path: "src/lib.rs",
+            kind: "modified",
+            insertions: 3,
+            deletions: 1,
+          },
+        ],
+        truncated: false,
+        stat: { files: 1, insertions: 3, deletions: 1, truncated: false },
+      }),
+    };
+    render(
+      <FilesPanel
+        client={client}
+        workspaceId="ws-1"
+        selected="src/lib.rs"
+        onOpenFile={vi.fn()}
+      />,
+    );
+    expect(await screen.findByText("src/lib.rs")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /src\/lib\.rs/ })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -1,11 +1,18 @@
 import { useCallback } from "react";
 
 import type { ApiClient } from "../api/client";
-import type { CodeFileChange } from "../api/types";
+import type { CodeFileChange, FileChangeKind } from "../api/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { useLiveResource } from "./useLiveContent";
+
+const FILE_KIND_LETTER: Record<FileChangeKind, string> = {
+  added: "A",
+  modified: "M",
+  deleted: "D",
+  renamed: "R",
+};
 
 /**
  * Changed files vs the workspace base, optionally filtered to one turn.
@@ -45,13 +52,16 @@ export function FilesPanel({
     errorMessage: "Could not load changed files",
   });
 
+  const files = listing?.files ?? [];
+  const empty = listing !== null && files.length === 0 && !error;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <div className="px-3 pt-3">
+      <div className="flex items-center justify-between gap-2 px-3 pt-3">
         <h2 className="text-sm font-medium">Changed files</h2>
-        {refreshing && (
-          <Spinner className="mt-2 size-3.5" aria-label="Refreshing" />
-        )}
+        <span className="grid size-3.5 shrink-0 place-items-center">
+          {refreshing && <Spinner className="size-3.5" aria-label="Refreshing" />}
+        </span>
       </div>
       {error && <p className="text-critical px-3 py-2 text-sm">{error}</p>}
       {listing?.truncated && (
@@ -66,31 +76,69 @@ export function FilesPanel({
           <Skeleton className="h-4 w-3/5" />
         </div>
       )}
-      <ul className="min-h-0 flex-1 overflow-y-auto px-3 pb-4">
-        {(listing?.files ?? []).map((file) => (
-          <li key={`${file.kind}:${file.path}`}>
-            <button
-              type="button"
-              className={cn(
-                "flex w-full items-baseline justify-between gap-3 border-b py-2 text-left text-xs",
-                selected === file.path && "bg-muted/40",
-              )}
-              onClick={() => onOpenFile(file.path)}
-            >
-              <code className="min-w-0 truncate" title={file.path}>
-                {fileLabel(file)}
-              </code>
-              <span className="text-success shrink-0 tabular-nums">
-                {statLabel(file)}
-              </span>
-            </button>
-          </li>
-        ))}
-      </ul>
-      {listing && listing.files.length === 0 && !error && (
+      {empty ? (
         <p className="text-muted-foreground px-3 py-6 text-sm">No files changed.</p>
-      )}
+      ) : listing ? (
+        <ul className="min-h-0 flex-1 overflow-y-auto px-3 pb-4">
+          {files.map((file) => {
+            const current = selected === file.path;
+            return (
+              <li key={`${file.kind}:${file.path}`}>
+                <button
+                  type="button"
+                  aria-current={current ? true : undefined}
+                  className={cn(
+                    "flex w-full items-baseline justify-between gap-3 border-b py-2 text-left text-xs",
+                    current && "bg-muted/40",
+                  )}
+                  onClick={() => onOpenFile(file.path)}
+                >
+                  <span className="flex min-w-0 items-baseline gap-2">
+                    <span
+                      className={cn(
+                        "w-3 shrink-0 font-mono",
+                        file.kind === "added" && "text-success-foreground-muted",
+                        file.kind === "modified" && "text-info-foreground-muted",
+                        file.kind === "deleted" && "text-critical-foreground-muted",
+                        file.kind === "renamed" && "text-warning-foreground-muted",
+                      )}
+                      aria-label={file.kind}
+                    >
+                      {FILE_KIND_LETTER[file.kind]}
+                    </span>
+                    <code className="min-w-0 truncate" title={file.path}>
+                      {fileLabel(file)}
+                    </code>
+                  </span>
+                  <FileStat file={file} />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
     </div>
+  );
+}
+
+function FileStat({ file }: { file: CodeFileChange }) {
+  if (file.insertions === 0 && file.deletions === 0) {
+    return (
+      <span className="shrink-0 tabular-nums">
+        <span className="text-success">+0</span>
+      </span>
+    );
+  }
+  return (
+    <span className="shrink-0 tabular-nums">
+      {file.insertions > 0 && (
+        <span className="text-success">+{file.insertions}</span>
+      )}
+      {file.insertions > 0 && file.deletions > 0 && " "}
+      {file.deletions > 0 && (
+        <span className="text-critical">−{file.deletions}</span>
+      )}
+    </span>
   );
 }
 
@@ -99,10 +147,4 @@ function fileLabel(file: CodeFileChange): string {
     return `${file.previous_path} → ${file.path}`;
   }
   return file.path;
-}
-
-function statLabel(file: CodeFileChange): string {
-  const added = file.insertions > 0 ? `+${file.insertions}` : "";
-  const removed = file.deletions > 0 ? `-${file.deletions}` : "";
-  return [added, removed].filter(Boolean).join(" ") || "+0";
 }


### PR DESCRIPTION
## Summary

The code-mode inspector is now a saved horizontal split next to the transcript, with real tabs and a per-turn files/diff scope.

## What each new mark answers

| Element | Need it answers |
| --- | --- |
| Horizontal resize handle (`autoSaveId="code-inspector"`) | How wide should the review rail be? Keyboard resize comes from `react-resizable-panels`. |
| Icon tabs (`components/ui/tabs.tsx`) | Which surface is showing? Arrow keys move between Files, Source control, and Pull request. Tooltips name the icon. |
| Scope chip (`Turn 4 ×`) | Which turn are these files and this diff from? Dismiss returns the rail to the whole worktree. |
| Old/new gutters | Which line in each side of the patch is this? `user-select: none` so a copy takes code, not numbers. |
| Per-file sticky header (`+n −m`, chevron) | Which file is this hunk in, and how large is it? Collapse hides the patch; diffs over 400 lines start behind **Show diff**. |
| A/M/D/R letter | What kind of change is this row? |
| Split `+n` / `−m` tones | How many insertions versus deletions? Success and critical stay on separate spans. |

Status color still comes only from the semantic quads. Reveals use 150ms ease-out and honor `prefers-reduced-motion`. There is no syntax highlighting: per-line highlight.js misparses fragments, fights the add/del tints, and costs a pass this rail does not need.

## Per-turn scope

`CodeUiStore.inspectorScope` is `{ turnId, label } | null`. A turn review seam's diffstat button sets the scope, opens the rail, and lands on Source control. Files and Diff finally receive the `turnId` they already accepted. The label is the transcript ordinal (`Turn 4`), never the turn UUID. Leaving the workspace clears the scope.

`CodeUiStore` changes in this PR are only `inspectorScope` and `setInspectorScope`.

## Sidebar archived link

Skipped. #2202 already redesigned the rail: **By status** shows an **Archived** group of the archived rows themselves. A per-repo **Archived (n)** link would fight that layout.

## Tests

- Diff-line parser: hunk math and rename/meta lines with no gutter numbers.
- DiffPanel: old/new gutters, `select-none`, collapse behind **Show diff**.
- FilesPanel: success/critical tones, A/M/D badges, `aria-current` on the selected row.
- CodeInspector: `tablist` semantics and `turnId` passthrough into files and diff.
- Workspace page: the review seam sets `Turn 1` and loads that turn's diff.

## Assertions replaced

- Inspector and workspace queries for Files / Pull request as `button` now use `tab`. Those controls are a tablist.
- `queryByRole("tab", { name: "Files" })` no longer asserts the whole page has no Files tab. The inspector now has one. The conversation strip assertion is `tablist` named **Open panels**.
- `Turn ${turnId}` is gone. The caption is the ordinal label or **This turn**.

## Validation

- `pnpm vitest run src/code` — 147 passed
- `pnpm vitest run` — 1167 passed
- `pnpm build` — `tsc` and Vite production build passed