### PR TITLE
fix(code): classify engine approvals and auto-accept them in Allow

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
@@ -116,6 +116,22 @@ describe("CodeApprovalCard", () => {
     ).not.toBeNull();
   });
 
+  it("does not render an unknown engine summary as the decision", () => {
+    render(
+      <CodeApprovalCard
+        approval={{
+          ...pendingCommand,
+          kind: { type: "other", summary: "unknown" },
+          harness_raw_json: "null",
+        }}
+        onDecide={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Allow this?")).toBeInTheDocument();
+    expect(screen.getByText("The engine needs approval")).toBeInTheDocument();
+    expect(screen.queryByText("unknown")).not.toBeInTheDocument();
+  });
+
   it("tones a denial as a warning and shows the feedback", () => {
     render(
       <CodeApprovalCard

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -200,7 +200,7 @@ function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
     case "other":
       return (
         <p className="text-muted-foreground text-[13.5px] break-words">
-          {approval.kind.summary}
+          {otherSummary(approval.kind.summary)}
         </p>
       );
   }
@@ -261,6 +261,14 @@ function approvalTitle(approval: CodeApprovalSnapshot): string {
     default:
       return "Allow this?";
   }
+}
+
+function otherSummary(summary: string): string {
+  const trimmed = summary.trim();
+  if (!trimmed || trimmed.toLowerCase() === "unknown") {
+    return "The engine needs approval";
+  }
+  return trimmed;
 }
 
 /** Past this, the payload is a file, not something a reader scrolls. */

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
@@ -50,6 +50,39 @@
     "type": "approval_requested",
     "harness_ref": {
       "call_id": "exec-f5557c0a-1ece-4571-8bd5-5a74e11e269a"
+    },
+    "raw": {
+      "availableDecisions": [
+        "accept",
+        {
+          "acceptWithExecpolicyAmendment": {
+            "execpolicy_amendment": [
+              "python3",
+              "-c",
+              "print(42)"
+            ]
+          }
+        },
+        "cancel"
+      ],
+      "command": "/bin/zsh -lc \"python3 -c 'print(42)'\"",
+      "commandActions": [
+        {
+          "command": "python3 -c 'print(42)'",
+          "type": "unknown"
+        }
+      ],
+      "cwd": "/workspace",
+      "environmentId": "local",
+      "itemId": "exec-f5557c0a-1ece-4571-8bd5-5a74e11e269a",
+      "proposedExecpolicyAmendment": [
+        "python3",
+        "-c",
+        "print(42)"
+      ],
+      "startedAtMs": 1786820086629,
+      "threadId": "01a006c6-ac48-7982-82d8-b355ca4e102d",
+      "turnId": "01a006c6-ac5a-7b70-85dc-eb2cbe79bd11"
     }
   },
   {

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
@@ -22,6 +22,39 @@
     "type": "approval_requested",
     "harness_ref": {
       "call_id": "exec-877a44a5-3d8b-4dbf-b89c-1a4131e2dade"
+    },
+    "raw": {
+      "availableDecisions": [
+        "accept",
+        {
+          "acceptWithExecpolicyAmendment": {
+            "execpolicy_amendment": [
+              "python3",
+              "-c",
+              "print(42)"
+            ]
+          }
+        },
+        "cancel"
+      ],
+      "command": "/bin/zsh -lc \"python3 -c 'print(42)'\"",
+      "commandActions": [
+        {
+          "command": "python3 -c 'print(42)'",
+          "type": "unknown"
+        }
+      ],
+      "cwd": "/workspace",
+      "environmentId": "local",
+      "itemId": "exec-877a44a5-3d8b-4dbf-b89c-1a4131e2dade",
+      "proposedExecpolicyAmendment": [
+        "python3",
+        "-c",
+        "print(42)"
+      ],
+      "startedAtMs": 1786820104582,
+      "threadId": "01a006c6-f970-7c32-87f2-1511e1be0f44",
+      "turnId": "01a006c6-f993-75d2-8630-20f032b06e9a"
     }
   },
   {

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
@@ -86,6 +86,24 @@
     "type": "approval_requested",
     "harness_ref": {
       "call_id": "per_006f236d0001lbewEtHOBSrhMp"
+    },
+    "raw": {
+      "always": [
+        "echo *"
+      ],
+      "id": "per_006f236d0001lbewEtHOBSrhMp",
+      "metadata": {
+        "command": "echo hi"
+      },
+      "patterns": [
+        "echo hi"
+      ],
+      "permission": "bash",
+      "sessionID": "ses_ff90dce38ffexSlvYI7KNTXa2o",
+      "tool": {
+        "callID": "call_00_XqOXPl42gfJx0xSVsgUu1333",
+        "messageID": "msg_006f231cd001xuQ6DLad4Eibab"
+      }
     }
   },
   {

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-deny.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-deny.expected.json
@@ -90,6 +90,24 @@
     "type": "approval_requested",
     "harness_ref": {
       "call_id": "per_006f28b45001X8Mo5OoIrM4xyl"
+    },
+    "raw": {
+      "always": [
+        "echo *"
+      ],
+      "id": "per_006f28b45001X8Mo5OoIrM4xyl",
+      "metadata": {
+        "command": "echo hi"
+      },
+      "patterns": [
+        "echo hi"
+      ],
+      "permission": "bash",
+      "sessionID": "ses_ff90d7992ffe7TX0YtIWyo6Nyl",
+      "tool": {
+        "callID": "call_00_UWLCr2nBoXdhyc2JM4ef2097",
+        "messageID": "msg_006f28674001BxouJjPPe4lD7X"
+      }
     }
   },
   {
@@ -314,6 +332,24 @@
     "type": "approval_requested",
     "harness_ref": {
       "call_id": "per_006f2966b001Edi4ogHcyFv2aT"
+    },
+    "raw": {
+      "always": [
+        "ls *"
+      ],
+      "id": "per_006f2966b001Edi4ogHcyFv2aT",
+      "metadata": {
+        "command": "ls -la"
+      },
+      "patterns": [
+        "ls -la"
+      ],
+      "permission": "bash",
+      "sessionID": "ses_ff90d7992ffe7TX0YtIWyo6Nyl",
+      "tool": {
+        "callID": "call_00_pTqLHUb6Tp5CWsKjACRA5197",
+        "messageID": "msg_006f291c6001FWSz6DRzZDHn24"
+      }
     }
   }
 ]

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -211,9 +211,12 @@ mod tests {
     #[test]
     fn fixture_replay_approval_approve() {
         let (events, _) = replay("approval-approve");
-        assert!(events
-            .iter()
-            .any(|event| matches!(event, HarnessEvent::ApprovalRequested { .. })));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            HarnessEvent::ApprovalRequested { raw, .. }
+                if raw.get("command").and_then(|value| value.as_str())
+                    .is_some_and(|cmd| cmd.contains("python3"))
+        )));
         assert!(events.iter().any(|event| matches!(
             event,
             HarnessEvent::ApprovalResolved {

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -281,7 +281,7 @@ impl CodexStreamParser {
         }
         vec![HarnessEvent::ApprovalRequested {
             harness_ref: HarnessApprovalRef { call_id },
-            raw: serde_json::Value::Null,
+            raw: params.clone(),
         }]
     }
 

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -356,6 +356,14 @@ impl CodexSession {
                         .expect("codex approvals")
                         .insert(harness_ref.call_id.clone(), id.clone());
                 }
+                if self.spec.permission_mode == CodePermissionMode::Allow {
+                    // Allow is the engine's unsupervised posture. A request
+                    // that still arrives must not park a card.
+                    let _ = self
+                        .decide(harness_ref.clone(), ApprovalDecision::Approve)
+                        .await;
+                    continue;
+                }
             }
             self.spec.sink.emit(event.clone()).await;
         }

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -222,9 +222,11 @@ mod tests {
     #[test]
     fn fixture_replay_approval_approve() {
         let (events, _) = replay("approval-approve");
-        assert!(events
-            .iter()
-            .any(|event| matches!(event, HarnessEvent::ApprovalRequested { .. })));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            HarnessEvent::ApprovalRequested { raw, .. }
+                if raw.get("permission") == Some(&serde_json::json!("bash"))
+        )));
         assert!(events.iter().any(|event| matches!(
             event,
             HarnessEvent::ApprovalResolved {

--- a/crates/tidebreak-harness/src/opencode/parse.rs
+++ b/crates/tidebreak-harness/src/opencode/parse.rs
@@ -431,7 +431,7 @@ impl OpencodeStreamParser {
         }
         vec![HarnessEvent::ApprovalRequested {
             harness_ref: HarnessApprovalRef { call_id },
-            raw: serde_json::Value::Null,
+            raw: props.clone(),
         }]
     }
 

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -121,7 +121,14 @@ pub(crate) fn session_create_body(mode: CodePermissionMode, model: Option<&str>)
             "permission": [
                 {"permission": "bash", "pattern": "*", "action": "allow"},
                 {"permission": "edit", "pattern": "*", "action": "allow"},
-                {"permission": "read", "pattern": "*", "action": "allow"}
+                {"permission": "read", "pattern": "*", "action": "allow"},
+                {"permission": "grep", "pattern": "*", "action": "allow"},
+                {"permission": "glob", "pattern": "*", "action": "allow"},
+                {"permission": "list", "pattern": "*", "action": "allow"},
+                {"permission": "external_directory", "pattern": "*", "action": "allow"},
+                {"permission": "websearch", "pattern": "*", "action": "allow"},
+                {"permission": "webfetch", "pattern": "*", "action": "allow"},
+                {"permission": "task", "pattern": "*", "action": "allow"}
             ]
         }),
     };
@@ -419,6 +426,16 @@ impl OpencodeSession {
             } = event
             {
                 *self.resume_ref.lock().expect("opencode resume") = Some(resume.clone());
+            }
+            if let HarnessEvent::ApprovalRequested { harness_ref, .. } = event {
+                if self.spec.permission_mode == CodePermissionMode::Allow {
+                    // Allow already grants every known rule. A request that
+                    // still arrives must not park a card.
+                    let _ = self
+                        .decide(harness_ref.clone(), ApprovalDecision::Approve)
+                        .await;
+                    continue;
+                }
             }
             self.spec.sink.emit(event.clone()).await;
         }
@@ -720,6 +737,9 @@ mod tests {
         assert!(rules
             .iter()
             .any(|rule| { rule["permission"] == "bash" && rule["action"] == "allow" }));
+        assert!(rules.iter().any(|rule| {
+            rule["permission"] == "external_directory" && rule["action"] == "allow"
+        }));
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -857,37 +857,78 @@ fn cap_raw(raw: &serde_json::Value) -> serde_json::Value {
 }
 
 fn kind_from_raw(raw: &serde_json::Value) -> CodeApprovalKind {
+    let input = raw
+        .get("input")
+        .or_else(|| raw.get("metadata"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    // Codex puts the command on the request itself, not under `input`.
+    if let Some(cmd) = raw
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .filter(|cmd| !cmd.is_empty())
+    {
+        return CodeApprovalKind::Command {
+            cmd: cmd.to_owned(),
+            cwd: raw
+                .get("cwd")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+        };
+    }
+    if let Some(cmd) = input
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .filter(|cmd| !cmd.is_empty())
+    {
+        return CodeApprovalKind::Command {
+            cmd: cmd.to_owned(),
+            cwd: input
+                .get("cwd")
+                .or_else(|| raw.get("cwd"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+        };
+    }
     let tool = raw
         .get("tool_name")
         .and_then(serde_json::Value::as_str)
-        .unwrap_or("unknown");
-    let input = raw.get("input").cloned().unwrap_or(serde_json::Value::Null);
+        .or_else(|| raw.get("permission").and_then(serde_json::Value::as_str))
+        .unwrap_or("");
+    let path = input
+        .get("file_path")
+        .or_else(|| input.get("path"))
+        .or_else(|| raw.get("path"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
     match tool {
-        "Write" | "Edit" | "NotebookEdit" => {
-            let path = input
-                .get("file_path")
-                .or_else(|| input.get("path"))
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("")
-                .to_owned();
-            CodeApprovalKind::FileWrite { paths: vec![path] }
-        }
-        "Bash" => CodeApprovalKind::Command {
-            cmd: input
-                .get("command")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("")
-                .to_owned(),
+        "Write" | "Edit" | "NotebookEdit" | "write" | "edit" => CodeApprovalKind::FileWrite {
+            paths: vec![path.to_owned()],
+        },
+        "Bash" | "bash" => CodeApprovalKind::Command {
+            cmd: String::new(),
             cwd: input
                 .get("cwd")
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_owned),
         },
-        "WebFetch" | "WebSearch" => CodeApprovalKind::Network {
+        "WebFetch" | "WebSearch" | "webfetch" | "websearch" => CodeApprovalKind::Network {
             summary: tool.to_owned(),
         },
-        _ => CodeApprovalKind::Other {
-            summary: tool.to_owned(),
+        "Read" | "read" | "Grep" | "grep" | "Glob" | "glob" | "NotebookRead" => {
+            CodeApprovalKind::Other {
+                summary: if path.is_empty() {
+                    tool.to_owned()
+                } else {
+                    format!("{tool} {path}")
+                },
+            }
+        }
+        "" | "unknown" => CodeApprovalKind::Other {
+            summary: "The engine needs approval".to_owned(),
+        },
+        other => CodeApprovalKind::Other {
+            summary: other.to_owned(),
         },
     }
 }
@@ -1001,5 +1042,44 @@ mod tests {
         assert_eq!(stored["truncated"], true);
         assert_eq!(stored["call_id"], "toolu_oversized");
         assert!(stored.get("tool_use_id").is_none());
+    }
+
+    #[test]
+    fn kind_from_raw_reads_codex_and_opencode_payloads() {
+        assert_eq!(
+            kind_from_raw(&serde_json::json!({
+                "command": "/bin/zsh -lc rg foo",
+                "cwd": "/workspace",
+            })),
+            CodeApprovalKind::Command {
+                cmd: "/bin/zsh -lc rg foo".into(),
+                cwd: Some("/workspace".into()),
+            }
+        );
+        assert_eq!(
+            kind_from_raw(&serde_json::json!({
+                "permission": "bash",
+                "metadata": { "command": "rg foo" },
+            })),
+            CodeApprovalKind::Command {
+                cmd: "rg foo".into(),
+                cwd: None,
+            }
+        );
+        assert_eq!(
+            kind_from_raw(&serde_json::json!({
+                "tool_name": "Read",
+                "input": { "file_path": "/workspace/README.md" },
+            })),
+            CodeApprovalKind::Other {
+                summary: "Read /workspace/README.md".into(),
+            }
+        );
+        assert_eq!(
+            kind_from_raw(&serde_json::Value::Null),
+            CodeApprovalKind::Other {
+                summary: "The engine needs approval".into(),
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary

Codex and OpenCode already send the command or path on an approval request. The parser dropped that payload, so the card showed **unknown** and parked a file read until the turn was interrupted.

Allow all still parked those leftover asks. OpenCode only pre-granted bash, edit, and read, so grep, glob, and reads outside the worktree still prompted.

This change:

- Keeps the engine payload and classifies Codex commands, OpenCode bash, and file reads so the card names what it is asking.
- Accepts leftover approval requests immediately when the session is Allow all, so the turn does not hang.
- Grants the extra OpenCode permission rules in Allow so the engine asks less often.

## Test plan

- [x] `cargo test -p tidebreak-server --lib code::session_worker::tests`
- [x] `cargo test -p tidebreak-harness --lib fixture_replay_approval`
- [x] `cargo test -p tidebreak-harness --lib permission_mode_mapping`
- [x] `pnpm exec vitest run src/code/CodeApprovalCard.dom.test.tsx`
- [ ] Start a new Allow all code session and confirm a file read does not park a card.
- [ ] In Ask, confirm a Codex or OpenCode shell approval shows the command instead of **unknown**.