### PR TITLE
feat(code): support native Codex redirect

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -824,6 +824,23 @@ describe("active turn steering", () => {
       invoked_skills: ["docx"],
     });
   });
+
+  it("binds Code guidance to the exact active turn", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.steerCodeSession("session-1", "turn-1", "change course");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1/code/sessions/session-1/steer");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      expected_turn_id: "turn-1",
+      guidance: "change course",
+    });
+  });
 });
 
 describe("historical image API", () => {

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -1970,11 +1970,18 @@ export class ApiClient {
    * Redirect the in-flight turn. The route answers with an empty status;
    * unsupported engines refuse with `steering_unavailable` rather than queue.
    */
-  steerCodeSession(sessionId: string, message: string): Promise<void> {
+  steerCodeSession(
+    sessionId: string,
+    expectedTurnId: string,
+    guidance: string,
+  ): Promise<void> {
     return this.json(`/code/sessions/${encodeURIComponent(sessionId)}/steer`, {
       method: "POST",
       headers: this.headers(true),
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({
+        expected_turn_id: expectedTurnId,
+        guidance,
+      }),
     });
   }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -336,7 +336,42 @@ describe("CodeComposer", () => {
     expect(await screen.findByText("Guidance sent")).toBeInTheDocument();
   });
 
-  it("queues mid-turn when steering is unsupported", async () => {
+  it("preserves text typed while a steer request is pending", async () => {
+    useUiStore.setState({ activeTurnSendMode: "steer" });
+    let resolveSteer!: () => void;
+    const onSteer = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSteer = resolve;
+        }),
+    );
+    renderComposer(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        onSend={vi.fn()}
+        onSteer={onSteer}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "try the other file" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    await waitFor(() =>
+      expect(onSteer).toHaveBeenCalledWith("try the other file"),
+    );
+
+    fireEvent.change(box, { target: { value: "also keep the API small" } });
+    resolveSteer();
+
+    await waitFor(() =>
+      expect(screen.getByText("Guidance sent")).toBeInTheDocument(),
+    );
+    expect(box).toHaveValue("also keep the API small");
+  });
+
+  it("refuses unsupported steering without silently queueing or clearing the draft", async () => {
     useUiStore.setState({ activeTurnSendMode: "steer" });
     const onSend = vi.fn().mockResolvedValue(QUEUED);
     renderComposer(
@@ -352,8 +387,12 @@ describe("CodeComposer", () => {
     fireEvent.change(box, { target: { value: "and run the tests" } });
     fireEvent.keyDown(box, { key: "Enter" });
 
-    await waitFor(() => expect(onSend).toHaveBeenCalledWith("and run the tests"));
-    expect(await screen.findByText("1 follow-up queued")).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Redirect isn’t available for this harness. Choose Queue to send this after the response.",
+    );
+    expect(onSend).not.toHaveBeenCalled();
+    expect(box).toHaveValue("and run the tests");
+    expect(screen.queryByText("1 follow-up queued")).toBeNull();
   });
 
   it("submits free-typed slash text verbatim when the engine lists no commands", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -44,6 +44,8 @@ import {
 } from "./labels";
 
 const MODES: CodePermissionMode[] = ["plan", "ask", "auto", "allow"];
+const STEERING_UNAVAILABLE =
+  "Redirect isn’t available for this harness. Choose Queue to send this after the response.";
 
 function appendComposerPrompt(current: string, prompt: string): string {
   const existing = current.trimEnd();
@@ -506,8 +508,9 @@ export function CodeComposer({
     attachments?: readonly { blob_id: string; media_type: string }[],
   ) => Promise<CodeTurnSubmission | void> | void;
   /**
-   * Redirect the in-flight turn. Absent when the harness cannot steer, so a
-   * mid-turn send stays on the queue path.
+   * Redirect the in-flight turn. Absent when the harness cannot steer. The
+   * composer refuses Redirect in that state; Queue is only used when the user
+   * explicitly selected Queue.
    */
   onSteer?: (message: string) => Promise<void>;
   onInterrupt: () => Promise<void> | void;
@@ -524,6 +527,8 @@ export function CodeComposer({
   const [steerPending, setSteerPending] = useState(false);
   const [steerError, setSteerError] = useState<string | null>(null);
   const [steerStatus, setSteerStatus] = useState<string | null>(null);
+  const draftRef = useRef("");
+  const steerRequestRef = useRef(0);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const images = useImageAttachments(
     client,
@@ -531,7 +536,6 @@ export function CodeComposer({
     sessionId ? async () => sessionId : undefined,
     "code",
   );
-  const canSteer = onSteer !== undefined;
   const showQueued = queued || followUpQueued;
   const [pathItems, setPathItems] = useState<string[]>([]);
   const searchPathsRef = useRef(searchPaths);
@@ -573,6 +577,17 @@ export function CodeComposer({
       : undefined;
 
   const pendingPrompt = useCodeUiStore((state) => state.pendingComposerPrompt);
+
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+
+  useEffect(() => {
+    steerRequestRef.current += 1;
+    setSteerPending(false);
+    setSteerError(null);
+    setSteerStatus(null);
+  }, [sessionId]);
 
   useEffect(() => {
     if (!pendingPrompt || pendingPrompt.scope !== composerPromptScope) return;
@@ -689,21 +704,35 @@ export function CodeComposer({
   }
 
   async function steer() {
-    const message = draft.trim();
-    if (!message || disabled || !onSteer) return;
+    const submittedDraft = draftRef.current;
+    const message = submittedDraft.trim();
+    if (!message || disabled) return;
+    if (!onSteer) {
+      setSteerStatus(null);
+      setSteerError(STEERING_UNAVAILABLE);
+      setNotice(null);
+      return;
+    }
+    const request = steerRequestRef.current + 1;
+    steerRequestRef.current = request;
     setSteerPending(true);
     setSteerError(null);
     setSteerStatus("Sending guidance…");
     setNotice(null);
     try {
       await onSteer(message);
-      setDraft("");
+      if (steerRequestRef.current !== request) return;
+      if (draftRef.current === submittedDraft) {
+        draftRef.current = "";
+        setDraft("");
+      }
       setSteerStatus("Guidance sent");
     } catch (err) {
+      if (steerRequestRef.current !== request) return;
       setSteerStatus(null);
       setSteerError(err instanceof Error ? err.message : "Could not steer");
     } finally {
-      setSteerPending(false);
+      if (steerRequestRef.current === request) setSteerPending(false);
     }
   }
 
@@ -789,20 +818,21 @@ export function CodeComposer({
             : undefined
         }
         onDraftChange={(value) => {
+          draftRef.current = value;
           setSteerError(null);
           setSteerStatus(null);
           setDraft(value);
         }}
         onSend={submit}
-        onSteer={canSteer ? steer : submit}
+        onSteer={steer}
         onQueue={submit}
         onStop={async () => {
           await onInterrupt();
         }}
         resetKey={sessionId ?? "code"}
-        steerError={canSteer ? steerError : null}
-        steerPending={canSteer ? steerPending : false}
-        steerStatus={canSteer ? steerStatus : null}
+        steerError={steerError}
+        steerPending={steerPending}
+        steerStatus={steerStatus}
       />
       {imageInput && (
         <input

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1154,7 +1154,11 @@ function CodeSessionPane({
   }
 
   async function steer(message: string) {
-    await client.steerCodeSession(session.id, message);
+    const expectedTurnId = store.getState().activeTurnId;
+    if (!expectedTurnId) {
+      throw new Error("The active turn changed. Try Redirect again.");
+    }
+    await client.steerCodeSession(session.id, expectedTurnId, message);
   }
 
   async function interrupt() {

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/manifest.toml
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/manifest.toml
@@ -59,13 +59,14 @@ verified = [
   "approval request item/commandExecution/requestApproval; decide via JSON-RPC result {decision: accept|decline}",
   "turn/completed status: completed | interrupted | failed",
   "commandExecution status: inProgress | completed | declined",
+  "generated non-experimental schema: turn/steer {threadId, expectedTurnId, input:[{type:text,text}], clientUserMessageId} => {turnId}",
 ]
 not_verified = [
   "codex exec --json event vocabulary (probed via --help only; not captured)",
   "deny feedback on item/commandExecution/requestApproval (decision is accept/decline/cancel only; no rejection string)",
   "item/fileChange/requestApproval and item/permissions/requestApproval (not seen in these captures)",
   "legacy execCommandApproval / applyPatchApproval methods (not seen)",
-  "turn/steer mid-turn steering",
+  "live turn/steer capture (wire contract is verified from generated schema, not a captured engine run)",
   "native file-change events (turn/diff/updated, item/fileChange/*)",
   "collaborationMode plan (Plan is mapped to sandbox=read-only instead)",
 ]

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -130,6 +130,7 @@ fn supports_native_steering(version: Option<&str>) -> bool {
             let patch = parts.next()?.parse::<u64>().ok()?;
             parts.next().is_none().then_some((major, minor, patch))
         })
+        .next()
         .is_some_and(|(major, minor, _)| major == 0 && minor == 147)
 }
 

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -76,13 +76,19 @@ impl HarnessAdapter for CodexAdapter {
         }
     }
 
-    fn capabilities(&self, _probe: &HarnessProbe) -> HarnessCaps {
+    fn capabilities(&self, probe: &HarnessProbe) -> HarnessCaps {
         HarnessCaps {
             resume: CapLevel::Supported,
             streaming_deltas: CapLevel::Supported,
             structured_approvals: CapLevel::Supported,
-            // `turn/steer` exists in the generated schema; not captured.
-            mid_turn_steering: CapLevel::Unknown,
+            // The non-experimental `turn/steer` contract is verified for the
+            // 0.147 line. Keep newer and older installations honest until
+            // their generated schema is checked too.
+            mid_turn_steering: if supports_native_steering(probe.version.as_deref()) {
+                CapLevel::Supported
+            } else {
+                CapLevel::Unknown
+            },
             plan_mode: CapLevel::Supported,
             // `thread/start` sandbox workspace-write + approvalPolicy
             // on-request; supervised by the captured approval channel.
@@ -110,6 +116,21 @@ impl HarnessAdapter for CodexAdapter {
         }
         Ok(Box::new(attach(spec).await?))
     }
+}
+
+fn supports_native_steering(version: Option<&str>) -> bool {
+    version
+        .into_iter()
+        .flat_map(str::split_whitespace)
+        .filter_map(|candidate| {
+            let candidate = candidate.strip_prefix('v').unwrap_or(candidate);
+            let mut parts = candidate.split('.');
+            let major = parts.next()?.parse::<u64>().ok()?;
+            let minor = parts.next()?.parse::<u64>().ok()?;
+            let patch = parts.next()?.parse::<u64>().ok()?;
+            parts.next().is_none().then_some((major, minor, patch))
+        })
+        .is_some_and(|(major, minor, _)| major == 0 && minor == 147)
 }
 
 /// Ask the same app-server protocol a real session uses. Codex has no
@@ -469,8 +490,36 @@ mod tests {
         assert_eq!(caps.reasoning_levels, CapLevel::Supported);
         assert_eq!(caps.image_input, CapLevel::Unknown);
         assert_eq!(caps.slash_commands, CapLevel::Unknown);
-        assert_eq!(caps.mid_turn_steering, CapLevel::Unknown);
+        assert_eq!(caps.mid_turn_steering, CapLevel::Supported);
         assert_eq!(caps.native_file_change_events, CapLevel::Unknown);
+    }
+
+    #[test]
+    fn steering_capability_is_gated_to_the_verified_0_147_line() {
+        let caps_for = |version: Option<&str>| {
+            CodexAdapter::new()
+                .capabilities(&HarnessProbe {
+                    found: true,
+                    binary_path: None,
+                    version: version.map(str::to_owned),
+                    authenticated: Some(true),
+                    stderr: String::new(),
+                    env: Vec::new(),
+                    commands: Vec::new(),
+                })
+                .mid_turn_steering
+        };
+
+        assert_eq!(caps_for(Some("codex-cli 0.147.0")), CapLevel::Supported);
+        assert_eq!(caps_for(Some("0.147.9")), CapLevel::Supported);
+        assert_eq!(caps_for(Some("codex-cli 0.146.3")), CapLevel::Unknown);
+        assert_eq!(caps_for(Some("codex-cli 0.148.0")), CapLevel::Unknown);
+        assert_eq!(
+            caps_for(Some("codex-cli 0.147.0-alpha.1")),
+            CapLevel::Unknown
+        );
+        assert_eq!(caps_for(Some("development")), CapLevel::Unknown);
+        assert_eq!(caps_for(None), CapLevel::Unknown);
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -88,6 +88,12 @@ impl CodexStreamParser {
         self.outbound_methods.insert(id_key(id), method.to_owned());
     }
 
+    /// Forget an outbound request that was cancelled or timed out before a
+    /// response could be consumed.
+    pub fn forget_outbound(&mut self, id: &Value) {
+        self.outbound_methods.remove(&id_key(id));
+    }
+
     /// Parse one NDJSON line. Never returns an error: unknown shapes increment
     /// [`Self::unrecognized`].
     pub fn push_line(&mut self, line: &str) -> Vec<HarnessEvent> {
@@ -358,7 +364,7 @@ impl CodexStreamParser {
                 }
                 Vec::new()
             }
-            "initialize" | "turn/interrupt" | "" => Vec::new(),
+            "initialize" | "turn/interrupt" | "turn/steer" | "" => Vec::new(),
             other => {
                 self.count_unrecognized(&format!("rpc-result/{other}"), value);
                 Vec::new()
@@ -378,6 +384,18 @@ impl CodexStreamParser {
                 level: HarnessNoticeLevel::Error,
                 message: bound(message, MAX_NOTICE_CHARS),
             }];
+        }
+        if method == "turn/steer" {
+            // The live session routes this response back to the caller that
+            // issued the control RPC. A rejected steer is not a failed turn.
+            return Vec::new();
+        }
+        if method.is_empty() {
+            // A cancelled or timed-out control can answer after its waiter is
+            // gone. An uncorrelated JSON-RPC error is protocol noise, not a
+            // failure of the active user turn.
+            self.count_unrecognized("rpc-error/unmatched", value);
+            return Vec::new();
         }
         vec![HarnessEvent::TurnFailed {
             error: BoundedError {
@@ -566,6 +584,46 @@ mod tests {
                 ..
             })
         ));
+        assert!(matches!(
+            out.events.last(),
+            Some(HarnessEvent::TurnCompleted { .. })
+        ));
+    }
+
+    #[test]
+    fn a_rejected_steer_does_not_fail_the_active_turn() {
+        let input = r#"
+{"dir":"out","msg":{"id":7,"method":"turn/steer","params":{"threadId":"thread","expectedTurnId":"turn","input":[{"type":"text","text":"redirect"}]}}}
+{"dir":"in","msg":{"id":7,"error":{"code":-32602,"message":"turn is no longer steerable"}}}
+{"dir":"in","msg":{"method":"turn/completed","params":{"turn":{"id":"turn","status":"completed"}}}}
+"#;
+        let out = CodexStreamParser::parse_ndjson(input);
+        assert_eq!(out.unrecognized, 0);
+        assert_eq!(
+            out.events
+                .iter()
+                .filter(|event| matches!(event, HarnessEvent::TurnFailed { .. }))
+                .count(),
+            0
+        );
+        assert!(matches!(
+            out.events.last(),
+            Some(HarnessEvent::TurnCompleted { .. })
+        ));
+    }
+
+    #[test]
+    fn an_unmatched_rpc_error_does_not_fail_the_active_turn() {
+        let input = r#"
+{"dir":"in","msg":{"id":7,"error":{"code":-32602,"message":"late response"}}}
+{"dir":"in","msg":{"method":"turn/completed","params":{"turn":{"id":"turn","status":"completed"}}}}
+"#;
+        let out = CodexStreamParser::parse_ndjson(input);
+        assert_eq!(out.unrecognized, 1);
+        assert!(!out
+            .events
+            .iter()
+            .any(|event| matches!(event, HarnessEvent::TurnFailed { .. })));
         assert!(matches!(
             out.events.last(),
             Some(HarnessEvent::TurnCompleted { .. })

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -1522,10 +1522,11 @@ done
             )
             .await;
 
-        let state = session.control_state.lock().expect("codex control state");
-        assert_eq!(state.turn, ControlTurn::Closed);
-        assert!(state.pending.is_empty());
-        drop(state);
+        {
+            let state = session.control_state.lock().expect("codex control state");
+            assert_eq!(state.turn, ControlTurn::Closed);
+            assert!(state.pending.is_empty());
+        }
         assert!(matches!(
             receiver.await.unwrap(),
             Err(HarnessError::SteeringRejected(_))

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -10,8 +10,8 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{ChildStdin, ChildStdout, Command};
-use tokio::sync::Mutex as AsyncMutex;
-use tokio::time::timeout;
+use tokio::sync::{oneshot, Mutex as AsyncMutex, Notify};
+use tokio::time::{timeout, Instant};
 use tracing::warn;
 
 use crate::codex::parse::CodexStreamParser;
@@ -24,6 +24,7 @@ use crate::{
 use tidebreak_core::{CodePermissionMode, MAX_NOTICE_CHARS};
 
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
+const CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_STDERR_BYTES: usize = 64 * 1_024;
 
 /// Live Codex session: one app-server child for the session lifetime.
@@ -41,15 +42,89 @@ pub struct CodexSession {
     child_pid: AtomicU32,
     stdin: Option<Arc<AsyncMutex<ChildStdin>>>,
     stdout: Option<Arc<AsyncMutex<StdoutReader>>>,
-    parser: Mutex<CodexStreamParser>,
+    parser: Arc<Mutex<CodexStreamParser>>,
     next_id: AtomicI64,
+    control_state: Arc<Mutex<ControlState>>,
+    control_state_changed: Arc<Notify>,
     pending_approvals: Mutex<HashMap<String, Value>>,
-    current_turn_id: Mutex<Option<String>>,
 }
 
 struct StdoutReader {
     stdout: ChildStdout,
     lines: StreamLineBuffer,
+}
+
+struct ControlState {
+    turn: ControlTurn,
+    pending: HashMap<i64, PendingSteer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ControlTurn {
+    Idle,
+    Starting,
+    Active(String),
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingWriteState {
+    Queued,
+    Writing,
+    Written,
+}
+
+struct PendingSteer {
+    expected_turn_id: String,
+    text: String,
+    reply: Option<oneshot::Sender<Result<(), HarnessError>>>,
+    deadline: Option<Instant>,
+    write_state: PendingWriteState,
+    accept_response: bool,
+}
+
+struct ControlRegistration<'a> {
+    session: &'a CodexSession,
+    rpc_id: i64,
+    armed: bool,
+}
+
+impl ControlRegistration<'_> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ControlRegistration<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let removed = {
+            let mut state = self
+                .session
+                .control_state
+                .lock()
+                .expect("codex control state");
+            if state
+                .pending
+                .get(&self.rpc_id)
+                .is_some_and(|pending| pending.write_state == PendingWriteState::Queued)
+            {
+                state.pending.remove(&self.rpc_id)
+            } else {
+                None
+            }
+        };
+        if removed.is_some() {
+            self.session
+                .parser
+                .lock()
+                .expect("codex parser")
+                .forget_outbound(&json!(self.rpc_id));
+            self.session.control_state_changed.notify_one();
+        }
+    }
 }
 
 impl CodexSession {
@@ -64,10 +139,14 @@ impl CodexSession {
             child_pid: AtomicU32::new(0),
             stdin: None,
             stdout: None,
-            parser: Mutex::new(CodexStreamParser::new()),
+            parser: Arc::new(Mutex::new(CodexStreamParser::new())),
             next_id: AtomicI64::new(1),
+            control_state: Arc::new(Mutex::new(ControlState {
+                turn: ControlTurn::Idle,
+                pending: HashMap::new(),
+            })),
+            control_state_changed: Arc::new(Notify::new()),
             pending_approvals: Mutex::new(HashMap::new()),
-            current_turn_id: Mutex::new(None),
         }
     }
 
@@ -102,6 +181,249 @@ impl CodexSession {
         self.write_message(&json!({ "id": id, "method": method, "params": params }))
             .await?;
         Ok(id)
+    }
+
+    /// Admit one native steer while `run_turn` remains the sole stdout reader.
+    /// The turn id and admission gate are read under the same lock, so a
+    /// terminal event cannot leave a request registered for the following
+    /// turn. The stdin writer is detached: cancellation before it owns the
+    /// write removes a queued request, while cancellation after that point
+    /// leaves the stream reader responsible for the acknowledgement and
+    /// `UserSteered` event.
+    async fn request_steer(&self, thread_id: String, text: String) -> Result<(), HarnessError> {
+        let Some(stdin) = self.stdin.clone() else {
+            return Err(HarnessError::SteeringRejected(
+                "the engine child has no stdin".into(),
+            ));
+        };
+        let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+        let (rpc_id, message, rx) = loop {
+            let changed = self.control_state_changed.notified();
+            let admitted = {
+                let mut state = self.control_state.lock().expect("codex control state");
+                match &state.turn {
+                    ControlTurn::Active(turn_id) => {
+                        let expected_turn_id = turn_id.clone();
+                        let rpc_id = self.next_rpc_id();
+                        let client_message_id = format!("tidebreak-steer-{rpc_id}");
+                        let message = steer_request(
+                            rpc_id,
+                            &thread_id,
+                            &expected_turn_id,
+                            &text,
+                            &client_message_id,
+                        );
+                        let (tx, rx) = oneshot::channel();
+                        self.parser
+                            .lock()
+                            .expect("codex parser")
+                            .note_outbound(&json!(rpc_id), "turn/steer");
+                        state.pending.insert(
+                            rpc_id,
+                            PendingSteer {
+                                expected_turn_id,
+                                text: text.clone(),
+                                reply: Some(tx),
+                                deadline: None,
+                                write_state: PendingWriteState::Queued,
+                                accept_response: true,
+                            },
+                        );
+                        Some(Ok((rpc_id, message, rx)))
+                    }
+                    ControlTurn::Starting => None,
+                    ControlTurn::Idle | ControlTurn::Closed => {
+                        Some(Err(HarnessError::SteeringRejected(
+                            "the active turn finished before steering was admitted".into(),
+                        )))
+                    }
+                }
+            };
+            if let Some(admitted) = admitted {
+                break admitted?;
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() || timeout(remaining, changed).await.is_err() {
+                return Err(HarnessError::SteeringRejected(
+                    "the active turn was not acknowledged by the engine".into(),
+                ));
+            }
+        };
+        self.control_state_changed.notify_one();
+
+        let mut registration = ControlRegistration {
+            session: self,
+            rpc_id,
+            armed: true,
+        };
+        spawn_control_write(
+            stdin,
+            Arc::clone(&self.control_state),
+            Arc::clone(&self.control_state_changed),
+            Arc::clone(&self.parser),
+            rpc_id,
+            message,
+        );
+        let result = rx.await.unwrap_or_else(|_| {
+            Err(HarnessError::SteeringRejected(
+                "the engine dropped the steering response".into(),
+            ))
+        });
+        registration.disarm();
+        result
+    }
+
+    fn begin_control_turn(&self) {
+        let pending = {
+            let mut state = self.control_state.lock().expect("codex control state");
+            state.turn = ControlTurn::Starting;
+            std::mem::take(&mut state.pending)
+        };
+        for (id, mut pending) in pending {
+            if let Some(reply) = pending.reply.take() {
+                let _ = reply.send(Err(HarnessError::SteeringRejected(
+                    "the prior turn ended before steering was accepted".into(),
+                )));
+            }
+            self.parser
+                .lock()
+                .expect("codex parser")
+                .forget_outbound(&json!(id));
+        }
+        self.control_state_changed.notify_waiters();
+    }
+
+    fn activate_control_turn(&self, turn_id: &str) {
+        let changed = {
+            let mut state = self.control_state.lock().expect("codex control state");
+            match &state.turn {
+                ControlTurn::Starting => {
+                    state.turn = ControlTurn::Active(turn_id.to_owned());
+                    true
+                }
+                ControlTurn::Active(active) if active == turn_id => false,
+                ControlTurn::Idle | ControlTurn::Active(_) | ControlTurn::Closed => false,
+            }
+        };
+        if changed {
+            self.control_state_changed.notify_waiters();
+        }
+    }
+
+    /// Close admission before a terminal event is emitted. Requests that have
+    /// not started writing are removed immediately. An in-flight write becomes
+    /// a bounded tombstone: its caller is rejected now, and the sole stream
+    /// reader still consumes its eventual response without emitting a steer.
+    fn close_control_turn_for_terminal(&self, detail: &str) {
+        let removed = {
+            let mut state = self.control_state.lock().expect("codex control state");
+            state.turn = ControlTurn::Closed;
+            let queued_ids = state
+                .pending
+                .iter()
+                .filter_map(|(id, pending)| {
+                    (pending.write_state == PendingWriteState::Queued).then_some(*id)
+                })
+                .collect::<Vec<_>>();
+            let removed = queued_ids
+                .into_iter()
+                .filter_map(|id| state.pending.remove(&id).map(|pending| (id, pending)))
+                .collect::<Vec<_>>();
+            for pending in state.pending.values_mut() {
+                pending.accept_response = false;
+                if let Some(reply) = pending.reply.take() {
+                    let _ = reply.send(Err(HarnessError::SteeringRejected(detail.into())));
+                }
+            }
+            removed
+        };
+        for (id, mut pending) in removed {
+            if let Some(reply) = pending.reply.take() {
+                let _ = reply.send(Err(HarnessError::SteeringRejected(detail.into())));
+            }
+            self.parser
+                .lock()
+                .expect("codex parser")
+                .forget_outbound(&json!(id));
+        }
+        self.control_state_changed.notify_waiters();
+    }
+
+    fn abort_control_turn(&self, detail: &str) {
+        let pending = {
+            let mut state = self.control_state.lock().expect("codex control state");
+            state.turn = ControlTurn::Closed;
+            std::mem::take(&mut state.pending)
+        };
+        for (id, mut pending) in pending {
+            if let Some(reply) = pending.reply.take() {
+                let _ = reply.send(Err(HarnessError::SteeringRejected(detail.into())));
+            }
+            self.parser
+                .lock()
+                .expect("codex parser")
+                .forget_outbound(&json!(id));
+        }
+        self.control_state_changed.notify_waiters();
+    }
+
+    fn next_control_deadline(&self) -> Option<Instant> {
+        self.control_state
+            .lock()
+            .expect("codex control state")
+            .pending
+            .values()
+            .filter_map(|pending| pending.deadline)
+            .min()
+    }
+
+    fn expire_control_requests(&self) {
+        let now = Instant::now();
+        let expired = {
+            let mut state = self.control_state.lock().expect("codex control state");
+            let ids = state
+                .pending
+                .iter()
+                .filter_map(|(id, pending)| {
+                    pending
+                        .deadline
+                        .is_some_and(|deadline| deadline <= now)
+                        .then_some(*id)
+                })
+                .collect::<Vec<_>>();
+            ids.into_iter()
+                .filter_map(|id| state.pending.remove(&id).map(|pending| (id, pending)))
+                .collect::<Vec<_>>()
+        };
+        for (id, mut pending) in expired {
+            if let Some(reply) = pending.reply.take() {
+                let _ = reply.send(Err(HarnessError::SteeringRejected(
+                    "timed out waiting for the engine to accept steering".into(),
+                )));
+            }
+            self.parser
+                .lock()
+                .expect("codex parser")
+                .forget_outbound(&json!(id));
+        }
+        self.control_state_changed.notify_waiters();
+    }
+
+    fn controls_pending(&self) -> bool {
+        !self
+            .control_state
+            .lock()
+            .expect("codex control state")
+            .pending
+            .is_empty()
+    }
+
+    fn active_control_turn_id(&self) -> Option<String> {
+        let state = self.control_state.lock().expect("codex control state");
+        match &state.turn {
+            ControlTurn::Active(turn_id) => Some(turn_id.clone()),
+            ControlTurn::Idle | ControlTurn::Starting | ControlTurn::Closed => None,
+        }
     }
 
     async fn notify(&self, method: &str, params: Option<Value>) -> Result<(), HarnessError> {
@@ -266,14 +588,42 @@ impl CodexSession {
     }
 
     async fn read_until_terminal_turn(&self) -> Result<(), HarnessError> {
+        let mut terminal = false;
         loop {
-            let lines = self.read_lines().await?;
-            if lines.is_empty() {
-                return Err(HarnessError::Other(
-                    "engine stdout closed before the turn finished".into(),
-                ));
+            let changed = self.control_state_changed.notified();
+            let deadline = self.next_control_deadline();
+            if terminal && !self.controls_pending() {
+                return Ok(());
             }
-            let mut terminal = false;
+
+            let lines = match deadline {
+                Some(deadline) => {
+                    tokio::select! {
+                        biased;
+                        lines = self.read_lines() => lines?,
+                        () = changed => continue,
+                        () = tokio::time::sleep_until(deadline) => {
+                            self.expire_control_requests();
+                            continue;
+                        }
+                    }
+                }
+                None => {
+                    tokio::select! {
+                        biased;
+                        lines = self.read_lines() => lines?,
+                        () = changed => continue,
+                    }
+                }
+            };
+            if lines.is_empty() {
+                let message = if terminal {
+                    "engine stdout closed before a control response arrived"
+                } else {
+                    "engine stdout closed before the turn finished"
+                };
+                return Err(HarnessError::Other(message.into()));
+            }
             for line in lines {
                 for event in self.emit_parsed(&line).await {
                     if matches!(
@@ -285,9 +635,6 @@ impl CodexSession {
                         terminal = true;
                     }
                 }
-            }
-            if terminal {
-                return Ok(());
             }
         }
     }
@@ -319,23 +666,54 @@ impl CodexSession {
     }
 
     async fn emit_parsed(&self, line: &str) -> Vec<HarnessEvent> {
-        if let Ok(value) = serde_json::from_str::<Value>(line) {
-            if let Some(turn_id) = value
-                .pointer("/result/turn/id")
-                .or_else(|| value.pointer("/params/turn/id"))
-                .or_else(|| value.pointer("/params/turnId"))
-                .and_then(Value::as_str)
-            {
-                *self.current_turn_id.lock().expect("codex turn") = Some(turn_id.to_owned());
-                // The engine acknowledged a turn on this thread, so it has
-                // written the thread's rollout: the id is resumable now.
-                self.thread_ran_a_turn.store(true, Ordering::SeqCst);
+        let value = serde_json::from_str::<Value>(line).ok();
+        if let Some(value) = value.as_ref() {
+            if is_rpc_response(&value) {
+                if let Some(rpc_id) = value_rpc_id(&value) {
+                    let pending = self
+                        .control_state
+                        .lock()
+                        .expect("codex control state")
+                        .pending
+                        .remove(&rpc_id);
+                    if let Some(mut pending) = pending {
+                        let result = validate_steer_response(&value, &pending.expected_turn_id);
+                        if pending.accept_response && result.is_ok() {
+                            self.spec
+                                .sink
+                                .emit(HarnessEvent::UserSteered { text: pending.text })
+                                .await;
+                        }
+                        if let Some(reply) = pending.reply.take() {
+                            let _ = reply.send(result);
+                        }
+                        self.control_state_changed.notify_waiters();
+                    }
+                }
             }
             if let Some(detail) = lost_resume_detail(&value) {
                 *self.resume_lost.lock().expect("codex resume lost") = Some(detail);
             }
         }
         let events = self.parser.lock().expect("codex parser").push_line(line);
+        let terminal = events.iter().any(|event| {
+            matches!(
+                event,
+                HarnessEvent::TurnCompleted { .. }
+                    | HarnessEvent::TurnFailed { .. }
+                    | HarnessEvent::TurnInterrupted
+            )
+        });
+        if terminal {
+            self.close_control_turn_for_terminal(
+                "the active turn finished before steering was accepted",
+            );
+        } else if let Some(turn_id) = value.as_ref().and_then(observed_turn_id) {
+            self.activate_control_turn(turn_id);
+            // The engine acknowledged a turn on this thread, so it has
+            // written the thread's rollout: the id is resumable now.
+            self.thread_ran_a_turn.store(true, Ordering::SeqCst);
+        }
         for event in &events {
             if let HarnessEvent::SessionStarted {
                 resume_ref: Some(resume),
@@ -380,7 +758,8 @@ impl HarnessSession for CodexSession {
         let Some(thread_id) = self.resume_ref.lock().expect("codex resume").clone() else {
             return Err(HarnessError::Other("thread has no resume ref".into()));
         };
-        let id = self
+        self.begin_control_turn();
+        let id = match self
             .request(
                 "turn/start",
                 json!({
@@ -388,7 +767,14 @@ impl HarnessSession for CodexSession {
                     "input": [{ "type": "text", "text": input.text }],
                 }),
             )
-            .await?;
+            .await
+        {
+            Ok(id) => id,
+            Err(err) => {
+                self.abort_control_turn("the turn did not start");
+                return Err(err);
+            }
+        };
         let _ = id;
         // Long-lived child: its exit is a session-level failure, not a turn
         // outcome, and `read_until_terminal_turn` already errors on a stream
@@ -397,10 +783,28 @@ impl HarnessSession for CodexSession {
         if let Some(detail) = self.lost_resume() {
             // The thread this session attached to is gone. Report the lost
             // resume rather than a turn failure the caller would retry.
+            self.abort_control_turn("the engine session was lost");
             return Err(HarnessError::ResumeLost(detail));
         }
-        terminal?;
-        Ok(TurnOutcome::Clean)
+        match terminal {
+            Ok(()) => {
+                self.abort_control_turn("the active turn finished before steering was accepted");
+                Ok(TurnOutcome::Clean)
+            }
+            Err(err) => {
+                self.abort_control_turn("the engine stopped before steering was accepted");
+                Err(err)
+            }
+        }
+    }
+
+    async fn steer(&self, text: String) -> Result<(), HarnessError> {
+        let Some(thread_id) = self.resume_ref.lock().expect("codex resume").clone() else {
+            return Err(HarnessError::SteeringRejected(
+                "the engine session has no thread id".into(),
+            ));
+        };
+        self.request_steer(thread_id, text).await
     }
 
     async fn decide(
@@ -444,7 +848,7 @@ impl HarnessSession for CodexSession {
 
     async fn interrupt(&self) -> Result<(), HarnessError> {
         let thread_id = self.resume_ref.lock().expect("codex resume").clone();
-        let turn_id = self.current_turn_id.lock().expect("codex turn").clone();
+        let turn_id = self.active_control_turn_id();
         if let (Some(thread_id), Some(turn_id)) = (thread_id, turn_id) {
             let id = self
                 .request(
@@ -519,11 +923,190 @@ fn line_is_rpc_id(line: &str, rpc_id: i64) -> bool {
     let Ok(value) = serde_json::from_str::<Value>(line) else {
         return false;
     };
+    if !is_rpc_response(&value) {
+        return false;
+    }
     match value.get("id") {
         Some(Value::Number(n)) => n.as_i64() == Some(rpc_id),
         Some(Value::String(s)) => s.parse::<i64>().ok() == Some(rpc_id),
         _ => false,
     }
+}
+
+fn is_rpc_response(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    object.contains_key("id")
+        && !object.contains_key("method")
+        && (object.contains_key("result") || object.contains_key("error"))
+}
+
+fn observed_turn_id(value: &Value) -> Option<&str> {
+    let method = value.get("method").and_then(Value::as_str);
+    if method == Some("turn/started") {
+        return value.pointer("/params/turn/id").and_then(Value::as_str);
+    }
+    if is_rpc_response(value) {
+        return value.pointer("/result/turn/id").and_then(Value::as_str);
+    }
+    None
+}
+
+fn value_rpc_id(value: &Value) -> Option<i64> {
+    match value.get("id") {
+        Some(Value::Number(number)) => number.as_i64(),
+        Some(Value::String(string)) => string.parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+fn rpc_error_detail(value: &Value) -> Option<String> {
+    let message = value.pointer("/error/message").and_then(Value::as_str)?;
+    Some(message.chars().take(MAX_NOTICE_CHARS).collect())
+}
+
+fn validate_steer_response(value: &Value, expected_turn_id: &str) -> Result<(), HarnessError> {
+    if let Some(detail) = rpc_error_detail(value) {
+        return Err(HarnessError::SteeringRejected(detail));
+    }
+    let accepted_turn_id = value
+        .pointer("/result/turnId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            HarnessError::SteeringRejected(
+                "the engine returned no turn id for the steering request".into(),
+            )
+        })?;
+    if accepted_turn_id != expected_turn_id {
+        return Err(HarnessError::SteeringRejected(format!(
+            "the engine acknowledged turn {accepted_turn_id}, not active turn {expected_turn_id}"
+        )));
+    }
+    Ok(())
+}
+
+fn steer_request(
+    rpc_id: i64,
+    thread_id: &str,
+    expected_turn_id: &str,
+    text: &str,
+    client_message_id: &str,
+) -> Value {
+    json!({
+        "id": rpc_id,
+        "method": "turn/steer",
+        "params": {
+            "threadId": thread_id,
+            "expectedTurnId": expected_turn_id,
+            "input": [{ "type": "text", "text": text }],
+            "clientUserMessageId": client_message_id,
+        }
+    })
+}
+
+fn spawn_control_write(
+    stdin: Arc<AsyncMutex<ChildStdin>>,
+    control_state: Arc<Mutex<ControlState>>,
+    changed: Arc<Notify>,
+    parser: Arc<Mutex<CodexStreamParser>>,
+    rpc_id: i64,
+    message: Value,
+) {
+    tokio::spawn(async move {
+        let line = match serde_json::to_vec(&message) {
+            Ok(mut line) => {
+                line.push(b'\n');
+                line
+            }
+            Err(err) => {
+                fail_control_write(
+                    &control_state,
+                    &changed,
+                    &parser,
+                    rpc_id,
+                    format!("serialize steering rpc: {err}"),
+                );
+                return;
+            }
+        };
+        let write = timeout(CONTROL_RPC_TIMEOUT, async {
+            let mut stdin = stdin.lock().await;
+            {
+                let mut state = control_state.lock().expect("codex control state");
+                let Some(pending) = state.pending.get_mut(&rpc_id) else {
+                    return Ok(false);
+                };
+                if pending.write_state != PendingWriteState::Queued {
+                    return Ok(false);
+                }
+                pending.write_state = PendingWriteState::Writing;
+            }
+            changed.notify_waiters();
+            stdin.write_all(&line).await?;
+            stdin.flush().await?;
+            Ok::<bool, std::io::Error>(true)
+        })
+        .await;
+        match write {
+            Ok(Ok(false)) => return,
+            Ok(Ok(true)) => {}
+            Ok(Err(err)) => {
+                fail_control_write(
+                    &control_state,
+                    &changed,
+                    &parser,
+                    rpc_id,
+                    format!("write steering rpc: {err}"),
+                );
+                return;
+            }
+            Err(_) => {
+                fail_control_write(
+                    &control_state,
+                    &changed,
+                    &parser,
+                    rpc_id,
+                    "timed out writing the steering request".into(),
+                );
+                return;
+            }
+        }
+        if let Some(pending) = control_state
+            .lock()
+            .expect("codex control state")
+            .pending
+            .get_mut(&rpc_id)
+        {
+            pending.write_state = PendingWriteState::Written;
+            pending.deadline = Some(Instant::now() + CONTROL_RPC_TIMEOUT);
+        }
+        changed.notify_waiters();
+    });
+}
+
+fn fail_control_write(
+    control_state: &Mutex<ControlState>,
+    changed: &Notify,
+    parser: &Mutex<CodexStreamParser>,
+    rpc_id: i64,
+    detail: String,
+) {
+    let pending = control_state
+        .lock()
+        .expect("codex control state")
+        .pending
+        .remove(&rpc_id);
+    if let Some(mut pending) = pending {
+        if let Some(reply) = pending.reply.take() {
+            let _ = reply.send(Err(HarnessError::SteeringRejected(detail)));
+        }
+    }
+    parser
+        .lock()
+        .expect("codex parser")
+        .forget_outbound(&json!(rpc_id));
+    changed.notify_waiters();
 }
 
 async fn drain_capped<R>(mut reader: R, cap: usize) -> String
@@ -630,7 +1213,37 @@ done
 "#;
 
     #[cfg(unix)]
+    const FAKE_STEERING_APP_SERVER: &str = r#"#!/bin/sh
+while IFS= read -r line; do
+  id=${line#*\"id\":}
+  id=${id%%,*}
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"id":%s,"result":{"userAgent":"fake/0.147.0"}}\n' "$id"
+      ;;
+    *'"method":"thread/start"'*)
+      printf '{"id":%s,"result":{"thread":{"id":"THREAD-1","cliVersion":"0.147.0","turns":[]}}}\n' "$id"
+      ;;
+    *'"method":"turn/start"'*)
+      printf '{"id":%s,"result":{"turn":{"id":"TURN-1","status":"inProgress"}}}\n' "$id"
+      printf '{"method":"turn/started","params":{"threadId":"THREAD-1","turn":{"id":"TURN-1","status":"inProgress"}}}\n'
+      ;;
+    *'"method":"turn/steer"'*)
+      printf '%s\n' "$line" >"$FAKE_CODEX_STEER"
+      printf '{"id":%s,"result":{"turnId":"TURN-1"}}\n' "$id"
+      printf '{"method":"turn/completed","params":{"threadId":"THREAD-1","turn":{"id":"TURN-1","status":"completed"}}}\n'
+      ;;
+  esac
+done
+"#;
+
+    #[cfg(unix)]
     fn write_fake_app_server(path: &std::path::Path) {
+        write_app_server(path, FAKE_APP_SERVER);
+    }
+
+    #[cfg(unix)]
+    fn write_app_server(path: &std::path::Path, script: &str) {
         // Write a sibling inode, fsync, then rename over `path` so execve
         // never sees a file that still has a writer (Linux ETXTBSY).
         use std::io::Write;
@@ -643,7 +1256,7 @@ done
             .mode(0o755)
             .open(&staging)
             .unwrap();
-        file.write_all(FAKE_APP_SERVER.as_bytes()).unwrap();
+        file.write_all(script.as_bytes()).unwrap();
         file.sync_all().unwrap();
         drop(file);
         std::fs::rename(&staging, path).unwrap();
@@ -660,6 +1273,61 @@ done
     #[async_trait]
     impl crate::HarnessEventSink for SilentSink {
         async fn emit(&self, _event: HarnessEvent) {}
+    }
+
+    #[derive(Default)]
+    struct RecordingSink {
+        events: Mutex<Vec<HarnessEvent>>,
+    }
+
+    #[async_trait]
+    impl crate::HarnessEventSink for RecordingSink {
+        async fn emit(&self, event: HarnessEvent) {
+            self.events.lock().expect("codex test events").push(event);
+        }
+    }
+
+    fn unit_session(sink: Arc<dyn crate::HarnessEventSink>) -> CodexSession {
+        CodexSession::new(SessionSpec {
+            worktree: PathBuf::from("."),
+            permission_mode: CodePermissionMode::Auto,
+            model: None,
+            resume_ref: Some("THREAD-1".into()),
+            extra_argv: Vec::new(),
+            extra_env: Vec::new(),
+            env: Vec::new(),
+            approval: None,
+            binary: PathBuf::from("codex"),
+            sink,
+        })
+    }
+
+    fn register_pending(
+        session: &CodexSession,
+        rpc_id: i64,
+        write_state: PendingWriteState,
+        deadline: Option<Instant>,
+    ) -> oneshot::Receiver<Result<(), HarnessError>> {
+        let (reply, receiver) = oneshot::channel();
+        session
+            .parser
+            .lock()
+            .expect("codex parser")
+            .note_outbound(&json!(rpc_id), "turn/steer");
+        let mut state = session.control_state.lock().expect("codex control state");
+        state.turn = ControlTurn::Active("TURN-1".into());
+        state.pending.insert(
+            rpc_id,
+            PendingSteer {
+                expected_turn_id: "TURN-1".into(),
+                text: "redirect".into(),
+                reply: Some(reply),
+                deadline,
+                write_state,
+                accept_response: true,
+            },
+        );
+        receiver
     }
 
     #[cfg(unix)]
@@ -746,5 +1414,355 @@ done
             panic!("expected a lost resume, got {err}");
         };
         assert!(detail.contains("thread not found"), "detail: {detail}");
+    }
+
+    #[test]
+    fn steer_response_must_acknowledge_the_expected_turn() {
+        validate_steer_response(&json!({ "result": { "turnId": "TURN-1" } }), "TURN-1").unwrap();
+        let mismatch =
+            validate_steer_response(&json!({ "result": { "turnId": "TURN-2" } }), "TURN-1")
+                .unwrap_err();
+        assert!(matches!(mismatch, HarnessError::SteeringRejected(_)));
+        let rejected = validate_steer_response(
+            &json!({ "error": { "message": "turn is no longer steerable" } }),
+            "TURN-1",
+        )
+        .unwrap_err();
+        assert!(matches!(rejected, HarnessError::SteeringRejected(_)));
+    }
+
+    #[test]
+    fn native_steer_request_matches_the_verified_json_shape() {
+        let request = steer_request(
+            41,
+            "THREAD-1",
+            "TURN-1",
+            "try the other file",
+            "tidebreak-steer-41",
+        );
+        assert_eq!(request["id"], 41);
+        assert_eq!(request["method"], "turn/steer");
+        assert_eq!(request["params"]["threadId"], "THREAD-1");
+        assert_eq!(request["params"]["expectedTurnId"], "TURN-1");
+        assert_eq!(
+            request["params"]["input"],
+            json!([{
+                "type": "text",
+                "text": "try the other file"
+            }])
+        );
+        assert_eq!(
+            request["params"]["clientUserMessageId"],
+            "tidebreak-steer-41"
+        );
+    }
+
+    #[test]
+    fn only_true_json_rpc_responses_match_waiters() {
+        assert!(!is_rpc_response(&json!({
+            "id": 7,
+            "method": "item/commandExecution/requestApproval",
+            "params": { "itemId": "call-1" }
+        })));
+        assert!(is_rpc_response(&json!({
+            "id": 7,
+            "result": { "turnId": "TURN-1" }
+        })));
+        assert!(is_rpc_response(&json!({
+            "id": "7",
+            "error": { "code": -32602, "message": "rejected" }
+        })));
+    }
+
+    #[tokio::test]
+    async fn same_id_server_request_does_not_resolve_steering() {
+        let sink = Arc::new(RecordingSink::default());
+        let session = unit_session(sink.clone());
+        let receiver = register_pending(
+            &session,
+            7,
+            PendingWriteState::Written,
+            Some(Instant::now() + CONTROL_RPC_TIMEOUT),
+        );
+
+        session
+            .emit_parsed(
+                r#"{"id":7,"method":"item/commandExecution/requestApproval","params":{"itemId":"call-1"}}"#,
+            )
+            .await;
+        assert!(session
+            .control_state
+            .lock()
+            .expect("codex control state")
+            .pending
+            .contains_key(&7));
+
+        session
+            .emit_parsed(r#"{"id":7,"result":{"turnId":"TURN-1"}}"#)
+            .await;
+        receiver.await.unwrap().unwrap();
+        let events = sink.events.lock().expect("codex test events");
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, HarnessEvent::UserSteered { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_closes_admission_and_rejects_queued_steering() {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        let receiver = register_pending(&session, 7, PendingWriteState::Queued, None);
+
+        session
+            .emit_parsed(
+                r#"{"method":"turn/completed","params":{"turn":{"id":"TURN-1","status":"completed"}}}"#,
+            )
+            .await;
+
+        let state = session.control_state.lock().expect("codex control state");
+        assert_eq!(state.turn, ControlTurn::Closed);
+        assert!(state.pending.is_empty());
+        drop(state);
+        assert!(matches!(
+            receiver.await.unwrap(),
+            Err(HarnessError::SteeringRejected(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn terminal_race_consumes_an_inflight_ack_without_a_steer_event() {
+        let sink = Arc::new(RecordingSink::default());
+        let session = unit_session(sink.clone());
+        let receiver = register_pending(
+            &session,
+            7,
+            PendingWriteState::Writing,
+            Some(Instant::now() + CONTROL_RPC_TIMEOUT),
+        );
+
+        session
+            .emit_parsed(
+                r#"{"method":"turn/completed","params":{"turn":{"id":"TURN-1","status":"completed"}}}"#,
+            )
+            .await;
+        assert!(matches!(
+            receiver.await.unwrap(),
+            Err(HarnessError::SteeringRejected(_))
+        ));
+        assert!(session
+            .control_state
+            .lock()
+            .expect("codex control state")
+            .pending
+            .contains_key(&7));
+
+        session
+            .emit_parsed(r#"{"id":7,"result":{"turnId":"TURN-1"}}"#)
+            .await;
+        assert!(session
+            .control_state
+            .lock()
+            .expect("codex control state")
+            .pending
+            .is_empty());
+        assert!(!sink
+            .events
+            .lock()
+            .expect("codex test events")
+            .iter()
+            .any(|event| matches!(event, HarnessEvent::UserSteered { .. })));
+    }
+
+    #[test]
+    fn cancellation_before_write_removes_the_registration() {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        let receiver = register_pending(&session, 7, PendingWriteState::Queued, None);
+        drop(receiver);
+        {
+            let _registration = ControlRegistration {
+                session: &session,
+                rpc_id: 7,
+                armed: true,
+            };
+        }
+        assert!(session
+            .control_state
+            .lock()
+            .expect("codex control state")
+            .pending
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn caller_cancellation_after_native_acceptance_keeps_user_steered() {
+        let sink = Arc::new(RecordingSink::default());
+        let session = unit_session(sink.clone());
+        let receiver = register_pending(
+            &session,
+            7,
+            PendingWriteState::Written,
+            Some(Instant::now() + CONTROL_RPC_TIMEOUT),
+        );
+        drop(receiver);
+
+        session
+            .emit_parsed(r#"{"id":7,"result":{"turnId":"TURN-1"}}"#)
+            .await;
+
+        let events = sink.events.lock().expect("codex test events");
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, HarnessEvent::UserSteered { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn user_steered_is_emitted_before_turn_completed() {
+        let sink = Arc::new(RecordingSink::default());
+        let session = unit_session(sink.clone());
+        let receiver = register_pending(
+            &session,
+            7,
+            PendingWriteState::Written,
+            Some(Instant::now() + CONTROL_RPC_TIMEOUT),
+        );
+
+        session
+            .emit_parsed(r#"{"id":7,"result":{"turnId":"TURN-1"}}"#)
+            .await;
+        session
+            .emit_parsed(
+                r#"{"method":"turn/completed","params":{"turn":{"id":"TURN-1","status":"completed"}}}"#,
+            )
+            .await;
+        receiver.await.unwrap().unwrap();
+
+        let events = sink.events.lock().expect("codex test events");
+        let steered = events
+            .iter()
+            .position(|event| matches!(event, HarnessEvent::UserSteered { .. }))
+            .unwrap();
+        let completed = events
+            .iter()
+            .position(|event| matches!(event, HarnessEvent::TurnCompleted { .. }))
+            .unwrap();
+        assert!(steered < completed);
+    }
+
+    #[tokio::test]
+    async fn rejected_or_mismatched_ack_never_emits_user_steered() {
+        for response in [
+            json!({ "id": 7, "error": { "message": "not steerable" } }),
+            json!({ "id": 7, "result": { "turnId": "TURN-2" } }),
+        ] {
+            let sink = Arc::new(RecordingSink::default());
+            let session = unit_session(sink.clone());
+            let receiver = register_pending(
+                &session,
+                7,
+                PendingWriteState::Written,
+                Some(Instant::now() + CONTROL_RPC_TIMEOUT),
+            );
+            session.emit_parsed(&response.to_string()).await;
+            assert!(matches!(
+                receiver.await.unwrap(),
+                Err(HarnessError::SteeringRejected(_))
+            ));
+            assert!(!sink
+                .events
+                .lock()
+                .expect("codex test events")
+                .iter()
+                .any(|event| matches!(event, HarnessEvent::UserSteered { .. })));
+        }
+    }
+
+    #[tokio::test]
+    async fn control_timeout_cleans_pending_state() {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        let receiver = register_pending(
+            &session,
+            7,
+            PendingWriteState::Written,
+            Some(Instant::now()),
+        );
+        session.expire_control_requests();
+        assert!(session
+            .control_state
+            .lock()
+            .expect("codex control state")
+            .pending
+            .is_empty());
+        assert!(matches!(
+            receiver.await.unwrap(),
+            Err(HarnessError::SteeringRejected(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn native_steer_uses_the_active_turn_id_and_waits_for_ack() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("codex");
+        write_app_server(&binary, FAKE_STEERING_APP_SERVER);
+        let mut spec = spec_for(dir.path(), &binary, None);
+        let sink = Arc::new(RecordingSink::default());
+        spec.sink = sink.clone();
+        spec.extra_env.push((
+            "FAKE_CODEX_STEER".into(),
+            dir.path().join("steer.json").to_string_lossy().into_owned(),
+        ));
+        let session = Arc::new(attach(spec).await.unwrap());
+        let running = tokio::spawn({
+            let session = Arc::clone(&session);
+            async move {
+                session
+                    .run_turn(TurnInput {
+                        text: "first turn".into(),
+                        model: None,
+                        images: Vec::new(),
+                    })
+                    .await
+            }
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if session.active_control_turn_id().is_some() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("fake turn was never acknowledged");
+
+        session.steer("try the other file".into()).await.unwrap();
+        running.await.unwrap().unwrap();
+
+        let request: Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join("steer.json")).unwrap())
+                .unwrap();
+        assert_eq!(request["method"], "turn/steer");
+        assert_eq!(request["params"]["threadId"], "THREAD-1");
+        assert_eq!(request["params"]["expectedTurnId"], "TURN-1");
+        assert_eq!(request["params"]["input"][0]["type"], "text");
+        assert_eq!(request["params"]["input"][0]["text"], "try the other file");
+        let steers: Vec<_> = sink
+            .events
+            .lock()
+            .expect("codex test events")
+            .iter()
+            .filter_map(|event| match event {
+                HarnessEvent::UserSteered { text } => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(steers, ["try the other file"]);
     }
 }

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -668,8 +668,8 @@ impl CodexSession {
     async fn emit_parsed(&self, line: &str) -> Vec<HarnessEvent> {
         let value = serde_json::from_str::<Value>(line).ok();
         if let Some(value) = value.as_ref() {
-            if is_rpc_response(&value) {
-                if let Some(rpc_id) = value_rpc_id(&value) {
+            if is_rpc_response(value) {
+                if let Some(rpc_id) = value_rpc_id(value) {
                     let pending = self
                         .control_state
                         .lock()
@@ -677,7 +677,7 @@ impl CodexSession {
                         .pending
                         .remove(&rpc_id);
                     if let Some(mut pending) = pending {
-                        let result = validate_steer_response(&value, &pending.expected_turn_id);
+                        let result = validate_steer_response(value, &pending.expected_turn_id);
                         if pending.accept_response && result.is_ok() {
                             self.spec
                                 .sink
@@ -691,7 +691,7 @@ impl CodexSession {
                     }
                 }
             }
-            if let Some(detail) = lost_resume_detail(&value) {
+            if let Some(detail) = lost_resume_detail(value) {
                 *self.resume_lost.lock().expect("codex resume lost") = Some(detail);
             }
         }

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -362,11 +362,14 @@ pub trait HarnessSession: Send + Sync {
     ///
     /// The default refuses: an adapter must override this only when its
     /// capability vector states [`CapLevel::Supported`] for mid-turn steering.
+    /// An accepting adapter owns the matching [`HarnessEvent::UserSteered`]
+    /// emission: emit it exactly once before returning `Ok(())`, and emit none
+    /// when admission is rejected. Keeping acknowledgement and event ordering
+    /// inside the protocol adapter lets a terminal event that follows in the
+    /// same native batch remain causally after the user's guidance.
     async fn steer(&self, text: String) -> Result<(), HarnessError> {
         let _ = text;
-        Err(HarnessError::Other(
-            "mid-turn steering is not available on this engine".into(),
-        ))
+        Err(HarnessError::SteeringUnsupported)
     }
 
     /// Engine-native resume token, when the stream has reported one.
@@ -449,6 +452,12 @@ pub enum HarnessError {
     /// rather than treat this as one failed turn.
     #[error("the engine no longer has this session: {0}")]
     ResumeLost(String),
+    /// The adapter has no verified same-turn steering channel.
+    #[error("mid-turn steering is not available on this engine")]
+    SteeringUnsupported,
+    /// The native engine refused a steer for the currently active turn.
+    #[error("the engine refused mid-turn steering: {0}")]
+    SteeringRejected(String),
     /// I/O or spawn failure.
     #[error("engine io: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1109,6 +1109,64 @@ impl CodeRuntime {
             .map_err(map_worker)
     }
 
+    pub(crate) async fn steer(
+        &self,
+        owner: &OwnerId,
+        id: CodeSessionId,
+        expected_turn_id: CodeTurnId,
+        message: String,
+    ) -> Result<(), ServerError> {
+        let session = self.get_session(owner, id).await?;
+        if session.lifecycle != CodeSessionLifecycle::Running {
+            return Err(ServerError::conflict_kind(
+                "no_active_turn",
+                "there is no active turn to steer; the message was not queued",
+            ));
+        }
+        let Some(active_turn) = get_open_turn(&self.db, owner, id).await? else {
+            return Err(ServerError::conflict_kind(
+                "no_active_turn",
+                "there is no active turn to steer; the message was not queued",
+            ));
+        };
+        if active_turn.id != expected_turn_id {
+            return Err(ServerError::conflict_kind(
+                "stale_turn",
+                format!(
+                    "turn {expected_turn_id} is no longer active; current turn is {}; the message was not queued",
+                    active_turn.id
+                ),
+            ));
+        }
+        let adapter = self.adapter(session.harness_kind)?;
+        let probe = self.probe(adapter.as_ref()).await;
+        let level = adapter.capabilities(&probe).mid_turn_steering;
+        if level != CapLevel::Supported {
+            return Err(ServerError::unprocessable_kind(
+                "steering_unavailable",
+                format!(
+                    "{harness} mid-turn steering is {level}; the message was not queued",
+                    harness = session.harness_kind,
+                    level = level.as_str(),
+                ),
+            ));
+        }
+        let handle = self.require_worker(id)?;
+        let (reply, rx) = oneshot::channel();
+        handle
+            .commands
+            .send(WorkerCommand::Steer {
+                expected_turn_id,
+                message,
+                reply,
+            })
+            .await
+            .map_err(|_| ServerError::internal("session worker is gone"))?;
+        rx.await
+            .map_err(|_| ServerError::internal("session worker dropped the steer"))?
+            .map_err(map_worker)
+    }
+
     pub(crate) async fn reap(
         &self,
         owner: &OwnerId,
@@ -1805,6 +1863,14 @@ fn map_worktree(err: WorktreeError) -> ServerError {
 fn map_worker(err: WorkerError) -> ServerError {
     match err {
         WorkerError::Conflict(message) => ServerError::conflict_kind("conflict", message),
+        WorkerError::NoActiveTurn(message) => ServerError::conflict_kind("no_active_turn", message),
+        WorkerError::StaleTurn(message) => ServerError::conflict_kind("stale_turn", message),
+        WorkerError::SteeringUnavailable(message) => {
+            ServerError::unprocessable_kind("steering_unavailable", message)
+        }
+        WorkerError::SteeringRejected(message) => {
+            ServerError::conflict_kind("steering_rejected", message)
+        }
         WorkerError::Failed(message) => ServerError::internal(message),
     }
 }

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -352,6 +352,17 @@ impl ScopedCode {
         self.runtime.interrupt(id).await
     }
 
+    pub(crate) async fn steer(
+        &self,
+        id: CodeSessionId,
+        expected_turn_id: CodeTurnId,
+        message: String,
+    ) -> Result<(), ServerError> {
+        self.runtime
+            .steer(&self.owner, id, expected_turn_id, message)
+            .await
+    }
+
     pub(crate) async fn reap(&self, id: CodeSessionId) -> Result<CodeSession, ServerError> {
         self.runtime.reap(&self.owner, id).await
     }

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -13,6 +13,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -53,6 +54,11 @@ pub(crate) enum WorkerCommand {
     Interrupt {
         reply: oneshot::Sender<Result<(), WorkerError>>,
     },
+    Steer {
+        expected_turn_id: CodeTurnId,
+        message: String,
+        reply: oneshot::Sender<Result<(), WorkerError>>,
+    },
     Shutdown,
 }
 
@@ -60,6 +66,14 @@ pub(crate) enum WorkerCommand {
 pub(crate) enum WorkerError {
     #[error("{0}")]
     Conflict(String),
+    #[error("{0}")]
+    NoActiveTurn(String),
+    #[error("{0}")]
+    StaleTurn(String),
+    #[error("{0}")]
+    SteeringUnavailable(String),
+    #[error("{0}")]
+    SteeringRejected(String),
     #[error("{0}")]
     Failed(String),
 }
@@ -305,7 +319,9 @@ async fn run_worker(
                     let _ = reply.send(result);
                 }
                 Some(command) => {
-                    if apply_control(engine.as_ref(), command).await == ControlFlow::Shutdown {
+                    if apply_control(engine.as_ref(), command, None).await
+                        == ControlFlow::Shutdown
+                    {
                         break;
                     }
                 }
@@ -321,6 +337,11 @@ enum ControlFlow {
     Continue,
     Shutdown,
 }
+
+#[cfg(not(test))]
+const STEER_CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(test)]
+const STEER_CONTROL_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Stop the engine's current turn, discarding the adapter's error: the turn
 /// is ending either way, and the outcome is what the worker journals.
@@ -342,7 +363,11 @@ async fn next_child_pid(changes: Option<&mut watch::Receiver<Option<i64>>>) -> O
     *changes.borrow()
 }
 
-async fn apply_control(engine: &dyn HarnessSession, command: WorkerCommand) -> ControlFlow {
+async fn apply_control(
+    engine: &dyn HarnessSession,
+    command: WorkerCommand,
+    active_turn_id: Option<CodeTurnId>,
+) -> ControlFlow {
     match command {
         WorkerCommand::Decide {
             approval,
@@ -361,6 +386,45 @@ async fn apply_control(engine: &dyn HarnessSession, command: WorkerCommand) -> C
                 .interrupt()
                 .await
                 .map_err(|err| WorkerError::Failed(err.to_string()));
+            let _ = reply.send(result);
+            ControlFlow::Continue
+        }
+        WorkerCommand::Steer {
+            expected_turn_id,
+            message,
+            reply,
+        } => {
+            let result = match active_turn_id {
+                None => Err(WorkerError::NoActiveTurn(
+                    "there is no active turn to steer; the message was not queued".into(),
+                )),
+                Some(active) if active != expected_turn_id => Err(WorkerError::StaleTurn(
+                    format!(
+                        "turn {expected_turn_id} is no longer active; current turn is {active}; the message was not queued"
+                    ),
+                )),
+                Some(_) => match tokio::time::timeout(
+                    STEER_CONTROL_TIMEOUT,
+                    engine.steer(message),
+                )
+                .await
+                {
+                    Ok(result) => result.map_err(|err| match err {
+                        HarnessError::SteeringUnsupported => WorkerError::SteeringUnavailable(
+                            "mid-turn steering is not available on this engine; the message was not queued"
+                                .into(),
+                        ),
+                        HarnessError::SteeringRejected(detail) => {
+                            WorkerError::SteeringRejected(detail)
+                        }
+                        other => WorkerError::Failed(other.to_string()),
+                    }),
+                    Err(_) => Err(WorkerError::SteeringRejected(
+                        "the engine did not acknowledge steering before the control timeout; the message was not queued"
+                            .into(),
+                    )),
+                },
+            };
             let _ = reply.send(result);
             ControlFlow::Continue
         }
@@ -490,28 +554,36 @@ async fn drive_turn(
     let mut commands_closed = false;
     let run = loop {
         tokio::select! {
-            result = &mut run => break result,
+            // Once a control has been accepted from the command channel, poll
+            // it before allowing a simultaneously-terminal turn to win. Native
+            // steering registers its response waiter on that first poll; the
+            // turn reader can then drain and demultiplex the acknowledgement.
+            biased;
             Some(flow) = controls.next(), if !controls.is_empty() => {
                 if flow == ControlFlow::Shutdown {
                     interrupted = true;
                     controls.push(Box::pin(interrupt_engine(engine)));
                 }
             }
-            pid = next_child_pid(pid_changes.as_mut()) => {
-                if session.child_pid != pid {
-                    session.child_pid = pid;
-                    let _ = save_session(db, session).await;
-                }
-            }
+            // A terminal result wins over commands that have not yet been
+            // admitted. This prevents guidance for turn A from entering the
+            // control set after A has already completed and then reaching B.
+            result = &mut run => break result,
             command = commands.recv(), if !commands_closed => match command {
                 Some(command) => {
                     interrupted |= matches!(command, WorkerCommand::Interrupt { .. });
-                    controls.push(Box::pin(apply_control(engine, command)));
+                    controls.push(Box::pin(apply_control(engine, command, Some(turn.id))));
                 }
                 None => {
                     commands_closed = true;
                     interrupted = true;
                     controls.push(Box::pin(interrupt_engine(engine)));
+                }
+            },
+            pid = next_child_pid(pid_changes.as_mut()) => {
+                if session.child_pid != pid {
+                    session.child_pid = pid;
+                    let _ = save_session(db, session).await;
                 }
             }
         }

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -1,8 +1,3 @@
-use axum::body::Body;
-use axum::extract::State;
-use axum::http::{header, HeaderMap, StatusCode};
-use axum::response::{IntoResponse, Response};
-
 use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, RawBytes};
@@ -11,13 +6,17 @@ use crate::routes::image_attachment::{
 };
 use crate::routes::SERVED_BYTES_CONTENT_POLICY;
 use crate::state::AppState;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
 
 use super::types::{
     CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuedCodeTurn,
     SequencedCodeEventFrame, SetAttentionBody, SteerBody, SubmitTurnBody,
 };
 use crate::code::runtime::SubmitTurnOutcome;
-use tidebreak_core::{CodeSessionId, WorkspaceId};
+use tidebreak_core::{CodeSessionId, TurnSteer, WorkspaceId};
 
 pub async fn create_session(
     code: ScopedCode,
@@ -115,17 +114,21 @@ pub async fn list_session_turns(
 }
 
 pub async fn steer_session(
-    Path(_id): Path<CodeSessionId>,
+    code: ScopedCode,
+    Path(id): Path<CodeSessionId>,
     Json(body): Json<SteerBody>,
 ) -> Result<StatusCode, ServerError> {
-    let message = body.message.trim();
-    if message.is_empty() {
-        return Err(ServerError::bad_request("message must not be empty"));
+    let guidance = body.guidance.trim().to_owned();
+    if guidance.is_empty()
+        || guidance.contains('\0')
+        || guidance.chars().count() > TurnSteer::MAX_CONTENT_LEN
+    {
+        return Err(ServerError::bad_request(
+            "guidance must be non-empty, contain no NUL characters, and fit the size limit",
+        ));
     }
-    Err(ServerError::unprocessable_kind(
-        "steering_unavailable",
-        "explicit mid-turn steering is not yet available; the message was not queued",
-    ))
+    code.steer(id, body.expected_turn_id, guidance).await?;
+    Ok(StatusCode::ACCEPTED)
 }
 
 pub async fn interrupt_session(

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -458,7 +458,8 @@ pub struct SubmitTurnAttachment {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SteerBody {
-    pub message: String,
+    pub expected_turn_id: tidebreak_core::CodeTurnId,
+    pub guidance: String,
 }
 
 /// A follow-up parked while the session is already running a turn.

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -16,7 +16,7 @@ use tidebreak_harness::{
     HarnessEvent, HarnessEventSink, HarnessProbe, HarnessSession, HostEnv, SessionSpec, TurnInput,
     TurnOutcome,
 };
-use tokio::sync::{oneshot, watch, Mutex};
+use tokio::sync::{oneshot, watch};
 
 /// Completer that records decisions and unparks a scripted turn.
 ///
@@ -76,6 +76,8 @@ pub(crate) struct ScriptedAdapter {
     events: Vec<HarnessEvent>,
     delay: Duration,
     mid_turn_steering: CapLevel,
+    steering_delay: Duration,
+    steering_rejection: Option<String>,
     structured_approvals: CapLevel,
     auto_mode: CapLevel,
     allow_mode: CapLevel,
@@ -98,6 +100,8 @@ impl ScriptedAdapter {
             events,
             delay: Duration::ZERO,
             mid_turn_steering: CapLevel::Unsupported,
+            steering_delay: Duration::ZERO,
+            steering_rejection: None,
             structured_approvals: CapLevel::Unsupported,
             auto_mode: CapLevel::Unsupported,
             allow_mode: CapLevel::Unsupported,
@@ -177,6 +181,18 @@ impl ScriptedAdapter {
         self
     }
 
+    pub(crate) fn with_steering_delay(mut self, delay: Duration) -> Self {
+        self.mid_turn_steering = CapLevel::Supported;
+        self.steering_delay = delay;
+        self
+    }
+
+    pub(crate) fn with_steering_rejection(mut self, detail: impl Into<String>) -> Self {
+        self.mid_turn_steering = CapLevel::Supported;
+        self.steering_rejection = Some(detail.into());
+        self
+    }
+
     /// Publish this pid for the duration of each turn, the way an adapter
     /// that spawns one child per turn does.
     #[allow(dead_code)]
@@ -251,12 +267,13 @@ impl HarnessAdapter for ScriptedAdapter {
             events: self.events.clone(),
             delay: self.delay,
             mid_turn_steering: self.mid_turn_steering,
+            steering_delay: self.steering_delay,
+            steering_rejection: self.steering_rejection.clone(),
             child_pid: self.child_pid,
             silent_interrupt: self.silent_interrupt,
             pid: ChildPid::new(),
             lost_resume: self.lost_resume.clone(),
             interrupt: Arc::new(AtomicBool::new(false)),
-            steered: Mutex::new(None),
             unrecognized: AtomicU64::new(0),
             unrecognized_per_turn: self.unrecognized_per_turn,
             approver: self.approver.clone(),
@@ -269,12 +286,13 @@ struct ScriptedSession {
     events: Vec<HarnessEvent>,
     delay: Duration,
     mid_turn_steering: CapLevel,
+    steering_delay: Duration,
+    steering_rejection: Option<String>,
     child_pid: Option<i64>,
     silent_interrupt: bool,
     pid: ChildPid,
     lost_resume: Option<String>,
     interrupt: Arc<AtomicBool>,
-    steered: Mutex<Option<String>>,
     unrecognized: AtomicU64,
     unrecognized_per_turn: u64,
     approver: Arc<ScriptedApprover>,
@@ -289,9 +307,6 @@ impl ScriptedSession {
             }
             if !self.delay.is_zero() {
                 tokio::time::sleep(self.delay).await;
-            }
-            if let Some(text) = self.steered.lock().await.take() {
-                self.sink.emit(HarnessEvent::UserSteered { text }).await;
             }
             if let HarnessEvent::ApprovalRequested { harness_ref, .. } = event {
                 self.sink.emit(event.clone()).await;
@@ -372,11 +387,15 @@ impl HarnessSession for ScriptedSession {
 
     async fn steer(&self, text: String) -> Result<(), HarnessError> {
         if self.mid_turn_steering != CapLevel::Supported {
-            return Err(HarnessError::Other(
-                "mid-turn steering is not available on this engine".into(),
-            ));
+            return Err(HarnessError::SteeringUnsupported);
         }
-        *self.steered.lock().await = Some(text);
+        if !self.steering_delay.is_zero() {
+            tokio::time::sleep(self.steering_delay).await;
+        }
+        if let Some(detail) = &self.steering_rejection {
+            return Err(HarnessError::SteeringRejected(detail.clone()));
+        }
+        self.sink.emit(HarnessEvent::UserSteered { text }).await;
         Ok(())
     }
 

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -18,8 +18,8 @@ use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CapLevel, CodeEvent, CodePermissionMode,
-    CodeSessionId, CodeSessionLifecycle, CodeTurnStatus, CodeWorkspaceStatus, DbStore, FenceReason,
-    HarnessKind, WorkspaceId,
+    CodeSessionId, CodeSessionLifecycle, CodeTurnId, CodeTurnStatus, CodeWorkspaceStatus, DbStore,
+    FenceReason, HarnessKind, WorkspaceId,
 };
 use tidebreak_harness::{AdapterRegistry, ApprovalDecision, HarnessApprovalRef, HarnessEvent};
 
@@ -871,6 +871,26 @@ async fn turn_statuses(
         .collect()
 }
 
+async fn wait_for_open_turn(runtime: &CodeRuntime, session_id: CodeSessionId) -> CodeTurnId {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(turn) = tidebreak_core::db::code::get_open_turn(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                session_id,
+            )
+            .await
+            .unwrap()
+            {
+                break turn.id;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("turn never became active")
+}
+
 #[tokio::test]
 async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
     // Claude Code advertises mid_turn_steering: Unknown. Queue-default must
@@ -1009,8 +1029,11 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
 }
 
 #[tokio::test]
-async fn explicit_steer_is_not_yet_available() {
-    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+async fn unsupported_explicit_steer_is_refused_without_queueing() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script()).with_delay(Duration::from_millis(40)),
+    )
+    .await;
     let addr = serve(router).await;
     let client = reqwest::Client::new();
     let repo = init_git_repo(dir.path());
@@ -1031,19 +1054,552 @@ async fn explicit_steer_is_not_yet_available() {
         .json::<serde_json::Value>()
         .await
         .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = wait_for_open_turn(&runtime, parsed).await;
     let refused = client
-        .post(format!(
-            "http://{addr}/code/sessions/{}/steer",
-            json_id(&session)
-        ))
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
         .bearer_auth(&token)
-        .json(&serde_json::json!({ "message": "redirect" }))
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "redirect",
+        }))
         .send()
         .await
         .unwrap();
     assert_eq!(refused.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
     let body: serde_json::Value = refused.json().await.unwrap();
     assert_eq!(body["kind"], "steering_unavailable");
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_up() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(40))
+            .with_steering(CapLevel::Supported),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let mut events = runtime.bus.subscribe(parsed);
+
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let CodeEvent::TurnStarted { turn_id } = events.recv().await.unwrap().event {
+                break turn_id;
+            }
+        }
+    })
+    .await
+    .expect("turn never started");
+
+    let first_steer = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "try the other file",
+        }))
+        .send();
+    let second_steer = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "keep the public API small",
+        }))
+        .send();
+    let (first_steer, second_steer) = tokio::join!(first_steer, second_steer);
+    assert_eq!(first_steer.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+    assert_eq!(
+        second_steer.unwrap().status(),
+        reqwest::StatusCode::ACCEPTED
+    );
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+
+    let mut steer_events = Vec::new();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let event = events.recv().await.unwrap().event;
+            if let CodeEvent::UserSteered { text } = &event {
+                steer_events.push(text.clone());
+            }
+            if matches!(event, CodeEvent::TurnCompleted { .. }) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("turn never completed");
+    steer_events.sort();
+    assert_eq!(
+        steer_events,
+        ["keep the public API small", "try the other file"]
+    );
+
+    let turns = tidebreak_core::db::code::list_turns(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap();
+    assert_eq!(turns.len(), 1, "steering must not create a follow-up turn");
+    assert_eq!(turns[0].user_input, "first");
+}
+
+#[tokio::test]
+async fn supported_steer_requires_an_active_turn() {
+    let (router, token, _runtime, dir) =
+        code_app_with(ScriptedAdapter::new(plain_text_script()).with_steering(CapLevel::Supported))
+            .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/sessions/{}/steer",
+            json_id(&session)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": CodeTurnId::new(),
+            "guidance": "too late",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "no_active_turn");
+}
+
+#[tokio::test]
+async fn steer_rejects_blank_nul_and_oversized_guidance() {
+    let (router, token, _runtime, dir) =
+        code_app_with(ScriptedAdapter::new(plain_text_script()).with_steering(CapLevel::Supported))
+            .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+
+    for guidance in [
+        "   ".to_owned(),
+        "contains\0nul".to_owned(),
+        "x".repeat(tidebreak_core::TurnSteer::MAX_CONTENT_LEN + 1),
+    ] {
+        let refused = client
+            .post(format!(
+                "http://{addr}/code/sessions/{}/steer",
+                json_id(&session)
+            ))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "expected_turn_id": CodeTurnId::new(),
+                "guidance": guidance,
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(refused.status(), reqwest::StatusCode::BAD_REQUEST);
+    }
+}
+
+#[tokio::test]
+async fn stale_turn_steering_is_rejected_before_reaching_the_adapter() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(80))
+            .with_steering(CapLevel::Supported),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = wait_for_open_turn(&runtime, parsed).await;
+    let stale_turn_id = loop {
+        let candidate = CodeTurnId::new();
+        if candidate != active_turn_id {
+            break candidate;
+        }
+    };
+
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": stale_turn_id,
+            "guidance": "wrong turn",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "stale_turn");
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+
+    let events = tidebreak_core::db::code::list_events(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+        0,
+    )
+    .await
+    .unwrap();
+    assert!(
+        events
+            .iter()
+            .all(|event| !matches!(event.event, CodeEvent::UserSteered { .. })),
+        "stale steering reached the adapter: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn stalled_native_steering_times_out_without_wedging_turn_completion() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(80))
+            .with_steering_delay(Duration::from_secs(1)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = wait_for_open_turn(&runtime, parsed).await;
+
+    let started = tokio::time::Instant::now();
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "this adapter never answers",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    assert!(
+        started.elapsed() < Duration::from_millis(750),
+        "worker-level timeout did not bound the stalled control"
+    );
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "steering_rejected");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), turn)
+            .await
+            .expect("turn completion was wedged")
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::ACCEPTED
+    );
+}
+
+#[tokio::test]
+async fn terminal_turn_event_closes_steering_before_a_late_command_is_admitted() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(20))
+            .with_steering(CapLevel::Supported),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let mut events = runtime.bus.subscribe(parsed);
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let mut active_turn_id = None;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            match events.recv().await.unwrap().event {
+                CodeEvent::TurnStarted { turn_id } => active_turn_id = Some(turn_id),
+                CodeEvent::TurnCompleted { .. } => break,
+                _ => {}
+            }
+        }
+    })
+    .await
+    .expect("turn never completed");
+
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id.expect("turn id"),
+            "guidance": "too late",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "no_active_turn");
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn a_native_steer_rejection_does_not_fail_or_redirect_the_turn() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_delay(Duration::from_millis(40))
+            .with_steering_rejection("turn is no longer steerable"),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let mut events = runtime.bus.subscribe(parsed);
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let active_turn_id = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let CodeEvent::TurnStarted { turn_id } = events.recv().await.unwrap().event {
+                break turn_id;
+            }
+        }
+    })
+    .await
+    .expect("turn never started");
+
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "expected_turn_id": active_turn_id,
+            "guidance": "redirect",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "steering_rejected");
+    assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+
+    let turns = tidebreak_core::db::code::list_turns(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap();
+    assert_eq!(turns.len(), 1);
+    assert_eq!(turns[0].status, CodeTurnStatus::Completed);
 }
 
 fn scripted_registry() -> AdapterRegistry {
@@ -3495,6 +4051,19 @@ async fn a_second_user_sees_neither_code_rows_nor_updates_of_another_owner() {
         .await
         .unwrap();
     assert_eq!(interrupted.status(), reqwest::StatusCode::NOT_FOUND);
+    let steered = client
+        .post(format!(
+            "http://{addr}/code/sessions/{alice_session_id}/steer"
+        ))
+        .bearer_auth(BOB_TOKEN)
+        .json(&serde_json::json!({
+            "expected_turn_id": CodeTurnId::new(),
+            "guidance": "whose session is this",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(steered.status(), reqwest::StatusCode::NOT_FOUND);
 
     // The updates channel. Bob's connect snapshot is empty even though Alice
     // has a live session, and Alice's turn produces no notice on his socket.


### PR DESCRIPTION
## Summary

- implement Codex app-server `turn/steer` against the shared Code-mode steering contract
- advertise Redirect only for the verified stable Codex 0.147.x protocol
- add cancellation-safe response tracking, bounded writes/responses, and request-ID collision protection
- fence late, rejected, mismatched, and terminal responses so they cannot corrupt turn state
- emit `UserSteered` exactly once and in transcript order

## Stack

- depends on #2285 (`feat(code): add safe mid-turn steering contract`)
- this PR contains only the native Codex adapter and its protocol coverage

## Validation

- standalone `rustfmt` passed
- `git diff --check` passed

Broad Rust and protocol tests are delegated to CI per repository guidance.
