### PR TITLE
feat(code): add watch and fix action

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -526,7 +526,10 @@ describe("CodeWorkspacePage", () => {
     expect(bar).toHaveTextContent("Draft");
     expect(bar).toHaveTextContent("2 checks");
 
-    await user.click(within(bar).getByRole("button", { name: "Merge" }));
+    await user.click(
+      within(bar).getByRole("button", { name: "More pull request actions" }),
+    );
+    await user.click(await screen.findByRole("menuitem", { name: "Merge" }));
     expect(
       (screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement)
         .value,

--- a/crates/tidebreak-desktop/ui/src/code/PrActionBar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrActionBar.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, GitPullRequest } from "lucide-react";
+import { ChevronDown, CircleDotDashed, GitPullRequest } from "lucide-react";
 
 import type { PullRequestDigest } from "../api/types";
 import { Button } from "@/components/ui/button";
@@ -109,8 +109,16 @@ export function PrActionBar({
             type="button"
             size="sm"
             className={cn("h-6 px-2 text-[11px]", rest.length > 0 && "rounded-r-none")}
+            title={
+              primary === "watch_and_fix"
+                ? "Runs in this task. Closing Tidebreak or interrupting the task stops the watch."
+                : undefined
+            }
             onClick={() => insert(primary)}
           >
+            {primary === "watch_and_fix" && (
+              <CircleDotDashed className="size-3" aria-hidden="true" />
+            )}
             {prBarActionLabel(primary)}
           </Button>
           {rest.length > 0 && (

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -12,15 +12,16 @@ function pr(partial: Partial<PullRequestDigest>): PullRequestDigest {
 }
 
 describe("prBarModel", () => {
-  it("offers merge when the PR is open and clean", () => {
+  it("leads with watch and fix when the PR is open and clean", () => {
     const model = prBarModel(
       pr({
         checks: [{ name: "ci", bucket: "pass" }],
       }),
     );
     expect(model.status).toBe("Ready to merge");
-    expect(model.actions[0]).toBe("merge");
+    expect(model.actions[0]).toBe("watch_and_fix");
     expect(model.actions).toEqual([
+      "watch_and_fix",
       "merge",
       "fix_errors",
       "resolve_conflicts",
@@ -53,7 +54,7 @@ describe("prBarModel", () => {
     });
   });
 
-  it("leads with fix errors when a check is failing", () => {
+  it("keeps the contextual fix action directly after watch and fix", () => {
     const model = prBarModel(
       pr({
         checks: [
@@ -63,14 +64,17 @@ describe("prBarModel", () => {
       }),
     );
     expect(model.status).toBe("1 check failing");
-    expect(model.actions[0]).toBe("fix_errors");
+    expect(model.actions.slice(0, 2)).toEqual(["watch_and_fix", "fix_errors"]);
   });
 
-  it("leads with resolve conflicts when the host reports a conflict", () => {
+  it("keeps the contextual conflict action directly after watch and fix", () => {
     const model = prBarModel(pr({ mergeable: "CONFLICTING" }));
     expect(prHasConflicts(pr({ mergeable: "CONFLICTING" }))).toBe(true);
     expect(model.status).toBe("Conflicts");
-    expect(model.actions[0]).toBe("resolve_conflicts");
+    expect(model.actions.slice(0, 2)).toEqual([
+      "watch_and_fix",
+      "resolve_conflicts",
+    ]);
   });
 
   it("names a draft even when checks are still pending", () => {
@@ -81,7 +85,7 @@ describe("prBarModel", () => {
       }),
     );
     expect(model.status).toBe("Draft");
-    expect(model.actions[0]).toBe("merge");
+    expect(model.actions.slice(0, 2)).toEqual(["watch_and_fix", "merge"]);
   });
 
   it("hides actions on a merged PR", () => {
@@ -98,5 +102,9 @@ describe("prBarPrompt", () => {
     expect(prBarPrompt("merge", digest)).toMatch(/main/);
     expect(prBarPrompt("fix_errors", digest)).toMatch(/failing checks/);
     expect(prBarPrompt("resolve_conflicts", digest)).toMatch(/conflicts/);
+    const watch = prBarPrompt("watch_and_fix", digest);
+    expect(watch).toMatch(/keep watching/i);
+    expect(watch).toMatch(/Enable auto-merge/);
+    expect(watch).toMatch(/required human approval/);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -1,7 +1,11 @@
 import type { PullRequestDigest } from "../api/types";
 import { prTone } from "./workspaceCards";
 
-export type PrBarAction = "merge" | "fix_errors" | "resolve_conflicts";
+export type PrBarAction =
+  | "watch_and_fix"
+  | "merge"
+  | "fix_errors"
+  | "resolve_conflicts";
 
 export type PrBarTone =
   | "ready"
@@ -83,6 +87,8 @@ export function prBarPrompt(
   const number = `#${pr.number}`;
   const base = pr.base_branch?.trim() || "the base branch";
   switch (action) {
+    case "watch_and_fix":
+      return `Watch pull request ${number} until it is mergeable. This watch runs in the current task, so stay on this workspace and branch. Repeatedly inspect required checks and actionable review feedback. Wait efficiently while work is pending. When a check fails or a reviewer requests a concrete change, diagnose it, make the smallest safe fix, run focused validation, commit, push, and keep watching. Enable auto-merge once required checks and automated reviews are green. Do not stop merely because checks are pending. Stop only when the pull request is merged or when a required human approval, missing permission, external outage, or product decision blocks progress; in that case report the exact blocker.`;
     case "merge":
       return `Merge pull request ${number} into ${base}. Use this workspace's existing merge path. Do not change the branch unless the merge requires it. Report the result.`;
     case "fix_errors":
@@ -94,6 +100,8 @@ export function prBarPrompt(
 
 export function prBarActionLabel(action: PrBarAction): string {
   switch (action) {
+    case "watch_and_fix":
+      return "Watch and fix";
     case "merge":
       return "Merge";
     case "fix_errors":
@@ -139,16 +147,17 @@ function barStatus(tone: PrBarTone, checks: PrCheckCounts): string {
 
 function barActions(tone: PrBarTone): PrBarAction[] {
   if (tone === "merged" || tone === "closed") return [];
-  const primary =
+  const contextual =
     tone === "conflict"
       ? "resolve_conflicts"
       : tone === "failing"
         ? "fix_errors"
         : "merge";
   return [
-    primary,
+    "watch_and_fix",
+    contextual,
     ...(["merge", "fix_errors", "resolve_conflicts"] as const).filter(
-      (action) => action !== primary,
+      (action) => action !== contextual,
     ),
   ];
 }


### PR DESCRIPTION
## What changed

- adds a persistent **Watch and fix** action to the Code workspace PR strip
- keeps context-specific Merge, Fix errors, and Resolve conflicts actions in the adjacent menu
- hands the active harness a complete CI/review repair loop prompt, including focused fixes, push/recheck behavior, auto-merge, and exact blockers
- hides the action for merged and closed pull requests

## Why

The PR surface already knows check state and can hand work back to the Code agent, but it only exposed one-shot actions. This gives every supported harness the useful Codex-style “keep watching, repair failures, and continue until mergeable” workflow immediately.

## Current lifecycle boundary

This first slice runs in the current Code task. The tooltip says that closing Tidebreak or interrupting the task stops the watch. A restart-durable watcher and visible child/fork task require new server-owned polling, session ancestry, and workspace-leasing primitives and are intentionally separate follow-up work.

## Compatibility and risk

This is renderer-only and uses the existing composer handoff. It does not change GitHub APIs, session admission, or harness protocols. The same generated instruction works across Claude Code, Codex CLI, OpenCode, and Grok CLI.

## Validation

- focused PR action tests: 7 passed
- TypeScript typecheck passed
- `git diff --check`
