### PR TITLE
refactor(desktop): polish code-mode interactions and restore tool-line detail

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -17,6 +17,11 @@ type ToolOutputPreviewProps = {
    * "· · · N more lines" instead of "Show N more lines".
    */
   bare?: boolean;
+  /**
+   * The reader expanded or collapsed the block. Hosts that follow the tail of
+   * a transcript use it to stop, so the block stays where it was clicked.
+   */
+  onToggle?: () => void;
 };
 
 /**
@@ -34,6 +39,7 @@ export function ToolOutputPreview({
   collapsedLines = DEFAULT_COLLAPSED_LINES,
   label = "Output",
   bare = false,
+  onToggle,
 }: ToolOutputPreviewProps) {
   const [expanded, setExpanded] = useState(false);
   const bodyId = useId();
@@ -76,10 +82,13 @@ export function ToolOutputPreview({
       {hiddenCount > 0 && (
         <button
           type="button"
-          className="text-muted-foreground hover:text-foreground text-[11px]"
+          className="text-muted-foreground hover:text-foreground ring-offset-background focus-visible:ring-ring cursor-pointer rounded-sm text-[11px] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-safe:transition-colors motion-safe:duration-[140ms] motion-safe:ease-out"
           aria-expanded={expanded}
           aria-controls={bodyId}
-          onClick={() => setExpanded((current) => !current)}
+          onClick={() => {
+            onToggle?.();
+            setExpanded((current) => !current);
+          }}
         >
           {expanded
             ? "Show less"

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -7,6 +7,7 @@ import { WithTooltip } from "@/components/ui/tooltip";
 import { formatMessageTimestamp } from "@/MessageFooter";
 import { cn } from "@/lib/utils";
 import { ScrollableContainer } from "@/ScrollableContainer";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
 
 /**
  * Parked engine approval. The normalized kind leads so the reader can decide;
@@ -19,11 +20,14 @@ export function CodeApprovalCard({
   deciding,
   error,
   onDecide,
+  onReveal,
 }: {
   approval: CodeApprovalSnapshot;
   deciding?: boolean;
   error?: string;
   onDecide: (decision: "approve" | "deny", feedback?: string) => void;
+  /** The reader opened the payload disclosure, which grows the card. */
+  onReveal?: () => void;
 }) {
   const [denying, setDenying] = useState(false);
   const [feedback, setFeedback] = useState("");
@@ -58,9 +62,16 @@ export function CodeApprovalCard({
       <div>
         <button
           type="button"
-          className="text-muted-foreground hover:text-foreground text-[11px]"
+          className={cn(
+            "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-[11px]",
+            FOCUS_RING,
+            HOVER_TINT,
+          )}
           aria-expanded={payloadOpen}
-          onClick={() => setPayloadOpen((current) => !current)}
+          onClick={() => {
+            onReveal?.();
+            setPayloadOpen((current) => !current);
+          }}
         >
           Harness payload
         </button>

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -2,6 +2,7 @@ import { FileCode, FileDiff, MessageSquare, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { panelKey, type PanelContent } from "@/panel/panelTypes";
+import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 
 /**
  * Center strip: Chat is always first and cannot close. File and diff tabs
@@ -36,6 +37,8 @@ export function CodeCenterTabs({
         aria-selected={conversationFocused}
         className={cn(
           "flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium",
+          FOCUS_RING_TIGHT,
+          HOVER_TINT,
           conversationFocused
             ? "bg-muted text-foreground"
             : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
@@ -53,6 +56,7 @@ export function CodeCenterTabs({
             key={panelKey(panel)}
             className={cn(
               "flex min-w-0 shrink-0 items-center rounded-md pr-1",
+              HOVER_TINT,
               active ? "bg-muted" : "hover:bg-muted/60",
             )}
           >
@@ -61,7 +65,9 @@ export function CodeCenterTabs({
               role="tab"
               aria-selected={active}
               className={cn(
-                "flex min-w-0 cursor-pointer items-center gap-1.5 py-1 pl-2 pr-1 text-xs font-medium",
+                "flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md py-1 pr-1 pl-2 text-xs font-medium",
+                FOCUS_RING_TIGHT,
+                HOVER_TINT,
                 active ? "text-foreground" : "text-muted-foreground",
               )}
               onClick={() => onSelectEditor(index)}
@@ -77,7 +83,11 @@ export function CodeCenterTabs({
             </button>
             <button
               type="button"
-              className="grid size-4 shrink-0 cursor-pointer place-items-center rounded-sm text-muted-foreground hover:text-foreground"
+              className={cn(
+                "text-muted-foreground hover:text-foreground grid size-4 shrink-0 cursor-pointer place-items-center rounded-sm",
+                FOCUS_RING_TIGHT,
+                HOVER_TINT,
+              )}
               onClick={() => onCloseEditor(index)}
             >
               <X className="size-3" />

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -3,11 +3,13 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { RouteFrame } from "@/RouteFrame";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { AddRepoPalette } from "./AddRepoPalette";
 import { CodeSidebar } from "./CodeSidebar";
 import { DoctorList } from "./DoctorList";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { isHarnessReady } from "./labels";
 
 /**
@@ -102,7 +104,11 @@ function CodeHomeBody() {
                   <li key={repo.id}>
                     <button
                       type="button"
-                      className="hover:bg-muted w-full rounded-md px-3 py-2 text-left text-sm"
+                      className={cn(
+                        "hover:bg-muted w-full cursor-pointer rounded-md px-3 py-2 text-left text-sm",
+                        FOCUS_RING,
+                        HOVER_TINT,
+                      )}
                       onClick={() =>
                         void navigate({
                           to: "/code/r/$repoId",

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -40,6 +40,7 @@ import type { CodeTranscriptItem } from "./CodeSessionReducer";
 import { useCodeUiStore } from "./CodeUiStore";
 import { DiffPanel } from "./DiffPanel";
 import { FilesPanel } from "./FilesPanel";
+import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { PrCard } from "./PrCard";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
@@ -142,7 +143,11 @@ export function CodeInspector({
           {scope && (
             <button
               type="button"
-              className="text-muted-foreground hover:text-foreground ml-auto truncate rounded-full border px-2 py-0.5 font-mono text-[11px]"
+              className={cn(
+                "text-muted-foreground hover:bg-muted hover:text-foreground ml-auto cursor-pointer truncate rounded-full border px-2 py-0.5 font-mono text-[11px]",
+                FOCUS_RING,
+                HOVER_TINT,
+              )}
               aria-label={`Clear ${scope.label} scope`}
               title={scope.label}
               onClick={() => setInspectorScope(null)}
@@ -364,7 +369,10 @@ function PrTab({
             {pr.url ? (
               <a
                 href={pr.url}
-                className="text-foreground truncate text-sm font-semibold underline-offset-2 hover:underline"
+                className={cn(
+                  "text-foreground cursor-pointer truncate rounded-sm text-sm font-semibold underline-offset-2 hover:underline",
+                  FOCUS_RING,
+                )}
                 title={pr.title ?? `#${pr.number}`}
                 onClick={(event) => {
                   event.preventDefault();
@@ -597,7 +605,11 @@ function CheckList({
     <div className="flex flex-col gap-1">
       <button
         type="button"
-        className="hover:bg-muted/50 -mx-1 flex items-center gap-2 rounded-md px-1 py-1 text-left text-xs"
+        className={cn(
+          "hover:bg-muted/50 -mx-1 flex cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-left text-xs",
+          FOCUS_RING_TIGHT,
+          HOVER_TINT,
+        )}
         onClick={() => setOpen((current) => !current)}
         aria-expanded={open}
       >
@@ -677,7 +689,11 @@ function CheckRow({ check }: { check: PullRequestCheck }) {
   return (
     <a
       href={check.url}
-      className="hover:bg-muted/50 -mx-1 flex items-center gap-2 rounded-md px-1 py-1 text-xs"
+      className={cn(
+        "hover:bg-muted/50 -mx-1 flex cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-xs",
+        FOCUS_RING_TIGHT,
+        HOVER_TINT,
+      )}
       onClick={(event) => {
         event.preventDefault();
         void openExternal(check.url!).catch(() => undefined);

--- a/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
@@ -3,12 +3,14 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { RouteFrame } from "@/RouteFrame";
 import { AttentionBadge } from "./AttentionBadge";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeSidebar } from "./CodeSidebar";
 import { useCodeUiStore } from "./CodeUiStore";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { WORKSPACE_STATUS_LABELS } from "./labels";
 
 /**
@@ -75,7 +77,11 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
           <li key={workspace.id}>
             <button
               type="button"
-              className="hover:bg-muted flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm"
+              className={cn(
+                "hover:bg-muted flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left text-sm",
+                FOCUS_RING,
+                HOVER_TINT,
+              )}
               onClick={() =>
                 void navigate({
                   to: "/code/w/$workspaceId",

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -34,6 +34,7 @@ import { CodeModeSwitch } from "./CodeModeSwitch";
 import { useCodeUiStore } from "./CodeUiStore";
 import { connectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { HARNESS_ICONS } from "./HarnessPicker";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import {
   useWorkspaceCardCommands,
@@ -114,7 +115,11 @@ export function CodeSidebar() {
         <SidebarSectionTitle className="px-0">Repos</SidebarSectionTitle>
         <button
           type="button"
-          className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          className={cn(
+            "text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer rounded-md p-1",
+            FOCUS_RING,
+            HOVER_TINT,
+          )}
           aria-label="Add repo"
           onClick={() => setAddRepoOpen(true)}
         >
@@ -154,7 +159,11 @@ export function CodeSidebar() {
         <div className="flex items-center">
           <button
             type="button"
-            className="cursor-pointer rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            className={cn(
+              "text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer rounded-md px-1.5 py-1 text-[11px] font-medium",
+              FOCUS_RING,
+              HOVER_TINT,
+            )}
             aria-label={`Sort workspaces: ${sortLabel}. Activate to cycle.`}
             onClick={() => setSortMode(nextWorkspaceSortMode(sortMode))}
           >
@@ -162,7 +171,11 @@ export function CodeSidebar() {
           </button>
           <button
             type="button"
-            className="cursor-pointer rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            className={cn(
+              "text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer rounded-md p-1",
+              FOCUS_RING,
+              HOVER_TINT,
+            )}
             aria-label="New workspace"
             onClick={() => startNewWorkspace()}
           >
@@ -288,7 +301,11 @@ function WorkspaceCard({
           aria-current={active ? "page" : undefined}
           data-active={active || undefined}
           title={attentionTitle}
-          className="flex w-full cursor-pointer flex-col gap-1 rounded-md px-2 py-1.5 text-left ring-offset-background motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none data-[active]:bg-muted"
+          className={cn(
+            "hover:bg-muted flex w-full cursor-pointer flex-col gap-1 rounded-md px-2 py-1.5 text-left data-[active]:bg-muted",
+            FOCUS_RING,
+            HOVER_TINT,
+          )}
           onClick={onOpen}
         >
           <span className="flex min-w-0 items-center gap-1.5">

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -71,7 +71,7 @@ describe("CodeTranscript", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Command run")).toBeInTheDocument();
     expect(screen.getByText("ls")).toBeInTheDocument();
-    expect(screen.getByText("1s")).toBeInTheDocument();
+    expect(screen.getByText("1.2s")).toBeInTheDocument();
     expect(screen.queryByLabelText("Output")).toBeNull();
     expect(screen.getByText("unrecognized event dropped")).toBeInTheDocument();
   });
@@ -113,7 +113,33 @@ describe("CodeTranscript", () => {
     const alert = screen.getByRole("alert");
     expect(alert).toHaveTextContent("Turn failed");
     expect(alert).toHaveTextContent("claude exited with status 1");
-    expect(alert).toHaveTextContent("4s");
+    expect(alert).toHaveTextContent("4.0s");
+  });
+
+  it("falls back to the tool name when the engine sends no target", () => {
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "tool",
+            id: "tool-bare",
+            turnId: "t1",
+            callId: "c4",
+            name: "Read",
+            // Harnesses open a call before its arguments finish streaming, so
+            // the path can arrive empty and never be restated.
+            detail: { kind: "file_read", path: "" },
+            status: "running",
+            preview: "",
+            startedAt: null,
+            durationMs: null,
+          },
+        ]}
+      />,
+    );
+    const line = screen.getByRole("button", { name: /File read/ });
+    expect(line).toHaveTextContent("File read");
+    expect(line).toHaveTextContent("Read");
   });
 
   it("holds the transcript's shape until the session hydrates", () => {
@@ -130,13 +156,15 @@ describe("CodeTranscript", () => {
     ).toBeInTheDocument();
   });
 
-  it("expands a failed tool and clamps long output", async () => {
+  it("expands a failed tool, clamps long output, and stops the transcript following", async () => {
     const preview = Array.from(
       { length: 13 },
       (_, index) => `line ${index + 1}`,
     ).join("\n");
+    const reveals: number[] = [];
     render(
       <CodeTranscript
+        onReveal={() => reveals.push(1)}
         items={[
           {
             kind: "tool",
@@ -163,6 +191,9 @@ describe("CodeTranscript", () => {
       screen.getByRole("button", { name: "· · · 1 more line" }),
     );
     expect(screen.getByLabelText("Output").textContent).toContain("line 13");
+    // Growing the column under the reader's cursor must not drag them to the
+    // tail, so every reveal reaches the host that owns the scroll.
+    expect(reveals).toHaveLength(1);
   });
 
   it("keeps a successful call closed and names a denial with the constant verb", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -24,7 +24,12 @@ import { TranscriptSkeleton } from "@/TranscriptSkeleton";
 import { UserMessage } from "@/UserMessage";
 import { cn } from "@/lib/utils";
 import type { CodeTranscriptItem } from "./CodeSessionReducer";
-import { formatTurnDuration, TurnReviewCard } from "./TurnReviewCard";
+import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+import {
+  formatElapsedDuration,
+  formatTurnDuration,
+  TurnReviewCard,
+} from "./TurnReviewCard";
 
 /**
  * The code-session transcript: the reader's prompts, markdown for assistant
@@ -48,6 +53,7 @@ export function CodeTranscript({
   streamStalled = false,
   animateStreaming = true,
   onOpenTurnDiff,
+  onReveal,
   scrollRef,
   contentRef,
   onScroll,
@@ -71,6 +77,14 @@ export function CodeTranscript({
   animateStreaming?: boolean;
   /** Scope the review sidebar to one turn's changes. */
   onOpenTurnDiff?: (turnId: string) => void;
+  /**
+   * The reader opened or closed something inline.
+   *
+   * A reveal grows the column under the row they clicked, and a transcript
+   * still following the tail would answer that by scrolling — moving the row
+   * out from under them. The host stops following instead.
+   */
+  onReveal?: () => void;
   scrollRef?: RefCallback<HTMLDivElement>;
   contentRef?: RefCallback<HTMLDivElement>;
   onScroll?: () => void;
@@ -116,6 +130,7 @@ export function CodeTranscript({
               }
               onDecide={onDecide}
               onOpenTurnDiff={onOpenTurnDiff}
+              onReveal={onReveal}
             />,
           ),
         )}
@@ -188,6 +203,7 @@ function TranscriptItem({
   approvalError,
   onDecide,
   onOpenTurnDiff,
+  onReveal,
 }: {
   item: CodeTranscriptItem;
   animateStreaming: boolean;
@@ -200,6 +216,7 @@ function TranscriptItem({
     feedback?: string,
   ) => void;
   onOpenTurnDiff?: (turnId: string) => void;
+  onReveal?: () => void;
 }) {
   switch (item.kind) {
     case "user":
@@ -223,7 +240,7 @@ function TranscriptItem({
         />
       );
     case "file_activity":
-      return <FileActivityRow files={item.files} />;
+      return <FileActivityRow files={item.files} onReveal={onReveal} />;
     case "assistant":
       return (
         <article className="message message-assistant" aria-label="Assistant">
@@ -249,6 +266,7 @@ function TranscriptItem({
           preview={item.preview}
           startedAt={item.startedAt}
           durationMs={item.durationMs}
+          onReveal={onReveal}
         />
       );
     case "notice":
@@ -263,6 +281,7 @@ function TranscriptItem({
           approval={approval}
           deciding={deciding}
           error={approvalError}
+          onReveal={onReveal}
           onDecide={(decision, feedback) =>
             onDecide?.(item.approvalId, decision, feedback)
           }
@@ -295,6 +314,7 @@ export function CodeToolCard({
   preview,
   startedAt = null,
   durationMs = null,
+  onReveal,
 }: {
   name: string;
   detail: ToolDetail;
@@ -302,6 +322,7 @@ export function CodeToolCard({
   preview: string;
   startedAt?: string | null;
   durationMs?: number | null;
+  onReveal?: () => void;
 }) {
   const [expanded, setExpanded] = useState(
     status === "failed" || status === "denied",
@@ -330,10 +351,17 @@ export function CodeToolCard({
     >
       <button
         type="button"
-        className="flex w-full items-center gap-2 py-0.5 text-left text-[13.5px]"
+        className={cn(
+          "-mx-1.5 flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-0.5 text-left text-[13.5px] hover:bg-muted/50",
+          FOCUS_RING_TIGHT,
+          HOVER_TINT,
+        )}
         aria-expanded={expanded || showTail}
         aria-controls={hasOutput ? bodyId : undefined}
-        onClick={() => setExpanded((current) => !current)}
+        onClick={() => {
+          onReveal?.();
+          setExpanded((current) => !current);
+        }}
       >
         <span className="text-muted-foreground shrink-0 [&>svg]:size-3.5">
           {toolIcon(detail)}
@@ -341,7 +369,9 @@ export function CodeToolCard({
         <span className="shrink-0 font-semibold">{verb}</span>
         <MiddleTruncate
           text={subject}
-          className="text-muted-foreground min-w-0 font-mono"
+          // The subject is the line's whole point, so it takes the free space
+          // and keeps a floor: a narrow column truncates it, never erases it.
+          className="text-muted-foreground min-w-[6ch] flex-1 font-mono"
         />
         <span className="text-muted-foreground ml-auto flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums">
           {status === "running" ? elapsed : duration}
@@ -365,7 +395,12 @@ export function CodeToolCard({
       )}
       {showExpanded && (
         <div id={bodyId}>
-          <ToolOutputPreview text={preview} collapsedLines={12} bare />
+          <ToolOutputPreview
+            text={preview}
+            collapsedLines={12}
+            bare
+            onToggle={onReveal}
+          />
         </div>
       )}
     </div>
@@ -458,7 +493,8 @@ function useElapsedLabel(startedAt: string | null, active: boolean): string | nu
   if (!startedAt) return null;
   const start = Date.parse(startedAt);
   if (!Number.isFinite(start)) return null;
-  return formatTurnDuration(Math.max(0, now - start));
+  // A counter that ticks once a second has no business showing tenths.
+  return formatElapsedDuration(Math.max(0, now - start));
 }
 
 function parseExitCode(preview: string): number | null {
@@ -468,17 +504,24 @@ function parseExitCode(preview: string): number | null {
   return Number.isFinite(code) ? code : null;
 }
 
+/**
+ * What the call was aimed at: the command, the path, the query.
+ *
+ * A harness that starts a call before its arguments have finished streaming
+ * sends an empty subject, and a line reading "File read" with nothing after it
+ * tells the reader less than the tool's own name does. The name is the floor.
+ */
 function toolSubject(detail: ToolDetail, name: string): string {
   switch (detail.kind) {
     case "command":
-      return detail.cmd;
+      return detail.cmd.trim() || name;
     case "file_read":
     case "file_edit":
-      return detail.path;
+      return detail.path.trim() || name;
     case "search":
-      return detail.query;
+      return detail.query.trim() || name;
     case "other":
-      return detail.summary || name;
+      return detail.summary.trim() || name;
   }
 }
 
@@ -490,8 +533,10 @@ function StatusGlyph({
   switch (status) {
     case "running":
       return (
+        // The one animation reduced motion keeps: it is the progress signal,
+        // and a frozen spinner reads as a hung call.
         <Loader2
-          className="text-info-foreground size-3.5 animate-spin motion-reduce:animate-none"
+          className="text-info-foreground size-3.5 animate-spin"
           aria-hidden="true"
         />
       );
@@ -572,8 +617,10 @@ function fileActivityTotals(
 
 function FileActivityRow({
   files,
+  onReveal,
 }: {
   files: Record<string, { kind: FileChangeKind; diffstat: Diffstat }>;
+  onReveal?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const { count, insertions, deletions } = fileActivityTotals(files);
@@ -583,8 +630,15 @@ function FileActivityRow({
       <button
         type="button"
         aria-expanded={open}
-        className="text-left"
-        onClick={() => setOpen((current) => !current)}
+        className={cn(
+          "-mx-1.5 cursor-pointer rounded-md px-1.5 py-0.5 text-left hover:text-foreground",
+          FOCUS_RING_TIGHT,
+          HOVER_TINT,
+        )}
+        onClick={() => {
+          onReveal?.();
+          setOpen((current) => !current);
+        }}
       >
         {count} {noun} changed ·{" "}
         <span className="text-success-foreground-muted tabular-nums">

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -68,6 +68,7 @@ import {
 import { submitAcceptedTurn } from "./CodeSessionSend";
 import { CodeSidebar } from "./CodeSidebar";
 import { CodeTranscript } from "./CodeTranscript";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 import { TerminalDrawer } from "./TerminalDrawer";
 import { TerminalPane } from "./TerminalPane";
@@ -607,7 +608,11 @@ function WorktreePathChip({ path }: { path: string }) {
       <WithTooltip label={label}>
         <button
           type="button"
-          className="text-muted-foreground hover:bg-muted hover:text-foreground max-w-44 shrink truncate rounded-md px-1.5 py-0.5 font-mono text-[11px] motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out"
+          className={cn(
+            "text-muted-foreground hover:bg-muted hover:text-foreground max-w-44 shrink cursor-pointer truncate rounded-md px-1.5 py-0.5 font-mono text-[11px]",
+            FOCUS_RING,
+            HOVER_TINT,
+          )}
           aria-label={
             copyState === "idle" ? `Copy worktree path ${path}` : label
           }
@@ -648,7 +653,10 @@ function PendingApprovalBadge({
     <button
       type="button"
       data-testid="pending-approval-badge"
-      className="cursor-pointer rounded-full border-0 bg-transparent p-0"
+      className={cn(
+        "cursor-pointer rounded-full border-0 bg-transparent p-0",
+        FOCUS_RING,
+      )}
       onClick={() => {
         document
           .querySelector('[data-code-approval-state="pending"]')
@@ -858,6 +866,7 @@ function CodeSessionPane({
           decidingId={decidingId}
           approvalError={approvalError}
           onOpenTurnDiff={onOpenTurnDiff}
+          onReveal={follow.pauseFollow}
           scrollRef={follow.scrollRef}
           contentRef={follow.contentRef}
           onScroll={follow.onScroll}
@@ -882,7 +891,8 @@ function CodeSessionPane({
         <button
           type="button"
           className={cn(
-            "border-border text-foreground bg-background pointer-events-none absolute bottom-3 left-1/2 z-[1] inline-flex -translate-x-1/2 items-center justify-center rounded-full border p-2 opacity-0 shadow transition-[opacity,background-color] duration-150 ease-in-out hover:bg-accent motion-reduce:transition-none",
+            "border-border text-foreground bg-background hover:bg-accent pointer-events-none absolute bottom-3 left-1/2 z-[1] inline-flex -translate-x-1/2 cursor-pointer items-center justify-center rounded-full border p-2 opacity-0 shadow transition-[opacity,background-color] duration-[140ms] ease-out motion-reduce:transition-none",
+            FOCUS_RING,
             follow.scrolledAway && "pointer-events-auto opacity-100",
           )}
           aria-label="Scroll to latest"

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
@@ -5,6 +5,7 @@ import type { ApiClient } from "../api/client";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
+import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { DiffstatBadge } from "./TurnReviewCard";
 import { useLiveResource } from "./useLiveContent";
 
@@ -138,13 +139,17 @@ function FileDiffSection({
       <header className="bg-background sticky top-0 z-10">
         <button
           type="button"
-          className="hover:bg-muted/40 flex w-full items-center gap-1.5 px-3 py-1.5 text-left"
+          className={cn(
+            "hover:bg-muted/40 flex w-full cursor-pointer items-center gap-1.5 px-3 py-1.5 text-left",
+            FOCUS_RING_TIGHT,
+            HOVER_TINT,
+          )}
           aria-expanded={expanded}
           onClick={() => setExpanded((current) => !current)}
         >
           <ChevronRight
             className={cn(
-              "text-muted-foreground size-3 shrink-0 transition-transform duration-150 ease-out motion-reduce:transition-none",
+              "text-muted-foreground size-3 shrink-0 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
               expanded && "rotate-90",
             )}
             aria-hidden="true"
@@ -159,7 +164,11 @@ function FileDiffSection({
             <span
               role="link"
               tabIndex={0}
-              className="text-muted-foreground hover:text-foreground shrink-0 text-[11px] underline-offset-2 hover:underline"
+              className={cn(
+                "text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded-sm text-[11px] underline-offset-2 hover:underline",
+                FOCUS_RING_TIGHT,
+                HOVER_TINT,
+              )}
               onClick={(event) => {
                 event.stopPropagation();
                 onOpenFile(group.path);
@@ -192,7 +201,11 @@ function FileDiffSection({
       ) : large ? (
         <button
           type="button"
-          className="text-muted-foreground hover:text-foreground px-3 py-2 text-xs"
+          className={cn(
+            "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm px-3 py-2 text-xs",
+            FOCUS_RING_TIGHT,
+            HOVER_TINT,
+          )}
           onClick={() => setExpanded(true)}
         >
           Show diff

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -12,6 +12,7 @@ import {
   filterPaths,
   type FileTreeNode,
 } from "./fileTree";
+import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { useLiveResource } from "./useLiveContent";
 
 const TREE_PAGE = 5000;
@@ -190,7 +191,11 @@ export function FilesPanel({
         ) : (
           <button
             type="button"
-            className="text-muted-foreground hover:text-foreground self-start text-[11px]"
+            className={cn(
+              "text-muted-foreground hover:text-foreground cursor-pointer self-start rounded-sm text-[11px]",
+              FOCUS_RING,
+              HOVER_TINT,
+            )}
             onClick={() => setFiltersOpen(true)}
           >
             Include / exclude
@@ -266,7 +271,9 @@ function TreeRow({
         aria-current={current ? true : undefined}
         style={{ paddingLeft: 8 + depth * 12 }}
         className={cn(
-          "flex w-full items-center gap-1 rounded-sm py-0.5 pr-2 text-left text-xs",
+          "flex w-full cursor-pointer items-center gap-1 rounded-sm py-0.5 pr-2 text-left text-xs",
+          FOCUS_RING_TIGHT,
+          HOVER_TINT,
           current && "bg-muted/60",
           !current && "hover:bg-muted/40",
         )}
@@ -278,7 +285,7 @@ function TreeRow({
         {node.kind === "dir" ? (
           <ChevronRight
             className={cn(
-              "text-muted-foreground size-3 shrink-0 transition-transform",
+              "text-muted-foreground size-3 shrink-0 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
               open && "rotate-90",
             )}
             aria-hidden

--- a/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalDrawer.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useCodeUiStore } from "./CodeUiStore";
+import { HOVER_TINT } from "./interactive";
 import { TerminalPane } from "./TerminalPane";
 
 export const DEFAULT_TERMINAL_DRAWER_HEIGHT = 240;
@@ -123,7 +124,10 @@ export function TerminalDrawer({
           aria-valuemin={MIN_TERMINAL_DRAWER_HEIGHT}
           aria-valuemax={MAX_TERMINAL_DRAWER_HEIGHT}
           aria-valuenow={height}
-          className="hover:bg-muted focus-visible:bg-muted flex h-1.5 shrink-0 cursor-ns-resize items-center justify-center focus-visible:outline-none"
+          className={cn(
+            "hover:bg-muted focus-visible:bg-muted flex h-1.5 shrink-0 cursor-ns-resize items-center justify-center focus-visible:outline-none",
+            HOVER_TINT,
+          )}
           onPointerDown={(event) => {
             event.preventDefault();
             dragRef.current = { startY: event.clientY, startHeight: height };

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { formatElapsedDuration, formatTurnDuration } from "./TurnReviewCard";
+
+describe("formatTurnDuration", () => {
+  it("never rounds a turn that happened to zero", () => {
+    expect(formatTurnDuration(0)).toBe("<1s");
+    expect(formatTurnDuration(420)).toBe("<1s");
+    expect(formatTurnDuration(999)).toBe("<1s");
+  });
+
+  it("carries a tenth while a tenth still separates two turns", () => {
+    expect(formatTurnDuration(1_000)).toBe("1.0s");
+    expect(formatTurnDuration(2_400)).toBe("2.4s");
+    expect(formatTurnDuration(9_949)).toBe("9.9s");
+  });
+
+  it("drops to whole seconds, then minutes, then hours", () => {
+    // The tenth rounds up to ten before the millisecond count does, and the
+    // seam must not read "10.0s" one tick and "10s" the next.
+    expect(formatTurnDuration(9_999)).toBe("10s");
+    expect(formatTurnDuration(10_000)).toBe("10s");
+    expect(formatTurnDuration(59_400)).toBe("59s");
+    expect(formatTurnDuration(72_000)).toBe("1m 12s");
+    expect(formatTurnDuration(134_000)).toBe("2m 14s");
+    expect(formatTurnDuration(3_930_000)).toBe("1h 5m");
+  });
+
+  it("reports nothing rather than a made-up figure", () => {
+    expect(formatTurnDuration(null)).toBeNull();
+    expect(formatTurnDuration(-1)).toBeNull();
+    expect(formatTurnDuration(Number.NaN)).toBeNull();
+  });
+});
+
+describe("formatElapsedDuration", () => {
+  it("stays on whole seconds, because it is read while it ticks", () => {
+    expect(formatElapsedDuration(300)).toBe("<1s");
+    expect(formatElapsedDuration(2_400)).toBe("2s");
+    expect(formatElapsedDuration(72_000)).toBe("1m 12s");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -7,6 +7,7 @@ import { WithTooltip } from "@/components/ui/tooltip";
 import { formatTokenCount } from "@/ContextUsage";
 import { cn } from "@/lib/utils";
 import type { CodeTranscriptItem } from "./CodeSessionReducer";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
 
 /**
  * What a turn came to, at the seam where it ended.
@@ -156,7 +157,11 @@ function TurnDiffstat({
   return (
     <button
       type="button"
-      className="focus-visible:ring-ring rounded-full focus-visible:ring-2 focus-visible:outline-none"
+      className={cn(
+        "hover:bg-muted cursor-pointer rounded-full",
+        FOCUS_RING,
+        HOVER_TINT,
+      )}
       aria-label="Review this turn's changes"
       onClick={() => onOpenTurnDiff(turnId)}
     >
@@ -175,10 +180,35 @@ export function DiffstatBadge({ stat }: { stat: Diffstat }) {
   );
 }
 
-/** How long the turn ran, at the precision the seam can carry. */
+/**
+ * How long the turn ran, at the precision the seam can carry.
+ *
+ * A sub-second turn rounded to "0s" reads as a broken clock rather than a fast
+ * engine, so anything under a second is "<1s" and the first ten seconds carry
+ * a tenth. Past that the tenth is noise and whole seconds, then minutes, say
+ * it better.
+ */
 export function formatTurnDuration(ms: number | null): string | null {
   if (ms === null || !Number.isFinite(ms) || ms < 0) return null;
-  const seconds = Math.round(ms / 1_000);
+  if (ms < 1_000) return "<1s";
+  const tenths = Math.round(ms / 100) / 10;
+  if (tenths < 10) return `${tenths.toFixed(1)}s`;
+  return coarseDuration(Math.round(ms / 1_000));
+}
+
+/**
+ * The same clock for a counter that ticks once a second.
+ *
+ * A live elapsed label reads its own tenth as jitter — it changes on a
+ * schedule the reader can see — so it stays on whole seconds throughout.
+ */
+export function formatElapsedDuration(ms: number | null): string | null {
+  if (ms === null || !Number.isFinite(ms) || ms < 0) return null;
+  if (ms < 1_000) return "<1s";
+  return coarseDuration(Math.floor(ms / 1_000));
+}
+
+function coarseDuration(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes}m ${seconds % 60}s`;

--- a/crates/tidebreak-desktop/ui/src/code/interactive.ts
+++ b/crates/tidebreak-desktop/ui/src/code/interactive.ts
@@ -1,0 +1,29 @@
+/**
+ * The three class strings every code-mode control shares.
+ *
+ * Hover and focus are the only two states a supervision surface has to get
+ * right on every row, and writing them out per control is how they drift: one
+ * row rings in `--ring`, the next in a border colour, a third has no keyboard
+ * state at all. These are token-derived and identical everywhere, so a control
+ * that reads as clickable also reads as focusable.
+ */
+
+/** Focus ring for controls with room around them: cards, chips, tabs, pills. */
+export const FOCUS_RING =
+  "ring-offset-background focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none";
+
+/**
+ * Focus ring for dense rows — transcript tool lines, tree rows, diff headers —
+ * where the two-pixel offset would collide with the row above.
+ */
+export const FOCUS_RING_TIGHT =
+  "ring-offset-background focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:outline-none";
+
+/**
+ * The hover colour change, at the reveal tempo and off under reduced motion.
+ *
+ * `motion-safe` rather than `motion-reduce:transition-none` because the tint
+ * itself is the state; only its easing is decoration.
+ */
+export const HOVER_TINT =
+  "motion-safe:transition-colors motion-safe:duration-[140ms] motion-safe:ease-out";

--- a/crates/tidebreak-desktop/ui/src/useTranscriptFollow.ts
+++ b/crates/tidebreak-desktop/ui/src/useTranscriptFollow.ts
@@ -30,6 +30,14 @@ export type TranscriptFollow = {
   armFollow: (behavior?: ScrollBehavior) => void;
   /** Stop following: the reader has been sent somewhere specific. */
   disarmFollow: () => void;
+  /**
+   * Stop following without claiming the reader has scrolled away.
+   *
+   * For a reveal opened in place — a tool line, a disclosure — where dragging
+   * the reader to the tail would move the very row they clicked. The next
+   * content measurement reports where they actually ended up.
+   */
+  pauseFollow: () => void;
   /** Whether follow is armed, readable without a re-render. */
   isFollowing: () => boolean;
   /** The viewport element, once mounted, for consumers that re-render on it. */
@@ -157,6 +165,10 @@ export function useTranscriptFollow({
     setScrolledAway(true);
   }, []);
 
+  const pauseFollow = useCallback(() => {
+    followsLatestRef.current = false;
+  }, []);
+
   const isFollowing = useCallback(() => followsLatestRef.current, []);
 
   const beginProgrammaticScroll = useCallback(() => {
@@ -244,6 +256,7 @@ export function useTranscriptFollow({
     scrollToBottom,
     armFollow,
     disarmFollow,
+    pauseFollow,
     isFollowing,
     scrollElement,
     viewportRef: scrollRef,


### PR DESCRIPTION
R2 of the code-mode refinement stack, on top of R1 (#2220). One concern:
how the surfaces respond to a pointer and a keyboard. No new components, no
new data, no restructuring — the diff is interaction states, one motion
tempo, two gate findings, and the plumbing that keeps an expansion from
moving the row under the reader's cursor.

## The two gate findings

**Inline tool lines rendered a bare verb.** The approved anatomy is glyph +
bold verb + muted mono target + meta + status glyph + chevron, and the
target was reaching the DOM but disappearing in two ways. Harness adapters
open a call before its arguments finish streaming and fill the missing
field with an empty string (`claude/parse.rs` `unwrap_or("")`, same in the
other three), so `File read` and `Command run` rendered with nothing after
them; the detail is fixed at `tool_started` and never restated, so the row
stayed empty for the life of the transcript. `toolSubject` now falls back
to the tool's own name, which is the floor the reader can always act on.
The subject also had no width floor: in a flex row between a `shrink-0`
verb and a `shrink-0` meta slot it was the only shrinkable item, so a
narrow column (rail plus review sidebar open) squeezed it to nothing. It
now takes the free space with a `6ch` floor, so it truncates instead of
vanishing. The server-side gap — a detail that arrives empty and is never
corrected — is worth its own issue; this is the honest client behaviour
either way.

**"Turn finished · 0s" reads as a broken clock.** `formatTurnDuration` now
returns `<1s` under a second, a tenth through the first ten seconds
(`2.4s`), whole seconds to a minute, then `1m 12s` and `1h 5m`. The tenth
rounds up to ten before the millisecond count does, so 9,999 ms reads
`10s`, not `10.0s`. A live elapsed counter reads its own tenth as jitter,
so `formatElapsedDuration` keeps the running tool line on whole seconds
while sharing the same `<1s` floor. Both stay tabular.

## Zero-jolt expansion

Expanding anything at the tail used to yank the transcript. The follow
machine watches the content box and scrolls to the bottom whenever it
grows, so opening a tool line at the bottom of the viewport moved that
line off screen — the one row the reader was reading. `useTranscriptFollow`
gains `pauseFollow`: stop following without claiming the reader scrolled
away, which `disarmFollow` does and which would flash the jump-to-latest
pill for a frame. Every in-place reveal in the transcript (tool line, tool
output "N more lines", file-activity row, approval payload disclosure)
reports through one `onReveal` prop, and the workspace page answers it with
`pauseFollow`. The next content measurement reports where the reader
actually ended up, so the pill appears only if they really are away from
the tail.

## Per surface

- **CodeTranscript** — tool line is one full-width target with a bleeding
  hover tint and a focus ring; the file-activity disclosure gets the same;
  both report reveals. Subject fallback and width floor as above. The
  running spinner keeps spinning under reduced motion (see below).
- **TurnReviewCard** — the diffstat button had a focus ring but no hover
  state, so it read as a label until you tabbed to it; it now tints and
  uses the shared ring with an offset.
- **CodeSidebar** — the sort control, both "add" buttons, and the workspace
  card share one ring and tempo. The card already had them; it now says so
  through the same constants.
- **CodeInspector** — the turn-scope chip, the check-summary toggle, the
  check rows, and the PR title link were all reachable by keyboard with no
  visible focus; the scope chip also had no hover fill.
- **FilesPanel** — explorer rows had a hover tint and no focus ring; the
  directory chevron animated at the browser default with no reduced-motion
  guard. The include/exclude toggle had neither ring nor cursor.
- **DiffPanel** — per-file header, the "Show diff" expander, and the "Open"
  affordance all gain rings; the chevron joins the one tempo.
- **CodeCenterTabs** — chat, file, and diff tabs plus their close buttons
  had hover only, so keyboard tab-switching was invisible.
- **CodeWorkspacePage** — the jump-to-latest pill was the only motion in
  code mode on `ease-in-out` at 150 ms; the worktree-path chip and the
  pending-approvals badge gain rings.
- **CodeApprovalCard** — the harness-payload disclosure gains a ring and
  reports its reveal.
- **CodeHome / CodeRepoPage** — repo and workspace list rows were
  hover-only.
- **TerminalDrawer** — the resize separator's focus fill now eases like
  every other state change.

New `src/code/interactive.ts` holds the three strings these share:
`FOCUS_RING` (`--ring`, offset 2), `FOCUS_RING_TIGHT` (offset 0, for dense
rows where 2px would collide with the row above), and `HOVER_TINT`
(`motion-safe` colour transition at the reveal tempo). Writing them out per
control is how they drift; this is why the same file has one ring in three
shapes today.

## Reduced-motion audit

Every animation in `src/code` is now 140 ms ease-out and guarded by
`motion-safe`/`motion-reduce`, with one deliberate exception: the running
tool line's spinner had `motion-reduce:animate-none`, which froze the only
signal that a call is still going and made a running tool read as a hung
one. The shared `Spinner` — used by every other panel in the product —
never had that guard. Progress is the content, not decoration.

## Tests

`pnpm vitest run src/code` (185 passed), `pnpm vitest run` (1206 passed),
`pnpm build`: all green.

- Extended the existing `CodeTranscript` tool-line assertions: the settled
  duration now reads `1.2s` and `4.0s` (the rounding change), the expand
  test also pins that a reveal reaches the host, and one new case covers a
  detail that arrives empty falling back to the tool name.
- New `TurnReviewCard.test.ts`: the duration boundaries, including the
  9,999 ms rounding edge and the elapsed variant's whole seconds.
- No tests deleted.

Not verified: nothing was driven in the live app, so hover, focus, and the
expand-at-the-tail behaviour are for the screenshot gate.
