### PR TITLE
refactor(desktop): design code-mode empty states and harden content edges

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { CodeApprovalCard } from "./CodeApprovalCard";
+import { CodeApprovalCard, MAX_PAYLOAD_CHARS } from "./CodeApprovalCard";
 import type { CodeApprovalSnapshot } from "../api/types";
 
 afterEach(() => {
@@ -77,6 +77,22 @@ describe("CodeApprovalCard", () => {
       "deny",
       "no — use the fixtures directory instead",
     );
+  });
+
+  it("caps a payload an engine sent a whole file in", () => {
+    const huge = "x".repeat(MAX_PAYLOAD_CHARS * 2);
+    render(
+      <CodeApprovalCard
+        approval={{
+          ...pendingWrite,
+          harness_raw_json: JSON.stringify({ content: huge }),
+        }}
+        onDecide={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Harness payload" }));
+    const shown = screen.getByText(/more characters not shown/);
+    expect(shown.textContent!.length).toBeLessThan(MAX_PAYLOAD_CHARS + 200);
   });
 
   it("tones an approved card as success and stamps both times", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -76,8 +76,14 @@ export function CodeApprovalCard({
           Harness payload
         </button>
         <Reveal open={payloadOpen}>
-          <ScrollableContainer className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 text-[11px] break-words whitespace-pre-wrap">
-            <pre className="font-mono">{prettyRaw(approval.harness_raw_json)}</pre>
+          {/*
+            One `pre`, not two: the scroll container is itself a `pre`, and a
+            nested one carried the browser's own `white-space: pre`, so the
+            wrapping asked for here never applied and a single long JSON line
+            scrolled sideways instead.
+          */}
+          <ScrollableContainer className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 font-mono text-[11px] break-words whitespace-pre-wrap">
+            {prettyRaw(approval.harness_raw_json)}
           </ScrollableContainer>
         </Reveal>
       </div>
@@ -274,10 +280,25 @@ function approvalTitle(approval: CodeApprovalSnapshot): string {
   }
 }
 
+/** Past this, the payload is a file, not something a reader scrolls. */
+export const MAX_PAYLOAD_CHARS = 20_000;
+
+/**
+ * The harness payload, pretty-printed and capped.
+ *
+ * An engine can attach an entire file's contents to one approval. Rendering
+ * that verbatim puts megabytes of text in the transcript's DOM, which the
+ * reader pays for on every later render of the card and never reads. The cap
+ * is stated rather than silent, so nobody mistakes the tail for the end.
+ */
 function prettyRaw(raw: string): string {
+  let text = raw;
   try {
-    return JSON.stringify(JSON.parse(raw), null, 2);
+    text = JSON.stringify(JSON.parse(raw), null, 2);
   } catch {
-    return raw;
+    // Not JSON: show what the engine sent, under the same cap.
   }
+  if (text.length <= MAX_PAYLOAD_CHARS) return text;
+  const dropped = text.length - MAX_PAYLOAD_CHARS;
+  return `${text.slice(0, MAX_PAYLOAD_CHARS)}\n… ${dropped.toLocaleString()} more characters not shown.`;
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -50,7 +50,8 @@ export function CodeCenterTabs({
       </button>
       {editorTabs.map((panel, index) => {
         const active = !conversationFocused && index === editorActiveIndex;
-        const label = centerTabLabel(panel);
+        const { name, suffix } = centerTabParts(panel);
+        const label = suffix ? `${name} ${suffix}` : name;
         return (
           <div
             key={panelKey(panel)}
@@ -77,8 +78,16 @@ export function CodeCenterTabs({
               ) : (
                 <FileCode className="size-3.5 shrink-0" />
               )}
-              <span className="max-w-40 truncate" title={centerTabTitle(panel)}>
-                {label}
+              <span
+                className="flex min-w-0 items-baseline gap-1"
+                title={centerTabTitle(panel)}
+              >
+                <span className="max-w-40 truncate">{name}</span>
+                {/*
+                  The suffix is what separates this tab from the plain file tab
+                  for the same path, so it never joins the part that truncates.
+                */}
+                {suffix && <span className="shrink-0">{suffix}</span>}
               </span>
             </button>
             <button
@@ -104,16 +113,29 @@ export function CodeCenterTabs({
 function centerTabTitle(panel: PanelContent): string {
   if (panel.type === "file") return panel.path;
   if (panel.type === "diff" && panel.path) return `${panel.path} (diff)`;
-  return centerTabLabel(panel);
+  const { name, suffix } = centerTabParts(panel);
+  return suffix ? `${name} ${suffix}` : name;
 }
 
-function centerTabLabel(panel: PanelContent): string {
+/**
+ * A tab's label, split into the part that may truncate and the part that may
+ * not.
+ */
+function centerTabParts(panel: PanelContent): {
+  name: string;
+  suffix: string | null;
+} {
   if (panel.type === "file") {
-    return panel.path.split("/").pop() || panel.path;
+    return { name: panel.path.split("/").pop() || panel.path, suffix: null };
   }
   if (panel.type === "diff") {
-    if (panel.path) return `${panel.path.split("/").pop() || panel.path} (diff)`;
-    return panel.turnId ? "Turn diff" : "Diff";
+    if (panel.path) {
+      return {
+        name: panel.path.split("/").pop() || panel.path,
+        suffix: "(diff)",
+      };
+    }
+    return { name: panel.turnId ? "Turn diff" : "Diff", suffix: null };
   }
-  return panel.type;
+  return { name: panel.type, suffix: null };
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -3,6 +3,13 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
 import { RouteFrame } from "@/RouteFrame";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
@@ -11,6 +18,7 @@ import { CodeSidebar } from "./CodeSidebar";
 import { DoctorList } from "./DoctorList";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { isHarnessReady } from "./labels";
+import { middleTruncate } from "./workspaceCards";
 
 /**
  * `/code` home: the doctor when no engine is usable, otherwise repo
@@ -83,50 +91,69 @@ function CodeHomeBody() {
           />
         </section>
       )}
-      {ready && (
-        <>
-          <section className="flex flex-col gap-3">
-            <h2 className="text-lg font-semibold">Add a repo</h2>
-            <p className="text-muted-foreground text-sm">
+      {ready && repos.length === 0 && loaded && (
+        // Nothing is registered, so the page has exactly one thing to say.
+        // A "Repos" heading over an empty list, under a second heading that
+        // repeats the same instruction, is two sections carrying one message.
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>No repos yet</EmptyTitle>
+            <EmptyDescription>
               Browse a local folder, or clone from a git URL or GitHub.
-            </p>
-            <Button type="button" className="self-start" onClick={() => setAddOpen(true)}>
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button type="button" onClick={() => setAddOpen(true)}>
               Add repo
             </Button>
-          </section>
-          <section className="flex flex-col gap-3">
+          </EmptyContent>
+        </Empty>
+      )}
+      {ready && repos.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-3">
             <h2 className="text-lg font-semibold">Repos</h2>
-            {repos.length === 0 ? (
-              <p className="text-muted-foreground text-sm">None registered yet.</p>
-            ) : (
-              <ul className="flex flex-col gap-1">
-                {repos.map((repo) => (
-                  <li key={repo.id}>
-                    <button
-                      type="button"
-                      className={cn(
-                        "hover:bg-muted w-full cursor-pointer rounded-md px-3 py-2 text-left text-sm",
-                        FOCUS_RING,
-                        HOVER_TINT,
-                      )}
-                      onClick={() =>
-                        void navigate({
-                          to: "/code/r/$repoId",
-                          params: { repoId: repo.id },
-                        })
-                      }
-                    >
-                      <span className="font-medium">{repo.display_name}</span>
-                      <span className="text-muted-foreground ml-2 font-mono text-xs">
-                        {repo.root_path}
-                      </span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
-        </>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => setAddOpen(true)}
+            >
+              Add repo
+            </Button>
+          </div>
+          <ul className="flex flex-col gap-1">
+            {repos.map((repo) => (
+              <li key={repo.id}>
+                <button
+                  type="button"
+                  className={cn(
+                    "hover:bg-muted flex w-full cursor-pointer items-baseline gap-2 rounded-md px-3 py-2 text-left text-sm",
+                    FOCUS_RING,
+                    HOVER_TINT,
+                  )}
+                  onClick={() =>
+                    void navigate({
+                      to: "/code/r/$repoId",
+                      params: { repoId: repo.id },
+                    })
+                  }
+                >
+                  <span className="min-w-0 shrink truncate font-medium">
+                    {repo.display_name}
+                  </span>
+                  {/* The tail of a path is what tells two checkouts apart. */}
+                  <span
+                    className="text-muted-foreground min-w-0 truncate font-mono text-xs"
+                    title={repo.root_path}
+                  >
+                    {middleTruncate(repo.root_path, 56)}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
       <AddRepoPalette open={addOpen} onOpenChange={setAddOpen} />
     </div>

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -203,6 +203,7 @@ export function CodeInspector({
             workspaceId={workspaceId}
             pr={pr}
             branch={workspace?.branch_name}
+            onOpenSourceControl={() => setTab("source")}
           />
         </TabsContent>
       </Tabs>
@@ -263,11 +264,14 @@ function PrTab({
   workspaceId,
   pr,
   branch,
+  onOpenSourceControl,
 }: {
   client: ApiClient;
   workspaceId: string;
   pr?: PullRequestDigest;
   branch?: string;
+  /** Send the reader to the tab that can actually open a pull request. */
+  onOpenSourceControl?: () => void;
 }) {
   const { confirm, dialog } = useConfirm();
   const [refreshing, setRefreshing] = useState(false);
@@ -338,13 +342,28 @@ function PrTab({
 
   if (!pr) {
     return (
-      <div className="text-muted-foreground flex flex-col gap-2 px-4 py-8 text-sm">
-        <p className="text-foreground font-medium">No pull request yet</p>
-        <p className="text-xs leading-relaxed">
-          This tab stays quiet until one exists. Commit, push, and Create PR
-          live in Source control. When a PR is opened, its status, checks, and
-          review comments land in this column.
-        </p>
+      // Commit, push, and Create PR all live one tab away — including the gh
+      // install and sign-in remediation, which the git card states with the
+      // exact commands. Repeating any of that here would be a second copy to
+      // keep true; a way over to it is not.
+      <div className="flex flex-col items-start gap-3 px-4 py-8">
+        <div className="flex flex-col gap-1.5">
+          <p className="text-sm font-medium">No pull request yet</p>
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            Once one exists, its status, checks, and review comments land here.
+          </p>
+        </div>
+        {onOpenSourceControl && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onOpenSourceControl}
+          >
+            <GitBranch />
+            Open Source control
+          </Button>
+        )}
       </div>
     );
   }

--- a/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
@@ -3,6 +3,12 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
 import { RouteFrame } from "@/RouteFrame";
 import { AttentionBadge } from "./AttentionBadge";
@@ -12,6 +18,7 @@ import { CodeSidebar } from "./CodeSidebar";
 import { useCodeUiStore } from "./CodeUiStore";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { WORKSPACE_STATUS_LABELS } from "./labels";
+import { middleTruncate } from "./workspaceCards";
 
 /**
  * One registered repo: its workspaces and the new-workspace flow.
@@ -54,9 +61,16 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8">
       <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-medium tracking-tight">{repo.display_name}</h1>
-          <p className="text-muted-foreground font-mono text-xs">{repo.root_path}</p>
+        <div className="min-w-0">
+          <h1 className="truncate text-2xl font-medium tracking-tight" title={repo.display_name}>
+            {repo.display_name}
+          </h1>
+          <p
+            className="text-muted-foreground truncate font-mono text-xs"
+            title={repo.root_path}
+          >
+            {middleTruncate(repo.root_path, 72)}
+          </p>
           <p className="text-muted-foreground text-xs">
             Default base {repo.default_base_ref}
           </p>
@@ -64,50 +78,72 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
         <Button
           type="button"
           size="sm"
+          className="shrink-0"
           onClick={() => startNewWorkspace(repoId)}
         >
           New workspace
         </Button>
       </div>
-      <ul className="flex flex-col gap-1">
-        {listed.length === 0 && (
-          <li className="text-muted-foreground text-sm">No workspaces yet.</li>
-        )}
-        {listed.map((workspace) => (
-          <li key={workspace.id}>
-            <button
-              type="button"
-              className={cn(
-                "hover:bg-muted flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left text-sm",
-                FOCUS_RING,
-                HOVER_TINT,
-              )}
-              onClick={() =>
-                void navigate({
-                  to: "/code/w/$workspaceId",
-                  params: { workspaceId: workspace.id },
-                })
-              }
-            >
-              <span className="flex min-w-0 items-center gap-2">
-                <span className="font-medium">
-                  {digests[workspace.id]?.title ?? workspace.title}
-                </span>
-                <span className="text-muted-foreground font-mono text-xs">
-                  {workspace.branch_name}
-                </span>
-                <AttentionBadge attention={digests[workspace.id]?.attention} compact />
-              </span>
-              <span className="text-muted-foreground flex items-center gap-2 text-xs">
-                {digests[workspace.id]?.pr_state && (
-                  <span>PR #{digests[workspace.id]?.pr_state?.number}</span>
+      {listed.length === 0 ? (
+        // The action is already in this page's header, a few centimetres away,
+        // so the zero state explains what a workspace is instead of repeating
+        // the button.
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>No workspaces yet</EmptyTitle>
+            <EmptyDescription>
+              A workspace is an isolated worktree on {repo.display_name}, with
+              its own branch and its own coding session.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {listed.map((workspace) => (
+            <li key={workspace.id}>
+              <button
+                type="button"
+                className={cn(
+                  "hover:bg-muted flex w-full cursor-pointer items-center justify-between gap-3 rounded-md px-3 py-2 text-left text-sm",
+                  FOCUS_RING,
+                  HOVER_TINT,
                 )}
-                {WORKSPACE_STATUS_LABELS[workspace.status]}
-              </span>
-            </button>
-          </li>
-        ))}
-      </ul>
+                onClick={() =>
+                  void navigate({
+                    to: "/code/w/$workspaceId",
+                    params: { workspaceId: workspace.id },
+                  })
+                }
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <span
+                    className="min-w-0 shrink truncate font-medium"
+                    title={digests[workspace.id]?.title ?? workspace.title}
+                  >
+                    {digests[workspace.id]?.title ?? workspace.title}
+                  </span>
+                  <span
+                    className="text-muted-foreground shrink-0 font-mono text-xs"
+                    title={workspace.branch_name}
+                  >
+                    {middleTruncate(workspace.branch_name, 32)}
+                  </span>
+                  <AttentionBadge
+                    attention={digests[workspace.id]?.attention}
+                    compact
+                  />
+                </span>
+                <span className="text-muted-foreground flex shrink-0 items-center gap-2 text-xs">
+                  {digests[workspace.id]?.pr_state && (
+                    <span>PR #{digests[workspace.id]?.pr_state?.number}</span>
+                  )}
+                  {WORKSPACE_STATUS_LABELS[workspace.status]}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -148,9 +148,10 @@ export function CodeSidebar() {
           );
         })}
         {repos.length === 0 && (
-          <p className="px-2 py-1 text-xs text-muted-foreground">
-            No repos registered
-          </p>
+          <SidebarEmptyAction
+            label="Add a repo"
+            onClick={() => setAddRepoOpen(true)}
+          />
         )}
       </div>
 
@@ -236,11 +237,18 @@ export function CodeSidebar() {
             })}
           </div>
         ))}
-        {groups.every((group) => group.workspaces.length === 0) && (
-          <p className="px-2 py-1 text-xs text-muted-foreground">
-            No workspaces yet
-          </p>
-        )}
+        {/*
+          With no repo registered there is nothing to open a workspace on, and
+          the line above already says so. Two dead-end lines stacked read as a
+          broken rail.
+        */}
+        {repos.length > 0 &&
+          groups.every((group) => group.workspaces.length === 0) && (
+            <SidebarEmptyAction
+              label="New workspace"
+              onClick={() => startNewWorkspace()}
+            />
+          )}
       </div>
 
       {dialogs}
@@ -252,6 +260,36 @@ export function CodeSidebar() {
       />
       <AddRepoPalette open={addRepoOpen} onOpenChange={setAddRepoOpen} />
     </SidebarFrame>
+  );
+}
+
+/**
+ * A rail section with nothing in it yet.
+ *
+ * The empty slot is where the reader is already looking, and the section's own
+ * `+` is a 14px target beside a heading. Making the line itself the control
+ * answers "what now?" where the question is asked, and adds no chrome: it
+ * replaces the label that was there.
+ */
+function SidebarEmptyAction({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer rounded-md px-2 py-1 text-left text-xs",
+        FOCUS_RING,
+        HOVER_TINT,
+      )}
+      onClick={onClick}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -342,7 +380,7 @@ function WorkspaceCard({
               <span className="truncate">{repoName}</span>
             </span>
             <span
-              className="min-w-0 flex-1 font-mono text-[11px] text-muted-foreground/90"
+              className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground/90"
               title={workspace.branch_name}
             >
               {branchShown}

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -10,7 +10,7 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import { useEffect, useId, useState, type RefCallback } from "react";
+import { memo, useEffect, useId, useState, type RefCallback } from "react";
 
 import type { CodeApprovalSnapshot, Diffstat, FileChangeKind, ToolDetail } from "../api/types";
 import { CodeApprovalCard } from "./CodeApprovalCard";
@@ -96,9 +96,16 @@ export function CodeTranscript({
     return (
       <div className="messages is-empty" ref={scrollRef} onScroll={onScroll}>
         {hydrated ? (
-          <p className="text-muted-foreground text-sm">
-            Send a message to start a turn.
-          </p>
+          // The engine, mode, and model are already chosen by the time a
+          // reader gets here, so this is not a welcome screen — it is the one
+          // instruction left, plus what it will produce.
+          <div className="flex max-w-sm flex-col items-center gap-1 text-center text-balance">
+            <p className="text-sm font-medium">Send a message to start a turn.</p>
+            <p className="text-muted-foreground text-[13.5px] leading-relaxed">
+              The engine's replies, the tools it runs, and the files it changes
+              all land here.
+            </p>
+          </div>
         ) : (
           <div className="messages-column">
             <TranscriptSkeleton />
@@ -195,7 +202,16 @@ function itemSignature(
   }
 }
 
-function TranscriptItem({
+/**
+ * One transcript row.
+ *
+ * Memoized on its props, and the reducer keeps every untouched item object
+ * identical across an update, so a streamed delta re-renders the row it
+ * changed rather than all of them. That is what keeps a long session's
+ * transcript honest without virtualization — but it only holds while the
+ * host passes stable callbacks, which `CodeWorkspacePage` does.
+ */
+const TranscriptItem = memo(function TranscriptItem({
   item,
   animateStreaming,
   approval,
@@ -299,7 +315,7 @@ function TranscriptItem({
     case "turn_boundary":
       return <TurnReviewCard turn={item} onOpenTurnDiff={onOpenTurnDiff} />;
   }
-}
+});
 
 /**
  * One engine action as a boxless line. The verb is a constant; the muted mono

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowDown, PanelRight, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
@@ -356,10 +356,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     <>
       {dialogs}
       <header className="flex h-12 shrink-0 items-center justify-between gap-3 border-b px-4">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <h1 className="flex min-w-0 items-center gap-2 text-sm font-medium">
             {title ? (
-              <span className="truncate" title={title}>
+              // The title takes the free space and yields it first: the repo
+              // name and the worktree path are short, fixed facts, and a long
+              // title that squeezed them out would cost the reader the two
+              // things that say which checkout this is.
+              <span className="min-w-0 flex-1 truncate" title={title}>
                 {title}
               </span>
             ) : error ? null : (
@@ -373,7 +377,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             )}
             {repoName && (
               <span
-                className="text-muted-foreground truncate text-xs font-normal"
+                className="text-muted-foreground max-w-32 shrink-0 truncate text-xs font-normal"
                 title={repoName}
               >
                 {repoName}
@@ -384,7 +388,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             )}
           </h1>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           {session && (
             <>
               <SessionAttentionBadge
@@ -609,7 +613,7 @@ function WorktreePathChip({ path }: { path: string }) {
         <button
           type="button"
           className={cn(
-            "text-muted-foreground hover:bg-muted hover:text-foreground max-w-44 shrink cursor-pointer truncate rounded-md px-1.5 py-0.5 font-mono text-[11px]",
+            "text-muted-foreground hover:bg-muted hover:text-foreground max-w-44 shrink-0 cursor-pointer truncate rounded-md px-1.5 py-0.5 font-mono text-[11px]",
             FOCUS_RING,
             HOVER_TINT,
           )}
@@ -818,6 +822,34 @@ function CodeSessionPane({
     };
   }, [client, session.id, approvalKey]);
 
+  // This pane re-renders on every streamed delta, so a callback written inline
+  // in the transcript's props would be a new identity each time and would
+  // re-render every row in the transcript with it.
+  const decideApproval = useCallback(
+    async (
+      approvalId: string,
+      decision: "approve" | "deny",
+      feedback?: string,
+    ) => {
+      setDecidingId(approvalId);
+      setApprovalError(undefined);
+      try {
+        const next = await client.decideCodeApproval(approvalId, {
+          decision,
+          feedback,
+        });
+        setApprovals((current) => ({ ...current, [approvalId]: next }));
+      } catch (err) {
+        setApprovalError(
+          friendlyErrorMessage(err, "Could not record that decision"),
+        );
+      } finally {
+        setDecidingId(null);
+      }
+    },
+    [client],
+  );
+
   function send(message: string) {
     // Sending is a deliberate return to the tail: whatever the reader was
     // reading, they now want to watch their own turn run.
@@ -870,23 +902,7 @@ function CodeSessionPane({
           scrollRef={follow.scrollRef}
           contentRef={follow.contentRef}
           onScroll={follow.onScroll}
-          onDecide={async (approvalId, decision, feedback) => {
-            setDecidingId(approvalId);
-            setApprovalError(undefined);
-            try {
-              const next = await client.decideCodeApproval(approvalId, {
-                decision,
-                feedback,
-              });
-              setApprovals((current) => ({ ...current, [approvalId]: next }));
-            } catch (err) {
-              setApprovalError(
-                friendlyErrorMessage(err, "Could not record that decision"),
-              );
-            } finally {
-              setDecidingId(null);
-            }
-          }}
+          onDecide={decideApproval}
         />
         <button
           type="button"

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
@@ -98,6 +98,32 @@ describe("DiffPanel", () => {
       screen.queryByRole("button", { name: "Show diff" }),
     ).not.toBeInTheDocument();
   });
+
+  it("says which scope came back empty", async () => {
+    const client = {
+      getCodeWorkspaceDiff: vi.fn().mockResolvedValue({
+        diff: "",
+        truncated: false,
+        stat: { files: 0, insertions: 0, deletions: 0, truncated: false },
+      }),
+    };
+    const { rerender } = render(
+      <DiffPanel
+        client={client}
+        workspaceId="ws-1"
+        turnId="turn-1"
+        turnLabel="Turn 4"
+      />,
+    );
+    expect(
+      await screen.findByText("Turn 4 changed no files."),
+    ).toBeInTheDocument();
+
+    rerender(<DiffPanel client={client} workspaceId="ws-1" />);
+    expect(
+      await screen.findByText("The worktree matches its base branch."),
+    ).toBeInTheDocument();
+  });
 });
 
 describe("groupUnifiedDiff", () => {

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
@@ -116,11 +116,31 @@ export function DiffPanel({
           />
         ))}
         {payload && groups.length === 0 && !error && (
-          <p className="text-muted-foreground px-3 py-6 text-sm">No diff.</p>
+          <p className="text-muted-foreground px-3 py-6 text-sm">
+            {emptyDiffText(file, turnId, turnLabel)}
+          </p>
         )}
       </div>
     </div>
   );
+}
+
+/**
+ * What an empty diff means, which depends entirely on what it was scoped to.
+ *
+ * The three cases are three different facts — this file is unchanged, this
+ * turn wrote nothing, the whole worktree matches its base — and a reader
+ * scoping the panel to a turn is asking exactly the question the middle one
+ * answers. One line of shared copy for all three ("No diff.") answers none.
+ */
+function emptyDiffText(
+  file?: string,
+  turnId?: string,
+  turnLabel?: string,
+): string {
+  if (file) return "No changes in this file.";
+  if (turnId) return `${turnLabel ?? "This turn"} changed no files.`;
+  return "The worktree matches its base branch.";
 }
 
 function FileDiffSection({

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -25,6 +25,8 @@ export function DoctorList({
   onRefresh?: () => void;
   refreshing?: boolean;
 }) {
+  const allReady =
+    report.harnesses.length > 0 && report.harnesses.every(isHarnessReady);
   return (
     <div className="flex flex-col gap-3">
       {onRefresh && (
@@ -43,6 +45,14 @@ export function DoctorList({
       {report.harnesses.map((entry) => (
         <DoctorCard key={entry.kind} entry={entry} />
       ))}
+      {allReady && (
+        // Every card here says "Ready", which leaves the reader checking each
+        // one to learn that nothing needs doing. One line states the verdict
+        // the cards add up to, and that the list is the whole list.
+        <p className="text-muted-foreground text-sm">
+          Every engine this build drives is installed and signed in.
+        </p>
+      )}
     </div>
   );
 }
@@ -89,7 +99,9 @@ function DoctorCard({ entry }: { entry: HarnessDoctorEntry }) {
 
 function Row({ label, value }: { label: string; value: string }) {
   return (
-    <p className="text-muted-foreground">
+    // A harness path or version carries no spaces to break at, so without this
+    // a deep install location runs past the card.
+    <p className="text-muted-foreground break-words">
       <span className="text-foreground font-medium">{label}: </span>
       {value}
     </p>

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
@@ -81,6 +81,23 @@ describe("FilesPanel", () => {
     );
   });
 
+  it("names the search that found nothing and offers the way back", async () => {
+    const client = makeClient();
+    render(
+      <FilesPanel client={client} workspaceId="ws-1" onOpenFile={vi.fn()} />,
+    );
+    expect(await screen.findByText("README.md")).toBeInTheDocument();
+    await userEvent
+      .setup()
+      .type(screen.getByRole("searchbox", { name: "Search files" }), "zzz");
+    expect(await screen.findByText("zzz")).toBeInTheDocument();
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Clear search and filters" }));
+    expect(await screen.findByText("README.md")).toBeInTheDocument();
+  });
+
   it("focuses search on Cmd+F and filters by include and exclude", async () => {
     const client = makeClient();
     render(

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -10,6 +10,7 @@ import {
   ancestorPaths,
   buildFileTree,
   filterPaths,
+  treeIndentPx,
   type FileTreeNode,
 } from "./fileTree";
 import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
@@ -216,11 +217,15 @@ export function FilesPanel({
         </div>
       )}
       {empty ? (
-        <p className="text-muted-foreground px-3 py-6 text-sm">
-          {query.trim() || include.trim() || exclude.trim()
-            ? "No matching files."
-            : "No files."}
-        </p>
+        <FilesEmpty
+          query={query.trim()}
+          filtered={Boolean(include.trim() || exclude.trim())}
+          onClear={() => {
+            setQuery("");
+            setInclude("");
+            setExclude("");
+          }}
+        />
       ) : ready ? (
         <ul
           className="min-h-0 flex-1 overflow-y-auto px-1 pb-4 pt-2"
@@ -240,6 +245,56 @@ export function FilesPanel({
           ))}
         </ul>
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * Nothing to list, in the two ways that can happen.
+ *
+ * A rail this narrow has no room for a full empty block, so the treatment is
+ * one quiet line — but a filtered miss says what was searched for and offers
+ * the way out, because "no matching files" beside a box the reader typed in
+ * two minutes ago leaves them guessing which of three filters is the culprit.
+ */
+function FilesEmpty({
+  query,
+  filtered,
+  onClear,
+}: {
+  query: string;
+  filtered: boolean;
+  onClear: () => void;
+}) {
+  if (!query && !filtered) {
+    return (
+      <p className="text-muted-foreground px-3 py-6 text-sm">
+        This worktree has no tracked files yet.
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col items-start gap-1 px-3 py-6">
+      <p className="text-muted-foreground line-clamp-2 min-w-0 max-w-full text-sm">
+        No files match{" "}
+        {query ? (
+          <span className="font-mono break-all">{query}</span>
+        ) : (
+          "these filters"
+        )}
+        .
+      </p>
+      <button
+        type="button"
+        className={cn(
+          "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-[11px]",
+          FOCUS_RING,
+          HOVER_TINT,
+        )}
+        onClick={onClear}
+      >
+        Clear search and filters
+      </button>
     </div>
   );
 }
@@ -269,7 +324,7 @@ function TreeRow({
       <button
         type="button"
         aria-current={current ? true : undefined}
-        style={{ paddingLeft: 8 + depth * 12 }}
+        style={{ paddingLeft: treeIndentPx(depth) }}
         className={cn(
           "flex w-full cursor-pointer items-center gap-1 rounded-sm py-0.5 pr-2 text-left text-xs",
           FOCUS_RING_TIGHT,

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
@@ -131,6 +131,47 @@ describe("TerminalPane", () => {
     );
   });
 
+  it("says the shell is opening until it answers, then gets out of the way", async () => {
+    let answer: (page: unknown) => void = () => {};
+    const client = {
+      listCodeTerminals: vi.fn().mockResolvedValue([]),
+      createCodeTerminal: vi.fn().mockResolvedValue({
+        id: "term-1",
+        workspace_id: "ws-1",
+        cols: 80,
+        rows: 24,
+        ended: false,
+        created_at: "2026-08-15T12:00:00.000Z",
+      }),
+      readCodeTerminal: vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            answer = resolve;
+          }),
+      ),
+      writeCodeTerminal: vi.fn(),
+      resizeCodeTerminal: vi.fn(),
+    };
+    render(<TerminalPane client={client} workspaceId="ws-1" />);
+    expect(await screen.findByTestId("terminal-starting")).toHaveTextContent(
+      "Opening a shell in the worktree…",
+    );
+
+    // A shell that answers with nothing is a cleared screen, not a pending one.
+    answer({
+      id: "term-1",
+      workspace_id: "ws-1",
+      bytes: "",
+      cursor: 0,
+      overflow: false,
+      truncated: false,
+      ended: false,
+    });
+    await waitFor(() =>
+      expect(screen.queryByTestId("terminal-starting")).toBeNull(),
+    );
+  });
+
   it("renders the ended-shell state", async () => {
     const client = {
       listCodeTerminals: vi.fn().mockResolvedValue([]),

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -194,6 +194,11 @@ export function TerminalPane({
   const [ended, setEnded] = useState(false);
   const [overflow, setOverflow] = useState(false);
   const [stalled, setStalled] = useState(false);
+  /**
+   * False until this renderer has heard from the shell at all — the window
+   * that covers spawning a process and reading its first bytes.
+   */
+  const [attached, setAttached] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -282,6 +287,7 @@ export function TerminalPane({
         );
         if (cancelled) return;
         cursorRef.current = page.cursor;
+        setAttached(true);
         if (page.overflow) setOverflow(true);
         if (page.ended) setEnded(true);
         const text = decodeTerminalBytes(page.bytes);
@@ -364,6 +370,7 @@ export function TerminalPane({
     setStalled(false);
     setEnded(false);
     setOverflow(false);
+    setAttached(false);
     setError(null);
     pendingRef.current = "";
     tidRef.current = null;
@@ -399,12 +406,29 @@ export function TerminalPane({
         </div>
       )}
       {error && <p className="text-critical px-3 py-2 text-sm">{error}</p>}
-      <div
-        ref={hostRef}
-        className="min-h-0 flex-1"
-        data-testid="terminal-host"
-        aria-label="Terminal output"
-      />
+      <div className="relative min-h-0 flex-1">
+        <div
+          ref={hostRef}
+          className="h-full"
+          data-testid="terminal-host"
+          aria-label="Terminal output"
+        />
+        {!attached && !error && (
+          // Spawning a shell and reading its first bytes takes a moment, and
+          // an empty black rectangle is indistinguishable from one that
+          // failed. The line sits over the host rather than above it so the
+          // terminal does not jump a row when the output lands, and it goes
+          // as soon as the shell answers — a live shell showing nothing is a
+          // cleared screen, not a pending one.
+          <p
+            role="status"
+            data-testid="terminal-starting"
+            className="text-muted-foreground pointer-events-none absolute inset-x-3 top-2 text-xs"
+          >
+            Opening a shell in the worktree…
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/fileTree.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/fileTree.test.ts
@@ -5,6 +5,7 @@ import {
   buildFileTree,
   filterPaths,
   matchGlob,
+  treeIndentPx,
 } from "./fileTree";
 
 describe("buildFileTree", () => {
@@ -54,5 +55,15 @@ describe("ancestorPaths", () => {
   it("lists parent directories of a file", () => {
     expect(ancestorPaths("src/code/mod.rs")).toEqual(["src", "src/code"]);
     expect(ancestorPaths("README.md")).toEqual([]);
+  });
+});
+
+describe("treeIndentPx", () => {
+  it("stops growing so a deep path still leaves room for the name", () => {
+    expect(treeIndentPx(0)).toBe(8);
+    expect(treeIndentPx(3)).toBe(44);
+    // Twenty levels deep would otherwise indent past the width of the rail.
+    expect(treeIndentPx(20)).toBe(treeIndentPx(8));
+    expect(treeIndentPx(8)).toBeLessThan(120);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/fileTree.ts
+++ b/crates/tidebreak-desktop/ui/src/code/fileTree.ts
@@ -10,6 +10,22 @@ export type FileTreeNode = {
   children?: FileTreeNode[];
 };
 
+/** Row indent per nesting level, and the depth past which it stops growing. */
+const INDENT_BASE_PX = 8;
+const INDENT_STEP_PX = 12;
+const MAX_INDENT_DEPTH = 8;
+
+/**
+ * Left padding for a tree row at `depth`.
+ *
+ * The indent stops growing at eight levels. The explorer lives in a rail a few
+ * hundred pixels wide, and past that depth each further step trades a readable
+ * file name for a nesting level the rows above already show.
+ */
+export function treeIndentPx(depth: number): number {
+  return INDENT_BASE_PX + Math.min(depth, MAX_INDENT_DEPTH) * INDENT_STEP_PX;
+}
+
 /** Build a directory tree from slash-separated relative paths. */
 export function buildFileTree(paths: readonly string[]): FileTreeNode[] {
   const root: FileTreeNode[] = [];


### PR DESCRIPTION
Third of the code-mode refinement stack, after #2220 (spacing and type) and
#2221 (interaction polish). Two concerns only: the zero state of every
code-mode surface, and what happens to those surfaces under hostile content.

## Empty states, one decision each

| Surface | Zero state | Why this treatment |
| --- | --- | --- |
| `/code` home, no repos | Shared `Empty` block: "No repos yet", how to add one, and the Add repo button | The whole page is the zero state, so it earns the full block. It also replaces two stacked sections ("Add a repo" with its own button, then a "Repos" heading over "None registered yet.") that carried one message between them. |
| `/code` home, repos listed | Repos section with the Add repo button on the heading row | The instruction is no longer news once a repo exists; the action stays. |
| Repo page, no workspaces | `Empty` block naming what a workspace is, no button | The page header already carries "New workspace" a few centimetres away. A second copy of it would be chrome; the missing information is what the thing is. |
| Rail, no repos | The empty line becomes a quiet "Add a repo" button | A full block cannot fit a 240px rail. The empty slot is where the reader looks, and the section's own `+` is a 14px target beside a heading. This replaces the dead label rather than adding to it. |
| Rail, no workspaces | Same treatment, "New workspace" — **suppressed entirely when no repo is registered** | With no repo there is nothing to open a workspace on, and the line above already says so. Two dead-end lines stacked read as a broken rail. |
| Files explorer, no files | One quiet line: "This worktree has no tracked files yet." | Narrow rail; nothing is actionable. |
| Files explorer, no search or filter matches | Names the query in mono and offers "Clear search and filters" | "No matching files." beside three inputs leaves the reader guessing which one is the culprit. |
| Diff panel, empty | Three distinct lines: no changes in this file / "Turn 4 changed no files." / "The worktree matches its base branch." | These are three different facts. The per-turn case is the one a reader who just clicked a turn diffstat is actually asking about, and it used to answer "No diff." |
| Inspector PR tab, no PR | Title, one line of what will land here, and an "Open Source control" button that switches tabs | Checked the gh-absent path: the remediation copy lives in the git card on Source control (warning block, exact commands in mono, copy control) and presents correctly. Restating it here would be a second copy to keep true — a way over to it is not. Trimmed the copy that narrated the tab's own quietness. |
| Transcript, hydrated and empty | Two lines, centred: the instruction at foreground weight, then what a turn produces | The engine, mode, and model are already chosen by the time a reader is here, so this is not a welcome screen. The old single muted sentence floating in the column was the default, not a decision. |
| Terminal drawer, before first output | "Opening a shell in the worktree…" over the host, gone as soon as the shell answers | An empty black rectangle looks the same as a failed one. It clears on the first read rather than on the first byte: a live shell showing nothing is a cleared screen, not a pending one. Positioned over the host so the terminal does not jump a row. |
| Doctor list, all healthy | One line: "Every engine this build drives is installed and signed in." | Otherwise the reader checks each card to learn that nothing needs doing. Also shows in Settings, which is where the all-ready case is most often read. |

## Content edges

Fixed:

- **Long workspace titles in the header.** The title now takes the free space and yields it first (`flex-1`), the repo name is capped and `shrink-0`, and the worktree-path chip stops shrinking. Before, a long title could squeeze the repo name to nothing — the two facts that say which checkout you are looking at. The header's right-hand controls got `shrink-0` so the left side is what gives.
- **Long branch names on rail cards.** The branch already middle-truncated to 22 characters but had no CSS floor, so a narrow rail overflowed the row. Added `truncate` under the middle truncation.
- **Long repo paths on the home and repo pages.** Both were raw `root_path` in a wrapping inline span. Now middle-truncated with the full path on hover, in a row that truncates.
- **Diff tabs in the centre strip.** `name.ts (diff)` truncated to `name.ts…`, which made a diff tab indistinguishable from the file tab for the same path. The suffix is now a separate `shrink-0` span, so only the file name truncates. The accessible name is unchanged.
- **Deep nesting in the explorer.** The indent was `8 + depth * 12` with no ceiling; twenty levels indented past the rail. Extracted `treeIndentPx`, which stops growing at eight levels.
- **Huge approval payloads.** Two problems. The disclosure nested a `pre` inside `ScrollableContainer` (itself a `pre`), so the browser's own `white-space: pre` won and the wrapping the class list asked for never applied — a single long JSON line scrolled sideways instead. And the payload was rendered whole: an engine that attaches a file's contents put megabytes into the transcript's DOM. Now one `pre` that wraps, capped at 20,000 characters with the remainder stated.
- **Long harness paths in the doctor cards.** No break opportunity in a path, so a deep install location ran past the card. `break-words`.

Verified intact, no change needed:

- Tool output with 500-character single lines wraps (`whitespace-pre-wrap break-words`) in both the clamped preview and the running tail; the tail stays height-capped so a streaming line cannot grow the row.
- Diffs with very long lines keep per-file horizontal scroll (`overflow-x-auto` on each file's `pre`, `min-w-max` rows) — R1/R2 left that intact.
- Command approvals and file-write path lists already wrap or middle-truncate.

**200-item transcripts.** Rows were *not* memoized — `isolatedCard` wraps each in an error boundary, which is not the same thing. Measured with a throwaway fixture: changing one item's text re-rendered all 200 rows. Two changes fix it without virtualization: `TranscriptItem` is now `memo`, and `onDecide` moved into a `useCallback` in `CodeSessionPane` (it was written inline, so it was a fresh identity on every streamed delta and would have defeated the memo for every row). Re-measured: 1 of 200. The reducer already keeps untouched item objects identical across an update, which is what makes this work; the doc comment on `TranscriptItem` records the dependency so a future inline callback in the host is a visible mistake.

## Tests

Added five, each for a failure worth acting on:

- `fileTree` — the tree indent stops growing (the rule the fix installs).
- `FilesPanel` — a search that matches nothing names the query, and clearing restores the tree.
- `DiffPanel` — a turn-scoped empty diff says the turn changed no files, and an unscoped one says the worktree matches its base.
- `CodeApprovalCard` — a payload twice the cap renders capped rather than whole.
- `TerminalPane` — the opening line shows before the shell answers and clears once it does, including when it answers with nothing.

No tests removed. `pnpm vitest run src/code` (28 files, 189), full `pnpm vitest run` (182 files, 1211), and `pnpm build` all pass.

Not verified: driving the running app. Screenshots for the state × theme sweep are the coordinator's gate.
