### PR TITLE
feat(desktop): add selective icon color

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AgentsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentsPanel.tsx
@@ -55,7 +55,7 @@ export function AgentsPanel({
         </div>
       ) : (
         <div className="flex flex-col items-center gap-2 p-8 text-center">
-          <Bot className="size-6 text-muted-foreground" aria-hidden="true" />
+          <Bot className="text-icon-violet size-6" aria-hidden="true" />
           <p className="text-sm font-medium">No background agents yet</p>
           <p className="text-sm text-muted-foreground">
             Ask for something to be worked on in the background and its agent

--- a/crates/tidebreak-desktop/ui/src/AppCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppCard.tsx
@@ -37,8 +37,8 @@ function AppCard({ entry }: { entry: ResultEntry }) {
   const appId = entry.targetId;
   return (
     <div className="bg-background flex max-w-full min-w-0 items-center gap-3 rounded-lg border px-4 py-3 text-left shadow-sm">
-      <span className="bg-muted rounded-md p-2" aria-hidden="true">
-        <LayoutGrid className="size-5" />
+      <span className="grid size-9 shrink-0 place-items-center" aria-hidden="true">
+        <LayoutGrid className="text-icon-blue size-5" />
       </span>
       <span className="flex min-w-0 flex-col">
         <span className="truncate text-sm font-semibold">{entry.label}</span>

--- a/crates/tidebreak-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -194,7 +194,7 @@ function BackgroundAgentDetail({
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="shrink-0 px-4 pt-4">
         <div className="flex items-start gap-2.5">
-          <div className="grid size-7 shrink-0 place-items-center rounded-lg border bg-muted text-muted-foreground">
+          <div className="text-icon-violet grid size-7 shrink-0 place-items-center">
             <Bot className="size-4" aria-hidden="true" />
           </div>
           <div className="min-w-0 flex-1">

--- a/crates/tidebreak-desktop/ui/src/FoldersView.tsx
+++ b/crates/tidebreak-desktop/ui/src/FoldersView.tsx
@@ -266,7 +266,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
         {nothingToShow && !error ? (
           <Empty>
             <EmptyHeader>
-              <EmptyMedia variant="icon">
+              <EmptyMedia variant="icon" className="text-icon-amber">
                 <FolderOpenIcon />
               </EmptyMedia>
               <EmptyTitle>No folders connected</EmptyTitle>

--- a/crates/tidebreak-desktop/ui/src/InboxView.tsx
+++ b/crates/tidebreak-desktop/ui/src/InboxView.tsx
@@ -23,32 +23,37 @@ import { useInbox } from "./Inbox";
 /** How each kind reads, and what it is answered by. */
 const KIND_PRESENTATION: Record<
   InboxItemKind,
-  { label: string; description: string; icon: LucideIcon }
+  { label: string; description: string; icon: LucideIcon; iconClass: string }
 > = {
   tool_approval: {
     label: "Approval",
     description: "An action is waiting for your decision.",
     icon: ShieldQuestion,
+    iconClass: "text-icon-rose",
   },
   question: {
     label: "Question",
     description: "The assistant asked you something before continuing.",
     icon: MessageCircleQuestion,
+    iconClass: "text-icon-cyan",
   },
   plan_review: {
     label: "Plan review",
     description: "A plan is waiting for you to accept or send back.",
     icon: ListChecks,
+    iconClass: "text-icon-violet",
   },
   folder_access: {
     label: "Folder access",
     description: "A folder needs connecting before the work can go on.",
     icon: FolderOpen,
+    iconClass: "text-icon-amber",
   },
   output_writeback: {
     label: "Save to folder",
     description: "A file is waiting for you to confirm the write.",
     icon: Save,
+    iconClass: "text-icon-green",
   },
 };
 
@@ -70,7 +75,7 @@ export function InboxView() {
     return (
       <Empty className="h-full">
         <EmptyHeader>
-          <EmptyMedia variant="icon">
+          <EmptyMedia variant="icon" className="text-success">
             <CircleCheck aria-hidden="true" />
           </EmptyMedia>
           <EmptyTitle>{loaded ? "Nothing is waiting" : "Loading…"}</EmptyTitle>
@@ -118,8 +123,8 @@ function InboxRow({ item, onOpen }: { item: InboxItem; onOpen: () => void }) {
       onClick={onOpen}
       className="hover:bg-muted flex w-full items-center gap-3 rounded-lg border p-3 text-left"
     >
-      <span className="bg-muted text-foreground flex size-8 shrink-0 items-center justify-center rounded-md">
-        <Icon aria-hidden="true" className="size-4" />
+      <span className="flex size-8 shrink-0 items-center justify-center">
+        <Icon aria-hidden="true" className={`${presentation.iconClass} size-5`} />
       </span>
       <span className="flex min-w-0 flex-col">
         <span className="flex min-w-0 items-center gap-2">

--- a/crates/tidebreak-desktop/ui/src/OutputCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/OutputCard.tsx
@@ -67,7 +67,7 @@ function OpenOutputCard({
 function OutputCardBody({ entry }: { entry: ResultEntry }) {
   return (
     <>
-      <span className="bg-muted rounded-md p-2" aria-hidden="true">
+      <span className="grid size-9 shrink-0 place-items-center" aria-hidden="true">
         <DocumentIcon mediaType={entry.mediaType} className="size-5" />
       </span>
       <span className="flex min-w-0 flex-col">

--- a/crates/tidebreak-desktop/ui/src/ToolIcon.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolIcon.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 
 import { isRendererToolName, type RendererToolName } from "./api";
+import { cn } from "./lib/utils";
 
 /**
  * The icon for a tool, derived only from its allowlisted renderer name.
@@ -67,6 +68,39 @@ const TOOL_ICONS: Record<RendererToolName, LucideIcon> = {
   other: Wrench,
 };
 
+/**
+ * Capability color is categorical, not status. Keep routine reads, lists,
+ * plans, and commands neutral; reserve color for the smaller set of actions
+ * where the capability boundary itself is useful to notice at a glance.
+ */
+const TOOL_ICON_TONES: Record<RendererToolName, string> = {
+  search: "text-icon-cyan",
+  list_documents: "text-muted-foreground",
+  read_document: "text-muted-foreground",
+  read_tool_result: "text-muted-foreground",
+  web_search: "text-icon-cyan",
+  web_extract: "text-icon-cyan",
+  read_delegated_file: "text-muted-foreground",
+  read_file: "text-muted-foreground",
+  list_dir: "text-muted-foreground",
+  write_file: "text-icon-green",
+  write_output_to_connected_folder: "text-icon-green",
+  request_folder_access: "text-icon-amber",
+  connect_folder: "text-icon-amber",
+  list_connected_folders: "text-muted-foreground",
+  list_folder: "text-muted-foreground",
+  read_connected_file: "text-muted-foreground",
+  import_connected_file: "text-icon-green",
+  ask_user_questions: "text-icon-rose",
+  exit_plan_mode: "text-muted-foreground",
+  update_task_plan: "text-muted-foreground",
+  spawn_sandbox_agent: "text-icon-violet",
+  wait_for_agents: "text-muted-foreground",
+  exec: "text-muted-foreground",
+  create_app: "text-icon-blue",
+  other: "text-muted-foreground",
+};
+
 export function ToolIcon({
   name,
   className,
@@ -74,6 +108,7 @@ export function ToolIcon({
   name: string;
   className?: string;
 }) {
-  const Icon = isRendererToolName(name) ? TOOL_ICONS[name] : TOOL_ICONS.other;
-  return <Icon className={className} />;
+  const safeName = isRendererToolName(name) ? name : "other";
+  const Icon = TOOL_ICONS[safeName];
+  return <Icon className={cn(TOOL_ICON_TONES[safeName], className)} />;
 }

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
@@ -37,6 +37,7 @@ export type StarterPromptOptions = {
 
 type StarterPrompt = {
   icon: typeof Sparkles;
+  iconClass: string;
   label: string;
   description: string;
   prompt: string;
@@ -53,6 +54,7 @@ type StarterPrompt = {
 const STARTER_PROMPTS: StarterPrompt[] = [
   {
     icon: Globe,
+    iconClass: "text-icon-cyan",
     label: "Brief this week's AI news",
     description: "Search the web, then write a sourced briefing.",
     prompt:
@@ -61,6 +63,7 @@ const STARTER_PROMPTS: StarterPrompt[] = [
   },
   {
     icon: Scale,
+    iconClass: "text-icon-amber",
     label: "Compare two public products",
     description: "Search, tabulate, and recommend with citations.",
     prompt:
@@ -69,6 +72,7 @@ const STARTER_PROMPTS: StarterPrompt[] = [
   },
   {
     icon: AppWindow,
+    iconClass: "text-icon-blue",
     label: "Build a local planner",
     description: "Create a small app in this workspace.",
     prompt:
@@ -76,6 +80,7 @@ const STARTER_PROMPTS: StarterPrompt[] = [
   },
   {
     icon: GitBranch,
+    iconClass: "text-icon-violet",
     label: "Research in parallel",
     description: "Split a briefing across background tasks.",
     prompt:
@@ -97,7 +102,7 @@ export function promptTitle(name: string): string {
 }
 
 const CARD_CLASS =
-  "flex items-center gap-2.5 rounded-[10px] border border-border bg-background px-3.5 py-2.5 text-[0.85rem] font-medium text-left text-foreground transition-[background-color,border-color] duration-[120ms] ease-in-out hover:border-[color-mix(in_srgb,var(--ink)_22%,var(--line))] hover:bg-accent [&_svg]:flex-none [&_svg]:text-muted-foreground [&:hover_svg]:text-foreground";
+  "flex items-center gap-2.5 rounded-[10px] border border-border bg-background px-3.5 py-2.5 text-[0.85rem] font-medium text-left text-foreground transition-[background-color,border-color] duration-[120ms] ease-in-out hover:border-[color-mix(in_srgb,var(--ink)_22%,var(--line))] hover:bg-accent [&_svg]:flex-none";
 
 export function WelcomeState({
   onSelectPrompt,
@@ -210,7 +215,7 @@ export function WelcomeState({
               className={CARD_CLASS}
               onClick={() => insertLibraryPrompt(prompt.name)}
             >
-              <Sparkles size={16} />
+              <Sparkles size={16} className="text-muted-foreground" />
               <span className="min-w-0">
                 <span className="block">{promptTitle(prompt.name)}</span>
                 {prompt.description && (
@@ -226,7 +231,14 @@ export function WelcomeState({
       {onSelectPrompt && libraryPrompts.length === 0 && (
         <div className="welcome-prompts" data-first-task-target="starters">
           {STARTER_PROMPTS.map(
-            ({ icon: Icon, label, description, prompt, enableInternet }) => (
+            ({
+              icon: Icon,
+              iconClass,
+              label,
+              description,
+              prompt,
+              enableInternet,
+            }) => (
               <button
                 key={label}
                 type="button"
@@ -238,7 +250,7 @@ export function WelcomeState({
                   )
                 }
               >
-                <Icon size={16} />
+                <Icon size={16} className={iconClass} />
                 <span className="min-w-0">
                   <span className="block">{label}</span>
                   <span className="block text-[0.78rem] font-normal text-muted-foreground">

--- a/crates/tidebreak-desktop/ui/src/apps/AppConsentSheet.tsx
+++ b/crates/tidebreak-desktop/ui/src/apps/AppConsentSheet.tsx
@@ -92,7 +92,10 @@ export function AppConsentSheet({
                 </span>
                 {binding.granted && (
                   <span className="text-muted-foreground flex items-center gap-1 text-xs">
-                    <ShieldCheck className="size-3" aria-hidden="true" />
+                    <ShieldCheck
+                      className="text-success size-3"
+                      aria-hidden="true"
+                    />
                     granted
                   </span>
                 )}
@@ -113,7 +116,10 @@ export function AppConsentSheet({
               {binding.access !== null && (
                 <div className="flex flex-col gap-0.5">
                   <span className="text-muted-foreground flex items-center gap-1.5 pl-1 text-xs">
-                    <FolderOpen className="size-3 shrink-0" aria-hidden="true" />
+                    <FolderOpen
+                      className="size-3 shrink-0"
+                      aria-hidden="true"
+                    />
                     Read files and folders
                   </span>
                   {binding.access === "read_write" && (
@@ -130,7 +136,10 @@ export function AppConsentSheet({
                     key={operationId}
                     className="text-muted-foreground flex items-center gap-1.5 pl-1 text-xs"
                   >
-                    <Globe className="size-3 shrink-0" aria-hidden="true" />
+                    <Globe
+                      className="size-3 shrink-0"
+                      aria-hidden="true"
+                    />
                     <span className="truncate font-mono">{operationId}</span>
                   </li>
                 ))}

--- a/crates/tidebreak-desktop/ui/src/apps/AppsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/apps/AppsView.tsx
@@ -108,7 +108,7 @@ export function AppsView({
         ) : !hasApps ? (
           <Empty>
             <EmptyHeader>
-              <EmptyMedia variant="icon">
+              <EmptyMedia variant="icon" className="text-icon-blue">
                 <LayoutGrid />
               </EmptyMedia>
               <EmptyTitle>No apps yet</EmptyTitle>
@@ -135,7 +135,10 @@ export function AppsView({
                   <span className="min-w-0 flex-1 truncate">{app.name}</span>
                   {app.granted && (
                     <Badge variant="outline" className="shrink-0 gap-1">
-                      <ShieldCheck className="size-3" aria-hidden="true" />
+                      <ShieldCheck
+                        className="text-success size-3"
+                        aria-hidden="true"
+                      />
                       Granted
                     </Badge>
                   )}

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -86,7 +86,7 @@ function CodeHomeBody() {
       {showLoading && (
         <Empty role="status">
           <EmptyHeader>
-            <EmptyMedia variant="icon">
+            <EmptyMedia variant="icon" className="text-muted-foreground">
               <Spinner aria-hidden="true" />
             </EmptyMedia>
             <EmptyTitle>Loading…</EmptyTitle>

--- a/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
@@ -32,12 +32,22 @@ export function CodeModeSwitch() {
           {
             value: "chat",
             label: "Chat",
-            icon: <MessageSquare className="size-3.5 shrink-0" aria-hidden />,
+            icon: (
+              <MessageSquare
+                className={`${value === "chat" ? "text-icon-blue" : ""} size-3.5 shrink-0`}
+                aria-hidden
+              />
+            ),
           },
           {
             value: "code",
             label: "Code",
-            icon: <FolderGit2 className="size-3.5 shrink-0" aria-hidden />,
+            icon: (
+              <FolderGit2
+                className={`${value === "code" ? "text-icon-violet" : ""} size-3.5 shrink-0`}
+                aria-hidden
+              />
+            ),
           },
         ]}
       />

--- a/crates/tidebreak-desktop/ui/src/components/ui/empty.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/empty.tsx
@@ -31,7 +31,7 @@ const emptyMediaVariants = cva(
     variants: {
       variant: {
         default: "bg-transparent",
-        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+        icon: "flex size-11 shrink-0 items-center justify-center text-muted-foreground [&_svg:not([class*='size-'])]:size-7",
       },
     },
     defaultVariants: { variant: "default" },

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputsView.tsx
@@ -224,7 +224,7 @@ export function OutputsView({
         ) : !hasOutputs ? (
           <Empty>
             <EmptyHeader>
-              <EmptyMedia variant="icon">
+              <EmptyMedia variant="icon" className="text-icon-green">
                 <FileOutputIcon />
               </EmptyMedia>
               <EmptyTitle>No outputs yet</EmptyTitle>

--- a/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
@@ -48,26 +48,27 @@ function panelTabFallbackLabel(panel: PanelContent): string {
   }
 }
 
-function PanelTabIcon({ panel }: { panel: PanelContent }) {
+function PanelTabIcon({ panel, active }: { panel: PanelContent; active: boolean }) {
   const className = "size-3.5 shrink-0";
+  const tone = (activeTone: string) => cn(className, active && activeTone);
   switch (panel.type) {
     case "document":
-      return <FileText className={className} />;
+      return <FileText className={tone("text-icon-blue")} />;
     case "outputs":
-      return <Package className={className} />;
+      return <Package className={tone("text-icon-green")} />;
     case "folders":
-      return <FolderOpen className={className} />;
+      return <FolderOpen className={tone("text-icon-amber")} />;
     case "permissions":
-      return <Shield className={className} />;
+      return <Shield className={tone("text-icon-green")} />;
     case "agents":
     case "agent":
-      return <Bot className={className} />;
+      return <Bot className={tone("text-icon-violet")} />;
     case "terminal":
-      return <SquareTerminal className={className} />;
+      return <SquareTerminal className={tone("text-icon-green")} />;
     case "file":
-      return <FileCode className={className} />;
+      return <FileCode className={tone("text-icon-blue")} />;
     case "diff":
-      return <FileDiff className={className} />;
+      return <FileDiff className={tone("text-icon-violet")} />;
   }
 }
 
@@ -122,7 +123,7 @@ export function PanelTabs({
                 active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
               )}
             >
-              <PanelTabIcon panel={panel} />
+              <PanelTabIcon panel={panel} active={active} />
               <span className="max-w-40 truncate">{label}</span>
             </button>
             <button

--- a/crates/tidebreak-desktop/ui/src/plugins/PluginGlyph.tsx
+++ b/crates/tidebreak-desktop/ui/src/plugins/PluginGlyph.tsx
@@ -6,43 +6,28 @@ import type { PluginCategory } from "@/api";
 import { cn } from "@/lib/utils";
 
 /**
- * The library's signature mark: a small instrument tile.
+ * The library's signature mark: a compact, colored instrument mark.
  *
  * A plugin is something you pick up and hand to the agent — the glyph has to
- * read as a tool at a glance, not as a muted list bullet. Known bundles get a
- * fixed wash and a purpose-built mark; everything else falls back to its
- * category so a user-written bundle still has a face.
+ * read as a tool at a glance, not as a muted list bullet. Color belongs to the
+ * mark itself rather than a colored tile behind it; known bundles get a fixed
+ * tone and purpose-built mark, while user bundles fall back to their category.
  */
 
 type GlyphTone = {
-  /** Soft wash behind the mark. */
-  wash: string;
   /** Ink for the lucide / path mark. */
   ink: string;
 };
 
 const CATEGORY_TONES: Record<PluginCategory, GlyphTone> = {
-  documents: {
-    wash: "bg-sky-100 dark:bg-sky-400/15",
-    ink: "text-sky-700 dark:text-sky-300",
-  },
-  data: {
-    wash: "bg-emerald-100 dark:bg-emerald-400/15",
-    ink: "text-emerald-700 dark:text-emerald-300",
-  },
-  visualization: {
-    wash: "bg-violet-100 dark:bg-violet-400/15",
-    ink: "text-violet-700 dark:text-violet-300",
-  },
-  other: {
-    wash: "bg-zinc-100 dark:bg-zinc-400/12",
-    ink: "text-zinc-600 dark:text-zinc-300",
-  },
+  documents: { ink: "text-icon-blue" },
+  data: { ink: "text-icon-green" },
+  visualization: { ink: "text-icon-violet" },
+  other: { ink: "text-icon-cyan" },
 };
 
 const SKILL_TONE: GlyphTone = {
-  wash: "bg-amber-100 dark:bg-amber-400/15",
-  ink: "text-amber-700 dark:text-amber-300",
+  ink: "text-icon-amber",
 };
 
 const CATEGORY_FALLBACK: Record<PluginCategory, LucideIcon> = {
@@ -86,8 +71,7 @@ export function PluginGlyph({
   return (
     <span
       className={cn(
-        "grid shrink-0 place-items-center ring-1 ring-inset ring-black/5 dark:ring-white/8",
-        tone.wash,
+        "grid shrink-0 place-items-center",
         tone.ink,
         SIZE_CLASS[size],
         className,
@@ -110,8 +94,7 @@ export function SkillGlyph({
   return (
     <span
       className={cn(
-        "grid shrink-0 place-items-center ring-1 ring-inset ring-black/5 dark:ring-white/8",
-        SKILL_TONE.wash,
+        "grid shrink-0 place-items-center",
         SKILL_TONE.ink,
         SIZE_CLASS[size],
         className,

--- a/crates/tidebreak-desktop/ui/src/plugins/PluginsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/plugins/PluginsView.tsx
@@ -122,7 +122,7 @@ export function PluginsView({
           {isEmpty && (
             <Empty>
               <EmptyHeader>
-                <EmptyMedia variant="icon">
+                <EmptyMedia variant="icon" className="text-icon-violet">
                   <Puzzle />
                 </EmptyMedia>
                 <EmptyTitle>No plugins installed</EmptyTitle>

--- a/crates/tidebreak-desktop/ui/src/plugins/SkillDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/plugins/SkillDialog.tsx
@@ -73,7 +73,7 @@ export function SkillDialog({
           </div>
 
           <div className="flex flex-col gap-2 pr-28">
-            <div className="grid size-10 place-items-center rounded-lg border bg-muted text-muted-foreground">
+            <div className="text-icon-amber grid size-10 place-items-center">
               <Sparkles className="size-5" aria-hidden="true" />
             </div>
             <DialogTitle className="flex items-baseline gap-2">

--- a/crates/tidebreak-desktop/ui/src/settings/sections.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.tsx
@@ -195,7 +195,8 @@ export type SettingsSectionDef = {
   /** The path segment under `/settings`, and its address. */
   path: string;
   label: string;
-  icon: ComponentType<{ size?: number }>;
+  icon: ComponentType<{ size?: number; className?: string }>;
+  iconClass: string;
   Component: FunctionComponent;
   /** Search params this section addresses with, validated at the route so an
    * unknown value never reaches the panel. */
@@ -221,6 +222,7 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     path: "providers",
     label: "Providers",
     icon: KeyRound,
+    iconClass: "text-icon-amber",
     Component: ProvidersSection,
     validateSearch: providersSearch,
     managedHidden: true,
@@ -229,32 +231,60 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     path: "gateway",
     label: "Model Gateway",
     icon: Waypoints,
+    iconClass: "text-icon-cyan",
     Component: GatewaySection,
     unmanagedHidden: true,
   },
-  { path: "models", label: "Models", icon: Cpu, Component: ModelsSection },
+  {
+    path: "models",
+    label: "Models",
+    icon: Cpu,
+    iconClass: "text-icon-violet",
+    Component: ModelsSection,
+  },
   // Next to Models rather than in a section of its own: every number here is a
   // fraction of the selected model's context window, so a reader who has just
   // changed models is in the right place to reconsider them.
-  { path: "context", label: "Context", icon: Gauge, Component: CompactionSection },
-  { path: "agents", label: "Agents", icon: Bot, Component: AgentsSection },
+  {
+    path: "context",
+    label: "Context",
+    icon: Gauge,
+    iconClass: "text-icon-blue",
+    Component: CompactionSection,
+  },
+  {
+    path: "agents",
+    label: "Agents",
+    icon: Bot,
+    iconClass: "text-icon-violet",
+    Component: AgentsSection,
+  },
   {
     path: "voice-transcription",
     label: "Voice input",
     icon: Mic,
+    iconClass: "text-icon-rose",
     Component: VoiceTranscriptionSection,
   },
-  { path: "web-search", label: "Web search", icon: Globe, Component: WebSearchSection },
+  {
+    path: "web-search",
+    label: "Web search",
+    icon: Globe,
+    iconClass: "text-icon-cyan",
+    Component: WebSearchSection,
+  },
   {
     path: "code-execution",
     label: "Code execution",
     icon: SquareTerminal,
+    iconClass: "text-icon-green",
     Component: CodeExecutionSection,
   },
   {
     path: "coding-harnesses",
     label: "Coding harnesses",
     icon: Terminal,
+    iconClass: "text-icon-amber",
     Component: CodingHarnessesSection,
     codeModeOnly: true,
   },
@@ -262,22 +292,37 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     path: "connected-apps",
     label: "Connected apps",
     icon: Blocks,
+    iconClass: "text-icon-blue",
     Component: ConnectedAppsSection,
   },
   {
     path: "permissions",
     label: "Permissions",
     icon: ShieldCheck,
+    iconClass: "text-icon-green",
     Component: PermissionsSection,
   },
-  { path: "appearance", label: "Appearance", icon: Palette, Component: AppearanceSection },
+  {
+    path: "appearance",
+    label: "Appearance",
+    icon: Palette,
+    iconClass: "text-icon-rose",
+    Component: AppearanceSection,
+  },
   {
     path: "experimental",
     label: "Experimental",
     icon: FlaskConical,
+    iconClass: "text-icon-violet",
     Component: ExperimentalSection,
   },
-  { path: "updates", label: "Updates", icon: RefreshCw, Component: UpdatesSection },
+  {
+    path: "updates",
+    label: "Updates",
+    icon: RefreshCw,
+    iconClass: "text-icon-green",
+    Component: UpdatesSection,
+  },
 ];
 
 /**

--- a/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/AppSidebar.tsx
@@ -31,6 +31,9 @@ export function AppSidebar({ chat }: { chat?: Chat }) {
   const chatsError = useChatListStore((state) => state.chatsError);
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const codeModeEnabled = useExperimentalFlags((state) => state.codeModeEnabled);
+  const appsActive = pathname === "/apps" || pathname.startsWith("/apps/");
+  const pluginsActive =
+    pathname === "/plugins" || pathname.startsWith("/plugins/");
 
   return (
     <SidebarFrame>
@@ -43,14 +46,20 @@ export function AppSidebar({ chat }: { chat?: Chat }) {
             — so each is a full page of its own rather than a tab beside one. */}
         <RouteButton
           label="Apps"
-          icon={<LayoutGrid />}
-          active={pathname === "/apps" || pathname.startsWith("/apps/")}
+          icon={
+            <LayoutGrid className={appsActive ? "text-icon-blue" : undefined} />
+          }
+          active={appsActive}
           onClick={() => void navigate({ to: "/apps" })}
         />
         <RouteButton
           label="Plugins"
-          icon={<Puzzle />}
-          active={pathname === "/plugins" || pathname.startsWith("/plugins/")}
+          icon={
+            <Puzzle
+              className={pluginsActive ? "text-icon-violet" : undefined}
+            />
+          }
+          active={pluginsActive}
           onClick={() => void navigate({ to: "/plugins" })}
         />
       </div>

--- a/crates/tidebreak-desktop/ui/src/sidebar/InboxButton.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/InboxButton.tsx
@@ -26,7 +26,7 @@ export function InboxButton() {
       className="data-[active]:bg-muted"
       onClick={() => void navigate({ to: "/inbox" })}
     >
-      <Inbox />
+      <Inbox className={active ? "text-icon-amber" : undefined} />
       <span>Inbox</span>
       {waiting > 0 && (
         <Badge

--- a/crates/tidebreak-desktop/ui/src/sidebar/SettingsSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SettingsSidebar.tsx
@@ -45,7 +45,7 @@ export function SettingsSidebar({ onBack }: { onBack: () => void }) {
               // how many sections were browsed.
               onClick={() => void navigate({ to, replace: true })}
             >
-              <Icon />
+              <Icon className={active ? section.iconClass : undefined} />
               <span>{section.label}</span>
             </SidebarButton>
           );

--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
@@ -94,7 +94,7 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
       <SidebarFooter className="flex flex-col gap-0.5">
         {updateReady && (
           <SidebarButton onClick={restartForUpdate}>
-            <RotateCw />
+            <RotateCw className="text-success" />
             <span>Restart to update</span>
             {updateState.version && (
               <span className="ml-auto text-xs text-muted-foreground">
@@ -107,7 +107,13 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
           aria-label={`Theme: ${themeMode}. Click to change.`}
           onClick={cycleTheme}
         >
-          {themeMode === "light" ? <Sun /> : themeMode === "dark" ? <Moon /> : <Monitor />}
+          {themeMode === "light" ? (
+            <Sun />
+          ) : themeMode === "dark" ? (
+            <Moon />
+          ) : (
+            <Monitor />
+          )}
           <span>Theme</span>
         </SidebarButton>
         <SidebarButton

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -78,6 +78,16 @@
   --citation-mark: var(--color-neutral-300);
   --citation-mark-active-ink: var(--foreground);
 
+  /* Categorical icon ink. The cool core follows the marketing site's indigo
+     and ice-blue palette; the warmer accents stay quieter so the system feels
+     branded rather than rainbow. Color lives on the glyph, never a tile. */
+  --icon-blue: oklch(0.555 0.232 263);
+  --icon-cyan: oklch(0.56 0.14 230);
+  --icon-violet: oklch(0.53 0.19 285);
+  --icon-amber: oklch(0.61 0.12 84);
+  --icon-rose: oklch(0.57 0.14 28);
+  --icon-green: oklch(0.53 0.12 162);
+
   --radius: 0.5rem;
 
   /* The app chrome is the page background; every content region is a card
@@ -181,6 +191,13 @@
   --citation-mark: var(--color-neutral-700);
   --citation-mark-active-ink: var(--background);
 
+  --icon-blue: oklch(0.75 0.17 263);
+  --icon-cyan: oklch(0.76 0.12 230);
+  --icon-violet: oklch(0.74 0.15 285);
+  --icon-amber: oklch(0.79 0.11 84);
+  --icon-rose: oklch(0.73 0.13 28);
+  --icon-green: oklch(0.74 0.11 162);
+
   --shadow-sm: 0 0px 8px 0px oklch(0 0 0 / 0.24);
   --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.28);
   --shadow-lg: 0 0px 12px 0px oklch(0 0 0 / 0.32);
@@ -245,6 +262,13 @@
   --color-info-border: var(--info-border);
 
   --color-brand-accent: var(--brand-accent);
+
+  --color-icon-blue: var(--icon-blue);
+  --color-icon-cyan: var(--icon-cyan);
+  --color-icon-violet: var(--icon-violet);
+  --color-icon-amber: var(--icon-amber);
+  --color-icon-rose: var(--icon-rose);
+  --color-icon-green: var(--icon-green);
 
   --font-sans: var(--sans);
   --font-mono: var(--mono);


### PR DESCRIPTION
## Summary

- add a Tidebreak-specific categorical icon palette for light and dark themes, anchored in the marketing site's indigo and cool blue family
- move color onto icon glyphs instead of colored background tiles across apps, plugins, skills, outputs, agents, inbox items, and empty states
- apply color selectively: active navigation and panel tabs, meaningful content-type marks, and notable tool boundaries retain color while repeated rows and utility chrome remain neutral
- keep semantic success and warning treatment separate from categorical capability color

## User impact

The desktop interface gains faster visual recognition and more personality without turning every icon into a competing accent. Neutral surfaces and utility controls remain quiet, while important destinations and content types get restrained color.

## Compatibility and risk

Visual-only React and theme-token changes. No API, persistence, routing, permission, or data-model changes. Existing interactions and accessibility semantics are unchanged.

## Validation

- `pnpm exec vitest run src/ToolIcon.test.tsx src/WelcomeState.test.tsx src/WelcomeState.dom.test.tsx src/FoldersView.test.tsx src/McpAppCard.dom.test.tsx src/DomainFavicon.dom.test.tsx` — 24 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`

The production build retains the repository's existing large-chunk warnings.
