### PR TITLE
fix(code): preserve replay journal sequences

### DIFF
--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -6,7 +6,7 @@ use axum::response::Response;
 use tokio::sync::broadcast::error::RecvError;
 
 use tidebreak_core::db::code::list_events;
-use tidebreak_core::{CodeEvent, CodeSessionId, OwnerId, SequencedCodeEvent};
+use tidebreak_core::{CodeSessionId, OwnerId};
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::code::ScopedCode;
@@ -115,7 +115,7 @@ async fn replay_after(
     let events = list_events(store, owner, session, *last_seq)
         .await
         .map_err(|_| ())?;
-    for event in compact_replay_events(events) {
+    for event in events {
         *last_seq = event.seq;
         send_frame(
             socket,
@@ -131,42 +131,6 @@ async fn replay_after(
     Ok(())
 }
 
-/// Collapse adjacent renderer-equivalent text deltas before they cross the
-/// WebSocket boundary. The durable journal and live stream remain lossless;
-/// replay retains the final sequence cursor for every compacted run.
-fn compact_replay_events(events: Vec<SequencedCodeEvent>) -> Vec<SequencedCodeEvent> {
-    let mut compacted = Vec::<SequencedCodeEvent>::with_capacity(events.len());
-    for event in events {
-        if let Some(previous) = compacted.last_mut() {
-            let consecutive = previous.seq.saturating_add(1) == event.seq;
-            let merged = if consecutive {
-                match (&mut previous.event, &event.event) {
-                    (
-                        CodeEvent::AssistantDelta { text: previous },
-                        CodeEvent::AssistantDelta { text: next },
-                    )
-                    | (
-                        CodeEvent::ReasoningDelta { text: previous },
-                        CodeEvent::ReasoningDelta { text: next },
-                    ) => {
-                        previous.push_str(next);
-                        true
-                    }
-                    _ => false,
-                }
-            } else {
-                false
-            };
-            if merged {
-                previous.seq = event.seq;
-                continue;
-            }
-        }
-        compacted.push(event);
-    }
-    compacted
-}
-
 async fn send_frame(
     socket: &mut WebSocket,
     frame: &SequencedCodeEventFrame,
@@ -175,71 +139,4 @@ async fn send_frame(
         return Ok(());
     };
     socket.send(Message::Text(json.into())).await
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn replay_compaction_preserves_text_boundaries_and_final_sequences() {
-        let compacted = compact_replay_events(vec![
-            SequencedCodeEvent {
-                seq: 1,
-                event: CodeEvent::AssistantDelta { text: "hel".into() },
-            },
-            SequencedCodeEvent {
-                seq: 2,
-                event: CodeEvent::AssistantDelta { text: "lo".into() },
-            },
-            SequencedCodeEvent {
-                seq: 3,
-                event: CodeEvent::ReasoningDelta {
-                    text: "think".into(),
-                },
-            },
-            SequencedCodeEvent {
-                seq: 4,
-                event: CodeEvent::ReasoningDelta { text: "ing".into() },
-            },
-            SequencedCodeEvent {
-                seq: 5,
-                event: CodeEvent::TurnInterrupted,
-            },
-            SequencedCodeEvent {
-                seq: 7,
-                event: CodeEvent::AssistantDelta {
-                    text: "again".into(),
-                },
-            },
-        ]);
-
-        assert_eq!(
-            compacted,
-            vec![
-                SequencedCodeEvent {
-                    seq: 2,
-                    event: CodeEvent::AssistantDelta {
-                        text: "hello".into(),
-                    },
-                },
-                SequencedCodeEvent {
-                    seq: 4,
-                    event: CodeEvent::ReasoningDelta {
-                        text: "thinking".into(),
-                    },
-                },
-                SequencedCodeEvent {
-                    seq: 5,
-                    event: CodeEvent::TurnInterrupted,
-                },
-                SequencedCodeEvent {
-                    seq: 7,
-                    event: CodeEvent::AssistantDelta {
-                        text: "again".into(),
-                    },
-                },
-            ]
-        );
-    }
 }

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1609,6 +1609,95 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
     assert_eq!(recovered, vec![current + 1, current + 2]);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_replay_emits_every_durable_sequence_after_the_cursor_in_order() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let replay_after_seq = tidebreak_core::db::code::list_events(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+        0,
+    )
+    .await
+    .unwrap()
+    .last()
+    .map_or(0, |event| event.seq);
+
+    let first_delta_seq = tidebreak_core::db::code::append_event(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+        1,
+        &tidebreak_core::CodeEvent::AssistantDelta { text: "hel".into() },
+    )
+    .await
+    .unwrap();
+    let second_delta_seq = tidebreak_core::db::code::append_event(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+        1,
+        &tidebreak_core::CodeEvent::AssistantDelta { text: "lo".into() },
+    )
+    .await
+    .unwrap();
+
+    let mut replay_request =
+        format!("ws://{addr}/code/sessions/{session_id}/events?after={replay_after_seq}")
+            .into_client_request()
+            .unwrap();
+    replay_request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut replay_socket, _) = connect_async(replay_request).await.unwrap();
+
+    let mut replayed = Vec::new();
+    for _ in 0..2 {
+        let frame = tokio::time::timeout(Duration::from_secs(2), replay_socket.next())
+            .await
+            .expect("durable replay timed out")
+            .expect("replay socket closed")
+            .unwrap();
+        let WsMessage::Text(text) = frame else {
+            continue;
+        };
+        replayed.push(serde_json::from_str::<serde_json::Value>(text.as_str()).unwrap());
+    }
+    assert_eq!(
+        replayed
+            .iter()
+            .map(|frame| frame["seq"].as_i64().unwrap())
+            .collect::<Vec<_>>(),
+        vec![first_delta_seq, second_delta_seq]
+    );
+    assert_eq!(replayed[0]["event"]["text"], "hel");
+    assert_eq!(replayed[1]["event"]["text"], "lo");
+    assert_eq!(replayed[0]["replayed"], true);
+    assert_eq!(replayed[1]["replayed"], true);
+}
+
 #[tokio::test]
 async fn superseded_worker_cannot_append_to_the_journal() {
     let (router, token, runtime, dir) = code_app(plain_text_script()).await;


### PR DESCRIPTION
## What changed

- remove server-side replay compaction from the Code session WebSocket endpoint
- emit every durable journal event with `seq > after` in ascending sequence order
- replace the compaction unit test with an integration contract test covering adjacent assistant deltas

## Root cause

The replay endpoint merged adjacent text-delta journal rows into a rewritten WebSocket frame carrying only the final sequence number. Reconnecting API and CLI consumers therefore observed a different stream from the durable journal and could interpret the missing intermediate sequence as data loss.

## Backward compatibility and safety

This restores the documented row-for-row replay contract and makes replay match the live/debug journal stream again. It does not change the journal schema, live event delivery, or renderer-local batching and compaction. Existing clients receive more replay frames only where the server previously collapsed adjacent deltas; frame shapes and cursor semantics remain unchanged.

## Validation

- `cargo test -p tidebreak-server ws_replay -- --nocapture` (5 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
