### PR TITLE
feat(code): add safe mid-turn steering contract

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -824,6 +824,23 @@ describe("active turn steering", () => {
       invoked_skills: ["docx"],
     });
   });
+
+  it("binds Code guidance to the exact active turn", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.steerCodeSession("session-1", "turn-1", "change course");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1/code/sessions/session-1/steer");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      expected_turn_id: "turn-1",
+      guidance: "change course",
+    });
+  });
 });
 
 describe("historical image API", () => {

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -1970,11 +1970,18 @@ export class ApiClient {
    * Redirect the in-flight turn. The route answers with an empty status;
    * unsupported engines refuse with `steering_unavailable` rather than queue.
    */
-  steerCodeSession(sessionId: string, message: string): Promise<void> {
+  steerCodeSession(
+    sessionId: string,
+    expectedTurnId: string,
+    guidance: string,
+  ): Promise<void> {
     return this.json(`/code/sessions/${encodeURIComponent(sessionId)}/steer`, {
       method: "POST",
       headers: this.headers(true),
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({
+        expected_turn_id: expectedTurnId,
+        guidance,
+      }),
     });
   }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -336,7 +336,42 @@ describe("CodeComposer", () => {
     expect(await screen.findByText("Guidance sent")).toBeInTheDocument();
   });
 
-  it("queues mid-turn when steering is unsupported", async () => {
+  it("preserves text typed while a steer request is pending", async () => {
+    useUiStore.setState({ activeTurnSendMode: "steer" });
+    let resolveSteer!: () => void;
+    const onSteer = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSteer = resolve;
+        }),
+    );
+    renderComposer(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        onSend={vi.fn()}
+        onSteer={onSteer}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "try the other file" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    await waitFor(() =>
+      expect(onSteer).toHaveBeenCalledWith("try the other file"),
+    );
+
+    fireEvent.change(box, { target: { value: "also keep the API small" } });
+    resolveSteer();
+
+    await waitFor(() =>
+      expect(screen.getByText("Guidance sent")).toBeInTheDocument(),
+    );
+    expect(box).toHaveValue("also keep the API small");
+  });
+
+  it("refuses unsupported steering without silently queueing or clearing the draft", async () => {
     useUiStore.setState({ activeTurnSendMode: "steer" });
     const onSend = vi.fn().mockResolvedValue(QUEUED);
     renderComposer(
@@ -352,8 +387,12 @@ describe("CodeComposer", () => {
     fireEvent.change(box, { target: { value: "and run the tests" } });
     fireEvent.keyDown(box, { key: "Enter" });
 
-    await waitFor(() => expect(onSend).toHaveBeenCalledWith("and run the tests"));
-    expect(await screen.findByText("1 follow-up queued")).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Redirect isn’t available for this harness. Choose Queue to send this after the response.",
+    );
+    expect(onSend).not.toHaveBeenCalled();
+    expect(box).toHaveValue("and run the tests");
+    expect(screen.queryByText("1 follow-up queued")).toBeNull();
   });
 
   it("submits free-typed slash text verbatim when the engine lists no commands", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -44,6 +44,8 @@ import {
 } from "./labels";
 
 const MODES: CodePermissionMode[] = ["plan", "ask", "auto", "allow"];
+const STEERING_UNAVAILABLE =
+  "Redirect isn’t available for this harness. Choose Queue to send this after the response.";
 
 function appendComposerPrompt(current: string, prompt: string): string {
   const existing = current.trimEnd();
@@ -506,8 +508,9 @@ export function CodeComposer({
     attachments?: readonly { blob_id: string; media_type: string }[],
   ) => Promise<CodeTurnSubmission | void> | void;
   /**
-   * Redirect the in-flight turn. Absent when the harness cannot steer, so a
-   * mid-turn send stays on the queue path.
+   * Redirect the in-flight turn. Absent when the harness cannot steer. The
+   * composer refuses Redirect in that state; Queue is only used when the user
+   * explicitly selected Queue.
    */
   onSteer?: (message: string) => Promise<void>;
   onInterrupt: () => Promise<void> | void;
@@ -524,6 +527,8 @@ export function CodeComposer({
   const [steerPending, setSteerPending] = useState(false);
   const [steerError, setSteerError] = useState<string | null>(null);
   const [steerStatus, setSteerStatus] = useState<string | null>(null);
+  const draftRef = useRef("");
+  const steerRequestRef = useRef(0);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const images = useImageAttachments(
     client,
@@ -531,7 +536,6 @@ export function CodeComposer({
     sessionId ? async () => sessionId : undefined,
     "code",
   );
-  const canSteer = onSteer !== undefined;
   const showQueued = queued || followUpQueued;
   const [pathItems, setPathItems] = useState<string[]>([]);
   const searchPathsRef = useRef(searchPaths);
@@ -573,6 +577,17 @@ export function CodeComposer({
       : undefined;
 
   const pendingPrompt = useCodeUiStore((state) => state.pendingComposerPrompt);
+
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+
+  useEffect(() => {
+    steerRequestRef.current += 1;
+    setSteerPending(false);
+    setSteerError(null);
+    setSteerStatus(null);
+  }, [sessionId]);
 
   useEffect(() => {
     if (!pendingPrompt || pendingPrompt.scope !== composerPromptScope) return;
@@ -689,21 +704,35 @@ export function CodeComposer({
   }
 
   async function steer() {
-    const message = draft.trim();
-    if (!message || disabled || !onSteer) return;
+    const submittedDraft = draftRef.current;
+    const message = submittedDraft.trim();
+    if (!message || disabled) return;
+    if (!onSteer) {
+      setSteerStatus(null);
+      setSteerError(STEERING_UNAVAILABLE);
+      setNotice(null);
+      return;
+    }
+    const request = steerRequestRef.current + 1;
+    steerRequestRef.current = request;
     setSteerPending(true);
     setSteerError(null);
     setSteerStatus("Sending guidance…");
     setNotice(null);
     try {
       await onSteer(message);
-      setDraft("");
+      if (steerRequestRef.current !== request) return;
+      if (draftRef.current === submittedDraft) {
+        draftRef.current = "";
+        setDraft("");
+      }
       setSteerStatus("Guidance sent");
     } catch (err) {
+      if (steerRequestRef.current !== request) return;
       setSteerStatus(null);
       setSteerError(err instanceof Error ? err.message : "Could not steer");
     } finally {
-      setSteerPending(false);
+      if (steerRequestRef.current === request) setSteerPending(false);
     }
   }
 
@@ -789,20 +818,21 @@ export function CodeComposer({
             : undefined
         }
         onDraftChange={(value) => {
+          draftRef.current = value;
           setSteerError(null);
           setSteerStatus(null);
           setDraft(value);
         }}
         onSend={submit}
-        onSteer={canSteer ? steer : submit}
+        onSteer={steer}
         onQueue={submit}
         onStop={async () => {
           await onInterrupt();
         }}
         resetKey={sessionId ?? "code"}
-        steerError={canSteer ? steerError : null}
-        steerPending={canSteer ? steerPending : false}
-        steerStatus={canSteer ? steerStatus : null}
+        steerError={steerError}
+        steerPending={steerPending}
+        steerStatus={steerStatus}
       />
       {imageInput && (
         <input

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1154,7 +1154,11 @@ function CodeSessionPane({
   }
 
   async function steer(message: string) {
-    await client.steerCodeSession(session.id, message);
+    const expectedTurnId = store.getState().activeTurnId;
+    if (!expectedTurnId) {
+      throw new Error("The active turn changed. Try Redirect again.");
+    }
+    await client.steerCodeSession(session.id, expectedTurnId, message);
   }
 
   async function interrupt() {

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -362,11 +362,14 @@ pub trait HarnessSession: Send + Sync {
     ///
     /// The default refuses: an adapter must override this only when its
     /// capability vector states [`CapLevel::Supported`] for mid-turn steering.
+    /// An accepting adapter owns the matching [`HarnessEvent::UserSteered`]
+    /// emission: emit it exactly once before returning `Ok(())`, and emit none
+    /// when admission is rejected. Keeping acknowledgement and event ordering
+    /// inside the protocol adapter lets a terminal event that follows in the
+    /// same native batch remain causally after the user's guidance.
     async fn steer(&self, text: String) -> Result<(), HarnessError> {
         let _ = text;
-        Err(HarnessError::Other(
-            "mid-turn steering is not available on this engine".into(),
-        ))
+        Err(HarnessError::SteeringUnsupported)
     }
 
     /// Engine-native resume token, when the stream has reported one.
@@ -449,6 +452,12 @@ pub enum HarnessError {
     /// rather than treat this as one failed turn.
     #[error("the engine no longer has this session: {0}")]
     ResumeLost(String),
+    /// The adapter has no verified same-turn steering channel.
+    #[error("mid-turn steering is not available on this engine")]
+    SteeringUnsupported,
+    /// The native engine refused a steer for the currently active turn.
+    #[error("the engine refused mid-turn steering: {0}")]
+    SteeringRejected(String),
     /// I/O or spawn failure.
     #[error("engine io: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1109,6 +1109,64 @@ impl CodeRuntime {
             .map_err(map_worker)
     }
 
+    pub(crate) async fn steer(
+        &self,
+        owner: &OwnerId,
+        id: CodeSessionId,
+        expected_turn_id: CodeTurnId,
+        message: String,
+    ) -> Result<(), ServerError> {
+        let session = self.get_session(owner, id).await?;
+        if session.lifecycle != CodeSessionLifecycle::Running {
+            return Err(ServerError::conflict_kind(
+                "no_active_turn",
+                "there is no active turn to steer; the message was not queued",
+            ));
+        }
+        let Some(active_turn) = get_open_turn(&self.db, owner, id).await? else {
+            return Err(ServerError::conflict_kind(
+                "no_active_turn",
+                "there is no active turn to steer; the message was not queued",
+            ));
+        };
+        if active_turn.id != expected_turn_id {
+            return Err(ServerError::conflict_kind(
+                "stale_turn",
+                format!(
+                    "turn {expected_turn_id} is no longer active; current turn is {}; the message was not queued",
+                    active_turn.id
+                ),
+            ));
+        }
+        let adapter = self.adapter(session.harness_kind)?;
+        let probe = self.probe(adapter.as_ref()).await;
+        let level = adapter.capabilities(&probe).mid_turn_steering;
+        if level != CapLevel::Supported {
+            return Err(ServerError::unprocessable_kind(
+                "steering_unavailable",
+                format!(
+                    "{harness} mid-turn steering is {level}; the message was not queued",
+                    harness = session.harness_kind,
+                    level = level.as_str(),
+                ),
+            ));
+        }
+        let handle = self.require_worker(id)?;
+        let (reply, rx) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::Steer {
+                expected_turn_id,
+                message,
+                reply,
+            })
+            .await
+            .map_err(|_| ServerError::internal("session worker is gone"))?;
+        rx.await
+            .map_err(|_| ServerError::internal("session worker dropped the steer"))?
+            .map_err(map_worker)
+    }
+
     pub(crate) async fn reap(
         &self,
         owner: &OwnerId,
@@ -1805,6 +1863,14 @@ fn map_worktree(err: WorktreeError) -> ServerError {
 fn map_worker(err: WorkerError) -> ServerError {
     match err {
         WorkerError::Conflict(message) => ServerError::conflict_kind("conflict", message),
+        WorkerError::NoActiveTurn(message) => ServerError::conflict_kind("no_active_turn", message),
+        WorkerError::StaleTurn(message) => ServerError::conflict_kind("stale_turn", message),
+        WorkerError::SteeringUnavailable(message) => {
+            ServerError::unprocessable_kind("steering_unavailable", message)
+        }
+        WorkerError::SteeringRejected(message) => {
+            ServerError::conflict_kind("steering_rejected", message)
+        }
         WorkerError::Failed(message) => ServerError::internal(message),
     }
 }

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -352,6 +352,17 @@ impl ScopedCode {
         self.runtime.interrupt(id).await
     }
 
+    pub(crate) async fn steer(
+        &self,
+        id: CodeSessionId,
+        expected_turn_id: CodeTurnId,
+        message: String,
+    ) -> Result<(), ServerError> {
+        self.runtime
+            .steer(&self.owner, id, expected_turn_id, message)
+            .await
+    }
+
     pub(crate) async fn reap(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
         self.runtime.reap(&self.owner, id).await
     }

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -13,6 +13,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -53,6 +54,11 @@ pub(crate) enum WorkerCommand {
     Interrupt {
         reply: oneshot::Sender<Result<(), WorkerError>>,
     },
+    Steer {
+        expected_turn_id: CodeTurnId,
+        message: String,
+        reply: oneshot::Sender<Result<(), WorkerError>>,
+    },
     Shutdown,
 }
 
@@ -60,6 +66,14 @@ pub(crate) enum WorkerCommand {
 pub(crate) enum WorkerError {
     #[error("{0}")]
     Conflict(String),
+    #[error("{0}")]
+    NoActiveTurn(String),
+    #[error("{0}")]
+    StaleTurn(String),
+    #[error("{0}")]
+    SteeringUnavailable(String),
+    #[error("{0}")]
+    SteeringRejected(String),
     #[error("{0}")]
     Failed(String),
 }
@@ -305,7 +319,9 @@ async fn run_worker(
                     let _ = reply.send(result);
                 }
                 Some(command) => {
-                    if apply_control(engine.as_ref(), command).await == ControlFlow::Shutdown {
+                    if apply_control(engine.as_ref(), command, None).await
+                        == ControlFlow::Shutdown
+                    {
                         break;
                     }
                 }
@@ -321,6 +337,11 @@ enum ControlFlow {
     Continue,
     Shutdown,
 }
+
+#[cfg(not(test))]
+const STEER_CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(test)]
+const STEER_CONTROL_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Stop the engine's current turn, discarding the adapter's error: the turn
 /// is ending either way, and the outcome is what the worker journals.
@@ -342,7 +363,11 @@ async fn next_child_pid(changes: Option<&mut watch::Receiver<Option<i64>>>) -> O
     *changes.borrow()
 }
 
-async fn apply_control(engine: &dyn HarnessSession, command: WorkerCommand) -> ControlFlow {
+async fn apply_control(
+    engine: &dyn HarnessSession,
+    command: WorkerCommand,
+    active_turn_id: Option<CodeTurnId>,
+) -> ControlFlow {
     match command {
         WorkerCommand::Decide {
             approval,
@@ -361,6 +386,45 @@ async fn apply_control(engine: &dyn HarnessSession, command: WorkerCommand) -> C
                 .interrupt()
                 .await
                 .map_err(|err| WorkerError::Failed(err.to_string()));
+            let _ = reply.send(result);
+            ControlFlow::Continue
+        }
+        WorkerCommand::Steer {
+            expected_turn_id,
+            message,
+            reply,
+        } => {
+            let result = match active_turn_id {
+                None => Err(WorkerError::NoActiveTurn(
+                    "there is no active turn to steer; the message was not queued".into(),
+                )),
+                Some(active) if active != expected_turn_id => Err(WorkerError::StaleTurn(
+                    format!(
+                        "turn {expected_turn_id} is no longer active; current turn is {active}; the message was not queued"
+                    ),
+                )),
+                Some(_) => match tokio::time::timeout(
+                    STEER_CONTROL_TIMEOUT,
+                    engine.steer(message),
+                )
+                .await
+                {
+                    Ok(result) => result.map_err(|err| match err {
+                        HarnessError::SteeringUnsupported => WorkerError::SteeringUnavailable(
+                            "mid-turn steering is not available on this engine; the message was not queued"
+                                .into(),
+                        ),
+                        HarnessError::SteeringRejected(detail) => {
+                            WorkerError::SteeringRejected(detail)
+                        }
+                        other => WorkerError::Failed(other.to_string()),
+                    }),
+                    Err(_) => Err(WorkerError::SteeringRejected(
+                        "the engine did not acknowledge steering before the control timeout; the message was not queued"
+                            .into(),
+                    )),
+                },
+            };
             let _ = reply.send(result);
             ControlFlow::Continue
         }
@@ -490,28 +554,36 @@ async fn drive_turn(
     let mut commands_closed = false;
     let run = loop {
         tokio::select! {
-            result = &mut run => break result,
+            // Once a control has been accepted from the command channel, poll
+            // it before allowing a simultaneously-terminal turn to win. Native
+            // steering registers its response waiter on that first poll; the
+            // turn reader can then drain and demultiplex the acknowledgement.
+            biased;
             Some(flow) = controls.next(), if !controls.is_empty() => {
                 if flow == ControlFlow::Shutdown {
                     interrupted = true;
                     controls.push(Box::pin(interrupt_engine(engine)));
                 }
             }
-            pid = next_child_pid(pid_changes.as_mut()) => {
-                if session.child_pid != pid {
-                    session.child_pid = pid;
-                    let _ = save_session(db, session).await;
-                }
-            }
+            // A terminal result wins over commands that have not yet been
+            // admitted. This prevents guidance for turn A from entering the
+            // control set after A has already completed and then reaching B.
+            result = &mut run => break result,
             command = commands.recv(), if !commands_closed => match command {
                 Some(command) => {
                     interrupted |= matches!(command, WorkerCommand::Interrupt { .. });
-                    controls.push(Box::pin(apply_control(engine, command)));
+                    controls.push(Box::pin(apply_control(engine, command, Some(turn.id))));
                 }
                 None => {
                     commands_closed = true;
                     interrupted = true;
                     controls.push(Box::pin(interrupt_engine(engine)));
+                }
+            },
+            pid = next_child_pid(pid_changes.as_mut()) => {
+                if session.child_pid != pid {
+                    session.child_pid = pid;
+                    let _ = save_session(db, session).await;
                 }
             }
         }

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -1,8 +1,3 @@
-use axum::body::Body;
-use axum::extract::State;
-use axum::http::{header, HeaderMap, StatusCode};
-use axum::response::{IntoResponse, Response};
-
 use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, RawBytes};
@@ -11,13 +6,17 @@ use crate::routes::image_attachment::{
 };
 use crate::routes::SERVED_BYTES_CONTENT_POLICY;
 use crate::state::AppState;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
 
 use super::types::{
     CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuedCodeTurn,
     SequencedCodeEventFrame, SetAttentionBody, SteerBody, SubmitTurnBody,
 };
 use crate::code::runtime::SubmitTurnOutcome;
-use tidebreak_core::{CodeSessionId, WorkspaceId};
+use tidebreak_core::{CodeSessionId, TurnSteer, WorkspaceId};
 
 pub async fn create_session(
     code: ScopedCode,
@@ -115,17 +114,21 @@ pub async fn list_session_turns(
 }
 
 pub async fn steer_session(
-    Path(_id): Path<CodeSessionId>,
+    code: ScopedCode,
+    Path(id): Path<CodeSessionId>,
     Json(body): Json<SteerBody>,
 ) -> Result<StatusCode, ServerError> {
-    let message = body.message.trim();
-    if message.is_empty() {
-        return Err(ServerError::bad_request("message must not be empty"));
+    let guidance = body.guidance.trim().to_owned();
+    if guidance.is_empty()
+        || guidance.contains('\0')
+        || guidance.chars().count() > TurnSteer::MAX_CONTENT_LEN
+    {
+        return Err(ServerError::bad_request(
+            "guidance must be non-empty, contain no NUL characters, and fit the size limit",
+        ));
     }
-    Err(ServerError::unprocessable_kind(
-        "steering_unavailable",
-        "explicit mid-turn steering is not yet available; the message was not queued",
-    ))
+    code.steer(id, body.expected_turn_id, guidance).await?;
+    Ok(StatusCode::ACCEPTED)
 }
 
 pub async fn interrupt_session(

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -458,7 +458,8 @@ pub struct SubmitTurnAttachment {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SteerBody {
-    pub message: String,
+    pub expected_turn_id: tidebreak_core::CodeTurnId,
+    pub guidance: String,
 }
 
 /// A follow-up parked while the session is already running a turn.

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -16,7 +16,7 @@ use tidebreak_harness::{
     HarnessEvent, HarnessEventSink, HarnessProbe, HarnessSession, HostEnv, SessionSpec, TurnInput,
     TurnOutcome,
 };
-use tokio::sync::{oneshot, watch, Mutex};
+use tokio::sync::{oneshot, watch};
 
 /// Completer that records decisions and unparks a scripted turn.
 ///
@@ -76,6 +76,8 @@ pub(crate) struct ScriptedAdapter {
     events: Vec<HarnessEvent>,
     delay: Duration,
     mid_turn_steering: CapLevel,
+    steering_delay: Duration,
+    steering_rejection: Option<String>,
     structured_approvals: CapLevel,
     auto_mode: CapLevel,
     allow_mode: CapLevel,
@@ -98,6 +100,8 @@ impl ScriptedAdapter {
             events,
             delay: Duration::ZERO,
             mid_turn_steering: CapLevel::Unsupported,
+            steering_delay: Duration::ZERO,
+            steering_rejection: None,
             structured_approvals: CapLevel::Unsupported,
             auto_mode: CapLevel::Unsupported,
             allow_mode: CapLevel::Unsupported,
@@ -177,6 +181,18 @@ impl ScriptedAdapter {
         self
     }
 
+    pub(crate) fn with_steering_delay(mut self, delay: Duration) -> Self {
+        self.mid_turn_steering = CapLevel::Supported;
+        self.steering_delay = delay;
+        self
+    }
+
+    pub(crate) fn with_steering_rejection(mut self, detail: impl Into<String>) -> Self {
+        self.mid_turn_steering = CapLevel::Supported;
+        self.steering_rejection = Some(detail.into());
+        self
+    }
+
     /// Publish this pid for the duration of each turn, the way an adapter
     /// that spawns one child per turn does.
     #[allow(dead_code)]
@@ -251,12 +267,13 @@ impl HarnessAdapter for ScriptedAdapter {
             events: self.events.clone(),
             delay: self.delay,
             mid_turn_steering: self.mid_turn_steering,
+            steering_delay: self.steering_delay,
+            steering_rejection: self.steering_rejection.clone(),
             child_pid: self.child_pid,
             silent_interrupt: self.silent_interrupt,
             pid: ChildPid::new(),
             lost_resume: self.lost_resume.clone(),
             interrupt: Arc::new(AtomicBool::new(false)),
-            steered: Mutex::new(None),
             unrecognized: AtomicU64::new(0),
             unrecognized_per_turn: self.unrecognized_per_turn,
             approver: self.approver.clone(),
@@ -269,12 +286,13 @@ struct ScriptedSession {
     events: Vec<HarnessEvent>,
     delay: Duration,
     mid_turn_steering: CapLevel,
+    steering_delay: Duration,
+    steering_rejection: Option<String>,
     child_pid: Option<i64>,
     silent_interrupt: bool,
     pid: ChildPid,
     lost_resume: Option<String>,
     interrupt: Arc<AtomicBool>,
-    steered: Mutex<Option<String>>,
     unrecognized: AtomicU64,
     unrecognized_per_turn: u64,
     approver: Arc<ScriptedApprover>,
@@ -289,9 +307,6 @@ impl ScriptedSession {
             }
             if !self.delay.is_zero() {
                 tokio::time::sleep(self.delay).await;
-            }
-            if let Some(text) = self.steered.lock().await.take() {
-                self.sink.emit(HarnessEvent::UserSteered { text }).await;
             }
             if let HarnessEvent::ApprovalRequested { harness_ref, .. } = event {
                 self.sink.emit(event.clone()).await;
@@ -372,11 +387,15 @@ impl HarnessSession for ScriptedSession {
 
     async fn steer(&self, text: String) -> Result<(), HarnessError> {
         if self.mid_turn_steering != CapLevel::Supported {
-            return Err(HarnessError::Other(
-                "mid-turn steering is not available on this engine".into(),
-            ));
+            return Err(HarnessError::SteeringUnsupported);
         }
-        *self.steered.lock().await = Some(text);
+        if !self.steering_delay.is_zero() {
+            tokio::time::sleep(self.steering_delay).await;
+        }
+        if let Some(detail) = &self.steering_rejection {
+            return Err(HarnessError::SteeringRejected(detail.clone()));
+        }
+        self.sink.emit(HarnessEvent::UserSteered { text }).await;
         Ok(())
     }
 

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -18,8 +18,8 @@ use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CapLevel, CodeEvent, CodePermissionMode,
-    CodeSessionId, CodeSessionLifecycle, CodeTurnStatus, CodeWorkspaceStatus, DbStore, FenceReason,
-    HarnessKind, WorkspaceId,
+    CodeSessionId, CodeSessionLifecycle, CodeTurnId, CodeTurnStatus, CodeWorkspaceStatus, DbStore,
+    FenceReason, HarnessKind, WorkspaceId,
 };
 use tidebreak_harness::{AdapterRegistry, ApprovalDecision, HarnessApprovalRef, HarnessEvent};
 
@@ -871,6 +871,26 @@ async fn turn_statuses(
         .collect()
 }
 
+async fn wait_for_open_turn(runtime: &CodeRuntime, session_id: CodeSessionId) -> CodeTurnId {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(turn) = tidebreak_core::db::code::get_open_turn(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                session_id,
+            )
+            .await
+            .unwrap()
+            {
+                break turn.id;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("turn never became active")
+}
+
 #[tokio::test]
 async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
     // Claude Code advertises mid_turn_steering: Unknown. Queue-default must
@@ -1009,8 +1029,11 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
 }
 
 #[tokio::test]
-async fn explicit_steer_is_not_yet_available() {
-    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+async fn unsupported_explicit_steer_is_refused_without_queueing() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script()).with_delay(Duration::from_millis(40)),
+    )
+    .await;
     let addr = serve(router).await;
     let client = reqwest::Client::new();
     let repo = init_git_repo(dir.path());
@@ -1031,19 +1054,552 @@ async fn explicit_steer_is_not_yet_available() {
         .json::<serde_json::Value>()
         .await
         .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = wait_for_open_turn(&runtime, parsed).await;
     let refused = client
-        .post(format!(
-            "http://{addr}/code/sessions/{}/steer",
-            json_id(&session)
-        ))
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
         .bearer_auth(&token)
-        .json(&serde_json::json!({ "message": "redirect" }))
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "redirect",
+        }))
         .send()
         .await
         .unwrap();
     assert_eq!(refused.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
     let body: serde_json::Value = refused.json().await.unwrap();
     assert_eq!(body["kind"], "steering_unavailable");
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_up() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(40))
+            .with_steering(CapLevel::Supported),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let mut events = runtime.bus.subscribe(parsed);
+
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let CodeEvent::TurnStarted { turn_id } = events.recv().await.unwrap().event {
+                break turn_id;
+            }
+        }
+    })
+    .await
+    .expect("turn never started");
+
+    let first_steer = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "try the other file",
+        }))
+        .send();
+    let second_steer = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "keep the public API small",
+        }))
+        .send();
+    let (first_steer, second_steer) = tokio::join!(first_steer, second_steer);
+    assert_eq!(first_steer.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+    assert_eq!(
+        second_steer.unwrap().status(),
+        reqwest::StatusCode::ACCEPTED
+    );
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+
+    let mut steer_events = Vec::new();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let event = events.recv().await.unwrap().event;
+            if let CodeEvent::UserSteered { text } = &event {
+                steer_events.push(text.clone());
+            }
+            if matches!(event, CodeEvent::TurnCompleted { .. }) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("turn never completed");
+    steer_events.sort();
+    assert_eq!(
+        steer_events,
+        ["keep the public API small", "try the other file"]
+    );
+
+    let turns = tidebreak_core::db::code::list_turns(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap();
+    assert_eq!(turns.len(), 1, "steering must not create a follow-up turn");
+    assert_eq!(turns[0].user_input, "first");
+}
+
+#[tokio::test]
+async fn supported_steer_requires_an_active_turn() {
+    let (router, token, _runtime, dir) =
+        code_app_with(ScriptedAdapter::new(plain_text_script()).with_steering(CapLevel::Supported))
+            .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/steer",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": CodeTurnId::new(),
+            "guidance": "too late",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "no_active_turn");
+}
+
+#[tokio::test]
+async fn steer_rejects_blank_nul_and_oversized_guidance() {
+    let (router, token, _runtime, dir) =
+        code_app_with(ScriptedAdapter::new(plain_text_script()).with_steering(CapLevel::Supported))
+            .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    for guidance in [
+        "   ".to_owned(),
+        "contains\0nul".to_owned(),
+        "x".repeat(tidebreak_core::TurnSteer::MAX_CONTENT_LEN + 1),
+    ] {
+        let refused = client
+            .post(format!(
+                "http://{addr}/code/sessions/{}/steer",
+                json_id(&session)
+            ))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "expected_turn_id": CodeTurnId::new(),
+                "guidance": guidance,
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(refused.status(), reqwest::StatusCode::BAD_REQUEST);
+    }
+}
+
+#[tokio::test]
+async fn stale_turn_steering_is_rejected_before_reaching_the_adapter() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(80))
+            .with_steering(CapLevel::Supported),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = wait_for_open_turn(&runtime, parsed).await;
+    let stale_turn_id = loop {
+        let candidate = CodeTurnId::new();
+        if candidate != active_turn_id {
+            break candidate;
+        }
+    };
+
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": stale_turn_id,
+            "guidance": "wrong turn",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "stale_turn");
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+
+    let events = tidebreak_core::db::code::list_events(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+        0,
+    )
+    .await
+    .unwrap();
+    assert!(
+        events
+            .iter()
+            .all(|event| !matches!(event.event, CodeEvent::UserSteered { .. })),
+        "stale steering reached the adapter: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn stalled_native_steering_times_out_without_wedging_turn_completion() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(80))
+            .with_steering_delay(Duration::from_secs(1)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = wait_for_open_turn(&runtime, parsed).await;
+
+    let started = tokio::time::Instant::now();
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "this adapter never answers",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    assert!(
+        started.elapsed() < Duration::from_millis(750),
+        "worker-level timeout did not bound the stalled control"
+    );
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "steering_rejected");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), turn)
+            .await
+            .expect("turn completion was wedged")
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::ACCEPTED
+    );
+}
+
+#[tokio::test]
+async fn terminal_turn_event_closes_steering_before_a_late_command_is_admitted() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(20))
+            .with_steering(CapLevel::Supported),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let mut events = runtime.bus.subscribe(parsed);
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let mut active_turn_id = None;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            match events.recv().await.unwrap().event {
+                CodeEvent::TurnStarted { turn_id } => active_turn_id = Some(turn_id),
+                CodeEvent::TurnCompleted { .. } => break,
+                _ => {}
+            }
+        }
+    })
+    .await
+    .expect("turn never completed");
+
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id.expect("turn id"),
+            "guidance": "too late",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "no_active_turn");
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn a_native_steer_rejection_does_not_fail_or_redirect_the_turn() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(40))
+            .with_steering_rejection("turn is no longer steerable"),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let mut events = runtime.bus.subscribe(parsed);
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let CodeEvent::TurnStarted { turn_id } = events.recv().await.unwrap().event {
+                break turn_id;
+            }
+        }
+    })
+    .await
+    .expect("turn never started");
+
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "redirect",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "steering_rejected");
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+
+    let turns = tidebreak_core::db::code::list_turns(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap();
+    assert_eq!(turns.len(), 1);
+    assert_eq!(turns[0].status, CodeTurnStatus::Completed);
 }
 
 fn scripted_registry() -> AdapterRegistry {
@@ -3495,6 +4051,19 @@ async fn a_second_user_sees_neither_code_rows_nor_updates_of_another_owner() {
         .await
         .unwrap();
     assert_eq!(interrupted.status(), reqwest::StatusCode::NOT_FOUND);
+    let steered = client
+        .post(format!(
+            "http://{addr}/code/sessions/{alice_session_id}/steer"
+        ))
+        .bearer_auth(BOB_TOKEN)
+        .json(&serde_json::json!({
+            "expected_turn_id": CodeTurnId::new(),
+            "guidance": "whose session is this",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(steered.status(), reqwest::StatusCode::NOT_FOUND);
 
     // The updates channel. Bob's connect snapshot is empty even though Alice
     // has a live session, and Alice's turn produces no notice on his socket.


### PR DESCRIPTION
## Summary

- add an explicit turn-fenced steering request shared by Code-mode harnesses
- reject stale, inactive, unknown, or unsupported steering without silently queueing it
- preserve composer drafts on failed redirects and clear only the submitted snapshot on success
- centralize exactly-once `UserSteered` event ownership in harness adapters

## Contract

Requests carry both `expected_turn_id` and `guidance`. The server verifies the owner, active turn, adapter capability, worker generation, and completion fence before admitting a redirect. Unsupported or unproven harnesses remain unavailable rather than falling back to Queue.

## Validation

- `src/api.test.ts`: 67 passed
- `CodeComposer.dom.test.tsx`: 23 passed
- TypeScript typecheck passed
- standalone `rustfmt` passed
- `git diff --check` passed

Broad Rust and platform validation is delegated to CI per repository guidance.
