### PR TITLE
feat(server): owner-scope code mode (decision 48 step 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,6 +716,10 @@ jobs:
         run: >-
           cargo test -p tidebreak-core --no-default-features --features postgres
           --test postgres_turn_state --locked
+      - name: Exercise code-mode owner scoping on PostgreSQL
+        run: >-
+          cargo test -p tidebreak-core --no-default-features --features postgres
+          --test postgres_code_owner --locked
 
   ui:
     name: desktop UI

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -497,6 +497,10 @@ pub enum CodeApprovalKind {
 pub struct CodeRepo {
     /// Stable id.
     pub id: RepoId,
+    /// Principal this repository belongs to. Repositories are never shared
+    /// across owners: two users may register or clone the same remote and
+    /// each gets a checkout of their own.
+    pub owner: crate::OwnerId,
     /// Canonical git toplevel.
     pub root_path: String,
     /// Display name.
@@ -520,6 +524,8 @@ pub struct CodeRepo {
 pub struct CodeWorkspace {
     /// Stable id.
     pub id: WorkspaceId,
+    /// Principal this workspace belongs to, denormalized from its repo.
+    pub owner: crate::OwnerId,
     /// Owning repo.
     pub repo_id: RepoId,
     /// Display title.
@@ -545,6 +551,8 @@ pub struct CodeWorkspace {
 pub struct CodeSession {
     /// Stable id.
     pub id: CodeSessionId,
+    /// Principal this session belongs to, denormalized from its workspace.
+    pub owner: crate::OwnerId,
     /// Owning workspace.
     pub workspace_id: WorkspaceId,
     /// Engine this session is bound to.

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1658,6 +1658,7 @@ pub mod code_repo {
     pub struct Model {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
+        pub owner: String,
         pub root_path: String,
         pub display_name: String,
         pub default_base_ref: String,
@@ -1683,6 +1684,7 @@ pub mod code_workspace {
     pub struct Model {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
+        pub owner: String,
         pub repo_id: Uuid,
         pub title: String,
         pub worktree_path: String,
@@ -1709,6 +1711,7 @@ pub mod code_session {
     pub struct Model {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
+        pub owner: String,
         pub workspace_id: Uuid,
         pub harness_kind: String,
         pub harness_version: Option<String>,
@@ -1741,6 +1744,7 @@ pub mod code_turn {
     pub struct Model {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
+        pub owner: String,
         pub session_id: Uuid,
         pub ordinal: i64,
         pub status: String,
@@ -1773,6 +1777,7 @@ pub mod code_turn_attachment {
         pub turn_id: Uuid,
         #[sea_orm(primary_key, auto_increment = false)]
         pub ordinal: i32,
+        pub owner: String,
         pub blob_id: Uuid,
         pub media_type: String,
         pub byte_len: i64,
@@ -1797,6 +1802,7 @@ pub mod code_event {
         pub session_id: Uuid,
         #[sea_orm(primary_key, auto_increment = false)]
         pub seq: i64,
+        pub owner: String,
         #[sea_orm(column_type = "JsonBinary")]
         pub event: Json,
         pub created_at: DateTimeUtc,
@@ -1816,6 +1822,7 @@ pub mod code_approval {
     pub struct Model {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
+        pub owner: String,
         pub session_id: Uuid,
         pub turn_id: Uuid,
         #[sea_orm(column_type = "JsonBinary")]

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -11,6 +11,9 @@
 mod baseline;
 mod idens;
 
+#[cfg(test)]
+pub(crate) use baseline::tables_for_test;
+
 use sea_orm::ConnectionTrait;
 use sea_orm_migration::prelude::*;
 
@@ -38,7 +41,8 @@ impl MigrationTrait for Baseline {
         // name. Re-running CREATE TABLE would fail; fold leftover upgrades
         // into this snapshot instead and leave the rows alone.
         if manager.has_table("app").await? {
-            return ensure_app_owner(manager).await;
+            ensure_app_owner(manager).await?;
+            return ensure_code_owner(manager).await;
         }
         for entry in baseline::tables() {
             manager.create_table(entry.table).await?;
@@ -101,6 +105,64 @@ async fn ensure_app_owner(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
         .await
 }
 
+/// Owner columns for the code-mode tables, for self-host databases that
+/// recorded a baseline written before code mode joined the owner-scoped
+/// regime (decision 47, decision 48 step 1). Every row on such a database
+/// belongs to the local owner, which is what the column default says.
+///
+/// The owner-scoped repository index is created here too. A database written
+/// under the older baseline also carries a unique constraint on
+/// `code_repo.root_path` alone, which SQLite cannot drop in place; on those
+/// databases two owners cannot register the same path until the store is
+/// recreated. Fresh databases get the per-owner uniqueness the baseline
+/// declares.
+async fn ensure_code_owner(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    const CODE_TABLES: [&str; 7] = [
+        "code_repo",
+        "code_workspace",
+        "code_session",
+        "code_turn",
+        "code_turn_attachment",
+        "code_event",
+        "code_approval",
+    ];
+    for name in CODE_TABLES {
+        if !manager.has_table(name).await? {
+            continue;
+        }
+        if manager.has_column(name, "owner").await? {
+            continue;
+        }
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new(name))
+                    .add_column(
+                        ColumnDef::new(idens::CodeWorkspace::Owner)
+                            .text()
+                            .not_null()
+                            .default("local"),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+    }
+    if manager.has_table("code_workspace").await? {
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name("idx_code_workspace_owner_created")
+                    .table(idens::CodeWorkspace::Table)
+                    .col(idens::CodeWorkspace::Owner)
+                    .col(idens::CodeWorkspace::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
@@ -133,6 +195,63 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    /// The self-host durable branch: a database that recorded the older
+    /// baseline keeps its code rows and gains the owner column in place,
+    /// rather than having `CREATE TABLE` re-run against it.
+    #[tokio::test]
+    async fn an_existing_pre_owner_code_repo_is_backfilled_and_not_recreated() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        db.execute_unprepared(
+            "CREATE TABLE app (
+                id TEXT PRIMARY KEY NOT NULL,
+                name TEXT NOT NULL,
+                current_revision_id TEXT NOT NULL,
+                revision_count INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT,
+                owner TEXT NOT NULL DEFAULT 'local'
+            )",
+        )
+        .await
+        .unwrap();
+        db.execute_unprepared(
+            "CREATE TABLE code_repo (
+                id TEXT PRIMARY KEY NOT NULL,
+                root_path TEXT NOT NULL UNIQUE,
+                display_name TEXT NOT NULL,
+                default_base_ref TEXT NOT NULL,
+                branch_prefix TEXT NOT NULL,
+                setup_script TEXT,
+                archive_script TEXT,
+                quick_actions TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )",
+        )
+        .await
+        .unwrap();
+        db.execute_unprepared(concat!(
+            "INSERT INTO code_repo (id, root_path, display_name, default_base_ref, ",
+            "branch_prefix, quick_actions, created_at) VALUES ",
+            "('00000000-0000-0000-0000-000000000003', '/srv/legacy', 'legacy', 'main', ",
+            "'tidebreak/', '[]', '2026-08-14 00:00:00+00:00')"
+        ))
+        .await
+        .unwrap();
+
+        Migrator::up(&db, None).await.unwrap();
+
+        let row = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT owner FROM code_repo WHERE display_name = 'legacy'".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.try_get::<String>("", "owner").unwrap(), "local");
     }
 
     #[tokio::test]

--- a/crates/tidebreak-core/src/db/migration/baseline/code.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/code.rs
@@ -1,20 +1,40 @@
 //! Code-mode tables. No foreign keys into chat tables — the surfaces are
 //! type-and-schema separated.
+//!
+//! Every table here carries an `owner` column holding the storage key of the
+//! principal the row belongs to, the way chat, document, and app rows do. The
+//! column is denormalized onto child rows rather than reached through a join,
+//! so an owner-scoped query exists for every table and a shared database
+//! partitions cleanly by user. On the desktop profile every row belongs to
+//! the single local owner and keeps the default.
+//!
+//! Repositories are owned too: nothing in code mode is shared across owners,
+//! so two users may register or clone the same remote independently.
 
 use sea_orm_migration::prelude::*;
 
 use crate::db::migration::idens::*;
 
+/// Storage key written by unscoped (local-profile) writers.
+const LOCAL_OWNER: &str = "local";
+
+fn owner_column<T: IntoIden>(column: T) -> ColumnDef {
+    ColumnDef::new(column)
+        .text()
+        .not_null()
+        .default(LOCAL_OWNER)
+        .to_owned()
+}
+
 pub(super) fn code_repo_table() -> TableCreateStatement {
     Table::create()
         .table(CodeRepo::Table)
         .col(ColumnDef::new(CodeRepo::Id).uuid().not_null().primary_key())
-        .col(
-            ColumnDef::new(CodeRepo::RootPath)
-                .text()
-                .not_null()
-                .unique_key(),
-        )
+        .col(owner_column(CodeRepo::Owner))
+        // Registration paths are unique per owner, not per install: two users
+        // on a shared machine may each register the same path, and each one
+        // clones into an owner-keyed directory of their own.
+        .col(ColumnDef::new(CodeRepo::RootPath).text().not_null())
         .col(ColumnDef::new(CodeRepo::DisplayName).text().not_null())
         .col(ColumnDef::new(CodeRepo::DefaultBaseRef).text().not_null())
         .col(ColumnDef::new(CodeRepo::BranchPrefix).text().not_null())
@@ -34,7 +54,13 @@ pub(super) fn code_repo_table() -> TableCreateStatement {
 }
 
 pub(super) fn code_repo_indexes() -> Vec<IndexCreateStatement> {
-    vec![]
+    vec![Index::create()
+        .name("idx_code_repo_owner_root_path")
+        .table(CodeRepo::Table)
+        .col(CodeRepo::Owner)
+        .col(CodeRepo::RootPath)
+        .unique()
+        .to_owned()]
 }
 
 pub(super) fn code_workspace_table() -> TableCreateStatement {
@@ -46,6 +72,7 @@ pub(super) fn code_workspace_table() -> TableCreateStatement {
                 .not_null()
                 .primary_key(),
         )
+        .col(owner_column(CodeWorkspace::Owner))
         .col(ColumnDef::new(CodeWorkspace::RepoId).uuid().not_null())
         .col(ColumnDef::new(CodeWorkspace::Title).text().not_null())
         .col(
@@ -80,13 +107,21 @@ pub(super) fn code_workspace_table() -> TableCreateStatement {
 }
 
 pub(super) fn code_workspace_indexes() -> Vec<IndexCreateStatement> {
-    vec![Index::create()
-        .name("idx_code_workspace_repo_branch")
-        .table(CodeWorkspace::Table)
-        .col(CodeWorkspace::RepoId)
-        .col(CodeWorkspace::BranchName)
-        .unique()
-        .to_owned()]
+    vec![
+        Index::create()
+            .name("idx_code_workspace_repo_branch")
+            .table(CodeWorkspace::Table)
+            .col(CodeWorkspace::RepoId)
+            .col(CodeWorkspace::BranchName)
+            .unique()
+            .to_owned(),
+        Index::create()
+            .name("idx_code_workspace_owner_created")
+            .table(CodeWorkspace::Table)
+            .col(CodeWorkspace::Owner)
+            .col(CodeWorkspace::CreatedAt)
+            .to_owned(),
+    ]
 }
 
 pub(super) fn code_session_table() -> TableCreateStatement {
@@ -98,6 +133,7 @@ pub(super) fn code_session_table() -> TableCreateStatement {
                 .not_null()
                 .primary_key(),
         )
+        .col(owner_column(CodeSession::Owner))
         .col(ColumnDef::new(CodeSession::WorkspaceId).uuid().not_null())
         .col(ColumnDef::new(CodeSession::HarnessKind).text().not_null())
         .col(ColumnDef::new(CodeSession::HarnessVersion).text())
@@ -166,6 +202,7 @@ pub(super) fn code_turn_table() -> TableCreateStatement {
     Table::create()
         .table(CodeTurn::Table)
         .col(ColumnDef::new(CodeTurn::Id).uuid().not_null().primary_key())
+        .col(owner_column(CodeTurn::Owner))
         .col(ColumnDef::new(CodeTurn::SessionId).uuid().not_null())
         .col(ColumnDef::new(CodeTurn::Ordinal).big_integer().not_null())
         .col(ColumnDef::new(CodeTurn::Status).text().not_null())
@@ -207,6 +244,7 @@ pub(super) fn code_turn_indexes() -> Vec<IndexCreateStatement> {
 pub(super) fn code_turn_attachment_table() -> TableCreateStatement {
     Table::create()
         .table(CodeTurnAttachment::Table)
+        .col(owner_column(CodeTurnAttachment::Owner))
         .col(ColumnDef::new(CodeTurnAttachment::TurnId).uuid().not_null())
         .col(
             ColumnDef::new(CodeTurnAttachment::Ordinal)
@@ -264,6 +302,7 @@ pub(super) fn code_turn_attachment_indexes() -> Vec<IndexCreateStatement> {
 pub(super) fn code_event_table() -> TableCreateStatement {
     Table::create()
         .table(CodeEvent::Table)
+        .col(owner_column(CodeEvent::Owner))
         .col(ColumnDef::new(CodeEvent::SessionId).uuid().not_null())
         .col(ColumnDef::new(CodeEvent::Seq).big_integer().not_null())
         .col(ColumnDef::new(CodeEvent::Event).json_binary().not_null())
@@ -300,6 +339,7 @@ pub(super) fn code_approval_table() -> TableCreateStatement {
                 .not_null()
                 .primary_key(),
         )
+        .col(owner_column(CodeApproval::Owner))
         .col(ColumnDef::new(CodeApproval::SessionId).uuid().not_null())
         .col(ColumnDef::new(CodeApproval::TurnId).uuid().not_null())
         .col(ColumnDef::new(CodeApproval::Kind).json_binary().not_null())

--- a/crates/tidebreak-core/src/db/migration/baseline/mod.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/mod.rs
@@ -30,8 +30,8 @@ pub(super) const SEED_STATEMENTS: &[&str] = &[
 
 /// A table and the named indexes that belong to it. Implicit indexes come
 /// from the primary-key and unique column definitions in the table itself.
-pub(super) struct BaselineTable {
-    pub(super) table: TableCreateStatement,
+pub(crate) struct BaselineTable {
+    pub(crate) table: TableCreateStatement,
     pub(super) indexes: Vec<IndexCreateStatement>,
 }
 
@@ -39,6 +39,11 @@ pub(super) struct BaselineTable {
 /// already exist — and, on Postgres, only at unique constraints or unique
 /// indexes that already exist, which is why each table's indexes are created
 /// with it rather than in a second pass. `down` drops them in reverse.
+#[cfg(test)]
+pub(crate) fn tables_for_test() -> Vec<BaselineTable> {
+    tables()
+}
+
 pub(super) fn tables() -> Vec<BaselineTable> {
     vec![
         // Chats and their history.

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -805,6 +805,7 @@ pub(crate) enum CodeRepo {
     ArchiveScript,
     QuickActions,
     CreatedAt,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -820,6 +821,7 @@ pub(crate) enum CodeWorkspace {
     Pr,
     CreatedAt,
     ArchivedAt,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -840,6 +842,7 @@ pub(crate) enum CodeSession {
     AttentionSource,
     UnrecognizedEventCount,
     CreatedAt,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -857,6 +860,7 @@ pub(crate) enum CodeTurn {
     Narrative,
     StartedAt,
     EndedAt,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -867,6 +871,7 @@ pub(crate) enum CodeTurnAttachment {
     BlobId,
     MediaType,
     ByteLen,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -876,6 +881,7 @@ pub(crate) enum CodeEvent {
     Seq,
     Event,
     CreatedAt,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -890,4 +896,5 @@ pub(crate) enum CodeApproval {
     Feedback,
     RequestedAt,
     DecidedAt,
+    Owner,
 }

--- a/crates/tidebreak-core/src/db/ops/code/approval.rs
+++ b/crates/tidebreak-core/src/db/ops/code/approval.rs
@@ -4,13 +4,19 @@ use crate::code::{
     CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeSessionId, CodeTurnId,
 };
 use crate::error::{AgentError, Result};
+use crate::OwnerId;
 
 use super::super::super::{entities, store_err, DbStore};
 
-/// Insert an approval row.
-pub async fn insert_approval(store: &DbStore, approval: &CodeApproval) -> Result<()> {
+/// Insert an approval row under its session's owner.
+pub async fn insert_approval(
+    store: &DbStore,
+    owner: &OwnerId,
+    approval: &CodeApproval,
+) -> Result<()> {
     entities::code_approval::ActiveModel {
         id: Set(approval.id.0),
+        owner: Set(owner.as_str().to_owned()),
         session_id: Set(approval.session_id.0),
         turn_id: Set(approval.turn_id.0),
         kind: Set(serde_json::to_value(&approval.kind)?),
@@ -26,9 +32,14 @@ pub async fn insert_approval(store: &DbStore, approval: &CodeApproval) -> Result
     Ok(())
 }
 
-/// Load an approval by id.
-pub async fn get_approval(store: &DbStore, id: CodeApprovalId) -> Result<Option<CodeApproval>> {
+/// Load one of the owner's approvals by id.
+pub async fn get_approval(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: CodeApprovalId,
+) -> Result<Option<CodeApproval>> {
     let Some(row) = entities::code_approval::Entity::find_by_id(id.0)
+        .filter(entities::code_approval::Column::Owner.eq(owner.as_str()))
         .one(&store.conn)
         .await
         .map_err(store_err)?
@@ -39,7 +50,11 @@ pub async fn get_approval(store: &DbStore, id: CodeApprovalId) -> Result<Option<
 }
 
 /// Persist a decision or other mutation. Returns whether a row was updated.
-pub async fn save_approval(store: &DbStore, approval: &CodeApproval) -> Result<bool> {
+pub async fn save_approval(
+    store: &DbStore,
+    owner: &OwnerId,
+    approval: &CodeApproval,
+) -> Result<bool> {
     let result = entities::code_approval::Entity::update_many()
         .col_expr(
             entities::code_approval::Column::State,
@@ -54,19 +69,22 @@ pub async fn save_approval(store: &DbStore, approval: &CodeApproval) -> Result<b
             sea_orm::sea_query::Expr::value(approval.decided_at),
         )
         .filter(entities::code_approval::Column::Id.eq(approval.id.0))
+        .filter(entities::code_approval::Column::Owner.eq(owner.as_str()))
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
     Ok(result.rows_affected == 1)
 }
 
-/// List approvals, optionally filtered by state and session.
+/// The owner's approvals, optionally filtered by state and session.
 pub async fn list_approvals(
     store: &DbStore,
+    owner: &OwnerId,
     state: Option<CodeApprovalState>,
     session_id: Option<CodeSessionId>,
 ) -> Result<Vec<CodeApproval>> {
-    let mut query = entities::code_approval::Entity::find();
+    let mut query = entities::code_approval::Entity::find()
+        .filter(entities::code_approval::Column::Owner.eq(owner.as_str()));
     if let Some(state) = state {
         query = query.filter(entities::code_approval::Column::State.eq(state.as_str().to_owned()));
     }

--- a/crates/tidebreak-core/src/db/ops/code/journal.rs
+++ b/crates/tidebreak-core/src/db/ops/code/journal.rs
@@ -5,6 +5,7 @@ use sea_orm::{
 
 use crate::code::{CodeEvent, CodeSessionId, SequencedCodeEvent};
 use crate::error::{AgentError, Result};
+use crate::OwnerId;
 
 use super::super::super::{entities, store_err, DbStore};
 use super::{acquire_code_session_write_lock, CodeJournalError};
@@ -17,6 +18,7 @@ use super::{acquire_code_session_write_lock, CodeJournalError};
 /// worker cannot corrupt the stream.
 pub async fn append_event(
     store: &DbStore,
+    owner: &OwnerId,
     session_id: CodeSessionId,
     spawn_epoch: i64,
     event: &CodeEvent,
@@ -26,6 +28,7 @@ pub async fn append_event(
         return Err(CodeJournalError::SessionNotFound { session_id });
     }
     let Some(session) = entities::code_session::Entity::find_by_id(session_id.0)
+        .filter(entities::code_session::Column::Owner.eq(owner.as_str()))
         .one(&transaction)
         .await
         .map_err(store_err)?
@@ -40,6 +43,7 @@ pub async fn append_event(
         });
     }
     let last = entities::code_event::Entity::find()
+        .filter(entities::code_event::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_event::Column::SessionId.eq(session_id.0))
         .order_by_desc(entities::code_event::Column::Seq)
         .one(&transaction)
@@ -53,6 +57,7 @@ pub async fn append_event(
             ))
         })?;
     entities::code_event::ActiveModel {
+        owner: Set(owner.as_str().to_owned()),
         session_id: Set(session_id.0),
         seq: Set(seq),
         event: Set(serde_json::to_value(event).map_err(AgentError::from)?),
@@ -68,9 +73,11 @@ pub async fn append_event(
 /// Created-at of the newest journal row, if the session has any.
 pub async fn latest_event_created_at(
     store: &DbStore,
+    owner: &OwnerId,
     session_id: CodeSessionId,
 ) -> Result<Option<chrono::DateTime<Utc>>> {
     Ok(entities::code_event::Entity::find()
+        .filter(entities::code_event::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_event::Column::SessionId.eq(session_id.0))
         .order_by_desc(entities::code_event::Column::Seq)
         .one(&store.conn)
@@ -79,13 +86,15 @@ pub async fn latest_event_created_at(
         .map(|model| model.created_at))
 }
 
-/// Events for a session with `seq > after`, in order.
+/// Events for one of the owner's sessions with `seq > after`, in order.
 pub async fn list_events(
     store: &DbStore,
+    owner: &OwnerId,
     session_id: CodeSessionId,
     after: i64,
 ) -> Result<Vec<SequencedCodeEvent>> {
     entities::code_event::Entity::find()
+        .filter(entities::code_event::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_event::Column::SessionId.eq(session_id.0))
         .filter(entities::code_event::Column::Seq.gt(after))
         .order_by_asc(entities::code_event::Column::Seq)

--- a/crates/tidebreak-core/src/db/ops/code/repo.rs
+++ b/crates/tidebreak-core/src/db/ops/code/repo.rs
@@ -2,13 +2,15 @@ use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrde
 
 use crate::code::{CodeRepo, QuickAction, RepoId};
 use crate::error::{AgentError, Result};
+use crate::OwnerId;
 
 use super::super::super::{entities, store_err, DbStore};
 
-/// Insert a registered repository.
+/// Insert a registered repository. The row belongs to `repo.owner`.
 pub async fn insert_repo(store: &DbStore, repo: &CodeRepo) -> Result<()> {
     entities::code_repo::ActiveModel {
         id: Set(repo.id.0),
+        owner: Set(repo.owner.as_str().to_owned()),
         root_path: Set(repo.root_path.clone()),
         display_name: Set(repo.display_name.clone()),
         default_base_ref: Set(repo.default_base_ref.clone()),
@@ -24,9 +26,12 @@ pub async fn insert_repo(store: &DbStore, repo: &CodeRepo) -> Result<()> {
     Ok(())
 }
 
-/// Load a repository by id.
-pub async fn get_repo(store: &DbStore, id: RepoId) -> Result<Option<CodeRepo>> {
+/// Load one of the owner's repositories by id.
+///
+/// Another owner's repository is indistinguishable from a missing one.
+pub async fn get_repo(store: &DbStore, owner: &OwnerId, id: RepoId) -> Result<Option<CodeRepo>> {
     let Some(row) = entities::code_repo::Entity::find_by_id(id.0)
+        .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
         .one(&store.conn)
         .await
         .map_err(store_err)?
@@ -36,9 +41,14 @@ pub async fn get_repo(store: &DbStore, id: RepoId) -> Result<Option<CodeRepo>> {
     Ok(Some(repo_from_row(row)?))
 }
 
-/// Load a repository by its canonical toplevel path.
-pub async fn get_repo_by_root_path(store: &DbStore, root_path: &str) -> Result<Option<CodeRepo>> {
+/// Load one of the owner's repositories by its canonical toplevel path.
+pub async fn get_repo_by_root_path(
+    store: &DbStore,
+    owner: &OwnerId,
+    root_path: &str,
+) -> Result<Option<CodeRepo>> {
     let Some(row) = entities::code_repo::Entity::find()
+        .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_repo::Column::RootPath.eq(root_path))
         .one(&store.conn)
         .await
@@ -49,8 +59,25 @@ pub async fn get_repo_by_root_path(store: &DbStore, root_path: &str) -> Result<O
     Ok(Some(repo_from_row(row)?))
 }
 
-/// Every registered repository, most recently created first.
-pub async fn list_repos(store: &DbStore) -> Result<Vec<CodeRepo>> {
+/// The owner's registered repositories, most recently created first.
+pub async fn list_repos(store: &DbStore, owner: &OwnerId) -> Result<Vec<CodeRepo>> {
+    entities::code_repo::Entity::find()
+        .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
+        .order_by_desc(entities::code_repo::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(repo_from_row)
+        .collect()
+}
+
+/// Every registered repository on the machine, most recently created first.
+///
+/// A system path, not a request path: the boot-time checkpoint-ref sweep
+/// walks every repo regardless of who owns it. Nothing reachable from a
+/// route may call it.
+pub async fn list_repos_all_owners(store: &DbStore) -> Result<Vec<CodeRepo>> {
     entities::code_repo::Entity::find()
         .order_by_desc(entities::code_repo::Column::CreatedAt)
         .all(&store.conn)
@@ -89,15 +116,19 @@ pub async fn save_repo(store: &DbStore, repo: &CodeRepo) -> Result<bool> {
             sea_orm::sea_query::Expr::value(serde_json::to_value(&repo.quick_actions)?),
         )
         .filter(entities::code_repo::Column::Id.eq(repo.id.0))
+        .filter(entities::code_repo::Column::Owner.eq(repo.owner.as_str()))
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
     Ok(result.rows_affected == 1)
 }
 
-/// Delete a repository. Callers must have removed its workspaces first.
-pub async fn delete_repo(store: &DbStore, id: RepoId) -> Result<bool> {
-    let result = entities::code_repo::Entity::delete_by_id(id.0)
+/// Delete one of the owner's repositories. Callers must have removed its
+/// workspaces first.
+pub async fn delete_repo(store: &DbStore, owner: &OwnerId, id: RepoId) -> Result<bool> {
+    let result = entities::code_repo::Entity::delete_many()
+        .filter(entities::code_repo::Column::Id.eq(id.0))
+        .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
@@ -109,6 +140,7 @@ pub(super) fn repo_from_row(row: entities::code_repo::Model) -> Result<CodeRepo>
         .map_err(|err| AgentError::Store(format!("code_repo {} quick_actions: {err}", row.id)))?;
     Ok(CodeRepo {
         id: RepoId(row.id),
+        owner: OwnerId::new(&row.owner)?,
         root_path: row.root_path,
         display_name: row.display_name,
         default_base_ref: row.default_base_ref,

--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -8,14 +8,17 @@ use crate::code::{
     CodeSessionLifecycle, FenceReason, HarnessKind, WorkspaceId,
 };
 use crate::error::{AgentError, Result};
+use crate::OwnerId;
 
 use super::super::super::{entities, store_err, DbStore};
 use super::acquire_code_session_write_lock;
 
-/// Insert a session row.
+/// Insert a session row. The row belongs to `session.owner`, denormalized
+/// from the workspace it runs in.
 pub async fn insert_session(store: &DbStore, session: &CodeSession) -> Result<()> {
     entities::code_session::ActiveModel {
         id: Set(session.id.0),
+        owner: Set(session.owner.as_str().to_owned()),
         workspace_id: Set(session.workspace_id.0),
         harness_kind: Set(session.harness_kind.as_str().to_owned()),
         harness_version: Set(session.harness_version.clone()),
@@ -40,8 +43,35 @@ pub async fn insert_session(store: &DbStore, session: &CodeSession) -> Result<()
     Ok(())
 }
 
-/// Load a session by id.
-pub async fn get_session(store: &DbStore, id: CodeSessionId) -> Result<Option<CodeSession>> {
+/// Load one of the owner's sessions by id.
+///
+/// Another owner's session is indistinguishable from a missing one.
+pub async fn get_session(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: CodeSessionId,
+) -> Result<Option<CodeSession>> {
+    let Some(row) = entities::code_session::Entity::find_by_id(id.0)
+        .filter(entities::code_session::Column::Owner.eq(owner.as_str()))
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(session_from_row(row)?))
+}
+
+/// Load a session by id, whatever owner it belongs to.
+///
+/// A system path, not a request path: a session worker re-reads the row it
+/// was spawned against after bumping the spawn epoch, and the id it holds
+/// was authorized when the worker was created. Nothing reachable from a
+/// route may call it.
+pub async fn get_session_all_owners(
+    store: &DbStore,
+    id: CodeSessionId,
+) -> Result<Option<CodeSession>> {
     let Some(row) = entities::code_session::Entity::find_by_id(id.0)
         .one(&store.conn)
         .await
@@ -99,9 +129,10 @@ pub async fn bump_spawn_epoch(
     Ok(next)
 }
 
-/// Every session, most recently created first.
-pub async fn list_sessions(store: &DbStore) -> Result<Vec<CodeSession>> {
+/// The owner's sessions, most recently created first.
+pub async fn list_sessions(store: &DbStore, owner: &OwnerId) -> Result<Vec<CodeSession>> {
     entities::code_session::Entity::find()
+        .filter(entities::code_session::Column::Owner.eq(owner.as_str()))
         .order_by_desc(entities::code_session::Column::CreatedAt)
         .all(&store.conn)
         .await
@@ -111,12 +142,14 @@ pub async fn list_sessions(store: &DbStore) -> Result<Vec<CodeSession>> {
         .collect()
 }
 
-/// Sessions belonging to one workspace, most recently created first.
+/// The owner's sessions in one workspace, most recently created first.
 pub async fn list_sessions_for_workspace(
     store: &DbStore,
+    owner: &OwnerId,
     workspace_id: WorkspaceId,
 ) -> Result<Vec<CodeSession>> {
     entities::code_session::Entity::find()
+        .filter(entities::code_session::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_session::Column::WorkspaceId.eq(workspace_id.0))
         .order_by_desc(entities::code_session::Column::CreatedAt)
         .all(&store.conn)
@@ -127,8 +160,29 @@ pub async fn list_sessions_for_workspace(
         .collect()
 }
 
-/// Sessions in one lifecycle state.
-pub async fn list_sessions_by_lifecycle(
+/// Every session on the machine, most recently created first.
+///
+/// A system path, not a request path: boot recovery re-attaches a worker to
+/// each live session regardless of who owns it. Nothing reachable from a
+/// route may call it.
+pub async fn list_sessions_all_owners(store: &DbStore) -> Result<Vec<CodeSession>> {
+    entities::code_session::Entity::find()
+        .order_by_desc(entities::code_session::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(session_from_row)
+        .collect()
+}
+
+/// Sessions in one lifecycle state, across every owner.
+///
+/// A system path, not a request path: boot recovery and the stall sweep act
+/// on the whole machine's sessions, the way the chat side's unscoped store
+/// handle serves turn workers and retirement scans. Nothing reachable from a
+/// route may call it.
+pub async fn list_sessions_by_lifecycle_all_owners(
     store: &DbStore,
     lifecycle: CodeSessionLifecycle,
 ) -> Result<Vec<CodeSession>> {
@@ -150,6 +204,7 @@ pub async fn list_sessions_by_lifecycle(
 pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool> {
     let mut predicate = Condition::all()
         .add(entities::code_session::Column::Id.eq(session.id.0))
+        .add(entities::code_session::Column::Owner.eq(session.owner.as_str()))
         .add(entities::code_session::Column::SpawnEpoch.lte(session.spawn_epoch));
     if session.lifecycle != CodeSessionLifecycle::Ended {
         predicate = predicate.add(
@@ -216,7 +271,7 @@ pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool
     if result.rows_affected != 1 {
         // Rare, and invisible without a word: distinguish a superseded writer
         // from a row that is simply gone.
-        if let Some(current) = get_session(store, session.id).await? {
+        if let Some(current) = get_session(store, &session.owner, session.id).await? {
             tracing::warn!(
                 session = %session.id,
                 attempted_epoch = session.spawn_epoch,
@@ -267,6 +322,7 @@ pub(super) fn session_from_row(row: entities::code_session::Model) -> Result<Cod
     };
     Ok(CodeSession {
         id: CodeSessionId(row.id),
+        owner: OwnerId::new(&row.owner)?,
         workspace_id: WorkspaceId(row.workspace_id),
         harness_kind,
         harness_version: row.harness_version,

--- a/crates/tidebreak-core/src/db/ops/code/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/code/turn.rs
@@ -9,16 +9,18 @@ use crate::code::{
 use crate::error::{AgentError, Result};
 use crate::image::ImageMediaType;
 use crate::model::MAX_MESSAGE_ATTACHMENTS;
+use crate::OwnerId;
 
 use super::super::super::{entities, store_err, DbStore};
 use super::super::blob as blob_ops;
 
-/// Insert a turn row.
-pub async fn insert_turn(store: &DbStore, turn: &CodeTurn) -> Result<()> {
+/// Insert a turn row under its session's owner.
+pub async fn insert_turn(store: &DbStore, owner: &OwnerId, turn: &CodeTurn) -> Result<()> {
     validate_attachments(&turn.attachments)?;
     let txn = store.conn.begin().await.map_err(store_err)?;
     entities::code_turn::ActiveModel {
         id: Set(turn.id.0),
+        owner: Set(owner.as_str().to_owned()),
         session_id: Set(turn.session_id.0),
         ordinal: Set(turn.ordinal),
         status: Set(turn.status.as_str().to_owned()),
@@ -40,7 +42,7 @@ pub async fn insert_turn(store: &DbStore, turn: &CodeTurn) -> Result<()> {
     .insert(&txn)
     .await
     .map_err(store_err)?;
-    insert_attachments_on(&txn, turn.id, &turn.attachments).await?;
+    insert_attachments_on(&txn, owner, turn.id, &turn.attachments).await?;
     txn.commit().await.map_err(store_err)?;
     Ok(())
 }
@@ -71,6 +73,7 @@ fn validate_attachments(attachments: &[CodeTurnAttachment]) -> Result<()> {
 
 async fn insert_attachments_on<C>(
     conn: &C,
+    owner: &OwnerId,
     turn_id: CodeTurnId,
     attachments: &[CodeTurnAttachment],
 ) -> Result<()>
@@ -92,6 +95,7 @@ where
             })?;
             Ok(entities::code_turn_attachment::ActiveModel {
                 turn_id: Set(turn_id.0),
+                owner: Set(owner.as_str().to_owned()),
                 ordinal: Set(ordinal),
                 blob_id: Set(attachment.blob_id),
                 media_type: Set(attachment.media_type.as_str().to_owned()),
@@ -112,11 +116,16 @@ where
     Ok(())
 }
 
-async fn load_attachments_on<C>(conn: &C, turn_id: CodeTurnId) -> Result<Vec<CodeTurnAttachment>>
+async fn load_attachments_on<C>(
+    conn: &C,
+    owner: &OwnerId,
+    turn_id: CodeTurnId,
+) -> Result<Vec<CodeTurnAttachment>>
 where
     C: ConnectionTrait,
 {
     let rows = entities::code_turn_attachment::Entity::find()
+        .filter(entities::code_turn_attachment::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_turn_attachment::Column::TurnId.eq(turn_id.0))
         .order_by_asc(entities::code_turn_attachment::Column::Ordinal)
         .all(conn)
@@ -144,21 +153,31 @@ where
         .collect()
 }
 
-/// Load a turn by id.
-pub async fn get_turn(store: &DbStore, id: CodeTurnId) -> Result<Option<CodeTurn>> {
+/// Load one of the owner's turns by id.
+pub async fn get_turn(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: CodeTurnId,
+) -> Result<Option<CodeTurn>> {
     let Some(row) = entities::code_turn::Entity::find_by_id(id.0)
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
         .one(&store.conn)
         .await
         .map_err(store_err)?
     else {
         return Ok(None);
     };
-    turn_from_stored(store, row).await.map(Some)
+    turn_from_stored(store, owner, row).await.map(Some)
 }
 
-/// Turns of one session, oldest first.
-pub async fn list_turns(store: &DbStore, session_id: CodeSessionId) -> Result<Vec<CodeTurn>> {
+/// Turns of one of the owner's sessions, oldest first.
+pub async fn list_turns(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<Vec<CodeTurn>> {
     let rows = entities::code_turn::Entity::find()
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_turn::Column::SessionId.eq(session_id.0))
         .order_by_asc(entities::code_turn::Column::Ordinal)
         .all(&store.conn)
@@ -166,14 +185,19 @@ pub async fn list_turns(store: &DbStore, session_id: CodeSessionId) -> Result<Ve
         .map_err(store_err)?;
     let mut turns = Vec::with_capacity(rows.len());
     for row in rows {
-        turns.push(turn_from_stored(store, row).await?);
+        turns.push(turn_from_stored(store, owner, row).await?);
     }
     Ok(turns)
 }
 
-/// How many turns a session has recorded.
-pub async fn count_turns(store: &DbStore, session_id: CodeSessionId) -> Result<i64> {
+/// How many turns one of the owner's sessions has recorded.
+pub async fn count_turns(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<i64> {
     let count = entities::code_turn::Entity::find()
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_turn::Column::SessionId.eq(session_id.0))
         .count(&store.conn)
         .await
@@ -182,9 +206,14 @@ pub async fn count_turns(store: &DbStore, session_id: CodeSessionId) -> Result<i
         .map_err(|_| AgentError::Store(format!("turn count overflow for session {session_id}")))
 }
 
-/// Most recently created turn for a session, if any.
-pub async fn latest_turn(store: &DbStore, session_id: CodeSessionId) -> Result<Option<CodeTurn>> {
+/// Most recently created turn for one of the owner's sessions, if any.
+pub async fn latest_turn(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<Option<CodeTurn>> {
     let Some(row) = entities::code_turn::Entity::find()
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_turn::Column::SessionId.eq(session_id.0))
         .order_by_desc(entities::code_turn::Column::Ordinal)
         .one(&store.conn)
@@ -193,21 +222,30 @@ pub async fn latest_turn(store: &DbStore, session_id: CodeSessionId) -> Result<O
     else {
         return Ok(None);
     };
-    turn_from_stored(store, row).await.map(Some)
+    turn_from_stored(store, owner, row).await.map(Some)
 }
 
-/// The open (non-terminal) turn for a session, if any.
-pub async fn get_open_turn(store: &DbStore, session_id: CodeSessionId) -> Result<Option<CodeTurn>> {
-    let turns = list_turns(store, session_id).await?;
+/// The open (non-terminal) turn for one of the owner's sessions, if any.
+pub async fn get_open_turn(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<Option<CodeTurn>> {
+    let turns = list_turns(store, owner, session_id).await?;
     Ok(turns
         .into_iter()
         .rev()
         .find(|turn| turn.status == CodeTurnStatus::Running))
 }
 
-/// Next 1-based ordinal for a new turn on this session.
-pub async fn next_turn_ordinal(store: &DbStore, session_id: CodeSessionId) -> Result<i64> {
+/// Next 1-based ordinal for a new turn on one of the owner's sessions.
+pub async fn next_turn_ordinal(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<i64> {
     let last = entities::code_turn::Entity::find()
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_turn::Column::SessionId.eq(session_id.0))
         .order_by_desc(entities::code_turn::Column::Ordinal)
         .one(&store.conn)
@@ -220,7 +258,7 @@ pub async fn next_turn_ordinal(store: &DbStore, session_id: CodeSessionId) -> Re
 }
 
 /// Persist mutable turn fields. `id`, `session_id`, `ordinal`, and `started_at` stay as stored.
-pub async fn save_turn(store: &DbStore, turn: &CodeTurn) -> Result<bool> {
+pub async fn save_turn(store: &DbStore, owner: &OwnerId, turn: &CodeTurn) -> Result<bool> {
     let result = entities::code_turn::Entity::update_many()
         .col_expr(
             entities::code_turn::Column::Status,
@@ -261,15 +299,20 @@ pub async fn save_turn(store: &DbStore, turn: &CodeTurn) -> Result<bool> {
             sea_orm::sea_query::Expr::value(turn.ended_at),
         )
         .filter(entities::code_turn::Column::Id.eq(turn.id.0))
+        .filter(entities::code_turn::Column::Owner.eq(owner.as_str()))
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
     Ok(result.rows_affected == 1)
 }
 
-async fn turn_from_stored(store: &DbStore, row: entities::code_turn::Model) -> Result<CodeTurn> {
+async fn turn_from_stored(
+    store: &DbStore,
+    owner: &OwnerId,
+    row: entities::code_turn::Model,
+) -> Result<CodeTurn> {
     let mut turn = turn_from_row(row)?;
-    turn.attachments = load_attachments_on(&store.conn, turn.id).await?;
+    turn.attachments = load_attachments_on(&store.conn, owner, turn.id).await?;
     Ok(turn)
 }
 

--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -2,13 +2,16 @@ use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrde
 
 use crate::code::{CodeWorkspace, CodeWorkspaceStatus, PullRequestDigest, RepoId, WorkspaceId};
 use crate::error::{AgentError, Result};
+use crate::OwnerId;
 
 use super::super::super::{entities, store_err, DbStore};
 
-/// Insert a workspace.
+/// Insert a workspace. The row belongs to `workspace.owner`, denormalized
+/// from the repository it was created against.
 pub async fn insert_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Result<()> {
     entities::code_workspace::ActiveModel {
         id: Set(workspace.id.0),
+        owner: Set(workspace.owner.as_str().to_owned()),
         repo_id: Set(workspace.repo_id.0),
         title: Set(workspace.title.clone()),
         worktree_path: Set(workspace.worktree_path.clone()),
@@ -28,9 +31,16 @@ pub async fn insert_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Res
     Ok(())
 }
 
-/// Load a workspace by id.
-pub async fn get_workspace(store: &DbStore, id: WorkspaceId) -> Result<Option<CodeWorkspace>> {
+/// Load one of the owner's workspaces by id.
+///
+/// Another owner's workspace is indistinguishable from a missing one.
+pub async fn get_workspace(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: WorkspaceId,
+) -> Result<Option<CodeWorkspace>> {
     let Some(row) = entities::code_workspace::Entity::find_by_id(id.0)
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
         .one(&store.conn)
         .await
         .map_err(store_err)?
@@ -40,13 +50,15 @@ pub async fn get_workspace(store: &DbStore, id: WorkspaceId) -> Result<Option<Co
     Ok(Some(workspace_from_row(row)?))
 }
 
-/// Workspaces of one repo, or every workspace when `repo_id` is `None`.
-/// Most recently created first.
+/// The owner's workspaces in one repo, or all of them when `repo_id` is
+/// `None`. Most recently created first.
 pub async fn list_workspaces(
     store: &DbStore,
+    owner: &OwnerId,
     repo_id: Option<RepoId>,
 ) -> Result<Vec<CodeWorkspace>> {
-    let mut query = entities::code_workspace::Entity::find();
+    let mut query = entities::code_workspace::Entity::find()
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()));
     if let Some(repo_id) = repo_id {
         query = query.filter(entities::code_workspace::Column::RepoId.eq(repo_id.0));
     }
@@ -95,6 +107,7 @@ pub async fn save_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Resul
             sea_orm::sea_query::Expr::value(workspace.archived_at),
         )
         .filter(entities::code_workspace::Column::Id.eq(workspace.id.0))
+        .filter(entities::code_workspace::Column::Owner.eq(workspace.owner.as_str()))
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
@@ -108,6 +121,7 @@ pub async fn save_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Resul
 /// else, no matter when the write lands. Returns whether the row changed.
 pub async fn set_workspace_title_if(
     store: &DbStore,
+    owner: &OwnerId,
     id: WorkspaceId,
     expected: &str,
     title: &str,
@@ -118,6 +132,7 @@ pub async fn set_workspace_title_if(
             sea_orm::sea_query::Expr::value(title.to_owned()),
         )
         .filter(entities::code_workspace::Column::Id.eq(id.0))
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_workspace::Column::Title.eq(expected))
         .exec(&store.conn)
         .await
@@ -126,8 +141,10 @@ pub async fn set_workspace_title_if(
 }
 
 /// Delete a workspace row. Used to roll back a failed create that left no checkout.
-pub async fn delete_workspace(store: &DbStore, id: WorkspaceId) -> Result<bool> {
-    let result = entities::code_workspace::Entity::delete_by_id(id.0)
+pub async fn delete_workspace(store: &DbStore, owner: &OwnerId, id: WorkspaceId) -> Result<bool> {
+    let result = entities::code_workspace::Entity::delete_many()
+        .filter(entities::code_workspace::Column::Id.eq(id.0))
+        .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
@@ -150,6 +167,7 @@ pub(super) fn workspace_from_row(row: entities::code_workspace::Model) -> Result
     };
     Ok(CodeWorkspace {
         id: WorkspaceId(row.id),
+        owner: OwnerId::new(&row.owner)?,
         repo_id: RepoId(row.repo_id),
         title: row.title,
         worktree_path: row.worktree_path,

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -7,9 +7,11 @@ use crate::code::{
 };
 use crate::db::code::{
     append_event, bump_spawn_epoch, get_approval, get_repo, get_session, get_turn, get_workspace,
-    insert_approval, insert_repo, insert_session, insert_turn, insert_workspace, list_events,
-    save_session, set_workspace_title_if, CodeJournalError,
+    insert_approval, insert_repo, insert_session, insert_turn, insert_workspace, list_approvals,
+    list_events, list_repos, list_sessions, list_turns, save_session, set_workspace_title_if,
+    CodeJournalError,
 };
+use crate::OwnerId;
 use chrono::Utc;
 
 fn now() -> chrono::DateTime<Utc> {
@@ -23,13 +25,26 @@ async fn seeded_session() -> (
     CodeTurnId,
 ) {
     let (dir, store) = temp_store().await;
+    let (session_id, turn_id) = seed_owner(&store, &OwnerId::local(), "example").await;
+    (dir, store, session_id, turn_id)
+}
+
+/// Seed one owner's whole code-mode graph into an existing store: repo,
+/// workspace, session, turn. Two calls with different owners give the
+/// cross-owner fixture the isolation tests need.
+async fn seed_owner(
+    store: &crate::db::DbStore,
+    owner: &OwnerId,
+    label: &str,
+) -> (CodeSessionId, CodeTurnId) {
     let repo_id = RepoId::new();
     insert_repo(
-        &store,
+        store,
         &CodeRepo {
             id: repo_id,
-            root_path: "/tmp/example-repo".into(),
-            display_name: "example".into(),
+            owner: owner.clone(),
+            root_path: format!("/tmp/{label}-repo"),
+            display_name: label.to_owned(),
             default_base_ref: "main".into(),
             branch_prefix: "tidebreak/".into(),
             setup_script: None,
@@ -42,12 +57,13 @@ async fn seeded_session() -> (
     .unwrap();
     let workspace_id = WorkspaceId::new();
     insert_workspace(
-        &store,
+        store,
         &CodeWorkspace {
             id: workspace_id,
+            owner: owner.clone(),
             repo_id,
             title: "first".into(),
-            worktree_path: "/tmp/example-worktree".into(),
+            worktree_path: format!("/tmp/{label}-worktree"),
             branch_name: "tidebreak/first".into(),
             base_ref: "main".into(),
             status: CodeWorkspaceStatus::Active,
@@ -60,9 +76,10 @@ async fn seeded_session() -> (
     .unwrap();
     let session_id = CodeSessionId::new();
     insert_session(
-        &store,
+        store,
         &CodeSession {
             id: session_id,
+            owner: owner.clone(),
             workspace_id,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: Some("2.1.233".into()),
@@ -82,7 +99,8 @@ async fn seeded_session() -> (
     .unwrap();
     let turn_id = CodeTurnId::new();
     insert_turn(
-        &store,
+        store,
+        owner,
         &CodeTurn {
             id: turn_id,
             session_id,
@@ -101,7 +119,7 @@ async fn seeded_session() -> (
     )
     .await
     .unwrap();
-    (dir, store, session_id, turn_id)
+    (session_id, turn_id)
 }
 
 /// Background workspace naming writes through this swap: it must replace
@@ -110,18 +128,22 @@ async fn seeded_session() -> (
 #[tokio::test]
 async fn workspace_title_swap_replaces_only_the_expected_title() {
     let (_dir, store, session_id, _turn) = seeded_session().await;
-    let workspace_id = get_session(&store, session_id)
+    let workspace_id = get_session(&store, &OwnerId::local(), session_id)
         .await
         .unwrap()
         .unwrap()
         .workspace_id;
-    assert!(
-        set_workspace_title_if(&store, workspace_id, "first", "Derived name")
-            .await
-            .unwrap()
-    );
+    assert!(set_workspace_title_if(
+        &store,
+        &OwnerId::local(),
+        workspace_id,
+        "first",
+        "Derived name"
+    )
+    .await
+    .unwrap());
     assert_eq!(
-        get_workspace(&store, workspace_id)
+        get_workspace(&store, &OwnerId::local(), workspace_id)
             .await
             .unwrap()
             .unwrap()
@@ -130,13 +152,17 @@ async fn workspace_title_swap_replaces_only_the_expected_title() {
     );
     // A second writer holding the stale expectation no longer matches: the
     // title that landed first keeps the floor.
-    assert!(
-        !set_workspace_title_if(&store, workspace_id, "first", "Late derived name")
-            .await
-            .unwrap()
-    );
+    assert!(!set_workspace_title_if(
+        &store,
+        &OwnerId::local(),
+        workspace_id,
+        "first",
+        "Late derived name"
+    )
+    .await
+    .unwrap());
     assert_eq!(
-        get_workspace(&store, workspace_id)
+        get_workspace(&store, &OwnerId::local(), workspace_id)
             .await
             .unwrap()
             .unwrap()
@@ -148,22 +174,32 @@ async fn workspace_title_swap_replaces_only_the_expected_title() {
 #[tokio::test]
 async fn entity_graph_round_trips() {
     let (_dir, store, session_id, turn_id) = seeded_session().await;
-    let session = get_session(&store, session_id).await.unwrap().unwrap();
+    let session = get_session(&store, &OwnerId::local(), session_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(session.harness_kind, HarnessKind::ClaudeCode);
     assert_eq!(session.spawn_epoch, 0);
-    let turn = get_turn(&store, turn_id).await.unwrap().unwrap();
+    let turn = get_turn(&store, &OwnerId::local(), turn_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(turn.user_input, "hello");
-    let workspace = get_workspace(&store, session.workspace_id)
+    let workspace = get_workspace(&store, &OwnerId::local(), session.workspace_id)
         .await
         .unwrap()
         .unwrap();
     assert_eq!(workspace.status, CodeWorkspaceStatus::Active);
-    let repo = get_repo(&store, workspace.repo_id).await.unwrap().unwrap();
+    let repo = get_repo(&store, &OwnerId::local(), workspace.repo_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(repo.branch_prefix, "tidebreak/");
 
     let approval_id = CodeApprovalId::new();
     insert_approval(
         &store,
+        &OwnerId::local(),
         &CodeApproval {
             id: approval_id,
             session_id,
@@ -180,7 +216,10 @@ async fn entity_graph_round_trips() {
     )
     .await
     .unwrap();
-    let approval = get_approval(&store, approval_id).await.unwrap().unwrap();
+    let approval = get_approval(&store, &OwnerId::local(), approval_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(approval.state, CodeApprovalState::Pending);
 }
 
@@ -192,14 +231,20 @@ async fn entity_graph_round_trips() {
 #[tokio::test]
 async fn a_superseded_worker_cannot_regress_the_session_row() {
     let (_dir, store, session_id, _) = seeded_session().await;
-    let outgoing = get_session(&store, session_id).await.unwrap().unwrap();
+    let outgoing = get_session(&store, &OwnerId::local(), session_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         bump_spawn_epoch(&store, session_id, Some(99))
             .await
             .unwrap(),
         1
     );
-    let mut live = get_session(&store, session_id).await.unwrap().unwrap();
+    let mut live = get_session(&store, &OwnerId::local(), session_id)
+        .await
+        .unwrap()
+        .unwrap();
     live.lifecycle = CodeSessionLifecycle::Running;
     assert!(save_session(&store, &live).await.unwrap());
 
@@ -208,14 +253,23 @@ async fn a_superseded_worker_cannot_regress_the_session_row() {
     unwinding.child_pid = None;
     assert!(!save_session(&store, &unwinding).await.unwrap());
 
-    let row = get_session(&store, session_id).await.unwrap().unwrap();
+    let row = get_session(&store, &OwnerId::local(), session_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.spawn_epoch, 1);
     assert_eq!(row.lifecycle, CodeSessionLifecycle::Running);
     assert_eq!(row.child_pid, Some(99));
     // The live worker is still the one that owns the journal.
-    append_event(&store, session_id, 1, &CodeEvent::TurnInterrupted)
-        .await
-        .unwrap();
+    append_event(
+        &store,
+        &OwnerId::local(),
+        session_id,
+        1,
+        &CodeEvent::TurnInterrupted,
+    )
+    .await
+    .unwrap();
 }
 
 /// Archive marks the row Ended without bumping spawn_epoch. A same-epoch
@@ -224,7 +278,10 @@ async fn a_superseded_worker_cannot_regress_the_session_row() {
 #[tokio::test]
 async fn an_ended_session_cannot_be_revived_by_a_same_epoch_persist() {
     let (_dir, store, session_id, _) = seeded_session().await;
-    let mut ended = get_session(&store, session_id).await.unwrap().unwrap();
+    let mut ended = get_session(&store, &OwnerId::local(), session_id)
+        .await
+        .unwrap()
+        .unwrap();
     ended.lifecycle = CodeSessionLifecycle::Ended;
     ended.child_pid = None;
     assert!(save_session(&store, &ended).await.unwrap());
@@ -239,7 +296,10 @@ async fn an_ended_session_cannot_be_revived_by_a_same_epoch_persist() {
     idle.child_pid = Some(7);
     assert!(!save_session(&store, &idle).await.unwrap());
 
-    let row = get_session(&store, session_id).await.unwrap().unwrap();
+    let row = get_session(&store, &OwnerId::local(), session_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.lifecycle, CodeSessionLifecycle::Ended);
     assert_eq!(row.child_pid, None);
     assert_eq!(row.spawn_epoch, 0);
@@ -252,12 +312,14 @@ async fn an_ended_session_cannot_be_revived_by_a_same_epoch_persist() {
 async fn journal_rejects_stale_spawn_epoch() {
     let (_dir, store, session_id, _) = seeded_session().await;
     let event = CodeEvent::TurnInterrupted;
-    append_event(&store, session_id, 0, &event).await.unwrap();
+    append_event(&store, &OwnerId::local(), session_id, 0, &event)
+        .await
+        .unwrap();
     let new_epoch = bump_spawn_epoch(&store, session_id, Some(42))
         .await
         .unwrap();
     assert_eq!(new_epoch, 1);
-    let err = append_event(&store, session_id, 0, &event)
+    let err = append_event(&store, &OwnerId::local(), session_id, 0, &event)
         .await
         .unwrap_err();
     match err {
@@ -269,8 +331,12 @@ async fn journal_rejects_stale_spawn_epoch() {
         }
         other => panic!("expected stale epoch, got {other:?}"),
     }
-    append_event(&store, session_id, 1, &event).await.unwrap();
-    let events = list_events(&store, session_id, 0).await.unwrap();
+    append_event(&store, &OwnerId::local(), session_id, 1, &event)
+        .await
+        .unwrap();
+    let events = list_events(&store, &OwnerId::local(), session_id, 0)
+        .await
+        .unwrap();
     assert_eq!(events.len(), 2);
     assert_eq!(events[0].seq, 1);
     assert_eq!(events[1].seq, 2);
@@ -293,7 +359,10 @@ async fn spawn_epoch_bumps_are_serialized() {
     }
     epochs.sort_unstable();
     assert_eq!(epochs, (1..=n).collect::<Vec<_>>());
-    let session = get_session(&store, session_id).await.unwrap().unwrap();
+    let session = get_session(&store, &OwnerId::local(), session_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(session.spawn_epoch, n);
 }
 
@@ -307,6 +376,7 @@ async fn journal_seq_is_monotonic_under_concurrent_appends() {
         joins.push(tokio::spawn(async move {
             append_event(
                 &store,
+                &OwnerId::local(),
                 session_id,
                 0,
                 &CodeEvent::AssistantDelta {
@@ -323,7 +393,9 @@ async fn journal_seq_is_monotonic_under_concurrent_appends() {
     }
     seqs.sort_unstable();
     assert_eq!(seqs, (1..=n).collect::<Vec<_>>());
-    let events = list_events(&store, session_id, 0).await.unwrap();
+    let events = list_events(&store, &OwnerId::local(), session_id, 0)
+        .await
+        .unwrap();
     assert_eq!(events.len(), n as usize);
     assert!(events.windows(2).all(|pair| pair[0].seq + 1 == pair[1].seq));
 }
@@ -403,4 +475,282 @@ fn chat_and_code_entities_do_not_cross_reference() {
             );
         }
     });
+}
+
+/// Decision 47's validation for code mode: on a shared store, a second user
+/// sees none of another owner's `code_*` rows. Every table is exercised, not
+/// a sample, because the wrong implementation scopes the surfaces someone
+/// remembered and leaves the rest reachable.
+#[tokio::test]
+async fn owner_scoped_code_queries_partition_every_table() {
+    let (_dir, store) = temp_store().await;
+    let alice = OwnerId::new("alice").unwrap();
+    let bob = OwnerId::new("bob").unwrap();
+    let (alice_session, alice_turn) = seed_owner(&store, &alice, "alice").await;
+    let (bob_session, _bob_turn) = seed_owner(&store, &bob, "bob").await;
+
+    // Repositories and workspaces: each owner sees exactly one of each.
+    let alice_repos = list_repos(&store, &alice).await.unwrap();
+    assert_eq!(alice_repos.len(), 1);
+    assert_eq!(alice_repos[0].display_name, "alice");
+    let bob_repos = list_repos(&store, &bob).await.unwrap();
+    assert_eq!(bob_repos.len(), 1);
+    assert_eq!(bob_repos[0].display_name, "bob");
+    assert!(get_repo(&store, &bob, alice_repos[0].id)
+        .await
+        .unwrap()
+        .is_none());
+
+    let alice_workspace = get_session(&store, &alice, alice_session)
+        .await
+        .unwrap()
+        .unwrap()
+        .workspace_id;
+    assert!(get_workspace(&store, &bob, alice_workspace)
+        .await
+        .unwrap()
+        .is_none());
+
+    // Sessions: listed per owner, and another owner's id resolves to nothing.
+    assert_eq!(list_sessions(&store, &alice).await.unwrap().len(), 1);
+    assert_eq!(list_sessions(&store, &bob).await.unwrap().len(), 1);
+    assert!(get_session(&store, &bob, alice_session)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(get_session(&store, &alice, bob_session)
+        .await
+        .unwrap()
+        .is_none());
+
+    // Turns.
+    assert!(get_turn(&store, &bob, alice_turn).await.unwrap().is_none());
+    assert!(list_turns(&store, &bob, alice_session)
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Journal events: the second user replays nothing from the first user's
+    // session, whatever cursor they ask from.
+    append_event(
+        &store,
+        &alice,
+        alice_session,
+        0,
+        &CodeEvent::TurnInterrupted,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        list_events(&store, &alice, alice_session, 0)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(list_events(&store, &bob, alice_session, 0)
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Approvals.
+    let approval_id = CodeApprovalId::new();
+    insert_approval(
+        &store,
+        &alice,
+        &CodeApproval {
+            id: approval_id,
+            session_id: alice_session,
+            turn_id: alice_turn,
+            kind: CodeApprovalKind::FileWrite {
+                paths: vec!["secret.txt".into()],
+            },
+            harness_raw: serde_json::json!({"tool":"Write"}),
+            state: CodeApprovalState::Pending,
+            feedback: None,
+            requested_at: now(),
+            decided_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(get_approval(&store, &bob, approval_id)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(list_approvals(&store, &bob, None, None)
+        .await
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        list_approvals(&store, &alice, None, None)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+
+    // Writes do not cross either: a save carrying another owner's key changes
+    // no row, so a forged record cannot overwrite one it does not own.
+    assert!(
+        !set_workspace_title_if(&store, &bob, alice_workspace, "first", "stolen")
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        get_workspace(&store, &alice, alice_workspace)
+            .await
+            .unwrap()
+            .unwrap()
+            .title,
+        "first"
+    );
+}
+
+/// Two owners may register the same repository path. The uniqueness that
+/// keeps one owner from registering a path twice is per owner, not per
+/// install, or the second user on a shared machine could not use code mode
+/// on a repository the first user had already registered.
+#[tokio::test]
+async fn the_same_repository_path_can_belong_to_two_owners() {
+    let (_dir, store) = temp_store().await;
+    let alice = OwnerId::new("alice").unwrap();
+    let bob = OwnerId::new("bob").unwrap();
+    for owner in [&alice, &bob] {
+        insert_repo(
+            &store,
+            &CodeRepo {
+                id: RepoId::new(),
+                owner: owner.clone(),
+                root_path: "/srv/shared-checkout".into(),
+                display_name: "shared".into(),
+                default_base_ref: "main".into(),
+                branch_prefix: "tidebreak/".into(),
+                setup_script: None,
+                archive_script: None,
+                quick_actions: Vec::new(),
+                created_at: now(),
+            },
+        )
+        .await
+        .unwrap();
+    }
+    let found = crate::db::code::get_repo_by_root_path(&store, &bob, "/srv/shared-checkout")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found.owner, bob);
+}
+
+/// Decision 48 step 1 is structural: the owner column is on *every* code
+/// table, so an owner-scoped query exists for each one. A new `code_*` table
+/// added without an owner fails here rather than in review.
+#[test]
+fn every_code_table_carries_an_owner_column() {
+    let mut checked = Vec::new();
+    for entry in crate::db::migration::tables_for_test() {
+        let Some(name) = entry.table.get_table_name().map(|name| format!("{name:?}")) else {
+            continue;
+        };
+        // `TableRef` has no Display; its debug form names the table.
+        let name = name
+            .rsplit(['(', ')', '"', ' '])
+            .find(|part| part.starts_with("code_") || part.contains('_'))
+            .unwrap_or(&name)
+            .to_owned();
+        if !name.starts_with("code_") {
+            continue;
+        }
+        let has_owner = entry
+            .table
+            .get_columns()
+            .iter()
+            .any(|column| column.get_column_name() == "owner");
+        assert!(
+            has_owner,
+            "{name} has no owner column: every code_* table is owner-scoped \
+             (decision 48 step 1), so add one rather than reaching this row \
+             through a join"
+        );
+        checked.push(name);
+    }
+    checked.sort();
+    assert_eq!(
+        checked,
+        [
+            "code_approval",
+            "code_event",
+            "code_repo",
+            "code_session",
+            "code_turn",
+            "code_turn_attachment",
+            "code_workspace",
+        ],
+        "the set of code tables changed; confirm the new one is owner-scoped"
+    );
+}
+
+/// Every code-mode store function takes an owner, so there is no unscoped
+/// query for a caller to reach for by accident. The exceptions are named
+/// `_all_owners` and are documented as system paths — boot recovery, the
+/// stall sweep, and a worker re-reading the session it was spawned against.
+#[test]
+fn code_store_queries_are_owner_scoped_or_say_they_are_not() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/db/ops/code");
+    let mut unscoped = Vec::new();
+    for entry in std::fs::read_dir(&dir).expect("code ops directory") {
+        let path = entry.expect("code ops entry").path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).expect("code ops file");
+        let file = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_owned();
+        let mut lines = text.lines().peekable();
+        while let Some(line) = lines.next() {
+            let Some(rest) = line.trim_start().strip_prefix("pub async fn ") else {
+                continue;
+            };
+            let name = rest.split('(').next().unwrap_or_default().to_owned();
+            // `insert_*` and `save_*` carry the owner on the record itself;
+            // `bump_spawn_epoch` and the lock helpers act on an id a caller
+            // already authorized.
+            if name.starts_with("insert_")
+                || name.starts_with("save_")
+                || name == "bump_spawn_epoch"
+            {
+                continue;
+            }
+            if name.ends_with("_all_owners") {
+                continue;
+            }
+            // The owner parameter is on the signature, which may wrap.
+            let mut signature = line.to_owned();
+            for _ in 0..12 {
+                if signature.contains(") ->") {
+                    break;
+                }
+                match lines.peek() {
+                    Some(next) => {
+                        signature.push_str(next);
+                        lines.next();
+                    }
+                    None => break,
+                }
+            }
+            if !signature.contains("owner: &OwnerId") {
+                unscoped.push(format!("{file}::{name}"));
+            }
+        }
+    }
+    assert!(
+        unscoped.is_empty(),
+        "these code store queries take no owner: {unscoped:?}. Add an \
+         `owner: &OwnerId` parameter and filter on it, or, if this really is a \
+         system path rather than a request path, name it `*_all_owners` and \
+         say why in its documentation."
+    );
 }

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -720,6 +720,7 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
         store,
         &CodeRepo {
             id: repo_id,
+            owner: crate::OwnerId::local(),
             root_path: format!("/tmp/code-turn-{}", blob.id),
             display_name: "example".into(),
             default_base_ref: "main".into(),
@@ -737,6 +738,7 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
         store,
         &CodeWorkspace {
             id: workspace_id,
+            owner: crate::OwnerId::local(),
             repo_id,
             title: "first".into(),
             worktree_path: format!("/tmp/code-turn-wt-{}", blob.id),
@@ -755,6 +757,7 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
         store,
         &CodeSession {
             id: session_id,
+            owner: crate::OwnerId::local(),
             workspace_id,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: Some("scripted".into()),
@@ -774,6 +777,7 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
     .unwrap();
     insert_turn(
         store,
+        &crate::OwnerId::local(),
         &CodeTurn {
             id: CodeTurnId::new(),
             session_id,

--- a/crates/tidebreak-core/src/model/identity.rs
+++ b/crates/tidebreak-core/src/model/identity.rs
@@ -66,6 +66,19 @@ impl std::fmt::Display for OwnerId {
     }
 }
 
+impl Serialize for OwnerId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for OwnerId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        Self::new(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Largest attachment revision represented exactly by every supported client.
 ///
 /// JSON numbers become JavaScript `number` values in the desktop renderer, so

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -1,0 +1,276 @@
+#![cfg(feature = "postgres")]
+
+//! Owner scoping for code mode, on the backend a shared deployment runs.
+//!
+//! The SQLite suite in `db::tests::code` proves the same partitioning, but a
+//! shared machine is exactly the case owner scoping exists for (decisions 47
+//! and 48 step 1), and that machine runs PostgreSQL. The filters here are
+//! generated SQL, so backends can disagree — an owner column that is not
+//! actually compared would still pass on one and not the other.
+//!
+//! Skipped silently without `TIDEBREAK_POSTGRES_TEST_URL`, and hard-failed in
+//! CI, where `TIDEBREAK_REQUIRE_POSTGRES_TEST` is set.
+
+use chrono::Utc;
+use tidebreak_core::db::code::{
+    append_event, get_approval, get_repo, get_repo_by_root_path, get_session, get_turn,
+    get_workspace, insert_approval, insert_repo, insert_session, insert_turn, insert_workspace,
+    list_approvals, list_events, list_repos, list_sessions, list_turns, set_workspace_title_if,
+};
+use tidebreak_core::{
+    Attention, AttentionSource, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
+    CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionLifecycle,
+    CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, DbStore, HarnessKind,
+    OwnerId, RepoId, WorkspaceId,
+};
+
+static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Seed one owner's whole code graph and hand back the ids.
+async fn seed_owner(
+    store: &DbStore,
+    owner: &OwnerId,
+    label: &str,
+) -> (RepoId, WorkspaceId, CodeSessionId, CodeTurnId) {
+    let repo_id = RepoId::new();
+    insert_repo(
+        store,
+        &CodeRepo {
+            id: repo_id,
+            owner: owner.clone(),
+            root_path: format!("/srv/{label}-repo"),
+            display_name: label.to_owned(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: Vec::new(),
+            created_at: Utc::now(),
+        },
+    )
+    .await
+    .unwrap();
+    let workspace_id = WorkspaceId::new();
+    insert_workspace(
+        store,
+        &CodeWorkspace {
+            id: workspace_id,
+            owner: owner.clone(),
+            repo_id,
+            title: "first".into(),
+            worktree_path: format!("/srv/{label}-worktree"),
+            branch_name: format!("tidebreak/{label}"),
+            base_ref: "main".into(),
+            status: CodeWorkspaceStatus::Active,
+            pr: None,
+            created_at: Utc::now(),
+            archived_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    let session_id = CodeSessionId::new();
+    insert_session(
+        store,
+        &CodeSession {
+            id: session_id,
+            owner: owner.clone(),
+            workspace_id,
+            harness_kind: HarnessKind::ClaudeCode,
+            harness_version: None,
+            harness_resume_ref: None,
+            permission_mode: CodePermissionMode::Ask,
+            model: None,
+            lifecycle: CodeSessionLifecycle::Idle,
+            fence_reason: None,
+            child_pid: None,
+            spawn_epoch: 0,
+            attention: Attention::working(AttentionSource::Lifecycle),
+            unrecognized_event_count: 0,
+            created_at: Utc::now(),
+        },
+    )
+    .await
+    .unwrap();
+    let turn_id = CodeTurnId::new();
+    insert_turn(
+        store,
+        owner,
+        &CodeTurn {
+            id: turn_id,
+            session_id,
+            ordinal: 1,
+            status: CodeTurnStatus::Running,
+            user_input: format!("{label} asked for something"),
+            user_input_blob_id: None,
+            attachments: Vec::new(),
+            checkpoint_ref: None,
+            diffstat: None,
+            usage: None,
+            narrative: None,
+            started_at: Utc::now(),
+            ended_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    (repo_id, workspace_id, session_id, turn_id)
+}
+
+#[tokio::test]
+async fn postgres_code_queries_partition_by_owner() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("TIDEBREAK_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("TIDEBREAK_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("TIDEBREAK_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    // Unique keys per run: the lane shares one database across tests.
+    let run = uuid::Uuid::new_v4().simple().to_string();
+    let alice = OwnerId::new(&format!("alice-{run}")).unwrap();
+    let bob = OwnerId::new(&format!("bob-{run}")).unwrap();
+    let (alice_repo, alice_workspace, alice_session, alice_turn) =
+        seed_owner(&store, &alice, &format!("alice-{run}")).await;
+    let (_bob_repo, _bob_workspace, bob_session, _bob_turn) =
+        seed_owner(&store, &bob, &format!("bob-{run}")).await;
+
+    // Each owner's listings hold only their own rows.
+    let alice_repos = list_repos(&store, &alice).await.unwrap();
+    assert_eq!(alice_repos.len(), 1);
+    assert_eq!(alice_repos[0].id, alice_repo);
+    assert_eq!(list_sessions(&store, &bob).await.unwrap().len(), 1);
+
+    // By-id reads across owners resolve to nothing on this backend too.
+    assert!(get_repo(&store, &bob, alice_repo).await.unwrap().is_none());
+    assert!(get_workspace(&store, &bob, alice_workspace)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(get_session(&store, &bob, alice_session)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(get_turn(&store, &bob, alice_turn).await.unwrap().is_none());
+    assert!(get_session(&store, &alice, bob_session)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(list_turns(&store, &bob, alice_session)
+        .await
+        .unwrap()
+        .is_empty());
+
+    // The journal.
+    append_event(
+        &store,
+        &alice,
+        alice_session,
+        0,
+        &CodeEvent::TurnInterrupted,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        list_events(&store, &alice, alice_session, 0)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(list_events(&store, &bob, alice_session, 0)
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Approvals.
+    let approval_id = CodeApprovalId::new();
+    insert_approval(
+        &store,
+        &alice,
+        &CodeApproval {
+            id: approval_id,
+            session_id: alice_session,
+            turn_id: alice_turn,
+            kind: CodeApprovalKind::FileWrite {
+                paths: vec!["secret.txt".into()],
+            },
+            harness_raw: serde_json::json!({"tool":"Write"}),
+            state: CodeApprovalState::Pending,
+            feedback: None,
+            requested_at: Utc::now(),
+            decided_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(get_approval(&store, &bob, approval_id)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(list_approvals(&store, &bob, None, Some(alice_session))
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Writes do not cross either.
+    assert!(
+        !set_workspace_title_if(&store, &bob, alice_workspace, "first", "stolen")
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        get_workspace(&store, &alice, alice_workspace)
+            .await
+            .unwrap()
+            .unwrap()
+            .title,
+        "first"
+    );
+}
+
+/// Repository registration is unique per owner on PostgreSQL as well: the
+/// composite index is what allows a second user to register a path the first
+/// user already has.
+#[tokio::test]
+async fn postgres_repository_paths_are_unique_per_owner() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("TIDEBREAK_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("TIDEBREAK_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("TIDEBREAK_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let run = uuid::Uuid::new_v4().simple().to_string();
+    let alice = OwnerId::new(&format!("alice-{run}")).unwrap();
+    let bob = OwnerId::new(&format!("bob-{run}")).unwrap();
+    let shared_path = format!("/srv/shared-{run}");
+
+    let repo = |owner: &OwnerId| CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: shared_path.clone(),
+        display_name: "shared".into(),
+        default_base_ref: "main".into(),
+        branch_prefix: "tidebreak/".into(),
+        setup_script: None,
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: Utc::now(),
+    };
+    insert_repo(&store, &repo(&alice)).await.unwrap();
+    insert_repo(&store, &repo(&bob)).await.unwrap();
+
+    let found = get_repo_by_root_path(&store, &bob, &shared_path)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found.owner, bob);
+
+    // The same owner registering the same path twice is still refused.
+    assert!(insert_repo(&store, &repo(&alice)).await.is_err());
+}

--- a/crates/tidebreak-server/src/code/approval_bridge.rs
+++ b/crates/tidebreak-server/src/code/approval_bridge.rs
@@ -204,7 +204,12 @@ async fn handle_tools_call(
             }),
         ));
     }
-    let session = runtime.get_session(session_id).await?;
+    // Reached by a single-use capability token minted for this session, not
+    // by a bearer credential, so there is no principal to scope against here.
+    // The token is the authorization, and it names one session.
+    let session = tidebreak_core::db::code::get_session_all_owners(&runtime.db, session_id)
+        .await?
+        .ok_or_else(|| ServerError::not_found(format!("session {session_id} not found")))?;
     if session.lifecycle == CodeSessionLifecycle::Ended {
         return Err(ServerError::conflict_kind(
             "session_ended",

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -10,11 +10,12 @@ use tracing::warn;
 
 use tidebreak_core::db::code::{
     count_turns, get_session, get_workspace, latest_event_created_at, latest_turn, list_approvals,
-    list_sessions, list_sessions_by_lifecycle, list_sessions_for_workspace, save_session,
+    list_sessions, list_sessions_by_lifecycle_all_owners, list_sessions_for_workspace,
+    save_session,
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeApprovalState, CodeSession, CodeSessionId,
-    CodeSessionLifecycle, CodeTurnStatus, DbStore, WorkspaceId,
+    CodeSessionLifecycle, CodeTurnStatus, DbStore, OwnerId, WorkspaceId,
 };
 
 use super::bus::{CodeEventBus, CodeLiveUpdate, SessionDigest};
@@ -65,11 +66,12 @@ pub(crate) async fn persist_session(
 pub(crate) async fn apply_attention(
     db: &DbStore,
     bus: &CodeEventBus,
+    owner: &OwnerId,
     session_id: CodeSessionId,
     next: Attention,
     from_user: bool,
 ) -> Result<Option<Attention>, tidebreak_core::AgentError> {
-    let Some(mut session) = get_session(db, session_id).await? else {
+    let Some(mut session) = get_session(db, owner, session_id).await? else {
         return Ok(None);
     };
     if !replace_attention(&mut session, next, from_user) {
@@ -112,7 +114,13 @@ pub(crate) async fn compute_attention(
             ));
         }
     }
-    let pending = list_approvals(db, Some(CodeApprovalState::Pending), Some(session.id)).await?;
+    let pending = list_approvals(
+        db,
+        &session.owner,
+        Some(CodeApprovalState::Pending),
+        Some(session.id),
+    )
+    .await?;
     if !pending.is_empty() {
         return Ok(Attention::needs_you(
             "an approval is waiting",
@@ -130,7 +138,7 @@ pub(crate) async fn compute_attention(
         }
         return Ok(Attention::working(AttentionSource::Lifecycle));
     }
-    match latest_turn(db, session.id).await? {
+    match latest_turn(db, &session.owner, session.id).await? {
         Some(turn) if turn.status == CodeTurnStatus::Failed => Ok(Attention::needs_you(
             "the engine turn failed",
             AttentionSource::Lifecycle,
@@ -151,9 +159,10 @@ pub(crate) async fn compute_attention(
 pub(crate) async fn mark_viewed(
     db: &DbStore,
     bus: &CodeEventBus,
+    owner: &OwnerId,
     session_id: CodeSessionId,
 ) -> Result<(), tidebreak_core::AgentError> {
-    let Some(session) = get_session(db, session_id).await? else {
+    let Some(session) = get_session(db, owner, session_id).await? else {
         return Ok(());
     };
     if !matches!(session.attention.state, AttentionState::DoneUnreviewed) {
@@ -162,6 +171,7 @@ pub(crate) async fn mark_viewed(
     let _ = apply_attention(
         db,
         bus,
+        owner,
         session_id,
         Attention::working(AttentionSource::Lifecycle),
         false,
@@ -175,11 +185,12 @@ pub(crate) async fn mark_viewed(
 pub(crate) async fn user_set_attention(
     db: &DbStore,
     bus: &CodeEventBus,
+    owner: &OwnerId,
     session_id: CodeSessionId,
     clear: bool,
     note: Option<String>,
 ) -> Result<CodeSession, tidebreak_core::AgentError> {
-    let Some(mut session) = get_session(db, session_id).await? else {
+    let Some(mut session) = get_session(db, owner, session_id).await? else {
         return Err(tidebreak_core::AgentError::Store(format!(
             "session {session_id} not found"
         )));
@@ -209,7 +220,7 @@ pub(crate) async fn sweep_stalled(
     idle_secs: u32,
 ) -> Result<(), tidebreak_core::AgentError> {
     let now = Utc::now();
-    let running = list_sessions_by_lifecycle(db, CodeSessionLifecycle::Running).await?;
+    let running = list_sessions_by_lifecycle_all_owners(db, CodeSessionLifecycle::Running).await?;
     for session in running {
         let last = last_activity_at(db, &session).await?;
         let idle = now.signed_duration_since(last).num_seconds().max(0) as u32;
@@ -220,7 +231,7 @@ pub(crate) async fn sweep_stalled(
             AttentionState::Stalled { idle_secs: idle },
             AttentionSource::Heuristic,
         );
-        let _ = apply_attention(db, bus, session.id, next, false).await?;
+        let _ = apply_attention(db, bus, &session.owner, session.id, next, false).await?;
     }
     Ok(())
 }
@@ -229,9 +240,10 @@ pub(crate) async fn sweep_stalled(
 pub(crate) async fn note_activity(
     db: &DbStore,
     bus: &CodeEventBus,
+    owner: &OwnerId,
     session_id: CodeSessionId,
 ) -> Result<(), tidebreak_core::AgentError> {
-    let Some(session) = get_session(db, session_id).await? else {
+    let Some(session) = get_session(db, owner, session_id).await? else {
         return Ok(());
     };
     if session.lifecycle != CodeSessionLifecycle::Running {
@@ -243,6 +255,7 @@ pub(crate) async fn note_activity(
     let _ = apply_attention(
         db,
         bus,
+        owner,
         session_id,
         Attention::working(AttentionSource::Lifecycle),
         false,
@@ -253,7 +266,9 @@ pub(crate) async fn note_activity(
 
 pub(crate) async fn emit_digest(db: &DbStore, bus: &CodeEventBus, session: &CodeSession) {
     match build_digest(db, session).await {
-        Ok(digest) => bus.publish_update(CodeLiveUpdate::Digest(Box::new(digest))),
+        Ok(digest) => {
+            bus.publish_update(&session.owner, CodeLiveUpdate::Digest(Box::new(digest)));
+        }
         Err(err) => warn!(
             session = %session.id,
             error = %err,
@@ -265,9 +280,10 @@ pub(crate) async fn emit_digest(db: &DbStore, bus: &CodeEventBus, session: &Code
 pub(crate) async fn emit_workspace_digests(
     db: &DbStore,
     bus: &CodeEventBus,
+    owner: &OwnerId,
     workspace_id: WorkspaceId,
 ) {
-    match list_sessions_for_workspace(db, workspace_id).await {
+    match list_sessions_for_workspace(db, owner, workspace_id).await {
         Ok(sessions) => {
             for session in sessions {
                 emit_digest(db, bus, &session).await;
@@ -281,11 +297,15 @@ pub(crate) async fn emit_workspace_digests(
     }
 }
 
+/// The owner's live session digests, restated on every `/code/updates`
+/// connect. Scoped: a subscriber never learns that another owner's session
+/// exists.
 pub(crate) async fn list_digests(
     db: &DbStore,
+    owner: &OwnerId,
 ) -> Result<Vec<SessionDigest>, tidebreak_core::AgentError> {
     let mut out = Vec::new();
-    for session in list_sessions(db).await? {
+    for session in list_sessions(db, owner).await? {
         if session.lifecycle == CodeSessionLifecycle::Ended {
             continue;
         }
@@ -298,7 +318,7 @@ async fn build_digest(
     db: &DbStore,
     session: &CodeSession,
 ) -> Result<SessionDigest, tidebreak_core::AgentError> {
-    let workspace = get_workspace(db, session.workspace_id)
+    let workspace = get_workspace(db, &session.owner, session.workspace_id)
         .await?
         .ok_or_else(|| {
             tidebreak_core::AgentError::Store(format!(
@@ -306,7 +326,7 @@ async fn build_digest(
                 session.workspace_id, session.id
             ))
         })?;
-    let turn_count = count_turns(db, session.id).await?;
+    let turn_count = count_turns(db, &session.owner, session.id).await?;
     Ok(SessionDigest {
         workspace: session.workspace_id,
         session: session.id,
@@ -322,10 +342,10 @@ async fn last_activity_at(
     db: &DbStore,
     session: &CodeSession,
 ) -> Result<DateTime<Utc>, tidebreak_core::AgentError> {
-    if let Some(at) = latest_event_created_at(db, session.id).await? {
+    if let Some(at) = latest_event_created_at(db, &session.owner, session.id).await? {
         return Ok(at);
     }
-    if let Some(turn) = latest_turn(db, session.id).await? {
+    if let Some(turn) = latest_turn(db, &session.owner, session.id).await? {
         return Ok(turn.started_at);
     }
     Ok(session.created_at)
@@ -381,6 +401,7 @@ mod tests {
     fn session_with(attention: Attention) -> CodeSession {
         CodeSession {
             id: CodeSessionId::new(),
+            owner: tidebreak_core::OwnerId::local(),
             workspace_id: WorkspaceId::new(),
             harness_kind: tidebreak_core::HarnessKind::ClaudeCode,
             harness_version: None,

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -1,5 +1,5 @@
-//! In-memory live fan-out for one code-mode session plus the install-wide
-//! updates channel.
+//! In-memory live fan-out for one code-mode session plus the per-owner
+//! updates channels.
 //!
 //! The journal is the durable record a client replays on connect; this bus is
 //! the live tail. The session worker appends each event to the journal and
@@ -7,13 +7,21 @@
 //!
 //! `/code/updates` is unsequenced: a dropped notice costs nothing because the
 //! full digest is restated on every connect.
+//!
+//! Updates are keyed by owner rather than filtered on the way out. There is
+//! one broadcast channel per principal, so a subscriber's receiver carries
+//! only its own owner's notices and another owner's digest is not something
+//! the socket could drop — it never reaches it. Filtering published notices
+//! in the route, or in the client, would leave the cross-owner event on the
+//! wire for anyone who skipped the filter; decision 47 names that the wrong
+//! implementation.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
 
 use tidebreak_core::{
-    Attention, CodeSessionId, CodeSessionLifecycle, PullRequestDigest, RepoId, SequencedCodeEvent,
-    WorkspaceId,
+    Attention, CodeSessionId, CodeSessionLifecycle, OwnerId, PullRequestDigest, RepoId,
+    SequencedCodeEvent, WorkspaceId,
 };
 use tokio::sync::broadcast;
 
@@ -53,19 +61,18 @@ pub(crate) enum CodeLiveUpdate {
     CloneProgress(CloneProgress),
 }
 
-/// Per-session broadcast channels for live journal events, plus the
-/// install-wide digest channel.
+/// Per-session broadcast channels for live journal events, plus one digest
+/// channel per owner.
 pub(crate) struct CodeEventBus {
     channels: Mutex<HashMap<CodeSessionId, broadcast::Sender<SequencedCodeEvent>>>,
-    updates: broadcast::Sender<CodeLiveUpdate>,
+    updates: Mutex<HashMap<OwnerId, broadcast::Sender<CodeLiveUpdate>>>,
 }
 
 impl Default for CodeEventBus {
     fn default() -> Self {
-        let (updates, _) = broadcast::channel(UPDATES_BUFFER);
         Self {
             channels: Mutex::new(HashMap::new()),
-            updates,
+            updates: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -91,11 +98,24 @@ impl CodeEventBus {
         let _ = self.sender(session).send(event);
     }
 
-    pub(crate) fn subscribe_updates(&self) -> broadcast::Receiver<CodeLiveUpdate> {
-        self.updates.subscribe()
+    fn updates_sender(&self, owner: &OwnerId) -> broadcast::Sender<CodeLiveUpdate> {
+        self.updates
+            .lock()
+            .expect("code updates bus lock")
+            .entry(owner.clone())
+            .or_insert_with(|| broadcast::channel(UPDATES_BUFFER).0)
+            .clone()
     }
 
-    pub(crate) fn publish_update(&self, update: CodeLiveUpdate) {
-        let _ = self.updates.send(update);
+    /// Subscribe to one owner's updates. The receiver is the only view of the
+    /// channel a `/code/updates` socket gets, and it carries nothing else.
+    pub(crate) fn subscribe_updates(&self, owner: &OwnerId) -> broadcast::Receiver<CodeLiveUpdate> {
+        self.updates_sender(owner).subscribe()
+    }
+
+    /// Publish a notice to one owner. Publishers name the owner the notice
+    /// belongs to; there is no channel that reaches everyone.
+    pub(crate) fn publish_update(&self, owner: &OwnerId, update: CodeLiveUpdate) {
+        let _ = self.updates_sender(owner).send(update);
     }
 }

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -128,7 +128,7 @@ pub(crate) async fn after_turn_completed(
         Ok(recorded) => {
             turn.checkpoint_ref = Some(recorded.checkpoint_ref.clone());
             turn.diffstat = Some(recorded.diffstat.clone());
-            if let Err(err) = save_turn(db, turn).await {
+            if let Err(err) = save_turn(db, &session.owner, turn).await {
                 warn!(
                     session = %session.id,
                     turn = %turn.id,
@@ -174,7 +174,7 @@ async fn record_for_turn(
     session: &CodeSession,
     turn: &CodeTurn,
 ) -> Result<RecordedCheckpoint, CheckpointError> {
-    let workspace = get_workspace(db, session.workspace_id)
+    let workspace = get_workspace(db, &session.owner, session.workspace_id)
         .await
         .map_err(|err| CheckpointError::internal(err.to_string()))?
         .ok_or_else(|| CheckpointError::user("workspace not found"))?;
@@ -455,11 +455,11 @@ pub(crate) async fn resolve_diff_range(
             Ok((worktree, from, to, None))
         }
         Some(id) => {
-            let turn = get_turn(db, id)
+            let turn = get_turn(db, &workspace.owner, id)
                 .await
                 .map_err(|err| CheckpointError::internal(err.to_string()))?
                 .ok_or_else(|| CheckpointError::user("turn not found"))?;
-            let session = get_session(db, turn.session_id)
+            let session = get_session(db, &workspace.owner, turn.session_id)
                 .await
                 .map_err(|err| CheckpointError::internal(err.to_string()))?
                 .ok_or_else(|| CheckpointError::user("session not found"))?;
@@ -501,7 +501,7 @@ async fn previous_checkpoint_oid(
             return Ok(Some(oid));
         }
     }
-    let turns = list_turns(db, turn.session_id)
+    let turns = list_turns(db, &workspace.owner, turn.session_id)
         .await
         .map_err(|err| CheckpointError::internal(err.to_string()))?;
     Ok(turns
@@ -690,7 +690,7 @@ async fn journal(
     session: &CodeSession,
     event: CodeEvent,
 ) -> Result<(), tidebreak_core::db::code::CodeJournalError> {
-    let seq = append_event(db, session.id, session.spawn_epoch, &event).await?;
+    let seq = append_event(db, &session.owner, session.id, session.spawn_epoch, &event).await?;
     bus.publish(session.id, SequencedCodeEvent { seq, event });
     Ok(())
 }

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -14,7 +14,7 @@ use tokio::process::Command;
 use tokio::time::timeout;
 use uuid::Uuid;
 
-use tidebreak_core::{RepoId, Store};
+use tidebreak_core::{OwnerId, RepoId, Store};
 
 use super::bus::{CloneProgress, CodeLiveUpdate};
 use super::gh::{self, resolve_github_clone_url};
@@ -76,6 +76,43 @@ impl CloneJob {
     }
 }
 
+/// Directory a given owner's clones land in, under the deployment's shared
+/// clone parent.
+///
+/// The parent directory is one deployment-wide setting, so without a per-owner
+/// segment two users cloning the same remote would both target
+/// `<parent>/<name>` and the second would be refused — or worse, adopt the
+/// first user's checkout. The local profile keeps cloning straight into the
+/// parent, because there is exactly one owner and its paths are the ones users
+/// already have.
+///
+/// Owner keys are visible ASCII and may contain characters that are not safe
+/// in a path segment, so everything outside a conservative set is replaced.
+pub(crate) fn owner_clone_dir(parent: &Path, owner: &OwnerId) -> PathBuf {
+    if owner.is_local() {
+        return parent.to_path_buf();
+    }
+    let segment: String = owner
+        .as_str()
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    // A key of only separators must not resolve to the parent itself, and
+    // must never climb out of it.
+    let segment = segment.trim_matches('.').to_owned();
+    if segment.is_empty() {
+        parent.join("owner")
+    } else {
+        parent.join(segment)
+    }
+}
+
 /// Body fields after the route has rejected an empty or mixed source.
 pub(crate) struct CloneRequest {
     pub url: Option<String>,
@@ -105,6 +142,7 @@ impl CodeRuntime {
     /// Validate, remember the parent, return a job id, and spawn the clone.
     pub(crate) async fn start_clone(
         self: &std::sync::Arc<Self>,
+        owner: &OwnerId,
         request: CloneRequest,
     ) -> Result<CodeCloneJobSnapshot, ServerError> {
         let parent = PathBuf::from(request.parent_dir.trim());
@@ -128,7 +166,7 @@ impl CodeRuntime {
                 "name must be a single path segment",
             ));
         }
-        let target = parent.join(&name);
+        let target = owner_clone_dir(&parent, owner).join(&name);
         if target.exists() {
             return Err(ServerError::conflict_kind(
                 "clone_target_exists",
@@ -147,18 +185,25 @@ impl CodeRuntime {
             repo_id: None,
         };
         self.clone_jobs.insert(job.clone());
-        self.publish_clone(&job);
+        self.publish_clone(owner, &job);
 
         let runtime = std::sync::Arc::clone(self);
+        let owner = owner.clone();
         tokio::spawn(async move {
-            runtime.run_clone(id, source, target).await;
+            runtime.run_clone(&owner, id, source, target).await;
         });
         Ok(job.to_snapshot())
     }
 
-    async fn run_clone(self: std::sync::Arc<Self>, id: Uuid, url: String, target: PathBuf) {
+    async fn run_clone(
+        self: std::sync::Arc<Self>,
+        owner: &OwnerId,
+        id: Uuid,
+        url: String,
+        target: PathBuf,
+    ) {
         match clone_into(&url, &target, |phase, percent| {
-            self.touch_clone(id, |job| {
+            self.touch_clone(owner, id, |job| {
                 job.phase = phase.to_owned();
                 job.percent = Some(percent);
             });
@@ -166,11 +211,11 @@ impl CodeRuntime {
         .await
         {
             Ok(()) => match self
-                .register_repo(target, None, None, None, None, None)
+                .register_repo(owner, target, super::runtime::RepoRegistration::default())
                 .await
             {
                 Ok(repo) => {
-                    self.touch_clone(id, |job| {
+                    self.touch_clone(owner, id, |job| {
                         job.phase = "done".into();
                         job.percent = Some(100);
                         job.done = true;
@@ -178,38 +223,40 @@ impl CodeRuntime {
                     });
                 }
                 Err(error) => {
-                    self.fail_clone(id, error.message());
+                    self.fail_clone(owner, id, error.message());
                 }
             },
-            Err(error) => self.fail_clone(id, error),
+            Err(error) => self.fail_clone(owner, id, error),
         }
     }
 
-    fn touch_clone(&self, id: Uuid, update: impl FnOnce(&mut CloneJob)) {
+    fn touch_clone(&self, owner: &OwnerId, id: Uuid, update: impl FnOnce(&mut CloneJob)) {
         if let Some(job) = self.clone_jobs.apply(id, update) {
-            self.publish_clone(&job);
+            self.publish_clone(owner, &job);
         }
     }
 
-    fn fail_clone(&self, id: Uuid, error: impl Into<String>) {
+    fn fail_clone(&self, owner: &OwnerId, id: Uuid, error: impl Into<String>) {
         let error = bound_stderr(&error.into());
-        self.touch_clone(id, |job| {
+        self.touch_clone(owner, id, |job| {
             job.phase = "failed".into();
             job.done = true;
             job.error = Some(error);
         });
     }
 
-    fn publish_clone(&self, job: &CloneJob) {
-        self.bus
-            .publish_update(CodeLiveUpdate::CloneProgress(CloneProgress {
+    fn publish_clone(&self, owner: &OwnerId, job: &CloneJob) {
+        self.bus.publish_update(
+            owner,
+            CodeLiveUpdate::CloneProgress(CloneProgress {
                 job: job.id.to_string(),
                 phase: job.phase.clone(),
                 percent: job.percent,
                 done: job.done,
                 error: job.error.clone(),
                 repo_id: job.repo_id,
-            }));
+            }),
+        );
     }
 
     fn gh_search_path(&self) -> Option<String> {

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod clone;
 pub(crate) mod gh;
 pub(crate) mod recovery;
 pub(crate) mod runtime;
+pub(crate) mod scoped;
 pub(crate) mod session_worker;
 pub(crate) mod setup_script;
 pub(crate) mod terminal;
@@ -19,3 +20,4 @@ pub(crate) mod titling;
 pub(crate) mod worktree;
 
 pub(crate) use runtime::CodeRuntime;
+pub(crate) use scoped::ScopedCode;

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -10,7 +10,7 @@ use std::io::ErrorKind;
 
 use chrono::Utc;
 use tidebreak_core::db::code::{
-    append_event, get_open_turn, list_sessions_by_lifecycle, save_turn,
+    append_event, get_open_turn, list_sessions_by_lifecycle_all_owners, save_turn,
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeEvent, CodeSession, CodeSessionLifecycle,
@@ -47,7 +47,8 @@ pub(crate) async fn recover_running_sessions_with(
     bus: &CodeEventBus,
     probe: impl Fn(i64) -> PidLiveness,
 ) -> Result<Vec<RecoveryAction>, tidebreak_core::AgentError> {
-    let running = list_sessions_by_lifecycle(store, CodeSessionLifecycle::Running).await?;
+    let running =
+        list_sessions_by_lifecycle_all_owners(store, CodeSessionLifecycle::Running).await?;
     let mut actions = Vec::new();
     for session in running {
         if let Some(action) = recover_one(store, bus, session, &probe).await? {
@@ -171,12 +172,13 @@ async fn interrupt_open_turn(
     store: &DbStore,
     session: &CodeSession,
 ) -> Result<(), tidebreak_core::AgentError> {
-    if let Some(mut turn) = get_open_turn(store, session.id).await? {
+    if let Some(mut turn) = get_open_turn(store, &session.owner, session.id).await? {
         turn.status = CodeTurnStatus::Interrupted;
         turn.ended_at = Some(Utc::now());
-        save_turn(store, &turn).await?;
+        save_turn(store, &session.owner, &turn).await?;
         match append_event(
             store,
+            &session.owner,
             session.id,
             session.spawn_epoch,
             &CodeEvent::TurnInterrupted,
@@ -299,6 +301,7 @@ mod tests {
         let turn_id = CodeTurnId::new();
         insert_turn(
             &store,
+            &tidebreak_core::OwnerId::local(),
             &CodeTurn {
                 id: turn_id,
                 session_id,
@@ -336,6 +339,7 @@ mod tests {
             &store,
             &CodeRepo {
                 id: repo_id,
+                owner: tidebreak_core::OwnerId::local(),
                 root_path: directory.path().join("repo").display().to_string(),
                 display_name: "example".into(),
                 default_base_ref: "main".into(),
@@ -353,6 +357,7 @@ mod tests {
             &store,
             &CodeWorkspace {
                 id: workspace_id,
+                owner: tidebreak_core::OwnerId::local(),
                 repo_id,
                 title: "first".into(),
                 worktree_path: directory.path().join("wt").display().to_string(),
@@ -371,6 +376,7 @@ mod tests {
             &store,
             &CodeSession {
                 id: session_id,
+                owner: tidebreak_core::OwnerId::local(),
                 workspace_id,
                 harness_kind: HarnessKind::ClaudeCode,
                 harness_version: Some("2.1.233".into()),
@@ -402,7 +408,10 @@ mod tests {
             actions.as_slice(),
             [RecoveryAction::Interrupted { .. }]
         ));
-        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        let session = get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(session.lifecycle, CodeSessionLifecycle::Idle);
         assert!(matches!(
             session.attention.state,
@@ -411,7 +420,10 @@ mod tests {
                 ..
             }
         ));
-        let turn = get_turn(&store, turn_id).await.unwrap().unwrap();
+        let turn = get_turn(&store, &tidebreak_core::OwnerId::local(), turn_id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(turn.status, CodeTurnStatus::Interrupted);
     }
 
@@ -439,7 +451,10 @@ mod tests {
             actions.as_slice(),
             [RecoveryAction::Fenced { .. }]
         ));
-        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        let session = get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
         assert_eq!(session.fence_reason, Some(FenceReason::OrphanAlive));
         assert!(matches!(
@@ -448,7 +463,10 @@ mod tests {
                 reason: FenceReason::OrphanAlive
             }
         ));
-        let turn = get_turn(&store, turn_id).await.unwrap().unwrap();
+        let turn = get_turn(&store, &tidebreak_core::OwnerId::local(), turn_id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(turn.status, CodeTurnStatus::Running);
         assert!(
             decoy.try_wait().ok().flatten().is_none(),
@@ -468,10 +486,14 @@ mod tests {
         let (_dir, store, session_id) = seeded_session(None, CodeSessionLifecycle::Idle).await;
         let store = Arc::new(store);
         let bus = Arc::new(crate::code::bus::CodeEventBus::default());
-        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        let session = get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
+            .await
+            .unwrap()
+            .unwrap();
         let sink = crate::code::session_worker::sink_for(
             store.clone(),
             bus.clone(),
+            session.owner.clone(),
             session_id,
             session.spawn_epoch,
             None,
@@ -516,7 +538,10 @@ mod tests {
 
         let recorded = tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
-                let current = get_session(&store, session_id).await.unwrap().unwrap();
+                let current = get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
+                    .await
+                    .unwrap()
+                    .unwrap();
                 if let Some(pid) = current.child_pid {
                     return pid;
                 }
@@ -549,7 +574,10 @@ mod tests {
     #[tokio::test]
     async fn fenced_recovery_does_not_overwrite_a_manual_pin() {
         let (_dir, store, session_id, _) = seeded_running(Some(1)).await;
-        let mut session = get_session(&store, session_id).await.unwrap().unwrap();
+        let mut session = get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
+            .await
+            .unwrap()
+            .unwrap();
         session.attention = Attention::manual("hold");
         tidebreak_core::db::code::save_session(&store, &session)
             .await
@@ -562,7 +590,10 @@ mod tests {
             actions.as_slice(),
             [RecoveryAction::Fenced { .. }]
         ));
-        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        let session = get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
         assert!(
             matches!(session.attention.state, AttentionState::Manual { .. }),
@@ -582,7 +613,10 @@ mod tests {
             actions.as_slice(),
             [RecoveryAction::Fenced { .. }]
         ));
-        let session = get_session(&store, session_id).await.unwrap().unwrap();
+        let session = get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(session.lifecycle, CodeSessionLifecycle::Fenced);
     }
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -12,14 +12,15 @@ use tokio::sync::oneshot;
 use tidebreak_core::db::code::{
     delete_repo, delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path,
     get_session, get_workspace, insert_repo, insert_session, insert_workspace, list_approvals,
-    list_events, list_repos, list_sessions, list_sessions_for_workspace, list_turns,
-    list_workspaces, save_approval, save_repo, save_session, save_workspace,
+    list_events, list_repos, list_repos_all_owners, list_sessions, list_sessions_all_owners,
+    list_sessions_for_workspace, list_turns, list_workspaces, save_approval, save_repo,
+    save_session, save_workspace,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
     CodeApprovalState, CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId,
     CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, DbStore,
-    Diffstat, FenceReason, HarnessKind, RepoId, WorkspaceId,
+    Diffstat, FenceReason, HarnessKind, OwnerId, RepoId, WorkspaceId,
 };
 use tidebreak_harness::{
     builtin_registry, AdapterRegistry, ApprovalChannelSpec, ApprovalDecision, HarnessAdapter,
@@ -86,6 +87,17 @@ async fn wait_for_managed_node(
         }
         tokio::time::sleep(MANAGED_NODE_POLL_INTERVAL).await;
     }
+}
+
+/// Optional metadata on `POST /code/repos`. Every field left `None` takes
+/// the value [`CodeRuntime::register_repo`] derives from the checkout.
+#[derive(Debug, Default)]
+pub(crate) struct RepoRegistration {
+    pub display_name: Option<String>,
+    pub default_base_ref: Option<String>,
+    pub branch_prefix: Option<String>,
+    pub setup_script: Option<String>,
+    pub archive_script: Option<String>,
 }
 
 /// Result of `POST /code/sessions/{id}/turns`.
@@ -234,7 +246,7 @@ impl CodeRuntime {
         // that is still usable so submit_turn is not stuck after a restart.
         // Concurrently: each attach launches an engine child, so a serial pass
         // charged app launch the sum of every restored session.
-        let resumable: Vec<CodeSession> = list_sessions(&self.db)
+        let resumable: Vec<CodeSession> = list_sessions_all_owners(&self.db)
             .await?
             .into_iter()
             .filter(|session| {
@@ -397,20 +409,24 @@ impl CodeRuntime {
 
     pub(crate) async fn register_repo(
         &self,
+        owner: &OwnerId,
         root_path: PathBuf,
-        display_name: Option<String>,
-        default_base_ref: Option<String>,
-        branch_prefix: Option<String>,
-        setup_script: Option<String>,
-        archive_script: Option<String>,
+        metadata: RepoRegistration,
     ) -> Result<CodeRepo, ServerError> {
+        let RepoRegistration {
+            display_name,
+            default_base_ref,
+            branch_prefix,
+            setup_script,
+            archive_script,
+        } = metadata;
         let validated = validate_repo_path(&root_path).await.map_err(map_worktree)?;
         let toplevel = validated.toplevel.display().to_string();
-        let exact = get_repo_by_root_path(&self.db, &toplevel).await?;
+        let exact = get_repo_by_root_path(&self.db, owner, &toplevel).await?;
         #[cfg(windows)]
         let existing = match exact {
             Some(repo) => Some(repo),
-            None => list_repos(&self.db).await?.into_iter().find(|repo| {
+            None => list_repos(&self.db, owner).await?.into_iter().find(|repo| {
                 repo_paths_equivalent(std::path::Path::new(&repo.root_path), &validated.toplevel)
             }),
         };
@@ -440,6 +456,7 @@ impl CodeRuntime {
             });
         let repo = CodeRepo {
             id: RepoId::new(),
+            owner: owner.clone(),
             root_path: toplevel,
             display_name: name,
             default_base_ref: default_base_ref
@@ -457,12 +474,16 @@ impl CodeRuntime {
         Ok(repo)
     }
 
-    pub(crate) async fn list_repos(&self) -> Result<Vec<CodeRepo>, ServerError> {
-        Ok(list_repos(&self.db).await?)
+    pub(crate) async fn list_repos(&self, owner: &OwnerId) -> Result<Vec<CodeRepo>, ServerError> {
+        Ok(list_repos(&self.db, owner).await?)
     }
 
-    pub(crate) async fn get_repo(&self, id: RepoId) -> Result<CodeRepo, ServerError> {
-        get_repo(&self.db, id)
+    pub(crate) async fn get_repo(
+        &self,
+        owner: &OwnerId,
+        id: RepoId,
+    ) -> Result<CodeRepo, ServerError> {
+        get_repo(&self.db, owner, id)
             .await?
             .ok_or_else(|| ServerError::not_found(format!("repo {id} not found")))
     }
@@ -477,8 +498,8 @@ impl CodeRuntime {
         Ok(())
     }
 
-    pub(crate) async fn delete_repo(&self, id: RepoId) -> Result<(), ServerError> {
-        let workspaces = list_workspaces(&self.db, Some(id)).await?;
+    pub(crate) async fn delete_repo(&self, owner: &OwnerId, id: RepoId) -> Result<(), ServerError> {
+        let workspaces = list_workspaces(&self.db, owner, Some(id)).await?;
         if workspaces
             .iter()
             .any(|workspace| workspace.status != CodeWorkspaceStatus::Archived)
@@ -488,7 +509,7 @@ impl CodeRuntime {
                 "archive every workspace before deleting the repository",
             ));
         }
-        if !delete_repo(&self.db, id).await? {
+        if !delete_repo(&self.db, owner, id).await? {
             return Err(ServerError::not_found(format!("repo {id} not found")));
         }
         Ok(())
@@ -496,18 +517,19 @@ impl CodeRuntime {
 
     pub(crate) async fn create_workspace(
         &self,
+        owner: &OwnerId,
         repo_id: RepoId,
         title: Option<String>,
         base_ref: Option<String>,
     ) -> Result<CodeWorkspace, ServerError> {
-        let repo = self.get_repo(repo_id).await?;
+        let repo = self.get_repo(owner, repo_id).await?;
         let title = title
             .map(|value| value.trim().to_owned())
             .filter(|value| !value.is_empty())
             .unwrap_or_default();
         let id = WorkspaceId::new();
         let branch = branch_name(&repo.branch_prefix, &title, id.0.as_u128());
-        let existing = list_workspaces(&self.db, Some(repo_id)).await?;
+        let existing = list_workspaces(&self.db, owner, Some(repo_id)).await?;
         if existing
             .iter()
             .any(|workspace| workspace.branch_name == branch)
@@ -544,6 +566,7 @@ impl CodeRuntime {
             .unwrap_or_else(|| repo.default_base_ref.clone());
         let mut workspace = CodeWorkspace {
             id,
+            owner: owner.clone(),
             repo_id,
             title: display_title,
             worktree_path: path.display().to_string(),
@@ -558,7 +581,7 @@ impl CodeRuntime {
         match create_worktree(std::path::Path::new(&repo.root_path), &path, &branch, &base).await {
             Ok(()) => {}
             Err(err) => {
-                let _ = delete_workspace(&self.db, id).await;
+                let _ = delete_workspace(&self.db, owner, id).await;
                 return Err(map_worktree(err));
             }
         }
@@ -582,16 +605,18 @@ impl CodeRuntime {
 
     pub(crate) async fn list_workspaces(
         &self,
+        owner: &OwnerId,
         repo_id: Option<RepoId>,
     ) -> Result<Vec<CodeWorkspace>, ServerError> {
-        Ok(list_workspaces(&self.db, repo_id).await?)
+        Ok(list_workspaces(&self.db, owner, repo_id).await?)
     }
 
     pub(crate) async fn get_workspace(
         &self,
+        owner: &OwnerId,
         id: WorkspaceId,
     ) -> Result<CodeWorkspace, ServerError> {
-        get_workspace(&self.db, id)
+        get_workspace(&self.db, owner, id)
             .await?
             .ok_or_else(|| ServerError::not_found(format!("workspace {id} not found")))
     }
@@ -606,23 +631,30 @@ impl CodeRuntime {
                 workspace.id
             )));
         }
-        super::attention::emit_workspace_digests(&self.db, &self.bus, workspace.id).await;
+        super::attention::emit_workspace_digests(
+            &self.db,
+            &self.bus,
+            &workspace.owner,
+            workspace.id,
+        )
+        .await;
         Ok(())
     }
 
     pub(crate) async fn archive_workspace(
         &self,
+        owner: &OwnerId,
         id: WorkspaceId,
         force: bool,
     ) -> Result<CodeWorkspace, ServerError> {
-        let mut workspace = self.get_workspace(id).await?;
+        let mut workspace = self.get_workspace(owner, id).await?;
         if workspace.status == CodeWorkspaceStatus::Archived {
             return Ok(workspace);
         }
-        let repo = self.get_repo(workspace.repo_id).await?;
+        let repo = self.get_repo(owner, workspace.repo_id).await?;
         // Blockers first: a refused archive must leave the workspace exactly as
         // it was, and running the hook script is not "exactly as it was".
-        self.refuse_running_sessions(id, force).await?;
+        self.refuse_running_sessions(owner, id, force).await?;
         let path = std::path::Path::new(&workspace.worktree_path);
         if path.exists() {
             if let Some(block) = archive_blockers(path, &workspace.base_ref)
@@ -648,7 +680,7 @@ impl CodeRuntime {
                 ));
             }
         }
-        self.end_workspace_sessions(id).await?;
+        self.end_workspace_sessions(owner, id).await?;
         remove_worktree(std::path::Path::new(&repo.root_path), path)
             .await
             .map_err(map_worktree)?;
@@ -662,7 +694,7 @@ impl CodeRuntime {
             );
         }
         if let Err(error) = self
-            .sweep_repo_checkpoint_refs(std::path::Path::new(&repo.root_path), repo.id)
+            .sweep_repo_checkpoint_refs(owner, std::path::Path::new(&repo.root_path), repo.id)
             .await
         {
             tracing::warn!(
@@ -678,10 +710,11 @@ impl CodeRuntime {
 
     pub(crate) async fn commit_workspace(
         &self,
+        owner: &OwnerId,
         id: WorkspaceId,
         message: Option<String>,
     ) -> Result<CommitOutcome, ServerError> {
-        let workspace = self.require_live_workspace(id).await?;
+        let workspace = self.require_live_workspace(owner, id).await?;
         gh::commit_all(
             std::path::Path::new(&workspace.worktree_path),
             &workspace.title,
@@ -691,8 +724,12 @@ impl CodeRuntime {
         .map_err(map_gh)
     }
 
-    pub(crate) async fn push_workspace(&self, id: WorkspaceId) -> Result<PushOutcome, ServerError> {
-        let workspace = self.require_live_workspace(id).await?;
+    pub(crate) async fn push_workspace(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+    ) -> Result<PushOutcome, ServerError> {
+        let workspace = self.require_live_workspace(owner, id).await?;
         gh::push_branch(
             std::path::Path::new(&workspace.worktree_path),
             &workspace.branch_name,
@@ -703,9 +740,10 @@ impl CodeRuntime {
 
     pub(crate) async fn workspace_pr(
         &self,
+        owner: &OwnerId,
         id: WorkspaceId,
     ) -> Result<WorkspaceGitStatus, ServerError> {
-        let mut workspace = self.get_workspace(id).await?;
+        let mut workspace = self.get_workspace(owner, id).await?;
         let gh_path = self.gh_search_path_owned();
         let status = gh::workspace_git_status(
             std::path::Path::new(&workspace.worktree_path),
@@ -730,17 +768,19 @@ impl CodeRuntime {
     /// normal status path.
     pub(crate) async fn refresh_workspace_pr(
         &self,
+        owner: &OwnerId,
         id: WorkspaceId,
     ) -> Result<WorkspaceGitStatus, ServerError> {
         self.pr_cache.invalidate(id);
-        self.workspace_pr(id).await
+        self.workspace_pr(owner, id).await
     }
 
     pub(crate) async fn workspace_pr_comments(
         &self,
+        owner: &OwnerId,
         id: WorkspaceId,
     ) -> Result<gh::PrComments, ServerError> {
-        let workspace = self.get_workspace(id).await?;
+        let workspace = self.get_workspace(owner, id).await?;
         let gh_path = self.gh_search_path_owned();
         gh::load_pr_comments(
             std::path::Path::new(&workspace.worktree_path),
@@ -755,11 +795,12 @@ impl CodeRuntime {
     /// result. This is the only route to `gh pr merge`.
     pub(crate) async fn merge_workspace_pr(
         &self,
+        owner: &OwnerId,
         id: WorkspaceId,
         method: gh::MergeMethod,
         auto: bool,
     ) -> Result<WorkspaceGitStatus, ServerError> {
-        let workspace = self.require_live_workspace(id).await?;
+        let workspace = self.require_live_workspace(owner, id).await?;
         let gh_path = self.gh_search_path_owned();
         gh::merge_pull_request(
             std::path::Path::new(&workspace.worktree_path),
@@ -771,16 +812,17 @@ impl CodeRuntime {
         )
         .await
         .map_err(map_gh)?;
-        self.workspace_pr(id).await
+        self.workspace_pr(owner, id).await
     }
 
     pub(crate) async fn create_workspace_pr(
         &self,
+        owner: &OwnerId,
         id: WorkspaceId,
         title: Option<String>,
         body: Option<String>,
     ) -> Result<WorkspaceGitStatus, ServerError> {
-        let mut workspace = self.require_live_workspace(id).await?;
+        let mut workspace = self.require_live_workspace(owner, id).await?;
         let gh_path = self.gh_search_path_owned();
         let digest = gh::create_pull_request(
             std::path::Path::new(&workspace.worktree_path),
@@ -797,16 +839,17 @@ impl CodeRuntime {
         .map_err(map_gh)?;
         workspace.pr = Some(digest);
         self.save_workspace(&workspace).await?;
-        self.workspace_pr(id).await
+        self.workspace_pr(owner, id).await
     }
 
     pub(crate) async fn run_workspace_action(
         &self,
+        owner: &OwnerId,
         id: WorkspaceId,
         name: &str,
     ) -> Result<ActionOutcome, ServerError> {
-        let workspace = self.require_live_workspace(id).await?;
-        let repo = self.get_repo(workspace.repo_id).await?;
+        let workspace = self.require_live_workspace(owner, id).await?;
+        let repo = self.get_repo(owner, workspace.repo_id).await?;
         gh::run_named_action(
             std::path::Path::new(&workspace.worktree_path),
             &repo.quick_actions,
@@ -816,8 +859,12 @@ impl CodeRuntime {
         .map_err(map_gh)
     }
 
-    async fn require_live_workspace(&self, id: WorkspaceId) -> Result<CodeWorkspace, ServerError> {
-        let workspace = self.get_workspace(id).await?;
+    async fn require_live_workspace(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+    ) -> Result<CodeWorkspace, ServerError> {
+        let workspace = self.get_workspace(owner, id).await?;
         if workspace.status == CodeWorkspaceStatus::Archived {
             return Err(ServerError::conflict_kind(
                 "workspace_not_ready",
@@ -841,19 +888,20 @@ impl CodeRuntime {
 
     pub(crate) async fn create_session(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
         harness: HarnessKind,
         permission_mode: CodePermissionMode,
         model: Option<String>,
     ) -> Result<CodeSession, ServerError> {
-        let workspace = self.get_workspace(workspace_id).await?;
+        let workspace = self.get_workspace(owner, workspace_id).await?;
         if workspace.status != CodeWorkspaceStatus::Active {
             return Err(ServerError::conflict_kind(
                 "workspace_not_ready",
                 format!("workspace is {}", workspace.status.as_str()),
             ));
         }
-        let existing = list_sessions_for_workspace(&self.db, workspace_id).await?;
+        let existing = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
         if existing
             .iter()
             .any(|session| session.lifecycle != CodeSessionLifecycle::Ended)
@@ -900,6 +948,7 @@ impl CodeRuntime {
         }
         let session = CodeSession {
             id: CodeSessionId::new(),
+            owner: owner.clone(),
             workspace_id,
             harness_kind: harness,
             harness_version: probe.version.clone(),
@@ -918,8 +967,12 @@ impl CodeRuntime {
         self.attach_and_spawn_worker(session).await
     }
 
-    pub(crate) async fn get_session(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
-        get_session(&self.db, id)
+    pub(crate) async fn get_session(
+        &self,
+        owner: &OwnerId,
+        id: CodeSessionId,
+    ) -> Result<CodeSession, ServerError> {
+        get_session(&self.db, owner, id)
             .await?
             .ok_or_else(|| ServerError::not_found(format!("session {id} not found")))
     }
@@ -973,12 +1026,13 @@ impl CodeRuntime {
 
     pub(crate) async fn submit_turn(
         &self,
+        owner: &OwnerId,
         id: CodeSessionId,
         message: String,
         model: Option<String>,
         attachments: Vec<tidebreak_core::CodeTurnAttachment>,
     ) -> Result<SubmitTurnOutcome, ServerError> {
-        let mut session = self.get_session(id).await?;
+        let mut session = self.get_session(owner, id).await?;
         if session.lifecycle == CodeSessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
                 "session_fenced",
@@ -1014,7 +1068,7 @@ impl CodeRuntime {
         // follow-up. This does not consult mid_turn_steering — that cap
         // gates the separate /steer route only.
         let in_flight = session.lifecycle == CodeSessionLifecycle::Running
-            || get_open_turn(&self.db, id).await?.is_some();
+            || get_open_turn(&self.db, owner, id).await?.is_some();
         if in_flight {
             if !queue_follow_up(&handle, message, session.model.clone(), attachments) {
                 return Err(ServerError::conflict_kind(
@@ -1055,8 +1109,12 @@ impl CodeRuntime {
             .map_err(map_worker)
     }
 
-    pub(crate) async fn reap(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
-        let session = self.get_session(id).await?;
+    pub(crate) async fn reap(
+        &self,
+        owner: &OwnerId,
+        id: CodeSessionId,
+    ) -> Result<CodeSession, ServerError> {
+        let session = self.get_session(owner, id).await?;
         if session.lifecycle != CodeSessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
                 "not_fenced",
@@ -1070,7 +1128,7 @@ impl CodeRuntime {
             // moving. Wait for it, then reap the row as it stands now.
             Some(handle) => {
                 Self::shut_down_worker(id, handle).await;
-                self.get_session(id).await?
+                self.get_session(owner, id).await?
             }
             None => session,
         };
@@ -1082,18 +1140,23 @@ impl CodeRuntime {
 
     pub(crate) async fn set_attention(
         &self,
+        owner: &OwnerId,
         id: CodeSessionId,
         clear: bool,
         note: Option<String>,
     ) -> Result<CodeSession, ServerError> {
-        let _ = self.get_session(id).await?;
-        super::attention::user_set_attention(&self.db, &self.bus, id, clear, note)
+        let _ = self.get_session(owner, id).await?;
+        super::attention::user_set_attention(&self.db, &self.bus, owner, id, clear, note)
             .await
             .map_err(ServerError::from)
     }
 
-    pub(crate) async fn mark_session_viewed(&self, id: CodeSessionId) -> Result<(), ServerError> {
-        super::attention::mark_viewed(&self.db, &self.bus, id)
+    pub(crate) async fn mark_session_viewed(
+        &self,
+        owner: &OwnerId,
+        id: CodeSessionId,
+    ) -> Result<(), ServerError> {
+        super::attention::mark_viewed(&self.db, &self.bus, owner, id)
             .await
             .map_err(ServerError::from)
     }
@@ -1106,28 +1169,34 @@ impl CodeRuntime {
         *self.stall_sweep.lock().expect("stall sweep") = Some(guard);
     }
 
-    pub(crate) async fn list_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {
-        Ok(list_sessions(&self.db).await?)
+    pub(crate) async fn list_sessions(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<Vec<CodeSession>, ServerError> {
+        Ok(list_sessions(&self.db, owner).await?)
     }
 
     pub(crate) async fn list_workspace_sessions(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
     ) -> Result<Vec<CodeSession>, ServerError> {
-        let _ = self.get_workspace(workspace_id).await?;
-        Ok(list_sessions_for_workspace(&self.db, workspace_id).await?)
+        let _ = self.get_workspace(owner, workspace_id).await?;
+        Ok(list_sessions_for_workspace(&self.db, owner, workspace_id).await?)
     }
 
     pub(crate) async fn list_session_turns(
         &self,
+        owner: &OwnerId,
         session_id: CodeSessionId,
     ) -> Result<Vec<CodeTurn>, ServerError> {
-        let _ = self.get_session(session_id).await?;
-        Ok(list_turns(&self.db, session_id).await?)
+        let _ = self.get_session(owner, session_id).await?;
+        Ok(list_turns(&self.db, owner, session_id).await?)
     }
 
     pub(crate) async fn session_debug(
         &self,
+        owner: &OwnerId,
         session_id: CodeSessionId,
     ) -> Result<
         (
@@ -1137,19 +1206,20 @@ impl CodeRuntime {
         ),
         ServerError,
     > {
-        let session = self.get_session(session_id).await?;
-        let turns = list_turns(&self.db, session_id).await?;
-        let events = list_events(&self.db, session_id, 0).await?;
+        let session = self.get_session(owner, session_id).await?;
+        let turns = list_turns(&self.db, owner, session_id).await?;
+        let events = list_events(&self.db, owner, session_id, 0).await?;
         Ok((session, turns, events))
     }
 
     pub(crate) async fn workspace_tree(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
         query: &str,
         limit: Option<u32>,
     ) -> Result<(Vec<String>, bool), ServerError> {
-        let workspace = self.get_workspace(workspace_id).await?;
+        let workspace = self.get_workspace(owner, workspace_id).await?;
         worktree::list_tree_paths(
             std::path::Path::new(&workspace.worktree_path),
             query,
@@ -1161,13 +1231,14 @@ impl CodeRuntime {
 
     pub(crate) async fn workspace_search(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
         query: &str,
         include: &str,
         exclude: &str,
         limit: Option<u32>,
     ) -> Result<(Vec<worktree::WorktreeSearchMatch>, bool), ServerError> {
-        let workspace = self.require_live_workspace(workspace_id).await?;
+        let workspace = self.require_live_workspace(owner, workspace_id).await?;
         worktree::search_worktree_contents(
             std::path::Path::new(&workspace.worktree_path),
             query,
@@ -1181,10 +1252,11 @@ impl CodeRuntime {
 
     pub(crate) async fn workspace_files(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
         turn_id: Option<CodeTurnId>,
     ) -> Result<(Vec<ChangedFile>, bool, Diffstat, Option<CodeTurnId>), ServerError> {
-        let workspace = self.get_workspace(workspace_id).await?;
+        let workspace = self.get_workspace(owner, workspace_id).await?;
         let (worktree, from, to, turn) = resolve_diff_range(&self.db, &workspace, turn_id)
             .await
             .map_err(map_checkpoint)?;
@@ -1196,10 +1268,11 @@ impl CodeRuntime {
 
     pub(crate) async fn workspace_blob(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
         path: &str,
     ) -> Result<worktree::WorktreeBlob, ServerError> {
-        let workspace = self.require_live_workspace(workspace_id).await?;
+        let workspace = self.require_live_workspace(owner, workspace_id).await?;
         worktree::read_worktree_file(std::path::Path::new(&workspace.worktree_path), path)
             .await
             .map_err(map_worktree)
@@ -1207,11 +1280,12 @@ impl CodeRuntime {
 
     pub(crate) async fn workspace_diff(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
         turn_id: Option<CodeTurnId>,
         file: Option<&str>,
     ) -> Result<(String, bool, Diffstat, Option<CodeTurnId>), ServerError> {
-        let workspace = self.get_workspace(workspace_id).await?;
+        let workspace = self.get_workspace(owner, workspace_id).await?;
         let (worktree, from, to, turn) = resolve_diff_range(&self.db, &workspace, turn_id)
             .await
             .map_err(map_checkpoint)?;
@@ -1222,19 +1296,24 @@ impl CodeRuntime {
     }
 
     async fn sweep_orphaned_checkpoints(&self) -> Result<(), ServerError> {
-        for repo in list_repos(&self.db).await? {
-            self.sweep_repo_checkpoint_refs(std::path::Path::new(&repo.root_path), repo.id)
-                .await?;
+        for repo in list_repos_all_owners(&self.db).await? {
+            self.sweep_repo_checkpoint_refs(
+                &repo.owner,
+                std::path::Path::new(&repo.root_path),
+                repo.id,
+            )
+            .await?;
         }
         Ok(())
     }
 
     async fn sweep_repo_checkpoint_refs(
         &self,
+        owner: &OwnerId,
         repo_root: &std::path::Path,
         repo_id: RepoId,
     ) -> Result<(), ServerError> {
-        let live: Vec<WorkspaceId> = list_workspaces(&self.db, Some(repo_id))
+        let live: Vec<WorkspaceId> = list_workspaces(&self.db, owner, Some(repo_id))
             .await?
             .into_iter()
             .filter(|workspace| workspace.status != CodeWorkspaceStatus::Archived)
@@ -1248,13 +1327,14 @@ impl CodeRuntime {
 
     async fn refuse_running_sessions(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
         allow_running: bool,
     ) -> Result<(), ServerError> {
         if allow_running {
             return Ok(());
         }
-        let sessions = list_sessions_for_workspace(&self.db, workspace_id).await?;
+        let sessions = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
         if sessions
             .iter()
             .any(|session| session.lifecycle == CodeSessionLifecycle::Running)
@@ -1267,8 +1347,12 @@ impl CodeRuntime {
         Ok(())
     }
 
-    async fn end_workspace_sessions(&self, workspace_id: WorkspaceId) -> Result<(), ServerError> {
-        let sessions = list_sessions_for_workspace(&self.db, workspace_id).await?;
+    async fn end_workspace_sessions(
+        &self,
+        owner: &OwnerId,
+        workspace_id: WorkspaceId,
+    ) -> Result<(), ServerError> {
+        let sessions = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
         for mut session in sessions {
             if session.lifecycle == CodeSessionLifecycle::Ended {
                 continue;
@@ -1291,7 +1375,7 @@ impl CodeRuntime {
             }
             // The outgoing worker still holds this epoch, so a persist during
             // the wait can overwrite Ended. Re-assert from a fresh load.
-            let mut current = self.get_session(session.id).await?;
+            let mut current = self.get_session(owner, session.id).await?;
             current.lifecycle = CodeSessionLifecycle::Ended;
             current.child_pid = None;
             current.fence_reason = None;
@@ -1335,7 +1419,9 @@ impl CodeRuntime {
         &self,
         session: CodeSession,
     ) -> Result<CodeSession, ServerError> {
-        let workspace = self.get_workspace(session.workspace_id).await?;
+        let workspace = self
+            .get_workspace(&session.owner, session.workspace_id)
+            .await?;
         let adapter = self.adapter(session.harness_kind)?;
         // Cached, so the probe `create_session` already paid for is not paid
         // again on the way into the worker.
@@ -1365,6 +1451,7 @@ impl CodeRuntime {
         let sink = super::session_worker::sink_for(
             self.db.clone(),
             self.bus.clone(),
+            session.owner.clone(),
             session.id,
             attached.spawn_epoch,
             None,
@@ -1421,6 +1508,7 @@ impl CodeRuntime {
             .insert(session.id, handle);
         let pending = list_approvals(
             &self.db,
+            &attached.owner,
             Some(CodeApprovalState::Pending),
             Some(attached.id),
         )
@@ -1485,27 +1573,30 @@ impl CodeRuntime {
 
     pub(crate) async fn list_approvals(
         &self,
+        owner: &OwnerId,
         state: Option<CodeApprovalState>,
         session_id: Option<CodeSessionId>,
     ) -> Result<Vec<CodeApproval>, ServerError> {
-        Ok(list_approvals(&self.db, state, session_id).await?)
+        Ok(list_approvals(&self.db, owner, state, session_id).await?)
     }
 
     pub(crate) async fn get_approval(
         &self,
+        owner: &OwnerId,
         id: CodeApprovalId,
     ) -> Result<CodeApproval, ServerError> {
-        get_approval(&self.db, id)
+        get_approval(&self.db, owner, id)
             .await?
             .ok_or_else(|| ServerError::not_found(format!("approval {id} not found")))
     }
 
     pub(crate) async fn decide_approval(
         &self,
+        owner: &OwnerId,
         id: CodeApprovalId,
         decision: ApprovalDecision,
     ) -> Result<CodeApproval, ServerError> {
-        let mut approval = self.get_approval(id).await?;
+        let mut approval = self.get_approval(owner, id).await?;
         if approval.state != CodeApprovalState::Pending {
             return Err(ServerError::conflict_kind(
                 "approval_already_decided",
@@ -1549,13 +1640,14 @@ impl CodeRuntime {
             }
         }
         approval.decided_at = Some(now);
-        if !save_approval(&self.db, &approval).await? {
+        if !save_approval(&self.db, owner, &approval).await? {
             return Err(ServerError::not_found(format!("approval {id} not found")));
         }
-        let session = self.get_session(approval.session_id).await?;
+        let session = self.get_session(owner, approval.session_id).await?;
         journal_event(
             &self.db,
             &self.bus,
+            owner,
             approval.session_id,
             session.spawn_epoch,
             CodeEvent::ApprovalResolved {
@@ -1572,6 +1664,7 @@ impl CodeRuntime {
         .map_err(|err| ServerError::internal(err.to_string()))?;
         let still_pending = list_approvals(
             &self.db,
+            owner,
             Some(CodeApprovalState::Pending),
             Some(approval.session_id),
         )
@@ -1580,6 +1673,7 @@ impl CodeRuntime {
             let _ = super::attention::apply_attention(
                 &self.db,
                 &self.bus,
+                owner,
                 approval.session_id,
                 Attention::working(AttentionSource::Lifecycle),
                 false,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -1,0 +1,451 @@
+//! The request-facing code-mode runtime, bound to one authenticated principal.
+//!
+//! This is [`crate::scoped_store::ScopedStore`]'s counterpart for `/code/*`.
+//! Route handlers do not touch [`CodeRuntime`] directly: they extract a
+//! [`ScopedCode`], and every query it makes carries the requesting
+//! principal's [`OwnerId`]. The unscoped runtime handle never escapes this
+//! type, so route code cannot express a query that crosses owners — another
+//! owner's repository, workspace, session, turn, event, or approval is
+//! indistinguishable from one that does not exist (decisions 47 and 48).
+//!
+//! System paths — boot recovery, the stall sweep, session workers, the
+//! capability-token approval bridge — are not requests. They keep the
+//! unscoped handle on [`AppState`] and use the `_all_owners` store functions,
+//! which say so in their names.
+//!
+//! The extractor fails closed like [`AuthContext`] itself: on a route the auth
+//! middleware does not cover it answers `401`, never a defaulted owner.
+
+use std::sync::Arc;
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+
+use tidebreak_core::{
+    CodeApproval, CodeApprovalId, CodeApprovalState, CodePermissionMode, CodeRepo, CodeSession,
+    CodeSessionId, CodeTurn, CodeTurnId, CodeWorkspace, Diffstat, HarnessKind, OwnerId, RepoId,
+    SequencedCodeEvent, WorkspaceId,
+};
+use tidebreak_harness::ApprovalDecision;
+
+use super::checkpoint::ChangedFile;
+use super::clone::CloneRequest;
+use super::gh::{self, ActionOutcome, CommitOutcome, PushOutcome, WorkspaceGitStatus};
+use super::runtime::{CodeRuntime, RepoRegistration, SubmitTurnOutcome};
+use super::worktree;
+use crate::error::ServerError;
+use crate::principal::AuthContext;
+use crate::routes::code::types::{CodeCloneDefaults, CodeCloneJobSnapshot};
+use crate::state::AppState;
+
+/// Code mode as one authenticated principal may see it.
+///
+/// Constructed only from server state plus a verified [`AuthContext`], so the
+/// owner inside is always the one the auth middleware resolved. Fields stay
+/// private and no method returns the inner runtime handle.
+#[derive(Clone)]
+pub(crate) struct ScopedCode {
+    runtime: Arc<CodeRuntime>,
+    owner: OwnerId,
+}
+
+impl ScopedCode {
+    /// Bind the process's code runtime to the request's principal.
+    fn new(state: &AppState, auth: &AuthContext) -> Result<Self, ServerError> {
+        let runtime = state
+            .code
+            .clone()
+            .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))?;
+        Ok(Self {
+            runtime,
+            owner: auth.principal.owner_id(),
+        })
+    }
+
+    /// The principal's durable owner key, for the seams that take it directly:
+    /// the live buses, and background naming.
+    pub(crate) fn owner(&self) -> &OwnerId {
+        &self.owner
+    }
+
+    // ------------------------------------------------------------------
+    // Repositories. Per owner, like everything else here: two users may
+    // register or clone the same remote and neither sees the other's row.
+    // ------------------------------------------------------------------
+
+    pub(crate) async fn register_repo(
+        &self,
+        root_path: std::path::PathBuf,
+        metadata: RepoRegistration,
+    ) -> Result<CodeRepo, ServerError> {
+        self.runtime
+            .register_repo(&self.owner, root_path, metadata)
+            .await
+    }
+
+    pub(crate) async fn list_repos(&self) -> Result<Vec<CodeRepo>, ServerError> {
+        self.runtime.list_repos(&self.owner).await
+    }
+
+    pub(crate) async fn get_repo(&self, id: RepoId) -> Result<CodeRepo, ServerError> {
+        self.runtime.get_repo(&self.owner, id).await
+    }
+
+    pub(crate) async fn save_repo(&self, repo: &CodeRepo) -> Result<(), ServerError> {
+        self.runtime.save_repo(repo).await
+    }
+
+    pub(crate) async fn delete_repo(&self, id: RepoId) -> Result<(), ServerError> {
+        self.runtime.delete_repo(&self.owner, id).await
+    }
+
+    pub(crate) async fn clone_defaults(&self) -> Result<CodeCloneDefaults, ServerError> {
+        self.runtime.clone_defaults().await
+    }
+
+    pub(crate) async fn start_clone(
+        &self,
+        request: CloneRequest,
+    ) -> Result<CodeCloneJobSnapshot, ServerError> {
+        self.runtime.start_clone(&self.owner, request).await
+    }
+
+    pub(crate) fn get_clone_job(
+        &self,
+        id: uuid::Uuid,
+    ) -> Result<CodeCloneJobSnapshot, ServerError> {
+        self.runtime.get_clone_job(id)
+    }
+
+    // ------------------------------------------------------------------
+    // Workspaces.
+    // ------------------------------------------------------------------
+
+    pub(crate) async fn create_workspace(
+        &self,
+        repo_id: RepoId,
+        title: Option<String>,
+        base_ref: Option<String>,
+    ) -> Result<CodeWorkspace, ServerError> {
+        self.runtime
+            .create_workspace(&self.owner, repo_id, title, base_ref)
+            .await
+    }
+
+    pub(crate) async fn list_workspaces(
+        &self,
+        repo_id: Option<RepoId>,
+    ) -> Result<Vec<CodeWorkspace>, ServerError> {
+        self.runtime.list_workspaces(&self.owner, repo_id).await
+    }
+
+    pub(crate) async fn get_workspace(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<CodeWorkspace, ServerError> {
+        self.runtime.get_workspace(&self.owner, id).await
+    }
+
+    pub(crate) async fn save_workspace(
+        &self,
+        workspace: &CodeWorkspace,
+    ) -> Result<(), ServerError> {
+        self.runtime.save_workspace(workspace).await
+    }
+
+    pub(crate) async fn archive_workspace(
+        &self,
+        id: WorkspaceId,
+        force: bool,
+    ) -> Result<CodeWorkspace, ServerError> {
+        self.runtime.archive_workspace(&self.owner, id, force).await
+    }
+
+    pub(crate) async fn workspace_tree(
+        &self,
+        id: WorkspaceId,
+        query: &str,
+        limit: Option<u32>,
+    ) -> Result<(Vec<String>, bool), ServerError> {
+        self.runtime
+            .workspace_tree(&self.owner, id, query, limit)
+            .await
+    }
+
+    pub(crate) async fn workspace_search(
+        &self,
+        id: WorkspaceId,
+        query: &str,
+        include: &str,
+        exclude: &str,
+        limit: Option<u32>,
+    ) -> Result<(Vec<worktree::WorktreeSearchMatch>, bool), ServerError> {
+        self.runtime
+            .workspace_search(&self.owner, id, query, include, exclude, limit)
+            .await
+    }
+
+    pub(crate) async fn workspace_blob(
+        &self,
+        id: WorkspaceId,
+        path: &str,
+    ) -> Result<worktree::WorktreeBlob, ServerError> {
+        self.runtime.workspace_blob(&self.owner, id, path).await
+    }
+
+    pub(crate) async fn workspace_files(
+        &self,
+        id: WorkspaceId,
+        turn_id: Option<CodeTurnId>,
+    ) -> Result<(Vec<ChangedFile>, bool, Diffstat, Option<CodeTurnId>), ServerError> {
+        self.runtime.workspace_files(&self.owner, id, turn_id).await
+    }
+
+    pub(crate) async fn workspace_diff(
+        &self,
+        id: WorkspaceId,
+        turn_id: Option<CodeTurnId>,
+        file: Option<&str>,
+    ) -> Result<(String, bool, Diffstat, Option<CodeTurnId>), ServerError> {
+        self.runtime
+            .workspace_diff(&self.owner, id, turn_id, file)
+            .await
+    }
+
+    // ------------------------------------------------------------------
+    // Git surfaces on a workspace.
+    // ------------------------------------------------------------------
+
+    pub(crate) async fn commit_workspace(
+        &self,
+        id: WorkspaceId,
+        message: Option<String>,
+    ) -> Result<CommitOutcome, ServerError> {
+        self.runtime
+            .commit_workspace(&self.owner, id, message)
+            .await
+    }
+
+    pub(crate) async fn push_workspace(&self, id: WorkspaceId) -> Result<PushOutcome, ServerError> {
+        self.runtime.push_workspace(&self.owner, id).await
+    }
+
+    pub(crate) async fn workspace_pr(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        self.runtime.workspace_pr(&self.owner, id).await
+    }
+
+    pub(crate) async fn refresh_workspace_pr(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        self.runtime.refresh_workspace_pr(&self.owner, id).await
+    }
+
+    pub(crate) async fn workspace_pr_comments(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<gh::PrComments, ServerError> {
+        self.runtime.workspace_pr_comments(&self.owner, id).await
+    }
+
+    pub(crate) async fn merge_workspace_pr(
+        &self,
+        id: WorkspaceId,
+        method: gh::MergeMethod,
+        auto: bool,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        self.runtime
+            .merge_workspace_pr(&self.owner, id, method, auto)
+            .await
+    }
+
+    pub(crate) async fn create_workspace_pr(
+        &self,
+        id: WorkspaceId,
+        title: Option<String>,
+        body: Option<String>,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        self.runtime
+            .create_workspace_pr(&self.owner, id, title, body)
+            .await
+    }
+
+    pub(crate) async fn run_workspace_action(
+        &self,
+        id: WorkspaceId,
+        name: &str,
+    ) -> Result<ActionOutcome, ServerError> {
+        self.runtime
+            .run_workspace_action(&self.owner, id, name)
+            .await
+    }
+
+    // ------------------------------------------------------------------
+    // Sessions, turns, and the journal.
+    // ------------------------------------------------------------------
+
+    pub(crate) async fn create_session(
+        &self,
+        workspace_id: WorkspaceId,
+        harness: HarnessKind,
+        permission_mode: CodePermissionMode,
+        model: Option<String>,
+    ) -> Result<CodeSession, ServerError> {
+        self.runtime
+            .create_session(&self.owner, workspace_id, harness, permission_mode, model)
+            .await
+    }
+
+    pub(crate) async fn get_session(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
+        self.runtime.get_session(&self.owner, id).await
+    }
+
+    pub(crate) async fn list_workspace_sessions(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<CodeSession>, ServerError> {
+        self.runtime
+            .list_workspace_sessions(&self.owner, workspace_id)
+            .await
+    }
+
+    pub(crate) async fn list_session_turns(
+        &self,
+        id: CodeSessionId,
+    ) -> Result<Vec<CodeTurn>, ServerError> {
+        self.runtime.list_session_turns(&self.owner, id).await
+    }
+
+    pub(crate) async fn session_debug(
+        &self,
+        id: CodeSessionId,
+    ) -> Result<(CodeSession, Vec<CodeTurn>, Vec<SequencedCodeEvent>), ServerError> {
+        self.runtime.session_debug(&self.owner, id).await
+    }
+
+    pub(crate) async fn resolve_turn_attachments(
+        &self,
+        requested: &[(uuid::Uuid, String)],
+    ) -> Result<Vec<tidebreak_core::CodeTurnAttachment>, ServerError> {
+        self.runtime.resolve_turn_attachments(requested).await
+    }
+
+    pub(crate) async fn submit_turn(
+        &self,
+        id: CodeSessionId,
+        message: String,
+        model: Option<String>,
+        attachments: Vec<tidebreak_core::CodeTurnAttachment>,
+    ) -> Result<SubmitTurnOutcome, ServerError> {
+        self.runtime
+            .submit_turn(&self.owner, id, message, model, attachments)
+            .await
+    }
+
+    pub(crate) async fn interrupt(&self, id: CodeSessionId) -> Result<(), ServerError> {
+        // Authorize the session first: without this the worker registry would
+        // answer for a session id whatever owner holds it.
+        let _ = self.get_session(id).await?;
+        self.runtime.interrupt(id).await
+    }
+
+    pub(crate) async fn reap(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
+        self.runtime.reap(&self.owner, id).await
+    }
+
+    pub(crate) async fn set_attention(
+        &self,
+        id: CodeSessionId,
+        clear: bool,
+        note: Option<String>,
+    ) -> Result<CodeSession, ServerError> {
+        self.runtime
+            .set_attention(&self.owner, id, clear, note)
+            .await
+    }
+
+    // ------------------------------------------------------------------
+    // Approvals.
+    // ------------------------------------------------------------------
+
+    pub(crate) async fn list_approvals(
+        &self,
+        state: Option<CodeApprovalState>,
+        session_id: Option<CodeSessionId>,
+    ) -> Result<Vec<CodeApproval>, ServerError> {
+        self.runtime
+            .list_approvals(&self.owner, state, session_id)
+            .await
+    }
+
+    pub(crate) async fn decide_approval(
+        &self,
+        id: CodeApprovalId,
+        decision: ApprovalDecision,
+    ) -> Result<CodeApproval, ServerError> {
+        self.runtime
+            .decide_approval(&self.owner, id, decision)
+            .await
+    }
+
+    // ------------------------------------------------------------------
+    // Harness discovery. Probes describe the machine's binaries rather than
+    // any owner's rows, so they are the same answer for every principal; the
+    // per-harness unrecognized-event counts beside them are summed over the
+    // principal's own sessions.
+    // ------------------------------------------------------------------
+
+    pub(crate) async fn list_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {
+        self.runtime.list_sessions(&self.owner).await
+    }
+
+    pub(crate) fn adapters(&self) -> &tidebreak_harness::AdapterRegistry {
+        &self.runtime.adapters
+    }
+
+    pub(crate) fn adapter(
+        &self,
+        kind: HarnessKind,
+    ) -> Result<Arc<dyn tidebreak_harness::HarnessAdapter>, ServerError> {
+        self.runtime.adapter(kind)
+    }
+
+    pub(crate) async fn probe(
+        &self,
+        adapter: &dyn tidebreak_harness::HarnessAdapter,
+    ) -> tidebreak_harness::HarnessProbe {
+        self.runtime.probe(adapter).await
+    }
+
+    pub(crate) fn pin_install_error(&self, kind: HarnessKind) -> Option<String> {
+        self.runtime.pin_install_error(kind)
+    }
+
+    pub(crate) fn invalidate_probes(&self) {
+        self.runtime.invalidate_probes();
+    }
+
+    #[cfg(not(test))]
+    pub(crate) async fn refresh_pinned_harnesses(&self) {
+        self.runtime.refresh_pinned_harnesses().await;
+    }
+}
+
+impl FromRequestParts<AppState> for ScopedCode {
+    type Rejection = ServerError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let auth = AuthContext::from_request_parts(parts, state)
+            .await
+            .map_err(|_| {
+                ServerError::unauthorized("this request has no authenticated principal")
+            })?;
+        Self::new(state, &auth)
+    }
+}

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -22,14 +22,14 @@ use tokio::sync::{mpsc, oneshot, watch, Notify};
 use tracing::warn;
 
 use tidebreak_core::db::code::{
-    append_event, bump_spawn_epoch, get_open_turn, get_session, insert_approval, insert_turn,
-    next_turn_ordinal, save_session, save_turn, CodeJournalError,
+    append_event, bump_spawn_epoch, get_open_turn, get_session, get_session_all_owners,
+    insert_approval, insert_turn, next_turn_ordinal, save_session, save_turn, CodeJournalError,
 };
 use tidebreak_core::{
     Attention, AttentionSource, BlobStore, BoundedError, CodeApproval, CodeApprovalId,
     CodeApprovalKind, CodeApprovalState, CodeEvent, CodeSession, CodeSessionId,
     CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeTurnStatus, DbStore, FenceReason,
-    HarnessNoticeLevel,
+    HarnessNoticeLevel, OwnerId,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent, HarnessEventSink,
@@ -82,6 +82,9 @@ pub(crate) struct QueuedFollowUp {
 pub(crate) struct LiveSink {
     db: Arc<DbStore>,
     bus: Arc<CodeEventBus>,
+    /// Owner of the session this sink writes for. Carried explicitly so every
+    /// journal and approval write the worker makes stays inside one owner.
+    owner: OwnerId,
     session_id: CodeSessionId,
     spawn_epoch: i64,
     turn_id: std::sync::Mutex<Option<CodeTurnId>>,
@@ -113,7 +116,7 @@ impl LiveSink {
         let existing = *self.turn_id.lock().expect("code sink turn");
         let turn_id = match existing {
             Some(id) => id,
-            None => match get_open_turn(&self.db, self.session_id).await {
+            None => match get_open_turn(&self.db, &self.owner, self.session_id).await {
                 Ok(Some(turn)) => turn.id,
                 _ => return,
             },
@@ -129,12 +132,16 @@ impl LiveSink {
             requested_at: Utc::now(),
             decided_at: None,
         };
-        if insert_approval(&self.db, &approval).await.is_err() {
+        if insert_approval(&self.db, &self.owner, &approval)
+            .await
+            .is_err()
+        {
             return;
         }
         let _ = super::attention::apply_attention(
             &self.db,
             &self.bus,
+            &self.owner,
             self.session_id,
             Attention::needs_you("an approval is waiting", AttentionSource::Structured),
             false,
@@ -143,6 +150,7 @@ impl LiveSink {
         let _ = persist_and_publish(
             &self.db,
             &self.bus,
+            &self.owner,
             self.session_id,
             self.spawn_epoch,
             CodeEvent::ApprovalRequested {
@@ -176,6 +184,7 @@ impl HarnessEventSink for LiveSink {
         match persist_and_publish(
             &self.db,
             &self.bus,
+            &self.owner,
             self.session_id,
             self.spawn_epoch,
             code_event,
@@ -414,7 +423,7 @@ async fn drive_turn(
         session.model = Some(model);
     }
 
-    let ordinal = next_turn_ordinal(db, session.id)
+    let ordinal = next_turn_ordinal(db, &session.owner, session.id)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?;
     let mut turn = CodeTurn {
@@ -432,7 +441,7 @@ async fn drive_turn(
         started_at: Utc::now(),
         ended_at: None,
     };
-    insert_turn(db, &turn)
+    insert_turn(db, &session.owner, &turn)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?;
     sink.set_turn(turn.id);
@@ -453,6 +462,7 @@ async fn drive_turn(
     persist_and_publish(
         db,
         bus,
+        &session.owner,
         session.id,
         session.spawn_epoch,
         CodeEvent::TurnStarted { turn_id: turn.id },
@@ -529,9 +539,11 @@ async fn drive_turn(
     }
 
     // Re-read the turn: the sink may have already closed it.
-    if let Ok(Some(updated)) = get_open_turn(db, session.id).await {
+    if let Ok(Some(updated)) = get_open_turn(db, &session.owner, session.id).await {
         turn = updated;
-    } else if let Ok(Some(current)) = tidebreak_core::db::code::get_turn(db, turn.id).await {
+    } else if let Ok(Some(current)) =
+        tidebreak_core::db::code::get_turn(db, &session.owner, turn.id).await
+    {
         turn = current;
     }
 
@@ -548,6 +560,7 @@ async fn drive_turn(
                 let _ = persist_and_publish(
                     db,
                     bus,
+                    &session.owner,
                     session.id,
                     session.spawn_epoch,
                     CodeEvent::HarnessNotice {
@@ -580,18 +593,27 @@ async fn drive_turn(
                 };
                 turn.status = status;
                 turn.ended_at = Some(Utc::now());
-                let _ = save_turn(db, &turn).await;
-                let _ = persist_and_publish(db, bus, session.id, session.spawn_epoch, event).await;
+                let _ = save_turn(db, &session.owner, &turn).await;
+                let _ = persist_and_publish(
+                    db,
+                    bus,
+                    &session.owner,
+                    session.id,
+                    session.spawn_epoch,
+                    event,
+                )
+                .await;
             }
         }
         Err(err) => {
             if turn.status == CodeTurnStatus::Running {
                 turn.status = CodeTurnStatus::Failed;
                 turn.ended_at = Some(Utc::now());
-                let _ = save_turn(db, &turn).await;
+                let _ = save_turn(db, &session.owner, &turn).await;
                 let _ = persist_and_publish(
                     db,
                     bus,
+                    &session.owner,
                     session.id,
                     session.spawn_epoch,
                     CodeEvent::TurnFailed {
@@ -630,7 +652,8 @@ async fn drive_turn(
         }
     }
 
-    if let Ok(Some(current)) = tidebreak_core::db::code::get_turn(db, turn.id).await {
+    if let Ok(Some(current)) = tidebreak_core::db::code::get_turn(db, &session.owner, turn.id).await
+    {
         turn = current;
     }
     super::checkpoint::after_turn_completed(db, bus, session, &mut turn).await;
@@ -694,7 +717,7 @@ async fn hydrate_turn_images(
 }
 
 async fn session_was_ended(db: &DbStore, session: &mut CodeSession) -> bool {
-    match get_session(db, session.id).await {
+    match get_session(db, &session.owner, session.id).await {
         Ok(Some(current)) if current.lifecycle == CodeSessionLifecycle::Ended => {
             *session = current;
             true
@@ -719,7 +742,7 @@ pub(crate) async fn attach_engine(
     let epoch = bump_spawn_epoch(db, session_id, child_pid)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?;
-    let mut session = get_session(db, session_id)
+    let mut session = get_session_all_owners(db, session_id)
         .await
         .map_err(|err| WorkerError::Failed(err.to_string()))?
         .ok_or_else(|| WorkerError::Failed(format!("session {session_id} not found")))?;
@@ -738,6 +761,7 @@ pub(crate) async fn attach_engine(
     persist_and_publish(
         db,
         bus,
+        &session.owner,
         session_id,
         epoch,
         CodeEvent::SessionStarted {
@@ -757,6 +781,7 @@ pub(crate) async fn attach_engine(
 pub(crate) fn sink_for(
     db: Arc<DbStore>,
     bus: Arc<CodeEventBus>,
+    owner: OwnerId,
     session_id: CodeSessionId,
     spawn_epoch: i64,
     turn_id: Option<CodeTurnId>,
@@ -764,6 +789,7 @@ pub(crate) fn sink_for(
     Arc::new(LiveSink {
         db,
         bus,
+        owner,
         session_id,
         spawn_epoch,
         turn_id: std::sync::Mutex::new(turn_id),
@@ -774,24 +800,26 @@ pub(crate) fn sink_for(
 pub(crate) async fn journal_event(
     db: &DbStore,
     bus: &CodeEventBus,
+    owner: &OwnerId,
     session_id: CodeSessionId,
     spawn_epoch: i64,
     event: CodeEvent,
 ) -> Result<(), CodeJournalError> {
-    persist_and_publish(db, bus, session_id, spawn_epoch, event).await
+    persist_and_publish(db, bus, owner, session_id, spawn_epoch, event).await
 }
 
 async fn persist_and_publish(
     db: &DbStore,
     bus: &CodeEventBus,
+    owner: &OwnerId,
     session_id: CodeSessionId,
     spawn_epoch: i64,
     event: CodeEvent,
 ) -> Result<(), CodeJournalError> {
-    apply_side_effects(db, session_id, spawn_epoch, &event).await?;
-    let seq = append_event(db, session_id, spawn_epoch, &event).await?;
+    apply_side_effects(db, owner, session_id, spawn_epoch, &event).await?;
+    let seq = append_event(db, owner, session_id, spawn_epoch, &event).await?;
     if is_activity(&event) {
-        let _ = super::attention::note_activity(db, bus, session_id).await;
+        let _ = super::attention::note_activity(db, bus, owner, session_id).await;
     }
     bus.publish(
         session_id,
@@ -816,13 +844,14 @@ fn is_activity(event: &CodeEvent) -> bool {
 
 async fn apply_side_effects(
     db: &DbStore,
+    owner: &OwnerId,
     session_id: CodeSessionId,
     _spawn_epoch: i64,
     event: &CodeEvent,
 ) -> Result<(), CodeJournalError> {
     match event {
         CodeEvent::TurnCompleted { usage, checkpoint } => {
-            if let Ok(Some(mut turn)) = get_open_turn(db, session_id).await {
+            if let Ok(Some(mut turn)) = get_open_turn(db, owner, session_id).await {
                 turn.status = CodeTurnStatus::Completed;
                 turn.ended_at = Some(Utc::now());
                 turn.usage = Some(usage.clone());
@@ -830,21 +859,21 @@ async fn apply_side_effects(
                     turn.checkpoint_ref = hint.checkpoint_ref.clone();
                     turn.diffstat = hint.diffstat.clone();
                 }
-                let _ = save_turn(db, &turn).await;
+                let _ = save_turn(db, owner, &turn).await;
             }
         }
         CodeEvent::TurnFailed { .. } => {
-            if let Ok(Some(mut turn)) = get_open_turn(db, session_id).await {
+            if let Ok(Some(mut turn)) = get_open_turn(db, owner, session_id).await {
                 turn.status = CodeTurnStatus::Failed;
                 turn.ended_at = Some(Utc::now());
-                let _ = save_turn(db, &turn).await;
+                let _ = save_turn(db, owner, &turn).await;
             }
         }
         CodeEvent::TurnInterrupted => {
-            if let Ok(Some(mut turn)) = get_open_turn(db, session_id).await {
+            if let Ok(Some(mut turn)) = get_open_turn(db, owner, session_id).await {
                 turn.status = CodeTurnStatus::Interrupted;
                 turn.ended_at = Some(Utc::now());
-                let _ = save_turn(db, &turn).await;
+                let _ = save_turn(db, owner, &turn).await;
             }
         }
         _ => {}

--- a/crates/tidebreak-server/src/code/terminal.rs
+++ b/crates/tidebreak-server/src/code/terminal.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
-use tidebreak_core::{CodeTerminalId, WorkspaceId};
+use tidebreak_core::{CodeTerminalId, OwnerId, WorkspaceId};
 use tokio::sync::broadcast;
 
 /// Cap on live shells per workspace. A terminal is a convenience, not a data plane.
@@ -45,7 +45,10 @@ const NOTICE_BUFFER: usize = 64;
 /// In-memory process-wide registry of live auxiliary terminals.
 pub(crate) struct TerminalHub {
     inner: Mutex<HubInner>,
-    notices: broadcast::Sender<TerminalNotice>,
+    /// One notice channel per owner. Terminal activity rides
+    /// `/code/updates`, so it is partitioned the same way the digests are:
+    /// a subscriber's receiver only ever carries its own owner's notices.
+    notices: Mutex<HashMap<OwnerId, broadcast::Sender<TerminalNotice>>>,
 }
 
 struct HubInner {
@@ -55,6 +58,7 @@ struct HubInner {
 
 struct LiveTerminal {
     id: CodeTerminalId,
+    owner: OwnerId,
     workspace_id: WorkspaceId,
     ring: ByteRing,
     cols: u16,
@@ -114,22 +118,32 @@ pub(crate) enum TerminalError {
 
 impl TerminalHub {
     pub(crate) fn new() -> Self {
-        let (notices, _) = broadcast::channel(NOTICE_BUFFER);
         Self {
             inner: Mutex::new(HubInner {
                 by_id: HashMap::new(),
                 by_workspace: HashMap::new(),
             }),
-            notices,
+            notices: Mutex::new(HashMap::new()),
         }
     }
 
-    pub(crate) fn subscribe(&self) -> broadcast::Receiver<TerminalNotice> {
-        self.notices.subscribe()
+    fn notices_sender(&self, owner: &OwnerId) -> broadcast::Sender<TerminalNotice> {
+        self.notices
+            .lock()
+            .expect("terminal notice bus")
+            .entry(owner.clone())
+            .or_insert_with(|| broadcast::channel(NOTICE_BUFFER).0)
+            .clone()
+    }
+
+    /// Subscribe to one owner's terminal activity.
+    pub(crate) fn subscribe(&self, owner: &OwnerId) -> broadcast::Receiver<TerminalNotice> {
+        self.notices_sender(owner).subscribe()
     }
 
     pub(crate) fn open(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
         cwd: &Path,
         cols: Option<u16>,
@@ -142,6 +156,7 @@ impl TerminalHub {
         let id = CodeTerminalId::new();
         let live = LiveTerminal {
             id,
+            owner: owner.clone(),
             workspace_id,
             ring: ByteRing::new(TERMINAL_RING_BYTES),
             cols,
@@ -155,8 +170,9 @@ impl TerminalHub {
         };
         let handle = Arc::new(Mutex::new(live));
         self.insert(workspace_id, id, handle.clone());
-        start_reader(handle.clone(), self.notices.clone(), spawned.reader);
-        start_reaper(handle.clone(), self.notices.clone(), spawned.child);
+        let notices = self.notices_sender(owner);
+        start_reader(handle.clone(), notices.clone(), spawned.reader);
+        start_reaper(handle.clone(), notices, spawned.child);
         Ok(lock_snapshot(&handle))
     }
 
@@ -164,6 +180,7 @@ impl TerminalHub {
     #[cfg(test)]
     pub(crate) fn open_memory(
         &self,
+        owner: &OwnerId,
         workspace_id: WorkspaceId,
         cols: u16,
         rows: u16,
@@ -174,6 +191,7 @@ impl TerminalHub {
         let id = CodeTerminalId::new();
         let live = LiveTerminal {
             id,
+            owner: owner.clone(),
             workspace_id,
             ring: ByteRing::new(TERMINAL_RING_BYTES),
             cols,
@@ -269,7 +287,8 @@ impl TerminalHub {
             // Memory-backed terminals echo writes into the ring so tests can
             // drive the same read path the PTY reader uses.
             live.ring.write(bytes);
-            apply_coalesce(&mut live, &handle, &self.notices, workspace_id, id);
+            let notices = self.notices_sender(&live.owner.clone());
+            apply_coalesce(&mut live, &handle, &notices, workspace_id, id);
         }
         Ok(())
     }
@@ -348,7 +367,8 @@ impl TerminalHub {
         let mut live = handle.lock().expect("terminal");
         live.ring.write(bytes);
         let workspace_id = live.workspace_id;
-        apply_coalesce(&mut live, &handle, &self.notices, workspace_id, id);
+        let notices = self.notices_sender(&live.owner.clone());
+        apply_coalesce(&mut live, &handle, &notices, workspace_id, id);
     }
 
     fn reserve_slot(&self, workspace_id: WorkspaceId) -> Result<(), TerminalError> {
@@ -781,7 +801,7 @@ mod tests {
     fn two_readers_at_different_cursors_both_see_retained_bytes() {
         let hub = TerminalHub::new();
         let ws = workspace();
-        let snap = hub.open_memory(ws, 80, 24).unwrap();
+        let snap = hub.open_memory(&OwnerId::local(), ws, 80, 24).unwrap();
         hub.push_output(snap.id, b"hello ");
         hub.push_output(snap.id, b"world");
         let first = hub.read(ws, snap.id, 0);
@@ -795,8 +815,8 @@ mod tests {
     fn fast_producer_coalesces_notices_and_reader_gets_every_byte() {
         let hub = TerminalHub::new();
         let ws = workspace();
-        let snap = hub.open_memory(ws, 80, 24).unwrap();
-        let mut rx = hub.subscribe();
+        let snap = hub.open_memory(&OwnerId::local(), ws, 80, 24).unwrap();
+        let mut rx = hub.subscribe(&OwnerId::local());
         let mut expected = Vec::new();
         for i in 0..64u8 {
             let chunk = [i];
@@ -824,7 +844,7 @@ mod tests {
         let marker = b"TERM_MARKER_no_durable_9f3a7c1e";
         let ws = workspace();
         let first = TerminalHub::new();
-        let snap = first.open_memory(ws, 80, 24).unwrap();
+        let snap = first.open_memory(&OwnerId::local(), ws, 80, 24).unwrap();
         first.push_output(snap.id, marker);
         let before = first.read(ws, snap.id, 0);
         assert!(before.data.windows(marker.len()).any(|w| w == marker));
@@ -843,17 +863,17 @@ mod tests {
     fn write_size_and_workspace_caps() {
         let hub = TerminalHub::new();
         let ws = workspace();
-        let snap = hub.open_memory(ws, 80, 24).unwrap();
+        let snap = hub.open_memory(&OwnerId::local(), ws, 80, 24).unwrap();
         let too_big = vec![b'a'; MAX_TERMINAL_WRITE_BYTES + 1];
         assert!(matches!(
             hub.write(ws, snap.id, &too_big),
             Err(TerminalError::WriteTooLarge)
         ));
         for _ in 1..MAX_TERMINALS_PER_WORKSPACE {
-            hub.open_memory(ws, 80, 24).unwrap();
+            hub.open_memory(&OwnerId::local(), ws, 80, 24).unwrap();
         }
         assert!(matches!(
-            hub.open_memory(ws, 80, 24),
+            hub.open_memory(&OwnerId::local(), ws, 80, 24),
             Err(TerminalError::WorkspaceCap)
         ));
     }

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -21,7 +21,7 @@
 use std::sync::Arc;
 
 use tidebreak_core::db::code::{get_session, get_workspace, set_workspace_title_if};
-use tidebreak_core::{CodeSessionId, CodeWorkspaceStatus, Result, WorkspaceId};
+use tidebreak_core::{CodeSessionId, CodeWorkspaceStatus, OwnerId, Result, WorkspaceId};
 
 use crate::chat_titling::{
     derive_title_with_retries, head, MAX_TITLE_SOURCE_MESSAGE_BYTES, TITLE_TARGET_CHARS,
@@ -63,7 +63,12 @@ enum Outcome {
 /// Returns immediately; nothing waits on the result and a lost title costs
 /// nothing. Called from the front of turn submission so the name usually lands
 /// while the engine is still working, mirroring chat titling's hook point.
-pub(crate) fn spawn_for_turn(state: &AppState, session_id: CodeSessionId, message: String) {
+pub(crate) fn spawn_for_turn(
+    state: &AppState,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    message: String,
+) {
     let Some(code) = state.code.clone() else {
         return;
     };
@@ -73,8 +78,9 @@ pub(crate) fn spawn_for_turn(state: &AppState, session_id: CodeSessionId, messag
         return;
     }
     let state = state.clone();
+    let owner = owner.clone();
     tokio::spawn(async move {
-        match derive_workspace_title(&state, &code, session_id, &message).await {
+        match derive_workspace_title(&state, &code, &owner, session_id, &message).await {
             Ok(Outcome::Named(title)) => {
                 eprintln!("tidebreak: named a code workspace: {title}");
             }
@@ -95,17 +101,18 @@ pub(crate) fn spawn_for_turn(state: &AppState, session_id: CodeSessionId, messag
 async fn derive_workspace_title(
     state: &AppState,
     code: &Arc<CodeRuntime>,
+    owner: &OwnerId,
     session_id: CodeSessionId,
     message: &str,
 ) -> Result<Outcome> {
-    let Some(session) = get_session(&code.db, session_id).await? else {
+    let Some(session) = get_session(&code.db, owner, session_id).await? else {
         return Ok(Outcome::NotApplicable);
     };
     let Some(claim) = TitlingClaim::acquire(code, session.workspace_id) else {
         return Ok(Outcome::NotApplicable);
     };
     let _held = claim;
-    let Some(workspace) = get_workspace(&code.db, session.workspace_id).await? else {
+    let Some(workspace) = get_workspace(&code.db, owner, session.workspace_id).await? else {
         return Ok(Outcome::NotApplicable);
     };
     let placeholder = worktree::two_word_name(workspace.id.0.as_u128());
@@ -141,13 +148,13 @@ async fn derive_workspace_title(
     let Some(title) = title else {
         return Ok(Outcome::Declined);
     };
-    if !set_workspace_title_if(&code.db, workspace.id, &placeholder, &title).await? {
+    if !set_workspace_title_if(&code.db, owner, workspace.id, &placeholder, &title).await? {
         // Renamed while the call ran; the chosen name has the floor.
         return Ok(Outcome::NotApplicable);
     }
     // Announced only once the write applied, on the digest channel every list
     // surface already watches.
-    super::attention::emit_workspace_digests(&code.db, &code.bus, workspace.id).await;
+    super::attention::emit_workspace_digests(&code.db, &code.bus, owner, workspace.id).await;
     Ok(Outcome::Named(title))
 }
 

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 32;
+const DESKTOP_SCHEMA_EPOCH: u32 = 33;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -449,6 +449,21 @@ pub fn app(state: AppState) -> Router {
             "/voice-transcription/install",
             post(routes::post_voice_transcription_install),
         )
+        // Code mode's two deployment-plane routes. Installing a pinned harness
+        // writes a binary to this machine, and the clone parent directory is
+        // one shared setting that decides where every principal's checkouts
+        // land on its disk — both change what the deployment *is*, so neither
+        // belongs to a member (decisions 6 and 48 step 1). Reading and
+        // cloning into that directory stay on the member plane: those produce
+        // owner-scoped rows and owner-keyed checkouts.
+        .route(
+            "/code/harnesses/refresh",
+            post(routes::code::refresh_harnesses),
+        )
+        .route(
+            "/code/repos/clone-defaults",
+            get(routes::code::clone_defaults),
+        )
         .route_layer(axum::middleware::from_fn(auth::require_admin));
 
     let api = Router::new()
@@ -693,10 +708,6 @@ pub fn app(state: AppState) -> Router {
             "/code/repos",
             post(routes::code::create_repo).get(routes::code::list_repos),
         )
-        .route(
-            "/code/repos/clone-defaults",
-            get(routes::code::clone_defaults),
-        )
         .route("/code/repos/clone", post(routes::code::start_clone))
         .route("/code/repos/clone/{job}", get(routes::code::get_clone_job))
         .route(
@@ -706,10 +717,6 @@ pub fn app(state: AppState) -> Router {
                 .delete(routes::code::delete_repo),
         )
         .route("/code/harnesses", get(routes::code::list_harnesses))
-        .route(
-            "/code/harnesses/refresh",
-            post(routes::code::refresh_harnesses),
-        )
         .route(
             "/code/harnesses/{kind}/models",
             get(routes::code::list_harness_models),

--- a/crates/tidebreak-server/src/routes/code/approvals.rs
+++ b/crates/tidebreak-server/src/routes/code/approvals.rs
@@ -1,25 +1,22 @@
-use axum::extract::{Query, State};
+use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
+use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
-use crate::state::AppState;
 use tidebreak_core::CodeApprovalId;
 use tidebreak_harness::ApprovalDecision;
 
-use super::require_code;
 use super::types::{
     CodeApprovalDecision, CodeApprovalDecisionBody, CodeApprovalSnapshot, ListApprovalsQuery,
 };
 
 pub async fn list_approvals(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Query(query): Query<ListApprovalsQuery>,
 ) -> Result<Json<Vec<CodeApprovalSnapshot>>, ServerError> {
-    let approvals = require_code(&state)?
-        .list_approvals(query.state, query.session_id)
-        .await?;
+    let approvals = code.list_approvals(query.state, query.session_id).await?;
     Ok(Json(
         approvals
             .into_iter()
@@ -29,7 +26,7 @@ pub async fn list_approvals(
 }
 
 pub async fn decide_approval(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<CodeApprovalId>,
     Json(body): Json<CodeApprovalDecisionBody>,
 ) -> Result<impl IntoResponse, ServerError> {
@@ -39,6 +36,6 @@ pub async fn decide_approval(
             feedback: body.feedback,
         },
     };
-    let approval = require_code(&state)?.decide_approval(id, decision).await?;
+    let approval = code.decide_approval(id, decision).await?;
     Ok((StatusCode::OK, Json(CodeApprovalSnapshot::from(approval))))
 }

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -1,14 +1,12 @@
 //! Commit, push, pull-request, and quick-action routes for a workspace.
 
-use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
+use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
-use crate::state::AppState;
 
-use super::require_code;
 use super::types::{
     CodeActionSnapshot, CodeCommitSnapshot, CodePrCommentsSnapshot, CodePrMergeMethod,
     CodePushSnapshot, CodeWorkspacePrSnapshot, CommitWorkspaceBody, CreatePullRequestBody,
@@ -18,58 +16,50 @@ use crate::code::gh::{ActionOutcome, CommitOutcome, MergeMethod, PushOutcome, Wo
 use tidebreak_core::WorkspaceId;
 
 pub async fn commit_workspace(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Json(body): Json<CommitWorkspaceBody>,
 ) -> Result<Json<CodeCommitSnapshot>, ServerError> {
-    let outcome = require_code(&state)?
-        .commit_workspace(id, body.message)
-        .await?;
+    let outcome = code.commit_workspace(id, body.message).await?;
     Ok(Json(commit_snapshot(outcome)))
 }
 
 pub async fn push_workspace(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
 ) -> Result<Json<CodePushSnapshot>, ServerError> {
-    let outcome = require_code(&state)?.push_workspace(id).await?;
+    let outcome = code.push_workspace(id).await?;
     Ok(Json(push_snapshot(outcome)))
 }
 
 pub async fn create_pull_request(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Json(body): Json<CreatePullRequestBody>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let snapshot = require_code(&state)?
-        .create_workspace_pr(id, body.title, body.body)
-        .await?;
+    let snapshot = code.create_workspace_pr(id, body.title, body.body).await?;
     Ok((StatusCode::CREATED, Json(pr_snapshot(snapshot))))
 }
 
 pub async fn get_workspace_pr(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
 ) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
-    Ok(Json(pr_snapshot(
-        require_code(&state)?.workspace_pr(id).await?,
-    )))
+    Ok(Json(pr_snapshot(code.workspace_pr(id).await?)))
 }
 
 pub async fn refresh_workspace_pr(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
 ) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
-    Ok(Json(pr_snapshot(
-        require_code(&state)?.refresh_workspace_pr(id).await?,
-    )))
+    Ok(Json(pr_snapshot(code.refresh_workspace_pr(id).await?)))
 }
 
 pub async fn get_workspace_pr_comments(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
 ) -> Result<Json<CodePrCommentsSnapshot>, ServerError> {
-    let comments = require_code(&state)?.workspace_pr_comments(id).await?;
+    let comments = code.workspace_pr_comments(id).await?;
     Ok(Json(CodePrCommentsSnapshot {
         number: comments.number,
         comments: comments.comments,
@@ -77,7 +67,7 @@ pub async fn get_workspace_pr_comments(
 }
 
 pub async fn merge_workspace_pr(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Json(body): Json<MergeCodePrBody>,
 ) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
@@ -87,19 +77,15 @@ pub async fn merge_workspace_pr(
         CodePrMergeMethod::Rebase => MergeMethod::Rebase,
     };
     Ok(Json(pr_snapshot(
-        require_code(&state)?
-            .merge_workspace_pr(id, method, body.auto)
-            .await?,
+        code.merge_workspace_pr(id, method, body.auto).await?,
     )))
 }
 
 pub async fn run_workspace_action(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path((id, name)): Path<(WorkspaceId, String)>,
 ) -> Result<Json<CodeActionSnapshot>, ServerError> {
-    let outcome = require_code(&state)?
-        .run_workspace_action(id, &name)
-        .await?;
+    let outcome = code.run_workspace_action(id, &name).await?;
     Ok(Json(action_snapshot(outcome)))
 }
 

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -1,41 +1,34 @@
-use axum::extract::{Path, State};
+use axum::extract::Path;
 
+use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::Json;
-use crate::state::AppState;
 
-use super::require_code;
 use super::types::{HarnessDoctorEntry, HarnessDoctorReport, HarnessModel, HarnessModelList};
 use tidebreak_core::HarnessKind;
 
 /// The doctor surface, served from the memoized probes (decision 0034).
-pub async fn list_harnesses(
-    State(state): State<AppState>,
-) -> Result<Json<HarnessDoctorReport>, ServerError> {
-    Ok(Json(doctor(&state).await?))
+pub async fn list_harnesses(code: ScopedCode) -> Result<Json<HarnessDoctorReport>, ServerError> {
+    Ok(Json(doctor(&code).await?))
 }
 
 /// The explicit re-probe decision 0034 puts behind the doctor's refresh: drop
 /// the memoized probes, then report what a cold read finds. This is how a
 /// harness installed or signed into while the app runs becomes visible.
-pub async fn refresh_harnesses(
-    State(state): State<AppState>,
-) -> Result<Json<HarnessDoctorReport>, ServerError> {
-    let runtime = require_code(&state)?;
+pub async fn refresh_harnesses(code: ScopedCode) -> Result<Json<HarnessDoctorReport>, ServerError> {
     #[cfg(not(test))]
-    runtime.refresh_pinned_harnesses().await;
-    runtime.invalidate_probes();
-    Ok(Json(doctor(&state).await?))
+    code.refresh_pinned_harnesses().await;
+    code.invalidate_probes();
+    Ok(Json(doctor(&code).await?))
 }
 
 /// Models this harness currently lists. Not on the doctor path.
 pub async fn list_harness_models(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(kind): Path<HarnessKind>,
 ) -> Result<Json<HarnessModelList>, ServerError> {
-    let runtime = require_code(&state)?;
-    let adapter = runtime.adapter(kind)?;
-    let probe = runtime.probe(adapter.as_ref()).await;
+    let adapter = code.adapter(kind)?;
+    let probe = code.probe(adapter.as_ref()).await;
     if !probe.found {
         return Err(ServerError::unprocessable_kind(
             "harness_not_found",
@@ -54,24 +47,23 @@ pub async fn list_harness_models(
     Ok(Json(HarnessModelList { kind, models }))
 }
 
-async fn doctor(state: &AppState) -> Result<HarnessDoctorReport, ServerError> {
-    let runtime = require_code(state)?;
-    let sessions = runtime.list_sessions().await?;
+async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
+    let sessions = code.list_sessions().await?;
     let sessions = &sessions;
     // Probe the kinds concurrently. A cold probe is a login shell plus a
     // version and an authentication subprocess, so a serial walk over the
     // harnesses is most of what this route costs on a cache miss.
     let harnesses = futures::future::join_all(HarnessKind::ALL.iter().filter_map(|kind| {
-        let adapter = runtime.adapters.get(*kind)?;
+        let adapter = code.adapters().get(*kind)?;
         Some(async move {
-            let probe = runtime.probe(adapter.as_ref()).await;
+            let probe = code.probe(adapter.as_ref()).await;
             let caps = adapter.capabilities(&probe);
             let unrecognized_event_count = sessions
                 .iter()
                 .filter(|session| session.harness_kind == *kind)
                 .map(|session| session.unrecognized_event_count)
                 .sum();
-            let install_error = runtime.pin_install_error(*kind);
+            let install_error = code.pin_install_error(*kind);
             let remediation = if let Some(err) = install_error {
                 format!("could not install the pinned {kind} binary: {err}")
             } else if !probe.found {

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -1,4 +1,9 @@
 //! `/code/*` routes: repos, workspaces, sessions, doctor, event stream.
+//!
+//! Every route here is owner-scoped through `ScopedCode`. The routes that
+//! change what the machine *is* — installing pinned harness binaries, and the
+//! clone-parent-directory setting every principal shares — are registered on
+//! the deployment-plane router in `crate::lib` instead, behind `require_admin`.
 
 mod approvals;
 mod git;
@@ -7,7 +12,7 @@ mod repos;
 mod session_events;
 mod sessions;
 mod terminals;
-mod types;
+pub(crate) mod types;
 mod updates;
 mod workspaces;
 
@@ -49,13 +54,9 @@ pub(crate) use workspaces::{
     list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace, search_workspace,
 };
 
-use crate::code::CodeRuntime;
-use crate::error::ServerError;
-use crate::state::AppState;
-
-pub(crate) fn require_code(state: &AppState) -> Result<&CodeRuntime, ServerError> {
-    state
-        .code
-        .as_deref()
-        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))
-}
+// Nothing here reaches `AppState.code` directly. Every handler in this module
+// extracts a `crate::code::ScopedCode`, which binds the process runtime to the
+// requesting principal and refuses when code mode is not configured — so a new
+// `/code/*` route is owner-scoped by construction rather than by remembering
+// to filter (decision 6's "enforcement is a router property, not a handler
+// habit", applied to data scoping).

--- a/crates/tidebreak-server/src/routes/code/repos.rs
+++ b/crates/tidebreak-server/src/routes/code/repos.rs
@@ -1,71 +1,58 @@
-use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use std::path::PathBuf;
-use std::sync::Arc;
 use uuid::Uuid;
 
+use crate::code::runtime::RepoRegistration;
+use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
-use crate::state::AppState;
 
-use super::require_code;
 use super::types::{
     CloneRepoBody, CodeCloneDefaults, CodeCloneJobSnapshot, CodeRepoSnapshot, CreateRepoBody,
     PatchRepoBody,
 };
 use tidebreak_core::RepoId;
 
-fn require_code_arc(state: &AppState) -> Result<Arc<crate::code::CodeRuntime>, ServerError> {
-    state
-        .code
-        .clone()
-        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))
-}
-
 pub async fn create_repo(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Json(body): Json<CreateRepoBody>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let runtime = require_code(&state)?;
-    let repo = runtime
+    let repo = code
         .register_repo(
             PathBuf::from(body.path),
-            body.display_name,
-            body.default_base_ref,
-            body.branch_prefix,
-            body.setup_script,
-            body.archive_script,
+            RepoRegistration {
+                display_name: body.display_name,
+                default_base_ref: body.default_base_ref,
+                branch_prefix: body.branch_prefix,
+                setup_script: body.setup_script,
+                archive_script: body.archive_script,
+            },
         )
         .await?;
     Ok((StatusCode::CREATED, Json(CodeRepoSnapshot::from(repo))))
 }
 
-pub async fn list_repos(
-    State(state): State<AppState>,
-) -> Result<Json<Vec<CodeRepoSnapshot>>, ServerError> {
-    let runtime = require_code(&state)?;
-    let repos = runtime.list_repos().await?;
+pub async fn list_repos(code: ScopedCode) -> Result<Json<Vec<CodeRepoSnapshot>>, ServerError> {
+    let repos = code.list_repos().await?;
     Ok(Json(
         repos.into_iter().map(CodeRepoSnapshot::from).collect(),
     ))
 }
 
 pub async fn get_repo(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<RepoId>,
 ) -> Result<Json<CodeRepoSnapshot>, ServerError> {
-    let runtime = require_code(&state)?;
-    Ok(Json(CodeRepoSnapshot::from(runtime.get_repo(id).await?)))
+    Ok(Json(CodeRepoSnapshot::from(code.get_repo(id).await?)))
 }
 
 pub async fn patch_repo(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<RepoId>,
     Json(body): Json<PatchRepoBody>,
 ) -> Result<Json<CodeRepoSnapshot>, ServerError> {
-    let runtime = require_code(&state)?;
-    let mut repo = runtime.get_repo(id).await?;
+    let mut repo = code.get_repo(id).await?;
     if let Some(name) = body.display_name {
         let name = name.trim().to_owned();
         if name.is_empty() {
@@ -95,30 +82,27 @@ pub async fn patch_repo(
     if let Some(script) = body.archive_script {
         repo.archive_script = script.filter(|value| !value.trim().is_empty());
     }
-    runtime.save_repo(&repo).await?;
+    code.save_repo(&repo).await?;
     Ok(Json(CodeRepoSnapshot::from(repo)))
 }
 
 pub async fn delete_repo(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<RepoId>,
 ) -> Result<StatusCode, ServerError> {
-    require_code(&state)?.delete_repo(id).await?;
+    code.delete_repo(id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
-pub async fn clone_defaults(
-    State(state): State<AppState>,
-) -> Result<Json<CodeCloneDefaults>, ServerError> {
-    Ok(Json(require_code(&state)?.clone_defaults().await?))
+pub async fn clone_defaults(code: ScopedCode) -> Result<Json<CodeCloneDefaults>, ServerError> {
+    Ok(Json(code.clone_defaults().await?))
 }
 
 pub async fn start_clone(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Json(body): Json<CloneRepoBody>,
 ) -> Result<(StatusCode, Json<CodeCloneJobSnapshot>), ServerError> {
-    let runtime = require_code_arc(&state)?;
-    let job = runtime
+    let job = code
         .start_clone(crate::code::clone::CloneRequest {
             url: body.url,
             github: body.github,
@@ -130,8 +114,8 @@ pub async fn start_clone(
 }
 
 pub async fn get_clone_job(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(job): Path<Uuid>,
 ) -> Result<Json<CodeCloneJobSnapshot>, ServerError> {
-    Ok(Json(require_code(&state)?.get_clone_job(job)?))
+    Ok(Json(code.get_clone_job(job)?))
 }

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -6,41 +6,51 @@ use axum::response::Response;
 use tokio::sync::broadcast::error::RecvError;
 
 use tidebreak_core::db::code::list_events;
-use tidebreak_core::CodeSessionId;
+use tidebreak_core::{CodeSessionId, OwnerId};
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
+use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Path, Query};
 use crate::state::AppState;
 
-use super::require_code;
 use super::types::{SequencedCodeEventFrame, SessionEventsQuery};
 
 pub async fn session_events(
     State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<CodeSessionId>,
     Query(query): Query<SessionEventsQuery>,
     headers: axum::http::HeaderMap,
     upgrade: WebSocketUpgrade,
 ) -> Result<Response, ServerError> {
-    let runtime = require_code(&state)?;
-    let _ = runtime.get_session(id).await?;
+    // Authorize before upgrading: the per-session channel is keyed by id, so
+    // the principal's claim to this session is settled here, on the chat
+    // journal's pattern, rather than by filtering frames afterwards.
+    let _ = code.get_session(id).await?;
+    let owner = code.owner().clone();
     let upgrade = if offered_handshake_subprotocol(&headers) {
         upgrade.protocols([WS_HANDSHAKE_SUBPROTOCOL])
     } else {
         upgrade
     };
-    Ok(upgrade.on_upgrade(move |socket| stream_events(socket, state, id, query.after)))
+    Ok(upgrade.on_upgrade(move |socket| stream_events(socket, state, owner, id, query.after)))
 }
 
-async fn stream_events(mut socket: WebSocket, state: AppState, session: CodeSessionId, after: i64) {
+async fn stream_events(
+    mut socket: WebSocket,
+    state: AppState,
+    owner: OwnerId,
+    session: CodeSessionId,
+    after: i64,
+) {
     let Some(runtime) = state.code.clone() else {
         return;
     };
     let mut live = runtime.bus.subscribe(session);
-    let _ = runtime.mark_session_viewed(session).await;
+    let _ = runtime.mark_session_viewed(&owner, session).await;
     let mut last_seq = after;
-    if replay_after(&mut socket, &runtime.db, session, &mut last_seq)
+    if replay_after(&mut socket, &runtime.db, &owner, session, &mut last_seq)
         .await
         .is_err()
     {
@@ -58,7 +68,7 @@ async fn stream_events(mut socket: WebSocket, state: AppState, session: CodeSess
                         continue;
                     }
                     if event.seq > last_seq.saturating_add(1) {
-                        if replay_after(&mut socket, &runtime.db, session, &mut last_seq)
+                        if replay_after(&mut socket, &runtime.db, &owner, session, &mut last_seq)
                             .await
                             .is_err()
                         {
@@ -82,7 +92,7 @@ async fn stream_events(mut socket: WebSocket, state: AppState, session: CodeSess
                     }
                 }
                 Err(RecvError::Lagged(_)) => {
-                    if replay_after(&mut socket, &runtime.db, session, &mut last_seq)
+                    if replay_after(&mut socket, &runtime.db, &owner, session, &mut last_seq)
                         .await
                         .is_err()
                     {
@@ -98,10 +108,11 @@ async fn stream_events(mut socket: WebSocket, state: AppState, session: CodeSess
 async fn replay_after(
     socket: &mut WebSocket,
     store: &tidebreak_core::DbStore,
+    owner: &OwnerId,
     session: CodeSessionId,
     last_seq: &mut i64,
 ) -> Result<(), ()> {
-    let events = list_events(store, session, *last_seq)
+    let events = list_events(store, owner, session, *last_seq)
         .await
         .map_err(|_| ())?;
     for event in events {

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -3,6 +3,7 @@ use axum::extract::State;
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 
+use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, RawBytes};
 use crate::routes::image_attachment::{
@@ -11,7 +12,6 @@ use crate::routes::image_attachment::{
 use crate::routes::SERVED_BYTES_CONTENT_POLICY;
 use crate::state::AppState;
 
-use super::require_code;
 use super::types::{
     CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuedCodeTurn,
     SequencedCodeEventFrame, SetAttentionBody, SteerBody, SubmitTurnBody,
@@ -20,11 +20,11 @@ use crate::code::runtime::SubmitTurnOutcome;
 use tidebreak_core::{CodeSessionId, WorkspaceId};
 
 pub async fn create_session(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(workspace_id): Path<WorkspaceId>,
     Json(body): Json<CreateSessionBody>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let session = require_code(&state)?
+    let session = code
         .create_session(workspace_id, body.harness, body.permission_mode, body.model)
         .await?;
     Ok((
@@ -34,12 +34,10 @@ pub async fn create_session(
 }
 
 pub async fn list_workspace_sessions(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(workspace_id): Path<WorkspaceId>,
 ) -> Result<Json<Vec<CodeSessionSnapshot>>, ServerError> {
-    let sessions = require_code(&state)?
-        .list_workspace_sessions(workspace_id)
-        .await?;
+    let sessions = code.list_workspace_sessions(workspace_id).await?;
     Ok(Json(
         sessions
             .into_iter()
@@ -50,6 +48,7 @@ pub async fn list_workspace_sessions(
 
 pub async fn submit_turn(
     State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<CodeSessionId>,
     Json(body): Json<SubmitTurnBody>,
 ) -> Result<impl IntoResponse, ServerError> {
@@ -57,18 +56,17 @@ pub async fn submit_turn(
     if message.is_empty() {
         return Err(ServerError::bad_request("message must not be empty"));
     }
-    let runtime = require_code(&state)?;
     let requested = body
         .attachments
         .iter()
         .map(|item| (item.blob_id, item.media_type.clone()))
         .collect::<Vec<_>>();
-    let attachments = runtime.resolve_turn_attachments(&requested).await?;
+    let attachments = code.resolve_turn_attachments(&requested).await?;
     // From the front of the submit, like chat titling from the front of a
     // turn: a code turn can run for minutes, and the derived name should land
     // while the engine works, not after.
-    crate::code::titling::spawn_for_turn(&state, id, message.clone());
-    match runtime
+    crate::code::titling::spawn_for_turn(&state, code.owner(), id, message.clone());
+    match code
         .submit_turn(id, message.clone(), body.model, attachments)
         .await?
     {
@@ -88,10 +86,10 @@ pub async fn submit_turn(
 }
 
 pub async fn get_session_debug(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<CodeSessionId>,
 ) -> Result<Json<super::types::CodeSessionDebug>, ServerError> {
-    let (session, turns, events) = require_code(&state)?.session_debug(id).await?;
+    let (session, turns, events) = code.session_debug(id).await?;
     Ok(Json(super::types::CodeSessionDebug {
         session: CodeSessionSnapshot::from(session),
         turns: turns.into_iter().map(CodeTurnSnapshot::from).collect(),
@@ -107,10 +105,10 @@ pub async fn get_session_debug(
 }
 
 pub async fn list_session_turns(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<CodeSessionId>,
 ) -> Result<Json<Vec<CodeTurnSnapshot>>, ServerError> {
-    let turns = require_code(&state)?.list_session_turns(id).await?;
+    let turns = code.list_session_turns(id).await?;
     Ok(Json(
         turns.into_iter().map(CodeTurnSnapshot::from).collect(),
     ))
@@ -131,33 +129,27 @@ pub async fn steer_session(
 }
 
 pub async fn interrupt_session(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<CodeSessionId>,
 ) -> Result<StatusCode, ServerError> {
-    require_code(&state)?.interrupt(id).await?;
+    code.interrupt(id).await?;
     Ok(StatusCode::ACCEPTED)
 }
 
 pub async fn set_attention(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<CodeSessionId>,
     Json(body): Json<SetAttentionBody>,
 ) -> Result<Json<CodeSessionSnapshot>, ServerError> {
-    let session = require_code(&state)?
-        .set_attention(id, body.clear, body.note)
-        .await?;
+    let session = code.set_attention(id, body.clear, body.note).await?;
     Ok(Json(CodeSessionSnapshot::from(session)))
 }
 
 pub async fn reap_session(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<CodeSessionId>,
 ) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
-    let runtime = state
-        .code
-        .clone()
-        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))?;
-    let session = runtime.reap(id).await?;
+    let session = code.reap(id).await?;
     Ok((StatusCode::OK, Json(CodeSessionSnapshot::from(session))))
 }
 
@@ -166,12 +158,12 @@ pub async fn reap_session(
 /// what pins the blob.
 pub async fn publish_session_image(
     State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<CodeSessionId>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
-    let runtime = require_code(&state)?;
-    let _session = runtime.get_session(id).await?;
+    let _session = code.get_session(id).await?;
     let bytes = bytes.to_vec();
     let image = inspect_image_bytes(&bytes)?;
     require_declared_type_matches(&headers, image.media_type)?;
@@ -187,10 +179,10 @@ pub async fn publish_session_image(
 /// image a turn on this session already referenced.
 pub async fn get_session_image(
     State(state): State<AppState>,
+    code: ScopedCode,
     Path((id, blob_id)): Path<(CodeSessionId, uuid::Uuid)>,
 ) -> Result<Response, ServerError> {
-    let runtime = require_code(&state)?;
-    let turns = runtime.list_session_turns(id).await?;
+    let turns = code.list_session_turns(id).await?;
     let attachment = turns
         .iter()
         .flat_map(|turn| turn.attachments.iter())

--- a/crates/tidebreak-server/src/routes/code/terminals.rs
+++ b/crates/tidebreak-server/src/routes/code/terminals.rs
@@ -4,12 +4,12 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 
 use crate::code::terminal::{TerminalError, TerminalRead, TerminalSnapshot};
+use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
 use tidebreak_core::{CodeWorkspaceStatus, WorkspaceId};
 
-use super::require_code;
 use super::types::{
     CodeTerminalRead, CodeTerminalSnapshot, CreateTerminalBody, TerminalReadQuery,
     TerminalResizeBody, TerminalWriteBody, WorkspaceTerminalPath,
@@ -17,14 +17,16 @@ use super::types::{
 
 pub async fn create_terminal(
     axum::extract::State(state): axum::extract::State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Json(body): Json<CreateTerminalBody>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let workspace = require_code(&state)?.get_workspace(id).await?;
+    let workspace = code.get_workspace(id).await?;
     require_active(&workspace.status)?;
     let snap = state
         .terminals
         .open(
+            code.owner(),
             id,
             std::path::Path::new(&workspace.worktree_path),
             body.cols,
@@ -36,9 +38,10 @@ pub async fn create_terminal(
 
 pub async fn list_terminals(
     axum::extract::State(state): axum::extract::State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
 ) -> Result<Json<Vec<CodeTerminalSnapshot>>, ServerError> {
-    let _ = require_code(&state)?.get_workspace(id).await?;
+    let _ = code.get_workspace(id).await?;
     Ok(Json(
         state
             .terminals
@@ -51,18 +54,20 @@ pub async fn list_terminals(
 
 pub async fn close_workspace_terminals(
     axum::extract::State(state): axum::extract::State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
 ) -> Result<StatusCode, ServerError> {
-    let _ = require_code(&state)?.get_workspace(id).await?;
+    let _ = code.get_workspace(id).await?;
     state.terminals.close_workspace(id);
     Ok(StatusCode::NO_CONTENT)
 }
 
 pub async fn close_terminal(
     axum::extract::State(state): axum::extract::State<AppState>,
+    code: ScopedCode,
     Path(path): Path<WorkspaceTerminalPath>,
 ) -> Result<StatusCode, ServerError> {
-    let _ = require_code(&state)?.get_workspace(path.id).await?;
+    let _ = code.get_workspace(path.id).await?;
     state
         .terminals
         .close(path.id, path.tid)
@@ -72,10 +77,11 @@ pub async fn close_terminal(
 
 pub async fn read_terminal(
     axum::extract::State(state): axum::extract::State<AppState>,
+    code: ScopedCode,
     Path(path): Path<WorkspaceTerminalPath>,
     Query(query): Query<TerminalReadQuery>,
 ) -> Result<Json<CodeTerminalRead>, ServerError> {
-    let _ = require_code(&state)?.get_workspace(path.id).await?;
+    let _ = code.get_workspace(path.id).await?;
     Ok(Json(read_wire(
         path.tid,
         path.id,
@@ -85,10 +91,11 @@ pub async fn read_terminal(
 
 pub async fn write_terminal(
     axum::extract::State(state): axum::extract::State<AppState>,
+    code: ScopedCode,
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalWriteBody>,
 ) -> Result<StatusCode, ServerError> {
-    let _ = require_code(&state)?.get_workspace(path.id).await?;
+    let _ = code.get_workspace(path.id).await?;
     let bytes = decode_write(&body.bytes)?;
     state
         .terminals
@@ -99,10 +106,11 @@ pub async fn write_terminal(
 
 pub async fn resize_terminal(
     axum::extract::State(state): axum::extract::State<AppState>,
+    code: ScopedCode,
     Path(path): Path<WorkspaceTerminalPath>,
     Json(body): Json<TerminalResizeBody>,
 ) -> Result<Json<CodeTerminalSnapshot>, ServerError> {
-    let _ = require_code(&state)?.get_workspace(path.id).await?;
+    let _ = code.get_workspace(path.id).await?;
     let snap = state
         .terminals
         .resize(path.id, path.tid, body.cols, body.rows)

--- a/crates/tidebreak-server/src/routes/code/updates.rs
+++ b/crates/tidebreak-server/src/routes/code/updates.rs
@@ -1,40 +1,51 @@
-//! `WS /code/updates` — install-wide digest channel, restated on connect.
+//! `WS /code/updates` — the principal's digest channel, restated on connect.
+//!
+//! The channel is partitioned by owner in the bus rather than filtered here:
+//! [`ScopedCode`] resolves the requesting principal before the upgrade, and
+//! the receiver this socket holds is subscribed to that owner alone. A digest
+//! for another owner is not dropped on the way out — it never arrives, and no
+//! code in this file could publish it if it did. Decision 47 names the
+//! alternative, filtering an install-wide stream at the route or in the
+//! client, as the wrong implementation.
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
 use axum::response::Response;
 use tokio::sync::broadcast::error::RecvError;
 
+use tidebreak_core::OwnerId;
+
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::code::attention::list_digests;
 use crate::code::bus::CodeLiveUpdate;
+use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::state::AppState;
 
-use super::require_code;
 use super::types::{CodeSessionDigest, CodeUpdateNotice};
 
 pub async fn code_updates(
     State(state): State<AppState>,
+    code: ScopedCode,
     headers: axum::http::HeaderMap,
     upgrade: WebSocketUpgrade,
 ) -> Result<Response, ServerError> {
-    let _ = require_code(&state)?;
+    let owner = code.owner().clone();
     let upgrade = if offered_handshake_subprotocol(&headers) {
         upgrade.protocols([WS_HANDSHAKE_SUBPROTOCOL])
     } else {
         upgrade
     };
-    Ok(upgrade.on_upgrade(move |socket| stream_updates(socket, state)))
+    Ok(upgrade.on_upgrade(move |socket| stream_updates(socket, state, owner)))
 }
 
-async fn stream_updates(mut socket: WebSocket, state: AppState) {
+async fn stream_updates(mut socket: WebSocket, state: AppState, owner: OwnerId) {
     let Some(runtime) = state.code.clone() else {
         return;
     };
-    let mut live = runtime.bus.subscribe_updates();
-    let mut terminals = state.terminals.subscribe();
-    match list_digests(&runtime.db).await {
+    let mut live = runtime.bus.subscribe_updates(&owner);
+    let mut terminals = state.terminals.subscribe(&owner);
+    match list_digests(&runtime.db, &owner).await {
         Ok(sessions) => {
             let notice = CodeUpdateNotice::Snapshot {
                 sessions: sessions.into_iter().map(CodeSessionDigest::from).collect(),
@@ -69,7 +80,7 @@ async fn stream_updates(mut socket: WebSocket, state: AppState) {
                     }
                 }
                 Err(RecvError::Lagged(_)) => {
-                    match list_digests(&runtime.db).await {
+                    match list_digests(&runtime.db, &owner).await {
                         Ok(sessions) => {
                             let notice = CodeUpdateNotice::Snapshot {
                                 sessions: sessions

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -2,11 +2,11 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
+use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
 
-use super::require_code;
 use super::types::{
     ArchiveWorkspaceBody, CodeFileChange, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
     CodeWorkspaceSearch, CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot, CodeWorkspaceTree,
@@ -16,10 +16,10 @@ use super::types::{
 use tidebreak_core::WorkspaceId;
 
 pub async fn create_workspace(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Json(body): Json<CreateWorkspaceBody>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let workspace = require_code(&state)?
+    let workspace = code
         .create_workspace(body.repo_id, body.title, body.base_ref)
         .await?;
     Ok((
@@ -29,10 +29,10 @@ pub async fn create_workspace(
 }
 
 pub async fn list_workspaces(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Query(query): Query<ListWorkspacesQuery>,
 ) -> Result<Json<Vec<CodeWorkspaceSnapshot>>, ServerError> {
-    let workspaces = require_code(&state)?.list_workspaces(query.repo_id).await?;
+    let workspaces = code.list_workspaces(query.repo_id).await?;
     Ok(Json(
         workspaces
             .into_iter()
@@ -42,61 +42,59 @@ pub async fn list_workspaces(
 }
 
 pub async fn get_workspace(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
 ) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
     Ok(Json(CodeWorkspaceSnapshot::from(
-        require_code(&state)?.get_workspace(id).await?,
+        code.get_workspace(id).await?,
     )))
 }
 
 pub async fn patch_workspace(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Json(body): Json<PatchWorkspaceBody>,
 ) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
-    let runtime = require_code(&state)?;
-    let mut workspace = runtime.get_workspace(id).await?;
+    let mut workspace = code.get_workspace(id).await?;
     if let Some(title) = body.title {
         let title = title.trim().to_owned();
         if title.is_empty() {
             return Err(ServerError::bad_request("title must not be empty"));
         }
         workspace.title = title;
-        runtime.save_workspace(&workspace).await?;
+        code.save_workspace(&workspace).await?;
     }
     Ok(Json(CodeWorkspaceSnapshot::from(workspace)))
 }
 
 pub async fn archive_workspace(
     State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Json(body): Json<ArchiveWorkspaceBody>,
 ) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
-    let archived = require_code(&state)?
-        .archive_workspace(id, body.force)
-        .await?;
+    let archived = code.archive_workspace(id, body.force).await?;
     state.terminals.close_workspace(id);
     Ok(Json(CodeWorkspaceSnapshot::from(archived)))
 }
 
 pub async fn list_workspace_tree(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Query(query): Query<WorkspaceTreeQuery>,
 ) -> Result<Json<CodeWorkspaceTree>, ServerError> {
-    let (paths, truncated) = require_code(&state)?
+    let (paths, truncated) = code
         .workspace_tree(id, query.query.as_deref().unwrap_or(""), query.limit)
         .await?;
     Ok(Json(CodeWorkspaceTree { paths, truncated }))
 }
 
 pub async fn search_workspace(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Query(query): Query<WorkspaceSearchQuery>,
 ) -> Result<Json<CodeWorkspaceSearch>, ServerError> {
-    let (matches, truncated) = require_code(&state)?
+    let (matches, truncated) = code
         .workspace_search(
             id,
             &query.query,
@@ -119,13 +117,11 @@ pub async fn search_workspace(
 }
 
 pub async fn get_workspace_blob(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Query(query): Query<WorkspaceBlobQuery>,
 ) -> Result<Json<CodeWorkspaceBlob>, ServerError> {
-    let blob = require_code(&state)?
-        .workspace_blob(id, &query.path)
-        .await?;
+    let blob = code.workspace_blob(id, &query.path).await?;
     Ok(Json(CodeWorkspaceBlob {
         path: blob.path,
         content: blob.content,
@@ -135,13 +131,11 @@ pub async fn get_workspace_blob(
 }
 
 pub async fn list_workspace_files(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Query(query): Query<WorkspaceFilesQuery>,
 ) -> Result<Json<CodeWorkspaceFiles>, ServerError> {
-    let (files, truncated, stat, turn_id) = require_code(&state)?
-        .workspace_files(id, query.turn)
-        .await?;
+    let (files, truncated, stat, turn_id) = code.workspace_files(id, query.turn).await?;
     Ok(Json(CodeWorkspaceFiles {
         files: files
             .into_iter()
@@ -160,7 +154,7 @@ pub async fn list_workspace_files(
 }
 
 pub async fn get_workspace_diff(
-    State(state): State<AppState>,
+    code: ScopedCode,
     Path(id): Path<WorkspaceId>,
     Query(query): Query<WorkspaceDiffQuery>,
 ) -> Result<Json<CodeWorkspaceDiff>, ServerError> {
@@ -170,9 +164,8 @@ pub async fn get_workspace_diff(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
-    let (diff, truncated, stat, turn_id) = require_code(&state)?
-        .workspace_diff(id, query.turn, file.as_deref())
-        .await?;
+    let (diff, truncated, stat, turn_id) =
+        code.workspace_diff(id, query.turn, file.as_deref()).await?;
     Ok(Json(CodeWorkspaceDiff {
         diff,
         truncated,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -662,10 +662,14 @@ async fn no_force_archive_of_a_dirty_workspace_leaves_an_idle_session() {
     assert_eq!(body["kind"], "uncommitted");
 
     let parsed: CodeSessionId = json_id(&session).parse().unwrap();
-    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(row.lifecycle, CodeSessionLifecycle::Idle);
     assert!(std::path::Path::new(path).exists());
 
@@ -925,10 +929,14 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
 
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-                .await
-                .unwrap()
-                .unwrap();
+            let row = tidebreak_core::db::code::get_session(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                parsed,
+            )
+            .await
+            .unwrap()
+            .unwrap();
             if row.lifecycle == CodeSessionLifecycle::Running {
                 break;
             }
@@ -973,9 +981,13 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
 
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            let turns = tidebreak_core::db::code::list_turns(&runtime.db, parsed)
-                .await
-                .unwrap();
+            let turns = tidebreak_core::db::code::list_turns(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                parsed,
+            )
+            .await
+            .unwrap();
             if turns.len() >= 2
                 && turns[1].status == CodeTurnStatus::Completed
                 && turns[1].user_input == "follow-up"
@@ -1104,10 +1116,14 @@ async fn a_recovered_session_accepts_a_turn() {
     assert_eq!(body["user_input"], "after restart");
 
     let parsed: CodeSessionId = session_id.parse().unwrap();
-    let mut row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let mut row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     row.lifecycle = CodeSessionLifecycle::Fenced;
     row.fence_reason = Some(FenceReason::OrphanAlive);
     row.attention = Attention::new(
@@ -1304,10 +1320,14 @@ async fn archive_ends_the_session_before_removing_the_worktree() {
     assert_eq!(archived.status(), reqwest::StatusCode::OK);
     assert!(!std::path::Path::new(&path).exists());
     let parsed: CodeSessionId = json_id(&session).parse().unwrap();
-    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(row.lifecycle, CodeSessionLifecycle::Ended);
 
     let again = client
@@ -1382,10 +1402,14 @@ async fn archive_refuses_a_running_session_without_force() {
     });
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-                .await
-                .unwrap()
-                .unwrap();
+            let row = tidebreak_core::db::code::get_session(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                parsed,
+            )
+            .await
+            .unwrap()
+            .unwrap();
             if row.lifecycle == CodeSessionLifecycle::Running {
                 break;
             }
@@ -1421,10 +1445,14 @@ async fn archive_refuses_a_running_session_without_force() {
         .unwrap();
     assert_eq!(forced.status(), reqwest::StatusCode::OK);
     let _ = turn.await;
-    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(row.lifecycle, CodeSessionLifecycle::Ended);
 }
 
@@ -1533,6 +1561,7 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
     let current = *seqs.last().unwrap();
     let _ = tidebreak_core::db::code::append_event(
         &runtime.db,
+        &tidebreak_core::OwnerId::local(),
         parsed,
         1,
         &tidebreak_core::CodeEvent::HarnessNotice {
@@ -1544,6 +1573,7 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
     .unwrap();
     let seq_b = tidebreak_core::db::code::append_event(
         &runtime.db,
+        &tidebreak_core::OwnerId::local(),
         parsed,
         1,
         &tidebreak_core::CodeEvent::HarnessNotice {
@@ -1610,6 +1640,7 @@ async fn superseded_worker_cannot_append_to_the_journal() {
         .unwrap();
     let err = tidebreak_core::db::code::append_event(
         &runtime.db,
+        &tidebreak_core::OwnerId::local(),
         session_id,
         bumped - 1,
         &tidebreak_core::CodeEvent::TurnInterrupted,
@@ -1718,10 +1749,14 @@ async fn a_completed_turn_records_a_checkpoint_and_serves_bounded_review() {
     );
     assert_eq!(diff["truncated"], false);
 
-    let events =
-        tidebreak_core::db::code::list_events(&_runtime.db, json_id(&session).parse().unwrap(), 0)
-            .await
-            .unwrap();
+    let events = tidebreak_core::db::code::list_events(
+        &_runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        json_id(&session).parse().unwrap(),
+        0,
+    )
+    .await
+    .unwrap();
     assert!(
         events.iter().any(|framed| {
             matches!(
@@ -1812,10 +1847,14 @@ async fn a_failed_checkpoint_does_not_fail_the_turn() {
     assert_eq!(turn["status"], "completed");
     assert!(turn["checkpoint_ref"].is_null());
 
-    let events =
-        tidebreak_core::db::code::list_events(&runtime.db, json_id(&session).parse().unwrap(), 0)
-            .await
-            .unwrap();
+    let events = tidebreak_core::db::code::list_events(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        json_id(&session).parse().unwrap(),
+        0,
+    )
+    .await
+    .unwrap();
     assert!(
         events.iter().any(|framed| {
             matches!(
@@ -1918,10 +1957,14 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
     .expect("pending approval never appeared");
 
     let parsed: CodeSessionId = session_id.parse().unwrap();
-    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(row.lifecycle, CodeSessionLifecycle::Running);
     assert!(!turn.is_finished(), "run_turn must still be executing");
 
@@ -1953,9 +1996,14 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
     assert_eq!(finished.status(), reqwest::StatusCode::ACCEPTED);
     let body: serde_json::Value = finished.json().await.unwrap();
     assert_eq!(body["status"], "completed");
-    let events = tidebreak_core::db::code::list_events(&runtime.db, parsed, 0)
-        .await
-        .unwrap();
+    let events = tidebreak_core::db::code::list_events(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+        0,
+    )
+    .await
+    .unwrap();
     let kinds: Vec<&str> = events
         .iter()
         .map(|framed| match &framed.event {
@@ -2029,10 +2077,14 @@ async fn deny_feedback_reaches_the_scripted_engine() {
             let body: Vec<serde_json::Value> = listed.json().await.unwrap();
             if let Some(row) = body.into_iter().next() {
                 let parsed: CodeSessionId = json_id(&session).parse().unwrap();
-                let session = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-                    .await
-                    .unwrap()
-                    .unwrap();
+                let session = tidebreak_core::db::code::get_session(
+                    &runtime.db,
+                    &tidebreak_core::OwnerId::local(),
+                    parsed,
+                )
+                .await
+                .unwrap()
+                .unwrap();
                 if matches!(
                     session.attention.state,
                     AttentionState::NeedsYou {
@@ -2054,10 +2106,14 @@ async fn deny_feedback_reaches_the_scripted_engine() {
         .contains("Write"));
 
     let parsed: CodeSessionId = json_id(&session).parse().unwrap();
-    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(matches!(
         row.attention.state,
         AttentionState::NeedsYou { .. }
@@ -2196,10 +2252,14 @@ async fn pending_approval_survives_restart_and_is_decidable() {
     assert_eq!(pending[0]["id"], approval["id"]);
 
     let parsed: CodeSessionId = session_id.parse().unwrap();
-    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(matches!(
         row.attention.state,
         AttentionState::NeedsYou { .. }
@@ -2444,10 +2504,14 @@ async fn attention_follows_approval_completion_and_view() {
                 .unwrap();
             let body: Vec<serde_json::Value> = listed.json().await.unwrap();
             if let Some(row) = body.into_iter().next() {
-                let session = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-                    .await
-                    .unwrap()
-                    .unwrap();
+                let session = tidebreak_core::db::code::get_session(
+                    &runtime.db,
+                    &tidebreak_core::OwnerId::local(),
+                    parsed,
+                )
+                .await
+                .unwrap()
+                .unwrap();
                 if matches!(
                     session.attention.state,
                     AttentionState::NeedsYou {
@@ -2476,10 +2540,14 @@ async fn attention_follows_approval_completion_and_view() {
         .unwrap();
     assert_eq!(decided.status(), reqwest::StatusCode::OK);
 
-    let after_decision = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let after_decision = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(
         !matches!(
             after_decision.attention.state,
@@ -2494,10 +2562,14 @@ async fn attention_follows_approval_completion_and_view() {
 
     let finished = turn.await.unwrap();
     assert_eq!(finished.status(), reqwest::StatusCode::ACCEPTED);
-    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert_eq!(row.attention.state, AttentionState::DoneUnreviewed);
 
     let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
@@ -2509,10 +2581,14 @@ async fn attention_follows_approval_completion_and_view() {
     let (_socket, _) = connect_async(request).await.unwrap();
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-                .await
-                .unwrap()
-                .unwrap();
+            let row = tidebreak_core::db::code::get_session(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                parsed,
+            )
+            .await
+            .unwrap()
+            .unwrap();
             if row.attention.state == AttentionState::Working {
                 return;
             }
@@ -2547,10 +2623,14 @@ async fn stall_sweep_marks_a_silent_running_session() {
         .await
         .unwrap();
     let parsed: CodeSessionId = json_id(&session).parse().unwrap();
-    let mut row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let mut row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     row.lifecycle = CodeSessionLifecycle::Running;
     tidebreak_core::db::code::save_session(&runtime.db, &row)
         .await
@@ -2559,10 +2639,14 @@ async fn stall_sweep_marks_a_silent_running_session() {
     crate::code::attention::sweep_stalled(&runtime.db, &runtime.bus, 0)
         .await
         .unwrap();
-    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(
         matches!(row.attention.state, AttentionState::Stalled { .. }),
         "{:?}",
@@ -2611,10 +2695,14 @@ async fn user_can_pin_and_clear_attention() {
     assert_eq!(body["attention"]["source"], "user");
 
     let parsed: CodeSessionId = session_id.parse().unwrap();
-    let mut row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let mut row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     row.lifecycle = CodeSessionLifecycle::Running;
     tidebreak_core::db::code::save_session(&runtime.db, &row)
         .await
@@ -2622,10 +2710,14 @@ async fn user_can_pin_and_clear_attention() {
     crate::code::attention::sweep_stalled(&runtime.db, &runtime.bus, 0)
         .await
         .unwrap();
-    let row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     assert!(
         matches!(row.attention.state, AttentionState::Manual { .. }),
         "Manual must survive the stall sweep"
@@ -2873,10 +2965,14 @@ async fn a_lost_resume_fences_the_session_instead_of_failing_every_turn() {
     let parsed: CodeSessionId = session_id.parse().unwrap();
 
     // The session carries a ref from an earlier engine process.
-    let mut row = tidebreak_core::db::code::get_session(&runtime.db, parsed)
-        .await
-        .unwrap()
-        .unwrap();
+    let mut row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap();
     row.harness_resume_ref = Some("dead-thread".into());
     assert!(tidebreak_core::db::code::save_session(&runtime.db, &row)
         .await
@@ -3175,4 +3271,332 @@ fn _types(
     _mode: CodePermissionMode,
     _kind: HarnessKind,
 ) {
+}
+
+/// A self-host code app with two principals: alice is an admin, bob a member.
+async fn two_user_code_app() -> (Router, tempfile::TempDir, std::path::PathBuf) {
+    let (dir, store) = temp_db_store("code-two-user.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let tokens_file = dir.path().join("tokens");
+    std::fs::write(
+        &tokens_file,
+        format!("alice {ALICE_TOKEN} admin\nbob {BOB_TOKEN}\n"),
+    )
+    .unwrap();
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    let runtime = Arc::new(CodeRuntime::with_registry(
+        db,
+        dir.path().to_path_buf(),
+        registry,
+    ));
+    let mut config = Config::desktop(dir.path());
+    config.profile = tidebreak_core::Profile::SelfHost;
+    config.auth_tokens_file = Some(tokens_file);
+    let mut state = AppState::new(
+        config,
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime);
+    let repo = init_git_repo(dir.path());
+    (app(state), dir, repo)
+}
+
+/// Decision 47's validation for decision point 4, through real routes: a
+/// second user on a shared machine sees neither another owner's `code_*` rows
+/// nor their session events on the updates channel.
+///
+/// The plausible wrong implementation scopes the reads and leaves the live
+/// channel install-wide, so the digest half of this test is the load-bearing
+/// half.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_second_user_sees_neither_code_rows_nor_updates_of_another_owner() {
+    let (router, _dir, repo) = two_user_code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+
+    let (alice_repo, alice_workspace) =
+        register_and_workspace(&client, addr, ALICE_TOKEN, &repo).await;
+    let alice_session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&alice_workspace)
+        ))
+        .bearer_auth(ALICE_TOKEN)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let alice_session_id = json_id(&alice_session).to_owned();
+
+    // Bob's listings are empty, not filtered copies of Alice's.
+    for path in ["/code/repos", "/code/workspaces", "/code/approvals"] {
+        let listed = client
+            .get(format!("http://{addr}{path}"))
+            .bearer_auth(BOB_TOKEN)
+            .send()
+            .await
+            .unwrap()
+            .json::<Vec<serde_json::Value>>()
+            .await
+            .unwrap();
+        assert!(
+            listed.is_empty(),
+            "{path} carried another owner's rows to a second user"
+        );
+    }
+
+    // Every by-id read answers as if the row does not exist, which is what
+    // keeps the reply from confirming that it does.
+    for path in [
+        format!("/code/repos/{}", json_id(&alice_repo)),
+        format!("/code/workspaces/{}", json_id(&alice_workspace)),
+        format!("/code/workspaces/{}/sessions", json_id(&alice_workspace)),
+        format!("/code/workspaces/{}/files", json_id(&alice_workspace)),
+        format!("/code/workspaces/{}/diff", json_id(&alice_workspace)),
+        format!("/code/workspaces/{}/tree", json_id(&alice_workspace)),
+        format!("/code/workspaces/{}/terminals", json_id(&alice_workspace)),
+        format!("/code/sessions/{alice_session_id}/turns"),
+        format!("/code/sessions/{alice_session_id}/debug"),
+    ] {
+        let response = client
+            .get(format!("http://{addr}{path}"))
+            .bearer_auth(BOB_TOKEN)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            reqwest::StatusCode::NOT_FOUND,
+            "{path} answered a second user about another owner's row"
+        );
+    }
+
+    // Writes are refused the same way, so a guessed id is not a way in.
+    let submitted = client
+        .post(format!(
+            "http://{addr}/code/sessions/{alice_session_id}/turns"
+        ))
+        .bearer_auth(BOB_TOKEN)
+        .json(&serde_json::json!({ "message": "whose session is this" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(submitted.status(), reqwest::StatusCode::NOT_FOUND);
+    let interrupted = client
+        .post(format!(
+            "http://{addr}/code/sessions/{alice_session_id}/interrupt"
+        ))
+        .bearer_auth(BOB_TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(interrupted.status(), reqwest::StatusCode::NOT_FOUND);
+
+    // The updates channel. Bob's connect snapshot is empty even though Alice
+    // has a live session, and Alice's turn produces no notice on his socket.
+    let mut request = format!("ws://{addr}/code/updates")
+        .into_client_request()
+        .unwrap();
+    request.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {BOB_TOKEN}").parse().unwrap(),
+    );
+    let (mut bob_socket, _) = connect_async(request).await.unwrap();
+    let snapshot = next_json(&mut bob_socket).await;
+    assert_eq!(snapshot["type"], "snapshot");
+    assert!(
+        snapshot["sessions"]
+            .as_array()
+            .expect("snapshot sessions")
+            .is_empty(),
+        "the connect snapshot restated another owner's sessions"
+    );
+
+    let mut request = format!("ws://{addr}/code/updates")
+        .into_client_request()
+        .unwrap();
+    request.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {ALICE_TOKEN}").parse().unwrap(),
+    );
+    let (mut alice_socket, _) = connect_async(request).await.unwrap();
+    let alice_snapshot = next_json(&mut alice_socket).await;
+    assert_eq!(
+        alice_snapshot["sessions"]
+            .as_array()
+            .expect("alice sessions")
+            .len(),
+        1,
+        "the owner still sees her own session"
+    );
+
+    let _ = client
+        .post(format!(
+            "http://{addr}/code/sessions/{alice_session_id}/turns"
+        ))
+        .bearer_auth(ALICE_TOKEN)
+        .json(&serde_json::json!({ "message": "hi" }))
+        .send()
+        .await
+        .unwrap();
+
+    // Alice's socket carries the turn; Bob's stays silent for as long again.
+    let mut saw_turn = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        let Some(notice) =
+            tokio::time::timeout(Duration::from_millis(500), next_json(&mut alice_socket))
+                .await
+                .ok()
+        else {
+            continue;
+        };
+        if notice["type"] == "digest" && notice["turn_count"] == 1 {
+            saw_turn = true;
+            break;
+        }
+    }
+    assert!(saw_turn, "the owner's own digest must still arrive");
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), next_json(&mut bob_socket))
+            .await
+            .is_err(),
+        "a second user received a notice for another owner's session"
+    );
+}
+
+/// Deployment-plane code routes are admin-gated by where they are registered
+/// (decision 6). A member is refused; an admin is not.
+#[tokio::test(flavor = "multi_thread")]
+async fn code_deployment_plane_routes_refuse_a_member() {
+    let (router, _dir, _repo) = two_user_code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+
+    let member = client
+        .get(format!("http://{addr}/code/repos/clone-defaults"))
+        .bearer_auth(BOB_TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(member.status(), reqwest::StatusCode::FORBIDDEN);
+    let admin = client
+        .get(format!("http://{addr}/code/repos/clone-defaults"))
+        .bearer_auth(ALICE_TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(admin.status(), reqwest::StatusCode::OK);
+
+    let member_refresh = client
+        .post(format!("http://{addr}/code/harnesses/refresh"))
+        .bearer_auth(BOB_TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(member_refresh.status(), reqwest::StatusCode::FORBIDDEN);
+
+    // The member plane is untouched: the doctor read still answers a member.
+    let doctor = client
+        .get(format!("http://{addr}/code/harnesses"))
+        .bearer_auth(BOB_TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(doctor.status(), reqwest::StatusCode::OK);
+}
+
+/// Two users cloning the same remote must not collide on disk. The clone
+/// parent directory is one shared setting, so the owner segment is what keeps
+/// the second clone from landing on the first one's checkout.
+#[test]
+fn clone_targets_are_keyed_by_owner() {
+    use crate::code::clone::owner_clone_dir;
+    let parent = std::path::Path::new("/srv/checkouts");
+    // The local profile is single-user and keeps the paths people already have.
+    assert_eq!(
+        owner_clone_dir(parent, &tidebreak_core::OwnerId::local()),
+        parent.to_path_buf()
+    );
+    let alice = owner_clone_dir(parent, &tidebreak_core::OwnerId::new("alice").unwrap());
+    let bob = owner_clone_dir(parent, &tidebreak_core::OwnerId::new("bob").unwrap());
+    assert_ne!(alice, bob);
+    assert_eq!(alice, parent.join("alice"));
+    // An owner key is visible ASCII, so it may carry separators and dots that
+    // must not escape the parent or resolve to it.
+    let hostile = owner_clone_dir(
+        parent,
+        &tidebreak_core::OwnerId::new("../../etc/passwd").unwrap(),
+    );
+    assert_eq!(hostile.parent(), Some(parent));
+    assert!(hostile.starts_with(parent));
+    let dots = owner_clone_dir(parent, &tidebreak_core::OwnerId::new("..").unwrap());
+    assert_eq!(dots, parent.join("owner"));
+}
+
+/// The `/code/*` routes reach the store only through the owner-scoped view.
+///
+/// Decision 6 puts enforcement in the router rather than in handler habits,
+/// and decision 48 step 1 applies that to data scoping: a new code route is
+/// owner-scoped because of what it extracts, not because its author
+/// remembered to filter. This check is the tripwire for the two ways back
+/// out — an unscoped runtime gate, or a system-path store function called
+/// from a request path.
+#[test]
+fn code_routes_go_through_the_owner_scoped_view() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/routes/code");
+    let mut findings = Vec::new();
+    for entry in std::fs::read_dir(&dir).expect("code routes directory") {
+        let path = entry.expect("code routes entry").path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_owned();
+        let text = std::fs::read_to_string(&path).expect("code route file");
+        // A system-path store function is never a request path.
+        if text.contains("_all_owners") {
+            findings.push(format!(
+                "{name} calls an `_all_owners` store function; those are system \
+                 paths (boot recovery, the stall sweep), not request paths"
+            ));
+        }
+        // The pre-scoping gate answered "is code mode configured", never
+        // "whose row is this". `ScopedCode` answers both.
+        if text.contains("require_code(") {
+            findings.push(format!(
+                "{name} uses an unscoped code gate; extract `ScopedCode` instead"
+            ));
+        }
+        // Files that serve code data extract the scoped view. `mod.rs` and
+        // `types.rs` declare and shape, and serve nothing.
+        let serves_data = text.contains("pub async fn") && name != "mod.rs";
+        if serves_data && !text.contains("ScopedCode") {
+            findings.push(format!(
+                "{name} defines route handlers but never extracts `ScopedCode`"
+            ));
+        }
+    }
+    assert!(
+        findings.is_empty(),
+        "code routes must query through the owner-scoped view: {findings:?}"
+    );
 }

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -342,7 +342,10 @@ async fn quick_actions_return_bounded_output_and_do_not_need_a_session() {
     let (repo_body, workspace) =
         register_and_workspace(&client, addr, &token, &repo, "actions").await;
     let repo_id: RepoId = json_id(&repo_body).parse().unwrap();
-    let mut stored = runtime.get_repo(repo_id).await.unwrap();
+    let mut stored = runtime
+        .get_repo(&tidebreak_core::OwnerId::local(), repo_id)
+        .await
+        .unwrap();
     stored.quick_actions = vec![
         QuickAction {
             name: "echo".into(),
@@ -406,7 +409,10 @@ async fn auto_run_on_create_runs_after_setup() {
         .unwrap();
     let repo_body: serde_json::Value = registered.json().await.unwrap();
     let repo_id: RepoId = json_id(&repo_body).parse().unwrap();
-    let mut stored = runtime.get_repo(repo_id).await.unwrap();
+    let mut stored = runtime
+        .get_repo(&tidebreak_core::OwnerId::local(), repo_id)
+        .await
+        .unwrap();
     stored.quick_actions = vec![QuickAction {
         name: "stamp".into(),
         command: "printf 'auto\\n' > stamp.txt".into(),

--- a/crates/tidebreak-server/src/tests/code_titling.rs
+++ b/crates/tidebreak-server/src/tests/code_titling.rs
@@ -212,7 +212,9 @@ async fn a_first_turn_names_an_untitled_workspace() {
     );
     assert_eq!(workspace["title"], serde_json::json!(placeholder));
 
-    let mut updates = runtime.bus.subscribe_updates();
+    let mut updates = runtime
+        .bus
+        .subscribe_updates(&tidebreak_core::OwnerId::local());
 
     let session = client
         .post(format!(


### PR DESCRIPTION
Code mode was the last surface outside the owner-scoped regime decision 6 built for chats, documents, and apps. The `code_*` tables carried no owner, and the `/code/*` routes answered any token-holder about any row — which is why a shared deployment cannot enable code mode today.

[Decision 47](docs/decisions/0047-gateway-linked-hosting.md) makes closing that gap decision point 4, and gates hosted multi-user code mode on it. [Decision 48](docs/decisions/0048-one-interaction-model.md) makes it convergence step 1, "because it is paid once". This is that step. Steps 2 through 5 — permission vocabulary, attention surface, turn submission, entity merge — are out of scope, as are the remote connection mode and gateway identity.

## What changed

**Owner columns, as a baseline edit plus an epoch bump.** Every `code_*` table gains an `owner` column, denormalized onto child rows the way chat rows carry theirs, rather than reached through a join — so an owner-scoped query exists for each table. The `DESKTOP_SCHEMA_EPOCH` bump ships in the same change, per [decision 2](docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md). Existing self-host databases take the column in place through the durable-baseline branch in `migration.rs`, following the `ensure_app_owner` precedent its module documentation prescribes. On the desktop profile everything belongs to the single local owner and keeps the column default.

**A scoped view, not scoped handlers.** `ScopedCode` is the code-mode counterpart of `ScopedStore`: an extractor that binds the process runtime to the requesting principal and never lets the unscoped handle escape. Route code therefore cannot express a cross-owner query — another owner's repository, workspace, session, turn, event, or approval is indistinguishable from one that does not exist. This follows decision 6's rule that enforcement is a router property rather than a handler habit, applied to data scoping.

System paths are not request paths and keep unscoped access, through store functions named `_all_owners` that say so in their names and documentation: boot recovery re-attaching workers, the stall sweep, and a session worker re-reading the row it was spawned against.

**Per-owner repositories and clone paths.** Nothing in code mode is shared across owners. Repository registration is unique per owner rather than per install, so a second user can register a path the first user already has. The shared clone parent directory gains an owner segment, so two users cloning the same remote land in separate directories instead of colliding.

**A partitioned updates channel, not a filtered one.** The bus holds one broadcast channel per principal. A subscriber's receiver carries only its own owner's digests and terminal notices, so a cross-owner notice is not dropped on the way out — it never arrives. Decision 47 names the alternative, filtering an install-wide stream at the route or in the client, as the wrong implementation.

**Deployment-plane code routes.** Installing pinned harness binaries (`POST /code/harnesses/refresh`) and the shared clone-parent-directory setting (`GET /code/repos/clone-defaults`) move to the deployment-plane router behind `require_admin`; both change what the machine is. The doctor read and cloning stay on the member plane, where they produce owner-scoped rows and owner-keyed checkouts.

Host paths and pids stay machine-private: `worktree_path` and `child_pid` are reachable only through owner-scoped lookups, and `child_pid` is still absent from every renderer-facing response.

## Validation

Matching the Validation sections of decisions 47 and 48:

- `a_second_user_sees_neither_code_rows_nor_updates_of_another_owner` drives two real principals against the assembled router on a shared store. Bob's listings are empty rather than filtered, every by-id read answers `404`, writes are refused the same way, and his `/code/updates` socket receives neither a connect snapshot naming Alice's session nor a live notice when her turn runs — while Alice's own socket still gets both.
- `owner_scoped_code_queries_partition_every_table` exercises every table rather than a sample, including that a save carrying another owner's key changes no row.
- `every_code_table_carries_an_owner_column` inspects the built baseline, so a new `code_*` table added without an owner fails here rather than in review.
- `code_store_queries_are_owner_scoped_or_say_they_are_not` and `code_routes_go_through_the_owner_scoped_view` are the repository checks, in the idiom of the existing id-space check. Both were mutation-tested: adding an unscoped store query makes the first fail with an actionable message.
- `code_deployment_plane_routes_refuse_a_member` asserts member `403` and admin non-`403` on the moved routes, and that the member plane is untouched.
- `clone_targets_are_keyed_by_owner` covers the collision case and the hostile-key cases (an owner key may contain separators and dots; neither escapes the parent).
- The id-space checks from decision 30 still pass — they retire at step 5, not here.

## Checks run

- `cargo fmt --all --check` — clean.
- `cargo clippy -p tidebreak-core -p tidebreak-server --all-targets -- -D warnings` — clean.
- `cargo test -p tidebreak-core --lib` — 677 passed.
- `cargo test -p tidebreak-server --lib` — 990 passed. One unrelated failure, `code_terminals::create_write_read_and_two_cursors`, reproduces identically on unmodified `main` under full-suite load and passes in isolation and on rerun; it is a pre-existing PTY timing flake, not a regression here.
- PostgreSQL, both lanes, against a real server: the new `postgres_code_owner` target (2 passed) and the existing `postgres_turn_state` target (29 passed). The new target is added to the durable-turn CI job beside the existing one.
