### PR TITLE
feat(desktop): offer the center's openers from one + menu

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -12,6 +12,7 @@ import {
   FileCode,
   FileDiff,
   Globe2,
+  SquareTerminal,
   ListX,
   MessageSquare,
   MoveLeft,
@@ -29,6 +30,12 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { panelKey, type PanelContent } from "@/panel/panelTypes";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
@@ -69,6 +76,8 @@ export function CodeCenterTabs({
   onCopyPath,
   onNewTab,
   onNewBrowser,
+  onNewDiff,
+  onNewTerminal,
   browserTitles = {},
   region = "primary",
   showMainAgent = true,
@@ -90,8 +99,13 @@ export function CodeCenterTabs({
   onCloseOtherEditors: (index: number) => void;
   onCloseEditorsToRight: (index: number) => void;
   onCopyPath: (path: string) => void;
+  /** Open the file picker; the menu's "Open file" entry. */
   onNewTab: () => void;
   onNewBrowser?: () => void;
+  /** Open the all-changes diff as a center tab. */
+  onNewDiff?: () => void;
+  /** Open the workspace terminal. */
+  onNewTerminal?: () => void;
   browserTitles?: Readonly<Record<string, string>>;
   region?: CenterTabRegion;
   showMainAgent?: boolean;
@@ -325,32 +339,48 @@ export function CodeCenterTabs({
           </ContextMenu>
         );
       })}
-      <button
-        type="button"
-        className={cn(
-          "text-muted-foreground hover:bg-muted hover:text-foreground grid size-6 shrink-0 cursor-pointer place-items-center rounded-md",
-          FOCUS_RING_TIGHT,
-          HOVER_TINT,
-        )}
-        aria-label="New tab"
-        onClick={onNewTab}
-      >
-        <Plus className="size-3.5" />
-      </button>
-      {onNewBrowser && (
-        <button
-          type="button"
-          className={cn(
-            "text-muted-foreground hover:bg-muted hover:text-foreground grid size-6 shrink-0 cursor-pointer place-items-center rounded-md",
-            FOCUS_RING_TIGHT,
-            HOVER_TINT,
+      {/* One + for everything the center can open. A bare click must say
+          what it will do, so the button offers the choices instead of
+          jumping into the file picker. */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "text-muted-foreground hover:bg-muted hover:text-foreground grid size-6 shrink-0 cursor-pointer place-items-center rounded-md",
+              FOCUS_RING_TIGHT,
+              HOVER_TINT,
+            )}
+            aria-label="New tab"
+          >
+            <Plus className="size-3.5" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-44">
+          <DropdownMenuItem onSelect={onNewTab}>
+            <FileCode />
+            Open file…
+          </DropdownMenuItem>
+          {onNewDiff && (
+            <DropdownMenuItem onSelect={onNewDiff}>
+              <FileDiff />
+              All changes
+            </DropdownMenuItem>
           )}
-          aria-label="New browser tab"
-          onClick={onNewBrowser}
-        >
-          <Globe2 className="size-3.5" />
-        </button>
-      )}
+          {onNewBrowser && (
+            <DropdownMenuItem onSelect={onNewBrowser}>
+              <Globe2 />
+              New browser tab
+            </DropdownMenuItem>
+          )}
+          {onNewTerminal && (
+            <DropdownMenuItem onSelect={onNewTerminal}>
+              <SquareTerminal />
+              Terminal
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
       {region === "primary" && onSplitActive && (
         <button
           type="button"

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -982,6 +982,9 @@ describe("CodeWorkspacePage", () => {
     expect(mainPanel).toHaveAttribute("aria-labelledby", mainAgent.id);
 
     await user.click(screen.getByRole("button", { name: "New tab" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Open file…" }),
+    );
     const picker = await screen.findByRole("textbox", {
       name: "Search files by name",
     });
@@ -1003,7 +1006,10 @@ describe("CodeWorkspacePage", () => {
     const user = userEvent.setup();
     const { router } = await mountWorkspace(client);
 
-    await user.click(await screen.findByRole("button", { name: "New browser tab" }));
+    await user.click(screen.getByRole("button", { name: "New tab" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "New browser tab" }),
+    );
 
     expect(await screen.findByRole("tab", { name: "Browser" })).toHaveAttribute(
       "aria-selected",

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -537,6 +537,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onCopyPath={copyEditorPath}
         onNewTab={() => requestNewTab("primary")}
         onNewBrowser={() => openBrowser(undefined, "primary")}
+        onNewDiff={() =>
+          setWorkspaceLayout(openCodeEditor(layout, { type: "diff" }, "primary"))
+        }
+        onNewTerminal={() => setWorkspaceLayout(toggleTerminalLayout(layout))}
         onMoveEditorToOtherGroup={(index) =>
           setWorkspaceLayout(moveEditorTab(layout, "primary", index, "secondary"))
         }
@@ -660,6 +664,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onCopyPath={copyEditorPath}
         onNewTab={() => requestNewTab("secondary")}
         onNewBrowser={() => openBrowser(undefined, "secondary")}
+        onNewDiff={() =>
+          setWorkspaceLayout(
+            openCodeEditor(layout, { type: "diff" }, "secondary"),
+          )
+        }
+        onNewTerminal={() => setWorkspaceLayout(toggleTerminalLayout(layout))}
         onMoveEditorToOtherGroup={(index) =>
           setWorkspaceLayout(moveEditorTab(layout, "secondary", index, "primary"))
         }

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -63,6 +63,7 @@ import {
   openCodeEditor,
   removedCodeBrowserIds,
   splitCodeChromeLayout,
+  openTerminalLayout,
   toggleTerminalLayout,
 } from "./codeChrome";
 import {
@@ -540,7 +541,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onNewDiff={() =>
           setWorkspaceLayout(openCodeEditor(layout, { type: "diff" }, "primary"))
         }
-        onNewTerminal={() => setWorkspaceLayout(toggleTerminalLayout(layout))}
+        onNewTerminal={() => setWorkspaceLayout(openTerminalLayout(layout))}
         onMoveEditorToOtherGroup={(index) =>
           setWorkspaceLayout(moveEditorTab(layout, "primary", index, "secondary"))
         }
@@ -669,7 +670,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             openCodeEditor(layout, { type: "diff" }, "secondary"),
           )
         }
-        onNewTerminal={() => setWorkspaceLayout(toggleTerminalLayout(layout))}
+        onNewTerminal={() => setWorkspaceLayout(openTerminalLayout(layout))}
         onMoveEditorToOtherGroup={(index) =>
           setWorkspaceLayout(moveEditorTab(layout, "secondary", index, "primary"))
         }

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -504,6 +504,12 @@ function closeLayoutTab(layout: LayoutState, index: number): LayoutState {
   };
 }
 
+/** Open the terminal drawer; a no-op when it is already in the layout. */
+export function openTerminalLayout(layout: LayoutState): LayoutState {
+  if (layout.tabs.some((tab) => tab.type === "terminal")) return layout;
+  return toggleTerminalLayout(layout);
+}
+
 /** Open the terminal drawer, or close it if it is already in the layout. */
 export function toggleTerminalLayout(layout: LayoutState): LayoutState {
   const index = layout.tabs.findIndex((tab) => tab.type === "terminal");

--- a/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { CodeCenterTabs } from "@/code/CodeCenterTabs";
+import type { PanelContent } from "@/panel/panelTypes";
+
+/**
+ * The center tab strip: the persistent Main agent tab, editor tabs, and the
+ * single `+` that offers everything the center can open — a file, the
+ * all-changes diff, a browser, or the terminal — instead of jumping straight
+ * into the file picker.
+ */
+function TabStrip({
+  editorTabs,
+  withBrowser = true,
+  withDiff = true,
+  withTerminal = true,
+  region = "primary" as const,
+}: {
+  editorTabs: PanelContent[];
+  withBrowser?: boolean;
+  withDiff?: boolean;
+  withTerminal?: boolean;
+  region?: "primary" | "secondary";
+}) {
+  const [active, setActive] = useState(editorTabs.length > 0 ? 0 : -1);
+  const [chatFocused, setChatFocused] = useState(editorTabs.length === 0);
+  return (
+    <CodeCenterTabs
+      editorTabs={editorTabs}
+      editorActiveIndex={active}
+      conversationFocused={chatFocused}
+      onSelectChat={() => setChatFocused(true)}
+      onSelectEditor={(index) => {
+        setChatFocused(false);
+        setActive(index);
+      }}
+      onCloseEditor={fn()}
+      onCloseAllEditors={fn()}
+      onCloseOtherEditors={fn()}
+      onCloseEditorsToRight={fn()}
+      onCopyPath={fn()}
+      onNewTab={fn()}
+      onNewBrowser={withBrowser ? fn() : undefined}
+      onNewDiff={withDiff ? fn() : undefined}
+      onNewTerminal={withTerminal ? fn() : undefined}
+      onSplitActive={fn()}
+      region={region}
+      showMainAgent={region === "primary"}
+      browserTitles={{ "browser-1": "Storybook — Tidebreak" }}
+    />
+  );
+}
+
+const meta = {
+  title: "Code/Center tabs",
+  component: TabStrip,
+  args: { editorTabs: [] },
+  decorators: [
+    (Story) => (
+      <div className="border-border-subtle mx-auto max-w-3xl rounded-md border pt-0">
+        <Story />
+        <div className="text-foreground-subtle p-8 text-center text-xs">
+          tab panel
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TabStrip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Conversation alone; the `+` menu is the whole affordance. */
+export const ConversationOnly: Story = {};
+
+export const FilesOpen: Story = {
+  args: {
+    editorTabs: [
+      { type: "file", path: "crates/tidebreak-server/src/code/watch.rs" },
+      { type: "file", path: "docs/code-mode.md" },
+      { type: "diff" },
+    ],
+  },
+};
+
+export const WithBrowserTab: Story = {
+  args: {
+    editorTabs: [
+      { type: "file", path: "src/lib.rs" },
+      { type: "browser", browserId: "browser-1" },
+    ],
+  },
+};
+
+/** A split's right-hand group: no Main agent tab, close-group affordance. */
+export const SecondaryGroup: Story = {
+  args: {
+    region: "secondary",
+    editorTabs: [{ type: "diff", path: "src/lib.rs" }],
+  },
+};
+
+/** Only the file picker is offered when a region has no other openers. */
+export const MinimalMenu: Story = {
+  args: {
+    editorTabs: [],
+    withBrowser: false,
+    withDiff: false,
+    withTerminal: false,
+  },
+};


### PR DESCRIPTION
## Summary

- the tab strip's `+` jumped straight into the file picker, and the browser opener was a second unlabeled glyph beside it
- one `+` now drops the list of what the center can open — Open file…, All changes (diff), New browser tab, Terminal — so a bare click says what it will do
- the two new openers are optional props; a region without them lists only the file picker
- the browser-obscure contract holds: the menu is a Radix overlay, so native webviews yield while it is open
- Storybook covers the strip: conversation-only, files open, browser tab, split's secondary group, and the minimal menu

## Validation

- desktop UI typecheck clean; CodeWorkspacePage dom suite passes (24 tests)
- Storybook build passes