### PR TITLE
chore(desktop): sync the refreshed component set to the design system

### DIFF
--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -7,28 +7,88 @@
   "srcDir": "src",
   "tsconfig": "tsconfig.json",
   "cssEntry": ".ds-compiled.css",
-  "extraEntries": ["sonner"],
+  "extraEntries": [
+    "sonner"
+  ],
   "readmeHeader": ".design-sync/conventions.md",
   "overrides": {
-    "Dialog": { "cardMode": "single", "viewport": "720x480", "primaryStory": "RenameWorkspace" },
-    "AlertDialog": { "cardMode": "single", "viewport": "720x480", "primaryStory": "DiscardChanges" },
-    "DropdownMenu": { "cardMode": "single", "viewport": "480x420", "primaryStory": "WorkspaceMenu" },
-    "Select": { "cardMode": "single", "viewport": "480x420" },
-    "Popover": { "cardMode": "single", "viewport": "480x360", "primaryStory": "ChatActivity" },
-    "Tooltip": { "cardMode": "single", "viewport": "480x240" },
-    "Toaster": { "cardMode": "single", "viewport": "640x360", "primaryStory": "TurnFinished" },
-    "Table": { "cardMode": "column" },
-    "ResizablePanelGroup": { "cardMode": "column" },
-    "AttentionCard": { "cardMode": "column" },
-    "DomainFavicon": { "cardMode": "column" },
-    "PanelPrimaryHeader": { "cardMode": "column" },
-    "Progress": { "cardMode": "column" },
-    "ScrollArea": { "cardMode": "column" },
-    "ScrollableContainer": { "cardMode": "column" },
-    "Skeleton": { "cardMode": "column" },
-    "Tabs": { "cardMode": "column" },
-    "ToolActivityGroup": { "cardMode": "column" },
-    "ToolIcon": { "cardMode": "column" }
+    "Dialog": {
+      "cardMode": "single",
+      "viewport": "720x480",
+      "primaryStory": "RenameWorkspace"
+    },
+    "AlertDialog": {
+      "cardMode": "single",
+      "viewport": "720x480",
+      "primaryStory": "DiscardChanges"
+    },
+    "DropdownMenu": {
+      "cardMode": "single",
+      "viewport": "480x420",
+      "primaryStory": "WorkspaceMenu"
+    },
+    "Select": {
+      "cardMode": "single",
+      "viewport": "480x420"
+    },
+    "Popover": {
+      "cardMode": "single",
+      "viewport": "480x360",
+      "primaryStory": "ChatActivity"
+    },
+    "Tooltip": {
+      "cardMode": "single",
+      "viewport": "480x240"
+    },
+    "Toaster": {
+      "cardMode": "single",
+      "viewport": "640x360",
+      "primaryStory": "TurnFinished"
+    },
+    "Table": {
+      "cardMode": "column"
+    },
+    "ResizablePanelGroup": {
+      "cardMode": "column"
+    },
+    "AttentionCard": {
+      "cardMode": "column"
+    },
+    "DomainFavicon": {
+      "cardMode": "column"
+    },
+    "PanelPrimaryHeader": {
+      "cardMode": "column"
+    },
+    "Progress": {
+      "cardMode": "column"
+    },
+    "ScrollArea": {
+      "cardMode": "column"
+    },
+    "ScrollableContainer": {
+      "cardMode": "column"
+    },
+    "Skeleton": {
+      "cardMode": "column"
+    },
+    "Tabs": {
+      "cardMode": "column"
+    },
+    "ToolActivityGroup": {
+      "cardMode": "column"
+    },
+    "ToolIcon": {
+      "cardMode": "column"
+    },
+    "ContextMenu": {
+      "cardMode": "single",
+      "viewport": "480x420",
+      "primaryStory": "WorkspaceMenu"
+    },
+    "MiddleTruncate": {
+      "cardMode": "column"
+    }
   },
   "componentSrcMap": {
     "AlertDialog": "src/components/ui/alert-dialog.tsx",
@@ -87,6 +147,12 @@
     "HarnessPicker": "src/code/HarnessPicker.tsx",
     "DoctorList": "src/code/DoctorList.tsx",
     "CodeToolCard": "src/code/CodeTranscript.tsx",
-    "HarnessNotice": "src/code/CodeTranscript.tsx"
+    "HarnessNotice": "src/code/CodeTranscript.tsx",
+    "SegmentedControl": "src/components/ui/segmented.tsx",
+    "ContextMenu": "src/components/ui/context-menu.tsx",
+    "ToolOutputPreview": "src/ToolOutputPreview.tsx",
+    "UserMessage": "src/UserMessage.tsx",
+    "TranscriptSkeleton": "src/TranscriptSkeleton.tsx",
+    "MiddleTruncate": "src/code/MiddleTruncate.tsx"
   }
 }

--- a/.design-sync/previews/ContextMenu.tsx
+++ b/.design-sync/previews/ContextMenu.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "tidebreak-desktop-ui";
+
+/** Radix context menus open only from a contextmenu event; fire one on mount
+ * so the card shows the open state. */
+export function WorkspaceMenu() {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new MouseEvent("contextmenu", {
+        bubbles: true,
+        clientX: r.left + 40,
+        clientY: r.top + 24,
+      }),
+    );
+  }, []);
+  return (
+    <ContextMenu modal={false}>
+      <ContextMenuTrigger asChild>
+        <div
+          ref={ref}
+          style={{
+            width: 260,
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            padding: "10px 12px",
+            fontSize: 13.5,
+          }}
+        >
+          <div style={{ fontWeight: 500 }}>Tighten retry backoff</div>
+          <div style={{ fontFamily: "var(--mono)", fontSize: 11, color: "var(--muted-foreground)" }}>
+            tidebreak/tighten-retry-backoff
+          </div>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem>Open workspace</ContextMenuItem>
+        <ContextMenuItem>New session</ContextMenuItem>
+        <ContextMenuItem>Rename…</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem>Copy branch name</ContextMenuItem>
+        <ContextMenuItem>Copy worktree path</ContextMenuItem>
+        <ContextMenuItem>Open pull request</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem variant="destructive">Archive</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/.design-sync/previews/MiddleTruncate.tsx
+++ b/.design-sync/previews/MiddleTruncate.tsx
@@ -1,0 +1,24 @@
+import { MiddleTruncate } from "tidebreak-desktop-ui";
+
+const path = "crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts";
+const branch = "tidebreak/terminal-theme-tokens-and-keyboard-resize";
+
+export function Widths() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, fontFamily: "var(--mono)", fontSize: 12 }}>
+      {[360, 260, 180].map((w) => (
+        <div key={w} style={{ width: w, border: "1px solid var(--border)", borderRadius: 6, padding: "4px 8px" }}>
+          <MiddleTruncate text={path} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function BranchName() {
+  return (
+    <div style={{ width: 220, fontFamily: "var(--mono)", fontSize: 12 }}>
+      <MiddleTruncate text={branch} />
+    </div>
+  );
+}

--- a/.design-sync/previews/SegmentedControl.tsx
+++ b/.design-sync/previews/SegmentedControl.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { SegmentedControl } from "tidebreak-desktop-ui";
+
+export function ModeSwitch() {
+  const [mode, setMode] = useState<"chat" | "code">("code");
+  return (
+    <div style={{ width: 240 }}>
+      <SegmentedControl
+        aria-label="Mode"
+        value={mode}
+        onValueChange={setMode}
+        options={[
+          { value: "chat", label: "Chat" },
+          { value: "code", label: "Code" },
+        ]}
+      />
+    </div>
+  );
+}
+
+export function ThreeWay() {
+  const [sort, setSort] = useState<"repo" | "status" | "created">("status");
+  return (
+    <div style={{ width: 320 }}>
+      <SegmentedControl
+        aria-label="Sort workspaces"
+        value={sort}
+        onValueChange={setSort}
+        options={[
+          { value: "repo", label: "By repo" },
+          { value: "status", label: "By status" },
+          { value: "created", label: "Created" },
+        ]}
+      />
+    </div>
+  );
+}

--- a/.design-sync/previews/ToolOutputPreview.tsx
+++ b/.design-sync/previews/ToolOutputPreview.tsx
@@ -1,0 +1,33 @@
+import { ToolOutputPreview } from "tidebreak-desktop-ui";
+
+const testRun = `$ cargo test -p tidebreak-server --locked
+   Compiling tidebreak-core v0.0.0
+   Compiling tidebreak-harness v0.0.0
+   Compiling tidebreak-server v0.0.0
+running 214 tests
+test journal::replay_flattens_on_provider_switch ... ok
+test journal::records_turn_boundaries ... ok
+test turn::cancellation_accounts_usage ... ok
+test turn::retries_transient_failure ... ok
+test approvals::grant_ladder_orders_narrowest_first ... ok
+test approvals::deny_with_feedback_steers ... ok
+test recovery::dead_pid_closes_turn_interrupted ... ok
+test recovery::live_pid_fences_until_reap ... ok
+test attention::stall_sweep_marks_idle_sessions ... ok
+test result: ok. 214 passed; 0 failed; 2 ignored; finished in 41.32s`;
+
+export function ClampedWithExpander() {
+  return (
+    <div style={{ maxWidth: "40rem" }}>
+      <ToolOutputPreview text={testRun} label="Command output" />
+    </div>
+  );
+}
+
+export function ShortOutput() {
+  return (
+    <div style={{ maxWidth: "40rem" }}>
+      <ToolOutputPreview text={"18,204"} label="Command output" />
+    </div>
+  );
+}

--- a/.design-sync/previews/TranscriptSkeleton.tsx
+++ b/.design-sync/previews/TranscriptSkeleton.tsx
@@ -1,0 +1,9 @@
+import { TranscriptSkeleton } from "tidebreak-desktop-ui";
+
+export function Loading() {
+  return (
+    <div style={{ maxWidth: "42rem" }}>
+      <TranscriptSkeleton />
+    </div>
+  );
+}

--- a/.design-sync/previews/UserMessage.tsx
+++ b/.design-sync/previews/UserMessage.tsx
@@ -1,0 +1,25 @@
+import { UserMessage } from "tidebreak-desktop-ui";
+
+export function ShortAsk() {
+  return (
+    <div className="messages-column" style={{ maxWidth: "40rem" }}>
+      <UserMessage
+        text="Run the suite and fix whatever fails."
+        createdAt="2026-08-18T14:31:00Z"
+      />
+    </div>
+  );
+}
+
+export function MultiParagraph() {
+  return (
+    <div className="messages-column" style={{ maxWidth: "40rem" }}>
+      <UserMessage
+        text={
+          "The retry test fails about one run in five on CI.\n\n1. Reproduce it under `--test-threads=1`\n2. Check whether the mock clock races the timer registration\n3. Keep the public API unchanged"
+        }
+        createdAt="2026-08-18T09:12:00Z"
+      />
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/design-system.ts
+++ b/crates/tidebreak-desktop/ui/src/design-system.ts
@@ -29,6 +29,9 @@ export * from "./components/ui/textarea";
 export * from "./components/ui/toggle";
 export * from "./components/ui/tooltip";
 
+export * from "./components/ui/segmented";
+export * from "./components/ui/context-menu";
+
 export * from "./components/PanelHeader";
 export * from "./components/SearchInput";
 export * from "./components/OptionListbox";
@@ -55,6 +58,10 @@ export * from "./ContextUsageIndicator";
 export * from "./ChangeSummaryCard";
 export * from "./AppCard";
 
+export * from "./ToolOutputPreview";
+export * from "./UserMessage";
+export * from "./TranscriptSkeleton";
+
 export * from "./sidebar/primitives";
 
 export * from "./code/AttentionBadge";
@@ -62,3 +69,5 @@ export * from "./code/TurnReviewCard";
 export * from "./code/HarnessPicker";
 export * from "./code/DoctorList";
 export * from "./code/CodeTranscript";
+export * from "./code/MiddleTruncate";
+


### PR DESCRIPTION
Adds the six shared components the code-mode overhaul introduced to the design-system entry, the sync component map, and the authored preview set (screenshot-verified). The design project itself is already refreshed from this build; this PR lands the reproducible inputs. 63 components total, render check clean.