### PR TITLE
fix(deploy): keep Rust sources named like credential files in the build context

### DIFF
--- a/deploy/self-host/Dockerfile.dockerignore
+++ b/deploy/self-host/Dockerfile.dockerignore
@@ -71,3 +71,9 @@
 **/.next/**
 **/.git
 **/.git/**
+
+# Rust sources are reviewed compile inputs, so a module whose name matches a
+# credential pattern above — src/web_search/credentials.rs is real — stays in
+# the context. This wins because it is last; every non-source file the block
+# above denies stays denied.
+!crates/*/src/**/*.rs

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -729,6 +729,7 @@ test("the self-host Docker context is allowlisted and denies hidden credentials"
     "!crates/tidebreak-sandbox-agent/documents-requirements.txt",
     "!skills/*/SKILL.md",
     "!plugins/*/PLUGIN.md",
+    "!crates/*/src/**/*.rs",
   ]) {
     assert.ok(dockerIgnore.includes(`${required}\n`), `missing allow rule ${required}`);
   }
@@ -789,6 +790,9 @@ test(
       "crates/demo/Cargo.toml",
       "crates/demo/build.rs",
       "crates/demo/src/lib.rs",
+      // A source module named like a credential file must survive the deny
+      // block: tidebreak-server has src/web_search/credentials.rs for real.
+      "crates/demo/src/web/credentials.rs",
       "crates/tidebreak-code-execution/baseline_python_deps.txt",
       "crates/tidebreak-sandbox-agent/documents-requirements.txt",
       "skills/demo/SKILL.md",
@@ -805,6 +809,7 @@ test(
       "crates/demo/src/deep/.harmless-hidden-file",
       "skills/demo/.draft",
       "plugins/demo/credentials.json",
+      "crates/demo/src/credentials.json",
       "outside/secret.txt",
     ];
 


### PR DESCRIPTION
The self-host image does not build: `deploy/self-host/Dockerfile.dockerignore` denies `**/credentials.*` as credential defense, which also drops `crates/tidebreak-server/src/web_search/credentials.rs` — a real module — from the build context, so `cargo build` fails with E0583 (first publish run: https://github.com/brightwave-inc/tidebreak/actions/runs/32380149832). The local `docker compose up --build` path has the same gap.

The fix is a trailing re-include, `!crates/*/src/**/*.rs`: Rust sources under a crate's `src` are reviewed compile inputs, and last-match-wins keeps every non-source credential pattern denied. `workflow-security.test.mjs` now requires the rule and probes both directions in a real BuildKit context: `crates/demo/src/web/credentials.rs` must survive, `crates/demo/src/credentials.json` must not.

Checks: `node scripts/workflow-security.test.mjs` — 36 pass, 0 skipped (the Docker context probes ran for real).