### PR TITLE
feat(desktop): refuse host authority while attached remotely

### DIFF
--- a/crates/tidebreak-desktop/src/client_execution.rs
+++ b/crates/tidebreak-desktop/src/client_execution.rs
@@ -79,6 +79,9 @@ pub(crate) async fn resolve_folder_access_request(
     state: State<'_, HostAccess>,
     request: ResolveFolderAccessRequest,
 ) -> Result<(), String> {
+    state
+        .require_local(crate::host_authority::Authority::ClientExecutor)
+        .await?;
     if request.chat_id.is_nil() || request.call_id.is_nil() {
         return Err("invalid folder-access request identity".to_owned());
     }

--- a/crates/tidebreak-desktop/src/client_execution/computer_use.rs
+++ b/crates/tidebreak-desktop/src/client_execution/computer_use.rs
@@ -484,6 +484,9 @@ pub(crate) async fn stop_computer_use_control(
     app: AppHandle,
     state: State<'_, HostAccess>,
 ) -> Result<(), String> {
+    state
+        .require_local(crate::host_authority::Authority::ComputerUse)
+        .await?;
     state.computer_use.halt().await;
     emit_state(&app, &state.computer_use);
     Ok(())
@@ -496,6 +499,9 @@ pub(crate) async fn resume_computer_use_control(
     app: AppHandle,
     state: State<'_, HostAccess>,
 ) -> Result<(), String> {
+    state
+        .require_local(crate::host_authority::Authority::ComputerUse)
+        .await?;
     if native_binary_choice(
         &app,
         "Resume computer control?",

--- a/crates/tidebreak-desktop/src/client_execution/output_writeback.rs
+++ b/crates/tidebreak-desktop/src/client_execution/output_writeback.rs
@@ -53,6 +53,9 @@ pub(crate) async fn resolve_output_writeback_request(
     state: State<'_, HostAccess>,
     request: ResolveOutputWritebackRequest,
 ) -> Result<(), String> {
+    state
+        .require_local(crate::host_authority::Authority::ClientExecutor)
+        .await?;
     if request.chat_id.is_nil() || request.call_id.is_nil() {
         return Err("invalid output write-back request identity".to_owned());
     }

--- a/crates/tidebreak-desktop/src/deliverables.rs
+++ b/crates/tidebreak-desktop/src/deliverables.rs
@@ -67,6 +67,9 @@ pub(crate) async fn export_deliverable(
     host_access: State<'_, HostAccess>,
     request: ExportDeliverableRequest,
 ) -> Result<OutputExportResult, String> {
+    host_access
+        .require_local(crate::host_authority::Authority::NativeExport)
+        .await?;
     if request.operation_id.is_nil()
         || request.output_id.as_uuid().is_nil()
         || request.chat_id.is_nil()

--- a/crates/tidebreak-desktop/src/documents.rs
+++ b/crates/tidebreak-desktop/src/documents.rs
@@ -237,6 +237,9 @@ pub(crate) async fn export_library_document(
     host_access: State<'_, HostAccess>,
     request: LibraryDocumentRequest,
 ) -> Result<bool, String> {
+    host_access
+        .require_local(crate::host_authority::Authority::NativeExport)
+        .await?;
     let (chat_id, document_id) =
         resolve_document_scope(&host_access, request.chat_id, request.document_id).await?;
     let _picker = host_access

--- a/crates/tidebreak-desktop/src/host_access.rs
+++ b/crates/tidebreak-desktop/src/host_access.rs
@@ -30,6 +30,9 @@ pub(crate) struct HostAccess {
     pub(super) control_plane: OnceCell<ControlPlaneClient>,
     pub(super) receipts: ReceiptStore,
     staged_folders: OnceCell<std::sync::Arc<dyn tidebreak_server::code_execution::StagedFolders>>,
+    /// Which machine this client is attached to. Host authority applies to the
+    /// local one only, so every native command consults this first.
+    remote: std::sync::Arc<crate::remote::RemoteAttachment>,
 }
 
 impl HostAccess {
@@ -37,6 +40,7 @@ impl HostAccess {
         app: AppHandle,
         data_dir: PathBuf,
         home_dir: PathBuf,
+        remote: std::sync::Arc<crate::remote::RemoteAttachment>,
     ) -> Result<Self, String> {
         let receipts = ReceiptStore::open(&data_dir)
             .map_err(|_| "could not open private client-execution receipts".to_owned())?;
@@ -52,7 +56,22 @@ impl HostAccess {
             control_plane: OnceCell::new(),
             receipts,
             staged_folders: OnceCell::new(),
+            remote,
         })
+    }
+
+    /// Refuse `authority` unless this client is attached to the local machine.
+    ///
+    /// The error is the bare stable reason code — see
+    /// [`crate::host_authority`] for why, and for the four codes.
+    pub(crate) async fn require_local(
+        &self,
+        authority: crate::host_authority::Authority,
+    ) -> Result<(), String> {
+        crate::host_authority::require_local_authority(
+            self.remote.current().await.as_ref(),
+            authority,
+        )
     }
 
     /// Install the server's per-turn exec staging registry.
@@ -548,6 +567,9 @@ pub(crate) async fn connect_folder(
     state: State<'_, HostAccess>,
     request: ConnectFolderRequest,
 ) -> Result<Option<ConnectedFolder>, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     let context = state.context(request.chat_id).await?;
     let _picker = state
         .picker
@@ -584,6 +606,9 @@ pub(crate) async fn list_connected_folders(
     state: State<'_, HostAccess>,
     chat_id: Uuid,
 ) -> Result<Vec<ConnectedFolder>, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     connected_folders(&state, chat_id).await
 }
 
@@ -646,6 +671,9 @@ async fn connected_folders(
 pub(crate) async fn list_approved_folders(
     state: State<'_, HostAccess>,
 ) -> Result<Vec<ConnectedFolder>, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     approved_folders(&state).await
 }
 
@@ -659,6 +687,9 @@ pub(crate) async fn list_approved_folders(
 pub(crate) async fn list_capability_consents(
     state: State<'_, HostAccess>,
 ) -> Result<Vec<tidebreak_server::consent::ConsentStatementSnapshot>, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     let result = state
         .broker
         .control(ControlRequest::ListGrantStatements)
@@ -782,6 +813,9 @@ pub(crate) async fn revoke_capability_consent(
     state: State<'_, HostAccess>,
     request: RevokeCapabilityConsentRequest,
 ) -> Result<bool, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     let subject = match request.level {
         tidebreak_core::GrantLevel::Chat { chat_id } => GrantSubject::conversation(chat_id.0),
         tidebreak_core::GrantLevel::Project { project_id } => GrantSubject::project(project_id.0),
@@ -809,6 +843,9 @@ pub(crate) async fn connect_approved_folder(
     state: State<'_, HostAccess>,
     request: ConnectApprovedFolderRequest,
 ) -> Result<Option<ConnectedFolder>, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     state.context(request.chat_id).await?;
     let chat_label = conversation_label(&state, request.chat_id).await?;
     let root = approved_roots(&state)
@@ -873,6 +910,9 @@ pub(crate) async fn grant_folder_capability(
     state: State<'_, HostAccess>,
     request: GrantFolderCapabilityRequest,
 ) -> Result<Option<bool>, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     let chat_label = conversation_label(&state, request.chat_id).await?;
     let root = connected_folders(&state, request.chat_id)
         .await?
@@ -923,6 +963,9 @@ pub(crate) async fn disconnect_folder(
     state: State<'_, HostAccess>,
     request: DisconnectFolderRequest,
 ) -> Result<bool, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     let context = state.context(request.chat_id).await?;
     let _root_change = state.root_changes.lock().await;
     crate::client_execution::root_attachment_reconciliation::disconnect_root(
@@ -952,6 +995,9 @@ pub(crate) async fn forget_folder(
     state: State<'_, HostAccess>,
     request: ForgetFolderRequest,
 ) -> Result<bool, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     let _root_change = state.root_changes.lock().await;
     let result = state
         .broker
@@ -995,6 +1041,9 @@ pub(crate) async fn purge_deleted_conversation_subject(
     state: State<'_, HostAccess>,
     request: PurgeDeletedConversationSubjectRequest,
 ) -> Result<bool, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     if request.chat_id.is_nil() {
         return Err("invalid conversation identity".to_owned());
     }
@@ -1159,6 +1208,9 @@ pub(crate) async fn pick_code_directory(
     app: AppHandle,
     state: State<'_, HostAccess>,
 ) -> Result<Option<String>, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
     let _picker = state
         .picker
         .try_lock()

--- a/crates/tidebreak-desktop/src/host_authority.rs
+++ b/crates/tidebreak-desktop/src/host_authority.rs
@@ -1,0 +1,135 @@
+//! What this client may ask of the host it runs on, and what it says when it
+//! may not.
+//!
+//! Four authorities exist only on the machine this process runs on: the folder
+//! broker, the client executor, native export, and computer use. All four reach
+//! the user's own filesystem, screen, or input devices through credentials the
+//! renderer never holds.
+//!
+//! When the client is attached to a remote machine (decision record 47), the
+//! conversation lives somewhere else and none of those credentials apply to it.
+//! The failure mode this module exists to prevent is the half-working one the
+//! record names: a remote-attached client that quietly performs a folder
+//! operation or a native export against the *wrong* host — the server's
+//! filesystem, or this machine's, for a conversation on neither.
+//!
+//! So each authority refuses, and each refuses with its own stable reason, on
+//! the pattern `output_writeback_authority_unavailable` set: a machine-readable
+//! code that a client branches on, never prose. The renderer owns the copy.
+
+use crate::remote::Attached;
+
+/// A capability that exists only on the machine this process runs on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Authority {
+    /// Connecting, listing, granting, and revoking host folders.
+    FolderBroker,
+    /// Running a tool call this client claimed on the host's behalf.
+    ClientExecutor,
+    /// Writing bytes to a destination chosen in a native save dialog.
+    NativeExport,
+    /// Observing and halting control of this computer's screen and input.
+    ComputerUse,
+}
+
+/// The folder broker is not this client's to reach.
+pub(crate) const FOLDER_BROKER_UNAVAILABLE: &str = "folder_broker_authority_unavailable";
+/// The client executor is not this client's to reach.
+pub(crate) const CLIENT_EXECUTOR_UNAVAILABLE: &str = "client_executor_authority_unavailable";
+/// Native export is not this client's to reach.
+pub(crate) const NATIVE_EXPORT_UNAVAILABLE: &str = "native_export_authority_unavailable";
+/// Computer-use control is not this client's to reach.
+pub(crate) const COMPUTER_USE_UNAVAILABLE: &str = "computer_use_authority_unavailable";
+
+impl Authority {
+    /// The stable reason this authority gives when it is unavailable.
+    ///
+    /// One string per authority, not one shared string: a client that can only
+    /// learn "something host-shaped was refused" cannot tell the user which
+    /// capability it lost, and the four are lost for the same cause but have
+    /// four different consequences.
+    pub(crate) const fn unavailable_reason(self) -> &'static str {
+        match self {
+            Self::FolderBroker => FOLDER_BROKER_UNAVAILABLE,
+            Self::ClientExecutor => CLIENT_EXECUTOR_UNAVAILABLE,
+            Self::NativeExport => NATIVE_EXPORT_UNAVAILABLE,
+            Self::ComputerUse => COMPUTER_USE_UNAVAILABLE,
+        }
+    }
+}
+
+/// Refuse an authority the current attachment does not carry.
+///
+/// The error *is* the reason code, with no prose around it. These commands
+/// otherwise return free-text `String` errors, so the renderer distinguishes a
+/// refusal from a failure by comparing against the code rather than by reading
+/// the message — see `hostAuthorityRefusal` in `ui/src/host.ts`.
+pub(crate) fn require_local_authority(
+    attachment: Option<&Attached>,
+    authority: Authority,
+) -> Result<(), String> {
+    match attachment {
+        None => Ok(()),
+        Some(_) => Err(authority.unavailable_reason().to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attached() -> Attached {
+        Attached {
+            base_url: "https://machine.example.com".to_owned(),
+            token: "token-value".to_owned(),
+        }
+    }
+
+    const ALL: [Authority; 4] = [
+        Authority::FolderBroker,
+        Authority::ClientExecutor,
+        Authority::NativeExport,
+        Authority::ComputerUse,
+    ];
+
+    /// The decision-47 validation case: attached remotely, every host authority
+    /// refuses, and refuses with its own reason rather than succeeding against
+    /// the wrong host.
+    #[test]
+    fn every_authority_refuses_while_attached_remotely() {
+        let attached = attached();
+        for authority in ALL {
+            let refusal = require_local_authority(Some(&attached), authority)
+                .expect_err("a remote attachment carries no host authority");
+            assert_eq!(refusal, authority.unavailable_reason());
+        }
+    }
+
+    #[test]
+    fn every_authority_is_available_on_the_local_machine() {
+        for authority in ALL {
+            assert!(require_local_authority(None, authority).is_ok());
+        }
+    }
+
+    /// The codes are the contract. Written out rather than derived, so renaming
+    /// a variant cannot silently change what a client sees.
+    #[test]
+    fn the_reasons_are_stable_and_distinct() {
+        let reasons: Vec<&str> = ALL
+            .iter()
+            .map(|authority| authority.unavailable_reason())
+            .collect();
+        assert_eq!(
+            reasons,
+            vec![
+                "folder_broker_authority_unavailable",
+                "client_executor_authority_unavailable",
+                "native_export_authority_unavailable",
+                "computer_use_authority_unavailable",
+            ]
+        );
+        let unique: std::collections::HashSet<&&str> = reasons.iter().collect();
+        assert_eq!(unique.len(), reasons.len());
+    }
+}

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -28,6 +28,7 @@ mod deep_link;
 mod deliverables;
 mod documents;
 mod host_access;
+mod host_authority;
 mod image_attachments;
 mod node_install;
 mod office_install;
@@ -703,15 +704,22 @@ pub fn run() {
             // (stderr-only if that file cannot be created).
             tidebreak_server::logging::init_logging(&data);
             let home = home_dir(&handle)?;
-            let host_access = host_access::HostAccess::new(handle.clone(), data.clone(), home)?;
-            app.manage(host_access);
-            // Registered before the server boots: `server_info` consults the
-            // attachment first, and a remote client must not wait on a local
-            // boot it is not using.
-            app.manage(Arc::new(remote::RemoteAttachment::new(
+            // Built before anything that reaches the host: `server_info`
+            // consults the attachment first, because a remote client must not
+            // wait on a local boot it is not using, and every host-authority
+            // command consults it to decide whether it may act at all.
+            let attachment = Arc::new(remote::RemoteAttachment::new(
                 &data,
                 channel::current().keychain_service(),
-            )));
+            ));
+            let host_access = host_access::HostAccess::new(
+                handle.clone(),
+                data.clone(),
+                home,
+                attachment.clone(),
+            )?;
+            app.manage(host_access);
+            app.manage(attachment);
 
             tauri::async_runtime::spawn(async move {
                 if let Err(error) = boot_server(handle, &info_tx, store_tx, data.clone()).await {

--- a/crates/tidebreak-desktop/ui/src/host.test.ts
+++ b/crates/tidebreak-desktop/ui/src/host.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { hostAuthorityRefusal } from "./host";
+
+/**
+ * The four codes are the contract with the native shell. They are written out
+ * here rather than imported, so a rename on either side fails this test instead
+ * of passing silently.
+ */
+describe("host authority refusals", () => {
+  it("names the authority a remote-attached client lost", () => {
+    expect(hostAuthorityRefusal("folder_broker_authority_unavailable")).toBe("folder_broker");
+    expect(hostAuthorityRefusal("client_executor_authority_unavailable")).toBe("client_executor");
+    expect(hostAuthorityRefusal("native_export_authority_unavailable")).toBe("native_export");
+    expect(hostAuthorityRefusal("computer_use_authority_unavailable")).toBe("computer_use");
+  });
+
+  it("leaves every other failure alone", () => {
+    expect(hostAuthorityRefusal("host broker returned an unexpected response")).toBeNull();
+    expect(hostAuthorityRefusal("folder_broker_authority_unavailable extra")).toBeNull();
+    expect(hostAuthorityRefusal(new Error("folder_broker_authority_unavailable"))).toBeNull();
+    expect(hostAuthorityRefusal(undefined)).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/host.ts
+++ b/crates/tidebreak-desktop/ui/src/host.ts
@@ -16,6 +16,45 @@ export type ConnectedFolder = {
 export type FolderAccessDecision = "allow" | "decline";
 export type OutputWritebackDecision = "allow" | "decline";
 
+/**
+ * A host capability that exists only on the machine this app runs on.
+ *
+ * While this client is attached to a remote machine, none of the four apply to
+ * the conversation you are looking at, and each command that needs one refuses
+ * rather than acting against the wrong host.
+ */
+export type HostAuthority =
+  | "folder_broker"
+  | "client_executor"
+  | "native_export"
+  | "computer_use";
+
+/**
+ * The stable reason each authority gives when it is unavailable, following the
+ * precedent `output_writeback_authority_unavailable` set. These strings are the
+ * contract with the native shell; the copy that reaches the user is the
+ * renderer's, derived from the authority rather than from the code.
+ */
+const AUTHORITY_BY_REASON: Record<string, HostAuthority> = {
+  folder_broker_authority_unavailable: "folder_broker",
+  client_executor_authority_unavailable: "client_executor",
+  native_export_authority_unavailable: "native_export",
+  computer_use_authority_unavailable: "computer_use",
+};
+
+/**
+ * Which authority a failed host command refused for, or `null` if it failed for
+ * some other reason.
+ *
+ * A refusal arrives as the bare reason code and nothing else, which is what
+ * separates it from the free-text errors these commands otherwise return.
+ */
+export function hostAuthorityRefusal(error: unknown): HostAuthority | null {
+  const reason = typeof error === "string" ? error : null;
+  if (reason === null) return null;
+  return AUTHORITY_BY_REASON[reason] ?? null;
+}
+
 export function hasNativeHost(): boolean {
   return isTauri();
 }


### PR DESCRIPTION
Stacked on #2265. Review that one first; this diff is only the second commit.

Four capabilities exist only on the machine this process runs on: the folder broker, the client executor, native export, and computer use. All four reach your own filesystem, screen, or input devices through credentials the renderer never holds. While the client is attached to a remote machine, none of them apply to the conversation you are looking at.

## What this refuses, and why separately

Decision record 47 names the failure mode to prevent: a remote-attached client that half-works, performing a folder operation or a native export against the wrong host — the server's filesystem, or this machine's, for a conversation on neither. Each authority refuses instead, with its own stable reason:

| Authority | Reason |
|---|---|
| Folder broker | `folder_broker_authority_unavailable` |
| Client executor | `client_executor_authority_unavailable` |
| Native export | `native_export_authority_unavailable` |
| Computer use | `computer_use_authority_unavailable` |

Four reasons rather than one shared one. They are lost for the same cause but have four different consequences, and a client that can only learn "something host-shaped was refused" cannot tell you which capability it lost.

## Where the gate sits

`HostAccess` holds the attachment, and every host-authority command opens with `require_local`. That is the chokepoint: all seventeen commands already take `State<HostAccess>`, so the gate costs one line each and nothing reaches the broker, the control plane, or a save dialog ahead of it.

The error is the bare reason code with no prose around it, following `output_writeback_authority_unavailable`. These commands otherwise return free-text errors, so `hostAuthorityRefusal` in the renderer tells a refusal from a failure by comparing against the code rather than reading the message. The copy stays the renderer's to write, which is how export failures already work.

## One deliberate exception

`computer_use_state` is left ungated. It reports the native control state this process holds, which is genuinely empty while you are working on another machine. Refusing a read that already answers correctly would only cost the indicator its ability to say nothing is happening.

## Checks

- `cargo fmt --all --check`
- `cargo test -p tidebreak-desktop --lib` — 166 pass, including the decision-47 validation case: attached remotely, every authority refuses with its own reason rather than succeeding against the wrong host.
- `cargo clippy -p tidebreak-desktop --all-targets` — clean
- `tsc --noEmit`, plus a new `host.test.ts` that pins the four codes on the renderer side so a rename on either side fails a test instead of passing silently.