### PR TITLE
fix(code): reveal restored transcripts atomically

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
@@ -19,6 +19,88 @@ afterEach(() => {
 });
 
 describe("CodeSessionController", () => {
+  it("reveals an empty transcript after the initial socket stays quiet", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const batches: Array<{
+      events: readonly SequencedCodeEventFrame[];
+      settled: boolean;
+    }> = [];
+    const controller = new CodeSessionController({
+      openSocket: (_after, onFrame) => {
+        const socket = new FakeSocket(onFrame);
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+      getAfter: () => 0,
+      onEvents: (events, settled) => batches.push({ events, settled }),
+      onConnectionState: () => undefined,
+    });
+    controller.start();
+
+    sockets[0]?.onopen?.();
+    expect(batches).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(39);
+    expect(batches).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(batches).toEqual([{ events: [], settled: true }]);
+
+    controller.dispose();
+  });
+
+  it("reveals replay as one settled view after the replay burst", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const batches: Array<{
+      events: readonly SequencedCodeEventFrame[];
+      settled: boolean;
+    }> = [];
+    const controller = new CodeSessionController({
+      openSocket: (_after, onFrame) => {
+        const socket = new FakeSocket(onFrame);
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+      getAfter: () => 0,
+      onEvents: (events, settled) => batches.push({ events, settled }),
+      onConnectionState: () => undefined,
+    });
+    controller.start();
+    sockets[0]?.onopen?.();
+    sockets[0]?.emit({
+      seq: 1,
+      replayed: true,
+      event: { type: "assistant_delta", text: "History" },
+    });
+
+    expect(batches).toHaveLength(0);
+    await vi.runAllTimersAsync();
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.settled).toBe(true);
+    expect(batches[0]?.events).toHaveLength(1);
+
+    controller.dispose();
+  });
+
+  it("reveals the durable snapshot while reconnecting after an initial failure", () => {
+    const batches: Array<{
+      events: readonly SequencedCodeEventFrame[];
+      settled: boolean;
+    }> = [];
+    const controller = new CodeSessionController({
+      openSocket: () => {
+        throw new Error("offline");
+      },
+      getAfter: () => 0,
+      onEvents: (events, settled) => batches.push({ events, settled }),
+      onConnectionState: () => undefined,
+    });
+    controller.start();
+
+    expect(batches).toEqual([{ events: [], settled: true }]);
+    controller.dispose();
+  });
+
   it("compacts adjacent replay deltas without losing their final sequence", async () => {
     vi.useFakeTimers();
     const sockets: FakeSocket[] = [];

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -23,9 +23,14 @@ export type CodeSessionControllerOptions = {
   getAfter: () => number;
   /**
    * Deliver an ordered journal chunk. Replayed history is coalesced to one
-   * browser paint; live frames still arrive immediately.
+   * browser paint; live frames still arrive immediately. The boolean is true
+   * on the one delivery that should also reveal the initial transcript, so
+   * consumers can publish history and hydration in one state update.
    */
-  onEvents: (events: readonly SequencedCodeEventFrame[]) => void;
+  onEvents: (
+    events: readonly SequencedCodeEventFrame[],
+    initialViewSettled: boolean,
+  ) => void;
   onConnectionState: (state: CodeConnectionState) => void;
   /**
    * Snapshot of durable turns, applied once before the first socket opens so
@@ -33,12 +38,6 @@ export type CodeSessionControllerOptions = {
    */
   hydrateTurns?: () => Promise<CodeTurnSnapshot[]>;
   onHydrate?: (turns: CodeTurnSnapshot[]) => void;
-  /**
-   * The snapshot settled, whether it arrived or failed. The transcript hangs
-   * its skeleton on this rather than on `onHydrate`, so a session whose history
-   * could not be read still reaches a state the reader can send from.
-   */
-  onHydrateSettled?: () => void;
 };
 
 /**
@@ -73,6 +72,7 @@ export class CodeSessionController {
       }
     | null = null;
   private replayFlush: ReturnType<typeof setTimeout> | null = null;
+  private initialViewSettled = false;
 
   constructor(private readonly options: CodeSessionControllerOptions) {}
 
@@ -91,7 +91,6 @@ export class CodeSessionController {
         if (this.disposed) return;
       }
     }
-    this.options.onHydrateSettled?.();
     this.connect();
   }
 
@@ -182,11 +181,24 @@ export class CodeSessionController {
 
   private flushReplay(): void {
     const frames = this.takeReplay();
-    if (!this.disposed && frames.length > 0) this.options.onEvents(frames);
+    const settled = this.settleInitialView();
+    if (!this.disposed && (frames.length > 0 || settled)) {
+      this.options.onEvents(frames, settled);
+    }
+  }
+
+  private settleInitialView(): boolean {
+    if (this.disposed || this.initialViewSettled) return false;
+    this.initialViewSettled = true;
+    return true;
   }
 
   private scheduleReconnect(): void {
     if (this.disposed || this.reconnectTimer !== null) return;
+    // A failed initial socket must not strand the reader behind a skeleton.
+    // Publish any replay already received, then expose the durable snapshot
+    // while the normal reconnect loop keeps trying in the background.
+    this.flushReplay();
     this.options.onConnectionState("reconnecting");
     const delay = this.reconnectDelayMs;
     this.reconnectDelayMs = nextReconnectDelay(this.reconnectDelayMs);
@@ -211,7 +223,7 @@ export class CodeSessionController {
           return;
         }
         const replay = this.takeReplay();
-        this.options.onEvents([...replay, frame]);
+        this.options.onEvents([...replay, frame], this.settleInitialView());
       });
     } catch {
       this.scheduleReconnect();
@@ -223,6 +235,15 @@ export class CodeSessionController {
       if (this.disposed || this.socket !== socket) return;
       this.reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
       this.options.onConnectionState("live");
+      // The protocol has no explicit replay-complete frame. If this session
+      // has no journal rows, the same quiet window used for a replay burst is
+      // the only boundary needed before revealing the transcript.
+      if (!this.initialViewSettled && this.replayFlush === null) {
+        this.replayFlush = setTimeout(() => {
+          this.replayFlush = null;
+          this.flushReplay();
+        }, CODE_REPLAY_SETTLE_MS);
+      }
     };
     socket.onerror = () => {
       if (this.disposed || this.socket !== socket) return;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -183,11 +183,11 @@ export function fileActivityItemId(turnId: string | null): string {
 }
 
 /**
- * The durable snapshot has settled, whether it arrived or failed.
+ * The durable snapshot and initial journal replay have settled.
  *
- * The skeleton comes down either way: a snapshot that could not be read leaves
- * an empty transcript the reader can send into, not a placeholder that never
- * resolves.
+ * The skeleton comes down even if either source was empty or unavailable: the
+ * reader still reaches a transcript they can send into, but never watches a
+ * historical turn rebuild itself over several paints.
  */
 export function markCodeSessionHydrated(
   state: CodeSessionState,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -29,10 +29,16 @@ afterEach(() => {
 
 describe("CodeSessionRegistry", () => {
   it("marks the session hydrated even when the snapshot cannot be read", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
     const openSocket = (
       after: number,
       onFrame: (frame: SequencedCodeEventFrame) => void,
-    ) => new FakeSocket(after, onFrame) as unknown as WebSocket;
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
 
     const store = acquireCodeSession("s1", openSocket, undefined, async () => {
       throw new Error("offline");
@@ -41,8 +47,12 @@ describe("CodeSessionRegistry", () => {
 
     await Promise.resolve();
     await Promise.resolve();
-    // The skeleton has to come down either way: a snapshot that never arrives
-    // must leave a transcript the reader can send into.
+    expect(store.getState().hydrated).toBe(false);
+    sockets[0]?.onopen?.();
+    await vi.runAllTimersAsync();
+    // The skeleton has to come down either way once the initial journal is
+    // quiet: a snapshot that never arrives must still leave a transcript the
+    // reader can send into.
     expect(store.getState().hydrated).toBe(true);
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -8,7 +8,6 @@ import {
 import {
   applyAcceptedTurn,
   hydrateCodeTurns,
-  markCodeSessionHydrated,
   type CodeSessionDeps,
 } from "./CodeSessionReducer";
 
@@ -79,12 +78,14 @@ export function acquireCodeSession(
   const controller = new CodeSessionController({
     openSocket,
     getAfter: () => store.getState().lastSeq,
-    onEvents: (frames) => {
+    onEvents: (frames, initialViewSettled) => {
       // A turn the socket announces has no prompt bubble yet: submit answers
       // only when the turn ends, and a queued follow-up is never answered
       // with a turn at all. Pull the snapshot so the transcript shows what
       // the engine is working on while it works.
-      for (const effect of store.getState().applyEvents(frames, deps)) {
+      for (const effect of store
+        .getState()
+        .applyEvents(frames, deps, initialViewSettled)) {
         if (effect.type === "turn_began") fillPrompt(effect.turnId);
       }
     },
@@ -94,9 +95,6 @@ export function acquireCodeSession(
     hydrateTurns,
     onHydrate: (turns) => {
       store.getState().update((session) => hydrateCodeTurns(session, turns));
-    },
-    onHydrateSettled: () => {
-      store.getState().update(markCodeSessionHydrated);
     },
   });
   registry.set(sessionId, { store, controller, refCount: 1 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
@@ -3,6 +3,7 @@ import type { SequencedCodeEventFrame } from "../api/types";
 import type { CodeConnectionState } from "./CodeSessionController";
 import {
   initialCodeSessionState,
+  markCodeSessionHydrated,
   reduceCodeSessionEvent,
   type CodeSessionDeps,
   type CodeSessionEffect,
@@ -39,10 +40,12 @@ export type CodeSessionStore = CodeSessionState & {
    * A reopened session can contain hundreds of journal frames. Publishing
    * every frame separately forces React's external-store subscribers to
    * synchronously re-render the whole transcript for every historical token.
+   * `settleInitialView` lowers the hydration skeleton in that same update.
    */
   applyEvents: (
     framed: readonly SequencedCodeEventFrame[],
     deps: CodeSessionDeps,
+    settleInitialView?: boolean,
   ) => CodeSessionEffect[];
   update: (change: (session: CodeSessionState) => CodeSessionState) => void;
   reset: () => void;
@@ -53,6 +56,7 @@ export function createCodeSessionStore() {
     const applyEvents = (
       framed: readonly SequencedCodeEventFrame[],
       deps: CodeSessionDeps,
+      settleInitialView = false,
     ): CodeSessionEffect[] => {
       const current = sessionOf(get());
       let state = current;
@@ -62,6 +66,7 @@ export function createCodeSessionStore() {
         state = transition.state;
         effects.push(...transition.effects);
       }
+      if (settleInitialView) state = markCodeSessionHydrated(state);
 
       // The reducer returns its input for duplicate/stale frames. Do not turn
       // that no-op into a fresh Zustand snapshot and wake every subscriber.

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -240,16 +240,15 @@ describe("CodeTranscript", () => {
 
   it("holds the transcript's shape until the session hydrates", () => {
     const { container, rerender } = render(
-      <CodeTranscript items={[]} hydrated={false} />,
+      <CodeTranscript items={items} hydrated={false} />,
     );
     expect(container.querySelector(".animate-pulse")).not.toBeNull();
     expect(screen.queryByText("Send a message to start a turn.")).toBeNull();
+    expect(screen.queryByText("Looking at the tree.")).toBeNull();
 
-    rerender(<CodeTranscript items={[]} hydrated />);
+    rerender(<CodeTranscript items={items} hydrated />);
     expect(container.querySelector(".animate-pulse")).toBeNull();
-    expect(
-      screen.getByText("Send a message to start a turn."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Looking at the tree.")).toBeInTheDocument();
   });
 
   it("expands a failed tool, clamps long output, and stops the transcript following", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -94,28 +94,33 @@ export function CodeTranscript({
   contentRef?: RefCallback<HTMLDivElement>;
   onScroll?: () => void;
 }) {
-  // Only greet a session that is genuinely empty. A session still reading its
-  // turns is transiently empty too, and inviting the reader to start a turn
-  // there would flash over history that is about to arrive.
+  // The durable turn snapshot lands before the journal replay that fills in
+  // assistant text and tool activity. Hide both sources until that initial
+  // replay settles; otherwise a reopened workspace shows its user prompts and
+  // then visibly reconstructs every response underneath them.
+  if (!hydrated) {
+    return (
+      <div className="messages is-empty" ref={scrollRef} onScroll={onScroll}>
+        <div className="messages-column">
+          <TranscriptSkeleton />
+        </div>
+      </div>
+    );
+  }
+
+  // Only greet a session that is genuinely empty. The engine, mode, and model
+  // are already chosen, so this is the one instruction left plus what the
+  // first turn will produce.
   if (items.length === 0) {
     return (
       <div className="messages is-empty" ref={scrollRef} onScroll={onScroll}>
-        {hydrated ? (
-          // The engine, mode, and model are already chosen by the time a
-          // reader gets here, so this is not a welcome screen — it is the one
-          // instruction left, plus what it will produce.
-          <div className="flex max-w-sm flex-col items-center gap-1 text-center text-balance">
-            <p className="text-sm font-medium">Send a message to start a turn.</p>
-            <p className="text-muted-foreground text-[13.5px] leading-relaxed">
-              The engine's replies, the tools it runs, and the files it changes
-              all land here.
-            </p>
-          </div>
-        ) : (
-          <div className="messages-column">
-            <TranscriptSkeleton />
-          </div>
-        )}
+        <div className="flex max-w-sm flex-col items-center gap-1 text-center text-balance">
+          <p className="text-sm font-medium">Send a message to start a turn.</p>
+          <p className="text-muted-foreground text-[13.5px] leading-relaxed">
+            The engine's replies, the tools it runs, and the files it changes
+            all land here.
+          </p>
+        </div>
       </div>
     );
   }
@@ -863,4 +868,3 @@ function CodeTurnImages({
     />
   );
 }
-

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -154,14 +154,16 @@ function makeClient() {
     ),
     listCodeSessionTurns: vi.fn(async () => [TURN]),
     listCodeApprovals: vi.fn(async () => []),
-    openCodeEvents: vi.fn(
-      () =>
-        ({
-          close() {},
-          addEventListener() {},
-          removeEventListener() {},
-        }) as unknown as WebSocket,
-    ),
+    openCodeEvents: vi.fn(() => {
+      const socket = {
+        onopen: null as WebSocket["onopen"],
+        close() {},
+        addEventListener() {},
+        removeEventListener() {},
+      } as unknown as WebSocket;
+      queueMicrotask(() => socket.onopen?.(new Event("open")));
+      return socket;
+    }),
     getCodeRepo: vi.fn(async () => REPO),
     archiveCodeWorkspace: vi.fn(async () => ({
       ...WORKSPACE,


### PR DESCRIPTION
## What changed

- keeps restored Code transcripts behind one skeleton until both the durable turn snapshot and initial event replay have settled
- publishes replay frames and the hydration transition in one session-store update
- reveals genuinely empty sessions after the same bounded quiet window
- falls back to a usable transcript while the event socket reconnects

## Why

Reopened sessions could briefly show user turns, then visibly reconstruct assistant text and tool activity underneath them. The replay is now revealed atomically, so restoring a workspace feels like loading a completed document rather than replaying old typing.

## Stack

This is the next focused slice after #2253. Its branch contains the replay-compaction commits until #2253 lands; the PR diff will shrink to this atomic-reveal commit when the base work is on `main`.

## Compatibility and risk

The event protocol is unchanged. The renderer still applies live frames immediately after initial settlement. The main edge cases—empty history, replay history, snapshot failure, and initial socket failure—have focused coverage.

## Validation

- 5 focused UI test files, 45 tests passed
- TypeScript typecheck passed
- `git diff --check`
