### PR TITLE
perf(code): cache quick-open file lists

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.dom.test.tsx
@@ -85,4 +85,94 @@ describe("CodeQuickOpen", () => {
     ).toHaveFocus();
     expect(client.listCodeWorkspaceTree).toHaveBeenCalledTimes(1);
   });
+
+  it("reuses the file list until the worktree revision changes", async () => {
+    const user = userEvent.setup();
+    const client = {
+      listCodeWorkspaceTree: vi.fn(async () => ({
+        paths: ["src/main.rs"],
+        truncated: false,
+      })),
+    };
+    const { rerender } = render(
+      <CodeQuickOpen
+        client={client}
+        workspaceId="ws-1"
+        contentRevision={0}
+        onOpenFile={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    expect(
+      await screen.findByRole("button", { name: "src/main.rs" }),
+    ).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+
+    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    expect(
+      await screen.findByRole("button", { name: "src/main.rs" }),
+    ).toBeInTheDocument();
+    expect(client.listCodeWorkspaceTree).toHaveBeenCalledTimes(1);
+    await user.keyboard("{Escape}");
+
+    rerender(
+      <CodeQuickOpen
+        client={client}
+        workspaceId="ws-1"
+        contentRevision={1}
+        onOpenFile={vi.fn()}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    await waitFor(() =>
+      expect(client.listCodeWorkspaceTree).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("drops filenames when the workspace changes", async () => {
+    let resolveSecond:
+      | ((value: { paths: string[]; truncated: boolean }) => void)
+      | undefined;
+    const client = {
+      listCodeWorkspaceTree: vi
+        .fn()
+        .mockResolvedValueOnce({ paths: ["old.ts"], truncated: false })
+        .mockImplementationOnce(
+          () =>
+            new Promise<{ paths: string[]; truncated: boolean }>((resolve) => {
+              resolveSecond = resolve;
+            }),
+        ),
+    };
+    const { rerender } = render(
+      <CodeQuickOpen
+        client={client}
+        workspaceId="ws-1"
+        contentRevision={0}
+        onOpenFile={vi.fn()}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    expect(
+      await screen.findByRole("button", { name: "old.ts" }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <CodeQuickOpen
+        client={client}
+        workspaceId="ws-2"
+        contentRevision={0}
+        onOpenFile={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    expect(screen.queryByRole("button", { name: "old.ts" })).not.toBeInTheDocument();
+    resolveSecond?.({ paths: ["new.ts"], truncated: false });
+    expect(
+      await screen.findByRole("button", { name: "new.ts" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
@@ -32,18 +32,22 @@ export function CodeQuickOpen({
   openRequest?: number;
 }) {
   const [open, setOpen] = useState(false);
+  const [openWorkspaceId, setOpenWorkspaceId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [paths, setPaths] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const loadedKeyRef = useRef<string | null>(null);
+  const treeKey = `${workspaceId}:${contentRevision}`;
 
   const reveal = useCallback(() => {
     setQuery("");
     setActiveIndex(0);
+    setOpenWorkspaceId(workspaceId);
     setOpen(true);
-  }, []);
+  }, [workspaceId]);
 
   useEffect(() => {
     function onQuickOpen(event: KeyboardEvent) {
@@ -61,7 +65,24 @@ export function CodeQuickOpen({
   }, [openRequest, reveal]);
 
   useEffect(() => {
-    if (!open) return;
+    loadedKeyRef.current = null;
+    setPaths([]);
+    setLoading(false);
+    setError(null);
+    setQuery("");
+    setActiveIndex(0);
+    setOpenWorkspaceId(null);
+    setOpen(false);
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (
+      !open ||
+      openWorkspaceId !== workspaceId ||
+      loadedKeyRef.current === treeKey
+    ) {
+      return;
+    }
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -70,6 +91,7 @@ export function CodeQuickOpen({
       .then((tree) => {
         if (cancelled) return;
         setPaths(tree.paths);
+        loadedKeyRef.current = treeKey;
         setLoading(false);
       })
       .catch((caught) => {
@@ -80,7 +102,7 @@ export function CodeQuickOpen({
     return () => {
       cancelled = true;
     };
-  }, [client, workspaceId, open, contentRevision]);
+  }, [client, workspaceId, open, openWorkspaceId, treeKey]);
 
   const results = useMemo(
     () => rankQuickOpenPaths(paths, query).slice(0, VISIBLE_RESULTS),
@@ -98,7 +120,13 @@ export function CodeQuickOpen({
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setOpenWorkspaceId(null);
+      }}
+    >
       <DialogContent
         withCloseButton={false}
         className="top-1/2 max-w-2xl gap-0 overflow-hidden rounded-xl p-0 shadow-2xl"


### PR DESCRIPTION
## What changed

- cache the workspace filename list across repeated quick-open invocations
- invalidate the cache when the worktree content revision changes
- clear stale results and close the picker when switching workspaces
- cover cache reuse, revision invalidation, and workspace transitions

## Why

Opening Cmd/Ctrl+P repeatedly should be instant and should not issue the same large workspace-tree request every time. The picker also must never show filenames from the previously selected workspace.

## Compatibility and risk

This is a UI-only behavior change with no API or persisted-data changes. Cache invalidation continues to use the existing content revision, and workspace changes explicitly discard all cached state.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeQuickOpen.dom.test.tsx` — 5 passed
- `git diff --check`