### PR TITLE
fix(code): treat a zombie-only process group stop as success on macOS

### DIFF
--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -313,10 +313,19 @@ fn signal_process_group(process_group: libc::pid_t, signal: libc::c_int) -> io::
     }
 
     let error = io::Error::last_os_error();
-    if error.raw_os_error() == Some(libc::ESRCH) {
-        Ok(())
-    } else {
-        Err(error)
+    match error.raw_os_error() {
+        // The group is gone entirely.
+        Some(libc::ESRCH) => Ok(()),
+        // macOS answers EPERM, not ESRCH, for a group whose only members
+        // are unreaped zombies: signals cannot be posted to a zombie, and
+        // the group still exists through it, so the kernel reports the
+        // delivery as refused. The leader is deliberately kept unreaped to
+        // pin the group id (see [`ProcessTreeChild::interrupt`]), so an
+        // engine that exits just as a stop arrives lands exactly here.
+        // Nothing is left to signal; the caller's wait() reports the true
+        // exit.
+        Some(libc::EPERM) if cfg!(target_os = "macos") => Ok(()),
+        _ => Err(error),
     }
 }
 
@@ -591,6 +600,26 @@ mod unix_process_tree_tests {
 
     const ASSERTION_TIMEOUT: Duration = Duration::from_secs(5);
     const INTERRUPT_GRACE: Duration = Duration::from_millis(50);
+
+    #[tokio::test]
+    async fn interrupting_after_the_tree_already_exited_is_not_an_error() {
+        // The leader stays unreaped to pin the group id, and macOS reports
+        // EPERM for a group holding only zombies. A stop racing an engine
+        // that just finished must succeed, not surface a permission error.
+        let mut command = Command::new("/usr/bin/true");
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut child = spawn_process_tree(&mut command).unwrap();
+        sleep(Duration::from_millis(300)).await;
+
+        let status = timeout(ASSERTION_TIMEOUT, child.interrupt(INTERRUPT_GRACE))
+            .await
+            .expect("interrupt of an exited tree completed")
+            .unwrap();
+        assert!(status.success(), "true exited nonzero: {status:?}");
+    }
 
     #[tokio::test]
     async fn interrupting_a_process_tree_stops_an_int_ignoring_descendant() {


### PR DESCRIPTION
## Summary

- macOS returns `EPERM`, not `ESRCH`, for `kill(-pgid, sig)` when the group's only members are unreaped zombies; `signal_process_group` treated that as an error
- the process tree deliberately keeps its exited leader unreaped to pin the group id, so a Stop racing an engine that just finished hit exactly this state: the tree was already dead, the turn settled as `interrupted`, and the interrupt route still answered `500 engine io: Operation not permitted`
- treat macOS `EPERM` like `ESRCH` on this path; the caller's `wait()` still reports the true exit
- add a regression test that interrupts an already-exited tree; it fails without the fix on macOS and passes with it

## Found by

Live Stop/Queue/Redirect verification of every supported harness against a real server (macOS):

| harness | Stop | Queue | Redirect |
|---|---|---|---|
| claude_code 2.1.234 | 500 on race → **PASS with this fix** | pass | honest 422 refusal |
| codex 0.147.0 | pass | pass | **pass live**: `turn/steer` accepted, `UserSteered` journaled, same turn, output visibly steered |
| opencode 1.18.18 | pass | pass | honest 422 refusal |
| grok 1.0.5 | 500 on race → **PASS with this fix** | pass | honest 422 refusal |

No harness silently converted a refused Redirect into a queue, and queued follow-ups ran exactly once after the running turn.

## Validation

- targeted `unix_process_tree_tests` run locally on macOS: the new test fails pre-fix, passes post-fix; full module green
- live re-verification on a rebuilt server: Claude Code and Grok interrupts now answer 202 and the turn interrupts
- `terminating_a_process_tree_stops_its_descendant_and_closes_its_pipe` flaked once locally on unmodified main as well — pre-existing, unrelated

Broad Rust build and clippy delegated to CI.