### PR TITLE
feat(desktop): add optional starting prompt to new workspace

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -26,7 +26,10 @@ vi.mock("sonner", () => ({
 afterEach(() => {
   cleanup();
   useCodeCatalogStore.getState().reset();
-  useCodeUiStore.setState({ lastCreate: null });
+  useCodeUiStore.setState({
+    lastCreate: null,
+    pendingComposerPrompt: null,
+  });
   toastError.mockReset();
 });
 
@@ -221,9 +224,10 @@ describe("NewWorkspaceDialog", () => {
         model: "gpt-5.6-sol",
       }),
     );
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
   });
 
-  it("lists the workspace block before harness, then model", async () => {
+  it("lists repo, harness, model, then starting prompt, then the rest", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({
       repos,
@@ -255,12 +259,62 @@ describe("NewWorkspaceDialog", () => {
     ].map((el) => el.textContent);
     expect(labels).toEqual([
       "Repo",
-      "Title",
-      "Base ref",
       "Harness",
       "Model",
+      "Starting prompt",
+      "Title",
+      "Base ref",
       "Permission mode",
     ]);
+  });
+
+  it("inserts a starting prompt into the workspace composer after create", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const createCodeWorkspace = vi.fn(async () =>
+      workspace("ws-prompt", "repo-new", "2026-08-20T00:00:00.000Z"),
+    );
+    const createCodeSession = vi.fn(async () =>
+      session("ws-prompt", "claude_code", "2026-08-20T00:00:00.000Z"),
+    );
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace,
+          createCodeSession,
+          listCodeHarnessModels: vi.fn(async () => ({
+            kind: "claude_code" as const,
+            models: [{ id: "sonnet", label: "Sonnet", default: true }],
+          })),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Starting prompt" }), {
+      target: { value: "  list the files  " },
+    });
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(createCodeWorkspace).toHaveBeenCalled(),
+    );
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toEqual({
+      scope: "ws-prompt",
+      text: "list the files",
+      submit: false,
+    });
   });
 
   it("drops the previous harness model while the next catalog loads", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -28,6 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { usesCommandModifier } from "@/ShellShortcuts";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
@@ -52,9 +53,10 @@ import {
  * Every field arrives answered, so the dialog is one keystroke deep: Cmd+Enter
  * from anywhere in it creates with what is on screen. Repo, harness, and model
  * open on what this reader used last — the catalog knows, and `lastCreate`
- * covers a fresh window. The title is optional: left blank, the server
- * generates a two-word name and later replaces it with one derived from the
- * first turn, the same way chats are named.
+ * covers a fresh window. The starting prompt is optional: filled in, it lands
+ * in the workspace composer after create. The title is optional too: left
+ * blank, the server generates a two-word name and later replaces it with one
+ * derived from the first turn, the same way chats are named.
  *
  * Permission mode defaults to the most autonomous posture the harness honors
  * (decision 0039, amended). Whichever posture that is, the row states it.
@@ -114,6 +116,7 @@ export function NewWorkspaceDialog({
   const lastCreate = useCodeUiStore((state) => state.lastCreate);
   const rememberCreate = useCodeUiStore((state) => state.rememberCreate);
   const [repoId, setRepoId] = useState("");
+  const [startingPrompt, setStartingPrompt] = useState("");
   const [title, setTitle] = useState("");
   const [baseRef, setBaseRef] = useState("");
   const [pickedHarness, setPickedHarness] = useState<HarnessKind | null>(null);
@@ -147,6 +150,7 @@ export function NewWorkspaceDialog({
     const nextRepo =
       defaultRepoId ?? recentRepoId(repos, known, lastCreate?.repoId);
     setRepoId(nextRepo);
+    setStartingPrompt("");
     setTitle("");
     setBaseRef(
       repos.find((repo) => repo.id === nextRepo)?.default_base_ref ?? "",
@@ -230,6 +234,10 @@ export function NewWorkspaceDialog({
         return;
       }
       upsertWorkspace(workspace);
+      const prompt = startingPrompt.trim();
+      if (prompt) {
+        useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
+      }
       try {
         const gateway = gatewayCodeModels(models, harness, defaultModelKey);
         const listed =
@@ -314,24 +322,6 @@ export function NewWorkspaceDialog({
               </SelectContent>
             </Select>
           </div>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="font-medium">Title</span>
-            <Input
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              disabled={creating}
-              placeholder="Named automatically"
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="font-medium">Base ref</span>
-            <Input
-              value={baseRef}
-              onChange={(event) => setBaseRef(event.target.value)}
-              disabled={creating}
-              placeholder={selectedRepo?.default_base_ref}
-            />
-          </label>
           <div className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Harness</span>
             <HarnessPicker
@@ -358,6 +348,34 @@ export function NewWorkspaceDialog({
               variant="field"
             />
           </div>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Starting prompt</span>
+            <Textarea
+              value={startingPrompt}
+              onChange={(event) => setStartingPrompt(event.target.value)}
+              disabled={creating}
+              placeholder="Optional"
+              rows={3}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Title</span>
+            <Input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              disabled={creating}
+              placeholder="Named automatically"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Base ref</span>
+            <Input
+              value={baseRef}
+              onChange={(event) => setBaseRef(event.target.value)}
+              disabled={creating}
+              placeholder={selectedRepo?.default_base_ref}
+            />
+          </label>
           <div className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Permission mode</span>
             <Select


### PR DESCRIPTION
## Summary

- Reorder the new-workspace dialog to repo, harness, model, then an optional starting prompt, then title, base ref, and permission mode.
- If you fill in a starting prompt, create still opens the workspace, and that text is inserted into the composer so you can send it as the first turn.

## Test plan

- [x] `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/NewWorkspaceDialog.dom.test.tsx`
- [ ] Open **New workspace**, confirm field order, leave the starting prompt blank, and create. The composer stays empty.
- [ ] Fill in a starting prompt and create. The workspace composer shows that text, trimmed, ready to send.