### PR TITLE
fix(ui): allow vetted DOMPurify security release

### DIFF
--- a/crates/tidebreak-desktop/ui/pnpm-workspace.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-workspace.yaml
@@ -9,6 +9,9 @@ overrides:
   # monaco-editor 0.56.0 pins 3.4.8. 3.4.14 closes GHSA-55q2-fjhq-7xh7
   # (IN_PLACE hook XSS) and the three earlier DOMPurify advisories on that line.
   dompurify@3.4.8: 3.4.14
+minimumReleaseAgeExclude:
+  # Permit this reviewed security fix without exempting future DOMPurify releases.
+  - dompurify@3.4.14
 allowBuilds:
   canvas: true
   esbuild: true


### PR DESCRIPTION
## What changed

- Add a `minimumReleaseAgeExclude` entry scoped to exactly `dompurify@3.4.14`.
- Keep the existing transitive override from Monaco's vulnerable `dompurify@3.4.8` pin.
- Preserve release-age verification for every other package and future DOMPurify versions.

## Why

pnpm 11 revalidates committed lockfiles against its minimum release-age policy. `dompurify@3.4.14` was intentionally selected as an urgent security update, but its recent publication timestamp caused fresh installs on `main` to fail with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` even though the manifest and lockfile were consistent.

A version-specific exception allows the reviewed security release without broadly weakening the supply-chain policy or reverting to the vulnerable dependency.

## Compatibility and risk

This changes dependency-install policy only. It does not change the resolved package graph, lockfile, runtime behavior, persisted data, or wire formats. The exception cannot match later DOMPurify releases.

## Validation

- `corepack pnpm@11.22.0 --dir crates/tidebreak-desktop/ui install --frozen-lockfile --lockfile-only --ignore-scripts`
- `corepack pnpm@10.18.3 --dir crates/tidebreak-desktop/ui install --frozen-lockfile --lockfile-only --ignore-scripts`
- `git diff --check`

Both pnpm versions accepted the unchanged frozen lockfile, and pnpm 11 reported that all 758 lockfile entries passed its supply-chain policy checks.
