### PR TITLE
ci: require writer approval on outsider pull requests

### DIFF
--- a/.github/workflows/engineering-approval.yml
+++ b/.github/workflows/engineering-approval.yml
@@ -1,0 +1,48 @@
+name: Engineering approval
+
+on:
+  # Trusted default-branch workflow. Forks cannot delete this job. Checkout is
+  # always the pull request's base SHA, never the head.
+  pull_request_target:
+    types:
+      [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+  # Required checks must report on speculative merge groups or the queue stalls.
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: engineering-approval-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
+jobs:
+  approval:
+    name: engineering approval
+    if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' || github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Accept merge groups already gated on the pull request
+        if: ${{ github.event_name == 'merge_group' }}
+        run: echo "Merge groups reuse the pull request approval check."
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: ${{ github.event_name != 'merge_group' }}
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Require a writer approval for non-maintainers
+        if: ${{ github.event_name != 'merge_group' }}
+        env:
+          CANONICAL_REPOSITORY: brightwave-inc/tidebreak
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/check-engineering-approval.mjs

--- a/.github/workflows/engineering-approval.yml
+++ b/.github/workflows/engineering-approval.yml
@@ -2,7 +2,7 @@ name: Engineering approval
 
 on:
   # Trusted default-branch workflow. Forks cannot delete this job. Checkout is
-  # always the pull request's base SHA, never the head.
+  # the commit that contains this workflow file, never the pull request head.
   pull_request_target:
     types:
       [opened, reopened, synchronize, ready_for_review, converted_to_draft]
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: ${{ github.event_name != 'merge_group' }}
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.workflow_sha }}
           fetch-depth: 1
           persist-credentials: false
       - name: Require a writer approval for non-maintainers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,10 @@ queue or enable auto-merge. GitHub groups ready pull requests, runs the
 required checks on that combined tree, and squash-merges the group if those
 checks pass.
 
+A pull request whose author cannot write to the repository needs an approving
+review from someone who can, on the current head commit, before it can enter
+the queue. Maintainers can enable auto-merge without a second review.
+
 You do not need to rebase onto `main` first. If the group fails, GitHub
 removes the pull request that broke it. Rebase, fix, and queue it again.
 

--- a/scripts/check-engineering-approval.mjs
+++ b/scripts/check-engineering-approval.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export const WRITE_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+
+export function hasWritePermission(permission) {
+  return WRITE_PERMISSIONS.has(permission);
+}
+
+const TERMINAL_REVIEW_STATES = new Set([
+  "APPROVED",
+  "CHANGES_REQUESTED",
+  "DISMISSED",
+]);
+
+export function latestWriterReviews(reviews, permissionFor) {
+  const latest = new Map();
+  for (const review of reviews) {
+    if (!TERMINAL_REVIEW_STATES.has(review.state)) continue;
+    if (typeof review.user !== "string" || review.user.length === 0) continue;
+    if (!hasWritePermission(permissionFor(review.user))) continue;
+    latest.set(review.user, review);
+  }
+  return [...latest.values()];
+}
+
+export function evaluateEngineeringApproval({
+  eventName,
+  author,
+  headSha,
+  reviews,
+  permissionFor,
+}) {
+  if (eventName === "merge_group") {
+    return {
+      ok: true,
+      reason: "merge groups reuse the pull request approval check",
+    };
+  }
+
+  if (typeof author !== "string" || author.length === 0) {
+    return { ok: false, reason: "the pull request author is missing" };
+  }
+
+  if (hasWritePermission(permissionFor(author))) {
+    return {
+      ok: true,
+      reason: `${author} can write to the repository, so this pull request does not need a separate approval`,
+    };
+  }
+
+  if (typeof headSha !== "string" || headSha.length === 0) {
+    return { ok: false, reason: "the pull request head SHA is missing" };
+  }
+
+  const approvers = latestWriterReviews(reviews, permissionFor)
+    .filter((review) => review.state === "APPROVED")
+    .filter((review) => review.commitId === headSha)
+    .map((review) => review.user);
+  if (approvers.length > 0) {
+    return {
+      ok: true,
+      reason: `${approvers.join(", ")} approved ${headSha.slice(0, 7)}`,
+    };
+  }
+
+  return {
+    ok: false,
+    reason: [
+      `${author} cannot write to this repository.`,
+      "An approving review from someone with write access is required on the current head commit.",
+    ].join(" "),
+  };
+}
+
+function ghApi(path, extraArgs = []) {
+  return execFileSync("gh", ["api", ...extraArgs, path], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function permissionFor(repository, login) {
+  try {
+    const payload = JSON.parse(
+      ghApi(`repos/${repository}/collaborators/${login}/permission`),
+    );
+    return typeof payload.permission === "string" ? payload.permission : "none";
+  } catch {
+    return "none";
+  }
+}
+
+function reviewsFor(repository, number) {
+  const raw = ghApi(`repos/${repository}/pulls/${number}/reviews`, [
+    "--paginate",
+    "--jq",
+    ".[] | {state, commitId: .commit_id, user: .user.login}",
+  ]);
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+}
+
+function main() {
+  const eventName = process.env.EVENT_NAME ?? "";
+  if (eventName === "merge_group") {
+    const decision = evaluateEngineeringApproval({
+      eventName,
+      author: "",
+      headSha: "",
+      reviews: [],
+      permissionFor: () => "none",
+    });
+    console.log(decision.reason);
+    return;
+  }
+
+  const repository = process.env.CANONICAL_REPOSITORY ?? "";
+  const number = process.env.PR_NUMBER ?? "";
+  const author = process.env.PR_AUTHOR ?? "";
+  const headSha = process.env.PR_HEAD_SHA ?? "";
+  if (!repository || !number || !author || !headSha) {
+    console.error(
+      "CANONICAL_REPOSITORY, PR_NUMBER, PR_AUTHOR, and PR_HEAD_SHA are required",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const cache = new Map();
+  const decision = evaluateEngineeringApproval({
+    eventName,
+    author,
+    headSha,
+    reviews: reviewsFor(repository, number),
+    permissionFor: (login) => {
+      if (!cache.has(login)) {
+        cache.set(login, permissionFor(repository, login));
+      }
+      return cache.get(login);
+    },
+  });
+  if (decision.ok) {
+    console.log(decision.reason);
+    return;
+  }
+  console.error(decision.reason);
+  process.exitCode = 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/check-engineering-approval.test.mjs
+++ b/scripts/check-engineering-approval.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateEngineeringApproval,
+  hasWritePermission,
+} from "./check-engineering-approval.mjs";
+
+const permissions = {
+  naingthet: "admin",
+  bkotara: "write",
+  vvnlo: "read",
+  outsider: "read",
+};
+
+function decide(overrides) {
+  return evaluateEngineeringApproval({
+    eventName: "pull_request_target",
+    author: "outsider",
+    headSha: "abc123def456",
+    reviews: [],
+    permissionFor: (login) => permissions[login] ?? "none",
+    ...overrides,
+  });
+}
+
+test("write permissions are admin, maintain, and write", () => {
+  assert.equal(hasWritePermission("admin"), true);
+  assert.equal(hasWritePermission("maintain"), true);
+  assert.equal(hasWritePermission("write"), true);
+  assert.equal(hasWritePermission("read"), false);
+  assert.equal(hasWritePermission("none"), false);
+  assert.equal(hasWritePermission("triage"), false);
+});
+
+test("merge groups pass without looking up reviewers", () => {
+  const decision = decide({
+    eventName: "merge_group",
+    author: "",
+    headSha: "",
+    permissionFor: () => {
+      throw new Error("merge groups must not look up permissions");
+    },
+  });
+  assert.equal(decision.ok, true);
+});
+
+test("a writer can merge their own pull request without a review", () => {
+  const decision = decide({ author: "naingthet" });
+  assert.equal(decision.ok, true);
+  assert.match(decision.reason, /naingthet/);
+});
+
+test("a read-only org member still needs a writer approval", () => {
+  const decision = decide({ author: "vvnlo" });
+  assert.equal(decision.ok, false);
+});
+
+test("an outsider with no reviews cannot merge", () => {
+  const decision = decide({});
+  assert.equal(decision.ok, false);
+  assert.match(decision.reason, /outsider/);
+});
+
+test("an outsider needs a writer approval on the current head", () => {
+  const decision = decide({
+    reviews: [
+      { state: "APPROVED", commitId: "abc123def456", user: "bkotara" },
+    ],
+  });
+  assert.equal(decision.ok, true);
+  assert.match(decision.reason, /bkotara/);
+});
+
+test("an approval of an older commit does not count", () => {
+  const decision = decide({
+    reviews: [
+      { state: "APPROVED", commitId: "000000000000", user: "bkotara" },
+    ],
+  });
+  assert.equal(decision.ok, false);
+});
+
+test("a read-only approval does not count", () => {
+  const decision = decide({
+    reviews: [
+      { state: "APPROVED", commitId: "abc123def456", user: "vvnlo" },
+    ],
+  });
+  assert.equal(decision.ok, false);
+});
+
+test("a comment or dismissed review does not count", () => {
+  for (const state of ["COMMENTED", "DISMISSED", "CHANGES_REQUESTED"]) {
+    const decision = decide({
+      reviews: [{ state, commitId: "abc123def456", user: "bkotara" }],
+    });
+    assert.equal(decision.ok, false, state);
+  }
+});
+
+test("a later changes-requested review replaces an approval", () => {
+  const decision = decide({
+    reviews: [
+      { state: "APPROVED", commitId: "abc123def456", user: "bkotara" },
+      {
+        state: "CHANGES_REQUESTED",
+        commitId: "abc123def456",
+        user: "bkotara",
+      },
+    ],
+  });
+  assert.equal(decision.ok, false);
+});
+
+test("a later approval on the current head replaces an older review", () => {
+  const decision = decide({
+    reviews: [
+      { state: "CHANGES_REQUESTED", commitId: "000000000000", user: "bkotara" },
+      { state: "APPROVED", commitId: "abc123def456", user: "bkotara" },
+    ],
+  });
+  assert.equal(decision.ok, true);
+});
+
+test("a missing author or head SHA fails closed", () => {
+  assert.equal(decide({ author: "" }).ok, false);
+  assert.equal(decide({ headSha: "" }).ok, false);
+});

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -521,7 +521,7 @@ const mutations = [
     expected: "engineering approval is a trusted base-branch check",
     mutate: (source) =>
       source.replace(
-        "ref: ${{ github.event.pull_request.base.sha }}",
+        "ref: ${{ github.workflow_sha }}",
         "ref: ${{ github.event.pull_request.head.sha }}",
       ),
   },

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -515,6 +515,16 @@ const mutations = [
         "Tidebreak-macos-legacy.dmg",
       ),
   },
+  {
+    name: "engineering approval checks out the pull request head",
+    file: ".github/workflows/engineering-approval.yml",
+    expected: "engineering approval is a trusted base-branch check",
+    mutate: (source) =>
+      source.replace(
+        "ref: ${{ github.event.pull_request.base.sha }}",
+        "ref: ${{ github.event.pull_request.head.sha }}",
+      ),
+  },
 ];
 
 test("workflow-security controls fail closed under targeted mutations", async (t) => {

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -490,7 +490,7 @@ test("engineering approval is a trusted base-branch check", () => {
     approval,
     /github\.event_name == 'pull_request_target' \|\| github\.event_name == 'pull_request_review' \|\| github\.event_name == 'merge_group'/,
   );
-  assert.match(approval, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
+  assert.match(approval, /ref: \$\{\{ github\.workflow_sha \}\}/);
   assert.doesNotMatch(
     approval,
     /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -473,6 +473,40 @@ test("PR lanes are scope-gated, never label-gated", () => {
   assert.doesNotMatch(desktopCargo, /document-parsers/);
 });
 
+test("engineering approval is a trusted base-branch check", () => {
+  const workflow = workflows["engineering-approval.yml"];
+  const approval = workflowJob(workflow, "approval");
+
+  assert.match(
+    workflow,
+    /^on:\n(?:  #.*\n)+  pull_request_target:\n    types:\n/m,
+  );
+  assert.match(workflow, /^  pull_request_review:\n    types: /m);
+  assert.match(workflow, /^  merge_group:\n/m);
+  assert.match(workflow, /^permissions:\n  contents: read\n/m);
+  assert.doesNotMatch(workflow, /secrets\./);
+  assert.doesNotMatch(workflow, /^\s*pull_request:\n/m);
+  assert.match(
+    approval,
+    /github\.event_name == 'pull_request_target' \|\| github\.event_name == 'pull_request_review' \|\| github\.event_name == 'merge_group'/,
+  );
+  assert.match(approval, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
+  assert.doesNotMatch(
+    approval,
+    /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,
+  );
+  assert.match(
+    approval,
+    /PR_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,
+  );
+  assert.match(approval, /CANONICAL_REPOSITORY: brightwave-inc\/tidebreak/);
+  assert.match(approval, /node scripts\/check-engineering-approval\.mjs/);
+  assert.match(
+    approval,
+    /echo "Merge groups reuse the pull request approval check\."/,
+  );
+});
+
 test("merge queue groups re-run required CI", () => {
   const ci = workflows["ci.yml"];
   const changes = workflowJob(ci, "changes");


### PR DESCRIPTION
## What changed

Outsider pull requests cannot enter the merge queue until someone with write access approves the current head commit. Maintainer pull requests stay green without a second review.

GitHub's native code-owner rule cannot do that split: it also blocks Engineering authors, who cannot approve their own pull requests. This check runs from `pull_request_target` against the pull request's **base** SHA, so a fork cannot replace the job with one that always passes.

An approval of an older commit does not count. A later `CHANGES_REQUESTED` review from the same writer replaces their approval.

## Validation

- `node --test scripts/check-engineering-approval.test.mjs scripts/workflow-security.test.mjs`
- `node --test scripts/workflow-security-mutations.test.mjs`

After this lands on `main`, the next step is to add `engineering approval` as a required status check and require this workflow from `refs/heads/main`. The check cannot be required before the workflow exists on the default branch, or every open pull request stalls.

## Compatibility and risk

Fork pull requests fail closed until a writer approves the current head. Dependabot and other bot authors need the same approval. Maintainers are unchanged.

## Tracking

None.