### PR TITLE
ci: run required checks on merge queue groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types:
       [opened, reopened, synchronize, edited, labeled, unlabeled, ready_for_review]
+  # Speculative merge groups from the main merge queue. Required checks must
+  # report here or the queue never drains. Scope detection diffs the group
+  # against its base the same way a pull request diffs against main.
+  merge_group:
   # Backstop the deliberately scoped post-merge capability lanes even during a
   # week with no relevant merge. The non-PR full-validation path below makes a
   # scheduled run exercise every lane.
@@ -36,20 +40,28 @@ concurrency:
 jobs:
   pr-title:
     name: semantic PR title
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     steps:
+      # A merge group has no pull-request title payload. The same check name
+      # is required on the queue, and the title was already judged when the
+      # pull request entered it.
+      - name: Accept titles already checked on the pull request
+        if: ${{ github.event_name == 'merge_group' }}
+        run: echo "Merge groups reuse the pull request title check."
       # The title and labels come from the event payload, so this job never
       # needs the pull request's own code — only the trusted base-branch copy
       # of the policy it is judged by.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1
       - name: Validate Conventional Commit title
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           CANONICAL_REPOSITORY: brightwave-inc/tidebreak
           GH_TOKEN: ${{ github.token }}
@@ -124,6 +136,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           PUSH_BASE_SHA: ${{ github.event.before }}
           PUSH_HEAD_SHA: ${{ github.event.after }}
         run: |
@@ -142,6 +156,11 @@ jobs:
             pull_request)
               base_sha="$PR_BASE_SHA"
               head_sha="$PR_HEAD_SHA"
+              diff_range="$base_sha...$head_sha"
+              ;;
+            merge_group)
+              base_sha="$MERGE_GROUP_BASE_SHA"
+              head_sha="$MERGE_GROUP_HEAD_SHA"
               diff_range="$base_sha...$head_sha"
               ;;
             push)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,19 @@ dev`, or run the React UI in a browser against `tidebreak serve` via
   becomes the squash commit used for release calculation.
 - Write a clear PR description: what changed and why.
 
+## Merging
+
+`main` uses a batched merge queue. After review, add the pull request to the
+queue or enable auto-merge. GitHub groups ready pull requests, runs the
+required checks on that combined tree, and squash-merges the group if those
+checks pass.
+
+You do not need to rebase onto `main` first. If the group fails, GitHub
+removes the pull request that broke it. Rebase, fix, and queue it again.
+
+Every queued pull request must target `main`. Do not stack pull requests that
+target each other.
+
 ## Contributor License Agreement
 
 By submitting a contribution, you agree that your contribution is provided under

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -454,6 +454,27 @@ test("PR lanes are scope-gated, never label-gated", () => {
   assert.doesNotMatch(desktopCargo, /document-parsers/);
 });
 
+test("merge queue groups re-run required CI", () => {
+  const ci = workflows["ci.yml"];
+  const changes = workflowJob(ci, "changes");
+  const prTitle = workflowJob(ci, "pr-title");
+
+  // Required checks never run unless the workflow listens for merge_group.
+  // Keep the trigger after pull_request so the trusted base-branch trigger
+  // regex still matches this file.
+  assert.match(ci, /pull_request:\n\s+types:\n[\s\S]*?\n  merge_group:\n/);
+  assert.match(changes, /merge_group\)\n\s+base_sha="\$MERGE_GROUP_BASE_SHA"/);
+  assert.match(changes, /MERGE_GROUP_BASE_SHA: \$\{\{ github\.event\.merge_group\.base_sha \}\}/);
+  assert.match(changes, /MERGE_GROUP_HEAD_SHA: \$\{\{ github\.event\.merge_group\.head_sha \}\}/);
+  // The title job is a required check. Merge groups have no PR payload, so
+  // the same name must still report success or the queue stalls.
+  assert.match(
+    prTitle,
+    /if: \$\{\{ github\.event_name == 'pull_request' \|\| github\.event_name == 'merge_group' \}\}/,
+  );
+  assert.match(prTitle, /github\.event_name == 'merge_group'/);
+});
+
 test("native Windows CI is an explicit PR opt-in with a main backstop", () => {
   const windows = workflowJob(workflows["ci.yml"], "windows-check");
   const windowsCiGate =


### PR DESCRIPTION
## Summary

Prepare Tidebreak for a batched GitHub merge queue on `main`.

CI now listens for `merge_group`. The queue builds a temporary branch of ready pull requests, and required checks have to report on that branch or the queue never drains.

- Diff merge groups against their base the same way a pull request diffs against `main`, so a docs-only group still skips Rust.
- Keep the `semantic PR title` check name on merge groups. The group has no title payload, so the job succeeds after the pull request already passed that check.
- Document the queue in `CONTRIBUTING.md`.

This pull request does **not** turn the queue on. Merge it first. After it is on `main`, enable a squash / all-green queue with a short grouping window (about 2 minutes, max 8). Leave `HEADGREEN` off.

Do not stack pull requests that target each other into this queue. Every queued pull request must target `main`.

## Test plan

- [x] `node --test scripts/*.test.mjs` (includes the new merge-queue workflow assertion)
- [ ] GitHub CI on this pull request
- [ ] After merge: enable the `main` merge queue and land a pair of ready pull requests through it