### PR TITLE
fix(desktop): restore sidebar width on refresh

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -593,6 +593,20 @@ describe("app shell", () => {
     expect(window.localStorage.getItem("tidebreak.sidebar-collapsed")).toBe("true");
   });
 
+  it("publishes the restored sidebar width when the shell appears after boot", async () => {
+    hasNativeHost.mockReturnValue(true);
+    useUiStore.setState({ sidebarWidth: 216 });
+
+    await mountApp();
+    await screen.findByText("Welcome to Tidebreak");
+
+    const shell = document.querySelector<HTMLElement>(".app-shell");
+    expect(shell?.style.getPropertyValue("--sidebar-expanded-width")).toBe("216px");
+    expect(document.querySelector<HTMLElement>("[data-sidebar]")?.style.width).toBe(
+      "216px",
+    );
+  });
+
   it("unmounts the titlebar with the rail, and Cmd/Ctrl+B brings both back", async () => {
     // The leftover chrome only exists on the native host: the titlebar is
     // `position: absolute; width: var(--sidebar-expanded-width)`, and that

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { Outlet, useNavigate, useRouter } from "@tanstack/react-router";
 import { isTauri } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
@@ -44,7 +44,6 @@ import { Logomark } from "./Logomark";
 import { ManagedGate } from "./ManagedGate";
 import { resolvedRoleKey } from "./ModelSelection";
 import { SidebarExpandStrip } from "./sidebar/SidebarExpandStrip";
-import { useSyncSidebarWidthCssVar } from "./sidebar/primitives";
 import { Titlebar } from "./Titlebar";
 import { WindowDragStrip } from "./WindowDragStrip";
 import { useActiveChatId } from "./useActiveChatId";
@@ -133,9 +132,7 @@ export function AppShell() {
   const desktopNavigation = useDesktopNavigation();
   const zoom = useInterfaceZoom();
   const sidebarCollapsed = useUiStore((state) => state.sidebarCollapsed);
-  // The expanded rail width is published by the shell, not the rail itself, so
-  // the titlebar can size to it while the rail is mounted.
-  useSyncSidebarWidthCssVar();
+  const sidebarWidth = useUiStore((state) => state.sidebarWidth);
   // Read at keydown rather than subscribed to: which mode a shortcut fires in
   // is the route's answer, and the shell has no other reason to re-render on
   // every navigation.
@@ -693,7 +690,17 @@ export function AppShell() {
           restartForUpdate: onRestartForUpdate,
         }}
       >
-        <div className={`app-shell${nativeTitlebar ? " with-titlebar" : ""}`}>
+        <div
+          className={`app-shell${nativeTitlebar ? " with-titlebar" : ""}`}
+          // Publish this as part of the shell's first render. An effect that
+          // queries for `.app-shell` can run while the boot or managed gate is
+          // still showing, then never retry when the shell finally mounts.
+          style={
+            {
+              "--sidebar-expanded-width": `${sidebarWidth}px`,
+            } as CSSProperties
+          }
+        >
           {confirmDialog}
           <ShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
           {nativeTitlebar && !sidebarCollapsed && (

--- a/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
@@ -1,7 +1,6 @@
 import {
   forwardRef,
   useCallback,
-  useEffect,
   useRef,
   useState,
   type ComponentProps,
@@ -26,25 +25,6 @@ import {
  * never disappears with the rail. Expanded width is reader-chosen and
  * remembered.
  */
-
-/**
- * Publish the expanded rail width onto the shell so the overlay titlebar can
- * size itself to the rail. Cleared on collapse: the titlebar unmounts with the
- * rail, and the fallback 280px would otherwise paint leftover chrome.
- */
-export function useSyncSidebarWidthCssVar() {
-  const sidebarWidthPx = useUiStore((state) => state.sidebarWidth);
-  const collapsed = useUiStore((state) => state.sidebarCollapsed);
-  useEffect(() => {
-    const shell = document.querySelector<HTMLElement>(".app-shell");
-    if (!shell) return;
-    if (collapsed) {
-      shell.style.removeProperty("--sidebar-expanded-width");
-      return;
-    }
-    shell.style.setProperty("--sidebar-expanded-width", `${sidebarWidthPx}px`);
-  }, [sidebarWidthPx, collapsed]);
-}
 
 /**
  * Drag handle on the rail's trailing edge. Double-click restores the default


### PR DESCRIPTION
## Summary

- publish the restored sidebar width on the app shell during its first render
- remove the timing-sensitive effect that queried for `.app-shell`
- add a regression test covering a custom saved width after the boot and managed-policy gate

## Root cause

On refresh, the sidebar-width synchronization effect could run while the boot screen or managed-policy gate was still mounted. Because `.app-shell` did not exist yet and the stored width did not change afterward, the effect never retried. The sidebar rendered at its saved width while the overlaid titlebar kept the 280px CSS fallback, producing a mismatched notch over the content.

## User impact

The sidebar and native titlebar now use the same restored width on the first shell render, so refreshing no longer leaves the content partially covered. Existing collapse and resize behavior is unchanged.

## Compatibility and risk

This is a renderer-only layout change. It does not alter persisted preference keys or backend APIs. The CSS variable remains driven by the same Zustand state, but is now applied synchronously instead of through a DOM query.

## Validation

- `pnpm exec vitest run src/AppShell.dom.test.tsx` — 22 tests passed
- `pnpm exec tsc --noEmit`
- `git diff --check`
