### PR TITLE
feat(desktop): storybook coverage for code-mode IA components

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -298,8 +298,10 @@ function SidebarEmptyAction({
 /**
  * One workspace on the expanded rail: title + attention, repo chip + branch,
  * trailing glyphs, and a nested session row when something is live.
+ *
+ * Exported for Storybook; the rail is its only product caller.
  */
-function WorkspaceCard({
+export function WorkspaceCard({
   workspace,
   digest,
   session,

--- a/crates/tidebreak-desktop/ui/src/stories/AttentionBadge.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/AttentionBadge.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { AttentionBadge } from "@/code/AttentionBadge";
+import {
+  attentionDoneUnreviewed,
+  attentionFenced,
+  attentionManual,
+  attentionNeedsYou,
+  attentionStalled,
+  attentionWorking,
+} from "./fixtures";
+
+/**
+ * The server-computed attention vocabulary, as list surfaces wear it. Working
+ * deliberately renders nothing; every other state must stay tellable at a
+ * glance in both the labeled badge and the rail's compact dot.
+ */
+const meta = {
+  title: "Code/Attention badge",
+  component: AttentionBadge,
+  decorators: [
+    (Story) => (
+      <div className="flex items-center gap-3 pt-8 pl-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AttentionBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Renders nothing on purpose: quiet is the default. */
+export const Working: Story = {
+  args: { attention: attentionWorking },
+};
+
+export const NeedsYou: Story = {
+  args: { attention: attentionNeedsYou },
+};
+
+export const Stalled: Story = {
+  args: { attention: attentionStalled },
+};
+
+export const DoneUnreviewed: Story = {
+  args: { attention: attentionDoneUnreviewed },
+};
+
+export const Fenced: Story = {
+  args: { attention: attentionFenced },
+};
+
+export const ManualPin: Story = {
+  args: { attention: attentionManual },
+};
+
+/** The rail's dot form for every visible state, side by side. */
+export const CompactDots: Story = {
+  args: { attention: attentionNeedsYou, compact: true },
+  render: () => (
+    <>
+      <AttentionBadge attention={attentionNeedsYou} compact />
+      <AttentionBadge attention={attentionStalled} compact />
+      <AttentionBadge attention={attentionDoneUnreviewed} compact />
+      <AttentionBadge attention={attentionFenced} compact />
+      <AttentionBadge attention={attentionManual} compact />
+    </>
+  ),
+};

--- a/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { DoctorList } from "@/code/DoctorList";
+import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
+
+/**
+ * The harness doctor: every engine's probe, capability matrix, and
+ * remediation. Honest capability differences (Codex's supported steering,
+ * Grok's refusals) must read directly from the matrix.
+ */
+const meta = {
+  title: "Code/Harness doctor",
+  component: DoctorList,
+  args: { report: harnessDoctor, onRefresh: fn() },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DoctorList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Every engine present and usable; capability levels differ honestly. */
+export const AllReady: Story = {};
+
+/** Missing binary and signed-out engine, each with its remediation. */
+export const NeedsSetup: Story = {
+  args: { report: harnessDoctorDegraded },
+};
+
+export const Refreshing: Story = {
+  args: { refreshing: true },
+};
+
+/** A machine with no engines at all. */
+export const Empty: Story = {
+  args: { report: { harnesses: [] } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import { StartSessionPrompt } from "@/code/StartSessionPrompt";
+import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
+
+/**
+ * The session-start surface: harness picker, caps-driven permission modes,
+ * and the first message. Mode lists must follow each engine's declared
+ * capabilities — Grok's honest refusals leave it Auto-only.
+ */
+function withRouter(children: ReactNode) {
+  const rootRoute = createRootRoute({ component: () => children });
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+  return <RouterProvider router={router as never} />;
+}
+
+function StartSession({
+  harnesses,
+  starting = false,
+}: {
+  harnesses: typeof harnessDoctor.harnesses;
+  starting?: boolean;
+}) {
+  return (
+    <StartSessionPrompt
+      workspaceId="ws-1"
+      harnesses={harnesses}
+      starting={starting}
+      selectedMode={null}
+      onSelectMode={fn()}
+      onStart={fn()}
+    />
+  );
+}
+
+const meta = {
+  title: "Code/Start session",
+  component: StartSession,
+  args: { harnesses: harnessDoctor.harnesses },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-xl pt-8">{withRouter(<Story />)}</div>
+    ),
+  ],
+} satisfies Meta<typeof StartSession>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Four engines, each with its honest mode list. */
+export const AllEngines: Story = {};
+
+export const Starting: Story = {
+  args: { starting: true },
+};
+
+/** Engines that need install or sign-in before a session can start. */
+export const NeedsSetup: Story = {
+  args: { harnesses: harnessDoctorDegraded.harnesses },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { TurnReviewCard } from "@/code/TurnReviewCard";
+
+function boundary(
+  overrides: Partial<Parameters<typeof TurnReviewCard>[0]["turn"]> = {},
+): Parameters<typeof TurnReviewCard>[0]["turn"] {
+  return {
+    kind: "turn_boundary",
+    id: "boundary-turn-1",
+    turnId: "turn-1",
+    status: "completed",
+    durationMs: 84_000,
+    usage: {
+      input_tokens: 48_213,
+      output_tokens: 2_931,
+      cache_read_input_tokens: 31_002,
+      cache_creation_input_tokens: 0,
+    },
+    error: null,
+    diffstat: { files: 3, insertions: 96, deletions: 14, truncated: false },
+    ...overrides,
+  };
+}
+
+/**
+ * The transcript's turn seam: how each engine turn ended, what it cost, and
+ * what it changed. Failure and interruption must read differently from
+ * success, and the diffstat is the door into the turn-scoped review.
+ */
+const meta = {
+  title: "Code/Turn review card",
+  component: TurnReviewCard,
+  args: { turn: boundary(), onOpenTurnDiff: fn() },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TurnReviewCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Completed: Story = {};
+
+/** A turn that changed nothing still says it finished. */
+export const CompletedNoChanges: Story = {
+  args: { turn: boundary({ diffstat: null }) },
+};
+
+export const Failed: Story = {
+  args: {
+    turn: boundary({
+      status: "failed",
+      error: "the engine exited before the turn completed",
+      diffstat: null,
+    }),
+  },
+};
+
+export const Interrupted: Story = {
+  args: {
+    turn: boundary({
+      status: "interrupted",
+      durationMs: 12_000,
+      diffstat: { files: 1, insertions: 4, deletions: 0, truncated: false },
+    }),
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { WorkspaceCard } from "@/code/CodeSidebar";
+import type { WorkspaceCommand } from "@/code/workspaceActions";
+import {
+  attentionNeedsYou,
+  attentionStalled,
+  codeDigest,
+  codeSession,
+  codeWorkspace,
+} from "./fixtures";
+
+const COMMANDS: WorkspaceCommand[] = [
+  { id: "open", label: "Open" },
+  { id: "rename", label: "Rename…" },
+  { id: "copy-branch", label: "Copy branch name" },
+  { id: "archive", label: "Archive…", destructive: true, separated: true },
+];
+
+/**
+ * One workspace on the rail: title + attention dot, repo chip + branch, PR
+ * glyph, and a nested session row when something is live. The card carries
+ * every state the sidebar must make tellable at a glance.
+ */
+const meta = {
+  title: "Code/Workspace card",
+  component: WorkspaceCard,
+  args: {
+    workspace: codeWorkspace,
+    digest: codeDigest(),
+    session: codeSession,
+    repoName: "tidebreak",
+    active: false,
+    terminalOpen: false,
+    commands: COMMANDS,
+    onOpen: fn(),
+    onCommand: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-[280px] pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WorkspaceCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A session is running; the nested row narrates it. */
+export const Working: Story = {};
+
+export const NeedsYou: Story = {
+  args: {
+    digest: codeDigest({ attention: attentionNeedsYou, lifecycle: "idle" }),
+  },
+};
+
+export const Stalled: Story = {
+  args: {
+    digest: codeDigest({ attention: attentionStalled }),
+  },
+};
+
+/** No live session: just identity, quiet. */
+export const Idle: Story = {
+  args: { digest: undefined, session: undefined },
+};
+
+export const ActiveWithTerminal: Story = {
+  args: { active: true, terminalOpen: true },
+};
+
+export const WithPullRequest: Story = {
+  args: {
+    digest: codeDigest({
+      pr_state: {
+        number: 184,
+        url: "https://github.com/example/tidebreak/pull/184",
+        state: "open",
+        checks_summary: "7 passing, 1 failing",
+      },
+    }),
+  },
+};
+
+/** Long names must truncate, never wrap or push the glyphs out. */
+export const LongNames: Story = {
+  args: {
+    workspace: {
+      ...codeWorkspace,
+      title: "Rework the entire onboarding flow for multi-repo workspaces",
+      branch_name:
+        "tidebreak/rework-the-entire-onboarding-flow-for-multi-repo-workspaces",
+    },
+    digest: codeDigest({
+      title: "Rework the entire onboarding flow for multi-repo workspaces",
+    }),
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -1,6 +1,13 @@
 import type {
+  Attention,
+  CodeSessionDigest,
+  CodeSessionSnapshot,
   CodeWatchSnapshot,
   CodeWorkspacePrSnapshot,
+  CodeWorkspaceSnapshot,
+  HarnessCaps,
+  HarnessDoctorEntry,
+  HarnessDoctorReport,
   PendingUserQuestions,
   TaskPlan,
   ToolActionPreview,
@@ -172,4 +179,170 @@ export const blockedWatchPrGit: CodeWorkspacePrSnapshot = {
     detail: "a review or repository requirement is outstanding",
     cycles: 1,
   },
+};
+
+// ---------------------------------------------------------------------------
+// Code mode: attention vocabulary, rail cards, and the harness doctor.
+// ---------------------------------------------------------------------------
+
+export const attentionWorking: Attention = {
+  state: { type: "working" },
+  source: "lifecycle",
+};
+
+/** Strongest state: a structured signal that only the user can resolve. */
+export const attentionNeedsYou: Attention = {
+  state: {
+    type: "needs_you",
+    prompt: "an approval is waiting",
+    source: "structured",
+  },
+  source: "structured",
+};
+
+export const attentionStalled: Attention = {
+  state: { type: "stalled", idle_secs: 154 },
+  source: "heuristic",
+};
+
+export const attentionDoneUnreviewed: Attention = {
+  state: { type: "done_unreviewed" },
+  source: "lifecycle",
+};
+
+export const attentionFenced: Attention = {
+  state: { type: "fenced", reason: { type: "orphan_alive" } },
+  source: "lifecycle",
+};
+
+export const attentionManual: Attention = {
+  state: { type: "manual", note: "waiting on the design call" },
+  source: "user",
+};
+
+export const codeWorkspace: CodeWorkspaceSnapshot = {
+  id: "ws-1",
+  repo_id: "repo-1",
+  title: "Scoped UI workshop",
+  worktree_path: "/Users/sam/tidebreak/code/worktrees/tidebreak/scoped-ui-workshop",
+  branch_name: "tidebreak/scoped-ui-workshop",
+  base_ref: "main",
+  status: "active",
+  created_at: "2026-08-20T09:00:00.000Z",
+};
+
+export const codeSession: CodeSessionSnapshot = {
+  id: "sess-1",
+  workspace_id: "ws-1",
+  kind: "interactive",
+  harness_kind: "claude_code",
+  harness_version: "2.1.234 (Claude Code)",
+  permission_mode: "ask",
+  lifecycle: "running",
+  attention: attentionWorking,
+  unrecognized_event_count: 0,
+  created_at: "2026-08-20T09:05:00.000Z",
+};
+
+export function codeDigest(
+  overrides: Partial<CodeSessionDigest> = {},
+): CodeSessionDigest {
+  return {
+    workspace: "ws-1",
+    session: "sess-1",
+    kind: "interactive",
+    lifecycle: "running",
+    attention: attentionWorking,
+    title: "Scoped UI workshop",
+    turn_count: 4,
+    ...overrides,
+  };
+}
+
+const fullCaps: HarnessCaps = {
+  resume: "supported",
+  streaming_deltas: "supported",
+  structured_approvals: "supported",
+  mid_turn_steering: "unknown",
+  plan_mode: "supported",
+  auto_mode: "supported",
+  allow_mode: "supported",
+  reasoning_levels: "supported",
+  native_file_change_events: "supported",
+  native_interrupt: "supported",
+  image_input: "supported",
+  slash_commands: "supported",
+};
+
+function doctorEntry(
+  overrides: Partial<HarnessDoctorEntry> & Pick<HarnessDoctorEntry, "kind">,
+): HarnessDoctorEntry {
+  return {
+    found: true,
+    tier: "reference",
+    caps: fullCaps,
+    commands: [],
+    remediation: "",
+    stderr: "",
+    unrecognized_event_count: 0,
+    ...overrides,
+  };
+}
+
+/** The live matrix: every engine present, honest capability differences. */
+export const harnessDoctor: HarnessDoctorReport = {
+  harnesses: [
+    doctorEntry({
+      kind: "claude_code",
+      version: "2.1.234 (Claude Code)",
+      path: "~/.local/share/tidebreak/tools/harnesses/claude_code",
+      authenticated: true,
+    }),
+    doctorEntry({
+      kind: "codex",
+      version: "codex-cli 0.147.0",
+      tier: "secondary",
+      authenticated: true,
+      caps: { ...fullCaps, mid_turn_steering: "supported", image_input: "unknown" },
+    }),
+    doctorEntry({
+      kind: "opencode",
+      version: "1.18.18",
+      tier: "tertiary",
+      authenticated: true,
+      caps: { ...fullCaps, allow_mode: "unknown", reasoning_levels: "unknown" },
+    }),
+    doctorEntry({
+      kind: "grok",
+      version: "grok 1.0.5",
+      tier: "best_effort",
+      authenticated: false,
+      caps: {
+        ...fullCaps,
+        mid_turn_steering: "unsupported",
+        plan_mode: "unsupported",
+        structured_approvals: "unsupported",
+      },
+    }),
+  ],
+};
+
+/** A machine with work to do before a session can start. */
+export const harnessDoctorDegraded: HarnessDoctorReport = {
+  harnesses: [
+    doctorEntry({
+      kind: "claude_code",
+      found: false,
+      remediation: "Install Claude Code, then refresh.",
+      stderr: "claude: command not found",
+    }),
+    doctorEntry({
+      kind: "codex",
+      version: "codex-cli 0.147.0",
+      tier: "secondary",
+      authenticated: false,
+      remediation: "Run codex login in a terminal, then refresh.",
+      caps: { ...fullCaps, mid_turn_steering: "supported" },
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary

Storybook coverage for the code-mode IA vocabulary, with typed fixtures reused across stories:

- **Attention badge** — the full server-computed attention set (needs-you, stalled, done-unreviewed, fenced, manual pin) in both the labeled badge and the rail's compact dot; Working deliberately renders nothing
- **Workspace card** — the rail card with working / needs-you / stalled sessions, idle identity, active + terminal glyphs, PR glyph, and long-name truncation (`WorkspaceCard` exported for Storybook; the rail remains its only product caller)
- **Harness doctor** — the honest capability matrix (Codex's supported steering, Grok's refusals), a degraded machine with remediations, refreshing, and empty
- **Start session** — caps-driven mode lists per engine, starting state, needs-setup (memory-router decorator for the picker's settings link)
- **Turn review card** — completed with diffstat, completed-no-changes, failed, interrupted

## Validation

- desktop UI typecheck clean; sidebar + card suites pass
- Storybook build passes