### PR TITLE
refactor(desktop): unify work/chat transcript cards

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
@@ -241,11 +241,10 @@ type ExecActivityDetail = Extract<
 >;
 
 /**
- * A command step's card: the same collapsed chrome a foreground exec card
- * uses — monospace command, outcome pill, chevron. The body holds the full
- * unelided command line and, once the step has settled, the tail of what the
- * command printed; a failed card starts open so the reader lands on what
- * failed.
+ * A command step's row: the same boxless expandable chrome a foreground exec
+ * call and code mode use. The body holds the outcome, full unelided command
+ * line and, once the step has settled, the tail of what the command printed;
+ * a failed row starts open so the reader lands on what failed.
  */
 function ExecActivityCard({
   detail,
@@ -271,7 +270,7 @@ function ExecActivityCard({
       titleClassName={narrated === null ? "font-mono" : undefined}
       badge={<ExecActivityBadge outcome={outcome} exitCode={detail.exit_code} />}
       defaultExpanded={failed}
-      className={cn(failed && "border-critical/35")}
+      className={cn(failed && "text-critical")}
       // The assistive label names the command, not the sentence about it: it
       // stands in for a title the reader can see but a screen reader would
       // otherwise get only truncated, and the literal action is the part that

--- a/crates/tidebreak-desktop/ui/src/AppCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppCard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 
 import type { ResultEntry } from "@/api";
 import { Button } from "@/components/ui/button";
+import { TRANSCRIPT_RESULT_CARD_FRAME } from "@/TranscriptResultCard";
 
 /**
  * The cards a phase hangs under itself for the apps it published.
@@ -36,11 +37,11 @@ function AppCard({ entry }: { entry: ResultEntry }) {
   const navigate = useNavigate();
   const appId = entry.targetId;
   return (
-    <div className="bg-background flex max-w-full min-w-0 items-center gap-3 rounded-lg border px-4 py-3 text-left shadow-sm">
+    <div className={TRANSCRIPT_RESULT_CARD_FRAME}>
       <span className="grid size-9 shrink-0 place-items-center" aria-hidden="true">
         <LayoutGrid className="text-icon-blue size-5" />
       </span>
-      <span className="flex min-w-0 flex-col">
+      <span className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm font-semibold">{entry.label}</span>
         {entry.meta && (
           <span className="text-muted-foreground text-xs tabular-nums">

--- a/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
@@ -478,7 +478,8 @@ describe("activity phases", () => {
     ).toEqual(["Searched sources", "Read a file", "Searched the web"]);
   });
 
-  it("surfaces a command card outside the collapsed region", () => {
+  it("surfaces a command row outside the collapsed region", async () => {
+    const user = userEvent.setup();
     list([
       { id: "t1", role: "tool", callId: "c1", name: "search", status: "completed" },
       {
@@ -494,6 +495,9 @@ describe("activity phases", () => {
     // Collapsed: the rail lists nothing, but the command is still readable.
     expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
     expect(screen.getByText("cargo build")).toBeInTheDocument();
+    expect(screen.queryByText("Done")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cargo build/ }));
     expect(screen.getByText("Done")).toBeInTheDocument();
   });
 
@@ -996,7 +1000,12 @@ describe("actionable tool results", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Open output deck.pptx" }));
+    const outputCard = screen.getByRole("button", {
+      name: "Open output deck.pptx",
+    });
+    expect(outputCard).toHaveClass("w-full", "max-w-md");
+
+    await user.click(outputCard);
     await waitFor(() => {
       expect(router.state.location.search).toMatchObject({
         tabs: "outputs.output-1",
@@ -1148,9 +1157,12 @@ describe("actionable tool results", () => {
     await user.click(screen.getByRole("button", { name: "Created an app" }));
     expect(screen.getAllByText("Sentry triage")).toHaveLength(1);
 
-    await user.click(
-      screen.getByRole("button", { name: "Open app Sentry triage" }),
-    );
+    const openApp = screen.getByRole("button", {
+      name: "Open app Sentry triage",
+    });
+    expect(openApp.parentElement).toHaveClass("w-full", "max-w-md");
+
+    await user.click(openApp);
     await waitFor(() => {
       expect(router.state.location.pathname).toBe("/apps/app-1");
     });

--- a/crates/tidebreak-desktop/ui/src/OutputCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/OutputCard.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { readDeliverable, type DeliverablePreview } from "@/deliverables";
 import { parseChartFigure } from "@/outputs/chartFigure";
 import { usePanelNav } from "@/panel/usePanelNav";
+import { TRANSCRIPT_RESULT_CARD_FRAME } from "@/TranscriptResultCard";
 import { useActiveChatId } from "@/useActiveChatId";
 
 // The plotting engine is a large dependency and most conversations never make a
@@ -41,9 +42,6 @@ export function OutputCardList({ outputs }: { outputs: ResultEntry[] }) {
   );
 }
 
-const CARD_FRAME =
-  "bg-background inline-flex max-w-full min-w-0 items-center gap-3 rounded-lg border px-4 py-3 text-left shadow-sm";
-
 function OpenOutputCard({
   entry,
   outputId,
@@ -55,7 +53,7 @@ function OpenOutputCard({
   return (
     <button
       type="button"
-      className={`${CARD_FRAME} hover:bg-muted/40 cursor-pointer transition-colors`}
+      className={`${TRANSCRIPT_RESULT_CARD_FRAME} hover:bg-muted/40 cursor-pointer transition-colors`}
       onClick={() => openPanel({ type: "outputs", outputId })}
       aria-label={`Open output ${entry.label}`}
     >
@@ -92,7 +90,7 @@ function OutputCard({ entry }: { entry: ResultEntry }) {
 
   if (outputId === null) {
     return (
-      <div className={CARD_FRAME}>
+      <div className={TRANSCRIPT_RESULT_CARD_FRAME}>
         <OutputCardBody entry={entry} />
       </div>
     );

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { useChatSessionStore } from "./ChatSessionStore";
@@ -54,5 +55,36 @@ describe("ToolCommandCard sandbox preparation", () => {
     );
 
     expect(screen.queryByText(/Preparing the sandbox image/)).toBeNull();
+  });
+});
+
+describe("ToolCommandCard expansion", () => {
+  it("reveals the backend and successful outcome with the command detail", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToolCommandCard
+        name="exec"
+        status="completed"
+        preview={preview}
+        result={{
+          tool: "exec",
+          exitCode: 0,
+          timedOut: false,
+          outputTruncated: false,
+          stdout: "rendered\n",
+          stderr: "",
+          backend: "local",
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Local")).toBeNull();
+    expect(screen.queryByText("Done")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: /python3 render.py/ }));
+
+    expect(screen.getByText("Local")).toBeTruthy();
+    expect(screen.getByText("Done")).toBeTruthy();
+    expect(screen.getByLabelText("Output")).toHaveTextContent("rendered");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.test.tsx
@@ -132,19 +132,68 @@ describe("ToolCommandCard", () => {
     expect(done).toContain('aria-expanded="false"');
   });
 
-  it("carries the outcome in a badge rather than a second line of prose", () => {
-    for (const [status, badge] of [
-      ["running", "Running…"],
-      ["waiting_approval", "Waiting for approval"],
-      ["completed", "Done"],
-      ["failed", "Failed"],
-      ["cancelled", "Not run"],
-    ] as const) {
-      const markup = renderToStaticMarkup(
-        <ToolCommandCard name="exec" status={status} preview={preview} result={null} />,
-      );
-      expect(visibleText(markup)).toContain(badge);
-    }
+  it("keeps settled metadata in the expanded detail", () => {
+    const completed = visibleText(
+      renderToStaticMarkup(
+        <ToolCommandCard
+          name="exec"
+          status="completed"
+          preview={preview}
+          result={null}
+        />,
+      ),
+    );
+    const waiting = visibleText(
+      renderToStaticMarkup(
+        <ToolCommandCard
+          name="exec"
+          status="waiting_approval"
+          preview={preview}
+          result={null}
+        />,
+      ),
+    );
+    const cancelled = visibleText(
+      renderToStaticMarkup(
+        <ToolCommandCard
+          name="exec"
+          status="cancelled"
+          preview={preview}
+          result={null}
+        />,
+      ),
+    );
+
+    expect(completed).not.toContain("Done");
+    expect(waiting).not.toContain("Waiting for approval");
+    expect(cancelled).not.toContain("Not run");
+
+    // Active and failed commands start open, so their status is already part
+    // of the detail the reader needs now.
+    expect(
+      visibleText(
+        renderToStaticMarkup(
+          <ToolCommandCard
+            name="exec"
+            status="running"
+            preview={preview}
+            result={null}
+          />,
+        ),
+      ),
+    ).toContain("Running…");
+    expect(
+      visibleText(
+        renderToStaticMarkup(
+          <ToolCommandCard
+            name="exec"
+            status="failed"
+            preview={preview}
+            result={null}
+          />,
+        ),
+      ),
+    ).toContain("Failed");
   });
 
   it("says a degraded run is degraded without needing the card opened", () => {
@@ -331,7 +380,7 @@ describe("outcome badges", () => {
     expect(badge({ ...ran, exitCode: null, timedOut: true }, "failed")).toContain(
       "Timed out",
     );
-    expect(badge(ran, "completed")).toContain("Done");
+    expect(badge(ran, "completed")).not.toContain("Done");
     // No result to be specific about yet.
     expect(badge(null, "failed")).toContain("Failed");
   });

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
@@ -11,9 +11,9 @@ import { Badge } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import type { ToolTone } from "./ToolStatusIcon";
-import { ScrollableContainer } from "./ScrollableContainer";
+import { ToolStatusIcon, type ToolTone } from "./ToolStatusIcon";
 import { ToolCardShell } from "./ToolCardShell";
+import { ToolOutputPreview } from "./ToolOutputPreview";
 import { toolPreviewHeadline, toolPreviewPresentation } from "./ToolPreview";
 import { useChatSessionStore } from "./ChatSessionStore";
 
@@ -318,11 +318,14 @@ export function ToolCommandCard({
             />
           </>
         }
-        defaultExpanded={running}
+        trailing={
+          <ToolStatusIcon tone={presentation.tone} className="size-3.5" />
+        }
+        defaultExpanded={running || presentation.tone === "failed"}
       >
         {tabbed ? (
           <Tabs defaultValue="output">
-            <TabsList className="flex w-full items-center justify-start gap-1 border-b px-1">
+            <TabsList className="flex w-full items-center justify-start gap-1 px-0">
               <TabsTrigger value="command" className="py-1 text-xs capitalize">
                 command
               </TabsTrigger>
@@ -330,33 +333,39 @@ export function ToolCommandCard({
                 output
               </TabsTrigger>
             </TabsList>
-            <div className="p-1">
+            <div className="pt-1">
               <TabsContent value="command" className="mt-0">
-                <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-                  {command.detail}
-                </ScrollableContainer>
+                <ToolOutputPreview
+                  text={command.detail}
+                  collapsedLines={12}
+                  label="Command"
+                  bare
+                />
               </TabsContent>
               <TabsContent value="output" className="mt-0">
                 {output === null ? (
-                  <p className="text-muted-foreground flex items-center gap-1.5 p-2 text-xs">
+                  <p className="text-muted-foreground flex items-center gap-1.5 py-1 text-xs">
                     <Spinner className="size-3.5" aria-hidden="true" />
                     Waiting for output…
                   </p>
                 ) : null}
                 {output !== null && (
-                  <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-                    {output}
-                  </ScrollableContainer>
+                  <ToolOutputPreview
+                    text={output}
+                    collapsedLines={12}
+                    bare
+                  />
                 )}
               </TabsContent>
             </div>
           </Tabs>
         ) : (
-          <div className="p-1">
-            <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-              {command.detail}
-            </ScrollableContainer>
-          </div>
+          <ToolOutputPreview
+            text={command.detail}
+            collapsedLines={12}
+            label="Command"
+            bare
+          />
         )}
       </ToolCardShell>
       {/* Outside the collapsible body on purpose: a card that reports a

--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -2,6 +2,7 @@ import { useId, useState, type ReactNode } from "react";
 import { ChevronDown } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { FOCUS_RING_TIGHT, HOVER_TINT } from "@/code/interactive";
 
 type ToolCardShellProps = {
   /** What ran, drawn from the tool's allowlisted name. */
@@ -10,83 +11,107 @@ type ToolCardShellProps = {
   title: ReactNode;
   /** Monospace when the title is a command rather than prose. */
   titleClassName?: string;
-  /** The outcome, always visible — a collapsed card still has to report. */
-  badge: ReactNode;
+  /** Secondary execution facts, shown with the expanded detail. */
+  badge?: ReactNode;
+  /** Compact metadata that belongs on the collapsed row. */
+  trailing?: ReactNode;
   /** Open on mount, which is worth doing only while work is still happening. */
   defaultExpanded?: boolean;
-  /** Extra card-level classes, e.g. a failure tint on the border. */
+  /** Controlled expansion for hosts that already own reveal state. */
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+  /** Extra row-level classes. */
   className?: string;
+  bodyClassName?: string;
   children: ReactNode;
   /** Assistive label; the visible title is usually not the whole sentence. */
   label: string;
+  /** Work/chat tool rows announce status changes; code-mode rows do not. */
+  announce?: boolean;
 };
 
 /**
- * The chrome every tool-result card shares: one header line that names what ran
- * and how it ended, over a body the reader opens when they want it.
+ * The shared expandable tool row used by work/chat and code mode.
  *
- * A transcript should read as a conversation with occasional notes about what
- * the agent did, not as a log. So the default is one line, the outcome stays on
- * that line, and the detail is one click away — a stream of tool calls stays
- * scannable instead of flooding the conversation with output.
+ * The collapsed state is deliberately boxless: a transcript should read as a
+ * conversation with occasional notes about what ran, not as a stack of nested
+ * panels. Provider and outcome metadata live with the expanded detail unless a
+ * host supplies genuinely glanceable trailing metadata, such as code mode's
+ * duration and status glyph.
  */
 export function ToolCardShell({
   icon,
   title,
   titleClassName,
   badge,
+  trailing,
   defaultExpanded = false,
+  expanded: controlledExpanded,
+  onExpandedChange,
   className,
+  bodyClassName,
   children,
   label,
+  announce = true,
 }: ToolCardShellProps) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [uncontrolledExpanded, setUncontrolledExpanded] =
+    useState(defaultExpanded);
+  const expanded = controlledExpanded ?? uncontrolledExpanded;
   const bodyId = useId();
+
+  function setExpanded(expanded: boolean) {
+    if (controlledExpanded === undefined) setUncontrolledExpanded(expanded);
+    onExpandedChange?.(expanded);
+  }
 
   return (
     <section
-      className={cn(
-        "bg-background max-w-prose overflow-hidden rounded-lg border",
-        className,
-      )}
+      className={cn("max-w-prose [overflow-anchor:none]", className)}
       aria-label={label}
-      role="status"
-      aria-live="polite"
-      aria-atomic="true"
+      role={announce ? "status" : undefined}
+      aria-live={announce ? "polite" : undefined}
+      aria-atomic={announce ? "true" : undefined}
     >
       <button
         type="button"
-        className="hover:bg-muted/50 focus-visible:ring-ring flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden"
+        className={cn(
+          "-mx-1.5 flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-0.5 text-left text-[13.5px] hover:bg-muted/50",
+          FOCUS_RING_TIGHT,
+          HOVER_TINT,
+        )}
         aria-expanded={expanded}
         aria-controls={bodyId}
-        onClick={() => setExpanded((current) => !current)}
+        onClick={() => setExpanded(!expanded)}
       >
-        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium">
-          <ChevronDown
-            className={cn(
-              "size-3.5 shrink-0 transition-transform",
-              !expanded && "-rotate-90",
-            )}
-            aria-hidden="true"
-          />
+        <span className="text-muted-foreground shrink-0 [&>svg]:size-3.5">
           {icon}
-          {/* A truncated command is unreadable, and the card's body may not
-              repeat it. The native tooltip gives the whole line back to anyone
-              who hovers, for the titles that are plain text to begin with. */}
+        </span>
+        <span className={cn("min-w-0 flex-1", titleClassName)}>
           <span
-            className={cn("truncate", titleClassName)}
+            className={cn(typeof title === "string" && "block truncate")}
             title={typeof title === "string" ? title : undefined}
           >
             {title}
           </span>
         </span>
-        {/* One end cluster: a fragment would become sibling flex children,
-            so justify-between would split them and they would not share a
-            height with the outcome pill. */}
-        <span className="flex shrink-0 items-stretch gap-1">{badge}</span>
+        <span className="text-muted-foreground ml-auto flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums">
+          {trailing}
+          <ChevronDown
+            className={cn(
+              "text-muted-foreground/50 size-3.5 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
+              !expanded && "-rotate-90",
+            )}
+            aria-hidden="true"
+          />
+        </span>
       </button>
       {expanded && (
-        <div id={bodyId} className="border-t">
+        <div id={bodyId} className={cn("mt-1.5", bodyClassName)}>
+          {badge && (
+            <div className="mb-1.5 flex flex-wrap items-center gap-1">
+              {badge}
+            </div>
+          )}
           {children}
         </div>
       )}

--- a/crates/tidebreak-desktop/ui/src/TranscriptResultCard.ts
+++ b/crates/tidebreak-desktop/ui/src/TranscriptResultCard.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared frame for compact, actionable things a work/chat turn produced.
+ *
+ * Apps and ordinary file outputs carry different content, but they should
+ * occupy the same responsive footprint in the transcript. Rich inline
+ * surfaces such as charts and MCP views keep their own content-sized frames.
+ */
+export const TRANSCRIPT_RESULT_CARD_FRAME =
+  "bg-background flex w-full max-w-md min-w-0 items-center gap-3 rounded-lg border px-4 py-3 text-left shadow-sm";

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -1,6 +1,5 @@
 import {
   Check,
-  ChevronDown,
   CircleSlash,
   FileCode,
   FileSearch,
@@ -19,6 +18,7 @@ import { AssistantWorkingIndicator } from "@/AssistantWorkingIndicator";
 import { MessageFooter } from "@/MessageFooter";
 import { isolatedCard } from "@/PendingCard";
 import { ThinkingAccordion } from "@/ThinkingAccordion";
+import { ToolCardShell } from "@/ToolCardShell";
 import { ToolOutputPreview } from "@/ToolOutputPreview";
 import { TranscriptSkeleton } from "@/TranscriptSkeleton";
 import { UserMessage } from "@/UserMessage";
@@ -448,7 +448,6 @@ export function CodeToolCard({
   const [expanded, setExpanded] = useState(
     status === "failed" || status === "denied",
   );
-  const bodyId = useId();
   const verb = toolVerb(detail, status);
   const subject = toolSubject(detail, name);
   const hasOutput = preview.trim().length > 0;
@@ -469,32 +468,22 @@ export function CodeToolCard({
     // byte of its own output, and a transcript of thirty of them would announce
     // each one atomically, over and over. The outcome rides the line's own name
     // instead, and the turn announcer says when the work as a whole ends.
-    <div className="max-w-prose [overflow-anchor:none]">
-      <button
-        type="button"
-        className={cn(
-          "-mx-1.5 flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-0.5 text-left text-[13.5px] hover:bg-muted/50",
-          FOCUS_RING_TIGHT,
-          HOVER_TINT,
-        )}
-        aria-expanded={expanded || showTail}
-        aria-controls={hasOutput ? bodyId : undefined}
-        onClick={() => {
-          onReveal?.();
-          setExpanded((current) => !current);
-        }}
-      >
-        <span className="text-muted-foreground shrink-0 [&>svg]:size-3.5">
-          {toolIcon(detail)}
-        </span>
-        <span className="shrink-0 font-semibold">{verb}</span>
-        <MiddleTruncate
-          text={subject}
-          // The subject is the line's whole point, so it takes the free space
-          // and keeps a floor: a narrow column truncates it, never erases it.
-          className="text-muted-foreground min-w-[6ch] flex-1 font-mono"
-        />
-        <span className="text-muted-foreground ml-auto flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums">
+    <ToolCardShell
+      icon={toolIcon(detail)}
+      title={
+        <>
+          <span className="shrink-0 font-semibold">{verb}</span>
+          <MiddleTruncate
+            text={subject}
+            // The subject is the line's whole point, so it takes the free space
+            // and keeps a floor: a narrow column truncates it, never erases it.
+            className="text-muted-foreground min-w-[6ch] flex-1 font-mono"
+          />
+        </>
+      }
+      titleClassName="flex items-center gap-2"
+      trailing={
+        <>
           {status === "running" ? elapsed : duration}
           {status !== "running" && exitCode !== null && (
             <span>exit {exitCode}</span>
@@ -503,31 +492,26 @@ export function CodeToolCard({
               fact for everyone else, in the same place in the line. */}
           <span className="sr-only">{status}</span>
           <StatusGlyph status={status} />
-          <ChevronDown
-            className={cn(
-              "text-muted-foreground/50 size-3.5 transition-transform duration-[140ms] ease-out motion-reduce:transition-none",
-              !(expanded || showTail) && "-rotate-90",
-            )}
-            aria-hidden="true"
-          />
-        </span>
-      </button>
-      {showTail && (
-        <div id={bodyId}>
-          <StreamingTail text={preview} />
-        </div>
-      )}
+        </>
+      }
+      expanded={expanded || showTail}
+      onExpandedChange={(next) => {
+        onReveal?.();
+        setExpanded(next);
+      }}
+      label={`${verb} ${subject} ${status}`}
+      announce={false}
+    >
+      {showTail && <StreamingTail text={preview} />}
       {showExpanded && (
-        <div id={bodyId}>
-          <ToolOutputPreview
-            text={preview}
-            collapsedLines={12}
-            bare
-            onToggle={onReveal}
-          />
-        </div>
+        <ToolOutputPreview
+          text={preview}
+          collapsedLines={12}
+          bare
+          onToggle={onReveal}
+        />
       )}
-    </div>
+    </ToolCardShell>
   );
 }
 


### PR DESCRIPTION
## Summary

- standardize ordinary app and output cards on one responsive transcript footprint
- share the boxless expandable tool-row component between Work/Chat and Code mode
- move Work/Chat execution backend and outcome pills into the expanded detail
- reuse the bare command/output presentation while preserving running and failed expansion behavior

## Compatibility and risk

- no wire-format, persistence, routing, or execution behavior changes
- chart outputs and embedded MCP app surfaces retain their content-sized frames
- accessibility labels and Code-mode status, duration, exit-code, and streaming behavior remain covered

## Verification

- `pnpm exec vitest run src/ToolCallCard.test.tsx src/ToolCallCard.dom.test.tsx src/code/CodeTranscript.dom.test.tsx src/AgentActivityTimeline.dom.test.tsx src/MessageList.dom.test.tsx` — 78 tests passed
- `pnpm exec tsc --noEmit`
- `git diff --check`
- visually verified the updated weekly-planner Work/Chat transcript and an existing populated Code workspace in the local app