### PR TITLE
fix(code): recover workspace startup after harness switches

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -126,6 +126,7 @@ export function HarnessModelMenu({
   value,
   onChange,
   disabled,
+  loading = false,
   variant = "composer",
 }: {
   harness: HarnessKind;
@@ -133,6 +134,7 @@ export function HarnessModelMenu({
   value?: string;
   onChange?: (model: string) => void;
   disabled?: boolean;
+  loading?: boolean;
   /** Composer sits above the draft; field fills a form row. */
   variant?: "composer" | "field";
 }) {
@@ -169,16 +171,21 @@ export function HarnessModelMenu({
   const visible = searching ? matches : (activeGroup?.options ?? []);
   const locked = disabled || !onChange;
   if (!current) {
-    if (variant !== "field") return null;
+    if (variant !== "field" && !loading) return null;
+    const label = loading ? "Loading models…" : "Default model";
     return (
       <Button
         type="button"
-        variant="outline"
-        className="h-10 w-full justify-between px-3 font-normal"
+        variant={variant === "field" ? "outline" : "ghost"}
+        className={
+          variant === "field"
+            ? "h-10 w-full justify-between px-3 font-normal"
+            : "h-8 max-w-56 gap-2"
+        }
         disabled
-        aria-label="Model"
+        aria-label={loading ? "Loading models" : "Model: Default"}
       >
-        <span className="text-muted-foreground">Loading models…</span>
+        <span className="text-muted-foreground truncate">{label}</span>
         <ChevronDown className="size-4 opacity-50" />
       </Button>
     );
@@ -425,6 +432,7 @@ export function CodeComposer({
   harness,
   model,
   modelOptions,
+  modelLoading = false,
   sessionId,
   history,
   queued = false,
@@ -447,6 +455,7 @@ export function CodeComposer({
   harness?: HarnessKind;
   model?: string;
   modelOptions?: readonly CodeModelOption[];
+  modelLoading?: boolean;
   sessionId?: string;
   /** Prior user prompts, newest first, for Up/Down recall. */
   history?: readonly string[];
@@ -653,11 +662,12 @@ export function CodeComposer({
         draft={draft}
         history={history}
         modelMenu={
-          harness && modelOptions && modelOptions.length > 0 ? (
+          harness && ((modelOptions?.length ?? 0) > 0 || modelLoading) ? (
             <HarnessModelMenu
               harness={harness}
-              options={modelOptions}
+              options={modelOptions ?? []}
               value={selectedModel || undefined}
+              loading={modelLoading}
               onChange={
                 onModelChange
                   ? (next) => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -120,6 +120,14 @@ function app(client: Partial<AppContextValue["client"]>): AppContextValue {
     }),
     restartForUpdate: async () => {},
   } as AppContextValue;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 describe("NewWorkspaceDialog", () => {
@@ -245,6 +253,61 @@ describe("NewWorkspaceDialog", () => {
       "Model",
       "Permission mode",
     ]);
+  });
+
+  it("drops the previous harness model while the next catalog loads", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code"), harness("codex")],
+        notices: [],
+      } as never,
+    });
+    const codex = deferred<{
+      kind: "codex";
+      models: { id: string; label: string; default: boolean }[];
+    }>();
+    const listCodeHarnessModels = vi.fn((kind: HarnessKind) =>
+      kind === "codex"
+        ? codex.promise
+        : Promise.resolve({
+            kind: "claude_code" as const,
+            models: [{ id: "sonnet", label: "Sonnet", default: true }],
+          }),
+    );
+    await renderWithRouter(
+      <AppContextProvider value={app({ listCodeHarnessModels })}>
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const user = userEvent.setup();
+    expect(
+      await screen.findByRole("button", { name: "Model: Sonnet" }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    await user.click(screen.getByRole("option", { name: /Codex CLI/ }));
+
+    expect(
+      screen.queryByRole("button", { name: "Model: Sonnet" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Loading models" }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      codex.resolve({
+        kind: "codex",
+        models: [
+          { id: "gpt-5.6-luna", label: "GPT 5.6 Luna", default: true },
+        ],
+      });
+    });
+    expect(
+      await screen.findByRole("button", { name: "Model: GPT 5.6 Luna" }),
+    ).toBeEnabled();
   });
 
   it("keeps the repo picker enabled when opened from a repo", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -16,10 +16,18 @@ import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 
+const toastError = vi.hoisted(() => vi.fn());
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastError,
+  },
+}));
+
 afterEach(() => {
   cleanup();
   useCodeCatalogStore.getState().reset();
   useCodeUiStore.setState({ lastCreate: null });
+  toastError.mockReset();
 });
 
 const CAPS = {
@@ -341,6 +349,64 @@ describe("NewWorkspaceDialog", () => {
     const repoField = screen.getByRole("combobox", { name: "Repo" });
     expect(repoField).toHaveTextContent("legacy");
     expect(repoField).toBeEnabled();
+  });
+
+  it("opens a created workspace when its first session cannot start", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("codex")],
+        notices: [],
+      } as never,
+    });
+    const created = workspace(
+      "ws-recover",
+      "repo-new",
+      "2026-08-19T00:00:00.000Z",
+    );
+    const onOpenChange = vi.fn();
+    const createCodeSession = vi.fn(async () => {
+      throw new Error("Codex sign-in expired");
+    });
+    const { router } = await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace: vi.fn(async () => created),
+          createCodeSession,
+          listCodeHarnessModels: vi.fn(async () => ({
+            kind: "codex" as const,
+            models: [
+              { id: "gpt-5.6-luna", label: "GPT 5.6 Luna", default: true },
+            ],
+          })),
+        })}
+      >
+        <NewWorkspaceDialog
+          open
+          onOpenChange={onOpenChange}
+          repos={repos}
+        />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-recover"),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(useCodeCatalogStore.getState().workspaces).toContainEqual(created);
+    expect(
+      useCodeCatalogStore.getState().sessionsByWorkspace[created.id],
+    ).toBeUndefined();
+    expect(toastError).toHaveBeenCalledWith(
+      "Workspace created, but the session could not start. Codex sign-in expired",
+    );
   });
 
   it("lets the reader search the model list", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -216,33 +216,45 @@ export function NewWorkspaceDialog({
     if (!canCreate) return;
     setCreating(true);
     try {
-      const workspace = await client.createCodeWorkspace({
-        repo_id: repoId,
-        title: title.trim() || undefined,
-        base_ref: baseRef.trim() || undefined,
-      });
+      let workspace: CodeWorkspaceSnapshot;
+      try {
+        workspace = await client.createCodeWorkspace({
+          repo_id: repoId,
+          title: title.trim() || undefined,
+          base_ref: baseRef.trim() || undefined,
+        });
+      } catch (error) {
+        toast.error(
+          friendlyErrorMessage(error, "Could not create the workspace"),
+        );
+        return;
+      }
       upsertWorkspace(workspace);
-      const gateway = gatewayCodeModels(models, harness, defaultModelKey);
-      const listed =
-        gateway.length > 0
-          ? gateway
-          : await ensureHarnessModels(client, harness);
-      const posted =
-        model ?? listed.find((option) => option.default)?.id ?? listed[0]?.id;
-      const session = await client.createCodeSession(workspace.id, {
-        harness,
-        permission_mode: postedMode,
-        model: posted,
-      });
-      rememberSession(session);
-      rememberCreate({ repoId, harness, model: posted });
+      try {
+        const gateway = gatewayCodeModels(models, harness, defaultModelKey);
+        const listed =
+          gateway.length > 0
+            ? gateway
+            : await ensureHarnessModels(client, harness);
+        const posted =
+          model ?? listed.find((option) => option.default)?.id ?? listed[0]?.id;
+        const session = await client.createCodeSession(workspace.id, {
+          harness,
+          permission_mode: postedMode,
+          model: posted,
+        });
+        rememberSession(session);
+        rememberCreate({ repoId, harness, model: posted });
+      } catch (error) {
+        toast.error(
+          `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
+        );
+      }
       onOpenChange(false);
       await navigate({
         to: "/code/w/$workspaceId",
         params: { workspaceId: workspace.id },
       });
-    } catch (error) {
-      toast.error(friendlyErrorMessage(error, "Could not create the workspace"));
     } finally {
       setCreating(false);
     }

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -123,6 +123,7 @@ export function NewWorkspaceDialog({
   const [creating, setCreating] = useState(false);
   const [model, setModel] = useState<string | undefined>();
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
+  const [modelLoading, setModelLoading] = useState(false);
   const repoTrigger = useRef<HTMLButtonElement>(null);
   const command = useMemo(() => usesCommandModifier(navigator.userAgent), []);
 
@@ -153,6 +154,8 @@ export function NewWorkspaceDialog({
     setPickedHarness(null);
     setPermissionMode(null);
     setModel(undefined);
+    setModelOptions([]);
+    setModelLoading(false);
     // Reset against the dialog opening, not against catalog refreshes
     // mid-open — a workspace created elsewhere must not move this form.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -188,13 +191,18 @@ export function NewWorkspaceDialog({
     if (gateway.length > 0) {
       setModelOptions(gateway);
       setModel(pick(gateway));
+      setModelLoading(false);
       return;
     }
+    setModelOptions([]);
+    setModel(undefined);
+    setModelLoading(true);
     let cancelled = false;
     void ensureHarnessModels(client, harness).then((listed) => {
       if (cancelled) return;
       setModelOptions(listed);
       setModel(pick(listed));
+      setModelLoading(false);
     });
     return () => {
       cancelled = true;
@@ -317,7 +325,12 @@ export function NewWorkspaceDialog({
             <HarnessPicker
               harnesses={allHarnesses}
               value={harness}
-              onChange={setPickedHarness}
+              onChange={(next) => {
+                setModelOptions([]);
+                setModel(undefined);
+                setModelLoading(true);
+                setPickedHarness(next);
+              }}
               disabled={creating}
             />
           </div>
@@ -328,6 +341,7 @@ export function NewWorkspaceDialog({
               options={modelOptions}
               value={model}
               onChange={setModel}
+              loading={modelLoading}
               disabled={creating}
               variant="field"
             />

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, screen } from "@testing-library/react";
+import { act, cleanup, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -82,6 +82,14 @@ function entry(
     stderr: "",
     unrecognized_event_count: 0,
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 describe("StartSessionPrompt", () => {
@@ -211,6 +219,61 @@ describe("StartSessionPrompt", () => {
       "list the files",
       "claude-opus-5",
     );
+  });
+
+  it("never carries a model across a harness switch", async () => {
+    const user = userEvent.setup();
+    const codex = deferred<{
+      kind: "codex";
+      models: { id: string; label: string; default: boolean }[];
+    }>();
+    const client = {
+      listCodeHarnessModels: vi.fn((kind: HarnessDoctorEntry["kind"]) =>
+        kind === "codex"
+          ? codex.promise
+          : Promise.resolve({
+              kind: "claude_code" as const,
+              models: [{ id: "sonnet", label: "Sonnet", default: true }],
+            }),
+      ),
+    };
+    await renderWithRouter(
+      wrap(
+        <StartSessionPrompt
+          harnesses={[entry("claude_code", {}), entry("codex", {})]}
+          starting={false}
+          selectedMode={null}
+          onSelectMode={vi.fn()}
+          onStart={vi.fn()}
+          client={client}
+        />,
+      ),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Model: Sonnet" }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    await user.click(screen.getByRole("option", { name: /Codex CLI/ }));
+
+    expect(
+      screen.queryByRole("button", { name: "Model: Sonnet" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Loading models" }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      codex.resolve({
+        kind: "codex",
+        models: [
+          { id: "gpt-5.6-luna", label: "GPT 5.6 Luna", default: true },
+        ],
+      });
+    });
+    expect(
+      await screen.findByRole("button", { name: "Model: GPT 5.6 Luna" }),
+    ).toBeInTheDocument();
   });
 
   it("narrows to a picked mode", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -62,6 +62,7 @@ export function StartSessionPrompt({
   const [picked, setPicked] = useState<HarnessKind | null>(null);
   const [model, setModel] = useState<string | undefined>();
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
+  const [modelLoading, setModelLoading] = useState(false);
   const root = useRef<HTMLDivElement>(null);
   const ensureHarnessModels = useCodeCatalogStore((state) => state.ensureHarnessModels);
   const ready = harnesses.filter((entry) => !harnessUnusableReason(entry));
@@ -82,6 +83,7 @@ export function StartSessionPrompt({
     if (!selectedKind) {
       setModelOptions([]);
       setModel(undefined);
+      setModelLoading(false);
       return;
     }
     const gateway = gatewayCodeModels(
@@ -92,18 +94,24 @@ export function StartSessionPrompt({
     if (gateway.length > 0) {
       setModelOptions(gateway);
       setModel(gateway.find((option) => option.default)?.id ?? gateway[0]?.id);
+      setModelLoading(false);
       return;
     }
     if (!client) {
       setModelOptions([]);
       setModel(undefined);
+      setModelLoading(false);
       return;
     }
+    setModelOptions([]);
+    setModel(undefined);
+    setModelLoading(true);
     let cancelled = false;
     void ensureHarnessModels(client, selectedKind).then((listed) => {
       if (cancelled) return;
       setModelOptions(listed);
       setModel(listed.find((option) => option.default)?.id ?? listed[0]?.id);
+      setModelLoading(false);
     });
     return () => {
       cancelled = true;
@@ -130,7 +138,12 @@ export function StartSessionPrompt({
           harnesses={harnesses}
           value={selected?.kind ?? null}
           disabled={starting}
-          onChange={setPicked}
+          onChange={(next) => {
+            setModelOptions([]);
+            setModel(undefined);
+            setModelLoading(true);
+            setPicked(next);
+          }}
         />
         {mode === "auto" && selected && autoIsUnsupervised(selected.caps) && (
           <p className="text-muted-foreground text-xs">{UNSUPERVISED_AUTO_NOTE}</p>
@@ -148,6 +161,7 @@ export function StartSessionPrompt({
           harness={selected?.kind}
           model={model}
           modelOptions={modelOptions}
+          modelLoading={modelLoading}
           onModelChange={setModel}
           onModeChange={onSelectMode}
           onSend={async (message) => {


### PR DESCRIPTION
## What changed

This PR preserves two coupled, focused commits:

1. `improve(code): reset models when switching harnesses`
   - clears the previous harness model immediately
   - shows an explicit loading state while the next harness catalog resolves
   - applies the behavior in both the new-workspace dialog and empty-workspace session prompt

2. `fix(code): recover newly created workspaces`
   - separates workspace creation failures from initial session startup failures
   - keeps and opens a successfully created workspace when the first session cannot start
   - reports the session error so the user can retry from the recovered workspace

## Why

A model selected for one harness could remain visible and be submitted while another harness catalog was still loading. Separately, a session startup failure after successful workspace creation left the workspace created but did not navigate the user to it, making recovery unclear.

## Compatibility and risk

- No API or persistence schema changes.
- Existing successful workspace/session creation behavior is unchanged.
- Scope is limited to five Code-mode UI and test files.
- The final files match the previously validated preservation commit `1a7f7d7f` for this slice.

## Validation

- Focused Vitest: 2 files, 12 tests passed
- Full desktop UI suite (triggered by the package test wrapper): 190 files, 1,284 tests passed
- TypeScript: `tsc --noEmit` passed
- `git diff --check` passed
