### PR TITLE
feat(providers): fall back to environment variables for provider base URLs

### DIFF
--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -397,16 +397,66 @@ impl ProviderKind {
         !matches!(self, Self::Ollama)
     }
 
-    /// The URL this kind actually calls: a stored override, else the default,
-    /// with hosted presets ignoring any stored value.
+    /// Environment variable consulted for this kind's base URL when the
+    /// deployment plane holds none.
+    ///
+    /// Only kinds that accept a stored base URL have one. Hosted presets and
+    /// the first-party Gemini and xAI endpoints are fixed, so no variable can
+    /// redirect them.
+    pub const fn base_url_env_var(self) -> Option<&'static str> {
+        match self {
+            Self::Anthropic => Some("ANTHROPIC_BASE_URL"),
+            Self::Openai => Some("OPENAI_BASE_URL"),
+            Self::Ollama => Some("OLLAMA_BASE_URL"),
+            Self::OpenaiCompatible => Some("OPENAI_COMPATIBLE_BASE_URL"),
+            Self::Xai
+            | Self::Gemini
+            | Self::Fireworks
+            | Self::Together
+            | Self::Openrouter
+            | Self::ModelGateway => None,
+        }
+    }
+
+    /// The URL this kind actually calls: a stored override, else the
+    /// environment fallback, else the default, with hosted presets ignoring
+    /// both.
     pub fn effective_base_url(self, configured: Option<&str>) -> Option<String> {
+        self.effective_base_url_from(configured, |name| std::env::var(name).ok())
+    }
+
+    /// [`effective_base_url`](Self::effective_base_url) against an injected
+    /// environment, so tests can exercise the fallback without mutating the
+    /// process environment.
+    fn effective_base_url_from(
+        self,
+        configured: Option<&str>,
+        lookup: impl Fn(&str) -> Option<String>,
+    ) -> Option<String> {
         if self.has_fixed_endpoint() {
             return self.default_base_url().map(str::to_owned);
         }
         configured
             .filter(|url| !url.is_empty())
             .map(str::to_owned)
+            .or_else(|| self.env_base_url_from(lookup))
             .or_else(|| self.default_base_url().map(str::to_owned))
+    }
+
+    /// The environment fallback for this kind's base URL.
+    ///
+    /// A value that is empty, unparseable, or that this kind may not call over
+    /// the offered transport is ignored, exactly as an empty API-key variable
+    /// is: the deployment falls back to the built-in default rather than
+    /// failing the boot or dropping the route.
+    fn env_base_url_from(self, lookup: impl Fn(&str) -> Option<String>) -> Option<String> {
+        let url = lookup(self.base_url_env_var()?)?;
+        if url.is_empty() {
+            return None;
+        }
+        // A kind that needs no credential may be reached over loopback HTTP,
+        // matching what the deployment plane accepts for a stored value.
+        base_url_is_allowed(&url, !self.requires_credential()).then_some(url)
     }
 
     /// Store setting key for this kind's non-secret config.
@@ -1553,8 +1603,15 @@ pub async fn update_provider(
         config.models = models;
     }
 
-    // openai_compatible needs a base URL to be useful when enabled.
-    if kind == ProviderKind::OpenaiCompatible && config.enabled && config.base_url.is_none() {
+    // openai_compatible needs a base URL to be useful when enabled. The
+    // environment fallback counts, so a deployment that supplies the endpoint
+    // through its environment can still enable the provider.
+    if kind == ProviderKind::OpenaiCompatible
+        && config.enabled
+        && kind
+            .effective_base_url(config.base_url.as_deref())
+            .is_none()
+    {
         return Err(ServerError::bad_request(
             "openai_compatible requires a base_url when enabled",
         ));
@@ -2921,6 +2978,130 @@ mod tests {
                 .as_deref(),
             Some("https://api.fireworks.ai/inference/v1")
         );
+    }
+
+    /// A lookup that answers one variable, standing in for the process
+    /// environment so the precedence tests never mutate it.
+    fn env_of(name: &'static str, value: &'static str) -> impl Fn(&str) -> Option<String> {
+        move |requested| (requested == name).then(|| value.to_string())
+    }
+
+    #[test]
+    fn a_stored_base_url_wins_over_the_environment_fallback() {
+        assert_eq!(
+            ProviderKind::Anthropic
+                .effective_base_url_from(
+                    Some("https://stored.example/v1"),
+                    env_of("ANTHROPIC_BASE_URL", "https://env.example/v1"),
+                )
+                .as_deref(),
+            Some("https://stored.example/v1")
+        );
+    }
+
+    #[test]
+    fn the_environment_fallback_answers_when_nothing_is_stored() {
+        assert_eq!(
+            ProviderKind::Anthropic
+                .effective_base_url_from(None, env_of("ANTHROPIC_BASE_URL", "https://env.example"),)
+                .as_deref(),
+            Some("https://env.example")
+        );
+        assert_eq!(
+            ProviderKind::Openai
+                .effective_base_url_from(None, env_of("OPENAI_BASE_URL", "https://env.example/v1"))
+                .as_deref(),
+            Some("https://env.example/v1")
+        );
+        assert_eq!(
+            ProviderKind::OpenaiCompatible
+                .effective_base_url_from(
+                    None,
+                    env_of("OPENAI_COMPATIBLE_BASE_URL", "https://env.example/v1"),
+                )
+                .as_deref(),
+            Some("https://env.example/v1")
+        );
+        // An empty stored value is not a value, so the fallback still answers.
+        assert_eq!(
+            ProviderKind::Openai
+                .effective_base_url_from(
+                    Some(""),
+                    env_of("OPENAI_BASE_URL", "https://env.example/v1"),
+                )
+                .as_deref(),
+            Some("https://env.example/v1")
+        );
+    }
+
+    /// A credentialless kind may be pointed at loopback HTTP from the
+    /// environment, exactly as it may from a stored value.
+    #[test]
+    fn the_ollama_fallback_accepts_loopback_http() {
+        assert_eq!(
+            ProviderKind::Ollama
+                .effective_base_url_from(
+                    None,
+                    env_of("OLLAMA_BASE_URL", "http://localhost:11434/v1"),
+                )
+                .as_deref(),
+            Some("http://localhost:11434/v1")
+        );
+    }
+
+    /// Same posture as an empty `*_API_KEY`: an unusable value is ignored,
+    /// never an error, and the built-in default still applies.
+    #[test]
+    fn an_unusable_environment_base_url_is_ignored() {
+        for value in [
+            "",
+            "not a url",
+            "ftp://example.com/v1",
+            // Cleartext to a non-loopback host, for a kind that carries a key.
+            "http://proxy.internal/v1",
+            // Credentials embedded in the URL.
+            "https://user:pass@example.com/v1",
+        ] {
+            let lookup =
+                |requested: &str| (requested == "ANTHROPIC_BASE_URL").then(|| value.to_string());
+            assert_eq!(
+                ProviderKind::Anthropic.effective_base_url_from(None, lookup),
+                None,
+                "`{value}` must not become Anthropic's endpoint"
+            );
+            let lookup =
+                |requested: &str| (requested == "OLLAMA_BASE_URL").then(|| value.to_string());
+            assert_eq!(
+                ProviderKind::Ollama
+                    .effective_base_url_from(None, lookup)
+                    .as_deref(),
+                Some("http://127.0.0.1:11434/v1"),
+                "`{value}` must leave Ollama on its default endpoint"
+            );
+        }
+    }
+
+    /// Fixed first-party and hosted-preset endpoints ignore the environment,
+    /// exactly as they ignore a stored value.
+    #[test]
+    fn fixed_endpoint_kinds_have_no_environment_fallback() {
+        for kind in [
+            ProviderKind::Xai,
+            ProviderKind::Gemini,
+            ProviderKind::Fireworks,
+            ProviderKind::Together,
+            ProviderKind::Openrouter,
+            ProviderKind::ModelGateway,
+        ] {
+            assert_eq!(kind.base_url_env_var(), None);
+            assert_eq!(
+                kind.effective_base_url_from(None, |_| Some(
+                    "https://attacker.invalid/v1".to_string()
+                )),
+                kind.default_base_url().map(str::to_owned),
+                "{kind} must keep its fixed endpoint"
+            );
+        }
     }
 
     #[test]

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -3240,6 +3240,71 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
     assert_eq!(routes[0].kind, tidebreak_router::RouteKind::ModelGateway);
 }
 
+/// A deployment with no stored endpoint takes its provider base URL from the
+/// environment, and a stored endpoint still wins over it.
+#[tokio::test]
+async fn a_base_url_environment_fallback_reaches_the_route() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}/test.db?mode=rwc",
+            dir.path().display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    providers::write_credential(
+        &*secrets,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderCredential::api_key("sk-stored"),
+    )
+    .await
+    .unwrap();
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let _env = ENV_LOCK.lock().await;
+    let _base_url = ScopedEnv::set("ANTHROPIC_BASE_URL", "https://relay.example/v1");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let policy =
+        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
+    let route = providers::collect_routes(&*store, &*secrets, None, None, &policy)
+        .await
+        .into_iter()
+        .find(|route| route.kind == tidebreak_router::RouteKind::Anthropic)
+        .expect("the stored key must offer an Anthropic route");
+    assert_eq!(route.base_url.as_deref(), Some("https://relay.example/v1"));
+
+    // A stored endpoint outranks the variable.
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: Some("https://stored.example/v1".to_string()),
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    let route = providers::collect_routes(&*store, &*secrets, None, None, &policy)
+        .await
+        .into_iter()
+        .find(|route| route.kind == tidebreak_router::RouteKind::Anthropic)
+        .expect("the stored key must offer an Anthropic route");
+    assert_eq!(route.base_url.as_deref(), Some("https://stored.example/v1"));
+}
+
 /// The resolver's fail-closed branch: a profile whose stored policy exists
 /// but cannot be read must resolve to no egress, not to its BYOK routes.
 #[tokio::test]

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -174,6 +174,7 @@ aspirational.
 | `TIDEBREAK_CONTAINER_EXECUTION_ENABLED` | no | `false` | Enables the container code-execution backend. The compose stack does not configure one. |
 | `TIDEBREAK_CONTAINER_IMAGE` | no | server default | Agent container image, when the above is on. |
 | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `GEMINI_API_KEY`, `FIREWORKS_API_KEY`, `TOGETHER_API_KEY` | no | unset | Fallback provider credentials, consulted when no credential is stored for that provider. A container has no OS keychain, so this is how a self-host deployment supplies model keys. |
+| `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `OPENAI_COMPATIBLE_BASE_URL`, `OLLAMA_BASE_URL` | no | unset | Fallback provider endpoints, consulted when no base URL is stored for that provider. Point a provider at a compatible endpoint from your chart or compose file instead of setting it after first boot. Use HTTPS; Ollama also accepts HTTP on a loopback address. An unusable value is ignored, and the provider keeps its built-in endpoint. |
 | `TIDEBREAK_LISTEN_ADDR` | no | loopback, ephemeral port | Self-host only: the address and port the API binds, e.g. `0.0.0.0:8080`. The desktop profile refuses to boot with it set — that profile's loopback binding is what its per-launch token assumes. The image sets it to `0.0.0.0:8080` so the container is reachable at a known port. |
 
 ## Compose quickstart


### PR DESCRIPTION
## What this changes

Provider credentials already fall back to environment variables, because a
container has no OS keychain. The provider endpoint had no such fallback: it
lived only in the deployment plane, so a hosted machine could not be fully
configured from its chart or compose file. An admin had to attach after first
boot and set the base URL by hand.

This adds the matching endpoint fallbacks, at the same seam and with the same
precedence rule.

## Environment variables

| Variable | Provider |
| --- | --- |
| `ANTHROPIC_BASE_URL` | `anthropic` |
| `OPENAI_BASE_URL` | `openai` |
| `OPENAI_COMPATIBLE_BASE_URL` | `openai_compatible` |
| `OLLAMA_BASE_URL` | `ollama` |

The names are bare and vendor-standard, matching the API-key fallbacks
(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) rather than the `TIDEBREAK_` namespace
the server keeps for its own configuration. `ANTHROPIC_BASE_URL` and
`OPENAI_BASE_URL` are also what the upstream SDKs read, so a deployment that
already sets them for other tooling gets the same endpoint here.

Only providers that accept a stored base URL get a variable. Gemini and xAI use
fixed first-party endpoints, the hosted presets (Fireworks, Together, OpenRouter)
pin their own, and the model gateway takes its URL from policy. All six ignore
the environment exactly as they ignore a stored value.

## Precedence and failure

- A stored base URL wins. The variable is read only when nothing is stored,
  which is the API-key rule.
- An unusable value is ignored, never an error. Empty, unparseable, embedded
  credentials, a non-HTTPS scheme, or cleartext to a non-loopback host all leave
  the provider on its built-in endpoint instead of failing the boot or dropping
  the route. This matches the API-key posture, where an empty variable reads as
  unset.
- Validation reuses `base_url_is_allowed`, the same helper the stored write path
  uses. A provider that needs no credential — Ollama — may be pointed at
  loopback HTTP, as it may from a stored value.
- A managed profile is unaffected. Route collection skips every BYOK provider
  before reading anything, so these variables are as inert there as the stored
  keys.

Enabling `openai_compatible` now accepts an endpoint from the environment, where
it previously required a stored one.

## Tests

Unit tests cover stored-wins precedence, the fallback answering when nothing is
stored, loopback HTTP for Ollama, each unusable-value shape, and the fixed-endpoint
providers refusing to be redirected. They inject the lookup rather than mutating
the process environment. One end-to-end test uses the existing `ScopedEnv` harness
to confirm the real variable reaches the router route.

`cargo test -p tidebreak-server`, `cargo fmt --check`, `cargo clippy -p
tidebreak-server --all-targets`, and `cargo machete` are clean.
