### PR TITLE
feat(desktop): keep PR status above the inspector tabs

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -11,12 +11,14 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CodeComposer } from "./CodeComposer";
+import { useCodeUiStore } from "./CodeUiStore";
 import { HttpError } from "../api/client";
 import { useUiStore } from "../UiStore";
 
 afterEach(() => {
   cleanup();
   useUiStore.setState({ activeTurnSendMode: "queue" });
+  useCodeUiStore.setState({ pendingComposerPrompt: null });
 });
 
 const QUEUED = {
@@ -25,6 +27,23 @@ const QUEUED = {
 };
 
 describe("CodeComposer", () => {
+  it("inserts a pending inspector prompt into the draft", async () => {
+    useCodeUiStore.getState().offerComposerPrompt("Merge pull request #41.");
+    render(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole("textbox", { name: "Message" })).toHaveValue(
+      "Merge pull request #41.",
+    );
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
+  });
+
   it("states the session's mode in the composer", () => {
     render(
       <CodeComposer

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -36,6 +36,7 @@ import {
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { CodeTurnSubmission } from "./parsers";
+import { useCodeUiStore } from "./CodeUiStore";
 import {
   codeModelVendor,
   groupCodeModelOptions,
@@ -529,6 +530,20 @@ export function CodeComposer({
           loadPromptBody: async (name: string) => `/${name}`,
         }
       : undefined;
+
+  const pendingPrompt = useCodeUiStore((state) => state.pendingComposerPrompt);
+
+  useEffect(() => {
+    if (!pendingPrompt) return;
+    const text = useCodeUiStore.getState().takeComposerPrompt();
+    if (!text) return;
+    setDraft(text);
+    window.requestAnimationFrame(() => {
+      document
+        .querySelector<HTMLTextAreaElement>("[data-composer-input]")
+        ?.focus();
+    });
+  }, [pendingPrompt]);
 
   useEffect(() => {
     if (model) setSelectedModel(model);

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -12,7 +12,10 @@ import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 afterEach(() => {
   cleanup();
   useCodeUpdatesStore.getState().reset();
-  useCodeUiStore.setState({ inspectorScope: null });
+  useCodeUiStore.setState({
+    inspectorScope: null,
+    pendingComposerPrompt: null,
+  });
   vi.clearAllMocks();
 });
 
@@ -84,6 +87,35 @@ function makeClient(): Pick<
   };
 }
 
+it("keeps the PR action bar visible on Files and Source control", async () => {
+  render(
+    <CodeInspector
+      client={makeClient() as never}
+      workspaceId="ws-1"
+      workspace={{ ...WORKSPACE, pr: PR } as never}
+      contentRevision={0}
+    />,
+  );
+
+  const bar = screen.getByTestId("pr-action-bar");
+  expect(bar).toHaveTextContent("#41");
+  expect(bar).toHaveTextContent("Draft");
+  expect(bar).toHaveTextContent("2 checks");
+  expect(screen.getByRole("button", { name: "Merge" })).toBeInTheDocument();
+
+  await userEvent.setup().click(screen.getByRole("tab", { name: "Files" }));
+  expect(screen.getByTestId("pr-action-bar")).toBeInTheDocument();
+  await userEvent.setup().click(
+    screen.getByRole("tab", { name: "Source control" }),
+  );
+  expect(screen.getByTestId("pr-action-bar")).toBeInTheDocument();
+
+  await userEvent.setup().click(screen.getByRole("button", { name: "Merge" }));
+  expect(useCodeUiStore.getState().pendingComposerPrompt).toMatch(
+    /Merge pull request #41/,
+  );
+});
+
 it("shows PR state, checks, comments, and holds merge for a draft", async () => {
   const client = makeClient();
   render(
@@ -98,13 +130,17 @@ it("shows PR state, checks, comments, and holds merge for a draft", async () => 
   await userEvent.setup().click(screen.getByRole("tab", { name: "Pull request" }));
   await screen.findByText("Fix login flow");
 
-  // Draft wins over the open state token, and holds the merge buttons.
-  expect(screen.getByText("Draft")).toBeInTheDocument();
+  // Draft wins over the open state token, and holds the tab merge buttons.
+  // The inspector bar also says Draft; its Merge writes a prompt instead.
+  expect(screen.getAllByText("Draft").length).toBeGreaterThan(0);
   expect(screen.getByText("Changes requested")).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
   expect(
     screen.getByRole("button", { name: "Enable auto-merge" }),
   ).toBeDisabled();
+  const tabMerge = screen
+    .getAllByRole("button", { name: "Merge" })
+    .find((button) => button.hasAttribute("disabled"));
+  expect(tabMerge).toBeDefined();
 
   // Checks render individually with their buckets counted.
   expect(screen.getByText("1 passing")).toBeInTheDocument();

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -42,6 +42,7 @@ import { DiffPanel } from "./DiffPanel";
 import { FilesPanel } from "./FilesPanel";
 import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { MiddleTruncate } from "./MiddleTruncate";
+import { PrActionBar } from "./PrActionBar";
 import { PrCard } from "./PrCard";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
@@ -115,6 +116,7 @@ export function CodeInspector({
       aria-label="Workspace surfaces"
       data-testid="code-inspector"
     >
+      {pr && <PrActionBar pr={pr} />}
       <Tabs
         value={tab}
         onValueChange={(next) => setTab(next as InspectorTab)}

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -168,6 +168,13 @@ export type CodeUiStore = {
   /** Record a successful create so the next dialog opens on the same choices. */
   rememberCreate: (defaults: CodeCreateDefaults) => void;
   setTerminalDrawerHeight: (workspaceId: string, height: number) => void;
+  /**
+   * Prompt waiting for the code composer. The inspector bar writes; the
+   * composer takes and clears so a remount cannot insert twice.
+   */
+  pendingComposerPrompt: string | null;
+  offerComposerPrompt: (prompt: string) => void;
+  takeComposerPrompt: () => string | null;
 };
 
 export const useCodeUiStore = create<CodeUiStore>()((set) => ({
@@ -179,6 +186,14 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   workspaceSortMode: readStoredWorkspaceSort(),
   lastCreate: readStoredCreateDefaults(),
   terminalDrawerHeights: readStoredTerminalDrawerHeights(),
+  pendingComposerPrompt: null,
+  offerComposerPrompt: (prompt) => set({ pendingComposerPrompt: prompt }),
+  takeComposerPrompt: () => {
+    const prompt = useCodeUiStore.getState().pendingComposerPrompt;
+    if (!prompt) return null;
+    set({ pendingComposerPrompt: null });
+    return prompt;
+  },
   startNewWorkspace: (repoId) => {
     const { repos } = useCodeCatalogStore.getState();
     if (repos.length === 0) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -177,7 +177,7 @@ export type CodeUiStore = {
   takeComposerPrompt: () => string | null;
 };
 
-export const useCodeUiStore = create<CodeUiStore>()((set) => ({
+export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   newWorkspaceOpen: false,
   newWorkspaceRepoId: undefined,
   addRepoOpen: false,
@@ -188,8 +188,8 @@ export const useCodeUiStore = create<CodeUiStore>()((set) => ({
   terminalDrawerHeights: readStoredTerminalDrawerHeights(),
   pendingComposerPrompt: null,
   offerComposerPrompt: (prompt) => set({ pendingComposerPrompt: prompt }),
-  takeComposerPrompt: () => {
-    const prompt = useCodeUiStore.getState().pendingComposerPrompt;
+  takeComposerPrompt: (): string | null => {
+    const prompt = get().pendingComposerPrompt;
     if (!prompt) return null;
     set({ pendingComposerPrompt: null });
     return prompt;

--- a/crates/tidebreak-desktop/ui/src/code/PrActionBar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrActionBar.tsx
@@ -1,0 +1,134 @@
+import { ChevronDown, GitPullRequest } from "lucide-react";
+
+import type { PullRequestDigest } from "../api/types";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { openExternal } from "@/host";
+import { FOCUS_RING } from "./interactive";
+import {
+  prBarActionLabel,
+  prBarModel,
+  prBarPrompt,
+  type PrBarAction,
+  type PrBarTone,
+} from "./prActions";
+import { useCodeUiStore } from "./CodeUiStore";
+
+const TONE_CLASS: Record<PrBarTone, string> = {
+  ready:
+    "border-success-border bg-success-background text-success-foreground",
+  pending: "border-border bg-muted/40 text-foreground",
+  failing:
+    "border-critical-border bg-critical-background text-critical-foreground",
+  conflict:
+    "border-warning-border bg-warning-background text-warning-foreground",
+  draft: "border-border bg-muted/40 text-muted-foreground",
+  merged: "border-border bg-muted/40 text-foreground",
+  closed:
+    "border-critical-border bg-critical-background text-critical-foreground",
+};
+
+/**
+ * Persistent PR strip above the inspector tabs.
+ *
+ * Status and the check count stay visible on Files and Source control. Each
+ * action writes a prompt into the composer rather than calling GitHub here.
+ */
+export function PrActionBar({ pr }: { pr: PullRequestDigest }) {
+  const offerComposerPrompt = useCodeUiStore((state) => state.offerComposerPrompt);
+  const model = prBarModel(pr);
+  const [primary, ...rest] = model.actions;
+
+  function insert(action: PrBarAction) {
+    offerComposerPrompt(prBarPrompt(action, pr));
+    window.requestAnimationFrame(() => {
+      document
+        .querySelector<HTMLTextAreaElement>("[data-composer-input]")
+        ?.focus();
+    });
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center gap-2 border-b px-2 py-1.5",
+        TONE_CLASS[model.tone],
+      )}
+      data-testid="pr-action-bar"
+    >
+      {model.url ? (
+        <a
+          href={model.url}
+          className={cn(
+            "shrink-0 rounded-sm font-mono text-[11px] font-semibold underline-offset-2 hover:underline",
+            FOCUS_RING,
+          )}
+          title={pr.title ?? `#${model.number}`}
+          onClick={(event) => {
+            event.preventDefault();
+            void openExternal(model.url!).catch(() => undefined);
+          }}
+        >
+          #{model.number}
+        </a>
+      ) : (
+        <span className="shrink-0 font-mono text-[11px] font-semibold">
+          #{model.number}
+        </span>
+      )}
+      <GitPullRequest className="size-3 shrink-0" aria-hidden="true" />
+      <p className="min-w-0 flex-1 truncate text-[11px] font-medium">
+        {model.status}
+        {model.checks.total > 0 && (
+          <span className="font-normal opacity-80">
+            {" "}
+            · {model.checks.total}{" "}
+            {model.checks.total === 1 ? "check" : "checks"}
+          </span>
+        )}
+      </p>
+      {primary && (
+        <div className="flex shrink-0 items-center">
+          <Button
+            type="button"
+            size="sm"
+            className={cn("h-6 px-2 text-[11px]", rest.length > 0 && "rounded-r-none")}
+            onClick={() => insert(primary)}
+          >
+            {prBarActionLabel(primary)}
+          </Button>
+          {rest.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  size="sm"
+                  className="h-6 rounded-l-none border-l border-l-background/20 px-1"
+                  aria-label="More pull request actions"
+                >
+                  <ChevronDown className="size-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                {rest.map((action) => (
+                  <DropdownMenuItem
+                    key={action}
+                    onSelect={() => insert(action)}
+                  >
+                    {prBarActionLabel(action)}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import type { PullRequestDigest } from "../api/types";
+import { prBarModel, prBarPrompt, prHasConflicts } from "./prActions";
+
+function pr(partial: Partial<PullRequestDigest>): PullRequestDigest {
+  return {
+    number: 41,
+    state: "open",
+    ...partial,
+  };
+}
+
+describe("prBarModel", () => {
+  it("offers merge when the PR is open and clean", () => {
+    const model = prBarModel(
+      pr({
+        checks: [{ name: "ci", bucket: "pass" }],
+      }),
+    );
+    expect(model.status).toBe("Ready to merge");
+    expect(model.actions[0]).toBe("merge");
+    expect(model.actions).toEqual([
+      "merge",
+      "fix_errors",
+      "resolve_conflicts",
+    ]);
+    expect(model.checks).toEqual({
+      passing: 1,
+      pending: 0,
+      failing: 0,
+      total: 1,
+    });
+  });
+
+  it("leads with fix errors when a check is failing", () => {
+    const model = prBarModel(
+      pr({
+        checks: [
+          { name: "ci / rust", bucket: "fail" },
+          { name: "ci / ui", bucket: "pass" },
+        ],
+      }),
+    );
+    expect(model.status).toBe("1 check failing");
+    expect(model.actions[0]).toBe("fix_errors");
+  });
+
+  it("leads with resolve conflicts when the host reports a conflict", () => {
+    const model = prBarModel(pr({ mergeable: "CONFLICTING" }));
+    expect(prHasConflicts(pr({ mergeable: "CONFLICTING" }))).toBe(true);
+    expect(model.status).toBe("Conflicts");
+    expect(model.actions[0]).toBe("resolve_conflicts");
+  });
+
+  it("names a draft even when checks are still pending", () => {
+    const model = prBarModel(
+      pr({
+        draft: true,
+        checks: [{ name: "ci", bucket: "pending" }],
+      }),
+    );
+    expect(model.status).toBe("Draft");
+    expect(model.actions[0]).toBe("merge");
+  });
+
+  it("hides actions on a merged PR", () => {
+    const model = prBarModel(pr({ state: "merged", merged: true }));
+    expect(model.status).toBe("Merged");
+    expect(model.actions).toEqual([]);
+  });
+});
+
+describe("prBarPrompt", () => {
+  it("names the PR and the base branch", () => {
+    const digest = pr({ base_branch: "main", title: "Fix login" });
+    expect(prBarPrompt("merge", digest)).toMatch(/#41/);
+    expect(prBarPrompt("merge", digest)).toMatch(/main/);
+    expect(prBarPrompt("fix_errors", digest)).toMatch(/failing checks/);
+    expect(prBarPrompt("resolve_conflicts", digest)).toMatch(/conflicts/);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -1,0 +1,145 @@
+import type { PullRequestDigest } from "../api/types";
+import { prTone } from "./workspaceCards";
+
+export type PrBarAction = "merge" | "fix_errors" | "resolve_conflicts";
+
+export type PrBarTone =
+  | "ready"
+  | "pending"
+  | "failing"
+  | "conflict"
+  | "draft"
+  | "merged"
+  | "closed";
+
+export type PrCheckCounts = {
+  passing: number;
+  pending: number;
+  failing: number;
+  total: number;
+};
+
+export type PrBarModel = {
+  number: number;
+  url?: string | null;
+  status: string;
+  tone: PrBarTone;
+  actions: PrBarAction[];
+  checks: PrCheckCounts;
+};
+
+/** Counts from individual checks when present, else the one-line summary. */
+export function prCheckCounts(pr: PullRequestDigest): PrCheckCounts {
+  const checks = pr.checks ?? [];
+  if (checks.length > 0) {
+    const passing = checks.filter((check) => check.bucket === "pass").length;
+    const pending = checks.filter((check) => check.bucket === "pending").length;
+    const failing = checks.filter((check) => check.bucket === "fail").length;
+    return { passing, pending, failing, total: checks.length };
+  }
+  const summary = pr.checks_summary ?? "";
+  const passing = Number(/(\d+) passing/.exec(summary)?.[1] ?? 0);
+  const pending = Number(/(\d+) pending/.exec(summary)?.[1] ?? 0);
+  const failing = Number(/(\d+) failing/.exec(summary)?.[1] ?? 0);
+  return { passing, pending, failing, total: passing + pending + failing };
+}
+
+export function prHasConflicts(pr: PullRequestDigest): boolean {
+  const mergeable = pr.mergeable?.toLowerCase();
+  const mergeState = pr.merge_state_status?.toLowerCase();
+  return mergeable === "conflicting" || mergeState === "dirty";
+}
+
+/**
+ * What the inspector bar shows for a live PR: one status phrase, the check
+ * count, and the actions that insert a prompt.
+ */
+export function prBarModel(pr: PullRequestDigest): PrBarModel {
+  const checks = prCheckCounts(pr);
+  const tone = barTone(pr, checks);
+  return {
+    number: pr.number,
+    url: pr.url,
+    status: barStatus(tone, checks),
+    tone,
+    actions: barActions(tone),
+    checks,
+  };
+}
+
+export function prBarPrompt(
+  action: PrBarAction,
+  pr: PullRequestDigest,
+): string {
+  const number = `#${pr.number}`;
+  const base = pr.base_branch?.trim() || "the base branch";
+  switch (action) {
+    case "merge":
+      return `Merge pull request ${number} into ${base}. Use this workspace's existing merge path. Do not change the branch unless the merge requires it. Report the result.`;
+    case "fix_errors":
+      return `Pull request ${number} has failing checks. Inspect the failing CI, fix the cause in this workspace, and push. Do not merge.`;
+    case "resolve_conflicts":
+      return `Pull request ${number} has merge conflicts with ${base}. Rebase or merge ${base}, resolve every conflict in this workspace, and push. Do not merge the pull request.`;
+  }
+}
+
+export function prBarActionLabel(action: PrBarAction): string {
+  switch (action) {
+    case "merge":
+      return "Merge";
+    case "fix_errors":
+      return "Fix errors";
+    case "resolve_conflicts":
+      return "Resolve conflicts";
+  }
+}
+
+function barTone(pr: PullRequestDigest, checks: PrCheckCounts): PrBarTone {
+  const chip = prTone(pr);
+  if (chip === "merged") return "merged";
+  if (chip === "closed") return "closed";
+  if (prHasConflicts(pr)) return "conflict";
+  if (checks.failing > 0) return "failing";
+  if (chip === "draft") return "draft";
+  if (checks.pending > 0) return "pending";
+  return "ready";
+}
+
+function barStatus(tone: PrBarTone, checks: PrCheckCounts): string {
+  switch (tone) {
+    case "ready":
+      return "Ready to merge";
+    case "pending":
+      return checks.pending === 1
+        ? "1 check pending"
+        : `${checks.pending} checks pending`;
+    case "failing":
+      return checks.failing === 1
+        ? "1 check failing"
+        : `${checks.failing} checks failing`;
+    case "conflict":
+      return "Conflicts";
+    case "draft":
+      return "Draft";
+    case "merged":
+      return "Merged";
+    case "closed":
+      return "Closed";
+  }
+}
+
+function barActions(tone: PrBarTone): PrBarAction[] {
+  if (tone === "merged" || tone === "closed") return [];
+  const primary =
+    tone === "conflict"
+      ? "resolve_conflicts"
+      : tone === "failing"
+        ? "fix_errors"
+        : "merge";
+  return [
+    primary,
+    ...(["merge", "fix_errors", "resolve_conflicts"] as const).filter(
+      (action) => action !== primary,
+    ),
+  ];
+}


### PR DESCRIPTION
## Summary

The pull-request state lived only on its own tab. The inspector now shows a strip above **Files**, **Source control**, and **Pull request**: number, status, check count, and **Merge** / **Fix errors** / **Resolve conflicts**.

Each action writes a prompt into the composer and focuses it. The primary button follows the host state (ready, failing checks, or conflicts). The menu still offers the other two.

## Test plan

- [x] `pnpm exec vitest run src/code/prActions.test.ts src/code/CodeInspector.dom.test.tsx src/code/CodeComposer.dom.test.tsx`
- [ ] Open a workspace with an open PR. Confirm the strip stays visible when you switch inspector tabs.
- [ ] Click **Merge**. Confirm the composer fills with a merge prompt.
- [ ] On a PR with failing checks, confirm the primary button is **Fix errors**.
- [ ] On a conflicting PR, confirm the primary button is **Resolve conflicts**.