### PR TITLE
fix(harness): carry completed tool arguments so transcripts name their subject

### DIFF
--- a/crates/tidebreak-core/fixtures/code-journal-events.json
+++ b/crates/tidebreak-core/fixtures/code-journal-events.json
@@ -34,7 +34,11 @@
     "type": "tool_completed",
     "call_id": "toolu_1",
     "outcome": "succeeded",
-    "preview": "demo"
+    "preview": "demo",
+    "detail": {
+      "kind": "file_read",
+      "path": "README.md"
+    }
   },
   {
     "type": "file_changed",

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -51,6 +51,41 @@ pub enum ToolDetail {
     },
 }
 
+impl ToolDetail {
+    /// The subject a transcript line names: the command, path, or query.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        match self {
+            Self::Command { cmd, .. } => cmd,
+            Self::FileEdit { path } | Self::FileRead { path } => path,
+            Self::Search { query } => query,
+            Self::Other { summary } => summary,
+        }
+    }
+
+    /// How much this detail says about the call, for the correction channel.
+    ///
+    /// An engine can open a tool call before its arguments finish streaming,
+    /// so the detail on [`CodeEvent::ToolStarted`] may name nothing. A later
+    /// detail built from the complete arguments rides
+    /// [`CodeEvent::ToolCompleted`] and replaces the first one only when it
+    /// scores higher, so a correction never downgrades a line that already
+    /// names its subject.
+    ///
+    /// Zero is a detail with no subject, one is a bare tool name, and two is
+    /// a real command, path, or query.
+    #[must_use]
+    pub fn specificity(&self) -> u8 {
+        if self.subject().trim().is_empty() {
+            0
+        } else if matches!(self, Self::Other { .. }) {
+            1
+        } else {
+            2
+        }
+    }
+}
+
 /// How a tool call finished.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
@@ -212,6 +247,16 @@ pub enum CodeEvent {
         outcome: ToolOutcome,
         /// Bounded preview of the result.
         preview: String,
+        /// Classification rebuilt from the call's complete arguments.
+        ///
+        /// Engines open a tool call before its arguments finish streaming, so
+        /// the detail on [`CodeEvent::ToolStarted`] can name nothing. This is
+        /// the correction: adapters that see the final arguments fill it in,
+        /// and renderers merge it into the started call. It is `None` when
+        /// the engine's completion payload carries no arguments.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        detail: Option<ToolDetail>,
     },
     /// A file changed. The diff body is loaded from a bounded GET route.
     FileChanged {
@@ -357,6 +402,9 @@ mod tests {
                 call_id: "toolu_1".into(),
                 outcome: ToolOutcome::Succeeded,
                 preview: "demo".into(),
+                detail: Some(ToolDetail::FileRead {
+                    path: "README.md".into(),
+                }),
             },
             CodeEvent::FileChanged {
                 path: "src/lib.rs".into(),

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -198,6 +198,87 @@ describe("turn lifecycle", () => {
   });
 });
 
+describe("late tool arguments", () => {
+  function toolItem(state: CodeSessionState) {
+    return state.items.find((item) => item.kind === "tool");
+  }
+
+  it("names the subject an empty started detail could not", () => {
+    // Engines open a call before its arguments finish streaming, so the
+    // started detail can be empty and the line falls back to the tool name.
+    const { state } = play([
+      { type: "turn_started", turn_id: "t1" },
+      {
+        type: "tool_started",
+        call_id: "c1",
+        name: "Bash",
+        detail: { kind: "command", cmd: "", cwd: "" },
+      },
+      {
+        type: "tool_completed",
+        call_id: "c1",
+        outcome: "succeeded",
+        preview: "ok",
+        detail: {
+          kind: "command",
+          cmd: "cargo test -p tidebreak-server",
+          cwd: "/workspace",
+        },
+      },
+    ]);
+    expect(toolItem(state)).toMatchObject({
+      detail: {
+        kind: "command",
+        cmd: "cargo test -p tidebreak-server",
+        cwd: "/workspace",
+      },
+    });
+  });
+
+  it("keeps a populated detail rather than taking a weaker correction", () => {
+    const { state } = play([
+      { type: "turn_started", turn_id: "t1" },
+      {
+        type: "tool_started",
+        call_id: "c1",
+        name: "Bash",
+        detail: { kind: "command", cmd: "cargo test", cwd: "/workspace" },
+      },
+      {
+        type: "tool_completed",
+        call_id: "c1",
+        outcome: "succeeded",
+        preview: "ok",
+        detail: { kind: "other", summary: "Bash" },
+      },
+    ]);
+    expect(toolItem(state)).toMatchObject({
+      detail: { kind: "command", cmd: "cargo test", cwd: "/workspace" },
+    });
+  });
+
+  it("leaves the started detail alone when no correction rides the completion", () => {
+    const { state } = play([
+      { type: "turn_started", turn_id: "t1" },
+      {
+        type: "tool_started",
+        call_id: "c1",
+        name: "read_file",
+        detail: { kind: "file_read", path: "README.md" },
+      },
+      {
+        type: "tool_completed",
+        call_id: "c1",
+        outcome: "succeeded",
+        preview: "demo",
+      },
+    ]);
+    expect(toolItem(state)).toMatchObject({
+      detail: { kind: "file_read", path: "README.md" },
+    });
+  });
+});
+
 const SNAPSHOT_TURN = {
   id: "t1",
   session_id: "sess-1",

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -399,6 +399,7 @@ export function reduceCodeSessionEvent(
                   ...item,
                   status: event.outcome,
                   preview: event.preview,
+                  detail: mergeToolDetail(item.detail, event.detail),
                   durationMs: framed.replayed
                     ? null
                     : durationMs(item.startedAt, deps.now()),
@@ -717,4 +718,44 @@ function durationMs(
     return null;
   }
   return end - start;
+}
+
+/**
+ * How much a detail says about the call: the subject a tool line names.
+ *
+ * Zero is a detail with no subject, one is a bare tool name, and two is a
+ * real command, path, or query. Mirrors `ToolDetail::specificity` in
+ * `tidebreak-core`.
+ */
+function toolDetailSpecificity(detail: ToolDetail): number {
+  const subject =
+    detail.kind === "command"
+      ? detail.cmd
+      : detail.kind === "search"
+        ? detail.query
+        : detail.kind === "other"
+          ? detail.summary
+          : detail.path;
+  if (!subject.trim()) return 0;
+  return detail.kind === "other" ? 1 : 2;
+}
+
+/**
+ * Fold a completed call's detail into the one its start carried.
+ *
+ * Engines open a tool call before its arguments finish streaming, so the
+ * detail on `tool_started` can name nothing and the line falls back to the
+ * tool's name. `tool_completed` carries the detail rebuilt from the complete
+ * arguments, which is the more trustworthy view — it wins unless it says
+ * less, so a correction never downgrades a line that already names its
+ * subject.
+ */
+function mergeToolDetail(
+  current: ToolDetail,
+  correction: ToolDetail | null | undefined,
+): ToolDetail {
+  if (!correction) return current;
+  return toolDetailSpecificity(correction) >= toolDetailSpecificity(current)
+    ? correction
+    : current;
 }

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -7,6 +7,7 @@ import {
   parseCodeCloneDefaults,
   parseCodeCloneJob,
   parseCodeCommit,
+  parseCodeEvent,
   parseCodePush,
   parseCodeSession,
   parseCodeSessionList,
@@ -384,6 +385,29 @@ describe("parseCodeAction", () => {
       timed_out: false,
     };
     expect(parseCodeAction(action)).toEqual(action);
+  });
+});
+
+describe("parseCodeEvent", () => {
+  it("takes tool_completed with or without the late-argument detail", () => {
+    const completed = {
+      type: "tool_completed",
+      call_id: "toolu_1",
+      outcome: "succeeded",
+      preview: "ok",
+    };
+    // The correction is optional: adapters that never see the final
+    // arguments omit it, and dropping the whole event over the new key
+    // would stop every tool line from resolving.
+    expect(parseCodeEvent(completed)).toEqual(completed);
+    const corrected = {
+      ...completed,
+      detail: { kind: "command", cmd: "cargo test", cwd: "/workspace" },
+    };
+    expect(parseCodeEvent(corrected)).toEqual(corrected);
+    expect(
+      parseCodeEvent({ ...completed, detail: { kind: "command", cmd: 7 } }),
+    ).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1287,13 +1287,14 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
         detail,
       };
     }
-    case "tool_completed":
+    case "tool_completed": {
       if (
         !onlyKeys<Extract<WireCodeEvent, { type: "tool_completed" }>>(value, [
           "type",
           "call_id",
           "outcome",
           "preview",
+          "detail",
         ]) ||
         !nonEmpty(value.call_id) ||
         !isMember(value.outcome, TOOL_OUTCOMES) ||
@@ -1301,12 +1302,23 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
       ) {
         return null;
       }
+      // The server omits `detail` when the engine's completion payload
+      // carried no arguments. A present-but-malformed one is a wire
+      // disagreement, so it rejects the event rather than dropping a field.
+      let detail: ToolDetail | undefined;
+      if (value.detail !== undefined && value.detail !== null) {
+        const parsed = parseToolDetail(value.detail);
+        if (!parsed) return null;
+        detail = parsed;
+      }
       return {
         type: "tool_completed",
         call_id: value.call_id,
         outcome: value.outcome,
         preview: value.preview,
+        ...(detail ? { detail } : {}),
       };
+    }
     case "turn_completed": {
       if (
         !onlyKeys<Extract<WireCodeEvent, { type: "turn_completed" }>>(value, [

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -936,7 +936,17 @@ outcome: ToolOutcome,
 /**
  * Bounded preview of the result.
  */
-preview: string, } | { "type": "file_changed", 
+preview: string, 
+/**
+ * Classification rebuilt from the call's complete arguments.
+ *
+ * Engines open a tool call before its arguments finish streaming, so
+ * the detail on [`CodeEvent::ToolStarted`] can name nothing. This is
+ * the correction: adapters that see the final arguments fill it in,
+ * and renderers merge it into the started call. It is `None` when
+ * the engine's completion payload carries no arguments.
+ */
+detail?: ToolDetail, } | { "type": "file_changed", 
 /**
  * Path relative to the worktree, when the engine reports one.
  */

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
@@ -18,7 +18,11 @@
     "type": "tool_completed",
     "call_id": "toolu_01AccXU5wrjo1GDyiNaAGDXM",
     "outcome": "succeeded",
-    "preview": "File created successfully at: /workspace/probe.txt (file state is current in your context — no need to Read it back)"
+    "preview": "File created successfully at: /workspace/probe.txt (file state is current in your context — no need to Read it back)",
+    "detail": {
+      "kind": "file_edit",
+      "path": "/workspace/probe.txt"
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
@@ -18,7 +18,11 @@
     "type": "tool_completed",
     "call_id": "toolu_01Pwo7nMXPQZWnBMyeTuL8ts",
     "outcome": "failed",
-    "preview": "no — use the fixtures directory instead"
+    "preview": "no — use the fixtures directory instead",
+    "detail": {
+      "kind": "file_edit",
+      "path": "/workspace/probe.txt"
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
@@ -23,7 +23,11 @@
     "type": "tool_completed",
     "call_id": "toolu_01NHAnSCW3oCoKt9Y5yijZtC",
     "outcome": "failed",
-    "preview": "Claude requested permissions to write to /workspace/probe.txt, but you haven't granted it yet."
+    "preview": "Claude requested permissions to write to /workspace/probe.txt, but you haven't granted it yet.",
+    "detail": {
+      "kind": "file_edit",
+      "path": "/workspace/probe.txt"
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
@@ -30,7 +30,11 @@
     "type": "tool_completed",
     "call_id": "toolu_019ykdV8Jr64h8Yd3HUjbsUF",
     "outcome": "succeeded",
-    "preview": "1\tdemo\n2\t\n3\tA tiny fixture repository.\n4\t"
+    "preview": "1\tdemo\n2\t\n3\tA tiny fixture repository.\n4\t",
+    "detail": {
+      "kind": "file_read",
+      "path": "/workspace/README.md"
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
@@ -65,7 +65,12 @@
     "type": "tool_completed",
     "call_id": "exec-f5557c0a-1ece-4571-8bd5-5a74e11e269a",
     "outcome": "succeeded",
-    "preview": "42\n"
+    "preview": "42\n",
+    "detail": {
+      "kind": "command",
+      "cmd": "/bin/zsh -lc \"python3 -c 'print(42)'\"",
+      "cwd": "/workspace"
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
@@ -37,7 +37,12 @@
     "type": "tool_completed",
     "call_id": "exec-877a44a5-3d8b-4dbf-b89c-1a4131e2dade",
     "outcome": "denied",
-    "preview": ""
+    "preview": "",
+    "detail": {
+      "kind": "command",
+      "cmd": "/bin/zsh -lc \"python3 -c 'print(42)'\"",
+      "cwd": "/workspace"
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
@@ -22,7 +22,12 @@
     "type": "tool_completed",
     "call_id": "exec-59525603-b92d-49e3-a3f2-b59f9373bdff",
     "outcome": "succeeded",
-    "preview": "alpha\n"
+    "preview": "alpha\n",
+    "detail": {
+      "kind": "command",
+      "cmd": "/bin/zsh -lc \"sed -n '1,200p' note.txt\"",
+      "cwd": "/workspace"
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
@@ -101,7 +101,12 @@
     "type": "tool_completed",
     "call_id": "call_00_XqOXPl42gfJx0xSVsgUu1333",
     "outcome": "succeeded",
-    "preview": "/Users/redacted/.zshenv:.:1: no such file or directory: /tmp/redacted-opencode-home/home/.cargo/env\nhi\n"
+    "preview": "/Users/redacted/.zshenv:.:1: no such file or directory: /tmp/redacted-opencode-home/home/.cargo/env\nhi\n",
+    "detail": {
+      "kind": "command",
+      "cmd": "echo hi",
+      "cwd": ""
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-deny.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-deny.expected.json
@@ -106,7 +106,12 @@
     "type": "tool_completed",
     "call_id": "call_00_UWLCr2nBoXdhyc2JM4ef2097",
     "outcome": "denied",
-    "preview": "The user rejected permission to use this specific tool call with the following feedback: use the fixtures directory instead"
+    "preview": "The user rejected permission to use this specific tool call with the following feedback: use the fixtures directory instead",
+    "detail": {
+      "kind": "command",
+      "cmd": "echo hi",
+      "cwd": ""
+    }
   },
   {
     "type": "assistant_delta",
@@ -233,7 +238,11 @@
     "type": "tool_completed",
     "call_id": "call_00_viY1Lx1AXCvyGzESMURk7927",
     "outcome": "succeeded",
-    "preview": "No files found"
+    "preview": "No files found",
+    "detail": {
+      "kind": "search",
+      "query": "**/fixtures/**"
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/tool-use.expected.json
@@ -105,7 +105,11 @@
     "type": "tool_completed",
     "call_id": "call_00_hWtj3zfWzwaUyytIP55s8125",
     "outcome": "succeeded",
-    "preview": "demo\n\nA tiny fixture repository."
+    "preview": "demo\n\nA tiny fixture repository.",
+    "detail": {
+      "kind": "file_read",
+      "path": "/workspace/README.md"
+    }
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -197,13 +197,22 @@ mod tests {
     #[test]
     fn fixture_replay_tool_use() {
         let (events, _) = replay("tool-use");
+        // `content_block_start` opens the call with `input: {}`, so the
+        // started detail names nothing. The complete arguments arrive on the
+        // `assistant` message and ride the completion as a correction —
+        // without it the transcript line falls back to "Read".
         assert!(events.iter().any(|event| matches!(
             event,
-            HarnessEvent::ToolStarted { name, .. } if name == "Read"
+            HarnessEvent::ToolStarted { name, detail, .. }
+                if name == "Read" && detail.specificity() == 0
         )));
-        assert!(events
-            .iter()
-            .any(|event| matches!(event, HarnessEvent::ToolCompleted { .. })));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            HarnessEvent::ToolCompleted {
+                detail: Some(tidebreak_core::ToolDetail::FileRead { path }),
+                ..
+            } if path == "/workspace/README.md"
+        )));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/claude/parse.rs
+++ b/crates/tidebreak-harness/src/claude/parse.rs
@@ -5,7 +5,7 @@
 //! and are logged (size-capped). They are never fatal and never dropped
 //! silently.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use serde_json::Value;
 use tidebreak_core::{
@@ -24,7 +24,10 @@ pub struct ClaudeStreamParser {
     unrecognized: u64,
     resume_ref: Option<String>,
     version: Option<String>,
-    started_tools: HashSet<String>,
+    /// call id → best detail emitted or recorded for that call so far.
+    started_tools: HashMap<String, ToolDetail>,
+    /// call id → detail to correct the started call with, once it resolves.
+    late_details: HashMap<String, ToolDetail>,
     emitted_session: bool,
 }
 
@@ -262,6 +265,7 @@ impl ClaudeStreamParser {
                     let is_error = block.get("is_error").and_then(Value::as_bool) == Some(true);
                     let preview = tool_result_preview(&block);
                     if !call_id.is_empty() {
+                        let detail = self.late_details.remove(&call_id);
                         events.push(HarnessEvent::ToolCompleted {
                             call_id,
                             outcome: if is_error {
@@ -270,6 +274,7 @@ impl ClaudeStreamParser {
                                 ToolOutcome::Succeeded
                             },
                             preview,
+                            detail,
                         });
                     }
                 }
@@ -327,7 +332,7 @@ impl ClaudeStreamParser {
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_owned();
-        if call_id.is_empty() || !self.started_tools.insert(call_id.clone()) {
+        if call_id.is_empty() {
             return Vec::new();
         }
         let name = block
@@ -336,10 +341,24 @@ impl ClaudeStreamParser {
             .unwrap_or("unknown")
             .to_owned();
         let input = block.get("input").cloned().unwrap_or(Value::Null);
+        let detail = tool_detail(&name, &input);
+        // `content_block_start` opens the call with `input: {}` and the
+        // arguments stream in after it, so the first view of a call names
+        // nothing. The `assistant` message repeats the same block with the
+        // assembled input; that later view is the correction, and it rides
+        // the call's `ToolCompleted`.
+        if let Some(started) = self.started_tools.get(&call_id) {
+            if detail.specificity() > started.specificity() {
+                self.started_tools.insert(call_id.clone(), detail.clone());
+                self.late_details.insert(call_id, detail);
+            }
+            return Vec::new();
+        }
+        self.started_tools.insert(call_id.clone(), detail.clone());
         vec![HarnessEvent::ToolStarted {
             call_id,
-            name: name.clone(),
-            detail: tool_detail(&name, &input),
+            name,
+            detail,
         }]
     }
 

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -192,13 +192,20 @@ mod tests {
     #[test]
     fn fixture_replay_tool_use() {
         let (events, _) = replay("tool-use");
+        // `item/started` already carries the whole command, so the started
+        // detail names its subject; `item/completed` repeats it.
         assert!(events.iter().any(|event| matches!(
             event,
-            HarnessEvent::ToolStarted { name, .. } if name == "commandExecution"
+            HarnessEvent::ToolStarted { name, detail, .. }
+                if name == "commandExecution" && detail.specificity() > 0
         )));
-        assert!(events
-            .iter()
-            .any(|event| matches!(event, HarnessEvent::ToolCompleted { .. })));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            HarnessEvent::ToolCompleted {
+                detail: Some(tidebreak_core::ToolDetail::Command { cmd, .. }),
+                ..
+            } if cmd.contains("note.txt")
+        )));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -404,15 +404,10 @@ impl CodexStreamParser {
         if call_id.is_empty() || !self.started_tools.insert(call_id.clone()) {
             return Vec::new();
         }
-        let cmd = item.get("command").and_then(Value::as_str).unwrap_or("");
-        let cwd = item.get("cwd").and_then(Value::as_str).unwrap_or("");
         vec![HarnessEvent::ToolStarted {
             call_id,
             name: "commandExecution".into(),
-            detail: ToolDetail::Command {
-                cmd: bound(cmd, MAX_EVENT_TEXT_CHARS),
-                cwd: cwd.to_owned(),
-            },
+            detail: command_detail(item),
         }]
     }
 
@@ -437,10 +432,14 @@ impl CodexStreamParser {
             .get("aggregatedOutput")
             .and_then(Value::as_str)
             .unwrap_or("");
+        // `item/completed` repeats the whole item, command included, so the
+        // resolved call can always name its own subject.
+        let detail = command_detail(item);
         vec![HarnessEvent::ToolCompleted {
             call_id,
             outcome,
             preview: bound(preview, MAX_PREVIEW_CHARS),
+            detail: (detail.specificity() > 0).then_some(detail),
         }]
     }
 
@@ -455,6 +454,22 @@ impl CodexStreamParser {
             payload = %rendered,
             "unrecognized engine event"
         );
+    }
+}
+
+/// Classification for a `commandExecution` item. Both `item/started` and
+/// `item/completed` carry the whole item, so both can name the command.
+fn command_detail(item: &Value) -> ToolDetail {
+    ToolDetail::Command {
+        cmd: bound(
+            item.get("command").and_then(Value::as_str).unwrap_or(""),
+            MAX_EVENT_TEXT_CHARS,
+        ),
+        cwd: item
+            .get("cwd")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned(),
     }
 }
 

--- a/crates/tidebreak-harness/src/grok/parse.rs
+++ b/crates/tidebreak-harness/src/grok/parse.rs
@@ -209,6 +209,10 @@ impl GrokStreamParser {
             call_id,
             outcome,
             preview,
+            // `tool_call` already carries the whole `rawInput`, so the started
+            // call names its subject. `tool_call_update` repeats no arguments
+            // at all, so there is nothing to correct it with.
+            detail: None,
         }]
     }
 

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -92,6 +92,13 @@ pub enum HarnessEvent {
         outcome: ToolOutcome,
         /// Bounded preview.
         preview: String,
+        /// Classification rebuilt from the call's complete arguments, when
+        /// the engine reports them by the time the call resolves. Engines
+        /// open a call before its arguments finish streaming, so the detail
+        /// on [`HarnessEvent::ToolStarted`] can name nothing; this corrects
+        /// it. `None` when the adapter never sees final arguments.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<ToolDetail>,
     },
     /// A file changed.
     FileChanged {

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -202,13 +202,21 @@ mod tests {
     #[test]
     fn fixture_replay_tool_use() {
         let (events, _) = replay("tool-use");
+        // The `pending` part opens the call with `input: {}`, so the started
+        // detail names nothing. The terminal part repeats the complete input
+        // and rides the completion as a correction.
         assert!(events.iter().any(|event| matches!(
             event,
-            HarnessEvent::ToolStarted { name, .. } if name == "read"
+            HarnessEvent::ToolStarted { name, detail, .. }
+                if name == "read" && detail.specificity() == 0
         )));
-        assert!(events
-            .iter()
-            .any(|event| matches!(event, HarnessEvent::ToolCompleted { .. })));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            HarnessEvent::ToolCompleted {
+                detail: Some(tidebreak_core::ToolDetail::FileRead { path }),
+                ..
+            } if path == "/workspace/README.md"
+        )));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/opencode/parse.rs
+++ b/crates/tidebreak-harness/src/opencode/parse.rs
@@ -399,10 +399,16 @@ impl OpencodeStreamParser {
                     .or_else(|| state.get("output").and_then(Value::as_str))
                     .or(if error.is_empty() { None } else { Some(error) })
                     .unwrap_or("");
+                // The `pending` part that opens the call carries `input: {}`;
+                // the arguments land on the `running` and terminal parts. The
+                // terminal part is the correction for the call already
+                // started, and the detail above for one that was not.
+                let detail = tool_detail(&name, &input);
                 events.push(HarnessEvent::ToolCompleted {
                     call_id,
                     outcome,
                     preview: bound(preview, MAX_PREVIEW_CHARS),
+                    detail: (detail.specificity() > 0).then_some(detail),
                 });
                 events
             }

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -920,10 +920,12 @@ fn map_event(event: HarnessEvent, turn_id: Option<CodeTurnId>) -> Option<CodeEve
             call_id,
             outcome,
             preview,
+            detail,
         } => CodeEvent::ToolCompleted {
             call_id,
             outcome,
             preview,
+            detail,
         },
         HarnessEvent::FileChanged {
             path,

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 31;
+const DESKTOP_SCHEMA_EPOCH: u32 = 32;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -236,7 +236,7 @@ bounded):
 | `AssistantDelta` / `AssistantMessage` | streamed or whole assistant text |
 | `ReasoningDelta` | streamed thinking text where the harness reports it |
 | `ToolStarted` | call id, name, `ToolDetail` (`Command {cmd, cwd}` \| `FileEdit {path}` \| `FileRead {path}` \| `Search {query}` \| `Other {summary}`) |
-| `ToolCompleted` | call id, outcome, bounded preview |
+| `ToolCompleted` | call id, outcome, bounded preview, optional corrected `ToolDetail` |
 | `FileChanged` | path, change kind, diffstat |
 | `ApprovalRequested` | approval id (hint; body loads from the approvals route) |
 | `ApprovalResolved` | approval id, decision |
@@ -247,6 +247,14 @@ bounded):
 | `CheckpointRecorded` | turn id, diffstat |
 | `HarnessNotice` | level, message — the visible-degradation channel |
 | `AttentionChanged` | state, source |
+
+Engines open a tool call before its arguments finish streaming, so the
+`ToolDetail` on `ToolStarted` can name nothing and the transcript line falls
+back to the tool's name. `ToolCompleted` carries the detail rebuilt from the
+complete arguments as a correction, and the renderer takes it unless it says
+less than what the line already shows. An adapter whose completion payload
+carries no arguments leaves it unset — Grok's `tool_call` frame already
+carries the whole `rawInput`, so it has nothing to correct.
 
 ## Server API surface
 


### PR DESCRIPTION
## The gap

Engines open a tool call before its arguments finish streaming. Adapters built
the `ToolDetail` from that not-yet-complete payload and filled the missing
fields with `""`, so the journaled `tool_started` carried an empty command or
path — and nothing ever corrected it. The transcript's inline tool line falls
back to the tool's name when its subject is empty, which is why a real call
rendered as "Command run Bash" instead of "Command run cargo test -p
tidebreak-server". The line is the only place a reader learns what the engine
actually did, so it lived or died on that subject.

The fixtures show it directly. Claude Code's `content_block_start` opens the
call with `input: {}` and streams `input_json_delta` after it; opencode's
`pending` tool part carries `input: {}` and the arguments land on the frames
that follow.

## The correction channel

`CodeEvent::ToolCompleted` gains an optional `detail`, rebuilt from the
complete arguments when the call resolves. Additive and wire-compatible: the
field is `skip_serializing_if = "Option::is_none"` and `#[ts(optional)]`, so
existing rows read back unchanged and the generated TypeScript declares it
optional rather than nullable.

It is a correction, not a replacement. An adapter that can already see complete
arguments when the call opens still emits a complete `tool_started`. The
reducer merges a non-null completed detail into the existing tool item and
takes it only when it says at least as much as the line already shows, so a
correction never downgrades a populated line to a bare tool name. `ToolDetail`
gained `subject()` and `specificity()` in `tidebreak-core` to state that
ordering once; `CodeSessionReducer.ts` mirrors it.

Equality matters in one real case rather than being a tie-breaking detail:
opencode's `glob` start falls back to the tool name as the query, and the
completion carries the actual pattern. Both score the same, so the rule is
"the correction wins unless it says less", not "unless it says more".

## Per-adapter fixture coverage

Behavior is derived from the checked-in fixtures only.

| Adapter | What its fixtures show | Result |
|---|---|---|
| claude-code 2.1.233 | `content_block_start` opens with `input: {}`; the following `assistant` message repeats the block with the assembled input, before the `tool_result` | Records the later, more specific view and rides it on `ToolCompleted` |
| opencode 1.18.18 | `pending` part has `input: {}`; the `running` and terminal (`completed`/`error`) parts carry the full input | Builds the correction from the terminal part |
| codex 0.147.0 | `item/started` already carries the whole command; `item/completed` repeats it | Start was never empty; the completion carries the same detail |
| grok 1.0.4 | `tool_call` carries the whole `rawInput`; `tool_call_update` repeats no arguments at all | Start was never empty, and there is nothing to correct with — stays `None` |

Grok is the one adapter that emits no completed detail, and it is left that way
deliberately rather than synthesized from a frame that does not carry it.

## Tests

- `fixture_replay_tool_use` for claude-code and opencode now assert both halves
  of the bug: the started detail names nothing (`specificity() == 0`) and the
  completed detail names the real path. Codex's asserts its start is already
  populated and its completion repeats the command.
- `CodeSessionReducer.test.ts` covers the merge: empty start upgraded to a
  populated correction, a populated start kept against a weaker one, and an
  absent correction leaving the line alone.
- `parsers.test.ts` covers the validator: `tool_completed` parses with and
  without `detail`, and a malformed detail rejects the event. Without the new
  key in the `onlyKeys` allowlist every completion would be dropped silently,
  which nothing else catches.
- Harness expected sequences, `code-journal-events.json`, and
  `generated/wire.ts` regenerated.

## Schema epoch

`DESKTOP_SCHEMA_EPOCH` moves 31 to 32. The field is additive and old rows
deserialize unchanged, but ADR 0002 makes a persisted-format change and the
epoch bump one change, and the pinned journal fixture names the bump as the
fix. Pre-v1 local data is disposable by that record's design.

## Not verified

The change was not driven in the running app; the transcript rendering is
covered by the reducer tests rather than by a live session.