### PR TITLE
feat(code): add first-class browser tabs

### DIFF
--- a/crates/tidebreak-desktop/Cargo.toml
+++ b/crates/tidebreak-desktop/Cargo.toml
@@ -45,7 +45,7 @@ semver = "=1.0.28"
 sha2 = { workspace = true }
 symphonia = { workspace = true }
 opus-decoder = { workspace = true }
-tauri = { version = "=2.11.5", features = [] }
+tauri = { version = "=2.11.5", features = ["unstable"] }
 tauri-plugin-deep-link = "=2.4.9"
 tauri-plugin-dialog = "=2.7.2"
 tauri-plugin-shell = "=2.3.5"

--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -25,6 +25,7 @@
 # Shell bootstrap and native window control
 server_info: hands the renderer the embedded server's address and per-launch token — the handshake that makes every HTTP route reachable, so it cannot itself be one.
 request_user_attention: native window attention hint when a parked question needs the user.
+code_browser_command: creates and controls sandboxed native child webviews whose bounds and lifecycle exist only in the desktop shell.
 
 # Attaching this client to a machine it does not host (ADR 0047)
 remote_machine_state: reports which machine this client is attached to, from shell-held state that exists before any machine is reachable.

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -1,0 +1,431 @@
+//! Native child-webview host for Code-mode browser tabs.
+//!
+//! Remote pages never receive Tidebreak IPC. The main app webview owns every
+//! command and event, while this module validates the external URL again at
+//! the native boundary and limits all handles to the `code-browser-` prefix.
+
+use serde::{Deserialize, Serialize};
+use tauri::{
+    webview::{DownloadEvent, NewWindowResponse, PageLoadEvent, WebviewBuilder},
+    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Rect, Webview, WebviewUrl,
+};
+use url::Url;
+
+const BROWSER_LABEL_PREFIX: &str = "code-browser-";
+const CODE_BROWSER_EVENT: &str = "code-browser:event";
+const MAX_BROWSER_ID_CHARS: usize = 80;
+const MAX_BROWSER_URL_CHARS: usize = 8_192;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CodeBrowserCommandRequest {
+    session_id: String,
+    action: CodeBrowserAction,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+enum CodeBrowserAction {
+    Create {
+        url: String,
+        bounds: CodeBrowserBounds,
+        visible: bool,
+    },
+    Navigate {
+        url: String,
+    },
+    Reload,
+    Stop,
+    Back,
+    Forward,
+    SetBounds {
+        bounds: CodeBrowserBounds,
+    },
+    SetVisible {
+        visible: bool,
+    },
+    Snapshot,
+    Close,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+struct CodeBrowserBounds {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CodeBrowserSnapshot {
+    exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CodeBrowserEvent {
+    session_id: String,
+    #[serde(rename = "type")]
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+#[tauri::command]
+pub(crate) async fn code_browser_command(
+    app: AppHandle,
+    request: CodeBrowserCommandRequest,
+) -> Result<CodeBrowserSnapshot, String> {
+    let label = browser_label(&request.session_id)?;
+    let existing = app.get_webview(&label);
+
+    match request.action {
+        CodeBrowserAction::Create {
+            url,
+            bounds,
+            visible,
+        } => {
+            if let Some(webview) = existing {
+                set_bounds(&webview, bounds)?;
+                set_visible(&webview, visible)?;
+                return snapshot(&webview);
+            }
+            create_browser(&app, &request.session_id, &label, &url, bounds, visible)
+        }
+        CodeBrowserAction::Snapshot => match existing {
+            Some(webview) => snapshot(&webview),
+            None => Ok(CodeBrowserSnapshot {
+                exists: false,
+                url: None,
+            }),
+        },
+        CodeBrowserAction::Close => {
+            if let Some(webview) = existing {
+                webview.close().map_err(browser_error)?;
+            }
+            Ok(CodeBrowserSnapshot {
+                exists: false,
+                url: None,
+            })
+        }
+        action => {
+            let webview = existing.ok_or_else(|| "browser session is not open".to_owned())?;
+            run_action(&app, &request.session_id, &webview, action)?;
+            snapshot(&webview)
+        }
+    }
+}
+
+fn create_browser(
+    app: &AppHandle,
+    session_id: &str,
+    label: &str,
+    url: &str,
+    bounds: CodeBrowserBounds,
+    visible: bool,
+) -> Result<CodeBrowserSnapshot, String> {
+    let main = app
+        .get_webview("main")
+        .ok_or_else(|| "main webview is not available".to_owned())?;
+    let window = app
+        .get_window("main")
+        .ok_or_else(|| "main window is not available".to_owned())?;
+    let renderer_url = main.url().ok();
+    let target = validated_url(url, renderer_url.as_ref())?;
+    let safe_bounds = validated_bounds(bounds)?;
+
+    let navigation_main = main.clone();
+    let navigation_session = session_id.to_owned();
+    let navigation_renderer_url = renderer_url.clone();
+    let popup_main = main.clone();
+    let popup_session = session_id.to_owned();
+    let load_main = main.clone();
+    let load_session = session_id.to_owned();
+    let title_main = main.clone();
+    let title_session = session_id.to_owned();
+    let download_main = main.clone();
+    let download_session = session_id.to_owned();
+
+    let builder = WebviewBuilder::new(label, WebviewUrl::External(target))
+        .on_navigation(move |url| {
+            if validated_url(url.as_str(), navigation_renderer_url.as_ref()).is_ok() {
+                true
+            } else {
+                emit_event(
+                    &navigation_main,
+                    CodeBrowserEvent {
+                        session_id: navigation_session.clone(),
+                        kind: "navigation_blocked",
+                        url: Some(url.to_string()),
+                        title: None,
+                        message: Some(
+                            "This address is not allowed in the in-app browser".to_owned(),
+                        ),
+                    },
+                );
+                false
+            }
+        })
+        .on_new_window(move |url, _features| {
+            emit_event(
+                &popup_main,
+                CodeBrowserEvent {
+                    session_id: popup_session.clone(),
+                    kind: "popup_blocked",
+                    url: Some(url.to_string()),
+                    title: None,
+                    message: None,
+                },
+            );
+            NewWindowResponse::Deny
+        })
+        .on_page_load(move |_webview, payload| {
+            emit_event(
+                &load_main,
+                CodeBrowserEvent {
+                    session_id: load_session.clone(),
+                    kind: match payload.event() {
+                        PageLoadEvent::Started => "navigation_started",
+                        PageLoadEvent::Finished => "navigation_finished",
+                    },
+                    url: Some(payload.url().to_string()),
+                    title: None,
+                    message: None,
+                },
+            );
+        })
+        .on_document_title_changed(move |webview, title| {
+            emit_event(
+                &title_main,
+                CodeBrowserEvent {
+                    session_id: title_session.clone(),
+                    kind: "title_changed",
+                    url: webview.url().ok().map(|url| url.to_string()),
+                    title: Some(title.chars().take(160).collect()),
+                    message: None,
+                },
+            );
+        })
+        .on_download(move |_webview, event| {
+            if let DownloadEvent::Requested { url, .. } = event {
+                emit_event(
+                    &download_main,
+                    CodeBrowserEvent {
+                        session_id: download_session.clone(),
+                        kind: "download_blocked",
+                        url: Some(url.to_string()),
+                        title: None,
+                        message: None,
+                    },
+                );
+            }
+            false
+        });
+
+    let webview = window
+        .add_child(
+            builder,
+            LogicalPosition::new(safe_bounds.x, safe_bounds.y),
+            LogicalSize::new(safe_bounds.width, safe_bounds.height),
+        )
+        .map_err(browser_error)?;
+    if !visible {
+        webview.hide().map_err(browser_error)?;
+    }
+    snapshot(&webview)
+}
+
+fn run_action(
+    app: &AppHandle,
+    session_id: &str,
+    webview: &Webview,
+    action: CodeBrowserAction,
+) -> Result<(), String> {
+    match action {
+        CodeBrowserAction::Navigate { url } => {
+            let renderer_url = app.get_webview("main").and_then(|main| main.url().ok());
+            webview
+                .navigate(validated_url(&url, renderer_url.as_ref())?)
+                .map_err(browser_error)
+        }
+        CodeBrowserAction::Reload => webview.reload().map_err(browser_error),
+        CodeBrowserAction::Stop => webview.eval("window.stop()").map_err(browser_error),
+        CodeBrowserAction::Back => webview.eval("window.history.back()").map_err(browser_error),
+        CodeBrowserAction::Forward => webview
+            .eval("window.history.forward()")
+            .map_err(browser_error),
+        CodeBrowserAction::SetBounds { bounds } => set_bounds(webview, bounds),
+        CodeBrowserAction::SetVisible { visible } => set_visible(webview, visible),
+        CodeBrowserAction::Create { .. }
+        | CodeBrowserAction::Snapshot
+        | CodeBrowserAction::Close => Err(format!(
+            "browser action is not valid for the open session {session_id}"
+        )),
+    }
+}
+
+fn set_bounds(webview: &Webview, bounds: CodeBrowserBounds) -> Result<(), String> {
+    let bounds = validated_bounds(bounds)?;
+    webview
+        .set_bounds(Rect {
+            position: LogicalPosition::new(bounds.x, bounds.y).into(),
+            size: LogicalSize::new(bounds.width, bounds.height).into(),
+        })
+        .map_err(browser_error)
+}
+
+fn set_visible(webview: &Webview, visible: bool) -> Result<(), String> {
+    if visible {
+        webview.show().map_err(browser_error)
+    } else {
+        webview.hide().map_err(browser_error)
+    }
+}
+
+fn snapshot(webview: &Webview) -> Result<CodeBrowserSnapshot, String> {
+    Ok(CodeBrowserSnapshot {
+        exists: true,
+        url: Some(webview.url().map_err(browser_error)?.to_string()),
+    })
+}
+
+fn validated_url(value: &str, renderer_url: Option<&Url>) -> Result<Url, String> {
+    if value.len() > MAX_BROWSER_URL_CHARS {
+        return Err("browser address is too long".to_owned());
+    }
+    let url = Url::parse(value).map_err(|_| "browser address is not valid".to_owned())?;
+    if url.as_str().len() > MAX_BROWSER_URL_CHARS {
+        return Err("browser address is too long".to_owned());
+    }
+    if url.scheme() != "http" && url.scheme() != "https" {
+        return Err("only HTTP and HTTPS addresses can open in the browser".to_owned());
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("browser addresses cannot contain credentials".to_owned());
+    }
+    if renderer_url.is_some_and(|renderer| same_app_origin(&url, renderer)) {
+        return Err("the Tidebreak application origin cannot open as a browser tab".to_owned());
+    }
+    Ok(url)
+}
+
+fn same_app_origin(left: &Url, right: &Url) -> bool {
+    if left.scheme() != right.scheme()
+        || left.port_or_known_default() != right.port_or_known_default()
+    {
+        return false;
+    }
+    match (left.host_str(), right.host_str()) {
+        (Some(left), Some(right)) if left.eq_ignore_ascii_case(right) => true,
+        (Some(left), Some(right)) => is_loopback_host(left) && is_loopback_host(right),
+        _ => false,
+    }
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
+fn validated_bounds(bounds: CodeBrowserBounds) -> Result<CodeBrowserBounds, String> {
+    if !bounds.x.is_finite()
+        || !bounds.y.is_finite()
+        || !bounds.width.is_finite()
+        || !bounds.height.is_finite()
+        || bounds.x < 0.0
+        || bounds.y < 0.0
+        || bounds.width < 1.0
+        || bounds.height < 1.0
+    {
+        return Err("browser bounds are not valid".to_owned());
+    }
+    Ok(bounds)
+}
+
+fn browser_label(session_id: &str) -> Result<String, String> {
+    if session_id.is_empty()
+        || session_id.chars().count() > MAX_BROWSER_ID_CHARS
+        || !session_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        return Err("browser session id is not valid".to_owned());
+    }
+    Ok(format!("{BROWSER_LABEL_PREFIX}{session_id}"))
+}
+
+fn emit_event(main: &Webview, event: CodeBrowserEvent) {
+    let _ = main.emit(CODE_BROWSER_EVENT, event);
+}
+
+fn browser_error(error: impl std::fmt::Display) -> String {
+    format!("browser host: {error}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_ids_are_bounded_and_safe_for_tauri_labels() {
+        assert_eq!(
+            browser_label("browser_123").unwrap(),
+            "code-browser-browser_123"
+        );
+        assert!(browser_label("").is_err());
+        assert!(browser_label("has/slash").is_err());
+        assert!(browser_label(&"a".repeat(MAX_BROWSER_ID_CHARS + 1)).is_err());
+    }
+
+    #[test]
+    fn browser_urls_are_http_only_and_cannot_reenter_the_app_origin() {
+        let renderer = Url::parse("http://localhost:1420/code/w/one").unwrap();
+        assert!(validated_url("https://example.com/docs", Some(&renderer)).is_ok());
+        assert!(validated_url("http://localhost:3000", Some(&renderer)).is_ok());
+        assert!(validated_url("http://localhost:1420/other", Some(&renderer)).is_err());
+        assert!(validated_url("http://127.0.0.1:1420/other", Some(&renderer)).is_err());
+        assert!(validated_url("http://[::1]:1420/other", Some(&renderer)).is_err());
+        assert!(validated_url("file:///tmp/secret", Some(&renderer)).is_err());
+        assert!(validated_url("https://name:secret@example.com", Some(&renderer)).is_err());
+        assert!(validated_url(
+            &format!("https://example.com/{}", "a".repeat(MAX_BROWSER_URL_CHARS)),
+            Some(&renderer)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn browser_bounds_reject_offscreen_and_non_finite_values() {
+        assert!(validated_bounds(CodeBrowserBounds {
+            x: 0.0,
+            y: 20.0,
+            width: 800.0,
+            height: 500.0,
+        })
+        .is_ok());
+        assert!(validated_bounds(CodeBrowserBounds {
+            x: -1.0,
+            y: 0.0,
+            width: 800.0,
+            height: 500.0,
+        })
+        .is_err());
+        assert!(validated_bounds(CodeBrowserBounds {
+            x: 0.0,
+            y: 0.0,
+            width: f64::NAN,
+            height: 500.0,
+        })
+        .is_err());
+    }
+}

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -22,6 +22,7 @@ mod broker;
 mod channel;
 mod chat_debug;
 mod client_execution;
+mod code_browser;
 #[cfg(test)]
 mod command_parity;
 mod deep_link;
@@ -651,6 +652,7 @@ pub fn run() {
             disconnect_remote_machine,
             put_native_mcp_servers,
             request_user_attention,
+            code_browser::code_browser_command,
             attachments::attach_chat_files,
             attachments::attach_dropped_chat_files,
             image_attachments::publish_chat_image,

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -11,6 +11,7 @@ import {
   Copy,
   FileCode,
   FileDiff,
+  Globe2,
   ListX,
   MessageSquare,
   MoveLeft,
@@ -67,6 +68,8 @@ export function CodeCenterTabs({
   onCloseEditorsToRight,
   onCopyPath,
   onNewTab,
+  onNewBrowser,
+  browserTitles = {},
   region = "primary",
   showMainAgent = true,
   onMoveEditorToOtherGroup,
@@ -88,6 +91,8 @@ export function CodeCenterTabs({
   onCloseEditorsToRight: (index: number) => void;
   onCopyPath: (path: string) => void;
   onNewTab: () => void;
+  onNewBrowser?: () => void;
+  browserTitles?: Readonly<Record<string, string>>;
   region?: CenterTabRegion;
   showMainAgent?: boolean;
   onMoveEditorToOtherGroup?: (index: number) => void;
@@ -178,7 +183,7 @@ export function CodeCenterTabs({
       )}
       {editorTabs.map((panel, index) => {
         const active = !conversationFocused && index === editorActiveIndex;
-        const { name, suffix } = centerTabParts(panel);
+        const { name, suffix } = centerTabParts(panel, browserTitles);
         const label = suffix ? `${name} ${suffix}` : name;
         const path =
           panel.type === "file" || panel.type === "diff"
@@ -231,12 +236,14 @@ export function CodeCenterTabs({
                 >
                   {panel.type === "diff" ? (
                     <FileDiff className="size-3.5 shrink-0" />
+                  ) : panel.type === "browser" ? (
+                    <Globe2 className="size-3.5 shrink-0" />
                   ) : (
                     <FileCode className="size-3.5 shrink-0" />
                   )}
                   <span
                     className="flex min-w-0 items-baseline gap-1"
-                    title={centerTabTitle(panel)}
+                    title={centerTabTitle(panel, browserTitles)}
                   >
                     <span className="max-w-40 truncate">{name}</span>
                     {/* The suffix stays outside the truncating name. */}
@@ -330,6 +337,20 @@ export function CodeCenterTabs({
       >
         <Plus className="size-3.5" />
       </button>
+      {onNewBrowser && (
+        <button
+          type="button"
+          className={cn(
+            "text-muted-foreground hover:bg-muted hover:text-foreground grid size-6 shrink-0 cursor-pointer place-items-center rounded-md",
+            FOCUS_RING_TIGHT,
+            HOVER_TINT,
+          )}
+          aria-label="New browser tab"
+          onClick={onNewBrowser}
+        >
+          <Globe2 className="size-3.5" />
+        </button>
+      )}
       {region === "primary" && onSplitActive && (
         <button
           type="button"
@@ -379,10 +400,13 @@ function TabContextMenuContent({
 }
 
 /** The whole path behind a tab whose label is only the file name. */
-function centerTabTitle(panel: PanelContent): string {
+function centerTabTitle(
+  panel: PanelContent,
+  browserTitles: Readonly<Record<string, string>>,
+): string {
   if (panel.type === "file") return panel.path;
   if (panel.type === "diff" && panel.path) return `${panel.path} (diff)`;
-  const { name, suffix } = centerTabParts(panel);
+  const { name, suffix } = centerTabParts(panel, browserTitles);
   return suffix ? `${name} ${suffix}` : name;
 }
 
@@ -390,7 +414,10 @@ function centerTabTitle(panel: PanelContent): string {
  * A tab's label, split into the part that may truncate and the part that may
  * not.
  */
-function centerTabParts(panel: PanelContent): {
+function centerTabParts(
+  panel: PanelContent,
+  browserTitles: Readonly<Record<string, string>>,
+): {
   name: string;
   suffix: string | null;
 } {
@@ -405,6 +432,12 @@ function centerTabParts(panel: PanelContent): {
       };
     }
     return { name: panel.turnId ? "Turn diff" : "Diff", suffix: null };
+  }
+  if (panel.type === "browser") {
+    return {
+      name: browserTitles[panel.browserId]?.trim() || "Browser",
+      suffix: null,
+    };
   }
   return { name: panel.type, suffix: null };
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -32,6 +32,41 @@ import { resetCodeSessionRegistry } from "./CodeSessionRegistry";
 import { useCodeUiStore } from "./CodeUiStore";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeWorkspacePage } from "./CodeWorkspacePage";
+import {
+  readStoredBrowserSession,
+  seedBrowserSession,
+  writeStoredBrowserSession,
+} from "./browser/browserPersistence";
+
+const browserMocks = vi.hoisted(() => ({
+  close: vi.fn(async () => undefined),
+}));
+
+vi.mock("./browser/browserHost", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./browser/browserHost")>();
+  return { ...actual, closeCodeBrowser: browserMocks.close };
+});
+
+vi.mock("./browser/CodeBrowserTab", () => ({
+  CodeBrowserTab: ({
+    browserId,
+    obscured,
+    onTitleChange,
+  }: {
+    browserId: string;
+    obscured?: boolean;
+    onTitleChange?: (title: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid={`browser-panel-${browserId}`}
+      data-obscured={String(Boolean(obscured))}
+      onClick={() => onTitleChange?.("Tidebreak docs")}
+    >
+      Browser panel
+    </button>
+  ),
+}));
 
 vi.mock("@xterm/xterm", () => ({
   Terminal: class {
@@ -404,6 +439,9 @@ afterEach(() => {
     pendingComposerPrompt: null,
     composerActionScope: null,
   });
+  browserMocks.close.mockClear();
+  window.localStorage.clear();
+  vi.restoreAllMocks();
 });
 
 describe("CodeWorkspacePage", () => {
@@ -937,6 +975,109 @@ describe("CodeWorkspacePage", () => {
       "true",
     );
     expect(screen.getByTestId("file-viewer")).toHaveTextContent("src/lib.rs");
+  });
+
+  it("opens, restores, and retitles a browser as a center editor tab", async () => {
+    const client = makeClient();
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(
+      "browser-1" as `${string}-${string}-${string}-${string}-${string}`,
+    );
+    const user = userEvent.setup();
+    const { router } = await mountWorkspace(client);
+
+    await user.click(await screen.findByRole("button", { name: "New browser tab" }));
+
+    expect(await screen.findByRole("tab", { name: "Browser" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(
+      await screen.findByTestId("browser-panel-browser-1"),
+    ).toBeInTheDocument();
+    expect(readStoredBrowserSession("browser-1")?.workspaceId).toBe("ws-1");
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        tabs: "browser.browser-1",
+      }),
+    );
+
+    await user.click(screen.getByTestId("browser-panel-browser-1"));
+    expect(screen.getByRole("tab", { name: "Tidebreak docs" })).toBeInTheDocument();
+  });
+
+  it("restores a persisted browser title without polling storage", async () => {
+    const client = makeClient();
+    const session = seedBrowserSession({
+      browserId: "browser-restored",
+      workspaceId: "ws-1",
+      initialUrl: "https://docs.tidebreak.dev",
+    });
+    writeStoredBrowserSession({ ...session, title: "Tidebreak handbook" });
+
+    await mountWorkspace(
+      client,
+      "/code/w/ws-1?tabs=browser.browser-restored",
+    );
+
+    expect(
+      await screen.findByRole("tab", { name: "Tidebreak handbook" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("hides the native browser behind dialogs and portaled menus", async () => {
+    const client = makeClient();
+    seedBrowserSession({
+      browserId: "browser-1",
+      workspaceId: "ws-1",
+    });
+    const user = userEvent.setup();
+    await mountWorkspace(client, "/code/w/ws-1?tabs=browser.browser-1");
+
+    const panel = await screen.findByTestId("browser-panel-browser-1");
+    expect(panel).toHaveAttribute("data-obscured", "false");
+
+    await user.click(screen.getByRole("button", { name: "New tab" }));
+    await waitFor(() => expect(panel).toHaveAttribute("data-obscured", "true"));
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(panel).toHaveAttribute("data-obscured", "false"));
+
+    fireEvent.contextMenu(screen.getByRole("tab", { name: "Browser" }));
+    await screen.findByRole("menu");
+    await waitFor(() => expect(panel).toHaveAttribute("data-obscured", "true"));
+  });
+
+  it("closes a native browser only when its editor tab is removed", async () => {
+    const client = makeClient();
+    seedBrowserSession({ browserId: "browser-1", workspaceId: "ws-1" });
+    const user = userEvent.setup();
+    await mountWorkspace(
+      client,
+      "/code/w/ws-1?tabs=browser.browser-1&split=file.README.md",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Move split tabs to main group" }),
+    );
+    expect(browserMocks.close).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Close Browser" }));
+    await waitFor(() =>
+      expect(browserMocks.close).toHaveBeenCalledExactlyOnceWith("browser-1"),
+    );
+  });
+
+  it("closes surviving native browser sessions when the workspace tears down", async () => {
+    const client = makeClient();
+    seedBrowserSession({ browserId: "browser-1", workspaceId: "ws-1" });
+    const mounted = await mountWorkspace(
+      client,
+      "/code/w/ws-1?tabs=browser.browser-1",
+    );
+    await screen.findByTestId("browser-panel-browser-1");
+
+    mounted.unmount();
+
+    expect(browserMocks.close).toHaveBeenCalledExactlyOnceWith("browser-1");
   });
 
   it("moves and drags file tabs into a reloadable split group", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -33,7 +33,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { PanelLayout } from "@/panel/PanelLayout";
-import type { PanelContent } from "@/panel/panelTypes";
+import type { LayoutState, PanelContent } from "@/panel/panelTypes";
 import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
 import { RouteFrame } from "@/RouteFrame";
 import { followScrollBehavior } from "@/ChatScroll";
@@ -48,6 +48,7 @@ import {
 } from "@/ShellShortcuts";
 import { AttentionBadge } from "./AttentionBadge";
 import {
+  codeBrowserIds,
   closeAllEditorTabs,
   closeCodeChromeTab,
   closeEditorTab,
@@ -60,6 +61,7 @@ import {
   mergeEditorSplit,
   moveEditorTab,
   openCodeEditor,
+  removedCodeBrowserIds,
   splitCodeChromeLayout,
   toggleTerminalLayout,
 } from "./codeChrome";
@@ -72,10 +74,19 @@ import {
   SPLIT_EDITOR_PANEL_ID,
 } from "./CodeCenterTabs";
 import { DiffPanel } from "./DiffPanel";
+import { closeCodeBrowser } from "./browser/browserHost";
+import {
+  seedBrowserSession,
+  storedBrowserTitle,
+} from "./browser/browserPersistence";
 
 const FileViewer = lazy(async () => {
   const module = await import("./FileViewer");
   return { default: module.FileViewer };
+});
+const CodeBrowserTab = lazy(async () => {
+  const module = await import("./browser/CodeBrowserTab");
+  return { default: module.CodeBrowserTab };
 });
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { CodeInspector, type InspectorTab } from "./CodeInspector";
@@ -137,7 +148,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const { run, dialogs } = useWorkspaceCardCommands();
   const layout = useLayoutState();
   const { setLayout } = usePanelNav();
+  const layoutRef = useRef(layout);
+  const previousLayoutRef = useRef(layout);
+  const closedBrowserIdsRef = useRef(new Set<string>());
+  const workspaceBrowserIdsRef = useRef(new Set<string>());
   const chrome = splitCodeChromeLayout(layout);
+  const workspaceOverlayOpen = useWorkspaceOverlayOpen();
   const reviewSidebarOpen = useCodeUiStore((state) => state.reviewSidebarOpen);
   const toggleReviewSidebar = useCodeUiStore(
     (state) => state.toggleReviewSidebar,
@@ -173,6 +189,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     line: number;
     revision: number;
   } | null>(null);
+  const [browserTitles, setBrowserTitles] = useState<Record<string, string>>(
+    () => storedBrowserTitles(layout),
+  );
   const digest = useCodeUpdatesStore((state) => state.byWorkspace[workspaceId]);
   const setViewedWorkspace = useCodeUpdatesStore(
     (state) => state.setViewedWorkspace,
@@ -187,6 +206,46 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const rememberedSession = useCodeCatalogStore(
     (state) => state.sessionsByWorkspace[workspaceId] ?? null,
   );
+
+  layoutRef.current = layout;
+
+  const closeBrowserPanels = useCallback((browserIds: readonly string[]) => {
+    for (const browserId of browserIds) {
+      if (closedBrowserIdsRef.current.has(browserId)) continue;
+      closedBrowserIdsRef.current.add(browserId);
+      void closeCodeBrowser(browserId);
+    }
+  }, []);
+
+  function setWorkspaceLayout(next: LayoutState) {
+    setLayout(next);
+  }
+
+  useEffect(() => {
+    const ids = codeBrowserIds(layout);
+    for (const browserId of ids) {
+      closedBrowserIdsRef.current.delete(browserId);
+      workspaceBrowserIdsRef.current.add(browserId);
+    }
+    closeBrowserPanels(removedCodeBrowserIds(previousLayoutRef.current, layout));
+    previousLayoutRef.current = layout;
+    setBrowserTitles((current) => {
+      let changed = false;
+      const next: Record<string, string> = {};
+      for (const browserId of ids) {
+        const title = current[browserId] ?? storedBrowserTitle(browserId);
+        next[browserId] = title;
+        if (current[browserId] !== title) changed = true;
+      }
+      if (Object.keys(current).length !== ids.length) changed = true;
+      return changed ? next : current;
+    });
+  }, [closeBrowserPanels, layout]);
+
+  useEffect(() => {
+    workspaceBrowserIdsRef.current = new Set(codeBrowserIds(layoutRef.current));
+    return () => closeBrowserPanels([...workspaceBrowserIdsRef.current]);
+  }, [closeBrowserPanels, workspaceId]);
 
   useEffect(() => {
     setViewedWorkspace(workspaceId);
@@ -295,7 +354,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     : [];
 
   function openTurnDiff(turnId: string) {
-    setLayout(openCodeEditor(layout, { type: "diff", turnId }));
+    setWorkspaceLayout(openCodeEditor(layout, { type: "diff", turnId }));
   }
 
   function openFile(
@@ -312,11 +371,29 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             revision: (current?.revision ?? 0) + 1,
           },
     );
-    setLayout(openCodeEditor(layout, { type: "file", path }, preferredRegion));
+    setWorkspaceLayout(
+      openCodeEditor(layout, { type: "file", path }, preferredRegion),
+    );
   }
 
   function openFileDiff(path: string) {
-    setLayout(openCodeEditor(layout, { type: "diff", path }));
+    setWorkspaceLayout(openCodeEditor(layout, { type: "diff", path }));
+  }
+
+  function openBrowser(url?: string, preferredRegion?: CodeEditorRegion) {
+    const browserId = crypto.randomUUID();
+    const browser = seedBrowserSession({
+      browserId,
+      workspaceId,
+      initialUrl: url,
+    });
+    setBrowserTitles((current) => ({
+      ...current,
+      [browserId]: browser.title || "Browser",
+    }));
+    setWorkspaceLayout(
+      openCodeEditor(layout, { type: "browser", browserId }, preferredRegion),
+    );
   }
 
   function requestNewTab(region: CodeEditorRegion) {
@@ -340,8 +417,13 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
 
   function dropDraggedEditor(region: CodeEditorRegion) {
     if (!draggedEditor || draggedEditor.region === region) return;
-    setLayout(
-      moveEditorTab(layout, draggedEditor.region, draggedEditor.index, region),
+    setWorkspaceLayout(
+      moveEditorTab(
+        layout,
+        draggedEditor.region,
+        draggedEditor.index,
+        region,
+      ),
     );
     setDraggedEditor(null);
   }
@@ -398,6 +480,21 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             contentRevision={contentRevision}
             onOpenFile={(path) => openFile(path, undefined, region)}
           />
+        ) : panel.type === "browser" ? (
+          <Suspense fallback={<Skeleton className="h-full w-full" />}>
+            <CodeBrowserTab
+              workspaceId={workspaceId}
+              browserId={panel.browserId}
+              obscured={workspaceOverlayOpen}
+              onTitleChange={(title) =>
+                setBrowserTitles((current) =>
+                  current[panel.browserId] === title
+                    ? current
+                    : { ...current, [panel.browserId]: title },
+                )
+              }
+            />
+          </Suspense>
         ) : null}
       </div>
     );
@@ -417,32 +514,34 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     >
       <CodeCenterTabs
         editorTabs={editorTabs}
+        browserTitles={browserTitles}
         editorActiveIndex={chrome.editors.activeIndex}
         conversationFocused={showingChat}
-        onSelectChat={() => setLayout(focusConversation(layout))}
+        onSelectChat={() => setWorkspaceLayout(focusConversation(layout))}
         onSelectEditor={(index) =>
-          setLayout(focusEditorTab(layout, index, "primary"))
+          setWorkspaceLayout(focusEditorTab(layout, index, "primary"))
         }
         onCloseEditor={(index) =>
-          setLayout(closeEditorTab(layout, index, "primary"))
+          setWorkspaceLayout(closeEditorTab(layout, index, "primary"))
         }
         onCloseAllEditors={() =>
-          setLayout(closeAllEditorTabs(layout, "primary"))
+          setWorkspaceLayout(closeAllEditorTabs(layout, "primary"))
         }
-        onCloseEveryEditor={() => setLayout(closeAllEditorTabs(layout))}
+        onCloseEveryEditor={() => setWorkspaceLayout(closeAllEditorTabs(layout))}
         onCloseOtherEditors={(index) =>
-          setLayout(closeOtherEditorTabs(layout, index, "primary"))
+          setWorkspaceLayout(closeOtherEditorTabs(layout, index, "primary"))
         }
         onCloseEditorsToRight={(index) =>
-          setLayout(closeEditorTabsToRight(layout, index, "primary"))
+          setWorkspaceLayout(closeEditorTabsToRight(layout, index, "primary"))
         }
         onCopyPath={copyEditorPath}
         onNewTab={() => requestNewTab("primary")}
+        onNewBrowser={() => openBrowser(undefined, "primary")}
         onMoveEditorToOtherGroup={(index) =>
-          setLayout(moveEditorTab(layout, "primary", index, "secondary"))
+          setWorkspaceLayout(moveEditorTab(layout, "primary", index, "secondary"))
         }
         onSplitActive={() =>
-          setLayout(
+          setWorkspaceLayout(
             moveEditorTab(
               layout,
               "primary",
@@ -465,8 +564,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         <PanelLayout
           layout={chrome.panels}
           framed={false}
-          onFocusTab={(index) => setLayout(focusCodeChromeTab(layout, index))}
-          onCloseTab={(index) => setLayout(closeCodeChromeTab(layout, index))}
+          onFocusTab={(index) => setWorkspaceLayout(focusCodeChromeTab(layout, index))}
+          onCloseTab={(index) => setWorkspaceLayout(closeCodeChromeTab(layout, index))}
           renderChat={(visible) => (
             // The panel slot is a plain block. `.chat-pane` claims that height
             // so `.message-view` can grow and the composer stays at the bottom,
@@ -539,30 +638,32 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         region="secondary"
         showMainAgent={false}
         editorTabs={splitEditorTabs}
+        browserTitles={browserTitles}
         editorActiveIndex={chrome.splitEditors.activeIndex}
         conversationFocused={false}
         onSelectChat={() => undefined}
         onSelectEditor={(index) =>
-          setLayout(focusEditorTab(layout, index, "secondary"))
+          setWorkspaceLayout(focusEditorTab(layout, index, "secondary"))
         }
         onCloseEditor={(index) =>
-          setLayout(closeEditorTab(layout, index, "secondary"))
+          setWorkspaceLayout(closeEditorTab(layout, index, "secondary"))
         }
         onCloseAllEditors={() =>
-          setLayout(closeAllEditorTabs(layout, "secondary"))
+          setWorkspaceLayout(closeAllEditorTabs(layout, "secondary"))
         }
         onCloseOtherEditors={(index) =>
-          setLayout(closeOtherEditorTabs(layout, index, "secondary"))
+          setWorkspaceLayout(closeOtherEditorTabs(layout, index, "secondary"))
         }
         onCloseEditorsToRight={(index) =>
-          setLayout(closeEditorTabsToRight(layout, index, "secondary"))
+          setWorkspaceLayout(closeEditorTabsToRight(layout, index, "secondary"))
         }
         onCopyPath={copyEditorPath}
         onNewTab={() => requestNewTab("secondary")}
+        onNewBrowser={() => openBrowser(undefined, "secondary")}
         onMoveEditorToOtherGroup={(index) =>
-          setLayout(moveEditorTab(layout, "secondary", index, "primary"))
+          setWorkspaceLayout(moveEditorTab(layout, "secondary", index, "primary"))
         }
-        onCloseGroup={() => setLayout(mergeEditorSplit(layout))}
+        onCloseGroup={() => setWorkspaceLayout(mergeEditorSplit(layout))}
         onDragEditorStart={(index) =>
           setDraggedEditor({ region: "secondary", index })
         }
@@ -614,7 +715,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           client={client}
           workspaceId={workspaceId}
           shortcutHint={shortcutHints.terminal}
-          onClose={() => setLayout(toggleTerminalLayout(layout))}
+          onClose={() => setWorkspaceLayout(toggleTerminalLayout(layout))}
         />
       )}
     </div>
@@ -697,7 +798,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
               size="icon-xs"
               aria-pressed={chrome.terminal !== null}
               aria-label="Terminal"
-              onClick={() => setLayout(toggleTerminalLayout(layout))}
+              onClick={() => setWorkspaceLayout(toggleTerminalLayout(layout))}
             >
               <SquareTerminal />
             </Button>
@@ -798,6 +899,56 @@ function useCodeShortcutHints(): { terminal: string; review: string } {
       review: shortcutHint("toggle-code-review", command),
     };
   }, []);
+}
+
+function storedBrowserTitles(layout: LayoutState): Record<string, string> {
+  return Object.fromEntries(
+    codeBrowserIds(layout).map((browserId) => [
+      browserId,
+      storedBrowserTitle(browserId),
+    ]),
+  );
+}
+
+/** Native child webviews must yield whenever a portaled app surface overlaps them. */
+function useWorkspaceOverlayOpen(): boolean {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const selector = [
+      '[role="dialog"][data-state="open"]',
+      '[role="alertdialog"][data-state="open"]',
+      '[role="menu"][data-state="open"]',
+      '[role="listbox"][data-state="open"]',
+    ].join(",");
+    let frame: number | null = null;
+    const update = () => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        setOpen(document.querySelector(selector) !== null);
+      });
+    };
+    const stateObserver = new MutationObserver(update);
+    stateObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["data-state", "role"],
+      subtree: true,
+    });
+    // Radix portals are direct body children. Keep transcript and editor DOM
+    // churn out of this observer so streaming content does not trigger global
+    // overlay queries.
+    const portalObserver = new MutationObserver(update);
+    portalObserver.observe(document.body, { childList: true });
+    update();
+    return () => {
+      stateObserver.disconnect();
+      portalObserver.disconnect();
+      if (frame !== null) window.cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  return open;
 }
 
 function shortcutHint(id: ShellShortcutAction, command: boolean): string {

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -1,0 +1,319 @@
+import { useEffect, useId, useRef, type FormEvent } from "react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  ExternalLink,
+  History,
+  Laptop,
+  LoaderCircle,
+  LockKeyhole,
+  RefreshCw,
+  Search,
+  ShieldAlert,
+  X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { FOCUS_RING_TIGHT, HOVER_TINT } from "../interactive";
+import {
+  browserSecurity,
+  MAX_BROWSER_URL_CHARS,
+} from "./browserNavigation";
+import type { BrowserSession } from "./browserSession";
+
+export function BrowserToolbar({
+  session,
+  address,
+  addressError,
+  canGoBack,
+  canGoForward,
+  onAddressChange,
+  onNavigate,
+  onBack,
+  onForward,
+  onReload,
+  onStop,
+  onSelectHistory,
+  onOpenExternal,
+  onOverlayOpenChange,
+}: {
+  session: BrowserSession;
+  address: string;
+  addressError: string | null;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  onAddressChange: (value: string) => void;
+  onNavigate: () => void;
+  onBack: () => void;
+  onForward: () => void;
+  onReload: () => void;
+  onStop: () => void;
+  onSelectHistory: (index: number) => void;
+  onOpenExternal: () => void;
+  onOverlayOpenChange: (open: boolean) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const addressErrorId = useId();
+  const securityId = useId();
+  const security = session.url ? browserSecurity(session.url) : null;
+
+  useEffect(() => {
+    if (!session.url) inputRef.current?.focus();
+  }, [session.url]);
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    onNavigate();
+  }
+
+  return (
+    <div className="shrink-0 border-b bg-background px-2 py-1.5">
+      <div className="flex min-w-0 items-center gap-1">
+        <WithTooltip label="Back">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            disabled={!canGoBack}
+            onClick={onBack}
+          >
+            <ArrowLeft />
+            <span className="sr-only">Back</span>
+          </Button>
+        </WithTooltip>
+        <WithTooltip label="Forward">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            disabled={!canGoForward}
+            onClick={onForward}
+          >
+            <ArrowRight />
+            <span className="sr-only">Forward</span>
+          </Button>
+        </WithTooltip>
+        <WithTooltip label={session.loadState === "loading" ? "Stop" : "Reload"}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            disabled={!session.url}
+            onClick={session.loadState === "loading" ? onStop : onReload}
+          >
+            {session.loadState === "loading" ? (
+              <X />
+            ) : (
+              <RefreshCw />
+            )}
+            <span className="sr-only">
+              {session.loadState === "loading" ? "Stop" : "Reload"}
+            </span>
+          </Button>
+        </WithTooltip>
+
+        <form className="min-w-0 flex-1" onSubmit={submit}>
+          <label
+            className={cn(
+              "flex h-control-sm min-w-0 items-center gap-2 rounded-md border bg-muted/35 px-2 text-xs",
+              "focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/25",
+              addressError && "border-critical/50 ring-2 ring-critical/10",
+            )}
+          >
+            <SecurityIcon id={securityId} security={security?.kind} />
+            <input
+              ref={inputRef}
+              value={address}
+              type="text"
+              inputMode="url"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              maxLength={MAX_BROWSER_URL_CHARS}
+              placeholder="Address or search"
+              aria-label="Address or search"
+              aria-invalid={Boolean(addressError)}
+              aria-describedby={[
+                security ? securityId : null,
+                addressError ? addressErrorId : null,
+              ]
+                .filter(Boolean)
+                .join(" ") || undefined}
+              className="min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
+              onChange={(event) => onAddressChange(event.target.value)}
+              onFocus={(event) => event.currentTarget.select()}
+            />
+            {session.loadState === "loading" ? (
+              <LoaderCircle className="size-3.5 shrink-0 motion-safe:animate-spin text-muted-foreground" />
+            ) : (
+              <Search className="size-3.5 shrink-0 text-muted-foreground" />
+            )}
+          </label>
+        </form>
+
+        <DropdownMenu onOpenChange={onOverlayOpenChange}>
+          <WithTooltip label="History">
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                disabled={session.history.length === 0}
+              >
+                <History />
+                <span className="sr-only">History</span>
+              </Button>
+            </DropdownMenuTrigger>
+          </WithTooltip>
+          <DropdownMenuContent
+            align="end"
+            className="max-h-[min(24rem,var(--radix-dropdown-menu-content-available-height))] w-80 overflow-y-auto"
+          >
+            {[...session.history].reverse().map((entry, reverseIndex) => {
+              const index = session.history.length - reverseIndex - 1;
+              const current = index === session.historyIndex;
+              return (
+                <DropdownMenuItem
+                  key={`${entry.url}-${index}`}
+                  className="items-start gap-2"
+                  aria-current={current ? "page" : undefined}
+                  onSelect={() => onSelectHistory(index)}
+                >
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "mt-2 size-1.5 shrink-0 rounded-full",
+                      current ? "bg-primary" : "bg-transparent",
+                    )}
+                  />
+                  <span className="min-w-0">
+                    <span className="block truncate text-xs font-medium">
+                      {entry.title || entry.url}
+                    </span>
+                    {entry.title && (
+                      <span className="block truncate text-[11px] text-muted-foreground">
+                        {entry.url}
+                      </span>
+                    )}
+                  </span>
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <WithTooltip label="Open externally">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            disabled={!session.url}
+            onClick={onOpenExternal}
+          >
+            <ExternalLink />
+            <span className="sr-only">Open externally</span>
+          </Button>
+        </WithTooltip>
+      </div>
+      {addressError && (
+        <div className="px-1 pt-1">
+          <p
+            id={addressErrorId}
+            role="alert"
+            className="truncate text-[11px] text-critical"
+          >
+            {addressError}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SecurityIcon({
+  id,
+  security,
+}: {
+  id: string;
+  security: "secure" | "local" | "insecure" | undefined;
+}) {
+  const className = "size-3.5 shrink-0";
+  if (security === "secure") {
+    return (
+      <>
+        <LockKeyhole className={cn(className, "text-success")} />
+        <span id={id} className="sr-only">Secure</span>
+      </>
+    );
+  }
+  if (security === "local") {
+    return (
+      <>
+        <Laptop className={cn(className, "text-info")} />
+        <span id={id} className="sr-only">Local</span>
+      </>
+    );
+  }
+  if (security === "insecure") {
+    return (
+      <>
+        <ShieldAlert className={cn(className, "text-warning")} />
+        <span id={id} className="sr-only">Not secure</span>
+      </>
+    );
+  }
+  return <Search className={cn(className, "text-muted-foreground")} />;
+}
+
+export function BrowserNoticeRow({
+  message,
+  actionLabel,
+  onAction,
+  onDismiss,
+}: {
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="flex min-h-8 shrink-0 items-center gap-2 border-b bg-warning-background px-3 py-1 text-xs text-warning-foreground">
+      <AlertTriangle className="size-3.5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">{message}</span>
+      {actionLabel && onAction && (
+        <button
+          type="button"
+          className={cn(
+            "shrink-0 rounded px-1.5 py-0.5 font-medium underline underline-offset-2",
+            FOCUS_RING_TIGHT,
+            HOVER_TINT,
+          )}
+          onClick={onAction}
+        >
+          {actionLabel}
+        </button>
+      )}
+      <button
+        type="button"
+        className={cn(
+          "grid size-5 shrink-0 place-items-center rounded",
+          FOCUS_RING_TIGHT,
+          HOVER_TINT,
+        )}
+        onClick={onDismiss}
+      >
+        <X className="size-3" />
+        <span className="sr-only">Dismiss</span>
+      </button>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -1,0 +1,480 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  BrowserHostAction,
+  BrowserHostEvent,
+  BrowserHostSnapshot,
+  CodeBrowserHost,
+} from "./browserHost";
+import { writeStoredBrowserSession } from "./browserPersistence";
+import {
+  beginBrowserNavigation,
+  createBrowserSession,
+} from "./browserSession";
+import { CodeBrowserTab } from "./CodeBrowserTab";
+
+type CommandCall = { sessionId: string; action: BrowserHostAction };
+
+function browserHost(options?: {
+  createGate?: Promise<void>;
+  createError?: string;
+  existing?: boolean;
+}): {
+  host: CodeBrowserHost;
+  calls: CommandCall[];
+  emit: (event: BrowserHostEvent) => void;
+  openExternal: ReturnType<typeof vi.fn>;
+} {
+  const calls: CommandCall[] = [];
+  let handler: ((event: BrowserHostEvent) => void) | null = null;
+  const openExternal = vi.fn().mockResolvedValue(undefined);
+  const host: CodeBrowserHost = {
+    available: () => true,
+    subscribe: vi.fn(async (next) => {
+      handler = next;
+      return () => {
+        handler = null;
+      };
+    }),
+    command: vi.fn(async (sessionId, action) => {
+      calls.push({ sessionId, action });
+      if (action.type === "snapshot") {
+        return options?.existing
+          ? { exists: true, url: "https://example.com/restored" }
+          : { exists: false };
+      }
+      if (action.type === "create" && options?.createError) {
+        throw new Error(options.createError);
+      }
+      if (action.type === "create" && options?.createGate) {
+        await options.createGate;
+      }
+      return {
+        exists: true,
+        url: "url" in action ? action.url : undefined,
+      } satisfies BrowserHostSnapshot;
+    }),
+    openExternal,
+  };
+  return {
+    host,
+    calls,
+    emit: (event) => handler?.(event),
+    openExternal,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+    x: 120,
+    y: 180,
+    width: 840,
+    height: 560,
+    top: 180,
+    right: 960,
+    bottom: 740,
+    left: 120,
+    toJSON: () => ({}),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("CodeBrowserTab", () => {
+  it("creates a native surface, follows navigation, and exposes browser controls", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="http://localhost:3000"
+        host={runtime.host}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+    expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
+
+    runtime.emit({
+      sessionId: "browser-1",
+      type: "navigation_finished",
+      url: "http://localhost:3000/dashboard",
+    });
+    runtime.emit({
+      sessionId: "browser-1",
+      type: "title_changed",
+      title: "Local dashboard",
+    });
+
+    expect(await screen.findByLabelText("Browser: Local dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reload" })).toBeEnabled();
+
+    const input = screen.getByRole("textbox", { name: "Address or search" });
+    expect(input).toHaveAccessibleDescription("Local");
+    await userEvent.click(input);
+    await userEvent.clear(input);
+    await userEvent.type(input, "docs.rs/tauri{enter}");
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-1",
+        action: { type: "navigate", url: "https://docs.rs/tauri" },
+      }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Open externally" }));
+    expect(runtime.openExternal).toHaveBeenCalledWith("https://docs.rs/tauri");
+
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-1",
+        action: { type: "back" },
+      }),
+    );
+  });
+
+  it("keeps invalid input in the omnibox and reports the precise error", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        host={runtime.host}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Address or search" });
+    await userEvent.type(input, "file:///tmp/secret{enter}");
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Only HTTP and HTTPS addresses can open here",
+    );
+    expect(input).toHaveValue("file:///tmp/secret");
+    expect(runtime.calls.some(({ action }) => action.type === "navigate")).toBe(false);
+  });
+
+  it("hides the native surface for app overlays and restores it afterwards", async () => {
+    const runtime = browserHost();
+    const view = render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    view.rerender(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+        obscured
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-1",
+        action: { type: "set_visible", visible: false },
+      }),
+    );
+
+    view.rerender(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-1",
+        action: { type: "set_visible", visible: true },
+      }),
+    );
+  });
+
+  it("hides a native view that finishes creating after its tab unmounts", async () => {
+    let releaseCreate: (() => void) | undefined;
+    const createGate = new Promise<void>((resolve) => {
+      releaseCreate = resolve;
+    });
+    const runtime = browserHost({ createGate });
+    const view = render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    view.unmount();
+    releaseCreate?.();
+
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-1",
+        action: { type: "set_visible", visible: false },
+      }),
+    );
+  });
+
+  it("replaces the native session when the same panel slot selects another browser tab", async () => {
+    const runtime = browserHost();
+    const view = render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/one"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-1",
+        action: expect.objectContaining({
+          type: "create",
+          url: "https://example.com/one",
+        }),
+      }),
+    );
+
+    view.rerender(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-2"
+        initialUrl="https://example.com/two"
+        host={runtime.host}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-2",
+        action: expect.objectContaining({
+          type: "create",
+          url: "https://example.com/two",
+        }),
+      }),
+    );
+    expect(screen.getByRole("textbox", { name: "Address or search" })).toHaveValue(
+      "example.com/two",
+    );
+  });
+
+  it("uses persisted history after recreating a missing native webview", async () => {
+    const runtime = browserHost();
+    const first = createBrowserSession({
+      id: "browser-1",
+      workspaceId: "workspace-1",
+      initialUrl: "https://example.com/one",
+    });
+    writeStoredBrowserSession(
+      beginBrowserNavigation(first, "https://example.com/two"),
+    );
+
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-1",
+        action: expect.objectContaining({
+          type: "create",
+          url: "https://example.com/two",
+        }),
+      }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-1",
+        action: { type: "navigate", url: "https://example.com/one" },
+      }),
+    );
+    expect(runtime.calls).not.toContainEqual({
+      sessionId: "browser-1",
+      action: { type: "back" },
+    });
+  });
+
+  it("ignores a late title event from the page navigated away from", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/one"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    runtime.emit({
+      sessionId: "browser-1",
+      type: "navigation_finished",
+      url: "https://example.com/two",
+    });
+    runtime.emit({
+      sessionId: "browser-1",
+      type: "title_changed",
+      url: "https://example.com/one",
+      title: "Old page",
+    });
+    expect(screen.queryByLabelText("Browser: Old page")).toBeNull();
+
+    runtime.emit({
+      sessionId: "browser-1",
+      type: "title_changed",
+      url: "https://example.com/two",
+      title: "Current page",
+    });
+    expect(
+      await screen.findByLabelText("Browser: Current page"),
+    ).toBeInTheDocument();
+  });
+
+  it("turns popup requests into a controlled notice instead of opening a window", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    runtime.emit({
+      sessionId: "browser-1",
+      type: "popup_blocked",
+      url: "https://example.com/sign-in",
+    });
+    expect(await screen.findByText("This page tried to open a new window")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Open here" }));
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        sessionId: "browser-1",
+        action: { type: "navigate", url: "https://example.com/sign-in" },
+      }),
+    );
+  });
+
+  it("routes blocked downloads externally and offers no retry for unsafe navigation", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    runtime.emit({
+      sessionId: "browser-1",
+      type: "download_blocked",
+      url: "https://example.com/archive.zip",
+    });
+    const downloadNotice = await screen.findByText(
+      "Downloads are not available in the in-app browser yet",
+    );
+    await userEvent.click(
+      within(downloadNotice.parentElement!).getByRole("button", {
+        name: "Open externally",
+      }),
+    );
+    expect(runtime.openExternal).toHaveBeenCalledWith(
+      "https://example.com/archive.zip",
+    );
+
+    runtime.emit({
+      sessionId: "browser-1",
+      type: "navigation_blocked",
+      url: "file:///tmp/secret",
+    });
+    expect(
+      await screen.findByText("This address cannot open in the in-app browser"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open here" })).toBeNull();
+  });
+
+  it("renders a retryable failure without losing the requested address", async () => {
+    const runtime = browserHost({ createError: "native view failed" });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/docs"
+        host={runtime.host}
+      />,
+    );
+
+    expect(await screen.findByText("Could not open this page")).toBeInTheDocument();
+    expect(screen.getByText("native view failed")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Address or search" })).toHaveValue(
+      "example.com/docs",
+    );
+    expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
+  });
+
+  it("does not create an iframe fallback outside the native desktop", async () => {
+    const runtime = browserHost();
+    runtime.host.available = () => false;
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    expect(document.querySelector("iframe")).toBeNull();
+    expect(
+      await screen.findByText(
+        "The in-app browser is available in the Tidebreak desktop app",
+      ),
+    ).toBeInTheDocument();
+    fireEvent.submit(screen.getByRole("textbox", { name: "Address or search" }).closest("form")!);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -1,0 +1,611 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { ExternalLink, Globe2, RefreshCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { friendlyErrorMessage } from "@/lib/utils";
+import { BrowserNoticeRow, BrowserToolbar } from "./BrowserToolbar";
+import {
+  type BrowserBounds,
+  type BrowserHostEvent,
+  type CodeBrowserHost,
+  nativeCodeBrowserHost,
+} from "./browserHost";
+import {
+  browserDisplayAddress,
+  browserTarget,
+  validateBrowserUrl,
+} from "./browserNavigation";
+import {
+  readStoredBrowserSession,
+  restoreOrCreateBrowserSession,
+  writeStoredBrowserSession,
+} from "./browserPersistence";
+import {
+  beginBrowserNavigation,
+  canBrowserGoBack,
+  canBrowserGoForward,
+  failBrowserSession,
+  finishBrowserNavigation,
+  moveBrowserHistory,
+  observeBrowserNavigation,
+  setBrowserNotice,
+  setBrowserTitle,
+  type BrowserSession,
+} from "./browserSession";
+
+const SLOW_LOAD_MS = 15_000;
+const PERSIST_DELAY_MS = 150;
+
+export type CodeBrowserTabProps = {
+  workspaceId: string;
+  browserId: string;
+  initialUrl?: string;
+  /** Hide the native view while app-owned DOM overlays cover the editor. */
+  obscured?: boolean;
+  host?: CodeBrowserHost;
+  onTitleChange?: (title: string) => void;
+};
+
+export function CodeBrowserTab(props: CodeBrowserTabProps) {
+  return (
+    <CodeBrowserTabSession
+      key={`${props.workspaceId}:${props.browserId}`}
+      {...props}
+    />
+  );
+}
+
+function CodeBrowserTabSession({
+  workspaceId,
+  browserId,
+  initialUrl,
+  obscured = false,
+  host = nativeCodeBrowserHost,
+  onTitleChange,
+}: CodeBrowserTabProps) {
+  const [session, setSession] = useState(() =>
+    restoreOrCreateBrowserSession({ browserId, workspaceId, initialUrl }),
+  );
+  const [address, setAddress] = useState(session.address);
+  const [addressError, setAddressError] = useState<string | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [slow, setSlow] = useState(false);
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const mountedRef = useRef(true);
+  const nativeReady = useRef(false);
+  const nativeHistoryAvailable = useRef(false);
+  const lastNativeBounds = useRef<BrowserBounds | null>(null);
+  const persistTimer = useRef<number | null>(null);
+  const sessionRef = useRef(session);
+  const visible = !obscured && !historyOpen && session.loadState !== "failed";
+  const visibleRef = useRef(visible);
+
+  sessionRef.current = session;
+  visibleRef.current = visible;
+
+  const updateSession = useCallback(
+    (update: (current: BrowserSession) => BrowserSession) => {
+      setSession((current) => {
+        const next = update(current);
+        sessionRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const settleCreatedNativeView = useCallback(async () => {
+    nativeReady.current = true;
+    await host.command(browserId, {
+      type: "set_visible",
+      visible: mountedRef.current && visibleRef.current,
+    });
+    const bounds = readBrowserBounds(surfaceRef.current);
+    if (bounds && !sameBrowserBounds(lastNativeBounds.current, bounds)) {
+      lastNativeBounds.current = bounds;
+      await host.command(browserId, { type: "set_bounds", bounds });
+    }
+  }, [browserId, host]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    onTitleChange?.(session.title);
+  }, [onTitleChange, session.title]);
+
+  useEffect(() => {
+    if (persistTimer.current !== null) {
+      window.clearTimeout(persistTimer.current);
+    }
+    persistTimer.current = window.setTimeout(() => {
+      persistTimer.current = null;
+      writeStoredBrowserSession(sessionRef.current);
+    }, PERSIST_DELAY_MS);
+    return () => {
+      if (persistTimer.current !== null) {
+        window.clearTimeout(persistTimer.current);
+        persistTimer.current = null;
+      }
+    };
+  }, [session]);
+
+  useEffect(
+    () => () => {
+      // An explicit tab close removes storage before or after this component's
+      // cleanup depending on React's unmount order. Do not resurrect a session
+      // the workspace owner has already closed.
+      if (readStoredBrowserSession(browserId)) {
+        writeStoredBrowserSession(sessionRef.current);
+      }
+    },
+    [browserId],
+  );
+
+  useEffect(() => {
+    if (session.loadState !== "loading") {
+      setSlow(false);
+      return;
+    }
+    const timer = window.setTimeout(() => setSlow(true), SLOW_LOAD_MS);
+    return () => window.clearTimeout(timer);
+  }, [session.loadState, session.url]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unsubscribe: (() => void) | undefined;
+
+    async function boot() {
+      const current = sessionRef.current;
+      if (!host.available()) {
+        if (current.url) {
+          updateSession((value) =>
+            failBrowserSession(
+              value,
+              "The in-app browser is available in the Tidebreak desktop app",
+            ),
+          );
+        }
+        return;
+      }
+      try {
+        const stop = await host.subscribe((event) => {
+          if (!cancelled && event.sessionId === browserId) {
+            handleHostEvent(event);
+          }
+        });
+        if (cancelled) {
+          stop();
+          return;
+        }
+        unsubscribe = stop;
+      } catch (error) {
+        if (!cancelled) {
+          updateSession((value) =>
+            failBrowserSession(
+              value,
+              friendlyErrorMessage(error, "Could not connect to the in-app browser"),
+            ),
+          );
+        }
+        return;
+      }
+
+      if (!current.url) return;
+      const bounds = readBrowserBounds(surfaceRef.current);
+      if (!bounds) return;
+
+      try {
+        const snapshot = await host.command(browserId, { type: "snapshot" });
+        if (cancelled) return;
+        if (snapshot.exists) {
+          nativeReady.current = true;
+          nativeHistoryAvailable.current = true;
+          if (snapshot.url) {
+            updateSession((value) =>
+              finishBrowserNavigation(value, snapshot.url!),
+            );
+            setAddress(browserDisplayAddress(snapshot.url));
+          }
+          await host.command(browserId, { type: "set_bounds", bounds });
+          lastNativeBounds.current = bounds;
+          await host.command(browserId, {
+            type: "set_visible",
+            visible: visibleRef.current,
+          });
+        } else {
+          await host.command(browserId, {
+            type: "create",
+            url: current.url,
+            bounds,
+            visible: visibleRef.current,
+          });
+          lastNativeBounds.current = bounds;
+          await settleCreatedNativeView();
+          nativeHistoryAvailable.current = current.history.length <= 1;
+        }
+      } catch (error) {
+        if (!cancelled) {
+          updateSession((value) =>
+            failBrowserSession(
+              value,
+              friendlyErrorMessage(error, "Could not open the in-app browser"),
+            ),
+          );
+        }
+      }
+    }
+
+    function handleHostEvent(event: BrowserHostEvent) {
+      if (event.type === "navigation_started" && event.url) {
+        updateSession((current) =>
+          observeBrowserNavigation(current, event.url!, "loading"),
+        );
+        setAddress(browserDisplayAddress(event.url));
+        setAddressError(null);
+      } else if (event.type === "navigation_finished" && event.url) {
+        updateSession((current) =>
+          finishBrowserNavigation(current, event.url!),
+        );
+        setAddress(browserDisplayAddress(event.url));
+      } else if (event.type === "title_changed" && event.title) {
+        updateSession((current) =>
+          event.url && event.url !== current.url
+            ? current
+            : setBrowserTitle(current, event.title!),
+        );
+      } else if (event.type === "popup_blocked") {
+        updateSession((current) =>
+          setBrowserNotice(current, {
+            kind: "popup",
+            url: event.url,
+            message: "This page tried to open a new window",
+          }),
+        );
+      } else if (event.type === "download_blocked") {
+        updateSession((current) =>
+          setBrowserNotice(current, {
+            kind: "download",
+            url: event.url,
+            message: "Downloads are not available in the in-app browser yet",
+          }),
+        );
+      } else if (event.type === "navigation_blocked") {
+        updateSession((current) =>
+          setBrowserNotice(current, {
+            kind: "blocked",
+            url: event.url,
+            message: event.message || "This address cannot open in the in-app browser",
+          }),
+        );
+      }
+    }
+
+    void boot();
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+      if (nativeReady.current && host.available()) {
+        void host
+          .command(browserId, { type: "set_visible", visible: false })
+          .catch(() => undefined);
+      }
+    };
+  }, [browserId, host, settleCreatedNativeView, updateSession]);
+
+  useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface || !host.available()) return;
+    let frame: number | null = null;
+
+    const sync = () => {
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        const bounds = readBrowserBounds(surface);
+        if (
+          !bounds ||
+          !nativeReady.current ||
+          sameBrowserBounds(lastNativeBounds.current, bounds)
+        ) {
+          return;
+        }
+        lastNativeBounds.current = bounds;
+        void host
+          .command(browserId, { type: "set_bounds", bounds })
+          .catch(() => {
+            if (sameBrowserBounds(lastNativeBounds.current, bounds)) {
+              lastNativeBounds.current = null;
+            }
+          });
+      });
+    };
+
+    const observer = new ResizeObserver(sync);
+    observer.observe(surface);
+    window.addEventListener("resize", sync);
+    sync();
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", sync);
+      if (frame !== null) window.cancelAnimationFrame(frame);
+    };
+  }, [browserId, host]);
+
+  useEffect(() => {
+    if (!nativeReady.current || !host.available()) return;
+    void host
+      .command(browserId, { type: "set_visible", visible })
+      .catch(() => undefined);
+  }, [browserId, host, visible]);
+
+  async function navigate(input = address) {
+    const target = browserTarget(input);
+    if (!target.ok) {
+      setAddressError(target.message);
+      return;
+    }
+    setAddressError(null);
+    setAddress(browserDisplayAddress(target.url));
+    updateSession((current) => beginBrowserNavigation(current, target.url));
+
+    if (!host.available()) {
+      updateSession((current) =>
+        failBrowserSession(
+          current,
+          "The in-app browser is available in the Tidebreak desktop app",
+        ),
+      );
+      return;
+    }
+    try {
+      if (nativeReady.current) {
+        await host.command(browserId, { type: "navigate", url: target.url });
+        return;
+      }
+      const bounds = readBrowserBounds(surfaceRef.current);
+      if (!bounds) throw new Error("The browser surface is not ready");
+      await host.command(browserId, {
+        type: "create",
+        url: target.url,
+        bounds,
+        visible,
+      });
+      lastNativeBounds.current = bounds;
+      await settleCreatedNativeView();
+      nativeHistoryAvailable.current = sessionRef.current.history.length <= 1;
+    } catch (error) {
+      if (mountedRef.current) {
+        updateSession((current) =>
+          failBrowserSession(
+            current,
+            friendlyErrorMessage(error, "Could not open that address"),
+          ),
+        );
+      }
+    }
+  }
+
+  async function history(direction: -1 | 1) {
+    const next = moveBrowserHistory(sessionRef.current, direction);
+    if (next === sessionRef.current) return;
+    updateSession(() => next);
+    setAddress(next.address);
+    if (nativeHistoryAvailable.current) {
+      await runHostCommand(direction === -1 ? "back" : "forward");
+    } else if (next.url) {
+      await runHostAction({ type: "navigate", url: next.url });
+    }
+  }
+
+  async function selectHistory(index: number) {
+    const target = sessionRef.current.history[index];
+    if (!target || target.url === sessionRef.current.url) return;
+    const next = beginBrowserNavigation(sessionRef.current, target.url);
+    updateSession(() => next);
+    setAddress(browserDisplayAddress(target.url));
+    nativeHistoryAvailable.current = false;
+    await runHostAction({ type: "navigate", url: target.url });
+  }
+
+  async function runHostCommand(type: "reload" | "stop" | "back" | "forward") {
+    await runHostAction({ type });
+  }
+
+  async function runHostAction(
+    action:
+      | { type: "reload" | "stop" | "back" | "forward" }
+      | { type: "navigate"; url: string },
+  ) {
+    if (!host.available() || !nativeReady.current) return;
+    try {
+      await host.command(browserId, action);
+    } catch (error) {
+      updateSession((current) =>
+        failBrowserSession(
+          current,
+          friendlyErrorMessage(error, "The browser command failed"),
+        ),
+      );
+    }
+  }
+
+  async function reload() {
+    if (!session.url) return;
+    updateSession((current) => ({
+      ...current,
+      loadState: "loading",
+      error: null,
+    }));
+    await runHostCommand("reload");
+  }
+
+  async function stop() {
+    await runHostCommand("stop");
+    updateSession((current) => ({
+      ...current,
+      loadState: current.url ? "ready" : "idle",
+    }));
+  }
+
+  async function openExternal(url = session.url) {
+    if (!url) return;
+    await host.openExternal(url).catch(() => undefined);
+  }
+
+  const notice = session.notice;
+  const noticeTarget = notice?.url ? validateBrowserUrl(notice.url) : null;
+  const actionableNoticeUrl = noticeTarget?.ok ? noticeTarget.url : null;
+  const noticeAction = actionableNoticeUrl && notice
+    ? notice.kind === "popup"
+      ? {
+          label: "Open here",
+          run: () => {
+            updateSession((current) => setBrowserNotice(current, null));
+            void navigate(actionableNoticeUrl);
+          },
+        }
+      : notice.kind === "download"
+        ? {
+            label: "Open externally",
+            run: () => {
+              updateSession((current) => setBrowserNotice(current, null));
+              void openExternal(actionableNoticeUrl);
+            },
+          }
+        : null
+    : null;
+  const showNative = Boolean(session.url) && session.loadState !== "failed";
+
+  return (
+    <section
+      className="flex min-h-0 flex-1 flex-col bg-background text-foreground"
+      aria-label={session.title === "Browser" ? "Browser" : `Browser: ${session.title}`}
+    >
+      <BrowserToolbar
+        session={session}
+        address={address}
+        addressError={addressError}
+        canGoBack={canBrowserGoBack(session)}
+        canGoForward={canBrowserGoForward(session)}
+        onAddressChange={(value) => {
+          setAddress(value);
+          if (addressError) setAddressError(null);
+        }}
+        onNavigate={() => void navigate()}
+        onBack={() => void history(-1)}
+        onForward={() => void history(1)}
+        onReload={() => void reload()}
+        onStop={() => void stop()}
+        onSelectHistory={(index) => void selectHistory(index)}
+        onOpenExternal={() => void openExternal()}
+        onOverlayOpenChange={setHistoryOpen}
+      />
+      {notice && (
+        <BrowserNoticeRow
+          message={notice.message}
+          actionLabel={noticeAction?.label}
+          onAction={noticeAction?.run}
+          onDismiss={() =>
+            updateSession((current) => setBrowserNotice(current, null))
+          }
+        />
+      )}
+      {!notice && slow && session.loadState === "loading" && (
+        <BrowserNoticeRow
+          message="This page is taking longer than expected"
+          actionLabel="Open externally"
+          onAction={() => void openExternal()}
+          onDismiss={() => setSlow(false)}
+        />
+      )}
+      <div ref={surfaceRef} className="relative min-h-0 flex-1 overflow-hidden">
+        {!showNative && (
+          <BrowserFallback
+            error={session.error}
+            hasUrl={Boolean(session.url)}
+            onRetry={session.url ? () => void navigate() : undefined}
+            onOpenExternal={session.url ? () => void openExternal() : undefined}
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function BrowserFallback({
+  error,
+  hasUrl,
+  onRetry,
+  onOpenExternal,
+}: {
+  error: string | null;
+  hasUrl: boolean;
+  onRetry?: () => void;
+  onOpenExternal?: () => void;
+}) {
+  return (
+    <div className="grid h-full min-h-72 place-items-center px-6 py-10">
+      <div className="max-w-sm text-center">
+        <Globe2 className="mx-auto size-7 text-muted-foreground" />
+        <h2 className="mt-4 text-sm font-medium">
+          {error ? "Could not open this page" : "Open a page in this workspace"}
+        </h2>
+        <p className="mt-1.5 text-xs leading-5 text-muted-foreground">
+          {error ||
+            "Use the address bar for a local development server, documentation, or a pull request."}
+        </p>
+        {hasUrl && (onRetry || onOpenExternal) && (
+          <div className="mt-4 flex items-center justify-center gap-2">
+            {onRetry && (
+              <Button type="button" variant="secondary" size="sm" onClick={onRetry}>
+                <RefreshCw />
+                Try again
+              </Button>
+            )}
+            {onOpenExternal && (
+              <Button type="button" variant="outline" size="sm" onClick={onOpenExternal}>
+                <ExternalLink />
+                Open externally
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function readBrowserBounds(element: HTMLElement | null): BrowserBounds | null {
+  if (!element) return null;
+  const bounds = element.getBoundingClientRect();
+  if (bounds.width < 1 || bounds.height < 1) return null;
+  return {
+    x: bounds.x,
+    y: bounds.y,
+    width: bounds.width,
+    height: bounds.height,
+  };
+}
+
+function sameBrowserBounds(
+  left: BrowserBounds | null,
+  right: BrowserBounds,
+): boolean {
+  return Boolean(
+    left &&
+      left.x === right.x &&
+      left.y === right.y &&
+      left.width === right.width &&
+      left.height === right.height,
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  closeCodeBrowser,
+  type CodeBrowserHost,
+} from "./browserHost";
+import {
+  readStoredBrowserSession,
+  writeStoredBrowserSession,
+} from "./browserPersistence";
+import { createBrowserSession } from "./browserSession";
+
+describe("browser host lifecycle", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("removes persisted state and closes the native view on explicit tab close", async () => {
+    writeStoredBrowserSession(
+      createBrowserSession({
+        id: "browser-1",
+        workspaceId: "workspace-1",
+        initialUrl: "https://example.com",
+      }),
+    );
+    const command = vi.fn().mockResolvedValue({ exists: false });
+    const host: CodeBrowserHost = {
+      available: () => true,
+      command,
+      subscribe: vi.fn(async () => () => undefined),
+      openExternal: vi.fn(async () => undefined),
+    };
+
+    await closeCodeBrowser("browser-1", host);
+
+    expect(readStoredBrowserSession("browser-1")).toBeNull();
+    expect(command).toHaveBeenCalledWith("browser-1", { type: "close" });
+  });
+
+  it("still removes persisted state when no native desktop host exists", async () => {
+    writeStoredBrowserSession(
+      createBrowserSession({ id: "browser-1", workspaceId: "workspace-1" }),
+    );
+    const command = vi.fn();
+    const host: CodeBrowserHost = {
+      available: () => false,
+      command,
+      subscribe: vi.fn(async () => () => undefined),
+      openExternal: vi.fn(async () => undefined),
+    };
+
+    await closeCodeBrowser("browser-1", host);
+
+    expect(readStoredBrowserSession("browser-1")).toBeNull();
+    expect(command).not.toHaveBeenCalled();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
@@ -1,0 +1,130 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+import { openExternal } from "@/host";
+import { removeStoredBrowserSession } from "./browserPersistence";
+
+export const CODE_BROWSER_EVENT = "code-browser:event";
+
+let cachedZoom:
+  | { cssViewportWidth: number; browserZoomScale: number }
+  | undefined;
+
+export type BrowserBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type BrowserHostAction =
+  | { type: "create"; url: string; bounds: BrowserBounds; visible: boolean }
+  | { type: "navigate"; url: string }
+  | { type: "reload" }
+  | { type: "stop" }
+  | { type: "back" }
+  | { type: "forward" }
+  | { type: "set_bounds"; bounds: BrowserBounds }
+  | { type: "set_visible"; visible: boolean }
+  | { type: "snapshot" }
+  | { type: "close" };
+
+export type BrowserHostSnapshot = {
+  exists: boolean;
+  url?: string;
+};
+
+export type BrowserHostEvent = {
+  sessionId: string;
+  type:
+    | "navigation_started"
+    | "navigation_finished"
+    | "title_changed"
+    | "popup_blocked"
+    | "download_blocked"
+    | "navigation_blocked";
+  url?: string;
+  title?: string;
+  message?: string;
+};
+
+export type CodeBrowserHost = {
+  available: () => boolean;
+  command: (
+    sessionId: string,
+    action: BrowserHostAction,
+  ) => Promise<BrowserHostSnapshot>;
+  subscribe: (
+    handler: (event: BrowserHostEvent) => void,
+  ) => Promise<() => void>;
+  openExternal: (url: string) => Promise<void>;
+};
+
+export const nativeCodeBrowserHost: CodeBrowserHost = {
+  available: isTauri,
+  command: async (sessionId, action) => {
+    const normalized = await logicalBrowserAction(action);
+    return invoke<BrowserHostSnapshot>("code_browser_command", {
+      request: { sessionId, action: normalized },
+    });
+  },
+  subscribe: async (handler) =>
+    listen<BrowserHostEvent>(CODE_BROWSER_EVENT, (event) =>
+      handler(event.payload),
+    ),
+  openExternal: async (url) => {
+    if (!(await openExternal(url))) {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  },
+};
+
+async function logicalBrowserAction(
+  action: BrowserHostAction,
+): Promise<BrowserHostAction> {
+  if (action.type !== "create" && action.type !== "set_bounds") return action;
+
+  try {
+    const cssViewportWidth = window.innerWidth;
+    let browserZoomScale = cachedZoom?.cssViewportWidth === cssViewportWidth
+      ? cachedZoom.browserZoomScale
+      : undefined;
+    if (browserZoomScale === undefined) {
+      const current = getCurrentWindow();
+      const [physical, scaleFactor] = await Promise.all([
+        current.innerSize(),
+        current.scaleFactor(),
+      ]);
+      const logicalWidth = physical.width / scaleFactor;
+      browserZoomScale = cssViewportWidth > 0
+        ? logicalWidth / cssViewportWidth
+        : 1;
+      cachedZoom = { cssViewportWidth, browserZoomScale };
+    }
+    if (!Number.isFinite(browserZoomScale) || browserZoomScale <= 0) {
+      return action;
+    }
+    return {
+      ...action,
+      bounds: {
+        x: action.bounds.x * browserZoomScale,
+        y: action.bounds.y * browserZoomScale,
+        width: action.bounds.width * browserZoomScale,
+        height: action.bounds.height * browserZoomScale,
+      },
+    };
+  } catch {
+    return action;
+  }
+}
+
+/** Explicit tab close. Tab switches only hide the native child webview. */
+export async function closeCodeBrowser(
+  browserId: string,
+  host: CodeBrowserHost = nativeCodeBrowserHost,
+): Promise<void> {
+  removeStoredBrowserSession(browserId);
+  if (!host.available()) return;
+  await host.command(browserId, { type: "close" }).catch(() => undefined);
+}

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserNavigation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserNavigation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  browserDisplayAddress,
+  browserSecurity,
+  browserTarget,
+  MAX_BROWSER_URL_CHARS,
+  validateBrowserUrl,
+} from "./browserNavigation";
+
+describe("browser navigation", () => {
+  it("normalizes local servers, private hosts, and public sites", () => {
+    expect(browserTarget("localhost:3000")).toEqual({
+      ok: true,
+      url: "http://localhost:3000/",
+    });
+    expect(browserTarget("192.168.1.4:5173/app")).toEqual({
+      ok: true,
+      url: "http://192.168.1.4:5173/app",
+    });
+    expect(browserTarget("[::1]:4173/app")).toEqual({
+      ok: true,
+      url: "http://[::1]:4173/app",
+    });
+    expect(browserTarget("docs.rs/tauri")).toEqual({
+      ok: true,
+      url: "https://docs.rs/tauri",
+    });
+  });
+
+  it("searches plain language and rejects unsafe schemes and credentials", () => {
+    expect(browserTarget("tauri child webview")).toEqual({
+      ok: true,
+      url: "https://www.google.com/search?q=tauri%20child%20webview",
+    });
+    expect(browserTarget("file:///tmp/token")).toMatchObject({ ok: false });
+    expect(browserTarget("javascript:alert(1)")).toMatchObject({ ok: false });
+    expect(validateBrowserUrl("https://user:secret@example.com")).toMatchObject({
+      ok: false,
+    });
+    expect(
+      validateBrowserUrl(
+        `https://example.com/${"a".repeat(MAX_BROWSER_URL_CHARS)}`,
+      ),
+    ).toEqual({ ok: false, message: "That address is too long" });
+  });
+
+  it("derives honest security labels from the committed URL", () => {
+    expect(browserSecurity("https://example.com")).toEqual({
+      kind: "secure",
+      label: "Secure",
+    });
+    expect(browserSecurity("http://localhost:3000")).toEqual({
+      kind: "local",
+      label: "Local",
+    });
+    expect(browserSecurity("http://[::1]:3000")).toEqual({
+      kind: "local",
+      label: "Local",
+    });
+    expect(browserSecurity("http://example.com")).toEqual({
+      kind: "insecure",
+      label: "Not secure",
+    });
+    expect(browserDisplayAddress("https://example.com/docs?q=one")).toBe(
+      "example.com/docs?q=one",
+    );
+    expect(browserDisplayAddress("http://example.com/docs")).toBe(
+      "http://example.com/docs",
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserNavigation.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserNavigation.ts
@@ -1,0 +1,141 @@
+export const DEFAULT_BROWSER_SEARCH_URL =
+  "https://www.google.com/search?q=";
+export const MAX_BROWSER_URL_CHARS = 8_192;
+
+export type BrowserSecurity =
+  | { kind: "secure"; label: "Secure" }
+  | { kind: "local"; label: "Local" }
+  | { kind: "insecure"; label: "Not secure" };
+
+export type BrowserTarget =
+  | { ok: true; url: string }
+  | { ok: false; message: string };
+
+/**
+ * Turn one omnibox submission into a safe HTTP(S) target.
+ *
+ * Explicit schemes stay explicit. Loopback and host:port inputs default to
+ * HTTP because that is how local dev servers normally listen. A hostname with
+ * a dot defaults to HTTPS. Everything else becomes a search.
+ */
+export function browserTarget(
+  input: string,
+  searchUrl = DEFAULT_BROWSER_SEARCH_URL,
+): BrowserTarget {
+  const value = input.trim();
+  if (!value) return { ok: false, message: "Enter an address or search" };
+
+  const explicitScheme = /^[a-z][a-z\d+.-]*:(?!\d)/i.test(value);
+  const noWhitespace = !/\s/.test(value);
+  const localTarget = isLikelyLocalTarget(value);
+  const webTarget = noWhitespace && isLikelyWebTarget(value);
+
+  if (explicitScheme || localTarget || webTarget) {
+    const candidate = localTarget
+      ? `http://${value}`
+      : explicitScheme
+        ? value
+        : `https://${value}`;
+    return validateBrowserUrl(candidate);
+  }
+
+  return validateBrowserUrl(`${searchUrl}${encodeURIComponent(value)}`);
+}
+
+export function validateBrowserUrl(value: string): BrowserTarget {
+  if (value.length > MAX_BROWSER_URL_CHARS) {
+    return { ok: false, message: "That address is too long" };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return { ok: false, message: "That address is not valid" };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      ok: false,
+      message: "Only HTTP and HTTPS addresses can open here",
+    };
+  }
+  if (parsed.username || parsed.password) {
+    return {
+      ok: false,
+      message: "Addresses with embedded credentials are not supported",
+    };
+  }
+  if (!parsed.hostname) {
+    return { ok: false, message: "That address has no host" };
+  }
+  if (parsed.href.length > MAX_BROWSER_URL_CHARS) {
+    return { ok: false, message: "That address is too long" };
+  }
+
+  return { ok: true, url: parsed.href };
+}
+
+export function browserSecurity(url: string): BrowserSecurity {
+  const parsed = new URL(url);
+  if (parsed.protocol === "https:") return { kind: "secure", label: "Secure" };
+  if (isLoopbackHost(parsed.hostname)) return { kind: "local", label: "Local" };
+  return { kind: "insecure", label: "Not secure" };
+}
+
+export function browserDisplayAddress(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.protocol === "http:") return parsed.href;
+  const suffix = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  return `${parsed.host}${suffix === "/" ? "" : suffix}`;
+}
+
+function isLikelyLocalTarget(value: string): boolean {
+  const host = value.split(/[/?#]/, 1)[0]?.toLowerCase() ?? "";
+  const hostname = normalizeHostname(host.startsWith("[")
+    ? host.slice(0, host.indexOf("]") + 1)
+    : host.split(":", 1)[0] ?? host);
+  return (
+    hostname === "localhost" ||
+    hostname === "0.0.0.0" ||
+    hostname === "127.0.0.1" ||
+    hostname.startsWith("127.") ||
+    hostname === "::1" ||
+    isPrivateIpv4(hostname)
+  );
+}
+
+function isLikelyWebTarget(value: string): boolean {
+  const host = value.split(/[/?#]/, 1)[0] ?? "";
+  return host.includes(".") || /^\[[0-9a-f:]+\](?::\d+)?$/i.test(host);
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const host = normalizeHostname(hostname);
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "0.0.0.0" ||
+    host === "::1" ||
+    host.startsWith("127.") ||
+    isPrivateIpv4(host)
+  );
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/, "");
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const octets = hostname.split(".").map(Number);
+  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part))) {
+    return false;
+  }
+  return (
+    octets[0] === 10 ||
+    (octets[0] === 172 && (octets[1] ?? 0) >= 16 && (octets[1] ?? 0) <= 31) ||
+    (octets[0] === 192 && octets[1] === 168)
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  readStoredBrowserSession,
+  removeStoredBrowserSession,
+  seedBrowserSession,
+  storedBrowserTitle,
+  writeStoredBrowserSession,
+} from "./browserPersistence";
+import { beginBrowserNavigation, createBrowserSession } from "./browserSession";
+
+describe("browser persistence", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("round-trips useful state but clears transient failures", () => {
+    const session = {
+      ...createBrowserSession({
+        id: "browser-1",
+        workspaceId: "workspace-1",
+        initialUrl: "https://example.com/docs",
+      }),
+      loadState: "failed" as const,
+      error: "network failed",
+      notice: {
+        kind: "popup" as const,
+        url: "https://example.com/sign-in",
+        message: "popup",
+      },
+    };
+    writeStoredBrowserSession(session);
+    expect(readStoredBrowserSession("browser-1")).toMatchObject({
+      id: "browser-1",
+      workspaceId: "workspace-1",
+      url: "https://example.com/docs",
+      loadState: "ready",
+      error: null,
+      notice: null,
+    });
+  });
+
+  it("keeps the selected entry correct when stored history is trimmed", () => {
+    let session = createBrowserSession({
+      id: "browser-1",
+      workspaceId: "workspace-1",
+    });
+    for (let index = 0; index < 60; index += 1) {
+      session = beginBrowserNavigation(
+        session,
+        `https://example.com/${index}`,
+        index,
+      );
+    }
+    writeStoredBrowserSession(session);
+    const restored = readStoredBrowserSession("browser-1");
+    expect(restored?.history).toHaveLength(50);
+    expect(restored?.history[restored.historyIndex]?.url).toBe(
+      "https://example.com/59",
+    );
+  });
+
+  it("drops malformed sessions and removes closed sessions", () => {
+    window.localStorage.setItem(
+      "tidebreak.code-browser-sessions.v1",
+      JSON.stringify({ "browser-1": { version: 9 } }),
+    );
+    expect(readStoredBrowserSession("browser-1")).toBeNull();
+
+    writeStoredBrowserSession(
+      createBrowserSession({ id: "browser-1", workspaceId: "workspace-1" }),
+    );
+    removeStoredBrowserSession("browser-1");
+    expect(readStoredBrowserSession("browser-1")).toBeNull();
+  });
+
+  it("seeds a new panel before mount and exposes its lightweight tab title", () => {
+    seedBrowserSession({
+      browserId: "browser-1",
+      workspaceId: "workspace-1",
+      initialUrl: "https://example.com/docs",
+    });
+
+    expect(readStoredBrowserSession("browser-1")).toMatchObject({
+      workspaceId: "workspace-1",
+      url: "https://example.com/docs",
+    });
+    expect(storedBrowserTitle("browser-1")).toBe("Browser");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
@@ -1,0 +1,208 @@
+import {
+  createBrowserSession,
+  type BrowserHistoryEntry,
+  type BrowserSession,
+} from "./browserSession";
+import {
+  browserDisplayAddress,
+  validateBrowserUrl,
+} from "./browserNavigation";
+
+const STORAGE_KEY = "tidebreak.code-browser-sessions.v1";
+const MAX_STORED_SESSIONS = 24;
+const MAX_STORED_HISTORY = 50;
+
+type StoredBrowserSessions = Record<string, BrowserSession>;
+
+export function readStoredBrowserSession(
+  browserId: string,
+  storage: Pick<Storage, "getItem"> = window.localStorage,
+): BrowserSession | null {
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    return parseBrowserSession(
+      (parsed as Record<string, unknown>)[browserId],
+      browserId,
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredBrowserSession(
+  session: BrowserSession,
+  storage: Pick<Storage, "getItem" | "setItem"> = window.localStorage,
+): void {
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : {};
+    const sessions: StoredBrowserSessions = {};
+    if (parsed && typeof parsed === "object") {
+      for (const [id, candidate] of Object.entries(
+        parsed as Record<string, unknown>,
+      )) {
+        const valid = parseBrowserSession(candidate, id);
+        if (valid) sessions[id] = valid;
+      }
+    }
+    sessions[session.id] = persistableSession(session);
+    const bounded = Object.fromEntries(
+      Object.entries(sessions)
+        .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
+        .slice(0, MAX_STORED_SESSIONS),
+    );
+    storage.setItem(STORAGE_KEY, JSON.stringify(bounded));
+  } catch {
+    // Browser restoration is useful, but storage must never block navigation.
+  }
+}
+
+export function removeStoredBrowserSession(
+  browserId: string,
+  storage: Pick<Storage, "getItem" | "setItem"> = window.localStorage,
+): void {
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return;
+    const sessions = { ...(parsed as Record<string, unknown>) };
+    delete sessions[browserId];
+    storage.setItem(STORAGE_KEY, JSON.stringify(sessions));
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+export function restoreOrCreateBrowserSession({
+  browserId,
+  workspaceId,
+  initialUrl,
+}: {
+  browserId: string;
+  workspaceId: string;
+  initialUrl?: string;
+}): BrowserSession {
+  const restored = readStoredBrowserSession(browserId);
+  if (restored?.workspaceId === workspaceId) return restored;
+  const created = createBrowserSession({
+    id: browserId,
+    workspaceId,
+    initialUrl,
+  });
+  writeStoredBrowserSession(created);
+  return created;
+}
+
+/** Seed a newly allocated browser tab before the URL-backed panel mounts. */
+export function seedBrowserSession({
+  browserId,
+  workspaceId,
+  initialUrl,
+}: {
+  browserId: string;
+  workspaceId: string;
+  initialUrl?: string;
+}): BrowserSession {
+  const session = createBrowserSession({
+    id: browserId,
+    workspaceId,
+    initialUrl,
+  });
+  writeStoredBrowserSession(session);
+  return session;
+}
+
+/** Lightweight title lookup for center-tab rendering before the panel mounts. */
+export function storedBrowserTitle(browserId: string): string {
+  return readStoredBrowserSession(browserId)?.title || "Browser";
+}
+
+function persistableSession(session: BrowserSession): BrowserSession {
+  const historyStart = Math.max(
+    0,
+    session.history.length - MAX_STORED_HISTORY,
+  );
+  const history = session.history.slice(historyStart);
+  const shiftedIndex = session.historyIndex - historyStart;
+  return {
+    ...session,
+    loadState: session.url ? "ready" : "idle",
+    error: null,
+    notice: null,
+    history,
+    historyIndex: history.length
+      ? Math.min(Math.max(shiftedIndex, 0), history.length - 1)
+      : -1,
+  };
+}
+
+function parseBrowserSession(
+  value: unknown,
+  expectedId: string,
+): BrowserSession | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (
+    record.version !== 1 ||
+    record.id !== expectedId ||
+    typeof record.workspaceId !== "string" ||
+    typeof record.title !== "string" ||
+    typeof record.updatedAt !== "number" ||
+    !Number.isFinite(record.updatedAt)
+  ) {
+    return null;
+  }
+
+  const history = parseHistory(record.history);
+  const rawIndex =
+    typeof record.historyIndex === "number" &&
+    Number.isInteger(record.historyIndex)
+      ? record.historyIndex
+      : history.length - 1;
+  const historyIndex = history.length
+    ? Math.min(Math.max(rawIndex, 0), history.length - 1)
+    : -1;
+  const current = history[historyIndex];
+  const rawUrl = typeof record.url === "string" ? record.url : current?.url;
+  const target = rawUrl ? validateBrowserUrl(rawUrl) : null;
+  const url = target?.ok ? target.url : null;
+
+  return {
+    version: 1,
+    id: expectedId,
+    workspaceId: record.workspaceId,
+    url,
+    address: url ? browserDisplayAddress(url) : "",
+    title: record.title.slice(0, 160) || "Browser",
+    loadState: url ? "ready" : "idle",
+    error: null,
+    notice: null,
+    history,
+    historyIndex,
+    updatedAt: record.updatedAt,
+  };
+}
+
+function parseHistory(value: unknown): BrowserHistoryEntry[] {
+  if (!Array.isArray(value)) return [];
+  const history: BrowserHistoryEntry[] = [];
+  for (const candidate of value.slice(-MAX_STORED_HISTORY)) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const record = candidate as Record<string, unknown>;
+    if (typeof record.url !== "string") continue;
+    const target = validateBrowserUrl(record.url);
+    if (!target.ok) continue;
+    history.push({
+      url: target.url,
+      title:
+        typeof record.title === "string"
+          ? record.title.replace(/\s+/g, " ").trim().slice(0, 160) || undefined
+          : undefined,
+    });
+  }
+  return history;
+}

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserSession.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserSession.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  beginBrowserNavigation,
+  canBrowserGoBack,
+  canBrowserGoForward,
+  createBrowserSession,
+  finishBrowserNavigation,
+  moveBrowserHistory,
+  setBrowserTitle,
+} from "./browserSession";
+
+describe("browser sessions", () => {
+  it("branches history after navigating back", () => {
+    let session = createBrowserSession({
+      id: "browser-1",
+      workspaceId: "workspace-1",
+      initialUrl: "https://example.com/one",
+      now: 1,
+    });
+    session = beginBrowserNavigation(session, "https://example.com/two", 2);
+    session = finishBrowserNavigation(session, "https://example.com/two", 3);
+    session = moveBrowserHistory(session, -1, 4);
+
+    expect(canBrowserGoBack(session)).toBe(false);
+    expect(canBrowserGoForward(session)).toBe(true);
+
+    session = beginBrowserNavigation(session, "https://example.com/three", 5);
+    expect(session.history.map((entry) => entry.url)).toEqual([
+      "https://example.com/one",
+      "https://example.com/three",
+    ]);
+    expect(canBrowserGoForward(session)).toBe(false);
+  });
+
+  it("updates the active history title without changing tab identity", () => {
+    const session = setBrowserTitle(
+      createBrowserSession({
+        id: "browser-1",
+        workspaceId: "workspace-1",
+        initialUrl: "https://example.com",
+      }),
+      "  Example   documentation  ",
+    );
+    expect(session.id).toBe("browser-1");
+    expect(session.title).toBe("Example documentation");
+    expect(session.history[0]?.title).toBe("Example documentation");
+  });
+
+  it("bounds retained navigation history", () => {
+    let session = createBrowserSession({
+      id: "browser-1",
+      workspaceId: "workspace-1",
+    });
+    for (let index = 0; index < 60; index += 1) {
+      session = beginBrowserNavigation(
+        session,
+        `https://example.com/${index}`,
+        index,
+      );
+    }
+    expect(session.history).toHaveLength(50);
+    expect(session.history[0]?.url).toBe("https://example.com/10");
+    expect(session.historyIndex).toBe(49);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserSession.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserSession.ts
@@ -1,0 +1,212 @@
+import { browserDisplayAddress, validateBrowserUrl } from "./browserNavigation";
+
+const MAX_HISTORY_ENTRIES = 50;
+const MAX_TITLE_CHARS = 160;
+
+export type BrowserLoadState = "idle" | "loading" | "ready" | "failed";
+
+export type BrowserHistoryEntry = {
+  url: string;
+  title?: string;
+};
+
+export type BrowserNotice = {
+  kind: "popup" | "download" | "blocked";
+  url?: string;
+  message: string;
+};
+
+export type BrowserSession = {
+  version: 1;
+  id: string;
+  workspaceId: string;
+  url: string | null;
+  address: string;
+  title: string;
+  loadState: BrowserLoadState;
+  error: string | null;
+  notice: BrowserNotice | null;
+  history: BrowserHistoryEntry[];
+  historyIndex: number;
+  updatedAt: number;
+};
+
+export function createBrowserSession({
+  id,
+  workspaceId,
+  initialUrl,
+  now = Date.now(),
+}: {
+  id: string;
+  workspaceId: string;
+  initialUrl?: string;
+  now?: number;
+}): BrowserSession {
+  const target = initialUrl ? validateBrowserUrl(initialUrl) : null;
+  const url = target?.ok ? target.url : null;
+  return {
+    version: 1,
+    id,
+    workspaceId,
+    url,
+    address: url ? browserDisplayAddress(url) : "",
+    title: "Browser",
+    loadState: url ? "loading" : "idle",
+    error: target && !target.ok ? target.message : null,
+    notice: null,
+    history: url ? [{ url }] : [],
+    historyIndex: url ? 0 : -1,
+    updatedAt: now,
+  };
+}
+
+export function beginBrowserNavigation(
+  session: BrowserSession,
+  url: string,
+  now = Date.now(),
+): BrowserSession {
+  const current = session.history[session.historyIndex];
+  const history =
+    current?.url === url
+      ? session.history
+      : [
+          ...session.history.slice(0, session.historyIndex + 1),
+          { url },
+        ].slice(-MAX_HISTORY_ENTRIES);
+  return {
+    ...session,
+    url,
+    address: browserDisplayAddress(url),
+    loadState: "loading",
+    error: null,
+    notice: null,
+    history,
+    historyIndex: history.length - 1,
+    updatedAt: now,
+  };
+}
+
+export function observeBrowserNavigation(
+  session: BrowserSession,
+  url: string,
+  loadState: Extract<BrowserLoadState, "loading" | "ready">,
+  now = Date.now(),
+): BrowserSession {
+  const current = session.history[session.historyIndex];
+  if (current?.url === url) {
+    return {
+      ...session,
+      url,
+      address: browserDisplayAddress(url),
+      loadState,
+      error: null,
+      updatedAt: now,
+    };
+  }
+  return {
+    ...beginBrowserNavigation(session, url, now),
+    loadState,
+  };
+}
+
+export function finishBrowserNavigation(
+  session: BrowserSession,
+  url: string,
+  now = Date.now(),
+): BrowserSession {
+  return observeBrowserNavigation(session, url, "ready", now);
+}
+
+export function setBrowserTitle(
+  session: BrowserSession,
+  title: string,
+  now = Date.now(),
+): BrowserSession {
+  const clean = cleanTitle(title);
+  const history = session.history.map((entry, index) =>
+    index === session.historyIndex
+      ? { ...entry, title: clean || undefined }
+      : entry,
+  );
+  return {
+    ...session,
+    title: clean || "Browser",
+    history,
+    updatedAt: now,
+  };
+}
+
+export function moveBrowserHistory(
+  session: BrowserSession,
+  direction: -1 | 1,
+  now = Date.now(),
+): BrowserSession {
+  const historyIndex = session.historyIndex + direction;
+  const target = session.history[historyIndex];
+  if (!target) return session;
+  return {
+    ...session,
+    historyIndex,
+    url: target.url,
+    address: browserDisplayAddress(target.url),
+    title: target.title || "Browser",
+    loadState: "loading",
+    error: null,
+    notice: null,
+    updatedAt: now,
+  };
+}
+
+export function selectBrowserHistory(
+  session: BrowserSession,
+  index: number,
+  now = Date.now(),
+): BrowserSession {
+  const target = session.history[index];
+  if (!target) return session;
+  return {
+    ...session,
+    historyIndex: index,
+    url: target.url,
+    address: browserDisplayAddress(target.url),
+    title: target.title || "Browser",
+    loadState: "loading",
+    error: null,
+    notice: null,
+    updatedAt: now,
+  };
+}
+
+export function failBrowserSession(
+  session: BrowserSession,
+  error: string,
+  now = Date.now(),
+): BrowserSession {
+  return {
+    ...session,
+    loadState: "failed",
+    error,
+    updatedAt: now,
+  };
+}
+
+export function setBrowserNotice(
+  session: BrowserSession,
+  notice: BrowserNotice | null,
+  now = Date.now(),
+): BrowserSession {
+  return { ...session, notice, updatedAt: now };
+}
+
+export function canBrowserGoBack(session: BrowserSession): boolean {
+  return session.historyIndex > 0;
+}
+
+export function canBrowserGoForward(session: BrowserSession): boolean {
+  return session.historyIndex >= 0 &&
+    session.historyIndex < session.history.length - 1;
+}
+
+function cleanTitle(title: string): string {
+  return title.replace(/\s+/g, " ").trim().slice(0, MAX_TITLE_CHARS);
+}

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
@@ -8,12 +8,14 @@ import {
   closeEditorTabsToRight,
   closeFocusedCodeTab,
   closeOtherEditorTabs,
+  codeBrowserIds,
   focusCodeChromeTab,
   focusConversation,
   focusEditorTab,
   mergeEditorSplit,
   moveEditorTab,
   openCodeEditor,
+  removedCodeBrowserIds,
   splitCodeChromeLayout,
   toggleTerminalLayout,
 } from "./codeChrome";
@@ -150,6 +152,74 @@ describe("code chrome layout", () => {
       "diff",
       "terminal",
     ]);
+  });
+
+  it("treats browser sessions as editor tabs without confusing them with the inspector", () => {
+    const layout = {
+      tabs: [
+        { type: "folders" as const },
+        { type: "browser" as const, browserId: "browser-1" },
+      ],
+      activeIndex: 1,
+      fullscreen: false,
+    };
+
+    const chrome = splitCodeChromeLayout(layout);
+    expect(chrome.panels.tabs).toEqual([{ type: "folders" }]);
+    expect(chrome.editors.tabs).toEqual([
+      { type: "browser", browserId: "browser-1" },
+    ]);
+    expect(
+      openCodeEditor(layout, {
+        type: "browser",
+        browserId: "browser-2",
+      }).tabs,
+    ).toContainEqual({ type: "browser", browserId: "browser-2" });
+  });
+
+  it("reports only browser sessions truly removed by close operations", () => {
+    const layout = {
+      tabs: [
+        { type: "browser" as const, browserId: "browser-1" },
+        { type: "file" as const, path: "src/lib.rs" },
+      ],
+      activeIndex: 0,
+      fullscreen: false,
+      editorSplit: {
+        tabs: [{ type: "browser" as const, browserId: "browser-2" }],
+        activeIndex: 0,
+      },
+    };
+
+    const moved = moveEditorTab(layout, "primary", 0, "secondary");
+    expect(removedCodeBrowserIds(layout, moved)).toEqual([]);
+    expect(codeBrowserIds(mergeEditorSplit(moved))).toEqual([
+      "browser-2",
+      "browser-1",
+    ]);
+
+    const closed = closeAllEditorTabs(layout, "secondary");
+    expect(removedCodeBrowserIds(layout, closed)).toEqual(["browser-2"]);
+
+    const primaryOnly = closeOtherEditorTabs(layout, 1, "primary");
+    expect(removedCodeBrowserIds(layout, primaryOnly)).toEqual(["browser-1"]);
+
+    const withBrowserOnRight = {
+      ...layout,
+      tabs: [
+        { type: "file" as const, path: "src/lib.rs" },
+        { type: "browser" as const, browserId: "browser-1" },
+      ],
+    };
+    expect(
+      removedCodeBrowserIds(
+        withBrowserOnRight,
+        closeEditorTabsToRight(withBrowserOnRight, 0, "primary"),
+      ),
+    ).toEqual(["browser-1"]);
+    expect(
+      removedCodeBrowserIds(layout, closeAllEditorTabs(layout)),
+    ).toEqual(["browser-1", "browser-2"]);
   });
 
   it("closes editor-tab groups without dropping side panels or the terminal", () => {

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -61,7 +61,30 @@ function isDrawerTab(tab: PanelContent): boolean {
 }
 
 export function isEditorTab(tab: PanelContent): boolean {
-  return tab.type === "file" || tab.type === "diff";
+  return tab.type === "file" || tab.type === "diff" || tab.type === "browser";
+}
+
+export type CodeEditorPanel = Extract<
+  PanelContent,
+  { type: "file" | "diff" | "browser" }
+>;
+
+/** Browser session ids removed by a layout transition, once each. */
+export function removedCodeBrowserIds(
+  previous: LayoutState,
+  next: LayoutState,
+): string[] {
+  const remaining = new Set(codeBrowserIds(next));
+  return codeBrowserIds(previous).filter((id) => !remaining.has(id));
+}
+
+/** Browser session ids owned by either editor group, once each. */
+export function codeBrowserIds(layout: LayoutState): string[] {
+  const ids = new Set<string>();
+  for (const panel of [...layout.tabs, ...(layout.editorSplit?.tabs ?? [])]) {
+    if (panel.type === "browser") ids.add(panel.browserId);
+  }
+  return [...ids];
 }
 
 export type CodeEditorRegion = "primary" | "secondary";
@@ -290,7 +313,7 @@ export function closeEditorTabsToRight(
 /** Open one editor in the group that last had focus, unless a group is named. */
 export function openCodeEditor(
   layout: LayoutState,
-  panel: Extract<PanelContent, { type: "file" | "diff" }>,
+  panel: CodeEditorPanel,
   preferredRegion?: CodeEditorRegion,
 ): LayoutState {
   const key = panelKey(panel);
@@ -371,7 +394,7 @@ export function moveEditorTab(
   const without = closeEditorTab(layout, editorIndex, "secondary");
   return openCodeEditor(
     without,
-    target as Extract<PanelContent, { type: "file" | "diff" }>,
+    target as CodeEditorPanel,
     "primary",
   );
 }
@@ -384,7 +407,7 @@ export function mergeEditorSplit(layout: LayoutState): LayoutState {
   for (const tab of splitTabs) {
     next = openCodeEditor(
       next,
-      tab as Extract<PanelContent, { type: "file" | "diff" }>,
+      tab as CodeEditorPanel,
       "primary",
     );
   }

--- a/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
@@ -4,6 +4,7 @@ import {
   FileDiff,
   FileText,
   FolderOpen,
+  Globe2,
   Package,
   Shield,
   SquareTerminal,
@@ -45,6 +46,8 @@ function panelTabFallbackLabel(panel: PanelContent): string {
         : panel.turnId
           ? "Turn diff"
           : "Diff";
+    case "browser":
+      return "Browser";
   }
 }
 
@@ -69,6 +72,8 @@ function PanelTabIcon({ panel, active }: { panel: PanelContent; active: boolean 
       return <FileCode className={tone("text-icon-blue")} />;
     case "diff":
       return <FileDiff className={tone("text-icon-violet")} />;
+    case "browser":
+      return <Globe2 className={tone("text-icon-blue")} />;
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
@@ -28,7 +28,9 @@ export type PanelContent =
   /** One worktree file in the workspace center. */
   | { type: "file"; path: string }
   /** A colored diff in the workspace center. */
-  | { type: "diff"; path?: string; turnId?: string };
+  | { type: "diff"; path?: string; turnId?: string }
+  /** One native browser session in the workspace center. */
+  | { type: "browser"; browserId: string };
 
 export type PanelType = PanelContent["type"];
 
@@ -41,14 +43,14 @@ export type LayoutState = {
   activeIndex: number;
   fullscreen: boolean;
   /**
-   * Code workspace: the conversation tab is selected while file/diff tabs
+   * Code workspace: the conversation tab is selected while editor tabs
    * stay open. Absent everywhere else.
    */
   conversationFocused?: boolean;
   /**
    * Code workspace: a second editor group to the right of the main-agent
-   * group. The transcript itself never moves or mounts twice; only file and
-   * diff tabs are stored here.
+   * group. The transcript itself never moves or mounts twice; only editor
+   * tabs are stored here.
    */
   editorSplit?: {
     tabs: PanelContent[];
@@ -79,6 +81,8 @@ export function panelKey(panel: PanelContent): string {
       return `file:${panel.path}`;
     case "diff":
       return `diff:${panel.turnId ?? ""}:${panel.path ?? ""}`;
+    case "browser":
+      return `browser:${panel.browserId}`;
     default:
       return panel.type;
   }

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
@@ -52,6 +52,14 @@ describe("panel URLs", () => {
     expect(parsePanelSegment("files")).toBeNull();
   });
 
+  it("round-trips opaque browser tab identities without putting URLs in the layout", () => {
+    const browser = { type: "browser" as const, browserId: "browser_one-2" };
+    expect(encodePanelSegment(browser)).toBe("browser.browser_one-2");
+    expect(parsePanelSegment("browser.browser_one-2")).toEqual(browser);
+    expect(parsePanelSegment("browser")).toBeNull();
+    expect(parsePanelSegment("browser.browser%2Fone.two")).toBeNull();
+  });
+
   // The conversation holds its own region now; a URL still naming it as a
   // panel is describing a tab that does not exist.
   it("no longer reads the conversation as a panel", () => {
@@ -88,6 +96,7 @@ describe("panel URLs", () => {
       { type: "terminal", terminalId: "term-1" },
       { type: "file", path: "src/lib.rs" },
       { type: "diff", path: "src/lib.rs", turnId: "turn-1" },
+      { type: "browser", browserId: "browser-1" },
     ] as const) {
       expect(parsePanelSegment(encodePanelSegment(panel))).toEqual(panel);
     }
@@ -211,5 +220,25 @@ describe("layout URLs", () => {
         split: "file.src%2Flib.rs,file.README.md",
       }).editorSplit?.tabs,
     ).toEqual([{ type: "file", path: "README.md" }]);
+  });
+
+  it("restores browser tabs in either editor group", () => {
+    const layout = {
+      tabs: [{ type: "browser" as const, browserId: "browser-primary" }],
+      activeIndex: 0,
+      fullscreen: false,
+      editorSplit: {
+        tabs: [{ type: "browser" as const, browserId: "browser-secondary" }],
+        activeIndex: 0,
+        focused: true,
+      },
+    };
+
+    expect(searchFromLayout(layout)).toMatchObject({
+      tabs: "browser.browser-primary",
+      split: "browser.browser-secondary",
+      splitFocused: "1",
+    });
+    expect(layoutFromSearch(searchFromLayout(layout))).toEqual(layout);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
@@ -54,6 +54,8 @@ export function parsePanelSegment(segment: string): PanelContent | null {
       return parseFileTarget(id);
     case "diff":
       return parseDiffTarget(id);
+    case "browser":
+      return parseBrowserTarget(id);
     default:
       // `apps` and `plugins` were panel segments before the libraries became
       // routes of their own. A bare `files` catalog is still retired.
@@ -98,6 +100,18 @@ function parseDiffTarget(id: string): PanelContent | null {
   return null;
 }
 
+function parseBrowserTarget(id: string): PanelContent | null {
+  if (!id) return null;
+  try {
+    const browserId = decodeURIComponent(id);
+    return /^[A-Za-z0-9_-]{1,80}$/.test(browserId)
+      ? { type: "browser", browserId }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function parseDocumentTarget(id: string): PanelContent | null {
   if (!id) return null;
   const separator = id.indexOf(".");
@@ -139,6 +153,8 @@ export function encodePanelSegment(panel: PanelContent): string {
       if (panel.path) return `diff.f.${encodeURIComponent(panel.path)}`;
       return "diff";
     }
+    case "browser":
+      return `browser.${encodeURIComponent(panel.browserId)}`;
   }
 }
 
@@ -149,7 +165,7 @@ export type PanelSearch = {
   active?: string;
   /** `"1"` when the region has taken the whole window. */
   fullscreen?: string;
-  /** Code workspace: file/diff tabs in the right editor group. */
+  /** Code workspace: editor tabs in the right editor group. */
   split?: string;
   /** Code workspace: the tab showing in the right editor group. */
   splitActive?: string;
@@ -194,7 +210,14 @@ export function layoutFromSearch(search: PanelSearch): LayoutState {
   const splitTabs: PanelContent[] = [];
   for (const segment of search.split?.split(TAB_SEPARATOR) ?? []) {
     const panel = parsePanelSegment(segment.trim());
-    if (!panel || (panel.type !== "file" && panel.type !== "diff")) continue;
+    if (
+      !panel ||
+      (panel.type !== "file" &&
+        panel.type !== "diff" &&
+        panel.type !== "browser")
+    ) {
+      continue;
+    }
     const key = panelKey(panel);
     if (seen.has(key)) continue;
     seen.add(key);
@@ -277,7 +300,7 @@ export function searchFromLayout(layout: LayoutState): PanelSearch {
         ? layout.tabs.map(encodePanelSegment).join(TAB_SEPARATOR)
         : undefined,
     // The first tab is the default, so naming it would only lengthen the URL.
-    // `chat` keeps file/diff tabs open while the conversation is showing.
+    // `chat` keeps editor tabs open while the conversation is showing.
     active: layout.conversationFocused
       ? "chat"
       : layout.activeIndex > 0 && active

--- a/docs/code-browser-integration.md
+++ b/docs/code-browser-integration.md
@@ -1,0 +1,160 @@
+# Code-mode browser integration
+
+## Product role
+
+The browser is a first-class center-editor tab, alongside files and diffs. It
+is not an inspector destination and it does not replace the user's default
+browser. Its job is to keep local development servers, documentation, and pull
+requests in the same workspace as the task that produced them.
+
+The browser chrome stays deliberately compact:
+
+- back and forward;
+- reload while idle, stop while loading;
+- one address and search field;
+- a security label derived from the actual URL;
+- bounded per-tab history;
+- open in the system browser.
+
+Each browser tab owns one durable browser session. Closing a tab destroys that
+session. Merely selecting another tab hides its native view so cookies, form
+state, and the page's own history can survive normal workspace navigation.
+
+## Architecture
+
+### Editor ownership
+
+The existing URL-backed layout remains authoritative for tab order, active
+group, splits, and restoration. The browser panel should be represented as:
+
+```ts
+{ type: "browser"; browserId: string }
+```
+
+`browserId` is identity, not the current URL. The URL changes often and must
+not turn one tab into a new tab. Browser session state is stored separately by
+that ID.
+
+Browser tabs participate in the same primary and secondary editor groups as
+files and diffs. Main agent remains a persistent tab. Inspector navigation
+remains separate.
+
+### Browser state
+
+The browser-specific state layer stores:
+
+- the last committed URL and address text;
+- title;
+- loading, ready, and failure state;
+- a bounded navigation history and current index;
+- the last meaningful browser notice;
+- the workspace that owns the tab.
+
+Transient native handles and DOM bounds are never persisted. Storage is
+best-effort and versioned. Invalid or oversized stored data is discarded.
+
+### Native rendering
+
+An iframe is not the product implementation. Tidebreak's main content-security
+policy intentionally permits frames only from loopback, many real sites deny
+framing, and cross-origin frames cannot provide trustworthy navigation state.
+
+The desktop host instead creates a Tauri child webview over the browser tab's
+content rectangle. Browser-specific IPC owns create, navigate, reload, stop,
+back, forward, bounds, visibility, snapshot, and close. The native host emits
+navigation, title, popup, and download events back to the main app webview.
+
+The remote page receives no Tidebreak capability. External URL validation is
+performed in both the renderer and native host. Only HTTP and HTTPS are
+accepted, credentials in URLs are rejected, and non-web schemes are blocked.
+In development, both loopback spellings of the Vite origin are rejected so a
+browser tab cannot enter the one remote origin that receives debug capability.
+
+### Native overlay behavior
+
+A child webview is a native sibling of the app webview, not a DOM child. DOM
+portals cannot draw over it. `CodeBrowserTab` therefore accepts an `obscured`
+prop and hides the native view while a workspace dialog, command palette, or
+other app-owned overlay covers the editor area. The aggregate must include tab
+context menus and workspace menus whose portals can overlap the editor, not
+only modal dialogs. The browser also hides itself while its own history menu is
+open.
+
+The content rectangle is measured in logical CSS pixels and updated through a
+coalesced `ResizeObserver`. This covers editor splits and resizable side rails
+without a per-frame layout loop.
+
+## Owner-file integration signatures
+
+The sidecar deliberately does not edit the current workspace owner files. The
+integration PR needs these narrow changes:
+
+1. Add `{ type: "browser"; browserId: string }` to `PanelContent`, key it as
+   `browser:${browserId}`, and encode it as `browser.${browserId}`.
+2. Treat browser panels as editor tabs in `codeChrome.ts`. Generalize
+   `openCodeEditor` from file/diff to file/diff/browser.
+3. Render a browser icon and browser title in `CodeCenterTabs.tsx`. The title
+   can be supplied by `storedBrowserTitle(browserId)` and falls back to
+   `Browser`. Keep an in-memory title map updated from `CodeBrowserTab`'s
+   `onTitleChange` callback so title changes repaint the strip without polling
+   local storage.
+4. Add an `openBrowser(url?: string, preferredRegion?)` command in the
+   workspace owner. It creates an opaque browser ID, calls
+   `seedBrowserSession({ browserId, workspaceId, initialUrl: url })`, and opens
+   the panel through the existing editor-layout path.
+5. Render
+   `<CodeBrowserTab workspaceId browserId obscured={workspaceOverlayOpen} onTitleChange={...} />`
+   from the editor-panel switch. The component resets itself when `browserId`
+   changes, so the shared active-panel slot cannot carry one tab's React state
+   into another browser tab. `workspaceOverlayOpen` must aggregate quick-open,
+   dialogs, and any portaled menu that can cross the browser content rectangle.
+6. Before removing browser panels for explicit single-tab, close-other,
+   close-right, close-all, or workspace teardown actions, call
+   `closeCodeBrowser(browserId)` for every browser ID the layout mutation will
+   remove. Switching tabs or collapsing/merging a split must not close native
+   sessions that remain in the resulting layout.
+7. Route links from transcripts, pull requests, and an eventual `Open in`
+   control through `openBrowser`; retain `Open externally` as an explicit
+   alternate action.
+
+## Failure and recovery
+
+- Invalid address input stays in the toolbar with a precise inline error.
+- Native creation or command failures replace the web surface with a retry
+  state and preserve the requested URL.
+- A long load keeps the page visible and reports that it is taking longer,
+  rather than destroying an authenticated or slow session.
+- Popups and downloads are denied by the embedded host. The toolbar exposes
+  safe HTTP(S) popup URLs in the current tab and safe download URLs externally.
+  Unsafe blocked navigation never offers a retry action.
+- On remount, the renderer asks the native host for a snapshot. If the native
+  view no longer exists, it is recreated from persisted state.
+- A surviving native view keeps using its real back/forward stack. If the
+  desktop process lost that view, restored history entries navigate directly
+  until the new native stack is trustworthy, avoiding a visible URL change
+  backed by a no-op `window.history.back()`.
+- A plain browser build shows a desktop-only fallback and retains Open
+  externally; it never attempts an iframe.
+
+## Platform constraints
+
+- Tauri 2.11 child webviews require the `unstable` Cargo feature. The project
+  pins Tauri exactly, which limits API drift risk.
+- Child-webview creation runs through an async Tauri command. The pinned API
+  documents a WebView2 deadlock when child views are created from synchronous
+  commands on Windows.
+- Child webviews are desktop-only. This feature does not provide a mobile
+  implementation.
+- Hidden-webview background throttling is only configurable on macOS 14+ and
+  iOS 17+; Windows and Linux ignore that setting. The browser must not promise
+  background execution.
+- Native child webviews sit above DOM overlays on macOS, Windows, and Linux.
+  The explicit `obscured` contract is required for dialogs and palettes.
+- Browser-engine behavior follows the platform runtime: WKWebView on macOS,
+  WebView2 on Windows, and WebKitGTK on Linux. Cross-platform validation must
+  cover authentication, redirects, history, popup denial, and process restart.
+- Downloads are denied in this slice because there is no consented destination
+  or product-owned download shelf yet.
+- A popup that starts as `about:blank` and navigates later cannot be recovered
+  after denial. OAuth flows built around that bootstrap need a deliberate
+  popup-host design or an explicit Open externally fallback in a later slice.


### PR DESCRIPTION
## Summary

- add browser documents as first-class center-pane tabs in Code workspaces
- support primary/secondary editor groups, splits, persisted navigation state, and restoration
- use a native Tauri child webview instead of iframes
- validate navigation to HTTP/HTTPS URLs while rejecting credentials and application origins
- deny popups/downloads and hide native overlays behind dialogs, menus, and quick-open
- clean up native views when tabs or workspaces close
- document the native-browser lifecycle and security model

## Validation

- focused browser/workspace tests: 80 passed
- TypeScript typecheck passed
- standalone `rustfmt` passed
- `git diff --check` passed

CI is expected to provide the pinned Tauri 2.11.5 compile, platform coverage, and broad Rust checks. A live macOS pass will follow against the CI-tested head.
