### PR TITLE
feat(desktop): hide the sidebar entirely when collapsed

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -43,6 +43,8 @@ import { useInterfaceZoom } from "./InterfaceZoom";
 import { Logomark } from "./Logomark";
 import { ManagedGate } from "./ManagedGate";
 import { resolvedRoleKey } from "./ModelSelection";
+import { SidebarExpandStrip } from "./sidebar/SidebarExpandStrip";
+import { useSyncSidebarWidthCssVar } from "./sidebar/primitives";
 import { Titlebar } from "./Titlebar";
 import { WindowDragStrip } from "./WindowDragStrip";
 import { useActiveChatId } from "./useActiveChatId";
@@ -130,6 +132,10 @@ export function AppShell() {
   const desktopUpdates = useDesktopUpdates();
   const desktopNavigation = useDesktopNavigation();
   const zoom = useInterfaceZoom();
+  // The expanded rail width is published by the shell, not the rail itself, so
+  // the value survives a collapse — the expand strip and the titlebar both
+  // depend on it.
+  useSyncSidebarWidthCssVar();
   // Read at keydown rather than subscribed to: which mode a shortcut fires in
   // is the route's answer, and the shell has no other reason to re-render on
   // every navigation.
@@ -696,6 +702,7 @@ export function AppShell() {
               navigation={desktopNavigation}
             />
           )}
+          <SidebarExpandStrip macOverlay={macOverlayTitlebar} />
           <ComputerUseIndicator />
           {/* Each route renders its own rail beside its content — see RouteFrame. */}
           <div className="app-body">

--- a/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
@@ -2,7 +2,6 @@ import { FolderGit2, MessageSquare } from "lucide-react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 
 import { SegmentedControl } from "@/components/ui/segmented";
-import { useSidebarWidth } from "@/sidebar/primitives";
 import { isCodeRoute } from "./routes";
 
 type Mode = "chat" | "code";
@@ -18,7 +17,6 @@ export function CodeModeSwitch() {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
-  const isCompact = useSidebarWidth() === "compact";
   const value: Mode = isCodeRoute(pathname) ? "code" : "chat";
 
   return (
@@ -26,7 +24,6 @@ export function CodeModeSwitch() {
       <SegmentedControl
         aria-label="App mode"
         value={value}
-        compact={isCompact}
         onValueChange={(next) => {
           if (next === value) return;
           void navigate({ to: next === "code" ? "/code" : "/" });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -19,11 +19,7 @@ import {
 } from "@/components/ui/context-menu";
 import { cn } from "@/lib/utils";
 import { useLayoutState } from "@/panel/usePanelNav";
-import {
-  SidebarButton,
-  SidebarSectionTitle,
-  useSidebarWidth,
-} from "@/sidebar/primitives";
+import { SidebarButton, SidebarSectionTitle } from "@/sidebar/primitives";
 import { SidebarFrame } from "@/sidebar/SidebarFrame";
 import type {
   CodeSessionDigest,
@@ -75,7 +71,6 @@ export function CodeSidebar() {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
-  const isCompact = useSidebarWidth() === "compact";
   const repos = useCodeCatalogStore((state) => state.repos);
   const workspaces = useCodeCatalogStore((state) => state.workspaces);
   const sessions = useCodeCatalogStore((state) => state.sessionsByWorkspace);
@@ -115,25 +110,17 @@ export function CodeSidebar() {
     <SidebarFrame>
       <CodeModeSwitch />
 
-      {!isCompact && (
-        <div className="flex items-center justify-between px-2">
-          <SidebarSectionTitle className="px-0">Repos</SidebarSectionTitle>
-          <button
-            type="button"
-            className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-            aria-label="Add repo"
-            onClick={() => setAddRepoOpen(true)}
-          >
-            <Plus size={14} />
-          </button>
-        </div>
-      )}
-      {isCompact && (
-        <SidebarButton aria-label="Add repo" onClick={() => setAddRepoOpen(true)}>
-          <Plus />
-          <span>Add repo</span>
-        </SidebarButton>
-      )}
+      <div className="flex items-center justify-between px-2">
+        <SidebarSectionTitle className="px-0">Repos</SidebarSectionTitle>
+        <button
+          type="button"
+          className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="Add repo"
+          onClick={() => setAddRepoOpen(true)}
+        >
+          <Plus size={14} />
+        </button>
+      </div>
       <div className="flex shrink-0 flex-col gap-0.5">
         {repos.map((repo) => {
           const active = pathname === `/code/r/${repo.id}`;
@@ -155,134 +142,92 @@ export function CodeSidebar() {
             </SidebarButton>
           );
         })}
-        {repos.length === 0 && !isCompact && (
+        {repos.length === 0 && (
           <p className="px-2 py-1 text-xs text-muted-foreground">
             No repos registered
           </p>
         )}
       </div>
 
-      {!isCompact && (
-        <div className="mt-3 flex items-center justify-between gap-1 px-2">
-          <SidebarSectionTitle className="px-0">Workspaces</SidebarSectionTitle>
-          <div className="flex items-center">
-            <button
-              type="button"
-              className="cursor-pointer rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-              aria-label={`Sort workspaces: ${sortLabel}. Activate to cycle.`}
-              onClick={() => setSortMode(nextWorkspaceSortMode(sortMode))}
-            >
-              {sortLabel}
-            </button>
-            <button
-              type="button"
-              className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-              aria-label="New workspace"
-              onClick={() => startNewWorkspace()}
-            >
-              <Plus size={14} />
-            </button>
-          </div>
+      <div className="mt-3 flex items-center justify-between gap-1 px-2">
+        <SidebarSectionTitle className="px-0">Workspaces</SidebarSectionTitle>
+        <div className="flex items-center">
+          <button
+            type="button"
+            className="cursor-pointer rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={`Sort workspaces: ${sortLabel}. Activate to cycle.`}
+            onClick={() => setSortMode(nextWorkspaceSortMode(sortMode))}
+          >
+            {sortLabel}
+          </button>
+          <button
+            type="button"
+            className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="New workspace"
+            onClick={() => startNewWorkspace()}
+          >
+            <Plus size={14} />
+          </button>
         </div>
-      )}
-      {isCompact && (
-        <SidebarButton
-          aria-label="New workspace"
-          onClick={() => startNewWorkspace()}
-        >
-          <Plus />
-          <span>New workspace</span>
-        </SidebarButton>
-      )}
+      </div>
       <div className="flex min-h-0 flex-col gap-0.5">
-        {isCompact &&
-          groups
-            .flatMap((group) => group.workspaces)
-            .map((workspace) => {
-              const active = pathname === `/code/w/${workspace.id}`;
+        {groups.map((group) => (
+          <div key={group.key} className="flex flex-col gap-0.5">
+            {group.label && (
+              <div
+                className="truncate px-2 pt-2 pb-1 text-[11px] font-medium text-muted-foreground/90"
+                title={group.label}
+              >
+                {group.label}
+              </div>
+            )}
+            {group.workspaces.map((workspace) => {
               const digest = digests[workspace.id];
+              const pr = digest?.pr_state ?? workspace.pr;
               return (
-                <SidebarButton
+                <WorkspaceCard
                   key={workspace.id}
-                  aria-current={active ? "page" : undefined}
-                  data-active={active || undefined}
-                  className="data-[active]:bg-muted"
-                  onClick={() =>
+                  workspace={workspace}
+                  digest={digest}
+                  session={sessions[workspace.id]}
+                  repoName={
+                    repos.find((repo) => repo.id === workspace.repo_id)
+                      ?.display_name ?? workspace.repo_id
+                  }
+                  active={pathname === `/code/w/${workspace.id}`}
+                  terminalOpen={terminalOpen && viewedWorkspaceId === workspace.id}
+                  commands={workspaceCommands({
+                    hasPr: Boolean(pr),
+                    archived: workspace.status === "archived",
+                    hasSession: Boolean(sessions[workspace.id]),
+                    attentionPinned:
+                      (digest?.attention ?? sessions[workspace.id]?.attention)
+                        ?.state.type === "manual",
+                  })}
+                  onOpen={() =>
                     void navigate({
                       to: "/code/w/$workspaceId",
                       params: { workspaceId: workspace.id },
                     })
                   }
-                >
-                  <FolderGit2 />
-                  {/* The digest restates the title on every notice, so a
-                      background rename lands here without a catalog refresh. */}
-                  <span>{digest?.title ?? workspace.title}</span>
-                  <AttentionBadge attention={digest?.attention} compact />
-                </SidebarButton>
+                  onCommand={(command) =>
+                    run(command, {
+                      workspace,
+                      title: digest?.title ?? workspace.title,
+                      pr,
+                      session: sessions[workspace.id],
+                    })
+                  }
+                />
               );
             })}
-        {!isCompact &&
-          groups.map((group) => (
-            <div key={group.key} className="flex flex-col gap-0.5">
-              {group.label && (
-                <div
-                  className="truncate px-2 pt-2 pb-1 text-[11px] font-medium text-muted-foreground/90"
-                  title={group.label}
-                >
-                  {group.label}
-                </div>
-              )}
-              {group.workspaces.map((workspace) => {
-                const digest = digests[workspace.id];
-                const pr = digest?.pr_state ?? workspace.pr;
-                return (
-                  <WorkspaceCard
-                    key={workspace.id}
-                    workspace={workspace}
-                    digest={digest}
-                    session={sessions[workspace.id]}
-                    repoName={
-                      repos.find((repo) => repo.id === workspace.repo_id)
-                        ?.display_name ?? workspace.repo_id
-                    }
-                    active={pathname === `/code/w/${workspace.id}`}
-                    terminalOpen={
-                      terminalOpen && viewedWorkspaceId === workspace.id
-                    }
-                    commands={workspaceCommands({
-                      hasPr: Boolean(pr),
-                      archived: workspace.status === "archived",
-                      hasSession: Boolean(sessions[workspace.id]),
-                      attentionPinned:
-                        (digest?.attention ?? sessions[workspace.id]?.attention)
-                          ?.state.type === "manual",
-                    })}
-                    onOpen={() =>
-                      void navigate({
-                        to: "/code/w/$workspaceId",
-                        params: { workspaceId: workspace.id },
-                      })
-                    }
-                    onCommand={(command) =>
-                      run(command, {
-                        workspace,
-                        title: digest?.title ?? workspace.title,
-                        pr,
-                        session: sessions[workspace.id],
-                      })
-                    }
-                  />
-                );
-              })}
-            </div>
-          ))}
-        {!isCompact &&
-          groups.every((group) => group.workspaces.length === 0) && (
-            <p className="px-2 py-1 text-xs text-muted-foreground">
-              No workspaces yet
-            </p>
-          )}
+          </div>
+        ))}
+        {groups.every((group) => group.workspaces.length === 0) && (
+          <p className="px-2 py-1 text-xs text-muted-foreground">
+            No workspaces yet
+          </p>
+        )}
       </div>
 
       {dialogs}

--- a/crates/tidebreak-desktop/ui/src/components/ui/segmented.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/segmented.tsx
@@ -23,14 +23,12 @@ export function SegmentedControl<T extends string>({
   onValueChange,
   options,
   "aria-label": ariaLabel,
-  compact = false,
   className,
 }: {
   value: T;
   onValueChange: (value: T) => void;
   options: readonly SegmentedOption<T>[];
   "aria-label": string;
-  compact?: boolean;
   className?: string;
 }) {
   const refs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -96,7 +94,6 @@ export function SegmentedControl<T extends string>({
               checked
                 ? "bg-background text-foreground"
                 : "text-muted-foreground hover:text-foreground",
-              compact && "px-1.5 [&_span]:hidden",
             )}
             onClick={() => onValueChange(option.value)}
             onKeyDown={(event) => onKeyDown(event, index)}

--- a/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { LayoutGrid, Puzzle, SquarePen } from "lucide-react";
+import { LayoutGrid, Puzzle } from "lucide-react";
 
 import type { Chat } from "@/api";
 import { useApp } from "@/AppContext";
@@ -10,7 +10,7 @@ import { useExperimentalFlags } from "@/experimental";
 import { ChatsSection } from "./ChatsSection";
 import { InboxButton } from "./InboxButton";
 import { ProjectsSection } from "./ProjectsSection";
-import { SidebarButton, useSidebarWidth } from "./primitives";
+import { SidebarButton } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
 
 /**
@@ -27,29 +27,13 @@ import { SidebarFrame } from "./SidebarFrame";
  */
 export function AppSidebar({ chat }: { chat?: Chat }) {
   const navigate = useNavigate();
-  const { newChat, refreshChats } = useApp();
+  const { refreshChats } = useApp();
   const chatsError = useChatListStore((state) => state.chatsError);
-  const creatingChat = useChatListStore((state) => state.creatingChat);
-  const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const pathname = useRouterState({ select: (state) => state.location.pathname });
-  const isCompact = useSidebarWidth() === "compact";
   const codeModeEnabled = useExperimentalFlags((state) => state.codeModeEnabled);
 
   return (
     <SidebarFrame>
-      {/* Expanded, starting a chat is the + on the Chats section header. The
-          compact rail hides that section, so it keeps a row of its own. */}
-      {isCompact && (
-        <SidebarButton
-          aria-label={creatingChat ? "Starting…" : "New chat"}
-          onClick={newChat}
-          disabled={creatingChat || deletingChatId !== null}
-        >
-          <SquarePen />
-          <span>New chat</span>
-        </SidebarButton>
-      )}
-
       {codeModeEnabled && <CodeModeSwitch />}
 
       <div className="flex shrink-0 flex-col gap-0.5">

--- a/crates/tidebreak-desktop/ui/src/sidebar/ChatsSection.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/ChatsSection.tsx
@@ -23,7 +23,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { RecentChatRow } from "./RecentChatRow";
-import { useSidebarWidth } from "./primitives";
 
 /** Case-insensitive match on the title, with untitled chats matching "new chat". */
 export function matchesChatSearch(chat: Chat, query: string): boolean {
@@ -122,17 +121,12 @@ export function ChatsSection({ activeChatId }: { activeChatId?: string }) {
   const filtering = useChatsSectionState((state) => state.filtering);
   const query = useChatsSectionState((state) => state.query);
   const { toggleCollapsed, setFiltering, setQuery } = useChatsSectionState.getState();
-  const isCompact = useSidebarWidth() === "compact";
 
   // The filter appears from a menu selection, so nothing natural has focus.
   const filterRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (filtering) filterRef.current?.querySelector("input")?.focus();
   }, [filtering]);
-
-  // Icons-only has no room for titles, and a column of identical glyphs says
-  // nothing — the list stands down and the rail's rows carry the narrow width.
-  if (isCompact) return null;
 
   const listed = listedChats(chats, query);
   // A collapsed list hides the per-row markers, so the header has to say when

--- a/crates/tidebreak-desktop/ui/src/sidebar/ProjectsSection.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/ProjectsSection.tsx
@@ -28,7 +28,6 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { NewProjectDialog } from "./NewProjectDialog";
 import { RecentChatRow } from "./RecentChatRow";
-import { useSidebarWidth } from "./primitives";
 
 /**
  * The rail's projects, above the chat list.
@@ -87,12 +86,7 @@ export function ProjectsSection({ activeChatId }: { activeChatId?: string }) {
   const chatIdsWithPendingPrompts = useChatAttention(
     (state) => state.chatIdsWithPendingPrompts,
   );
-  const isCompact = useSidebarWidth() === "compact";
   const [creatingOpen, setCreatingOpen] = useState(false);
-
-  // Icons-only leaves no room for a nested tree, the same reason the chat list
-  // stands down at this width.
-  if (isCompact) return null;
 
   return (
     <div className="mt-4 flex shrink-0 flex-col">

--- a/crates/tidebreak-desktop/ui/src/sidebar/SettingsSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SettingsSidebar.tsx
@@ -1,11 +1,10 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { ArrowLeft, PanelLeftOpen } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 
 import { useExperimentalFlags } from "@/experimental";
 import { useManagedPolicy } from "@/managedPolicy";
 import { settingsSectionsFor } from "@/settings/sections";
-import { useUiStore } from "@/UiStore";
-import { Sidebar, SidebarButton, SidebarContent, useSidebarWidth } from "./primitives";
+import { Sidebar, SidebarButton, SidebarContent } from "./primitives";
 
 /**
  * The rail while settings is open: the way back to the app, then a link to each
@@ -19,8 +18,6 @@ import { Sidebar, SidebarButton, SidebarContent, useSidebarWidth } from "./primi
  */
 export function SettingsSidebar({ onBack }: { onBack: () => void }) {
   const navigate = useNavigate();
-  const toggleSidebar = useUiStore((state) => state.toggleSidebar);
-  const isCompact = useSidebarWidth() === "compact";
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const { managed } = useManagedPolicy();
   const codeModeEnabled = useExperimentalFlags((state) => state.codeModeEnabled);
@@ -29,12 +26,6 @@ export function SettingsSidebar({ onBack }: { onBack: () => void }) {
   return (
     <Sidebar>
       <SidebarContent className="mt-2 gap-1 overflow-y-auto px-2">
-        {isCompact && (
-          <SidebarButton aria-label="Expand sidebar" onClick={toggleSidebar}>
-            <PanelLeftOpen />
-            <span>Expand sidebar</span>
-          </SidebarButton>
-        )}
         <SidebarButton className="text-muted-foreground" onClick={onBack}>
           <ArrowLeft />
           <span>Back to app</span>

--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarExpandStrip.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarExpandStrip.tsx
@@ -1,0 +1,36 @@
+import { PanelLeftOpen } from "lucide-react";
+
+import { WithTooltip } from "@/components/ui/tooltip";
+import { useUiStore } from "@/UiStore";
+
+/**
+ * The way back when the rail is collapsed away.
+ *
+ * Collapsed means the sidebar is gone from the layout entirely, so the shell
+ * owes the reader a control to return it. This strip pins one expand button
+ * beside the macOS traffic lights (at the plain left edge everywhere else),
+ * and doubles as the window's drag region where the overlay titlebar sits.
+ */
+export function SidebarExpandStrip({ macOverlay }: { macOverlay: boolean }) {
+  const collapsed = useUiStore((state) => state.sidebarCollapsed);
+  const toggleSidebar = useUiStore((state) => state.toggleSidebar);
+  if (!collapsed) return null;
+
+  return (
+    <div
+      className={`sidebar-expand-strip${macOverlay ? " is-mac-overlay" : ""}`}
+      {...(macOverlay ? { "data-tauri-drag-region": true } : {})}
+    >
+      <WithTooltip label="Expand sidebar" side="bottom">
+        <button
+          type="button"
+          className="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-[color-mix(in_srgb,var(--ink)_8%,transparent)] hover:text-foreground"
+          aria-label="Expand sidebar"
+          onClick={toggleSidebar}
+        >
+          <PanelLeftOpen size={16} />
+        </button>
+      </WithTooltip>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
@@ -5,7 +5,6 @@ import {
   Monitor,
   Moon,
   PanelLeftClose,
-  PanelLeftOpen,
   RotateCw,
   Settings,
   Sun,
@@ -21,7 +20,6 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
-  useSidebarWidth,
 } from "./primitives";
 import { useTheme } from "@/theme";
 import { useUiStore } from "@/UiStore";
@@ -39,7 +37,6 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
   const { updateState, restartForUpdate } = useApp();
   const { mode: themeMode, cycle: cycleTheme } = useTheme();
   const toggleSidebar = useUiStore((state) => state.toggleSidebar);
-  const isCompact = useSidebarWidth() === "compact";
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const [appName, setAppName] = useState("Tidebreak");
 
@@ -67,45 +64,30 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
           aria-label="Home"
           onClick={() => void navigate({ to: "/" })}
         >
-          {/* Compact keeps a square footprint so the home control lines up
-              with the column of square rail buttons under it. Expanded uses
-              the mark's own ratio beside the name, the same lockup as the
+          {/* The mark's own ratio beside the name, the same lockup as the
               public site header. */}
-          <Logomark
-            width={isCompact ? "28" : "30"}
-            height={isCompact ? "28" : "16"}
-          />
-          {!isCompact && (
-            <span className="truncate font-mono text-sm font-medium leading-none">
-              {appName}
-            </span>
-          )}
+          <Logomark width="30" height="16" />
+          <span className="truncate font-mono text-sm font-medium leading-none">
+            {appName}
+          </span>
         </button>
         <span className="grow" />
-        {!isCompact && (
-          <WithTooltip label="Collapse sidebar" side="bottom">
-            <button
-              type="button"
-              className="cursor-pointer rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              aria-label="Collapse sidebar"
-              onClick={toggleSidebar}
-            >
-              <PanelLeftClose size={15} />
-            </button>
-          </WithTooltip>
-        )}
+        <WithTooltip label="Collapse sidebar" side="bottom">
+          <button
+            type="button"
+            className="cursor-pointer rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            aria-label="Collapse sidebar"
+            onClick={toggleSidebar}
+          >
+            <PanelLeftClose size={15} />
+          </button>
+        </WithTooltip>
       </SidebarHeader>
 
       {/* min-h-0 so the chat list inside can be the part that scrolls: without
           it the content column grows to its content and the rail's own rows
           scroll away with the list. */}
       <SidebarContent className="min-h-0 gap-1 overflow-y-auto px-2">
-        {isCompact && (
-          <SidebarButton aria-label="Expand sidebar" onClick={toggleSidebar}>
-            <PanelLeftOpen />
-            <span>Expand sidebar</span>
-          </SidebarButton>
-        )}
         {children}
       </SidebarContent>
 

--- a/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
@@ -9,12 +9,7 @@ import {
 } from "react";
 import { Slot } from "@radix-ui/react-slot";
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   SIDEBAR_DEFAULT_WIDTH,
@@ -24,33 +19,31 @@ import {
 } from "@/UiStore";
 
 /**
- * The navigation rail, in two widths.
+ * The navigation rail, shown or gone.
  *
- * Compact keeps the rail rather than hiding it: a sidebar that disappears takes
- * the way back with it, and the reader is left hunting for a control to bring
- * it back. Collapsed here means icons only, still reachable, with each item's
- * name in a tooltip. Expanded width is reader-chosen and remembered.
+ * When collapsed the rail leaves the layout entirely; the shell keeps a single
+ * expand button pinned beside the window's traffic lights so the way back
+ * never disappears with the rail. Expanded width is reader-chosen and
+ * remembered.
  */
-export type SidebarWidth = "compact" | "expanded";
-
-export function useSidebarWidth(): SidebarWidth {
-  return useUiStore((state) => (state.sidebarCollapsed ? "compact" : "expanded"));
-}
 
 /**
- * Publish the expanded rail width onto the shell so chrome that sits over the
- * rail (the titlebar) can track it without reading the store itself.
+ * Publish the expanded rail width onto the shell so the overlay titlebar can
+ * size itself to it. Runs at the app-shell level rather than inside the rail
+ * so the value stays current after a collapse unmounts it.
  */
-function useSyncSidebarWidthCssVar(widthPx: number, isCompact: boolean) {
+export function useSyncSidebarWidthCssVar() {
+  const sidebarWidthPx = useUiStore((state) => state.sidebarWidth);
+  const collapsed = useUiStore((state) => state.sidebarCollapsed);
   useEffect(() => {
     const shell = document.querySelector<HTMLElement>(".app-shell");
     if (!shell) return;
-    if (isCompact) {
+    if (collapsed) {
       shell.style.removeProperty("--sidebar-expanded-width");
       return;
     }
-    shell.style.setProperty("--sidebar-expanded-width", `${widthPx}px`);
-  }, [widthPx, isCompact]);
+    shell.style.setProperty("--sidebar-expanded-width", `${sidebarWidthPx}px`);
+  }, [sidebarWidthPx, collapsed]);
 }
 
 /**
@@ -155,11 +148,10 @@ function SidebarResizeHandle({
 }
 
 export function Sidebar({ className, children, ...props }: ComponentProps<"div">) {
-  const width = useSidebarWidth();
-  const isCompact = width === "compact";
+  const collapsed = useUiStore((state) => state.sidebarCollapsed);
   const sidebarWidthPx = useUiStore((state) => state.sidebarWidth);
   const [resizing, setResizing] = useState(false);
-  useSyncSidebarWidthCssVar(sidebarWidthPx, isCompact);
+  if (collapsed) return null;
 
   return (
     <TooltipProvider>
@@ -167,21 +159,19 @@ export function Sidebar({ className, children, ...props }: ComponentProps<"div">
         {...props}
         className={cn(
           "relative flex shrink-0 flex-col overflow-hidden",
-          // Animate collapse/expand, but not live drags — easing lags the pointer.
-          !isCompact && !resizing && "transition-[flex-basis,min-width,width] duration-200",
+          // Animate width changes, but not live drags — easing lags the pointer.
+          !resizing && "transition-[flex-basis,min-width,width] duration-200",
           className,
         )}
         style={{
-          flex: isCompact
-            ? "0 0 var(--sidebar-compact-width)"
-            : `0 0 ${sidebarWidthPx}px`,
-          minWidth: isCompact ? "var(--sidebar-compact-width)" : `${sidebarWidthPx}px`,
-          width: isCompact ? undefined : sidebarWidthPx,
+          flex: `0 0 ${sidebarWidthPx}px`,
+          minWidth: `${sidebarWidthPx}px`,
+          width: sidebarWidthPx,
         }}
-        data-sidebar={width}
+        data-sidebar="expanded"
       >
         {children}
-        {!isCompact && <SidebarResizeHandle onDraggingChange={setResizing} />}
+        <SidebarResizeHandle onDraggingChange={setResizing} />
       </div>
     </TooltipProvider>
   );
@@ -216,12 +206,10 @@ export function SidebarFooter({
 }
 
 export function SidebarSectionTitle({ className, ...props }: ComponentProps<"div">) {
-  const isCompact = useSidebarWidth() === "compact";
   return (
     <div
       className={cn(
-        "line-clamp-1 shrink-0 truncate px-2 py-1 text-sm font-medium text-muted-foreground opacity-100 transition-opacity",
-        isCompact && "opacity-0",
+        "line-clamp-1 shrink-0 truncate px-2 py-1 text-sm font-medium text-muted-foreground",
         className,
       )}
       {...props}
@@ -229,48 +217,19 @@ export function SidebarSectionTitle({ className, ...props }: ComponentProps<"div
   );
 }
 
-/**
- * A row in the rail. Compact hides everything but the leading icon and moves
- * the label — taken from the first `span` — into a tooltip, so one definition
- * serves both widths.
- */
 export function SidebarButton({
   asChild = false,
-  children,
   className,
   ...props
 }: ComponentProps<"button"> & { asChild?: boolean }) {
   const Comp = asChild ? Slot : "button";
-  const [label, setLabel] = useState("");
-  const isCompact = useSidebarWidth() === "compact";
-
-  const measureLabel = (element: HTMLButtonElement | null) => {
-    if (!element) return;
-    setLabel(element.querySelector("span")?.textContent ?? "");
-  };
-
-  const button = (
+  return (
     <Comp
-      ref={measureLabel}
       className={cn(
         "inline-flex w-full cursor-pointer items-center gap-2 rounded-md p-2 text-left text-sm font-[450] whitespace-nowrap ring-offset-background transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
-        isCompact && "justify-center [&>*:not(:first-child)]:hidden",
         className,
       )}
       {...props}
-    >
-      {children}
-    </Comp>
-  );
-
-  if (!isCompact) return button;
-
-  return (
-    <Tooltip delayDuration={150}>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent side="right" align="center">
-        {label}
-      </TooltipContent>
-    </Tooltip>
+    />
   );
 }

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -85,9 +85,8 @@
   --sidebar-expanded-min: 200px;
   --sidebar-expanded-max: 480px;
   --sidebar-expanded-width: 280px;
-  --sidebar-compact-width: calc(var(--spacing) * 14);
   /* macOS overlay traffic lights at trafficLightPosition (16, 20), plus a
-     gap before the history buttons. The compact rail is narrower than this. */
+     gap before the history buttons. */
   --mac-traffic-light-inset: 84px;
 
   --shadow-sm: 0 0px 8px 0px oklch(0 0 0 / 0.06);
@@ -1655,39 +1654,10 @@ body {
   padding-top: 40px;
 }
 
-/* A compact rail is narrower than the macOS traffic-light cluster. It remains
-   the drag target, but the optional history buttons disappear until the rail
-   is expanded rather than spilling over the routed header. */
-.app-shell:has([data-sidebar="compact"]) .titlebar {
-  width: var(--sidebar-compact-width);
-  padding-inline: 0.25rem;
-}
-
-.app-shell:has([data-sidebar="compact"]) .titlebar.is-mac-overlay {
-  /* Cover the overflowing lights so the window still drags there. */
-  width: var(--mac-traffic-light-inset);
-  padding-left: 0;
-}
-
-.app-shell:has([data-sidebar="compact"])
-  .titlebar.is-mac-overlay
-  .titlebar-nav {
-  display: none;
-}
-
-/* Chrome that shares the traffic-light row (the chat breadcrumb) has to start
-   after the cluster when the rail cannot contain it. The extra inset is only
-   the overflow past the rail — the same 84px line the expanded history
-   buttons already use. */
+/* Chrome that shares the traffic-light row (the chat breadcrumb) starts after
+   the cluster the same way the expanded history buttons do. */
 .window-chrome-row {
   padding-left: 1rem;
-}
-
-.app-shell:has([data-sidebar="compact"]):has(.titlebar.is-mac-overlay)
-  .window-chrome-row {
-  padding-left: calc(
-    var(--mac-traffic-light-inset) - var(--sidebar-compact-width)
-  );
 }
 
 /* Full-window surfaces that replace the shell (boot and error screens, the
@@ -1700,6 +1670,28 @@ body {
   right: 0;
   height: 40px;
   z-index: 50;
+}
+
+/* A collapsed sidebar leaves no rail, so the shell pins a single expand
+   button beside the traffic lights instead (at the plain left edge
+   elsewhere). It is the window's drag region where the overlay titlebar
+   would be. */
+.sidebar-expand-strip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 40;
+  display: flex;
+  height: 40px;
+  width: 120px;
+  align-items: center;
+  gap: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.sidebar-expand-strip.is-mac-overlay {
+  padding-left: var(--mac-traffic-light-inset);
 }
 
 .app-body {


### PR DESCRIPTION
Collapsing the sidebar now removes it from the layout instead of shrinking it to an icon rail. A single expand button stays pinned beside the macOS traffic lights (at the plain left edge elsewhere) so the way back never disappears with the rail.

## What changes

- The rail unmounts on collapse rather than going icon-only. The compact width, the per-component `isCompact` branches, and the compact-rail CSS overrides all come out with it.
- The shell now owns the expanded-width CSS var (`useSyncSidebarWidthCssVar`) and renders a new `SidebarExpandStrip` — both have to outlive the rail's unmount. The strip doubles as the window's drag region where the macOS overlay titlebar sits.
- `SegmentedControl` loses its `compact` prop (only the sidebar used it).

## Verification

- `pnpm --dir ui exec tsc --noEmit` clean.
- `pnpm --dir ui test` — 1182/1182 pass.

## Notes

- Net −122 lines; the icon-rail path was the larger half of the primitives.
- The `toggle-sidebar` shortcut (Cmd/Ctrl+B) still works; it now flips between rail-on and rail-off.

Auto-merge is not enabled; this is a visual change worth a look before it lands.