### PR TITLE
refactor(desktop): close code-mode theme parity and logged visual debt

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -8,6 +8,7 @@ import { formatMessageTimestamp } from "@/MessageFooter";
 import { cn } from "@/lib/utils";
 import { ScrollableContainer } from "@/ScrollableContainer";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
+import { MiddleTruncate } from "./MiddleTruncate";
 
 /**
  * Parked engine approval. The normalized kind leads so the reader can decide;
@@ -246,29 +247,6 @@ function Reveal({ open, children }: { open: boolean; children: ReactNode }) {
     >
       <div className="overflow-hidden">{children}</div>
     </div>
-  );
-}
-
-function MiddleTruncate({
-  text,
-  className,
-}: {
-  text: string;
-  className?: string;
-}) {
-  const tail = Math.min(28, Math.max(12, Math.ceil(text.length / 3)));
-  if (text.length <= 40) {
-    return (
-      <span className={cn("block truncate", className)} title={text}>
-        {text}
-      </span>
-    );
-  }
-  return (
-    <span className={cn("flex min-w-0", className)} title={text}>
-      <span className="truncate">{text.slice(0, -tail)}</span>
-      <span className="shrink-0">{text.slice(-tail)}</span>
-    </span>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -41,6 +41,7 @@ import { useCodeUiStore } from "./CodeUiStore";
 import { DiffPanel } from "./DiffPanel";
 import { FilesPanel } from "./FilesPanel";
 import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+import { MiddleTruncate } from "./MiddleTruncate";
 import { PrCard } from "./PrCard";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
@@ -409,13 +410,14 @@ function PrTab({
               </p>
             )}
           </div>
-          <p
-            className="text-muted-foreground mt-1 truncate font-mono text-xs"
-            title={branchLine ?? undefined}
-          >
-            #{pr.number}
-            {branchLine ? ` · ${branchLine}` : ""}
-          </p>
+          {/*
+            The base branch is the half a reader checks, and it is the half an
+            end-truncate eats first on a long feature-branch name.
+          */}
+          <MiddleTruncate
+            text={branchLine ? `#${pr.number} · ${branchLine}` : `#${pr.number}`}
+            className="text-muted-foreground mt-1 font-mono text-xs"
+          />
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <Badge variant={prStateVariant(tone)} size="sm">
@@ -636,7 +638,9 @@ function CheckList({
           icon={<Check className="size-3.5" />}
           count={counts.passing}
           label="passing"
-          className="text-success"
+          // These three carry a word each, so they take the readable ink rather
+          // than the mark colour the bare glyphs below use.
+          className="text-success-foreground"
         />
         <CheckCount
           icon={<CircleDashed className="size-3.5" />}
@@ -648,7 +652,7 @@ function CheckList({
           icon={<X className="size-3.5" />}
           count={counts.failing}
           label="failing"
-          className="text-critical"
+          className="text-critical-foreground"
         />
       </button>
       {open &&

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -135,7 +135,7 @@ describe("CodeSidebar", () => {
     fireEvent.contextMenu(card);
     const archive = await screen.findByRole("menuitem", { name: "Archive" });
     expect(archive).toBeInTheDocument();
-    expect(archive.className).toContain("text-destructive");
+    expect(archive.className).toContain("text-critical");
 
     fireEvent.keyDown(archive, { key: "Escape" });
     await waitFor(() => expect(card).toHaveFocus());

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -385,7 +385,7 @@ function WorkspaceCard({
               <span className="truncate">{repoName}</span>
             </span>
             <span
-              className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground/90"
+              className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground"
               title={workspace.branch_name}
             >
               {branchShown}

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { CodeTranscript } from "./CodeTranscript";
+import type { CodeApprovalSnapshot } from "../api/types";
 import type { CodeTranscriptItem } from "./CodeSessionReducer";
 
 afterEach(() => {
@@ -338,5 +339,53 @@ describe("CodeTranscript", () => {
       />,
     );
     expect(screen.queryByText("Working")).toBeNull();
+  });
+
+  it("hangs a parked approval off the tool line it is waiting on", () => {
+    // Nothing on the wire links the two: the card and the still-running line
+    // above it show the same command, and only their adjacency says so. A
+    // decided approval, or one that follows anything else, stands alone.
+    const parked: CodeTranscriptItem[] = [
+      items[0],
+      {
+        kind: "tool",
+        id: "tool-parked",
+        turnId: "t1",
+        callId: "c7",
+        name: "Bash",
+        detail: { kind: "command", cmd: "rm -rf /tmp/scratch", cwd: "/tmp" },
+        status: "running",
+        preview: "",
+        startedAt: "2026-08-15T12:00:00.000Z",
+        durationMs: null,
+      },
+      { kind: "approval", id: "approval:a7", approvalId: "a7", state: "pending" },
+    ];
+    const approval: CodeApprovalSnapshot = {
+      id: "a7",
+      session_id: "s1",
+      turn_id: "t1",
+      kind: { type: "command", cmd: "rm -rf /tmp/scratch", cwd: "/tmp" },
+      harness_raw_json: "{}",
+      state: "pending",
+      requested_at: "2026-08-15T12:00:00.000Z",
+    };
+
+    const { rerender } = render(
+      <CodeTranscript items={parked} approvals={{ a7: approval }} />,
+    );
+    expect(
+      document.querySelector('[data-code-approval-attached="true"]'),
+    ).not.toBeNull();
+
+    rerender(
+      <CodeTranscript
+        items={[items[0], parked[2]!]}
+        approvals={{ a7: approval }}
+      />,
+    );
+    expect(
+      document.querySelector('[data-code-approval-attached="true"]'),
+    ).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -25,6 +25,7 @@ import { UserMessage } from "@/UserMessage";
 import { cn } from "@/lib/utils";
 import type { CodeTranscriptItem } from "./CodeSessionReducer";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+import { MiddleTruncate } from "./MiddleTruncate";
 import {
   formatElapsedDuration,
   formatTurnDuration,
@@ -117,7 +118,7 @@ export function CodeTranscript({
   return (
     <div className="messages" ref={scrollRef} onScroll={onScroll}>
       <div className="messages-column" ref={contentRef}>
-        {items.map((item) =>
+        {items.map((item, index) =>
           isolatedCard(
             item.id,
             itemSignature(item, decidingId, approvalError),
@@ -127,6 +128,7 @@ export function CodeTranscript({
               approval={
                 item.kind === "approval" ? approvals[item.approvalId] : undefined
               }
+              attached={parksTheCallAbove(items, index)}
               deciding={
                 item.kind === "approval" && decidingId === item.approvalId
               }
@@ -228,11 +230,31 @@ export function shouldShowCodeWorking(
 }
 
 /**
+ * Whether this approval is the one the tool line directly above it is parked
+ * on.
+ *
+ * Nothing on the wire says so — an approval carries no tool-call id — but the
+ * journal only ever parks the call it just started, so an approval that lands
+ * straight after a still-running tool line belongs to it. The pair is then
+ * drawn as one unit, because the card repeats the command the line above
+ * already shows and two separate blocks saying the same thing reads as two
+ * things happening.
+ */
+function parksTheCallAbove(
+  items: readonly CodeTranscriptItem[],
+  index: number,
+): boolean {
+  const item = items[index];
+  if (item?.kind !== "approval") return false;
+  const previous = items[index - 1];
+  return previous?.kind === "tool" && previous.status === "running";
+}
+
+/**
  * The data a row draws on, reduced to what decides whether it can render, so a
  * row that threw on a half-written result is retried when the result lands
  * rather than staying broken for the life of the transcript.
- */
-function itemSignature(
+ */function itemSignature(
   item: CodeTranscriptItem,
   decidingId?: string | null,
   approvalError?: string,
@@ -269,6 +291,7 @@ const TranscriptItem = memo(function TranscriptItem({
   item,
   animateStreaming,
   approval,
+  attached = false,
   deciding,
   approvalError,
   onDecide,
@@ -278,6 +301,8 @@ const TranscriptItem = memo(function TranscriptItem({
   item: CodeTranscriptItem;
   animateStreaming: boolean;
   approval?: CodeApprovalSnapshot;
+  /** This approval parks the tool line directly above it. */
+  attached?: boolean;
   deciding?: boolean;
   approvalError?: string;
   onDecide?: (
@@ -361,6 +386,14 @@ const TranscriptItem = memo(function TranscriptItem({
         <div
           data-code-approval-id={item.approvalId}
           data-code-approval-state={item.state}
+          data-code-approval-attached={attached || undefined}
+          className={cn(
+            // A rail dropped from the tool line's own icon column, closing the
+            // column gap above it. The card is the same command in full, so it
+            // has to read as that line's continuation rather than as the next
+            // thing the engine did.
+            attached && "border-border -mt-2 ml-[7px] border-l pt-2 pl-4",
+          )}
         >
           {card}
         </div>
@@ -634,32 +667,6 @@ function StatusGlyph({
   }
 }
 
-/** Keep the tail of a command or path when the header runs out of room. */
-function MiddleTruncate({
-  text,
-  className,
-}: {
-  text: string;
-  className?: string;
-}) {
-  const tail = Math.min(28, Math.max(12, Math.ceil(text.length / 3)));
-  if (text.length <= 40) {
-    return (
-      <span className={cn("block truncate", className)} title={text}>
-        {text}
-      </span>
-    );
-  }
-  return (
-    <span className={cn("flex min-w-0", className)} title={text}>
-      <span className="truncate">{text.slice(0, -tail)}</span>
-      <span className="shrink-0">{text.slice(-tail)}</span>
-    </span>
-  );
-}
-
-
-
 const FILE_KIND_LETTER: Record<FileChangeKind, string> = {
   added: "A",
   modified: "M",
@@ -719,10 +726,15 @@ function FileActivityRow({
         }}
       >
         {count} {noun} changed ·{" "}
-        <span className="text-success-foreground-muted tabular-nums">
+        {/*
+          The full `-foreground` ink, not the 75% `-muted` one: at 75% over a
+          white page these numerals land near 3:1, which reads as greyed-out
+          rather than green in the light theme while looking fine in the dark.
+        */}
+        <span className="text-success-foreground tabular-nums">
           +{insertions}
         </span>{" "}
-        <span className="text-critical-foreground-muted tabular-nums">
+        <span className="text-critical-foreground tabular-nums">
           −{deletions}
         </span>
       </button>
@@ -743,10 +755,10 @@ function FileActivityRow({
               <span
                 className={cn(
                   "w-3 shrink-0 font-mono",
-                  file.kind === "added" && "text-success-foreground-muted",
-                  file.kind === "modified" && "text-info-foreground-muted",
-                  file.kind === "deleted" && "text-critical-foreground-muted",
-                  file.kind === "renamed" && "text-warning-foreground-muted",
+                  file.kind === "added" && "text-success-foreground",
+                  file.kind === "modified" && "text-info-foreground",
+                  file.kind === "deleted" && "text-critical-foreground",
+                  file.kind === "renamed" && "text-warning-foreground",
                 )}
                 aria-hidden
               >

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -918,7 +918,7 @@ function CodeSessionPane({
         {connectionState === "reconnecting" && (
           <p
             role="status"
-            className="text-info-foreground-muted pointer-events-none absolute inset-x-0 top-2 z-[1] text-center text-[11px] [animation:code-reveal_140ms_ease-out] motion-reduce:animate-none"
+            className="text-info-foreground pointer-events-none absolute inset-x-0 top-2 z-[1] text-center text-[11px] [animation:code-reveal_140ms_ease-out] motion-reduce:animate-none"
           >
             Reconnecting to the session…
           </p>

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+import { MiddleTruncate } from "./MiddleTruncate";
 import { DiffstatBadge } from "./TurnReviewCard";
 import { useLiveResource } from "./useLiveContent";
 
@@ -82,15 +83,18 @@ export function DiffPanel({
       <header className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b px-3 py-2">
         <div className="min-w-0">
           <h2 className="text-sm font-medium">Diff</h2>
-          <p
-            className="text-muted-foreground truncate font-mono text-[11px]"
-            title={scopeCaption}
-          >
-            {scopeCaption}
-          </p>
+          <MiddleTruncate
+            text={scopeCaption}
+            className="text-muted-foreground font-mono text-[11px]"
+          />
         </div>
         <div className="flex items-center gap-2">
-          {refreshing && <Spinner className="size-3.5" aria-label="Refreshing" />}
+          {/* A fixed slot, so a refresh does not nudge the diffstat sideways. */}
+          <span className="grid size-3.5 shrink-0 place-items-center">
+            {refreshing && (
+              <Spinner className="size-3.5" aria-label="Refreshing" />
+            )}
+          </span>
           {payload && <DiffstatBadge stat={payload.stat} />}
         </div>
       </header>
@@ -188,12 +192,10 @@ function FileDiffSection({
               )}
               aria-hidden="true"
             />
-            <span
-              className="text-muted-foreground min-w-0 flex-1 truncate font-mono text-xs"
-              title={group.path}
-            >
-              {group.path}
-            </span>
+            <MiddleTruncate
+              text={group.path}
+              className="text-muted-foreground min-w-0 flex-1 font-mono text-xs"
+            />
           </button>
         </h3>
         {onOpenFile && (
@@ -214,14 +216,19 @@ function FileDiffSection({
           </button>
         )}
         <span className="shrink-0 font-mono text-[11px] tabular-nums">
-          <span className="text-success">+{insertions}</span>{" "}
-          <span className="text-critical">−{deletions}</span>
+          {/*
+            `--success` and `--critical` are mark colours: they clear 3:1
+            against either background, which an icon needs and a numeral this
+            small does not. The `-foreground` inks clear 9:1 in both themes.
+          */}
+          <span className="text-success-foreground">+{insertions}</span>{" "}
+          <span className="text-critical-foreground">−{deletions}</span>
         </span>
       </header>
       {expanded ? (
         <pre
           id={bodyId}
-          className="overflow-x-auto py-1 font-mono text-xs leading-5"
+          className="overflow-x-auto py-1 font-mono text-[13px] leading-5"
         >
           {group.lines.map((line, index) => (
             <DiffLineRow
@@ -250,11 +257,14 @@ function FileDiffSection({
 
 function DiffLineRow({ line }: { line: DiffLine }) {
   return (
+    // The tint carries "added" or "removed"; the ink carries readability. Tinted
+    // ink on a tinted row is what made added lines a 3.2:1 pale green in the
+    // light theme while reading fine in the dark one.
     <span
       className={cn(
         "flex min-h-4 min-w-max",
-        line.kind === "add" && "text-success bg-success/10",
-        line.kind === "del" && "text-critical bg-critical/10",
+        line.kind === "add" && "text-success-foreground bg-success/10",
+        line.kind === "del" && "text-critical-foreground bg-critical/10",
         (line.kind === "hunk" || line.kind === "meta") && "text-muted-foreground",
       )}
     >

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -62,15 +62,15 @@ function DoctorCard({ entry }: { entry: HarnessDoctorEntry }) {
   return (
     <Card className="gap-3 p-4">
       <CardHeader className="justify-between">
-        <CardTitle className="text-base">{HARNESS_LABELS[entry.kind]}</CardTitle>
+        <CardTitle className="text-sm">{HARNESS_LABELS[entry.kind]}</CardTitle>
         <Badge variant={ready ? "success" : "warning"} size="sm">
           {ready ? "Ready" : entry.found ? "Sign in" : "Not found"}
         </Badge>
       </CardHeader>
       <CardContent className="gap-1 text-sm">
         <Row label="Found" value={entry.found ? "yes" : "no"} />
-        {entry.path && <Row label="Path" value={entry.path} />}
-        {entry.version && <Row label="Version" value={entry.version} />}
+        {entry.path && <Row label="Path" value={entry.path} mono />}
+        {entry.version && <Row label="Version" value={entry.version} mono />}
         <Row label="Tier" value={HARNESS_TIER_LABELS[entry.tier]} />
         <Row label="Capabilities" value={capsSummary(entry)} />
         <Row
@@ -97,13 +97,22 @@ function DoctorCard({ entry }: { entry: HarnessDoctorEntry }) {
   );
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function Row({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  /** An install path or a version string: mono, like everywhere else. */
+  mono?: boolean;
+}) {
   return (
     // A harness path or version carries no spaces to break at, so without this
     // a deep install location runs past the card.
     <p className="text-muted-foreground break-words">
       <span className="text-foreground font-medium">{label}: </span>
-      {value}
+      <span className={mono ? "font-mono" : undefined}>{value}</span>
     </p>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/FileViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FileViewer.tsx
@@ -6,6 +6,7 @@ import type { CodeWorkspaceBlob } from "../api/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { configureMonaco, monacoLanguage, monacoTheme } from "./monacoEnv";
+import { MiddleTruncate } from "./MiddleTruncate";
 import { useLiveResource } from "./useLiveContent";
 
 /**
@@ -43,11 +44,23 @@ export function FileViewer({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <header className="flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2">
-        <p className="min-w-0 truncate font-mono text-xs" title={path}>
-          {path}
-        </p>
-        {refreshing && <Spinner className="size-3.5" aria-label="Refreshing" />}
+      {/*
+        Deliberately the same two-line header as `DiffPanel`: a heading over a
+        mono caption, the same padding, the same fixed spinner slot. The two
+        panels share one center tab strip, so any difference in their header
+        height shows up as the file body jumping when the reader switches tabs.
+      */}
+      <header className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b px-3 py-2">
+        <div className="min-w-0">
+          <h2 className="text-sm font-medium">File</h2>
+          <MiddleTruncate
+            text={path}
+            className="text-muted-foreground font-mono text-[11px]"
+          />
+        </div>
+        <span className="grid size-3.5 shrink-0 place-items-center">
+          {refreshing && <Spinner className="size-3.5" aria-label="Refreshing" />}
+        </span>
       </header>
       {error && <p className="text-critical px-3 py-2 text-sm">{error}</p>}
       {!data && !error && (
@@ -87,7 +100,11 @@ function BlobBody({ blob }: { blob: CodeWorkspaceBlob }) {
             readOnly: true,
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
+            // The same 13px/20px as the diff body. The two views open the same
+            // file from the same tab strip, so a reader flipping between them
+            // should see the same lines in the same places.
             fontSize: 13,
+            lineHeight: 20,
             wordWrap: "on",
             renderLineHighlight: "none",
             automaticLayout: true,

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -466,7 +466,13 @@ function TreeRow({
           <span className="size-3 shrink-0" aria-hidden />
         )}
         <Icon className="text-muted-foreground size-3.5 shrink-0" aria-hidden />
-        <span className="min-w-0 truncate" title={node.path}>
+        {/*
+          Mono, like every other path-shaped surface in code mode: the explorer
+          was the one place a file name was set in the UI face, which made the
+          same name look like two different strings in the tree and in the tab
+          it opened.
+        */}
+        <span className="min-w-0 truncate font-mono" title={node.path}>
           {node.name}
         </span>
       </div>

--- a/crates/tidebreak-desktop/ui/src/code/MiddleTruncate.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/MiddleTruncate.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * A command, path, or branch that keeps its tail when the row runs out of room.
+ *
+ * The unique part of a path is its end, so an end-truncated
+ * `crates/tidebreak-server/src/routes/…` tells a reader nothing they did not
+ * already know. This keeps a tail proportional to the string and lets the head
+ * take whatever space is left, so the same name reads the same way in a 200px
+ * rail and a full-width panel — no character cap, no per-site tuning.
+ *
+ * The full text always rides along as `title`, because every one of these
+ * surfaces can truncate to something ambiguous.
+ */
+export function MiddleTruncate({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  // Short strings have no interesting tail to protect, and splitting them into
+  // two boxes only costs the browser a wrap opportunity.
+  if (text.length <= SHORT_ENOUGH) {
+    return (
+      <span className={cn("block truncate", className)} title={text}>
+        {text}
+      </span>
+    );
+  }
+  const tail = Math.min(TAIL_MAX, Math.max(TAIL_MIN, Math.ceil(text.length / 3)));
+  return (
+    <span className={cn("flex min-w-0", className)} title={text}>
+      <span className="truncate">{text.slice(0, -tail)}</span>
+      <span className="shrink-0">{text.slice(-tail)}</span>
+    </span>
+  );
+}
+
+const SHORT_ENOUGH = 40;
+const TAIL_MIN = 12;
+const TAIL_MAX = 28;

--- a/crates/tidebreak-desktop/ui/src/components/ui/context-menu.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/context-menu.tsx
@@ -38,7 +38,13 @@ const contextMenuItemVariants = cva(
     variants: {
       variant: {
         default: "focus:bg-accent focus:text-accent-foreground",
-        destructive: "text-destructive focus:bg-critical-background",
+        // `--destructive` on `--critical-background` is 3.9:1 in the light
+        // theme and 1.9:1 in the dark one — the row goes nearly blank at the
+        // moment the reader lands on the most dangerous item in the menu. The
+        // mark colour reads on the popover, and the ink the critical tint was
+        // built for reads on the tint.
+        destructive:
+          "text-critical focus:bg-critical-background focus:text-critical-foreground",
       },
     },
     defaultVariants: {

--- a/crates/tidebreak-desktop/ui/src/components/ui/dropdown-menu.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/dropdown-menu.tsx
@@ -35,7 +35,10 @@ const dropdownMenuItemVariants = cva(
     variants: {
       variant: {
         default: "focus:bg-accent focus:text-accent-foreground",
-        destructive: "text-destructive focus:bg-critical-background",
+        // Same pairing as the context menu's destructive item, for the same
+        // reason: the focused row must not go to 1.9:1 in the dark theme.
+        destructive:
+          "text-critical focus:bg-critical-background focus:text-critical-foreground",
       },
     },
     defaultVariants: {

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -23,7 +23,12 @@
 
   --border: var(--color-zinc-200);
   --input: oklch(0.929 0.013 255.508);
-  --ring: oklch(0.704 0.04 256.788);
+  /* The focus ring has to clear 3:1 against whatever it rings. At 0.704 it
+     cleared 2.6:1 on a white page and 2.9:1 on a hovered row — visible in the
+     dark theme, where the same value sits on a dark ground, and close to
+     invisible in the light one. 0.58 clears 4.3:1 on the page, 4.1:1 on a
+     card, and 3.4:1 on `--muted`. */
+  --ring: oklch(0.58 0.04 256.788);
 
   --primary: var(--color-zinc-900);
   --primary-foreground: var(--color-zinc-100);


### PR DESCRIPTION
The last pass of the code-mode refinement stack: read every code-mode surface in
both themes, and close the visual debt earlier layers logged.

R4 (#2226) merged while this was in flight, so it targets `main`.

## Light/dark parity

Contrast was measured, not eyeballed: every token pairing below was converted
from oklch to sRGB and scored against WCAG 2.1. The pattern the sweep found is
one mistake repeated — the design system has two inks per tone, and the mark
colour (`--success`) was being used where the readable ink (`--success-foreground`)
belongs. The mark colour is tuned to clear 3:1, which an icon needs; in the dark
theme it happens to clear 10:1 as well, so nothing looked wrong there while the
light theme sat at 3.2:1.

| Surface | Was | Now |
| --- | --- | --- |
| Diff added/removed lines (`DiffPanel`) | 3.22 / 4.39 light | 8.44 / 9.26 both themes |
| Per-file `+n −n` counts (`DiffPanel`) | 3.22 light | 9.07 / 10.06 |
| Turn file-activity counts and A/M/D/R letters (`CodeTranscript`) | 3.01 light | 9.07+ |
| PR check counts (`CodeInspector`) | 3.22 light | 9.07 / 10.06 |
| "Reconnecting to the session…" (`CodeWorkspacePage`) | 3.04 light | 9.47 |
| Workspace-card branch name (`CodeSidebar`) | 3.49 light | 4.83 |
| Focused destructive menu item (`context-menu`, `dropdown-menu`) | 1.86 dark, 3.90 light | 8.24 both |
| `--ring` focus indicator | 2.63 light | 4.28 light |

Two of these reach outside `src/code/`, deliberately:

- **`--ring`** in the light theme cleared 2.6:1 against the page and 2.9:1
  against a hovered row, so the focus indicator R4 spent a PR wiring up was
  close to invisible in one of the two themes. `0.704 → 0.58` on the same hue
  clears 4.3:1 on the page, 4.1:1 on a card, 3.4:1 on `--muted`.
- **The destructive menu item** paired `text-destructive` with
  `focus:bg-critical-background`: dark red on dark red, 1.9:1, at the moment
  the reader lands on Archive or Delete. Both menu primitives now take the ink
  the critical tint was built for. `context-menu` is code-mode-only;
  `dropdown-menu` carries the identical defect on chat's delete actions and is
  fixed with it rather than left to diverge.

No new colour is introduced and no hardcoded colour is added. The two raw
palette usages in `workspaceCards.ts` stay: the repo-chip swatches are identity,
not status, and GitHub's merged-PR purple has no token — both already carry
explicit light and dark values and a comment saying why.

Nothing regressed in the terminal (#2205); its theme derivation and its
light/dark test are untouched.

## Logged debt from earlier layers

1. **Shared middle-truncation primitive.** `MiddleTruncate` was duplicated
   byte-for-byte in `CodeTranscript` and `CodeApprovalCard`. Extracted to
   `src/code/MiddleTruncate.tsx` — fluid, no character cap, `title` built in —
   and adopted at both old sites plus the diff scope caption, the per-file diff
   headers, the file-viewer path, and the PR branch line (where an end-truncate
   ate the base branch, the half a reader is checking).
2. **`DiffPanel` and `FileViewer` header heights.** The diff header was two
   lines and the file header one, so switching center tabs moved the body about
   20px. `FileViewer` now carries the same structure: heading, mono caption,
   same padding, same fixed spinner slot. Both spinner slots are fixed-size, so
   a refresh no longer nudges the diffstat sideways either.
3. **Explorer paths in sans.** The files tree was the only path-shaped surface
   set in the UI face, which made one file name look like two different strings
   between the tree and the tab it opened. Now mono at 12px, matching every
   other path in code mode.
4. **Monaco vs the diff body.** Chosen: **13px/20px for both**, by moving the
   diff body up from 12px rather than moving Monaco down. 13px is on the design
   ramp (13/14 body) where 12px is not, it sits directly under the transcript's
   13.5px mono, and the two views open the same file from the same tab strip —
   a reader flipping between them now sees the same lines in the same places.
   Monaco gains an explicit `lineHeight: 20` to match `leading-5`.
5. **`DoctorList`.** The 16px card title drops to the ramp's 14px, and harness
   paths and versions render mono. This shows in Settings too and reads
   coherently there.
6. **Approval-parked tool lines.** The card and the still-running line above it
   render the same command, 8px apart, as two unrelated blocks. An approval that
   directly follows a running tool line is now drawn hanging off it: the column
   gap closes and a rail drops from the tool line's own icon column into the
   card. Adjacency only — no wire change, and the card's command block already
   matched the tool line's 13.5px mono.

## Tests

One added: a parked approval renders attached to the tool line above it, and an
approval that follows anything else does not. Nothing on the wire links the two,
so the ordering rule is the contract worth pinning.

One updated: `CodeSidebar.dom.test.tsx` asserted the archive item's destructive
tone by class name; the class changed with the fix above, the assertion still
pins the same fact.

No theme-toggling DOM tests added. Colour classes are not a contract worth
pinning per surface, and the terminal — where the computed theme genuinely is a
contract — already has its own.

## Not done

- `badge.tsx` pairs `-foreground-muted` ink with the tone tint at roughly 2.9:1
  in the light theme. It is applied consistently app-wide and looks like a
  deliberate softening rather than a code-mode defect, so changing every badge in
  the product does not belong in this PR. Worth its own look.
- Chat's own `text-destructive` body copy sits at 3.7:1 in the dark theme, same
  root cause as the menu item. Out of scope here.
