### PR TITLE
fix(code): scope editor tab actions and focused close

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -22,7 +22,10 @@ import {
   prependReplacementChat,
 } from "./ChatDeletion";
 import { useChatListStore } from "./ChatListStore";
-import { closeCodeChromeTab, splitCodeChromeLayout, toggleTerminalLayout } from "./code/codeChrome";
+import {
+  closeFocusedCodeTab,
+  toggleTerminalLayout,
+} from "./code/codeChrome";
 import { useCodeUiStore } from "./code/CodeUiStore";
 import {
   codeRepoIdFromPath,
@@ -201,9 +204,8 @@ export function AppShell() {
       const workspaceId = codeWorkspaceIdFromPath(pathname);
       if (!workspaceId) return false;
       const layout = layoutFromSearch(search as PanelSearch);
-      const chrome = splitCodeChromeLayout(layout);
-      if (chrome.panels.tabs.length === 0) return false;
-      const next = closeCodeChromeTab(layout, chrome.panels.activeIndex);
+      const next = closeFocusedCodeTab(layout);
+      if (!next) return false;
       void navigate({
         to: "/code/w/$workspaceId",
         params: { workspaceId },

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -62,6 +62,7 @@ export function CodeCenterTabs({
   onSelectEditor,
   onCloseEditor,
   onCloseAllEditors,
+  onCloseEveryEditor,
   onCloseOtherEditors,
   onCloseEditorsToRight,
   onCopyPath,
@@ -81,6 +82,8 @@ export function CodeCenterTabs({
   onSelectEditor: (index: number) => void;
   onCloseEditor: (index: number) => void;
   onCloseAllEditors: () => void;
+  /** Global close used by the persistent Main agent tab. */
+  onCloseEveryEditor?: () => void;
   onCloseOtherEditors: (index: number) => void;
   onCloseEditorsToRight: (index: number) => void;
   onCopyPath: (path: string) => void;
@@ -165,7 +168,7 @@ export function CodeCenterTabs({
             <ContextMenuItem
               className="gap-3 py-2"
               disabled={editorTabs.length === 0}
-              onSelect={onCloseAllEditors}
+              onSelect={onCloseEveryEditor ?? onCloseAllEditors}
             >
               <ListX />
               Close other tabs

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -391,7 +391,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onCloseEditor={(index) =>
           setLayout(closeEditorTab(layout, index, "primary"))
         }
-        onCloseAllEditors={() => setLayout(closeAllEditorTabs(layout))}
+        onCloseAllEditors={() =>
+          setLayout(closeAllEditorTabs(layout, "primary"))
+        }
+        onCloseEveryEditor={() => setLayout(closeAllEditorTabs(layout))}
         onCloseOtherEditors={(index) =>
           setLayout(closeOtherEditorTabs(layout, index, "primary"))
         }
@@ -511,7 +514,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onCloseEditor={(index) =>
           setLayout(closeEditorTab(layout, index, "secondary"))
         }
-        onCloseAllEditors={() => setLayout(closeAllEditorTabs(layout))}
+        onCloseAllEditors={() =>
+          setLayout(closeAllEditorTabs(layout, "secondary"))
+        }
         onCloseOtherEditors={(index) =>
           setLayout(closeOtherEditorTabs(layout, index, "secondary"))
         }

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
@@ -6,6 +6,7 @@ import {
   closeCodeChromeTab,
   closeEditorTab,
   closeEditorTabsToRight,
+  closeFocusedCodeTab,
   closeOtherEditorTabs,
   focusCodeChromeTab,
   focusConversation,
@@ -275,6 +276,56 @@ describe("code chrome layout", () => {
       { type: "file", path: "src/lib.rs" },
     ]);
   });
+
+  it("closes the editor tab that owns focus for the shell shortcut", () => {
+    const primary = {
+      tabs: [
+        { type: "file" as const, path: "src/lib.rs" },
+        { type: "diff" as const, path: "src/main.rs" },
+        { type: "terminal" as const },
+      ],
+      activeIndex: 1,
+      fullscreen: false,
+      conversationFocused: false,
+      editorSplit: {
+        tabs: [{ type: "file" as const, path: "README.md" }],
+        activeIndex: 0,
+      },
+    };
+
+    expect(closeFocusedCodeTab(primary)).toEqual({
+      ...primary,
+      tabs: [
+        { type: "file", path: "src/lib.rs" },
+        { type: "terminal" },
+      ],
+      activeIndex: 0,
+    });
+
+    const secondary = {
+      ...primary,
+      editorSplit: { ...primary.editorSplit, focused: true },
+    };
+    expect(closeFocusedCodeTab(secondary)).toEqual({
+      ...primary,
+      editorSplit: undefined,
+    });
+  });
+
+  it(
+    "does not claim Cmd/Ctrl+W when the persistent conversation owns focus",
+    () => {
+      const layout = {
+        tabs: [{ type: "file" as const, path: "src/lib.rs" }],
+        activeIndex: 0,
+        fullscreen: false,
+        conversationFocused: true,
+      };
+
+      expect(closeFocusedCodeTab(layout)).toBeNull();
+      expect(closeFocusedCodeTab(EMPTY_LAYOUT)).toBeNull();
+    },
+  );
 
   it("opens new editors in the group that last received focus", () => {
     const split = moveEditorTab(

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
@@ -191,6 +191,58 @@ describe("code chrome layout", () => {
     });
   });
 
+  it("scopes close actions to the editor group that owns the menu", () => {
+    const layout = {
+      tabs: [
+        { type: "folders" as const },
+        { type: "file" as const, path: "src/lib.rs" },
+        { type: "diff" as const, path: "src/main.rs" },
+        { type: "terminal" as const },
+      ],
+      activeIndex: 2,
+      fullscreen: false,
+      editorSplit: {
+        tabs: [
+          { type: "file" as const, path: "README.md" },
+          { type: "diff" as const, path: "README.md" },
+        ],
+        activeIndex: 1,
+        focused: true,
+      },
+    };
+
+    expect(closeAllEditorTabs(layout, "primary")).toEqual({
+      ...layout,
+      tabs: [{ type: "folders" }, { type: "terminal" }],
+      activeIndex: 0,
+      conversationFocused: undefined,
+    });
+    expect(closeAllEditorTabs(layout, "secondary")).toEqual({
+      ...layout,
+      editorSplit: undefined,
+    });
+
+    expect(closeOtherEditorTabs(layout, 0, "primary")).toEqual({
+      ...layout,
+      tabs: [
+        { type: "folders" },
+        { type: "file", path: "src/lib.rs" },
+        { type: "terminal" },
+      ],
+      activeIndex: 1,
+      conversationFocused: false,
+      editorSplit: { ...layout.editorSplit, focused: undefined },
+    });
+    expect(closeOtherEditorTabs(layout, 0, "secondary")).toEqual({
+      ...layout,
+      editorSplit: {
+        tabs: [{ type: "file", path: "README.md" }],
+        activeIndex: 0,
+        focused: true,
+      },
+    });
+  });
+
   it("moves editor tabs into a durable secondary group and back", () => {
     const layout = {
       tabs: [

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -143,12 +143,36 @@ export function closeEditorTab(
   return next;
 }
 
-/** Close every file and diff tab, returning the center to the conversation. */
-export function closeAllEditorTabs(layout: LayoutState): LayoutState {
+/**
+ * Close every file and diff tab in one editor group. With no region, close
+ * both groups and return the center to the conversation (the Main agent menu).
+ */
+export function closeAllEditorTabs(
+  layout: LayoutState,
+  region?: CodeEditorRegion,
+): LayoutState {
+  if (region === "secondary") {
+    return layout.editorSplit ? { ...layout, editorSplit: undefined } : layout;
+  }
+
   const tabs = layout.tabs.filter((tab) => !isEditorTab(tab));
-  if (tabs.length === layout.tabs.length && !layout.editorSplit) return layout;
+  const closeSplit = region === undefined;
+  if (
+    tabs.length === layout.tabs.length &&
+    (!closeSplit || !layout.editorSplit)
+  ) {
+    return layout;
+  }
   if (tabs.length === 0) {
-    return { ...EMPTY_LAYOUT, editorSplit: undefined };
+    return closeSplit || !layout.editorSplit
+      ? { ...EMPTY_LAYOUT, editorSplit: undefined }
+      : {
+          ...layout,
+          tabs: [],
+          activeIndex: 0,
+          fullscreen: false,
+          conversationFocused: undefined,
+        };
   }
 
   const active = layout.tabs[layout.activeIndex];
@@ -160,7 +184,7 @@ export function closeAllEditorTabs(layout: LayoutState): LayoutState {
     tabs,
     activeIndex,
     conversationFocused: undefined,
-    editorSplit: undefined,
+    editorSplit: closeSplit ? undefined : layout.editorSplit,
   };
 }
 
@@ -173,18 +197,14 @@ export function closeOtherEditorTabs(
   if (region === "secondary") {
     const target = layout.editorSplit?.tabs[editorIndex];
     if (!target) return layout;
-    const tabs = layout.tabs.filter((tab) => !isEditorTab(tab));
     return {
       ...layout,
-      tabs,
-      activeIndex: Math.min(layout.activeIndex, Math.max(0, tabs.length - 1)),
-      conversationFocused: undefined,
       editorSplit: { tabs: [target], activeIndex: 0, focused: true },
     };
   }
   const editors = layout.tabs.filter(isEditorTab);
   const target = editors[editorIndex];
-  if (!target || (editors.length <= 1 && !layout.editorSplit)) return layout;
+  if (!target || editors.length <= 1) return layout;
   const targetKey = panelKey(target);
   const tabs = layout.tabs.filter(
     (tab) => !isEditorTab(tab) || panelKey(tab) === targetKey,
@@ -194,7 +214,9 @@ export function closeOtherEditorTabs(
     tabs,
     activeIndex: tabs.findIndex((tab) => panelKey(tab) === targetKey),
     conversationFocused: false,
-    editorSplit: undefined,
+    editorSplit: layout.editorSplit
+      ? { ...layout.editorSplit, focused: undefined }
+      : undefined,
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -66,6 +66,33 @@ export function isEditorTab(tab: PanelContent): boolean {
 
 export type CodeEditorRegion = "primary" | "secondary";
 
+/**
+ * Close the tab the Code workspace is actually showing.
+ *
+ * Editor tabs live outside the legacy side-panel strip, and the right split
+ * keeps its own focus marker. Shell shortcuts must follow those two facts or
+ * Cmd/Ctrl+W falls through to the native window-close behavior while a file
+ * tab is visibly selected. `null` means the persistent conversation (or no
+ * workspace tab at all) owns focus and there is nothing closable here.
+ */
+export function closeFocusedCodeTab(layout: LayoutState): LayoutState | null {
+  const chrome = splitCodeChromeLayout(layout);
+  if (layout.editorSplit?.focused && chrome.splitEditors.tabs.length > 0) {
+    return closeEditorTab(
+      layout,
+      chrome.splitEditors.activeIndex,
+      "secondary",
+    );
+  }
+  if (!chrome.editors.conversationFocused && chrome.editors.tabs.length > 0) {
+    return closeEditorTab(layout, chrome.editors.activeIndex, "primary");
+  }
+  if (chrome.panels.tabs.length > 0) {
+    return closeCodeChromeTab(layout, chrome.panels.activeIndex);
+  }
+  return null;
+}
+
 /** Show the conversation while keeping file and diff tabs open. */
 export function focusConversation(layout: LayoutState): LayoutState {
   return {


### PR DESCRIPTION
## What changed

- scope **Close all** and **Close other tabs** to the editor group whose menu invoked the action
- keep the Main agent tab's close-other action global across both editor groups
- make Cmd/Ctrl+W close the currently focused primary or secondary editor tab
- preserve native window-close behavior when the persistent conversation owns focus

## Why

Split editor groups previously shared global close behavior, so actions from one pane could unexpectedly discard tabs in the other. The shell shortcut also only inspected the legacy side-panel strip, allowing Cmd/Ctrl+W to fall through to native window close while a center editor tab was visibly focused.

These two commits are coupled around the same editor-focus and tab-close state machine, while remaining separately reviewable in history.

## Commits

1. `improve(code): scope editor group tab actions`
2. `fix(code): close the focused workspace tab`

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/codeChrome.test.ts src/code/CodeWorkspacePage.dom.test.tsx src/AppShell.dom.test.tsx` — 3 files, 54 tests passed
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `git diff --check origin/main...HEAD`

## Compatibility and risk

No API or persistence format changes. The change is limited to Code-mode UI state transitions and shell shortcut routing, with focused unit and DOM coverage for both split-pane and conversation-focus behavior.
