### PR TITLE
fix(desktop): spotlight a specific first-task row

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
@@ -158,6 +158,12 @@ it("opens when the first-task walkthrough is on the tools step", () => {
     />,
   );
 
-  expect(screen.getByRole("menuitem", { name: "Attach files" })).toBeInTheDocument();
-  expect(screen.getByRole("menuitem", { name: /Network/ })).toBeInTheDocument();
+  expect(screen.getByRole("menuitem", { name: "Attach files" })).toHaveAttribute(
+    "data-first-task-target",
+    "attach-files",
+  );
+  expect(screen.getByRole("menuitem", { name: /Network/ })).toHaveAttribute(
+    "data-first-task-target",
+    "network",
+  );
 });

--- a/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.tsx
@@ -103,7 +103,6 @@ export function ComposerToolsMenu({
               variant="ghost"
               size="icon-8"
               aria-label="Tools"
-              data-first-task-target="tools"
               disabled={disabled}
             >
               <Plus size={16} />
@@ -121,6 +120,7 @@ export function ComposerToolsMenu({
             <DropdownMenuItem
               disabled={disabled || attachFiles.attaching}
               onSelect={attachFiles.onAttach}
+              data-first-task-target="attach-files"
             >
               {attachFiles.attaching ? (
                 <LoaderCircle className="size-4 animate-spin" />
@@ -134,6 +134,7 @@ export function ComposerToolsMenu({
             <DropdownMenuItem
               disabled={disabled || attachFolder.working}
               onSelect={attachFolder.onAttach}
+              data-first-task-target="attach-folder"
             >
               {attachFolder.working ? (
                 <LoaderCircle className="size-4 animate-spin" />
@@ -157,6 +158,7 @@ export function ComposerToolsMenu({
           {network && NetworkIcon && (
             <DropdownMenuItem
               disabled={disabled || network.disabled}
+              data-first-task-target="network"
               onSelect={() => {
                 // The walkthrough holds this menu open, so a second overlay
                 // would sit under the spotlight and trap focus.

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.dom.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -15,16 +15,39 @@ import {
 function Targets() {
   return (
     <>
-      <button data-first-task-target="model">Model</button>
       <div data-first-task-target="model-menu">Model menu</div>
-      <button data-first-task-target="tools">Tools</button>
+      <div data-first-task-target="model-choice">Selected model</div>
       <div data-first-task-target="tools-menu">Tools menu</div>
-      <button data-first-task-target="permissions">Ask</button>
+      <div data-first-task-target="network">Network</div>
+      <div data-first-task-target="attach-files">Attach files</div>
       <div data-first-task-target="permissions-menu">Permissions menu</div>
+      <div data-first-task-target="permissions-ask">Ask mode</div>
       <div data-first-task-target="starters">Starters</div>
+      <div data-first-task-target="starter-choice">First starter</div>
       <textarea data-composer-input aria-label="Message" />
     </>
   );
+}
+
+function mockTargetRect(
+  name: string,
+  rect: Pick<DOMRect, "top" | "left" | "width" | "height">,
+): void {
+  const element = document.querySelector(`[data-first-task-target="${name}"]`);
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`missing first-task target ${name}`);
+  }
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+    x: rect.left,
+    y: rect.top,
+    top: rect.top,
+    left: rect.left,
+    right: rect.left + rect.width,
+    bottom: rect.top + rect.height,
+    width: rect.width,
+    height: rect.height,
+    toJSON: () => ({}),
+  });
 }
 
 function WalkthroughHarness({
@@ -135,7 +158,7 @@ describe("FirstTaskWalkthrough", () => {
     render(<WalkthroughHarness onClose={onClose} />);
     await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
 
-    const target = screen.getByText("Model");
+    const target = screen.getByText("Selected model");
     fireEvent.pointerDown(target);
     fireEvent.mouseDown(target);
     fireEvent.pointerUp(target);
@@ -149,5 +172,53 @@ describe("FirstTaskWalkthrough", () => {
       "aria-live",
       "polite",
     );
+  });
+
+  it("upgrades the spotlight from the open menu to the specific row", async () => {
+    function LateChoice() {
+      const [ready, setReady] = useState(false);
+      useEffect(() => {
+        const frame = window.requestAnimationFrame(() => setReady(true));
+        return () => window.cancelAnimationFrame(frame);
+      }, []);
+      return (
+        <>
+          <div data-first-task-target="model-menu">Model menu</div>
+          {ready && <div data-first-task-target="model-choice">Selected model</div>}
+          <textarea data-composer-input aria-label="Message" />
+        </>
+      );
+    }
+
+    render(
+      <>
+        <LateChoice />
+        <FirstTaskWalkthrough open onClose={vi.fn()} />
+      </>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Selected model")).toBeInTheDocument(),
+    );
+    mockTargetRect("model-menu", { top: 40, left: 20, width: 320, height: 280 });
+    mockTargetRect("model-choice", { top: 80, left: 28, width: 240, height: 36 });
+    fireEvent(window, new Event("resize"));
+
+    await waitFor(() => {
+      const ring = document.querySelector("[data-first-task-ring]");
+      expect(ring).toHaveStyle({ width: "248px", height: "44px" });
+    });
+  });
+
+  it("spotlights the specific box that opened, not the trigger or the whole menu", async () => {
+    render(<WalkthroughHarness onClose={vi.fn()} />);
+    mockTargetRect("model-menu", { top: 40, left: 20, width: 320, height: 280 });
+    mockTargetRect("model-choice", { top: 80, left: 28, width: 240, height: 36 });
+    fireEvent(window, new Event("resize"));
+
+    await waitFor(() => {
+      const ring = document.querySelector("[data-first-task-ring]");
+      expect(ring).toHaveStyle({ width: "248px", height: "44px" });
+    });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
@@ -15,10 +15,12 @@ export type FirstTaskSurface = "model" | "tools" | "permissions" | null;
 type WalkthroughStep = {
   id: string;
   surface: FirstTaskSurface;
-  /** Opened menu content, preferred once the surface has mounted. */
-  target: string;
-  /** Trigger still in the bar, used before the menu portal exists. */
-  fallbackTarget: string;
+  /**
+   * Boxes that appear for this step, most specific first. The trigger in the
+   * composer bar is not a candidate: it is already on screen, and locking onto
+   * it hides the row the copy is talking about.
+   */
+  targets: readonly string[];
   title: string;
   body: string;
 };
@@ -27,40 +29,35 @@ const STEPS: readonly WalkthroughStep[] = [
   {
     id: "model",
     surface: "model",
-    target: "model-menu",
-    fallbackTarget: "model",
+    targets: ["model-choice", "model-menu"],
     title: "Choose a model",
     body: "The model menu is open. Models differ in speed, reasoning, and the inputs they understand. The current default is a good place to start.",
   },
   {
     id: "internet",
     surface: "tools",
-    target: "tools-menu",
-    fallbackTarget: "tools",
+    targets: ["network", "tools-menu"],
     title: "Set internet access",
     body: "The Tools menu is open. Network is this chat's internet setting. Internet access is what web search and current information need. Leave it off when Tidebreak should use only your message and attachments.",
   },
   {
     id: "permissions",
     surface: "permissions",
-    target: "permissions-menu",
-    fallbackTarget: "permissions",
+    targets: ["permissions-ask", "permissions-menu"],
     title: "Choose a permission level",
     body: "The permission menu is open. Plan stays read-only, Ask confirms actions, Auto handles routine workspace work, and Allow all runs without asking in this chat. Ask is a balanced place to start.",
   },
   {
     id: "attachments",
     surface: "tools",
-    target: "tools-menu",
-    fallbackTarget: "tools",
+    targets: ["attach-files", "attach-folder", "tools-menu"],
     title: "Add attachments",
     body: "Attach files or a folder from this menu when the task needs your documents. Desktop Tidebreak can read what you attach.",
   },
   {
     id: "starters",
     surface: null,
-    target: "starters",
-    fallbackTarget: "starters",
+    targets: ["starter-choice", "starters"],
     title: "Start a real task",
     body: "These prompts are complete. Pick one and send it to watch Tidebreak search, write, or build. You do not need to attach anything first.",
   },
@@ -129,10 +126,16 @@ function targetSelector(target: string): string {
 }
 
 function resolveTarget(step: WalkthroughStep): HTMLElement | null {
-  return (
-    document.querySelector<HTMLElement>(targetSelector(step.target)) ??
-    document.querySelector<HTMLElement>(targetSelector(step.fallbackTarget))
-  );
+  for (const target of step.targets) {
+    const element = document.querySelector<HTMLElement>(targetSelector(target));
+    if (element) return element;
+  }
+  return null;
+}
+
+function isPreferredTarget(step: WalkthroughStep, element: HTMLElement): boolean {
+  const preferred = step.targets[0];
+  return preferred != null && element.matches(targetSelector(preferred));
 }
 
 function focusComposer(): void {
@@ -228,16 +231,28 @@ export function FirstTaskWalkthrough({
       if (cancelled) return;
       const next = resolveTarget(step);
       if (!next) {
+        if (target) {
+          observer.disconnect();
+          target = null;
+        }
         setRect(null);
         if (frames++ < 30) {
           window.requestAnimationFrame(find);
         }
         return;
       }
-      target = next;
-      next.scrollIntoView({ block: "nearest", inline: "nearest" });
-      measure(next);
-      observer.observe(next);
+      if (target !== next) {
+        if (target) observer.unobserve(target);
+        target = next;
+        next.scrollIntoView({ block: "nearest", inline: "nearest" });
+        measure(next);
+        observer.observe(next);
+      }
+      // The menu portal can land after a fallback row. Keep looking for the
+      // specific box until it mounts or the retry budget runs out.
+      if (!isPreferredTarget(step, next) && frames++ < 30) {
+        window.requestAnimationFrame(find);
+      }
     };
     find();
 
@@ -349,6 +364,7 @@ export function FirstTaskWalkthrough({
             style={{ clipPath: clipPathFor(rect, inset) }}
           />
           <div
+            data-first-task-ring
             className="absolute rounded-[10px] ring-2 ring-[var(--brightwave)] ring-offset-2 ring-offset-transparent"
             style={{
               top: rect.top - inset,

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
@@ -185,5 +185,8 @@ it("opens when the first-task walkthrough is on the model step", () => {
     />,
   );
 
-  expect(screen.getByRole("menuitem", { name: "Claude Sonnet 4" })).toBeInTheDocument();
+  expect(screen.getByRole("menuitem", { name: "Claude Sonnet 4" })).toHaveAttribute(
+    "data-first-task-target",
+    "model-choice",
+  );
 });

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
@@ -484,6 +484,14 @@ export function ModelMenu({
     void onChange(model.key);
   }
 
+  const visibleModels = searching
+    ? searchResults
+    : (activeGroup?.models ?? []);
+  const spotlightKey =
+    (known ?? usableDefault)?.key ??
+    visibleModels.find((model) => model.available)?.key ??
+    null;
+
   function modelRow(model: ModelInfo, showProvider: boolean = false) {
     const selected = isDefault
       ? usableDefault?.key === model.key
@@ -496,6 +504,9 @@ export function ModelMenu({
         // closes on it. Re-selecting the current row still closes naturally.
         onSelect={() => chooseModel(model, selected)}
         className="flex items-center gap-2"
+        data-first-task-target={
+          model.key === spotlightKey ? "model-choice" : undefined
+        }
       >
         <ProviderIcon
           provider={model.vendor ?? model.provider}
@@ -528,7 +539,6 @@ export function ModelMenu({
           className="h-8 max-w-56 gap-2"
           disabled={disabled}
           aria-label={triggerLabel}
-          data-first-task-target="model"
           title={triggerLabel}
         >
           {pillModel ? (

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -165,6 +165,9 @@ it("opens when the first-task walkthrough is on the permissions step", () => {
     <PermissionModeMenu scopeKey="chat-1" value="ask" onChange={vi.fn()} />,
   );
 
-  expect(screen.getByRole("menuitem", { name: /Ask/ })).toBeInTheDocument();
+  expect(screen.getByRole("menuitem", { name: /Ask/ })).toHaveAttribute(
+    "data-first-task-target",
+    "permissions-ask",
+  );
   expect(screen.getByRole("menuitem", { name: /Plan/ })).toBeInTheDocument();
 });

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
@@ -176,7 +176,6 @@ export function PermissionModeMenu({
           disabled={controlsDisabled}
           aria-label={`Permissions: ${current.label}`}
           aria-busy={saving}
-          data-first-task-target="permissions"
         >
           <CurrentIcon className="size-4 text-foreground" />
           {current.label}
@@ -203,6 +202,9 @@ export function PermissionModeMenu({
                 void selectMode(option.value);
               }}
               className="flex flex-col items-start gap-0.5 py-3"
+              data-first-task-target={
+                option.value === "ask" ? "permissions-ask" : undefined
+              }
             >
               <div className="flex w-full items-center justify-between">
                 <span className="flex items-center gap-2 font-medium">

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.dom.test.tsx
@@ -79,6 +79,7 @@ describe("WelcomeState starters", () => {
     const starter = screen.getByRole("button", {
       name: /Brief this week's AI news/,
     });
+    expect(starter).toHaveAttribute("data-first-task-target", "starter-choice");
     await waitFor(() => expect(library.list).toHaveBeenCalled());
     fireEvent.click(starter);
     expect(onSelectPrompt).toHaveBeenCalledWith(

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
@@ -208,11 +208,12 @@ export function WelcomeState({
       )}
       {onSelectPrompt && libraryPrompts.length > 0 && (
         <div className="welcome-prompts" data-first-task-target="starters">
-          {libraryPrompts.map((prompt) => (
+          {libraryPrompts.map((prompt, index) => (
             <button
               key={prompt.name}
               type="button"
               className={CARD_CLASS}
+              data-first-task-target={index === 0 ? "starter-choice" : undefined}
               onClick={() => insertLibraryPrompt(prompt.name)}
             >
               <Sparkles size={16} className="text-muted-foreground" />
@@ -231,18 +232,22 @@ export function WelcomeState({
       {onSelectPrompt && libraryPrompts.length === 0 && (
         <div className="welcome-prompts" data-first-task-target="starters">
           {STARTER_PROMPTS.map(
-            ({
-              icon: Icon,
-              iconClass,
-              label,
-              description,
-              prompt,
-              enableInternet,
-            }) => (
+            (
+              {
+                icon: Icon,
+                iconClass,
+                label,
+                description,
+                prompt,
+                enableInternet,
+              },
+              index,
+            ) => (
               <button
                 key={label}
                 type="button"
                 className={CARD_CLASS}
+                data-first-task-target={index === 0 ? "starter-choice" : undefined}
                 onClick={() =>
                   onSelectPrompt(
                     prompt,


### PR DESCRIPTION
## What changed

The first-task walkthrough was ringing the composer trigger. That hid the menu row the copy describes.

Each step now spotlights the box that opened:

- Choose a model: the current model row
- Set internet access: Network
- Choose a permission level: Ask
- Add attachments: Attach files, or Attach folder if files is missing
- Start a real task: the first starter card

If the specific row is late to mount, the ring starts on the open menu and moves to that row.

## Validation

- `pnpm exec vitest run src/FirstTaskWalkthrough.dom.test.tsx src/WelcomeState.test.tsx src/WelcomeState.dom.test.tsx src/ComposerToolsMenu.dom.test.tsx src/PermissionModeMenu.dom.test.tsx src/ModelMenu.dom.test.tsx` — 30 tests passed
- `git diff --check`

I did not click through the live desktop tour.

## Compatibility and risk

None. Visual-only React change. No API, persistence, or permission changes.