### PR TITLE
feat: authenticate hosted machines through gateway (ADR 0049)

### DIFF
--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -16,6 +16,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::error::{AgentError, Result};
 
@@ -94,6 +95,28 @@ pub struct Config {
     /// ignores this.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_tokens_file: Option<PathBuf>,
+    /// Model Gateway base URL used to authenticate self-hosted callers.
+    ///
+    /// Mutually exclusive with [`Config::auth_tokens_file`]. The server sends
+    /// each presented `tidebreak` resource token to the Gateway's live
+    /// principal endpoint, so Gateway membership, deactivation, session
+    /// revocation, and administrator changes apply without a generated roster.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_gateway_url: Option<String>,
+    /// Optional server-to-server Model Gateway URL used only for principal
+    /// validation. The public [`Config::auth_gateway_url`] remains the identity
+    /// authority exposed to clients; this override supports clusters that
+    /// cannot hairpin through that public origin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_gateway_verifier_url: Option<String>,
+    /// Canonical public base URL of this self-hosted Tidebreak machine.
+    ///
+    /// Gateway-backed authentication hashes this URL into the OAuth resource,
+    /// binding every user credential to this one machine. It must be the same
+    /// normalized URL desktop clients use to attach (including any ingress
+    /// path prefix, without a trailing slash).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
     /// The address the API binds, for deployments that must be reachable from
     /// outside the machine (a container publishing a port, say). `None` — the
     /// default — keeps the loopback, ephemeral-port bind every profile has
@@ -164,6 +187,9 @@ impl Config {
             container_execution_enabled: false,
             container_image: None,
             auth_tokens_file: None,
+            auth_gateway_url: None,
+            auth_gateway_verifier_url: None,
+            public_url: None,
             listen_addr: None,
         }
     }
@@ -174,7 +200,10 @@ impl Config {
     /// this to the platform's app-data location),
     /// `TIDEBREAK_CONTAINER_EXECUTION_ENABLED` (default `false`),
     /// `TIDEBREAK_CONTAINER_IMAGE` (defaulting to the server's default agent
-    /// image), `TIDEBREAK_AUTH_TOKENS_FILE` (self-host only; required there),
+    /// image), `TIDEBREAK_AUTH_TOKENS_FILE` or `TIDEBREAK_AUTH_GATEWAY_URL`
+    /// (self-host only; exactly one is required there), optional
+    /// `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` for cluster-internal validation,
+    /// `TIDEBREAK_PUBLIC_URL` for machine-bound Gateway credentials,
     /// and `TIDEBREAK_LISTEN_ADDR` (self-host only; default loopback on an
     /// ephemeral port).
     pub fn from_env() -> Result<Self> {
@@ -184,6 +213,9 @@ impl Config {
             std::env::var("TIDEBREAK_CONTAINER_EXECUTION_ENABLED").ok(),
             std::env::var("TIDEBREAK_CONTAINER_IMAGE").ok(),
             std::env::var_os("TIDEBREAK_AUTH_TOKENS_FILE"),
+            std::env::var("TIDEBREAK_AUTH_GATEWAY_URL").ok(),
+            std::env::var("TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL").ok(),
+            std::env::var("TIDEBREAK_PUBLIC_URL").ok(),
             std::env::var("TIDEBREAK_LISTEN_ADDR").ok(),
         )
     }
@@ -195,12 +227,16 @@ impl Config {
     /// An **empty** value is treated as unset: a caller that exports
     /// `TIDEBREAK_DATA_DIR=` (or an empty profile) gets the documented defaults,
     /// not an empty path rooted at the current directory.
+    #[allow(clippy::too_many_arguments)] // mirrors the environment variables one-to-one
     fn from_vars(
         profile: Option<String>,
         data_dir: Option<OsString>,
         container_execution_enabled: Option<String>,
         container_image: Option<String>,
         auth_tokens_file: Option<OsString>,
+        auth_gateway_url: Option<String>,
+        auth_gateway_verifier_url: Option<String>,
+        public_url: Option<String>,
         listen_addr: Option<String>,
     ) -> Result<Self> {
         let profile = match profile.filter(|value| !value.is_empty()).as_deref() {
@@ -227,6 +263,10 @@ impl Config {
         let auth_tokens_file = auth_tokens_file
             .filter(|path| !path.is_empty())
             .map(PathBuf::from);
+        let auth_gateway_url = auth_gateway_url.filter(|value| !value.trim().is_empty());
+        let auth_gateway_verifier_url =
+            auth_gateway_verifier_url.filter(|value| !value.trim().is_empty());
+        let public_url = public_url.filter(|value| !value.trim().is_empty());
         let listen_addr = match listen_addr.filter(|value| !value.is_empty()) {
             None => None,
             Some(value) => Some(value.parse::<SocketAddr>().map_err(|_| {
@@ -248,6 +288,9 @@ impl Config {
             container_execution_enabled,
             container_image,
             auth_tokens_file,
+            auth_gateway_url,
+            auth_gateway_verifier_url,
+            public_url,
             listen_addr,
         })
     }
@@ -295,6 +338,18 @@ impl Config {
     }
 }
 
+/// OAuth resource bound to one exact, already-canonical Tidebreak public URL.
+///
+/// Callers canonicalize first because URL parsing belongs at their trust
+/// boundary: the server validates operator config, while desktop validates the
+/// user-entered remote address. Hashing is shared so both sides cannot drift.
+#[must_use]
+pub fn tidebreak_machine_resource(canonical_public_url: &str) -> String {
+    let digest = Sha256::digest(canonical_public_url.as_bytes());
+    let hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
+    format!("tidebreak:{hex}")
+}
+
 fn is_false(value: &bool) -> bool {
     !*value
 }
@@ -323,8 +378,18 @@ mod tests {
     fn empty_data_dir_var_falls_back_to_the_default() {
         // `TIDEBREAK_DATA_DIR=` (set but empty) must behave like unset, not point
         // the store at `tidebreak.db` in the current directory.
-        let config =
-            Config::from_vars(None, Some(OsString::new()), None, None, None, None).unwrap();
+        let config = Config::from_vars(
+            None,
+            Some(OsString::new()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         let expected = std::env::current_dir().unwrap().join(".tidebreak");
         assert_eq!(config.data_dir, expected);
         assert_eq!(config.profile, Profile::Desktop);
@@ -335,6 +400,9 @@ mod tests {
         let config = Config::from_vars(
             Some(String::new()),
             Some(OsString::from("/data")),
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -353,6 +421,9 @@ mod tests {
             None,
             Some(OsString::from("/etc/tidebreak/tokens")),
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert_eq!(config.profile, Profile::SelfHost);
@@ -365,7 +436,18 @@ mod tests {
 
     #[test]
     fn unknown_profile_var_is_an_error() {
-        assert!(Config::from_vars(Some("bogus".into()), None, None, None, None, None).is_err());
+        assert!(Config::from_vars(
+            Some("bogus".into()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None
+        )
+        .is_err());
     }
 
     /// The desktop server is loopback-only by design, so a configured address
@@ -392,6 +474,9 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
             Some("0.0.0.0:8080".into()),
         )
         .unwrap();
@@ -404,6 +489,9 @@ mod tests {
         // back to the loopback default the operator was trying to escape.
         assert!(Config::from_vars(
             Some("self_host".into()),
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -429,6 +517,9 @@ mod tests {
         assert!(!config.container_execution_enabled);
         assert_eq!(config.container_image, None);
         assert_eq!(config.auth_tokens_file, None);
+        assert_eq!(config.auth_gateway_url, None);
+        assert_eq!(config.auth_gateway_verifier_url, None);
+        assert_eq!(config.public_url, None);
     }
 
     #[test]
@@ -448,6 +539,9 @@ mod tests {
             Some("tidebreak-sandbox-agent:dev".into()),
             None,
             None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert!(config.container_execution_enabled);
@@ -455,6 +549,57 @@ mod tests {
             config.container_image.as_deref(),
             Some("tidebreak-sandbox-agent:dev")
         );
-        assert!(Config::from_vars(None, None, Some("yes".into()), None, None, None).is_err());
+        assert!(Config::from_vars(
+            None,
+            None,
+            Some("yes".into()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn gateway_auth_url_is_loaded_for_self_host() {
+        let config = Config::from_vars(
+            Some("self_host".into()),
+            Some(OsString::from("/data")),
+            None,
+            None,
+            None,
+            Some("https://gateway.example.test".into()),
+            Some("https://gateway.model-gateway.svc.cluster.local".into()),
+            Some("https://tidebreak.example.test".into()),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            config.auth_gateway_url.as_deref(),
+            Some("https://gateway.example.test")
+        );
+        assert_eq!(
+            config.auth_gateway_verifier_url.as_deref(),
+            Some("https://gateway.model-gateway.svc.cluster.local")
+        );
+        assert_eq!(
+            config.public_url.as_deref(),
+            Some("https://tidebreak.example.test")
+        );
+    }
+
+    #[test]
+    fn tidebreak_machine_resource_is_stable_and_url_specific() {
+        assert_eq!(
+            tidebreak_machine_resource("https://tidebreak.example.test"),
+            "tidebreak:3c6444cbec9b33f56b4ed0f1bf7015741c69cf7e516977c52975c6a0012a097b"
+        );
+        assert_ne!(
+            tidebreak_machine_resource("https://tidebreak.example.test"),
+            tidebreak_machine_resource("https://other.example.test")
+        );
     }
 }

--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -30,6 +30,8 @@ code_browser_command: creates and controls sandboxed native child webviews whose
 # Attaching this client to a machine it does not host (ADR 0047)
 remote_machine_state: reports which machine this client is attached to, from shell-held state that exists before any machine is reachable.
 connect_remote_machine: stores the machine token in the OS credential store, which only the native shell can reach.
+connect_gateway_remote_machine: mints a machine-bound token from the shell's keychain-held Gateway OAuth session (ADR 0049); the rotating refresh credential never leaves the native shell.
+remote_machine_access_token: refreshes that machine-bound token from the same keychain-held session so HTTP calls and new sockets use the latest value.
 disconnect_remote_machine: removes that stored token from the OS credential store.
 
 # OS pickers, drops, and save dialogs

--- a/crates/tidebreak-desktop/src/deep_link.rs
+++ b/crates/tidebreak-desktop/src/deep_link.rs
@@ -70,6 +70,18 @@ impl PairingStore {
     pub(crate) fn new(rx: watch::Receiver<Option<PairingHandle>>) -> Self {
         Self { rx }
     }
+
+    pub(crate) async fn handle(&self) -> Result<PairingHandle, String> {
+        let mut rx = self.rx.clone();
+        loop {
+            if let Some(handle) = rx.borrow().clone() {
+                return Ok(handle);
+            }
+            rx.changed()
+                .await
+                .map_err(|_| "the embedded server did not start".to_string())?;
+        }
+    }
 }
 
 /// A validated provision link: the gateway URL to pair with, and its origin
@@ -586,15 +598,7 @@ fn show_pairing_failure(app: &tauri::AppHandle, origin: &str, failure: &PairingE
 }
 
 async fn wait_pairing_handle(app: &tauri::AppHandle) -> Result<PairingHandle, String> {
-    let mut rx = app.state::<PairingStore>().rx.clone();
-    loop {
-        if let Some(handle) = rx.borrow().clone() {
-            return Ok(handle);
-        }
-        rx.changed()
-            .await
-            .map_err(|_| "the embedded server did not start".to_string())?;
-    }
+    app.state::<PairingStore>().handle().await
 }
 
 /// Growth cap for `pairing.log`. Every ignored deep link writes a line, and

--- a/crates/tidebreak-desktop/src/host_authority.rs
+++ b/crates/tidebreak-desktop/src/host_authority.rs
@@ -77,11 +77,12 @@ pub(crate) fn require_local_authority(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::remote::AttachedAuth;
 
     fn attached() -> Attached {
         Attached {
             base_url: "https://machine.example.com".to_owned(),
-            token: "token-value".to_owned(),
+            auth: AttachedAuth::StaticToken("token-value".to_owned()),
         }
     }
 

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -52,6 +52,9 @@ pub struct ServerInfo {
     /// attached to. Host authority exists only on the local machine, so every
     /// caller that reaches the host branches on this.
     pub attachment: remote::Attachment,
+    /// Whether the bearer is a short-lived Model Gateway resource token the
+    /// shell can refresh from its existing OAuth session.
+    pub gateway_auth: bool,
 }
 
 #[derive(Clone)]
@@ -67,6 +70,7 @@ impl NativeServerInfo {
             base_url: self.base_url.clone(),
             token: self.token.clone(),
             attachment: remote::Attachment::Local,
+            gateway_auth: false,
         }
     }
 }
@@ -94,15 +98,54 @@ struct AppState {
 async fn server_info(
     state: tauri::State<'_, Arc<AppState>>,
     attachment: tauri::State<'_, Arc<remote::RemoteAttachment>>,
+    pairing: tauri::State<'_, deep_link::PairingStore>,
 ) -> Result<ServerInfo, String> {
     if let Some(attached) = attachment.current().await {
+        let (token, gateway_auth) = remote_token(&attached, &pairing).await?;
         return Ok(ServerInfo {
             base_url: attached.base_url,
-            token: attached.token,
+            token,
             attachment: remote::Attachment::Remote,
+            gateway_auth,
         });
     }
     Ok(wait_server_info(state.inner()).await?.renderer_info())
+}
+
+async fn remote_token(
+    attached: &remote::Attached,
+    pairing: &deep_link::PairingStore,
+) -> Result<(String, bool), String> {
+    match &attached.auth {
+        remote::AttachedAuth::StaticToken(token) => Ok((token.clone(), false)),
+        remote::AttachedAuth::Gateway { gateway_url } => {
+            let resource = tidebreak_core::config::tidebreak_machine_resource(&attached.base_url);
+            pairing
+                .handle()
+                .await?
+                .hosted_tidebreak_access_token(gateway_url, &resource)
+                .await
+                .map(|token| (token, true))
+                .map_err(|error| error.to_string())
+        }
+    }
+}
+
+/// Return a fresh credential for the currently attached machine. Gateway mode
+/// rotates through the existing desktop OAuth session; static mode returns the
+/// legacy stored bearer.
+#[tauri::command]
+async fn remote_machine_access_token(
+    attachment: tauri::State<'_, Arc<remote::RemoteAttachment>>,
+    pairing: tauri::State<'_, deep_link::PairingStore>,
+) -> Result<String, String> {
+    let attached = attachment
+        .current()
+        .await
+        .ok_or_else(|| "this window is not attached to a remote machine".to_string())?;
+    remote_token(&attached, &pairing)
+        .await
+        .map(|(token, _)| token)
 }
 
 /// Report which machine this client is attached to.
@@ -124,6 +167,29 @@ async fn connect_remote_machine(
     token: String,
 ) -> Result<remote::RemoteMachineState, remote::RemoteConnectError> {
     attachment.connect(&base_url, &token).await
+}
+
+/// Attach to a hosted machine using the Model Gateway session this desktop
+/// already holds. No user bearer is persisted or copied.
+#[tauri::command]
+async fn connect_gateway_remote_machine(
+    attachment: tauri::State<'_, Arc<remote::RemoteAttachment>>,
+    pairing: tauri::State<'_, deep_link::PairingStore>,
+    base_url: String,
+) -> Result<remote::RemoteMachineState, remote::RemoteConnectError> {
+    let (base_url, gateway_url, resource) = remote::discover_gateway(&base_url).await?;
+    let handle = pairing.handle().await.map_err(|error| {
+        remote::RemoteConnectError::detailed(remote::REASON_GATEWAY_AUTH_UNAVAILABLE, error)
+    })?;
+    let token = handle
+        .hosted_tidebreak_access_token(&gateway_url, &resource)
+        .await
+        .map_err(|error| {
+            remote::RemoteConnectError::detailed(remote::REASON_GATEWAY_AUTH_UNAVAILABLE, error)
+        })?;
+    attachment
+        .connect_gateway(&base_url, &gateway_url, &token)
+        .await
 }
 
 /// Detach from the remote machine and forget its token.
@@ -649,6 +715,8 @@ pub fn run() {
             server_info,
             remote_machine_state,
             connect_remote_machine,
+            connect_gateway_remote_machine,
+            remote_machine_access_token,
             disconnect_remote_machine,
             put_native_mcp_servers,
             request_user_attention,
@@ -985,6 +1053,7 @@ mod server_info_tests {
         // The embedded server is always the local machine; the renderer reads
         // host authority off this field.
         assert!(serialized.contains(r#""attachment":"local""#));
+        assert!(serialized.contains(r#""gatewayAuth":false"#));
     }
 
     #[test]

--- a/crates/tidebreak-desktop/src/remote.rs
+++ b/crates/tidebreak-desktop/src/remote.rs
@@ -3,14 +3,15 @@
 //! A machine is a running `tidebreak-server`. Normally the desktop app is both
 //! machine and client: the shell boots the embedded server on loopback and the
 //! webview attaches to it. Decision record 47 adds the other shape — the same
-//! webview attached to a server somewhere else, reached with a base URL and a
-//! token the user supplies.
+//! webview attached to a server somewhere else. Gateway-backed machines reuse
+//! the desktop's existing OAuth session; standalone machines still accept a
+//! base URL and a token the user supplies.
 //!
 //! Two rules govern the address:
 //!
-//! - **TLS unless loopback.** The token is a long-lived bearer credential for
-//!   somebody's whole account, so cleartext to anywhere but this machine hands
-//!   it to whoever is on the path. This is the same line
+//! - **TLS unless loopback.** Every attachment presents a bearer credential,
+//!   so cleartext to anywhere but this machine hands it to whoever is on the
+//!   path. This is the same line
 //!   [`crate::deep_link`] holds for a provision link, and both call
 //!   [`url_host_is_loopback`] so there is one rule, not two.
 //! - **The address is proved before it is stored.** Connecting probes the
@@ -28,10 +29,11 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
+use tidebreak_core::config::tidebreak_machine_resource;
 use tidebreak_core::keychain::KeychainSecretProvider;
 use tidebreak_core::storage::SecretProvider;
 
-/// Keychain key holding the bearer token for the attached remote machine.
+/// Keychain key holding the bearer token for a legacy static-token machine.
 const TOKEN_KEY: &str = "desktop.remote-machine.token";
 
 /// File under the profile data dir holding the attached machine's address.
@@ -42,9 +44,15 @@ const ADDRESS_FILE: &str = "remote-machine.json";
 /// Route the connect probe calls. Cheap, authenticated, and present on every
 /// profile, so a 2xx proves both reachability and a token the machine accepts.
 const PROBE_PATH: &str = "/policy";
+/// Public machine metadata used to select Gateway-backed authentication.
+const DISCOVERY_PATH: &str = "/auth/discovery";
 
 /// How long the connect probe waits before calling a machine unreachable.
 const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Discovery is a tiny fixed-shape document. A hard cap prevents a machine
+/// endpoint from turning that unauthenticated read into an unbounded buffer.
+const MAX_DISCOVERY_RESPONSE_BYTES: usize = 16 * 1024;
 
 /// Which machine the renderer is attached to.
 ///
@@ -90,16 +98,19 @@ pub const REASON_TOKEN_REFUSED: &str = "remote_machine_token_refused";
 pub const REASON_NOT_A_MACHINE: &str = "remote_machine_not_a_machine";
 /// The token could not be stored in, or read from, the OS credential store.
 pub const REASON_TOKEN_STORAGE_FAILED: &str = "remote_machine_token_storage_failed";
+/// The machine is not Gateway-backed, or it names a different Gateway than
+/// the one managing this desktop profile.
+pub const REASON_GATEWAY_AUTH_UNAVAILABLE: &str = "remote_machine_gateway_auth_unavailable";
 
 impl RemoteConnectError {
-    fn new(reason: &'static str) -> Self {
+    pub(crate) fn new(reason: &'static str) -> Self {
         Self {
             reason,
             detail: None,
         }
     }
 
-    fn detailed(reason: &'static str, detail: impl std::fmt::Display) -> Self {
+    pub(crate) fn detailed(reason: &'static str, detail: impl std::fmt::Display) -> Self {
         Self {
             reason,
             detail: Some(detail.to_string()),
@@ -122,10 +133,23 @@ pub struct RemoteMachineState {
 #[serde(rename_all = "camelCase")]
 struct StoredAddress {
     base_url: String,
+    #[serde(default)]
+    auth: StoredAuth,
 }
 
-/// The shell's remote-attachment state: the address on disk, the token in the
-/// OS credential store, and a cached read of both.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+enum StoredAuth {
+    #[default]
+    StaticToken,
+    Gateway {
+        gateway_url: String,
+    },
+}
+
+/// The shell's remote-attachment state: public connection metadata on disk,
+/// the optional legacy static token in the OS credential store, and a cached
+/// read of both.
 pub struct RemoteAttachment {
     address_path: PathBuf,
     secrets: Arc<dyn SecretProvider>,
@@ -133,11 +157,17 @@ pub struct RemoteAttachment {
     cached: RwLock<Option<Option<Attached>>>,
 }
 
-/// A live remote attachment: address plus the token that reaches it.
+/// A live remote attachment: address plus the selected authentication source.
 #[derive(Clone, Debug)]
 pub struct Attached {
     pub base_url: String,
-    pub token: String,
+    pub auth: AttachedAuth,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AttachedAuth {
+    StaticToken(String),
+    Gateway { gateway_url: String },
 }
 
 impl RemoteAttachment {
@@ -163,9 +193,9 @@ impl RemoteAttachment {
 
     /// The current attachment, reading disk and keychain at most once.
     ///
-    /// An address with no token behind it reads as *not attached*: the token is
-    /// what makes the address usable, and half an attachment would boot the
-    /// renderer against a machine it cannot authenticate to.
+    /// A legacy static-token address with no token behind it reads as *not
+    /// attached*. Gateway attachments need only their public Gateway URL; the
+    /// short-lived bearer is minted from the existing OAuth session at use.
     pub async fn current(&self) -> Option<Attached> {
         if let Some(cached) = self.cached.read().await.as_ref() {
             return cached.clone();
@@ -178,10 +208,15 @@ impl RemoteAttachment {
     async fn read_through(&self) -> Option<Attached> {
         let bytes = std::fs::read(&self.address_path).ok()?;
         let stored: StoredAddress = serde_json::from_slice(&bytes).ok()?;
-        let token = self.secrets.get_secret(TOKEN_KEY).await.ok()??;
+        let auth = match stored.auth {
+            StoredAuth::StaticToken => {
+                AttachedAuth::StaticToken(self.secrets.get_secret(TOKEN_KEY).await.ok()??)
+            }
+            StoredAuth::Gateway { gateway_url } => AttachedAuth::Gateway { gateway_url },
+        };
         Some(Attached {
             base_url: stored.base_url,
-            token,
+            auth,
         })
     }
 
@@ -214,20 +249,21 @@ impl RemoteAttachment {
             return Err(RemoteConnectError::new(REASON_TOKEN_REFUSED));
         }
         probe(&base_url, token).await?;
-        self.store(&base_url, token).await?;
+        self.store_static(&base_url, token).await?;
         Ok(RemoteMachineState {
             attachment: Attachment::Remote,
             base_url: Some(base_url),
         })
     }
 
-    async fn store(&self, base_url: &str, token: &str) -> Result<(), RemoteConnectError> {
+    async fn store_static(&self, base_url: &str, token: &str) -> Result<(), RemoteConnectError> {
         self.secrets
             .set_secret(TOKEN_KEY, token)
             .await
             .map_err(|error| RemoteConnectError::detailed(REASON_TOKEN_STORAGE_FAILED, error))?;
         let body = serde_json::to_vec_pretty(&StoredAddress {
             base_url: base_url.to_owned(),
+            auth: StoredAuth::StaticToken,
         })
         .expect("a struct of owned strings serializes");
         // Token first, address second: a crash between the two leaves an
@@ -238,9 +274,42 @@ impl RemoteAttachment {
             .map_err(|error| RemoteConnectError::detailed(REASON_TOKEN_STORAGE_FAILED, error))?;
         *self.cached.write().await = Some(Some(Attached {
             base_url: base_url.to_owned(),
-            token: token.to_owned(),
+            auth: AttachedAuth::StaticToken(token.to_owned()),
         }));
         Ok(())
+    }
+
+    /// Attach with a short-lived token minted from this desktop's existing
+    /// Model Gateway session. Only the machine and Gateway URLs are persisted;
+    /// the user token is refreshed from the OAuth session and never becomes a
+    /// second long-lived credential in the keychain.
+    pub async fn connect_gateway(
+        &self,
+        base_url: &str,
+        gateway_url: &str,
+        token: &str,
+    ) -> Result<RemoteMachineState, RemoteConnectError> {
+        let base_url = validated_base_url(base_url)?;
+        let gateway_url = validated_gateway_url(gateway_url)?;
+        probe(&base_url, token).await?;
+        let body = serde_json::to_vec_pretty(&StoredAddress {
+            base_url: base_url.clone(),
+            auth: StoredAuth::Gateway {
+                gateway_url: gateway_url.clone(),
+            },
+        })
+        .expect("a struct of owned strings serializes");
+        std::fs::write(&self.address_path, body)
+            .map_err(|error| RemoteConnectError::detailed(REASON_TOKEN_STORAGE_FAILED, error))?;
+        let _ = self.secrets.delete_secret(TOKEN_KEY).await;
+        *self.cached.write().await = Some(Some(Attached {
+            base_url: base_url.clone(),
+            auth: AttachedAuth::Gateway { gateway_url },
+        }));
+        Ok(RemoteMachineState {
+            attachment: Attachment::Remote,
+            base_url: Some(base_url),
+        })
     }
 
     /// Drop the attachment and forget the token. Returns the local state.
@@ -257,6 +326,87 @@ impl RemoteAttachment {
             base_url: None,
         }
     }
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+enum AuthDiscovery {
+    Gateway {
+        gateway_url: String,
+        resource: String,
+    },
+    StaticToken,
+    Local,
+}
+
+/// Discover the Gateway identity authority a hosted machine is configured to
+/// use. This endpoint carries no credential and returns no user data.
+///
+/// The machine audience is derived locally from the canonical validated base
+/// URL. Discovery may echo it for diagnostics, but cannot choose it.
+pub async fn discover_gateway(
+    base_url: &str,
+) -> Result<(String, String, String), RemoteConnectError> {
+    let base_url = validated_base_url(base_url)?;
+    let resource = tidebreak_machine_resource(&base_url);
+    let client = reqwest::Client::builder()
+        .timeout(PROBE_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("fixed HTTP client configuration is valid");
+    let response = client
+        .get(format!("{base_url}{DISCOVERY_PATH}"))
+        .send()
+        .await
+        .map_err(|error| RemoteConnectError::detailed(REASON_UNREACHABLE, error))?;
+    if !response.status().is_success() {
+        return Err(RemoteConnectError::detailed(
+            REASON_NOT_A_MACHINE,
+            format!("status {}", response.status()),
+        ));
+    }
+    let body = read_discovery_body(response).await?;
+    let discovery: AuthDiscovery = serde_json::from_slice(&body)
+        .map_err(|error| RemoteConnectError::detailed(REASON_NOT_A_MACHINE, error))?;
+    match discovery {
+        AuthDiscovery::Gateway {
+            gateway_url,
+            resource: advertised,
+        } if advertised == resource => {
+            Ok((base_url, validated_gateway_url(&gateway_url)?, resource))
+        }
+        AuthDiscovery::Gateway { .. } | AuthDiscovery::StaticToken | AuthDiscovery::Local => {
+            Err(RemoteConnectError::new(REASON_GATEWAY_AUTH_UNAVAILABLE))
+        }
+    }
+}
+
+async fn read_discovery_body(response: reqwest::Response) -> Result<Vec<u8>, RemoteConnectError> {
+    use futures::StreamExt as _;
+
+    let too_large = || {
+        RemoteConnectError::detailed(
+            REASON_NOT_A_MACHINE,
+            "discovery response exceeded its byte budget",
+        )
+    };
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_DISCOVERY_RESPONSE_BYTES as u64)
+    {
+        return Err(too_large());
+    }
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.map_err(|error| RemoteConnectError::detailed(REASON_NOT_A_MACHINE, error))?;
+        if body.len().saturating_add(chunk.len()) > MAX_DISCOVERY_RESPONSE_BYTES {
+            return Err(too_large());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
 }
 
 /// Normalize a user-entered base URL, or say why it cannot be used.
@@ -296,6 +446,22 @@ fn normalized(url: &tauri::Url) -> String {
     url.as_str().trim_end_matches('/').to_owned()
 }
 
+fn validated_gateway_url(raw: &str) -> Result<String, RemoteConnectError> {
+    let url = tauri::Url::parse(raw.trim())
+        .map_err(|error| RemoteConnectError::detailed(REASON_GATEWAY_AUTH_UNAVAILABLE, error))?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || (url.scheme() == "http" && !url_host_is_loopback(&url))
+    {
+        return Err(RemoteConnectError::new(REASON_GATEWAY_AUTH_UNAVAILABLE));
+    }
+    Ok(normalized(&url))
+}
+
 /// Whether a URL's host is this machine.
 ///
 /// `localhost` counts because the resolver is required to map it to a loopback
@@ -317,6 +483,7 @@ pub fn url_host_is_loopback(url: &tauri::Url) -> bool {
 async fn probe(base_url: &str, token: &str) -> Result<(), RemoteConnectError> {
     let client = reqwest::Client::builder()
         .timeout(PROBE_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .expect("fixed HTTP client configuration is valid");
     let response = client
@@ -343,6 +510,41 @@ fn classify_probe(status: u16) -> Result<(), RemoteConnectError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    async fn serve_once(
+        response_for_base_url: impl FnOnce(&str) -> Vec<u8>,
+    ) -> (String, tokio::task::JoinHandle<Vec<u8>>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let response = response_for_base_url(&base_url);
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            loop {
+                let read = stream.read(&mut buffer).await.unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            stream.write_all(&response).await.unwrap();
+            request
+        });
+        (base_url, task)
+    }
+
+    fn ok_json(body: &str) -> Vec<u8> {
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+        .into_bytes()
+    }
 
     fn reason(raw: &str) -> &'static str {
         validated_base_url(raw)
@@ -426,6 +628,147 @@ mod tests {
         );
     }
 
+    #[test]
+    fn machine_resource_uses_the_canonical_validated_base_url() {
+        let canonical = validated_base_url("https://machine.example.com/").unwrap();
+        assert_eq!(canonical, "https://machine.example.com");
+        assert_eq!(
+            tidebreak_machine_resource(&canonical),
+            "tidebreak:46e3f66ef15f895d5561433564bfd02ab4b0dee3d3ef535d714a1ea03c7729a3"
+        );
+        assert_eq!(
+            tidebreak_machine_resource(&canonical),
+            tidebreak_machine_resource(
+                &validated_base_url(" https://machine.example.com ").unwrap()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn discovery_must_echo_the_independently_derived_machine_resource() {
+        let (base_url, served) = serve_once(|base_url| {
+            let body = serde_json::json!({
+                "mode": "gateway",
+                "gateway_url": "https://gateway.example.com",
+                "resource": tidebreak_machine_resource(base_url),
+            })
+            .to_string();
+            ok_json(&body)
+        })
+        .await;
+        let expected_resource = tidebreak_machine_resource(&base_url);
+        assert_eq!(
+            discover_gateway(&base_url).await.unwrap(),
+            (
+                base_url.clone(),
+                "https://gateway.example.com".to_owned(),
+                expected_resource,
+            )
+        );
+        served.await.unwrap();
+
+        let (base_url, served) = serve_once(|_| {
+            ok_json(
+                &serde_json::json!({
+                    "mode": "gateway",
+                    "gateway_url": "https://gateway.example.com",
+                    "resource": format!("tidebreak:{}", "0".repeat(64)),
+                })
+                .to_string(),
+            )
+        })
+        .await;
+        assert_eq!(
+            discover_gateway(&base_url).await.unwrap_err().reason,
+            REASON_GATEWAY_AUTH_UNAVAILABLE
+        );
+        served.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn discovery_body_is_bounded_with_or_without_content_length() {
+        let declared = MAX_DISCOVERY_RESPONSE_BYTES + 1;
+        let (base_url, served) = serve_once(move |_| {
+            format!("HTTP/1.1 200 OK\r\nContent-Length: {declared}\r\nConnection: close\r\n\r\n")
+                .into_bytes()
+        })
+        .await;
+        assert_eq!(
+            discover_gateway(&base_url).await.unwrap_err().reason,
+            REASON_NOT_A_MACHINE
+        );
+        served.await.unwrap();
+
+        let oversized = vec![b'x'; MAX_DISCOVERY_RESPONSE_BYTES + 1];
+        let (base_url, served) = serve_once(move |_| {
+            let mut response = format!(
+                "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n{:x}\r\n",
+                oversized.len()
+            )
+            .into_bytes();
+            response.extend_from_slice(&oversized);
+            response.extend_from_slice(b"\r\n0\r\n\r\n");
+            response
+        })
+        .await;
+        assert_eq!(
+            discover_gateway(&base_url).await.unwrap_err().reason,
+            REASON_NOT_A_MACHINE
+        );
+        served.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn discovery_and_bearer_probe_refuse_redirects() {
+        let discovery_target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let discovery_target_url = format!("http://{}", discovery_target.local_addr().unwrap());
+        let (base_url, served) = serve_once(move |_| {
+            format!(
+                "HTTP/1.1 302 Found\r\nLocation: {discovery_target_url}/stolen\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            .into_bytes()
+        })
+        .await;
+        assert_eq!(
+            discover_gateway(&base_url).await.unwrap_err().reason,
+            REASON_NOT_A_MACHINE
+        );
+        served.await.unwrap();
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                discovery_target.accept()
+            )
+            .await
+            .is_err(),
+            "discovery followed a redirect"
+        );
+
+        let probe_target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let probe_target_url = format!("http://{}", probe_target.local_addr().unwrap());
+        let (base_url, served) = serve_once(move |_| {
+            format!(
+                "HTTP/1.1 307 Temporary Redirect\r\nLocation: {probe_target_url}/stolen\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            .into_bytes()
+        })
+        .await;
+        assert_eq!(
+            probe(&base_url, "machine-bearer").await.unwrap_err().reason,
+            REASON_NOT_A_MACHINE
+        );
+        let request = String::from_utf8(served.await.unwrap()).unwrap();
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer machine-bearer"));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), probe_target.accept())
+                .await
+                .is_err(),
+            "bearer-bearing policy probe followed a redirect"
+        );
+    }
+
     #[tokio::test]
     async fn an_address_without_a_token_reads_as_not_attached() {
         let dir = tempfile::tempdir().unwrap();
@@ -441,12 +784,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn legacy_address_json_still_loads_as_static_token_auth() {
+        let dir = tempfile::tempdir().unwrap();
+        let secrets = Arc::new(TestSecrets::default());
+        secrets.set_secret(TOKEN_KEY, "token-value").await.unwrap();
+        let attachment = RemoteAttachment::with_secrets(dir.path(), secrets);
+        std::fs::write(
+            dir.path().join(ADDRESS_FILE),
+            br#"{"baseUrl":"https://machine.example.com"}"#,
+        )
+        .unwrap();
+
+        let attached = attachment.current().await.unwrap();
+        assert_eq!(attached.base_url, "https://machine.example.com");
+        assert_eq!(
+            attached.auth,
+            AttachedAuth::StaticToken("token-value".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_attachment_loads_without_a_persisted_access_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let attachment =
+            RemoteAttachment::with_secrets(dir.path(), Arc::new(TestSecrets::default()));
+        std::fs::write(
+            dir.path().join(ADDRESS_FILE),
+            br#"{
+  "baseUrl": "https://machine.example.com",
+  "auth": {
+    "mode": "gateway",
+    "gateway_url": "https://gateway.example.com"
+  }
+}"#,
+        )
+        .unwrap();
+
+        let attached = attachment.current().await.unwrap();
+        assert_eq!(attached.base_url, "https://machine.example.com");
+        assert_eq!(
+            attached.auth,
+            AttachedAuth::Gateway {
+                gateway_url: "https://gateway.example.com".to_owned()
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn disconnect_forgets_both_halves() {
         let dir = tempfile::tempdir().unwrap();
         let secrets = Arc::new(TestSecrets::default());
         let attachment = RemoteAttachment::with_secrets(dir.path(), secrets.clone());
         attachment
-            .store("https://machine.example.com", "token-value")
+            .store_static("https://machine.example.com", "token-value")
             .await
             .unwrap();
         assert_eq!(

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -15,6 +15,7 @@ import {
 import { AppContextProvider } from "./AppContext";
 
 import { resolveServerInfo } from "./boot";
+import { remoteMachineAccessToken } from "./remoteMachine";
 import {
   deletionDescription,
   detachChatFolders,
@@ -240,6 +241,26 @@ export function AppShell() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (!client || !info?.gatewayAuth) return;
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const token = await remoteMachineAccessToken();
+        if (cancelled) return;
+        client.setAccessToken(token);
+        connectOutputs(client.baseUrl, token);
+      } catch (error) {
+        if (!cancelled) console.warn("could not refresh hosted Tidebreak access", error);
+      }
+    };
+    const timer = window.setInterval(() => void refresh(), 30_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [client, info]);
 
   useEffect(() => {
     if (!client || !info) return;

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -231,10 +231,23 @@ async function throwIfNotOk(response: Response): Promise<void> {
 }
 
 export class ApiClient {
+  private accessToken: string;
+
   constructor(
     readonly baseUrl: string,
-    readonly token: string,
-  ) {}
+    token: string,
+  ) {
+    this.accessToken = token;
+  }
+
+  get token(): string {
+    return this.accessToken;
+  }
+
+  /** Replace the short-lived bearer used by subsequent HTTP and WebSocket connections. */
+  setAccessToken(token: string): void {
+    this.accessToken = token;
+  }
 
   private headers(json = false): HeadersInit {
     const headers: Record<string, string> = {

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -239,6 +239,7 @@ export type ServerInfo = {
   baseUrl: string;
   token: string;
   attachment: Attachment;
+  gatewayAuth: boolean;
 };
 
 /** What the shell knows about the current attachment. */
@@ -267,7 +268,8 @@ export type RemoteConnectReason =
   | "remote_machine_unreachable"
   | "remote_machine_token_refused"
   | "remote_machine_not_a_machine"
-  | "remote_machine_token_storage_failed";
+  | "remote_machine_token_storage_failed"
+  | "remote_machine_gateway_auth_unavailable";
 
 export type ProviderKind = WireProviderKind;
 /** Stable provider-scoped key used for new settings and chat overrides. */

--- a/crates/tidebreak-desktop/ui/src/boot.ts
+++ b/crates/tidebreak-desktop/ui/src/boot.ts
@@ -56,7 +56,7 @@ async function desktopListenInfo(): Promise<ServerInfo | null> {
       typeof record.baseUrl === "string" ? record.baseUrl.trim().replace(/\/$/, "") : "";
     const token = typeof record.token === "string" ? record.token.trim() : "";
     if (!baseUrl || !token) return null;
-    return { baseUrl, token, attachment: "local" };
+    return { baseUrl, token, attachment: "local", gatewayAuth: false };
   } catch {
     return null;
   }
@@ -71,5 +71,6 @@ function envServerInfo(): ServerInfo | null {
     baseUrl: baseUrl.replace(/\/$/, ""),
     token,
     attachment: "local",
+    gatewayAuth: false,
   };
 }

--- a/crates/tidebreak-desktop/ui/src/remoteMachine.test.ts
+++ b/crates/tidebreak-desktop/ui/src/remoteMachine.test.ts
@@ -21,6 +21,7 @@ describe("remote connect refusals", () => {
       "remote_machine_token_refused",
       "remote_machine_not_a_machine",
       "remote_machine_token_storage_failed",
+      "remote_machine_gateway_auth_unavailable",
     ] as const;
     for (const reason of reasons) {
       const refused = remoteConnectError({ reason, detail: null });

--- a/crates/tidebreak-desktop/ui/src/remoteMachine.ts
+++ b/crates/tidebreak-desktop/ui/src/remoteMachine.ts
@@ -36,6 +36,18 @@ export async function connectRemoteMachine(
   return await invoke<RemoteMachineState>("connect_remote_machine", { baseUrl, token });
 }
 
+/** Attach using the Model Gateway session this desktop already holds. */
+export async function connectGatewayRemoteMachine(
+  baseUrl: string,
+): Promise<RemoteMachineState> {
+  return await invoke<RemoteMachineState>("connect_gateway_remote_machine", { baseUrl });
+}
+
+/** Mint or retrieve a fresh bearer for the currently attached machine. */
+export async function remoteMachineAccessToken(): Promise<string> {
+  return await invoke<string>("remote_machine_access_token");
+}
+
 /** Detach and forget the machine's token. */
 export async function disconnectRemoteMachine(): Promise<RemoteMachineState> {
   return await invoke<RemoteMachineState>("disconnect_remote_machine");
@@ -73,6 +85,8 @@ const CONNECT_COPY: Record<RemoteConnectReason, string> = {
     "Something answered at that address, but not a Tidebreak machine. Check the address.",
   remote_machine_token_storage_failed:
     "The token could not be saved to this computer's credential store. Nothing was changed.",
+  remote_machine_gateway_auth_unavailable:
+    "This machine is not connected to the same Model Gateway as this app. Sign in through that Gateway, or use a static token for a standalone machine.",
 };
 
 export function connectFailureMessage(error: RemoteConnectError): string {

--- a/crates/tidebreak-desktop/ui/src/settings/MachinePanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/MachinePanel.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { useConfirm } from "@/components/ConfirmDialog";
 import {
   HOST_AUTHORITIES,
+  connectGatewayRemoteMachine,
   connectFailureMessage,
   connectRemoteMachine,
   disconnectRemoteMachine,
@@ -86,6 +87,23 @@ export function MachinePanel() {
     }
   }
 
+  async function connectWithGateway() {
+    setBusy(true);
+    setError(null);
+    try {
+      await connectGatewayRemoteMachine(baseUrl);
+      reattach();
+    } catch (failure) {
+      const refused = remoteConnectError(failure);
+      setError(
+        refused
+          ? connectFailureMessage(refused)
+          : friendlyErrorMessage(failure, "Could not connect through Model Gateway."),
+      );
+      setBusy(false);
+    }
+  }
+
   async function disconnect() {
     const accepted = await confirm({
       title: "Work on this computer again?",
@@ -153,7 +171,7 @@ export function MachinePanel() {
       ) : (
         <SettingsSection
           title="Connect to a machine"
-          description="Enter the address of a Tidebreak server and a token for your account on it. The address must use https unless the machine is on this computer, because the token would otherwise travel in the clear."
+          description="Enter the hosted Tidebreak address. If it uses the same Model Gateway as this app, your existing sign-in supplies access automatically."
         >
           <SettingsField label="Address" hint="For example, https://tidebreak.example.com.">
             <Input
@@ -165,9 +183,18 @@ export function MachinePanel() {
               disabled={busy}
             />
           </SettingsField>
+          <div>
+            <Button
+              onClick={() => void connectWithGateway()}
+              disabled={busy || !baseUrl.trim()}
+            >
+              <Server size={16} aria-hidden />
+              Connect with Model Gateway
+            </Button>
+          </div>
           <SettingsField
-            label="Token"
-            hint="Whoever runs the machine issues this. It is stored in this computer's credential store, not in a file."
+            label="Standalone token"
+            hint="Only for a Tidebreak machine that is not connected to Model Gateway."
           >
             <Input
               type="password"
@@ -184,7 +211,7 @@ export function MachinePanel() {
               disabled={busy || !baseUrl.trim() || !token.trim()}
             >
               <Server size={16} aria-hidden />
-              Connect
+              Connect with token
             </Button>
           </div>
           {error && <SettingsError>{error}</SettingsError>}

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -7,11 +7,11 @@
 //!   [`Principal::LocalOwner`]. It's the one thing standing between the agent
 //!   and any other local process that finds the port, so the check is
 //!   mandatory on every non-health route.
-//! - **Self-host** authenticates with static named bearer tokens from an
-//!   operator-maintained file ([`TokenMap`]); each token names the configured
-//!   user it belongs to, resolved to [`Principal::User`]. The per-launch token
-//!   names nobody on a shared deployment and is not accepted there — a
-//!   credential that names no one is rejected at this middleware (#853).
+//! - **Self-host** authenticates either with live Model Gateway identity or
+//!   static named bearer tokens from an operator-maintained file ([`TokenMap`]).
+//!   Both resolve to [`Principal::User`]. The per-launch token names nobody on
+//!   a shared deployment and is not accepted there — a credential that names
+//!   no one is rejected at this middleware (#853).
 //!
 //! # Self-host token file
 //!
@@ -54,6 +54,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::time::Duration;
 
 use axum::extract::{Request, State};
 use axum::http::{
@@ -62,6 +63,8 @@ use axum::http::{
 };
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
+use axum::Json;
+use futures::StreamExt as _;
 use tidebreak_core::{AgentError, Profile, Result};
 
 use crate::principal::{AuthContext, Principal, Role, UserId};
@@ -84,6 +87,39 @@ pub const CLIENT_EXECUTOR_HEADER: HeaderName =
 /// Scoped credential for publishing caller-held bytes into one chat.
 pub const LOCAL_IMPORT_HEADER: HeaderName = HeaderName::from_static("x-tidebreak-local-import");
 
+/// Public, non-secret authentication metadata for native clients attaching to
+/// a hosted machine. A client uses this to discover that it should mint a
+/// Gateway `tidebreak` resource token instead of asking a person to paste a
+/// long-lived static bearer.
+#[derive(serde::Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub(crate) enum AuthDiscovery {
+    Gateway {
+        gateway_url: String,
+        resource: String,
+    },
+    StaticToken,
+    Local,
+}
+
+pub(crate) async fn discovery(State(state): State<AppState>) -> Json<AuthDiscovery> {
+    let discovery = match state.config.profile {
+        Profile::SelfHost => match state.config.auth_gateway_url.as_deref() {
+            Some(gateway_url) => AuthDiscovery::Gateway {
+                gateway_url: gateway_url.trim_end_matches('/').to_owned(),
+                resource: state
+                    .principal_authenticator
+                    .gateway_resource()
+                    .expect("Gateway authenticator exposes its machine resource")
+                    .to_owned(),
+            },
+            None => AuthDiscovery::StaticToken,
+        },
+        _ => AuthDiscovery::Local,
+    };
+    Json(discovery)
+}
+
 /// Reject requests whose bearer token does not resolve to a principal — from
 /// `Authorization: Bearer <token>`, or (on WebSocket upgrades only)
 /// `Sec-WebSocket-Protocol: tidebreak-token.<token>`.
@@ -95,11 +131,25 @@ pub async fn require_token(
     mut request: Request,
     next: Next,
 ) -> Response {
-    let resolved =
-        extract_token(request.headers()).and_then(|presented| resolve_principal(&state, presented));
+    let presented = extract_token(request.headers()).map(str::to_owned);
+    let resolved = match presented.as_deref() {
+        Some(presented) => resolve_principal(&state, presented).await,
+        None => None,
+    };
 
     match resolved {
         Some(principal) => {
+            if matches!(
+                state.principal_authenticator.as_ref(),
+                PrincipalAuthenticator::Gateway(_)
+            ) {
+                request.extensions_mut().insert(GatewayAuthLease {
+                    bearer: presented
+                        .expect("a resolved principal had a presented token")
+                        .into(),
+                    principal: principal.clone(),
+                });
+            }
             request.extensions_mut().insert(AuthContext {
                 principal,
                 client_executor: false,
@@ -110,12 +160,36 @@ pub async fn require_token(
     }
 }
 
+/// Process-memory lease retained by Gateway-authenticated WebSocket tasks.
+///
+/// The bearer is intentionally private and this type deliberately implements
+/// neither `Debug` nor serialization. Socket loops use it only to re-check the
+/// live Gateway principal; static-token and local sockets receive no lease.
+#[derive(Clone)]
+pub(crate) struct GatewayAuthLease {
+    bearer: std::sync::Arc<str>,
+    principal: Principal,
+}
+
+impl GatewayAuthLease {
+    /// Revalidate the original credential and require identity and role to be
+    /// unchanged. Refusal, expiry, deactivation, demotion/promotion, and
+    /// verifier outages all fail closed.
+    pub(crate) async fn revalidate(&self, state: &AppState) -> bool {
+        state
+            .principal_authenticator
+            .resolve(&self.bearer)
+            .await
+            .is_some_and(|principal| principal == self.principal)
+    }
+}
+
 /// Map the presented credential to WHO is asking, per the boot profile.
 ///
 /// `None` is a 401: a token that names no one admits no one. Unknown future
 /// profiles resolve nobody until they choose an authenticator — fail closed,
 /// never defaulted to the local owner.
-fn resolve_principal(state: &AppState, presented: &str) -> Option<Principal> {
+async fn resolve_principal(state: &AppState, presented: &str) -> Option<Principal> {
     match state.config.profile {
         // The per-launch bearer is loopback-only and handed to one client, so
         // the verified caller *is* the local owner.
@@ -124,20 +198,227 @@ fn resolve_principal(state: &AppState, presented: &str) -> Option<Principal> {
         // Every self-host credential names a configured user. The per-launch
         // bearer is deliberately not consulted: on a shared deployment it
         // names nobody, so it authenticates nobody.
-        Profile::SelfHost => state
-            .principal_tokens
-            .resolve(presented)
-            .map(|(id, role)| Principal::User { id, role }),
+        Profile::SelfHost => state.principal_authenticator.resolve(presented).await,
         _ => None,
     }
+}
+
+/// The self-host credential-to-principal mechanism selected at boot.
+///
+/// Gateway mode is the hosted default: every request is checked against the
+/// Gateway's live account and session state. Static tokens remain available
+/// for standalone self-host deployments with no Model Gateway.
+pub(crate) enum PrincipalAuthenticator {
+    None,
+    Static(TokenMap),
+    Gateway(GatewayAuthenticator),
+}
+
+impl PrincipalAuthenticator {
+    pub(crate) fn from_config(config: &tidebreak_core::Config) -> Result<Self> {
+        match (
+            config.auth_tokens_file.as_deref(),
+            config.auth_gateway_url.as_deref(),
+            config.auth_gateway_verifier_url.as_deref(),
+            config.public_url.as_deref(),
+        ) {
+            (Some(path), None, None, _) => Ok(Self::Static(TokenMap::load(path)?)),
+            (None, Some(gateway_url), verifier_url, Some(public_url)) => {
+                let public_url = canonical_public_url(public_url)?;
+                Ok(Self::Gateway(GatewayAuthenticator::new(
+                    verifier_url.unwrap_or(gateway_url),
+                    tidebreak_core::config::tidebreak_machine_resource(&public_url),
+                )?))
+            }
+            (None, Some(_), _, None) => Err(AgentError::config(
+                "TIDEBREAK_PUBLIC_URL is required with TIDEBREAK_AUTH_GATEWAY_URL so user credentials can be bound to this exact machine",
+            )),
+            (Some(_), Some(_), _, _) | (Some(_), None, Some(_), _) => Err(AgentError::config(
+                "self-host authentication is ambiguous: set exactly one of \
+                 TIDEBREAK_AUTH_TOKENS_FILE or TIDEBREAK_AUTH_GATEWAY_URL",
+            )),
+            (None, None, Some(_), _) => Err(AgentError::config(
+                "TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL requires \
+                 TIDEBREAK_AUTH_GATEWAY_URL to name the public identity authority",
+            )),
+            (None, None, None, _) => Err(AgentError::config(
+                "self-host requires a principal-naming authenticator: set \
+                 TIDEBREAK_AUTH_GATEWAY_URL for Model Gateway identity, or \
+                 TIDEBREAK_AUTH_TOKENS_FILE for standalone static tokens",
+            )),
+        }
+    }
+
+    async fn resolve(&self, presented: &str) -> Option<Principal> {
+        match self {
+            Self::None => None,
+            Self::Static(tokens) => tokens
+                .resolve(presented)
+                .map(|(id, role)| Principal::User { id, role }),
+            Self::Gateway(gateway) => match gateway.resolve(presented).await {
+                Ok(principal) => principal,
+                Err(error) => {
+                    tracing::warn!(%error, "model-gateway could not validate Tidebreak caller");
+                    None
+                }
+            },
+        }
+    }
+
+    fn gateway_resource(&self) -> Option<&str> {
+        match self {
+            Self::Gateway(gateway) => Some(&gateway.resource),
+            Self::None | Self::Static(_) => None,
+        }
+    }
+}
+
+/// Live verifier for Gateway-issued `tidebreak` resource tokens.
+pub(crate) struct GatewayAuthenticator {
+    principal_url: reqwest::Url,
+    resource: String,
+    client: reqwest::Client,
+}
+
+#[derive(serde::Deserialize)]
+struct GatewayPrincipal {
+    user_id: uuid::Uuid,
+    is_admin: bool,
+}
+
+impl GatewayAuthenticator {
+    const RESPONSE_LIMIT: usize = 16 * 1024;
+
+    fn new(base_url: &str, resource: String) -> Result<Self> {
+        let mut base = reqwest::Url::parse(base_url.trim()).map_err(|error| {
+            AgentError::config(format!("invalid Model Gateway verifier URL: {error}"))
+        })?;
+        if !base.username().is_empty()
+            || base.password().is_some()
+            || base.query().is_some()
+            || base.fragment().is_some()
+        {
+            return Err(AgentError::config(
+                "the Model Gateway verifier URL must not contain credentials, a query, or a fragment",
+            ));
+        }
+        let loopback = base.host_str().is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .trim_start_matches('[')
+                    .trim_end_matches(']')
+                    .parse::<std::net::IpAddr>()
+                    .is_ok_and(|address| address.is_loopback())
+        });
+        if base.scheme() != "https" && !(base.scheme() == "http" && loopback) {
+            return Err(AgentError::config(
+                "the Model Gateway verifier URL must use https (http is allowed only for loopback development)",
+            ));
+        }
+        base.set_path("/api/v1/tidebreak/principal");
+        base.set_query(None);
+        base.set_fragment(None);
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| AgentError::config(format!("gateway auth client: {error}")))?;
+        Ok(Self {
+            principal_url: base,
+            resource,
+            client,
+        })
+    }
+
+    async fn resolve(&self, presented: &str) -> Result<Option<Principal>> {
+        if !presented.starts_with("mg_at_") || presented.len() > 512 {
+            return Ok(None);
+        }
+        let response = self
+            .client
+            .get(self.principal_url.clone())
+            .query(&[("resource", &self.resource)])
+            .bearer_auth(presented)
+            .send()
+            .await
+            .map_err(|error| AgentError::msg(format!("gateway auth request failed: {error}")))?;
+        if matches!(
+            response.status(),
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+        ) {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            return Err(AgentError::msg(format!(
+                "gateway auth returned status {}",
+                response.status()
+            )));
+        }
+        if response
+            .content_length()
+            .is_some_and(|length| length > Self::RESPONSE_LIMIT as u64)
+        {
+            return Err(AgentError::msg("gateway auth response exceeded size limit"));
+        }
+        let mut bytes = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| {
+                AgentError::msg(format!("gateway auth response failed: {error}"))
+            })?;
+            if bytes.len().saturating_add(chunk.len()) > Self::RESPONSE_LIMIT {
+                return Err(AgentError::msg("gateway auth response exceeded size limit"));
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        let principal: GatewayPrincipal = serde_json::from_slice(&bytes).map_err(|error| {
+            AgentError::msg(format!("gateway auth response was invalid: {error}"))
+        })?;
+        let id = UserId::new(&principal.user_id.to_string())?;
+        let role = if principal.is_admin {
+            Role::Admin
+        } else {
+            Role::Member
+        };
+        Ok(Some(Principal::User { id, role }))
+    }
+}
+
+fn canonical_public_url(raw: &str) -> Result<String> {
+    let url = reqwest::Url::parse(raw.trim())
+        .map_err(|error| AgentError::config(format!("invalid Tidebreak public URL: {error}")))?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(AgentError::config(
+            "the Tidebreak public URL must be an HTTP(S) base URL without credentials, a query, or a fragment",
+        ));
+    }
+    let loopback = url.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
+    });
+    if url.scheme() != "https" && !(url.scheme() == "http" && loopback) {
+        return Err(AgentError::config(
+            "the Tidebreak public URL must use https (http is allowed only for loopback development)",
+        ));
+    }
+    Ok(url.as_str().trim_end_matches('/').to_owned())
 }
 
 /// The self-host profile's static credential-to-principal mapping.
 ///
 /// Loaded once at boot from the operator's token file (format in the module
-/// docs). This is the seam a future authenticator (gateway-derived identity,
-/// #578) replaces: whatever verifies the credential, the middleware's output
-/// stays "which [`UserId`] is asking".
+/// docs). This remains the standalone compatibility implementation behind the
+/// same principal-authenticator seam used by live Gateway identity.
 #[derive(Debug, Default)]
 pub struct TokenMap {
     /// `(token, user, role)` triples; tokens are unique, users may repeat —
@@ -547,6 +828,8 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
+    use axum::routing::get;
+    use axum::Router;
 
     fn headers(pairs: &[(HeaderName, &str)]) -> HeaderMap {
         let mut map = HeaderMap::new();
@@ -769,5 +1052,99 @@ mod tests {
             Some("split-token")
         );
         assert!(offered_handshake_subprotocol(&headers));
+    }
+
+    #[tokio::test]
+    async fn gateway_auth_maps_live_identity_and_fails_closed() {
+        let user_id = uuid::Uuid::new_v4();
+        let resource =
+            tidebreak_core::config::tidebreak_machine_resource("https://tidebreak.example.test");
+        let expected_resource = resource.clone();
+        let app = Router::new().route(
+            "/api/v1/tidebreak/principal",
+            get(
+                move |query: axum::extract::Query<HashMap<String, String>>, headers: HeaderMap| {
+                    let expected_resource = expected_resource.clone();
+                    async move {
+                        if query.get("resource") != Some(&expected_resource) {
+                            return StatusCode::UNAUTHORIZED.into_response();
+                        }
+                        match headers
+                            .get(AUTHORIZATION)
+                            .and_then(|value| value.to_str().ok())
+                        {
+                            Some("Bearer mg_at_admin") => Json(serde_json::json!({
+                                "user_id": user_id,
+                                "is_admin": true,
+                            }))
+                            .into_response(),
+                            Some("Bearer mg_at_member") => Json(serde_json::json!({
+                                "user_id": user_id,
+                                "is_admin": false,
+                            }))
+                            .into_response(),
+                            Some("Bearer mg_at_broken") => StatusCode::BAD_GATEWAY.into_response(),
+                            _ => StatusCode::UNAUTHORIZED.into_response(),
+                        }
+                    }
+                },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let verifier = GatewayAuthenticator::new(&format!("http://{address}"), resource).unwrap();
+
+        let admin = verifier.resolve("mg_at_admin").await.unwrap().unwrap();
+        assert!(admin.is_admin());
+        assert_eq!(admin.owner_id().as_str(), format!("user:{user_id}"));
+
+        let member = verifier.resolve("mg_at_member").await.unwrap().unwrap();
+        assert!(!member.is_admin());
+        assert_eq!(member.owner_id().as_str(), format!("user:{user_id}"));
+
+        assert!(verifier.resolve("mg_at_revoked").await.unwrap().is_none());
+        assert!(verifier
+            .resolve("not-a-gateway-token")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(verifier.resolve("mg_at_broken").await.is_err());
+        server.abort();
+    }
+
+    #[test]
+    fn self_host_requires_exactly_one_principal_authenticator() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let mut config = tidebreak_core::Config::desktop(data_dir.path());
+        config.profile = Profile::SelfHost;
+        assert!(PrincipalAuthenticator::from_config(&config).is_err());
+
+        config.auth_gateway_url = Some("https://gateway.example.test".to_owned());
+        config.auth_gateway_verifier_url =
+            Some("https://gateway.model-gateway.svc.cluster.local".to_owned());
+        assert!(PrincipalAuthenticator::from_config(&config).is_err());
+        config.public_url = Some("https://tidebreak.example.test".to_owned());
+        assert!(matches!(
+            PrincipalAuthenticator::from_config(&config),
+            Ok(PrincipalAuthenticator::Gateway(_))
+        ));
+
+        let tokens = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tokens.path(),
+            "admin 0123456789abcdef0123456789abcdef admin\n",
+        )
+        .unwrap();
+        config.auth_tokens_file = Some(tokens.path().to_owned());
+        assert!(PrincipalAuthenticator::from_config(&config).is_err());
+
+        config.auth_gateway_url = None;
+        assert!(PrincipalAuthenticator::from_config(&config).is_err());
+        config.auth_gateway_verifier_url = None;
+        assert!(matches!(
+            PrincipalAuthenticator::from_config(&config),
+            Ok(PrincipalAuthenticator::Static(_))
+        ));
     }
 }

--- a/crates/tidebreak-server/src/connectors/gateway.rs
+++ b/crates/tidebreak-server/src/connectors/gateway.rs
@@ -27,14 +27,26 @@ use tokio::sync::{mpsc, Mutex};
 pub const RESOURCE_CONTROL: &str = "control";
 /// The audience for inference calls on the gateway's compatible routes.
 pub const RESOURCE_LLM: &str = "llm";
+/// The audience accepted by a Gateway-backed Tidebreak server.
+pub const RESOURCE_TIDEBREAK: &str = "tidebreak";
 
-const SCOPE: &str = "openid profile offline_access models:read inference:invoke";
+const SCOPE: &str = "openid profile offline_access models:read inference:invoke tidebreak:access";
 /// The secret-store key the gateway session lives under. Public so the secret
 /// cache can treat it as a miss-passthrough key, and so [`crate::secret_rehome`]
 /// can name every stored credential.
 pub const SECRET_KEY: &str = "gateway.credentials_v1";
 /// Refresh an access token this close to expiry instead of using it.
 const EXPIRY_LEEWAY_SECONDS: u64 = 60;
+
+/// Whether a resource carries a bearer for a Tidebreak machine.
+///
+/// The bare resource is retained while hosted deployments move to the
+/// machine-bound `tidebreak:<sha256>` audience. Neither form belongs in the
+/// durable per-resource cache: a desktop can mint it again from the rotating
+/// refresh session when it needs to attach or reconnect.
+fn is_tidebreak_resource(resource: &str) -> bool {
+    resource == RESOURCE_TIDEBREAK || resource.starts_with("tidebreak:")
+}
 
 /// True when an operation failed because there is no usable gateway session —
 /// never signed in, session revoked, or refresh-token reuse detected. Callers
@@ -514,7 +526,11 @@ impl CredentialVault {
     }
 
     pub async fn save(&self, credentials: &GatewayCredentials) -> Result<()> {
-        let raw = serde_json::to_string(credentials)?;
+        let mut durable = credentials.clone();
+        durable
+            .access_tokens
+            .retain(|resource, _| !is_tidebreak_resource(resource));
+        let raw = serde_json::to_string(&durable)?;
         self.secrets.set_secret(SECRET_KEY, &raw).await
     }
 
@@ -1108,6 +1124,9 @@ pub struct GatewayConnection {
     auth: GatewayAuth,
     vault: CredentialVault,
     token_motion: Mutex<()>,
+    /// Short-lived machine bearers keyed by resource. They are deliberately
+    /// process-only: the rotating refresh token is the durable credential.
+    volatile_tokens: Mutex<HashMap<String, CachedAccessToken>>,
     /// Attestation contexts and the access tokens minted inside them.
     /// Memory-only by design: context ids are pinned server-side to the
     /// session they were first used with, so persisting them would carry
@@ -1140,6 +1159,7 @@ impl GatewayConnection {
             auth,
             vault,
             token_motion: Mutex::new(()),
+            volatile_tokens: Mutex::new(HashMap::new()),
             attested: Mutex::new(AttestedTokens::default()),
         }
     }
@@ -1159,6 +1179,7 @@ impl GatewayConnection {
     /// state left to ever revoke it.
     pub async fn store_session(&self, session: &AuthorizedSession) -> Result<()> {
         let _guard = self.token_motion.lock().await;
+        self.volatile_tokens.lock().await.clear();
         // Attestation contexts are pinned to the session being replaced.
         *self.attested.lock().await = AttestedTokens::default();
         // An unreadable stored blob is skipped, as in sign-out: it carries no
@@ -1236,6 +1257,9 @@ impl GatewayConnection {
     /// A fresh access token for `resource`, from cache when possible and via
     /// rotating refresh otherwise.
     pub async fn access_token(&self, resource: &str) -> Result<String> {
+        if is_tidebreak_resource(resource) {
+            return self.volatile_access_token_bound(resource, None).await;
+        }
         self.access_token_bound(resource, None).await
     }
 
@@ -1246,8 +1270,78 @@ impl GatewayConnection {
         resource: &str,
         expected_installation: &str,
     ) -> Result<String> {
+        if is_tidebreak_resource(resource) {
+            return self
+                .volatile_access_token_bound(resource, Some(expected_installation))
+                .await;
+        }
         self.access_token_bound(resource, Some(expected_installation))
             .await
+    }
+
+    /// A fresh access token held only in this process.
+    ///
+    /// Refresh rotation remains serialized with every other token mint, and
+    /// the rotated refresh token is saved before the access token becomes
+    /// usable. Tidebreak resources route here automatically through
+    /// [`Self::access_token`].
+    pub async fn volatile_access_token(&self, resource: &str) -> Result<String> {
+        self.volatile_access_token_bound(resource, None).await
+    }
+
+    async fn volatile_access_token_bound(
+        &self,
+        resource: &str,
+        expected_installation: Option<&str>,
+    ) -> Result<String> {
+        let _guard = self.token_motion.lock().await;
+        let Some(mut credentials) = self.vault.load().await? else {
+            return Err(sign_in_required("no gateway session is stored"));
+        };
+        if !self.matches_deployment(&credentials) {
+            return Err(sign_in_required(
+                "the stored gateway session belongs to a different gateway deployment",
+            ));
+        }
+        if expected_installation.is_some_and(|expected| credentials.installation_id != expected) {
+            return Err(sign_in_required(
+                "the model gateway session changed after this route was selected",
+            ));
+        }
+        {
+            let mut volatile = self.volatile_tokens.lock().await;
+            volatile.retain(|_, cached| cached.is_fresh());
+            if let Some(cached) = volatile.get(resource) {
+                return Ok(cached.token.clone());
+            }
+        }
+        let token = match self
+            .auth
+            .refresh(
+                &credentials.refresh_token,
+                resource,
+                &credentials.installation_id,
+                None,
+            )
+            .await
+        {
+            Ok(token) => token,
+            Err(error) => {
+                self.retire_refused_session(&error).await;
+                return Err(error);
+            }
+        };
+        credentials.refresh_token = token.refresh_token.clone();
+        self.vault.save(&credentials).await?;
+        self.volatile_tokens.lock().await.insert(
+            resource.to_string(),
+            CachedAccessToken {
+                token: token.access_token.clone(),
+                expires_at_unix: token.expires_at_unix,
+                scope: token.scope.clone(),
+            },
+        );
+        Ok(token.access_token)
     }
 
     async fn access_token_bound(
@@ -1561,6 +1655,7 @@ impl GatewayConnection {
     /// refresh-token expiry.
     pub async fn sign_out(&self) -> Result<()> {
         let _guard = self.token_motion.lock().await;
+        self.volatile_tokens.lock().await.clear();
         *self.attested.lock().await = AttestedTokens::default();
         if let Some(credentials) = self.vault.load().await? {
             self.revoke_stored(&credentials).await;

--- a/crates/tidebreak-server/src/connectors/gateway.rs
+++ b/crates/tidebreak-server/src/connectors/gateway.rs
@@ -30,7 +30,10 @@ pub const RESOURCE_LLM: &str = "llm";
 /// The audience accepted by a Gateway-backed Tidebreak server.
 pub const RESOURCE_TIDEBREAK: &str = "tidebreak";
 
-const SCOPE: &str = "openid profile offline_access models:read inference:invoke tidebreak:access";
+// `tidebreak:access` is deliberately absent: the Gateway derives it from the
+// machine-bound resource at refresh time, so requesting it at sign-in would
+// only break sign-in against Gateways that predate the Tidebreak audience.
+const SCOPE: &str = "openid profile offline_access models:read inference:invoke";
 /// The secret-store key the gateway session lives under. Public so the secret
 /// cache can treat it as a miss-passthrough key, and so [`crate::secret_rehome`]
 /// can name every stored credential.

--- a/crates/tidebreak-server/src/connectors/mod.rs
+++ b/crates/tidebreak-server/src/connectors/mod.rs
@@ -41,5 +41,6 @@ pub use gateway::{
     GatewayCatalogFetch, GatewayCatalogModel, GatewayConnection, GatewayConsentOutcome,
     GatewayCredentials, GatewayIdentity, GatewayInvokeOutcome, GatewayMeta, GatewayModel,
     GatewayOperationSummary, GatewayRegistrationOutcome, GatewaySurfaces, PendingSignIn, TokenSet,
-    MEMBER_CATALOG_V1, RESOURCE_CONTROL, RESOURCE_LLM, SECRET_KEY as GATEWAY_SECRET_KEY,
+    MEMBER_CATALOG_V1, RESOURCE_CONTROL, RESOURCE_LLM, RESOURCE_TIDEBREAK,
+    SECRET_KEY as GATEWAY_SECRET_KEY,
 };

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -859,6 +859,9 @@ pub fn app(state: AppState) -> Router {
         ))
         .with_state(state.clone());
     let frame_state = state.clone();
+    let auth_discovery = Router::new()
+        .route("/auth/discovery", get(auth::discovery))
+        .with_state(state.clone());
 
     // Loopback-only + bearer token is the real gate. CORS names the origins
     // this app actually loads its frontend from rather than mirroring whatever
@@ -904,6 +907,7 @@ pub fn app(state: AppState) -> Router {
 
     Router::new()
         .merge(view_frames)
+        .merge(auth_discovery)
         .merge(api)
         // Inside CORS, so a foreign preflight is answered by the CORS layer's
         // own rejection rather than by a bare 403.
@@ -1943,17 +1947,10 @@ async fn connect_db(config: &Config) -> Result<Arc<DbStore>> {
             Ok(Arc::new(store))
         }
         Profile::SelfHost => {
-            let tokens = config.auth_tokens_file.as_deref().ok_or_else(|| {
-                AgentError::config(
-                    "refusing to open a shared store without a principal-naming \
-                     authenticator: self-host requires TIDEBREAK_AUTH_TOKENS_FILE \
-                     (format in the auth module docs)",
-                )
-            })?;
-            // Load and discard: boot proves the authenticator names someone
-            // before the shared store exists. State assembly re-loads the
-            // same file as the request path's credential map.
-            auth::TokenMap::load(tokens)?;
+            // Validate and discard: boot proves a principal-naming
+            // authenticator is configured before the shared store exists.
+            // State assembly constructs the live verifier used by requests.
+            auth::PrincipalAuthenticator::from_config(config)?;
             let store = tidebreak_core::DbStore::connect(&config.database_url()?).await?;
             Ok(Arc::new(store))
         }

--- a/crates/tidebreak-server/src/pairing.rs
+++ b/crates/tidebreak-server/src/pairing.rs
@@ -75,6 +75,43 @@ impl PairingHandle {
     pub fn store(&self) -> Arc<dyn Store> {
         self.store.clone()
     }
+
+    /// Mint a fresh user credential for a hosted Tidebreak machine that names
+    /// the same Gateway managing this desktop profile.
+    pub async fn hosted_tidebreak_access_token(
+        &self,
+        gateway_url: &str,
+        resource: &str,
+    ) -> Result<String> {
+        let expected = GatewayAuthConfig::new(gateway_url)?.base_url().to_string();
+        let policy = self.gateway.policy()?;
+        let Some(actual) = policy.gateway_url else {
+            return Err(AgentError::SignInRequired(
+                "this Tidebreak profile is not managed by a Model Gateway".into(),
+            ));
+        };
+        if actual != expected {
+            return Err(AgentError::SignInRequired(format!(
+                "the hosted Tidebreak machine uses {expected}, but this profile is managed by {actual}"
+            )));
+        }
+        let connection = self.gateway.connection().await?.ok_or_else(|| {
+            AgentError::SignInRequired("no managed Model Gateway connection is available".into())
+        })?;
+        let machine = resource.strip_prefix("tidebreak:").ok_or_else(|| {
+            AgentError::config("hosted Tidebreak credentials require a machine-bound resource")
+        })?;
+        if machine.len() != 64
+            || !machine
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            return Err(AgentError::config(
+                "hosted Tidebreak credentials require a lowercase SHA-256 machine resource",
+            ));
+        }
+        connection.access_token(resource).await
+    }
 }
 
 /// Why a pairing did not provision this profile.

--- a/crates/tidebreak-server/src/principal.rs
+++ b/crates/tidebreak-server/src/principal.rs
@@ -58,12 +58,12 @@ pub enum Role {
 pub enum Principal {
     /// The one person at the machine, authenticated by the per-launch bearer.
     LocalOwner,
-    /// A named user on a shared deployment, resolved from a configured
-    /// credential (today the self-host token file — see [`crate::auth`]).
+    /// A named user on a shared deployment, resolved from live Model Gateway
+    /// identity or a standalone static token (see [`crate::auth`]).
     User {
         /// Who the credential names.
         id: UserId,
-        /// What the token file says they may reconfigure.
+        /// What the selected authenticator says they may reconfigure.
         role: Role,
     },
 }

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -3,15 +3,17 @@
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
 use axum::response::Response;
+use axum::Extension;
 use tokio::sync::broadcast::error::RecvError;
 
 use tidebreak_core::db::code::list_events;
 use tidebreak_core::{CodeSessionId, OwnerId};
 
-use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
+use crate::auth::{offered_handshake_subprotocol, GatewayAuthLease, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Path, Query};
+use crate::routes::events::{gateway_auth_revalidation_timer, wait_for_gateway_auth_revalidation};
 use crate::state::AppState;
 
 use super::types::{SequencedCodeEventFrame, SessionEventsQuery};
@@ -22,6 +24,7 @@ pub async fn session_events(
     Path(id): Path<CodeSessionId>,
     Query(query): Query<SessionEventsQuery>,
     headers: axum::http::HeaderMap,
+    auth_lease: Option<Extension<GatewayAuthLease>>,
     upgrade: WebSocketUpgrade,
 ) -> Result<Response, ServerError> {
     // Authorize before upgrading: the per-session channel is keyed by id, so
@@ -29,12 +32,14 @@ pub async fn session_events(
     // journal's pattern, rather than by filtering frames afterwards.
     let _ = code.get_session(id).await?;
     let owner = code.owner().clone();
+    let auth_lease = auth_lease.map(|Extension(lease)| lease);
     let upgrade = if offered_handshake_subprotocol(&headers) {
         upgrade.protocols([WS_HANDSHAKE_SUBPROTOCOL])
     } else {
         upgrade
     };
-    Ok(upgrade.on_upgrade(move |socket| stream_events(socket, state, owner, id, query.after)))
+    Ok(upgrade
+        .on_upgrade(move |socket| stream_events(socket, state, owner, id, query.after, auth_lease)))
 }
 
 async fn stream_events(
@@ -43,7 +48,9 @@ async fn stream_events(
     owner: OwnerId,
     session: CodeSessionId,
     after: i64,
+    auth_lease: Option<GatewayAuthLease>,
 ) {
+    let mut auth_revalidation = gateway_auth_revalidation_timer(auth_lease.as_ref());
     let Some(runtime) = state.code.clone() else {
         return;
     };
@@ -61,6 +68,16 @@ async fn stream_events(
             incoming = socket.recv() => match incoming {
                 None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
                 _ => {}
+            },
+            _ = wait_for_gateway_auth_revalidation(&mut auth_revalidation) => {
+                let invalid = match auth_lease.as_ref() {
+                    Some(lease) => !lease.revalidate(&state).await,
+                    None => false,
+                };
+                if invalid {
+                    let _ = socket.send(Message::Close(None)).await;
+                    break;
+                }
             },
             live_event = live.recv() => match live_event {
                 Ok(event) => {

--- a/crates/tidebreak-server/src/routes/code/updates.rs
+++ b/crates/tidebreak-server/src/routes/code/updates.rs
@@ -11,15 +11,17 @@
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
 use axum::response::Response;
+use axum::Extension;
 use tokio::sync::broadcast::error::RecvError;
 
 use tidebreak_core::OwnerId;
 
-use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
+use crate::auth::{offered_handshake_subprotocol, GatewayAuthLease, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::code::attention::list_digests;
 use crate::code::bus::CodeLiveUpdate;
 use crate::code::ScopedCode;
 use crate::error::ServerError;
+use crate::routes::events::{gateway_auth_revalidation_timer, wait_for_gateway_auth_revalidation};
 use crate::state::AppState;
 
 use super::types::{CodeSessionDigest, CodeUpdateNotice};
@@ -28,18 +30,26 @@ pub async fn code_updates(
     State(state): State<AppState>,
     code: ScopedCode,
     headers: axum::http::HeaderMap,
+    auth_lease: Option<Extension<GatewayAuthLease>>,
     upgrade: WebSocketUpgrade,
 ) -> Result<Response, ServerError> {
     let owner = code.owner().clone();
+    let auth_lease = auth_lease.map(|Extension(lease)| lease);
     let upgrade = if offered_handshake_subprotocol(&headers) {
         upgrade.protocols([WS_HANDSHAKE_SUBPROTOCOL])
     } else {
         upgrade
     };
-    Ok(upgrade.on_upgrade(move |socket| stream_updates(socket, state, owner)))
+    Ok(upgrade.on_upgrade(move |socket| stream_updates(socket, state, owner, auth_lease)))
 }
 
-async fn stream_updates(mut socket: WebSocket, state: AppState, owner: OwnerId) {
+async fn stream_updates(
+    mut socket: WebSocket,
+    state: AppState,
+    owner: OwnerId,
+    auth_lease: Option<GatewayAuthLease>,
+) {
+    let mut auth_revalidation = gateway_auth_revalidation_timer(auth_lease.as_ref());
     let Some(runtime) = state.code.clone() else {
         return;
     };
@@ -61,6 +71,16 @@ async fn stream_updates(mut socket: WebSocket, state: AppState, owner: OwnerId) 
             incoming = socket.recv() => match incoming {
                 None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
                 _ => {}
+            },
+            _ = wait_for_gateway_auth_revalidation(&mut auth_revalidation) => {
+                let invalid = match auth_lease.as_ref() {
+                    Some(lease) => !lease.revalidate(&state).await,
+                    None => false,
+                };
+                if invalid {
+                    let _ = socket.send(Message::Close(None)).await;
+                    break;
+                }
             },
             update = live.recv() => match update {
                 Ok(CodeLiveUpdate::Digest(digest)) => {

--- a/crates/tidebreak-server/src/routes/events.rs
+++ b/crates/tidebreak-server/src/routes/events.rs
@@ -1,19 +1,48 @@
 //! Route handlers extracted from the parent `routes` module.
 
+use std::future::pending;
+use std::time::Duration;
+
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
 use axum::response::Response;
+use axum::Extension;
 use serde::Deserialize;
 use tokio::sync::broadcast::error::RecvError;
+use tokio::time::{Instant, Interval, MissedTickBehavior};
 
 use tidebreak_core::{AgentEvent, ChatId, SequencedEvent, Store};
 
-use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
+use crate::auth::{offered_handshake_subprotocol, GatewayAuthLease, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::error::ServerError;
 use crate::event_projection::{RendererChatFrame, RendererChatMetadata, RendererSequencedEvent};
 use crate::extract::{Path, Query};
 use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
+
+const GATEWAY_AUTH_REVALIDATION_INTERVAL: Duration = Duration::from_secs(60);
+
+pub(in crate::routes) fn gateway_auth_revalidation_timer(
+    lease: Option<&GatewayAuthLease>,
+) -> Option<Interval> {
+    lease.map(|_| {
+        let mut interval = tokio::time::interval_at(
+            Instant::now() + GATEWAY_AUTH_REVALIDATION_INTERVAL,
+            GATEWAY_AUTH_REVALIDATION_INTERVAL,
+        );
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        interval
+    })
+}
+
+pub(in crate::routes) async fn wait_for_gateway_auth_revalidation(timer: &mut Option<Interval>) {
+    match timer {
+        Some(timer) => {
+            timer.tick().await;
+        }
+        None => pending::<()>().await,
+    }
+}
 
 /// Query for `GET /chats/{id}/events`.
 #[derive(Debug, Deserialize)]
@@ -43,19 +72,28 @@ pub async fn chat_events(
     Path(id): Path<ChatId>,
     Query(query): Query<EventsQuery>,
     headers: axum::http::HeaderMap,
+    auth_lease: Option<Extension<GatewayAuthLease>>,
     upgrade: WebSocketUpgrade,
 ) -> Result<Response, ServerError> {
     store.require_chat(id).await?;
+    let auth_lease = auth_lease.map(|Extension(lease)| lease);
     let upgrade = if offered_handshake_subprotocol(&headers) {
         upgrade.protocols([WS_HANDSHAKE_SUBPROTOCOL])
     } else {
         upgrade
     };
-    Ok(upgrade.on_upgrade(move |socket| stream_events(socket, state, id, query.after)))
+    Ok(upgrade.on_upgrade(move |socket| stream_events(socket, state, id, query.after, auth_lease)))
 }
 
 /// Serve one client's event stream for `chat`: replay from the journal, then live.
-async fn stream_events(mut socket: WebSocket, state: AppState, chat: ChatId, after: i64) {
+async fn stream_events(
+    mut socket: WebSocket,
+    state: AppState,
+    chat: ChatId,
+    after: i64,
+    auth_lease: Option<GatewayAuthLease>,
+) {
+    let mut auth_revalidation = gateway_auth_revalidation_timer(auth_lease.as_ref());
     // Subscribe before replaying, so an event emitted during replay is buffered on
     // the live channel rather than lost in the gap between the two.
     let mut live = state.events.subscribe(chat);
@@ -104,6 +142,16 @@ async fn stream_events(mut socket: WebSocket, state: AppState, chat: ChatId, aft
             incoming = socket.recv() => match incoming {
                 None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
                 _ => {}
+            },
+            _ = wait_for_gateway_auth_revalidation(&mut auth_revalidation) => {
+                let invalid = match auth_lease.as_ref() {
+                    Some(lease) => !lease.revalidate(&state).await,
+                    None => false,
+                };
+                if invalid {
+                    let _ = socket.send(Message::Close(None)).await;
+                    break;
+                }
             },
             notice = metadata.recv() => match notice {
                 Ok(notice) => {

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -193,10 +193,10 @@ pub struct AppState {
     /// Authenticates the local owner on the desktop profile; on self-host it
     /// names nobody and admits nobody.
     pub token: Arc<str>,
-    /// The self-host profile's named bearer tokens (credential → user).
-    /// Loaded from `Config::auth_tokens_file` at assembly; empty on desktop,
-    /// where `require_token` never consults it.
-    pub(crate) principal_tokens: Arc<crate::auth::TokenMap>,
+    /// The self-host profile's credential-to-principal verifier. Gateway mode
+    /// checks live account state; static-token mode remains for standalone
+    /// deployments. Desktop never consults it.
+    pub(crate) principal_authenticator: Arc<crate::auth::PrincipalAuthenticator>,
     /// A second per-launch secret required for native-only operations.
     pub(crate) client_executor_token: Arc<str>,
     /// A per-launch capability limited to publishing caller-supplied bytes.
@@ -361,19 +361,13 @@ impl AppState {
         // Resolve the profile's principal-naming credentials up front, so a
         // self-host server that could authenticate nobody fails assembly
         // instead of starting and rejecting every request.
-        let principal_tokens = match config.profile {
+        let principal_authenticator = match config.profile {
             Profile::SelfHost => {
-                let path = config.auth_tokens_file.as_deref().ok_or_else(|| {
-                    AgentError::config(
-                        "self-host requires TIDEBREAK_AUTH_TOKENS_FILE (named bearer tokens \
-                         mapping token to user; see the auth module docs)",
-                    )
-                })?;
-                Arc::new(crate::auth::TokenMap::load(path)?)
+                Arc::new(crate::auth::PrincipalAuthenticator::from_config(&config)?)
             }
             // Desktop (and any future single-user embedding) authenticates
             // with the per-launch bearer only.
-            _ => Arc::default(),
+            _ => Arc::new(crate::auth::PrincipalAuthenticator::None),
         };
         let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
         let blob_writes = Arc::new(BlobWriteGuard::new(config.data_dir.join("blob-locks")));
@@ -423,7 +417,7 @@ impl AppState {
             file_preview_permits: Arc::new(Semaphore::new(2)),
             agent_config,
             token: Uuid::new_v4().to_string().into(),
-            principal_tokens,
+            principal_authenticator,
             client_executor_token: mint_client_executor_token(),
             local_import_token: mint_local_import_token(),
             client_executor_id,

--- a/crates/tidebreak-server/tests/connectors_gateway_flow.rs
+++ b/crates/tidebreak-server/tests/connectors_gateway_flow.rs
@@ -21,7 +21,7 @@ use sha2::{Digest, Sha256};
 use tidebreak_core::{Result as CoreResult, SecretProvider};
 use tidebreak_server::connectors::{
     is_sign_in_required, CredentialVault, GatewayAuth, GatewayAuthConfig, GatewayCatalogFetch,
-    GatewayConnection, GatewayInvokeOutcome, RESOURCE_CONTROL, RESOURCE_LLM,
+    GatewayConnection, GatewayInvokeOutcome, GATEWAY_SECRET_KEY, RESOURCE_CONTROL, RESOURCE_LLM,
 };
 
 const INSTALLATION: &str = "11111111-2222-3333-4444-555555555555";
@@ -471,6 +471,12 @@ fn browser() -> reqwest::Client {
 }
 
 async fn signed_in_connection() -> (Arc<FakeGateway>, GatewayConnection) {
+    let (gateway, connection, _) = signed_in_connection_with_secrets().await;
+    (gateway, connection)
+}
+
+async fn signed_in_connection_with_secrets(
+) -> (Arc<FakeGateway>, GatewayConnection, Arc<MockSecrets>) {
     let gateway = Arc::new(FakeGateway::default());
     let address = serve_fake_gateway(gateway.clone()).await;
     let auth =
@@ -482,10 +488,10 @@ async fn signed_in_connection() -> (Arc<FakeGateway>, GatewayConnection) {
     browser().get(&url).send().await.unwrap();
     let session = finish.await.unwrap().unwrap();
 
-    let connection =
-        GatewayConnection::new(auth, CredentialVault::new(Arc::new(MockSecrets::default())));
+    let secrets = Arc::new(MockSecrets::default());
+    let connection = GatewayConnection::new(auth, CredentialVault::new(secrets.clone()));
     connection.store_session(&session).await.unwrap();
-    (gateway, connection)
+    (gateway, connection, secrets)
 }
 
 #[tokio::test]
@@ -541,6 +547,72 @@ async fn access_tokens_cache_per_resource_and_rotate_on_refresh() {
     assert_eq!(models[1].protocol, "openai_chat_completions");
     let identity = connection.identity().await.unwrap();
     assert_eq!(identity.user_id, USER);
+}
+
+#[tokio::test]
+async fn tidebreak_machine_tokens_and_cache_entries_never_reach_the_vault() {
+    let (gateway, connection, secrets) = signed_in_connection_with_secrets().await;
+    let resource = format!("tidebreak:{}", "a".repeat(64));
+
+    // Simulate an entry persisted by an older desktop. The next vault save
+    // must scrub it in addition to keeping the newly minted bearer volatile.
+    let mut seeded: Value = serde_json::from_str(
+        &secrets
+            .get_secret(GATEWAY_SECRET_KEY)
+            .await
+            .unwrap()
+            .expect("the signed-in session is stored"),
+    )
+    .unwrap();
+    let refresh_before = seeded["refresh_token"].as_str().unwrap().to_owned();
+    seeded["access_tokens"].as_object_mut().unwrap().insert(
+        resource.clone(),
+        json!({
+            "token": "old-persisted-tidebreak-bearer",
+            "expires_at_unix": u64::MAX,
+            "scope": "tidebreak:access",
+        }),
+    );
+    secrets
+        .set_secret(GATEWAY_SECRET_KEY, &serde_json::to_string(&seeded).unwrap())
+        .await
+        .unwrap();
+
+    let exchanges = gateway.token_requests.load(Ordering::SeqCst);
+    let token = connection.access_token(&resource).await.unwrap();
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), exchanges + 1);
+    assert_eq!(
+        connection.access_token(&resource).await.unwrap(),
+        token,
+        "a live connection should reuse its process-only Tidebreak token"
+    );
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), exchanges + 1);
+
+    let persisted = secrets
+        .get_secret(GATEWAY_SECRET_KEY)
+        .await
+        .unwrap()
+        .expect("refresh rotation remains durable");
+    let persisted_json: Value = serde_json::from_str(&persisted).unwrap();
+    let access_tokens = persisted_json["access_tokens"].as_object().unwrap();
+    assert!(
+        access_tokens
+            .keys()
+            .all(|resource| resource != "tidebreak" && !resource.starts_with("tidebreak:")),
+        "the durable cache contained a Tidebreak machine resource: {access_tokens:?}"
+    );
+    assert!(!persisted.contains("old-persisted-tidebreak-bearer"));
+    assert!(!persisted.contains(&token));
+    assert_ne!(
+        persisted_json["refresh_token"].as_str().unwrap(),
+        refresh_before,
+        "the rotating refresh token must still be persisted"
+    );
+    assert_eq!(
+        gateway.access_tokens.lock().unwrap().get(&token),
+        Some(&resource),
+        "the volatile bearer still carries the requested machine audience"
+    );
 }
 
 #[tokio::test]

--- a/docs/decisions/0047-gateway-linked-hosting.md
+++ b/docs/decisions/0047-gateway-linked-hosting.md
@@ -9,20 +9,19 @@
   [`docs/gateway-boundary.md`](../gateway-boundary.md),
   [`docs/self-hosting.md`](../self-hosting.md),
   [`docs/deferred.md`](../deferred.md),
-  [`0048-one-interaction-model.md`](0048-one-interaction-model.md)
+  [`0048-one-interaction-model.md`](0048-one-interaction-model.md),
+  [`0049-gateway-authenticated-hosted-machines.md`](0049-gateway-authenticated-hosted-machines.md)
 - Supersedes: none
 
 ## Context
 
 The self-host profile exists so a team can run one shared Tidebreak server:
-PostgreSQL store, an operator token file resolving each request to a named
-principal with a role, fail-closed boot, plain HTTP behind the operator's
-fronting infrastructure (decision 6). What does not exist is any way to *use*
-that deployment from the product's own clients, or any identity source beyond
-the hand-edited token file. `docs/deferred.md` parks all of it: a member
-client (a desktop connection mode or a hosted web UI), a supervision-first
-mobile client, remote session execution, and "auth beyond the static token
-file waits on gateway-derived identity."
+PostgreSQL store, a principal-naming authenticator, fail-closed boot, and plain
+HTTP behind the operator's fronting infrastructure (decision 6). At the time
+of this decision, the only implemented authenticator was an operator token
+file and the product had no way to attach its own client to that deployment.
+Decision 49 completes the Gateway-authenticator and desktop-attachment parts
+of this plan; this record remains the machine/client and owner-scoping record.
 
 Meanwhile the desktop app is deliberately local. The server refuses
 non-loopback hosts in the desktop profile, the client has no product path for
@@ -31,15 +30,13 @@ client executor, native export, computer use — rides credentials the renderer
 never holds, which `docs/host-access.md` already names as "the intended
 consequence for host authority and a defect for anything else."
 
-What is changing: model gateway deployments (the product
+What was proposed here: model gateway deployments (the product
 [`docs/gateway-boundary.md`](../gateway-boundary.md) already integrates with
 as an OAuth client) are growing the ability to deploy `tidebreak-server` as
-an optional component of the gateway installation — colocated database,
-fronting and TLS from the operator's infrastructure, and the token file
-generated from the gateway's user roster rather than edited by hand. That
-gives a team one self-hosted installation instead of two, and it makes the
-deferred member-client work worth unblocking: agents keep running when a
-laptop closes, and any device the user holds can supervise them.
+an optional component of the gateway installation — colocated database, with
+fronting and TLS from the operator's infrastructure and identity derived from
+Gateway users. Decision 49 deliberately skips the provisional generated roster
+and verifies Gateway-issued user credentials directly.
 
 Two facts bound the design:
 
@@ -60,15 +57,11 @@ the single interaction model those clients speak.
 ## Decision
 
 1. **A gateway-linked deployment is a self-host deployment whose identity
-   derives from a gateway roster.** In its first form, the gateway's
-   deployment tooling generates the token file from its roster and
-   `tidebreak-server` is unchanged: the token file remains the
-   credential-to-principal seam exactly as decision 6 left it. The end state
-   is a gateway authenticator behind that same seam — the server verifies
-   gateway-issued credentials directly, answering the same *which user,
-   which role* question, and the token file retires. Decision 6 anticipated
-   this authenticator; this record commits to building it, in a follow-up
-   record that specifies the verification mechanism.
+   derives from Gateway accounts.** Decision 49 specifies the implemented
+   mechanism: Tidebreak verifies a dedicated resource token through Gateway,
+   receives the stable user UUID and live administrator bit, and keeps static
+   token files only for standalone compatibility. The generated-roster bridge
+   described during this record's design is not the hosted default.
 2. **Machine and client become the product vocabulary.** A running
    `tidebreak-server` instance is a machine. Renderer-shaped clients — the
    desktop webview, and later web and mobile surfaces — attach to a machine
@@ -77,9 +70,11 @@ the single interaction model those clients speak.
    governs the gateway boundary: probe, don't pin.
 3. **The desktop app gains a remote connection mode** — the deferred member
    client, chosen over a hosted web UI as the first client because its
-   approval and consent surfaces already exist. Connecting takes a base URL
-   and a token; TLS is required unless the host is loopback, mirroring the
-   pairing rule in [`docs/gateway-boundary.md`](../gateway-boundary.md).
+   approval and consent surfaces already exist. Gateway-backed connection
+   takes a base URL and reuses the desktop's existing Gateway OAuth session;
+   standalone compatibility takes a base URL and static token. TLS is required
+   unless the host is loopback, mirroring the pairing rule in
+   [`docs/gateway-boundary.md`](../gateway-boundary.md).
    While attached to a remote machine, host-authority features degrade
    legibly: routes and tools that require the client executor or the host
    broker are absent or refused with stable reasons, on the pattern headless
@@ -137,17 +132,16 @@ record does not claim one.
 - The desktop profile's loopback lockdown is untouched; a new connection
   mode must not weaken the origin and loopback refusals for the local
   server.
-- Until the gateway authenticator lands, revocation is as fast as the next
-  roster provisioning run. Teams needing instant revocation are the trigger
-  for building the authenticator.
+- Decision 49's Gateway authenticator makes deactivation, session revocation,
+  and role changes effective on the next live principal validation. The
+  next-provision window applies only to standalone static-token operation.
 - The disposable regime means a team's hosted history can vanish on upgrade.
   That is accepted on purpose, stated in operator documentation, and revisited
   at 1.0, when the compatibility commitment inverts the pre-1.0 rules.
 - Owner scoping for code mode is now on the critical path of two records
   (this one and decision 48), which is the point: it is paid once.
-- Revisit when the remote wire is proven and a web or mobile client starts
-  (the client surface may deserve its own record), when the gateway
-  authenticator is designed, or at 1.0.
+- Revisit when a web or mobile client starts (the client surface may deserve
+  its own record), or at 1.0.
 
 ## Validation
 
@@ -162,5 +156,6 @@ record does not claim one.
 - The plausible wrong implementation of decision point 4 scopes reads but
   not events: a second user on a shared machine must see neither another
   owner's `code_*` rows nor their session events on the updates channel.
-- Provisioned-identity drill: a token absent from the regenerated file is
-  refused; the server still fails closed when the file is missing entirely.
+- Gateway-identity drill: inactive, revoked, and wrong-resource credentials
+  are refused; the server still fails closed when neither Gateway identity nor
+  a standalone token file is configured.

--- a/docs/decisions/0049-gateway-authenticated-hosted-machines.md
+++ b/docs/decisions/0049-gateway-authenticated-hosted-machines.md
@@ -1,0 +1,73 @@
+# 49. Gateway-authenticated hosted machines
+
+- Status: Proposed
+- Date: 2026-08-19
+- Owners: server, desktop
+- Related: [`0047-gateway-linked-hosting.md`](0047-gateway-linked-hosting.md),
+  [`0006-self-host-deployment-plane-authorization.md`](0006-self-host-deployment-plane-authorization.md),
+  [`../gateway-boundary.md`](../gateway-boundary.md)
+- Supersedes: decision 47's provisional roster/token-file identity mechanism
+
+## Context
+
+Decision 47 made the token file a bridge, not the destination. Generating one
+standing Tidebreak token for every Model Gateway user leaves two identity
+systems to operate, delays revocation until another provisioning run, and
+requires a separate credential delivery channel. Terraform cannot repair that
+without placing user secrets in state.
+
+Tidebreak desktop already owns the stronger primitive: an authorization-code +
+PKCE Model Gateway session with rotating refresh tokens and resource-bound
+access tokens. The server already has a single credential-to-principal seam,
+and all owner-scoped code-mode storage keys derive from that principal.
+
+## Decision
+
+1. A self-host server selects exactly one principal authenticator at boot:
+   `TIDEBREAK_AUTH_GATEWAY_URL` for hosted Gateway identity, or
+   `TIDEBREAK_AUTH_TOKENS_FILE` for standalone compatibility. Both or neither
+   is a boot error before the shared store opens. An optional
+   `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` changes only the server-to-server
+   principal lookup route; discovery continues to expose the public identity
+   URL so the desktop can match its existing OAuth session.
+2. Gateway mode accepts only `mg_at_` access tokens and resolves them through
+   `GET /api/v1/tidebreak/principal` at the configured Gateway. The response's
+   stable user UUID maps to Tidebreak `user:<uuid>` owner identity; its live
+   administrator bit maps to Tidebreak's deployment-plane role.
+3. Gateway refusal, timeout, non-success response, oversized body, or malformed
+   identity admits nobody. The server never falls back to its per-launch token,
+   a shared deployment credential, email identity, or static tokens.
+4. A hosted machine exposes public, non-secret `/auth/discovery` metadata naming
+   its authentication mode, Gateway URL, and `tidebreak` resource. The desktop
+   uses this only to select the authority it is already signed into.
+5. “Connect with Model Gateway” mints the `tidebreak` resource from the
+   desktop's existing OAuth session, probes the machine, and persists only the
+   machine and Gateway URLs. The shell refreshes that token periodically from
+   the rotating session; HTTP calls and new WebSocket handshakes use the latest
+   value.
+6. Static-token attachment remains available for ordinary self-host servers.
+   Its existing token-file format and role semantics are unchanged.
+
+## Consequences
+
+- A person who can use Model Gateway can use the hosted Tidebreak machine with
+  the same account; no Tidebreak account or copied token is provisioned.
+- Gateway deactivation, session revocation, and role changes are enforced by
+  the next validation request.
+- Gateway availability is now on the authentication path for its hosted
+  Tidebreak machine. The dependency is deliberately fail closed.
+- WebSocket authentication still uses `Sec-WebSocket-Protocol`; operators must
+  exclude it from proxy logs even though the bearer is now short-lived.
+- The local-laptop authority boundary is unchanged. A remote hosted machine
+  does not gain access to the desktop's folders, input, screen, or native
+  executor.
+
+## Validation
+
+- Member and administrator Gateway projections map to distinct Tidebreak roles
+  while preserving the same stable UUID owner key.
+- Revoked, inactive, wrong-resource, malformed, and Gateway-unreachable cases
+  all return `401` from the Tidebreak API.
+- The desktop stores no Gateway resource token for a Gateway-backed attachment
+  and refreshes before access-token expiry.
+- Static-token self-host tests continue to pass unchanged.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -19,14 +19,15 @@ Selecting `TIDEBREAK_PROFILE=self_host` changes three things about the server:
   binary must be built with tidebreak-server's `postgres` feature for the
   driver to exist at all.
 - **Every request must name a user.** The desktop profile's per-launch bearer
-  token authenticates nobody here; credentials come from an operator-managed
-  token file and resolve to a named principal carrying a role. Chats, projects,
-  documents, transcripts, and the event stream are owner-scoped to that
-  principal.
+  token authenticates nobody here. A hosted deployment validates short-lived
+  Model Gateway `tidebreak` resource tokens; a standalone deployment can use
+  the operator-managed token file. Both resolve to a named principal carrying
+  a role. Chats, projects, documents, transcripts, code workspaces, and event
+  streams are owner-scoped to that principal.
 - **Boot fails closed.** The server refuses to open the shared store unless
-  `TIDEBREAK_AUTH_TOKENS_FILE` is set and loads cleanly — a shared database
-  never comes up behind an API that cannot tell its callers apart, or that
-  nobody is empowered to configure.
+  exactly one of `TIDEBREAK_AUTH_GATEWAY_URL` or
+  `TIDEBREAK_AUTH_TOKENS_FILE` is valid — a shared database never comes up
+  behind an API that cannot tell its callers apart.
 
 The deployment posture is stated in
 [decision record 6](decisions/0006-self-host-deployment-plane-authorization.md):
@@ -46,9 +47,33 @@ and for what is still integration work.
 
 - Docker with Compose v2.
 - A machine that can reach your model provider's API.
-- Somewhere private to keep the tokens file and the database password.
+- Somewhere private to keep the database password, plus either a Model Gateway
+  installation or a standalone tokens file.
 
-## Generating tokens
+## Model Gateway identity (hosted default)
+
+Set `TIDEBREAK_AUTH_GATEWAY_URL` to the Model Gateway base URL. Tidebreak
+desktop's “Connect with Model Gateway” flow discovers this URL from the hosted
+machine, mints a short-lived `tidebreak` resource token from the OAuth session
+the app already holds, and refreshes it automatically.
+
+The hosted server asks the Gateway to resolve that token on every request.
+Active Gateway users become Tidebreak members, Gateway administrators become
+Tidebreak administrators, and the stable Gateway user UUID becomes the owner
+key. Deactivation, session revocation, and role changes require no Tidebreak
+roster update or token redistribution. If the Gateway cannot validate a token,
+the request is refused.
+
+Do not set `TIDEBREAK_AUTH_TOKENS_FILE` in this mode. Selecting both mechanisms
+is an ambiguous configuration and the server refuses to start.
+
+`TIDEBREAK_AUTH_GATEWAY_URL` must remain the public Gateway identity URL that
+the desktop is signed into. If the hosted server cannot reach that URL from its
+cluster, set `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` to a cluster-routable HTTPS
+URL. Only the server's principal checks use the override; `/auth/discovery`
+continues to publish the public URL.
+
+## Generating tokens for standalone compatibility
 
 The token file is the credential-to-principal map, and it is also where roles
 are managed — there is deliberately no UI for that. One line per token,
@@ -98,8 +123,9 @@ rejected alternatives, and what would make us revisit it are in
 
 ### What a member runs
 
-The member surface is the HTTP API and the `tidebreak` CLI pointed at the
-deployment. Give each teammate a token from the file above and a base URL:
+For the standalone token-file mode, the member surface is the HTTP API and the
+`tidebreak` CLI pointed at the deployment. Give each teammate a token from the
+file above and a base URL:
 
 ```sh
 export TIDEBREAK_SERVER_URL=https://tidebreak.example
@@ -112,11 +138,11 @@ cargo run -p tidebreak-cli -- --server "$TIDEBREAK_SERVER_URL" -p "summarize yes
 docs describe. A member token receives `403` on deployment-plane routes, which
 is the intended degradation — not a desktop Settings panel.
 
-The packaged desktop app is the local Desktop profile. It embeds its own
-server, uses a per-launch loopback token, and does not connect to a remote
-self-host deployment. A remote-server connection mode, or a hosted web UI
-served by the deployment, is parked — see
-[What comes after v1](deferred.md#a-client-for-self-host-teammates).
+The packaged desktop app still embeds its local Desktop-profile server, but it
+can attach its renderer to a remote self-host machine. For a Gateway-backed
+machine, Settings → Machine → “Connect with Model Gateway” reuses the app's
+managed Gateway session and stores no Tidebreak user token. “Connect with
+token” remains available for this standalone compatibility mode.
 
 Give `admin` only to the people who actually administer the deployment: MCP
 server definitions spawn processes on the host, and the provider credentials
@@ -138,7 +164,9 @@ aspirational.
 | --- | --- | --- | --- |
 | `TIDEBREAK_PROFILE` | yes | `desktop` | `self_host` (or `selfhost`) selects this profile. Anything else is desktop or a config error. |
 | `TIDEBREAK_DATABASE_URL` | yes (self-host) | — | PostgreSQL connection string for the shared store. |
-| `TIDEBREAK_AUTH_TOKENS_FILE` | yes (self-host) | — | Path to the token file above. Absent, boot fails before the store opens. |
+| `TIDEBREAK_AUTH_GATEWAY_URL` | one auth mode required | — | Public Model Gateway identity URL exposed to clients and, by default, used for live validation. HTTPS required except for loopback development. |
+| `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` | no | `TIDEBREAK_AUTH_GATEWAY_URL` | Optional server-to-server Gateway URL for principal validation when the public origin is not cluster-routable. Requires Gateway auth. |
+| `TIDEBREAK_AUTH_TOKENS_FILE` | one auth mode required | — | Standalone compatibility: path to the static token file above. Mutually exclusive with Gateway auth. |
 | `TIDEBREAK_DATA_DIR` | no | `./.tidebreak` | Instance lock, logs, per-turn scratch. Durable state lives in PostgreSQL, not here. |
 | `TIDEBREAK_LOG` | no | built-in policy | `tracing` filter directives, e.g. `debug` or `warn,tidebreak_server=trace`. An invalid spec falls back to the default. |
 | `TIDEBREAK_MODEL` | no | built-in default | Default model name; also settable at runtime through settings or per chat. |
@@ -230,8 +258,9 @@ docker compose exec -T postgres pg_dump -U tidebreak tidebreak | gzip > tidebrea
 
 Restore into a fresh, empty database before starting the server against it.
 
-The tokens file and `.env` are not in either volume. Back them up separately,
-as secrets.
+The `.env` file is not in either volume. Back it up separately as a secret. In
+standalone compatibility mode, back up the tokens file too; Gateway-backed
+mode has no Tidebreak token file.
 
 ## Upgrading
 


### PR DESCRIPTION
Implements decision 49: hosted Tidebreak machines authenticate people through their existing Model Gateway session instead of a provisioned token file.

## Server
- A self-host server selects exactly one principal authenticator at boot: `TIDEBREAK_AUTH_GATEWAY_URL` or `TIDEBREAK_AUTH_TOKENS_FILE`. Both or neither is a boot error (decision 1).
- Gateway mode resolves `mg_at_` bearers through `GET /api/v1/tidebreak/principal`, mapping the stable user UUID to `user:<uuid>` ownership and the live administrator bit to the deployment-plane role (decision 2). Refusal, timeout, oversized or malformed responses admit nobody (decision 3).
- `TIDEBREAK_PUBLIC_URL` is required in gateway mode. The server hashes the canonical URL into the OAuth resource (`tidebreak:<sha256>`), binding every user credential to this one machine; a token captured from another Tidebreak host does not replay here.
- `/auth/discovery` advertises the mode, Gateway URL, and the machine-bound resource (decision 4).
- Gateway-authenticated WebSockets revalidate the original bearer every 60 seconds and close on identity or role change, so revocation reaches long-lived sockets (decision 5 / consequences).

## Desktop
- "Connect with Model Gateway" derives the machine resource locally from the validated base URL; discovery must echo it but cannot choose it. Discovery and probe refuse redirects and read bounded bodies.
- Machine bearers stay process-only: Tidebreak resources bypass the durable per-resource cache, entries persisted by older builds are scrubbed on the next vault save, and the rotating refresh token remains the only durable credential (validation item 3).
- The two new Tauri commands are recorded in `native-only-commands.txt`: both mint from the keychain-held OAuth session, which only the native shell can reach.

## Static tokens
Static-token attachment is unchanged for ordinary self-host servers (decision 6).

## Checks
- `cargo test -p tidebreak-core -p tidebreak-server -p tidebreak-desktop` — pass (one unrelated PTY test, `code_terminals::create_write_read_and_two_cursors`, is flaky under parallel load and passes in isolation)
- `cargo clippy --all-targets` on the three crates — clean
- `cargo fmt --check` — clean
- UI: `vitest run` 1349 pass, `tsc` clean