### PR TITLE
refactor(desktop): normalize code-mode spacing and type ramp

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -55,7 +55,7 @@ export function ToolOutputPreview({
           aria-label={label}
           className={
             bare
-              ? "text-muted-foreground overflow-x-auto pr-7 font-mono text-[13px] break-words whitespace-pre-wrap [overflow-anchor:none]"
+              ? "text-muted-foreground overflow-x-auto pr-7 font-mono text-[13.5px] break-words whitespace-pre-wrap [overflow-anchor:none]"
               : "bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-xs break-words whitespace-pre-wrap"
           }
         >

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -42,7 +42,7 @@ export function CodeApprovalCard({
       data-testid="code-approval-card"
     >
       <div className="flex items-baseline justify-between gap-3">
-        <h3 className="text-[13px] font-medium break-words">
+        <h3 className="text-[13.5px] font-medium break-words">
           {approvalTitle(approval)}
         </h3>
         <ApprovalState approval={approval} />
@@ -53,7 +53,7 @@ export function CodeApprovalCard({
         decidedAt={approval.decided_at}
       />
       {approval.state === "denied" && approval.feedback && (
-        <p className="text-[13px] break-words">{approval.feedback}</p>
+        <p className="text-[13.5px] break-words">{approval.feedback}</p>
       )}
       <div>
         <button
@@ -151,7 +151,7 @@ function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
     case "command":
       return (
         <div className="flex flex-col gap-1">
-          <pre className="bg-muted overflow-x-auto rounded-md p-2 font-mono text-[13px] break-words whitespace-pre-wrap">
+          <pre className="bg-muted overflow-x-auto rounded-md p-2 font-mono text-[13.5px] break-words whitespace-pre-wrap">
             {approval.kind.cmd || "Command"}
           </pre>
           {approval.kind.cwd && (
@@ -166,17 +166,17 @@ function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
         <ul className="space-y-0.5">
           {approval.kind.paths.map((path) => (
             <li key={path}>
-              <MiddleTruncate text={path} className="font-mono text-[11px]" />
+              <MiddleTruncate text={path} className="font-mono text-[13.5px]" />
             </li>
           ))}
         </ul>
       ) : (
-        <p className="text-muted-foreground text-[13px]">File write</p>
+        <p className="text-muted-foreground text-[13.5px]">File write</p>
       );
     case "network":
     case "other":
       return (
-        <p className="text-muted-foreground text-[13px] break-words">
+        <p className="text-muted-foreground text-[13.5px] break-words">
           {approval.kind.summary}
         </p>
       );

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -71,7 +71,9 @@ export function CodeCenterTabs({
               ) : (
                 <FileCode className="size-3.5 shrink-0" />
               )}
-              <span className="max-w-40 truncate">{label}</span>
+              <span className="max-w-40 truncate" title={centerTabTitle(panel)}>
+                {label}
+              </span>
             </button>
             <button
               type="button"
@@ -86,6 +88,13 @@ export function CodeCenterTabs({
       })}
     </div>
   );
+}
+
+/** The whole path behind a tab whose label is only the file name. */
+function centerTabTitle(panel: PanelContent): string {
+  if (panel.type === "file") return panel.path;
+  if (panel.type === "diff" && panel.path) return `${panel.path} (diff)`;
+  return centerTabLabel(panel);
 }
 
 function centerTabLabel(panel: PanelContent): string {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -199,7 +199,9 @@ export function HarnessModelMenu({
           option={option}
           className="size-4 shrink-0"
         />
-        <span className="min-w-0 flex-1 truncate text-sm">{option.label}</span>
+        <span className="min-w-0 flex-1 truncate text-sm" title={option.label}>
+          {option.label}
+        </span>
         {index < 9 && (
           <span className="text-muted-foreground rounded-md border px-1.5 py-0.5 font-mono text-2xs">
             ⌘{index + 1}

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -201,7 +201,7 @@ export function HarnessModelMenu({
         />
         <span className="min-w-0 flex-1 truncate text-sm">{option.label}</span>
         {index < 9 && (
-          <span className="text-muted-foreground rounded-md border px-1.5 py-0.5 font-mono text-[10px]">
+          <span className="text-muted-foreground rounded-md border px-1.5 py-0.5 font-mono text-2xs">
             ⌘{index + 1}
           </span>
         )}

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -144,6 +144,7 @@ export function CodeInspector({
               type="button"
               className="text-muted-foreground hover:text-foreground ml-auto truncate rounded-full border px-2 py-0.5 font-mono text-[11px]"
               aria-label={`Clear ${scope.label} scope`}
+              title={scope.label}
               onClick={() => setInspectorScope(null)}
             >
               {scope.label} ×
@@ -364,6 +365,7 @@ function PrTab({
               <a
                 href={pr.url}
                 className="text-foreground truncate text-sm font-semibold underline-offset-2 hover:underline"
+                title={pr.title ?? `#${pr.number}`}
                 onClick={(event) => {
                   event.preventDefault();
                   void openExternal(pr.url!).catch(() => undefined);
@@ -372,12 +374,18 @@ function PrTab({
                 {pr.title ?? `#${pr.number}`}
               </a>
             ) : (
-              <p className="truncate text-sm font-semibold">
+              <p
+                className="truncate text-sm font-semibold"
+                title={pr.title ?? `#${pr.number}`}
+              >
                 {pr.title ?? `#${pr.number}`}
               </p>
             )}
           </div>
-          <p className="text-muted-foreground mt-1 truncate text-xs">
+          <p
+            className="text-muted-foreground mt-1 truncate font-mono text-xs"
+            title={branchLine ?? undefined}
+          >
             #{pr.number}
             {branchLine ? ` · ${branchLine}` : ""}
           </p>
@@ -563,12 +571,12 @@ function CommentRow({ comment }: { comment: PullRequestComment }) {
           </span>
         )}
         {comment.kind === "inline" && comment.path && (
-          <span className="truncate font-mono">
+          <span className="truncate font-mono" title={comment.path}>
             {comment.path}
             {comment.line !== undefined ? `:${comment.line}` : ""}
           </span>
         )}
-        {when && <span className="ml-auto shrink-0">{when}</span>}
+        {when && <span className="ml-auto shrink-0 tabular-nums">{when}</span>}
       </div>
       <p className="text-xs leading-relaxed whitespace-pre-wrap">
         {comment.body}
@@ -589,24 +597,24 @@ function CheckList({
     <div className="flex flex-col gap-1">
       <button
         type="button"
-        className="hover:bg-muted/50 flex w-full items-center gap-2 rounded-md px-1 py-1 text-left text-xs"
+        className="hover:bg-muted/50 -mx-1 flex items-center gap-2 rounded-md px-1 py-1 text-left text-xs"
         onClick={() => setOpen((current) => !current)}
         aria-expanded={open}
       >
         <CheckCount
-          icon={<Check className="size-3" />}
+          icon={<Check className="size-3.5" />}
           count={counts.passing}
           label="passing"
           className="text-success"
         />
         <CheckCount
-          icon={<CircleDashed className="size-3" />}
+          icon={<CircleDashed className="size-3.5" />}
           count={counts.pending}
           label="pending"
           className="text-muted-foreground"
         />
         <CheckCount
-          icon={<X className="size-3" />}
+          icon={<X className="size-3.5" />}
           count={counts.failing}
           label="failing"
           className="text-critical"
@@ -632,7 +640,7 @@ function CheckCount({
   className: string;
 }) {
   return (
-    <span className={cn("flex items-center gap-1", className)}>
+    <span className={cn("flex items-center gap-1 tabular-nums", className)}>
       {icon}
       {count} {label}
     </span>
@@ -651,7 +659,9 @@ function CheckRow({ check }: { check: PullRequestCheck }) {
   const body = (
     <>
       <Icon className={cn("size-3.5 shrink-0", tone)} />
-      <span className="min-w-0 flex-1 truncate">{check.name}</span>
+      <span className="min-w-0 flex-1 truncate" title={check.name}>
+        {check.name}
+      </span>
       {check.detail && (
         <span className="text-muted-foreground shrink-0 capitalize">
           {check.detail}
@@ -661,13 +671,13 @@ function CheckRow({ check }: { check: PullRequestCheck }) {
   );
   if (!check.url) {
     return (
-      <div className="flex items-center gap-2 px-1 py-1 text-xs">{body}</div>
+      <div className="-mx-1 flex items-center gap-2 px-1 py-1 text-xs">{body}</div>
     );
   }
   return (
     <a
       href={check.url}
-      className="hover:bg-muted/50 flex items-center gap-2 rounded-md px-1 py-1 text-xs"
+      className="hover:bg-muted/50 -mx-1 flex items-center gap-2 rounded-md px-1 py-1 text-xs"
       onClick={(event) => {
         event.preventDefault();
         void openExternal(check.url!).catch(() => undefined);

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -226,7 +226,10 @@ export function CodeSidebar() {
           groups.map((group) => (
             <div key={group.key} className="flex flex-col gap-0.5">
               {group.label && (
-                <div className="mt-1 truncate px-2 pt-1 pb-0.5 text-[11px] font-medium text-muted-foreground/90">
+                <div
+                  className="truncate px-2 pt-2 pb-1 text-[11px] font-medium text-muted-foreground/90"
+                  title={group.label}
+                >
                   {group.label}
                 </div>
               )}
@@ -340,7 +343,7 @@ function WorkspaceCard({
           aria-current={active ? "page" : undefined}
           data-active={active || undefined}
           title={attentionTitle}
-          className="flex w-full cursor-pointer flex-col gap-0.5 rounded-md px-2 py-1.5 text-left ring-offset-background motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none data-[active]:bg-muted"
+          className="flex w-full cursor-pointer flex-col gap-1 rounded-md px-2 py-1.5 text-left ring-offset-background motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none data-[active]:bg-muted"
           onClick={onOpen}
         >
           <span className="flex min-w-0 items-center gap-1.5">
@@ -384,7 +387,7 @@ function WorkspaceCard({
             </span>
           </span>
           {showSession && digest && (
-            <span className="mt-0.5 flex min-w-0 items-center gap-1.5 pl-0.5 text-[11px] text-muted-foreground">
+            <span className="flex min-w-0 items-center gap-1.5 pl-0.5 text-[11px] text-muted-foreground">
               <ChevronRight
                 className="size-3 shrink-0 opacity-50"
                 aria-hidden

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -330,7 +330,7 @@ export function CodeToolCard({
     >
       <button
         type="button"
-        className="flex w-full items-center gap-2 py-0.5 text-left text-[13px]"
+        className="flex w-full items-center gap-2 py-0.5 text-left text-[13.5px]"
         aria-expanded={expanded || showTail}
         aria-controls={hasOutput ? bodyId : undefined}
         onClick={() => setExpanded((current) => !current)}
@@ -441,7 +441,7 @@ function StreamingTail({ text }: { text: string }) {
   return (
     <pre
       aria-label="Output"
-      className="text-muted-foreground max-h-[17.4em] overflow-hidden font-mono text-[13px] break-words whitespace-pre-wrap [overflow-anchor:none]"
+      className="text-muted-foreground max-h-[17.4em] overflow-hidden font-mono text-[13.5px] break-words whitespace-pre-wrap [overflow-anchor:none]"
     >
       {tail}
     </pre>
@@ -616,7 +616,7 @@ function FileActivityRow({
                 {FILE_KIND_LETTER[file.kind]}
               </span>
               <PathLabel path={path} />
-              <span className="shrink-0 tabular-nums">
+              <span className="ml-auto shrink-0 tabular-nums">
                 +{file.diffstat.insertions} −{file.diffstat.deletions}
               </span>
             </li>

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -370,7 +370,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         <div className="min-w-0">
           <h1 className="flex min-w-0 items-center gap-2 text-sm font-medium">
             {title ? (
-              <span className="truncate">{title}</span>
+              <span className="truncate" title={title}>
+                {title}
+              </span>
             ) : error ? null : (
               <span
                 data-testid="workspace-header-skeleton"
@@ -381,7 +383,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
               </span>
             )}
             {repoName && (
-              <span className="text-muted-foreground truncate text-xs font-normal">
+              <span
+                className="text-muted-foreground truncate text-xs font-normal"
+                title={repoName}
+              >
                 {repoName}
               </span>
             )}
@@ -620,7 +625,7 @@ function WorktreePathChip({ path }: { path: string }) {
           }
           onClick={() => void onCopy()}
         >
-          {middleTruncate(path, 28)}
+          {middleTruncate(path, 24)}
         </button>
       </WithTooltip>
       <span className="sr-only" role="status" aria-live="polite">
@@ -665,7 +670,7 @@ function PendingApprovalBadge({
           });
       }}
     >
-      <Badge variant="warning" size="sm">
+      <Badge variant="warning" size="sm" className="tabular-nums">
         {pending} {pending === 1 ? "approval" : "approvals"}
       </Badge>
     </button>

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
@@ -81,7 +81,10 @@ export function DiffPanel({
       <header className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b px-3 py-2">
         <div className="min-w-0">
           <h2 className="text-sm font-medium">Diff</h2>
-          <p className="text-muted-foreground truncate font-mono text-[11px]">
+          <p
+            className="text-muted-foreground truncate font-mono text-[11px]"
+            title={scopeCaption}
+          >
             {scopeCaption}
           </p>
         </div>
@@ -146,7 +149,10 @@ function FileDiffSection({
             )}
             aria-hidden="true"
           />
-          <h3 className="text-muted-foreground min-w-0 flex-1 truncate font-mono text-xs">
+          <h3
+            className="text-muted-foreground min-w-0 flex-1 truncate font-mono text-xs"
+            title={group.path}
+          >
             {group.path}
           </h3>
           {onOpenFile && (
@@ -175,7 +181,7 @@ function FileDiffSection({
         </button>
       </header>
       {expanded ? (
-        <pre className="overflow-x-auto py-1 font-mono text-[11px] leading-5">
+        <pre className="overflow-x-auto py-1 font-mono text-xs leading-5">
           {group.lines.map((line, index) => (
             <DiffLineRow
               key={`${group.path}:${index}`}

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -161,7 +161,7 @@ export function FilesPanel({
           {busy && <Spinner className="size-3.5" aria-label="Refreshing" />}
         </span>
       </div>
-      <div className="flex flex-col gap-1.5 px-3 pt-2">
+      <div className="flex flex-col gap-2 px-3 pt-2">
         <SearchInput
           size="sm"
           value={query}

--- a/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.tsx
@@ -142,7 +142,7 @@ export function TerminalDrawer({
         </div>
         <header className="flex h-8 shrink-0 items-center gap-2 px-3">
           <SquareTerminal className="text-muted-foreground size-3.5 shrink-0" />
-          <h2 className="min-w-0 flex-1 truncate text-xs font-medium">Terminal</h2>
+          <h2 className="min-w-0 flex-1 truncate text-sm font-medium">Terminal</h2>
           <WithTooltip
             label={shortcutHint ? `Hide terminal ${shortcutHint}` : "Hide terminal"}
           >

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -60,7 +60,7 @@ export function TurnReviewCard({
         <p className="flex items-center gap-1.5 font-medium">
           <TriangleAlert size={14} aria-hidden="true" />
           Turn failed
-          {duration && <span className="font-normal">· {duration}</span>}
+          {duration && <span className="font-normal tabular-nums">· {duration}</span>}
         </p>
         <p>{turn.error ?? "The engine stopped without saying why."}</p>
         {narrative}
@@ -74,7 +74,7 @@ export function TurnReviewCard({
       <SeamRow label="Turn interrupted" tone="warning">
         <CircleSlash size={13} aria-hidden="true" />
         <span>Turn interrupted</span>
-        {duration && <span>· {duration}</span>}
+        {duration && <span className="tabular-nums">· {duration}</span>}
         {narrative}
         {diffstat}
       </SeamRow>
@@ -85,7 +85,7 @@ export function TurnReviewCard({
     <SeamRow label="Turn finished" tone="quiet">
       <Check size={13} aria-hidden="true" />
       <span>Turn finished</span>
-      {duration && <span>· {duration}</span>}
+      {duration && <span className="tabular-nums">· {duration}</span>}
       {narrative}
       {diffstat}
       <TurnUsage usage={turn.usage} />
@@ -167,7 +167,7 @@ function TurnDiffstat({
 
 export function DiffstatBadge({ stat }: { stat: Diffstat }) {
   return (
-    <Badge variant="outline" size="sm">
+    <Badge variant="outline" size="sm" className="tabular-nums">
       {stat.files} file{stat.files === 1 ? "" : "s"} +{stat.insertions} −
       {stat.deletions}
       {stat.truncated ? " · truncated" : ""}


### PR DESCRIPTION
R1 of the code-mode refinement stack, based on #2211 (`thet/fix-engine-session-launch`) rather than `main`; retarget once #2211 lands. One concern only: spacing and typography. No behavior, no restructuring, no new UI elements — the diff is classes, one `title` helper, and hover-recovery attributes.

## The ramp this settles on

Code mode was carrying six text sizes with no rule for which was which (`text-[10px]`, `text-2xs`, `text-[11px]`, `text-xs`, `text-[13px]`, `text-[13.5px]`, `text-sm`). Four now, each with a job:

- **14px `text-sm`** — prose and panel titles: messages, dialog copy, form labels, "Files", "Diff", "Terminal", "Git".
- **13.5px `text-[13.5px]`** — dense row body: transcript tool lines and their output, what an approval is asking for, the sidebar card title.
- **12px `text-xs`** — secondary: captions, notes, empty states, explorer and diff rows, header sub-labels.
- **11px `text-[11px]`** — meta: durations, counts, timestamps, path and branch chips, diff gutters, disclosure toggles.
- 10px `text-2xs` survives for keycap chips only, which is the app-wide convention shared with chat's dialogs.

`gap-1.5` and `py-0.5` stay where they express tight internal leading. The rule applied here is the Tailwind scale with no arbitrary pixel values, plus equal spacing between sibling rows.

## What was off, surface by surface

**CodeTranscript** — the tool row, its streaming tail, and the expanded output preview sat at 13px while the rest of the transcript body ran 14px. All three now share 13.5px, so a tool card does not change size when it expands. Per-file `+N −M` counts were sitting wherever the path left them; they now right-align on the row's meta axis with the durations above them.

**TurnReviewCard** — durations and diffstat counts were proportional figures, so a turn's elapsed time jittered as it counted. Both are tabular now.

**CodeApprovalCard** — the title, the denial feedback, the command block, and the network summary were 13px; the file paths under a `file_write` request were 11px, two steps below the command block that asks the same question. Everything the reader is deciding on now reads at 13.5px.

**CodeSidebar workspace cards** — the card's three rows sat 2px apart, except the session row, which added its own 2px margin on top of the gap. All three are 4px apart now. Group headers stacked `mt-1` on `pt-1` on the list gap; that is one 8px/4px band, and the header carries a `title` so a truncated group name is recoverable.

**CodeWorkspacePage header** — the worktree chip middle-truncated to 28 characters inside a 44-unit box that then end-truncated it again, losing the tail the middle-truncation existed to protect; the budget now fits the box. The title and repo name are hover-recoverable, and the approvals badge is tabular.

**CodeInspector** — check summary icons were 12px above 14px icons in the rows they summarize; one glyph width now. Check counts and comment timestamps are tabular. Check rows sat 4px inside the column's left edge; they align with everything else and keep the hover bleed. The scope chip, PR title, check names, inline comment paths, and the branch line are all hover-recoverable, and the branch line is mono like every other git reference.

**DiffPanel** — diff lines were 11px, below the ramp's floor for anything you actually read; they are 12px now with the gutters left at 11px meta, which is the usual editor relationship. The scope caption and per-file path headers gained titles.

**FilesPanel** — the filter stack was 6px apart; 8px, on the scale.

**CodeCenterTabs** — a tab shows only the file name and truncates at 160px, with nothing behind it. The full path is now the tab's title.

**FileViewer, NewWorkspaceDialog, StartSessionPrompt, HarnessPicker, workspaceActions, TerminalPane** — audited, already on the ramp, unchanged.

**TerminalDrawer** — its title was 12px while every other panel title in the same product is 14px.

**CodeComposer** — the model-menu keycap used a raw `text-[10px]` where the rest of the app uses `text-2xs` for the same chip; same size, one token. Truncated model names are hover-recoverable.

**ToolOutputPreview** (shared location, code mode is its only consumer) — its `bare` variant renders inside the code tool card, so it has to match the row it belongs to; it moved with the row to 13.5px. The boxed variant stays 12px, matching the panel mono size.

## Tests

`pnpm vitest run src/code` (179 passed), `pnpm vitest run` (1200 passed), `pnpm build`: all green. No test assertions changed — nothing in the suite pins these classes.

## Logged, not fixed (bigger than spacing and type)

1. **No shared fluid middle-truncation.** `MiddleTruncate` is duplicated privately in `CodeTranscript.tsx` and `CodeApprovalCard.tsx`, so surfaces without a copy (diff scope caption, per-file diff headers, PR branch line) end-truncate paths and lose the tail. They get `title` attributes here. A shared primitive is the real fix.
2. **Panel headers do not share a height.** `DiffPanel` has a title plus a caption; `FileViewer` has a single path line. Switching center tabs shifts the content below by the difference.
3. **The files explorer is sans, not mono.** Its rows are names, not paths, so this may be right — but it is the one place a path-shaped thing is not mono, and it deserves a decision at the screenshot gate.
4. **Monaco's font size (13px) is set as a prop, outside the ramp**, near but not equal to the 12px diff body next to it.
5. **`DoctorList` uses a 16px card title and shows harness paths in sans.** It is shared with Settings, so its ramp is a wider question than code mode.
6. **The diff body moving from 11px to 12px is the one density change here** and the item most worth a look in the screenshot sweep.
