### PR TITLE
fix(code): bump the desktop schema epoch for the watch baseline

### DIFF
--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 33;
+const DESKTOP_SCHEMA_EPOCH: u32 = 34;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
## Summary

- #2289 edited the schema baseline (`code_session.kind`, `code_watch`) without the `DESKTOP_SCHEMA_EPOCH` bump decision 2 requires, so an existing pre-v1 desktop database kept its old schema
- symptom on a live dev profile: every stall sweep, watch sweep, and workspace digest fails with `no such column: code_session.kind` / `no such table: code_watch`
- bump the epoch to 34 so pre-v1 databases rebuild on next launch

Pre-v1 lifecycle applies: the rebuild deletes the local SQLite database by design.

## Validation

- one-line constant change; `git diff --check` clean
- the epoch round-trip tests in `desktop_schema.rs` cover the reset path in CI