### PR TITLE
test: stabilize terminal cursor and admission lease tests

### DIFF
--- a/crates/tidebreak-core/src/db/tests.rs
+++ b/crates/tidebreak-core/src/db/tests.rs
@@ -2927,7 +2927,7 @@ async fn turn_admission_reservation_is_global_exact_and_recoverable() {
     };
     let first_token = uuid::Uuid::new_v4();
     let first_lease = match store
-        .begin_turn_admission(&request, first_token, chrono::Duration::milliseconds(50))
+        .begin_turn_admission(&request, first_token, chrono::Duration::seconds(30))
         .await
         .unwrap()
     {
@@ -2965,7 +2965,20 @@ async fn turn_admission_reservation_is_global_exact_and_recoverable() {
         BeginTurnAdmissionOutcome::IdentityConflict
     );
 
-    tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+    // Expire the reservation explicitly instead of asking a loaded runner to
+    // finish all assertions inside a tiny wall-clock lease.
+    let expired_at =
+        ops::agent_run::database_now(&store.conn).await.unwrap() - chrono::Duration::seconds(1);
+    let mut reservation: entities::turn_admission::ActiveModel =
+        entities::turn_admission::Entity::find_by_id(turn_id.0)
+            .one(&store.conn)
+            .await
+            .unwrap()
+            .unwrap()
+            .into();
+    reservation.lease_expires_at = Set(Some(expired_at));
+    reservation.update(&store.conn).await.unwrap();
+
     let takeover_token = uuid::Uuid::new_v4();
     let takeover_lease = match store
         .begin_turn_admission(&request, takeover_token, chrono::Duration::seconds(1))

--- a/crates/tidebreak-server/src/tests/code_terminals.rs
+++ b/crates/tidebreak-server/src/tests/code_terminals.rs
@@ -165,7 +165,9 @@ async fn create_write_read_and_two_cursors() {
     let list: Vec<serde_json::Value> = listed.json().await.unwrap();
     assert_eq!(list.len(), 1);
 
-    let payload = b"echo TERM_TWO_READERS_ok\r";
+    // End the producer after the marker so the cursor snapshot below cannot
+    // race trailing PTY output (for example, the shell's next prompt).
+    let payload = b"echo TERM_TWO_READERS_ok; exit\r";
     let written = client
         .post(format!(
             "http://{addr}/code/workspaces/{workspace_id}/terminals/{tid}/write"
@@ -180,6 +182,7 @@ async fn create_write_read_and_two_cursors() {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
     let mut body = Vec::new();
     let mut cursor = 0u64;
+    let mut ended = false;
     while tokio::time::Instant::now() < deadline {
         let read = client
             .get(format!(
@@ -193,10 +196,11 @@ async fn create_write_read_and_two_cursors() {
         let page: serde_json::Value = read.json().await.unwrap();
         body.extend(decode_b64(page["bytes"].as_str().unwrap()));
         cursor = page["cursor"].as_u64().unwrap();
-        if body
+        ended = page["ended"].as_bool() == Some(true);
+        let marker_seen = body
             .windows(b"TERM_TWO_READERS_ok".len())
-            .any(|w| w == b"TERM_TWO_READERS_ok")
-        {
+            .any(|w| w == b"TERM_TWO_READERS_ok");
+        if marker_seen && ended {
             break;
         }
         tokio::time::sleep(Duration::from_millis(40)).await;
@@ -207,6 +211,7 @@ async fn create_write_read_and_two_cursors() {
         "shell did not echo the written command: {:?}",
         String::from_utf8_lossy(&body)
     );
+    assert!(ended, "shell did not exit after the marker");
 
     let late = client
         .get(format!(


### PR DESCRIPTION
## Summary

- end the terminal test's shell producer before asserting that a cursor remains stable
- wait for both the output marker and terminal termination before taking the final cursor snapshot
- replace the turn-admission test's 50 ms wall-clock lease with an explicitly expired database reservation

## Root cause

Both tests raced real time. The terminal test could observe its marker before trailing PTY output arrived, allowing the cursor to advance between reads. The admission test expected several database assertions to complete before a 50 ms lease expired, which was not reliable on slow runners.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- focused terminal cursor test
- focused turn-admission reservation test
- 10 consecutive runs of each focused test

Closes #2225
