### PR TITLE
feat(desktop): open first-task surfaces and ship watchable starters

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -791,8 +791,11 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             setComposerDraft(next);
             if (!next.trim()) voice.resetInputUsed();
           }}
-          onSelectPrompt={(prompt) => {
+          onSelectPrompt={(prompt, options) => {
             setComposerDraft(prompt);
+            if (options?.enableInternet) {
+              void onNetworkPolicyChange({ mode: "open" });
+            }
             voice.resetInputUsed();
           }}
           onSend={onSend}

--- a/crates/tidebreak-desktop/ui/src/ChatView.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.tsx
@@ -29,6 +29,7 @@ import { ComposerPrompt } from "./ComposerPrompt";
 import { ChatUsageDialog } from "./ChatUsageDialog";
 import type { ComposerNetwork, ComposerReasoning } from "./ComposerToolsMenu";
 import { MessageList, type RetryableTurn } from "./MessageList";
+import type { StarterPromptOptions } from "./WelcomeState";
 import { revealPendingCall } from "./TranscriptFocus";
 import { useTranscriptVisible } from "./TranscriptVisibility";
 import { useFolderAccessRequests } from "./useFolderAccessRequests";
@@ -85,7 +86,7 @@ export type ChatViewProps = {
   nativeDropTarget?: ReactNode;
   attachError: string | null;
   onDraftChange: (value: string) => void;
-  onSelectPrompt: (prompt: string) => void;
+  onSelectPrompt: (prompt: string, options?: StarterPromptOptions) => void;
   onSend: () => Promise<void>;
   /** Queue the draft to run after the active turn; absent disables queueing. */
   onQueue?: () => Promise<void>;

--- a/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
@@ -5,12 +5,14 @@ import { toast } from "sonner";
 import { afterEach, expect, it, vi } from "vitest";
 
 import { ComposerToolsMenu } from "./ComposerToolsMenu";
+import { useFirstTaskGuide } from "./FirstTaskWalkthrough";
 
 vi.mock("sonner", () => ({ toast: { warning: vi.fn() } }));
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  useFirstTaskGuide.getState().setSurface(null);
 });
 
 const LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
@@ -144,4 +146,18 @@ it("keeps the plugins row off a surface with no library to reach", async () => {
 
   await open();
   expect(screen.queryByText("Plugins")).not.toBeInTheDocument();
+});
+
+it("opens when the first-task walkthrough is on the tools step", () => {
+  useFirstTaskGuide.getState().setSurface("tools");
+  render(
+    <ComposerToolsMenu
+      disabled={false}
+      attachFiles={{ attaching: false, onAttach: vi.fn() }}
+      network={{ value: { mode: "off" }, onChange: vi.fn() }}
+    />,
+  );
+
+  expect(screen.getByRole("menuitem", { name: "Attach files" })).toBeInTheDocument();
+  expect(screen.getByRole("menuitem", { name: /Network/ })).toBeInTheDocument();
 });

--- a/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
+import { useGuidedMenu } from "./FirstTaskWalkthrough";
 
 export type ComposerNetwork = {
   value: NetworkPolicy;
@@ -77,6 +78,7 @@ export function ComposerToolsMenu({
   // the menu, and a dialog rendered inside the menu's content would be torn
   // down with it before it could open.
   const [networkOpen, setNetworkOpen] = useState(false);
+  const guided = useGuidedMenu("tools");
 
   const hasAttachments = Boolean(attachFiles || attachFolder);
   const hasSettings = Boolean(network || reasoning);
@@ -89,7 +91,11 @@ export function ComposerToolsMenu({
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu
+        open={guided.open}
+        modal={guided.modal}
+        onOpenChange={guided.onOpenChange}
+      >
         <WithTooltip label="Tools">
           <DropdownMenuTrigger asChild>
             <Button
@@ -104,7 +110,13 @@ export function ComposerToolsMenu({
             </Button>
           </DropdownMenuTrigger>
         </WithTooltip>
-        <DropdownMenuContent align="start" side="top" className="w-60">
+        <DropdownMenuContent
+          align="start"
+          side="top"
+          className="w-60"
+          data-first-task-target="tools-menu"
+          onEscapeKeyDown={guided.onEscapeKeyDown}
+        >
           {attachFiles && (
             <DropdownMenuItem
               disabled={disabled || attachFiles.attaching}
@@ -146,6 +158,9 @@ export function ComposerToolsMenu({
             <DropdownMenuItem
               disabled={disabled || network.disabled}
               onSelect={() => {
+                // The walkthrough holds this menu open, so a second overlay
+                // would sit under the spotlight and trap focus.
+                if (guided.guided) return;
                 // Opened once the menu has actually gone. Raising the dialog in
                 // the same commit leaves two overlays each claiming focus and
                 // hiding the other from assistive tech.

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
@@ -9,14 +9,19 @@ import {
   FIRST_TASK_WALKTHROUGH_KEY,
   FirstTaskWalkthrough,
   shouldOfferFirstTaskWalkthrough,
+  useFirstTaskGuide,
 } from "./FirstTaskWalkthrough";
 
 function Targets() {
   return (
     <>
       <button data-first-task-target="model">Model</button>
+      <div data-first-task-target="model-menu">Model menu</div>
       <button data-first-task-target="tools">Tools</button>
+      <div data-first-task-target="tools-menu">Tools menu</div>
       <button data-first-task-target="permissions">Ask</button>
+      <div data-first-task-target="permissions-menu">Permissions menu</div>
+      <div data-first-task-target="starters">Starters</div>
       <textarea data-composer-input aria-label="Message" />
     </>
   );
@@ -42,29 +47,44 @@ function WalkthroughHarness({
   );
 }
 
-beforeEach(() => window.localStorage.clear());
-afterEach(cleanup);
+beforeEach(() => {
+  window.localStorage.clear();
+  useFirstTaskGuide.getState().setSurface(null);
+});
+afterEach(() => {
+  cleanup();
+  useFirstTaskGuide.getState().setSurface(null);
+});
 
 describe("FirstTaskWalkthrough", () => {
-  it("walks the four setup controls, remembers completion, and returns focus", async () => {
+  it("walks the setup controls, opens each surface, remembers completion, and returns focus", async () => {
     const onClose = vi.fn();
     render(<WalkthroughHarness onClose={onClose} />);
 
     expect(
       screen.getByRole("heading", { name: "Choose a model" }),
     ).toBeInTheDocument();
+    expect(useFirstTaskGuide.getState().surface).toBe("model");
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(
       screen.getByRole("heading", { name: "Set internet access" }),
     ).toBeInTheDocument();
+    expect(useFirstTaskGuide.getState().surface).toBe("tools");
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(
       screen.getByRole("heading", { name: "Choose a permission level" }),
     ).toBeInTheDocument();
+    expect(useFirstTaskGuide.getState().surface).toBe("permissions");
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(
       screen.getByRole("heading", { name: "Add attachments" }),
     ).toBeInTheDocument();
+    expect(useFirstTaskGuide.getState().surface).toBe("tools");
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(
+      screen.getByRole("heading", { name: "Start a real task" }),
+    ).toBeInTheDocument();
+    expect(useFirstTaskGuide.getState().surface).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Done" }));
 
     expect(onClose).toHaveBeenCalledWith("completed");
@@ -105,9 +125,7 @@ describe("FirstTaskWalkthrough", () => {
     expect(next).toHaveFocus();
 
     await user.tab();
-    expect(screen.getByRole("dialog")).toContainElement(
-      document.activeElement as HTMLElement | null,
-    );
+    expect(screen.getByRole("button", { name: "Skip setup" })).toHaveFocus();
   });
 
   it("does not turn a click on the highlighted control into a permanent skip", async () => {
@@ -125,7 +143,7 @@ describe("FirstTaskWalkthrough", () => {
     expect(onClose).not.toHaveBeenCalled();
     expect(window.localStorage.getItem(FIRST_TASK_WALKTHROUGH_KEY)).toBeNull();
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(screen.getByText("1 of 4").parentElement?.parentElement).toHaveAttribute(
+    expect(screen.getByText("1 of 5").closest("[aria-live]")).toHaveAttribute(
       "aria-live",
       "polite",
     );

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
@@ -125,7 +125,9 @@ describe("FirstTaskWalkthrough", () => {
     expect(next).toHaveFocus();
 
     await user.tab();
-    expect(screen.getByRole("button", { name: "Skip setup" })).toHaveFocus();
+    expect(screen.getByRole("dialog")).toContainElement(
+      document.activeElement as HTMLElement | null,
+    );
   });
 
   it("does not turn a click on the highlighted control into a permanent skip", async () => {

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
@@ -1,22 +1,24 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { create } from "zustand";
 
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from "@/components/ui/dialog";
 
 export const FIRST_TASK_WALKTHROUGH_KEY =
-  "tidebreak.first-task-walkthrough.v1";
+  "tidebreak.first-task-walkthrough.v2";
 
 export type FirstTaskWalkthroughOutcome = "completed" | "skipped";
 
+/** Composer surface the walkthrough opens so the spotlight has something real to show. */
+export type FirstTaskSurface = "model" | "tools" | "permissions" | null;
+
 type WalkthroughStep = {
   id: string;
+  surface: FirstTaskSurface;
+  /** Opened menu content, preferred once the surface has mounted. */
   target: string;
+  /** Trigger still in the bar, used before the menu portal exists. */
+  fallbackTarget: string;
   title: string;
   body: string;
 };
@@ -24,27 +26,43 @@ type WalkthroughStep = {
 const STEPS: readonly WalkthroughStep[] = [
   {
     id: "model",
-    target: "model",
+    surface: "model",
+    target: "model-menu",
+    fallbackTarget: "model",
     title: "Choose a model",
-    body: "Models differ in speed, reasoning, and the inputs they understand. The current default is a good place to start.",
+    body: "The model menu is open. Models differ in speed, reasoning, and the inputs they understand. The current default is a good place to start.",
   },
   {
     id: "internet",
-    target: "tools",
+    surface: "tools",
+    target: "tools-menu",
+    fallbackTarget: "tools",
     title: "Set internet access",
-    body: "Open Tools and choose Network when the task needs websites or current information. Leave it off when Tidebreak should use only your message and attachments.",
+    body: "The Tools menu is open. Network is this chat's internet setting. Internet access is what web search and current information need. Leave it off when Tidebreak should use only your message and attachments.",
   },
   {
     id: "permissions",
-    target: "permissions",
+    surface: "permissions",
+    target: "permissions-menu",
+    fallbackTarget: "permissions",
     title: "Choose a permission level",
-    body: "Plan stays read-only, Ask confirms actions, Auto handles routine workspace work, and Allow all runs without asking in this chat. Ask is a balanced place to start.",
+    body: "The permission menu is open. Plan stays read-only, Ask confirms actions, Auto handles routine workspace work, and Allow all runs without asking in this chat. Ask is a balanced place to start.",
   },
   {
     id: "attachments",
-    target: "tools",
+    surface: "tools",
+    target: "tools-menu",
+    fallbackTarget: "tools",
     title: "Add attachments",
-    body: "Open Tools to attach files from your computer. This option appears in the desktop app when local file access is available.",
+    body: "Attach files or a folder from this menu when the task needs your documents. Desktop Tidebreak can read what you attach.",
+  },
+  {
+    id: "starters",
+    surface: null,
+    target: "starters",
+    fallbackTarget: "starters",
+    title: "Start a real task",
+    body: "These prompts are complete. Pick one and send it to watch Tidebreak search, write, or build. You do not need to attach anything first.",
   },
 ] as const;
 
@@ -56,6 +74,38 @@ type ElementRect = {
   width: number;
   height: number;
 };
+
+type FirstTaskGuideState = {
+  surface: FirstTaskSurface;
+  setSurface: (surface: FirstTaskSurface) => void;
+};
+
+export const useFirstTaskGuide = create<FirstTaskGuideState>((set) => ({
+  surface: null,
+  setSurface: (surface) => set({ surface }),
+}));
+
+/**
+ * Controlled open state for a composer menu the walkthrough is allowed to
+ * force open. While that surface is active the menu stays open and is not
+ * modal, so the walkthrough card can keep keyboard focus.
+ */
+export function useGuidedMenu(surface: Exclude<FirstTaskSurface, null>) {
+  const guided = useFirstTaskGuide((state) => state.surface === surface);
+  const [open, setOpen] = useState(false);
+  return {
+    guided,
+    open: guided || open,
+    modal: !guided,
+    onOpenChange: (next: boolean) => {
+      if (guided) return;
+      setOpen(next);
+    },
+    onEscapeKeyDown: (event: { preventDefault: () => void }) => {
+      if (guided) event.preventDefault();
+    },
+  };
+}
 
 export function shouldOfferFirstTaskWalkthrough(): boolean {
   try {
@@ -78,12 +128,44 @@ function targetSelector(target: string): string {
   return `[data-first-task-target="${CSS.escape(target)}"]`;
 }
 
+function resolveTarget(step: WalkthroughStep): HTMLElement | null {
+  return (
+    document.querySelector<HTMLElement>(targetSelector(step.target)) ??
+    document.querySelector<HTMLElement>(targetSelector(step.fallbackTarget))
+  );
+}
+
 function focusComposer(): void {
   window.requestAnimationFrame(() => {
     document
       .querySelector<HTMLTextAreaElement>("[data-composer-input]")
       ?.focus();
   });
+}
+
+function focusableIn(root: HTMLElement): HTMLElement[] {
+  return [
+    ...root.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ];
+}
+
+function clipPathFor(rect: ElementRect, inset: number): string {
+  const left = rect.left - inset;
+  const top = rect.top - inset;
+  const right = rect.left + rect.width + inset;
+  const bottom = rect.top + rect.height + inset;
+  return `polygon(
+    0% 0%, 0% 100%, 100% 100%, 100% 0%,
+    0% 0%,
+    ${left}px ${top}px,
+    ${left}px ${bottom}px,
+    ${right}px ${bottom}px,
+    ${right}px ${top}px,
+    ${left}px ${top}px,
+    0% 0%
+  )`;
 }
 
 export function FirstTaskWalkthrough({
@@ -95,25 +177,30 @@ export function FirstTaskWalkthrough({
 }) {
   const [stepIndex, setStepIndex] = useState(0);
   const [rect, setRect] = useState<ElementRect | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const setSurface = useFirstTaskGuide((state) => state.setSurface);
   const step = STEPS[stepIndex];
 
   useEffect(() => {
     if (!open) {
       setStepIndex(0);
       setRect(null);
+      setSurface(null);
       return;
     }
+    setSurface(step.surface);
+  }, [open, setSurface, step.surface]);
 
-    const target = document.querySelector<HTMLElement>(
-      targetSelector(step.target),
-    );
-    if (!target) {
-      setRect(null);
-      return;
-    }
+  useEffect(() => {
+    if (!open) return;
 
-    target.scrollIntoView({ block: "nearest", inline: "nearest" });
-    const update = () => {
+    let cancelled = false;
+    let frames = 0;
+    let target: HTMLElement | null = null;
+    const observer = new ResizeObserver(() => {
+      if (!target || cancelled) return;
       const next = target.getBoundingClientRect();
       setRect({
         top: next.top,
@@ -123,22 +210,112 @@ export function FirstTaskWalkthrough({
         width: next.width,
         height: next.height,
       });
-    };
-    update();
+    });
 
-    const observer = new ResizeObserver(update);
-    observer.observe(target);
-    window.addEventListener("resize", update);
-    window.addEventListener("scroll", update, true);
-    return () => {
-      observer.disconnect();
-      window.removeEventListener("resize", update);
-      window.removeEventListener("scroll", update, true);
+    const measure = (element: HTMLElement) => {
+      const next = element.getBoundingClientRect();
+      setRect({
+        top: next.top,
+        left: next.left,
+        right: next.right,
+        bottom: next.bottom,
+        width: next.width,
+        height: next.height,
+      });
     };
-  }, [open, step.target]);
+
+    const find = () => {
+      if (cancelled) return;
+      const next = resolveTarget(step);
+      if (!next) {
+        setRect(null);
+        if (frames++ < 30) {
+          window.requestAnimationFrame(find);
+        }
+        return;
+      }
+      target = next;
+      next.scrollIntoView({ block: "nearest", inline: "nearest" });
+      measure(next);
+      observer.observe(next);
+    };
+    find();
+
+    const onViewport = () => {
+      if (target) measure(target);
+    };
+    window.addEventListener("resize", onViewport);
+    window.addEventListener("scroll", onViewport, true);
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+      window.removeEventListener("resize", onViewport);
+      window.removeEventListener("scroll", onViewport, true);
+    };
+  }, [open, step]);
+
+  useEffect(() => {
+    if (!open) return;
+    cardRef.current?.focus();
+  }, [open, stepIndex]);
+
+  useEffect(() => {
+    if (!open) return;
+    const cycleFocus = (event: KeyboardEvent) => {
+      const card = cardRef.current;
+      if (!card) return;
+      const focusable = focusableIn(card);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        card.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey) {
+        if (active === first || !card.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+      if (active === last || !card.contains(active)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        storeOutcome("skipped");
+        setSurface(null);
+        onCloseRef.current("skipped");
+        focusComposer();
+        return;
+      }
+      if (event.key === "Tab") cycleFocus(event);
+    };
+    const onFocusIn = (event: FocusEvent) => {
+      const card = cardRef.current;
+      if (!card) return;
+      const target = event.target;
+      if (target instanceof Node && card.contains(target)) return;
+      const focusable = focusableIn(card);
+      (focusable[0] ?? card).focus();
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("focusin", onFocusIn);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("focusin", onFocusIn);
+    };
+  }, [open, setSurface]);
 
   function finish(outcome: FirstTaskWalkthroughOutcome) {
     storeOutcome(outcome);
+    setSurface(null);
     onClose(outcome);
     focusComposer();
   }
@@ -161,33 +338,35 @@ export function FirstTaskWalkthrough({
       ? rect.top - 12
       : rect.bottom + 12
     : window.innerHeight / 2;
+  const inset = 4;
 
-  return (
-    <Dialog
-      open={open}
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen) finish("skipped");
-      }}
-    >
-      {rect && createPortal(
-        <div
-          className="pointer-events-none fixed z-[101] rounded-[10px] ring-2 ring-[var(--brightwave)] ring-offset-2 ring-offset-transparent"
-          aria-hidden="true"
-          style={{
-            top: rect.top - 4,
-            left: rect.left - 4,
-            width: rect.width + 8,
-            height: rect.height + 8,
-            boxShadow: "0 0 0 9999px rgb(0 0 0 / 0.01)",
-          }}
-        />,
-        document.body,
+  return createPortal(
+    <>
+      {rect && (
+        <div className="pointer-events-none fixed inset-0 z-[100]" aria-hidden="true">
+          <div
+            className="pointer-events-auto absolute inset-0 bg-black/50"
+            style={{ clipPath: clipPathFor(rect, inset) }}
+          />
+          <div
+            className="absolute rounded-[10px] ring-2 ring-[var(--brightwave)] ring-offset-2 ring-offset-transparent"
+            style={{
+              top: rect.top - inset,
+              left: rect.left - inset,
+              width: rect.width + inset * 2,
+              height: rect.height + inset * 2,
+            }}
+          />
+        </div>
       )}
-      <DialogContent
-        withCloseButton={false}
-        onInteractOutside={(event) => event.preventDefault()}
-        overlayClassName="z-[100] bg-black/45"
-        className="z-[102] block max-w-none translate-x-0 translate-y-0 gap-0 rounded-xl border-border bg-popover p-4 text-popover-foreground shadow-xl duration-0 data-[state=closed]:animate-none data-[state=open]:animate-none"
+      <div
+        ref={cardRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="first-task-walkthrough-title"
+        aria-describedby="first-task-walkthrough-body"
+        tabIndex={-1}
+        className="fixed z-[102] max-w-none rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-xl outline-none"
         style={{
           top: dialogTop,
           left: dialogLeft,
@@ -206,12 +385,18 @@ export function FirstTaskWalkthrough({
               {stepIndex + 1} of {STEPS.length}
             </span>
           </div>
-          <DialogTitle className="mt-3 text-base tracking-[-0.01em]">
+          <h2
+            id="first-task-walkthrough-title"
+            className="mt-3 text-base font-semibold tracking-[-0.01em]"
+          >
             {step.title}
-          </DialogTitle>
-          <DialogDescription className="mt-1.5 leading-relaxed">
+          </h2>
+          <p
+            id="first-task-walkthrough-body"
+            className="text-muted-foreground mt-1.5 text-sm leading-relaxed"
+          >
             {step.body}
-          </DialogDescription>
+          </p>
         </div>
         <div className="mt-4 flex items-center gap-2">
           <Button
@@ -247,7 +432,8 @@ export function FirstTaskWalkthrough({
             {stepIndex === STEPS.length - 1 ? "Done" : "Next"}
           </Button>
         </div>
-      </DialogContent>
-    </Dialog>
+      </div>
+    </>,
+    document.body,
   );
 }

--- a/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
@@ -146,7 +146,9 @@ export function HomeRoute() {
   const [walkthroughAvailable, setWalkthroughAvailable] = useState(
     shouldOfferFirstTaskWalkthrough,
   );
-  const [walkthroughOpen, setWalkthroughOpen] = useState(false);
+  const [walkthroughOpen, setWalkthroughOpen] = useState(
+    shouldOfferFirstTaskWalkthrough,
+  );
   const newChat = useNewChatSettings();
   // What the pickers show and the created chat will get: this visit's picks
   // over the server's sticky defaults. Only the explicit picks are sent; the
@@ -378,11 +380,16 @@ export function HomeRoute() {
           {/* The same null state an empty conversation shows: home is where a
               chat starts, so it greets the same way. Picking a starter prompt
               fills the composer rather than sending, the way it does in a chat.
-              Home's starters come from the installed prompt library when it has
-              any; otherwise the built-in openers stand. */}
+              Web starters also turn internet access on so the turn can search
+              without another click. Home's starters come from the installed
+              prompt library when it has any; otherwise the built-in openers
+              stand. */}
           <WelcomeState
-            onSelectPrompt={(prompt) => {
+            onSelectPrompt={(prompt, options) => {
               setDraft(prompt);
+              if (options?.enableInternet) {
+                newChat.setNetworkPolicy({ mode: "open" });
+              }
               voice.resetInputUsed();
             }}
             executionConfigClient={client}
@@ -394,7 +401,7 @@ export function HomeRoute() {
                 : undefined
             }
             onStartWalkthrough={
-              walkthroughAvailable
+              walkthroughAvailable && !walkthroughOpen
                 ? () => setWalkthroughOpen(true)
                 : undefined
             }

--- a/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
@@ -146,9 +146,7 @@ export function HomeRoute() {
   const [walkthroughAvailable, setWalkthroughAvailable] = useState(
     shouldOfferFirstTaskWalkthrough,
   );
-  const [walkthroughOpen, setWalkthroughOpen] = useState(
-    shouldOfferFirstTaskWalkthrough,
-  );
+  const [walkthroughOpen, setWalkthroughOpen] = useState(false);
   const newChat = useNewChatSettings();
   // What the pickers show and the created chat will get: this visit's picks
   // over the server's sticky defaults. Only the explicit picks are sent; the

--- a/crates/tidebreak-desktop/ui/src/MessageList.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.tsx
@@ -43,7 +43,7 @@ import {
   ToolActivityGroup,
   ToolActivityUnavailable,
 } from "./ToolActivityGroup";
-import { WelcomeState } from "./WelcomeState";
+import { WelcomeState, type StarterPromptOptions } from "./WelcomeState";
 import { isolatedCard } from "./PendingCard";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
@@ -266,7 +266,7 @@ type MessageListProps = {
     decision: OutputWritebackDecision,
   ) => void;
   onOutputWritebackCancel?: (callId: string, turnId: string) => void;
-  onSelectPrompt?: (prompt: string) => void;
+  onSelectPrompt?: (prompt: string, options?: StarterPromptOptions) => void;
   /** Resend the failed turn. Offered only on the transcript's newest failure. */
   onRetryTurn?: (turn: RetryableTurn) => void;
   hydrated?: boolean;

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { afterEach, expect, it, vi } from "vitest";
 
 import { ModelMenu } from "./ModelMenu";
+import { useFirstTaskGuide } from "./FirstTaskWalkthrough";
 import type { ModelInfo } from "./api";
 
 vi.mock("sonner", () => ({ toast: { warning: vi.fn() } }));
@@ -12,6 +13,7 @@ vi.mock("sonner", () => ({ toast: { warning: vi.fn() } }));
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  useFirstTaskGuide.getState().setSurface(null);
 });
 
 const MODELS: ModelInfo[] = [
@@ -170,4 +172,18 @@ it("splits a mixed gateway catalog into vendor tabs", async () => {
   expect(gatewayTab.querySelector(".lucide-network")).not.toBeNull();
   await user.click(gatewayTab);
   expect(screen.getByRole("menuitem", { name: "Mystery Model" })).toBeTruthy();
+});
+
+it("opens when the first-task walkthrough is on the model step", () => {
+  useFirstTaskGuide.getState().setSurface("model");
+  render(
+    <ModelMenu
+      models={MODELS}
+      value="anthropic::claude-sonnet-4"
+      onSetUpProvider={() => {}}
+      onChange={() => {}}
+    />,
+  );
+
+  expect(screen.getByRole("menuitem", { name: "Claude Sonnet 4" })).toBeInTheDocument();
 });

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
+import { useGuidedMenu } from "./FirstTaskWalkthrough";
 import { cn } from "@/lib/utils";
 
 const CACHE_CHANGE_WARNING =
@@ -449,6 +450,7 @@ export function ModelMenu({
   // the model was chosen here or inherited from Settings.
   const pillModel = known ?? (isDefault ? usableDefault : null);
 
+  const guided = useGuidedMenu("model");
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const searchInput = useRef<HTMLInputElement>(null);
@@ -464,6 +466,7 @@ export function ModelMenu({
   const searching = query.length > 0;
 
   function openMenu(next: boolean) {
+    if (guided.guided && !next) return;
     if (next) {
       setQuery("");
       setActiveGroupId(
@@ -514,7 +517,11 @@ export function ModelMenu({
   }
 
   return (
-    <DropdownMenu open={open} onOpenChange={openMenu}>
+    <DropdownMenu
+      open={guided.open || open}
+      modal={guided.modal}
+      onOpenChange={openMenu}
+    >
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
@@ -542,6 +549,8 @@ export function ModelMenu({
         side="top"
         collisionPadding={12}
         className="model-menu-content w-80 p-0"
+        data-first-task-target="model-menu"
+        onEscapeKeyDown={guided.onEscapeKeyDown}
         onKeyDownCapture={(event) => {
           if (event.target === searchInput.current) return;
           if (event.metaKey || event.ctrlKey || event.altKey) return;

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -6,12 +6,14 @@ import { afterEach, expect, it, vi } from "vitest";
 import type { ManagedPolicy, PermissionMode } from "./api";
 import { ManagedPolicyContext } from "./managedPolicy";
 import { PermissionModeMenu } from "./PermissionModeMenu";
+import { useFirstTaskGuide } from "./FirstTaskWalkthrough";
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  useFirstTaskGuide.getState().setSurface(null);
 });
 
 /**
@@ -155,4 +157,14 @@ it("does not toast a failed write after keyed chat navigation unmounts it", asyn
   expect(
     screen.getByRole("button", { name: "Permissions: Ask" }),
   ).toBeEnabled();
+});
+
+it("opens when the first-task walkthrough is on the permissions step", () => {
+  useFirstTaskGuide.getState().setSurface("permissions");
+  render(
+    <PermissionModeMenu scopeKey="chat-1" value="ask" onChange={vi.fn()} />,
+  );
+
+  expect(screen.getByRole("menuitem", { name: /Ask/ })).toBeInTheDocument();
+  expect(screen.getByRole("menuitem", { name: /Plan/ })).toBeInTheDocument();
 });

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useGuidedMenu } from "./FirstTaskWalkthrough";
 import { cn } from "@/lib/utils";
 
 /**
@@ -161,8 +162,13 @@ export function PermissionModeMenu({
   const current = permissionModeOption(effective);
   const CurrentIcon = current.icon;
   const controlsDisabled = disabled || saving;
+  const guided = useGuidedMenu("permissions");
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      open={guided.open}
+      modal={guided.modal}
+      onOpenChange={guided.onOpenChange}
+    >
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
@@ -177,7 +183,13 @@ export function PermissionModeMenu({
           <ChevronDown className="size-4 opacity-50" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" side="top" className="w-72">
+      <DropdownMenuContent
+        align="end"
+        side="top"
+        className="w-72"
+        data-first-task-target="permissions-menu"
+        onEscapeKeyDown={guided.onEscapeKeyDown}
+      >
         {PERMISSION_MODE_SCALE.map((option) => {
           const selected = current.value === option.value;
           const locked = overCeiling(option.value);

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.dom.test.tsx
@@ -55,7 +55,7 @@ describe("WelcomeState starters", () => {
     // step aside once the library has something to say.
     expect(screen.queryByText(/Retired brief/)).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Write a report from files" }),
+      screen.queryByRole("button", { name: /Brief this week's AI news/ }),
     ).not.toBeInTheDocument();
 
     fireEvent.click(card);
@@ -77,12 +77,13 @@ describe("WelcomeState starters", () => {
     // Shown from the first paint, not after the catalog answers: an install
     // with no prompts must never see home flicker or empty out.
     const starter = screen.getByRole("button", {
-      name: "Write a report from files",
+      name: /Brief this week's AI news/,
     });
     await waitFor(() => expect(library.list).toHaveBeenCalled());
     fireEvent.click(starter);
     expect(onSelectPrompt).toHaveBeenCalledWith(
-      expect.stringContaining("written report"),
+      expect.stringContaining("Search the web"),
+      { enableInternet: true },
     );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.test.tsx
@@ -35,23 +35,22 @@ describe("WelcomeState", () => {
       screen.getByRole("heading", { name: "How can I help?" }),
     ).toBeInTheDocument();
     for (const label of [
-      "Write a report from files",
-      "Analyze a spreadsheet",
-      "Delegate work in parallel",
-      "Turn a folder into an app",
+      "Brief this week's AI news",
+      "Compare two public products",
+      "Build a local planner",
+      "Research in parallel",
     ]) {
-      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: new RegExp(label) })).toBeInTheDocument();
     }
-    // Nothing on home offers to search sources any more.
-    expect(screen.queryByText(/search/i)).toBeNull();
 
-    // A prompt has to stand on its own before anything is attached: it asks
-    // for the input it is missing rather than assuming hidden context.
+    // A starter has to stand on its own: it names the work and starts, rather
+    // than asking what to attach or what the task is.
     fireEvent.click(
-      screen.getByRole("button", { name: "Write a report from files" }),
+      screen.getByRole("button", { name: /Brief this week's AI news/ }),
     );
     expect(onSelectPrompt).toHaveBeenCalledWith(
-      expect.stringMatching(/Tell me what to attach/),
+      expect.stringMatching(/Search the web/),
+      { enableInternet: true },
     );
   });
 

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import {
   AppWindow,
-  ChartColumn,
-  FileText,
+  GitBranch,
+  Globe,
+  Scale,
   Sparkles,
-  Users,
 } from "lucide-react";
 import type {
   ApiClient,
@@ -30,44 +30,57 @@ export type PromptLibraryApis = Pick<PluginsApis, "list" | "promptBody">;
 /** How many library prompts home offers before it stops listing them. */
 const MAX_LIBRARY_PROMPTS = 6;
 
+/** Optional setup applied when a built-in starter is picked. */
+export type StarterPromptOptions = {
+  enableInternet?: boolean;
+};
+
 type StarterPrompt = {
   icon: typeof Sparkles;
   label: string;
+  description: string;
   prompt: string;
+  enableInternet?: boolean;
 };
 
 /**
  * The starters home falls back to with no prompt library installed.
  *
- * Each one names a finished result rather than a chat behavior, and each
- * prompt stands on its own before anything is attached: it says which input
- * is missing and what to do first, so a card that is clicked and sent
- * immediately still starts a real conversation.
+ * Each prompt is complete: it names the work, the tools to use, and the
+ * finished artifact, so a card that is clicked and sent starts a turn the
+ * reader can watch without attaching files or answering a follow-up.
  */
 const STARTER_PROMPTS: StarterPrompt[] = [
   {
-    icon: FileText,
-    label: "Write a report from files",
+    icon: Globe,
+    label: "Brief this week's AI news",
+    description: "Search the web, then write a sourced briefing.",
     prompt:
-      "I want a written report I can share, built from my own files. Tell me what to attach and which sections you would cover, then draft it once the files are in.",
+      "Search the web for the most important AI model and product news from the past seven days. Write a one-page briefing with sources. Cover what shipped, why it matters, and what to watch next. Start now. Do not ask me what to include.",
+    enableInternet: true,
   },
   {
-    icon: ChartColumn,
-    label: "Analyze a spreadsheet",
+    icon: Scale,
+    label: "Compare two public products",
+    description: "Search, tabulate, and recommend with citations.",
     prompt:
-      "I want a spreadsheet analyzed and the findings charted. Tell me what to attach, then walk the data, call out what actually changed, and build the charts that show it.",
-  },
-  {
-    icon: Users,
-    label: "Delegate work in parallel",
-    prompt:
-      "I have work that could run several ways at once. Ask me what the work is, then split it into background tasks you can run in parallel and report back on each.",
+      "Search the web for current public pricing and specs for a cloud NVIDIA H100 versus H200 GPU instance from at least two providers. Build a comparison table covering price, memory, availability notes, and who each is for. Recommend when to pick which, and cite sources. Start now. Do not ask me for more requirements.",
+    enableInternet: true,
   },
   {
     icon: AppWindow,
-    label: "Turn a folder into an app",
+    label: "Build a local planner",
+    description: "Create a small app in this workspace.",
     prompt:
-      "I want a small private app that runs on my own machine over a folder of files. Ask me which folder and what it should do, then build it.",
+      "Build a small local web app I can open on this machine: a personal weekly planner with add, edit, and complete for tasks. No login, single page, clean UI. Create the files in this workspace and tell me how to open it. Start now. Do not wait for a folder or more product direction.",
+  },
+  {
+    icon: GitBranch,
+    label: "Research in parallel",
+    description: "Split a briefing across background tasks.",
+    prompt:
+      "Search the web and split this into parallel background tasks: (1) EU AI Act enforcement developments this year, (2) US state AI bills that passed or advanced this year, (3) policy responses published by major AI labs. Synthesize a one-page brief with sources. Start now. Do not ask me to pick a region or angle.",
+    enableInternet: true,
   },
 ];
 
@@ -94,7 +107,7 @@ export function WelcomeState({
   description = "Ask a question, work through your files, or start a task.",
   onStartWalkthrough,
 }: {
-  onSelectPrompt?: (prompt: string) => void;
+  onSelectPrompt?: (prompt: string, options?: StarterPromptOptions) => void;
   executionConfigClient?: Pick<ApiClient, "getCodeExecutionConfig">;
   heading?: string;
   description?: string;
@@ -189,7 +202,7 @@ export function WelcomeState({
         </Button>
       )}
       {onSelectPrompt && libraryPrompts.length > 0 && (
-        <div className="welcome-prompts">
+        <div className="welcome-prompts" data-first-task-target="starters">
           {libraryPrompts.map((prompt) => (
             <button
               key={prompt.name}
@@ -211,18 +224,30 @@ export function WelcomeState({
         </div>
       )}
       {onSelectPrompt && libraryPrompts.length === 0 && (
-        <div className="welcome-prompts">
-          {STARTER_PROMPTS.map(({ icon: Icon, label, prompt }) => (
-            <button
-              key={label}
-              type="button"
-              className={CARD_CLASS}
-              onClick={() => onSelectPrompt(prompt)}
-            >
-              <Icon size={16} />
-              <span>{label}</span>
-            </button>
-          ))}
+        <div className="welcome-prompts" data-first-task-target="starters">
+          {STARTER_PROMPTS.map(
+            ({ icon: Icon, label, description, prompt, enableInternet }) => (
+              <button
+                key={label}
+                type="button"
+                className={CARD_CLASS}
+                onClick={() =>
+                  onSelectPrompt(
+                    prompt,
+                    enableInternet ? { enableInternet: true } : undefined,
+                  )
+                }
+              >
+                <Icon size={16} />
+                <span className="min-w-0">
+                  <span className="block">{label}</span>
+                  <span className="block text-[0.78rem] font-normal text-muted-foreground">
+                    {description}
+                  </span>
+                </span>
+              </button>
+            ),
+          )}
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary

The first-task walkthrough only ringed closed composer buttons. It now opens the model, tools, and permissions menus and spotlights the live surface.

The fallback starter cards no longer ask what to attach. Each prompt is a complete task you can send without extra setup:

- Brief this week's AI news
- Compare two public products
- Build a local planner
- Research in parallel

Search cards turn internet access on for that chat.

## Test plan

- [x] `pnpm exec vitest run src/FirstTaskWalkthrough.dom.test.tsx src/WelcomeState.test.tsx src/WelcomeState.dom.test.tsx src/ComposerToolsMenu.dom.test.tsx src/PermissionModeMenu.dom.test.tsx src/ModelMenu.dom.test.tsx`
- [ ] Clear `tidebreak.first-task-walkthrough.v2` from localStorage and open home. Confirm the tour opens the model menu, then tools, then permissions.
- [ ] Click **Brief this week's AI news**. Confirm the composer fills and network is Internet access.