### PR TITLE
fix(desktop): synchronize document viewer themes

### DIFF
--- a/crates/tidebreak-desktop/ui/src/document/DocxViewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocxViewer.dom.test.tsx
@@ -2,6 +2,7 @@
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
+import { setThemeMode } from "@/theme";
 import { clearFileDownloadCache, type FileBytesSource } from "./useFileDownload";
 
 const docxMocks = vi.hoisted(() => ({
@@ -32,15 +33,19 @@ function source(id = "doc-1"): FileBytesSource {
 }
 
 beforeEach(() => {
+  setThemeMode("light");
   clearFileDownloadCache();
   docxMocks.props = null;
   URL.createObjectURL = vi.fn(() => "blob:docx-preview");
   URL.revokeObjectURL = vi.fn();
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  setThemeMode("system");
+});
 
-it("configures Extend as a fixed-light, viewer-only DOCX surface", async () => {
+it("keeps the viewer read-only and follows live app theme changes", async () => {
   const { container, unmount } = render(<DocxViewer source={source()} />);
 
   await waitFor(() =>
@@ -53,7 +58,13 @@ it("configures Extend as a fixed-light, viewer-only DOCX surface", async () => {
     showUpload: false,
     src: "blob:docx-preview",
   });
-  expect(container.firstElementChild).toHaveClass("bg-white");
+  expect(container.firstElementChild).toHaveClass("bg-background");
+  expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+
+  setThemeMode("dark");
+  await waitFor(() =>
+    expect(docxMocks.props).toMatchObject({ isDark: true }),
+  );
   expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
 
   unmount();

--- a/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
@@ -4,12 +4,13 @@ import { useRef } from "react";
 import { DocxViewerPreview } from "@/components/extend/docx-viewer";
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
 import {
-  LIGHT_DOCUMENT_SURFACE,
+  DOCUMENT_VIEWER_SURFACE,
   useSecureViewerLinks,
 } from "@/document/extendViewerSurface";
 import { useLocalDocumentUrl } from "@/document/useLocalDocumentUrl";
 import type { FileBytesSource } from "@/document/useFileDownload";
 import { cn } from "@/lib/utils";
+import { useTheme } from "@/theme";
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   source: FileBytesSource;
@@ -25,6 +26,7 @@ export default function DocxViewer({
   className,
   ...restProps
 }: Props) {
+  const { resolved: resolvedTheme } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const file = useLocalDocumentUrl(source);
   useSecureViewerLinks(containerRef);
@@ -35,7 +37,7 @@ export default function DocxViewer({
       className={cn(
         "relative flex min-h-0 flex-col overflow-hidden",
         className,
-        LIGHT_DOCUMENT_SURFACE,
+        DOCUMENT_VIEWER_SURFACE,
       )}
       {...restProps}
     >
@@ -48,12 +50,12 @@ export default function DocxViewer({
           <ViewerMessage>Loading document…</ViewerMessage>
         )
       ) : (
-        <div className="min-h-0 grow overflow-hidden rounded-md border bg-white shadow-xs">
+        <div className="min-h-0 grow overflow-hidden rounded-md border bg-background shadow-xs">
           <DocxViewerPreview
             className="h-full min-h-0"
             defaultZoom={50}
             fileName="document.docx"
-            isDark={false}
+            isDark={resolvedTheme === "dark"}
             onIsDarkChange={() => undefined}
             showDownload={false}
             showToolbar

--- a/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.dom.test.tsx
@@ -4,6 +4,8 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { setThemeMode } from "@/theme";
+
 const xlsxMocks = vi.hoisted(() => {
   const controller = {
     activeCellAddress: "B7",
@@ -77,12 +79,16 @@ const source: FileBytesSource = {
 
 describe("NativeSpreadsheetViewer", () => {
   beforeEach(() => {
+    setThemeMode("light");
     xlsxMocks.useXlsxViewerController.mockClear();
     xlsxMocks.xlsxViewer.mockClear();
     xlsxMocks.controller.selectRange.mockClear();
     xlsxMocks.controller.setActiveTabIndex.mockClear();
   });
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    setThemeMode("system");
+  });
 
   it("preserves cached Excel results and exposes a read-only canvas", async () => {
     render(
@@ -142,6 +148,13 @@ describe("NativeSpreadsheetViewer", () => {
     expect(
       viewerProps.getCellStyle({ ...context, value: "Launch thesis" }),
     ).toBeUndefined();
+
+    setThemeMode("dark");
+    await waitFor(() =>
+      expect(xlsxMocks.xlsxViewer).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isDark: true }),
+      ),
+    );
   });
 
   it("selects a cited A1 range on the cited sheet", async () => {

--- a/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.tsx
@@ -42,6 +42,7 @@ import {
   type FileBytesSource,
 } from "@/document/useFileDownload";
 import { cn } from "@/lib/utils";
+import { useTheme } from "@/theme";
 
 // Make the parser asset an application resource. The viewer's default loader
 // can discover its package-relative WASM in a browser build, but an explicit
@@ -56,8 +57,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 }
 
 const MAX_WORKBOOK_BYTES = 16 * 1024 * 1024;
-const LIGHT_WORKBOOK_SURFACE =
-  "bg-white text-zinc-950 [color-scheme:light] [--accent:#f4f4f5] [--accent-foreground:#18181b] [--background:#fff] [--border:#e4e4e7] [--foreground:#09090b] [--muted:#f4f4f5] [--muted-foreground:#71717a]";
+const WORKBOOK_SURFACE = "bg-background text-foreground";
 const LARGE_MERGED_VALUE_PATTERN =
   /^(?:[$€£¥]\s*)?\(?-?\d[\d,\s]*(?:\.\d+)?%?\)?$/;
 
@@ -74,12 +74,13 @@ export default function NativeSpreadsheetViewer({
   className,
   ...restProps
 }: Props) {
+  const { resolved: resolvedTheme } = useTheme();
   const fileDownload = useFileDownload(source, { parseAs: "arrayBuffer" });
 
   if (fileDownload.isLoading) {
     return (
       <div
-        className={cn(LIGHT_WORKBOOK_SURFACE, "relative min-h-0", className)}
+        className={cn(WORKBOOK_SURFACE, "relative min-h-0", className)}
         {...restProps}
       >
         {fileDownload.progress ? (
@@ -94,7 +95,7 @@ export default function NativeSpreadsheetViewer({
   if (fileDownload.error || fileDownload.data === null) {
     return (
       <div
-        className={cn(LIGHT_WORKBOOK_SURFACE, "relative min-h-0", className)}
+        className={cn(WORKBOOK_SURFACE, "relative min-h-0", className)}
         {...restProps}
       >
         <ViewerMessage>This workbook could not be loaded.</ViewerMessage>
@@ -106,6 +107,7 @@ export default function NativeSpreadsheetViewer({
     <LoadedWorkbook
       key={source.cacheKey}
       data={fileDownload.data}
+      dark={resolvedTheme === "dark"}
       mediaType={mediaType}
       highlightRange={highlightRange}
       className={className}
@@ -116,12 +118,14 @@ export default function NativeSpreadsheetViewer({
 
 interface LoadedWorkbookProps extends HTMLAttributes<HTMLDivElement> {
   data: ArrayBuffer;
+  dark: boolean;
   mediaType: string;
   highlightRange?: SheetHighlightRange;
 }
 
 function LoadedWorkbook({
   data,
+  dark,
   mediaType,
   highlightRange,
   className,
@@ -132,7 +136,7 @@ function LoadedWorkbook({
   if (projection.error) {
     return (
       <div
-        className={cn(LIGHT_WORKBOOK_SURFACE, "relative min-h-0", className)}
+        className={cn(WORKBOOK_SURFACE, "relative min-h-0", className)}
         {...restProps}
       >
         <ViewerMessage>This workbook could not be prepared.</ViewerMessage>
@@ -143,7 +147,7 @@ function LoadedWorkbook({
   if (!projection.value) {
     return (
       <div
-        className={cn(LIGHT_WORKBOOK_SURFACE, "relative min-h-0", className)}
+        className={cn(WORKBOOK_SURFACE, "relative min-h-0", className)}
         {...restProps}
       >
         <ViewerMessage spinner>Preparing workbook…</ViewerMessage>
@@ -154,6 +158,7 @@ function LoadedWorkbook({
   return (
     <RenderedWorkbook
       data={projection.value.data}
+      dark={dark}
       conditionalStylesBySheet={projection.value.conditionalStylesBySheet}
       formulasBySheet={projection.value.formulasBySheet}
       mediaType={mediaType}
@@ -174,6 +179,7 @@ interface RenderedWorkbookProps extends LoadedWorkbookProps {
 
 function RenderedWorkbook({
   data,
+  dark,
   conditionalStylesBySheet,
   formulasBySheet,
   mediaType,
@@ -229,7 +235,7 @@ function RenderedWorkbook({
   return (
     <div
       className={cn(
-        LIGHT_WORKBOOK_SURFACE,
+        WORKBOOK_SURFACE,
         "min-h-0 overflow-hidden",
         className,
       )}
@@ -249,7 +255,7 @@ function RenderedWorkbook({
         )}
         experimentalCanvas
         getCellStyle={getCellStyle}
-        isDark={false}
+        isDark={dark}
         loadingState={
           <ViewerMessage spinner>Reading workbook…</ViewerMessage>
         }

--- a/crates/tidebreak-desktop/ui/src/document/PdfViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/PdfViewer.tsx
@@ -8,7 +8,7 @@ import {
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
 import { useRegisterPdfControls } from "@/document/PdfControlsContext";
 import {
-  LIGHT_DOCUMENT_SURFACE,
+  DOCUMENT_VIEWER_SURFACE,
   useSecureViewerLinks,
 } from "@/document/extendViewerSurface";
 import { useLocalDocumentUrl } from "@/document/useLocalDocumentUrl";
@@ -103,7 +103,7 @@ export function PdfViewer({
       className={className}
       {...restProps}
     >
-      <div className="min-h-0 grow overflow-hidden rounded-md border bg-white shadow-xs">
+      <div className="min-h-0 grow overflow-hidden rounded-md border bg-background shadow-xs">
         <ExtendPdfViewer
           ref={viewerRef}
           className="h-full min-h-0"
@@ -129,7 +129,7 @@ const ViewerShell = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
       className={cn(
         "relative flex min-h-0 flex-col overflow-hidden",
         className,
-        LIGHT_DOCUMENT_SURFACE,
+        DOCUMENT_VIEWER_SURFACE,
       )}
       {...props}
     />

--- a/crates/tidebreak-desktop/ui/src/document/PresentationViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/PresentationViewer.tsx
@@ -15,7 +15,7 @@ import { FileDownloadProgressIndicator } from "@/components/document/FileDownloa
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import {
-  LIGHT_DOCUMENT_SURFACE,
+  DOCUMENT_VIEWER_SURFACE,
   useSecureViewerLinks,
 } from "@/document/extendViewerSurface";
 import {
@@ -109,7 +109,7 @@ function DirectPresentationSurface({
       className={cn(
         "relative flex min-h-0 flex-col overflow-hidden",
         className,
-        LIGHT_DOCUMENT_SURFACE,
+        DOCUMENT_VIEWER_SURFACE,
       )}
     >
       {file.error ? (
@@ -128,7 +128,7 @@ function DirectPresentationSurface({
           </div>
         )
       ) : (
-        <div className="min-h-0 grow overflow-hidden rounded-md border bg-white shadow-xs">
+        <div className="min-h-0 grow overflow-hidden rounded-md border bg-background shadow-xs">
           <PptxViewerPreview
             className="h-full min-h-0"
             defaultThumbnailSidebarOpen

--- a/crates/tidebreak-desktop/ui/src/document/extendViewerSurface.ts
+++ b/crates/tidebreak-desktop/ui/src/document/extendViewerSurface.ts
@@ -4,12 +4,11 @@ import { useEffect } from "react";
 import { openExternal } from "@/host";
 
 /**
- * Office documents are authored against a paper-like light canvas. Keep the
- * embedded viewer controls on the same palette even when Tidebreak's app chrome
- * is dark; this also keeps DOCX and PPTX rendering independent of app theme.
+ * The viewer chrome follows Tidebreak's live palette. Individual pages and
+ * slides may still keep their authored paper/slide colors, but controls and
+ * the surrounding canvas should never require a reload after a theme change.
  */
-export const LIGHT_DOCUMENT_SURFACE =
-  "bg-white text-zinc-950 [color-scheme:light] [--accent:#f4f4f5] [--accent-foreground:#18181b] [--background:#fff] [--border:#e4e4e7] [--card:#fafafa] [--card-foreground:#18181b] [--destructive:#dc2626] [--destructive-foreground:#fff] [--foreground:#09090b] [--input:#e4e4e7] [--muted:#f4f4f5] [--muted-foreground:#71717a] [--popover:#fff] [--popover-foreground:#27272a] [--primary:#18181b] [--primary-foreground:#fafafa] [--ring:#a1a1aa] [--secondary:#f4f4f5] [--secondary-foreground:#52525b]";
+export const DOCUMENT_VIEWER_SURFACE = "bg-background text-foreground";
 
 /**
  * Document engines may materialize hyperlinks after their initial render. Keep


### PR DESCRIPTION
## What changed

- Make DOCX and spreadsheet viewers react to live dark/light theme changes.
- Refresh PDF and presentation viewer surfaces when the application theme changes.
- Centralize theme-aware viewer surface extension behavior.
- Add DOM coverage for switching themes without reloading the document manually.

## Why

The embedded document viewers captured theme state during initialization and did not consistently react when the application theme changed. Users had to refresh the document viewer before its colors matched the rest of Tidebreak.

## Impact

All supported document surfaces now follow the application theme immediately, keeping document inspection visually coherent while working in Code mode or elsewhere in the desktop app.

## Backwards compatibility

Document loading and rendering APIs are unchanged. The update only synchronizes existing viewer instances with the current theme.

## Safety and risk

Low risk. The change is isolated to document-viewer presentation and is covered by focused DOM tests plus the complete UI suite and production build.

## Validation

- UI tests — 188 files, 1,264 tests passed
- Production UI build passed
- `cargo fmt --check`
- `git diff --check`

This PR is independent and targets `main` directly.