### PR TITLE
fix(desktop): brand code-mode models by family

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -11,11 +11,13 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
-import { CodeComposer } from "./CodeComposer";
+import { CodeComposer, HarnessModelMenu } from "./CodeComposer";
 import { useCodeUiStore } from "./CodeUiStore";
 import { HttpError } from "../api/client";
 import { useComposerDrafts } from "../ComposerDrafts";
+import { OpenAIIcon, ProviderIcon } from "../ProviderIcons";
 import { useUiStore } from "../UiStore";
 
 function app(): AppContextValue {
@@ -570,6 +572,37 @@ describe("CodeComposer", () => {
     expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "Send message" }));
     expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("HarnessModelMenu", () => {
+  it("brands an open-model row by its family, not the engine", () => {
+    const option = {
+      id: "deepseek-v4-flash-0731",
+      label: "DeepSeek V4 Flash 0731",
+      source: "Codex CLI",
+    };
+    const markup = renderToStaticMarkup(
+      <HarnessModelMenu
+        harness="codex"
+        options={[option]}
+        value={option.id}
+        onChange={() => {}}
+        variant="field"
+      />,
+    );
+    expect(markup).toContain(
+      renderToStaticMarkup(
+        <ProviderIcon
+          provider="model_gateway"
+          modelId={option.id}
+          className="size-4 shrink-0"
+        />,
+      ),
+    );
+    expect(markup).not.toContain(
+      renderToStaticMarkup(<OpenAIIcon className="size-4 shrink-0" />),
+    );
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -13,6 +13,7 @@ import { Composer } from "../Composer";
 import { IMAGE_MEDIA_TYPES } from "../ImageAttachments";
 import { useImageAttachments } from "../useImageAttachments";
 import { reasoningEffortOptions } from "../ModelMenu";
+import { familyForModelId } from "../modelFamilies";
 import { PermissionModeMenu } from "../PermissionModeMenu";
 import {
   ClaudeIcon,
@@ -102,7 +103,7 @@ const HARNESS_ICONS: Record<
   grok: XaiIcon,
 };
 
-/** The mark for one picker row: its vendor, or the engine's own mark. */
+/** The mark for one picker row: vendor, then open-model family, then the engine. */
 function CodeModelMark({
   harness,
   option,
@@ -113,9 +114,13 @@ function CodeModelMark({
   className?: string;
 }) {
   const vendor = codeModelVendor(option);
-  if (vendor) {
+  if (vendor || familyForModelId(option.id)) {
     return (
-      <ProviderIcon provider={vendor} modelId={option.id} className={className} />
+      <ProviderIcon
+        provider={vendor ?? "model_gateway"}
+        modelId={option.id}
+        className={className}
+      />
     );
   }
   const Icon = HARNESS_ICONS[harness];


### PR DESCRIPTION
## Summary

The code-mode model picker grouped DeepSeek and GLM under the right rail tab, but each row fell back to the engine mark when the id had no first-party vendor. On Codex CLI that painted DeepSeek and GLM with the OpenAI blossom.

`CodeModelMark` now uses the family icon when the model id names one. An unrecognized id still uses the engine mark.

## Test plan

- [x] `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeComposer.dom.test.tsx`
- [ ] In New workspace, pick Codex CLI, then open Model. Confirm DeepSeek shows the whale and GLM shows the Z.ai mark, not the OpenAI blossom.