### PR TITLE
fix(desktop): unmount the titlebar when the sidebar is collapsed

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -89,6 +89,7 @@ const listPendingFolderAccessRequests = vi.fn(async () => [] as unknown[]);
 const listInbox = vi.fn(async () => [] as unknown[]);
 const listPendingOutputWritebackRequests = vi.fn(async () => [] as unknown[]);
 const requestUserAttention = vi.fn(async () => {});
+const hasNativeHost = vi.hoisted(() => vi.fn(() => false));
 
 /** One waiting question, as the shell's cross-chat read returns it. */
 function parked(chatId: string, callId: string) {
@@ -155,10 +156,14 @@ vi.mock("./api", () => ({
 }));
 
 vi.mock("./host", () => ({
-  hasNativeHost: () => false,
+  hasNativeHost,
   hasMacOverlayTitlebar: () => false,
   requestUserAttention,
   onPairingChanged: () => () => undefined,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
 }));
 
 vi.mock("./updates", () => ({
@@ -324,6 +329,7 @@ beforeEach(() => {
     expandedProjectIds: [],
   });
   useUiStore.setState({ sidebarCollapsed: false, sidebarWidth: SIDEBAR_DEFAULT_WIDTH });
+  hasNativeHost.mockReturnValue(false);
   // Module-level chrome state survives a render, so a test that collapsed or
   // filtered the list would otherwise decide the next one's rail.
   useChatsSectionState.setState({ collapsed: false, filtering: false, query: "" });
@@ -585,6 +591,34 @@ describe("app shell", () => {
 
     expect(useUiStore.getState().sidebarCollapsed).toBe(true);
     expect(window.localStorage.getItem("tidebreak.sidebar-collapsed")).toBe("true");
+  });
+
+  it("unmounts the titlebar with the rail, and Cmd/Ctrl+B brings both back", async () => {
+    // The leftover chrome only exists on the native host: the titlebar is
+    // `position: absolute; width: var(--sidebar-expanded-width)`, and that
+    // var falls back to 280px once collapse removes it.
+    hasNativeHost.mockReturnValue(true);
+    const user = userEvent.setup();
+    await mountApp();
+    await screen.findByText("Welcome to Tidebreak");
+
+    expect(document.querySelector("[data-sidebar]")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+
+    expect(useUiStore.getState().sidebarCollapsed).toBe(true);
+    expect(document.querySelector("[data-sidebar]")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Back" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+
+    // Ctrl is the command modifier under jsdom's non-mac user agent.
+    await user.keyboard("{Control>}b{/Control}");
+
+    expect(useUiStore.getState().sidebarCollapsed).toBe(false);
+    expect(document.querySelector("[data-sidebar]")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Expand sidebar" })).not.toBeInTheDocument();
   });
 
   it("keeps watching for the agent's questions while settings is open", async () => {

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -132,9 +132,9 @@ export function AppShell() {
   const desktopUpdates = useDesktopUpdates();
   const desktopNavigation = useDesktopNavigation();
   const zoom = useInterfaceZoom();
+  const sidebarCollapsed = useUiStore((state) => state.sidebarCollapsed);
   // The expanded rail width is published by the shell, not the rail itself, so
-  // the value survives a collapse — the expand strip and the titlebar both
-  // depend on it.
+  // the titlebar can size to it while the rail is mounted.
   useSyncSidebarWidthCssVar();
   // Read at keydown rather than subscribed to: which mode a shortcut fires in
   // is the route's answer, and the shell has no other reason to re-render on
@@ -696,7 +696,7 @@ export function AppShell() {
         <div className={`app-shell${nativeTitlebar ? " with-titlebar" : ""}`}>
           {confirmDialog}
           <ShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
-          {nativeTitlebar && (
+          {nativeTitlebar && !sidebarCollapsed && (
             <Titlebar
               macOverlay={macOverlayTitlebar}
               navigation={desktopNavigation}

--- a/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
@@ -29,8 +29,8 @@ import {
 
 /**
  * Publish the expanded rail width onto the shell so the overlay titlebar can
- * size itself to it. Runs at the app-shell level rather than inside the rail
- * so the value stays current after a collapse unmounts it.
+ * size itself to the rail. Cleared on collapse: the titlebar unmounts with the
+ * rail, and the fallback 280px would otherwise paint leftover chrome.
  */
 export function useSyncSidebarWidthCssVar() {
   const sidebarWidthPx = useUiStore((state) => state.sidebarWidth);


### PR DESCRIPTION
#2219 hid the sidebar on collapse but dropped the follow-up that unmounted the titlebar with it.

`.titlebar` is `position: absolute; width: var(--sidebar-expanded-width)`. Collapse removes that CSS var, so the bar falls back to the stylesheet default of 280px and paints a 40px strip over the conversation. `SidebarExpandStrip` (same `z-index: 40`) then sits on leftover chrome.

## What changes

- `AppShell` renders `Titlebar` only when `nativeTitlebar && !sidebarCollapsed`.
- `SidebarExpandStrip` stays as the collapsed expand control.
- Cmd/Ctrl+B still flips `sidebarCollapsed` and brings the rail and titlebar back.
- An `AppShell` DOM test covers the unmount and the shortcut restore.

## Verification

- `pnpm --dir crates/tidebreak-desktop/ui test` — 1201/1201 pass.

Do not merge until desktop UI is green.