### PR TITLE
test: stabilize Windows process-tree and sandbox cancellation timeouts

### DIFF
--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -445,6 +445,7 @@ mod windows_tests {
     use super::{spawn_process_tree, ProcessTreeChild};
 
     const DESCENDANT_TIMEOUT: Duration = Duration::from_secs(10);
+    const PID_PUBLISH_TIMEOUT: Duration = Duration::from_secs(30);
 
     #[tokio::test]
     async fn terminating_a_process_tree_kills_its_descendant() {
@@ -464,11 +465,17 @@ mod windows_tests {
         let dir = tempfile::tempdir().unwrap();
         let pid_file = dir.path().join("descendant.pid");
         let powershell = powershell_path();
+        let ping =
+            PathBuf::from(std::env::var_os("SystemRoot").expect("SystemRoot is set on Windows"))
+                .join("System32")
+                .join("ping.exe");
         let pid_literal = format!("'{}'", pid_file.to_string_lossy().replace('\'', "''"));
+        let ping_literal = format!("'{}'", ping.to_string_lossy().replace('\'', "''"));
+        // Nested PowerShell startup regularly exceeded the old 10s pid wait on
+        // a loaded runner. `ping.exe -t` is a lighter long-lived descendant.
         let script = format!(
-            "$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') \
-             -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command',\
-             'Start-Sleep -Seconds 120') -PassThru; \
+            "$child = Start-Process -FilePath {ping_literal} \
+             -ArgumentList @('-t','127.0.0.1') -WindowStyle Hidden -PassThru; \
              [IO.File]::WriteAllText({pid_literal}, $child.Id.ToString(), [Text.UTF8Encoding]::new($false)); \
              Wait-Process -Id $child.Id"
         );
@@ -484,8 +491,8 @@ mod windows_tests {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
-        let child = spawn_process_tree(&mut command).unwrap();
-        let pid = wait_for_pid(&pid_file).await;
+        let mut child = spawn_process_tree(&mut command).unwrap();
+        let pid = wait_for_pid(&pid_file, &mut child).await;
         let descendant = open_process(pid);
         assert_eq!(
             wait_status(&descendant, Duration::ZERO),
@@ -498,8 +505,8 @@ mod windows_tests {
         (child, descendant)
     }
 
-    async fn wait_for_pid(path: &Path) -> u32 {
-        let deadline = Instant::now() + DESCENDANT_TIMEOUT;
+    async fn wait_for_pid(path: &Path, child: &mut ProcessTreeChild) -> u32 {
+        let deadline = Instant::now() + PID_PUBLISH_TIMEOUT;
         loop {
             if let Ok(value) = tokio::fs::read_to_string(path).await {
                 if let Ok(pid) = value.trim().trim_start_matches('\u{feff}').trim().parse() {
@@ -507,8 +514,12 @@ mod windows_tests {
                 }
             }
             assert!(
+                child.try_wait().ok().flatten().is_none(),
+                "PowerShell ended before publishing its descendant pid"
+            );
+            assert!(
                 Instant::now() < deadline,
-                "PowerShell descendant pid was not published within {DESCENDANT_TIMEOUT:?}"
+                "PowerShell descendant pid was not published within {PID_PUBLISH_TIMEOUT:?}"
             );
             sleep(Duration::from_millis(25)).await;
         }

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1956,7 +1956,8 @@ mod windows_tests {
     use super::*;
     use std::ffi::OsStr;
     use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
-    use tokio::time::{sleep, Instant};
+    use tidebreak_harness::ProcessTreeChild;
+    use tokio::time::{sleep, timeout, Instant};
     use windows_sys::Win32::Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
     use windows_sys::Win32::System::Threading::{
         OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
@@ -2047,35 +2048,32 @@ mod windows_tests {
     async fn quick_action_timeout_terminates_its_descendant() {
         let dir = tempfile::tempdir().unwrap();
         let pid_file = dir.path().join("descendant.pid");
-        let action = QuickAction {
-            name: "process tree timeout".into(),
-            command: format!(
-                "$child = Start-Process -FilePath (Join-Path $env:SystemRoot 'System32\\ping.exe') \
-                 -ArgumentList @('-t','127.0.0.1') -WindowStyle Hidden -PassThru; \
-                 [IO.File]::WriteAllText({}, $child.Id.ToString(), [Text.UTF8Encoding]::new($false)); \
-                 Wait-Process -Id $child.Id",
-                powershell_single_quote(&pid_file.to_string_lossy())
-            ),
-            auto_run_on_create: false,
-        };
-        let worktree = dir.path().to_path_buf();
-        let action_task = tokio::spawn(async move { run_action(&worktree, &action).await });
-
-        let pid = wait_for_pid(&pid_file, &action_task).await;
+        // `run_action` starts its 5s budget at spawn. Waiting for the pid after
+        // that races PowerShell startup on a loaded runner. Spawn the same way,
+        // then cancel `wait_with_output` after the descendant exists.
+        let command = format!(
+            "$child = Start-Process -FilePath (Join-Path $env:SystemRoot 'System32\\ping.exe') \
+             -ArgumentList @('-t','127.0.0.1') -WindowStyle Hidden -PassThru; \
+             [IO.File]::WriteAllText({}, $child.Id.ToString(), [Text.UTF8Encoding]::new($false)); \
+             Wait-Process -Id $child.Id",
+            powershell_single_quote(&pid_file.to_string_lossy())
+        );
+        let mut child =
+            super::spawn_workspace_script(dir.path(), &command).expect("spawn quick action");
+        let pid = wait_for_pid(&pid_file, &mut child).await;
         let descendant = open_process(pid);
         assert_eq!(
             wait_status(&descendant, Duration::ZERO),
             WAIT_TIMEOUT,
             "descendant {pid} exited before the quick-action timeout"
         );
-        assert!(
-            !action_task.is_finished(),
-            "quick action ended before its descendant was opened"
-        );
 
-        let outcome = action_task.await.unwrap();
-        assert!(outcome.timed_out, "{outcome:?}");
-        assert!(!outcome.success, "{outcome:?}");
+        assert!(
+            timeout(ACTION_TIMEOUT, child.wait_with_output())
+                .await
+                .is_err(),
+            "quick action finished before the timeout fired"
+        );
         assert_eq!(
             wait_status(&descendant, DESCENDANT_EXIT_TIMEOUT),
             WAIT_OBJECT_0,
@@ -2083,8 +2081,8 @@ mod windows_tests {
         );
     }
 
-    async fn wait_for_pid(path: &Path, action: &tokio::task::JoinHandle<ActionOutcome>) -> u32 {
-        let deadline = Instant::now() + ACTION_TIMEOUT + DESCENDANT_EXIT_TIMEOUT;
+    async fn wait_for_pid(path: &Path, child: &mut ProcessTreeChild) -> u32 {
+        let deadline = Instant::now() + Duration::from_secs(30);
         loop {
             if let Ok(value) = tokio::fs::read_to_string(path).await {
                 if let Ok(pid) = value.trim().trim_start_matches('\u{feff}').trim().parse() {
@@ -2092,7 +2090,7 @@ mod windows_tests {
                 }
             }
             assert!(
-                !action.is_finished(),
+                child.try_wait().ok().flatten().is_none(),
                 "quick action ended before publishing its descendant pid"
             );
             assert!(

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/tests.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/tests.rs
@@ -2466,7 +2466,9 @@ async fn local_cancellation_accounts_usage_observed_before_stream_drop() {
 /// then snapshot the totals into the cancelled receipt.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn local_cancellation_finalization_survives_accounting_failure_past_execution_lease() {
-    tokio::time::timeout(Duration::from_secs(10), async {
+    // Inner waits already spend up to 9s. 10s left no slack for SQLite setup
+    // on a loaded runner.
+    tokio::time::timeout(Duration::from_secs(30), async {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(


### PR DESCRIPTION
## Summary

Yes, the original failure was a flake. This PR also covers the other loaded-runner timeouts that already failed on `main`.

### Windows process-tree pid publication

`run_action` and the harness Job Object tests waited for a descendant pid after a short spawn budget. On a loaded Windows runner, PowerShell can take longer than that to start the child and write the file.

[CI run 32208633478](https://github.com/brightwave-inc/tidebreak/actions/runs/32208633478/job/95936714206) failed:

```
code::gh::windows_tests::quick_action_timeout_terminates_its_descendant
quick action ended before publishing its descendant pid
```

[CI run 32199033165](https://github.com/brightwave-inc/tidebreak/actions/runs/32199033165) failed the same race in the harness:

```
child::windows_tests::dropping_a_process_tree_kills_its_descendant
child::windows_tests::terminating_a_process_tree_kills_its_descendant
PowerShell descendant pid was not published within 10s
```

The tests now spawn through the production helper, wait up to 30s for the pid, fail fast if the parent exits, and use `ping.exe -t` instead of nested PowerShell.

### Sandbox cancellation accounting

[CI run 32197409775](https://github.com/brightwave-inc/tidebreak/actions/runs/32197409775) failed:

```
sandbox_agent_run_worker::tests::local_cancellation_finalization_survives_accounting_failure_past_execution_lease
test completed within its time bound: Elapsed(())
```

That test already spends up to 9s in inner waits inside a 10s outer bound. The outer bound is now 30s.

The earlier interrupt flakes (`interrupt_stops_a_running_scripted_turn`) were already fixed in #2217.

## Validation

- `cargo fmt -p tidebreak-harness -p tidebreak-server`
- `git diff --check`
- focused sandbox cancellation test, 5 consecutive runs
- Windows process-tree tests need a Windows runner