### PR TITLE
perf(code): coalesce model catalog requests

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { CodeWorkspaceSnapshot } from "../api/types";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
@@ -39,5 +39,135 @@ describe("CodeCatalogStore.upsertWorkspace", () => {
       useCodeCatalogStore.getState().workspaces.map((item) => item.id),
     ).toEqual(["ws-a", "ws-b"]);
     expect(useCodeCatalogStore.getState().workspaces[1]?.title).toBe("viewed");
+  });
+});
+
+describe("CodeCatalogStore.ensureHarnessModels", () => {
+  it("caches an empty native model catalog", async () => {
+    const client = {
+      listCodeHarnessModels: vi.fn(async () => ({
+        kind: "codex" as const,
+        models: [],
+      })),
+    };
+
+    await useCodeCatalogStore
+      .getState()
+      .ensureHarnessModels(client, "codex");
+    await useCodeCatalogStore
+      .getState()
+      .ensureHarnessModels(client, "codex");
+
+    expect(client.listCodeHarnessModels).toHaveBeenCalledOnce();
+    expect(useCodeCatalogStore.getState().modelsByHarness.codex).toEqual([]);
+  });
+
+  it("shares one in-flight native model probe across pickers", async () => {
+    let resolve!: (value: {
+      kind: "opencode";
+      models: { id: string; label: string; default: boolean }[];
+    }) => void;
+    const response = new Promise<Parameters<typeof resolve>[0]>((done) => {
+      resolve = done;
+    });
+    const client = {
+      listCodeHarnessModels: vi.fn(() => response),
+    };
+
+    const first = useCodeCatalogStore
+      .getState()
+      .ensureHarnessModels(client, "opencode");
+    const second = useCodeCatalogStore
+      .getState()
+      .ensureHarnessModels(client, "opencode");
+    resolve({
+      kind: "opencode",
+      models: [{ id: "glm-5.2", label: "GLM 5.2", default: true }],
+    });
+
+    expect(await first).toEqual(await second);
+    expect(client.listCodeHarnessModels).toHaveBeenCalledOnce();
+    expect(useCodeCatalogStore.getState().modelsByHarness.opencode).toEqual([
+      expect.objectContaining({ id: "glm-5.2", default: true }),
+    ]);
+  });
+
+  it("shares the initial catalog refresh with an opening picker", async () => {
+    let resolveCodex!: (value: { kind: "codex"; models: [] }) => void;
+    const codex = new Promise<Parameters<typeof resolveCodex>[0]>((done) => {
+      resolveCodex = done;
+    });
+    const client = {
+      listCodeRepos: vi.fn(async () => []),
+      listCodeWorkspaces: vi.fn(async () => []),
+      getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+      listCodeHarnessModels: vi.fn((kind: string) =>
+        kind === "codex"
+          ? codex
+          : Promise.resolve({ kind, models: [] }),
+      ),
+    };
+
+    const refresh = useCodeCatalogStore.getState().refresh(client as never);
+    await Promise.resolve();
+    await Promise.resolve();
+    const picker = useCodeCatalogStore
+      .getState()
+      .ensureHarnessModels(client as never, "codex");
+    resolveCodex({ kind: "codex", models: [] });
+    await Promise.all([refresh, picker]);
+
+    expect(client.listCodeHarnessModels).toHaveBeenCalledTimes(4);
+    expect(
+      client.listCodeHarnessModels.mock.calls.filter(
+        ([kind]) => kind === "codex",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("reprobes cached models on an explicit catalog refresh", async () => {
+    useCodeCatalogStore.setState({ modelsByHarness: { codex: [] } });
+    const client = {
+      listCodeRepos: vi.fn(async () => []),
+      listCodeWorkspaces: vi.fn(async () => []),
+      getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+      listCodeHarnessModels: vi.fn(async (kind: string) => ({
+        kind,
+        models:
+          kind === "codex"
+            ? [{ id: "gpt-5.6-luna", label: "GPT-5.6 Luna", default: true }]
+            : [],
+      })),
+    };
+
+    await useCodeCatalogStore.getState().refresh(client as never);
+
+    expect(client.listCodeHarnessModels).toHaveBeenCalledTimes(4);
+    expect(useCodeCatalogStore.getState().modelsByHarness.codex).toEqual([
+      expect.objectContaining({ id: "gpt-5.6-luna", default: true }),
+    ]);
+  });
+});
+
+describe("CodeCatalogStore.refresh", () => {
+  it("shares one catalog request across the sidebar and route body", async () => {
+    const client = {
+      listCodeRepos: vi.fn(async () => []),
+      listCodeWorkspaces: vi.fn(async () => []),
+      getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+      listCodeHarnessModels: vi.fn(async (kind: string) => ({
+        kind,
+        models: [],
+      })),
+    };
+
+    const first = useCodeCatalogStore.getState().refresh(client as never);
+    const second = useCodeCatalogStore.getState().refresh(client as never);
+    await Promise.all([first, second]);
+
+    expect(client.listCodeRepos).toHaveBeenCalledOnce();
+    expect(client.listCodeWorkspaces).toHaveBeenCalledOnce();
+    expect(client.getHarnessDoctor).toHaveBeenCalledOnce();
+    expect(client.listCodeHarnessModels).toHaveBeenCalledTimes(4);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -17,6 +17,11 @@ const HARNESS_KINDS: HarnessKind[] = [
   "grok",
 ];
 
+/** One native model probe per harness, shared by every open picker. */
+const modelRequests = new Map<HarnessKind, Promise<CodeModelOption[]>>();
+/** Sidebar and route bodies mount together; they share one catalog refresh. */
+let catalogRefresh: Promise<void> | null = null;
+
 /**
  * Repos, workspaces, and the last session each workspace opened.
  *
@@ -62,6 +67,34 @@ type CodeCatalogStore = CodeCatalogState & {
   reset: () => void;
 };
 
+function loadHarnessModels(
+  client: Pick<ApiClient, "listCodeHarnessModels">,
+  kind: HarnessKind,
+  get: () => CodeCatalogStore,
+  force: boolean,
+): Promise<CodeModelOption[]> {
+  const cached = get().modelsByHarness[kind];
+  // An empty array is a finished probe: this engine advertised no models.
+  // Treating it as a cache miss makes every picker open run the CLI again.
+  if (!force && cached !== undefined) return Promise.resolve(cached);
+  const pending = modelRequests.get(kind);
+  if (pending) return pending;
+
+  const request = client
+    .listCodeHarnessModels(kind)
+    .then((listed) => {
+      const models = harnessCodeModels(listed.models, kind);
+      get().rememberHarnessModels(kind, models);
+      return models;
+    })
+    .catch(() => [])
+    .finally(() => {
+      if (modelRequests.get(kind) === request) modelRequests.delete(kind);
+    });
+  modelRequests.set(kind, request);
+  return request;
+}
+
 export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
   repos: [],
   workspaces: [],
@@ -70,63 +103,53 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
   modelsByHarness: {},
   loaded: false,
   error: null,
-  refresh: async (client) => {
-    try {
-      const [repos, workspaces] = await Promise.all([
-        client.listCodeRepos(),
-        client.listCodeWorkspaces(),
-      ]);
-      set({ repos, workspaces, loaded: true, error: null });
-    } catch (error) {
-      set({
-        loaded: true,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return;
-    }
-    const extras: Promise<void>[] = [
-      client
-        .getHarnessDoctor()
-        .then((doctor) => set({ doctor }))
-        .catch(() => {
-          // Home waits on a settled report. An empty one leaves the loading
-          // empty and shows the install section instead of spinning forever.
-          if (get().doctor === null) {
-            set({ doctor: { harnesses: [] } });
-          }
-        }),
-    ];
-    for (const kind of HARNESS_KINDS) {
-      extras.push(
+  refresh: (client) => {
+    if (catalogRefresh) return catalogRefresh;
+    let request: Promise<void>;
+    request = (async () => {
+      try {
+        const [repos, workspaces] = await Promise.all([
+          client.listCodeRepos(),
+          client.listCodeWorkspaces(),
+        ]);
+        set({ repos, workspaces, loaded: true, error: null });
+      } catch (error) {
+        set({
+          loaded: true,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      }
+      const extras: Promise<void>[] = [
         client
-          .listCodeHarnessModels(kind)
-          .then((listed) => {
-            get().rememberHarnessModels(
-              kind,
-              harnessCodeModels(listed.models, kind),
-            );
-          })
-          .catch(() => undefined),
-      );
-    }
-    await Promise.all(extras);
+          .getHarnessDoctor()
+          .then((doctor) => set({ doctor }))
+          .catch(() => {
+            // Home waits on a settled report. An empty one leaves the loading
+            // empty and shows the install section instead of spinning forever.
+            if (get().doctor === null) {
+              set({ doctor: { harnesses: [] } });
+            }
+          }),
+      ];
+      for (const kind of HARNESS_KINDS) {
+        extras.push(
+          loadHarnessModels(client, kind, get, true).then(() => undefined),
+        );
+      }
+      await Promise.all(extras);
+    })().finally(() => {
+      if (catalogRefresh === request) catalogRefresh = null;
+    });
+    catalogRefresh = request;
+    return request;
   },
   refreshDoctor: async (client) => {
     const doctor = await client.refreshHarnessDoctor();
     set({ doctor });
   },
-  ensureHarnessModels: async (client, kind) => {
-    const cached = get().modelsByHarness[kind];
-    if (cached && cached.length > 0) return cached;
-    try {
-      const listed = await client.listCodeHarnessModels(kind);
-      const models = harnessCodeModels(listed.models, kind);
-      get().rememberHarnessModels(kind, models);
-      return models;
-    } catch {
-      return [];
-    }
-  },
+  ensureHarnessModels: (client, kind) =>
+    loadHarnessModels(client, kind, get, false),
   rememberHarnessModels: (kind, models) => {
     set({
       modelsByHarness: { ...get().modelsByHarness, [kind]: models },
@@ -165,6 +188,8 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     set({ workspaces });
   },
   reset: () => {
+    catalogRefresh = null;
+    modelRequests.clear();
     set({
       repos: [],
       workspaces: [],


### PR DESCRIPTION
## What changed

- cache completed empty model catalogs so opening another picker does not rerun the harness CLI
- share in-flight per-harness model probes across concurrent consumers
- coalesce catalog refreshes mounted by the sidebar and route body
- keep explicit refreshes authoritative by reprobing cached harness catalogs

## Why

Code mode can mount multiple model consumers together. Empty catalogs were treated as cache misses, and simultaneous mounts issued duplicate native model discovery requests. This avoids repeated CLI work while preserving explicit refresh behavior.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeCatalogStore.test.ts` (6 passed)
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `git diff --check`