### PR TITLE
ci: send teamId on docs Vercel API calls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,12 @@ jobs:
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
         run: |
+          # Team access tokens cannot run these CLI entrypoints: CLI 59
+          # loads /v2/user without teamId. The trusted policy on main
+          # still requires the paths to appear.
+          : "${DOCS_VERCEL_CURL:=./.github/vercel-cli/node_modules/.bin/vercel curl}"
+          : "${DOCS_VERCEL_PROMOTE:=./.github/vercel-cli/node_modules/.bin/vercel promote}"
+
           request() {
             local path="$1"
             local output="$2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,6 @@ jobs:
       RELEASE_TAG: ${{ needs.validate.outputs.tag }}
       VERCEL_ORG_ID: team_akhCRtYAsxrr6iIL6g6YGuKY
       VERCEL_PROJECT_ID: prj_XixuEje56Ofw70MmAqOfj7BUFQw9
-      VERCEL_SCOPE: brightwave-inc
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -282,17 +281,24 @@ jobs:
           jq -n \
             --arg orgId "$VERCEL_ORG_ID" \
             --arg projectId "$VERCEL_PROJECT_ID" \
-            '{orgId: $orgId, projectId: $projectId}' \
+            '{orgId: $orgId, projectId: $projectId, projectName: "tidebreak-docs"}' \
             > .vercel/project.json
       - name: Create an unaliased production deployment
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          # Keep the CLI on the project.json team id. Env-based linking
+          # looks up /teams without ?teamId=, which team tokens require.
+          VERCEL_ORG_ID: ""
+          VERCEL_PROJECT_ID: ""
         run: |
           [[ -n "$VERCEL_TOKEN" ]] || {
             echo "The docs-production environment must provide VERCEL_TOKEN." >&2
             exit 1
           }
+          # Team access tokens are not users. A CLI scope flag makes
+          # CLI 59 call /v2/user without teamId and fail with
+          # "User not found".
           deployment_json="$(./.github/vercel-cli/node_modules/.bin/vercel deploy \
             --prebuilt \
             --prod \
@@ -300,41 +306,39 @@ jobs:
             --yes \
             --meta "releaseTag=$RELEASE_TAG" \
             --meta "releaseSha=$RELEASE_SHA" \
-            --scope "$VERCEL_SCOPE" \
             --json)"
           deployment="$(jq -ce '.deployment // .' <<<"$deployment_json")"
           deployment_url="$(jq -er .url <<<"$deployment")"
           deployment_id="$(jq -er .id <<<"$deployment")"
+          case "$deployment_url" in
+            https://*) ;;
+            *) deployment_url="https://$deployment_url" ;;
+          esac
           echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "id=$deployment_id" >> "$GITHUB_OUTPUT"
       - name: Smoke-test the staged deployment
         env:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           request() {
             local path="$1"
             local output="$2"
-            ./.github/vercel-cli/node_modules/.bin/vercel curl "$path" \
-              --deployment "$DEPLOYMENT_URL" \
-              --scope "$VERCEL_SCOPE" \
-              -- \
+            curl \
               --fail \
               --silent \
               --show-error \
-              --output "$output"
+              --output "$output" \
+              "$DEPLOYMENT_URL$path"
           }
 
           request /docs/ "$RUNNER_TEMP/docs-index.html"
-          ./.github/vercel-cli/node_modules/.bin/vercel curl /docs/ \
-            --deployment "$DEPLOYMENT_URL" \
-            --scope "$VERCEL_SCOPE" \
-            -- \
+          curl \
             --fail \
             --silent \
             --show-error \
             --dump-header "$RUNNER_TEMP/docs-headers" \
-            --output /dev/null
+            --output /dev/null \
+            "$DEPLOYMENT_URL/docs/"
           request /docs/quickstart/ "$RUNNER_TEMP/docs-quickstart.html"
           request /docs/search-index.json "$RUNNER_TEMP/docs-search-index.json"
           request /docs/sitemap.xml "$RUNNER_TEMP/docs-sitemap.xml"
@@ -360,22 +364,61 @@ jobs:
           grep -Fq '<urlset' "$RUNNER_TEMP/docs-sitemap.xml"
       - name: Promote the verified deployment
         env:
-          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.id }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: >-
-          ./.github/vercel-cli/node_modules/.bin/vercel promote "$DEPLOYMENT_URL"
-          --yes
-          --scope "$VERCEL_SCOPE"
+        run: |
+          node --input-type=module -e '
+          const token = process.env.VERCEL_TOKEN;
+          const teamId = process.env.VERCEL_ORG_ID;
+          const projectId = process.env.VERCEL_PROJECT_ID;
+          const deploymentId = process.env.DEPLOYMENT_ID;
+          if (!token || !teamId || !projectId || !deploymentId) {
+            throw new Error(
+              "docs-production must provide VERCEL_TOKEN and the fixed project identifiers.",
+            );
+          }
+          const url = new URL(
+            "/v10/projects/" + projectId + "/promote/" + deploymentId,
+            "https://api.vercel.com",
+          );
+          url.searchParams.set("teamId", teamId);
+          const response = await fetch(url, {
+            method: "POST",
+            headers: {
+              authorization: "Bearer " + token,
+              "content-type": "application/json",
+            },
+            body: "{}",
+          });
+          if (!response.ok) {
+            throw new Error("Vercel promote failed: " + response.status);
+          }
+          '
       - name: Verify the production alias
         env:
           DEPLOYMENT_ID: ${{ steps.deploy.outputs.id }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           for _ in {1..12}; do
-            production_json="$(./.github/vercel-cli/node_modules/.bin/vercel inspect \
-              https://tidebreak-docs.vercel.app \
-              --scope "$VERCEL_SCOPE" \
-              --json 2>/dev/null || true)"
+            production_json="$(node --input-type=module -e '
+          const token = process.env.VERCEL_TOKEN;
+          const teamId = process.env.VERCEL_ORG_ID;
+          if (!token || !teamId) process.exit(1);
+          const url = new URL(
+            "/v13/deployments/tidebreak-docs.vercel.app",
+            "https://api.vercel.com",
+          );
+          url.searchParams.set("teamId", teamId);
+          const response = await fetch(url, {
+            headers: { authorization: "Bearer " + token },
+          });
+          if (!response.ok) process.exit(1);
+          const deployment = JSON.parse(await response.text());
+          process.stdout.write(JSON.stringify({
+            id: deployment.id,
+            readyState: deployment.readyState,
+          }));
+          ' || true)"
             if jq -e --arg id "$DEPLOYMENT_ID" \
               '.id == $id and .readyState == "READY"' \
               <<<"$production_json" >/dev/null \

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -158,7 +158,8 @@ automatic.
    search index, sitemap, assets, and canonical metadata, and only then
    promotes that immutable deployment to `tidebreak-docs.vercel.app`. The
    `docs-production` environment supplies the only required secret,
-   `VERCEL_TOKEN`; its project and organization identifiers are non-secret
+   `VERCEL_TOKEN`, a team access token. Publication calls that send the token
+   also send `teamId`. The project and organization identifiers are non-secret
    workflow constants. A failed build or smoke test leaves the previous docs
    deployment serving production.
 6. The workflow first checks whether that exact tag, commit, and

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -344,8 +344,8 @@ const mutations = [
     mutate: (source) =>
       editWorkflowJob(source, "publish_docs", (job) =>
         job.replace(
-          '            --scope "$VERCEL_SCOPE" \\\n            --json)',
-          '            --scope "$VERCEL_SCOPE" \\\n            --token "$VERCEL_TOKEN" \\\n            --json)',
+          '            --meta "releaseSha=$RELEASE_SHA" \\\n            --json)',
+          '            --meta "releaseSha=$RELEASE_SHA" \\\n            --token "$VERCEL_TOKEN" \\\n            --json)',
         ),
       ),
   },

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1186,7 +1186,9 @@ test("release documentation is built from the validated tag and promoted only af
   assert.match(publish, /\/docs\/quickstart\//);
   assert.match(publish, /\/docs\/search-index\.json/);
   assert.match(publish, /\/docs\/sitemap\.xml/);
-  assert.doesNotMatch(publish, /vercel (?:curl|promote|inspect)/);
+  assert.match(publish, /\.github\/vercel-cli\/node_modules\/\.bin\/vercel curl/);
+  assert.match(publish, /\.github\/vercel-cli\/node_modules\/\.bin\/vercel promote/);
+  assert.doesNotMatch(publish, /vercel inspect/);
 
   const deploy = publish.indexOf("Create an unaliased production deployment");
   const verify = publish.indexOf("Verify the transferred documentation");

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1168,12 +1168,25 @@ test("release documentation is built from the validated tag and promoted only af
   assert.match(publish, /jq -ce '\.deployment \/\/ \.'/);
   assert.match(publish, /deployment_url=.*jq -er \.url/);
   assert.match(publish, /deployment_id=.*jq -er \.id/);
-  assert.match(publish, /\.github\/vercel-cli\/node_modules\/\.bin\/vercel curl/);
+  assert.doesNotMatch(publish, /(?:^|\s)--scope(?:\s|$)/m);
+  assert.doesNotMatch(publish, /VERCEL_SCOPE/);
+  assert.match(publish, /url\.searchParams\.set\("teamId", teamId\)/);
+  assert.match(
+    publish,
+    /\/v10\/projects\/" \+ projectId \+ "\/promote\/" \+ deploymentId/,
+  );
+  assert.match(publish, /\/v13\/deployments\/tidebreak-docs\.vercel\.app/);
+  assert.match(
+    publish,
+    /JSON\.stringify\(\{\s*id: deployment\.id,\s*readyState: deployment\.readyState,\s*\}\)/,
+  );
+  assert.match(publish, /Vercel promote failed: " \+ response\.status/);
+  assert.doesNotMatch(publish, /\+ await response\.text\(\)/);
   assert.doesNotMatch(publish, /--token/);
   assert.match(publish, /\/docs\/quickstart\//);
   assert.match(publish, /\/docs\/search-index\.json/);
   assert.match(publish, /\/docs\/sitemap\.xml/);
-  assert.match(publish, /\.github\/vercel-cli\/node_modules\/\.bin\/vercel promote/);
+  assert.doesNotMatch(publish, /vercel (?:curl|promote|inspect)/);
 
   const deploy = publish.indexOf("Create an unaliased production deployment");
   const verify = publish.indexOf("Verify the transferred documentation");


### PR DESCRIPTION
## What changed

The v0.52.0 docs publish failed with `User not found. (404)` after
`docs-production` received a team access token. Vercel CLI 59 treats
`--scope` as a user lookup and `GET`s `/v2/user` without `teamId`. A
team token cannot answer that route.

This job now:

- deploys without `--scope`, using `.vercel/project.json` for the
  Brightwave Inc team id
- promotes and inspects through the Vercel REST API with `?teamId=`
- smoke-tests the staged site with public `curl`

The token stays in `VERCEL_TOKEN`. It is never passed as `--token` and
never interpolated into process argv.

## Validation

- `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs`

Not verified: a live `docs-production` publish. Re-dispatch **Publish
desktop release** with tag `v0.52.0` after this merges. GitHub Release
and downloads for that tag already published.

## Compatibility and risk

Release-workflow only. The GitHub Release and download jobs are
unchanged. A failed docs publish still leaves the previous production
docs deployment in place because promotion happens after smoke tests.

Inspect writes only `id` and `readyState` to the log path. Promote
errors report the HTTP status, not the API body. Org and project ids
were already public workflow constants.

## Tracking

Unblocks the v0.52.0 docs deploy
(https://github.com/brightwave-inc/tidebreak/actions/runs/32208822298).