### PR TITLE
ci: retry the flaky headless and Windows lifecycle suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,11 +570,33 @@ jobs:
       # path-identity, and process-tree boundaries. A cross-target check cannot
       # prove those behaviors; run the harness suite and the server's code-mode
       # modules on NTFS with the Windows process APIs available.
+      # Process-tree teardown races PowerShell startup on a loaded runner.
+      # Three attempts cover that without dropping the Windows contract.
       - name: Code mode Windows lifecycle tests
+        shell: pwsh
         run: |
-          cargo test -p tidebreak-code-execution --locked
-          cargo test -p tidebreak-harness --locked
-          cargo test -p tidebreak-server --lib code:: --locked
+          $ErrorActionPreference = "Continue"
+          $PSNativeCommandUseErrorActionPreference = $false
+          $attempts = 3
+          $suites = @(
+            @("test", "-p", "tidebreak-code-execution", "--locked"),
+            @("test", "-p", "tidebreak-harness", "--locked"),
+            @("test", "-p", "tidebreak-server", "--lib", "code::", "--locked")
+          )
+          foreach ($suite in $suites) {
+            $passed = $false
+            for ($attempt = 1; $attempt -le $attempts; $attempt++) {
+              & cargo @suite
+              if ($LASTEXITCODE -eq 0) {
+                $passed = $true
+                break
+              }
+              Write-Host "cargo $($suite -join ' ') failed on attempt $attempt/$attempts"
+            }
+            if (-not $passed) {
+              exit 1
+            }
+          }
       # Boot-critical persistence, proven on the OS that ships it: the desktop
       # profile's SQLite open/migrate lifecycle (tidebreak-server's
       # desktop_schema module, including the Windows MoveFileExW marker swap)
@@ -630,8 +652,20 @@ jobs:
       - name: Fetch the complete workspace lockfile
         if: ${{ github.ref == 'refs/heads/main' }}
         run: cargo fetch --locked
+      # Linux ETXTBSY still hits a freshly written fake harness binary on a
+      # loaded runner. Three attempts cover that without dropping the contract.
       - name: headless tests
-        run: cargo test --workspace --exclude tidebreak-desktop --locked
+        run: |
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if cargo test --workspace --exclude tidebreak-desktop --locked; then
+              exit 0
+            fi
+            echo "headless tests failed on attempt ${attempt}/${attempts}" >&2
+            if [[ "$attempt" -eq "$attempts" ]]; then
+              exit 1
+            fi
+          done
 
   postgres:
     name: postgres state machine

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -406,6 +406,8 @@ test("PR lanes are scope-gated, never label-gated", () => {
     testJob,
     /cargo test --workspace --exclude tidebreak-desktop --locked/,
   );
+  assert.match(testJob, /attempts=3/);
+  assert.match(testJob, /headless tests failed on attempt/);
   assert.doesNotMatch(ci, /^  parsers:$/m);
   assert.doesNotMatch(ci, /outputs\.parsers|echo "parsers=/);
   assert.match(changes, /\*\.md\|docs\/\*\|assets\/\*\|\.githooks\/\*/);
@@ -496,6 +498,9 @@ test("native Windows CI is an explicit PR opt-in with a main backstop", () => {
     windows,
     /uses: mozilla-actions\/sccache-action@[0-9a-f]{40}/,
   );
+  assert.match(windows, /\$attempts = 3/);
+  assert.match(windows, /tidebreak-server", "--lib", "code::"/);
+  assert.match(windows, /failed on attempt/);
 });
 
 test("UI tests and production build each gate the UI lane", () => {


### PR DESCRIPTION
## Summary

Yes, retries help these two. They are startup races, not broken contracts.

Recent `main` CI failed on:

- `codex::session::tests::a_thread_that_ran_no_turn_is_not_a_resume_ref` with Linux `ETXTBSY` after writing the fake Codex binary ([run 32212746975](https://github.com/brightwave-inc/tidebreak/actions/runs/32212746975))
- `code::gh::windows_tests::quick_action_timeout_terminates_its_descendant` when PowerShell exited before publishing a descendant pid ([run 32208633478](https://github.com/brightwave-inc/tidebreak/actions/runs/32208633478))

#2230 already widened the Windows wait. The next push still flaked. This keeps both suites and retries each command three times.

## Validation

- `node --test scripts/workflow-security.test.mjs scripts/*.test.mjs`
- `git diff --check`