### PR TITLE
docs: close the unclosed strong tag in the README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <h1 align="center">Tidebreak</h1>
 
 <p align="center">
-  <strong>A local-first agentic coworker you can configure without limit. Choose your files and model. Walk away with a spreadsheet, deck, or working app.
+  <strong>A local-first agentic coworker you can configure without limit. Choose your files and model. Walk away with a spreadsheet, deck, or working app.</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Test PR.

The README tagline opens `<strong>` on line 9 and never closes it. Closing it keeps the bold from leaking past the tagline in GitHub's renderer.

Docs-only, one line. Open as a draft to exercise the PR pipeline; close it if you only wanted the pipeline run.