### PR TITLE
feat(code): make watch-and-fix a durable forked task

### DIFF
--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -54,6 +54,9 @@ pub struct CodeWorkspaceSnapshot {
 pub struct CodeSessionSnapshot {
     pub id: CodeSessionId,
     pub workspace_id: WorkspaceId,
+    /// Defaults to interactive so older servers without the field still parse.
+    #[serde(default = "default_session_kind")]
+    pub kind: tidebreak_core::CodeSessionKind,
     pub harness_kind: HarnessKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harness_version: Option<String>,
@@ -69,6 +72,10 @@ pub struct CodeSessionSnapshot {
     #[serde(default)]
     pub unrecognized_event_count: i64,
     pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+fn default_session_kind() -> tidebreak_core::CodeSessionKind {
+    tidebreak_core::CodeSessionKind::Interactive
 }
 
 /// One user→engine turn.

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -805,10 +805,11 @@ async fn resolve_start_mode(
 
 fn pick_active_session(sessions: &[CodeSessionSnapshot]) -> Option<CodeSessionId> {
     let usable = |session: &&CodeSessionSnapshot| {
-        !matches!(
-            session.lifecycle,
-            CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
-        )
+        session.kind == tidebreak_core::CodeSessionKind::Interactive
+            && !matches!(
+                session.lifecycle,
+                CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+            )
     };
     sessions
         .iter()

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -102,6 +102,10 @@ code_id_type!(
     /// Identifies one auxiliary terminal attached to a workspace.
     CodeTerminalId
 );
+code_id_type!(
+    /// Identifies one durable watch task on a workspace's pull request.
+    CodeWatchId
+);
 
 /// Which external agent engine a session is bound to.
 ///
@@ -202,6 +206,38 @@ impl CodeSessionLifecycle {
             "running" => Some(Self::Running),
             "fenced" => Some(Self::Fenced),
             "ended" => Some(Self::Ended),
+            _ => None,
+        }
+    }
+}
+
+/// Why a session exists: the user's conversation, or an automation task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeSessionKind {
+    /// The user's conversation with the engine.
+    Interactive,
+    /// A watch task's session; it runs fix turns, never user input.
+    Watch,
+}
+
+impl CodeSessionKind {
+    /// Stable database and wire token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Interactive => "interactive",
+            Self::Watch => "watch",
+        }
+    }
+
+    /// Parse a stored/wire token.
+    #[must_use]
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "interactive" => Some(Self::Interactive),
+            "watch" => Some(Self::Watch),
             _ => None,
         }
     }
@@ -414,6 +450,11 @@ pub struct PullRequestDigest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub base_branch: Option<String>,
+    /// Head commit SHA the digest was read against, when the host reported
+    /// one. The watch sweep uses it to avoid re-fixing the same head.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub head_sha: Option<String>,
     /// True when auto-merge is enabled on the host.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
@@ -559,6 +600,8 @@ pub struct CodeSession {
     pub owner: crate::OwnerId,
     /// Owning workspace.
     pub workspace_id: WorkspaceId,
+    /// Why the session exists: user conversation or watch task.
+    pub kind: CodeSessionKind,
     /// Engine this session is bound to.
     pub harness_kind: HarnessKind,
     /// Version observed at last launch, when known.
@@ -630,6 +673,92 @@ pub struct CodeTurnAttachment {
     pub media_type: crate::image::ImageMediaType,
     /// Size of the stored bytes.
     pub byte_len: u64,
+}
+
+/// State of a persisted watch task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeWatchState {
+    /// Polling the host; nothing is actionable right now.
+    Watching,
+    /// A fix turn is running or was just submitted.
+    Fixing,
+    /// Progress needs the user; polling continues in case it clears.
+    Blocked,
+    /// Terminal: the pull request merged, closed, or became ready.
+    Done,
+    /// Terminal: the user stopped the watch.
+    Stopped,
+    /// Terminal: the watch cannot continue (session gone, workspace archived).
+    Failed,
+}
+
+impl CodeWatchState {
+    /// Stable database and wire token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Watching => "watching",
+            Self::Fixing => "fixing",
+            Self::Blocked => "blocked",
+            Self::Done => "done",
+            Self::Stopped => "stopped",
+            Self::Failed => "failed",
+        }
+    }
+
+    /// Parse a stored/wire token.
+    #[must_use]
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "watching" => Some(Self::Watching),
+            "fixing" => Some(Self::Fixing),
+            "blocked" => Some(Self::Blocked),
+            "done" => Some(Self::Done),
+            "stopped" => Some(Self::Stopped),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+
+    /// True when the watch no longer sweeps.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Done | Self::Stopped | Self::Failed)
+    }
+}
+
+/// Persisted watch task: a durable background loop that keeps one
+/// workspace's pull request moving until it merges or needs the user.
+///
+/// The watch owns a dedicated [`CodeSessionKind::Watch`] session in the same
+/// worktree. It never merges or arms auto-merge — decision 42 reserves those
+/// for the user.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodeWatch {
+    /// Stable id.
+    pub id: CodeWatchId,
+    /// Principal this watch belongs to, denormalized from its workspace.
+    pub owner: crate::OwnerId,
+    /// Workspace whose pull request is watched.
+    pub workspace_id: WorkspaceId,
+    /// The watch's dedicated session.
+    pub session_id: CodeSessionId,
+    /// Pull request number at watch start.
+    pub pr_number: u64,
+    /// Watch state.
+    pub state: CodeWatchState,
+    /// Human-readable reason for the current state, when one exists.
+    pub detail: Option<String>,
+    /// Head SHA the last fix turn was submitted against, when any.
+    pub last_fix_head: Option<String>,
+    /// Fix turns submitted so far.
+    pub cycles: i64,
+    /// Creation time.
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Last sweep write.
+    pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
 /// Persisted approval record.

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1713,6 +1713,7 @@ pub mod code_session {
         pub id: Uuid,
         pub owner: String,
         pub workspace_id: Uuid,
+        pub kind: String,
         pub harness_kind: String,
         pub harness_version: Option<String>,
         pub harness_resume_ref: Option<String>,
@@ -1833,6 +1834,32 @@ pub mod code_approval {
         pub feedback: Option<String>,
         pub requested_at: DateTimeUtc,
         pub decided_at: Option<DateTimeUtc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod code_watch {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "code_watch")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub owner: String,
+        pub workspace_id: Uuid,
+        pub session_id: Uuid,
+        pub pr_number: i64,
+        pub state: String,
+        pub detail: Option<String>,
+        pub last_fix_head: Option<String>,
+        pub cycles: i64,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/tidebreak-core/src/db/migration/baseline/code.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/code.rs
@@ -435,14 +435,10 @@ pub(super) fn code_watch_table() -> TableCreateStatement {
                 .from(CodeWatch::Table, CodeWatch::SessionId)
                 .to(CodeSession::Table, CodeSession::Id),
         )
-        .check(Expr::col(CodeWatch::State).is_in([
-            "watching",
-            "fixing",
-            "blocked",
-            "done",
-            "stopped",
-            "failed",
-        ]))
+        .check(
+            Expr::col(CodeWatch::State)
+                .is_in(["watching", "fixing", "blocked", "done", "stopped", "failed"]),
+        )
         .check(Expr::col(CodeWatch::PrNumber).gte(1))
         .check(Expr::col(CodeWatch::Cycles).gte(0))
         .to_owned()

--- a/crates/tidebreak-core/src/db/migration/baseline/code.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/code.rs
@@ -135,6 +135,12 @@ pub(super) fn code_session_table() -> TableCreateStatement {
         )
         .col(owner_column(CodeSession::Owner))
         .col(ColumnDef::new(CodeSession::WorkspaceId).uuid().not_null())
+        .col(
+            ColumnDef::new(CodeSession::Kind)
+                .text()
+                .not_null()
+                .default("interactive"),
+        )
         .col(ColumnDef::new(CodeSession::HarnessKind).text().not_null())
         .col(ColumnDef::new(CodeSession::HarnessVersion).text())
         .col(ColumnDef::new(CodeSession::HarnessResumeRef).text())
@@ -184,6 +190,7 @@ pub(super) fn code_session_table() -> TableCreateStatement {
             Expr::col(CodeSession::Lifecycle)
                 .is_in(["created", "idle", "running", "fenced", "ended"]),
         )
+        .check(Expr::col(CodeSession::Kind).is_in(["interactive", "watch"]))
         .check(Expr::col(CodeSession::PermissionMode).is_in(["plan", "ask", "auto", "allow"]))
         .check(Expr::col(CodeSession::SpawnEpoch).gte(0))
         .check(Expr::col(CodeSession::UnrecognizedEventCount).gte(0))
@@ -378,5 +385,73 @@ pub(super) fn code_approval_indexes() -> Vec<IndexCreateStatement> {
         .table(CodeApproval::Table)
         .col(CodeApproval::SessionId)
         .col(CodeApproval::State)
+        .to_owned()]
+}
+
+/// Durable watch tasks. One active watch per workspace, enforced in the
+/// create path rather than by a partial index so terminal rows keep the
+/// history.
+pub(super) fn code_watch_table() -> TableCreateStatement {
+    Table::create()
+        .table(CodeWatch::Table)
+        .col(
+            ColumnDef::new(CodeWatch::Id)
+                .uuid()
+                .not_null()
+                .primary_key(),
+        )
+        .col(owner_column(CodeWatch::Owner))
+        .col(ColumnDef::new(CodeWatch::WorkspaceId).uuid().not_null())
+        .col(ColumnDef::new(CodeWatch::SessionId).uuid().not_null())
+        .col(ColumnDef::new(CodeWatch::PrNumber).big_integer().not_null())
+        .col(ColumnDef::new(CodeWatch::State).text().not_null())
+        .col(ColumnDef::new(CodeWatch::Detail).text())
+        .col(ColumnDef::new(CodeWatch::LastFixHead).text())
+        .col(
+            ColumnDef::new(CodeWatch::Cycles)
+                .big_integer()
+                .not_null()
+                .default(0),
+        )
+        .col(
+            ColumnDef::new(CodeWatch::CreatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(CodeWatch::UpdatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_code_watch_workspace")
+                .from(CodeWatch::Table, CodeWatch::WorkspaceId)
+                .to(CodeWorkspace::Table, CodeWorkspace::Id),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_code_watch_session")
+                .from(CodeWatch::Table, CodeWatch::SessionId)
+                .to(CodeSession::Table, CodeSession::Id),
+        )
+        .check(Expr::col(CodeWatch::State).is_in([
+            "watching",
+            "fixing",
+            "blocked",
+            "done",
+            "stopped",
+            "failed",
+        ]))
+        .check(Expr::col(CodeWatch::PrNumber).gte(1))
+        .check(Expr::col(CodeWatch::Cycles).gte(0))
+        .to_owned()
+}
+
+pub(super) fn code_watch_indexes() -> Vec<IndexCreateStatement> {
+    vec![Index::create()
+        .name("idx_code_watch_workspace")
+        .table(CodeWatch::Table)
+        .col(CodeWatch::WorkspaceId)
         .to_owned()]
 }

--- a/crates/tidebreak-core/src/db/migration/baseline/mod.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/mod.rs
@@ -204,6 +204,7 @@ pub(super) fn tables() -> Vec<BaselineTable> {
         ),
         entry(code::code_event_table(), code::code_event_indexes()),
         entry(code::code_approval_table(), code::code_approval_indexes()),
+        entry(code::code_watch_table(), code::code_watch_indexes()),
     ]
 }
 

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -829,6 +829,7 @@ pub(crate) enum CodeSession {
     Table,
     Id,
     WorkspaceId,
+    Kind,
     HarnessKind,
     HarnessVersion,
     HarnessResumeRef,
@@ -896,5 +897,21 @@ pub(crate) enum CodeApproval {
     Feedback,
     RequestedAt,
     DecidedAt,
+    Owner,
+}
+
+#[derive(DeriveIden)]
+pub(crate) enum CodeWatch {
+    Table,
+    Id,
+    WorkspaceId,
+    SessionId,
+    PrNumber,
+    State,
+    Detail,
+    LastFixHead,
+    Cycles,
+    CreatedAt,
+    UpdatedAt,
     Owner,
 }

--- a/crates/tidebreak-core/src/db/ops/code/mod.rs
+++ b/crates/tidebreak-core/src/db/ops/code/mod.rs
@@ -15,6 +15,7 @@ pub mod journal;
 pub mod repo;
 pub mod session;
 pub mod turn;
+pub mod watch;
 pub mod workspace;
 
 pub use approval::*;
@@ -22,6 +23,7 @@ pub use journal::*;
 pub use repo::*;
 pub use session::*;
 pub use turn::*;
+pub use watch::*;
 pub use workspace::*;
 
 /// Typed journal-append failure. A stale spawn epoch is a distinct variant so

--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -5,7 +5,7 @@ use sea_orm::{
 
 use crate::code::{
     Attention, AttentionSource, AttentionState, CodePermissionMode, CodeSession, CodeSessionId,
-    CodeSessionLifecycle, FenceReason, HarnessKind, WorkspaceId,
+    CodeSessionKind, CodeSessionLifecycle, FenceReason, HarnessKind, WorkspaceId,
 };
 use crate::error::{AgentError, Result};
 use crate::OwnerId;
@@ -20,6 +20,7 @@ pub async fn insert_session(store: &DbStore, session: &CodeSession) -> Result<()
         id: Set(session.id.0),
         owner: Set(session.owner.as_str().to_owned()),
         workspace_id: Set(session.workspace_id.0),
+        kind: Set(session.kind.as_str().to_owned()),
         harness_kind: Set(session.harness_kind.as_str().to_owned()),
         harness_version: Set(session.harness_version.clone()),
         harness_resume_ref: Set(session.harness_resume_ref.clone()),
@@ -299,6 +300,12 @@ pub(super) fn session_from_row(row: entities::code_session::Model) -> Result<Cod
             row.id, row.permission_mode
         ))
     })?;
+    let kind = CodeSessionKind::from_str(&row.kind).ok_or_else(|| {
+        AgentError::Store(format!(
+            "code_session {} has unknown kind {}",
+            row.id, row.kind
+        ))
+    })?;
     let lifecycle = CodeSessionLifecycle::from_str(&row.lifecycle).ok_or_else(|| {
         AgentError::Store(format!(
             "code_session {} has unknown lifecycle {}",
@@ -324,6 +331,7 @@ pub(super) fn session_from_row(row: entities::code_session::Model) -> Result<Cod
         id: CodeSessionId(row.id),
         owner: OwnerId::new(&row.owner)?,
         workspace_id: WorkspaceId(row.workspace_id),
+        kind,
         harness_kind,
         harness_version: row.harness_version,
         harness_resume_ref: row.harness_resume_ref,

--- a/crates/tidebreak-core/src/db/ops/code/watch.rs
+++ b/crates/tidebreak-core/src/db/ops/code/watch.rs
@@ -1,0 +1,129 @@
+//! Persistence for durable watch tasks.
+
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
+
+use crate::code::{CodeSessionId, CodeWatch, CodeWatchId, CodeWatchState, WorkspaceId};
+use crate::error::{AgentError, Result};
+use crate::OwnerId;
+
+use super::super::super::{entities, store_err, DbStore};
+
+/// Insert a watch row. The row belongs to `watch.owner`, denormalized from
+/// the workspace it watches.
+pub async fn insert_watch(store: &DbStore, watch: &CodeWatch) -> Result<()> {
+    entities::code_watch::ActiveModel {
+        id: Set(watch.id.0),
+        owner: Set(watch.owner.as_str().to_owned()),
+        workspace_id: Set(watch.workspace_id.0),
+        session_id: Set(watch.session_id.0),
+        pr_number: Set(i64::try_from(watch.pr_number)
+            .map_err(|_| AgentError::Store(format!("code_watch {} pr number", watch.id)))?),
+        state: Set(watch.state.as_str().to_owned()),
+        detail: Set(watch.detail.clone()),
+        last_fix_head: Set(watch.last_fix_head.clone()),
+        cycles: Set(watch.cycles),
+        created_at: Set(watch.created_at),
+        updated_at: Set(watch.updated_at),
+    }
+    .insert(&store.conn)
+    .await
+    .map_err(store_err)?;
+    Ok(())
+}
+
+/// The owner's most recent watch on one workspace, terminal or not.
+pub async fn latest_watch_for_workspace(
+    store: &DbStore,
+    owner: &OwnerId,
+    workspace_id: WorkspaceId,
+) -> Result<Option<CodeWatch>> {
+    let row = entities::code_watch::Entity::find()
+        .filter(entities::code_watch::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_watch::Column::WorkspaceId.eq(workspace_id.0))
+        .order_by_desc(entities::code_watch::Column::CreatedAt)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?;
+    row.map(watch_from_row).transpose()
+}
+
+/// Every non-terminal watch on the machine.
+///
+/// A system path, not a request path: the watch sweep drives every owner's
+/// watches, the way boot recovery re-attaches every owner's sessions.
+/// Nothing reachable from a route may call it.
+pub async fn list_active_watches_all_owners(store: &DbStore) -> Result<Vec<CodeWatch>> {
+    entities::code_watch::Entity::find()
+        .filter(
+            entities::code_watch::Column::State
+                .is_in(["watching", "fixing", "blocked"].map(str::to_owned)),
+        )
+        .order_by_asc(entities::code_watch::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(watch_from_row)
+        .collect()
+}
+
+/// Persist mutable watch fields. Identity and `created_at` stay as stored,
+/// and a terminal state is never overwritten. Returns `false` when nothing
+/// was written.
+pub async fn save_watch(store: &DbStore, watch: &CodeWatch) -> Result<bool> {
+    let result = entities::code_watch::Entity::update_many()
+        .col_expr(
+            entities::code_watch::Column::State,
+            sea_orm::sea_query::Expr::value(watch.state.as_str().to_owned()),
+        )
+        .col_expr(
+            entities::code_watch::Column::Detail,
+            sea_orm::sea_query::Expr::value(watch.detail.clone()),
+        )
+        .col_expr(
+            entities::code_watch::Column::LastFixHead,
+            sea_orm::sea_query::Expr::value(watch.last_fix_head.clone()),
+        )
+        .col_expr(
+            entities::code_watch::Column::Cycles,
+            sea_orm::sea_query::Expr::value(watch.cycles),
+        )
+        .col_expr(
+            entities::code_watch::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(watch.updated_at),
+        )
+        .filter(entities::code_watch::Column::Id.eq(watch.id.0))
+        .filter(entities::code_watch::Column::Owner.eq(watch.owner.as_str()))
+        .filter(
+            entities::code_watch::Column::State
+                .is_in(["watching", "fixing", "blocked"].map(str::to_owned)),
+        )
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
+fn watch_from_row(row: entities::code_watch::Model) -> Result<CodeWatch> {
+    let state = CodeWatchState::from_str(&row.state).ok_or_else(|| {
+        AgentError::Store(format!(
+            "code_watch {} has unknown state {}",
+            row.id, row.state
+        ))
+    })?;
+    let pr_number = u64::try_from(row.pr_number)
+        .map_err(|_| AgentError::Store(format!("code_watch {} pr number", row.id)))?;
+    Ok(CodeWatch {
+        id: CodeWatchId(row.id),
+        owner: OwnerId::new(&row.owner)?,
+        workspace_id: WorkspaceId(row.workspace_id),
+        session_id: CodeSessionId(row.session_id),
+        pr_number,
+        state,
+        detail: row.detail,
+        last_fix_head: row.last_fix_head,
+        cycles: row.cycles,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    })
+}

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -1,7 +1,8 @@
 use super::temp_store;
 use crate::code::{
     Attention, AttentionSource, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
-    CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionLifecycle,
+    CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind,
+    CodeSessionLifecycle,
     CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId,
     WorkspaceId,
 };
@@ -81,6 +82,7 @@ async fn seed_owner(
             id: session_id,
             owner: owner.clone(),
             workspace_id,
+            kind: CodeSessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: Some("2.1.233".into()),
             harness_resume_ref: None,

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -685,6 +685,7 @@ fn every_code_table_carries_an_owner_column() {
             "code_session",
             "code_turn",
             "code_turn_attachment",
+            "code_watch",
             "code_workspace",
         ],
         "the set of code tables changed; confirm the new one is owner-scoped"

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -2,9 +2,8 @@ use super::temp_store;
 use crate::code::{
     Attention, AttentionSource, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
     CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind,
-    CodeSessionLifecycle,
-    CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId,
-    WorkspaceId,
+    CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus,
+    HarnessKind, RepoId, WorkspaceId,
 };
 use crate::db::code::{
     append_event, bump_spawn_epoch, get_approval, get_repo, get_session, get_turn, get_workspace,

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -709,8 +709,8 @@ impl ReferenceClass {
 async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
     use crate::code::{
         Attention, AttentionSource, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId,
-        CodeSessionKind, CodeSessionLifecycle, CodeTurn, CodeTurnAttachment, CodeTurnId, CodeTurnStatus,
-        CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
+        CodeSessionKind, CodeSessionLifecycle, CodeTurn, CodeTurnAttachment, CodeTurnId,
+        CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
     };
     use crate::db::code::{insert_repo, insert_session, insert_turn, insert_workspace};
 

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -709,7 +709,7 @@ impl ReferenceClass {
 async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
     use crate::code::{
         Attention, AttentionSource, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId,
-        CodeSessionLifecycle, CodeTurn, CodeTurnAttachment, CodeTurnId, CodeTurnStatus,
+        CodeSessionKind, CodeSessionLifecycle, CodeTurn, CodeTurnAttachment, CodeTurnId, CodeTurnStatus,
         CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
     };
     use crate::db::code::{insert_repo, insert_session, insert_turn, insert_workspace};
@@ -759,6 +759,7 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
             id: session_id,
             owner: crate::OwnerId::local(),
             workspace_id,
+            kind: CodeSessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: Some("scripted".into()),
             harness_resume_ref: None,

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -143,9 +143,10 @@ pub use client_tools::{
 pub use code::{
     should_replace, ApprovalDecisionKind, Attention, AttentionSource, AttentionState, BoundedError,
     CapLevel, CheckpointHint, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
-    CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionLifecycle,
-    CodeTerminalId, CodeTurn, CodeTurnAttachment, CodeTurnId, CodeTurnStatus, CodeUsage,
-    CodeWorkspace, CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps,
+    CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind,
+    CodeSessionLifecycle, CodeTerminalId, CodeTurn, CodeTurnAttachment, CodeTurnId, CodeTurnStatus,
+    CodeUsage, CodeWatch, CodeWatchId, CodeWatchState, CodeWorkspace, CodeWorkspaceStatus,
+    Diffstat, FenceReason, FileChangeKind, HarnessCaps,
     HarnessCommand, HarnessKind, HarnessNoticeLevel, HarnessTier, PullRequestCheck,
     PullRequestCheckBucket, PullRequestComment, PullRequestCommentKind, PullRequestDigest,
     QuickAction, RepoId, SequencedCodeEvent, ToolDetail, ToolOutcome, WorkspaceId,

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -146,12 +146,11 @@ pub use code::{
     CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind,
     CodeSessionLifecycle, CodeTerminalId, CodeTurn, CodeTurnAttachment, CodeTurnId, CodeTurnStatus,
     CodeUsage, CodeWatch, CodeWatchId, CodeWatchState, CodeWorkspace, CodeWorkspaceStatus,
-    Diffstat, FenceReason, FileChangeKind, HarnessCaps,
-    HarnessCommand, HarnessKind, HarnessNoticeLevel, HarnessTier, PullRequestCheck,
-    PullRequestCheckBucket, PullRequestComment, PullRequestCommentKind, PullRequestDigest,
-    QuickAction, RepoId, SequencedCodeEvent, ToolDetail, ToolOutcome, WorkspaceId,
-    MAX_ATTENTION_NOTE, MAX_ATTENTION_PROMPT, MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS,
-    MAX_PREVIEW_CHARS, MAX_TOOL_SUMMARY_CHARS,
+    Diffstat, FenceReason, FileChangeKind, HarnessCaps, HarnessCommand, HarnessKind,
+    HarnessNoticeLevel, HarnessTier, PullRequestCheck, PullRequestCheckBucket, PullRequestComment,
+    PullRequestCommentKind, PullRequestDigest, QuickAction, RepoId, SequencedCodeEvent, ToolDetail,
+    ToolOutcome, WorkspaceId, MAX_ATTENTION_NOTE, MAX_ATTENTION_PROMPT, MAX_EVENT_TEXT_CHARS,
+    MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS, MAX_TOOL_SUMMARY_CHARS,
 };
 pub use compaction::{
     CompactionPolicy, CompactionSelection, CompactionSourceBoundary, CompactionTokenBounds,

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -20,9 +20,8 @@ use tidebreak_core::db::code::{
 use tidebreak_core::{
     Attention, AttentionSource, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
     CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind,
-    CodeSessionLifecycle,
-    CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, DbStore, HarnessKind,
-    OwnerId, RepoId, WorkspaceId,
+    CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus,
+    DbStore, HarnessKind, OwnerId, RepoId, WorkspaceId,
 };
 
 static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -19,7 +19,8 @@ use tidebreak_core::db::code::{
 };
 use tidebreak_core::{
     Attention, AttentionSource, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
-    CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionLifecycle,
+    CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind,
+    CodeSessionLifecycle,
     CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, DbStore, HarnessKind,
     OwnerId, RepoId, WorkspaceId,
 };
@@ -76,6 +77,7 @@ async fn seed_owner(
             id: session_id,
             owner: owner.clone(),
             workspace_id,
+            kind: CodeSessionKind::Interactive,
             harness_kind: HarnessKind::ClaudeCode,
             harness_version: None,
             harness_resume_ref: None,

--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1590,6 +1590,7 @@ describe("code workspace sessions", () => {
     const session = {
       id: "sess-1",
       workspace_id: "ws-1",
+      kind: "interactive",
       harness_kind: "claude_code",
       permission_mode: "plan",
       lifecycle: "idle",

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -93,6 +93,7 @@ import {
   type CodeWorkspaceBlob,
   type CodeWorkspaceTree,
   type CodeWorkspacePrSnapshot,
+  type CodeWatchSnapshot,
   type CodePrCommentsSnapshot,
   type CodePrMergeMethod,
   type CodeWorkspaceSnapshot,
@@ -141,6 +142,7 @@ import {
   parseCodeWorkspaceBlob,
   parseCodeWorkspaceTree,
   parseCodeWorkspacePr,
+  parseCodeWatch,
   parseCodePrComments,
   parseHarnessModelList,
   parseHarnessDoctorReport,
@@ -2142,6 +2144,32 @@ export class ApiClient {
         ),
       ),
       "code pull request",
+    );
+  }
+
+  /** Start a durable watch on the workspace's open pull request. */
+  async startCodeWatch(workspaceId: string): Promise<CodeWatchSnapshot> {
+    return requireParsed(
+      parseCodeWatch(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/watch`,
+          { method: "POST", headers: this.headers() },
+        ),
+      ),
+      "code watch",
+    );
+  }
+
+  /** Stop the workspace's active watch and end its session. */
+  async stopCodeWatch(workspaceId: string): Promise<CodeWatchSnapshot> {
+    return requireParsed(
+      parseCodeWatch(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/watch`,
+          { method: "DELETE", headers: this.headers() },
+        ),
+      ),
+      "code watch",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -110,6 +110,7 @@ import {
   type CodePermissionMode as WireCodePermissionMode,
   type CodeRepoSnapshot as WireCodeRepoSnapshot,
   type CodeSessionId as WireCodeSessionId,
+  type CodeSessionKind as WireCodeSessionKind,
   type CodeSessionLifecycle as WireCodeSessionLifecycle,
   type CodeSessionSnapshot as WireCodeSessionSnapshot,
   type CodeTurnId as WireCodeTurnId,
@@ -124,6 +125,8 @@ import {
   type CodeWorkspaceTree as WireCodeWorkspaceTree,
   type CodeWorkspaceBlob as WireCodeWorkspaceBlob,
   type CodeWorkspacePrSnapshot as WireCodeWorkspacePrSnapshot,
+  type CodeWatchSnapshot as WireCodeWatchSnapshot,
+  type CodeWatchState as WireCodeWatchState,
   type CodeActionSnapshot as WireCodeActionSnapshot,
   type CodeCommitSnapshot as WireCodeCommitSnapshot,
   type CodePushSnapshot as WireCodePushSnapshot,
@@ -1043,6 +1046,7 @@ export type CodeWorkspaceStatus = WireCodeWorkspaceStatus;
 /** One durable conversation with an external coding engine. */
 export type CodeSessionSnapshot = WireCodeSessionSnapshot;
 export type CodeSessionId = WireCodeSessionId;
+export type CodeSessionKind = WireCodeSessionKind;
 export type CodeSessionLifecycle = WireCodeSessionLifecycle;
 export type CodePermissionMode = WireCodePermissionMode;
 export type FenceReason = WireFenceReason;
@@ -1067,6 +1071,9 @@ export type CodeWorkspaceTree = WireCodeWorkspaceTree;
 export type CodeWorkspaceBlob = WireCodeWorkspaceBlob;
 export type CodeWorkspaceDiff = WireCodeWorkspaceDiff;
 export type CodeWorkspacePrSnapshot = WireCodeWorkspacePrSnapshot;
+/** One durable watch task on a workspace's pull request. */
+export type CodeWatchSnapshot = WireCodeWatchSnapshot;
+export type CodeWatchState = WireCodeWatchState;
 export type CodeCommitSnapshot = WireCodeCommitSnapshot;
 export type CodePushSnapshot = WireCodePushSnapshot;
 export type CodeActionSnapshot = WireCodeActionSnapshot;

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -18,6 +18,7 @@ function digest(overrides: Partial<CodeSessionDigest> = {}): CodeSessionDigest {
   return {
     workspace: "ws-1",
     session: "sess-1",
+    kind: "interactive",
     lifecycle: "idle",
     attention: working,
     title: "first change",
@@ -53,6 +54,24 @@ describe("reduceCodeUpdates", () => {
     expect(Object.keys(restated.byWorkspace)).toEqual(["ws-3"]);
   });
 
+  it("never lets a watch session displace the interactive digest", () => {
+    const empty = { byWorkspace: {}, cloneJobs: {}, viewedWorkspaceId: null };
+    const seeded = reduceCodeUpdates(empty, {
+      type: "snapshot",
+      sessions: [
+        digest(),
+        digest({ session: "sess-watch", kind: "watch", lifecycle: "running" }),
+      ],
+    });
+    expect(seeded.byWorkspace["ws-1"].session).toBe("sess-1");
+    const afterWatchDigest = reduceCodeUpdates(seeded, {
+      type: "digest",
+      digest: digest({ session: "sess-watch", kind: "watch", turn_count: 5 }),
+    });
+    expect(afterWatchDigest.byWorkspace["ws-1"].session).toBe("sess-1");
+    expect(afterWatchDigest.byWorkspace["ws-1"].turn_count).toBe(0);
+  });
+
   it("maps notices onto reducer actions", () => {
     expect(
       noticeToAction({
@@ -65,6 +84,7 @@ describe("reduceCodeUpdates", () => {
         type: "digest",
         workspace: "ws-1",
         session: "sess-1",
+        kind: "interactive",
         lifecycle: "running",
         attention: working,
         title: "first change",
@@ -75,6 +95,7 @@ describe("reduceCodeUpdates", () => {
       digest: {
         workspace: "ws-1",
         session: "sess-1",
+        kind: "interactive",
         lifecycle: "running",
         attention: working,
         title: "first change",

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -49,13 +49,18 @@ export function reduceCodeUpdates(
 ): CodeUpdatesState {
   switch (action.type) {
     case "snapshot": {
+      // One digest per workspace: the interactive session. A watch session's
+      // digest never displaces the conversation the list surfaces show; its
+      // state reaches the UI through the workspace PR snapshot instead.
       const byWorkspace: Record<string, CodeSessionDigest> = {};
       for (const digest of action.sessions) {
+        if (digest.kind === "watch") continue;
         byWorkspace[digest.workspace] = digest;
       }
       return { ...state, byWorkspace };
     }
     case "digest":
+      if (action.digest.kind === "watch") return state;
       return {
         ...state,
         byWorkspace: {
@@ -106,6 +111,7 @@ export function noticeToAction(notice: CodeUpdateNotice): CodeUpdatesAction | nu
       digest: {
         workspace: notice.workspace,
         session: notice.session,
+        kind: notice.kind,
         lifecycle: notice.lifecycle,
         attention: notice.attention,
         title: notice.title,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -143,6 +143,7 @@ const REPO = {
 const SESSION: CodeSessionSnapshot = {
   id: "sess-1",
   workspace_id: "ws-1",
+  kind: "interactive" as const,
   harness_kind: "claude_code" as const,
   permission_mode: "ask" as const,
   lifecycle: "idle" as const,
@@ -235,6 +236,26 @@ function makeClient() {
         remediation: "",
       }),
     ),
+    startCodeWatch: vi.fn(async () => ({
+      id: "watch-1",
+      workspace_id: "ws-1",
+      session_id: "sess-watch",
+      pr_number: 41,
+      state: "watching" as const,
+      cycles: 0,
+      created_at: "2026-08-15T00:00:00.000Z",
+      updated_at: "2026-08-15T00:00:00.000Z",
+    })),
+    stopCodeWatch: vi.fn(async () => ({
+      id: "watch-1",
+      workspace_id: "ws-1",
+      session_id: "sess-watch",
+      pr_number: 41,
+      state: "stopped" as const,
+      cycles: 0,
+      created_at: "2026-08-15T00:00:00.000Z",
+      updated_at: "2026-08-15T00:00:00.000Z",
+    })),
     commitCodeWorkspace: vi.fn(async () => ({
       sha: "abc123",
       message: "Fix login",
@@ -658,14 +679,11 @@ describe("CodeWorkspacePage", () => {
     await user.click(
       await screen.findByRole("menuitem", { name: "Watch and fix" }),
     );
+    // Watch and fix is a durable server-side task, not a composer prompt.
     await waitFor(() =>
-      expect(client.submitCodeTurn).toHaveBeenLastCalledWith(
-        "sess-1",
-        expect.stringMatching(/Watch pull request #41/),
-        undefined,
-        undefined,
-      ),
+      expect(client.startCodeWatch).toHaveBeenCalledWith("ws-1"),
     );
+    expect(client.submitCodeTurn).toHaveBeenCalledTimes(1);
 
     await user.click(screen.getByRole("button", { name: "Workspace actions" }));
     const menu = await screen.findByRole("menu");

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -10,7 +10,11 @@ import {
 import { toast } from "sonner";
 
 import { HttpError, type ApiClient } from "../api/client";
-import type { PullRequestDigest } from "../api/types";
+import type {
+  CodeWatchSnapshot,
+  CodeWatchState,
+  PullRequestDigest,
+} from "../api/types";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -61,7 +65,13 @@ export function WorkspaceWorkflowControl({
   resource,
   onOpenSourceControl,
 }: {
-  client: Pick<ApiClient, "pushCodeWorkspace" | "createCodePullRequest">;
+  client: Pick<
+    ApiClient,
+    | "pushCodeWorkspace"
+    | "createCodePullRequest"
+    | "startCodeWatch"
+    | "stopCodeWatch"
+  >;
   workspaceId: string;
   branchName: string;
   baseRef?: string;
@@ -81,7 +91,13 @@ export function WorkspaceWorkflowControl({
     () => workspaceWorkflowModel(resource.data, fallbackPr),
     [fallbackPr, resource.data],
   );
-  const primary = model.primary;
+  const watch = resource.data?.watch;
+  const watchActive =
+    watch !== undefined &&
+    (watch.state === "watching" ||
+      watch.state === "fixing" ||
+      watch.state === "blocked");
+  const primary = watchActive ? undefined : model.primary;
   const busy = resource.busy;
   const primaryLabel = primary
     ? workspaceWorkflowActionLabel(primary, model.stage)
@@ -93,12 +109,53 @@ export function WorkspaceWorkflowControl({
     model.pr?.checks?.filter(
       (check) => check.bucket === "fail" || check.bucket === "pending",
     ) ?? [];
+  // While a watch runs, agent actions would contend for the same worktree;
+  // local Git and navigation actions stay available.
+  const secondaryActions = watchActive
+    ? model.secondary.filter(
+        (action) =>
+          action === "open_pr" ||
+          action === "open_source" ||
+          action === "push" ||
+          action === "create_pr",
+      )
+    : model.secondary;
 
-  function runAgentAction(action: PrWorkflowAction) {
+  function runAgentAction(action: Exclude<PrWorkflowAction, "watch_and_fix">) {
     const pr = model.pr;
     if (!pr) return;
     setDetailsOpen(false);
     runComposerPrompt(workspaceId, prWorkflowPrompt(action, pr));
+  }
+
+  async function startWatch() {
+    setDetailsOpen(false);
+    try {
+      await resource.runMutation("watch", async () => {
+        await client.startCodeWatch(workspaceId);
+        await resource.refresh();
+      });
+      toast.success("Watching the pull request");
+    } catch (err) {
+      const message = friendlyErrorMessage(err, "Could not start the watch");
+      resource.setMutationError(message);
+      toast.error(message);
+    }
+  }
+
+  async function stopWatch() {
+    setDetailsOpen(false);
+    try {
+      await resource.runMutation("stop_watch", async () => {
+        await client.stopCodeWatch(workspaceId);
+        await resource.refresh();
+      });
+      toast.success("Stopped watching");
+    } catch (err) {
+      const message = friendlyErrorMessage(err, "Could not stop the watch");
+      resource.setMutationError(message);
+      toast.error(message);
+    }
   }
 
   async function run(action: WorkspaceWorkflowAction) {
@@ -152,6 +209,9 @@ export function WorkspaceWorkflowControl({
           resource.setMutationError(message);
           toast.error(message);
         }
+        return;
+      case "watch_and_fix":
+        await startWatch();
         return;
       default:
         runAgentAction(action);
@@ -280,6 +340,17 @@ export function WorkspaceWorkflowControl({
                 </dd>
               </div>
             ) : null}
+            {watch ? (
+              <div className="flex items-center gap-3 py-2.5">
+                <dt className="text-foreground-subtle shrink-0">Watch</dt>
+                <dd
+                  className="min-w-0 flex-1 truncate text-right"
+                  title={watch.detail}
+                >
+                  {watchStatusLabel(watch)}
+                </dd>
+              </div>
+            ) : null}
           </dl>
 
           {activeChecks.length > 0 ? (
@@ -356,7 +427,39 @@ export function WorkspaceWorkflowControl({
         </PopoverContent>
       </Popover>
 
-      {primary === "open_pr" && primaryLabel && model.pr?.url ? (
+      {watchActive && watch ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="border-border-subtle min-w-0 rounded-none border-0 border-l bg-transparent px-2.5 hover:bg-muted/70"
+          title={
+            watch.detail
+              ? `${watchStateLabel(watch.state)}: ${watch.detail}. Click to stop watching.`
+              : "A watch task is keeping this pull request moving. Click to stop watching."
+          }
+          disabled={busy !== null}
+          aria-busy={busy === "stop_watch"}
+          data-testid="workspace-watch-control"
+          onClick={() => void stopWatch()}
+        >
+          {busy === "stop_watch" ? (
+            <Spinner aria-hidden />
+          ) : (
+            <CircleDotDashed
+              className={cn(
+                watch.state === "blocked"
+                  ? "text-warning"
+                  : "text-info-foreground",
+              )}
+              aria-hidden
+            />
+          )}
+          <span className="truncate max-[760px]:sr-only">
+            {busy === "stop_watch" ? "Stopping…" : watchStateLabel(watch.state)}
+          </span>
+        </Button>
+      ) : primary === "open_pr" && primaryLabel && model.pr?.url ? (
         <Button
           asChild
           variant="ghost"
@@ -418,7 +521,7 @@ export function WorkspaceWorkflowControl({
         </Button>
       ) : null}
 
-      {model.secondary.length > 0 ? (
+      {secondaryActions.length > 0 ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -433,7 +536,7 @@ export function WorkspaceWorkflowControl({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-44">
-            {model.secondary.map((action) => (
+            {secondaryActions.map((action) => (
               <DropdownMenuItem key={action} onSelect={() => void run(action)}>
                 {workspaceWorkflowActionLabel(action, model.stage)}
               </DropdownMenuItem>
@@ -443,4 +546,28 @@ export function WorkspaceWorkflowControl({
       ) : null}
     </div>
   );
+}
+
+function watchStateLabel(state: CodeWatchState): string {
+  switch (state) {
+    case "watching":
+      return "Watching";
+    case "fixing":
+      return "Fixing";
+    case "blocked":
+      return "Watch blocked";
+    case "done":
+      return "Watch done";
+    case "stopped":
+      return "Watch stopped";
+    case "failed":
+      return "Watch failed";
+  }
+}
+
+function watchStatusLabel(watch: CodeWatchSnapshot): string {
+  const base = watch.detail ?? watchStateLabel(watch.state);
+  return watch.cycles > 0
+    ? `${base} · ${watch.cycles} fix ${watch.cycles === 1 ? "turn" : "turns"}`
+    : base;
 }

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -31,6 +31,7 @@ import {
 const SESSION = {
   id: "sess-1",
   workspace_id: "ws-1",
+  kind: "interactive",
   harness_kind: "claude_code",
   permission_mode: "plan",
   lifecycle: "idle",
@@ -437,6 +438,7 @@ describe("pull request state in live updates", () => {
   const digest = {
     workspace: "ws-1",
     session: "sess-1",
+    kind: "interactive",
     lifecycle: "idle",
     attention: { state: { type: "working" }, source: "lifecycle" },
     title: "Fix login",
@@ -585,6 +587,18 @@ describe("liveCodeSession", () => {
     expect(ended && live).toBeTruthy();
     expect(liveCodeSession([ended!, live!])?.id).toBe("sess-1");
     expect(liveCodeSession([ended!])).toBeNull();
+  });
+
+  it("never attaches a watch session to the workspace page", () => {
+    const watch = parseCodeSession({
+      ...SESSION,
+      id: "watch-1",
+      kind: "watch",
+    });
+    const live = parseCodeSession(SESSION);
+    expect(watch && live).toBeTruthy();
+    expect(liveCodeSession([watch!, live!])?.id).toBe("sess-1");
+    expect(liveCodeSession([watch!])).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -9,6 +9,8 @@ import type {
   CodePermissionMode,
   CodeRepoSnapshot,
   CodeSessionLifecycle,
+  CodeSessionKind,
+  CodeWatchState,
   CodeSessionSnapshot,
   CodeFileChange,
   CodeTurnSnapshot,
@@ -22,6 +24,7 @@ import type {
   CodeWorkspaceBlob,
   CodeWorkspaceTree,
   CodeWorkspacePrSnapshot,
+  CodeWatchSnapshot,
   CodeWorkspaceSnapshot,
   CodeActionSnapshot,
   CodeCommitSnapshot,
@@ -67,6 +70,7 @@ import type {
   CodeTurnAttachment as WireCodeTurnAttachment,
   CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
   CodeWorkspacePrSnapshot as WireCodeWorkspacePrSnapshot,
+  CodeWatchSnapshot as WireCodeWatchSnapshot,
   CodeActionSnapshot as WireCodeActionSnapshot,
   CodeCommitSnapshot as WireCodeCommitSnapshot,
   CodePushSnapshot as WireCodePushSnapshot,
@@ -120,6 +124,15 @@ const SESSION_LIFECYCLES = new Set<CodeSessionLifecycle>([
   "running",
   "fenced",
   "ended",
+]);
+const SESSION_KINDS = new Set<CodeSessionKind>(["interactive", "watch"]);
+const WATCH_STATES = new Set<CodeWatchState>([
+  "watching",
+  "fixing",
+  "blocked",
+  "done",
+  "stopped",
+  "failed",
 ]);
 const WORKSPACE_STATUSES = new Set<CodeWorkspaceStatus>([
   "creating",
@@ -443,6 +456,7 @@ export function parsePullRequestDigest(
       "merge_state_status",
       "head_branch",
       "base_branch",
+      "head_sha",
       "auto_merge_enabled",
       "in_merge_queue",
     ]) ||
@@ -456,6 +470,7 @@ export function parsePullRequestDigest(
     !optionalStringField(value.merge_state_status) ||
     !optionalStringField(value.head_branch) ||
     !optionalStringField(value.base_branch) ||
+    !optionalStringField(value.head_sha) ||
     !optionalBooleanField(value.draft) ||
     !optionalBooleanField(value.merged) ||
     !optionalBooleanField(value.auto_merge_enabled) ||
@@ -483,6 +498,7 @@ export function parsePullRequestDigest(
       : {}),
     ...(value.head_branch ? { head_branch: value.head_branch } : {}),
     ...(value.base_branch ? { base_branch: value.base_branch } : {}),
+    ...(value.head_sha ? { head_sha: value.head_sha } : {}),
     ...(typeof value.auto_merge_enabled === "boolean"
       ? { auto_merge_enabled: value.auto_merge_enabled }
       : {}),
@@ -536,6 +552,7 @@ export function parseCodeWorkspacePr(
       "gh_found",
       "gh_authenticated",
       "remediation",
+      "watch",
     ]) ||
     typeof value.dirty !== "boolean" ||
     typeof value.unpushed !== "boolean" ||
@@ -566,7 +583,51 @@ export function parseCodeWorkspacePr(
     if (!pr) return null;
     parsed.pr = pr;
   }
+  if (value.watch !== undefined) {
+    const watch = parseCodeWatch(value.watch);
+    if (!watch) return null;
+    parsed.watch = watch;
+  }
   return parsed;
+}
+
+export function parseCodeWatch(value: unknown): CodeWatchSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeWatchSnapshot>(value, [
+      "id",
+      "workspace_id",
+      "session_id",
+      "pr_number",
+      "state",
+      "detail",
+      "cycles",
+      "created_at",
+      "updated_at",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.workspace_id) ||
+    !nonEmpty(value.session_id) ||
+    !isFiniteNumber(value.pr_number) ||
+    !isMember(value.state, WATCH_STATES) ||
+    (value.detail !== undefined && typeof value.detail !== "string") ||
+    !isFiniteNumber(value.cycles) ||
+    !nonEmpty(value.created_at) ||
+    !nonEmpty(value.updated_at)
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    workspace_id: value.workspace_id,
+    session_id: value.session_id,
+    pr_number: value.pr_number,
+    state: value.state,
+    cycles: value.cycles,
+    created_at: value.created_at,
+    updated_at: value.updated_at,
+    ...(value.detail !== undefined ? { detail: value.detail } : {}),
+  };
 }
 
 const PR_COMMENT_KINDS = new Set<PullRequestCommentKind>([
@@ -694,6 +755,7 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
     !onlyKeys<WireCodeSessionSnapshot>(value, [
       "id",
       "workspace_id",
+      "kind",
       "harness_kind",
       "harness_version",
       "harness_resume_ref",
@@ -707,6 +769,7 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
     ]) ||
     !nonEmpty(value.id) ||
     !nonEmpty(value.workspace_id) ||
+    !isMember(value.kind, SESSION_KINDS) ||
     !isMember(value.harness_kind, HARNESS_KINDS) ||
     !optionalString(value.harness_version) ||
     !optionalString(value.harness_resume_ref) ||
@@ -728,6 +791,7 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
   return {
     id: value.id,
     workspace_id: value.workspace_id,
+    kind: value.kind,
     harness_kind: value.harness_kind,
     permission_mode: value.permission_mode,
     lifecycle: value.lifecycle,
@@ -763,7 +827,12 @@ export function parseCodeSessionList(
 export function liveCodeSession(
   sessions: readonly CodeSessionSnapshot[],
 ): CodeSessionSnapshot | null {
-  return sessions.find((session) => session.lifecycle !== "ended") ?? null;
+  return (
+    sessions.find(
+      (session) =>
+        session.kind === "interactive" && session.lifecycle !== "ended",
+    ) ?? null
+  );
 }
 
 export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {
@@ -1779,6 +1848,7 @@ export function parseCodeSessionDigest(
     !onlyKeys<WireCodeSessionDigest>(value, [
       "workspace",
       "session",
+      "kind",
       "lifecycle",
       "attention",
       "title",
@@ -1787,6 +1857,7 @@ export function parseCodeSessionDigest(
     ]) ||
     !nonEmpty(value.workspace) ||
     !nonEmpty(value.session) ||
+    !isMember(value.kind, SESSION_KINDS) ||
     !isMember(value.lifecycle, SESSION_LIFECYCLES) ||
     typeof value.title !== "string" ||
     !isFiniteNumber(value.turn_count)
@@ -1801,6 +1872,7 @@ export function parseCodeSessionDigest(
   return {
     workspace: value.workspace,
     session: value.session,
+    kind: value.kind,
     lifecycle: value.lifecycle,
     attention,
     title: value.title,
@@ -1836,6 +1908,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
           "type",
           "workspace",
           "session",
+          "kind",
           "lifecycle",
           "attention",
           "title",
@@ -1844,6 +1917,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         ]) ||
         !nonEmpty(value.workspace) ||
         !nonEmpty(value.session) ||
+        !isMember(value.kind, SESSION_KINDS) ||
         !isMember(value.lifecycle, SESSION_LIFECYCLES) ||
         typeof value.title !== "string" ||
         !isFiniteNumber(value.turn_count)
@@ -1859,6 +1933,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         type: "digest",
         workspace: value.workspace,
         session: value.session,
+        kind: value.kind,
         lifecycle: value.lifecycle,
         attention,
         title: value.title,

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -171,13 +171,6 @@ describe("prWorkflowPrompt", () => {
     expect(prWorkflowPrompt("address_feedback", digest)).toMatch(
       /requested changes/,
     );
-    const watch = prWorkflowPrompt("watch_and_fix", digest);
-    expect(watch).toMatch(/keep watching/i);
-    expect(watch).toMatch(/Enable auto-merge/);
-    expect(watch).toMatch(/required human approval/);
-    expect(watch).toMatch(/current head SHA/);
-    expect(watch).toMatch(/rebase onto main/);
-    expect(watch).toMatch(/mark it ready for review/);
     expect(prWorkflowPrompt("mark_ready", digest)).toMatch(/ready for review/);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -97,8 +97,13 @@ export function prWorkflowStatus(pr: PullRequestDigest): PrWorkflowStatus {
   return { state: workflowState(pr, checks), checks };
 }
 
+/**
+ * Prompt actions run in the workspace's interactive session. "Watch and fix"
+ * is not one of them: it starts a durable server-side watch task instead
+ * (`POST /code/workspaces/{id}/watch`).
+ */
 export function prWorkflowPrompt(
-  action: PrWorkflowAction,
+  action: Exclude<PrWorkflowAction, "watch_and_fix">,
   pr: PullRequestDigest,
 ): string {
   const number = `#${pr.number}`;
@@ -106,9 +111,6 @@ export function prWorkflowPrompt(
   const context = prWorkflowPromptContext(pr);
   let instruction: string;
   switch (action) {
-    case "watch_and_fix":
-      instruction = `Watch pull request ${number} until it is mergeable. This watch runs in the current task, so stay on this workspace and branch. On every cycle, associate checks with the current head SHA and inspect required checks, actionable review feedback, draft status, mergeability, and whether the branch is behind ${base}. Wait efficiently while work is pending. When a check fails, a reviewer requests a concrete change, conflicts appear, or the branch must be updated, diagnose it, make the smallest safe fix, fetch and rebase onto ${base} when needed, resolve conflicts, run focused validation, commit if needed, push, and keep watching against the new head SHA. If the pull request is a draft, mark it ready for review before enabling auto-merge when that action is authorized; otherwise report the required authorization as the blocker. Enable auto-merge once required checks and automated reviews are green. Do not stop merely because checks are pending. Stop only when the pull request is merged or when a required human approval, missing permission, external outage, or product decision blocks progress; in that case report the exact blocker.`;
-      break;
     case "mark_ready":
       instruction = `Mark pull request ${number} ready for review. First confirm the current head is pushed and the pull request is still a draft. Do not merge it. Report the result.`;
       break;

--- a/crates/tidebreak-desktop/ui/src/code/useCodeWorkspacePr.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useCodeWorkspacePr.ts
@@ -10,7 +10,9 @@ export type CodeWorkspacePrMutation =
   | "push"
   | "create_pr"
   | "merge"
-  | "auto_merge";
+  | "auto_merge"
+  | "watch"
+  | "stop_watch";
 
 export type CodeWorkspacePrResource = LiveResource<CodeWorkspacePrSnapshot> & {
   busy: CodeWorkspacePrMutation | null;

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -55,6 +55,7 @@ function digest(
   return {
     workspace: workspaceId,
     session: `sess-${workspaceId}`,
+    kind: "interactive",
     lifecycle: "idle",
     attention: working,
     title: workspaceId,

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1166,12 +1166,17 @@ export type CodeRepoSnapshot = { id: RepoId, root_path: string, display_name: st
 /**
  * Cheap per-session digest on `/code/updates`.
  */
-export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, pr_state?: PullRequestDigest, };
+export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, pr_state?: PullRequestDigest, };
 
 /**
  * Identifies one durable conversation with an external agent engine.
  */
 export type CodeSessionId = string;
+
+/**
+ * Why a session exists: the user's conversation, or an automation task.
+ */
+export type CodeSessionKind = "interactive" | "watch";
 
 /**
  * Lifecycle of a persisted code session.
@@ -1181,7 +1186,7 @@ export type CodeSessionLifecycle = "created" | "idle" | "running" | "fenced" | "
 /**
  * One durable conversation with an external agent engine.
  */
-export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: CodePermissionMode, model?: string, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string, };
+export type CodeSessionSnapshot = { id: CodeSessionId, workspace_id: WorkspaceId, kind: CodeSessionKind, harness_kind: HarnessKind, harness_version?: string, harness_resume_ref?: string, permission_mode: CodePermissionMode, model?: string, lifecycle: CodeSessionLifecycle, fence_reason?: FenceReason, attention: Attention, unrecognized_event_count: number, created_at: string, };
 
 /**
  * Unsequenced activity notice published on the updates channel.
@@ -1253,7 +1258,7 @@ export type CodeUpdateNotice = { "type": "snapshot",
 /**
  * One row per live session.
  */
-sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, 
+sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, 
 /**
  * Boxed to keep the notice enum's variants near one size; the wire
  * shape is unchanged.
@@ -1282,6 +1287,21 @@ cache_read_input_tokens: number,
 cache_creation_input_tokens: number, };
 
 /**
+ * Identifies one durable watch task on a workspace's pull request.
+ */
+export type CodeWatchId = string;
+
+/**
+ * One durable watch task on a workspace's pull request.
+ */
+export type CodeWatchSnapshot = { id: CodeWatchId, workspace_id: WorkspaceId, session_id: CodeSessionId, pr_number: number, state: CodeWatchState, detail?: string, cycles: number, created_at: string, updated_at: string, };
+
+/**
+ * State of a persisted watch task.
+ */
+export type CodeWatchState = "watching" | "fixing" | "blocked" | "done" | "stopped" | "failed";
+
+/**
  * One worktree file's text for the center viewer.
  */
 export type CodeWorkspaceBlob = { path: string, content: string, truncated: boolean, binary: boolean, };
@@ -1299,7 +1319,7 @@ export type CodeWorkspaceFiles = { files: Array<CodeFileChange>, truncated: bool
 /**
  * PR + checks digest plus the local git facts the PR card needs.
  */
-export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, };
+export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, watch?: CodeWatchSnapshot, };
 
 /**
  * Bounded content-search response for `GET /code/workspaces/{id}/search`.
@@ -2863,6 +2883,11 @@ head_branch?: string,
  * Base branch name on the host.
  */
 base_branch?: string, 
+/**
+ * Head commit SHA the digest was read against, when the host reported
+ * one. The watch sweep uses it to avoid re-fixing the same head.
+ */
+head_sha?: string, 
 /**
  * True when auto-merge is enabled on the host.
  */

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import type { CodeWorkspacePrSnapshot } from "@/api";
+import { WorkspaceWorkflowControl } from "@/code/WorkspaceWorkflowControl";
+import type {
+  CodeWorkspacePrMutation,
+  CodeWorkspacePrResource,
+} from "@/code/useCodeWorkspacePr";
+import {
+  blockedWatchPrGit,
+  dirtyGit,
+  fixingPrGit,
+  openPrGit,
+  readyForPrGit,
+  watchingPrGit,
+} from "./fixtures";
+
+function resourceFor(
+  snapshot: CodeWorkspacePrSnapshot | null,
+  busy: CodeWorkspacePrMutation | null = null,
+): CodeWorkspacePrResource {
+  return {
+    data: snapshot,
+    error: null,
+    refreshing: false,
+    refresh: async () => {},
+    adopt: () => {},
+    busy,
+    mutationError: null,
+    setMutationError: () => {},
+    refreshFromHost: async () => undefined,
+    runMutation: async () => undefined,
+  };
+}
+
+function WorkflowState({
+  snapshot,
+  busy = null,
+}: {
+  snapshot: CodeWorkspacePrSnapshot | null;
+  busy?: CodeWorkspacePrMutation | null;
+}) {
+  return (
+    <WorkspaceWorkflowControl
+      client={{
+        pushCodeWorkspace: fn(),
+        createCodePullRequest: fn(),
+        startCodeWatch: fn(),
+        stopCodeWatch: fn(),
+      }}
+      workspaceId="ws-1"
+      branchName="tidebreak/scoped-ui-workshop"
+      baseRef="main"
+      resource={resourceFor(snapshot, busy)}
+      onOpenSourceControl={fn()}
+    />
+  );
+}
+
+const meta = {
+  title: "Code/Workspace workflow",
+  component: WorkflowState,
+  args: { snapshot: openPrGit },
+  decorators: [
+    (Story) => (
+      <div className="flex justify-end pt-8 pr-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WorkflowState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  args: { snapshot: null },
+};
+
+export const Uncommitted: Story = {
+  args: { snapshot: dirtyGit },
+};
+
+export const ReadyForPullRequest: Story = {
+  args: { snapshot: readyForPrGit },
+};
+
+export const PullRequestOpen: Story = {};
+
+/** A durable watch task is polling; checks are still running. */
+export const Watching: Story = {
+  args: { snapshot: watchingPrGit },
+};
+
+/** The watch task is running a fix turn against failing checks. */
+export const WatchFixing: Story = {
+  args: { snapshot: fixingPrGit },
+};
+
+/** The watch task parked on something only the user can do. */
+export const WatchBlocked: Story = {
+  args: { snapshot: blockedWatchPrGit },
+};
+
+export const StoppingWatch: Story = {
+  args: { snapshot: watchingPrGit, busy: "stop_watch" },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -1,4 +1,5 @@
 import type {
+  CodeWatchSnapshot,
   CodeWorkspacePrSnapshot,
   PendingUserQuestions,
   TaskPlan,
@@ -112,5 +113,63 @@ export const openPrGit: CodeWorkspacePrSnapshot = {
     state: "open",
     title: "Add a scoped UI workshop",
     checks_summary: "8 passing, 1 pending, 0 failing",
+  },
+};
+
+const watchBase: CodeWatchSnapshot = {
+  id: "watch-1",
+  workspace_id: "ws-1",
+  session_id: "sess-watch",
+  pr_number: 184,
+  state: "watching",
+  cycles: 0,
+  created_at: "2026-08-20T09:00:00.000Z",
+  updated_at: "2026-08-20T09:05:00.000Z",
+};
+
+/** Watch task polling a PR whose checks are still running. */
+export const watchingPrGit: CodeWorkspacePrSnapshot = {
+  ...openPrGit,
+  pr: {
+    ...openPrGit.pr!,
+    checks: [
+      { name: "test", bucket: "pass" },
+      { name: "clippy", bucket: "pending" },
+    ],
+  },
+  watch: watchBase,
+};
+
+/** Watch task driving a fix turn against failing checks. */
+export const fixingPrGit: CodeWorkspacePrSnapshot = {
+  ...openPrGit,
+  pr: {
+    ...openPrGit.pr!,
+    checks_summary: "7 passing, 1 failing",
+    checks: [
+      { name: "test", bucket: "pass" },
+      { name: "clippy", bucket: "fail", detail: "exit 101" },
+    ],
+  },
+  watch: {
+    ...watchBase,
+    state: "fixing",
+    detail: "fixing failing checks",
+    cycles: 2,
+  },
+};
+
+/** Watch task parked on something only the user can do. */
+export const blockedWatchPrGit: CodeWorkspacePrSnapshot = {
+  ...openPrGit,
+  pr: {
+    ...openPrGit.pr!,
+    review_decision: "review_required",
+  },
+  watch: {
+    ...watchBase,
+    state: "blocked",
+    detail: "a review or repository requirement is outstanding",
+    cycles: 1,
   },
 };

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -15,7 +15,7 @@ use tidebreak_core::db::code::{
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeApprovalState, CodeSession, CodeSessionId,
-    CodeSessionLifecycle, CodeTurnStatus, DbStore, OwnerId, WorkspaceId,
+    CodeSessionKind, CodeSessionLifecycle, CodeTurnStatus, DbStore, OwnerId, WorkspaceId,
 };
 
 use super::bus::{CodeEventBus, CodeLiveUpdate, SessionDigest};
@@ -330,6 +330,7 @@ async fn build_digest(
     Ok(SessionDigest {
         workspace: session.workspace_id,
         session: session.id,
+        kind: session.kind,
         lifecycle: session.lifecycle,
         attention: session.attention.clone(),
         title: workspace.title,
@@ -403,6 +404,7 @@ mod tests {
             id: CodeSessionId::new(),
             owner: tidebreak_core::OwnerId::local(),
             workspace_id: WorkspaceId::new(),
+            kind: CodeSessionKind::Interactive,
             harness_kind: tidebreak_core::HarnessKind::ClaudeCode,
             harness_version: None,
             harness_resume_ref: None,

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -15,7 +15,7 @@ use tidebreak_core::db::code::{
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeApprovalState, CodeSession, CodeSessionId,
-    CodeSessionKind, CodeSessionLifecycle, CodeTurnStatus, DbStore, OwnerId, WorkspaceId,
+    CodeSessionLifecycle, CodeTurnStatus, DbStore, OwnerId, WorkspaceId,
 };
 
 use super::bus::{CodeEventBus, CodeLiveUpdate, SessionDigest};
@@ -382,7 +382,7 @@ impl Drop for StallSweepGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tidebreak_core::{should_replace, FenceReason, WorkspaceId};
+    use tidebreak_core::{should_replace, CodeSessionKind, FenceReason, WorkspaceId};
 
     fn auto_working() -> Attention {
         Attention::working(AttentionSource::Lifecycle)

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -20,8 +20,8 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use tidebreak_core::{
-    Attention, CodeSessionId, CodeSessionLifecycle, OwnerId, PullRequestDigest, RepoId,
-    SequencedCodeEvent, WorkspaceId,
+    Attention, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, OwnerId, PullRequestDigest,
+    RepoId, SequencedCodeEvent, WorkspaceId,
 };
 use tokio::sync::broadcast;
 
@@ -33,6 +33,7 @@ const UPDATES_BUFFER: usize = 256;
 pub(crate) struct SessionDigest {
     pub workspace: WorkspaceId,
     pub session: CodeSessionId,
+    pub kind: CodeSessionKind,
     pub lifecycle: CodeSessionLifecycle,
     pub attention: Attention,
     pub title: String,

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -349,6 +349,7 @@ pub(crate) async fn create_pull_request(
         merge_state_status: None,
         head_branch: None,
         base_branch: None,
+        head_sha: None,
         auto_merge_enabled: None,
         in_merge_queue: None,
     };
@@ -1115,6 +1116,7 @@ fn pr_view_snapshot_from_json(json: &str, checks_table: &str) -> Option<PrViewSn
         merge_state_status: lower_token("mergeStateStatus"),
         head_branch: branch("headRefName"),
         base_branch: branch("baseRefName"),
+        head_sha: head_oid.clone(),
         auto_merge_enabled: Some(
             parsed
                 .get("autoMergeRequest")

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod session_worker;
 pub(crate) mod setup_script;
 pub(crate) mod terminal;
 pub(crate) mod titling;
+pub(crate) mod watch;
 pub(crate) mod worktree;
 
 pub(crate) use runtime::CodeRuntime;

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -13,8 +13,8 @@ use tidebreak_core::db::code::{
     append_event, get_open_turn, list_sessions_by_lifecycle_all_owners, save_turn,
 };
 use tidebreak_core::{
-    Attention, AttentionSource, AttentionState, CodeEvent, CodeSession, CodeSessionLifecycle,
-    CodeTurnStatus, DbStore, FenceReason,
+    Attention, AttentionSource, AttentionState, CodeEvent, CodeSession, CodeSessionKind,
+    CodeSessionLifecycle, CodeTurnStatus, DbStore, FenceReason,
 };
 
 use super::attention::{persist_session, replace_attention};
@@ -378,6 +378,7 @@ mod tests {
                 id: session_id,
                 owner: tidebreak_core::OwnerId::local(),
                 workspace_id,
+                kind: CodeSessionKind::Interactive,
                 harness_kind: HarnessKind::ClaudeCode,
                 harness_version: Some("2.1.233".into()),
                 harness_resume_ref: None,

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -13,8 +13,8 @@ use tidebreak_core::db::code::{
     append_event, get_open_turn, list_sessions_by_lifecycle_all_owners, save_turn,
 };
 use tidebreak_core::{
-    Attention, AttentionSource, AttentionState, CodeEvent, CodeSession, CodeSessionKind,
-    CodeSessionLifecycle, CodeTurnStatus, DbStore, FenceReason,
+    Attention, AttentionSource, AttentionState, CodeEvent, CodeSession, CodeSessionLifecycle,
+    CodeTurnStatus, DbStore, FenceReason,
 };
 
 use super::attention::{persist_session, replace_attention};
@@ -284,8 +284,8 @@ mod tests {
         get_session, get_turn, insert_repo, insert_session, insert_turn, insert_workspace,
     };
     use tidebreak_core::{
-        Attention, CodePermissionMode, CodeRepo, CodeSessionId, CodeTurn, CodeTurnId,
-        CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
+        Attention, CodePermissionMode, CodeRepo, CodeSessionId, CodeSessionKind, CodeTurn,
+        CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
     };
     use tidebreak_harness::HarnessAdapter;
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -19,8 +19,8 @@ use tidebreak_core::db::code::{
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
     CodeApprovalState, CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionId,
-    CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, DbStore,
-    Diffstat, FenceReason, HarnessKind, OwnerId, RepoId, WorkspaceId,
+    CodeSessionKind, CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeWorkspace,
+    CodeWorkspaceStatus, DbStore, Diffstat, FenceReason, HarnessKind, OwnerId, RepoId, WorkspaceId,
 };
 use tidebreak_harness::{
     builtin_registry, AdapterRegistry, ApprovalChannelSpec, ApprovalDecision, HarnessAdapter,
@@ -130,6 +130,8 @@ pub(crate) struct CodeRuntime {
     pub(crate) gh_search_path: Mutex<Option<String>>,
     stall_sweep: Mutex<Option<super::attention::StallSweepGuard>>,
     stall_started: AtomicBool,
+    watch_sweep: Mutex<Option<super::watch::WatchSweepGuard>>,
+    watch_started: AtomicBool,
     /// Workspaces with a background naming call in flight.
     ///
     /// One call per workspace at a time; a second trigger is dropped rather
@@ -166,6 +168,8 @@ impl CodeRuntime {
             gh_search_path: Mutex::new(None),
             stall_sweep: Mutex::new(None),
             stall_started: AtomicBool::new(false),
+            watch_sweep: Mutex::new(None),
+            watch_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
         }
     }
@@ -194,7 +198,14 @@ impl CodeRuntime {
     ) -> impl std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> {
         self.set_loopback_base(loopback_base);
         let runtime = self.clone();
-        async move { runtime.recover().await }
+        async move {
+            let actions = runtime.recover().await;
+            // After recovery so resumed watch sessions have workers to drive;
+            // the sweep reads its work list from the `code_watch` table, so
+            // active watches resume with no extra state.
+            runtime.ensure_watch_sweep();
+            actions
+        }
     }
 
     #[cfg(any(test, feature = "scripted-harness"))]
@@ -222,6 +233,8 @@ impl CodeRuntime {
             gh_search_path: Mutex::new(None),
             stall_sweep: Mutex::new(None),
             stall_started: AtomicBool::new(false),
+            watch_sweep: Mutex::new(None),
+            watch_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
         }
     }
@@ -894,6 +907,32 @@ impl CodeRuntime {
         permission_mode: CodePermissionMode,
         model: Option<String>,
     ) -> Result<CodeSession, ServerError> {
+        self.create_session_of_kind(
+            owner,
+            workspace_id,
+            CodeSessionKind::Interactive,
+            harness,
+            permission_mode,
+            model,
+        )
+        .await
+    }
+
+    /// Shared create path for interactive sessions and watch sessions.
+    ///
+    /// One active session per workspace *per kind*: a watch session shares
+    /// the worktree with the conversation it forked from, so the guard keeps
+    /// one of each rather than one in total. The watch sweep serializes fix
+    /// turns against interactive turns before submitting.
+    pub(super) async fn create_session_of_kind(
+        &self,
+        owner: &OwnerId,
+        workspace_id: WorkspaceId,
+        kind: CodeSessionKind,
+        harness: HarnessKind,
+        permission_mode: CodePermissionMode,
+        model: Option<String>,
+    ) -> Result<CodeSession, ServerError> {
         let workspace = self.get_workspace(owner, workspace_id).await?;
         if workspace.status != CodeWorkspaceStatus::Active {
             return Err(ServerError::conflict_kind(
@@ -904,11 +943,14 @@ impl CodeRuntime {
         let existing = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
         if existing
             .iter()
-            .any(|session| session.lifecycle != CodeSessionLifecycle::Ended)
+            .any(|session| session.lifecycle != CodeSessionLifecycle::Ended && session.kind == kind)
         {
             return Err(ServerError::conflict_kind(
                 "session_exists",
-                "this workspace already has an active session",
+                match kind {
+                    CodeSessionKind::Interactive => "this workspace already has an active session",
+                    CodeSessionKind::Watch => "this workspace already has an active watch session",
+                },
             ));
         }
         let adapter = self.adapter(harness)?;
@@ -950,6 +992,7 @@ impl CodeRuntime {
             id: CodeSessionId::new(),
             owner: owner.clone(),
             workspace_id,
+            kind,
             harness_kind: harness,
             harness_version: probe.version.clone(),
             harness_resume_ref: None,
@@ -1225,6 +1268,57 @@ impl CodeRuntime {
         }
         let guard = super::attention::StallSweepGuard::spawn(self.db.clone(), self.bus.clone());
         *self.stall_sweep.lock().expect("stall sweep") = Some(guard);
+    }
+
+    /// Start the watch sweep once. The guard holds a weak runtime handle so
+    /// this field never keeps its own runtime alive.
+    pub(super) fn ensure_watch_sweep(self: &Arc<Self>) {
+        if self.watch_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let guard = super::watch::WatchSweepGuard::spawn(Arc::downgrade(self));
+        *self.watch_sweep.lock().expect("watch sweep") = Some(guard);
+    }
+
+    /// End one session: mark the row ended, stop its worker, and re-assert.
+    ///
+    /// The same steps [`Self::end_workspace_sessions`] takes per session,
+    /// for callers that must end a single session (the watch path) without
+    /// touching the workspace's other sessions.
+    pub(super) async fn end_session_row(
+        &self,
+        owner: &OwnerId,
+        session_id: CodeSessionId,
+    ) -> Result<(), ServerError> {
+        let Some(mut session) = get_session(&self.db, owner, session_id).await? else {
+            return Ok(());
+        };
+        if session.lifecycle == CodeSessionLifecycle::Ended {
+            return Ok(());
+        }
+        let handle = self
+            .workers
+            .lock()
+            .expect("code workers")
+            .remove(&session.id);
+        session.lifecycle = CodeSessionLifecycle::Ended;
+        session.child_pid = None;
+        session.fence_reason = None;
+        super::attention::persist_session(&self.db, &self.bus, &session).await?;
+        if let Some(handle) = handle {
+            Self::shut_down_worker(session.id, handle).await;
+        }
+        let mut current = self.get_session(owner, session.id).await?;
+        current.lifecycle = CodeSessionLifecycle::Ended;
+        current.child_pid = None;
+        current.fence_reason = None;
+        if !super::attention::persist_session(&self.db, &self.bus, &current).await? {
+            return Err(ServerError::conflict_kind(
+                "session_not_ended",
+                "the session did not stay ended after the worker stopped",
+            ));
+        }
+        Ok(())
     }
 
     pub(crate) async fn list_sessions(

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -244,6 +244,27 @@ impl ScopedCode {
         self.runtime.refresh_workspace_pr(&self.owner, id).await
     }
 
+    pub(crate) async fn start_watch(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<tidebreak_core::CodeWatch, ServerError> {
+        self.runtime.start_watch(&self.owner, id).await
+    }
+
+    pub(crate) async fn stop_watch(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<tidebreak_core::CodeWatch, ServerError> {
+        self.runtime.stop_watch(&self.owner, id).await
+    }
+
+    pub(crate) async fn latest_watch(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<Option<tidebreak_core::CodeWatch>, ServerError> {
+        self.runtime.latest_watch(&self.owner, id).await
+    }
+
     pub(crate) async fn workspace_pr_comments(
         &self,
         id: WorkspaceId,

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -704,7 +704,10 @@ mod tests {
     fn behind_is_actionable_and_queue_waits() {
         let mut pr = base_pr();
         pr.merge_state_status = Some("behind".to_owned());
-        assert_eq!(assess(&pr), WatchAssessment::Actionable(WatchReason::Behind));
+        assert_eq!(
+            assess(&pr),
+            WatchAssessment::Actionable(WatchReason::Behind)
+        );
         let mut pr = base_pr();
         pr.in_merge_queue = Some(true);
         assert_eq!(assess(&pr), WatchAssessment::Waiting);

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -1,0 +1,728 @@
+//! Durable watch tasks: a server-side loop that keeps one workspace's pull
+//! request moving until it merges or genuinely needs the user.
+//!
+//! The watch owns a dedicated [`CodeSessionKind::Watch`] session in the same
+//! worktree as the conversation it forked from. Each sweep reads the PR
+//! digest through the normal `workspace_pr` path (so the updates channel sees
+//! every read), classifies it, and either waits, submits one bounded fix
+//! turn, or parks the watch with a reason. The sweep is try-based and reads
+//! its work list from the `code_watch` table every tick, so a restart resumes
+//! every active watch with no extra recovery state (decision 9's promoter is
+//! the precedent).
+//!
+//! The watch never merges, never arms auto-merge, and never marks a draft
+//! ready: decision 42 reserves PR state changes for the user. It reports
+//! those moments as `NeedsYou` instead.
+
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use chrono::Utc;
+use tracing::warn;
+
+use tidebreak_core::db::code::{
+    get_session, insert_watch, latest_watch_for_workspace, list_active_watches_all_owners,
+    list_sessions_for_workspace, save_watch,
+};
+use tidebreak_core::{
+    Attention, AttentionSource, CodePermissionMode, CodeSessionKind, CodeSessionLifecycle,
+    CodeWatch, CodeWatchId, CodeWatchState, CodeWorkspaceStatus, HarnessKind, OwnerId,
+    PullRequestDigest, WorkspaceId,
+};
+
+use super::attention::{apply_attention, emit_workspace_digests};
+use super::runtime::CodeRuntime;
+use crate::error::ServerError;
+
+/// How often the watch sweep walks active watches.
+pub(crate) const WATCH_SWEEP_INTERVAL: Duration = Duration::from_secs(47);
+
+/// What one PR digest asks of the watch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WatchAssessment {
+    /// The pull request merged; the watch is complete.
+    Merged,
+    /// The pull request closed without merging.
+    Closed,
+    /// Something a fix turn can address.
+    Actionable(WatchReason),
+    /// The host is still working; keep polling.
+    Waiting,
+    /// Every requirement the watch can affect is green.
+    Ready,
+    /// Only the user can advance it; keep polling in case it clears.
+    NeedsUser(&'static str),
+}
+
+/// The concrete condition a fix turn is asked to address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WatchReason {
+    /// One or more checks failed.
+    FailingChecks,
+    /// The branch conflicts with its base.
+    Conflicts,
+    /// The branch is behind its base and must be updated.
+    Behind,
+    /// A reviewer requested changes.
+    ChangesRequested,
+}
+
+impl WatchReason {
+    pub(crate) const fn describe(self) -> &'static str {
+        match self {
+            Self::FailingChecks => "failing checks",
+            Self::Conflicts => "merge conflicts",
+            Self::Behind => "the branch is behind its base",
+            Self::ChangesRequested => "requested changes",
+        }
+    }
+}
+
+/// Classify one digest the way the workflow control does, minus the actions
+/// decision 42 reserves for the user.
+pub(crate) fn assess(pr: &PullRequestDigest) -> WatchAssessment {
+    let state = pr.state.trim().to_ascii_lowercase();
+    if pr.merged == Some(true) || state == "merged" {
+        return WatchAssessment::Merged;
+    }
+    if state == "closed" {
+        return WatchAssessment::Closed;
+    }
+    if pr.draft == Some(true) {
+        return WatchAssessment::NeedsUser("the pull request is a draft");
+    }
+    let mergeable = pr.mergeable.as_deref().map(str::trim).unwrap_or("");
+    let merge_state = pr
+        .merge_state_status
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("");
+    if mergeable == "conflicting" || merge_state == "dirty" {
+        return WatchAssessment::Actionable(WatchReason::Conflicts);
+    }
+    if pr.review_decision.as_deref().map(str::trim) == Some("changes_requested") {
+        return WatchAssessment::Actionable(WatchReason::ChangesRequested);
+    }
+    let checks = pr.checks.as_deref().unwrap_or(&[]);
+    let failing = checks
+        .iter()
+        .filter(|check| check.bucket == tidebreak_core::PullRequestCheckBucket::Fail)
+        .count();
+    if failing > 0 {
+        return WatchAssessment::Actionable(WatchReason::FailingChecks);
+    }
+    if pr.in_merge_queue == Some(true) {
+        return WatchAssessment::Waiting;
+    }
+    if merge_state == "behind" {
+        return WatchAssessment::Actionable(WatchReason::Behind);
+    }
+    if merge_state == "blocked"
+        || merge_state == "unstable"
+        || pr.review_decision.as_deref().map(str::trim) == Some("review_required")
+    {
+        return WatchAssessment::NeedsUser("a review or repository requirement is outstanding");
+    }
+    if pr.auto_merge_enabled == Some(true) {
+        return WatchAssessment::Waiting;
+    }
+    let pending = checks
+        .iter()
+        .filter(|check| check.bucket == tidebreak_core::PullRequestCheckBucket::Pending)
+        .count();
+    if pending > 0 {
+        return WatchAssessment::Waiting;
+    }
+    if mergeable == "mergeable" && merge_state == "clean" {
+        return WatchAssessment::Ready;
+    }
+    WatchAssessment::Waiting
+}
+
+/// The instruction one fix turn runs. Scoped to a single cycle: the loop
+/// lives in the sweep, not in the engine's context window.
+pub(crate) fn fix_turn_instruction(reason: WatchReason, pr: &PullRequestDigest) -> String {
+    let number = pr.number;
+    let base = pr
+        .base_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("the base branch");
+    let instruction = match reason {
+        WatchReason::FailingChecks => format!(
+            "Pull request #{number} has failing checks. Inspect the latest failing CI logs \
+             for the current head SHA, reproduce the cause when practical, make the smallest \
+             safe fix in this workspace, run focused validation, commit, and push. Do not \
+             merge, enable auto-merge, or change the pull request's draft or review state."
+        ),
+        WatchReason::Conflicts => format!(
+            "Pull request #{number} has merge conflicts with {base}. Fetch and rebase onto \
+             {base}, resolve every conflict in this workspace, run focused validation, commit \
+             if needed, and push the updated head. Do not merge or enable auto-merge."
+        ),
+        WatchReason::Behind => format!(
+            "Update pull request #{number} from {base}. Fetch the latest base branch, rebase \
+             this workspace branch onto it, resolve any conflicts, run focused validation, \
+             and push the updated head. Do not merge or enable auto-merge."
+        ),
+        WatchReason::ChangesRequested => format!(
+            "Pull request #{number} has requested changes. Inspect the latest unresolved \
+             review feedback, implement each actionable request in this workspace, run \
+             focused validation, commit, push, and reply where context is useful. Do not \
+             merge, enable auto-merge, or resolve review threads you did not address."
+        ),
+    };
+    let mut lines = vec![instruction, String::new()];
+    lines.push(format!(
+        "Pull request: #{number}{}",
+        pr.title
+            .as_deref()
+            .map(|title| format!(" - {title}"))
+            .unwrap_or_default()
+    ));
+    if let Some(url) = pr.url.as_deref() {
+        lines.push(format!("URL: {url}"));
+    }
+    if let Some(summary) = pr.checks_summary.as_deref() {
+        lines.push(format!("Checks: {summary}"));
+    }
+    let active = pr
+        .checks
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .filter(|check| check.bucket == tidebreak_core::PullRequestCheckBucket::Fail)
+        .collect::<Vec<_>>();
+    if !active.is_empty() {
+        lines.push("Failing checks:".to_owned());
+        for check in active {
+            let mut line = format!("- {}", check.name);
+            if let Some(detail) = check.detail.as_deref() {
+                line.push_str(&format!(": {detail}"));
+            }
+            if let Some(url) = check.url.as_deref() {
+                line.push_str(&format!("\n  {url}"));
+            }
+            lines.push(line);
+        }
+    }
+    lines.join("\n")
+}
+
+impl CodeRuntime {
+    /// Start a durable watch on the workspace's open pull request.
+    ///
+    /// Forks a dedicated watch session in the same worktree. The session
+    /// reuses the interactive session's engine and model when one exists and
+    /// always runs `auto`: a watch that must stop for every command approval
+    /// is a prompt in disguise.
+    pub(crate) async fn start_watch(
+        self: &Arc<Self>,
+        owner: &OwnerId,
+        workspace_id: WorkspaceId,
+    ) -> Result<CodeWatch, ServerError> {
+        let workspace = self.get_workspace(owner, workspace_id).await?;
+        if workspace.status != CodeWorkspaceStatus::Active {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                format!("workspace is {}", workspace.status.as_str()),
+            ));
+        }
+        if let Some(existing) = latest_watch_for_workspace(&self.db, owner, workspace_id).await? {
+            if !existing.state.is_terminal() {
+                return Err(ServerError::conflict_kind(
+                    "watch_exists",
+                    "this workspace already has an active watch",
+                ));
+            }
+        }
+        let status = self.refresh_workspace_pr(owner, workspace_id).await?;
+        let Some(pr) = status.pr else {
+            return Err(ServerError::conflict_kind(
+                "no_pull_request",
+                "this workspace has no pull request to watch",
+            ));
+        };
+        match assess(&pr) {
+            WatchAssessment::Merged => {
+                return Err(ServerError::conflict_kind(
+                    "pr_not_open",
+                    "the pull request has already merged",
+                ));
+            }
+            WatchAssessment::Closed => {
+                return Err(ServerError::conflict_kind(
+                    "pr_not_open",
+                    "the pull request is closed",
+                ));
+            }
+            _ => {}
+        }
+        let sessions = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
+        let (harness, model) = sessions
+            .iter()
+            .find(|session| session.kind == CodeSessionKind::Interactive)
+            .map(|session| (session.harness_kind, session.model.clone()))
+            .unwrap_or((HarnessKind::ClaudeCode, None));
+        let session = self
+            .create_session_of_kind(
+                owner,
+                workspace_id,
+                CodeSessionKind::Watch,
+                harness,
+                CodePermissionMode::Auto,
+                model,
+            )
+            .await?;
+        let now = Utc::now();
+        let watch = CodeWatch {
+            id: CodeWatchId::new(),
+            owner: owner.clone(),
+            workspace_id,
+            session_id: session.id,
+            pr_number: pr.number,
+            state: CodeWatchState::Watching,
+            detail: None,
+            last_fix_head: None,
+            cycles: 0,
+            created_at: now,
+            updated_at: now,
+        };
+        insert_watch(&self.db, &watch).await?;
+        self.ensure_watch_sweep();
+        emit_workspace_digests(&self.db, &self.bus, owner, workspace_id).await;
+        Ok(watch)
+    }
+
+    /// Stop the workspace's active watch and end its session.
+    pub(crate) async fn stop_watch(
+        &self,
+        owner: &OwnerId,
+        workspace_id: WorkspaceId,
+    ) -> Result<CodeWatch, ServerError> {
+        let Some(mut watch) = latest_watch_for_workspace(&self.db, owner, workspace_id).await?
+        else {
+            return Err(ServerError::not_found("this workspace has no watch"));
+        };
+        if watch.state.is_terminal() {
+            return Err(ServerError::conflict_kind(
+                "watch_not_active",
+                "the watch has already finished",
+            ));
+        }
+        finish_watch(
+            self,
+            &mut watch,
+            CodeWatchState::Stopped,
+            Some("stopped by the user".to_owned()),
+        )
+        .await?;
+        Ok(watch)
+    }
+
+    /// The workspace's most recent watch, terminal or not.
+    pub(crate) async fn latest_watch(
+        &self,
+        owner: &OwnerId,
+        workspace_id: WorkspaceId,
+    ) -> Result<Option<CodeWatch>, ServerError> {
+        Ok(latest_watch_for_workspace(&self.db, owner, workspace_id).await?)
+    }
+}
+
+/// One pass over every active watch. Failures on one watch never stop the
+/// others.
+pub(crate) async fn sweep_watches(runtime: &Arc<CodeRuntime>) {
+    let watches = match list_active_watches_all_owners(&runtime.db).await {
+        Ok(watches) => watches,
+        Err(err) => {
+            warn!(error = %err, "code-mode watch sweep could not list watches");
+            return;
+        }
+    };
+    for mut watch in watches {
+        if let Err(err) = sweep_one(runtime, &mut watch).await {
+            warn!(
+                watch = %watch.id,
+                workspace = %watch.workspace_id,
+                error = %err.message(),
+                "code-mode watch sweep failed for one watch"
+            );
+        }
+    }
+}
+
+async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<(), ServerError> {
+    let owner = watch.owner.clone();
+    let Some(session) = get_session(&runtime.db, &owner, watch.session_id).await? else {
+        return finish_watch(
+            runtime.as_ref(),
+            watch,
+            CodeWatchState::Failed,
+            Some("the watch session is gone".to_owned()),
+        )
+        .await;
+    };
+    match session.lifecycle {
+        CodeSessionLifecycle::Ended => {
+            return finish_watch(
+                runtime.as_ref(),
+                watch,
+                CodeWatchState::Failed,
+                Some("the watch session ended".to_owned()),
+            )
+            .await;
+        }
+        CodeSessionLifecycle::Fenced => {
+            return finish_watch(
+                runtime.as_ref(),
+                watch,
+                CodeWatchState::Failed,
+                Some("the watch session is fenced; reap it and start a new watch".to_owned()),
+            )
+            .await;
+        }
+        // A fix turn (or its recovery) is still in flight; check back next
+        // sweep rather than hammering the host meanwhile.
+        CodeSessionLifecycle::Running => return Ok(()),
+        CodeSessionLifecycle::Created | CodeSessionLifecycle::Idle => {}
+    }
+    let workspace = match runtime.get_workspace(&owner, watch.workspace_id).await {
+        Ok(workspace) => workspace,
+        Err(_) => {
+            return finish_watch(
+                runtime.as_ref(),
+                watch,
+                CodeWatchState::Failed,
+                Some("the workspace is gone".to_owned()),
+            )
+            .await;
+        }
+    };
+    if workspace.status != CodeWorkspaceStatus::Active {
+        return finish_watch(
+            runtime.as_ref(),
+            watch,
+            CodeWatchState::Failed,
+            Some(format!("the workspace is {}", workspace.status.as_str())),
+        )
+        .await;
+    }
+    // Another session's turn owns the worktree right now; wait.
+    let sessions = list_sessions_for_workspace(&runtime.db, &owner, watch.workspace_id).await?;
+    if sessions
+        .iter()
+        .any(|other| other.lifecycle == CodeSessionLifecycle::Running)
+    {
+        return Ok(());
+    }
+    let status = runtime
+        .refresh_workspace_pr(&owner, watch.workspace_id)
+        .await?;
+    let Some(pr) = status.pr else {
+        return park_watch(
+            runtime.as_ref(),
+            watch,
+            "the pull request digest is unavailable; is GitHub CLI signed in?",
+        )
+        .await;
+    };
+    if pr.number != watch.pr_number {
+        return finish_watch(
+            runtime.as_ref(),
+            watch,
+            CodeWatchState::Failed,
+            Some(format!(
+                "the workspace's pull request changed from #{} to #{}",
+                watch.pr_number, pr.number
+            )),
+        )
+        .await;
+    }
+    match assess(&pr) {
+        WatchAssessment::Merged => {
+            finish_watch(
+                runtime.as_ref(),
+                watch,
+                CodeWatchState::Done,
+                Some("the pull request merged".to_owned()),
+            )
+            .await
+        }
+        WatchAssessment::Closed => {
+            finish_watch(
+                runtime.as_ref(),
+                watch,
+                CodeWatchState::Done,
+                Some("the pull request closed without merging".to_owned()),
+            )
+            .await
+        }
+        WatchAssessment::Ready => {
+            let done = finish_watch(
+                runtime.as_ref(),
+                watch,
+                CodeWatchState::Done,
+                Some("the pull request is ready; merging is yours".to_owned()),
+            )
+            .await;
+            let _ = apply_attention(
+                &runtime.db,
+                &runtime.bus,
+                &owner,
+                watch.session_id,
+                Attention::needs_you(
+                    "the pull request is ready to merge",
+                    AttentionSource::Structured,
+                ),
+                false,
+            )
+            .await;
+            done
+        }
+        WatchAssessment::NeedsUser(reason) => park_watch(runtime.as_ref(), watch, reason).await,
+        WatchAssessment::Waiting => {
+            if watch.state != CodeWatchState::Watching || watch.detail.is_some() {
+                watch.state = CodeWatchState::Watching;
+                watch.detail = None;
+                persist_watch(runtime.as_ref(), watch).await?;
+            }
+            Ok(())
+        }
+        WatchAssessment::Actionable(reason) => {
+            let same_head = watch.last_fix_head.is_some()
+                && watch.last_fix_head.as_deref() == pr.head_sha.as_deref();
+            if same_head {
+                // The previous fix turn ran against this same head and the
+                // condition is still present: repeating it would loop.
+                return park_watch(
+                    runtime.as_ref(),
+                    watch,
+                    "a fix attempt did not resolve the problem",
+                )
+                .await;
+            }
+            watch.state = CodeWatchState::Fixing;
+            watch.detail = Some(format!("fixing {}", reason.describe()));
+            watch.last_fix_head = pr.head_sha.clone();
+            watch.cycles = watch.cycles.saturating_add(1);
+            persist_watch(runtime.as_ref(), watch).await?;
+            let instruction = fix_turn_instruction(reason, &pr);
+            let session_id = watch.session_id;
+            let task_runtime = Arc::clone(runtime);
+            let task_owner = owner.clone();
+            // Detached: a fix turn can run for minutes and the sweep must
+            // keep serving other watches. The next sweeps see the session
+            // Running and stand by.
+            tokio::spawn(async move {
+                if let Err(err) = task_runtime
+                    .submit_turn(&task_owner, session_id, instruction, None, Vec::new())
+                    .await
+                {
+                    warn!(
+                        session = %session_id,
+                        error = %err.message(),
+                        "code-mode watch fix turn failed to submit"
+                    );
+                }
+            });
+            Ok(())
+        }
+    }
+}
+
+/// Park a watch as blocked with a reason, surfacing `NeedsYou` once.
+async fn park_watch(
+    runtime: &CodeRuntime,
+    watch: &mut CodeWatch,
+    reason: &str,
+) -> Result<(), ServerError> {
+    if watch.state == CodeWatchState::Blocked && watch.detail.as_deref() == Some(reason) {
+        return Ok(());
+    }
+    watch.state = CodeWatchState::Blocked;
+    watch.detail = Some(reason.to_owned());
+    persist_watch(runtime, watch).await?;
+    let _ = apply_attention(
+        &runtime.db,
+        &runtime.bus,
+        &watch.owner,
+        watch.session_id,
+        Attention::needs_you(reason, AttentionSource::Structured),
+        false,
+    )
+    .await;
+    Ok(())
+}
+
+/// Move a watch to a terminal state and end its session.
+async fn finish_watch(
+    runtime: &CodeRuntime,
+    watch: &mut CodeWatch,
+    state: CodeWatchState,
+    detail: Option<String>,
+) -> Result<(), ServerError> {
+    watch.state = state;
+    watch.detail = detail;
+    persist_watch(runtime, watch).await?;
+    let owner = watch.owner.clone();
+    runtime.end_session_row(&owner, watch.session_id).await?;
+    emit_workspace_digests(&runtime.db, &runtime.bus, &watch.owner, watch.workspace_id).await;
+    Ok(())
+}
+
+async fn persist_watch(runtime: &CodeRuntime, watch: &mut CodeWatch) -> Result<(), ServerError> {
+    watch.updated_at = Utc::now();
+    save_watch(&runtime.db, watch).await?;
+    emit_workspace_digests(&runtime.db, &runtime.bus, &watch.owner, watch.workspace_id).await;
+    Ok(())
+}
+
+/// Abort the watch sweep when the runtime is dropped.
+///
+/// The loop holds a [`Weak`] runtime handle: an `Arc` would keep the runtime
+/// alive from its own field and the guard's `Drop` could never run.
+pub(crate) struct WatchSweepGuard(Option<tokio::task::JoinHandle<()>>);
+
+impl WatchSweepGuard {
+    pub(crate) fn spawn(runtime: Weak<CodeRuntime>) -> Self {
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(WATCH_SWEEP_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let Some(runtime) = runtime.upgrade() else {
+                    return;
+                };
+                sweep_watches(&runtime).await;
+            }
+        });
+        Self(Some(handle))
+    }
+}
+
+impl Drop for WatchSweepGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidebreak_core::{PullRequestCheck, PullRequestCheckBucket};
+
+    fn base_pr() -> PullRequestDigest {
+        PullRequestDigest {
+            number: 12,
+            url: Some("https://github.com/example/demo/pull/12".to_owned()),
+            state: "open".to_owned(),
+            title: Some("demo".to_owned()),
+            checks_summary: None,
+            checks: None,
+            draft: Some(false),
+            merged: Some(false),
+            review_decision: None,
+            mergeable: None,
+            merge_state_status: None,
+            head_branch: Some("feature".to_owned()),
+            base_branch: Some("main".to_owned()),
+            head_sha: Some("abc123".to_owned()),
+            auto_merge_enabled: Some(false),
+            in_merge_queue: None,
+        }
+    }
+
+    fn check(bucket: PullRequestCheckBucket) -> PullRequestCheck {
+        PullRequestCheck {
+            name: "ci".to_owned(),
+            bucket,
+            detail: None,
+            url: None,
+        }
+    }
+
+    #[test]
+    fn merged_and_closed_are_terminal() {
+        let mut pr = base_pr();
+        pr.merged = Some(true);
+        assert_eq!(assess(&pr), WatchAssessment::Merged);
+        let mut pr = base_pr();
+        pr.state = "closed".to_owned();
+        assert_eq!(assess(&pr), WatchAssessment::Closed);
+    }
+
+    #[test]
+    fn conflicts_outrank_failing_checks() {
+        let mut pr = base_pr();
+        pr.mergeable = Some("conflicting".to_owned());
+        pr.checks = Some(vec![check(PullRequestCheckBucket::Fail)]);
+        assert_eq!(
+            assess(&pr),
+            WatchAssessment::Actionable(WatchReason::Conflicts)
+        );
+    }
+
+    #[test]
+    fn failing_checks_are_actionable_while_pending_wait() {
+        let mut pr = base_pr();
+        pr.checks = Some(vec![
+            check(PullRequestCheckBucket::Fail),
+            check(PullRequestCheckBucket::Pending),
+        ]);
+        assert_eq!(
+            assess(&pr),
+            WatchAssessment::Actionable(WatchReason::FailingChecks)
+        );
+        let mut pr = base_pr();
+        pr.checks = Some(vec![check(PullRequestCheckBucket::Pending)]);
+        assert_eq!(assess(&pr), WatchAssessment::Waiting);
+    }
+
+    #[test]
+    fn drafts_and_required_reviews_need_the_user() {
+        let mut pr = base_pr();
+        pr.draft = Some(true);
+        assert!(matches!(assess(&pr), WatchAssessment::NeedsUser(_)));
+        let mut pr = base_pr();
+        pr.review_decision = Some("review_required".to_owned());
+        assert!(matches!(assess(&pr), WatchAssessment::NeedsUser(_)));
+    }
+
+    #[test]
+    fn clean_and_mergeable_is_ready() {
+        let mut pr = base_pr();
+        pr.mergeable = Some("mergeable".to_owned());
+        pr.merge_state_status = Some("clean".to_owned());
+        assert_eq!(assess(&pr), WatchAssessment::Ready);
+    }
+
+    #[test]
+    fn behind_is_actionable_and_queue_waits() {
+        let mut pr = base_pr();
+        pr.merge_state_status = Some("behind".to_owned());
+        assert_eq!(assess(&pr), WatchAssessment::Actionable(WatchReason::Behind));
+        let mut pr = base_pr();
+        pr.in_merge_queue = Some(true);
+        assert_eq!(assess(&pr), WatchAssessment::Waiting);
+    }
+
+    #[test]
+    fn fix_instruction_never_asks_to_merge() {
+        let mut pr = base_pr();
+        pr.checks = Some(vec![check(PullRequestCheckBucket::Fail)]);
+        for reason in [
+            WatchReason::FailingChecks,
+            WatchReason::Conflicts,
+            WatchReason::Behind,
+            WatchReason::ChangesRequested,
+        ] {
+            let text = fix_turn_instruction(reason, &pr).to_ascii_lowercase();
+            assert!(text.contains("do not merge"), "{reason:?}");
+            assert!(!text.contains("enable auto-merge once"), "{reason:?}");
+        }
+    }
+}

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -783,6 +783,11 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::merge_workspace_pr),
         )
         .route(
+            "/code/workspaces/{id}/watch",
+            post(routes::code::start_workspace_watch)
+                .delete(routes::code::stop_workspace_watch),
+        )
+        .route(
             "/code/workspaces/{id}/actions/{name}",
             post(routes::code::run_workspace_action),
         )

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -784,8 +784,7 @@ pub fn app(state: AppState) -> Router {
         )
         .route(
             "/code/workspaces/{id}/watch",
-            post(routes::code::start_workspace_watch)
-                .delete(routes::code::stop_workspace_watch),
+            post(routes::code::start_workspace_watch).delete(routes::code::stop_workspace_watch),
         )
         .route(
             "/code/workspaces/{id}/actions/{name}",

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -9,8 +9,8 @@ use crate::extract::{Json, Path};
 
 use super::types::{
     CodeActionSnapshot, CodeCommitSnapshot, CodePrCommentsSnapshot, CodePrMergeMethod,
-    CodePushSnapshot, CodeWorkspacePrSnapshot, CommitWorkspaceBody, CreatePullRequestBody,
-    MergeCodePrBody,
+    CodePushSnapshot, CodeWatchSnapshot, CodeWorkspacePrSnapshot, CommitWorkspaceBody,
+    CreatePullRequestBody, MergeCodePrBody,
 };
 use crate::code::gh::{ActionOutcome, CommitOutcome, MergeMethod, PushOutcome, WorkspaceGitStatus};
 use tidebreak_core::WorkspaceId;
@@ -38,21 +38,41 @@ pub async fn create_pull_request(
     Json(body): Json<CreatePullRequestBody>,
 ) -> Result<impl IntoResponse, ServerError> {
     let snapshot = code.create_workspace_pr(id, body.title, body.body).await?;
-    Ok((StatusCode::CREATED, Json(pr_snapshot(snapshot))))
+    Ok((StatusCode::CREATED, Json(pr_snapshot(snapshot, None))))
 }
 
 pub async fn get_workspace_pr(
     code: ScopedCode,
     Path(id): Path<WorkspaceId>,
 ) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
-    Ok(Json(pr_snapshot(code.workspace_pr(id).await?)))
+    let status = code.workspace_pr(id).await?;
+    let watch = code.latest_watch(id).await?;
+    Ok(Json(pr_snapshot(status, watch)))
 }
 
 pub async fn refresh_workspace_pr(
     code: ScopedCode,
     Path(id): Path<WorkspaceId>,
 ) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
-    Ok(Json(pr_snapshot(code.refresh_workspace_pr(id).await?)))
+    let status = code.refresh_workspace_pr(id).await?;
+    let watch = code.latest_watch(id).await?;
+    Ok(Json(pr_snapshot(status, watch)))
+}
+
+pub async fn start_workspace_watch(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+) -> Result<impl IntoResponse, ServerError> {
+    let watch = code.start_watch(id).await?;
+    Ok((StatusCode::CREATED, Json(CodeWatchSnapshot::from(watch))))
+}
+
+pub async fn stop_workspace_watch(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodeWatchSnapshot>, ServerError> {
+    let watch = code.stop_watch(id).await?;
+    Ok(Json(CodeWatchSnapshot::from(watch)))
 }
 
 pub async fn get_workspace_pr_comments(
@@ -76,9 +96,9 @@ pub async fn merge_workspace_pr(
         CodePrMergeMethod::Merge => MergeMethod::Merge,
         CodePrMergeMethod::Rebase => MergeMethod::Rebase,
     };
-    Ok(Json(pr_snapshot(
-        code.merge_workspace_pr(id, method, body.auto).await?,
-    )))
+    let status = code.merge_workspace_pr(id, method, body.auto).await?;
+    let watch = code.latest_watch(id).await?;
+    Ok(Json(pr_snapshot(status, watch)))
 }
 
 pub async fn run_workspace_action(
@@ -104,7 +124,10 @@ fn push_snapshot(outcome: PushOutcome) -> CodePushSnapshot {
     }
 }
 
-fn pr_snapshot(status: WorkspaceGitStatus) -> CodeWorkspacePrSnapshot {
+fn pr_snapshot(
+    status: WorkspaceGitStatus,
+    watch: Option<tidebreak_core::CodeWatch>,
+) -> CodeWorkspacePrSnapshot {
     CodeWorkspacePrSnapshot {
         dirty: status.dirty,
         unpushed: status.unpushed,
@@ -115,6 +138,7 @@ fn pr_snapshot(status: WorkspaceGitStatus) -> CodeWorkspacePrSnapshot {
         gh_found: status.gh_found,
         gh_authenticated: status.gh_authenticated,
         remediation: status.remediation,
+        watch: watch.map(CodeWatchSnapshot::from),
     }
 }
 

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use approvals::{decide_approval, list_approvals};
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,
     merge_workspace_pr, push_workspace, refresh_workspace_pr, run_workspace_action,
+    start_workspace_watch, stop_workspace_watch,
 };
 pub(crate) use harnesses::{list_harness_models, list_harnesses, refresh_harnesses};
 pub(crate) use repos::{

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -5,10 +5,10 @@ use ts_rs::TS;
 
 use tidebreak_core::{
     Attention, CapLevel, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
-    CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionLifecycle, CodeTerminalId,
-    CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, Diffstat,
-    FenceReason, FileChangeKind, HarnessCaps, HarnessKind, HarnessTier, PullRequestDigest,
-    QuickAction, RepoId, WorkspaceId,
+    CodeEvent, CodePermissionMode, CodeRepo, CodeSession, CodeSessionKind, CodeSessionLifecycle,
+    CodeTerminalId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWatch, CodeWatchId, CodeWatchState,
+    CodeWorkspace, CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps,
+    HarnessKind, HarnessTier, PullRequestDigest, QuickAction, RepoId, WorkspaceId,
 };
 
 /// A registered local git repository.
@@ -86,6 +86,7 @@ impl From<CodeWorkspace> for CodeWorkspaceSnapshot {
 pub struct CodeSessionSnapshot {
     pub id: tidebreak_core::CodeSessionId,
     pub workspace_id: WorkspaceId,
+    pub kind: CodeSessionKind,
     pub harness_kind: HarnessKind,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
@@ -111,6 +112,7 @@ impl From<CodeSession> for CodeSessionSnapshot {
         Self {
             id: session.id,
             workspace_id: session.workspace_id,
+            kind: session.kind,
             harness_kind: session.harness_kind,
             harness_version: session.harness_version,
             harness_resume_ref: session.harness_resume_ref,
@@ -380,6 +382,41 @@ pub struct CodeWorkspacePrSnapshot {
     #[ts(optional)]
     pub gh_authenticated: Option<bool>,
     pub remediation: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub watch: Option<CodeWatchSnapshot>,
+}
+
+/// One durable watch task on a workspace's pull request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeWatchSnapshot {
+    pub id: CodeWatchId,
+    pub workspace_id: WorkspaceId,
+    pub session_id: tidebreak_core::CodeSessionId,
+    pub pr_number: u64,
+    pub state: CodeWatchState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub detail: Option<String>,
+    pub cycles: i64,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<CodeWatch> for CodeWatchSnapshot {
+    fn from(watch: CodeWatch) -> Self {
+        Self {
+            id: watch.id,
+            workspace_id: watch.workspace_id,
+            session_id: watch.session_id,
+            pr_number: watch.pr_number,
+            state: watch.state,
+            detail: watch.detail,
+            cycles: watch.cycles,
+            created_at: watch.created_at,
+            updated_at: watch.updated_at,
+        }
+    }
 }
 
 /// Body of `POST /code/workspaces/{id}/pr/merge`.
@@ -704,6 +741,7 @@ pub struct CodeTerminalActivityNotice {
 pub struct CodeSessionDigest {
     pub workspace: WorkspaceId,
     pub session: tidebreak_core::CodeSessionId,
+    pub kind: CodeSessionKind,
     pub lifecycle: CodeSessionLifecycle,
     pub attention: Attention,
     pub title: String,
@@ -718,6 +756,7 @@ impl From<crate::code::bus::SessionDigest> for CodeSessionDigest {
         Self {
             workspace: digest.workspace,
             session: digest.session,
+            kind: digest.kind,
             lifecycle: digest.lifecycle,
             attention: digest.attention,
             title: digest.title,
@@ -742,6 +781,7 @@ pub enum CodeUpdateNotice {
     Digest {
         workspace: WorkspaceId,
         session: tidebreak_core::CodeSessionId,
+        kind: CodeSessionKind,
         lifecycle: CodeSessionLifecycle,
         attention: Attention,
         title: String,
@@ -791,6 +831,7 @@ impl CodeUpdateNotice {
         Self::Digest {
             workspace: wire.workspace,
             session: wire.session,
+            kind: wire.kind,
             lifecycle: wire.lifecycle,
             attention: wire.attention,
             title: wire.title,

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -109,7 +109,9 @@ Baseline schema edit plus a `DESKTOP_SCHEMA_EPOCH` bump, per
   (`Creating | SetupFailed | Active | Archived`), `pr` (JSON digest:
   number, url, state, checks summary; nullable), `created_at`,
   `archived_at`.
-- **`code_session`** — `id`, `workspace_id`, `harness_kind`,
+- **`code_session`** — `id`, `workspace_id`, `kind`
+  (`Interactive | Watch`, per
+  [`0049`](decisions/0049-watch-and-fix-is-a-durable-task.md)), `harness_kind`,
   `harness_version` (observed at launch), `harness_resume_ref` (the
   harness's own session/thread id for resume), `permission_mode`,
   `lifecycle` (`Created | Idle | Running | Fenced | Ended`), `fence_reason`
@@ -128,6 +130,13 @@ Baseline schema edit plus a `DESKTOP_SCHEMA_EPOCH` bump, per
   normalized classification), `harness_raw` (JSON, size-capped), `state`
   (`Pending | Approved | Denied`), `feedback`, `requested_at`,
   `decided_at`.
+- **`code_watch`** — `id`, `workspace_id`, `session_id` (the watch's
+  dedicated `kind = watch` session), `pr_number`, `state`
+  (`Watching | Fixing | Blocked | Done | Stopped | Failed`), `detail`,
+  `last_fix_head`, `cycles`, `created_at`, `updated_at`. Driven by a
+  try-based sweep that reads active rows every tick, so restarts resume
+  watches with no extra recovery state
+  ([`0049`](decisions/0049-watch-and-fix-is-a-durable-task.md)).
 
 Boot recovery (`code/recovery.rs`, per
 [`0032`](decisions/0032-code-workspaces-worktrees-checkpoints.md)): sessions
@@ -284,6 +293,7 @@ GET             /code/workspaces/{id}/files          changed files vs base, per-
 GET             /code/workspaces/{id}/diff?turn=&file=   bounded unified diff
 POST            /code/workspaces/{id}/git/commit | /git/push | /git/pr
 GET             /code/workspaces/{id}/pr             PR + checks digest (gh; graceful absence)
+POST/DELETE     /code/workspaces/{id}/watch          durable watch-and-fix task (0049)
 POST            /code/workspaces/{id}/actions/{name} quick action; output journaled
 
 POST/GET/DELETE /code/workspaces/{id}/terminals

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -111,7 +111,7 @@ Baseline schema edit plus a `DESKTOP_SCHEMA_EPOCH` bump, per
   `archived_at`.
 - **`code_session`** — `id`, `workspace_id`, `kind`
   (`Interactive | Watch`, per
-  [`0049`](decisions/0049-watch-and-fix-is-a-durable-task.md)), `harness_kind`,
+  [`0050`](decisions/0050-watch-and-fix-is-a-durable-task.md)), `harness_kind`,
   `harness_version` (observed at launch), `harness_resume_ref` (the
   harness's own session/thread id for resume), `permission_mode`,
   `lifecycle` (`Created | Idle | Running | Fenced | Ended`), `fence_reason`
@@ -136,7 +136,7 @@ Baseline schema edit plus a `DESKTOP_SCHEMA_EPOCH` bump, per
   `last_fix_head`, `cycles`, `created_at`, `updated_at`. Driven by a
   try-based sweep that reads active rows every tick, so restarts resume
   watches with no extra recovery state
-  ([`0049`](decisions/0049-watch-and-fix-is-a-durable-task.md)).
+  ([`0050`](decisions/0050-watch-and-fix-is-a-durable-task.md)).
 
 Boot recovery (`code/recovery.rs`, per
 [`0032`](decisions/0032-code-workspaces-worktrees-checkpoints.md)): sessions
@@ -293,7 +293,7 @@ GET             /code/workspaces/{id}/files          changed files vs base, per-
 GET             /code/workspaces/{id}/diff?turn=&file=   bounded unified diff
 POST            /code/workspaces/{id}/git/commit | /git/push | /git/pr
 GET             /code/workspaces/{id}/pr             PR + checks digest (gh; graceful absence)
-POST/DELETE     /code/workspaces/{id}/watch          durable watch-and-fix task (0049)
+POST/DELETE     /code/workspaces/{id}/watch          durable watch-and-fix task (0050)
 POST            /code/workspaces/{id}/actions/{name} quick action; output journaled
 
 POST/GET/DELETE /code/workspaces/{id}/terminals

--- a/docs/decisions/0049-watch-and-fix-is-a-durable-task.md
+++ b/docs/decisions/0049-watch-and-fix-is-a-durable-task.md
@@ -1,0 +1,65 @@
+# 49. Watch-and-Fix Is a Durable Server-Side Task
+
+- Status: Accepted
+- Date: 2026-08-20
+- Owners: code mode
+- Related: [`0009-queued-turns.md`](0009-queued-turns.md),
+  [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),
+  [`0033-code-mode-approvals.md`](0033-code-mode-approvals.md),
+  [`0035-code-mode-wire-contract.md`](0035-code-mode-wire-contract.md),
+  [`0042-user-initiated-pr-merge.md`](0042-user-initiated-pr-merge.md)
+
+## Context
+
+"Watch and fix" was a prompt: the workflow control composed a long
+instruction into the workspace's interactive session and asked the engine to
+loop — poll checks, fix failures, rebase, and keep watching. That shape has
+structural problems no prompt wording can fix. The watch dies with the turn,
+the session, or the app. It occupies the user's conversation for hours. Its
+polling burns engine context on waiting. And the prompt asked the agent to
+enable auto-merge through its own `gh`, side-stepping the merge boundary
+[record 42](0042-user-initiated-pr-merge.md) draws.
+
+Everything a durable watch needs already exists: sessions recover across
+restarts with spawn-epoch fencing, turns can be driven programmatically
+through the session worker, the PR digest path reads host state with
+head-SHA consistency, and [record 9](0009-queued-turns.md) established the
+try-based sweep as the cheap durable-driver idiom.
+
+## Decision
+
+Watch and fix is a server-side task backed by a `code_watch` row and driven
+by a try-based sweep. The sweep reads its work list from the table every
+tick, so a restart resumes every active watch with no extra recovery state.
+
+The watch owns a dedicated session — `code_session.kind = watch` — in the
+same worktree as the conversation it forked from. One active session per
+workspace becomes one per *kind*: the interactive conversation and the watch
+coexist, and the sweep submits a fix turn only while no session in the
+workspace is running a turn, so the two never contend for the worktree.
+Watch sessions run `auto`; approvals they raise park in the normal approval
+flow. List surfaces keep showing the interactive session: watch digests
+carry their kind and never displace the conversation in the updates store.
+
+Each sweep classifies the fresh PR digest and takes exactly one step:
+submit a bounded fix turn (failing checks, conflicts, behind, requested
+changes), wait (pending checks, merge queue), park with `NeedsYou` (draft,
+review required, a fix attempt that did not move the head), or finish
+(merged, closed, ready). The fix instruction is scoped to a single cycle;
+the loop lives in the sweep, not in the engine's context window.
+
+The watch never merges, never arms auto-merge, and never marks a draft
+ready. Those are PR state changes record 42 reserves for the user; the
+watch reports "ready to merge" and stops.
+
+## Consequences
+
+- A watch survives app restarts, engine crashes, and closed laptops that
+  recover; its history is ordinary turns in an ordinary session journal.
+- The digest gains a `kind`, the PR digest gains `head_sha`, and the PR
+  snapshot gains a `watch` block; clients that predate them parse on.
+- A fix turn that leaves the head unchanged parks the watch instead of
+  looping — the escalation is visible, not silent retry.
+- The interactive composer is free while the watch runs; agent-prompt
+  workflow actions hide while a watch is active so two agents never edit
+  one worktree at once.

--- a/docs/decisions/0050-watch-and-fix-is-a-durable-task.md
+++ b/docs/decisions/0050-watch-and-fix-is-a-durable-task.md
@@ -1,4 +1,4 @@
-# 49. Watch-and-Fix Is a Durable Server-Side Task
+# 50. Watch-and-Fix Is a Durable Server-Side Task
 
 - Status: Accepted
 - Date: 2026-08-20

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -223,7 +223,11 @@ purpose:
   earlier checkpoint waits until review flows have settled.
 - **Multiple sessions per workspace.** The data model keeps room for
   follow-up and successor sessions in one worktree; v1 runs one active
-  session per workspace.
+  session per workspace. Watch tasks
+  ([record 49](decisions/0049-watch-and-fix-is-a-durable-task.md)) take the
+  first step: one interactive session plus one watch session may share a
+  worktree, serialized so only one turn runs at a time. Free-form
+  concurrent sessions stay parked.
 - **Changing a session's permission mode after it starts.** The mode is
   chosen at session creation, refused per harness capability there
   ([record 33](decisions/0033-code-mode-approvals.md),

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -224,7 +224,7 @@ purpose:
 - **Multiple sessions per workspace.** The data model keeps room for
   follow-up and successor sessions in one worktree; v1 runs one active
   session per workspace. Watch tasks
-  ([record 49](decisions/0049-watch-and-fix-is-a-durable-task.md)) take the
+  ([record 50](decisions/0050-watch-and-fix-is-a-durable-task.md)) take the
   first step: one interactive session plus one watch session may share a
   worktree, serialized so only one turn runs at a time. Free-form
   concurrent sessions stay parked.


### PR DESCRIPTION
## Summary

- replace the prompt-only Watch and fix with a durable server-side watch task (new decision record 0049)
- add `code_watch` table and a try-based sweep that reads active rows every tick, so restarts resume watches with no extra recovery state
- give sessions a `kind` (`interactive` | `watch`): the watch forks a dedicated auto-mode session in the same worktree, and fix turns submit only while no other session in the workspace runs a turn
- classify the fresh PR digest each sweep and take one step: bounded fix turn (failing checks, conflicts, behind, requested changes), wait, park with NeedsYou, or finish
- add `head_sha` to the PR digest so a fix turn that does not move the head parks the watch instead of looping
- honor decision 42: the watch never merges, arms auto-merge, or marks drafts ready — the old prompt's auto-merge instruction is gone
- routes `POST`/`DELETE /code/workspaces/{id}/watch`; watch state rides the PR snapshot; watch digests carry their kind and never displace the interactive session in the updates store
- workflow control starts/stops the watch and shows Watching / Fixing / Blocked; Storybook stories cover the states
- CLI mirrors `kind` and never picks a watch session for `code run --ws`

## Validation

- TypeScript typecheck clean; full desktop UI suite passes (199 files, 1385 tests)
- Storybook build passes
- standalone formatting review and `git diff --check` (the two wire.ts trailing-space notes match the ts-rs generator's own output)

Broad Rust build, clippy, and the wire-type parity test are delegated to CI per repository guidance.