### PR TITLE
feat(code): show subscription usage in sidebar

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -98,6 +98,7 @@ import {
   type CodeWorkspaceSnapshot,
   type CodeCloneDefaults,
   type CodeCloneJobSnapshot,
+  type CodeSubscriptionUsage,
   type HarnessDoctorReport,
   type HarnessKind,
   type SequencedCodeEventFrame,
@@ -145,6 +146,7 @@ import {
   parseHarnessDoctorReport,
   parseSequencedCodeEvent,
   parseCodeUpdateNotice,
+  parseCodeSubscriptionUsage,
 } from "../code/parsers";
 
 const WS_HANDSHAKE = "tidebreak-v1";
@@ -1760,6 +1762,15 @@ export class ApiClient {
         await this.json("/code/harnesses", { headers: this.headers() }),
       ),
       "harness doctor",
+    );
+  }
+
+  async getCodeSubscriptionUsage(): Promise<CodeSubscriptionUsage> {
+    return requireParsed(
+      parseCodeSubscriptionUsage(
+        await this.json("/code/usage", { headers: this.headers() }),
+      ),
+      "subscription usage",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -1048,6 +1048,37 @@ export type CodeUpdateNotice = WireCodeUpdateNotice;
 export type CodeCloneDefaults = WireCodeCloneDefaults;
 export type CodeCloneJobSnapshot = WireCodeCloneJobSnapshot;
 
+/** Subscription quota windows exposed by Model Gateway or a direct harness. */
+export type CodeSubscriptionUsage = {
+  source: "model_gateway" | "direct" | "unavailable";
+  providers: CodeSubscriptionUsageProvider[];
+  diagnostics: string[];
+};
+
+export type CodeSubscriptionUsageProvider = {
+  id: string;
+  label: string;
+  accounts: CodeSubscriptionUsageAccount[];
+};
+
+export type CodeSubscriptionUsageAccount = {
+  id: string;
+  label: string;
+  is_own: boolean;
+  state: string;
+  updated_at_unix_seconds?: number;
+  windows: CodeSubscriptionUsageWindow[];
+};
+
+export type CodeSubscriptionUsageWindow = {
+  key: string;
+  label: string;
+  used_percent: number;
+  resets_at_unix_seconds?: number;
+  status?: string;
+  model_scope?: string;
+};
+
 /** Journaled engine event and the sequenced WebSocket frame that carries it. */
 export type CodeApprovalSnapshot = WireCodeApprovalSnapshot;
 export type CodeApprovalState = WireCodeApprovalState;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -43,6 +43,34 @@ const client = {
     },
   ]),
   getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+  getCodeSubscriptionUsage: vi.fn(async () => ({
+    source: "model_gateway" as const,
+    diagnostics: [],
+    providers: [
+      {
+        id: "anthropic",
+        label: "Anthropic Direct",
+        accounts: [
+          {
+            id: "personal",
+            label: "Personal",
+            is_own: true,
+            state: "available",
+            updated_at_unix_seconds: Math.floor(Date.now() / 1000),
+            windows: [
+              {
+                key: "7d-fable",
+                label: "Weekly (Fable)",
+                used_percent: 91,
+                resets_at_unix_seconds: Math.floor(Date.now() / 1000) + 3600,
+                status: "allowed_warning",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })),
   listCodeHarnessModels: vi.fn(async () => ({
     kind: "claude_code" as const,
     models: [],
@@ -118,6 +146,30 @@ describe("CodeSidebar", () => {
       screen.getByRole("button", { name: "Fix login · app · tidebreak/fix-login" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "New workspace" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", {
+        name: "Subscription usage, highest window 91% used",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the subscription details from the fixed rail footer", async () => {
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Subscription usage, highest window 91% used",
+      }),
+    );
+    expect(await screen.findByText("Subscription usage")).toBeInTheDocument();
+    expect(screen.getByText("Model Gateway")).toBeInTheDocument();
+    expect(screen.getByText("Weekly (Fable)")).toBeInTheDocument();
+    expect(screen.getByText("91% used")).toBeInTheDocument();
   });
 
   it("opens the workspace context menu from the keyboard and gives focus back", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -31,6 +31,7 @@ import { AttentionBadge } from "./AttentionBadge";
 import { AddRepoPalette } from "./AddRepoPalette";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { CodeModeSwitch } from "./CodeModeSwitch";
+import { CodeSubscriptionUsage } from "./CodeSubscriptionUsage";
 import { useCodeUiStore } from "./CodeUiStore";
 import { connectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { HARNESS_ICONS } from "./HarnessPicker";
@@ -109,7 +110,7 @@ export function CodeSidebar() {
   const sortLabel = WORKSPACE_SORT_MODE_LABELS[sortMode];
 
   return (
-    <SidebarFrame>
+    <SidebarFrame footer={<CodeSubscriptionUsage />}>
       <CodeModeSwitch />
 
       <div className="flex items-center justify-between px-2">

--- a/crates/tidebreak-desktop/ui/src/code/CodeSubscriptionUsage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSubscriptionUsage.tsx
@@ -1,0 +1,403 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+} from "react";
+import { Gauge, RefreshCw } from "lucide-react";
+
+import { useApp } from "@/AppContext";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { ClaudeIcon, OpenAIIcon, XaiIcon } from "@/ProviderIcons";
+import { SidebarButton } from "@/sidebar/primitives";
+import type {
+  CodeSubscriptionUsage,
+  CodeSubscriptionUsageAccount,
+  CodeSubscriptionUsageProvider,
+  CodeSubscriptionUsageWindow,
+} from "../api/types";
+import { FOCUS_RING } from "./interactive";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+/**
+ * The code rail's subscription-quota surface.
+ *
+ * The closed state is deliberately one quiet status row. The open state has
+ * enough room for every provider window, but keeps shared team subscriptions
+ * behind progressive disclosure so a large Model Gateway roster does not bury
+ * the reader's own accounts.
+ */
+export function CodeSubscriptionUsage() {
+  const { client } = useApp();
+  const [report, setReport] = useState<CodeSubscriptionUsage | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showShared, setShowShared] = useState(false);
+  const refreshInFlight = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (refreshInFlight.current) return;
+    refreshInFlight.current = true;
+    setRefreshing(true);
+    try {
+      const next = await client.getCodeSubscriptionUsage();
+      setReport(next);
+      setError(null);
+    } catch {
+      setError("Usage could not be refreshed.");
+    } finally {
+      refreshInFlight.current = false;
+      setRefreshing(false);
+    }
+  }, [client]);
+
+  useEffect(() => {
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  const summary = useMemo(() => usageSummary(report), [report]);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <SidebarButton
+          aria-label={summary.ariaLabel}
+          className="group/usage"
+        >
+          <Gauge className={summary.toneClass} />
+          <span className="min-w-0 flex-1 truncate">Usage</span>
+          {summary.percent !== null ? (
+            <span className="flex shrink-0 items-center gap-1.5">
+              <span className="bg-muted h-1.5 w-11 overflow-hidden rounded-full">
+                <span
+                  className={cn("block h-full rounded-full", summary.barClass)}
+                  style={{ width: `${Math.min(100, summary.percent)}%` }}
+                />
+              </span>
+              <span className={cn("w-8 text-right text-xs tabular-nums", summary.toneClass)}>
+                {Math.round(summary.percent)}%
+              </span>
+            </span>
+          ) : (
+            <span className="text-muted-foreground text-xs">
+              {refreshing ? "Loading" : "Unavailable"}
+            </span>
+          )}
+        </SidebarButton>
+      </PopoverTrigger>
+      <PopoverContent
+        side="right"
+        align="end"
+        sideOffset={8}
+        className="flex max-h-[min(640px,calc(100vh-24px))] w-[min(430px,calc(100vw-24px))] flex-col gap-0 overflow-hidden p-0"
+      >
+        <div className="flex shrink-0 items-start justify-between gap-4 border-b px-4 py-3.5">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-semibold">Subscription usage</h2>
+              {report && (
+                <span className="text-muted-foreground rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium">
+                  {sourceLabel(report.source)}
+                </span>
+              )}
+            </div>
+            <p className="text-muted-foreground mt-0.5 text-xs">
+              Provider limits and reset times for coding harnesses.
+            </p>
+          </div>
+          <button
+            type="button"
+            className={cn(
+              "text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer rounded-md p-1.5",
+              FOCUS_RING,
+            )}
+            aria-label="Refresh subscription usage"
+            disabled={refreshing}
+            onClick={() => void refresh()}
+          >
+            <RefreshCw className={cn("size-3.5", refreshing && "animate-spin")} />
+          </button>
+        </div>
+
+        <div className="min-h-0 overflow-y-auto px-4 py-3">
+          {error && <p className="text-critical text-xs">{error}</p>}
+          {!report && !error && <UsageSkeleton />}
+          {report && report.providers.length === 0 && (
+            <UnavailableUsage diagnostics={report.diagnostics} />
+          )}
+          {report && report.providers.length > 0 && (
+            <div className="flex flex-col gap-4">
+              {report.diagnostics.length > 0 && (
+                <p className="text-muted-foreground text-[11px]">
+                  {report.diagnostics[0]}
+                </p>
+              )}
+              {report.providers.map((provider) => (
+                <ProviderUsage
+                  key={provider.id}
+                  provider={provider}
+                  showShared={showShared}
+                />
+              ))}
+              {hasSharedAccounts(report) && (
+                <button
+                  type="button"
+                  className={cn(
+                    "text-muted-foreground hover:text-foreground w-fit cursor-pointer text-xs underline-offset-2 hover:underline",
+                    FOCUS_RING,
+                  )}
+                  onClick={() => setShowShared((shown) => !shown)}
+                >
+                  {showShared ? "Hide shared accounts" : "Show shared accounts"}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ProviderUsage({
+  provider,
+  showShared,
+}: {
+  provider: CodeSubscriptionUsageProvider;
+  showShared: boolean;
+}) {
+  const Icon = providerIcon(provider.id);
+  const own = provider.accounts.filter((account) => account.is_own);
+  const shown = showShared
+    ? provider.accounts
+    : own.length > 0
+      ? own
+      : provider.accounts.slice(0, 1);
+  return (
+    <section className="flex flex-col gap-2.5">
+      <div className="flex items-center gap-2">
+        <span className="border-border/70 bg-muted/50 grid size-7 place-items-center rounded-md border">
+          <Icon className="size-3.5" />
+        </span>
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-medium">{provider.label}</h3>
+          {provider.accounts.length > shown.length && (
+            <p className="text-muted-foreground text-[10px]">
+              {provider.accounts.length - shown.length} shared hidden
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 pl-9">
+        {shown.map((account) => (
+          <AccountUsage key={account.id} account={account} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AccountUsage({ account }: { account: CodeSubscriptionUsageAccount }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="truncate text-xs font-medium">{account.label}</span>
+        <span className={cn("shrink-0 text-[10px]", accountStateClass(account.state))}>
+          {accountStateLabel(account.state)}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2.5">
+        {account.windows.map((window) => (
+          <UsageWindowRow key={`${account.id}-${window.key}`} window={window} />
+        ))}
+      </div>
+      {account.updated_at_unix_seconds && (
+        <span className="text-muted-foreground text-[10px] tabular-nums">
+          Updated {formatAge(account.updated_at_unix_seconds)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function UsageWindowRow({ window }: { window: CodeSubscriptionUsageWindow }) {
+  const percent = Math.max(0, window.used_percent);
+  const tone = usageTone(percent, window.status);
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between gap-3 text-[11px]">
+        <span className="text-muted-foreground min-w-0 truncate" title={window.label}>
+          {window.label}
+        </span>
+        <span className={cn("shrink-0 font-medium tabular-nums", tone.text)}>
+          {formatPercent(percent)}
+        </span>
+      </div>
+      <div className="bg-muted h-1.5 overflow-hidden rounded-full">
+        <div
+          className={cn("h-full rounded-full transition-[width] duration-300", tone.bar)}
+          style={{ width: `${Math.min(100, percent)}%` }}
+        />
+      </div>
+      {window.resets_at_unix_seconds && (
+        <span className="text-muted-foreground text-[10px] tabular-nums">
+          {formatReset(window.resets_at_unix_seconds)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function UsageSkeleton() {
+  return (
+    <div className="flex animate-pulse flex-col gap-4" role="status" aria-label="Loading usage">
+      {[0, 1].map((index) => (
+        <div key={index} className="flex gap-3">
+          <div className="bg-muted size-7 shrink-0 rounded-md" />
+          <div className="flex flex-1 flex-col gap-2">
+            <div className="bg-muted h-3 w-24 rounded" />
+            <div className="bg-muted h-1.5 w-full rounded-full" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function UnavailableUsage({ diagnostics }: { diagnostics: string[] }) {
+  return (
+    <div className="flex flex-col gap-2 py-2">
+      <p className="text-sm font-medium">No machine-readable limits found</p>
+      <p className="text-muted-foreground text-xs leading-5">
+        Tidebreak reads Model Gateway when modelctl is available, then falls
+        back to Codex directly. Claude Code and Grok do not currently expose a
+        stable non-interactive subscription-usage command.
+      </p>
+      {diagnostics[0] && (
+        <p className="text-muted-foreground text-[11px]">{diagnostics[0]}</p>
+      )}
+    </div>
+  );
+}
+
+function usageSummary(report: CodeSubscriptionUsage | null): {
+  percent: number | null;
+  ariaLabel: string;
+  toneClass: string;
+  barClass: string;
+} {
+  const windows = report?.providers.flatMap((provider) => {
+    const own = provider.accounts.filter((account) => account.is_own);
+    const accounts = own.length > 0 ? own : provider.accounts;
+    return accounts.flatMap((account) => account.windows);
+  });
+  const mostUsed = windows?.reduce<CodeSubscriptionUsageWindow | null>(
+    (current, window) =>
+      current === null || window.used_percent > current.used_percent
+        ? window
+        : current,
+    null,
+  );
+  if (!mostUsed) {
+    return {
+      percent: null,
+      ariaLabel: "Subscription usage unavailable",
+      toneClass: "text-muted-foreground",
+      barClass: "bg-muted-foreground",
+    };
+  }
+  const tone = usageTone(mostUsed.used_percent, mostUsed.status);
+  return {
+    percent: mostUsed.used_percent,
+    ariaLabel: `Subscription usage, highest window ${formatPercent(mostUsed.used_percent)}`,
+    toneClass: tone.text,
+    barClass: tone.bar,
+  };
+}
+
+function usageTone(percent: number, status?: string) {
+  if (percent >= 100 || status === "rejected") {
+    return { text: "text-critical", bar: "bg-critical" };
+  }
+  if (percent >= 85 || status === "allowed_warning") {
+    return { text: "text-warning-foreground", bar: "bg-warning" };
+  }
+  return { text: "text-foreground", bar: "bg-foreground/55" };
+}
+
+function providerIcon(id: string): ComponentType<{ className?: string }> {
+  switch (id) {
+    case "anthropic":
+      return ClaudeIcon;
+    case "openai":
+      return OpenAIIcon;
+    case "xai":
+      return XaiIcon;
+    default:
+      return Gauge;
+  }
+}
+
+function sourceLabel(source: CodeSubscriptionUsage["source"]): string {
+  switch (source) {
+    case "model_gateway":
+      return "Model Gateway";
+    case "direct":
+      return "Direct CLI";
+    case "unavailable":
+      return "Unavailable";
+  }
+}
+
+function hasSharedAccounts(report: CodeSubscriptionUsage): boolean {
+  return report.providers.some((provider) =>
+    provider.accounts.some((account) => !account.is_own),
+  );
+}
+
+function accountStateLabel(state: string): string {
+  if (state === "available") return "Available";
+  if (state === "cooling_down" || state === "limited") return "Limited";
+  if (state === "reauthorization_required") return "Sign in again";
+  return state.replaceAll("_", " ");
+}
+
+function accountStateClass(state: string): string {
+  if (state === "available") return "text-muted-foreground";
+  if (state === "cooling_down" || state === "limited") return "text-critical";
+  return "text-warning-foreground";
+}
+
+function formatPercent(percent: number): string {
+  const rounded = Math.round(percent * 10) / 10;
+  return `${rounded}% used`;
+}
+
+function formatReset(timestamp: number): string {
+  const seconds = timestamp - Date.now() / 1000;
+  if (seconds < -30) return "Reset time passed";
+  if (seconds <= 30) return "Resets now";
+  return `Resets in ${formatDuration(seconds)}`;
+}
+
+function formatAge(timestamp: number): string {
+  const seconds = Math.max(0, Date.now() / 1000 - timestamp);
+  if (seconds < 60) return "just now";
+  return `${formatDuration(seconds)} ago`;
+}
+
+function formatDuration(totalSeconds: number): string {
+  const minutes = Math.max(1, Math.round(totalSeconds / 60));
+  const days = Math.floor(minutes / 1_440);
+  const hours = Math.floor((minutes % 1_440) / 60);
+  const remainingMinutes = minutes % 60;
+  if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  if (hours > 0) return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+  return `${remainingMinutes}m`;
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -11,6 +11,7 @@ import {
   parseCodePush,
   parseCodeSession,
   parseCodeSessionList,
+  parseCodeSubscriptionUsage,
   parseCodeUpdateNotice,
   parseCodeTerminal,
   parseCodeTerminalList,
@@ -37,6 +38,79 @@ const SESSION = {
   unrecognized_event_count: 0,
   created_at: "2026-08-15T12:00:00.000Z",
 };
+
+describe("parseCodeSubscriptionUsage", () => {
+  it("accepts normalized personal and shared provider windows", () => {
+    const usage = {
+      source: "model_gateway",
+      diagnostics: [],
+      providers: [
+        {
+          id: "anthropic",
+          label: "Anthropic Direct",
+          accounts: [
+            {
+              id: "personal",
+              label: "Personal",
+              is_own: true,
+              state: "available",
+              updated_at_unix_seconds: 1_776_000_000,
+              windows: [
+                {
+                  key: "weekly",
+                  label: "Weekly (7d)",
+                  used_percent: 58,
+                  resets_at_unix_seconds: 1_776_086_400,
+                  status: "allowed",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(parseCodeSubscriptionUsage(usage)).toEqual(usage);
+  });
+
+  it("rejects malformed usage percentages and sources", () => {
+    const unavailable = {
+      source: "unavailable",
+      providers: [],
+      diagnostics: ["No machine-readable usage source was found."],
+    };
+    expect(parseCodeSubscriptionUsage(unavailable)).toEqual(unavailable);
+    expect(
+      parseCodeSubscriptionUsage({ ...unavailable, source: "shell_scrape" }),
+    ).toBeNull();
+    expect(
+      parseCodeSubscriptionUsage({
+        source: "direct",
+        diagnostics: [],
+        providers: [
+          {
+            id: "openai",
+            label: "Codex",
+            accounts: [
+              {
+                id: "codex",
+                label: "Codex Pro",
+                is_own: true,
+                state: "available",
+                windows: [
+                  {
+                    key: "session",
+                    label: "Session (5h)",
+                    used_percent: "58",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+});
 
 describe("parseCodeSessionList", () => {
   it("accepts GET /code/workspaces/{id}/sessions", () => {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -43,6 +43,7 @@ import type {
   CodeUpdateNotice,
   CodeCloneDefaults,
   CodeCloneJobSnapshot,
+  CodeSubscriptionUsage,
   PullRequestDigest,
   PullRequestComment,
   PullRequestCommentKind,
@@ -146,6 +147,94 @@ const ATTENTION_SOURCES = new Set<AttentionSource>([
   "lifecycle",
   "user",
 ]);
+const USAGE_SOURCES = new Set<CodeSubscriptionUsage["source"]>([
+  "model_gateway",
+  "direct",
+  "unavailable",
+]);
+
+export function parseCodeSubscriptionUsage(
+  value: unknown,
+): CodeSubscriptionUsage | null {
+  if (
+    !isRecord(value) ||
+    !isMember(value.source, USAGE_SOURCES) ||
+    !Array.isArray(value.providers) ||
+    !Array.isArray(value.diagnostics) ||
+    !value.diagnostics.every((item) => typeof item === "string")
+  ) {
+    return null;
+  }
+  const providers: CodeSubscriptionUsage["providers"] = [];
+  for (const provider of value.providers) {
+    if (
+      !isRecord(provider) ||
+      !nonEmpty(provider.id) ||
+      !nonEmpty(provider.label) ||
+      !Array.isArray(provider.accounts)
+    ) {
+      return null;
+    }
+    const accounts = [];
+    for (const account of provider.accounts) {
+      if (
+        !isRecord(account) ||
+        !nonEmpty(account.id) ||
+        !nonEmpty(account.label) ||
+        typeof account.is_own !== "boolean" ||
+        typeof account.state !== "string" ||
+        (account.updated_at_unix_seconds !== undefined &&
+          !isFiniteNumber(account.updated_at_unix_seconds)) ||
+        !Array.isArray(account.windows)
+      ) {
+        return null;
+      }
+      const windows = [];
+      for (const window of account.windows) {
+        if (
+          !isRecord(window) ||
+          !nonEmpty(window.key) ||
+          !nonEmpty(window.label) ||
+          !isFiniteNumber(window.used_percent) ||
+          (window.resets_at_unix_seconds !== undefined &&
+            !isFiniteNumber(window.resets_at_unix_seconds)) ||
+          !optionalString(window.status) ||
+          !optionalString(window.model_scope)
+        ) {
+          return null;
+        }
+        windows.push({
+          key: window.key,
+          label: window.label,
+          used_percent: window.used_percent,
+          ...(window.resets_at_unix_seconds !== undefined
+            ? { resets_at_unix_seconds: window.resets_at_unix_seconds }
+            : {}),
+          ...(window.status !== undefined ? { status: window.status } : {}),
+          ...(window.model_scope !== undefined
+            ? { model_scope: window.model_scope }
+            : {}),
+        });
+      }
+      accounts.push({
+        id: account.id,
+        label: account.label,
+        is_own: account.is_own,
+        state: account.state,
+        windows,
+        ...(account.updated_at_unix_seconds !== undefined
+          ? { updated_at_unix_seconds: account.updated_at_unix_seconds }
+          : {}),
+      });
+    }
+    providers.push({ id: provider.id, label: provider.label, accounts });
+  }
+  return {
+    source: value.source,
+    providers,
+    diagnostics: [...value.diagnostics],
+  };
+}
 
 export function parseCodeCloneJob(value: unknown): CodeCloneJobSnapshot | null {
   if (

--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarFrame.tsx
@@ -32,7 +32,13 @@ import { useUiStore } from "@/UiStore";
  * everywhere but settings, which has its own section list and no use for a
  * chat list beside it.
  */
-export function SidebarFrame({ children }: { children: ReactNode }) {
+export function SidebarFrame({
+  children,
+  footer,
+}: {
+  children: ReactNode;
+  footer?: ReactNode;
+}) {
   const navigate = useNavigate();
   const { updateState, restartForUpdate } = useApp();
   const { mode: themeMode, cycle: cycleTheme } = useTheme();
@@ -92,6 +98,7 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
       </SidebarContent>
 
       <SidebarFooter className="flex flex-col gap-0.5">
+        {footer}
         {updateReady && (
           <SidebarButton onClick={restartForUpdate}>
             <RotateCw className="text-success" />

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -717,6 +717,7 @@ pub fn app(state: AppState) -> Router {
                 .delete(routes::code::delete_repo),
         )
         .route("/code/harnesses", get(routes::code::list_harnesses))
+        .route("/code/usage", get(routes::code::subscription_usage))
         .route(
             "/code/harnesses/{kind}/models",
             get(routes::code::list_harness_models),

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -14,6 +14,7 @@ mod sessions;
 mod terminals;
 pub(crate) mod types;
 mod updates;
+mod usage;
 mod workspaces;
 
 pub(crate) use crate::code::approval_bridge::approval_prompt;
@@ -49,6 +50,7 @@ pub(crate) use types::{
     SequencedCodeEventFrame,
 };
 pub(crate) use updates::code_updates;
+pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, get_workspace_blob, get_workspace_diff,
     list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace, search_workspace,

--- a/crates/tidebreak-server/src/routes/code/usage.rs
+++ b/crates/tidebreak-server/src/routes/code/usage.rs
@@ -1,0 +1,536 @@
+//! Subscription quota usage for code mode.
+//!
+//! Model Gateway is the richest source and already exposes a stable JSON CLI
+//! contract. When it is absent or signed out, Codex's app-server protocol is a
+//! useful direct-provider fallback. Other harnesses remain visible in the UI
+//! through the doctor, but are not guessed here when their CLIs expose no
+//! machine-readable quota command.
+
+use std::collections::BTreeMap;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tidebreak_harness::{filter_child_env, probe_shell, HostEnv, ProbeCapture};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::code::ScopedCode;
+use crate::error::ServerError;
+use crate::extract::Json;
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(12);
+const MAX_JSON_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct CodeSubscriptionUsage {
+    source: UsageSource,
+    providers: Vec<UsageProvider>,
+    diagnostics: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum UsageSource {
+    ModelGateway,
+    Direct,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct UsageProvider {
+    id: String,
+    label: String,
+    accounts: Vec<UsageAccount>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct UsageAccount {
+    id: String,
+    label: String,
+    is_own: bool,
+    state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at_unix_seconds: Option<i64>,
+    windows: Vec<UsageWindow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct UsageWindow {
+    key: String,
+    label: String,
+    used_percent: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resets_at_unix_seconds: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model_scope: Option<String>,
+}
+
+/// Read every subscription quota source the local code installation can
+/// answer. Source failures are diagnostics, not route failures: a missing
+/// optional CLI must render as an honest empty state rather than a broken rail.
+pub(crate) async fn subscription_usage(
+    _code: ScopedCode,
+) -> Result<Json<CodeSubscriptionUsage>, ServerError> {
+    Ok(Json(collect_usage().await))
+}
+
+async fn collect_usage() -> CodeSubscriptionUsage {
+    let mut diagnostics = Vec::new();
+    match collect_modelctl().await {
+        Ok(Some(report)) if !report.providers.is_empty() => return report,
+        Ok(_) => diagnostics.push("Model Gateway returned no subscription usage.".into()),
+        Err(error) => {
+            tracing::debug!("model-gateway usage unavailable: {error}");
+            diagnostics.push("Model Gateway usage is unavailable.".into());
+        }
+    }
+
+    match collect_codex().await {
+        Ok(Some(provider)) => CodeSubscriptionUsage {
+            source: UsageSource::Direct,
+            providers: vec![provider],
+            diagnostics: Vec::new(),
+        },
+        Ok(None) => {
+            diagnostics.push("Codex returned no subscription usage.".into());
+            CodeSubscriptionUsage {
+                source: UsageSource::Unavailable,
+                providers: Vec::new(),
+                diagnostics,
+            }
+        }
+        Err(error) => {
+            tracing::debug!("direct Codex usage unavailable: {error}");
+            diagnostics.push("Direct Codex usage is unavailable.".into());
+            CodeSubscriptionUsage {
+                source: UsageSource::Unavailable,
+                providers: Vec::new(),
+                diagnostics,
+            }
+        }
+    }
+}
+
+async fn collect_modelctl() -> Result<Option<CodeSubscriptionUsage>, String> {
+    let probe = probe_shell(&HostEnv::from_process(), "modelctl")
+        .await
+        .map_err(|error| error.to_string())?;
+    let mut command = command_from_probe(&probe);
+    command.args(["--json", "usage"]);
+    let output = timeout(COMMAND_TIMEOUT, command.output())
+        .await
+        .map_err(|_| "usage command timed out".to_owned())?
+        .map_err(|error| format!("could not run usage command: {error}"))?;
+    if !output.status.success() {
+        return Err(bounded_text(&output.stderr, 320));
+    }
+    if output.stdout.len() > MAX_JSON_BYTES {
+        return Err("usage response was too large".into());
+    }
+    let raw: ModelctlUsage = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("could not decode usage response: {error}"))?;
+    Ok(Some(normalize_modelctl(raw)))
+}
+
+fn command_from_probe(probe: &ProbeCapture) -> Command {
+    let mut command = Command::new(&probe.binary);
+    command
+        .env_clear()
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    for (key, value) in filter_child_env(probe.env.iter().cloned()) {
+        command.env(key, value);
+    }
+    command
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelctlUsage {
+    #[serde(default)]
+    providers: Vec<ModelctlProvider>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelctlProvider {
+    provider_kind: String,
+    name: String,
+    #[serde(default)]
+    bindings: Vec<ModelctlBinding>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelctlBinding {
+    #[serde(default)]
+    is_own: bool,
+    limit_state: String,
+    usage_updated_at_unix_seconds: Option<i64>,
+    #[serde(default)]
+    usage_windows: Vec<ModelctlWindow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelctlWindow {
+    key: String,
+    label: String,
+    used_percent: f64,
+    resets_at_unix_seconds: Option<i64>,
+    status: Option<String>,
+    model_scope: Option<String>,
+}
+
+fn normalize_modelctl(raw: ModelctlUsage) -> CodeSubscriptionUsage {
+    let providers = raw
+        .providers
+        .into_iter()
+        .filter_map(|provider| {
+            let mut own_index = 0usize;
+            let mut shared_index = 0usize;
+            let accounts = provider
+                .bindings
+                .into_iter()
+                .filter(|binding| !binding.usage_windows.is_empty())
+                .map(|binding| {
+                    let (id, label) = if binding.is_own {
+                        own_index += 1;
+                        (
+                            format!("personal-{own_index}"),
+                            if own_index == 1 {
+                                "Personal".to_owned()
+                            } else {
+                                format!("Personal {own_index}")
+                            },
+                        )
+                    } else {
+                        shared_index += 1;
+                        (
+                            format!("shared-{shared_index}"),
+                            if shared_index == 1 {
+                                "Shared".to_owned()
+                            } else {
+                                format!("Shared {shared_index}")
+                            },
+                        )
+                    };
+                    UsageAccount {
+                        id,
+                        label,
+                        is_own: binding.is_own,
+                        state: binding.limit_state,
+                        updated_at_unix_seconds: binding.usage_updated_at_unix_seconds,
+                        windows: binding
+                            .usage_windows
+                            .into_iter()
+                            .map(|window| UsageWindow {
+                                key: window.key,
+                                label: window.label,
+                                used_percent: window.used_percent,
+                                resets_at_unix_seconds: window.resets_at_unix_seconds,
+                                status: window.status,
+                                model_scope: window.model_scope,
+                            })
+                            .collect(),
+                    }
+                })
+                .collect::<Vec<_>>();
+            (!accounts.is_empty()).then_some(UsageProvider {
+                id: provider.provider_kind,
+                label: provider.name,
+                accounts,
+            })
+        })
+        .collect();
+    CodeSubscriptionUsage {
+        source: UsageSource::ModelGateway,
+        providers,
+        diagnostics: Vec::new(),
+    }
+}
+
+async fn collect_codex() -> Result<Option<UsageProvider>, String> {
+    let probe = probe_shell(&HostEnv::from_process(), "codex")
+        .await
+        .map_err(|error| error.to_string())?;
+    let mut command = command_from_probe(&probe);
+    command
+        .args(["app-server", "--stdio"])
+        .stderr(Stdio::null());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("could not start app server: {error}"))?;
+    let mut stdin = child.stdin.take().ok_or("app server has no stdin")?;
+    let stdout = child.stdout.take().ok_or("app server has no stdout")?;
+    let request = format!(
+        "{}\n{}\n{}\n",
+        json!({"id": 1, "method": "initialize", "params": {"clientInfo": {"name": "tidebreak-usage", "version": env!("CARGO_PKG_VERSION")}, "capabilities": {"experimentalApi": false}}}),
+        json!({"method": "initialized"}),
+        json!({"id": 2, "method": "account/rateLimits/read", "params": null})
+    );
+    stdin
+        .write_all(request.as_bytes())
+        .await
+        .map_err(|error| format!("could not query app server: {error}"))?;
+    stdin
+        .flush()
+        .await
+        .map_err(|error| format!("could not query app server: {error}"))?;
+    drop(stdin);
+
+    let read = async {
+        let mut lines = BufReader::new(stdout).lines();
+        while let Some(line) = lines
+            .next_line()
+            .await
+            .map_err(|error| format!("could not read app server: {error}"))?
+        {
+            if line.len() > MAX_JSON_BYTES {
+                return Err("app-server response was too large".into());
+            }
+            let value: Value = match serde_json::from_str(&line) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            if value.get("id").and_then(Value::as_i64) == Some(2) {
+                if let Some(error) = value.get("error") {
+                    return Err(format!("rate-limit request failed: {error}"));
+                }
+                return normalize_codex(value.get("result").cloned().unwrap_or(Value::Null));
+            }
+        }
+        Err("app server closed before answering".into())
+    };
+    let result = timeout(COMMAND_TIMEOUT, read)
+        .await
+        .map_err(|_| "rate-limit request timed out".to_owned())?;
+    let _ = child.kill().await;
+    result
+}
+
+fn normalize_codex(result: Value) -> Result<Option<UsageProvider>, String> {
+    let raw: CodexRateLimits = serde_json::from_value(result)
+        .map_err(|error| format!("could not decode rate limits: {error}"))?;
+    let snapshots = raw.rate_limits_by_limit_id.unwrap_or_else(|| {
+        let mut snapshots = BTreeMap::new();
+        snapshots.insert("codex".into(), raw.rate_limits);
+        snapshots
+    });
+    let mut windows = Vec::new();
+    let mut state = "available".to_owned();
+    let mut plan = None;
+    for (limit_id, snapshot) in snapshots {
+        let limit_label = snapshot
+            .limit_name
+            .clone()
+            .unwrap_or_else(|| humanize_limit_id(&limit_id));
+        if snapshot.rate_limit_reached_type.is_some()
+            || snapshot.spend_control_reached == Some(true)
+        {
+            state = "limited".into();
+        }
+        plan = plan.or(snapshot.plan_type.clone());
+        if let Some(window) = snapshot.primary {
+            windows.push(codex_window(&limit_id, &limit_label, "primary", window));
+        }
+        if let Some(window) = snapshot.secondary {
+            windows.push(codex_window(&limit_id, &limit_label, "secondary", window));
+        }
+    }
+    if windows.is_empty() {
+        return Ok(None);
+    }
+    windows.sort_by(|left, right| left.label.cmp(&right.label));
+    Ok(Some(UsageProvider {
+        id: "openai".into(),
+        label: "Codex".into(),
+        accounts: vec![UsageAccount {
+            id: "codex-direct".into(),
+            label: plan
+                .map(|plan| format!("Codex {}", title_case(&plan)))
+                .unwrap_or_else(|| "Codex".into()),
+            is_own: true,
+            state,
+            updated_at_unix_seconds: Some(chrono::Utc::now().timestamp()),
+            windows,
+        }],
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexRateLimits {
+    rate_limits: CodexSnapshot,
+    rate_limits_by_limit_id: Option<BTreeMap<String, CodexSnapshot>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexSnapshot {
+    limit_name: Option<String>,
+    primary: Option<CodexWindow>,
+    secondary: Option<CodexWindow>,
+    plan_type: Option<String>,
+    rate_limit_reached_type: Option<String>,
+    spend_control_reached: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodexWindow {
+    used_percent: f64,
+    window_duration_mins: Option<i64>,
+    resets_at: Option<i64>,
+}
+
+fn codex_window(limit_id: &str, limit_label: &str, slot: &str, window: CodexWindow) -> UsageWindow {
+    let duration = window
+        .window_duration_mins
+        .map(format_window_duration)
+        .unwrap_or_else(|| title_case(slot));
+    let label = if limit_label == "Codex" {
+        duration
+    } else {
+        format!("{duration} · {limit_label}")
+    };
+    UsageWindow {
+        key: format!("{limit_id}-{slot}"),
+        label,
+        used_percent: window.used_percent,
+        resets_at_unix_seconds: window.resets_at,
+        status: None,
+        model_scope: None,
+    }
+}
+
+fn format_window_duration(minutes: i64) -> String {
+    if minutes % 10_080 == 0 {
+        format!("Weekly ({}d)", minutes / 1_440)
+    } else if minutes % 1_440 == 0 {
+        format!("{}d", minutes / 1_440)
+    } else if minutes % 60 == 0 {
+        format!("Session ({}h)", minutes / 60)
+    } else {
+        format!("{minutes}m")
+    }
+}
+
+fn humanize_limit_id(id: &str) -> String {
+    if id == "codex" {
+        return "Codex".into();
+    }
+    title_case(&id.replace(['_', '-'], " "))
+}
+
+fn title_case(value: &str) -> String {
+    value
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            chars
+                .next()
+                .map(|first| first.to_uppercase().collect::<String>() + chars.as_str())
+                .unwrap_or_default()
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn bounded_text(bytes: &[u8], max_chars: usize) -> String {
+    String::from_utf8_lossy(bytes)
+        .trim()
+        .chars()
+        .take(max_chars)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modelctl_usage_keeps_own_and_shared_accounts() {
+        let raw: ModelctlUsage = serde_json::from_value(json!({
+            "providers": [{
+                "provider_kind": "anthropic",
+                "name": "Anthropic Direct",
+                "bindings": [{
+                    "binding_id": "mine",
+                    "label": "Personal",
+                    "is_own": true,
+                    "owner_email": "reader@example.com",
+                    "limit_state": "available",
+                    "usage_updated_at_unix_seconds": 123,
+                    "usage_windows": [{
+                        "key": "5h",
+                        "label": "Session (5h)",
+                        "used_percent": 14.0,
+                        "resets_at_unix_seconds": 456,
+                        "status": "allowed",
+                        "model_scope": null
+                    }]
+                }, {
+                    "binding_id": "shared",
+                    "label": "Team",
+                    "is_own": false,
+                    "owner_email": "owner@example.com",
+                    "limit_state": "available",
+                    "usage_windows": [{
+                        "key": "7d",
+                        "label": "Weekly (7d)",
+                        "used_percent": 52.0
+                    }]
+                }]
+            }]
+        }))
+        .expect("fixture");
+        let report = normalize_modelctl(raw);
+        assert_eq!(report.source, UsageSource::ModelGateway);
+        assert_eq!(report.providers[0].accounts.len(), 2);
+        assert!(report.providers[0].accounts[0].is_own);
+        assert_eq!(
+            report.providers[0].accounts[1].windows[0].used_percent,
+            52.0
+        );
+    }
+
+    #[test]
+    fn codex_multi_bucket_usage_becomes_readable_windows() {
+        let provider = normalize_codex(json!({
+            "rateLimits": {"primary": null, "secondary": null},
+            "rateLimitsByLimitId": {
+                "codex": {
+                    "limitName": null,
+                    "primary": {"usedPercent": 88, "windowDurationMins": 300, "resetsAt": 456},
+                    "secondary": null,
+                    "planType": "pro",
+                    "rateLimitReachedType": null,
+                    "spendControlReached": false
+                },
+                "codex_spark": {
+                    "limitName": "GPT-5 Spark",
+                    "primary": {"usedPercent": 12, "windowDurationMins": 10080, "resetsAt": 789},
+                    "secondary": null,
+                    "planType": "pro",
+                    "rateLimitReachedType": null,
+                    "spendControlReached": false
+                }
+            }
+        }))
+        .expect("decode")
+        .expect("provider");
+        assert_eq!(provider.accounts[0].label, "Codex Pro");
+        assert!(provider.accounts[0]
+            .windows
+            .iter()
+            .any(|window| window.label == "Session (5h)"));
+        assert!(provider.accounts[0]
+            .windows
+            .iter()
+            .any(|window| window.label == "Weekly (7d) · GPT-5 Spark"));
+    }
+}


### PR DESCRIPTION
## Summary

- add a fixed subscription-usage meter to the bottom of the Code mode sidebar
- show provider/account quota windows, reset timing, warning states, refresh controls, and progressive disclosure for shared accounts
- read rich usage data from `modelctl --json usage`, with a direct Codex app-server fallback when Model Gateway is unavailable
- preserve an honest unavailable state for harnesses without a stable machine-readable quota interface

## Implementation

The server exposes a new owner-scoped `GET /code/usage` route. Model Gateway is preferred because it provides normalized multi-provider and shared-account data. If it is unavailable, Tidebreak queries Codex through `account/rateLimits/read` and maps its primary and secondary windows into the same response shape.

The renderer validates the response before displaying it. Raw Model Gateway account labels, binding identifiers, and owner emails are not returned to the renderer; accounts receive local `Personal` and `Shared` labels instead. Collection failures degrade to diagnostics or an unavailable report rather than breaking Code mode.

The sidebar keeps the compact meter in the fixed footer above Theme and Settings. The detailed popover is viewport-bounded and scrollable, and automatic refreshes cannot overlap an in-flight request.

## Compatibility and risk

- no schema or persistent-data migration
- no behavior change for Chat mode or other sidebar consumers
- installations without Model Gateway continue to work through direct Codex usage when available
- Claude Code and Grok usage remain unavailable rather than relying on unstable shell scraping
- provider commands are time-limited and response sizes are bounded

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tidebreak-server routes::code::usage::tests --lib`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/code/parsers.test.ts src/code/CodeSidebar.dom.test.tsx`
- live visual verification with Model Gateway data in light and dark themes
- verified default and minimum-width sidebars, warning/critical meters, bounded scrolling, and shared-account disclosure
