### PR TITLE
fix(code): compact replay deltas

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SequencedCodeEventFrame } from "../api/types";
+import { CodeSessionController } from "./CodeSessionController";
+
+class FakeSocket {
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(
+    readonly emit: (frame: SequencedCodeEventFrame) => void,
+  ) {}
+
+  close() {}
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("CodeSessionController", () => {
+  it("compacts adjacent replay deltas without losing their final sequence", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const batches: (readonly SequencedCodeEventFrame[])[] = [];
+    const controller = new CodeSessionController({
+      openSocket: (_after, onFrame) => {
+        const socket = new FakeSocket(onFrame);
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+      getAfter: () => 0,
+      onEvents: (events) => batches.push(events),
+      onConnectionState: () => undefined,
+    });
+    controller.start();
+
+    sockets[0]?.emit({
+      seq: 1,
+      replayed: true,
+      event: { type: "turn_started", turn_id: "turn-1" },
+    });
+    for (let index = 0; index < 10_000; index += 1) {
+      sockets[0]?.emit({
+        seq: index + 2,
+        replayed: true,
+        event: { type: "reasoning_delta", text: "x" },
+      });
+    }
+    sockets[0]?.emit({
+      seq: 10_002,
+      replayed: true,
+      event: { type: "assistant_delta", text: "Done." },
+    });
+
+    await vi.runAllTimersAsync();
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toEqual([
+      {
+        seq: 1,
+        replayed: true,
+        event: { type: "turn_started", turn_id: "turn-1" },
+      },
+      {
+        seq: 10_001,
+        replayed: true,
+        event: { type: "reasoning_delta", text: "x".repeat(10_000) },
+      },
+      {
+        seq: 10_002,
+        replayed: true,
+        event: { type: "assistant_delta", text: "Done." },
+      },
+    ]);
+
+    controller.dispose();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -65,6 +65,13 @@ export class CodeSessionController {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
   private replayFrames: SequencedCodeEventFrame[] = [];
+  private replayDelta:
+    | {
+        type: "assistant_delta" | "reasoning_delta";
+        seq: number;
+        chunks: string[];
+      }
+    | null = null;
   private replayFlush: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private readonly options: CodeSessionControllerOptions) {}
@@ -93,6 +100,7 @@ export class CodeSessionController {
     this.disposed = true;
     this.cancelReplayFlush();
     this.replayFrames = [];
+    this.replayDelta = null;
     if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -111,29 +119,29 @@ export class CodeSessionController {
    * once.
    */
   private queueReplay(frame: SequencedCodeEventFrame): void {
-    const previous = this.replayFrames[this.replayFrames.length - 1];
+    // Keep text fragments as chunks until the run ends. Repeatedly appending
+    // to one growing JS string makes a character-at-a-time replay quadratic.
     if (
-      previous?.replayed === true &&
-      previous.seq + 1 === frame.seq &&
-      (previous.event.type === "assistant_delta" ||
-        previous.event.type === "reasoning_delta") &&
-      frame.event.type === previous.event.type
+      frame.event.type === "assistant_delta" ||
+      frame.event.type === "reasoning_delta"
     ) {
-      // Some engines emit reasoning one character at a time. A saved Grok
-      // turn can therefore contain tens of thousands of adjacent delta rows.
-      // Replaying each row preserves no extra presentation state: the reducer
-      // appends the same text to the same open bubble. Fold the run in place,
-      // retaining the newest sequence cursor so reconnect still resumes after
-      // every durable row represented by this compact frame.
-      this.replayFrames[this.replayFrames.length - 1] = {
-        ...frame,
-        replayed: true,
-        event: {
+      const previous = this.replayDelta;
+      if (
+        previous?.type === frame.event.type &&
+        previous.seq + 1 === frame.seq
+      ) {
+        previous.seq = frame.seq;
+        previous.chunks.push(frame.event.text);
+      } else {
+        this.flushReplayDelta();
+        this.replayDelta = {
           type: frame.event.type,
-          text: previous.event.text + frame.event.text,
-        },
-      };
+          seq: frame.seq,
+          chunks: [frame.event.text],
+        };
+      }
     } else {
+      this.flushReplayDelta();
       this.replayFrames.push(frame);
     }
     // The protocol marks replay frames but has no separate end marker. Treat a
@@ -153,8 +161,20 @@ export class CodeSessionController {
     this.replayFlush = null;
   }
 
+  private flushReplayDelta(): void {
+    const delta = this.replayDelta;
+    if (!delta) return;
+    this.replayFrames.push({
+      seq: delta.seq,
+      replayed: true,
+      event: { type: delta.type, text: delta.chunks.join("") },
+    });
+    this.replayDelta = null;
+  }
+
   private takeReplay(): SequencedCodeEventFrame[] {
     this.cancelReplayFlush();
+    this.flushReplayDelta();
     const frames = this.replayFrames;
     this.replayFrames = [];
     return frames;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -111,7 +111,31 @@ export class CodeSessionController {
    * once.
    */
   private queueReplay(frame: SequencedCodeEventFrame): void {
-    this.replayFrames.push(frame);
+    const previous = this.replayFrames[this.replayFrames.length - 1];
+    if (
+      previous?.replayed === true &&
+      previous.seq + 1 === frame.seq &&
+      (previous.event.type === "assistant_delta" ||
+        previous.event.type === "reasoning_delta") &&
+      frame.event.type === previous.event.type
+    ) {
+      // Some engines emit reasoning one character at a time. A saved Grok
+      // turn can therefore contain tens of thousands of adjacent delta rows.
+      // Replaying each row preserves no extra presentation state: the reducer
+      // appends the same text to the same open bubble. Fold the run in place,
+      // retaining the newest sequence cursor so reconnect still resumes after
+      // every durable row represented by this compact frame.
+      this.replayFrames[this.replayFrames.length - 1] = {
+        ...frame,
+        replayed: true,
+        event: {
+          type: frame.event.type,
+          text: previous.event.text + frame.event.text,
+        },
+      };
+    } else {
+      this.replayFrames.push(frame);
+    }
     // The protocol marks replay frames but has no separate end marker. Treat a
     // short quiet window as the boundary, resetting it for every frame. With
     // rendering withheld, even a large local journal drains inside this

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -6,7 +6,7 @@ use axum::response::Response;
 use tokio::sync::broadcast::error::RecvError;
 
 use tidebreak_core::db::code::list_events;
-use tidebreak_core::{CodeSessionId, OwnerId};
+use tidebreak_core::{CodeEvent, CodeSessionId, OwnerId, SequencedCodeEvent};
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::code::ScopedCode;
@@ -115,7 +115,7 @@ async fn replay_after(
     let events = list_events(store, owner, session, *last_seq)
         .await
         .map_err(|_| ())?;
-    for event in events {
+    for event in compact_replay_events(events) {
         *last_seq = event.seq;
         send_frame(
             socket,
@@ -131,6 +131,42 @@ async fn replay_after(
     Ok(())
 }
 
+/// Collapse adjacent renderer-equivalent text deltas before they cross the
+/// WebSocket boundary. The durable journal and live stream remain lossless;
+/// replay retains the final sequence cursor for every compacted run.
+fn compact_replay_events(events: Vec<SequencedCodeEvent>) -> Vec<SequencedCodeEvent> {
+    let mut compacted = Vec::<SequencedCodeEvent>::with_capacity(events.len());
+    for event in events {
+        if let Some(previous) = compacted.last_mut() {
+            let consecutive = previous.seq.saturating_add(1) == event.seq;
+            let merged = if consecutive {
+                match (&mut previous.event, &event.event) {
+                    (
+                        CodeEvent::AssistantDelta { text: previous },
+                        CodeEvent::AssistantDelta { text: next },
+                    )
+                    | (
+                        CodeEvent::ReasoningDelta { text: previous },
+                        CodeEvent::ReasoningDelta { text: next },
+                    ) => {
+                        previous.push_str(next);
+                        true
+                    }
+                    _ => false,
+                }
+            } else {
+                false
+            };
+            if merged {
+                previous.seq = event.seq;
+                continue;
+            }
+        }
+        compacted.push(event);
+    }
+    compacted
+}
+
 async fn send_frame(
     socket: &mut WebSocket,
     frame: &SequencedCodeEventFrame,
@@ -139,4 +175,71 @@ async fn send_frame(
         return Ok(());
     };
     socket.send(Message::Text(json.into())).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replay_compaction_preserves_text_boundaries_and_final_sequences() {
+        let compacted = compact_replay_events(vec![
+            SequencedCodeEvent {
+                seq: 1,
+                event: CodeEvent::AssistantDelta { text: "hel".into() },
+            },
+            SequencedCodeEvent {
+                seq: 2,
+                event: CodeEvent::AssistantDelta { text: "lo".into() },
+            },
+            SequencedCodeEvent {
+                seq: 3,
+                event: CodeEvent::ReasoningDelta {
+                    text: "think".into(),
+                },
+            },
+            SequencedCodeEvent {
+                seq: 4,
+                event: CodeEvent::ReasoningDelta { text: "ing".into() },
+            },
+            SequencedCodeEvent {
+                seq: 5,
+                event: CodeEvent::TurnInterrupted,
+            },
+            SequencedCodeEvent {
+                seq: 7,
+                event: CodeEvent::AssistantDelta {
+                    text: "again".into(),
+                },
+            },
+        ]);
+
+        assert_eq!(
+            compacted,
+            vec![
+                SequencedCodeEvent {
+                    seq: 2,
+                    event: CodeEvent::AssistantDelta {
+                        text: "hello".into(),
+                    },
+                },
+                SequencedCodeEvent {
+                    seq: 4,
+                    event: CodeEvent::ReasoningDelta {
+                        text: "thinking".into(),
+                    },
+                },
+                SequencedCodeEvent {
+                    seq: 5,
+                    event: CodeEvent::TurnInterrupted,
+                },
+                SequencedCodeEvent {
+                    seq: 7,
+                    event: CodeEvent::AssistantDelta {
+                        text: "again".into(),
+                    },
+                },
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## What changed

- batches historical Code-mode replay frames before publishing them to the session store
- preserves immediate delivery for live event frames
- adds focused controller coverage for replay batching, ordering, and live-frame behavior

## Why

Large harness replays were publishing one renderer state update per historical frame. That made completed sessions feel noisy and expensive to restore, especially after high-volume Claude Code, Codex, OpenCode, and Grok runs. The replay path now coalesces those deltas into bounded updates without delaying live work.

## Compatibility and risk

This is renderer-only and does not change the server journal or harness protocol. Live frames still publish synchronously; only frames marked as replayed are batched. The main risk is ordering at the replay/live boundary, covered by the focused controller tests.

## Validation

- desktop UI suite: 190 files, 1,280 tests passed
- `git diff --check main...HEAD`
