### PR TITLE
feat(desktop): make the watch fork a navigable child task

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   ChevronRight,
   CircleAlert,
+  CircleDotDashed,
   FolderGit2,
   GitPullRequest,
   Plus,
@@ -79,6 +80,7 @@ export function CodeSidebar() {
   const sessions = useCodeCatalogStore((state) => state.sessionsByWorkspace);
   const refresh = useCodeCatalogStore((state) => state.refresh);
   const digests = useCodeUpdatesStore((state) => state.byWorkspace);
+  const watchDigests = useCodeUpdatesStore((state) => state.watchByWorkspace);
   const newWorkspaceOpen = useCodeUiStore((state) => state.newWorkspaceOpen);
   const newWorkspaceRepoId = useCodeUiStore(
     (state) => state.newWorkspaceRepoId,
@@ -202,6 +204,14 @@ export function CodeSidebar() {
               const pr = digest?.pr_state ?? workspace.pr;
               return (
                 <WorkspaceCard
+                  watch={watchDigests[workspace.id]}
+                  onOpenWatch={(sessionId) =>
+                    void navigate({
+                      to: "/code/w/$workspaceId",
+                      params: { workspaceId: workspace.id },
+                      search: { task: sessionId },
+                    })
+                  }
                   key={workspace.id}
                   workspace={workspace}
                   digest={digest}
@@ -311,6 +321,8 @@ export function WorkspaceCard({
   commands,
   onOpen,
   onCommand,
+  watch,
+  onOpenWatch,
 }: {
   workspace: CodeWorkspaceSnapshot;
   digest: CodeSessionDigest | undefined;
@@ -321,6 +333,10 @@ export function WorkspaceCard({
   commands: WorkspaceCommand[];
   onOpen: () => void;
   onCommand: (command: WorkspaceCommand["id"]) => void;
+  /** The workspace's live watch task, when one is running. */
+  watch?: CodeSessionDigest;
+  /** Open the watch task's transcript. */
+  onOpenWatch?: (sessionId: string) => void;
 }) {
   // The digest restates the title on every notice, so a background rename
   // lands here without a catalog refresh.
@@ -429,8 +445,49 @@ export function WorkspaceCard({
           />
         ))}
       </ContextMenuContent>
+      {watch && (
+        <button
+          type="button"
+          className={cn(
+            "hover:bg-muted mt-0.5 ml-4 flex w-[calc(100%-1rem)] cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-left text-[11px] text-muted-foreground",
+            FOCUS_RING,
+            HOVER_TINT,
+          )}
+          aria-label={`Open watch task ${watchTaskName(watch)}`}
+          title={watchRowTooltip(watch)}
+          data-testid="workspace-watch-row"
+          onClick={() => onOpenWatch?.(watch.session)}
+        >
+          <CircleDotDashed
+            className={cn(
+              "size-3 shrink-0",
+              watch.attention.state.type === "needs_you"
+                ? "text-critical"
+                : "text-info-foreground",
+            )}
+            aria-hidden
+          />
+          <span className="min-w-0 flex-1 truncate">
+            {watchTaskName(watch)}
+          </span>
+          <AttentionBadge attention={watch.attention} compact />
+        </button>
+      )}
     </ContextMenu>
   );
+}
+
+/** The fork's name: what the watch was asked to do, not a session id. */
+function watchTaskName(watch: CodeSessionDigest): string {
+  const number = watch.pr_state?.number;
+  return number ? `Fix PR #${number}` : "Watch and fix";
+}
+
+function watchRowTooltip(watch: CodeSessionDigest): string {
+  const name = watchTaskName(watch);
+  return `${name} — forked from this workspace's conversation. ${
+    watch.lifecycle === "running" ? "A fix turn is running." : "Watching."
+  }`;
 }
 
 function WorkspaceMenuItem({

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 
 describe("reduceCodeUpdates", () => {
   it("replaces the map on snapshot and upserts a digest", () => {
-    const empty = { byWorkspace: {}, cloneJobs: {}, viewedWorkspaceId: null };
+    const empty = { byWorkspace: {}, watchByWorkspace: {}, cloneJobs: {}, viewedWorkspaceId: null };
     const afterSnapshot = reduceCodeUpdates(empty, {
       type: "snapshot",
       sessions: [digest(), digest({ workspace: "ws-2", session: "sess-2", title: "other" })],
@@ -55,7 +55,7 @@ describe("reduceCodeUpdates", () => {
   });
 
   it("never lets a watch session displace the interactive digest", () => {
-    const empty = { byWorkspace: {}, cloneJobs: {}, viewedWorkspaceId: null };
+    const empty = { byWorkspace: {}, watchByWorkspace: {}, cloneJobs: {}, viewedWorkspaceId: null };
     const seeded = reduceCodeUpdates(empty, {
       type: "snapshot",
       sessions: [
@@ -64,12 +64,24 @@ describe("reduceCodeUpdates", () => {
       ],
     });
     expect(seeded.byWorkspace["ws-1"].session).toBe("sess-1");
+    expect(seeded.watchByWorkspace["ws-1"].session).toBe("sess-watch");
     const afterWatchDigest = reduceCodeUpdates(seeded, {
       type: "digest",
       digest: digest({ session: "sess-watch", kind: "watch", turn_count: 5 }),
     });
     expect(afterWatchDigest.byWorkspace["ws-1"].session).toBe("sess-1");
     expect(afterWatchDigest.byWorkspace["ws-1"].turn_count).toBe(0);
+    expect(afterWatchDigest.watchByWorkspace["ws-1"].turn_count).toBe(5);
+    const afterEnd = reduceCodeUpdates(afterWatchDigest, {
+      type: "digest",
+      digest: digest({
+        session: "sess-watch",
+        kind: "watch",
+        lifecycle: "ended",
+      }),
+    });
+    expect(afterEnd.watchByWorkspace["ws-1"]).toBeUndefined();
+    expect(afterEnd.byWorkspace["ws-1"].session).toBe("sess-1");
   });
 
   it("maps notices onto reducer actions", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -26,6 +26,8 @@ import { requestUserAttention } from "../host";
 
 export type CodeUpdatesState = {
   byWorkspace: Record<string, CodeSessionDigest>;
+  /** Live watch-task sessions, one per workspace, beside the conversation. */
+  watchByWorkspace: Record<string, CodeSessionDigest>;
   cloneJobs: Record<string, CodeCloneJobSnapshot>;
   viewedWorkspaceId: string | null;
 };
@@ -39,6 +41,7 @@ export type CodeUpdatesAction =
 
 const EMPTY: CodeUpdatesState = {
   byWorkspace: {},
+  watchByWorkspace: {},
   cloneJobs: {},
   viewedWorkspaceId: null,
 };
@@ -49,18 +52,35 @@ export function reduceCodeUpdates(
 ): CodeUpdatesState {
   switch (action.type) {
     case "snapshot": {
-      // One digest per workspace: the interactive session. A watch session's
-      // digest never displaces the conversation the list surfaces show; its
-      // state reaches the UI through the workspace PR snapshot instead.
+      // Two digests per workspace at most: the conversation, and its watch
+      // task. A watch session never displaces the conversation the list
+      // surfaces show; it is the workspace's child task.
       const byWorkspace: Record<string, CodeSessionDigest> = {};
+      const watchByWorkspace: Record<string, CodeSessionDigest> = {};
       for (const digest of action.sessions) {
-        if (digest.kind === "watch") continue;
-        byWorkspace[digest.workspace] = digest;
+        if (digest.kind === "watch") {
+          watchByWorkspace[digest.workspace] = digest;
+        } else {
+          byWorkspace[digest.workspace] = digest;
+        }
       }
-      return { ...state, byWorkspace };
+      return { ...state, byWorkspace, watchByWorkspace };
     }
     case "digest":
-      if (action.digest.kind === "watch") return state;
+      if (action.digest.kind === "watch") {
+        if (action.digest.lifecycle === "ended") {
+          const { [action.digest.workspace]: _ended, ...watchByWorkspace } =
+            state.watchByWorkspace;
+          return { ...state, watchByWorkspace };
+        }
+        return {
+          ...state,
+          watchByWorkspace: {
+            ...state.watchByWorkspace,
+            [action.digest.workspace]: action.digest,
+          },
+        };
+      }
       return {
         ...state,
         byWorkspace: {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -998,6 +998,58 @@ describe("CodeWorkspacePage", () => {
     expect(screen.getByTestId("file-viewer")).toHaveTextContent("src/lib.rs");
   });
 
+  it("attaches the watch task's transcript via ?task and offers its controls", async () => {
+    const client = makeClient();
+    const watchSession = {
+      ...SESSION,
+      id: "sess-watch",
+      kind: "watch" as const,
+      permission_mode: "auto" as const,
+      lifecycle: "idle" as const,
+    };
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION, watchSession]);
+    client.getCodeWorkspacePr.mockResolvedValue({
+      dirty: false,
+      unpushed: false,
+      ahead: 0,
+      has_upstream: true,
+      suggested_commit_message: "",
+      pr: PR,
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+      watch: {
+        id: "watch-1",
+        workspace_id: "ws-1",
+        session_id: "sess-watch",
+        pr_number: PR.number,
+        state: "watching" as const,
+        cycles: 1,
+        created_at: "2026-08-20T09:00:00.000Z",
+        updated_at: "2026-08-20T09:05:00.000Z",
+      },
+    });
+    const user = userEvent.setup();
+    const { router } = await mountWorkspace(client, "/code/w/ws-1?task=sess-watch");
+
+    const bar = await screen.findByTestId("watch-task-bar");
+    expect(bar).toHaveTextContent(`Watching PR #${PR.number}`);
+    // The watch bar replaces the composer: the sweep drives this session.
+    expect(
+      screen.queryByRole("textbox", { name: "Message" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      within(bar).getByRole("button", { name: "Back to main task" }),
+    );
+    await waitFor(() =>
+      expect(router.state.location.search).not.toHaveProperty(
+        "task",
+        "sess-watch",
+      ),
+    );
+  });
+
   it("opens source control and PR details as center tabs from the + menu", async () => {
     const client = makeClient();
     client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: PR });

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -6,8 +6,9 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
-import { ArrowDown, PanelRight, SquareTerminal } from "lucide-react";
+import { ArrowDown, CircleDotDashed, PanelRight, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
 import type { ApiClient } from "../api/client";
@@ -17,10 +18,13 @@ import type {
   CodePermissionMode,
   CodeRepoSnapshot,
   CodeSessionSnapshot,
+  CodeWatchSnapshot,
   CodeWorkspaceSnapshot,
   HarnessKind,
   ModelInfo,
 } from "../api/types";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+
 import { useApp } from "@/AppContext";
 import { copyPlainText } from "@/ClipboardCopyButton";
 import { Badge } from "@/components/ui/badge";
@@ -157,6 +161,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const workspaceBrowserIdsRef = useRef(new Set<string>());
   const chrome = splitCodeChromeLayout(layout);
   const workspaceOverlayOpen = useWorkspaceOverlayOpen();
+  const navigate = useNavigate();
+  const taskParam = (useSearch({ strict: false }) as { task?: string }).task;
   const reviewSidebarOpen = useCodeUiStore((state) => state.reviewSidebarOpen);
   const toggleReviewSidebar = useCodeUiStore(
     (state) => state.toggleReviewSidebar,
@@ -256,8 +262,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   }, [setViewedWorkspace, workspaceId]);
 
   useEffect(() => {
+    if (taskParam) return;
     if (rememberedSession) setSession(rememberedSession);
-  }, [rememberedSession]);
+  }, [rememberedSession, taskParam]);
 
   useEffect(() => {
     return () => {
@@ -280,8 +287,18 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         const catalogState = useCodeCatalogStore.getState();
         catalogState.upsertWorkspace(next);
         const live = liveCodeSession(sessions);
-        if (live) {
-          catalogState.rememberSession(live);
+        if (live) catalogState.rememberSession(live);
+        // `?task=` attaches a child task's transcript — today, the watch
+        // session — instead of the conversation.
+        const named = taskParam
+          ? sessions.find(
+              (candidate) =>
+                candidate.id === taskParam && candidate.lifecycle !== "ended",
+            )
+          : undefined;
+        if (named) {
+          setSession(named);
+        } else if (live) {
           setSession(live);
         } else if (!catalogState.sessionsByWorkspace[workspaceId]) {
           setSession(null);
@@ -297,7 +314,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     return () => {
       cancelled = true;
     };
-  }, [client, workspaceId, reloadToken]);
+  }, [client, workspaceId, reloadToken, taskParam]);
 
   async function startSession(
     harness: HarnessKind,
@@ -402,6 +419,18 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   function requestNewTab(region: CodeEditorRegion) {
     setQuickOpenTarget(region);
     setQuickOpenRequest((request) => request + 1);
+  }
+
+  /** Attach a child task's transcript (or the conversation when undefined). */
+  function openWorkspaceTask(sessionId: string | undefined) {
+    void navigate({
+      to: "/code/w/$workspaceId",
+      params: { workspaceId },
+      search: (current: Record<string, unknown>) => ({
+        ...current,
+        task: sessionId,
+      }),
+    });
   }
 
   function openInspectorTab(tab: InspectorTab) {
@@ -664,6 +693,20 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                   defaultModelKey={defaultModelKey}
                   disabled={fenced || workspace?.status !== "active"}
                   onOpenTurnDiff={openTurnDiff}
+                  composerOverride={
+                    session.kind === "watch" ? (
+                      <WatchTaskBar
+                        client={client}
+                        workspaceId={workspaceId}
+                        watch={prResource.data?.watch}
+                        onBack={() => openWorkspaceTask(undefined)}
+                        onStopped={() => {
+                          openWorkspaceTask(undefined);
+                          void prResource.refresh();
+                        }}
+                      />
+                    ) : undefined
+                  }
                 />
               )}
             </div>
@@ -836,6 +879,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
               fallbackPr={pr}
               resource={prResource}
               onOpenSourceControl={() => openInspectorTab("source")}
+              onOpenWatchTask={
+                prResource.data?.watch
+                  ? () => openWorkspaceTask(prResource.data?.watch?.session_id)
+                  : undefined
+              }
             />
           )}
           {session && (
@@ -1159,6 +1207,7 @@ function CodeSessionPane({
   defaultModelKey,
   disabled,
   onOpenTurnDiff,
+  composerOverride,
 }: {
   session: CodeSessionSnapshot;
   workspaceId: string;
@@ -1168,6 +1217,12 @@ function CodeSessionPane({
   disabled: boolean;
   /** Scope the review sidebar to one turn's changes, from a turn's diffstat. */
   onOpenTurnDiff?: (turnId: string) => void;
+  /**
+   * Replace the composer. A watch task's transcript is read-along: the sweep
+   * drives its turns, so the seat where the user would type carries the watch
+   * controls instead.
+   */
+  composerOverride?: ReactNode;
 }) {
   const follow = useTranscriptFollow();
   const store = useRegisteredCodeSession(session.id, client);
@@ -1432,7 +1487,8 @@ function CodeSessionPane({
           <ArrowDown size={16} />
         </button>
       </div>
-      {lifecycle !== "ended" && (
+      {composerOverride}
+      {lifecycle !== "ended" && !composerOverride && (
         <CodeComposer
           running={busy || lifecycle === "running"}
           disabled={disabled}
@@ -1489,4 +1545,81 @@ function useRegisteredCodeSession(sessionId: string, client: ApiClient) {
     };
   }, [sessionId, client]);
   return storeRef.current;
+}
+
+/**
+ * The watch task's seat in the transcript view: the sweep drives this
+ * session's turns, so instead of a composer the reader gets what the watch
+ * is doing and the two decisions that are theirs — stop it, or go back.
+ */
+function WatchTaskBar({
+  client,
+  workspaceId,
+  watch,
+  onBack,
+  onStopped,
+}: {
+  client: Pick<ApiClient, "stopCodeWatch">;
+  workspaceId: string;
+  watch: CodeWatchSnapshot | undefined;
+  onBack: () => void;
+  onStopped: () => void;
+}) {
+  const [stopping, setStopping] = useState(false);
+  const active =
+    watch !== undefined &&
+    (watch.state === "watching" ||
+      watch.state === "fixing" ||
+      watch.state === "blocked");
+  const label = !watch
+    ? "This watch task has finished."
+    : watch.state === "fixing"
+      ? `Fixing PR #${watch.pr_number}${watch.cycles > 0 ? ` · fix turn ${watch.cycles}` : ""}`
+      : watch.state === "blocked"
+        ? `Watch blocked${watch.detail ? `: ${watch.detail}` : ""}`
+        : watch.state === "watching"
+          ? `Watching PR #${watch.pr_number}${watch.detail ? ` · ${watch.detail}` : ""}`
+          : `Watch ${watch.state}${watch.detail ? `: ${watch.detail}` : ""}`;
+  return (
+    <div
+      className="border-border-subtle bg-background/80 mx-auto mb-3 flex w-full max-w-3xl items-center gap-2 rounded-md border px-3 py-2 text-xs"
+      data-testid="watch-task-bar"
+    >
+      <CircleDotDashed
+        className={cn(
+          "size-3.5 shrink-0",
+          watch?.state === "blocked" ? "text-warning" : "text-info-foreground",
+        )}
+        aria-hidden
+      />
+      <span className="min-w-0 flex-1 truncate" title={watch?.detail}>
+        {label}
+      </span>
+      {active && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={stopping}
+          onClick={() => {
+            setStopping(true);
+            client
+              .stopCodeWatch(workspaceId)
+              .then(() => onStopped())
+              .catch((err) => {
+                toast.error(
+                  friendlyErrorMessage(err, "Could not stop the watch"),
+                );
+              })
+              .finally(() => setStopping(false));
+          }}
+        >
+          {stopping ? "Stopping…" : "Stop watching"}
+        </Button>
+      )}
+      <Button type="button" variant="ghost" size="sm" onClick={onBack}>
+        Back to main task
+      </Button>
+    </div>
+  );
 }

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -64,6 +64,7 @@ export function WorkspaceWorkflowControl({
   fallbackPr,
   resource,
   onOpenSourceControl,
+  onOpenWatchTask,
 }: {
   client: Pick<
     ApiClient,
@@ -78,6 +79,8 @@ export function WorkspaceWorkflowControl({
   fallbackPr?: PullRequestDigest;
   resource: CodeWorkspacePrResource;
   onOpenSourceControl: () => void;
+  /** Open the watch task's transcript; the segment is a link to the fork. */
+  onOpenWatchTask?: () => void;
 }) {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const popoverTitleId = useId();
@@ -409,6 +412,17 @@ export function WorkspaceWorkflowControl({
               <GitBranch aria-hidden />
               Source control
             </Button>
+            {watchActive && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={busy !== null}
+                onClick={() => void stopWatch()}
+              >
+                {busy === "stop_watch" ? "Stopping…" : "Stop watching"}
+              </Button>
+            )}
             {model.pr?.url ? (
               <Button asChild variant="ghost" size="sm" className="ml-auto">
                 <a
@@ -435,13 +449,20 @@ export function WorkspaceWorkflowControl({
           className="border-border-subtle min-w-0 rounded-none border-0 border-l bg-transparent px-2.5 hover:bg-muted/70"
           title={
             watch.detail
-              ? `${watchStateLabel(watch.state)}: ${watch.detail}. Click to stop watching.`
-              : "A watch task is keeping this pull request moving. Click to stop watching."
+              ? `${watchStateLabel(watch.state)}: ${watch.detail}. Click to open the watch task.`
+              : "A watch task is keeping this pull request moving. Click to open it."
           }
           disabled={busy !== null}
           aria-busy={busy === "stop_watch"}
           data-testid="workspace-watch-control"
-          onClick={() => void stopWatch()}
+          onClick={() => {
+            if (onOpenWatchTask) {
+              setDetailsOpen(false);
+              onOpenWatchTask();
+            } else {
+              void stopWatch();
+            }
+          }}
         >
           {busy === "stop_watch" ? (
             <Spinner aria-hidden />
@@ -456,7 +477,11 @@ export function WorkspaceWorkflowControl({
             />
           )}
           <span className="truncate max-[760px]:sr-only">
-            {busy === "stop_watch" ? "Stopping…" : watchStateLabel(watch.state)}
+            {busy === "stop_watch"
+              ? "Stopping…"
+              : onOpenWatchTask
+                ? `Watching in "Fix PR #${watch.pr_number}"`
+                : watchStateLabel(watch.state)}
           </span>
         </Button>
       ) : primary === "open_pr" && primaryLabel && model.pr?.url ? (

--- a/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/panelUrl.ts
@@ -180,6 +180,11 @@ export type PanelSearch = {
   /** `"1"` when the right editor group most recently received focus. */
   splitFocused?: string;
   /**
+   * Code workspace: the session id of a child task to attach instead of the
+   * conversation — today, a watch task. Absent means the conversation.
+   */
+  task?: string;
+  /**
    * The retired pair-of-slots grammar. Read on the way in so older links and
    * already-open windows still land somewhere; never written back out.
    */

--- a/crates/tidebreak-desktop/ui/src/panel/usePanelNav.ts
+++ b/crates/tidebreak-desktop/ui/src/panel/usePanelNav.ts
@@ -31,6 +31,7 @@ export function useLayoutState(): LayoutState {
 export function usePanelNav() {
   const navigate = useNavigate();
   const layout = useLayoutState();
+  const search = useSearch({ strict: false }) as PanelSearch;
   const { chatId, workspaceId } = useParams({ strict: false }) as {
     chatId?: string;
     workspaceId?: string;
@@ -45,7 +46,8 @@ export function usePanelNav() {
       void navigate({
         to: "/code/w/$workspaceId",
         params: { workspaceId },
-        search: searchFromLayout(next),
+        // Layout writes must not evict which task is attached.
+        search: { ...searchFromLayout(next), task: search.task },
       });
     } else if (chatId) {
       void navigate({

--- a/crates/tidebreak-desktop/ui/src/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/router.tsx
@@ -48,6 +48,7 @@ function panelSearchFrom(search: Record<string, unknown>): PanelSearch {
     split: text(search.split),
     splitActive: text(search.splitActive),
     splitFocused: text(search.splitFocused),
+    task: text(search.task),
     left: text(search.left),
     right: text(search.right),
   };

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -37,9 +37,12 @@ function resourceFor(
 function WorkflowState({
   snapshot,
   busy = null,
+  watchTaskLink = false,
 }: {
   snapshot: CodeWorkspacePrSnapshot | null;
   busy?: CodeWorkspacePrMutation | null;
+  /** Offer the "Watching in …" link the workspace page wires up. */
+  watchTaskLink?: boolean;
 }) {
   return (
     <WorkspaceWorkflowControl
@@ -54,6 +57,7 @@ function WorkflowState({
       baseRef="main"
       resource={resourceFor(snapshot, busy)}
       onOpenSourceControl={fn()}
+      onOpenWatchTask={watchTaskLink ? fn() : undefined}
     />
   );
 }
@@ -88,9 +92,9 @@ export const ReadyForPullRequest: Story = {
 
 export const PullRequestOpen: Story = {};
 
-/** A durable watch task is polling; checks are still running. */
+/** A durable watch task is polling; the segment links into the fork. */
 export const Watching: Story = {
-  args: { snapshot: watchingPrGit },
+  args: { snapshot: watchingPrGit, watchTaskLink: true },
 };
 
 /** The watch task is running a fix turn against failing checks. */


### PR DESCRIPTION
## Summary

The durable watch (decision 50) ran invisibly: the workflow control showed its state, but the fork's transcript was unreachable. This makes the fork a real child task, per the pane-centric design notes:

- the rail shows a nested **Fix PR #N** row under the workspace with the watch's attention dot; clicking opens the fork
- `?task=<session>` attaches a child task's transcript instead of the conversation; layout writes preserve it
- the watch task's seat carries the watch controls — state, **Stop watching**, **Back to main task** — instead of a composer, since the sweep drives its turns
- the header segment reads **Watching in "Fix PR #N"** and links into the fork; Stop moves to the details popover
- the updates store tracks watch digests per workspace beside the conversation's, dropping them when the watch session ends
- Storybook: the workflow control's Watching story shows the link form

## Validation

- desktop UI typecheck clean; code + panel suites pass (46 files, 374 tests), including a new dom test that attaches the fork via `?task`, asserts the composer yields to the watch bar, and navigates back
- Storybook build passes