### PR TITLE
refactor(desktop): complete the code-mode accessibility contract

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -58,6 +58,10 @@ export function ToolOutputPreview({
       <div className="group relative w-full">
         <pre
           id={bodyId}
+          // A bare `aria-label` on a `pre` names nothing: the element is
+          // generic. The group role is what carries the label — and the copy
+          // control beside it uses the same word.
+          role="group"
           aria-label={label}
           className={
             bare

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
@@ -35,6 +35,10 @@ export function AttentionBadge({
           tone === "info" && "bg-info-foreground-muted",
           className,
         )}
+        // A dot with no text is only a state if something says which one. On a
+        // bare `span` the label would be dropped; `img` is the role that takes
+        // a name and has no children to read.
+        role="img"
         aria-label={label}
         title={tooltip}
         data-attention={attention.state.type}

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 
 import type { CodeApprovalSnapshot } from "../api/types";
 import { Button } from "@/components/ui/button";
@@ -32,6 +32,7 @@ export function CodeApprovalCard({
   const [denying, setDenying] = useState(false);
   const [feedback, setFeedback] = useState("");
   const [payloadOpen, setPayloadOpen] = useState(false);
+  const payloadId = useId();
   const decided = approval.state !== "pending";
 
   useEffect(() => {
@@ -68,6 +69,7 @@ export function CodeApprovalCard({
             HOVER_TINT,
           )}
           aria-expanded={payloadOpen}
+          aria-controls={payloadOpen ? payloadId : undefined}
           onClick={() => {
             onReveal?.();
             setPayloadOpen((current) => !current);
@@ -82,7 +84,10 @@ export function CodeApprovalCard({
             wrapping asked for here never applied and a single long JSON line
             scrolled sideways instead.
           */}
-          <ScrollableContainer className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 font-mono text-[11px] break-words whitespace-pre-wrap">
+          <ScrollableContainer
+            id={payloadId}
+            className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 font-mono text-[11px] break-words whitespace-pre-wrap"
+          >
             {prettyRaw(approval.harness_raw_json)}
           </ScrollableContainer>
         </Reveal>

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -1,8 +1,20 @@
+import { useRef, type KeyboardEvent } from "react";
 import { FileCode, FileDiff, MessageSquare, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { panelKey, type PanelContent } from "@/panel/panelTypes";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+
+/** Ids the strip and the two center panels agree on, so tabs name panels. */
+export const CHAT_TAB_ID = "code-center-tab-chat";
+export const CHAT_PANEL_ID = "code-center-panel-chat";
+export const EDITOR_PANEL_ID = "code-center-panel-editor";
+const editorTabId = (index: number) => `code-center-tab-editor-${index}`;
+
+/** Which tab labels the editor panel right now. */
+export function centerEditorTabId(index: number): string {
+  return editorTabId(index);
+}
 
 /**
  * Center strip: Chat is always first and cannot close. File and diff tabs
@@ -23,7 +35,38 @@ export function CodeCenterTabs({
   onSelectEditor: (index: number) => void;
   onCloseEditor: (index: number) => void;
 }) {
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
   if (editorTabs.length === 0) return null;
+
+  /**
+   * The tabs pattern: one tab stop for the strip, arrows to move between
+   * tabs. Selection follows focus here because both are cheap — moving to a
+   * tab is what opening it means.
+   */
+  function select(position: number) {
+    const last = editorTabs.length;
+    const wrapped = position < 0 ? last : position > last ? 0 : position;
+    if (wrapped === 0) onSelectChat();
+    else onSelectEditor(wrapped - 1);
+    tabRefs.current[wrapped]?.focus();
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>, position: number) {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      select(position + 1);
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      select(position - 1);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      select(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      select(editorTabs.length);
+    }
+  }
 
   return (
     <div
@@ -34,7 +77,13 @@ export function CodeCenterTabs({
       <button
         type="button"
         role="tab"
+        id={CHAT_TAB_ID}
         aria-selected={conversationFocused}
+        aria-controls={CHAT_PANEL_ID}
+        tabIndex={conversationFocused ? 0 : -1}
+        ref={(node) => {
+          tabRefs.current[0] = node;
+        }}
         className={cn(
           "flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium",
           FOCUS_RING_TIGHT,
@@ -44,6 +93,7 @@ export function CodeCenterTabs({
             : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
         )}
         onClick={onSelectChat}
+        onKeyDown={(event) => onKeyDown(event, 0)}
       >
         <MessageSquare className="size-3.5" />
         Chat
@@ -53,8 +103,12 @@ export function CodeCenterTabs({
         const { name, suffix } = centerTabParts(panel);
         const label = suffix ? `${name} ${suffix}` : name;
         return (
+          // A tablist owns tabs. The close control is a second control on the
+          // same row, so the box that pairs them has to be transparent to
+          // assistive tech rather than a stray group inside the list.
           <div
             key={panelKey(panel)}
+            role="presentation"
             className={cn(
               "flex min-w-0 shrink-0 items-center rounded-md pr-1",
               HOVER_TINT,
@@ -64,7 +118,13 @@ export function CodeCenterTabs({
             <button
               type="button"
               role="tab"
+              id={editorTabId(index)}
               aria-selected={active}
+              aria-controls={EDITOR_PANEL_ID}
+              tabIndex={active ? 0 : -1}
+              ref={(node) => {
+                tabRefs.current[index + 1] = node;
+              }}
               className={cn(
                 "flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md py-1 pr-1 pl-2 text-xs font-medium",
                 FOCUS_RING_TIGHT,
@@ -72,6 +132,7 @@ export function CodeCenterTabs({
                 active ? "text-foreground" : "text-muted-foreground",
               )}
               onClick={() => onSelectEditor(index)}
+              onKeyDown={(event) => onKeyDown(event, index + 1)}
             >
               {panel.type === "diff" ? (
                 <FileDiff className="size-3.5 shrink-0" />

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -138,6 +138,12 @@ it("exposes a tablist and passes the scoped turn into files and source", async (
     "aria-selected",
     "true",
   );
+  // Icon-only tabs, so each carries its own name; the panel it opens is
+  // linked back to it.
+  const source = screen.getByRole("tab", { name: "Source control" });
+  const panel = screen.getByRole("tabpanel");
+  expect(source).toHaveAttribute("aria-controls", panel.id);
+  expect(panel).toHaveAttribute("aria-labelledby", source.id);
   expect(
     screen.getByRole("button", { name: "Clear Turn 4 scope" }),
   ).toBeInTheDocument();
@@ -184,6 +190,12 @@ it("gives the active inspector tab a selected fill idle tabs do not share", asyn
   expect(source).toHaveClass("bg-foreground/10");
   expect(files).not.toHaveClass("bg-foreground/10");
   expect(pr).not.toHaveClass("bg-foreground/10");
+
+  // Radix drives the arrows; this pins that the inspector still gets them.
+  source.focus();
+  await userEvent.setup().keyboard("{ArrowRight}");
+  expect(pr).toHaveAttribute("data-state", "active");
+  expect(pr).toHaveFocus();
 });
 
 it("labels a turn by its ordinal among user items", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
@@ -113,11 +113,14 @@ describe("CodeSidebar", () => {
     expect(screen.getByRole("radio", { name: "Chat" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Code" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "app" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Fix login" })).toBeInTheDocument();
+    // The card's name carries what the glyph rail shows, not just the title.
+    expect(
+      screen.getByRole("button", { name: "Fix login · app · tidebreak/fix-login" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "New workspace" })).toBeInTheDocument();
   });
 
-  it("opens the workspace context menu with a destructive Archive item", async () => {
+  it("opens the workspace context menu from the keyboard and gives focus back", async () => {
     await renderWithRouter(
       <AppContextProvider value={app}>
         <CodeSidebar />
@@ -125,10 +128,16 @@ describe("CodeSidebar", () => {
       { initialUrl: "/code" },
     );
 
-    const card = await screen.findByRole("button", { name: "Fix login" });
+    const card = await screen.findByRole("button", { name: /^Fix login/ });
+    card.focus();
+    // Shift+F10 and the Menu key reach the card as a plain `contextmenu`
+    // event with no pointer position — the same event this fires.
     fireEvent.contextMenu(card);
     const archive = await screen.findByRole("menuitem", { name: "Archive" });
     expect(archive).toBeInTheDocument();
     expect(archive.className).toContain("text-destructive");
+
+    fireEvent.keyDown(archive, { key: "Escape" });
+    await waitFor(() => expect(card).toHaveFocus());
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -51,6 +51,7 @@ import {
   prTone,
   repoAccentClass,
   sessionRowLabel,
+  workspaceCardLabel,
   WORKSPACE_SORT_MODE_LABELS,
 } from "./workspaceCards";
 
@@ -335,7 +336,17 @@ function WorkspaceCard({
       <ContextMenuTrigger asChild>
         <button
           type="button"
-          aria-label={title}
+          // The card's own text names the workspace; the glyph rail names its
+          // state. One explicit label carries both, in the order the card
+          // reads, so nothing on the rail is pointer-only information.
+          aria-label={workspaceCardLabel({
+            title,
+            repoName,
+            branchName: workspace.branch_name,
+            attention: digest?.attention,
+            pr,
+            terminalOpen,
+          })}
           aria-current={active ? "page" : undefined}
           data-active={active || undefined}
           title={attentionTitle}
@@ -351,20 +362,14 @@ function WorkspaceCard({
             <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium leading-5">
               {title}
             </span>
-            <span className="flex shrink-0 items-center gap-1">
+            <span className="flex shrink-0 items-center gap-1" aria-hidden>
               {pr && <PrGlyph pr={pr} />}
               {terminalOpen && (
-                <SquareTerminal
-                  className="size-3 text-muted-foreground"
-                  aria-label="Terminal open"
-                />
+                <SquareTerminal className="size-3 text-muted-foreground" />
               )}
               {digest?.attention.state.type === "needs_you" &&
                 digest.attention.state.source === "structured" && (
-                  <CircleAlert
-                    className="size-3 text-critical"
-                    aria-label="Pending approval"
-                  />
+                  <CircleAlert className="size-3 text-critical" />
                 )}
             </span>
           </span>
@@ -436,13 +441,12 @@ function WorkspaceMenuItem({
   );
 }
 
-/** PR-state mark. The number and title live on the tooltip. */
+/** PR-state mark. The card's own label carries the number and state. */
 function PrGlyph({ pr }: { pr: PullRequestDigest }) {
   const tone = prTone(pr);
   return (
     <GitPullRequest
       className={cn("size-3", PR_ICON_TONE_CLASSES[tone])}
-      aria-label={pr.title ? `PR #${pr.number} ${pr.title}` : `PR #${pr.number}`}
       data-pr-state={tone}
     />
   );

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -66,14 +66,77 @@ describe("CodeTranscript", () => {
   it("renders assistant text, a tool card, and a harness notice", () => {
     render(<CodeTranscript items={items} />);
     expect(screen.getByText("Looking at the tree.")).toBeInTheDocument();
+    // The line's outcome belongs to its own name. It is deliberately not a
+    // live region: see the streaming test below.
     expect(
-      screen.getByRole("status", { name: "Command run succeeded" }),
+      screen.getByRole("button", { name: /Command run.*succeeded/ }),
     ).toBeInTheDocument();
     expect(screen.getByText("Command run")).toBeInTheDocument();
     expect(screen.getByText("ls")).toBeInTheDocument();
     expect(screen.getByText("1.2s")).toBeInTheDocument();
     expect(screen.queryByLabelText("Output")).toBeNull();
     expect(screen.getByText("unrecognized event dropped")).toBeInTheDocument();
+  });
+
+  it("announces the turn's lifecycle and nothing that streams", () => {
+    // A tool line changes on every streamed byte. Wrapping it in a live region
+    // reads the whole session out, over and over, and buries the one thing a
+    // supervisor has to hear. The turn's start and end go through one region;
+    // the output goes through none.
+    const running: CodeTranscriptItem[] = [
+      items[0],
+      {
+        kind: "tool",
+        id: "tool-live",
+        turnId: "t1",
+        callId: "c9",
+        name: "Bash",
+        detail: { kind: "command", cmd: "seq 3", cwd: "/tmp" },
+        status: "running",
+        preview: "line 1\nline 2",
+        startedAt: "2026-08-15T12:00:00.000Z",
+        durationMs: null,
+      },
+    ];
+    // The region is mounted empty, so reopening a finished session does not
+    // read its last outcome at the reader before they ask for anything.
+    const { rerender } = render(<CodeTranscript items={[items[0]]} />);
+    expect(screen.getByTestId("code-turn-announcer")).toHaveTextContent("");
+
+    rerender(<CodeTranscript items={running} busy />);
+    expect(
+      screen
+        .getByLabelText("Output")
+        .closest('[aria-live], [role="status"], [role="alert"]'),
+    ).toBeNull();
+    expect(screen.getByTestId("code-turn-announcer")).toHaveTextContent(
+      "Turn running",
+    );
+
+    rerender(<CodeTranscript items={items} />);
+    expect(screen.getByTestId("code-turn-announcer")).toHaveTextContent(
+      "Turn finished · 2m 14s",
+    );
+  });
+
+  it("leaves a failed turn to its alert rather than saying it twice", () => {
+    const failed: CodeTranscriptItem[] = [
+      items[0],
+      {
+        kind: "turn_boundary",
+        id: "b3",
+        turnId: "t1",
+        status: "failed",
+        durationMs: 4_000,
+        usage: null,
+        error: "claude exited with status 1",
+        diffstat: null,
+      },
+    ];
+    const { rerender } = render(<CodeTranscript items={[items[0]]} busy />);
+    rerender(<CodeTranscript items={failed} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Turn failed");
+    expect(screen.getByTestId("code-turn-announcer")).toHaveTextContent("");
   });
 
   it("renders the prompt as markdown with a timestamped footer", () => {
@@ -194,6 +257,14 @@ describe("CodeTranscript", () => {
     // Growing the column under the reader's cursor must not drag them to the
     // tail, so every reveal reaches the host that owns the scroll.
     expect(reveals).toHaveLength(1);
+
+    // Collapsing the line leaves the reader on the line they collapsed: the
+    // toggle is the row itself, so there is nothing for focus to fall out of.
+    const line = screen.getByRole("button", { name: /Command run.*failed/ });
+    expect(line).toHaveAttribute("aria-expanded", "true");
+    await userEvent.click(line);
+    expect(line).toHaveAttribute("aria-expanded", "false");
+    expect(line).toHaveFocus();
   });
 
   it("keeps a successful call closed and names a denial with the constant verb", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -10,7 +10,7 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import { memo, useEffect, useId, useState, type RefCallback } from "react";
+import { memo, useEffect, useId, useRef, useState, type RefCallback } from "react";
 
 import type { CodeApprovalSnapshot, Diffstat, FileChangeKind, ToolDetail } from "../api/types";
 import { CodeApprovalCard } from "./CodeApprovalCard";
@@ -144,8 +144,62 @@ export function CodeTranscript({
         {shouldShowCodeWorking(items, busy, streamStalled) && (
           <AssistantWorkingIndicator />
         )}
+        <TurnLifecycleAnnouncer text={codeTurnAnnouncement(items, busy)} />
       </div>
     </div>
+  );
+}
+
+/**
+ * What a screen reader hears about the turn, and nothing else.
+ *
+ * Streaming text, tool output, and file activity all change many times a
+ * second; announcing any of them turns the transcript into a firehose that
+ * drowns the one thing a supervisor has to hear — whether the engine is still
+ * working, and how the turn ended. A failed turn is not announced here because
+ * `TurnReviewCard` already raises it as an alert, and a fact said twice is
+ * worse than a fact said once.
+ */
+export function codeTurnAnnouncement(
+  items: readonly CodeTranscriptItem[],
+  busy: boolean,
+): string {
+  if (busy) return "Turn running";
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item.kind !== "turn_boundary") continue;
+    if (item.status === "failed") return "";
+    const duration = formatTurnDuration(item.durationMs);
+    const label =
+      item.status === "interrupted" ? "Turn interrupted" : "Turn finished";
+    return duration ? `${label} · ${duration}` : label;
+  }
+  return "";
+}
+
+/**
+ * The one live region in the transcript.
+ *
+ * It is mounted empty and only fills in on a later change, so opening a
+ * finished session does not read its last turn's outcome out at the reader
+ * before they have asked for anything.
+ */
+function TurnLifecycleAnnouncer({ text }: { text: string }) {
+  const [announced, setAnnounced] = useState("");
+  const settled = useRef(false);
+
+  useEffect(() => {
+    if (!settled.current) {
+      settled.current = true;
+      return;
+    }
+    setAnnounced(text);
+  }, [text]);
+
+  return (
+    <span className="sr-only" role="status" data-testid="code-turn-announcer">
+      {announced}
+    </span>
   );
 }
 
@@ -360,11 +414,11 @@ export function CodeToolCard({
   const showExpanded = expanded && status !== "running" && hasOutput;
 
   return (
-    <div
-      className="max-w-prose [overflow-anchor:none]"
-      role="status"
-      aria-label={`${verb} ${status}`}
-    >
+    // Deliberately not a live region. A tool line changes on every streamed
+    // byte of its own output, and a transcript of thirty of them would announce
+    // each one atomically, over and over. The outcome rides the line's own name
+    // instead, and the turn announcer says when the work as a whole ends.
+    <div className="max-w-prose [overflow-anchor:none]">
       <button
         type="button"
         className={cn(
@@ -394,6 +448,9 @@ export function CodeToolCard({
           {status !== "running" && exitCode !== null && (
             <span>exit {exitCode}</span>
           )}
+          {/* The glyph is the outcome for a sighted reader; this is the same
+              fact for everyone else, in the same place in the line. */}
+          <span className="sr-only">{STATUS_WORDS[status]}</span>
           <StatusGlyph status={status} />
           <ChevronDown
             className={cn(
@@ -485,12 +542,26 @@ function toolVerb(
   }
 }
 
+/** The outcome word, for the readers the status glyph does not reach. */
+const STATUS_WORDS: Record<
+  "running" | "succeeded" | "failed" | "denied",
+  string
+> = {
+  running: "running",
+  succeeded: "succeeded",
+  failed: "failed",
+  denied: "denied",
+};
+
 /** Last twelve lines, height-capped so a streaming tail does not grow the row. */
 function StreamingTail({ text }: { text: string }) {
   const lines = text.replace(/\n+$/, "").split("\n");
   const tail = lines.slice(-12).join("\n");
   return (
     <pre
+      // `pre` is a generic element, so a bare `aria-label` on it names nothing.
+      // The group role is what makes the label reach assistive tech.
+      role="group"
       aria-label="Output"
       className="text-muted-foreground max-h-[17.4em] overflow-hidden font-mono text-[13.5px] break-words whitespace-pre-wrap [overflow-anchor:none]"
     >
@@ -639,6 +710,7 @@ function FileActivityRow({
   onReveal?: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  const listId = useId();
   const { count, insertions, deletions } = fileActivityTotals(files);
   const noun = count === 1 ? "file" : "files";
   return (
@@ -646,6 +718,7 @@ function FileActivityRow({
       <button
         type="button"
         aria-expanded={open}
+        aria-controls={listId}
         className={cn(
           "-mx-1.5 cursor-pointer rounded-md px-1.5 py-0.5 text-left hover:text-foreground",
           FOCUS_RING_TIGHT,
@@ -669,8 +742,13 @@ function FileActivityRow({
           "grid transition-[grid-template-rows] duration-[140ms] ease-out motion-reduce:transition-none",
           open ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
         )}
+        // A zero-height row is still in the accessibility tree: `overflow`
+        // hides pixels, not semantics. Without this a screen reader reads every
+        // changed file of every turn as if the summary were always open.
+        aria-hidden={!open}
+        inert={!open ? true : undefined}
       >
-        <ul className="min-h-0 overflow-hidden">
+        <ul id={listId} className="min-h-0 overflow-hidden">
           {Object.entries(files).map(([path, file]) => (
             <li key={path} className="flex items-baseline gap-2 pt-0.5">
               <span
@@ -681,10 +759,13 @@ function FileActivityRow({
                   file.kind === "deleted" && "text-critical-foreground-muted",
                   file.kind === "renamed" && "text-warning-foreground-muted",
                 )}
-                aria-label={file.kind}
+                aria-hidden
               >
                 {FILE_KIND_LETTER[file.kind]}
               </span>
+              {/* "A" reads as the letter A. The word is what carries the
+                  change kind once the glyph is gone. */}
+              <span className="sr-only">{file.kind}</span>
               <PathLabel path={path} />
               <span className="ml-auto shrink-0 tabular-nums">
                 +{file.diffstat.insertions} −{file.diffstat.deletions}

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -450,7 +450,7 @@ export function CodeToolCard({
           )}
           {/* The glyph is the outcome for a sighted reader; this is the same
               fact for everyone else, in the same place in the line. */}
-          <span className="sr-only">{STATUS_WORDS[status]}</span>
+          <span className="sr-only">{status}</span>
           <StatusGlyph status={status} />
           <ChevronDown
             className={cn(
@@ -541,17 +541,6 @@ function toolVerb(
       return "Search";
   }
 }
-
-/** The outcome word, for the readers the status glyph does not reach. */
-const STATUS_WORDS: Record<
-  "running" | "succeeded" | "failed" | "denied",
-  string
-> = {
-  running: "running",
-  succeeded: "succeeded",
-  failed: "failed",
-  denied: "denied",
-};
 
 /** Last twelve lines, height-capped so a streaming tail does not grow the row. */
 function StreamingTail({ text }: { text: string }) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -573,4 +573,51 @@ describe("CodeWorkspacePage", () => {
       }),
     );
   });
+
+  it("moves between center tabs with the arrows and names the panel each opens", async () => {
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Review this turn's changes" }),
+    );
+
+    const diff = await screen.findByRole("tab", { name: "Turn diff" });
+    const chat = screen.getByRole("tab", { name: "Chat" });
+    // One tab stop for the strip, and the panel a tab opens says which tab
+    // named it — otherwise the content below is orphaned from the control.
+    expect(diff).toHaveAttribute("tabindex", "0");
+    expect(chat).toHaveAttribute("tabindex", "-1");
+    const panel = document.getElementById(
+      diff.getAttribute("aria-controls") ?? "",
+    );
+    expect(panel).not.toBeNull();
+    expect(panel).toHaveAttribute("role", "tabpanel");
+    expect(panel).toHaveAttribute("aria-labelledby", diff.id);
+
+    diff.focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(chat).toHaveAttribute("aria-selected", "true");
+    expect(chat).toHaveFocus();
+    const chatPanel = document.getElementById(
+      chat.getAttribute("aria-controls") ?? "",
+    );
+    expect(chatPanel).toHaveAttribute("aria-labelledby", chat.id);
+  });
+
+  it("keeps the jump-to-latest pill out of the tab order until it is on screen", async () => {
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    await mountWorkspace(client);
+
+    await screen.findByRole("button", { name: "Review this turn's changes" });
+    // The pill is the keyboard path back to the tail. It is a real button, so
+    // it must leave the tab order rather than sit there invisibly focusable.
+    const pill = screen.getByLabelText("Scroll to latest");
+    expect(pill.tagName).toBe("BUTTON");
+    expect(pill).toHaveAttribute("aria-hidden", "true");
+    expect(pill).toHaveAttribute("tabindex", "-1");
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -48,7 +48,13 @@ import {
   splitCodeChromeLayout,
   toggleTerminalLayout,
 } from "./codeChrome";
-import { CodeCenterTabs } from "./CodeCenterTabs";
+import {
+  centerEditorTabId,
+  CHAT_PANEL_ID,
+  CHAT_TAB_ID,
+  CodeCenterTabs,
+  EDITOR_PANEL_ID,
+} from "./CodeCenterTabs";
 import { DiffPanel } from "./DiffPanel";
 
 const FileViewer = lazy(async () => {
@@ -255,6 +261,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const activeEditor = showingChat
     ? null
     : (editorTabs[chrome.editors.activeIndex] ?? null);
+  // With no editor tab there is no strip, so nothing names a panel and the
+  // conversation is just the page.
+  const stripped = editorTabs.length > 0;
 
   const workspaceMain = (
     <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
@@ -266,7 +275,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onSelectEditor={(index) => setLayout(focusEditorTab(layout, index))}
         onCloseEditor={(index) => setLayout(closeEditorTab(layout, index))}
       />
-      <div className={cn("min-h-0 flex-1", !showingChat && "hidden")}>
+      <div
+        className={cn("min-h-0 flex-1", !showingChat && "hidden")}
+        id={stripped ? CHAT_PANEL_ID : undefined}
+        role={stripped ? "tabpanel" : undefined}
+        aria-labelledby={stripped ? CHAT_TAB_ID : undefined}
+      >
       <PanelLayout
         layout={chrome.panels}
         framed={false}
@@ -319,7 +333,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       />
       </div>
       {!showingChat && activeEditor && (
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          id={EDITOR_PANEL_ID}
+          role="tabpanel"
+          aria-labelledby={centerEditorTabId(chrome.editors.activeIndex)}
+        >
           {activeEditor.type === "file" ? (
             <Suspense fallback={<Skeleton className="h-full w-full" />}>
               <FileViewer
@@ -567,11 +586,23 @@ function SessionLifecycleMark({
   });
   return (
     <WithTooltip label={tooltip}>
-      <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
+      {/*
+        The tooltip carries the engine version and the dropped-event warning,
+        and neither is anywhere else on the page. A span cannot be tabbed to,
+        so without a tab stop the whole explanation is hover-only.
+      */}
+      <span
+        tabIndex={0}
+        className={cn(
+          "text-muted-foreground inline-flex items-center gap-1.5 rounded-sm text-xs",
+          FOCUS_RING,
+        )}
+      >
         {unrecognizedEventCount > 0 && (
           <span
             data-testid="unrecognized-event-dot"
             className="bg-warning-foreground-muted inline-block size-2 shrink-0 rounded-full"
+            role="img"
             aria-label={`${unrecognizedEventCount} unread engine ${unrecognizedEventCount === 1 ? "event" : "events"}`}
           />
         )}
@@ -653,10 +684,14 @@ function PendingApprovalBadge({
       ).length,
   );
   if (pending === 0) return null;
+  const noun = pending === 1 ? "approval" : "approvals";
   return (
     <button
       type="button"
       data-testid="pending-approval-badge"
+      // The count alone names a state, not a control. This button scrolls the
+      // transcript to the first parked approval, so its name says so.
+      aria-label={`Jump to ${pending} pending ${noun}`}
       className={cn(
         "cursor-pointer rounded-full border-0 bg-transparent p-0",
         FOCUS_RING,
@@ -671,7 +706,7 @@ function PendingApprovalBadge({
       }}
     >
       <Badge variant="warning" size="sm" className="tabular-nums">
-        {pending} {pending === 1 ? "approval" : "approvals"}
+        {pending} {noun}
       </Badge>
     </button>
   );

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
@@ -89,14 +89,45 @@ describe("DiffPanel", () => {
     };
     render(<DiffPanel client={client} workspaceId="ws-1" />);
     expect(await screen.findByText("big.ts")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Show diff" })).toBeInTheDocument();
+    // The expander names the file it belongs to: a screen reader listing a
+    // multi-file diff's controls would otherwise get a column of "Show diff".
+    expect(
+      screen.getByRole("button", { name: "Show diff for big.ts" }),
+    ).toBeInTheDocument();
     expect(screen.queryByText("+line 0")).not.toBeInTheDocument();
 
-    await userEvent.setup().click(screen.getByRole("button", { name: "Show diff" }));
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Show diff for big.ts" }));
     expect(screen.getByText("+line 0")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Show diff" }),
+      screen.queryByRole("button", { name: /^Show diff/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps the file disclosure and its Open control side by side", async () => {
+    const client = {
+      getCodeWorkspaceDiff: vi.fn().mockResolvedValue({
+        diff: DIFF,
+        truncated: false,
+        stat: { files: 1, insertions: 1, deletions: 1, truncated: false },
+      }),
+    };
+    const onOpenFile = vi.fn();
+    render(
+      <DiffPanel client={client} workspaceId="ws-1" onOpenFile={onOpenFile} />,
+    );
+
+    // A control nested inside another control is reachable by neither.
+    const disclosure = await screen.findByRole("button", { name: "src/lib.rs" });
+    const open = screen.getByRole("button", { name: "Open src/lib.rs" });
+    expect(disclosure).toHaveAttribute("aria-expanded", "true");
+    expect(disclosure.contains(open)).toBe(false);
+
+    await userEvent.setup().click(open);
+    expect(onOpenFile).toHaveBeenCalledWith("src/lib.rs");
+    // Opening the file must not also collapse the section under the reader.
+    expect(disclosure).toHaveAttribute("aria-expanded", "true");
   });
 
   it("says which scope came back empty", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useId, useMemo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 import type { ApiClient } from "../api/client";
@@ -152,65 +152,77 @@ function FileDiffSection({
 }) {
   const large = group.lines.length > DIFF_COLLAPSE_LINE_THRESHOLD;
   const [expanded, setExpanded] = useState(!large);
+  const bodyId = useId();
   const { insertions, deletions } = fileDiffstat(group.lines);
 
   return (
     <section className="border-b last:border-b-0">
-      <header className="bg-background sticky top-0 z-10">
-        <button
-          type="button"
-          className={cn(
-            "hover:bg-muted/40 flex w-full cursor-pointer items-center gap-1.5 px-3 py-1.5 text-left",
-            FOCUS_RING_TIGHT,
-            HOVER_TINT,
-          )}
-          aria-expanded={expanded}
-          onClick={() => setExpanded((current) => !current)}
-        >
-          <ChevronRight
+      {/*
+        The disclosure and "Open" are two controls, not one nested in the
+        other: a button inside a button is neither reachable nor announceable,
+        and the disclosure's name swallowed the word "Open" along with the
+        counts. They sit side by side and read as one row.
+      */}
+      <header className="bg-background sticky top-0 z-10 flex items-center gap-1.5 pr-3">
+        {/*
+          The heading wraps the disclosure rather than sitting inside it: a
+          heading is how a reader jumps between files, and a button is how they
+          open one. Nesting either in the other loses one of the two.
+        */}
+        <h3 className="min-w-0 flex-1">
+          <button
+            type="button"
             className={cn(
-              "text-muted-foreground size-3 shrink-0 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
-              expanded && "rotate-90",
+              "hover:bg-muted/40 flex w-full min-w-0 cursor-pointer items-center gap-1.5 px-3 py-1.5 text-left",
+              FOCUS_RING_TIGHT,
+              HOVER_TINT,
             )}
-            aria-hidden="true"
-          />
-          <h3
-            className="text-muted-foreground min-w-0 flex-1 truncate font-mono text-xs"
-            title={group.path}
+            aria-expanded={expanded}
+            aria-controls={expanded ? bodyId : undefined}
+            onClick={() => setExpanded((current) => !current)}
           >
-            {group.path}
-          </h3>
-          {onOpenFile && (
-            <span
-              role="link"
-              tabIndex={0}
+            <ChevronRight
               className={cn(
-                "text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded-sm text-[11px] underline-offset-2 hover:underline",
-                FOCUS_RING_TIGHT,
-                HOVER_TINT,
+                "text-muted-foreground size-3 shrink-0 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
+                expanded && "rotate-90",
               )}
-              onClick={(event) => {
-                event.stopPropagation();
-                onOpenFile(group.path);
-              }}
-              onKeyDown={(event) => {
-                if (event.key !== "Enter" && event.key !== " ") return;
-                event.preventDefault();
-                event.stopPropagation();
-                onOpenFile(group.path);
-              }}
+              aria-hidden="true"
+            />
+            <span
+              className="text-muted-foreground min-w-0 flex-1 truncate font-mono text-xs"
+              title={group.path}
             >
-              Open
+              {group.path}
             </span>
-          )}
-          <span className="shrink-0 font-mono text-[11px] tabular-nums">
-            <span className="text-success">+{insertions}</span>{" "}
-            <span className="text-critical">−{deletions}</span>
-          </span>
-        </button>
+          </button>
+        </h3>
+        {onOpenFile && (
+          <button
+            type="button"
+            // The visible word is enough beside its own file name; a reader
+            // tabbing or listing controls gets one "Open" per file and needs
+            // the path to tell them apart.
+            aria-label={`Open ${group.path}`}
+            className={cn(
+              "text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded-sm text-[11px] underline-offset-2 hover:underline",
+              FOCUS_RING_TIGHT,
+              HOVER_TINT,
+            )}
+            onClick={() => onOpenFile(group.path)}
+          >
+            Open
+          </button>
+        )}
+        <span className="shrink-0 font-mono text-[11px] tabular-nums">
+          <span className="text-success">+{insertions}</span>{" "}
+          <span className="text-critical">−{deletions}</span>
+        </span>
       </header>
       {expanded ? (
-        <pre className="overflow-x-auto py-1 font-mono text-xs leading-5">
+        <pre
+          id={bodyId}
+          className="overflow-x-auto py-1 font-mono text-xs leading-5"
+        >
           {group.lines.map((line, index) => (
             <DiffLineRow
               key={`${group.path}:${index}`}
@@ -221,6 +233,7 @@ function FileDiffSection({
       ) : large ? (
         <button
           type="button"
+          aria-label={`Show diff for ${group.path}`}
           className={cn(
             "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm px-3 py-2 text-xs",
             FOCUS_RING_TIGHT,

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
@@ -75,10 +75,48 @@ describe("FilesPanel", () => {
       />,
     );
     expect(await screen.findByText("lib.rs")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "lib.rs" })).toHaveAttribute(
+    expect(screen.getByRole("treeitem", { name: "lib.rs" })).toHaveAttribute(
       "aria-current",
       "true",
     );
+  });
+
+  it("walks the tree with the arrow keys and opens a file from the keyboard", async () => {
+    const onOpenFile = vi.fn();
+    const client = makeClient();
+    render(
+      <FilesPanel client={client} workspaceId="ws-1" onOpenFile={onOpenFile} />,
+    );
+    expect(await screen.findByText("lib.rs")).toBeInTheDocument();
+
+    // One tab stop for the whole tree: the first row. The arrows do the rest.
+    const src = screen.getByRole("treeitem", { name: "src" });
+    expect(src).toHaveAttribute("tabindex", "0");
+    expect(src).toHaveAttribute("aria-level", "1");
+    expect(screen.getByRole("treeitem", { name: "lib.rs" })).toHaveAttribute(
+      "aria-level",
+      "2",
+    );
+    src.focus();
+
+    // Left closes an open folder; Right opens it again, and Right from an open
+    // folder steps into it.
+    fireEvent.keyDown(src, { key: "ArrowLeft" });
+    expect(screen.queryByText("lib.rs")).not.toBeInTheDocument();
+    expect(src).toHaveAttribute("aria-expanded", "false");
+    fireEvent.keyDown(src, { key: "ArrowRight" });
+    expect(screen.getByText("lib.rs")).toBeInTheDocument();
+    fireEvent.keyDown(src, { key: "ArrowRight" });
+    expect(screen.getByRole("treeitem", { name: "code" })).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement!, { key: "End" });
+    const last = screen.getByRole("treeitem", { name: "README.md" });
+    expect(last).toHaveFocus();
+    fireEvent.keyDown(last, { key: "Enter" });
+    expect(onOpenFile).toHaveBeenCalledWith("README.md");
+
+    fireEvent.keyDown(last, { key: "Home" });
+    expect(screen.getByRole("treeitem", { name: "src" })).toHaveFocus();
   });
 
   it("names the search that found nothing and offers the way back", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+} from "react";
+
 import { ChevronRight, File, Folder, FolderOpen } from "lucide-react";
 import type { ApiClient } from "../api/client";
 import { SearchInput } from "@/components/SearchInput";
@@ -10,10 +19,11 @@ import {
   ancestorPaths,
   buildFileTree,
   filterPaths,
+  flattenVisibleTree,
   treeIndentPx,
   type FileTreeNode,
 } from "./fileTree";
-import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { useLiveResource } from "./useLiveContent";
 
 const TREE_PAGE = 5000;
@@ -45,8 +55,10 @@ export function FilesPanel({
   const [searchHits, setSearchHits] = useState<string[] | null>(null);
   const [searchTruncated, setSearchTruncated] = useState(false);
   const [searching, setSearching] = useState(false);
+  const [focusedPath, setFocusedPath] = useState<string | null>(null);
   const searchInput = useRef<HTMLInputElement>(null);
   const root = useRef<HTMLDivElement>(null);
+  const rowRefs = useRef(new Map<string, HTMLLIElement>());
 
   const loadTree = useCallback(
     () => client.listCodeWorkspaceTree(workspaceId, { limit: TREE_PAGE }),
@@ -113,6 +125,24 @@ export function FilesPanel({
     return openDirs.has(path);
   }
 
+  // The drawn rows, in document order: what the arrow keys walk.
+  const rows = useMemo(
+    () =>
+      flattenVisibleTree(nodes, (path) => {
+        if (forcedOpen.has(path)) return true;
+        if (!path.includes("/")) return !closedTop.has(path);
+        return openDirs.has(path);
+      }),
+    [nodes, forcedOpen, closedTop, openDirs],
+  );
+  // Tab reaches the tree once; the arrows move inside it. The tab stop follows
+  // the reader, and falls back to the first row whenever the row they left is
+  // no longer drawn (a search, a collapsed parent, a refreshed worktree).
+  const tabStop =
+    rows.find((row) => row.node.path === focusedPath)?.node.path ??
+    rows[0]?.node.path ??
+    null;
+
   function toggleDir(path: string) {
     if (!path.includes("/")) {
       setClosedTop((current) => {
@@ -150,6 +180,65 @@ export function FilesPanel({
   const truncated = Boolean(tree?.truncated || searchTruncated);
   const empty = ready && nodes.length === 0 && !error;
   const busy = refreshing || searching;
+
+  function focusRow(path: string | undefined) {
+    if (!path) return;
+    setFocusedPath(path);
+    rowRefs.current.get(path)?.focus();
+  }
+
+  function activate(node: FileTreeNode) {
+    if (node.kind === "dir") toggleDir(node.path);
+    else onOpenFile(node.path);
+  }
+
+  /**
+   * The tree pattern's keys.
+   *
+   * Right and Left are the two that make a tree a tree: on a closed folder
+   * Right opens it and on an open one it steps in, and Left mirrors that by
+   * closing or climbing out. Everything else is list movement.
+   */
+  function onTreeKeyDown(event: ReactKeyboardEvent<HTMLUListElement>) {
+    const index = rows.findIndex((row) => row.node.path === tabStop);
+    const row = rows[index];
+    if (!row) return;
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        focusRow(rows[index + 1]?.node.path);
+        return;
+      case "ArrowUp":
+        event.preventDefault();
+        focusRow(rows[index - 1]?.node.path);
+        return;
+      case "ArrowRight":
+        event.preventDefault();
+        if (row.node.kind !== "dir") return;
+        if (!row.expanded) toggleDir(row.node.path);
+        else focusRow(rows[index + 1]?.node.path);
+        return;
+      case "ArrowLeft":
+        event.preventDefault();
+        if (row.node.kind === "dir" && row.expanded) toggleDir(row.node.path);
+        else focusRow(row.parent ?? undefined);
+        return;
+      case "Home":
+        event.preventDefault();
+        focusRow(rows[0]?.node.path);
+        return;
+      case "End":
+        event.preventDefault();
+        focusRow(rows[rows.length - 1]?.node.path);
+        return;
+      case "Enter":
+      case " ":
+        event.preventDefault();
+        activate(row.node);
+        return;
+      default:
+    }
+  }
 
   return (
     <div
@@ -231,6 +320,7 @@ export function FilesPanel({
           className="min-h-0 flex-1 overflow-y-auto px-1 pb-4 pt-2"
           role="tree"
           aria-label="Workspace files"
+          onKeyDown={onTreeKeyDown}
         >
           {nodes.map((node) => (
             <TreeRow
@@ -238,9 +328,11 @@ export function FilesPanel({
               node={node}
               depth={0}
               selected={selected}
+              tabStop={tabStop}
+              rowRefs={rowRefs}
               isOpen={isOpen}
-              onToggle={toggleDir}
-              onOpenFile={onOpenFile}
+              onFocusRow={setFocusedPath}
+              onActivate={activate}
             />
           ))}
         </ul>
@@ -299,20 +391,33 @@ function FilesEmpty({
   );
 }
 
+/**
+ * One row of the explorer tree.
+ *
+ * The row itself is the `treeitem`, not a button inside one: the tree pattern
+ * puts focus and the arrow keys on the item, and a nested button would take
+ * both and announce itself as a button in a tree. `aria-label` restates the
+ * name a sighted reader sees because a treeitem otherwise draws its name from
+ * everything it contains — for an open folder, that is the whole subtree.
+ */
 function TreeRow({
   node,
   depth,
   selected,
+  tabStop,
+  rowRefs,
   isOpen,
-  onToggle,
-  onOpenFile,
+  onFocusRow,
+  onActivate,
 }: {
   node: FileTreeNode;
   depth: number;
   selected?: string;
+  tabStop: string | null;
+  rowRefs: RefObject<Map<string, HTMLLIElement>>;
   isOpen: (path: string) => boolean;
-  onToggle: (path: string) => void;
-  onOpenFile: (file: string) => void;
+  onFocusRow: (path: string) => void;
+  onActivate: (node: FileTreeNode) => void;
 }) {
   const open = node.kind === "dir" && isOpen(node.path);
   const current = node.kind === "file" && selected === node.path;
@@ -320,22 +425,38 @@ function TreeRow({
     node.kind === "dir" ? (open ? FolderOpen : Folder) : File;
 
   return (
-    <li role="treeitem" aria-expanded={node.kind === "dir" ? open : undefined}>
-      <button
-        type="button"
-        aria-current={current ? true : undefined}
+    <li
+      role="treeitem"
+      aria-label={node.name}
+      aria-level={depth + 1}
+      aria-expanded={node.kind === "dir" ? open : undefined}
+      aria-current={current ? true : undefined}
+      tabIndex={tabStop === node.path ? 0 : -1}
+      ref={(element) => {
+        if (element) rowRefs.current.set(node.path, element);
+        else rowRefs.current.delete(node.path);
+      }}
+      className="group/row focus-visible:outline-none"
+      onFocus={(event) => {
+        if (event.target === event.currentTarget) onFocusRow(node.path);
+      }}
+      onClick={(event) => {
+        // Only the row that was clicked acts; the click still bubbles up
+        // through every ancestor row on its way to the tree.
+        event.stopPropagation();
+        onFocusRow(node.path);
+        onActivate(node);
+      }}
+    >
+      <div
         style={{ paddingLeft: treeIndentPx(depth) }}
         className={cn(
-          "flex w-full cursor-pointer items-center gap-1 rounded-sm py-0.5 pr-2 text-left text-xs",
-          FOCUS_RING_TIGHT,
+          "ring-offset-background flex w-full cursor-pointer items-center gap-1 rounded-sm py-0.5 pr-2 text-left text-xs",
+          "group-focus-visible/row:ring-ring group-focus-visible/row:ring-2 group-focus-visible/row:ring-offset-0",
           HOVER_TINT,
           current && "bg-muted/60",
           !current && "hover:bg-muted/40",
         )}
-        onClick={() => {
-          if (node.kind === "dir") onToggle(node.path);
-          else onOpenFile(node.path);
-        }}
       >
         {node.kind === "dir" ? (
           <ChevronRight
@@ -352,7 +473,7 @@ function TreeRow({
         <span className="min-w-0 truncate" title={node.path}>
           {node.name}
         </span>
-      </button>
+      </div>
       {open && node.children && (
         <ul role="group">
           {node.children.map((child) => (
@@ -361,9 +482,11 @@ function TreeRow({
               node={child}
               depth={depth + 1}
               selected={selected}
+              tabStop={tabStop}
+              rowRefs={rowRefs}
               isOpen={isOpen}
-              onToggle={onToggle}
-              onOpenFile={onOpenFile}
+              onFocusRow={onFocusRow}
+              onActivate={onActivate}
             />
           ))}
         </ul>

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -125,14 +125,10 @@ export function FilesPanel({
     return openDirs.has(path);
   }
 
-  // The drawn rows, in document order: what the arrow keys walk.
+  // The drawn rows, in document order: what the arrow keys walk. `isOpen` is a
+  // fresh closure every render, so the state it reads is the dep set.
   const rows = useMemo(
-    () =>
-      flattenVisibleTree(nodes, (path) => {
-        if (forcedOpen.has(path)) return true;
-        if (!path.includes("/")) return !closedTop.has(path);
-        return openDirs.has(path);
-      }),
+    () => flattenVisibleTree(nodes, isOpen),
     [nodes, forcedOpen, closedTop, openDirs],
   );
   // Tab reaches the tree once; the arrows move inside it. The tab stop follows
@@ -441,8 +437,8 @@ function TreeRow({
         if (event.target === event.currentTarget) onFocusRow(node.path);
       }}
       onClick={(event) => {
-        // Only the row that was clicked acts; the click still bubbles up
-        // through every ancestor row on its way to the tree.
+        // A click inside a nested row would otherwise reach every folder above
+        // it on the way out and collapse each one.
         event.stopPropagation();
         onFocusRow(node.path);
         onActivate(node);

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
@@ -129,6 +129,11 @@ describe("TerminalPane", () => {
     expect(await screen.findByTestId("terminal-truncated")).toHaveTextContent(
       "Output was truncated.",
     );
+    // xterm owns everything inside the host, so the host is the only place
+    // that can name the surface. A label on a bare div names nothing.
+    expect(screen.getByRole("group", { name: "Terminal output" })).toBe(
+      screen.getByTestId("terminal-host"),
+    );
   });
 
   it("says the shell is opening until it answers, then gets out of the way", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -411,6 +411,10 @@ export function TerminalPane({
           ref={hostRef}
           className="h-full"
           data-testid="terminal-host"
+          // xterm builds its own tree inside this host; the host itself is a
+          // plain div, so it needs a role that takes a name before the label
+          // reaches anyone.
+          role="group"
           aria-label="Terminal output"
         />
         {!attached && !error && (

--- a/crates/tidebreak-desktop/ui/src/code/fileTree.ts
+++ b/crates/tidebreak-desktop/ui/src/code/fileTree.ts
@@ -69,6 +69,43 @@ function sortTree(nodes: FileTreeNode[]): void {
   }
 }
 
+/** One row the explorer currently draws, with what arrow keys need to move. */
+export type VisibleTreeRow = {
+  node: FileTreeNode;
+  depth: number;
+  /** Owning directory path, or null at the root. */
+  parent: string | null;
+  expanded: boolean;
+};
+
+/**
+ * The tree as the reader sees it: one entry per drawn row, in document order.
+ *
+ * Arrow-key navigation moves between rows rather than between siblings, so it
+ * needs the collapsed subtrees already gone and each row's depth and parent
+ * carried alongside. Deriving that here keeps the key handler free of the
+ * recursion the renderer does.
+ */
+export function flattenVisibleTree(
+  nodes: readonly FileTreeNode[],
+  isOpen: (path: string) => boolean,
+): VisibleTreeRow[] {
+  const rows: VisibleTreeRow[] = [];
+  const walk = (
+    list: readonly FileTreeNode[],
+    depth: number,
+    parent: string | null,
+  ) => {
+    for (const node of list) {
+      const expanded = node.kind === "dir" && isOpen(node.path);
+      rows.push({ node, depth, parent, expanded });
+      if (expanded && node.children) walk(node.children, depth + 1, node.path);
+    }
+  };
+  walk(nodes, 0, null);
+  return rows;
+}
+
 /** Keep paths that match include (if set) and miss every exclude pattern. */
 export function filterPaths(
   paths: readonly string[],

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -12,6 +12,7 @@ import {
   groupWorkspacesByRepo,
   middleTruncate,
   prChipTone,
+  workspaceCardLabel,
   workspaceStatusRank,
 } from "./workspaceCards";
 
@@ -267,5 +268,40 @@ describe("formatCompactAge", () => {
     expect(formatCompactAge("2026-08-18T11:48:00.000Z", now)).toBe("12m");
     expect(formatCompactAge("2026-08-18T09:00:00.000Z", now)).toBe("3h");
     expect(formatCompactAge("2026-08-16T12:00:00.000Z", now)).toBe("2d");
+  });
+});
+
+describe("workspaceCardLabel", () => {
+  it("carries the state the glyph rail shows, in card order", () => {
+    expect(
+      workspaceCardLabel({
+        title: "Fix login",
+        repoName: "app",
+        branchName: "tidebreak/fix-login",
+        attention: {
+          state: {
+            type: "needs_you",
+            prompt: "Run this command?",
+            source: "structured",
+          },
+          source: "structured",
+        },
+        pr: { number: 12, state: "open" },
+        terminalOpen: true,
+      }),
+    ).toBe(
+      "Fix login · Run this command? · Pull request #12 Open · Terminal open · app · tidebreak/fix-login",
+    );
+  });
+
+  it("says nothing about state a working session does not have", () => {
+    expect(
+      workspaceCardLabel({
+        title: "Fix login",
+        repoName: "app",
+        branchName: "tidebreak/fix-login",
+        attention: { state: { type: "working" }, source: "lifecycle" },
+      }),
+    ).toBe("Fix login · app · tidebreak/fix-login");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -1,9 +1,10 @@
 import type {
+  Attention,
   CodeRepoSnapshot,
   CodeSessionDigest,
   CodeWorkspaceSnapshot,
 } from "../api/types";
-import { LIFECYCLE_LABELS } from "./labels";
+import { attentionLabel, LIFECYCLE_LABELS } from "./labels";
 
 /**
  * Pure presentation logic for workspace cards: grouping by repo, the state
@@ -243,6 +244,35 @@ export function sessionRowLabel(digest: CodeSessionDigest): string {
     default:
       return LIFECYCLE_LABELS[digest.lifecycle];
   }
+}
+
+/**
+ * The whole card as one line, for readers who get the name and nothing else.
+ *
+ * A card is a title, a state, and two identifiers spread across three rows and
+ * a glyph rail. Left to compose itself the button would announce only its
+ * title — the state glyphs are the point of the rail, and a triage read that
+ * cannot hear "needs you" is not a triage read. Order follows the card: what
+ * it is, then what it wants, then which checkout it is.
+ */
+export function workspaceCardLabel(input: {
+  title: string;
+  repoName: string;
+  branchName: string;
+  attention?: Attention;
+  pr?: { number: number; state: string; draft?: boolean };
+  terminalOpen?: boolean;
+}): string {
+  const parts = [input.title];
+  if (input.attention && input.attention.state.type !== "working") {
+    parts.push(attentionLabel(input.attention));
+  }
+  if (input.pr) {
+    parts.push(`Pull request #${input.pr.number} ${prToneLabel(input.pr)}`);
+  }
+  if (input.terminalOpen) parts.push("Terminal open");
+  parts.push(input.repoName, input.branchName);
+  return parts.join(" · ");
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/components/ui/spinner.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/spinner.tsx
@@ -18,6 +18,9 @@ const Spinner = React.forwardRef<
   return (
     <Loader2
       className={cn("size-4 animate-spin text-muted-foreground", className)}
+      // An `svg` is not an element that takes a name, so a caller's
+      // `aria-label` would be dropped without a role that does.
+      role={props["aria-label"] ? "img" : undefined}
       ref={ref}
       {...props}
     />


### PR DESCRIPTION
R4 of the code-mode refinement stack: roles and names, keyboard paths, live-region placement, and focus behaviour across `src/code/**`. Three shared primitives change too, each because code mode is the surface that exposed the gap.

No visual change is intended. Every fix below is a semantic or keyboard one.

## Live regions on streaming

**The firehose, fixed.** Every `CodeToolCard` wrapped itself in `role="status"` — an atomic polite live region — and a running call streams its output *inside* that region. A screen reader re-read the whole tool line, output and all, on every streamed byte, once per tool line in the transcript. The wrapper is now a plain container. The outcome moved to where it belongs: the line's own accessible name, beside the status glyph it mirrors.

**Turn lifecycle, added.** With the tool lines silenced, nothing announced that a turn started or ended. `CodeTranscript` now carries exactly one live region — an `sr-only` `role="status"` fed by `codeTurnAnnouncement(items, busy)`: "Turn running", then "Turn finished · 2m 14s" or "Turn interrupted". It mounts empty and only fills in on a later change, so reopening a finished session does not read its last outcome at the reader unprompted. A failed turn is deliberately *not* announced here: `TurnReviewCard` already raises it as an `alert`, and saying it twice is worse than saying it once.

**Verified already correct**, no change made:
- Failed turn → `role="alert"`; harness error notice → `alert`, warning/info → `status` (`HarnessNotice`).
- Reconnect bar, queued-follow-up pill, composer image notice, "Opening a shell…" → polite `role="status"`.
- Composer send failure and merge failure → `role="alert"`.
- Copy-to-clipboard announcements → `sr-only role="status" aria-live="polite"`.

## Roles and names

- **Workspace card** (`CodeSidebar`) — the card announced only its title. `aria-label={title}` overrode everything below it, so the glyph rail (attention dot, PR state, terminal, pending approval) was pointer-only information: a triage read could not hear "needs you". New pure `workspaceCardLabel()` builds the name in card order — title, attention, PR number and state, terminal, repo, branch — and the glyphs it now speaks for are `aria-hidden`.
- **Attention dot** — `<span aria-label>` with no role names nothing. Now `role="img"`.
- **Unread-engine-event dot** (workspace header) — same fix.
- **Tool output** (`StreamingTail`, and shared `ToolOutputPreview`) — `<pre aria-label="Output">` is a generic element; the label was dropped. Now `role="group"`.
- **Terminal host** — `<div aria-label="Terminal output">` around xterm's own tree, unnamed for the same reason. Now `role="group"`.
- **`Spinner`** (shared) — its doc comment tells callers to pass `aria-label` "when the glyph is the only signal", but lucide renders a bare `<svg>` and the label never reached anyone. It now sets `role="img"` when a caller labels it. Four code-mode surfaces relied on this: Files, Diff, FileViewer, PrCard.
- **Diff file section** — the "Open" control was `role="link" tabIndex={0}` *nested inside* the disclosure button, and an `<h3>` sat inside it too. A control inside a control is reachable by neither, and the disclosure's name swallowed "Open" and the ± counts. They are siblings now; the heading wraps the disclosure (the standard disclosure-heading shape), so heading navigation still lands per file. "Open" and "Show diff" take a label naming their file — a multi-file diff otherwise lists a column of identical controls.
- **Pending-approval badge** — named "2 approvals", a state rather than an action. Now "Jump to 2 pending approvals".
- **File-activity rows** — the A/M/D/R letter was `aria-label`ed on a bare span and read as the letter. The letter is `aria-hidden`; the word carries the change kind.
- **Verified already correct**: inspector icon tabs, terminal drawer controls, composer model/effort/permission menus, `WorkspaceOverflowMenu`, context-menu items, repo and sort-mode controls, `HarnessPicker`, `NewWorkspaceDialog` fields.

## Keyboard paths

- **Explorer tree** — it advertised `role="tree"` but was a list of buttons: no arrow keys, no `aria-level`, focus on a button *inside* each `treeitem` (which announced as a button, in a tree). Rebuilt to the ARIA tree pattern: the row is the treeitem, one roving tab stop for the whole tree, Up/Down between drawn rows, Right to open a folder or step into an open one, Left to close or climb out, Home/End, Enter/Space to activate. New pure `flattenVisibleTree()` derives the row order the keys walk. Each treeitem takes an explicit `aria-label` of its own name — a treeitem otherwise draws its name from everything it contains, which for an open folder is the whole subtree.
- **Center tabs** — a `tablist` whose tabs sat inside untyped wrapper `<div>`s, with no arrow keys and no panel linkage. Wrappers are `role="presentation"`; Left/Right/Home/End move and select with a roving tab stop; each tab `aria-controls` its panel and each panel is `aria-labelledby` its tab.
- **Session lifecycle mark** — its tooltip carries the engine version and the dropped-event warning, and nothing else on the page does. A `<span>` cannot be tabbed to, so it was hover-only. It now takes a tab stop and the focus ring.
- **Collapsed file-activity list** — `grid-rows-[0fr]` + `overflow-hidden` hides pixels, not semantics: every changed file of every turn was readable as though the summary were always open. Now `aria-hidden` + `inert` when closed, matching the `Reveal` shape already used in `CodeApprovalCard`.
- **`aria-controls`** added to the file-activity, harness-payload, and diff-file disclosures, which had `aria-expanded` and nothing to point at.
- **Verified already correct**, no change made: tool-line expand is a real button; the Chat/Code segmented switch is a proper radiogroup with arrows, Home/End and roving tabindex; Radix Tabs gives the inspector arrow keys (now pinned by a test); Radix ContextMenu opens from Shift+F10 / the Menu key, because it listens for the plain `contextmenu` event a keyboard fires, and returns focus to the card on close; the drawer separator keeps `tabIndex`, `aria-valuenow`, and ±32px arrows from #2205; dialogs keep Radix's focus trap untouched.

## Focus management

- Expanding or collapsing a tool line leaves focus on the line — the toggle is the row itself.
- The context menu returns focus to its card on Escape (Radix default, now asserted).
- The jump-to-latest pill is a real button that leaves the tab order (`tabindex="-1"`, `aria-hidden`) until it is on screen, rather than sitting there invisibly focusable.
- The explorer's tab stop follows the reader and falls back to the first row whenever the row they left stops being drawn.

## Tests

Assertions replaced, not piled on. Net +7 tests, all pinning a contract that can regress silently.

Replaced:
- `CodeTranscript` — `getByRole("status", { name: "Command run succeeded" })` asserted the firehose this PR removes; it is now a button-name assertion plus a test that the streaming output has no live-region ancestor.
- `FilesPanel` — the `aria-current` assertion moved from `button` to `treeitem`.
- `CodeSidebar` — the card is found by its full name; the context-menu test now goes through the keyboard path and checks focus return.
- `DiffPanel` — "Show diff" is matched by its file-qualified name.

Added: tree arrow-key navigation end to end; `workspaceCardLabel` unit coverage; turn-lifecycle announcement and the failed-turn exception; center-tab arrows and panel linkage; jump-to-latest tab order; inspector tab arrows; terminal host naming; the diff disclosure and its Open control not nesting.

## Checks

`pnpm vitest run` — 1220 passed (182 files). `pnpm build` clean. `tsc` clean. Full lanes on the PR.

Not verified: no screen reader was driven against a live session. The contracts above are asserted at the DOM level; the coordinator's screenshot sweep and any VoiceOver pass are still owed.
