### PR TITLE
deps(ui): bump transitive DOMPurify to 3.4.14

### DIFF
--- a/.github/vercel-cli/package.json
+++ b/.github/vercel-cli/package.json
@@ -5,5 +5,11 @@
   "packageManager": "pnpm@10.18.3",
   "dependencies": {
     "vercel": "59.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "path-to-regexp@8.2.0": "8.4.2",
+      "path-to-regexp@8.3.0": "8.4.2"
+    }
   }
 }

--- a/.github/vercel-cli/pnpm-lock.yaml
+++ b/.github/vercel-cli/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  path-to-regexp@8.2.0: 8.4.2
+  path-to-regexp@8.3.0: 8.4.2
+
 importers:
 
   .:
@@ -1208,12 +1212,8 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
-  path-to-regexp@8.2.0:
-    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
-    engines: {node: '>=16'}
-
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -1883,7 +1883,7 @@ snapshots:
       fs-extra: 11.1.0
       get-port: 5.1.1
       oxc-transform: 0.111.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
       resolve.exports: 2.0.3
       rolldown: 1.0.0-rc.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       srvx: 0.11.16
@@ -1961,7 +1961,7 @@ snapshots:
       '@vercel/node': 5.10.0
       '@vercel/static-config': 3.4.1
       fs-extra: 11.1.0
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
       ts-morph: 12.0.0
       zod: 3.22.4
     transitivePeerDependencies:
@@ -1989,7 +1989,7 @@ snapshots:
       micro: 9.3.5-canary.3
       ms: 2.1.1
       node-fetch: 2.6.7
-      path-to-regexp: 8.2.0
+      path-to-regexp: 8.4.2
       promisepipe: 3.0.0
       semver: 7.5.4
       stat-mode: 0.3.0
@@ -2033,7 +2033,7 @@ snapshots:
       '@vercel/node': 5.10.0
       '@vercel/static-config': 3.4.1
       fs-extra: 11.1.0
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
       ts-morph: 12.0.0
       zod: 3.22.4
     transitivePeerDependencies:
@@ -2695,9 +2695,7 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
-  path-to-regexp@8.2.0: {}
-
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   pend@1.2.0: {}
 

--- a/crates/tidebreak-desktop/ui/pnpm-lock.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@dukelib/sheets-wasm@0.1.21': 0.1.23
   nanoid@5.1.11: 5.1.16
+  dompurify@3.4.8: 3.4.14
 
 importers:
 
@@ -2657,8 +2658,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
@@ -7084,7 +7085,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.8:
+  dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7874,7 +7875,7 @@ snapshots:
 
   monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.4.8
+      dompurify: 3.4.14
       marked: 14.0.0
 
   ms@2.1.3: {}

--- a/crates/tidebreak-desktop/ui/pnpm-workspace.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-workspace.yaml
@@ -6,6 +6,9 @@ overrides:
   # worksheet chart layer for read-only previews.
   '@dukelib/sheets-wasm@0.1.21': 0.1.23
   nanoid@5.1.11: 5.1.16
+  # monaco-editor 0.56.0 pins 3.4.8. 3.4.14 closes GHSA-55q2-fjhq-7xh7
+  # (IN_PLACE hook XSS) and the three earlier DOMPurify advisories on that line.
+  dompurify@3.4.8: 3.4.14
 allowBuilds:
   canvas: true
   esbuild: true

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -6793,7 +6793,7 @@ License identifiers named across all declared expressions:
 - Repository: git+https://github.com/react-bootstrap/dom-helpers.git
 - License text: `LICENSE` ([L-1b0a9ba95a67](#l-1b0a9ba95a67))
 
-### dompurify 3.4.8
+### dompurify 3.4.14
 
 - License: `(MPL-2.0 OR Apache-2.0)`
 - Repository: git://github.com/cure53/DOMPurify.git


### PR DESCRIPTION
## What changed

Override `monaco-editor` 0.56.0's exact `dompurify@3.4.8` pin to `3.4.14` in the desktop UI lockfile. That closes Dependabot alerts 215–218, including the IN_PLACE hook XSS (`GHSA-55q2-fjhq-7xh7`). Regenerated `legal/THIRD-PARTY-NOTICES.md` for the new version.

Also override `path-to-regexp` 8.2.0 and 8.3.0 to 8.4.2 in `.github/vercel-cli`. That closes alerts 161–162 on the docs publish CLI. The `vercel` pin stays at 59.0.0.

Left the twelve `undici` 5.x alerts on that same CLI. Vercel 59 still depends on 5.28.4 and 5.29.0, and GitHub's range is `< 6.28.0` with no 5.x patch. Clearing them needs a 5 → 6 major override.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui install --frozen-lockfile`
- `pnpm --dir .github/vercel-cli install --frozen-lockfile --ignore-scripts`
- `node scripts/generate-third-party-notices.mjs --check`
- `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs scripts/third-party-notices.test.mjs` (87 passed)

Did not run the full UI suite. CI covers that lane.

## Compatibility and risk

DOMPurify 3.4.8 → 3.4.14 is a patch on monaco-editor's markdown sanitizer. path-to-regexp 8.2/8.3 → 8.4.2 stays on the 8.x line and only affects the isolated Vercel CLI used to publish docs.

No persisted or wire-format changes.