### PR TITLE
feat(code): refine the workspace workflow

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -1,12 +1,22 @@
-import { useRef, type KeyboardEvent, type ReactNode } from "react";
+import {
+  useRef,
+  type DragEvent,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import {
   ArrowRightFromLine,
   CircleX,
+  Columns2,
   Copy,
   FileCode,
   FileDiff,
   ListX,
   MessageSquare,
+  MoveLeft,
+  MoveRight,
+  PanelRightClose,
+  Plus,
   X,
 } from "lucide-react";
 
@@ -25,17 +35,24 @@ import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 /** Ids the strip and the two center panels agree on, so tabs name panels. */
 export const CHAT_TAB_ID = "code-center-tab-chat";
 export const CHAT_PANEL_ID = "code-center-panel-chat";
-export const EDITOR_PANEL_ID = "code-center-panel-editor";
-const editorTabId = (index: number) => `code-center-tab-editor-${index}`;
+export const EDITOR_PANEL_ID = "code-center-panel-editor-primary";
+export const SPLIT_EDITOR_PANEL_ID = "code-center-panel-editor-secondary";
+const editorTabId = (region: CenterTabRegion, index: number) =>
+  `code-center-tab-editor-${region}-${index}`;
+
+export type CenterTabRegion = "primary" | "secondary";
 
 /** Which tab labels the editor panel right now. */
-export function centerEditorTabId(index: number): string {
-  return editorTabId(index);
+export function centerEditorTabId(
+  index: number,
+  region: CenterTabRegion = "primary",
+): string {
+  return editorTabId(region, index);
 }
 
 /**
- * Center strip: Chat is always first and cannot close. File and diff tabs
- * sit beside it.
+ * Center strip: the main agent is always first and cannot close. File and diff
+ * tabs sit beside it, and the plus control opens a new file tab.
  */
 export function CodeCenterTabs({
   editorTabs,
@@ -48,6 +65,14 @@ export function CodeCenterTabs({
   onCloseOtherEditors,
   onCloseEditorsToRight,
   onCopyPath,
+  onNewTab,
+  region = "primary",
+  showMainAgent = true,
+  onMoveEditorToOtherGroup,
+  onSplitActive,
+  onCloseGroup,
+  onDragEditorStart,
+  onDragEditorEnd,
 }: {
   editorTabs: PanelContent[];
   editorActiveIndex: number;
@@ -59,10 +84,19 @@ export function CodeCenterTabs({
   onCloseOtherEditors: (index: number) => void;
   onCloseEditorsToRight: (index: number) => void;
   onCopyPath: (path: string) => void;
+  onNewTab: () => void;
+  region?: CenterTabRegion;
+  showMainAgent?: boolean;
+  onMoveEditorToOtherGroup?: (index: number) => void;
+  onSplitActive?: () => void;
+  onCloseGroup?: () => void;
+  onDragEditorStart?: (index: number) => void;
+  onDragEditorEnd?: () => void;
 }) {
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
-
-  if (editorTabs.length === 0) return null;
+  const tabOffset = showMainAgent ? 1 : 0;
+  const panelId =
+    region === "primary" ? EDITOR_PANEL_ID : SPLIT_EDITOR_PANEL_ID;
 
   /**
    * The tabs pattern: one tab stop for the strip, arrows to move between
@@ -70,10 +104,10 @@ export function CodeCenterTabs({
    * tab is what opening it means.
    */
   function select(position: number) {
-    const last = editorTabs.length;
+    const last = editorTabs.length + tabOffset - 1;
     const wrapped = position < 0 ? last : position > last ? 0 : position;
-    if (wrapped === 0) onSelectChat();
-    else onSelectEditor(wrapped - 1);
+    if (showMainAgent && wrapped === 0) onSelectChat();
+    else onSelectEditor(wrapped - tabOffset);
     tabRefs.current[wrapped]?.focus();
   }
 
@@ -89,7 +123,7 @@ export function CodeCenterTabs({
       select(0);
     } else if (event.key === "End") {
       event.preventDefault();
-      select(editorTabs.length);
+      select(editorTabs.length + tabOffset - 1);
     }
   }
 
@@ -97,46 +131,48 @@ export function CodeCenterTabs({
     <div
       className="flex shrink-0 items-center gap-1 overflow-x-auto border-b px-2 py-1"
       role="tablist"
-      aria-label="Workspace center"
+      aria-label={region === "primary" ? "Workspace center" : "Workspace split"}
     >
-      <ContextMenu>
-        <ContextMenuTrigger asChild>
-          <button
-            type="button"
-            role="tab"
-            id={CHAT_TAB_ID}
-            aria-selected={conversationFocused}
-            aria-controls={CHAT_PANEL_ID}
-            tabIndex={conversationFocused ? 0 : -1}
-            ref={(node) => {
-              tabRefs.current[0] = node;
-            }}
-            className={cn(
-              "flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium",
-              FOCUS_RING_TIGHT,
-              HOVER_TINT,
-              conversationFocused
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-            )}
-            onClick={onSelectChat}
-            onKeyDown={(event) => onKeyDown(event, 0)}
-          >
-            <MessageSquare className="size-3.5" />
-            Chat
-          </button>
-        </ContextMenuTrigger>
-        <TabContextMenuContent label="Chat">
-          <ContextMenuItem
-            className="gap-3 py-2"
-            disabled={editorTabs.length === 0}
-            onSelect={onCloseAllEditors}
-          >
-            <ListX />
-            Close other tabs
-          </ContextMenuItem>
-        </TabContextMenuContent>
-      </ContextMenu>
+      {showMainAgent && (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <button
+              type="button"
+              role="tab"
+              id={CHAT_TAB_ID}
+              aria-selected={conversationFocused}
+              aria-controls={CHAT_PANEL_ID}
+              tabIndex={conversationFocused ? 0 : -1}
+              ref={(node) => {
+                tabRefs.current[0] = node;
+              }}
+              className={cn(
+                "flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium",
+                FOCUS_RING_TIGHT,
+                HOVER_TINT,
+                conversationFocused
+                  ? "bg-muted text-foreground"
+                  : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+              )}
+              onClick={onSelectChat}
+              onKeyDown={(event) => onKeyDown(event, 0)}
+            >
+              <MessageSquare className="size-3.5" />
+              Main agent
+            </button>
+          </ContextMenuTrigger>
+          <TabContextMenuContent label="Main agent">
+            <ContextMenuItem
+              className="gap-3 py-2"
+              disabled={editorTabs.length === 0}
+              onSelect={onCloseAllEditors}
+            >
+              <ListX />
+              Close other tabs
+            </ContextMenuItem>
+          </TabContextMenuContent>
+        </ContextMenu>
+      )}
       {editorTabs.map((panel, index) => {
         const active = !conversationFocused && index === editorActiveIndex;
         const { name, suffix } = centerTabParts(panel);
@@ -152,22 +188,32 @@ export function CodeCenterTabs({
                   the same row, so this pair is transparent to assistive tech. */}
               <div
                 role="presentation"
+                draggable
                 className={cn(
-                  "flex min-w-0 shrink-0 items-center rounded-md pr-1",
+                  "flex min-w-0 shrink-0 cursor-grab items-center rounded-md pr-1 active:cursor-grabbing",
                   HOVER_TINT,
                   active ? "bg-muted" : "hover:bg-muted/60",
                 )}
+                onDragStart={(event: DragEvent<HTMLDivElement>) => {
+                  event.dataTransfer.effectAllowed = "move";
+                  event.dataTransfer.setData(
+                    "text/plain",
+                    `${region}:${index}`,
+                  );
+                  onDragEditorStart?.(index);
+                }}
+                onDragEnd={onDragEditorEnd}
               >
                 <button
                   type="button"
                   role="tab"
-                  id={editorTabId(index)}
+                  id={editorTabId(region, index)}
                   aria-label={label}
                   aria-selected={active}
-                  aria-controls={EDITOR_PANEL_ID}
+                  aria-controls={panelId}
                   tabIndex={active ? 0 : -1}
                   ref={(node) => {
-                    tabRefs.current[index + 1] = node;
+                    tabRefs.current[index + tabOffset] = node;
                   }}
                   className={cn(
                     "flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md py-1 pr-1 pl-2 text-xs font-medium",
@@ -176,7 +222,9 @@ export function CodeCenterTabs({
                     active ? "text-foreground" : "text-muted-foreground",
                   )}
                   onClick={() => onSelectEditor(index)}
-                  onKeyDown={(event) => onKeyDown(event, index + 1)}
+                  onKeyDown={(event) =>
+                    onKeyDown(event, index + tabOffset)
+                  }
                 >
                   {panel.type === "diff" ? (
                     <FileDiff className="size-3.5 shrink-0" />
@@ -219,6 +267,20 @@ export function CodeCenterTabs({
                   <ContextMenuSeparator />
                 </>
               )}
+              {onMoveEditorToOtherGroup && (
+                <>
+                  <ContextMenuItem
+                    className="gap-3 py-2"
+                    onSelect={() => onMoveEditorToOtherGroup(index)}
+                  >
+                    {region === "primary" ? <MoveRight /> : <MoveLeft />}
+                    {region === "primary"
+                      ? "Move to split right"
+                      : "Move to main group"}
+                  </ContextMenuItem>
+                  <ContextMenuSeparator />
+                </>
+              )}
               <ContextMenuItem
                 className="gap-3 py-2"
                 onSelect={() => onCloseEditor(index)}
@@ -253,6 +315,47 @@ export function CodeCenterTabs({
           </ContextMenu>
         );
       })}
+      <button
+        type="button"
+        className={cn(
+          "text-muted-foreground hover:bg-muted hover:text-foreground grid size-6 shrink-0 cursor-pointer place-items-center rounded-md",
+          FOCUS_RING_TIGHT,
+          HOVER_TINT,
+        )}
+        aria-label="New tab"
+        onClick={onNewTab}
+      >
+        <Plus className="size-3.5" />
+      </button>
+      {region === "primary" && onSplitActive && (
+        <button
+          type="button"
+          className={cn(
+            "text-muted-foreground hover:bg-muted hover:text-foreground grid size-6 shrink-0 cursor-pointer place-items-center rounded-md disabled:cursor-default disabled:opacity-40",
+            FOCUS_RING_TIGHT,
+            HOVER_TINT,
+          )}
+          aria-label="Split active tab right"
+          disabled={conversationFocused || editorTabs.length === 0}
+          onClick={onSplitActive}
+        >
+          <Columns2 className="size-3.5" />
+        </button>
+      )}
+      {region === "secondary" && onCloseGroup && (
+        <button
+          type="button"
+          className={cn(
+            "text-muted-foreground hover:bg-muted hover:text-foreground ml-auto grid size-6 shrink-0 cursor-pointer place-items-center rounded-md",
+            FOCUS_RING_TIGHT,
+            HOVER_TINT,
+          )}
+          aria-label="Move split tabs to main group"
+          onClick={onCloseGroup}
+        >
+          <PanelRightClose className="size-3.5" />
+        </button>
+      )}
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -658,10 +658,14 @@ export function CodeComposer({
               harness={harness}
               options={modelOptions}
               value={selectedModel || undefined}
-              onChange={(next) => {
-                setSelectedModel(next);
-                onModelChange?.(next);
-              }}
+              onChange={
+                onModelChange
+                  ? (next) => {
+                      setSelectedModel(next);
+                      onModelChange(next);
+                    }
+                  : undefined
+              }
             />
           ) : undefined
         }

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -87,7 +87,7 @@ function makeClient(): Pick<
   };
 }
 
-it("keeps the PR action bar visible on Files and Source control", async () => {
+it("leaves quick PR actions to the workspace header", async () => {
   render(
     <CodeInspector
       client={makeClient() as never}
@@ -97,23 +97,14 @@ it("keeps the PR action bar visible on Files and Source control", async () => {
     />,
   );
 
-  const bar = screen.getByTestId("pr-action-bar");
-  expect(bar).toHaveTextContent("#41");
-  expect(bar).toHaveTextContent("Draft");
-  expect(bar).toHaveTextContent("2 checks");
-  expect(screen.getByRole("button", { name: "Merge" })).toBeInTheDocument();
+  expect(screen.queryByTestId("pr-action-bar")).not.toBeInTheDocument();
 
   await userEvent.setup().click(screen.getByRole("tab", { name: "Files" }));
-  expect(screen.getByTestId("pr-action-bar")).toBeInTheDocument();
+  expect(screen.queryByTestId("pr-action-bar")).not.toBeInTheDocument();
   await userEvent.setup().click(
     screen.getByRole("tab", { name: "Source control" }),
   );
-  expect(screen.getByTestId("pr-action-bar")).toBeInTheDocument();
-
-  await userEvent.setup().click(screen.getByRole("button", { name: "Merge" }));
-  expect(useCodeUiStore.getState().pendingComposerPrompt).toMatch(
-    /Merge pull request #41/,
-  );
+  expect(screen.queryByTestId("pr-action-bar")).not.toBeInTheDocument();
 });
 
 it("shows PR state, checks, comments, and holds merge for a draft", async () => {
@@ -131,7 +122,6 @@ it("shows PR state, checks, comments, and holds merge for a draft", async () => 
   await screen.findByText("Fix login flow");
 
   // Draft wins over the open state token, and holds the tab merge buttons.
-  // The inspector bar also says Draft; its Merge writes a prompt instead.
   expect(screen.getAllByText("Draft").length).toBeGreaterThan(0);
   expect(screen.getByText("Changes requested")).toBeInTheDocument();
   expect(

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -43,7 +43,6 @@ import { DiffOverview } from "./DiffOverview";
 import { FilesPanel } from "./FilesPanel";
 import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { MiddleTruncate } from "./MiddleTruncate";
-import { PrActionBar } from "./PrActionBar";
 import { PrCard } from "./PrCard";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
@@ -118,7 +117,6 @@ export function CodeInspector({
       aria-label="Workspace surfaces"
       data-testid="code-inspector"
     >
-      {pr && <PrActionBar pr={pr} />}
       <Tabs
         value={tab}
         onValueChange={(next) => setTab(next as InspectorTab)}

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.dom.test.tsx
@@ -51,4 +51,38 @@ describe("CodeQuickOpen", () => {
     expect(onOpenFile).toHaveBeenCalledWith("src/model.rs");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
+
+  it("opens when the visible new-tab control increments its request", async () => {
+    const client = {
+      listCodeWorkspaceTree: vi.fn(async () => ({
+        paths: ["src/main.rs"],
+        truncated: false,
+      })),
+    };
+    const { rerender } = render(
+      <CodeQuickOpen
+        client={client}
+        workspaceId="ws-1"
+        contentRevision={0}
+        onOpenFile={vi.fn()}
+        openRequest={0}
+      />,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    rerender(
+      <CodeQuickOpen
+        client={client}
+        workspaceId="ws-1"
+        contentRevision={0}
+        onOpenFile={vi.fn()}
+        openRequest={1}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("textbox", { name: "Search files by name" }),
+    ).toHaveFocus();
+    expect(client.listCodeWorkspaceTree).toHaveBeenCalledTimes(1);
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { File, Search } from "lucide-react";
 
 import type { ApiClient } from "@/api/client";
@@ -22,11 +22,14 @@ export function CodeQuickOpen({
   workspaceId,
   contentRevision,
   onOpenFile,
+  openRequest = 0,
 }: {
   client: Pick<ApiClient, "listCodeWorkspaceTree">;
   workspaceId: string;
   contentRevision: number;
   onOpenFile: (path: string) => void;
+  /** Increment to open the picker from a visible New tab control. */
+  openRequest?: number;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -36,18 +39,26 @@ export function CodeQuickOpen({
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const reveal = useCallback(() => {
+    setQuery("");
+    setActiveIndex(0);
+    setOpen(true);
+  }, []);
+
   useEffect(() => {
     function onQuickOpen(event: KeyboardEvent) {
       if (event.key.toLowerCase() !== "p") return;
       if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return;
       event.preventDefault();
-      setQuery("");
-      setActiveIndex(0);
-      setOpen(true);
+      reveal();
     }
     window.addEventListener("keydown", onQuickOpen);
     return () => window.removeEventListener("keydown", onQuickOpen);
-  }, []);
+  }, [reveal]);
+
+  useEffect(() => {
+    if (openRequest > 0) reveal();
+  }, [openRequest, reveal]);
 
   useEffect(() => {
     if (!open) return;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -7,6 +7,9 @@ import {
 
 export type CodeConnectionState = "live" | "reconnecting";
 
+/** A brief quiet window means the initial journal burst has reached its tail. */
+export const CODE_REPLAY_SETTLE_MS = 40;
+
 export type CodeSessionControllerOptions = {
   /**
    * Open the session's event socket resuming after the given seq. The callback
@@ -18,7 +21,11 @@ export type CodeSessionControllerOptions = {
   ) => WebSocket;
   /** Read the resume cursor freshly on every (re)connect attempt. */
   getAfter: () => number;
-  onEvent: (event: SequencedCodeEventFrame) => void;
+  /**
+   * Deliver an ordered journal chunk. Replayed history is coalesced to one
+   * browser paint; live frames still arrive immediately.
+   */
+  onEvents: (events: readonly SequencedCodeEventFrame[]) => void;
   onConnectionState: (state: CodeConnectionState) => void;
   /**
    * Snapshot of durable turns, applied once before the first socket opens so
@@ -57,6 +64,8 @@ export class CodeSessionController {
   private socket: WebSocket | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+  private replayFrames: SequencedCodeEventFrame[] = [];
+  private replayFlush: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private readonly options: CodeSessionControllerOptions) {}
 
@@ -82,6 +91,8 @@ export class CodeSessionController {
   /** Close the socket and silence every callback and pending timer, forever. */
   dispose(): void {
     this.disposed = true;
+    this.cancelReplayFlush();
+    this.replayFrames = [];
     if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -90,6 +101,44 @@ export class CodeSessionController {
       this.socket.close();
       this.socket = null;
     }
+  }
+
+  /**
+   * WebSocket replay arrives as one task per historical frame. React's
+   * external-store contract treats each task as a synchronous update, so a
+   * large transcript can exceed its nested-update guard before history has
+   * settled. Collect replay frames until the burst goes quiet and reduce them
+   * once.
+   */
+  private queueReplay(frame: SequencedCodeEventFrame): void {
+    this.replayFrames.push(frame);
+    // The protocol marks replay frames but has no separate end marker. Treat a
+    // short quiet window as the boundary, resetting it for every frame. With
+    // rendering withheld, even a large local journal drains inside this
+    // window and appears as one settled transcript instead of typing itself
+    // into view over several paints.
+    this.cancelReplayFlush();
+    this.replayFlush = setTimeout(() => {
+      this.replayFlush = null;
+      this.flushReplay();
+    }, CODE_REPLAY_SETTLE_MS);
+  }
+
+  private cancelReplayFlush(): void {
+    if (this.replayFlush !== null) clearTimeout(this.replayFlush);
+    this.replayFlush = null;
+  }
+
+  private takeReplay(): SequencedCodeEventFrame[] {
+    this.cancelReplayFlush();
+    const frames = this.replayFrames;
+    this.replayFrames = [];
+    return frames;
+  }
+
+  private flushReplay(): void {
+    const frames = this.takeReplay();
+    if (!this.disposed && frames.length > 0) this.options.onEvents(frames);
   }
 
   private scheduleReconnect(): void {
@@ -113,7 +162,12 @@ export class CodeSessionController {
           console.error("dropping malformed code event frame", frame);
           return;
         }
-        this.options.onEvent(frame);
+        if (frame.replayed === true) {
+          this.queueReplay(frame);
+          return;
+        }
+        const replay = this.takeReplay();
+        this.options.onEvents([...replay, frame]);
       });
     } catch {
       this.scheduleReconnect();

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SequencedCodeEventFrame } from "../api/types";
 import {
   acquireCodeSession,
@@ -23,6 +23,7 @@ class FakeSocket {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   resetCodeSessionRegistry();
 });
 
@@ -205,5 +206,68 @@ describe("CodeSessionRegistry", () => {
       attachments: [],
     });
     expect(calls).toBe(2);
+  });
+
+  it("coalesces a large journal replay into one store publication", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const store = acquireCodeSession("s1", openSocket);
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    for (let index = 0; index < 200; index += 1) {
+      sockets[0]?.emit({
+        seq: index + 1,
+        replayed: true,
+        event: { type: "assistant_delta", text: "x" },
+      });
+    }
+
+    // Replay is withheld until one scheduled flush rather than forcing React
+    // through one external-store render for every historical token.
+    expect(store.getState().lastSeq).toBe(0);
+    await vi.runAllTimersAsync();
+    expect(store.getState().lastSeq).toBe(200);
+    expect(store.getState().assistantBuffer).toHaveLength(200);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes queued replay before the first live frame", () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const store = acquireCodeSession("s1", openSocket);
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    sockets[0]?.emit({
+      seq: 1,
+      replayed: true,
+      event: { type: "assistant_delta", text: "old" },
+    });
+    sockets[0]?.emit({
+      seq: 2,
+      event: { type: "assistant_delta", text: "live" },
+    });
+
+    expect(store.getState().lastSeq).toBe(2);
+    expect(store.getState().assistantBuffer).toBe("oldlive");
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -79,12 +79,12 @@ export function acquireCodeSession(
   const controller = new CodeSessionController({
     openSocket,
     getAfter: () => store.getState().lastSeq,
-    onEvent: (frame) => {
+    onEvents: (frames) => {
       // A turn the socket announces has no prompt bubble yet: submit answers
       // only when the turn ends, and a queued follow-up is never answered
       // with a turn at all. Pull the snapshot so the transcript shows what
       // the engine is working on while it works.
-      for (const effect of store.getState().applyEvent(frame, deps)) {
+      for (const effect of store.getState().applyEvents(frames, deps)) {
         if (effect.type === "turn_began") fillPrompt(effect.turnId);
       }
     },

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createCodeSessionStore } from "./CodeSessionStore";
+
+const deps = {
+  nextId: () => "item",
+  now: () => "2026-08-19T12:00:00.000Z",
+};
+
+describe("CodeSessionStore", () => {
+  it("publishes a replay chunk once after reducing every frame", () => {
+    const store = createCodeSessionStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    const effects = store.getState().applyEvents(
+      Array.from({ length: 200 }, (_, index) => ({
+        seq: index + 1,
+        replayed: true as const,
+        event: { type: "assistant_delta" as const, text: "x" },
+      })),
+      deps,
+    );
+
+    expect(effects).toEqual([]);
+    expect(store.getState().lastSeq).toBe(200);
+    expect(store.getState().assistantBuffer).toHaveLength(200);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not publish duplicate frames or unchanged external updates", () => {
+    const store = createCodeSessionStore();
+    store.getState().applyEvent(
+      { seq: 1, event: { type: "turn_started", turn_id: "turn-1" } },
+      deps,
+    );
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    expect(
+      store.getState().applyEvent(
+        { seq: 1, event: { type: "assistant_delta", text: "late" } },
+        deps,
+      ),
+    ).toEqual([]);
+    store.getState().update((session) => session);
+    store.getState().setConnectionState("live");
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(store.getState().assistantBuffer).toBe("");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
@@ -33,42 +33,76 @@ export type CodeSessionStore = CodeSessionState & {
     framed: SequencedCodeEventFrame,
     deps: CodeSessionDeps,
   ) => CodeSessionEffect[];
+  /**
+   * Reduce a replay chunk and publish it as one store update.
+   *
+   * A reopened session can contain hundreds of journal frames. Publishing
+   * every frame separately forces React's external-store subscribers to
+   * synchronously re-render the whole transcript for every historical token.
+   */
+  applyEvents: (
+    framed: readonly SequencedCodeEventFrame[],
+    deps: CodeSessionDeps,
+  ) => CodeSessionEffect[];
   update: (change: (session: CodeSessionState) => CodeSessionState) => void;
   reset: () => void;
 };
 
 export function createCodeSessionStore() {
-  return create<CodeSessionStore>()((set, get) => ({
-    ...initialCodeSessionState(),
-    connectionState: "live",
-    lastTurnBeganId: null,
-    setConnectionState: (connectionState) => set({ connectionState }),
-    applyEvent: (framed, deps) => {
-      const { state, effects } = reduceCodeSessionEvent(
-        sessionOf(get()),
-        framed,
-        deps,
-      );
-      const began = effects.find((effect) => effect.type === "turn_began");
-      set(began ? { ...state, lastTurnBeganId: began.turnId } : state);
+  return create<CodeSessionStore>()((set, get) => {
+    const applyEvents = (
+      framed: readonly SequencedCodeEventFrame[],
+      deps: CodeSessionDeps,
+    ): CodeSessionEffect[] => {
+      const current = sessionOf(get());
+      let state = current;
+      const effects: CodeSessionEffect[] = [];
+      for (const frame of framed) {
+        const transition = reduceCodeSessionEvent(state, frame, deps);
+        state = transition.state;
+        effects.push(...transition.effects);
+      }
+
+      // The reducer returns its input for duplicate/stale frames. Do not turn
+      // that no-op into a fresh Zustand snapshot and wake every subscriber.
+      if (state !== current) {
+        const began = [...effects]
+          .reverse()
+          .find((effect) => effect.type === "turn_began");
+        set(began ? { ...state, lastTurnBeganId: began.turnId } : state);
+      }
       return effects;
-    },
-    update: (change) => {
-      set(change(sessionOf(get())));
-    },
-    reset: () => {
-      set({
-        ...initialCodeSessionState(),
-        connectionState: "live",
-        lastTurnBeganId: null,
-      });
-    },
-  }));
+    };
+
+    return {
+      ...initialCodeSessionState(),
+      connectionState: "live",
+      lastTurnBeganId: null,
+      setConnectionState: (connectionState) => {
+        if (get().connectionState !== connectionState) set({ connectionState });
+      },
+      applyEvent: (framed, deps) => applyEvents([framed], deps),
+      applyEvents,
+      update: (change) => {
+        const current = sessionOf(get());
+        const next = change(current);
+        if (next !== current) set(next);
+      },
+      reset: () => {
+        set({
+          ...initialCodeSessionState(),
+          connectionState: "live",
+          lastTurnBeganId: null,
+        });
+      },
+    };
+  });
 }
 
 function sessionOf(store: CodeSessionStore): CodeSessionState {
   const {
     applyEvent,
+    applyEvents,
     update,
     reset,
     connectionState,
@@ -77,6 +111,7 @@ function sessionOf(store: CodeSessionStore): CodeSessionState {
     ...session
   } = store;
   void applyEvent;
+  void applyEvents;
   void update;
   void reset;
   void connectionState;

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -19,6 +19,11 @@ import {
 } from "@tanstack/react-router";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import type {
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+  PullRequestDigest,
+} from "@/api/types";
 import type { PanelSearch } from "@/panel/panelUrl";
 import { toast } from "sonner";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
@@ -74,7 +79,7 @@ vi.mock("react-resizable-panels", () => ({
   PanelResizeHandle: () => <div />,
 }));
 
-const WORKSPACE = {
+const WORKSPACE: CodeWorkspaceSnapshot = {
   id: "ws-1",
   repo_id: "repo-1",
   title: "Fix login",
@@ -95,7 +100,7 @@ const REPO = {
   created_at: "2026-08-15T00:00:00.000Z",
 };
 
-const SESSION = {
+const SESSION: CodeSessionSnapshot = {
   id: "sess-1",
   workspace_id: "ws-1",
   harness_kind: "claude_code" as const,
@@ -125,6 +130,20 @@ const TURN = {
     cache_read_input_tokens: 0,
     cache_creation_input_tokens: 0,
   },
+};
+
+const PR: PullRequestDigest = {
+  number: 41,
+  state: "open" as const,
+  title: "Fix login flow",
+  url: "https://github.com/acme/app/pull/41",
+  draft: true,
+  head_branch: "tidebreak/fix-login",
+  base_branch: "main",
+  checks: [
+    { name: "ci / rust", bucket: "pass" as const },
+    { name: "ci / ui", bucket: "pending" as const },
+  ],
 };
 
 function makeClient() {
@@ -192,7 +211,7 @@ function makeClient() {
         }) as unknown as WebSocket,
     ),
     listCodeWorkspaceTree: vi.fn(async () => ({
-      paths: [],
+      paths: [] as string[],
       truncated: false,
     })),
     listCodeWorkspaceFiles: vi.fn(async () => ({
@@ -303,6 +322,13 @@ async function mountWorkspace(
       active: typeof search.active === "string" ? search.active : undefined,
       fullscreen:
         typeof search.fullscreen === "string" ? search.fullscreen : undefined,
+      split: typeof search.split === "string" ? search.split : undefined,
+      splitActive:
+        typeof search.splitActive === "string" ? search.splitActive : undefined,
+      splitFocused:
+        typeof search.splitFocused === "string"
+          ? search.splitFocused
+          : undefined,
       left: typeof search.left === "string" ? search.left : undefined,
       right: typeof search.right === "string" ? search.right : undefined,
     }),
@@ -336,6 +362,7 @@ afterEach(() => {
   disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
   useCodeUiStore.setState({ reviewSidebarOpen: true, inspectorScope: null });
+  useCodeUiStore.setState({ pendingComposerPrompt: null });
 });
 
 describe("CodeWorkspacePage", () => {
@@ -414,6 +441,31 @@ describe("CodeWorkspacePage", () => {
     );
   });
 
+  it("shows the Codex session model even before its native catalog loads", async () => {
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([
+      {
+        ...SESSION,
+        harness_kind: "codex",
+        model: "gpt-5.6-luna",
+      },
+    ]);
+    client.listCodeHarnessModels.mockResolvedValue({
+      kind: "codex",
+      models: [],
+    } as never);
+    await mountWorkspace(client);
+
+    const model = await screen.findByRole("button", {
+      name: "Model: GPT 5.6 Luna",
+    });
+    expect(model).toBeDisabled();
+    expect(model).toHaveAttribute(
+      "title",
+      "Model: GPT 5.6 Luna (set when this session started)",
+    );
+  });
+
   it("toggles the review sidebar from the header control", async () => {
     const client = makeClient();
     const user = userEvent.setup();
@@ -445,13 +497,9 @@ describe("CodeWorkspacePage", () => {
     expect(
       await screen.findByRole("heading", { name: /Fix login/ }),
     ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByRole("heading", { name: /Fix login/ })).toHaveTextContent(
-        "app",
-      ),
-    );
 
     await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    expect(await screen.findByRole("menu")).toHaveTextContent("app");
     await user.click(await screen.findByRole("menuitem", { name: "Run: lint" }));
 
     await waitFor(() =>
@@ -463,6 +511,31 @@ describe("CodeWorkspacePage", () => {
         action: expect.objectContaining({ label: "View output" }),
       }),
     );
+  });
+
+  it("puts compact PR status and quick commands in the workspace header", async () => {
+    const client = makeClient();
+    client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: PR });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    const bar = await screen.findByTestId("pr-action-bar");
+    expect(bar).toHaveAttribute("data-variant", "header");
+    expect(bar.closest("header")).not.toBeNull();
+    expect(bar).toHaveTextContent("#41");
+    expect(bar).toHaveTextContent("Draft");
+    expect(bar).toHaveTextContent("2 checks");
+
+    await user.click(within(bar).getByRole("button", { name: "Merge" }));
+    expect(
+      (screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement)
+        .value,
+    ).toMatch(/Merge pull request #41/);
+
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    const menu = await screen.findByRole("menu");
+    expect(menu).toHaveTextContent("app");
+    expect(menu).toHaveTextContent(WORKSPACE.worktree_path);
   });
 
   it("leaves the archived workspace for its repo", async () => {
@@ -578,7 +651,9 @@ describe("CodeWorkspacePage", () => {
       await screen.findByRole("button", { name: "Review this turn's changes" }),
     );
 
-    expect(await screen.findByRole("tab", { name: "Chat" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("tab", { name: "Main agent" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Turn diff" })).toHaveAttribute(
       "aria-selected",
       "true",
@@ -602,7 +677,7 @@ describe("CodeWorkspacePage", () => {
     );
 
     const diff = await screen.findByRole("tab", { name: "Turn diff" });
-    const chat = screen.getByRole("tab", { name: "Chat" });
+    const chat = screen.getByRole("tab", { name: "Main agent" });
     // One tab stop for the strip, and the panel a tab opens says which tab
     // named it — otherwise the content below is orphaned from the control.
     expect(diff).toHaveAttribute("tabindex", "0");
@@ -678,14 +753,103 @@ describe("CodeWorkspacePage", () => {
       }),
     );
 
-    const chatTab = screen.getByRole("tab", { name: "Chat" });
+    const chatTab = screen.getByRole("tab", { name: "Main agent" });
     fireEvent.contextMenu(chatTab);
     await user.click(
       await screen.findByRole("menuitem", { name: "Close other tabs" }),
     );
     expect(
-      screen.queryByRole("tablist", { name: "Workspace center" }),
+      screen.getByRole("tablist", { name: "Workspace center" }),
+    ).toBeInTheDocument();
+    expect(chatTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("starts on the main-agent tab and opens a file from the visible new-tab control", async () => {
+    const client = makeClient();
+    client.listCodeWorkspaceTree.mockResolvedValue({
+      paths: ["README.md", "src/lib.rs"],
+      truncated: false,
+    });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    const mainAgent = await screen.findByRole("tab", { name: "Main agent" });
+    expect(mainAgent).toHaveAttribute("aria-selected", "true");
+    const mainPanel = document.getElementById(
+      mainAgent.getAttribute("aria-controls") ?? "",
+    );
+    expect(mainPanel).toHaveAttribute("role", "tabpanel");
+    expect(mainPanel).toHaveAttribute("aria-labelledby", mainAgent.id);
+
+    await user.click(screen.getByRole("button", { name: "New tab" }));
+    const picker = await screen.findByRole("textbox", {
+      name: "Search files by name",
+    });
+    expect(picker).toHaveFocus();
+    await user.click(await screen.findByRole("button", { name: "src/lib.rs" }));
+
+    expect(await screen.findByRole("tab", { name: "lib.rs" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByTestId("file-viewer")).toHaveTextContent("src/lib.rs");
+  });
+
+  it("moves and drags file tabs into a reloadable split group", async () => {
+    const client = makeClient();
+    const user = userEvent.setup();
+    const { router } = await mountWorkspace(
+      client,
+      "/code/w/ws-1?tabs=file.src%252Flib.rs,file.src%252Fmain.rs&active=file.src%252Fmain.rs",
+    );
+
+    const mainTab = await screen.findByRole("tab", { name: "main.rs" });
+    fireEvent.contextMenu(mainTab);
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Move to split right" }),
+    );
+
+    const splitStrip = await screen.findByRole("tablist", {
+      name: "Workspace split",
+    });
+    expect(
+      within(splitStrip).getByRole("tab", { name: "main.rs" }),
+    ).toHaveAttribute("aria-selected", "true");
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        tabs: "file.src%2Flib.rs",
+        split: "file.src%2Fmain.rs",
+        splitFocused: "1",
+      }),
+    );
+
+    await user.click(
+      within(splitStrip).getByRole("button", {
+        name: "Move split tabs to main group",
+      }),
+    );
+    expect(
+      screen.queryByRole("tablist", { name: "Workspace split" }),
     ).not.toBeInTheDocument();
+
+    const libTab = screen.getByRole("tab", { name: "lib.rs" });
+    const dataTransfer = {
+      effectAllowed: "none",
+      setData: vi.fn(),
+    };
+    fireEvent.dragStart(libTab, { dataTransfer });
+    const dropZone = await screen.findByTestId("split-drop-zone");
+    fireEvent.dragOver(dropZone, { dataTransfer });
+    fireEvent.drop(dropZone, { dataTransfer });
+
+    expect(
+      await screen.findByRole("tablist", { name: "Workspace split" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        split: "file.src%2Flib.rs",
+      }),
+    );
   });
 
   it("keeps the jump-to-latest pill out of the tab order until it is on screen", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -14,7 +14,7 @@ import type {
   ModelInfo,
 } from "../api/types";
 import { useApp } from "@/AppContext";
-import { copyPlainText, scheduleCopyStateReset } from "@/ClipboardCopyButton";
+import { copyPlainText } from "@/ClipboardCopyButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -45,9 +45,13 @@ import {
   closeEditorTab,
   closeEditorTabsToRight,
   closeOtherEditorTabs,
+  type CodeEditorRegion,
   focusCodeChromeTab,
   focusConversation,
   focusEditorTab,
+  mergeEditorSplit,
+  moveEditorTab,
+  openCodeEditor,
   splitCodeChromeLayout,
   toggleTerminalLayout,
 } from "./codeChrome";
@@ -57,6 +61,7 @@ import {
   CHAT_TAB_ID,
   CodeCenterTabs,
   EDITOR_PANEL_ID,
+  SPLIT_EDITOR_PANEL_ID,
 } from "./CodeCenterTabs";
 import { DiffPanel } from "./DiffPanel";
 
@@ -71,6 +76,7 @@ import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { liveCodeSession } from "./parsers";
 import { CodeComposer } from "./CodeComposer";
 import { CodeQuickOpen } from "./CodeQuickOpen";
+import { PrActionBar } from "./PrActionBar";
 import {
   acquireCodeSessionFromClient,
   releaseCodeSession,
@@ -78,7 +84,7 @@ import {
 import { submitAcceptedTurn } from "./CodeSessionSend";
 import { CodeSidebar } from "./CodeSidebar";
 import { CodeTranscript } from "./CodeTranscript";
-import { FOCUS_RING, HOVER_TINT } from "./interactive";
+import { FOCUS_RING } from "./interactive";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 import { TerminalDrawer } from "./TerminalDrawer";
 import { TerminalPane } from "./TerminalPane";
@@ -88,7 +94,6 @@ import {
   useWorkspaceCardCommands,
   workspaceHeaderCommands,
 } from "./workspaceActions";
-import { middleTruncate } from "./workspaceCards";
 import {
   createPermissionModes,
   fenceReasonText,
@@ -122,7 +127,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const catalog = useCodeCatalogStore();
   const { run, dialogs } = useWorkspaceCardCommands();
   const layout = useLayoutState();
-  const { setLayout, openPanel } = usePanelNav();
+  const { setLayout } = usePanelNav();
   const chrome = splitCodeChromeLayout(layout);
   const reviewSidebarOpen = useCodeUiStore((state) => state.reviewSidebarOpen);
   const toggleReviewSidebar = useCodeUiStore((state) => state.toggleReviewSidebar);
@@ -134,6 +139,13 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   );
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const [quickOpenRequest, setQuickOpenRequest] = useState(0);
+  const [quickOpenTarget, setQuickOpenTarget] =
+    useState<CodeEditorRegion>("primary");
+  const [draggedEditor, setDraggedEditor] = useState<{
+    region: CodeEditorRegion;
+    index: number;
+  } | null>(null);
   const [starting, setStarting] = useState(false);
   const [createMode, setCreateMode] = useState<CodePermissionMode | null>(null);
   const [fileReveal, setFileReveal] = useState<{
@@ -242,6 +254,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const doctorHarnesses = catalog.doctor?.harnesses ?? [];
   const title = digest?.title ?? workspace?.title;
   const repoName = repo?.display_name;
+  const pr = digest?.pr_state ?? workspace?.pr;
   const headerCommands = workspace
     ? workspaceHeaderCommands({
         archived: workspace.status === "archived",
@@ -253,10 +266,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     : [];
 
   function openTurnDiff(turnId: string) {
-    openPanel({ type: "diff", turnId });
+    setLayout(openCodeEditor(layout, { type: "diff", turnId }));
   }
 
-  function openFile(path: string, line?: number) {
+  function openFile(
+    path: string,
+    line?: number,
+    preferredRegion?: CodeEditorRegion,
+  ) {
     setFileReveal((current) =>
       line === undefined
         ? null
@@ -266,11 +283,31 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             revision: (current?.revision ?? 0) + 1,
           },
     );
-    openPanel({ type: "file", path });
+    setLayout(
+      openCodeEditor(layout, { type: "file", path }, preferredRegion),
+    );
   }
 
   function openFileDiff(path: string) {
-    openPanel({ type: "diff", path });
+    setLayout(openCodeEditor(layout, { type: "diff", path }));
+  }
+
+  function requestNewTab(region: CodeEditorRegion) {
+    setQuickOpenTarget(region);
+    setQuickOpenRequest((request) => request + 1);
+  }
+
+  function dropDraggedEditor(region: CodeEditorRegion) {
+    if (!draggedEditor || draggedEditor.region === region) return;
+    setLayout(
+      moveEditorTab(
+        layout,
+        draggedEditor.region,
+        draggedEditor.index,
+        region,
+      ),
+    );
+    setDraggedEditor(null);
   }
 
   function copyEditorPath(path: string) {
@@ -285,119 +322,251 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const activeEditor = showingChat
     ? null
     : (editorTabs[chrome.editors.activeIndex] ?? null);
-  // With no editor tab there is no strip, so nothing names a panel and the
-  // conversation is just the page.
-  const stripped = editorTabs.length > 0;
+  const splitEditorTabs = chrome.splitEditors.tabs;
+  const activeSplitEditor =
+    splitEditorTabs[chrome.splitEditors.activeIndex] ?? null;
+  const hasEditorSplit = splitEditorTabs.length > 0;
 
-  const workspaceMain = (
-    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+  function editorPanel(
+    panel: PanelContent,
+    region: CodeEditorRegion,
+    index: number,
+  ) {
+    const id =
+      region === "primary" ? EDITOR_PANEL_ID : SPLIT_EDITOR_PANEL_ID;
+    return (
+      <div
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        id={id}
+        role="tabpanel"
+        aria-labelledby={centerEditorTabId(index, region)}
+      >
+        {panel.type === "file" ? (
+          <Suspense fallback={<Skeleton className="h-full w-full" />}>
+            <FileViewer
+              client={client}
+              workspaceId={workspaceId}
+              path={panel.path}
+              contentRevision={contentRevision}
+              revealLine={
+                fileReveal?.path === panel.path ? fileReveal.line : undefined
+              }
+              revealRevision={fileReveal?.revision}
+            />
+          </Suspense>
+        ) : panel.type === "diff" ? (
+          <DiffPanel
+            client={client}
+            workspaceId={workspaceId}
+            turnId={panel.turnId}
+            file={panel.path}
+            contentRevision={contentRevision}
+            onOpenFile={(path) => openFile(path, undefined, region)}
+          />
+        ) : null}
+      </div>
+    );
+  }
+
+  const primaryEditorGroup = (
+    <div
+      className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+      data-testid="primary-editor-group"
+      onDragOver={(event) => {
+        if (draggedEditor?.region === "secondary") event.preventDefault();
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        dropDraggedEditor("primary");
+      }}
+    >
       <CodeCenterTabs
         editorTabs={editorTabs}
         editorActiveIndex={chrome.editors.activeIndex}
         conversationFocused={showingChat}
         onSelectChat={() => setLayout(focusConversation(layout))}
-        onSelectEditor={(index) => setLayout(focusEditorTab(layout, index))}
-        onCloseEditor={(index) => setLayout(closeEditorTab(layout, index))}
+        onSelectEditor={(index) =>
+          setLayout(focusEditorTab(layout, index, "primary"))
+        }
+        onCloseEditor={(index) =>
+          setLayout(closeEditorTab(layout, index, "primary"))
+        }
         onCloseAllEditors={() => setLayout(closeAllEditorTabs(layout))}
         onCloseOtherEditors={(index) =>
-          setLayout(closeOtherEditorTabs(layout, index))
+          setLayout(closeOtherEditorTabs(layout, index, "primary"))
         }
         onCloseEditorsToRight={(index) =>
-          setLayout(closeEditorTabsToRight(layout, index))
+          setLayout(closeEditorTabsToRight(layout, index, "primary"))
         }
         onCopyPath={copyEditorPath}
+        onNewTab={() => requestNewTab("primary")}
+        onMoveEditorToOtherGroup={(index) =>
+          setLayout(moveEditorTab(layout, "primary", index, "secondary"))
+        }
+        onSplitActive={() =>
+          setLayout(
+            moveEditorTab(
+              layout,
+              "primary",
+              chrome.editors.activeIndex,
+              "secondary",
+            ),
+          )
+        }
+        onDragEditorStart={(index) =>
+          setDraggedEditor({ region: "primary", index })
+        }
+        onDragEditorEnd={() => setDraggedEditor(null)}
       />
       <div
         className={cn("min-h-0 flex-1", !showingChat && "hidden")}
-        id={stripped ? CHAT_PANEL_ID : undefined}
-        role={stripped ? "tabpanel" : undefined}
-        aria-labelledby={stripped ? CHAT_TAB_ID : undefined}
+        id={CHAT_PANEL_ID}
+        role="tabpanel"
+        aria-labelledby={CHAT_TAB_ID}
       >
-      <PanelLayout
-        layout={chrome.panels}
-        framed={false}
-        onFocusTab={(index) => setLayout(focusCodeChromeTab(layout, index))}
-        onCloseTab={(index) => setLayout(closeCodeChromeTab(layout, index))}
-        renderChat={(visible) => (
-          // The panel slot is a plain block. `.chat-pane` claims that height
-          // so `.message-view` can grow and the composer stays at the bottom,
-          // including on an empty transcript.
-          <div className="chat-pane" hidden={!visible || !showingChat}>
-            {fenced && session?.fence_reason && (
-              <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
-                <p>{fenceReasonText(session.fence_reason)}</p>
-                <Button type="button" size="sm" className="self-start" onClick={() => void reap()}>
-                  Reap
-                </Button>
-              </div>
-            )}
-            {!session && workspace?.status === "active" && (
-              <StartSessionPrompt
-                harnesses={doctorHarnesses}
-                starting={starting}
-                selectedMode={createMode}
-                onSelectMode={setCreateMode}
-                client={client}
-                catalogModels={models}
-                defaultModelKey={defaultModelKey}
-                onStart={(harness, mode, message, model) =>
-                  startSession(harness, mode, message, model)
-                }
-              />
-            )}
-            {session && (
-              <CodeSessionPane
-                key={session.id}
-                session={session}
-                workspaceId={workspaceId}
-                client={client}
-                catalogModels={models}
-                defaultModelKey={defaultModelKey}
-                disabled={fenced || workspace?.status !== "active"}
-                onOpenTurnDiff={openTurnDiff}
-              />
-            )}
+        <PanelLayout
+          layout={chrome.panels}
+          framed={false}
+          onFocusTab={(index) => setLayout(focusCodeChromeTab(layout, index))}
+          onCloseTab={(index) => setLayout(closeCodeChromeTab(layout, index))}
+          renderChat={(visible) => (
+            // The panel slot is a plain block. `.chat-pane` claims that height
+            // so `.message-view` can grow and the composer stays at the bottom,
+            // including on an empty transcript.
+            <div className="chat-pane" hidden={!visible || !showingChat}>
+              {fenced && session?.fence_reason && (
+                <div className="border-warning-border bg-warning-background text-warning-foreground mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
+                  <p>{fenceReasonText(session.fence_reason)}</p>
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="self-start"
+                    onClick={() => void reap()}
+                  >
+                    Reap
+                  </Button>
+                </div>
+              )}
+              {!session && workspace?.status === "active" && (
+                <StartSessionPrompt
+                  harnesses={doctorHarnesses}
+                  starting={starting}
+                  selectedMode={createMode}
+                  onSelectMode={setCreateMode}
+                  client={client}
+                  catalogModels={models}
+                  defaultModelKey={defaultModelKey}
+                  onStart={(harness, mode, message, model) =>
+                    startSession(harness, mode, message, model)
+                  }
+                />
+              )}
+              {session && (
+                <CodeSessionPane
+                  key={session.id}
+                  session={session}
+                  workspaceId={workspaceId}
+                  client={client}
+                  catalogModels={models}
+                  defaultModelKey={defaultModelKey}
+                  disabled={fenced || workspace?.status !== "active"}
+                  onOpenTurnDiff={openTurnDiff}
+                />
+              )}
+            </div>
+          )}
+          renderPanel={(panel) =>
+            renderCodePanel(panel, client, workspaceId)
+          }
+        />
+      </div>
+      {!showingChat &&
+        activeEditor &&
+        editorPanel(activeEditor, "primary", chrome.editors.activeIndex)}
+    </div>
+  );
+
+  const splitEditorGroup = activeSplitEditor ? (
+    <div
+      className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+      data-testid="secondary-editor-group"
+      onDragOver={(event) => {
+        if (draggedEditor?.region === "primary") event.preventDefault();
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        dropDraggedEditor("secondary");
+      }}
+    >
+      <CodeCenterTabs
+        region="secondary"
+        showMainAgent={false}
+        editorTabs={splitEditorTabs}
+        editorActiveIndex={chrome.splitEditors.activeIndex}
+        conversationFocused={false}
+        onSelectChat={() => undefined}
+        onSelectEditor={(index) =>
+          setLayout(focusEditorTab(layout, index, "secondary"))
+        }
+        onCloseEditor={(index) =>
+          setLayout(closeEditorTab(layout, index, "secondary"))
+        }
+        onCloseAllEditors={() => setLayout(closeAllEditorTabs(layout))}
+        onCloseOtherEditors={(index) =>
+          setLayout(closeOtherEditorTabs(layout, index, "secondary"))
+        }
+        onCloseEditorsToRight={(index) =>
+          setLayout(closeEditorTabsToRight(layout, index, "secondary"))
+        }
+        onCopyPath={copyEditorPath}
+        onNewTab={() => requestNewTab("secondary")}
+        onMoveEditorToOtherGroup={(index) =>
+          setLayout(moveEditorTab(layout, "secondary", index, "primary"))
+        }
+        onCloseGroup={() => setLayout(mergeEditorSplit(layout))}
+        onDragEditorStart={(index) =>
+          setDraggedEditor({ region: "secondary", index })
+        }
+        onDragEditorEnd={() => setDraggedEditor(null)}
+      />
+      {editorPanel(
+        activeSplitEditor,
+        "secondary",
+        chrome.splitEditors.activeIndex,
+      )}
+    </div>
+  ) : null;
+
+  const workspaceMain = (
+    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
+        {hasEditorSplit ? (
+          <ResizablePanelGroup direction="horizontal" className="h-full min-h-0">
+            <ResizablePanel defaultSize={55} minSize={25} className="min-w-0">
+              {primaryEditorGroup}
+            </ResizablePanel>
+            <ResizableHandle />
+            <ResizablePanel defaultSize={45} minSize={25} className="min-w-0">
+              {splitEditorGroup}
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        ) : (
+          primaryEditorGroup
+        )}
+        {draggedEditor?.region === "primary" && !hasEditorSplit && (
+          <div
+            data-testid="split-drop-zone"
+            className="border-primary/50 bg-primary/8 text-primary absolute inset-y-3 right-3 z-10 grid w-[min(34%,18rem)] place-items-center rounded-lg border border-dashed text-xs font-medium shadow-sm backdrop-blur-sm"
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={(event) => {
+              event.preventDefault();
+              dropDraggedEditor("secondary");
+            }}
+          >
+            Drop to split right
           </div>
         )}
-        renderPanel={(panel) =>
-          renderCodePanel(panel, client, workspaceId)
-        }
-      />
       </div>
-      {!showingChat && activeEditor && (
-        <div
-          className="flex min-h-0 flex-1 flex-col overflow-hidden"
-          id={EDITOR_PANEL_ID}
-          role="tabpanel"
-          aria-labelledby={centerEditorTabId(chrome.editors.activeIndex)}
-        >
-          {activeEditor.type === "file" ? (
-            <Suspense fallback={<Skeleton className="h-full w-full" />}>
-              <FileViewer
-                client={client}
-                workspaceId={workspaceId}
-                path={activeEditor.path}
-                contentRevision={contentRevision}
-                revealLine={
-                  fileReveal?.path === activeEditor.path
-                    ? fileReveal.line
-                    : undefined
-                }
-                revealRevision={fileReveal?.revision}
-              />
-            </Suspense>
-          ) : activeEditor.type === "diff" ? (
-            <DiffPanel
-              client={client}
-              workspaceId={workspaceId}
-              turnId={activeEditor.turnId}
-              file={activeEditor.path}
-              contentRevision={contentRevision}
-              onOpenFile={openFile}
-            />
-          ) : null}
-        </div>
-      )}
       {chrome.terminal && (
         <TerminalDrawer
           client={client}
@@ -416,17 +585,21 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         client={client}
         workspaceId={workspaceId}
         contentRevision={contentRevision}
-        onOpenFile={openFile}
+        onOpenFile={(path) => openFile(path, undefined, quickOpenTarget)}
+        openRequest={quickOpenRequest}
       />
-      <header className="flex h-12 shrink-0 items-center justify-between gap-3 border-b px-4">
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b px-4">
         <div className="min-w-0 flex-1">
-          <h1 className="flex min-w-0 items-center gap-2 text-sm font-medium">
+          <h1 className="flex min-w-0 items-center text-sm font-medium">
             {title ? (
-              // The title takes the free space and yields it first: the repo
-              // name and the worktree path are short, fixed facts, and a long
-              // title that squeezed them out would cost the reader the two
-              // things that say which checkout this is.
-              <span className="min-w-0 flex-1 truncate" title={title}>
+              <span
+                className="min-w-0 flex-1 truncate"
+                title={
+                  [title, repoName, workspace?.worktree_path]
+                    .filter(Boolean)
+                    .join(" · ")
+                }
+              >
                 {title}
               </span>
             ) : error ? null : (
@@ -438,19 +611,13 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                 <Skeleton className="h-3 w-16" />
               </span>
             )}
-            {repoName && (
-              <span
-                className="text-muted-foreground max-w-32 shrink-0 truncate text-xs font-normal"
-                title={repoName}
-              >
-                {repoName}
-              </span>
-            )}
-            {workspace && (
-              <WorktreePathChip path={workspace.worktree_path} />
-            )}
           </h1>
         </div>
+        {pr && (
+          <div className="flex min-w-0 flex-1 justify-center">
+            <PrActionBar pr={pr} variant="header" />
+          </div>
+        )}
         <div className="flex shrink-0 items-center gap-2">
           {session && (
             <>
@@ -507,6 +674,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           {workspace && (
             <WorkspaceOverflowMenu
               commands={headerCommands}
+              context={{
+                repoName: repoName ?? undefined,
+                worktreePath: workspace.worktree_path,
+              }}
               onCommand={(command) =>
                 run(command.id, {
                   workspace,
@@ -657,61 +828,6 @@ function SessionLifecycleMark({
   );
 }
 
-function WorktreePathChip({ path }: { path: string }) {
-  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
-    "idle",
-  );
-
-  useEffect(() => {
-    if (copyState === "idle") return;
-    return scheduleCopyStateReset(() => setCopyState("idle"));
-  }, [copyState]);
-
-  async function onCopy() {
-    try {
-      await copyPlainText(path);
-      setCopyState("copied");
-    } catch {
-      setCopyState("failed");
-    }
-  }
-
-  const label =
-    copyState === "copied"
-      ? "Copied"
-      : copyState === "failed"
-        ? "Copy failed"
-        : path;
-
-  return (
-    <>
-      <WithTooltip label={label}>
-        <button
-          type="button"
-          className={cn(
-            "text-muted-foreground hover:bg-muted hover:text-foreground max-w-44 shrink-0 cursor-pointer truncate rounded-md px-1.5 py-0.5 font-mono text-[11px]",
-            FOCUS_RING,
-            HOVER_TINT,
-          )}
-          aria-label={
-            copyState === "idle" ? `Copy worktree path ${path}` : label
-          }
-          onClick={() => void onCopy()}
-        >
-          {middleTruncate(path, 24)}
-        </button>
-      </WithTooltip>
-      <span className="sr-only" role="status" aria-live="polite">
-        {copyState === "copied"
-          ? "Worktree path copied to clipboard."
-          : copyState === "failed"
-            ? "Worktree path could not be copied."
-            : ""}
-      </span>
-    </>
-  );
-}
-
 function PendingApprovalBadge({
   sessionId,
   client,
@@ -809,8 +925,27 @@ function CodeSessionPane({
       session.harness_kind,
       defaultModelKey,
     );
-    return gateway.length > 0 ? gateway : (cachedModels ?? []);
-  }, [cachedModels, catalogModels, defaultModelKey, session.harness_kind]);
+    const listed = gateway.length > 0 ? gateway : (cachedModels ?? []);
+    if (!session.model || listed.some((option) => option.id === session.model)) {
+      return listed;
+    }
+    // Historical or engine-default sessions can name a model that is hidden
+    // from today's catalog. Keep that truthful current model visible instead
+    // of silently labeling the session as whichever row is now default.
+    return [
+      ...harnessCodeModels(
+        [{ id: session.model, label: session.model }],
+        session.harness_kind,
+      ),
+      ...listed,
+    ];
+  }, [
+    cachedModels,
+    catalogModels,
+    defaultModelKey,
+    session.harness_kind,
+    session.model,
+  ]);
   const inferred = modelOptions.find((option) => option.default)?.id;
   const [model, setModel] = useState(session.model ?? inferred);
 

--- a/crates/tidebreak-desktop/ui/src/code/PrActionBar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrActionBar.tsx
@@ -40,7 +40,13 @@ const TONE_CLASS: Record<PrBarTone, string> = {
  * Status and the check count stay visible on Files and Source control. Each
  * action writes a prompt into the composer rather than calling GitHub here.
  */
-export function PrActionBar({ pr }: { pr: PullRequestDigest }) {
+export function PrActionBar({
+  pr,
+  variant = "inspector",
+}: {
+  pr: PullRequestDigest;
+  variant?: "inspector" | "header";
+}) {
   const offerComposerPrompt = useCodeUiStore((state) => state.offerComposerPrompt);
   const model = prBarModel(pr);
   const [primary, ...rest] = model.actions;
@@ -57,10 +63,14 @@ export function PrActionBar({ pr }: { pr: PullRequestDigest }) {
   return (
     <div
       className={cn(
-        "flex shrink-0 items-center gap-2 border-b px-2 py-1.5",
+        "flex min-w-0 shrink-0 items-center gap-2",
+        variant === "inspector"
+          ? "border-b px-2 py-1.5"
+          : "max-w-[min(46vw,38rem)] rounded-md border px-2 py-1",
         TONE_CLASS[model.tone],
       )}
       data-testid="pr-action-bar"
+      data-variant={variant}
     >
       {model.url ? (
         <a

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
@@ -10,6 +10,9 @@ import {
   focusCodeChromeTab,
   focusConversation,
   focusEditorTab,
+  mergeEditorSplit,
+  moveEditorTab,
+  openCodeEditor,
   splitCodeChromeLayout,
   toggleTerminalLayout,
 } from "./codeChrome";
@@ -35,6 +38,7 @@ describe("code chrome layout", () => {
     expect(splitCodeChromeLayout(layout)).toEqual({
       panels: EMPTY_LAYOUT,
       editors: EMPTY_LAYOUT,
+      splitEditors: EMPTY_LAYOUT,
       terminal: { type: "terminal" },
     });
   });
@@ -46,6 +50,9 @@ describe("code chrome layout", () => {
       { type: "agents" },
     ]);
     expect(splitCodeChromeLayout(foldersTerminalAgents).editors.tabs).toEqual([]);
+    expect(splitCodeChromeLayout(foldersTerminalAgents).splitEditors.tabs).toEqual(
+      [],
+    );
   });
 
   it("leaves a terminal-only layout as the conversation plus a drawer", () => {
@@ -58,6 +65,7 @@ describe("code chrome layout", () => {
     ).toEqual({
       panels: EMPTY_LAYOUT,
       editors: EMPTY_LAYOUT,
+      splitEditors: EMPTY_LAYOUT,
       terminal: { type: "terminal" },
     });
   });
@@ -181,5 +189,60 @@ describe("code chrome layout", () => {
       activeIndex: 0,
       conversationFocused: undefined,
     });
+  });
+
+  it("moves editor tabs into a durable secondary group and back", () => {
+    const layout = {
+      tabs: [
+        { type: "file" as const, path: "src/lib.rs" },
+        { type: "diff" as const, path: "src/main.rs" },
+        { type: "terminal" as const },
+      ],
+      activeIndex: 0,
+      fullscreen: false,
+    };
+
+    const split = moveEditorTab(layout, "primary", 0, "secondary");
+    expect(split.tabs).toEqual([
+      { type: "diff", path: "src/main.rs" },
+      { type: "terminal" },
+    ]);
+    expect(split.editorSplit).toEqual({
+      tabs: [{ type: "file", path: "src/lib.rs" }],
+      activeIndex: 0,
+      focused: true,
+    });
+    expect(splitCodeChromeLayout(split).splitEditors.tabs).toEqual([
+      { type: "file", path: "src/lib.rs" },
+    ]);
+
+    expect(moveEditorTab(split, "secondary", 0, "primary").editorSplit).toBe(
+      undefined,
+    );
+    expect(mergeEditorSplit(split).tabs.filter((tab) => tab.type === "file")).toEqual([
+      { type: "file", path: "src/lib.rs" },
+    ]);
+  });
+
+  it("opens new editors in the group that last received focus", () => {
+    const split = moveEditorTab(
+      {
+        tabs: [{ type: "file", path: "src/lib.rs" }],
+        activeIndex: 0,
+        fullscreen: false,
+      },
+      "primary",
+      0,
+      "secondary",
+    );
+    const opened = openCodeEditor(split, {
+      type: "file",
+      path: "src/main.rs",
+    });
+    expect(opened.editorSplit?.tabs).toEqual([
+      { type: "file", path: "src/lib.rs" },
+      { type: "file", path: "src/main.rs" },
+    ]);
+    expect(opened.editorSplit?.activeIndex).toBe(1);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -15,6 +15,7 @@ import {
 export function splitCodeChromeLayout(layout: LayoutState): {
   panels: LayoutState;
   editors: LayoutState;
+  splitEditors: LayoutState;
   terminal: Extract<PanelContent, { type: "terminal" }> | null;
 } {
   const terminal = layout.tabs.find((tab) => tab.type === "terminal") as
@@ -23,13 +24,20 @@ export function splitCodeChromeLayout(layout: LayoutState): {
   const active = layout.tabs[layout.activeIndex];
   const side = layout.tabs.filter((tab) => !isDrawerTab(tab) && !isEditorTab(tab));
   const editors = layout.tabs.filter(isEditorTab);
+  const splitTabs = layout.editorSplit?.tabs.filter(isEditorTab) ?? [];
+  const splitActive = layout.editorSplit?.tabs[layout.editorSplit.activeIndex];
 
+  const primaryEditors = sliceLayout(editors, active, false);
   return {
     panels: sliceLayout(side, active, layout.fullscreen),
-    editors: {
-      ...sliceLayout(editors, active, false),
-      conversationFocused: layout.conversationFocused,
-    },
+    editors:
+      layout.conversationFocused === undefined
+        ? primaryEditors
+        : {
+            ...primaryEditors,
+            conversationFocused: layout.conversationFocused,
+          },
+    splitEditors: sliceLayout(splitTabs, splitActive, false),
     terminal: terminal ?? null,
   };
 }
@@ -56,23 +64,73 @@ export function isEditorTab(tab: PanelContent): boolean {
   return tab.type === "file" || tab.type === "diff";
 }
 
+export type CodeEditorRegion = "primary" | "secondary";
+
 /** Show the conversation while keeping file and diff tabs open. */
 export function focusConversation(layout: LayoutState): LayoutState {
-  return { ...layout, conversationFocused: true };
+  return {
+    ...layout,
+    conversationFocused: true,
+    editorSplit: layout.editorSplit
+      ? { ...layout.editorSplit, focused: undefined }
+      : undefined,
+  };
 }
 
 /** Bring a file or diff tab forward. `editorIndex` counts only those tabs. */
-export function focusEditorTab(layout: LayoutState, editorIndex: number): LayoutState {
+export function focusEditorTab(
+  layout: LayoutState,
+  editorIndex: number,
+  region: CodeEditorRegion = "primary",
+): LayoutState {
+  if (region === "secondary") {
+    const split = layout.editorSplit;
+    if (!split?.tabs[editorIndex]) return layout;
+    return {
+      ...layout,
+      editorSplit: { ...split, activeIndex: editorIndex, focused: true },
+    };
+  }
   const editors = layout.tabs.filter(isEditorTab);
   const target = editors[editorIndex];
   if (!target) return layout;
   const index = layout.tabs.findIndex((tab) => panelKey(tab) === panelKey(target));
   if (index < 0) return layout;
-  return { ...layout, activeIndex: index, conversationFocused: false };
+  return {
+    ...layout,
+    activeIndex: index,
+    conversationFocused: false,
+    editorSplit: layout.editorSplit
+      ? { ...layout.editorSplit, focused: undefined }
+      : undefined,
+  };
 }
 
 /** Close a file or diff tab. `editorIndex` counts only those tabs. */
-export function closeEditorTab(layout: LayoutState, editorIndex: number): LayoutState {
+export function closeEditorTab(
+  layout: LayoutState,
+  editorIndex: number,
+  region: CodeEditorRegion = "primary",
+): LayoutState {
+  if (region === "secondary") {
+    const split = layout.editorSplit;
+    if (!split || editorIndex < 0 || editorIndex >= split.tabs.length) {
+      return layout;
+    }
+    const tabs = split.tabs.filter((_, index) => index !== editorIndex);
+    if (tabs.length === 0) return { ...layout, editorSplit: undefined };
+    let activeIndex = split.activeIndex;
+    if (editorIndex < activeIndex) activeIndex -= 1;
+    else if (editorIndex === activeIndex) activeIndex = editorIndex - 1;
+    return {
+      ...layout,
+      editorSplit: {
+        ...split,
+        tabs,
+        activeIndex: Math.min(Math.max(activeIndex, 0), tabs.length - 1),
+      },
+    };
+  }
   const editors = layout.tabs.filter(isEditorTab);
   const target = editors[editorIndex];
   if (!target) return layout;
@@ -88,8 +146,10 @@ export function closeEditorTab(layout: LayoutState, editorIndex: number): Layout
 /** Close every file and diff tab, returning the center to the conversation. */
 export function closeAllEditorTabs(layout: LayoutState): LayoutState {
   const tabs = layout.tabs.filter((tab) => !isEditorTab(tab));
-  if (tabs.length === layout.tabs.length) return layout;
-  if (tabs.length === 0) return EMPTY_LAYOUT;
+  if (tabs.length === layout.tabs.length && !layout.editorSplit) return layout;
+  if (tabs.length === 0) {
+    return { ...EMPTY_LAYOUT, editorSplit: undefined };
+  }
 
   const active = layout.tabs[layout.activeIndex];
   const activeIndex = active && !isEditorTab(active)
@@ -100,6 +160,7 @@ export function closeAllEditorTabs(layout: LayoutState): LayoutState {
     tabs,
     activeIndex,
     conversationFocused: undefined,
+    editorSplit: undefined,
   };
 }
 
@@ -107,10 +168,23 @@ export function closeAllEditorTabs(layout: LayoutState): LayoutState {
 export function closeOtherEditorTabs(
   layout: LayoutState,
   editorIndex: number,
+  region: CodeEditorRegion = "primary",
 ): LayoutState {
+  if (region === "secondary") {
+    const target = layout.editorSplit?.tabs[editorIndex];
+    if (!target) return layout;
+    const tabs = layout.tabs.filter((tab) => !isEditorTab(tab));
+    return {
+      ...layout,
+      tabs,
+      activeIndex: Math.min(layout.activeIndex, Math.max(0, tabs.length - 1)),
+      conversationFocused: undefined,
+      editorSplit: { tabs: [target], activeIndex: 0, focused: true },
+    };
+  }
   const editors = layout.tabs.filter(isEditorTab);
   const target = editors[editorIndex];
-  if (!target || editors.length <= 1) return layout;
+  if (!target || (editors.length <= 1 && !layout.editorSplit)) return layout;
   const targetKey = panelKey(target);
   const tabs = layout.tabs.filter(
     (tab) => !isEditorTab(tab) || panelKey(tab) === targetKey,
@@ -120,6 +194,7 @@ export function closeOtherEditorTabs(
     tabs,
     activeIndex: tabs.findIndex((tab) => panelKey(tab) === targetKey),
     conversationFocused: false,
+    editorSplit: undefined,
   };
 }
 
@@ -127,7 +202,21 @@ export function closeOtherEditorTabs(
 export function closeEditorTabsToRight(
   layout: LayoutState,
   editorIndex: number,
+  region: CodeEditorRegion = "primary",
 ): LayoutState {
+  if (region === "secondary") {
+    const split = layout.editorSplit;
+    if (!split || editorIndex >= split.tabs.length - 1) return layout;
+    const tabs = split.tabs.slice(0, editorIndex + 1);
+    return {
+      ...layout,
+      editorSplit: {
+        ...split,
+        tabs,
+        activeIndex: Math.min(split.activeIndex, tabs.length - 1),
+      },
+    };
+  }
   const editors = layout.tabs.filter(isEditorTab);
   const target = editors[editorIndex];
   const closing = editors.slice(editorIndex + 1);
@@ -147,6 +236,121 @@ export function closeEditorTabsToRight(
     tabs,
     activeIndex: Math.max(activeIndex, 0),
   };
+}
+
+/** Open one editor in the group that last had focus, unless a group is named. */
+export function openCodeEditor(
+  layout: LayoutState,
+  panel: Extract<PanelContent, { type: "file" | "diff" }>,
+  preferredRegion?: CodeEditorRegion,
+): LayoutState {
+  const key = panelKey(panel);
+  const primaryIndex = layout.tabs
+    .filter(isEditorTab)
+    .findIndex((tab) => panelKey(tab) === key);
+  if (primaryIndex >= 0) {
+    const urlIndex = editorUrlIndex(layout, primaryIndex);
+    const tabs = layout.tabs.slice();
+    tabs[urlIndex] = panel;
+    return focusEditorTab({ ...layout, tabs }, primaryIndex, "primary");
+  }
+  const splitIndex = layout.editorSplit?.tabs.findIndex(
+    (tab) => panelKey(tab) === key,
+  ) ?? -1;
+  if (splitIndex >= 0 && layout.editorSplit) {
+    const tabs = layout.editorSplit.tabs.slice();
+    tabs[splitIndex] = panel;
+    return focusEditorTab(
+      { ...layout, editorSplit: { ...layout.editorSplit, tabs } },
+      splitIndex,
+      "secondary",
+    );
+  }
+
+  const region =
+    preferredRegion ?? (layout.editorSplit?.focused ? "secondary" : "primary");
+  if (region === "secondary") {
+    const split = layout.editorSplit ?? { tabs: [], activeIndex: 0 };
+    return {
+      ...layout,
+      editorSplit: {
+        tabs: [...split.tabs, panel],
+        activeIndex: split.tabs.length,
+        focused: true,
+      },
+    };
+  }
+  const editors = layout.tabs.filter(isEditorTab);
+  return focusEditorTab(
+    { ...layout, tabs: [...layout.tabs, panel] },
+    editors.length,
+    "primary",
+  );
+}
+
+/** Move an existing file/diff tab between the two visible editor groups. */
+export function moveEditorTab(
+  layout: LayoutState,
+  from: CodeEditorRegion,
+  editorIndex: number,
+  to: CodeEditorRegion,
+): LayoutState {
+  if (from === to) return layout;
+  const target =
+    from === "primary"
+      ? layout.tabs.filter(isEditorTab)[editorIndex]
+      : layout.editorSplit?.tabs[editorIndex];
+  if (!target) return layout;
+
+  if (from === "primary") {
+    const without = closeEditorTab(layout, editorIndex, "primary");
+    const split = without.editorSplit ?? { tabs: [], activeIndex: 0 };
+    const existing = split.tabs.findIndex(
+      (tab) => panelKey(tab) === panelKey(target),
+    );
+    const tabs = existing >= 0 ? split.tabs : [...split.tabs, target];
+    return {
+      ...without,
+      editorSplit: {
+        tabs,
+        activeIndex: existing >= 0 ? existing : tabs.length - 1,
+        focused: true,
+      },
+    };
+  }
+
+  const without = closeEditorTab(layout, editorIndex, "secondary");
+  return openCodeEditor(
+    without,
+    target as Extract<PanelContent, { type: "file" | "diff" }>,
+    "primary",
+  );
+}
+
+/** Collapse the right group without closing its tabs. */
+export function mergeEditorSplit(layout: LayoutState): LayoutState {
+  const splitTabs = layout.editorSplit?.tabs.filter(isEditorTab) ?? [];
+  if (splitTabs.length === 0) return { ...layout, editorSplit: undefined };
+  let next: LayoutState = { ...layout, editorSplit: undefined };
+  for (const tab of splitTabs) {
+    next = openCodeEditor(
+      next,
+      tab as Extract<PanelContent, { type: "file" | "diff" }>,
+      "primary",
+    );
+  }
+  return next;
+}
+
+function editorUrlIndex(layout: LayoutState, editorIndex: number): number {
+  let remaining = editorIndex;
+  for (let index = 0; index < layout.tabs.length; index += 1) {
+    const tab = layout.tabs[index];
+    if (!tab || !isEditorTab(tab)) continue;
+    if (remaining === 0) return index;
+    remaining -= 1;
+  }
+  return -1;
 }
 
 /**
@@ -178,17 +382,18 @@ export function focusCodeChromeTab(layout: LayoutState, stripIndex: number): Lay
 export function closeCodeChromeTab(layout: LayoutState, stripIndex: number): LayoutState {
   const { panels, editors, terminal } = splitCodeChromeLayout(layout);
   const nextPanels = closeLayoutTab(panels, stripIndex);
-  return combineChrome(nextPanels, editors, terminal);
+  return combineChrome(nextPanels, editors, terminal, layout.editorSplit);
 }
 
 function combineChrome(
   panels: LayoutState,
   editors: LayoutState,
   terminal: Extract<PanelContent, { type: "terminal" }> | null,
+  editorSplit?: LayoutState["editorSplit"],
 ): LayoutState {
   const tabs = [...editors.tabs, ...panels.tabs];
   if (terminal) tabs.push(terminal);
-  if (tabs.length === 0) return EMPTY_LAYOUT;
+  if (tabs.length === 0 && !editorSplit) return EMPTY_LAYOUT;
   const focused =
     !editors.conversationFocused && editors.tabs[editors.activeIndex]
       ? editors.tabs[editors.activeIndex]
@@ -201,13 +406,22 @@ function combineChrome(
     activeIndex,
     fullscreen: panels.fullscreen && panels.tabs.length > 0,
     conversationFocused: editors.conversationFocused,
+    editorSplit,
   };
 }
 
 function closeLayoutTab(layout: LayoutState, index: number): LayoutState {
   if (index < 0 || index >= layout.tabs.length) return layout;
   const tabs = layout.tabs.filter((_, at) => at !== index);
-  if (tabs.length === 0) return EMPTY_LAYOUT;
+  if (tabs.length === 0) {
+    return {
+      ...layout,
+      tabs: [],
+      activeIndex: 0,
+      fullscreen: false,
+      conversationFocused: undefined,
+    };
+  }
   let activeIndex = layout.activeIndex;
   if (index < activeIndex) activeIndex -= 1;
   else if (index === activeIndex) activeIndex = index - 1;
@@ -231,7 +445,17 @@ export function toggleTerminalLayout(layout: LayoutState): LayoutState {
   }
 
   const tabs = layout.tabs.filter((_, at) => at !== index);
-  if (tabs.length === 0) return EMPTY_LAYOUT;
+  if (tabs.length === 0) {
+    return layout.editorSplit
+      ? {
+          ...layout,
+          tabs: [],
+          activeIndex: 0,
+          fullscreen: false,
+          conversationFocused: undefined,
+        }
+      : EMPTY_LAYOUT;
+  }
 
   let activeIndex = layout.activeIndex;
   if (index < activeIndex) activeIndex -= 1;

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -150,9 +150,11 @@ export function workspaceHeaderCommands(input: {
 export function WorkspaceOverflowMenu({
   commands,
   onCommand,
+  context,
 }: {
   commands: readonly WorkspaceCommand[];
   onCommand: (command: WorkspaceCommand) => void;
+  context?: { repoName?: string; worktreePath?: string };
 }) {
   if (commands.length === 0) return null;
   return (
@@ -168,6 +170,26 @@ export function WorkspaceOverflowMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {(context?.repoName || context?.worktreePath) && (
+          <>
+            <div className="flex max-w-72 flex-col gap-0.5 px-2 py-2">
+              {context.repoName && (
+                <span className="truncate text-xs font-medium">
+                  {context.repoName}
+                </span>
+              )}
+              {context.worktreePath && (
+                <span
+                  className="text-muted-foreground truncate font-mono text-[10px]"
+                  title={context.worktreePath}
+                >
+                  {context.worktreePath}
+                </span>
+              )}
+            </div>
+            <DropdownMenuSeparator />
+          </>
+        )}
         {commands.map((command) => (
           <WorkspaceOverflowItem
             key={`${command.id}:${command.actionName ?? ""}`}

--- a/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
@@ -45,6 +45,17 @@ export type LayoutState = {
    * stay open. Absent everywhere else.
    */
   conversationFocused?: boolean;
+  /**
+   * Code workspace: a second editor group to the right of the main-agent
+   * group. The transcript itself never moves or mounts twice; only file and
+   * diff tabs are stored here.
+   */
+  editorSplit?: {
+    tabs: PanelContent[];
+    activeIndex: number;
+    /** The second group received the most recent explicit focus. */
+    focused?: boolean;
+  };
 };
 
 export const EMPTY_LAYOUT: LayoutState = { tabs: [], activeIndex: 0, fullscreen: false };

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
@@ -103,6 +103,9 @@ describe("layout URLs", () => {
       tabs: undefined,
       active: undefined,
       fullscreen: undefined,
+      split: undefined,
+      splitActive: undefined,
+      splitFocused: undefined,
       left: undefined,
       right: undefined,
     });
@@ -178,5 +181,35 @@ describe("layout URLs", () => {
       left: undefined,
       right: undefined,
     });
+  });
+
+  it("round-trips a focused code editor split without duplicating tabs", () => {
+    const layout = {
+      tabs: [{ type: "file" as const, path: "src/lib.rs" }],
+      activeIndex: 0,
+      fullscreen: false,
+      editorSplit: {
+        tabs: [
+          { type: "diff" as const, path: "src/main.rs" },
+          { type: "file" as const, path: "README.md" },
+        ],
+        activeIndex: 1,
+        focused: true,
+      },
+    };
+
+    expect(searchFromLayout(layout)).toMatchObject({
+      tabs: "file.src%2Flib.rs",
+      split: "diff.f.src%2Fmain.rs,file.README.md",
+      splitActive: "file.README.md",
+      splitFocused: "1",
+    });
+    expect(layoutFromSearch(searchFromLayout(layout))).toEqual(layout);
+    expect(
+      layoutFromSearch({
+        tabs: "file.src%2Flib.rs",
+        split: "file.src%2Flib.rs,file.README.md",
+      }).editorSplit?.tabs,
+    ).toEqual([{ type: "file", path: "README.md" }]);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
@@ -149,6 +149,12 @@ export type PanelSearch = {
   active?: string;
   /** `"1"` when the region has taken the whole window. */
   fullscreen?: string;
+  /** Code workspace: file/diff tabs in the right editor group. */
+  split?: string;
+  /** Code workspace: the tab showing in the right editor group. */
+  splitActive?: string;
+  /** `"1"` when the right editor group most recently received focus. */
+  splitFocused?: string;
   /**
    * The retired pair-of-slots grammar. Read on the way in so older links and
    * already-open windows still land somewhere; never written back out.
@@ -184,14 +190,39 @@ export function layoutFromSearch(search: PanelSearch): LayoutState {
     seen.add(key);
     tabs.push(panel);
   }
-  if (tabs.length === 0) return EMPTY_LAYOUT;
+
+  const splitTabs: PanelContent[] = [];
+  for (const segment of search.split?.split(TAB_SEPARATOR) ?? []) {
+    const panel = parsePanelSegment(segment.trim());
+    if (!panel || (panel.type !== "file" && panel.type !== "diff")) continue;
+    const key = panelKey(panel);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    splitTabs.push(panel);
+  }
+  if (tabs.length === 0 && splitTabs.length === 0) return EMPTY_LAYOUT;
 
   return {
     tabs,
-    activeIndex: activeIndexFromSearch(search, tabs),
+    activeIndex: tabs.length > 0 ? activeIndexFromSearch(search, tabs) : 0,
     fullscreen: isFullscreenParam(search),
     conversationFocused: search.active === "chat" || undefined,
+    editorSplit:
+      splitTabs.length > 0
+        ? {
+            tabs: splitTabs,
+            activeIndex: namedIndex(search.splitActive, splitTabs),
+            focused: search.splitFocused === "1" || undefined,
+          }
+        : undefined,
   };
+}
+
+function namedIndex(segment: string | undefined, tabs: PanelContent[]): number {
+  const named = segment ? parsePanelSegment(segment) : null;
+  if (!named) return 0;
+  const index = tabs.findIndex((tab) => panelKey(tab) === panelKey(named));
+  return index < 0 ? 0 : index;
 }
 
 function activeIndexFromSearch(search: PanelSearch, tabs: PanelContent[]): number {
@@ -224,13 +255,27 @@ function isFullscreenParam(search: PanelSearch): boolean {
  */
 export function searchFromLayout(layout: LayoutState): PanelSearch {
   const cleared = { left: undefined, right: undefined };
-  if (layout.tabs.length === 0) {
-    return { ...cleared, tabs: undefined, active: undefined, fullscreen: undefined };
+  const split = layout.editorSplit;
+  const splitTabs = split?.tabs ?? [];
+  if (layout.tabs.length === 0 && splitTabs.length === 0) {
+    return {
+      ...cleared,
+      tabs: undefined,
+      active: undefined,
+      fullscreen: undefined,
+      split: undefined,
+      splitActive: undefined,
+      splitFocused: undefined,
+    };
   }
   const active = layout.tabs[layout.activeIndex];
+  const splitActive = splitTabs[split?.activeIndex ?? 0];
   return {
     ...cleared,
-    tabs: layout.tabs.map(encodePanelSegment).join(TAB_SEPARATOR),
+    tabs:
+      layout.tabs.length > 0
+        ? layout.tabs.map(encodePanelSegment).join(TAB_SEPARATOR)
+        : undefined,
     // The first tab is the default, so naming it would only lengthen the URL.
     // `chat` keeps file/diff tabs open while the conversation is showing.
     active: layout.conversationFocused
@@ -239,5 +284,14 @@ export function searchFromLayout(layout: LayoutState): PanelSearch {
         ? encodePanelSegment(active)
         : undefined,
     fullscreen: layout.fullscreen ? "1" : undefined,
+    split:
+      splitTabs.length > 0
+        ? splitTabs.map(encodePanelSegment).join(TAB_SEPARATOR)
+        : undefined,
+    splitActive:
+      split && split.activeIndex > 0 && splitActive
+        ? encodePanelSegment(splitActive)
+        : undefined,
+    splitFocused: split?.focused ? "1" : undefined,
   };
 }

--- a/crates/tidebreak-desktop/ui/src/panel/usePanelNav.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/usePanelNav.ts
@@ -9,7 +9,16 @@ export function useLayoutState(): LayoutState {
   const search = useSearch({ strict: false }) as PanelSearch;
   return useMemo(
     () => layoutFromSearch(search),
-    [search.tabs, search.active, search.fullscreen, search.left, search.right],
+    [
+      search.tabs,
+      search.active,
+      search.fullscreen,
+      search.split,
+      search.splitActive,
+      search.splitFocused,
+      search.left,
+      search.right,
+    ],
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/router.tsx
@@ -45,6 +45,9 @@ function panelSearchFrom(search: Record<string, unknown>): PanelSearch {
     tabs: text(search.tabs),
     active: text(search.active),
     fullscreen: text(search.fullscreen),
+    split: text(search.split),
+    splitActive: text(search.splitActive),
+    splitFocused: text(search.splitFocused),
     left: text(search.left),
     right: text(search.right),
   };

--- a/crates/tidebreak-desktop/ui/src/test/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/test/router.tsx
@@ -77,6 +77,13 @@ export async function renderWithRouter(
       tabs: typeof search.tabs === "string" ? search.tabs : undefined,
       active: typeof search.active === "string" ? search.active : undefined,
       fullscreen: typeof search.fullscreen === "string" ? search.fullscreen : undefined,
+      split: typeof search.split === "string" ? search.split : undefined,
+      splitActive:
+        typeof search.splitActive === "string" ? search.splitActive : undefined,
+      splitFocused:
+        typeof search.splitFocused === "string"
+          ? search.splitFocused
+          : undefined,
       left: typeof search.left === "string" ? search.left : undefined,
       right: typeof search.right === "string" ? search.right : undefined,
     }),

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -13,15 +13,21 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use serde_json::{json, Value};
 use tidebreak_core::{CapLevel, HarnessCaps, HarnessKind};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::codex::session::attach;
 use crate::probe::{observe_version, probe_shell, HostEnv};
-use crate::{HarnessAdapter, HarnessError, HarnessProbe, HarnessSession, SessionSpec};
+use crate::{
+    filter_child_env, spawn_process_tree, HarnessAdapter, HarnessError, HarnessProbe,
+    HarnessSession, ListedHarnessModel, SessionSpec,
+};
 
 const AUTH_TIMEOUT: Duration = Duration::from_secs(15);
+const MODEL_LIST_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Codex CLI adapter. Capabilities below are for the captured version
 /// 0.147.0: verified flags are `Supported`/`Unsupported`; anything not
@@ -91,12 +97,169 @@ impl HarnessAdapter for CodexAdapter {
         }
     }
 
+    async fn list_models(&self, probe: &HarnessProbe) -> Vec<ListedHarnessModel> {
+        let Some(binary) = probe.binary_path.as_deref() else {
+            return Vec::new();
+        };
+        list_app_server_models(binary, &probe.env).await
+    }
+
     async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
         if !spec.binary.is_absolute() {
             return Err(HarnessError::NotFound);
         }
         Ok(Box::new(attach(spec).await?))
     }
+}
+
+/// Ask the same app-server protocol a real session uses. Codex has no
+/// `models` CLI subcommand, so the generic harness probe necessarily returns
+/// an empty list even though the native picker has a catalog.
+async fn list_app_server_models(
+    binary: &Path,
+    env: &[(std::ffi::OsString, std::ffi::OsString)],
+) -> Vec<ListedHarnessModel> {
+    let mut command = Command::new(binary);
+    command
+        .args(["app-server", "--stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .env_clear();
+    for (key, value) in filter_child_env(env.iter().cloned()) {
+        command.env(key, value);
+    }
+    let Ok(mut child) = spawn_process_tree(&mut command) else {
+        return Vec::new();
+    };
+    let Some(mut stdin) = child.take_stdin() else {
+        return Vec::new();
+    };
+    let Some(stdout) = child.take_stdout() else {
+        return Vec::new();
+    };
+    let mut stdout = BufReader::new(stdout);
+
+    if write_rpc(
+        &mut stdin,
+        &json!({
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "clientInfo": { "name": "tidebreak-harness", "version": "0.0.0" },
+                "capabilities": { "experimentalApi": false }
+            }
+        }),
+    )
+    .await
+    .is_err()
+    {
+        return Vec::new();
+    }
+    if timeout(MODEL_LIST_TIMEOUT, read_rpc_result(&mut stdout, 1))
+        .await
+        .ok()
+        .flatten()
+        .is_none()
+    {
+        return Vec::new();
+    }
+    if write_rpc(&mut stdin, &json!({ "method": "initialized" }))
+        .await
+        .is_err()
+    {
+        return Vec::new();
+    }
+
+    let mut listed = Vec::new();
+    let mut cursor: Option<String> = None;
+    for page in 0..4_i64 {
+        let id = page + 2;
+        if write_rpc(
+            &mut stdin,
+            &json!({
+                "id": id,
+                "method": "model/list",
+                "params": {
+                    "cursor": cursor,
+                    "limit": 100,
+                    "includeHidden": false
+                }
+            }),
+        )
+        .await
+        .is_err()
+        {
+            break;
+        }
+        let Some(result) = timeout(MODEL_LIST_TIMEOUT, read_rpc_result(&mut stdout, id))
+            .await
+            .ok()
+            .flatten()
+        else {
+            break;
+        };
+        listed.extend(parse_model_list(&result));
+        cursor = result
+            .get("nextCursor")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        if cursor.is_none() {
+            break;
+        }
+    }
+    listed
+}
+
+async fn write_rpc(stdin: &mut tokio::process::ChildStdin, message: &Value) -> std::io::Result<()> {
+    let mut bytes = serde_json::to_vec(message).map_err(std::io::Error::other)?;
+    bytes.push(b'\n');
+    stdin.write_all(&bytes).await?;
+    stdin.flush().await
+}
+
+async fn read_rpc_result<R: AsyncBufRead + Unpin>(reader: &mut R, id: i64) -> Option<Value> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).await.ok()? == 0 {
+            return None;
+        }
+        let message: Value = serde_json::from_str(&line).ok()?;
+        if message.get("id").and_then(Value::as_i64) != Some(id) {
+            continue;
+        }
+        return message.get("result").cloned();
+    }
+}
+
+fn parse_model_list(result: &Value) -> Vec<ListedHarnessModel> {
+    result
+        .get("data")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|row| !row.get("hidden").and_then(Value::as_bool).unwrap_or(false))
+        .filter_map(|row| {
+            let id = row.get("model").or_else(|| row.get("id"))?.as_str()?.trim();
+            if id.is_empty() {
+                return None;
+            }
+            let label = row
+                .get("displayName")
+                .and_then(Value::as_str)
+                .filter(|label| !label.trim().is_empty())
+                .unwrap_or(id);
+            Some(ListedHarnessModel {
+                id: id.to_owned(),
+                label: label.to_owned(),
+                default: row
+                    .get("isDefault")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            })
+        })
+        .collect()
 }
 
 /// `codex login status` — "Logged in…" vs "Not logged in". Never reads tokens.
@@ -308,6 +471,36 @@ mod tests {
         assert_eq!(caps.slash_commands, CapLevel::Unknown);
         assert_eq!(caps.mid_turn_steering, CapLevel::Unknown);
         assert_eq!(caps.native_file_change_events, CapLevel::Unknown);
+    }
+
+    #[test]
+    fn native_model_catalog_uses_the_thread_start_token_and_hides_hidden_rows() {
+        let listed = parse_model_list(&json!({
+            "data": [
+                {
+                    "id": "catalog-row-1",
+                    "model": "gpt-5.6-luna",
+                    "displayName": "GPT-5.6-Luna",
+                    "hidden": false,
+                    "isDefault": true
+                },
+                {
+                    "id": "catalog-row-2",
+                    "model": "internal-model",
+                    "displayName": "Internal",
+                    "hidden": true,
+                    "isDefault": false
+                }
+            ]
+        }));
+        assert_eq!(
+            listed,
+            vec![ListedHarnessModel {
+                id: "gpt-5.6-luna".into(),
+                label: "GPT-5.6-Luna".into(),
+                default: true,
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Make the main agent history a real default center tab and add first-class tab creation, selection, closing, reordering, and persisted split-pane layout.
- Allow existing tabs to be dragged into adjacent pane groups, with keyboard and context-menu actions that follow the focused tab.
- Move the pull-request workflow into the workspace header and simplify the surrounding repository/status chrome.
- Tighten quick-open, panel navigation, session restoration, and workspace-action behavior so reopening a Code workspace feels immediate and stable.
- Expose Codex model discovery through the harness path used by Code mode and add focused coverage for the new workspace/session contracts.

## Why

Code mode still behaved like an experimental collection of panels: the main agent history was not presented as a durable tab, the center area could not be organized naturally, and important repository actions competed with low-value path/status chrome. This change establishes the core workspace model needed for a production-ready idea-to-PR flow.

## User impact

Opening a Code workspace now lands on a clear main-agent tab. Users can create and rearrange tabs, split the center area by dragging, recover the same layout after reopening, and reach the PR actions from the top bar. Existing panel routes and stored sessions continue to resolve through compatibility parsing.

## Compatibility and safety

- No database migration or wire-format change.
- Persisted Code chrome is additive and validated before restoration; invalid or obsolete state falls back to the default main-agent layout.
- Existing panel URLs remain accepted while new tab/group state is normalized at the workspace boundary.
- The harness change only improves Codex model discovery and does not change execution defaults or credentials.

## Risk

The primary risk is center-pane state synchronization across drag/drop, restoration, and session changes. The implementation keeps one normalized chrome state, scopes actions to the focused group, and adds DOM/unit coverage for the workspace, session store, registry, routing, quick-open, and chrome transitions.

## Validation

- Full Code mode UI suite: 36 files, 263 tests passed
- Focused Codex harness tests: 19 passed
- TypeScript typecheck passed
- Production desktop UI build passed
- `cargo fmt --all`
- `git diff --check`

CI is expected to run the complete workspace test matrix on the rebased `main` merge candidate.
