### PR TITLE
fix(desktop): hide idle sidebar resize rule

### DIFF
--- a/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/primitives.tsx
@@ -121,7 +121,10 @@ function SidebarResizeHandle({
         }
       }}
     >
-      <div className="absolute top-0 right-1 bottom-0 w-[0.5px] bg-border transition-all group-hover:w-px group-hover:translate-x-[0.5px] group-hover:bg-foreground/35 group-hover:delay-75 group-data-[dragging]:bg-foreground/75" />
+      {/* The hit target straddles the rail edge. Keep its rule off the idle
+          surface so it cannot show through a neighboring card's rounded
+          corner; reveal it only while the resize affordance is engaged. */}
+      <div className="absolute top-0 bottom-0 left-1/2 w-[0.5px] -translate-x-1/2 bg-border opacity-0 transition-all group-hover:w-px group-hover:bg-foreground/35 group-hover:opacity-100 group-hover:delay-75 group-focus-visible:opacity-100 group-data-[dragging]:bg-foreground/75 group-data-[dragging]:opacity-100" />
       <div className="absolute top-1/2 right-0 h-6 w-2 -translate-y-1/2 cursor-col-resize rounded-full border-[0.5px] border-border bg-background opacity-0 shadow transition duration-200 group-hover:opacity-100 group-hover:delay-75 group-data-[dragging]:opacity-100 group-data-[dragging]:border-foreground/10 group-data-[dragging]:bg-foreground" />
     </div>
   );


### PR DESCRIPTION
## Summary

- hide the sidebar resize hairline while the rail is idle
- center the rule on the resize target boundary
- reveal it on hover, keyboard focus, and active dragging

## Root cause

The resize handle rendered its full-height hairline continuously. Because the handle sits beside rounded content surfaces, the idle rule remained visible through the rounded corner cutout on first render and looked like it crossed the curve.

## User impact

The sidebar and content card now meet cleanly at rest. The resize affordance remains visible whenever the reader interacts with it, including keyboard focus.

## Compatibility and risk

This is a renderer-only styling change in the existing sidebar resize handle. It does not alter resize behavior, persisted widths, layout bounds, or backend APIs.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/AppShell.dom.test.tsx` — 23 tests passed
- `pnpm run build`
- `git diff --check`