### PR TITLE
docs(decisions): gateway-linked hosting and one interaction model (47, 48)

### DIFF
--- a/docs/decisions/0047-gateway-linked-hosting.md
+++ b/docs/decisions/0047-gateway-linked-hosting.md
@@ -1,0 +1,166 @@
+# 47. Gateway-linked hosting: machines, clients, and roster-derived identity
+
+- Status: Proposed
+- Date: 2026-08-19
+- Owners: server, desktop
+- Related: [`0006-self-host-deployment-plane-authorization.md`](0006-self-host-deployment-plane-authorization.md),
+  [`0017-gateway-capability-negotiation.md`](0017-gateway-capability-negotiation.md),
+  [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),
+  [`docs/gateway-boundary.md`](../gateway-boundary.md),
+  [`docs/self-hosting.md`](../self-hosting.md),
+  [`docs/deferred.md`](../deferred.md),
+  [`0048-one-interaction-model.md`](0048-one-interaction-model.md)
+- Supersedes: none
+
+## Context
+
+The self-host profile exists so a team can run one shared Tidebreak server:
+PostgreSQL store, an operator token file resolving each request to a named
+principal with a role, fail-closed boot, plain HTTP behind the operator's
+fronting infrastructure (decision 6). What does not exist is any way to *use*
+that deployment from the product's own clients, or any identity source beyond
+the hand-edited token file. `docs/deferred.md` parks all of it: a member
+client (a desktop connection mode or a hosted web UI), a supervision-first
+mobile client, remote session execution, and "auth beyond the static token
+file waits on gateway-derived identity."
+
+Meanwhile the desktop app is deliberately local. The server refuses
+non-loopback hosts in the desktop profile, the client has no product path for
+a user-supplied remote URL and token, and host authority — folder broker,
+client executor, native export, computer use — rides credentials the renderer
+never holds, which `docs/host-access.md` already names as "the intended
+consequence for host authority and a defect for anything else."
+
+What is changing: model gateway deployments (the product
+[`docs/gateway-boundary.md`](../gateway-boundary.md) already integrates with
+as an OAuth client) are growing the ability to deploy `tidebreak-server` as
+an optional component of the gateway installation — colocated database,
+fronting and TLS from the operator's infrastructure, and the token file
+generated from the gateway's user roster rather than edited by hand. That
+gives a team one self-hosted installation instead of two, and it makes the
+deferred member-client work worth unblocking: agents keep running when a
+laptop closes, and any device the user holds can supervise them.
+
+Two facts bound the design:
+
+- **Code mode is not multi-user-safe today.** The `code_*` tables carry no
+  `owner` column and the `/code/*` routes sit outside the owner-scoped
+  regime that decision 6 built for chat, documents, and apps. A shared
+  deployment cannot enable code mode until that closes.
+- **Tidebreak is pre-1.0 and keeps its breaking-change freedom.** The
+  baseline migration currently calls self-host databases durable. A
+  gateway-linked deployment must not quietly acquire a durability promise
+  that slows the product down.
+
+Assumed, not yet true: the end-state product shape is a **machine** — a
+place agents run, whether the loopback server inside the desktop app or a
+hosted server — and **clients** that attach to machines. Decision 48 defines
+the single interaction model those clients speak.
+
+## Decision
+
+1. **A gateway-linked deployment is a self-host deployment whose identity
+   derives from a gateway roster.** In its first form, the gateway's
+   deployment tooling generates the token file from its roster and
+   `tidebreak-server` is unchanged: the token file remains the
+   credential-to-principal seam exactly as decision 6 left it. The end state
+   is a gateway authenticator behind that same seam — the server verifies
+   gateway-issued credentials directly, answering the same *which user,
+   which role* question, and the token file retires. Decision 6 anticipated
+   this authenticator; this record commits to building it, in a follow-up
+   record that specifies the verification mechanism.
+2. **Machine and client become the product vocabulary.** A running
+   `tidebreak-server` instance is a machine. Renderer-shaped clients — the
+   desktop webview, and later web and mobile surfaces — attach to a machine
+   over the existing HTTP and WebSocket wire. Capability negotiation
+   (decision 17) governs client-to-machine version skew the same way it
+   governs the gateway boundary: probe, don't pin.
+3. **The desktop app gains a remote connection mode** — the deferred member
+   client, chosen over a hosted web UI as the first client because its
+   approval and consent surfaces already exist. Connecting takes a base URL
+   and a token; TLS is required unless the host is loopback, mirroring the
+   pairing rule in [`docs/gateway-boundary.md`](../gateway-boundary.md).
+   While attached to a remote machine, host-authority features degrade
+   legibly: routes and tools that require the client executor or the host
+   broker are absent or refused with stable reasons, on the pattern headless
+   write-back already set (`output_writeback_authority_unavailable`). A web
+   or mobile client is the same shape with less authority, and follows once
+   the remote wire is proven.
+4. **Code mode on a shared machine is gated on owner scoping.** The `code_*`
+   tables gain owners, and `/code/*` joins the owner-scoped regime, before a
+   multi-user deployment enables code mode. This is the first work item, and
+   decision 48 sequences it as convergence step one.
+5. **Gateway-linked deployments are disposable until 1.0.** For this
+   deployment class, the durable-self-host posture is narrowed: a baseline
+   edit may drop and recreate the shared store, as the desktop schema epoch
+   does locally. The deployment documentation states it, and operators of a
+   gateway-linked deployment are told the store carries no retention
+   promise. Ordinary operator-managed self-host deployments keep the
+   existing back-up-before-upgrade posture; the narrowing applies only where
+   the gateway tooling owns the database and can recreate it.
+
+Deliberately excluded: synchronizing a desktop profile's local data with a
+hosted machine (a distributed-state problem this record does not open);
+serving the gateway's own traffic or learning its schema (the boundary in
+[`docs/gateway-boundary.md`](../gateway-boundary.md) is unchanged in the
+client direction); remote session execution in managed sandboxes (the
+reverse-RPC spike's territory, its own future record); and host authority on
+remote machines — a hosted machine has no trusted host executor, and this
+record does not claim one.
+
+## Alternatives Considered
+
+- **A hosted web UI as the first client.** Serves the subway case directly,
+  but every consent, approval, and degradation surface would be built twice
+  before the wire is proven once. The desktop connection mode exercises the
+  same routes with surfaces that exist. Web follows; rejected as first.
+- **Keep the token file as the permanent identity story.** Two rosters per
+  team, drift, and hand-managed revocation. Rejected; the file is the
+  bridge, not the destination.
+- **Trusted-header auth from the fronting proxy.** Decision 6 already
+  rejected it as a default (fails open when the port is reachable directly)
+  while naming it a legitimate future authenticator. Nothing here changes
+  that judgment; the gateway authenticator will be a bearer-shaped
+  credential, fail-closed.
+- **Wait for 1.0 before hosting.** Postpones exactly the usage that will
+  teach us what the 1.0 compatibility surface should be. The disposable
+  regime in decision point 5 exists so hosting does not have to wait.
+- **Do nothing.** The deferred items stay parked and every team's answer to
+  "can I steer my agents from my phone" stays no.
+
+## Consequences
+
+- The renderer must treat host authority as conditional everywhere it
+  invokes shell commands today; each callsite needs a remote-attached
+  behavior, and "silently do it on the server's host instead" is the defect
+  the validation section targets.
+- The desktop profile's loopback lockdown is untouched; a new connection
+  mode must not weaken the origin and loopback refusals for the local
+  server.
+- Until the gateway authenticator lands, revocation is as fast as the next
+  roster provisioning run. Teams needing instant revocation are the trigger
+  for building the authenticator.
+- The disposable regime means a team's hosted history can vanish on upgrade.
+  That is accepted on purpose, stated in operator documentation, and revisited
+  at 1.0, when the compatibility commitment inverts the pre-1.0 rules.
+- Owner scoping for code mode is now on the critical path of two records
+  (this one and decision 48), which is the point: it is paid once.
+- Revisit when the remote wire is proven and a web or mobile client starts
+  (the client surface may deserve its own record), when the gateway
+  authenticator is designed, or at 1.0.
+
+## Validation
+
+- Existing refusals hold: a desktop per-launch token is refused on a
+  self-host deployment; a non-loopback host is refused in the desktop
+  profile. New refusal: the remote connection mode refuses a non-TLS,
+  non-loopback URL.
+- The plausible wrong implementation of decision point 3 half-works: a
+  remote-attached client that routes a native export or folder operation to
+  the *server's* filesystem. The test attaches remotely and asserts the
+  stable refusal, not a success against the wrong host.
+- The plausible wrong implementation of decision point 4 scopes reads but
+  not events: a second user on a shared machine must see neither another
+  owner's `code_*` rows nor their session events on the updates channel.
+- Provisioned-identity drill: a token absent from the regenerated file is
+  refused; the server still fails closed when the file is missing entirely.

--- a/docs/decisions/0048-one-interaction-model.md
+++ b/docs/decisions/0048-one-interaction-model.md
@@ -1,0 +1,195 @@
+# 48. One interaction model for chat and code
+
+- Status: Proposed
+- Date: 2026-08-19
+- Owners: server, code mode
+- Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),
+  [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),
+  [`0033-code-mode-approvals.md`](0033-code-mode-approvals.md),
+  [`0035-code-mode-wire-contract.md`](0035-code-mode-wire-contract.md),
+  [`0038-auto-is-a-declared-capability.md`](0038-auto-is-a-declared-capability.md),
+  [`0039-allow-is-a-first-class-code-permission-mode.md`](0039-allow-is-a-first-class-code-permission-mode.md),
+  [`0046-rich-turn-input-rides-harness-capabilities.md`](0046-rich-turn-input-rides-harness-capabilities.md),
+  [`0047-gateway-linked-hosting.md`](0047-gateway-linked-hosting.md),
+  [`docs/deferred.md`](../deferred.md) ("Chat–code convergence")
+- Supersedes: none
+
+## Context
+
+Decision 30 built code mode as a deliberately separate model and named its
+own destination: "no user-facing mode choice at all: a conversation bound to
+a repo-backed workspace behaves code-like, and a conversation without one is
+ordinary chat — context selects behavior," with the internal agent loop
+holding "no privileged seat" behind the decision-31 adapter contract. It also
+set the criterion — unification must mean "merging structures, not
+translating them" — and told us to revisit "when both models are proven."
+`docs/deferred.md` parks the same item as "a future record on top of two
+proven models." This is that record.
+
+Both models are now proven enough that the divergences are concrete rather
+than hypothetical. What exists twice today:
+
+1. Two permission enums with identical variants (`PermissionMode` and
+   `CodePermissionMode`, both `Plan | Ask | Auto | Allow`), differing in
+   lifecycle: chat's is changeable per chat, code's is fixed at session
+   creation and refused per declared harness capability (decisions 38, 39).
+2. Two journals implementing the same snapshot-replay-live contract: the
+   `event` table with `/chats/{id}/events`, and `code_event` with
+   `/code/sessions/{id}/events` plus the unsequenced `/code/updates` channel
+   (decision 35).
+3. Two approval models: chat's grant ladders and approval judge; code's
+   verbatim-payload rows with deny-with-feedback and deliberately no
+   standing grants (decision 33).
+4. Two turn state machines: chat's with durable waiting-for-client
+   continuations; code's with spawn-epoch fencing and pid-probe recovery
+   against a foreign process.
+5. Two attention surfaces: the chat inbox keyed on `ChatId`; code's
+   server-computed `AttentionState`, which decision 30 already notes is "not
+   code-private in ways that would block" a shared surface.
+6. Two ownership postures: chat, document, and app rows are owner-scoped;
+   `code_*` rows carry no owner at all.
+7. Two id spaces, enforced by repository checks so neither side can
+   reference the other.
+
+What raised the price of divergence: gateway-linked hosting (decision 47)
+means every client surface — the desktop app attached to a remote machine,
+then web and mobile clients — must otherwise speak two wire contracts, two
+journals, and two attention systems, forever, on every platform.
+
+## Decision
+
+Convergence becomes the plan of record, as a sequence in which each step is
+independently useful and lands before the next begins. The decision-30
+criterion governs throughout: every step merges a structure or does not
+happen; translation layers and discriminator columns remain rejected
+(decision 35's reasoning stands until the entities themselves merge).
+
+The merge has a direction, and it is not monolithic per side. **Code mode's
+structures survive**: the session and turn shape, spawn-epoch fencing, the
+sequenced per-session journal with the cheap updates digest channel
+(decision 35), the attention model, and the verbatim approval rows — these
+are the general case, built for supervising an engine the server does not
+control, and they are what remote and mobile clients need. **Chat
+contributes the content model**: attachments, rich turn input, documents and
+deliverables, and its grant ladders — re-expressed as capabilities of the
+internal engine rather than as a parallel subsystem. Decision 46's
+"attachment model" direction and this direction compose: chat's content
+riding code's structure. In the end state a chat is a session with the
+internal engine and no workspace, not a second kind of thing.
+
+1. **Owner scoping for code.** `code_*` tables gain owners and `/code/*`
+   joins the owner-scoped regime. Required by decision 47 regardless of
+   convergence; it goes first because it is paid once.
+2. **One permission vocabulary.** A single `PermissionMode` type, with
+   code's lifecycle as the default: the mode is chosen at conversation
+   creation, and mid-conversation changes are a capability an engine
+   declares (the internal engine declares it; harnesses mostly do not)
+   under the decision-38/39 honesty rules, instead of two parallel enums.
+3. **One attention surface.** The inbox adopts the code attention model:
+   every conversation, chat included, carries an `AttentionState`
+   (decision 30 already notes the wire shape is not code-private), so a
+   supervising client — the phone case — watches one queue with one
+   vocabulary. This forces the shared conversation identifier that step 5
+   needs, and is the first place the id spaces meet.
+4. **One turn-submission contract.** Decision 46's own revisit clause
+   executes: code turn input merges into the chat attachment model rather
+   than diverging further, with capability gates deciding what an engine
+   accepts.
+5. **One conversation, engines behind the adapter.** The internal agent
+   loop implements the decision-31 adapter contract as one engine among
+   several. A conversation bound to a repo-backed workspace selects a
+   harness engine; one without selects the internal engine. Chat and code
+   entities merge here into the code-shaped structures — turns, journal,
+   approvals — and the repository checks that kept the id spaces apart are
+   retired in the same change that makes them one space. The hard part is
+   named up front: chat's turn machinery — durable waiting-for-client
+   continuations, queued turns, the user-questions cards — must become
+   expressible through the adapter contract, because nothing may reach the
+   internal engine through a side door the adapter does not have. Whether
+   the internal engine then runs in-process behind the adapter trait or
+   graduates into an external harness process of its own is deliberately
+   deferred; the adapter contract is the boundary either way, and this
+   record does not choose the packaging.
+
+Approvals merge structurally in step 5 but keep their semantic split as
+capability, not subsystem: external harnesses retain verbatim-payload,
+no-standing-grants behavior (decision 33) as a declared property of the
+engine, while the internal engine keeps its grant ladders. One approval
+surface, two honesty postures.
+
+New client surfaces beyond the existing desktop app target the converged
+contract; the desktop client may bridge both contracts in the interim.
+Steps 1 through 4 are pre-convergence and safe to land while decision 47's
+remote wire is being proven; step 5 starts only after it is, so the merge
+happens on a contract that real remote clients have exercised.
+
+Deliberately excluded: a big-bang schema merge; reusing the chat `event`
+table for code via a discriminator (rejected in decision 35, still
+rejected); removing the harness adapters or re-privileging the internal
+loop; and any change to what host authority a machine has (decision 47's
+territory).
+
+## Alternatives Considered
+
+- **Keep two models indefinitely.** Every client pays twice on every
+  platform, and the wire contract for remote clients doubles. Decision 30
+  never intended this; rejected.
+- **Translate instead of merge.** A compatibility layer mapping code
+  entities into chat shapes at the route layer. This is exactly the outcome
+  decision 30 pre-rejected ("merging structures, not translating them") —
+  it fossilizes both models under a third. Rejected.
+- **Converge first, host second.** Cleanest wire for remote clients, but it
+  delays hosting behind the largest refactor in the codebase, and hosting is
+  what teaches which contract survives contact with remote clients.
+  Rejected as ordering; the sequence above interleaves them instead.
+- **Merge everything except the journals.** The journals are the wire; a
+  merge that leaves two event streams leaves clients speaking two
+  protocols, which is the cost this record exists to remove. Rejected.
+- **Do nothing until 1.0.** The 1.0 compatibility commitment would then
+  freeze two parallel contracts. Converging before 1.0 is the whole value
+  of being pre-1.0. Rejected.
+
+## Consequences
+
+- Steps are sized to be individually shippable, but step 5 is still a large
+  change to turns, journal, and approvals at once; the pre-1.0 disposable
+  regimes (desktop epoch, and decision 47's narrowed posture for
+  gateway-linked deployments) are what make it affordable. Landing step 5
+  after 1.0 would cost migrations this plan never budgets for.
+- Until step 5, clients carry both contracts. Web and mobile clients
+  started before step 5 completes would inherit that double cost, which is
+  an argument for sequencing them after it — decision 47 defers to this
+  record on that point.
+- The permission and attention merges (steps 2 and 3) change persisted
+  shapes and wire payloads; each takes the standard pre-1.0 baseline edit
+  plus epoch bump, stated per decision 2.
+- Capability honesty becomes the single mechanism carrying every behavioral
+  difference between engines. If a difference cannot be expressed as a
+  declared capability, that is the signal it is a design problem, not a
+  flag.
+- Revisit if step 5 shows chat's continuation model genuinely cannot be
+  expressed through the adapter contract (it, not code's fencing model, is
+  the side that must fit) — the fallback is one journal and one surface
+  over two execution backends, which is still most of the value. Revisit
+  also when the deferred packaging question is answered: if the internal
+  engine becomes an external harness process, that is its own record on
+  top of this one, not an edit to it.
+
+## Validation
+
+- The wrong implementation of step 5 keeps two tables and translates at the
+  route layer. The check is structural: after the merge, no route handler
+  maps one side's entities into the other side's shapes, and the retired
+  id-space repository checks are replaced by tests that one id resolves in
+  one space.
+- A conversation with no workspace must behave as today's chat: the
+  existing journal shape fixture, retargeted per decision 2, is the tripwire
+  that the merge changed structure deliberately rather than accidentally.
+- After step 2, an engine that declares a fixed permission mode still
+  refuses mid-conversation changes — the honesty rules, not the removed
+  enum, must carry that behavior.
+- After step 3, a code approval surfaces in the shared inbox and is
+  answerable from a renderer-shaped client with no code-mode-only routes
+  involved.
+- Owner scoping (step 1) validates as in decision 47: no cross-owner rows,
+  and no cross-owner events on the updates channel.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -36,11 +36,14 @@ static bearer token from the operator file. The packaged desktop app stays a
 local Desktop-profile product: it embeds its own server and does not point at
 a remote deployment.
 
-A later member client can be a desktop connection mode (URL, token, TLS
-expectations, Settings panels that degrade on a member `403`) or a hosted web
-UI the deployment serves. Either one is a second product surface, not an
-omission in the current server. Auth beyond the static token file waits on
-gateway-derived identity.
+The first member client is now specified:
+[decision 47](decisions/0047-gateway-linked-hosting.md) is a desktop remote
+connection mode (URL, token, TLS except on loopback) with host authority
+degrading on a remote machine. A hosted web UI and a supervision-first
+mobile client remain later surfaces on that same wire. Auth beyond the
+static token file is sequenced there too: roster-provisioned tokens first,
+a gateway authenticator behind decision 6's credential-to-principal seam as
+the end state.
 
 ## A coworker that can work later
 
@@ -236,14 +239,12 @@ purpose:
   editing to the user's editor via the worktree path. An embedded editor is
   a heavyweight dependency with its own product surface; it needs demand
   evidence first.
-- **Chat–code convergence.** The end state is one surface with no mode
-  choice: one conversation concept with an optional workspace binding, where
-  a workspace-bound conversation behaves code-like and engines — external
-  harnesses and Tidebreak's internal loop alike — sit behind the adapter
-  contract and are selected per conversation. The two modes are built
-  shape-compatible so this stays a mechanical merge
-  ([record 30](decisions/0030-code-mode-separate-surface.md)); the
-  convergence itself is a future record on top of two proven models.
+- **Chat–code convergence.** The plan of record is
+  [decision 48](decisions/0048-one-interaction-model.md): five independently
+  useful steps, with code-mode structures as the merge survivor and chat
+  contributing the content model. The work is no longer parked as a future
+  record; what remains deferred is the implementation, and whether the
+  internal engine later becomes an external harness process.
 - **A per-repo worktree-location override.** Worktrees live under the
   Tidebreak data directory; toolchains that misbehave outside the repo's
   ancestry are the known cost, and the override waits for real instances of


### PR DESCRIPTION
Two proposed records.

**Decision 47 — Gateway-linked hosting.** A gateway-linked deployment is a
self-host deployment whose identity derives from a gateway roster: the token
file is generated from the roster first, and a gateway authenticator behind
decision 6's credential-to-principal seam is the end state. The record adopts
machine/client vocabulary (a tidebreak-server instance is a machine; the
desktop app, then web and mobile surfaces, are clients that attach), makes a
desktop remote connection mode the first client with host authority degrading
legibly, gates shared-machine code mode on owner-scoping the code tables, and
narrows the durable-self-host posture to a disposable regime for this
deployment class until 1.0.

**Decision 48 — One interaction model for chat and code.** The convergence
record decision 30 and deferred.md anticipate, as five independently useful
steps: code owner scoping, one permission vocabulary, one attention surface,
one turn-submission contract, then the entity merge with the internal loop as
one engine behind the decision-31 adapter. The merge direction is explicit —
code-mode structures survive; chat contributes the content model — and
whether the internal engine later becomes an external harness process is
deliberately deferred.

Decision 47 also names a gap no doc stated before: `code_*` tables carry no
owner column and `/code/*` sits outside the owner-scoped regime, so shared
deployments cannot enable code mode until that closes.