### PR TITLE
feat(desktop): open source control and PR details as peer center tabs

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -11,6 +11,8 @@ import {
   Copy,
   FileCode,
   FileDiff,
+  GitBranch,
+  GitPullRequest,
   Globe2,
   SquareTerminal,
   ListX,
@@ -77,6 +79,8 @@ export function CodeCenterTabs({
   onNewTab,
   onNewBrowser,
   onNewDiff,
+  onNewSourceControl,
+  onNewPr,
   onNewTerminal,
   browserTitles = {},
   region = "primary",
@@ -104,6 +108,10 @@ export function CodeCenterTabs({
   onNewBrowser?: () => void;
   /** Open the all-changes diff as a center tab. */
   onNewDiff?: () => void;
+  /** Open source control as a center tab. */
+  onNewSourceControl?: () => void;
+  /** Open the pull request's details as a center tab. */
+  onNewPr?: () => void;
   /** Open the workspace terminal. */
   onNewTerminal?: () => void;
   browserTitles?: Readonly<Record<string, string>>;
@@ -252,6 +260,10 @@ export function CodeCenterTabs({
                     <FileDiff className="size-3.5 shrink-0" />
                   ) : panel.type === "browser" ? (
                     <Globe2 className="size-3.5 shrink-0" />
+                  ) : panel.type === "source_control" ? (
+                    <GitBranch className="size-3.5 shrink-0" />
+                  ) : panel.type === "pr" ? (
+                    <GitPullRequest className="size-3.5 shrink-0" />
                   ) : (
                     <FileCode className="size-3.5 shrink-0" />
                   )}
@@ -367,6 +379,18 @@ export function CodeCenterTabs({
               All changes
             </DropdownMenuItem>
           )}
+          {onNewSourceControl && (
+            <DropdownMenuItem onSelect={onNewSourceControl}>
+              <GitBranch />
+              Source control
+            </DropdownMenuItem>
+          )}
+          {onNewPr && (
+            <DropdownMenuItem onSelect={onNewPr}>
+              <GitPullRequest />
+              Pull request
+            </DropdownMenuItem>
+          )}
           {onNewBrowser && (
             <DropdownMenuItem onSelect={onNewBrowser}>
               <Globe2 />
@@ -468,6 +492,12 @@ function centerTabParts(
       name: browserTitles[panel.browserId]?.trim() || "Browser",
       suffix: null,
     };
+  }
+  if (panel.type === "source_control") {
+    return { name: "Source control", suffix: null };
+  }
+  if (panel.type === "pr") {
+    return { name: "Pull request", suffix: null };
   }
   return { name: panel.type, suffix: null };
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -301,7 +301,13 @@ export function inspectorTurnLabel(
  * user-initiated ways to land it. The digest arrives over the updates socket,
  * so actions only have to hit the server — the fresh state restates itself.
  */
-function PrTab({
+/**
+ * The pull request's own life: status, checks, and review comments.
+ *
+ * Exported so the center can host it as a peer tab; the inspector remains
+ * its other caller.
+ */
+export function PrTab({
   client,
   workspaceId,
   pr,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -998,6 +998,46 @@ describe("CodeWorkspacePage", () => {
     expect(screen.getByTestId("file-viewer")).toHaveTextContent("src/lib.rs");
   });
 
+  it("opens source control and PR details as center tabs from the + menu", async () => {
+    const client = makeClient();
+    client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: PR });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    await user.click(screen.getByRole("button", { name: "New tab" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Source control" }),
+    );
+    // The inspector also names a Source control tab; the center's tab is the
+    // one controlling the primary editor panel.
+    const centerTab = (name: string) =>
+      screen
+        .getAllByRole("tab", { name })
+        .find(
+          (tab) =>
+            tab.getAttribute("aria-controls") ===
+            "code-center-panel-editor-primary",
+        );
+    await waitFor(() =>
+      expect(centerTab("Source control")).toHaveAttribute(
+        "aria-selected",
+        "true",
+      ),
+    );
+    expect(
+      await screen.findByTestId("source-control-panel"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "New tab" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Pull request" }),
+    );
+    await waitFor(() =>
+      expect(centerTab("Pull request")).toHaveAttribute("aria-selected", "true"),
+    );
+    expect(await screen.findByTestId("pr-details-panel")).toBeInTheDocument();
+  });
+
   it("opens, restores, and retitles a browser as a center editor tab", async () => {
     const client = makeClient();
     vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -90,7 +90,9 @@ const CodeBrowserTab = lazy(async () => {
   return { default: module.CodeBrowserTab };
 });
 import { useCodeCatalogStore } from "./CodeCatalogStore";
-import { CodeInspector, type InspectorTab } from "./CodeInspector";
+import { CodeInspector, PrTab, type InspectorTab } from "./CodeInspector";
+import { DiffOverview } from "./DiffOverview";
+import { PrCardWithResource } from "./PrCard";
 import { useCodeUiStore } from "./CodeUiStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { liveCodeSession } from "./parsers";
@@ -496,6 +498,46 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
               }
             />
           </Suspense>
+        ) : panel.type === "source_control" ? (
+          <div
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+            data-testid="source-control-panel"
+          >
+            {workspace?.status !== "archived" && (
+              <div className="border-b px-3 py-3">
+                <PrCardWithResource
+                  client={client}
+                  workspaceId={workspaceId}
+                  framed={false}
+                  resource={prResource}
+                />
+              </div>
+            )}
+            <DiffOverview
+              client={client}
+              workspaceId={workspaceId}
+              contentRevision={contentRevision}
+              onOpenFile={(path) => openFileDiff(path)}
+            />
+          </div>
+        ) : panel.type === "pr" ? (
+          <div
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+            data-testid="pr-details-panel"
+          >
+            <PrTab
+              client={client}
+              workspaceId={workspaceId}
+              pr={prResource.data?.pr ?? workspace?.pr}
+              branch={workspace?.branch_name}
+              prResource={prResource}
+              onOpenSourceControl={() =>
+                setWorkspaceLayout(
+                  openCodeEditor(layout, { type: "source_control" }, region),
+                )
+              }
+            />
+          </div>
         ) : null}
       </div>
     );
@@ -540,6 +582,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onNewBrowser={() => openBrowser(undefined, "primary")}
         onNewDiff={() =>
           setWorkspaceLayout(openCodeEditor(layout, { type: "diff" }, "primary"))
+        }
+        onNewSourceControl={() =>
+          setWorkspaceLayout(
+            openCodeEditor(layout, { type: "source_control" }, "primary"),
+          )
+        }
+        onNewPr={() =>
+          setWorkspaceLayout(openCodeEditor(layout, { type: "pr" }, "primary"))
         }
         onNewTerminal={() => setWorkspaceLayout(openTerminalLayout(layout))}
         onMoveEditorToOtherGroup={(index) =>
@@ -669,6 +719,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           setWorkspaceLayout(
             openCodeEditor(layout, { type: "diff" }, "secondary"),
           )
+        }
+        onNewSourceControl={() =>
+          setWorkspaceLayout(
+            openCodeEditor(layout, { type: "source_control" }, "secondary"),
+          )
+        }
+        onNewPr={() =>
+          setWorkspaceLayout(openCodeEditor(layout, { type: "pr" }, "secondary"))
         }
         onNewTerminal={() => setWorkspaceLayout(openTerminalLayout(layout))}
         onMoveEditorToOtherGroup={(index) =>

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -61,12 +61,18 @@ function isDrawerTab(tab: PanelContent): boolean {
 }
 
 export function isEditorTab(tab: PanelContent): boolean {
-  return tab.type === "file" || tab.type === "diff" || tab.type === "browser";
+  return (
+    tab.type === "file" ||
+    tab.type === "diff" ||
+    tab.type === "browser" ||
+    tab.type === "source_control" ||
+    tab.type === "pr"
+  );
 }
 
 export type CodeEditorPanel = Extract<
   PanelContent,
-  { type: "file" | "diff" | "browser" }
+  { type: "file" | "diff" | "browser" | "source_control" | "pr" }
 >;
 
 /** Browser session ids removed by a layout transition, once each. */

--- a/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/panel/PanelTabs.tsx
@@ -48,6 +48,10 @@ function panelTabFallbackLabel(panel: PanelContent): string {
           : "Diff";
     case "browser":
       return "Browser";
+    case "source_control":
+      return "Source control";
+    case "pr":
+      return "Pull request";
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelTypes.ts
@@ -30,7 +30,11 @@ export type PanelContent =
   /** A colored diff in the workspace center. */
   | { type: "diff"; path?: string; turnId?: string }
   /** One native browser session in the workspace center. */
-  | { type: "browser"; browserId: string };
+  | { type: "browser"; browserId: string }
+  /** The change index plus commit, push, and PR creation, as a peer tab. */
+  | { type: "source_control" }
+  /** The pull request's own life: status, checks, and review comments. */
+  | { type: "pr" };
 
 export type PanelType = PanelContent["type"];
 

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.test.ts
@@ -222,6 +222,25 @@ describe("layout URLs", () => {
     ).toEqual([{ type: "file", path: "README.md" }]);
   });
 
+  it("restores source control and PR tabs in either editor group", () => {
+    const layout = {
+      tabs: [{ type: "source_control" as const }],
+      activeIndex: 0,
+      fullscreen: false,
+      editorSplit: {
+        tabs: [{ type: "pr" as const }],
+        activeIndex: 0,
+        focused: true,
+      },
+    };
+    expect(searchFromLayout(layout)).toMatchObject({
+      tabs: "source_control",
+      split: "pr",
+      splitFocused: "1",
+    });
+    expect(layoutFromSearch(searchFromLayout(layout))).toEqual(layout);
+  });
+
   it("restores browser tabs in either editor group", () => {
     const layout = {
       tabs: [{ type: "browser" as const, browserId: "browser-primary" }],

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
@@ -222,7 +222,9 @@ export function layoutFromSearch(search: PanelSearch): LayoutState {
       !panel ||
       (panel.type !== "file" &&
         panel.type !== "diff" &&
-        panel.type !== "browser")
+        panel.type !== "browser" &&
+        panel.type !== "source_control" &&
+        panel.type !== "pr")
     ) {
       continue;
     }

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
@@ -56,6 +56,10 @@ export function parsePanelSegment(segment: string): PanelContent | null {
       return parseDiffTarget(id);
     case "browser":
       return parseBrowserTarget(id);
+    case "source_control":
+      return id ? null : { type: "source_control" };
+    case "pr":
+      return id ? null : { type: "pr" };
     default:
       // `apps` and `plugins` were panel segments before the libraries became
       // routes of their own. A bare `files` catalog is still retired.
@@ -155,6 +159,10 @@ export function encodePanelSegment(panel: PanelContent): string {
     }
     case "browser":
       return `browser.${encodeURIComponent(panel.browserId)}`;
+    case "source_control":
+      return "source_control";
+    case "pr":
+      return "pr";
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
@@ -44,6 +44,8 @@ function TabStrip({
       onNewTab={fn()}
       onNewBrowser={withBrowser ? fn() : undefined}
       onNewDiff={withDiff ? fn() : undefined}
+      onNewSourceControl={withDiff ? fn() : undefined}
+      onNewPr={withDiff ? fn() : undefined}
       onNewTerminal={withTerminal ? fn() : undefined}
       onSplitActive={fn()}
       region={region}
@@ -81,6 +83,17 @@ export const FilesOpen: Story = {
       { type: "file", path: "crates/tidebreak-server/src/code/watch.rs" },
       { type: "file", path: "docs/code-mode.md" },
       { type: "diff" },
+    ],
+  },
+};
+
+/** Source control and the PR's details are peer tabs, not sidebar-only. */
+export const WorkflowTabs: Story = {
+  args: {
+    editorTabs: [
+      { type: "source_control" },
+      { type: "pr" },
+      { type: "file", path: "src/lib.rs" },
     ],
   },
 };


### PR DESCRIPTION
## Summary

- per the pane-centric design direction: the change index (commit / push / PR creation) and the pull request's details now open as ordinary center tabs beside files, diffs, and the browser
- reachable from the `+` menu, addressable in the tab URL grammar (`source_control`, `pr`), moved between panes, and restored after restart like every other tab
- the center reuses the inspector's pieces (`PrCardWithResource` + `DiffOverview`, exported `PrTab`); the inspector keeps hosting the same surfaces until the sidebar-navigation redesign retires it
- Storybook covers the new tabs in the strip

(Re-filed: #2293 was auto-closed when its stacked base merged and was deleted.)

## Validation

- desktop UI typecheck clean; full code + panel suites pass (46 files, 372 tests)
- Storybook build passes