### PR TITLE
feat(desktop): connect to a machine from settings

### DIFF
--- a/crates/tidebreak-desktop/ui/src/FoldersView.tsx
+++ b/crates/tidebreak-desktop/ui/src/FoldersView.tsx
@@ -42,7 +42,7 @@ import {
 } from "./FolderAccess";
 import { verbLabel } from "./settings/PermissionsPanel";
 import { useRefreshSignals } from "./RefreshSignals";
-import { friendlyErrorMessage } from "@/lib/utils";
+import { hostErrorMessage } from "@/remoteMachine";
 
 /**
  * A chat's connected folders: the directories the native host may reach on
@@ -92,7 +92,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
       // A panel that could not load is a standing state, not a transient
       // failure, so it stays on the page. Every action below reports through a
       // toast instead.
-      setError(friendlyErrorMessage(err, "The folders could not be loaded."));
+      setError(hostErrorMessage(err, "The folders could not be loaded."));
     }
   }
 
@@ -125,7 +125,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
       const connected = await open();
       if (connected) useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
-      toast.error(friendlyErrorMessage(err, "The folder could not be changed."));
+      toast.error(hostErrorMessage(err, "The folder could not be changed."));
     } finally {
       useNativePickerLatch.getState().release(holder);
       setWorking(false);
@@ -170,7 +170,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
       useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
       toast.error(
-        friendlyErrorMessage(err, "The folder could not be disconnected."),
+        hostErrorMessage(err, "The folder could not be disconnected."),
       );
     } finally {
       setWorking(false);
@@ -196,7 +196,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
       await forgetFolder(folder.rootId);
       useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
-      toast.error(friendlyErrorMessage(err, "The folder could not be forgotten."));
+      toast.error(hostErrorMessage(err, "The folder could not be forgotten."));
     } finally {
       setWorking(false);
     }
@@ -223,7 +223,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
       await revokeCapabilityConsent(statement);
       useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
-      toast.error(friendlyErrorMessage(err, "The access could not be revoked."));
+      toast.error(hostErrorMessage(err, "The access could not be revoked."));
     } finally {
       setWorking(false);
     }

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputsView.tsx
@@ -26,8 +26,8 @@ import {
   PICKER_HOLDERS,
   useNativePickerLatch,
 } from "@/NativePickerLatch";
-import { friendlyErrorMessage } from "@/lib/utils";
 import { useRefreshSignals } from "@/RefreshSignals";
+import { hostErrorMessage } from "@/remoteMachine";
 import { OutputsTable } from "./OutputsTable";
 
 export type OutputsApis = {
@@ -262,6 +262,11 @@ export function exportFailureMessage(
   }
 }
 
+/**
+ * Saving a file reaches this computer, so a window attached to a remote machine
+ * is refused rather than writing to the wrong host. That refusal gets its own
+ * sentence; everything else falls through to the ordinary failure copy.
+ */
 export function friendlyOutputError(error: unknown, fallback: string): string {
-  return friendlyErrorMessage(error, fallback);
+  return hostErrorMessage(error, fallback);
 }

--- a/crates/tidebreak-desktop/ui/src/remoteMachine.test.ts
+++ b/crates/tidebreak-desktop/ui/src/remoteMachine.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HOST_AUTHORITIES,
+  connectFailureMessage,
+  hostAuthorityLabel,
+  hostErrorMessage,
+  remoteConnectError,
+} from "./remoteMachine";
+
+describe("remote connect refusals", () => {
+  /**
+   * The shell sends a reason and nothing else. Every reason it can send needs
+   * copy here, or a user meets a blank where an explanation belongs.
+   */
+  it("words every reason the shell can send", () => {
+    const reasons = [
+      "remote_machine_url_invalid",
+      "remote_machine_requires_tls",
+      "remote_machine_unreachable",
+      "remote_machine_token_refused",
+      "remote_machine_not_a_machine",
+      "remote_machine_token_storage_failed",
+    ] as const;
+    for (const reason of reasons) {
+      const refused = remoteConnectError({ reason, detail: null });
+      expect(refused, reason).not.toBeNull();
+      expect(connectFailureMessage(refused!).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("says why https is required, because that is the refusal a reader can act on", () => {
+    const refused = remoteConnectError({ reason: "remote_machine_requires_tls", detail: null });
+    expect(connectFailureMessage(refused!)).toContain("https");
+  });
+
+  it("leaves anything that is not a worded refusal to the ordinary failure path", () => {
+    expect(remoteConnectError({ reason: "remote_machine_invented_reason" })).toBeNull();
+    expect(remoteConnectError("remote_machine_requires_tls")).toBeNull();
+    expect(remoteConnectError(null)).toBeNull();
+  });
+});
+
+describe("host authority refusals reaching a reader", () => {
+  it("names the capability and the reason instead of the raw code", () => {
+    const message = hostErrorMessage("folder_broker_authority_unavailable", "fallback");
+    expect(message).toContain(hostAuthorityLabel("folder_broker"));
+    expect(message).toContain("remote machine");
+    expect(message).not.toContain("folder_broker_authority_unavailable");
+  });
+
+  it("covers all four authorities", () => {
+    for (const authority of HOST_AUTHORITIES) {
+      expect(hostAuthorityLabel(authority).length).toBeGreaterThan(0);
+    }
+    expect(HOST_AUTHORITIES).toHaveLength(4);
+  });
+
+  it("falls through for an ordinary failure", () => {
+    expect(hostErrorMessage("host broker returned an unexpected response", "fallback")).toBe(
+      "host broker returned an unexpected response",
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/remoteMachine.ts
+++ b/crates/tidebreak-desktop/ui/src/remoteMachine.ts
@@ -1,0 +1,116 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
+import type {
+  RemoteConnectError,
+  RemoteConnectReason,
+  RemoteMachineState,
+} from "./api";
+import type { HostAuthority } from "./host";
+import { hostAuthorityRefusal } from "./host";
+import { friendlyErrorMessage } from "./lib/utils";
+
+/**
+ * Attaching this client to a machine it does not host.
+ *
+ * A machine is a running Tidebreak server. Normally this app is both machine
+ * and client. Attached remotely, it is only the client: the conversation, the
+ * agents, and the work all live somewhere else, and this computer contributes
+ * nothing but the window.
+ *
+ * The shell owns the address and the token. This module owns the copy — every
+ * refusal crosses the boundary as a stable reason, never as a sentence, so the
+ * wording below is the renderer's to change without touching the shell.
+ */
+
+/** Which machine this client is attached to. */
+export async function remoteMachineState(): Promise<RemoteMachineState> {
+  if (!isTauri()) return { attachment: "local", baseUrl: null };
+  return await invoke<RemoteMachineState>("remote_machine_state");
+}
+
+/** Attach to a machine. Throws a {@link RemoteConnectError} when refused. */
+export async function connectRemoteMachine(
+  baseUrl: string,
+  token: string,
+): Promise<RemoteMachineState> {
+  return await invoke<RemoteMachineState>("connect_remote_machine", { baseUrl, token });
+}
+
+/** Detach and forget the machine's token. */
+export async function disconnectRemoteMachine(): Promise<RemoteMachineState> {
+  return await invoke<RemoteMachineState>("disconnect_remote_machine");
+}
+
+/** A refused connect, or `null` when the failure was something else. */
+export function remoteConnectError(error: unknown): RemoteConnectError | null {
+  if (!error || typeof error !== "object") return null;
+  const candidate = error as { reason?: unknown; detail?: unknown };
+  if (typeof candidate.reason !== "string") return null;
+  if (!(candidate.reason in CONNECT_COPY)) return null;
+  return {
+    reason: candidate.reason as RemoteConnectReason,
+    detail: typeof candidate.detail === "string" ? candidate.detail : null,
+  };
+}
+
+/**
+ * What to say about each refusal.
+ *
+ * Exhaustive by construction: a new reason on the shell side has no entry here
+ * until someone writes one, and `remoteConnectError` will not recognize it, so
+ * an unworded refusal surfaces as an ordinary failure rather than as a blank.
+ */
+const CONNECT_COPY: Record<RemoteConnectReason, string> = {
+  remote_machine_url_invalid:
+    "That is not an address this app can use. Enter the full URL, starting with https://.",
+  remote_machine_requires_tls:
+    "The address must use https. Plain http reaches only a machine on this computer, because the token would otherwise travel in the clear.",
+  remote_machine_unreachable:
+    "That machine did not answer. Check the address, and check that you can reach it from this network.",
+  remote_machine_token_refused:
+    "That machine refused the token. Check that you copied all of it, and that it has not been revoked.",
+  remote_machine_not_a_machine:
+    "Something answered at that address, but not a Tidebreak machine. Check the address.",
+  remote_machine_token_storage_failed:
+    "The token could not be saved to this computer's credential store. Nothing was changed.",
+};
+
+export function connectFailureMessage(error: RemoteConnectError): string {
+  return CONNECT_COPY[error.reason];
+}
+
+/** What each host capability is called where a reader can see it. */
+const AUTHORITY_LABEL: Record<HostAuthority, string> = {
+  folder_broker: "Connected folders",
+  client_executor: "Tool calls that run on your computer",
+  native_export: "Saving files to this computer",
+  computer_use: "Computer use",
+};
+
+export function hostAuthorityLabel(authority: HostAuthority): string {
+  return AUTHORITY_LABEL[authority];
+}
+
+/** Every capability, in the order the panel lists them. */
+export const HOST_AUTHORITIES: HostAuthority[] = [
+  "folder_broker",
+  "client_executor",
+  "native_export",
+  "computer_use",
+];
+
+/**
+ * What a refused host command means, said once for all four.
+ *
+ * The cause is the same in every case — this window is attached to another
+ * machine — so the sentence names the cause, and the capability's own label
+ * carries the rest. Use it wherever a host command's failure reaches a reader,
+ * so a refusal never surfaces as its raw code.
+ */
+export function hostErrorMessage(error: unknown, fallback: string): string {
+  const authority = hostAuthorityRefusal(error);
+  if (authority) {
+    return `${AUTHORITY_LABEL[authority]} is not available while this window is attached to a remote machine. It reaches this computer, and your conversation is not on it.`;
+  }
+  return friendlyErrorMessage(error, fallback);
+}

--- a/crates/tidebreak-desktop/ui/src/settings/MachinePanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/MachinePanel.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useState } from "react";
+import { Laptop, Server } from "lucide-react";
+
+import type { RemoteMachineState } from "../api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useConfirm } from "@/components/ConfirmDialog";
+import {
+  HOST_AUTHORITIES,
+  connectFailureMessage,
+  connectRemoteMachine,
+  disconnectRemoteMachine,
+  hostAuthorityLabel,
+  remoteConnectError,
+  remoteMachineState,
+} from "@/remoteMachine";
+import { friendlyErrorMessage } from "@/lib/utils";
+import {
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+  SettingsStatus,
+} from "./primitives";
+
+/**
+ * Where you choose which machine this window works on.
+ *
+ * A machine is a running Tidebreak server. This app ships with one inside it,
+ * which is what you use by default. Attaching to another one means your
+ * conversations, your agents, and their work live there instead — so they keep
+ * running when you close this laptop, and any device you hold can supervise
+ * them.
+ *
+ * The trade is host authority, and the panel states it up front rather than
+ * letting you discover it when a folder picker refuses.
+ */
+export function MachinePanel() {
+  const [state, setState] = useState<RemoteMachineState | null>(null);
+  const [baseUrl, setBaseUrl] = useState("");
+  const [token, setToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { confirm, dialog: confirmDialog } = useConfirm();
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const current = await remoteMachineState();
+        if (!cancelled) setState(current);
+      } catch (failure) {
+        if (!cancelled) setError(friendlyErrorMessage(failure, "Could not read the connection."));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const remote = state?.attachment === "remote";
+
+  /**
+   * A reload rather than a state update: the API client, the event stream, and
+   * every cached read were built against the machine this window opened on.
+   * Rebuilding them piecemeal is how a client ends up half-attached.
+   */
+  function reattach() {
+    window.location.reload();
+  }
+
+  async function connect() {
+    setBusy(true);
+    setError(null);
+    try {
+      await connectRemoteMachine(baseUrl, token);
+      reattach();
+    } catch (failure) {
+      const refused = remoteConnectError(failure);
+      setError(
+        refused
+          ? connectFailureMessage(refused)
+          : friendlyErrorMessage(failure, "Could not connect to that machine."),
+      );
+      setBusy(false);
+    }
+  }
+
+  async function disconnect() {
+    const accepted = await confirm({
+      title: "Work on this computer again?",
+      description:
+        "This window reattaches to the Tidebreak server inside this app. Work on the other machine keeps running; you stop watching it, and this computer's copy of the token is forgotten.",
+      confirmLabel: "Disconnect",
+    });
+    if (!accepted) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await disconnectRemoteMachine();
+      reattach();
+    } catch (failure) {
+      setError(friendlyErrorMessage(failure, "Could not disconnect."));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <SettingsPanel
+      title="Machine"
+      description="Which Tidebreak server this window works on."
+      busy={busy}
+    >
+      {confirmDialog}
+      {remote ? (
+        <SettingsStatus
+          tone="ready"
+          label="Attached to a remote machine"
+          description={
+            <>
+              Your conversations and agents run on {state?.baseUrl}. They keep
+              running when you close this window.
+            </>
+          }
+        />
+      ) : (
+        <SettingsStatus
+          tone="disabled"
+          label="Working on this computer"
+          description="Your conversations and agents run inside this app, and stop when it does."
+        />
+      )}
+
+      {remote ? (
+        <SettingsSection
+          title="Remote machine"
+          description="Disconnecting returns this window to the server inside this app. It changes nothing on the remote machine."
+        >
+          <SettingsField label="Address">
+            <p className="flex items-center gap-2 text-sm">
+              <Server size={16} aria-hidden />
+              <span>{state?.baseUrl}</span>
+            </p>
+          </SettingsField>
+          <div>
+            <Button variant="outline" onClick={() => void disconnect()} disabled={busy}>
+              <Laptop size={16} aria-hidden />
+              Work on this computer
+            </Button>
+          </div>
+          {error && <SettingsError>{error}</SettingsError>}
+        </SettingsSection>
+      ) : (
+        <SettingsSection
+          title="Connect to a machine"
+          description="Enter the address of a Tidebreak server and a token for your account on it. The address must use https unless the machine is on this computer, because the token would otherwise travel in the clear."
+        >
+          <SettingsField label="Address" hint="For example, https://tidebreak.example.com.">
+            <Input
+              value={baseUrl}
+              onChange={(event) => setBaseUrl(event.target.value)}
+              placeholder="https://"
+              autoComplete="off"
+              spellCheck={false}
+              disabled={busy}
+            />
+          </SettingsField>
+          <SettingsField
+            label="Token"
+            hint="Whoever runs the machine issues this. It is stored in this computer's credential store, not in a file."
+          >
+            <Input
+              type="password"
+              value={token}
+              onChange={(event) => setToken(event.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+              disabled={busy}
+            />
+          </SettingsField>
+          <div>
+            <Button
+              onClick={() => void connect()}
+              disabled={busy || !baseUrl.trim() || !token.trim()}
+            >
+              <Server size={16} aria-hidden />
+              Connect
+            </Button>
+          </div>
+          {error && <SettingsError>{error}</SettingsError>}
+        </SettingsSection>
+      )}
+
+      <SettingsSection
+        title="What stays on this computer"
+        description={
+          remote
+            ? "These reach this computer's files, screen, and input. Your conversation is not on this computer, so they are unavailable until you disconnect."
+            : "These reach this computer's files, screen, and input. Attaching to a remote machine makes them unavailable, because your conversation would not be on this computer."
+        }
+      >
+        <ul className="flex flex-col gap-2 text-sm">
+          {HOST_AUTHORITIES.map((authority) => (
+            <li key={authority} className="flex items-center gap-2">
+              <Laptop
+                size={16}
+                aria-hidden
+                className={remote ? "text-muted-foreground" : "text-icon-green"}
+              />
+              <span className={remote ? "text-muted-foreground line-through" : undefined}>
+                {hostAuthorityLabel(authority)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </SettingsSection>
+    </SettingsPanel>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -8,6 +8,7 @@ import type {
   RendererToolName,
 } from "../api";
 import { useConfirm } from "../components/ConfirmDialog";
+import { hostErrorMessage } from "@/remoteMachine";
 import {
   grantFolderCapability,
   listCapabilityConsents,
@@ -23,7 +24,6 @@ import {
 } from "../NativePickerLatch";
 import { useRefreshSignals } from "../RefreshSignals";
 import { Button } from "@/components/ui/button";
-import { friendlyErrorMessage } from "@/lib/utils";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 
 // The "what may the agent do without asking" surface, rendered from the
@@ -445,7 +445,7 @@ export function PermissionsPanel({
       if (granted !== null) await reload();
     } catch (caught) {
       toast.error(
-        friendlyErrorMessage(caught, "The folder could not be granted access."),
+        hostErrorMessage(caught, "The folder could not be granted access."),
       );
     } finally {
       useNativePickerLatch.getState().release(PICKER_HOLDERS.grantFolderCapability);

--- a/crates/tidebreak-desktop/ui/src/settings/sections.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.tsx
@@ -12,6 +12,7 @@ import {
   ShieldCheck,
   SquareTerminal,
   Mic,
+  MonitorSmartphone,
   Terminal,
   Waypoints,
 } from "lucide-react";
@@ -26,6 +27,7 @@ import { CodeExecutionPanel } from "./CodeExecutionPanel";
 import { CompactionPanel } from "./CompactionPanel";
 import { ConnectedAppsPanel } from "./ConnectedAppsPanel";
 import { GatewayPanel } from "./GatewayPanel";
+import { MachinePanel } from "./MachinePanel";
 import { PermissionsPanel } from "./PermissionsPanel";
 import { ModelsPanel } from "./ModelsPanel";
 import { ProvidersPanel } from "./ProvidersPanel";
@@ -290,6 +292,16 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     icon: ShieldCheck,
     iconClass: "text-icon-green",
     Component: PermissionsSection,
+  },
+  // Last among the substantive sections: attaching to another machine changes
+  // what every section above it is configuring, so a reader meets them in
+  // their default meaning first.
+  {
+    path: "machine",
+    label: "Machine",
+    icon: MonitorSmartphone,
+    iconClass: "text-icon-cyan",
+    Component: MachinePanel,
   },
   {
     path: "appearance",

--- a/crates/tidebreak-desktop/ui/src/useFolderAccessRequests.test.ts
+++ b/crates/tidebreak-desktop/ui/src/useFolderAccessRequests.test.ts
@@ -7,7 +7,11 @@ import { useNativePickerLatch } from "./NativePickerLatch";
 import { usePendingPrompts } from "./PendingPrompts";
 import * as host from "./host";
 
-vi.mock("./host", () => ({
+vi.mock("./host", async (importOriginal) => ({
+  // The refusal mapping is real: a failed decision reads the error to tell a
+  // host-authority refusal from an ordinary failure, and stubbing that out
+  // would test a code path the app never runs.
+  ...(await importOriginal<typeof import("./host")>()),
   hasNativeHost: vi.fn(() => true),
   resolveFolderAccessRequest: vi.fn(),
 }));

--- a/crates/tidebreak-desktop/ui/src/useFolderAccessRequests.ts
+++ b/crates/tidebreak-desktop/ui/src/useFolderAccessRequests.ts
@@ -5,6 +5,7 @@ import {
   resolveFolderAccessRequest,
   type FolderAccessDecision,
 } from "./host";
+import { hostErrorMessage } from "./remoteMachine";
 import {
   PICKER_BUSY_MESSAGE,
   useNativePickerLatch,
@@ -79,7 +80,10 @@ export function useFolderAccessRequests(
       await resolveFolderAccessRequest(startedChatId, callId, decision);
     } catch (err) {
       if (stillOpen(startedChatId)) {
-        setErrors((current) => ({ ...current, [callId]: String(err) }));
+        setErrors((current) => ({
+          ...current,
+          [callId]: hostErrorMessage(err, "That could not be done."),
+        }));
       }
     } finally {
       finishResolving(callId, startedChatId);
@@ -94,7 +98,10 @@ export function useFolderAccessRequests(
       await client.cancel(startedChatId, turnId);
     } catch (err) {
       if (stillOpen(startedChatId)) {
-        setErrors((current) => ({ ...current, [callId]: String(err) }));
+        setErrors((current) => ({
+          ...current,
+          [callId]: hostErrorMessage(err, "That could not be done."),
+        }));
       }
     } finally {
       finishResolving(callId, startedChatId);

--- a/crates/tidebreak-desktop/ui/src/useOutputWritebackRequests.ts
+++ b/crates/tidebreak-desktop/ui/src/useOutputWritebackRequests.ts
@@ -6,6 +6,7 @@ import {
   resolveOutputWritebackRequest,
   type OutputWritebackDecision,
 } from "./host";
+import { hostErrorMessage } from "./remoteMachine";
 import { useOpenConversation } from "./OpenConversation";
 import { usePendingPrompts } from "./PendingPrompts";
 
@@ -53,7 +54,10 @@ export function useOutputWritebackRequests(
       await resolveOutputWritebackRequest(startedChatId, callId, decision);
     } catch (err) {
       if (stillOpen(startedChatId)) {
-        setErrors((current) => ({ ...current, [callId]: String(err) }));
+        setErrors((current) => ({
+          ...current,
+          [callId]: hostErrorMessage(err, "That could not be done."),
+        }));
       }
     } finally {
       if (stillOpen(startedChatId)) {
@@ -75,7 +79,10 @@ export function useOutputWritebackRequests(
       if (stillOpen(startedChatId)) refresh();
     } catch (err) {
       if (stillOpen(startedChatId)) {
-        setErrors((current) => ({ ...current, [callId]: String(err) }));
+        setErrors((current) => ({
+          ...current,
+          [callId]: hostErrorMessage(err, "That could not be done."),
+        }));
       }
     }
   }


### PR DESCRIPTION
Stacked on #2267, which is stacked on #2265. Review those first; this diff is only the third commit.

The last piece of decision record 47 point 3: a place to attach this window to another machine, and copy for what that costs.

## The Machine section

A new settings section takes an address and a token and says which machine you are on. It sits last among the substantive sections, because attaching changes what every section above it is configuring — you meet them in their default meaning first.

Connecting and disconnecting reload the window. The API client, the event stream, and every cached read were built against the machine this window opened on; rebuilding them piecemeal is how a client ends up half-attached.

The panel states the trade before you make it, rather than letting you find it when a folder picker refuses. It lists the four capabilities that stay on this computer — connected folders, tool calls that run here, saving files here, and computer use — and strikes them through while you are attached elsewhere.

## One place owns the words

`remoteMachine.ts` holds every sentence. Both boundaries send stable reasons and no prose, so the wording changes here without touching the shell: the six connect refusals from #2265 and the four host-authority refusals from #2267.

Connect reasons are recognized from a table rather than accepted as any string. A reason nobody has worded yet surfaces as an ordinary failure instead of as a blank.

## Refusals reach the reader

Wherever a host command can fail, a refusal now says which capability is unavailable and why, in place of the raw code: the folder-access and write-back decision cards, the folders panel, the permissions panel, and output export. Output export routes through `friendlyOutputError`, which was already the single chokepoint for that surface.

## Checks

- `cargo fmt --all --check`; `cargo test -p tidebreak-desktop --lib` — 166 pass, unchanged by this commit
- `tsc --noEmit`
- Full UI suite: 1293 tests across 192 files pass, including new tests that every connect reason has copy, that the https refusal says so, and that a host refusal names the capability rather than printing its code.

One existing test double needed widening: `useFolderAccessRequests.test.ts` mocked the whole host module, so the real refusal mapping is now spread in rather than stubbed out — otherwise the test would exercise a path the app never runs.