### PR TITLE
ci: fail Linux apt hangs instead of waiting out the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,9 +417,9 @@ jobs:
         with:
           version: v0.16.0
       - name: Install system deps (Tauri)
+        timeout-minutes: 8
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          scripts/install-linux-apt-packages.sh \
             cmake \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
@@ -471,9 +471,9 @@ jobs:
         with:
           version: v0.16.0
       - name: Install system deps (Tauri)
+        timeout-minutes: 8
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          scripts/install-linux-apt-packages.sh \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
@@ -635,9 +635,9 @@ jobs:
         with:
           version: v0.16.0
       - name: Install headless system deps
+        timeout-minutes: 8
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake mold
+          scripts/install-linux-apt-packages.sh cmake mold
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
         with:
           shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1558,9 +1558,9 @@ jobs:
           ref: ${{ needs.validate.outputs.sha }}
 
       - name: Install Linux packaging dependencies
+        timeout-minutes: 8
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          scripts/install-linux-apt-packages.sh \
             build-essential \
             cmake \
             file \

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -295,6 +295,12 @@ signs and collects only the completed package bytes. This avoids exposing a
 default-branch cache writer to code executed during a manually dispatched
 release.
 
+Hosted `ubuntu-22.04` runners pin apt at `azure.archive.ubuntu.com`, which can
+stall on `apt-get update` for most of the 90-minute job. The packaging step
+rewrites that mirror to `archive.ubuntu.com` (or `ports.ubuntu.com` on ARM),
+sets short apt timeouts, and fails the step in eight minutes if the public
+archive is also unreachable.
+
 The public download contract is rooted at:
 
 ```text

--- a/scripts/install-linux-apt-packages.sh
+++ b/scripts/install-linux-apt-packages.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Install Linux CI/release packages without stalling on a dead Azure mirror.
+#
+# Hosted ubuntu-22.04 runners pin apt to azure.archive.ubuntu.com. That mirror
+# regularly returns Ign: for InRelease and package payloads and can hang far
+# longer than a healthy archive.ubuntu.com fetch. Point apt at the public
+# Ubuntu archive first, then install with short timeouts and a few retries.
+set -euo pipefail
+
+if (($# == 0)); then
+  echo "usage: scripts/install-linux-apt-packages.sh PACKAGE [PACKAGE...]" >&2
+  exit 2
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+root="${TIDEBREAK_APT_ROOT:-}"
+if [[ -n "$root" ]]; then
+  sources_list="$root/etc/apt/sources.list"
+  sources_dir="$root/etc/apt/sources.list.d"
+  mirrors_file="$root/etc/apt/apt-mirrors.txt"
+  apt_conf_dir="$root/etc/apt/apt.conf.d"
+else
+  sources_list=/etc/apt/sources.list
+  sources_dir=/etc/apt/sources.list.d
+  mirrors_file=/etc/apt/apt-mirrors.txt
+  apt_conf_dir=/etc/apt/apt.conf.d
+fi
+
+if [[ -z "${TIDEBREAK_APT_DRY_RUN:-}" && "$(id -u)" -ne 0 ]]; then
+  sudo_prefix=(sudo)
+else
+  sudo_prefix=()
+fi
+
+run() {
+  if ((${#sudo_prefix[@]})); then
+    "${sudo_prefix[@]}" "$@"
+  else
+    "$@"
+  fi
+}
+
+if [[ -n "${TIDEBREAK_APT_CODENAME:-}" ]]; then
+  codename="$TIDEBREAK_APT_CODENAME"
+elif [[ -r /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  codename="$(. /etc/os-release && printf '%s\n' "$VERSION_CODENAME")"
+else
+  echo "unable to determine Ubuntu codename" >&2
+  exit 1
+fi
+
+if [[ -n "${TIDEBREAK_APT_ARCH:-}" ]]; then
+  arch="$TIDEBREAK_APT_ARCH"
+elif command -v dpkg >/dev/null; then
+  arch="$(dpkg --print-architecture)"
+else
+  echo "unable to determine dpkg architecture" >&2
+  exit 1
+fi
+
+case "$arch" in
+amd64)
+  archive_url="${TIDEBREAK_APT_ARCHIVE_URL:-http://archive.ubuntu.com/ubuntu}"
+  security_url="${TIDEBREAK_APT_SECURITY_URL:-http://security.ubuntu.com/ubuntu}"
+  ;;
+arm64)
+  archive_url="${TIDEBREAK_APT_ARCHIVE_URL:-http://ports.ubuntu.com/ubuntu-ports}"
+  security_url="${TIDEBREAK_APT_SECURITY_URL:-$archive_url}"
+  ;;
+*)
+  echo "unsupported apt architecture: $arch" >&2
+  exit 1
+  ;;
+esac
+
+rewrite_ubuntu_sources() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  run python3 -c '
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+archive_url = sys.argv[2]
+security_url = sys.argv[3]
+text = path.read_text()
+replacements = (
+    (r"https?://azure\.archive\.ubuntu\.com/ubuntu-ports", archive_url),
+    (r"https?://azure\.archive\.ubuntu\.com/ubuntu", archive_url),
+    (r"https?://security\.ubuntu\.com/ubuntu", security_url),
+)
+for pattern, replacement in replacements:
+    text = re.sub(pattern, replacement, text)
+path.write_text(text)
+' "$file" "$archive_url" "$security_url"
+}
+
+run mkdir -p "$(dirname "$sources_list")" "$sources_dir" "$apt_conf_dir"
+
+if [[ -f "$sources_list" ]]; then
+  rewrite_ubuntu_sources "$sources_list"
+else
+  cat <<SOURCES | run tee "$sources_list" >/dev/null
+deb $archive_url $codename main restricted universe multiverse
+deb $archive_url $codename-updates main restricted universe multiverse
+deb $archive_url $codename-backports main restricted universe multiverse
+deb $security_url $codename-security main restricted universe multiverse
+SOURCES
+fi
+
+shopt -s nullglob
+for file in "$sources_dir"/*.list "$sources_dir"/*.sources; do
+  rewrite_ubuntu_sources "$file"
+done
+shopt -u nullglob
+
+if [[ -e "$mirrors_file" || -n "$root" ]]; then
+  printf '%s\tpriority:1\n' "$archive_url" | run tee "$mirrors_file" >/dev/null
+fi
+
+cat <<CONF | run tee "$apt_conf_dir/99tidebreak-ci" >/dev/null
+Acquire::Retries "3";
+Acquire::http::Timeout "20";
+Acquire::https::Timeout "20";
+Acquire::ftp::Timeout "20";
+CONF
+
+apt_opts=(
+  -o Acquire::Retries=3
+  -o Acquire::http::Timeout=20
+  -o Acquire::https::Timeout=20
+  -o Dpkg::Use-Pty=0
+)
+
+if [[ -n "${TIDEBREAK_APT_DRY_RUN:-}" ]]; then
+  printf 'would run: apt-get %s update\n' "${apt_opts[*]}"
+  printf 'would run: apt-get %s install -y --no-install-recommends' "${apt_opts[*]}"
+  printf ' %s' "$@"
+  printf '\n'
+  exit 0
+fi
+
+run apt-get "${apt_opts[@]}" update
+run apt-get "${apt_opts[@]}" install -y --no-install-recommends "$@"

--- a/scripts/install-linux-apt-packages.test.mjs
+++ b/scripts/install-linux-apt-packages.test.mjs
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "install-linux-apt-packages.sh",
+);
+
+function runFixture({
+  arch,
+  sources = "",
+  extraLists = {},
+  mirrors = null,
+  extraEnv = {},
+  args = ["libwebkit2gtk-4.1-dev"],
+} = {}) {
+  const root = mkdtempSync(join(tmpdir(), "tidebreak-apt-"));
+  try {
+    mkdirSync(join(root, "etc/apt/sources.list.d"), { recursive: true });
+    mkdirSync(join(root, "etc/apt/apt.conf.d"), { recursive: true });
+    if (sources !== null) {
+      writeFileSync(join(root, "etc/apt/sources.list"), sources);
+    }
+    for (const [name, contents] of Object.entries(extraLists)) {
+      writeFileSync(join(root, "etc/apt/sources.list.d", name), contents);
+    }
+    if (mirrors !== null) {
+      writeFileSync(join(root, "etc/apt/apt-mirrors.txt"), mirrors);
+    }
+
+    const result = spawnSync(script, args, {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        TIDEBREAK_APT_ROOT: root,
+        TIDEBREAK_APT_ARCH: arch,
+        TIDEBREAK_APT_CODENAME: "jammy",
+        TIDEBREAK_APT_DRY_RUN: "1",
+        ...extraEnv,
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+
+    const read = (relative) => {
+      try {
+        return readFileSync(join(root, relative), "utf8");
+      } catch {
+        return null;
+      }
+    };
+    return {
+      stdout: result.stdout,
+      sources: read("etc/apt/sources.list"),
+      extraLists: Object.fromEntries(
+        Object.keys(extraLists).map((name) => [
+          name,
+          read(`etc/apt/sources.list.d/${name}`),
+        ]),
+      ),
+      mirrors: read("etc/apt/apt-mirrors.txt"),
+      conf: read("etc/apt/apt.conf.d/99tidebreak-ci"),
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("rewrites the Azure Ubuntu mirror to archive.ubuntu.com on amd64", () => {
+  const result = runFixture({
+    arch: "amd64",
+    sources: [
+      "deb http://azure.archive.ubuntu.com/ubuntu jammy main restricted",
+      "deb http://azure.archive.ubuntu.com/ubuntu jammy-updates main restricted",
+      "deb http://azure.archive.ubuntu.com/ubuntu jammy-backports main restricted",
+      "deb http://azure.archive.ubuntu.com/ubuntu jammy-security main restricted",
+      "",
+    ].join("\n"),
+    extraLists: {
+      "ubuntu.sources":
+        "URIs: http://azure.archive.ubuntu.com/ubuntu\nSuites: jammy jammy-updates jammy-backports\n",
+    },
+    mirrors: "http://azure.archive.ubuntu.com/ubuntu\tpriority:1\n",
+  });
+
+  assert.match(result.sources, /deb http:\/\/archive\.ubuntu\.com\/ubuntu jammy main/);
+  assert.doesNotMatch(result.sources, /azure\.archive\.ubuntu\.com/);
+  assert.match(
+    result.extraLists["ubuntu.sources"],
+    /URIs: http:\/\/archive\.ubuntu\.com\/ubuntu/,
+  );
+  assert.equal(
+    result.mirrors,
+    "http://archive.ubuntu.com/ubuntu\tpriority:1\n",
+  );
+  assert.match(result.conf, /Acquire::Retries "3";/);
+  assert.match(result.conf, /Acquire::http::Timeout "20";/);
+  assert.match(
+    result.stdout,
+    /would run: apt-get .*Acquire::http::Timeout=20.* update/,
+  );
+  assert.match(
+    result.stdout,
+    /install -y --no-install-recommends libwebkit2gtk-4\.1-dev/,
+  );
+});
+
+test("rewrites ARM runners to ports.ubuntu.com", () => {
+  const result = runFixture({
+    arch: "arm64",
+    sources: "deb http://azure.archive.ubuntu.com/ubuntu jammy main\n",
+    extraLists: {
+      "ubuntu.list": "deb http://azure.archive.ubuntu.com/ubuntu-ports jammy main\n",
+    },
+  });
+
+  assert.match(result.sources, /deb http:\/\/ports\.ubuntu\.com\/ubuntu-ports jammy main/);
+  assert.match(
+    result.extraLists["ubuntu.list"],
+    /deb http:\/\/ports\.ubuntu\.com\/ubuntu-ports jammy main/,
+  );
+  assert.equal(
+    result.mirrors,
+    "http://ports.ubuntu.com/ubuntu-ports\tpriority:1\n",
+  );
+});
+
+test("writes a public archive sources.list when none exists", () => {
+  const result = runFixture({
+    arch: "amd64",
+    sources: null,
+  });
+
+  assert.equal(
+    result.sources,
+    [
+      "deb http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse",
+      "deb http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse",
+      "deb http://archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse",
+      "deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("rejects an empty package list", () => {
+  const result = spawnSync(script, [], { encoding: "utf8" });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /usage: scripts\/install-linux-apt-packages\.sh/);
+});
+
+test("the helper is executable", () => {
+  chmodSync(script, 0o755);
+  const result = spawnSync("test", ["-x", script]);
+  assert.equal(result.status, 0);
+});

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -449,6 +449,22 @@ test("PR lanes are scope-gated, never label-gated", () => {
     desktop,
     /cargo test -p tidebreak-desktop --locked/,
   );
+  for (const [name, step] of [
+    ["lint", "Install system deps (Tauri)"],
+    ["desktop", "Install system deps (Tauri)"],
+    ["test", "Install headless system deps"],
+  ]) {
+    const job = workflowJob(ci, name);
+    const deps = job.match(
+      new RegExp(
+        `- name: ${step.replace(/[()]/g, "\\$&")}[\\s\\S]*?(?=\\n\\s+- (?:name:|uses:))`,
+      ),
+    )?.[0];
+    assert.ok(deps, `missing ${name} apt step`);
+    assert.match(deps, /timeout-minutes: 8/);
+    assert.match(deps, /scripts\/install-linux-apt-packages\.sh/);
+    assert.doesNotMatch(deps, /sudo apt-get update/);
+  }
   assert.match(
     desktopCargo,
     /tidebreak-server = \{ path = "\.\.\/tidebreak-server" \}/,
@@ -1612,6 +1628,17 @@ test("Linux packaging writes no shared cache before loading updater material", (
     /xdg-utils/,
     "AppImage packaging must install the xdg-mime provider on every runner",
   );
+  assert.match(
+    buildJob,
+    /scripts\/install-linux-apt-packages\.sh/,
+    "Linux packaging must pin apt to a public Ubuntu archive instead of a hanging Azure mirror",
+  );
+  const linuxDeps = buildJob.match(
+    /- name: Install Linux packaging dependencies[\s\S]*?(?=\n\s+- (?:name:|uses:))/,
+  )?.[0];
+  assert.ok(linuxDeps, "missing Linux packaging dependency step");
+  assert.match(linuxDeps, /timeout-minutes: 8/);
+  assert.doesNotMatch(linuxDeps, /sudo apt-get update/);
   assert.match(buildJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
   assert.match(buildJob, /version: 10\.18\.3/);
   assert.match(buildJob, /pnpm install --frozen-lockfile --ignore-scripts/);

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -455,9 +455,10 @@ test("PR lanes are scope-gated, never label-gated", () => {
     ["test", "Install headless system deps"],
   ]) {
     const job = workflowJob(ci, name);
+    const escapedStep = step.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const deps = job.match(
       new RegExp(
-        `- name: ${step.replace(/[()]/g, "\\$&")}[\\s\\S]*?(?=\\n\\s+- (?:name:|uses:))`,
+        `- name: ${escapedStep}[\\s\\S]*?(?=\\n\\s+- (?:name:|uses:))`,
       ),
     )?.[0];
     assert.ok(deps, `missing ${name} apt step`);


### PR DESCRIPTION
## What changed

Linux release and CI jobs no longer call bare `apt-get update` against the hosted runner's Azure Ubuntu mirror. They now run `scripts/install-linux-apt-packages.sh`, which rewrites `azure.archive.ubuntu.com` to `archive.ubuntu.com` on x86_64 and `ports.ubuntu.com` on ARM, sets 20s apt timeouts with three retries, and is bounded by an 8-minute step timeout.

v0.54.0's Linux x86_64 job sat on **Install Linux packaging dependencies** for ~58 minutes until it was cancelled. Linux aarch64 in the same run finished that step in 34 seconds. v0.53.0 already needed the public-archive fallback after a wave of Azure `Ign:` lines; this just makes that the first path and fails fast if the public archive is also unreachable.

## Validation

- `node --test scripts/install-linux-apt-packages.test.mjs`
- `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs`
- `bash -n scripts/install-linux-apt-packages.sh`

Did not rerun the production release workflow from this branch. The next Linux x86_64 package install is the live proof.

## Compatibility and risk

No product or wire-format change. The helper still installs the same packages. If both Azure and the public Ubuntu archive are down, the step now fails in 8 minutes instead of burning the 90-minute job timeout.

## Tracking

Follow-up to the stuck v0.54.0 job: https://github.com/brightwave-inc/tidebreak/actions/runs/32277870160/job/96149615899
