### PR TITLE
feat(desktop): warn before updates and rename chats to work

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AgentRunDisplay.ts
+++ b/crates/tidebreak-desktop/ui/src/AgentRunDisplay.ts
@@ -80,7 +80,7 @@ export function agentRunStatusDetail(run: AgentRun): string {
 
   switch (run.status) {
     case "active":
-      return "Ready for this chat";
+      return "Ready for this work";
     case "queued":
       return "Queued to start";
     case "running":

--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -88,6 +88,13 @@ const listInbox = vi.fn(async () => [] as unknown[]);
 const listPendingOutputWritebackRequests = vi.fn(async () => [] as unknown[]);
 const requestUserAttention = vi.fn(async () => {});
 const hasNativeHost = vi.hoisted(() => vi.fn(() => false));
+const desktopUpdateState = vi.hoisted(() => ({
+  status: "idle" as "idle" | "checking" | "downloading" | "ready",
+  version: null as string | null,
+  error: null as string | null,
+  enabled: true,
+}));
+const restartDesktop = vi.hoisted(() => vi.fn(async () => {}));
 
 /** One waiting question, as the shell's cross-chat read returns it. */
 function parked(chatId: string, callId: string) {
@@ -166,9 +173,10 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 vi.mock("./updates", () => ({
   useDesktopUpdates: () => ({
-    state: { status: "idle", version: null },
+    state: desktopUpdateState,
     check: vi.fn(),
-    restart: vi.fn(),
+    restart: restartDesktop,
+    upToDate: false,
   }),
 }));
 
@@ -289,6 +297,11 @@ beforeEach(() => {
   listPendingOutputWritebackRequests.mockReset();
   listPendingOutputWritebackRequests.mockResolvedValue([]);
   requestUserAttention.mockClear();
+  desktopUpdateState.status = "idle";
+  desktopUpdateState.version = null;
+  desktopUpdateState.error = null;
+  desktopUpdateState.enabled = true;
+  restartDesktop.mockClear();
   postMessage.mockClear();
   getPolicy.mockClear();
   getPolicy.mockResolvedValue(unmanaged);
@@ -363,18 +376,18 @@ describe("app shell", () => {
 
     // The row itself carries the marker while the list is showing…
     expect(
-      await screen.findByLabelText("New chat needs attention"),
+      await screen.findByLabelText("New work needs attention"),
     ).toBeInTheDocument();
     expect(requestUserAttention).toHaveBeenCalledOnce();
 
     // …and collapsing the list moves the report to the section header, so a
     // folded rail cannot hide that something is waiting. (`expanded` singles
     // out the section toggle from the header breadcrumb, which is also
-    // named "Chats".)
-    await user.click(screen.getByRole("button", { name: "Chats", expanded: true }));
-    expect(screen.queryByLabelText("New chat needs attention")).not.toBeInTheDocument();
+    // named "Work".)
+    await user.click(screen.getByRole("button", { name: "Work", expanded: true }));
+    expect(screen.queryByLabelText("New work needs attention")).not.toBeInTheDocument();
     expect(
-      await screen.findByLabelText("A chat needs attention"),
+      await screen.findByLabelText("Work needs attention"),
     ).toBeInTheDocument();
   });
 
@@ -390,7 +403,7 @@ describe("app shell", () => {
     expect(await screen.findByText("Welcome to Tidebreak")).toBeInTheDocument();
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
     expect(
-      await screen.findByText(/Could not load chats/),
+      await screen.findByText(/Could not load work/),
     ).toBeInTheDocument();
 
     listChats.mockResolvedValue(chats);
@@ -399,7 +412,7 @@ describe("app shell", () => {
     expect(
       (await screen.findAllByRole("button", { name: "Roadmap" })).length,
     ).toBeGreaterThan(0);
-    expect(screen.queryByText(/Could not load chats/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Could not load work/)).not.toBeInTheDocument();
   });
 
   it("starts a conversation from the home composer and sends what was written", async () => {
@@ -438,7 +451,7 @@ describe("app shell", () => {
     const { router } = await mountApp();
     await screen.findByText("Welcome to Tidebreak");
 
-    const chatList = screen.getByLabelText("Chats");
+    const chatList = screen.getByLabelText("Work list");
     const [row] = screen
       .getAllByRole("button", { name: "Roadmap" })
       .filter((button) => chatList.contains(button));
@@ -464,7 +477,7 @@ describe("app shell", () => {
 
     // A second place joins the strip and comes forward without closing the
     // first.
-    await user.click(screen.getByRole("button", { name: /^Chat activity/ }));
+    await user.click(screen.getByRole("button", { name: /^Work activity/ }));
     await user.click(await screen.findByRole("button", { name: /Outputs/ }));
 
     expect(await screen.findByTestId("outputs")).toBeInTheDocument();
@@ -530,20 +543,20 @@ describe("app shell", () => {
 
     // The filter lives behind the list's own options — there is no separate
     // page to go find a chat on.
-    await user.click(screen.getByRole("button", { name: "Chat list options" }));
-    await user.click(await screen.findByRole("menuitem", { name: "Filter chats" }));
-    const search = await screen.findByRole("searchbox", { name: "Filter chats" });
+    await user.click(screen.getByRole("button", { name: "Work list options" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Filter work" }));
+    const search = await screen.findByRole("searchbox", { name: "Filter work" });
 
     await user.type(search, "roadmap");
-    const chatList = screen.getByLabelText("Chats");
+    const chatList = screen.getByLabelText("Work list");
     expect(within(chatList).getByRole("button", { name: "Roadmap" })).toBeInTheDocument();
     expect(
-      within(chatList).queryByRole("button", { name: "New chat" }),
+      within(chatList).queryByRole("button", { name: "New work" }),
     ).not.toBeInTheDocument();
 
     await user.clear(search);
     await user.type(search, "nothing matches this");
-    expect(await screen.findByText("No chat title contains that.")).toBeInTheDocument();
+    expect(await screen.findByText("No work title contains that.")).toBeInTheDocument();
   });
 
   it("keeps chat-scoped places with the conversation", async () => {
@@ -551,12 +564,12 @@ describe("app shell", () => {
     await screen.findByText("Welcome to Tidebreak");
     // Not disabled — absent. Home has no conversation for the chip to
     // describe, and the rail itself carries nothing chat-scoped anymore.
-    expect(screen.queryByLabelText("Chat activity")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Work activity")).not.toBeInTheDocument();
     cleanup();
 
     await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
-    expect(screen.getByLabelText("Chat activity")).toBeInTheDocument();
+    expect(screen.getByLabelText("Work activity")).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: /Outputs/ })).toBeEnabled();
     expect(screen.getByRole("button", { name: /Folders/ })).toBeEnabled();
   });
@@ -568,12 +581,12 @@ describe("app shell", () => {
 
     // The rail is the chat list, with the open chat marked, so leaving for
     // another conversation is one click, not a trip through home.
-    const chatList = await screen.findByLabelText("Chats");
+    const chatList = await screen.findByLabelText("Work list");
     expect(
       within(chatList).getByRole("button", { name: "Roadmap" }),
     ).toHaveAttribute("aria-current", "page");
 
-    await user.click(within(chatList).getByRole("button", { name: "New chat" }));
+    await user.click(within(chatList).getByRole("button", { name: "New work" }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/c/chat-2"));
   });
@@ -709,6 +722,35 @@ describe("app shell", () => {
     await user.click(screen.getByRole("button", { name: "Back to app" }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/c/chat-1"));
+  });
+
+  it("confirms the sidebar restart and repeats the pre-v1 data warning", async () => {
+    desktopUpdateState.status = "ready";
+    desktopUpdateState.version = "0.9.0";
+    const user = userEvent.setup();
+    await mountApp();
+
+    await user.click(
+      await screen.findByRole("button", { name: /Restart to update/ }),
+    );
+
+    expect(
+      await screen.findByRole("alertdialog", {
+        name: "Restart Tidebreak to update?",
+      }),
+    ).toHaveTextContent(
+      "Until Tidebreak reaches version 1.0, this update may wipe all Tidebreak data on this device",
+    );
+    expect(restartDesktop).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(restartDesktop).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /Restart to update/ }));
+    await user.click(
+      await screen.findByRole("button", { name: "Restart and update" }),
+    );
+    await waitFor(() => expect(restartDesktop).toHaveBeenCalledOnce());
   });
 
   it("creates a project from the dialog and opens a chat inside it", async () => {

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -277,7 +277,7 @@ export function AppShell() {
         if (!cancelled) chatListActions.setChats(existingChats);
       } catch (err) {
         if (!cancelled) {
-          chatListActions.failChatsLoad(`Could not load chats: ${String(err)}`);
+          chatListActions.failChatsLoad(`Could not load work: ${String(err)}`);
         }
       }
     })();
@@ -293,7 +293,7 @@ export function AppShell() {
       chatListActions.setChats(await client.listChats());
       chatListActions.setChatsError(null);
     } catch (err) {
-      chatListActions.failChatsLoad(`Could not load chats: ${String(err)}`);
+      chatListActions.failChatsLoad(`Could not load work: ${String(err)}`);
     }
   }
 
@@ -453,7 +453,7 @@ export function AppShell() {
         params: { projectId, chatId: created.id },
       });
     } catch (err) {
-      toast.error(friendlyErrorMessage(err, "Could not create the chat."));
+      toast.error(friendlyErrorMessage(err, "Could not create the work."));
     } finally {
       creationInFlightRef.current = false;
       chatListActions.setCreatingChat(false);
@@ -479,7 +479,7 @@ export function AppShell() {
           : navigate({ to: "/c/$chatId", params: { chatId: chat.id } }));
       }
     } catch (err) {
-      toast.error(friendlyErrorMessage(err, "Could not move the chat."));
+      toast.error(friendlyErrorMessage(err, "Could not move the work."));
     } finally {
       projectMutationRef.current = false;
     }
@@ -506,7 +506,7 @@ export function AppShell() {
       chatListActions.setChatsError(null);
       await navigate({ to: "/c/$chatId", params: { chatId: created.id } });
     } catch (err) {
-      chatListActions.setChatsError(`Could not create a chat: ${String(err)}`);
+      chatListActions.setChatsError(`Could not create work: ${String(err)}`);
     } finally {
       creationInFlightRef.current = false;
       chatListActions.setCreatingChat(false);
@@ -515,7 +515,7 @@ export function AppShell() {
 
   async function onDeleteChat(target: Chat) {
     if (!client || deletionInFlightRef.current || creationInFlightRef.current) return;
-    const label = target.title?.trim() || "this chat";
+    const label = target.title?.trim() || "this work";
     // The listed chat carries the folders it had at the last refresh, which
     // predates anything connected since. The server refuses the delete on its
     // own count, so ask it what is attached before promising to detach it.
@@ -523,13 +523,13 @@ export function AppShell() {
     try {
       current = await client.getChat(target.id);
     } catch (err) {
-      chatListActions.setChatsError(`Could not delete chat: ${String(err)}`);
+      chatListActions.setChatsError(`Could not delete work: ${String(err)}`);
       return;
     }
     const confirmed = await confirm({
       title: `Delete ${label}?`,
       description: deletionDescription(current.root_attachments.length),
-      confirmLabel: "Delete chat",
+      confirmLabel: "Delete work",
       destructive: true,
     });
     if (!confirmed) return;
@@ -551,7 +551,7 @@ export function AppShell() {
         // Product delete already committed. Surface the host cleanup failure
         // without undoing the delete — startup reconcile is the backup path.
         chatListActions.setChatsError(
-          `Chat deleted, but host permissions could not be cleared: ${String(err)}`,
+          `Work deleted, but host permissions could not be cleared: ${String(err)}`,
         );
       }
       // Nothing left to send it to.
@@ -569,7 +569,7 @@ export function AppShell() {
       chatListActions.setChats(refreshed);
       await navigate({ to: "/c/$chatId", params: { chatId: next.id } });
     } catch (err) {
-      chatListActions.setChatsError(`Could not delete chat: ${String(err)}`);
+      chatListActions.setChatsError(`Could not delete work: ${String(err)}`);
     } finally {
       deletionInFlightRef.current = false;
       chatListActions.setDeletingChatId(null);
@@ -606,7 +606,7 @@ export function AppShell() {
       chatListActions.replaceChat(updated, true);
       chatListActions.endRename();
     } catch (err) {
-      chatListActions.setChatsError(`Could not rename chat: ${String(err)}`);
+      chatListActions.setChatsError(`Could not rename work: ${String(err)}`);
     } finally {
       chatListActions.setSavingTitle(false);
     }
@@ -616,7 +616,22 @@ export function AppShell() {
     const version = desktopUpdates.state.version;
     const confirmed = await confirm({
       title: "Restart Tidebreak to update?",
-      description: `${version ? `Version ${version}` : "The update"} is ready. Tidebreak will close and reopen. Wait for active work to finish before restarting.`,
+      description: (
+        <>
+          <span>
+            {version ? `Version ${version}` : "The update"} is ready. Tidebreak
+            will close and reopen. Wait for active work to finish before
+            restarting.
+          </span>
+          <span className="border-warning-border bg-warning-background text-warning-foreground mt-3 block rounded-md border px-3 py-2.5">
+            <strong className="block font-medium">Pre-v1 data warning</strong>
+            <span className="mt-0.5 block">
+              Until Tidebreak reaches version 1.0, this update may wipe all
+              Tidebreak data on this device.
+            </span>
+          </span>
+        </>
+      ),
       confirmLabel: "Restart and update",
     });
     if (confirmed) await desktopUpdates.restart();

--- a/crates/tidebreak-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ApprovalCard.tsx
@@ -214,7 +214,7 @@ export function ApprovalCard({
       </div>
       {canRemember && grantScope === "project" && (
         <p className="text-muted-foreground text-xs">
-          Saved answers apply to every chat in this project. Review them under
+          Saved answers apply to all work in this project. Review them under
           Settings → Permissions.
         </p>
       )}
@@ -341,7 +341,7 @@ export function grantLadder(
   // The label names the level the server will actually write. A chat filed
   // under a project grants across it, and saying "this chat" while writing
   // something wider is the one thing a consent label must never do.
-  const where = scope === "project" ? "in this project" : "in this chat";
+  const where = scope === "project" ? "in this project" : "in this work";
   return grantRungs.flatMap((grant): ApprovalOption[] => {
     if (grant === "whole_tool") {
       return [

--- a/crates/tidebreak-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -159,7 +159,7 @@ export function BackgroundAgentPanel({
         </div>
       ) : (
         <p className="p-4 text-sm text-muted-foreground" role="status">
-          This agent run is not part of this chat.
+          This agent run is not part of this work.
         </p>
       )}
     </PanelFrame>

--- a/crates/tidebreak-desktop/ui/src/ChatHeaderTitle.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatHeaderTitle.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/components/ui/button";
 import { WithTooltip } from "@/components/ui/tooltip";
 
 /**
- * BW-style breadcrumb header: "Chats / chat title".
+ * BW-style breadcrumb header: "Work / work title".
  *
  * Clicking "Chats" steps out of the conversation to home — the chat list lives
  * on the rail now, so out of a chat is the only place the crumb can lead.
@@ -37,7 +37,7 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
   const justNamed = useChatListStore(
     (state) => state.derivedTitleChatId === chat.id,
   );
-  const title = chat.title?.trim() || "New chat";
+  const title = chat.title?.trim() || "New work";
   const displayTitle = useTypewriterOnce(title, justNamed);
 
   return (
@@ -47,7 +47,7 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
         className="shrink-0 font-medium text-muted-foreground hover:underline cursor-pointer"
         onClick={() => void navigate({ to: "/" })}
       >
-        Chats
+        Work
       </button>
       <span className="text-muted-foreground shrink-0">/</span>
 
@@ -63,7 +63,7 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
           <Input
             className="col-start-1 row-start-1 h-auto max-w-sm min-w-0 px-2 py-1 text-sm"
             autoFocus
-            aria-label="Chat title"
+            aria-label="Work title"
             value={renameDraft}
             disabled={savingTitle}
             onChange={(event) => setRenameDraft(event.target.value)}
@@ -81,7 +81,7 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
           />
         </div>
       ) : (
-        <WithTooltip label="Rename chat">
+        <WithTooltip label="Rename work">
           <button
             type="button"
             className="min-w-0 truncate font-medium hover:underline cursor-pointer"
@@ -101,7 +101,7 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
             disabled={deletingChatId !== null}
           >
             <Ellipsis className="size-4" />
-            <span className="sr-only">Chat menu</span>
+            <span className="sr-only">Work menu</span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -230,7 +230,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             {
               id: nextId(),
               role: "error",
-              text: `Could not load this chat: ${String(err)}`,
+              text: `Could not load this work: ${String(err)}`,
             },
           ],
         }));
@@ -665,7 +665,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   // still needs a name so it is not silent to a screen reader.
   if (!chat) {
     return (
-      <div className="routed-surface-loading" role="status" aria-label="Loading chat" />
+      <div className="routed-surface-loading" role="status" aria-label="Loading work" />
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/ChatStatusChip.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatStatusChip.dom.test.tsx
@@ -58,7 +58,7 @@ it("summarizes activity on its face and opens the chat-scoped places", async () 
 
   // With the whole canvas available, the useful places are visible without a
   // disclosure click and the summary falls back to what the chat produced.
-  expect(screen.getByLabelText("Chat activity")).toHaveTextContent("2 outputs");
+  expect(screen.getByLabelText("Work activity")).toHaveTextContent("2 outputs");
   await userEvent.click(await screen.findByText("Outputs"));
   expect(onOpenOutputs).toHaveBeenCalled();
 
@@ -72,11 +72,11 @@ it("summarizes activity on its face and opens the chat-scoped places", async () 
 it("folds the open card down to an icon and restores it", async () => {
   renderChip({ outputCount: 2 });
 
-  await userEvent.click(screen.getByRole("button", { name: "Collapse chat activity" }));
-  expect(screen.queryByLabelText("Chat activity")).not.toBeInTheDocument();
+  await userEvent.click(screen.getByRole("button", { name: "Collapse work activity" }));
+  expect(screen.queryByLabelText("Work activity")).not.toBeInTheDocument();
 
-  await userEvent.click(screen.getByRole("button", { name: "Expand chat activity" }));
-  expect(screen.getByLabelText("Chat activity")).toHaveTextContent("2 outputs");
+  await userEvent.click(screen.getByRole("button", { name: "Expand work activity" }));
+  expect(screen.getByLabelText("Work activity")).toHaveTextContent("2 outputs");
 });
 
 /**
@@ -89,7 +89,7 @@ it("counts live background runs and opens the agents table", async () => {
     compact: true,
   });
 
-  const chip = screen.getByRole("button", { name: "Chat activity: 2 running" });
+  const chip = screen.getByRole("button", { name: "Work activity: 2 running" });
   await userEvent.click(chip);
   await userEvent.click(screen.getByText("2 of 3 running"));
   expect(onOpenAgents).toHaveBeenCalled();

--- a/crates/tidebreak-desktop/ui/src/ChatStatusChip.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatStatusChip.tsx
@@ -145,7 +145,7 @@ export function ChatStatusChip({
         <button
           type="button"
           className="activity-card-collapsed"
-          aria-label="Expand chat activity"
+          aria-label="Expand work activity"
           onClick={() => setCollapsed(false)}
         >
           <ActivityIcon className="size-4" aria-hidden="true" />
@@ -154,7 +154,7 @@ export function ChatStatusChip({
     }
 
     return (
-      <aside className="activity-card" aria-label="Chat activity">
+      <aside className="activity-card" aria-label="Work activity">
         <div className="activity-card-heading">
           <div>
             <p className="activity-card-kicker">Activity</p>
@@ -163,7 +163,7 @@ export function ChatStatusChip({
           <button
             type="button"
             className="activity-card-collapse-button"
-            aria-label="Collapse chat activity"
+            aria-label="Collapse work activity"
             onClick={() => setCollapsed(true)}
           >
             <ChevronUp className="size-4" aria-hidden="true" />
@@ -181,7 +181,7 @@ export function ChatStatusChip({
           type="button"
           className="flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-full border border-border px-2.5 text-xs whitespace-nowrap text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           aria-label={
-            faceLabel === "Activity" ? "Chat activity" : `Chat activity: ${faceLabel}`
+            faceLabel === "Activity" ? "Work activity" : `Work activity: ${faceLabel}`
           }
         >
           {liveRuns.length > 0 && (

--- a/crates/tidebreak-desktop/ui/src/ChatUsageDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatUsageDialog.tsx
@@ -68,7 +68,7 @@ export function ChatUsageDialog({
       } catch (caught) {
         if (!current) return;
         toast.error(
-          friendlyErrorMessage(caught, "Could not read this chat's usage."),
+          friendlyErrorMessage(caught, "Could not read this work's usage."),
         );
       }
     })();
@@ -115,7 +115,7 @@ function ContextWindowPanel({
       <section className="rounded-lg border bg-muted/30 px-3.5 py-4">
         <SectionLabel>Last turn</SectionLabel>
         <p className="mt-2 text-sm text-muted-foreground">
-          No turn has finished in this chat yet.
+          No turn has finished in this work yet.
         </p>
       </section>
     );
@@ -209,7 +209,7 @@ function ChatTotalsPanel({
   return (
     <section className="space-y-2.5">
       <div className="flex items-baseline justify-between gap-2">
-        <SectionLabel>This chat</SectionLabel>
+        <SectionLabel>This work</SectionLabel>
         {turns !== null && totals.turns > 0 && (
           <span className="text-2xs text-muted-foreground tabular-nums">
             {totals.turns} {totals.turns === 1 ? "turn" : "turns"}

--- a/crates/tidebreak-desktop/ui/src/ComposerCommands.ts
+++ b/crates/tidebreak-desktop/ui/src/ComposerCommands.ts
@@ -31,13 +31,13 @@ export type SlashCommandName = "usage" | "compact";
 export const SLASH_COMMANDS: readonly SlashCommand[] = [
   {
     name: "usage",
-    description: "Show this chat's context and token usage.",
+    description: "Show this work's context and token usage.",
     takesArgument: false,
   },
   {
     name: "compact",
     description:
-      "Summarize the earlier part of this chat now. Add what to keep: /compact the API design",
+      "Summarize the earlier part of this work now. Add what to keep: /compact the API design",
     takesArgument: true,
   },
 ];

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
@@ -38,14 +38,14 @@ const STEPS: readonly WalkthroughStep[] = [
     surface: "tools",
     targets: ["network", "tools-menu"],
     title: "Set internet access",
-    body: "The Tools menu is open. Network is this chat's internet setting. Internet access is what web search and current information need. Leave it off when Tidebreak should use only your message and attachments.",
+    body: "The Tools menu is open. Network is this work's internet setting. Internet access is what web search and current information need. Leave it off when Tidebreak should use only your message and attachments.",
   },
   {
     id: "permissions",
     surface: "permissions",
     targets: ["permissions-ask", "permissions-menu"],
     title: "Choose a permission level",
-    body: "The permission menu is open. Plan stays read-only, Ask confirms actions, Auto handles routine workspace work, and Allow all runs without asking in this chat. Ask is a balanced place to start.",
+    body: "The permission menu is open. Plan stays read-only, Ask confirms actions, Auto handles routine workspace work, and Allow all runs without asking in this work. Ask is a balanced place to start.",
   },
   {
     id: "attachments",

--- a/crates/tidebreak-desktop/ui/src/FolderAccessCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/FolderAccessCard.tsx
@@ -59,7 +59,7 @@ export function FolderAccessCard({
         <>
           <p className="text-muted-foreground text-sm">
             Folder consent is unavailable in browser-only mode. This desktop
-            cannot resolve a chat owned by the headless server.
+            cannot resolve work owned by the headless server.
           </p>
           <div className="flex flex-wrap gap-2">
             <Button variant="outline" size="sm" onClick={onCancel}>

--- a/crates/tidebreak-desktop/ui/src/FoldersView.tsx
+++ b/crates/tidebreak-desktop/ui/src/FoldersView.tsx
@@ -186,7 +186,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
     const accepted = await confirm({
       title: `Forget ${folder.displayName}?`,
       description:
-        "Withdraws Tidebreak's approval for this folder everywhere, for every chat. If the folder comes back, connect it again from scratch.",
+        "Withdraws Tidebreak's approval for this folder everywhere, for all work. If the folder comes back, connect it again from scratch.",
       confirmLabel: "Forget",
       destructive: true,
     });

--- a/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
@@ -334,7 +334,7 @@ export function HomeRoute() {
       await navigate({ to: "/c/$chatId", params: { chatId } });
       composerDraftActions.clearDraft(HOME_DRAFT_KEY);
     } catch (err) {
-      setError(`Could not start a chat: ${String(err)}`);
+      setError(`Could not start work: ${String(err)}`);
     } finally {
       chatListActions.setCreatingChat(false);
     }

--- a/crates/tidebreak-desktop/ui/src/InboxView.tsx
+++ b/crates/tidebreak-desktop/ui/src/InboxView.tsx
@@ -116,7 +116,7 @@ export function InboxView() {
 function InboxRow({ item, onOpen }: { item: InboxItem; onOpen: () => void }) {
   const presentation = KIND_PRESENTATION[item.kind];
   const Icon = presentation.icon;
-  const title = item.chatTitle?.trim() || "New chat";
+  const title = item.chatTitle?.trim() || "New work";
   return (
     <button
       type="button"

--- a/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
@@ -52,7 +52,7 @@ function approvalChoices() {
 }
 
 const ONCE = "1.Yes, allow it once";
-const REMEMBER = "2.Yes, and don't ask again in this chat";
+const REMEMBER = "2.Yes, and don't ask again in this work";
 
 /**
  * A grant made in a project chat reaches every chat in it, so the widest rung
@@ -246,7 +246,7 @@ describe("approval card interactions", () => {
       "3.Yes, and always allow any \u201ccargo test\u201d command",
       // The rungs this ladder previously could not offer.
       "4.Yes, and always allow any \u201ccargo\u201d command",
-      "5.Yes, and don't ask again about commands in this chat",
+      "5.Yes, and don't ask again about commands in this work",
       "6.No, don't allow this",
     ]);
     expect(onDecide).not.toHaveBeenCalled();
@@ -280,7 +280,7 @@ describe("approval card interactions", () => {
       "1.Yes, run it once",
       "2.Yes, and always allow exactly \u201ccargo test\u201d",
       "3.Yes, and always allow any \u201ccargo test\u201d command",
-      "4.Yes, and don't ask again about commands in this chat",
+      "4.Yes, and don't ask again about commands in this work",
       "5.No, don't allow this",
     ]);
     expect(screen.queryByText(MORE)).toBeNull();
@@ -294,7 +294,7 @@ describe("approval card interactions", () => {
     ).toEqual([ONCE, REMEMBER_IN_PROJECT, "3.No, don't allow this"]);
     // And says once, in full, what the rows cannot say without becoming
     // three long lines.
-    screen.getByText(/Saved answers apply to every chat in this project/);
+    screen.getByText(/Saved answers apply to all work in this project/);
   });
 
   it("returns the highlight to the narrowest grant when it widens the list", async () => {
@@ -350,7 +350,7 @@ describe("approval card interactions", () => {
     ).toEqual([
       ONCE,
       "2.Yes, and always allow exactly “quarterly filings”",
-      "3.Yes, and don't ask again in this chat",
+      "3.Yes, and don't ask again in this work",
       "4.No, don't allow this",
     ]);
     // The filters are part of what is being consented to, so the card shows
@@ -401,7 +401,7 @@ describe("approval card interactions", () => {
     render(
       card({
         summary:
-          "Allow Tidebreak to run a command that leaves the chat workspace and may reach the network?",
+          "Allow Tidebreak to run a command that leaves this work's workspace and may reach the network?",
         preview: {
           tool: "exec",
           command: "cargo",

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.test.tsx
@@ -143,9 +143,9 @@ describe("ModelMenu", () => {
         }}
       />,
     );
-    expect(markup).toContain(">Chat only<");
+    expect(markup).toContain(">Conversation only<");
     expect(markup).toContain(
-      "Chat only. Function tools are unsupported or cannot yet be continued safely in Tidebreak.",
+      "Conversation only. Function tools are unsupported or cannot yet be continued safely in Tidebreak.",
     );
     expect(markup).not.toContain("hosted model does not support");
   });

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
@@ -69,14 +69,14 @@ export function ModelToolCapabilityChip({ model }: { model: ModelInfo }) {
   if (model.supports_tools) return null;
   return (
     <WithTooltip
-      label="Tidebreak runs this model as chat-only because function tools are unsupported or tool use cannot yet be continued safely"
+      label="Tidebreak runs this model as conversation-only because function tools are unsupported or tool use cannot yet be continued safely"
       side="top"
     >
       <span
         className="text-muted-foreground border-border rounded-full border px-1.5 py-0.5 text-[0.65rem] leading-none"
-        aria-label="Chat only. Function tools are unsupported or cannot yet be continued safely in Tidebreak."
+        aria-label="Conversation only. Function tools are unsupported or cannot yet be continued safely in Tidebreak."
       >
-        Chat only
+        Conversation only
       </span>
     </WithTooltip>
   );

--- a/crates/tidebreak-desktop/ui/src/NetworkPolicyDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/NetworkPolicyDialog.tsx
@@ -23,7 +23,7 @@ const OPTIONS = [
   {
     mode: "off",
     label: "Offline",
-    description: "Opt in to blocking outbound network access for this chat.",
+    description: "Opt in to blocking outbound network access for this work.",
     icon: ShieldOff,
   },
   {

--- a/crates/tidebreak-desktop/ui/src/OutputWritebackCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/OutputWritebackCard.tsx
@@ -24,8 +24,8 @@ export function OutputWritebackCard({
     ? "Replace an existing file?"
     : "Write a file to a connected folder?";
   const subtitle = replacing
-    ? "The agent wants to replace a file in a folder connected to this chat. The native desktop will verify the connected folder, destination, and current output revision before writing."
-    : "The agent wants to write one of this chat's outputs into a folder connected to this chat. The native desktop will verify the connected folder, destination, and current output revision before writing.";
+    ? "The agent wants to replace a file in a folder connected to this work. The native desktop will verify the connected folder, destination, and current output revision before writing."
+    : "The agent wants to write one of this work's outputs into a folder connected to this work. The native desktop will verify the connected folder, destination, and current output revision before writing.";
   const allowLabel = replacing ? "Allow replacement" : "Allow write";
   const unavailable = replacing
     ? "File replacement is unavailable in browser-only mode."

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
@@ -60,7 +60,7 @@ const PERMISSION_MODE_SCALE: {
   {
     value: "allow",
     label: "Allow all",
-    description: "Everything runs without asking, in this chat only.",
+    description: "Everything runs without asking, in this work only.",
     icon: ShieldOff,
   },
 ];

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -37,7 +37,7 @@ export type ShellShortcutMode = "chat" | "code";
 /** The heading a shortcut sits under in the help dialog. */
 export type ShellShortcutGroup =
   | "Navigation"
-  | "Chat"
+  | "Work"
   | "Code"
   | "View"
   | "Help";
@@ -45,7 +45,7 @@ export type ShellShortcutGroup =
 /** Group headings in the order the help dialog lists them. */
 export const SHELL_SHORTCUT_GROUPS: readonly ShellShortcutGroup[] = [
   "Navigation",
-  "Chat",
+  "Work",
   "Code",
   "View",
   "Help",
@@ -136,8 +136,8 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     id: "new-chat",
     codes: ["KeyN"],
     mod: true,
-    description: "Start a new chat",
-    group: "Chat",
+    description: "Start new work",
+    group: "Work",
     scope: "chat",
     allowInEditable: true,
   },
@@ -186,7 +186,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     codes: ["KeyK"],
     mod: true,
     description: "Focus the message composer",
-    group: "Chat",
+    group: "Work",
     allowInEditable: true,
   },
   {

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.test.tsx
@@ -222,7 +222,7 @@ describe("toolApprovalPresentation", () => {
     });
     expect(toolApprovalPresentation("exec_may_run_networked_command")).toEqual({
       summary:
-        "Allow Tidebreak to run a command that leaves the chat workspace and may reach the network?",
+        "Allow Tidebreak to run a command that leaves this work's workspace and may reach the network?",
       canApprove: true,
       canRemember: true,
     });

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
@@ -518,7 +518,7 @@ export function toolApprovalPresentation(
   if (kind === "exec_may_run_networked_command") {
     return {
       summary:
-        "Allow Tidebreak to run a command that leaves the chat workspace and may reach the network?",
+        "Allow Tidebreak to run a command that leaves this work's workspace and may reach the network?",
       canApprove: true,
       canRemember: true,
     };
@@ -535,7 +535,7 @@ export function toolApprovalPresentation(
   if (kind === "workspace_may_modify_files") {
     return {
       summary:
-        "Allow Tidebreak to create or modify files in this chat's workspace?",
+        "Allow Tidebreak to create or modify files in this work's workspace?",
       canApprove: true,
       // The standing "yes" for workspace edits is the chat's Auto permission
       // mode, not a per-tool grant.
@@ -545,7 +545,7 @@ export function toolApprovalPresentation(
   if (kind === "delegate_may_run_background_agent") {
     return {
       summary:
-        "Allow a background agent to work on this on its own, reaching the network under this chat's policy?",
+        "Allow a background agent to work on this on its own, reaching the network under this work's policy?",
       canApprove: true,
       // Consent is for the whole run, so it is worth remembering: a run's own
       // calls never come back to be asked about individually.

--- a/crates/tidebreak-desktop/ui/src/ToolPreview.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ToolPreview.test.ts
@@ -99,7 +99,7 @@ describe("workspace write previews", () => {
       path: "reports/q3.md",
     });
     expect(write.headline).toBe("reports/q3.md");
-    expect(write.detail).toContain("this chat's workspace");
+    expect(write.detail).toContain("this work's workspace");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/ToolPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolPreview.tsx
@@ -53,7 +53,7 @@ export function toolPreviewPresentation(
     const headline = preview.path;
     return {
       headline,
-      detail: `${headline}\n# written into this chat's workspace`,
+      detail: `${headline}\n# written into this work's workspace`,
     };
   }
   if (preview.tool === "web_extract") {

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
@@ -192,7 +192,7 @@ export function WelcomeState({
   }
 
   return (
-    <section className="welcome" aria-label="Start a chat">
+    <section className="welcome" aria-label="Start work">
       <span className="welcome-mark" aria-hidden="true">
         <Logomark />
       </span>

--- a/crates/tidebreak-desktop/ui/src/apps/AppsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/apps/AppsView.tsx
@@ -115,7 +115,7 @@ export function AppsView({
               <EmptyDescription>
                 Ask Tidebreak to build a mini app in a conversation. What it
                 creates lives here — reopen it any time without re-running the
-                chat.
+                work.
               </EmptyDescription>
             </EmptyHeader>
           </Empty>

--- a/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
@@ -7,7 +7,7 @@ import { isCodeRoute } from "./routes";
 type Mode = "chat" | "code";
 
 /**
- * Chat / Code switch used at the top of both rails.
+ * Work / Code switch used at the top of both rails.
  *
  * One primitive, two hosts: both rails always show it so Code remains a
  * first-class product surface rather than a setting the reader has to find.
@@ -31,7 +31,7 @@ export function CodeModeSwitch() {
         options={[
           {
             value: "chat",
-            label: "Chat",
+            label: "Work",
             icon: (
               <MessageSquare
                 className={`${value === "chat" ? "text-icon-blue" : ""} size-3.5 shrink-0`}

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -138,7 +138,7 @@ describe("CodeSidebar", () => {
     );
 
     expect(screen.getByRole("radiogroup", { name: "App mode" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "Chat" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Work" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Code" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "app" })).toBeInTheDocument();
     // The card's name carries what the glyph rail shows, not just the title.

--- a/crates/tidebreak-desktop/ui/src/components/ConfirmDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ConfirmDialog.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
   useState,
   type ReactElement,
+  type ReactNode,
 } from "react";
 import {
   AlertDialog,
@@ -18,7 +19,7 @@ import {
 
 export type ConfirmOptions = {
   title: string;
-  description?: string;
+  description?: ReactNode;
   confirmLabel?: string;
   cancelLabel?: string;
   destructive?: boolean;

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -48,7 +48,7 @@ describe("AgentsPanel", () => {
     } as unknown as ApiClient;
 
     render(<AgentsPanel client={client} />);
-    await screen.findByText("Active background agents per chat");
+    await screen.findByText("Active background agents per work");
     expect(screen.getByRole("radio", { name: "Queue" })).toBeChecked();
     fireEvent.click(screen.getByRole("radio", { name: "Steer" }));
     expect(useUiStore.getState().activeTurnSendMode).toBe("steer");

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
@@ -154,7 +154,7 @@ export function AgentsPanel({ client }: { client: ApiClient }) {
       </SettingsSection>
       <SettingsSection>
         <SettingsField
-          label="Active background agents per chat"
+          label="Active background agents per work"
           hint="A spawn beyond this limit fails immediately and can be retried after wait_for_agents returns."
         >
           <Input

--- a/crates/tidebreak-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -239,7 +239,7 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
           </div>
 
           <p className="text-sm leading-relaxed text-muted-foreground">
-            Local execution confines writes to private chat scratch and routes
+            Local execution confines writes to private work scratch and routes
             any granted network access through a loopback broker. E2B and
             Daytona run commands in managed cloud sandboxes and reuse their
             workspace while it is alive. Docker runs them in a container on

--- a/crates/tidebreak-desktop/ui/src/settings/CompactionPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/CompactionPanel.tsx
@@ -141,7 +141,7 @@ export function CompactionPanel({ client }: { client: ApiClient }) {
       <SettingsSection>
         <SettingsField
           label="Compact when the conversation reaches"
-          hint="Percent of the model's context window. Below this, nothing is summarized. Type /compact in a chat to run it sooner."
+          hint="Percent of the model's context window. Below this, nothing is summarized. Type /compact in work to run it sooner."
         >
           <Input
             type="number"
@@ -167,7 +167,7 @@ export function CompactionPanel({ client }: { client: ApiClient }) {
             <>
               <SettingsField
                 label="Compact down to"
-                hint="Percent of the window the raw conversation is reduced to. The gap between this and the threshold is how long a chat runs before compacting again."
+                hint="Percent of the window the raw conversation is reduced to. The gap between this and the threshold is how long work runs before compacting again."
               >
                 <Input
                   type="number"

--- a/crates/tidebreak-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -131,13 +131,13 @@ describe("ModelsPanel", () => {
     // The chat row opens on the provider owning its saved (legacy) id, resolved
     // to that provider's canonical model.
     const chatProvider = await screen.findByRole("combobox", {
-      name: "Chat provider",
+      name: "Work provider",
     });
     await waitFor(() => expect(chatProvider).toHaveTextContent("OpenAI"));
     expect(
-      screen.getByRole("combobox", { name: "Chat model" }),
+      screen.getByRole("combobox", { name: "Work model" }),
     ).toHaveTextContent("GPT-4o");
-    await user.click(screen.getByRole("combobox", { name: "Chat model" }));
+    await user.click(screen.getByRole("combobox", { name: "Work model" }));
     expect(
       screen.getByRole("option", {
         name: "GPT No Schema — 128k context",
@@ -177,7 +177,7 @@ describe("ModelsPanel", () => {
     await user.click(utilityModel);
     expect(
       screen.getByRole("option", {
-        name: "Kimi K3 — 1M context — chat only",
+        name: "Kimi K3 — 1M context — conversation only",
       }),
     ).toBeInTheDocument();
     await user.keyboard("{Escape}");
@@ -277,10 +277,10 @@ describe("ModelsPanel under managed policy", () => {
     // No provider step: there is exactly one provider, so each role is a
     // single flat picker.
     const chatModel = await screen.findByRole("combobox", {
-      name: "Chat model",
+      name: "Work model",
     });
     expect(
-      screen.queryByRole("combobox", { name: "Chat provider" }),
+      screen.queryByRole("combobox", { name: "Work provider" }),
     ).toBeNull();
     expect(
       screen.queryByRole("combobox", { name: "Background work provider" }),
@@ -309,7 +309,7 @@ describe("ModelsPanel under managed policy", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("option", {
-        name: "Kimi K3 — 1M context — chat only",
+        name: "Kimi K3 — 1M context — conversation only",
       }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /Claude Opus/ })).toBeNull();
@@ -367,7 +367,7 @@ describe("ModelsPanel under managed policy", () => {
     });
     expect(screen.queryByText(/has not synced any models/)).toBeNull();
     expect(
-      screen.getByRole("combobox", { name: "Chat model" }),
+      screen.getByRole("combobox", { name: "Work model" }),
     ).toHaveTextContent("Automatic — Gateway Flagship");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ModelsPanel.tsx
@@ -61,15 +61,15 @@ const ROLES: {
 }[] = [
   {
     role: "chat",
-    title: "Chat",
+    title: "Work",
     hint: "New conversations start on this model, and each one can still override it.",
   },
   {
     role: "utility",
     title: "Background work",
-    hint: "Work Tidebreak does on its own — compacting a long conversation, for instance — runs here, so it is not billed at your conversation model. Left automatic, it picks the cheapest model your configured providers serve; with none available, that work is skipped rather than moved onto your chat model.",
+    hint: "Work Tidebreak does on its own — compacting a long conversation, for instance — runs here, so it is not billed at your conversation model. Left automatic, it picks the cheapest model your configured providers serve; with none available, that work is skipped rather than moved onto your work model.",
     managedHint:
-      "Work Tidebreak does on its own — compacting a long conversation, for instance — runs here, so it is not billed at your conversation model. Left automatic, it picks the smallest model your gateway serves; with none available, that work is skipped rather than moved onto your chat model.",
+      "Work Tidebreak does on its own — compacting a long conversation, for instance — runs here, so it is not billed at your conversation model. Left automatic, it picks the smallest model your gateway serves; with none available, that work is skipped rather than moved onto your work model.",
   },
 ];
 
@@ -528,7 +528,7 @@ function contextWindowSuffix(model: ModelInfo): string {
   const context = model.context_window
     ? ` — ${formatTokenCount(model.context_window)} context`
     : "";
-  return `${context}${model.supports_tools ? "" : " — chat only"}`;
+  return `${context}${model.supports_tools ? "" : " — conversation only"}`;
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
@@ -339,10 +339,10 @@ describe("permissions labeling and chat filter", () => {
   it("names a missing chat subject as deleted", () => {
     expect(
       levelLabel(execStatement, { chatIds: new Set() }),
-    ).toBe("Deleted chat 222222…2222");
+    ).toBe("Deleted work 222222…2222");
     // shortOpaqueId keeps first 6 and last 4 for long ids.
     expect(levelLabel(execStatement, { chatIds: new Set() })).toBe(
-      "Deleted chat 222222…2222",
+      "Deleted work 222222…2222",
     );
   });
 

--- a/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -204,9 +204,9 @@ export function levelLabel(
       : `Everything in project ${shortOpaqueId(statement.level.project_id)}`;
   }
   if (isMissingSubject(statement, known)) {
-    return `Deleted chat ${shortOpaqueId(statement.level.chat_id)}`;
+    return `Deleted work ${shortOpaqueId(statement.level.chat_id)}`;
   }
-  return title || `Chat ${shortOpaqueId(statement.level.chat_id)}`;
+  return title || `Work ${shortOpaqueId(statement.level.chat_id)}`;
 }
 
 /** Statements that reach one conversation: its own grants plus project grants. */
@@ -505,7 +505,7 @@ export function PermissionsPanel({
         !error && (
           <p className="text-sm text-muted-foreground">
             {chat
-              ? "Nothing saved for this chat yet. When you answer an approval with “always allow” or connect a folder, it appears here."
+              ? "Nothing saved for this work yet. When you answer an approval with “always allow” or connect a folder, it appears here."
               : "Nothing saved yet. When you answer an approval with “always allow” or connect a folder, it appears here."}
           </p>
         )}
@@ -527,7 +527,7 @@ export function PermissionsPanel({
       {unreadableFolders.length > 0 && (
         <SettingsSection
           title="Revoked folder access"
-          description="These folders are still connected to this chat, but the agent cannot read them. Grant read access to make one usable again — the host asks you to confirm."
+          description="These folders are still connected to this work, but the agent cannot read them. Grant read access to make one usable again — the host asks you to confirm."
         >
           <div className="flex flex-col gap-4">
             {unreadableFolders.map((folder) => (
@@ -560,7 +560,7 @@ export function PermissionsPanel({
         <div>
           <h2 className="text-sm font-medium">Permissions</h2>
           <p className="text-muted-foreground mt-1 text-sm">
-            What this chat can do without asking. Project-wide approvals that
+            What this work can do without asking. Project-wide approvals that
             reach it are included. Revoke anything to be asked again.
           </p>
         </div>

--- a/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.test.tsx
@@ -11,6 +11,17 @@ const idle: DesktopUpdateState = {
 };
 
 describe("UpdatesPanel", () => {
+  it("warns that pre-v1 updates may wipe local data", () => {
+    const markup = renderToStaticMarkup(
+      <UpdatesPanel state={idle} onCheck={vi.fn()} onRestart={vi.fn()} />,
+    );
+
+    expect(markup).toContain("Pre-v1 data warning");
+    expect(markup).toContain(
+      "any update may wipe all Tidebreak data on this device",
+    );
+  });
+
   it("keeps update checks disabled outside supported packaged builds", () => {
     const markup = renderToStaticMarkup(
       <UpdatesPanel

--- a/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/UpdatesPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { getVersion } from "@tauri-apps/api/app";
-import { RefreshCw, RotateCw } from "lucide-react";
+import { AlertTriangle, RefreshCw, RotateCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ClipboardCopyButton } from "../ClipboardCopyButton";
 import { hasNativeHost } from "../host";
@@ -57,13 +57,26 @@ export function UpdatesPanel({
     };
   }, []);
 
-
   return (
     <SettingsPanel
       title="Updates"
       description="Tidebreak checks shortly after launch and every five minutes, and downloads updates in the background. A downloaded update installs only after you choose Restart to update."
       busy={busy}
     >
+      <div
+        className="border-warning-border bg-warning-background text-warning-foreground flex items-start gap-3 rounded-md border px-4 py-3"
+        aria-label="Pre-v1 update warning"
+      >
+        <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        <div className="flex min-w-0 flex-col gap-0.5 text-sm">
+          <strong className="font-medium">Pre-v1 data warning</strong>
+          <p>
+            Until Tidebreak reaches version 1.0, any update may wipe all
+            Tidebreak data on this device.
+          </p>
+        </div>
+      </div>
+
       <SettingsSection title="Automatic updates">
         <p className="text-sm text-muted-foreground" aria-live="polite">
           {updateStateSummary(state)}

--- a/crates/tidebreak-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -185,7 +185,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
 
           <SettingsSection
             title="Search mode"
-            description="Which search a chat gets. Automatic uses your model provider's built-in search when the chat's model supports it, and the provider configured below otherwise."
+            description="Which search work gets. Automatic uses your model provider's built-in search when the selected model supports it, and the provider configured below otherwise."
           >
             <SettingsField
               label="Search mode"
@@ -335,7 +335,7 @@ function webSearchState(config: WebSearchConfigInfo | null): {
     return {
       kind: "disabled",
       label: "Off",
-      description: "No chat can search the web.",
+      description: "Work cannot search the web.",
     };
   }
   if (config?.mode === "vendor") {
@@ -343,7 +343,7 @@ function webSearchState(config: WebSearchConfigInfo | null): {
       kind: "ready",
       label: "Built-in search",
       description:
-        "Chats search through the model provider. A model without built-in search cannot search at all.",
+        "Work searches through the model provider. A model without built-in search cannot search at all.",
     };
   }
   if (!config?.provider) {

--- a/crates/tidebreak-desktop/ui/src/sidebar/ChatsSection.test.ts
+++ b/crates/tidebreak-desktop/ui/src/sidebar/ChatsSection.test.ts
@@ -20,10 +20,10 @@ describe("matchesChatSearch", () => {
   });
 
   it("searches an untitled chat under the name it is shown by", () => {
-    // The list labels these "New chat", so that is what searching for them has
+    // The list labels these "New work", so that is what searching for them has
     // to find — matching nothing would make them unreachable.
     expect(matchesChatSearch(chat(null), "new")).toBe(true);
-    expect(matchesChatSearch(chat("   "), "new chat")).toBe(true);
+    expect(matchesChatSearch(chat("   "), "new work")).toBe(true);
     expect(matchesChatSearch(chat(null), "roadmap")).toBe(false);
   });
 

--- a/crates/tidebreak-desktop/ui/src/sidebar/ChatsSection.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/ChatsSection.tsx
@@ -24,11 +24,11 @@ import {
 import { cn } from "@/lib/utils";
 import { RecentChatRow } from "./RecentChatRow";
 
-/** Case-insensitive match on the title, with untitled chats matching "new chat". */
+/** Case-insensitive match on the title, with untitled work matching "new work". */
 export function matchesChatSearch(chat: Chat, query: string): boolean {
   const trimmed = query.trim().toLowerCase();
   if (!trimmed) return true;
-  const title = chat.title?.trim() || "New chat";
+  const title = chat.title?.trim() || "New work";
   return title.toLowerCase().includes(trimmed);
 }
 
@@ -144,7 +144,7 @@ export function ChatsSection({ activeChatId }: { activeChatId?: string }) {
           onClick={toggleCollapsed}
           className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-left text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
         >
-          <span>Chats</span>
+          <span>Work</span>
           <ChevronRight
             aria-hidden="true"
             className={cn("size-3.5 transition-transform", !collapsed && "rotate-90")}
@@ -152,8 +152,8 @@ export function ChatsSection({ activeChatId }: { activeChatId?: string }) {
           {hiddenAttention && (
             <span
               className="text-warning ml-auto shrink-0"
-              aria-label="A chat needs attention"
-              title="A chat needs attention"
+              aria-label="Work needs attention"
+              title="Work needs attention"
             >
               <CircleAlert aria-hidden="true" size={15} />
             </span>
@@ -164,7 +164,7 @@ export function ChatsSection({ activeChatId }: { activeChatId?: string }) {
             <button
               type="button"
               className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              aria-label="Chat list options"
+              aria-label="Work list options"
             >
               <Ellipsis size={15} />
             </button>
@@ -172,14 +172,14 @@ export function ChatsSection({ activeChatId }: { activeChatId?: string }) {
           <DropdownMenuContent align="start">
             <DropdownMenuItem onSelect={() => setFiltering(!filtering)}>
               <ListFilter />
-              {filtering ? "Hide filter" : "Filter chats"}
+              {filtering ? "Hide filter" : "Filter work"}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
         <button
           type="button"
           className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-          aria-label={creatingChat ? "Starting…" : "New chat"}
+          aria-label={creatingChat ? "Starting…" : "New work"}
           disabled={creatingChat || deletingChatId !== null}
           onClick={newChat}
         >
@@ -191,8 +191,8 @@ export function ChatsSection({ activeChatId }: { activeChatId?: string }) {
         <div ref={filterRef} className="shrink-0 px-1 pt-1 pb-1.5">
           <SearchInput
             size="sm"
-            placeholder="Filter chats"
-            aria-label="Filter chats"
+            placeholder="Filter work"
+            aria-label="Filter work"
             value={query}
             onValueChange={setQuery}
           />
@@ -202,7 +202,7 @@ export function ChatsSection({ activeChatId }: { activeChatId?: string }) {
       {!collapsed && (
         <div
           className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto"
-          aria-label="Chats"
+          aria-label="Work list"
         >
           {listed.map((chat) => (
             <RecentChatRow
@@ -226,7 +226,7 @@ export function ChatsSection({ activeChatId }: { activeChatId?: string }) {
           ))}
           {listed.length === 0 && query.trim() && (
             <p className="px-2 py-1 text-xs text-muted-foreground">
-              No chat title contains that.
+              No work title contains that.
             </p>
           )}
         </div>

--- a/crates/tidebreak-desktop/ui/src/sidebar/NewProjectDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/NewProjectDialog.tsx
@@ -81,7 +81,7 @@ export function NewProjectDialog({
         <DialogHeader className="gap-1 pr-6">
           <DialogTitle className="text-base">New project</DialogTitle>
           <DialogDescription className="text-xs leading-relaxed">
-            Name it. A chat will open inside it.
+            Name it. New work will open inside it.
           </DialogDescription>
         </DialogHeader>
 

--- a/crates/tidebreak-desktop/ui/src/sidebar/ProjectsSection.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/ProjectsSection.tsx
@@ -175,7 +175,7 @@ export function ProjectsSection({ activeChatId }: { activeChatId?: string }) {
                       disabled={creatingChat || deletingChatId !== null}
                       onClick={() => newChatInProject(project.id)}
                     >
-                      New chat
+                      New work
                     </button>
                   )}
                 </div>
@@ -272,7 +272,7 @@ function ProjectRow({
       <button
         type="button"
         className="cursor-pointer rounded p-1 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 disabled:pointer-events-none"
-        aria-label={`New chat in ${title}`}
+        aria-label={`New work in ${title}`}
         disabled={mutating}
         onClick={onNewChat}
       >
@@ -294,7 +294,7 @@ function ProjectRow({
         <DropdownMenuContent align="end" side="right">
           <DropdownMenuItem onSelect={onNewChat}>
             <SquarePen />
-            New chat
+            New work
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={onOpenFiles}>
             <Files />

--- a/crates/tidebreak-desktop/ui/src/sidebar/RecentChatRow.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/RecentChatRow.tsx
@@ -58,9 +58,9 @@ export function RecentChatRow({
   onMoveToProject: (projectId: string | null) => void;
   onDelete: () => void;
 }) {
-  const title = chat.title?.trim() || "New chat";
+  const title = chat.title?.trim() || "New work";
   // A name the server just derived is typed out, so the row visibly stops being
-  // "New chat" instead of silently having always been something else. A name that
+  // "New work" instead of silently having always been something else. A name that
   // was already there when this mounted appears at once.
   const justNamed = useChatListStore(
     (state) => state.derivedTitleChatId === chat.id,
@@ -72,7 +72,7 @@ export function RecentChatRow({
       <Input
         className="h-auto px-2 py-1.5 text-sm"
         autoFocus
-        aria-label="Chat title"
+        aria-label="Work title"
         value={renameDraft}
         disabled={savingTitle}
         onChange={(event) => onRenameDraftChange(event.target.value)}


### PR DESCRIPTION
## Summary

- rename user-facing Chat/Chats terminology to Work across the desktop UI
- add a persistent pre-v1 data-loss warning to Updates settings
- require confirmation from the sidebar Restart to update action and repeat the warning in the dialog

## Implementation

- keeps internal Chat types, route names, API paths, IDs, and persisted role values unchanged
- allows the shared confirmation dialog description to render structured content so the warning is visually distinct
- updates affected UI expectations and adds coverage for the update warning and restart confirmation flow

## Backwards compatibility

This is a presentation-layer terminology change. Existing chat data, URLs, API contracts, serialized values, and stored settings remain compatible.

## Safety and risk

Risk is limited to UI copy and confirmation rendering. Restart remains opt-in, Cancel leaves the updater untouched, and the updater is invoked only after explicit confirmation.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `git diff --check`
- full UI suite: 194 test files, 1,347 tests passed