### PR TITLE
feat(server): on-behalf-of inference for hosted machines (decision 51)

### DIFF
--- a/crates/tidebreak-core/src/db/mod.rs
+++ b/crates/tidebreak-core/src/db/mod.rs
@@ -743,6 +743,10 @@ impl Store for DbStore {
         ops::conversation::get_chat(self, id, None).await
     }
 
+    async fn chat_owner(&self, id: ChatId) -> Result<Option<OwnerId>> {
+        ops::conversation::chat_owner(self, id).await
+    }
+
     async fn get_chat_scoped(&self, owner: &OwnerId, id: ChatId) -> Result<Option<Chat>> {
         ops::conversation::get_chat(self, id, Some(owner)).await
     }

--- a/crates/tidebreak-core/src/db/ops/conversation.rs
+++ b/crates/tidebreak-core/src/db/ops/conversation.rs
@@ -529,6 +529,17 @@ pub(in crate::db) async fn get_chat(
         .transpose()
 }
 
+pub(in crate::db) async fn chat_owner(store: &DbStore, id: ChatId) -> Result<Option<OwnerId>> {
+    let Some(model) = entities::chat::Entity::find_by_id(id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    OwnerId::new(&model.owner).map(Some)
+}
+
 pub(in crate::db) async fn list_chats(
     store: &DbStore,
     owner: Option<&OwnerId>,

--- a/crates/tidebreak-core/src/storage/store.rs
+++ b/crates/tidebreak-core/src/storage/store.rs
@@ -328,6 +328,20 @@ pub trait Store: Send + Sync {
     /// Fetch a chat by id, or `None` if it doesn't exist.
     async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>>;
 
+    /// Which owner a chat belongs to, or `None` when it does not exist.
+    ///
+    /// For system paths that act on an already-authorized chat id and still
+    /// need to name the person the work is for — a turn worker resolving that
+    /// caller's model credentials, for instance. Request paths scope through
+    /// [`OwnerId`] instead and never need this.
+    ///
+    /// The default answers `None`, which callers must read as "this store
+    /// cannot name an owner", never as "the local owner".
+    async fn chat_owner(&self, id: ChatId) -> Result<Option<OwnerId>> {
+        let _ = id;
+        Ok(None)
+    }
+
     /// List chats, most-recently-created first.
     async fn list_chats(&self) -> Result<Vec<Chat>>;
 

--- a/crates/tidebreak-router/src/router.rs
+++ b/crates/tidebreak-router/src/router.rs
@@ -485,6 +485,13 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
             if let Some(base) = &route.base_url {
                 p = p.with_base_url(base.clone());
             }
+            // A hosted machine that resolves Anthropic credentials per caller
+            // supplies a rotating source instead of a key. The adapter then
+            // asks for a bearer at each request, so a token that expires
+            // mid-turn is replaced without rebuilding the route.
+            if let Some(source) = route.token_source.clone() {
+                p = p.with_token_source(source);
+            }
             Some(Arc::new(p))
         }
         #[cfg(not(feature = "anthropic"))]

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -143,10 +143,17 @@ pub async fn require_token(
                 state.principal_authenticator.as_ref(),
                 PrincipalAuthenticator::Gateway(_)
             ) {
+                let bearer: std::sync::Arc<str> = presented
+                    .expect("a resolved principal had a presented token")
+                    .into();
+                // Remember the live caller token so this caller's turns can be
+                // driven on their own gateway authority (decision 51). The
+                // token stays in process memory and is never persisted.
+                if let Some(inference) = state.on_behalf_of_inference.as_ref() {
+                    inference.record_caller(&principal.owner_id(), bearer.clone());
+                }
                 request.extensions_mut().insert(GatewayAuthLease {
-                    bearer: presented
-                        .expect("a resolved principal had a presented token")
-                        .into(),
+                    bearer,
                     principal: principal.clone(),
                 });
             }

--- a/crates/tidebreak-server/src/gateway_runtime.rs
+++ b/crates/tidebreak-server/src/gateway_runtime.rs
@@ -1920,6 +1920,7 @@ mod tests {
             &*runtime.secrets,
             runtime.route_token_source().await,
             None,
+            None,
             &policy,
         )
         .await;
@@ -3255,6 +3256,7 @@ mod tests {
             &*runtime.secrets,
             runtime.route_token_source().await,
             None,
+            None,
             &policy,
         )
         .await;
@@ -3963,7 +3965,7 @@ mod tests {
         assert!(runtime.route_token_source().await.is_none());
         let policy = runtime.policy().unwrap();
         let routes =
-            providers::collect_routes(&*store, &*runtime.secrets, None, None, &policy).await;
+            providers::collect_routes(&*store, &*runtime.secrets, None, None, None, &policy).await;
         assert!(routes
             .iter()
             .all(|route| route.kind != tidebreak_router::RouteKind::ModelGateway));
@@ -4060,7 +4062,7 @@ mod tests {
         assert!(runtime.route_token_source().await.is_none());
         let tokens: Arc<dyn BearerTokenSource> = Arc::new(StaticTokens);
         let routes =
-            providers::collect_routes(&*store, &*secrets, Some(tokens), None, &policy).await;
+            providers::collect_routes(&*store, &*secrets, Some(tokens), None, None, &policy).await;
         assert!(routes
             .iter()
             .all(|route| route.kind != tidebreak_router::RouteKind::ModelGateway));

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -57,6 +57,7 @@ mod mcp_curated;
 pub mod media_type;
 mod model_registry;
 mod model_roles;
+mod obo_inference;
 /// OpenAPI ingest into the bounded operation catalog a `rest_api` connected
 /// app stores and the governed REST executor validates against.
 pub mod openapi_catalog;
@@ -1309,14 +1310,20 @@ async fn bind_inner(
         store.clone(),
         secrets.clone(),
     )?);
-    let resolver = Arc::new(KeyedResolver::new(
-        store.clone(),
-        secrets.clone(),
-        gateway.clone(),
-        chatgpt.clone(),
-        provisioned_policy.clone(),
-        os_policy.clone(),
-    ));
+    // One instance, shared by the resolver that builds each caller's routes
+    // and the authentication middleware that records each caller's live token.
+    let on_behalf_of_inference = obo_inference::OboInference::from_config(&config)?;
+    let resolver = Arc::new(
+        KeyedResolver::new(
+            store.clone(),
+            secrets.clone(),
+            gateway.clone(),
+            chatgpt.clone(),
+            provisioned_policy.clone(),
+            os_policy.clone(),
+        )
+        .with_on_behalf_of_inference(on_behalf_of_inference.clone()),
+    );
     // Under the `scripted-provider` feature only — absent from every released
     // binary — a scripted provider stands in for configured routing so a test
     // in another crate can drive a real turn. See [`scripted_provider`].
@@ -1413,7 +1420,8 @@ async fn bind_inner(
         chatgpt,
         provisioned_policy,
         os_policy,
-    )?;
+    )?
+    .with_on_behalf_of_inference(on_behalf_of_inference);
     state.agent_run_wake = agent_run_wake;
     state.sandbox_attempts = sandbox_attempts;
     state.sandbox_steering = sandbox_steering;

--- a/crates/tidebreak-server/src/obo_inference.rs
+++ b/crates/tidebreak-server/src/obo_inference.rs
@@ -1,0 +1,844 @@
+//! On-behalf-of inference for gateway-authenticated hosted machines
+//! (`docs/decisions/0051-on-behalf-of-inference-for-hosted-machines.md`).
+//!
+//! A hosted machine that authenticates callers against a Model Gateway
+//! (decision 49) already holds each caller's short-lived, machine-bound
+//! token. This module turns that token into inference authority for the same
+//! user: it exchanges the caller's bearer for a short-lived, inference-only
+//! gateway token and hands that token to the router as the credential for the
+//! caller's turns. The deployment needs no inference secret of its own, and
+//! the gateway meters every turn to the user who drove it.
+//!
+//! Three rules are load-bearing:
+//!
+//! - **Nothing here is durable.** Exchanged tokens live in this process's
+//!   memory, keyed by owner, and are minted again near expiry. They are never
+//!   written to the store, never logged, and never returned to a client.
+//! - **The exchange never falls back.** A refusal fails the caller's turn
+//!   closed. The server does not retry onto a shared credential, and one
+//!   user's refusal leaves every other user's turns running.
+//! - **A stored provider configuration wins.** This source is offered to the
+//!   router only where the deployment states no other inference path; see
+//!   [`crate::providers::collect_routes`].
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt as _;
+
+use tidebreak_core::{AgentError, OwnerId, Profile, Result};
+use tidebreak_router::BearerTokenSource;
+
+/// Mint a replacement this close to expiry instead of using the cached token.
+///
+/// Matches the desktop's refresh leeway, so a turn never opens a request with
+/// a credential that dies mid-stream.
+const EXPIRY_LEEWAY_SECONDS: u64 = 60;
+
+/// Cap on an exchange response body. The gateway answers with a small JSON
+/// object; anything larger is a misconfigured endpoint, not a token.
+const RESPONSE_LIMIT: usize = 16 * 1024;
+
+/// The audience the exchanged token is minted for. Inference only.
+const INFERENCE_AUDIENCE: &str = "llm";
+
+/// The OAuth token-exchange grant the gateway accepts for this flow.
+const TOKEN_EXCHANGE_GRANT: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+/// The subject-token type this server presents: the caller's access token.
+const SUBJECT_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:access_token";
+
+/// Seconds since the Unix epoch, saturating at zero before it.
+fn unix_time() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_secs())
+}
+
+/// One user's inference token and when it stops being usable.
+#[derive(Clone)]
+struct CachedToken {
+    token: Arc<str>,
+    expires_at_unix: u64,
+}
+
+impl CachedToken {
+    /// Whether this token is far enough from expiry to open a request with.
+    fn is_fresh(&self) -> bool {
+        self.expires_at_unix > unix_time().saturating_add(EXPIRY_LEEWAY_SECONDS)
+    }
+}
+
+/// What this process remembers about one caller.
+///
+/// `subject` is the most recent machine-bound bearer that caller presented,
+/// and `token` is the inference token exchanged from it. The `token` mutex is
+/// also the single-flight gate: concurrent turns for the same user queue on it
+/// and all but the first find a fresh token already there.
+struct UserSlot {
+    subject: std::sync::Mutex<Arc<str>>,
+    token: tokio::sync::Mutex<Option<CachedToken>>,
+}
+
+/// The OAuth error shape the gateway returns for a refused exchange.
+#[derive(serde::Deserialize)]
+struct OAuthError {
+    error: String,
+    error_description: Option<String>,
+}
+
+/// A successful exchange.
+#[derive(serde::Deserialize)]
+struct ExchangeResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+/// Per-caller inference credentials for a gateway-authenticated deployment.
+///
+/// Construct one per process with [`OboInference::from_config`], record each
+/// authenticated caller's bearer with [`OboInference::record_caller`], and ask
+/// for a caller's credential supplier with
+/// [`OboInference::token_source_for`].
+pub(crate) struct OboInference {
+    /// Where the exchange is POSTed. Honors the verifier override, because
+    /// this is a server-to-server call like principal validation.
+    token_url: reqwest::Url,
+    /// Anthropic-compatible inference base for exchanged tokens.
+    inference_base_url: String,
+    client: reqwest::Client,
+    users: std::sync::Mutex<HashMap<OwnerId, Arc<UserSlot>>>,
+}
+
+impl OboInference {
+    /// Build the per-caller inference path this deployment's configuration
+    /// asks for, or `None` when it asks for none.
+    ///
+    /// `None` is the answer for every deployment that is not a
+    /// gateway-authenticated hosted machine: the desktop profile, and a
+    /// self-host server running on static tokens. Those have no machine-bound
+    /// caller token to exchange, so they keep their configured providers
+    /// (decision 51, rules 5 and 6).
+    ///
+    /// # Errors
+    /// Fails when the configured gateway URL cannot carry a server-to-server
+    /// call, so a misconfigured deployment refuses to assemble rather than
+    /// failing every turn at run time.
+    pub(crate) fn from_config(config: &tidebreak_core::Config) -> Result<Option<Arc<Self>>> {
+        if config.profile != Profile::SelfHost {
+            return Ok(None);
+        }
+        let Some(gateway_url) = config.auth_gateway_url.as_deref() else {
+            return Ok(None);
+        };
+        let base = config
+            .auth_gateway_verifier_url
+            .as_deref()
+            .unwrap_or(gateway_url);
+        Ok(Some(Arc::new(Self::new(base)?)))
+    }
+
+    /// Build an exchange client against `base_url`.
+    ///
+    /// # Errors
+    /// Fails when `base_url` is unparseable, carries credentials, a query, or
+    /// a fragment, or is cleartext outside loopback development.
+    pub(crate) fn new(base_url: &str) -> Result<Self> {
+        let base = normalized_gateway_base(base_url)?;
+        let token_url = join_below(&base, "oauth/token")?;
+        let inference_base_url = join_below(&base, "compat/anthropic")?.to_string();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| {
+                AgentError::config(format!("on-behalf-of inference client: {error}"))
+            })?;
+        Ok(Self {
+            token_url,
+            inference_base_url,
+            client,
+            users: std::sync::Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// The Anthropic-compatible base URL exchanged tokens authenticate against.
+    pub(crate) fn inference_base_url(&self) -> &str {
+        &self.inference_base_url
+    }
+
+    /// Remember the bearer `owner` just authenticated with.
+    ///
+    /// Called from the authentication middleware for every gateway-verified
+    /// request, so the newest live token is the one a later turn exchanges. A
+    /// replacement subject does not invalidate the cached inference token:
+    /// both name the same user, and the cached one is still that user's.
+    pub(crate) fn record_caller(&self, owner: &OwnerId, bearer: Arc<str>) {
+        let Ok(mut users) = self.users.lock() else {
+            return;
+        };
+        match users.get(owner) {
+            Some(slot) => {
+                if let Ok(mut subject) = slot.subject.lock() {
+                    *subject = bearer;
+                }
+            }
+            None => {
+                users.insert(
+                    owner.clone(),
+                    Arc::new(UserSlot {
+                        subject: std::sync::Mutex::new(bearer),
+                        token: tokio::sync::Mutex::new(None),
+                    }),
+                );
+            }
+        }
+    }
+
+    /// A credential supplier for `owner`'s turns, or `None` when this process
+    /// has seen no live token for them.
+    ///
+    /// `None` is a fail-closed answer, not a fallback: the router is offered
+    /// no route, and the turn fails with the missing-credential shape rather
+    /// than running on somebody else's authority.
+    pub(crate) fn token_source_for(
+        self: &Arc<Self>,
+        owner: &OwnerId,
+    ) -> Option<Arc<dyn BearerTokenSource>> {
+        let users = self.users.lock().ok()?;
+        users.contains_key(owner).then(|| {
+            Arc::new(OboTokenSource {
+                inference: self.clone(),
+                owner: owner.clone(),
+            }) as Arc<dyn BearerTokenSource>
+        })
+    }
+
+    /// The current inference token for `owner`, exchanging one if the cached
+    /// token is missing or near expiry.
+    ///
+    /// # Errors
+    /// Fails when this process holds no subject token for `owner`, or when
+    /// the gateway refuses the exchange.
+    async fn bearer_for(&self, owner: &OwnerId) -> Result<String> {
+        let slot = {
+            let users = self.users.lock().map_err(|_| {
+                AgentError::msg("on-behalf-of inference state is unavailable in this process")
+            })?;
+            users.get(owner).cloned()
+        };
+        let Some(slot) = slot else {
+            return Err(AgentError::SignInRequired(
+                "this machine holds no live Model Gateway session for you; sign in again".into(),
+            ));
+        };
+
+        // Holding this across the exchange is the single-flight gate: a second
+        // turn for the same user waits here and then finds a fresh token.
+        let mut cached = slot.token.lock().await;
+        if let Some(current) = cached.as_ref() {
+            if current.is_fresh() {
+                return Ok(current.token.to_string());
+            }
+        }
+        let subject = {
+            let subject = slot.subject.lock().map_err(|_| {
+                AgentError::msg("on-behalf-of inference state is unavailable in this process")
+            })?;
+            subject.clone()
+        };
+        let minted = self.exchange(&subject).await?;
+        let token = minted.token.to_string();
+        *cached = Some(minted);
+        Ok(token)
+    }
+
+    /// Exchange one caller bearer for a short-lived inference token.
+    ///
+    /// # Errors
+    /// `invalid_grant` means the subject token, its session, or its user is
+    /// gone; that becomes the sign-in-required shape the client already
+    /// handles. Every other non-success is a refusal too — this never retries
+    /// onto another credential.
+    async fn exchange(&self, subject: &str) -> Result<CachedToken> {
+        let form: [(&str, &str); 4] = [
+            ("grant_type", TOKEN_EXCHANGE_GRANT),
+            ("subject_token", subject),
+            ("subject_token_type", SUBJECT_TOKEN_TYPE),
+            ("audience", INFERENCE_AUDIENCE),
+        ];
+        let response = self
+            .client
+            .post(self.token_url.clone())
+            .form(&form)
+            .send()
+            .await
+            .map_err(|error| {
+                AgentError::msg(format!("on-behalf-of token exchange failed: {error}"))
+            })?;
+        let status = response.status();
+        let body = read_bounded(response).await?;
+        if !status.is_success() {
+            return Err(exchange_refusal(&body));
+        }
+        let exchanged: ExchangeResponse = serde_json::from_slice(&body).map_err(|error| {
+            AgentError::msg(format!(
+                "the Model Gateway returned an unreadable token exchange response: {error}"
+            ))
+        })?;
+        if exchanged.access_token.is_empty() {
+            return Err(AgentError::msg(
+                "the Model Gateway returned an empty on-behalf-of token",
+            ));
+        }
+        Ok(CachedToken {
+            token: exchanged.access_token.into(),
+            expires_at_unix: unix_time().saturating_add(exchanged.expires_in),
+        })
+    }
+}
+
+/// Turn a refused exchange into the error its cause deserves.
+///
+/// A body that does not decode is still a refusal — never a reason to keep
+/// going with another credential.
+fn exchange_refusal(body: &[u8]) -> AgentError {
+    let Ok(refusal) = serde_json::from_slice::<OAuthError>(body) else {
+        return AgentError::msg("the Model Gateway refused the on-behalf-of token exchange");
+    };
+    let detail = refusal
+        .error_description
+        .unwrap_or_else(|| refusal.error.clone());
+    match refusal.error.as_str() {
+        "invalid_grant" => AgentError::SignInRequired(format!(
+            "your Model Gateway session is no longer valid: {detail}"
+        )),
+        "invalid_target" => AgentError::InvalidTarget(format!(
+            "the Model Gateway does not allow inference on your behalf: {detail}"
+        )),
+        _ => AgentError::msg(format!(
+            "the Model Gateway refused the on-behalf-of token exchange: {detail}"
+        )),
+    }
+}
+
+/// Read at most [`RESPONSE_LIMIT`] bytes, refusing anything larger.
+///
+/// # Errors
+/// Fails when the body is oversized or the connection breaks mid-read.
+async fn read_bounded(response: reqwest::Response) -> Result<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > RESPONSE_LIMIT as u64)
+    {
+        return Err(AgentError::msg(
+            "the Model Gateway token exchange response exceeded the size limit",
+        ));
+    }
+    let mut bytes = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| {
+            AgentError::msg(format!(
+                "the Model Gateway token exchange response failed: {error}"
+            ))
+        })?;
+        if bytes.len().saturating_add(chunk.len()) > RESPONSE_LIMIT {
+            return Err(AgentError::msg(
+                "the Model Gateway token exchange response exceeded the size limit",
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+/// Validate a gateway base URL for server-to-server use and normalize it so a
+/// subpath deployment keeps its prefix when paths are joined below it.
+///
+/// # Errors
+/// Fails on an unparseable URL, embedded credentials, a query or fragment, or
+/// cleartext outside loopback development.
+fn normalized_gateway_base(raw: &str) -> Result<reqwest::Url> {
+    let mut base = reqwest::Url::parse(raw.trim())
+        .map_err(|error| AgentError::config(format!("invalid Model Gateway URL: {error}")))?;
+    if !base.username().is_empty()
+        || base.password().is_some()
+        || base.query().is_some()
+        || base.fragment().is_some()
+    {
+        return Err(AgentError::config(
+            "the Model Gateway URL must not contain credentials, a query, or a fragment",
+        ));
+    }
+    let loopback = base.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
+    });
+    if base.scheme() != "https" && !(base.scheme() == "http" && loopback) {
+        return Err(AgentError::config(
+            "the Model Gateway URL must use https (http is allowed only for loopback development)",
+        ));
+    }
+    // A trailing slash makes `join` extend the base instead of replacing its
+    // last segment, which is what keeps a subpath deployment routable.
+    if !base.path().ends_with('/') {
+        let path = format!("{}/", base.path());
+        base.set_path(&path);
+    }
+    Ok(base)
+}
+
+/// Join `path` below `base`.
+///
+/// # Errors
+/// Fails when the result is not a valid URL.
+fn join_below(base: &reqwest::Url, path: &str) -> Result<reqwest::Url> {
+    base.join(path)
+        .map_err(|error| AgentError::config(format!("invalid Model Gateway endpoint: {error}")))
+}
+
+/// One caller's credential supplier, as the router sees it.
+///
+/// The router asks for a bearer at each request, so a token that expires
+/// mid-turn is replaced without rebuilding the route, and a session revoked
+/// mid-turn fails the next request closed.
+struct OboTokenSource {
+    inference: Arc<OboInference>,
+    owner: OwnerId,
+}
+
+#[async_trait]
+impl BearerTokenSource for OboTokenSource {
+    /// The owner this credential is bound to, so a cached router built for one
+    /// caller is never reused for another.
+    fn binding_id(&self) -> Option<&str> {
+        Some(self.owner.as_str())
+    }
+
+    async fn bearer_token(&self) -> Result<String> {
+        self.inference.bearer_for(&self.owner).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::routing::post;
+    use axum::{Json, Router};
+
+    use super::*;
+
+    /// What a fake gateway does with the next exchange it receives.
+    #[derive(Clone)]
+    struct FakeGateway {
+        /// How many exchanges it has served.
+        mints: Arc<AtomicUsize>,
+        /// Lifetime, in seconds, of each token it mints.
+        lifetime: Arc<AtomicUsize>,
+        /// The OAuth error to refuse with, or empty to succeed.
+        refusal: Arc<std::sync::Mutex<String>>,
+        /// How long each exchange takes to answer.
+        latency: Duration,
+    }
+
+    impl FakeGateway {
+        fn new() -> Self {
+            Self {
+                mints: Arc::new(AtomicUsize::new(0)),
+                lifetime: Arc::new(AtomicUsize::new(3600)),
+                refusal: Arc::new(std::sync::Mutex::new(String::new())),
+                latency: Duration::ZERO,
+            }
+        }
+
+        fn refuse_with(&self, error: &str) {
+            if let Ok(mut refusal) = self.refusal.lock() {
+                *refusal = error.to_owned();
+            }
+        }
+
+        fn served(&self) -> usize {
+            self.mints.load(Ordering::SeqCst)
+        }
+
+        /// Serve this gateway on loopback and return an exchange client
+        /// pointed at it, plus the running server's handle.
+        async fn start(self) -> (Arc<OboInference>, tokio::task::JoinHandle<()>) {
+            let state = self.clone();
+            let app = Router::new().route(
+                "/oauth/token",
+                post(move |form: axum::Form<HashMap<String, String>>| {
+                    let state = state.clone();
+                    async move {
+                        // The wire contract, asserted on the server side so a
+                        // drifted request fails the test rather than passing
+                        // silently.
+                        assert_eq!(
+                            form.get("grant_type").map(String::as_str),
+                            Some(TOKEN_EXCHANGE_GRANT)
+                        );
+                        assert_eq!(
+                            form.get("subject_token_type").map(String::as_str),
+                            Some(SUBJECT_TOKEN_TYPE)
+                        );
+                        assert_eq!(
+                            form.get("audience").map(String::as_str),
+                            Some(INFERENCE_AUDIENCE)
+                        );
+                        let subject = form
+                            .get("subject_token")
+                            .cloned()
+                            .unwrap_or_else(|| "missing".to_owned());
+                        assert!(subject.starts_with("mg_at_"));
+
+                        if !state.latency.is_zero() {
+                            tokio::time::sleep(state.latency).await;
+                        }
+                        let refusal = state
+                            .refusal
+                            .lock()
+                            .map(|refusal| refusal.clone())
+                            .unwrap_or_default();
+                        if !refusal.is_empty() {
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                Json(serde_json::json!({
+                                    "error": refusal,
+                                    "error_description": "the fake gateway refused",
+                                })),
+                            )
+                                .into_response();
+                        }
+                        let serial = state.mints.fetch_add(1, Ordering::SeqCst);
+                        Json(serde_json::json!({
+                            "access_token": format!("mg_at_inference_{serial}_for_{subject}"),
+                            "token_type": "Bearer",
+                            "expires_in": state.lifetime.load(Ordering::SeqCst),
+                            "scope": "inference:invoke",
+                        }))
+                        .into_response()
+                    }
+                }),
+            );
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            let server = tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            let inference = Arc::new(OboInference::new(&format!("http://{address}")).unwrap());
+            (inference, server)
+        }
+    }
+
+    use axum::response::IntoResponse as _;
+
+    fn owner(name: &str) -> OwnerId {
+        OwnerId::new(name).unwrap()
+    }
+
+    /// The happy path: a caller's machine-bound bearer becomes an
+    /// inference-only token for the same caller, and the inference base URL
+    /// is the gateway's Anthropic-compatible surface.
+    #[tokio::test]
+    async fn an_exchange_mints_an_inference_token_for_the_caller() {
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+
+        let token = inference.bearer_for(&alice).await.unwrap();
+        assert!(token.starts_with("mg_at_inference_"));
+        assert!(token.ends_with("mg_at_alice"));
+        assert!(inference
+            .inference_base_url()
+            .ends_with("/compat/anthropic"));
+        assert_eq!(gateway.served(), 1);
+        server.abort();
+    }
+
+    /// Each caller's turns run on their own token. One exchange never serves
+    /// another user.
+    #[tokio::test]
+    async fn each_caller_gets_their_own_token() {
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        let bob = owner("user:bob");
+        inference.record_caller(&alice, "mg_at_alice".into());
+        inference.record_caller(&bob, "mg_at_bob".into());
+
+        let alice_token = inference.bearer_for(&alice).await.unwrap();
+        let bob_token = inference.bearer_for(&bob).await.unwrap();
+        assert!(alice_token.ends_with("mg_at_alice"));
+        assert!(bob_token.ends_with("mg_at_bob"));
+        assert_ne!(alice_token, bob_token);
+        assert_eq!(gateway.served(), 2);
+        server.abort();
+    }
+
+    /// A live token is reused; one inside the expiry leeway is replaced.
+    #[tokio::test]
+    async fn a_cached_token_is_reused_until_it_nears_expiry() {
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+
+        let first = inference.bearer_for(&alice).await.unwrap();
+        let second = inference.bearer_for(&alice).await.unwrap();
+        assert_eq!(first, second, "a live token must be reused");
+        assert_eq!(gateway.served(), 1);
+
+        // A caller whose tokens are minted already inside the leeway window
+        // must exchange again for every request, rather than opening one with
+        // a credential that dies mid-stream.
+        gateway
+            .lifetime
+            .store(EXPIRY_LEEWAY_SECONDS as usize / 2, Ordering::SeqCst);
+        let bob = owner("user:bob");
+        inference.record_caller(&bob, "mg_at_bob".into());
+        let third = inference.bearer_for(&bob).await.unwrap();
+        assert_eq!(gateway.served(), 2);
+        let fourth = inference.bearer_for(&bob).await.unwrap();
+        assert_eq!(gateway.served(), 3);
+        assert_ne!(third, fourth, "a token near expiry must be minted again");
+        server.abort();
+    }
+
+    /// Concurrent turns for one caller share a single exchange.
+    #[tokio::test]
+    async fn concurrent_turns_for_one_caller_mint_once() {
+        let mut gateway = FakeGateway::new();
+        gateway.latency = Duration::from_millis(150);
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+
+        let mut turns = Vec::new();
+        for _ in 0..8 {
+            let inference = inference.clone();
+            let alice = alice.clone();
+            turns.push(tokio::spawn(
+                async move { inference.bearer_for(&alice).await },
+            ));
+        }
+        let mut tokens = Vec::new();
+        for turn in turns {
+            tokens.push(turn.await.unwrap().unwrap());
+        }
+        assert_eq!(gateway.served(), 1, "eight turns must not stampede");
+        assert!(
+            tokens.windows(2).all(|pair| pair[0] == pair[1]),
+            "every turn must run on the same token"
+        );
+        server.abort();
+    }
+
+    /// A revoked session, a deactivated user, or an expired subject token all
+    /// arrive as `invalid_grant`, and all become the sign-in-required shape
+    /// the client already handles.
+    #[tokio::test]
+    async fn a_dead_session_fails_closed_as_sign_in_required() {
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+        gateway.refuse_with("invalid_grant");
+
+        let error = inference.bearer_for(&alice).await.unwrap_err();
+        assert!(
+            matches!(error, AgentError::SignInRequired(_)),
+            "expected a sign-in-required refusal, got {error:?}"
+        );
+        assert_eq!(error.kind(), "authentication");
+        server.abort();
+    }
+
+    /// An audience this token may not reach is a refusal too, and a distinct
+    /// one: the deployment is misconfigured, the caller is not signed out.
+    #[tokio::test]
+    async fn a_disallowed_audience_is_its_own_refusal() {
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+        gateway.refuse_with("invalid_target");
+
+        let error = inference.bearer_for(&alice).await.unwrap_err();
+        assert!(
+            matches!(error, AgentError::InvalidTarget(_)),
+            "expected an invalid-target refusal, got {error:?}"
+        );
+        server.abort();
+    }
+
+    /// Rule 4: a session revoked mid-session fails the next turn closed. The
+    /// cached token is not served past its life, and nothing falls back.
+    #[tokio::test]
+    async fn a_refusal_mid_session_fails_the_next_turn_closed() {
+        let gateway = FakeGateway::new();
+        gateway
+            .lifetime
+            .store(EXPIRY_LEEWAY_SECONDS as usize / 2, Ordering::SeqCst);
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+
+        let first = inference.bearer_for(&alice).await.unwrap();
+        assert!(first.starts_with("mg_at_inference_"));
+
+        gateway.refuse_with("invalid_grant");
+        let error = inference.bearer_for(&alice).await.unwrap_err();
+        assert!(
+            matches!(error, AgentError::SignInRequired(_)),
+            "expected the turn to fail closed, got {error:?}"
+        );
+        server.abort();
+    }
+
+    /// A caller this process has never authenticated has no credential to
+    /// borrow, and is refused rather than served somebody else's.
+    #[tokio::test]
+    async fn an_unknown_caller_is_offered_no_credential() {
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let stranger = owner("user:stranger");
+
+        assert!(inference.token_source_for(&stranger).is_none());
+        let error = inference.bearer_for(&stranger).await.unwrap_err();
+        assert!(
+            matches!(error, AgentError::SignInRequired(_)),
+            "expected a sign-in-required refusal, got {error:?}"
+        );
+        assert_eq!(gateway.served(), 0);
+        server.abort();
+    }
+
+    /// The source the router holds names its caller, so a router cached for
+    /// one caller can never be mistaken for another's.
+    #[tokio::test]
+    async fn a_token_source_is_bound_to_its_caller() {
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+
+        let source = inference.token_source_for(&alice).unwrap();
+        assert_eq!(source.binding_id(), Some("user:alice"));
+        assert!(source
+            .bearer_token()
+            .await
+            .unwrap()
+            .ends_with("mg_at_alice"));
+        server.abort();
+    }
+
+    /// A caller who refreshes their machine-bound token keeps running: the
+    /// newest subject is the one a later exchange presents.
+    #[tokio::test]
+    async fn a_refreshed_subject_token_replaces_the_old_one() {
+        let gateway = FakeGateway::new();
+        gateway
+            .lifetime
+            .store(EXPIRY_LEEWAY_SECONDS as usize / 2, Ordering::SeqCst);
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice_first".into());
+        assert!(inference
+            .bearer_for(&alice)
+            .await
+            .unwrap()
+            .ends_with("mg_at_alice_first"));
+
+        inference.record_caller(&alice, "mg_at_alice_second".into());
+        assert!(inference
+            .bearer_for(&alice)
+            .await
+            .unwrap()
+            .ends_with("mg_at_alice_second"));
+        server.abort();
+    }
+
+    /// Rules 5 and 6: a deployment that is not a gateway-authenticated hosted
+    /// machine builds no per-caller inference path at all.
+    #[test]
+    fn only_a_gateway_authenticated_hosted_machine_resolves_per_caller() {
+        let mut config =
+            tidebreak_core::Config::desktop(std::path::PathBuf::from("/tmp/tidebreak-obo-test"));
+
+        config.profile = Profile::Desktop;
+        config.auth_gateway_url = Some("https://gateway.example".to_owned());
+        assert!(
+            OboInference::from_config(&config).unwrap().is_none(),
+            "the desktop profile is unchanged"
+        );
+
+        config.profile = Profile::SelfHost;
+        config.auth_gateway_url = None;
+        assert!(
+            OboInference::from_config(&config).unwrap().is_none(),
+            "a static-token server is unchanged"
+        );
+
+        config.auth_gateway_url = Some("https://gateway.example".to_owned());
+        let inference = OboInference::from_config(&config).unwrap().unwrap();
+        assert_eq!(
+            inference.inference_base_url(),
+            "https://gateway.example/compat/anthropic"
+        );
+    }
+
+    /// The exchange is a server-to-server call, so it honors the same
+    /// cluster-routable override the principal check does.
+    #[test]
+    fn the_verifier_override_redirects_the_exchange() {
+        let mut config =
+            tidebreak_core::Config::desktop(std::path::PathBuf::from("/tmp/tidebreak-obo-test"));
+        config.profile = Profile::SelfHost;
+        config.auth_gateway_url = Some("https://public.example".to_owned());
+        config.auth_gateway_verifier_url = Some("https://gateway.internal".to_owned());
+
+        let inference = OboInference::from_config(&config).unwrap().unwrap();
+        assert_eq!(
+            inference.token_url.as_str(),
+            "https://gateway.internal/oauth/token"
+        );
+        assert_eq!(
+            inference.inference_base_url(),
+            "https://gateway.internal/compat/anthropic"
+        );
+    }
+
+    /// A gateway deployed under a subpath keeps its prefix.
+    #[test]
+    fn a_subpath_deployment_keeps_its_prefix() {
+        let inference = OboInference::new("https://example.test/gateway").unwrap();
+        assert_eq!(
+            inference.token_url.as_str(),
+            "https://example.test/gateway/oauth/token"
+        );
+        assert_eq!(
+            inference.inference_base_url(),
+            "https://example.test/gateway/compat/anthropic"
+        );
+    }
+
+    /// A URL that cannot carry a server-to-server credential is refused at
+    /// assembly, not at the first turn.
+    #[test]
+    fn an_unusable_gateway_url_is_refused_at_assembly() {
+        assert!(OboInference::new("https://user:pass@example.test").is_err());
+        assert!(OboInference::new("https://example.test?probe=1").is_err());
+        assert!(OboInference::new("http://gateway.example").is_err());
+        assert!(OboInference::new("http://127.0.0.1:8080").is_ok());
+    }
+}

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -1859,6 +1859,14 @@ pub fn route_kind(kind: ProviderKind) -> tidebreak_router::RouteKind {
     }
 }
 
+/// A per-caller inference path offered where the deployment states no other
+/// one: the caller's rotating credential and the base URL it authenticates
+/// against.
+pub type OnBehalfOfInference = (
+    std::sync::Arc<dyn tidebreak_router::BearerTokenSource>,
+    String,
+);
+
 /// Collect enabled, credentialed routes for the composite router.
 ///
 /// A kind with no usable credential is skipped. OpenAI ChatGPT OAuth
@@ -1872,6 +1880,11 @@ pub fn route_kind(kind: ProviderKind) -> tidebreak_router::RouteKind {
 /// is the policy URL. On an unmanaged profile there is no gateway route at
 /// all: policy is the only gateway source, and a legacy stored row is never
 /// read.
+///
+/// `on_behalf_of` is the hosted machine's per-caller credential (decision 51).
+/// It becomes an Anthropic route only where the deployment states no other
+/// inference path for that provider — see
+/// [`on_behalf_of_states_the_only_path`].
 pub async fn collect_routes(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
@@ -1880,6 +1893,7 @@ pub async fn collect_routes(
         std::sync::Arc<dyn tidebreak_router::BearerTokenSource>,
         String,
     )>,
+    on_behalf_of: Option<OnBehalfOfInference>,
     policy: &crate::managed_policy::ManagedPolicy,
 ) -> Vec<tidebreak_router::Route> {
     let mut routes = Vec::new();
@@ -1973,6 +1987,27 @@ pub async fn collect_routes(
         if policy.managed {
             continue;
         }
+        // A hosted machine resolves this provider per caller only where the
+        // deployment states no other path to it (decision 51, rule 3).
+        if kind == ProviderKind::Anthropic {
+            if let Some((source, base_url)) = on_behalf_of.clone() {
+                if on_behalf_of_states_the_only_path(store, secrets, kind).await {
+                    routes.push(tidebreak_router::Route {
+                        kind: route_kind(kind),
+                        // The credential rotates; there is no key to snapshot.
+                        api_key: String::new(),
+                        base_url: Some(base_url),
+                        curated_models: model_registry::models_for(kind)
+                            .map(|spec| spec.id.to_string())
+                            .collect(),
+                        model_rewrites: HashMap::new(),
+                        token_source: Some(source),
+                        chatgpt_account_id: None,
+                    });
+                    continue;
+                }
+            }
+        }
         let config = match read_config(store, kind).await {
             Ok(c) => c,
             Err(_) => continue,
@@ -2049,6 +2084,35 @@ pub async fn collect_routes(
         });
     }
     routes
+}
+
+/// Whether per-caller inference is the only path this deployment states to
+/// `kind`.
+///
+/// Three statements outrank it, in the order a deployment makes them: a stored
+/// provider configuration row, a stored credential, and the environment
+/// fallbacks for the credential and the base URL. Any one of them means the
+/// operator has named an inference path, and decision 51 leaves it in force —
+/// including a row that disables the provider outright.
+///
+/// Every read failure answers `false`, so an unreadable store or secret skips
+/// the provider rather than routing a caller's turn on a guess.
+async fn on_behalf_of_states_the_only_path(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    kind: ProviderKind,
+) -> bool {
+    if !matches!(store.get_setting(&kind.setting_key()).await, Ok(None)) {
+        return false;
+    }
+    if !matches!(read_credential(secrets, kind).await, Ok(None)) {
+        return false;
+    }
+    if env_api_key(kind).is_some() {
+        return false;
+    }
+    kind.env_base_url_from(|name| std::env::var(name).ok())
+        .is_none()
 }
 
 /// One-shot boot migration for authentication that can outlive provider config.

--- a/crates/tidebreak-server/src/resolver.rs
+++ b/crates/tidebreak-server/src/resolver.rs
@@ -9,18 +9,26 @@
 //! The [`ProviderResolver`] seam also lets tests inject a provider directly
 //! instead of standing up a real backend.
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
-use tidebreak_core::{ModelProvider, SecretProvider, Store};
+use tidebreak_core::{ModelProvider, OwnerId, SecretProvider, Store};
 use tidebreak_router::Router;
 
 use crate::provider::UnconfiguredProvider;
 use crate::providers;
 
-/// Cache: fingerprint of the route set + the built provider.
-type CachedProvider = Option<(String, Arc<dyn ModelProvider>)>;
+/// Cache: per caller, the fingerprint of their route set + the built provider.
+///
+/// Keyed by caller because a hosted machine can resolve model credentials per
+/// caller (decision 51). Two callers' route sets fingerprint identically — the
+/// fingerprint records only *that* a live token source exists, never whose —
+/// so one shared slot would hand one caller another caller's credential. The
+/// key keeps them apart. Deployments that resolve no credential per caller use
+/// the single `None` entry and behave exactly as before.
+type CachedProviders = HashMap<Option<OwnerId>, (String, Arc<dyn ModelProvider>)>;
 
 /// Builds the model provider for the next turn.
 #[async_trait]
@@ -28,6 +36,21 @@ pub trait ProviderResolver: Send + Sync {
     /// Resolve the provider. Infallible: with no credentials it returns a
     /// fail-closed provider, so a turn surfaces `TurnFailed` instead of egressing.
     async fn resolve(&self) -> Arc<dyn ModelProvider>;
+
+    /// Resolve the provider for the caller a turn belongs to.
+    ///
+    /// `None` means the caller cannot be named — a system path with no person
+    /// behind it, or a chat whose owner no longer resolves. Implementations
+    /// that resolve credentials per caller must then offer none, so an
+    /// unattributable turn fails closed rather than borrowing someone's
+    /// authority.
+    ///
+    /// The default ignores the caller, which is right for every deployment
+    /// whose credentials are deployment-wide.
+    async fn resolve_for(&self, owner: Option<&OwnerId>) -> Arc<dyn ModelProvider> {
+        let _ = owner;
+        self.resolve().await
+    }
 
     /// Whether public model selections must resolve through the host registry.
     ///
@@ -53,7 +76,8 @@ pub struct ConfiguredResolver {
     chatgpt: Arc<crate::chatgpt_runtime::ChatGptRuntime>,
     provisioned_policy: Arc<dyn crate::managed_policy::ProvisionedPolicySource>,
     os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
-    cached: Mutex<CachedProvider>,
+    on_behalf_of: Option<Arc<crate::obo_inference::OboInference>>,
+    cached: Mutex<CachedProviders>,
 }
 
 impl ConfiguredResolver {
@@ -79,8 +103,23 @@ impl ConfiguredResolver {
             chatgpt,
             provisioned_policy,
             os_policy,
-            cached: Mutex::new(None),
+            on_behalf_of: None,
+            cached: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Resolve model credentials per caller through `on_behalf_of` wherever the
+    /// deployment states no other inference path (decision 51).
+    ///
+    /// Only a gateway-authenticated hosted machine supplies one. Every other
+    /// deployment leaves this unset and keeps its configured providers.
+    #[must_use]
+    pub(crate) fn with_on_behalf_of_inference(
+        mut self,
+        on_behalf_of: Option<Arc<crate::obo_inference::OboInference>>,
+    ) -> Self {
+        self.on_behalf_of = on_behalf_of;
+        self
     }
 }
 
@@ -90,6 +129,10 @@ pub type KeyedResolver = ConfiguredResolver;
 #[async_trait]
 impl ProviderResolver for ConfiguredResolver {
     async fn resolve(&self) -> Arc<dyn ModelProvider> {
+        self.resolve_for(None).await
+    }
+
+    async fn resolve_for(&self, owner: Option<&OwnerId>) -> Arc<dyn ModelProvider> {
         // A profile that claims to be managed but whose policy cannot be read
         // fails closed: no egress, rather than quietly reverting to BYOK routes.
         let Ok(policy) =
@@ -99,21 +142,39 @@ impl ProviderResolver for ConfiguredResolver {
         };
         let gateway_tokens = self.gateway.route_token_source().await;
         let chatgpt = self.chatgpt.route_auth().await;
+        // Per-caller credentials need a caller. An unnamed turn is offered
+        // none, which fails it closed instead of running it as somebody else.
+        let on_behalf_of = self
+            .on_behalf_of
+            .as_ref()
+            .zip(owner)
+            .and_then(|(inference, owner)| {
+                inference
+                    .token_source_for(owner)
+                    .map(|source| (source, inference.inference_base_url().to_owned()))
+            });
         let routes = providers::collect_routes(
             &*self.store,
             &*self.secrets,
             gateway_tokens,
             chatgpt,
+            on_behalf_of,
             &policy,
         )
         .await;
         let router = Router::build(routes);
         let fingerprint = router.fingerprint().to_string();
 
-        // Reuse the cached provider while the route set is unchanged. The lock
-        // is held only across the cheap clone below — never over an await.
+        // Reuse this caller's cached provider while their route set is
+        // unchanged. The lock is held only across the cheap clone below —
+        // never over an await.
+        let key = self
+            .on_behalf_of
+            .is_some()
+            .then(|| owner.cloned())
+            .flatten();
         let mut cached = self.cached.lock().unwrap();
-        if let Some((cached_fp, provider)) = cached.as_ref() {
+        if let Some((cached_fp, provider)) = cached.get(&key) {
             if *cached_fp == fingerprint {
                 return provider.clone();
             }
@@ -125,7 +186,7 @@ impl ProviderResolver for ConfiguredResolver {
         } else {
             Arc::new(router)
         };
-        *cached = Some((fingerprint, provider.clone()));
+        cached.insert(key, (fingerprint, provider.clone()));
         provider
     }
 

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -197,6 +197,10 @@ pub struct AppState {
     /// checks live account state; static-token mode remains for standalone
     /// deployments. Desktop never consults it.
     pub(crate) principal_authenticator: Arc<crate::auth::PrincipalAuthenticator>,
+    /// Per-caller inference credentials on a gateway-authenticated hosted
+    /// machine (decision 51). `None` everywhere else, which is what keeps
+    /// static-token and desktop deployments on their configured providers.
+    pub(crate) on_behalf_of_inference: Option<Arc<crate::obo_inference::OboInference>>,
     /// A second per-launch secret required for native-only operations.
     pub(crate) client_executor_token: Arc<str>,
     /// A per-launch capability limited to publishing caller-supplied bytes.
@@ -418,6 +422,7 @@ impl AppState {
             agent_config,
             token: Uuid::new_v4().to_string().into(),
             principal_authenticator,
+            on_behalf_of_inference: None,
             client_executor_token: mint_client_executor_token(),
             local_import_token: mint_local_import_token(),
             client_executor_id,
@@ -437,6 +442,21 @@ impl AppState {
 
     pub fn set_local_voice_runner(&mut self, runner: Arc<dyn LocalVoiceRunner>) {
         self.local_voice = runner;
+    }
+
+    /// Resolve model credentials per caller through `inference` (decision 51).
+    ///
+    /// Pass the same instance the resolver holds: the authentication
+    /// middleware records each caller's live gateway token here, and the
+    /// resolver reads it back when it builds that caller's routes. Two
+    /// instances would leave every turn without a credential.
+    #[must_use]
+    pub(crate) fn with_on_behalf_of_inference(
+        mut self,
+        inference: Option<Arc<crate::obo_inference::OboInference>>,
+    ) -> Self {
+        self.on_behalf_of_inference = inference;
+        self
     }
 }
 

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -1763,7 +1763,7 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
         &crate::managed_policy::NoOsPolicy,
     )
     .unwrap();
-    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, None, &policy).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].kind, tidebreak_router::RouteKind::Xai);
     assert_eq!(routes[0].base_url, None);
@@ -2725,7 +2725,7 @@ async fn resolver_includes_configured_curated_api_key_providers() {
             &crate::managed_policy::NoOsPolicy,
         )
         .unwrap();
-        let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+        let routes = providers::collect_routes(&*store, &*secrets, None, None, None, &policy).await;
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].kind, route_kind);
 
@@ -2792,7 +2792,7 @@ async fn openai_compatible_route_is_free_form_fallback() {
         &crate::managed_policy::NoOsPolicy,
     )
     .unwrap();
-    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, None, &policy).await;
     let router = tidebreak_router::Router::build(routes);
     assert_eq!(
         router.select("llama-3-local"),
@@ -2842,7 +2842,7 @@ async fn direct_compatible_presets_use_fixed_endpoints_and_distinct_routes() {
         &crate::managed_policy::NoOsPolicy,
     )
     .unwrap();
-    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, None, &policy).await;
     let fireworks = routes
         .iter()
         .find(|route| route.kind == tidebreak_router::RouteKind::Fireworks)
@@ -2969,7 +2969,7 @@ async fn ollama_is_usable_without_a_credential_and_serves_only_configured_models
     assert!(model.policy.supports_tools);
     assert!(!model.policy.supports_reasoning);
 
-    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, None, &policy).await;
     let route = routes
         .iter()
         .find(|route| route.kind == tidebreak_router::RouteKind::Ollama)
@@ -3072,7 +3072,7 @@ async fn openrouter_uses_its_fixed_endpoint_and_serves_only_configured_models() 
     assert!(!model.policy.supports_reasoning);
     assert!(!model.policy.supports_vendor_web_search);
 
-    let routes = providers::collect_routes(&*store, &*secrets, None, None, &policy).await;
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, None, &policy).await;
     let route = routes
         .iter()
         .find(|route| route.kind == tidebreak_router::RouteKind::Openrouter)
@@ -3115,6 +3115,14 @@ impl ScopedEnv {
     fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var(key).ok();
         std::env::set_var(key, value);
+        Self { key, previous }
+    }
+
+    /// Clear `key` for the scope, so a test asserts against a deployment that
+    /// states nothing rather than against the developer's own environment.
+    fn unset(key: &'static str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::remove_var(key);
         Self { key, previous }
     }
 }
@@ -3192,12 +3200,18 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
     let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
     let policy =
         crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
-    let kinds: Vec<_> =
-        providers::collect_routes(&*store, &*secrets, Some(tokens.clone()), None, &policy)
-            .await
-            .into_iter()
-            .map(|route| route.kind)
-            .collect();
+    let kinds: Vec<_> = providers::collect_routes(
+        &*store,
+        &*secrets,
+        Some(tokens.clone()),
+        None,
+        None,
+        &policy,
+    )
+    .await
+    .into_iter()
+    .map(|route| route.kind)
+    .collect();
     assert!(kinds.contains(&tidebreak_router::RouteKind::Anthropic));
     assert!(kinds.contains(&tidebreak_router::RouteKind::Gemini));
     assert!(!kinds.contains(&tidebreak_router::RouteKind::ModelGateway));
@@ -3207,8 +3221,15 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
     crate::managed_policy::provision(&*provisioned, "https://corp.gateway").unwrap();
     let policy =
         crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
-    let routes =
-        providers::collect_routes(&*store, &*secrets, Some(tokens.clone()), None, &policy).await;
+    let routes = providers::collect_routes(
+        &*store,
+        &*secrets,
+        Some(tokens.clone()),
+        None,
+        None,
+        &policy,
+    )
+    .await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].kind, tidebreak_router::RouteKind::ModelGateway);
     assert_eq!(
@@ -3235,7 +3256,8 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
     )
     .await
     .unwrap();
-    let routes = providers::collect_routes(&*store, &*secrets, Some(tokens), None, &policy).await;
+    let routes =
+        providers::collect_routes(&*store, &*secrets, Some(tokens), None, None, &policy).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].kind, tidebreak_router::RouteKind::ModelGateway);
 }
@@ -3278,7 +3300,7 @@ async fn a_base_url_environment_fallback_reaches_the_route() {
     let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
     let policy =
         crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
-    let route = providers::collect_routes(&*store, &*secrets, None, None, &policy)
+    let route = providers::collect_routes(&*store, &*secrets, None, None, None, &policy)
         .await
         .into_iter()
         .find(|route| route.kind == tidebreak_router::RouteKind::Anthropic)
@@ -3297,7 +3319,7 @@ async fn a_base_url_environment_fallback_reaches_the_route() {
     )
     .await
     .unwrap();
-    let route = providers::collect_routes(&*store, &*secrets, None, None, &policy)
+    let route = providers::collect_routes(&*store, &*secrets, None, None, None, &policy)
         .await
         .into_iter()
         .find(|route| route.kind == tidebreak_router::RouteKind::Anthropic)
@@ -5612,4 +5634,287 @@ async fn a_plugins_bundled_mcp_server_mounts_only_while_the_plugin_is_enabled() 
         !data.exists(),
         "uninstalling a plugin deletes the writable directory it was given"
     );
+}
+
+/// A stand-in for the caller's rotating gateway credential.
+struct FakeCallerCredential;
+
+#[async_trait::async_trait]
+impl tidebreak_router::BearerTokenSource for FakeCallerCredential {
+    fn binding_id(&self) -> Option<&str> {
+        Some("user:alice")
+    }
+
+    async fn bearer_token(&self) -> Result<String> {
+        Ok("mg_at_inference_for_alice".to_string())
+    }
+}
+
+/// The per-caller inference path a gateway-authenticated hosted machine
+/// offers, as `collect_routes` receives it.
+fn on_behalf_of() -> Option<providers::OnBehalfOfInference> {
+    Some((
+        Arc::new(FakeCallerCredential) as Arc<dyn tidebreak_router::BearerTokenSource>,
+        "https://gateway.example/compat/anthropic".to_string(),
+    ))
+}
+
+/// A store and secrets pair with nothing configured in either.
+async fn empty_deployment(dir: &tempfile::TempDir) -> (Arc<dyn Store>, Arc<dyn SecretProvider>) {
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}/test.db?mode=rwc",
+            dir.path().display()
+        ))
+        .await
+        .unwrap(),
+    );
+    (store, Arc::new(MemSecrets::default()))
+}
+
+/// Decision 51, rule 1: with gateway authentication and nothing else stated,
+/// the caller's own credential drives their turns against the gateway's
+/// Anthropic-compatible surface.
+#[tokio::test]
+async fn on_behalf_of_inference_serves_a_deployment_that_states_no_other_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let policy =
+        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
+
+    let route = providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy)
+        .await
+        .into_iter()
+        .find(|route| route.kind == tidebreak_router::RouteKind::Anthropic)
+        .expect("per-caller inference must offer an Anthropic route");
+
+    assert_eq!(
+        route.base_url.as_deref(),
+        Some("https://gateway.example/compat/anthropic")
+    );
+    assert!(
+        route.api_key.is_empty(),
+        "the credential rotates; no key may be snapshotted into the route"
+    );
+    let source = route
+        .token_source
+        .as_ref()
+        .expect("the route must carry the caller's rotating credential");
+    assert_eq!(source.binding_id(), Some("user:alice"));
+    assert!(
+        route
+            .curated_models
+            .iter()
+            .any(|model| model.starts_with("claude-")),
+        "the route must serve the curated Anthropic catalog"
+    );
+}
+
+/// Rule 3: a stored provider configuration always wins, so the deployment's
+/// own credential drives every caller's turns exactly as before.
+#[tokio::test]
+async fn a_stored_provider_configuration_outranks_on_behalf_of_inference() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+    providers::write_credential(
+        &*secrets,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderCredential::api_key("sk-stored"),
+    )
+    .await
+    .unwrap();
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let policy =
+        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
+
+    let route = providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy)
+        .await
+        .into_iter()
+        .find(|route| route.kind == tidebreak_router::RouteKind::Anthropic)
+        .expect("the stored key must still offer an Anthropic route");
+
+    assert_eq!(route.api_key, "sk-stored");
+    assert!(
+        route.token_source.is_none(),
+        "a stored configuration must not be displaced by per-caller inference"
+    );
+}
+
+/// Rule 3: a provider row that disables the provider is a statement too. The
+/// deployment said no, and per-caller inference does not overrule it.
+#[tokio::test]
+async fn a_disabled_provider_row_outranks_on_behalf_of_inference() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderConfig {
+            enabled: false,
+            base_url: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let policy =
+        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
+
+    let routes =
+        providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy).await;
+    assert!(
+        !routes
+            .iter()
+            .any(|route| route.kind == tidebreak_router::RouteKind::Anthropic),
+        "a disabled provider row must leave the provider unrouted"
+    );
+}
+
+/// Rule 3: the environment fallbacks keep their semantics. An environment
+/// credential names an inference path, so per-caller inference stays out of
+/// the way — including where the environment key alone routes nothing,
+/// because that is the behavior this record leaves in force.
+#[tokio::test]
+async fn an_environment_credential_outranks_on_behalf_of_inference() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::set("ANTHROPIC_API_KEY", "sk-from-the-environment");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let policy =
+        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
+
+    let routes =
+        providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy).await;
+    assert!(
+        !routes.iter().any(|route| route.token_source.is_some()),
+        "an environment credential must not be displaced by per-caller inference"
+    );
+}
+
+/// Rule 3: an environment base URL names an inference path of its own, even
+/// with no credential beside it, so per-caller inference stays out of the way.
+#[tokio::test]
+async fn an_environment_base_url_outranks_on_behalf_of_inference() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::set("ANTHROPIC_BASE_URL", "https://relay.example/v1");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let policy =
+        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
+
+    let routes =
+        providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy).await;
+    assert!(
+        !routes
+            .iter()
+            .any(|route| route.kind == tidebreak_router::RouteKind::Anthropic
+                && route.token_source.is_some()),
+        "an environment endpoint must not be displaced by per-caller inference"
+    );
+}
+
+/// Rule 5: without a per-caller credential the deployment routes exactly as
+/// it did before this record — here, not at all.
+#[tokio::test]
+async fn a_deployment_without_per_caller_inference_is_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let policy =
+        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
+
+    let routes = providers::collect_routes(&*store, &*secrets, None, None, None, &policy).await;
+    assert!(
+        routes.is_empty(),
+        "a deployment with no credentials must offer no routes"
+    );
+}
+
+/// The cross-caller invariant the resolver's cache exists to protect: two
+/// callers' route sets fingerprint identically, so a single cached provider
+/// would hand one caller the other's credential.
+#[tokio::test]
+async fn a_cached_provider_is_never_shared_between_callers() {
+    use crate::resolver::ProviderResolver as _;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+    let inference =
+        Arc::new(crate::obo_inference::OboInference::new("https://gateway.example").unwrap());
+    let alice = tidebreak_core::OwnerId::new("user:alice").unwrap();
+    let bob = tidebreak_core::OwnerId::new("user:bob").unwrap();
+    inference.record_caller(&alice, "mg_at_alice".into());
+    inference.record_caller(&bob, "mg_at_bob".into());
+
+    let resolver = resolver::ConfiguredResolver::new(
+        store.clone(),
+        secrets.clone(),
+        crate::gateway_runtime::GatewayRuntime::new(
+            store.clone(),
+            secrets.clone(),
+            crate::managed_policy::MemoryProvisionedPolicy::new(),
+            Arc::new(crate::managed_policy::NoOsPolicy),
+        ),
+        Arc::new(
+            crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone()).unwrap(),
+        ),
+        crate::managed_policy::MemoryProvisionedPolicy::new(),
+        Arc::new(crate::managed_policy::NoOsPolicy),
+    )
+    .with_on_behalf_of_inference(Some(inference.clone()));
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+
+    let for_alice = resolver.resolve_for(Some(&alice)).await;
+    let for_bob = resolver.resolve_for(Some(&bob)).await;
+    assert_eq!(for_alice.id().0, "router");
+    assert_eq!(for_bob.id().0, "router");
+    assert!(
+        !Arc::ptr_eq(&for_alice, &for_bob),
+        "two callers must not share one built provider"
+    );
+
+    // The same caller reuses their own cached provider.
+    let for_alice_again = resolver.resolve_for(Some(&alice)).await;
+    assert!(Arc::ptr_eq(&for_alice, &for_alice_again));
+
+    // A turn no owner can be named for is offered no credential at all.
+    assert_eq!(resolver.resolve_for(None).await.id().0, "unconfigured");
 }

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -930,7 +930,13 @@ impl TurnWorker {
                     }
                 }
             });
-            let provider = self.resolver.resolve().await;
+            // Resolve credentials for the person this turn belongs to. On a
+            // deployment whose credentials are deployment-wide the owner is
+            // ignored; on one that resolves them per caller, an owner that
+            // cannot be named yields no route and fails the turn closed
+            // rather than running it on somebody else's authority.
+            let owner = self.store.chat_owner(chat.id).await.unwrap_or_default();
+            let provider = self.resolver.resolve_for(owner.as_ref()).await;
             let steer = active.steer_inbox();
             let mut agent = Agent::new(provider, surface.tools.clone(), self.store.clone(), config)
                 .with_approvals(self.approvals.clone())

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -73,6 +73,23 @@ cluster, set `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL` to a cluster-routable HTTPS
 URL. Only the server's principal checks use the override; `/auth/discovery`
 continues to publish the public URL.
 
+In this mode model access needs no configured credential. The server exchanges
+each caller's Gateway token for a short-lived, inference-only token for the
+same user and drives that caller's turns with it, so the Gateway meters every
+turn to the person who ran it and the deployment holds no inference secret to
+rotate. The exchanged tokens stay in the server's memory: they are never
+stored, never logged, and never sent to a client. A caller whose Gateway
+session is revoked loses model access on their next turn, which fails with the
+same sign-in prompt the app already shows; other callers keep working.
+
+A stored provider configuration still wins, and so do the provider environment
+variables. Configure a provider in Settings, or set a credential such as
+`ANTHROPIC_API_KEY` or an endpoint such as `ANTHROPIC_BASE_URL`, and that path
+serves every caller exactly as it does today. Per-caller inference is the
+default only for a provider the deployment states no other path to. It also
+requires Gateway authentication: a server running on static tokens has no
+caller token to exchange and keeps its environment-configured providers.
+
 ## Generating tokens for standalone compatibility
 
 The token file is the credential-to-principal map, and it is also where roles


### PR DESCRIPTION
Implements [decision 51](docs/decisions/0051-on-behalf-of-inference-for-hosted-machines.md).

A gateway-authenticated hosted machine resolves model credentials per caller. It exchanges the caller's machine-bound gateway token for a short-lived, inference-only token for the same user, and drives that caller's turns with it against the gateway's Anthropic-compatible endpoint.

## How each rule lands

**1. Per-caller credentials when gateway authentication is on and nothing else overrides.** `crates/tidebreak-server/src/obo_inference.rs` is the new seam. `OboInference::from_config` builds one instance per process, and only for a self-host server with `TIDEBREAK_AUTH_GATEWAY_URL` set. `require_token` records each verified caller's bearer as it already builds the `GatewayAuthLease`. The turn worker names the turn's owner and asks the resolver for that caller's provider, which offers the router an Anthropic route pointed at `<gateway>/compat/anthropic` with the caller's rotating credential.

The exchange POSTs to the gateway's CLI token endpoint, form-encoded, with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, `subject_token`, `subject_token_type=urn:ietf:params:oauth:token-type:access_token`, and `audience=llm`. It honors `TIDEBREAK_AUTH_GATEWAY_VERIFIER_URL`, because it is a server-to-server call like the principal check.

**2. Process memory only, keyed by user, minted again near expiry.** Each owner holds a subject bearer and the token exchanged from it. The token is replaced within 60 seconds of expiry, matching the desktop's refresh leeway. Nothing is persisted, logged, or returned to a client. The per-owner mutex is also the single-flight gate, so concurrent turns for one caller share one exchange.

**3. A stored provider configuration always wins.** `on_behalf_of_states_the_only_path` in `providers.rs` offers the per-caller route only where the deployment states nothing else: no provider row (present or explicitly disabled), no stored credential, no `ANTHROPIC_API_KEY`, and no `ANTHROPIC_BASE_URL`. Every read failure answers "not the only path", so an unreadable store skips the provider rather than guessing.

**4. Fail closed.** `invalid_grant` becomes `AgentError::SignInRequired`, which already reaches the client as the `auth` turn-failure category with its sign-in affordance. `invalid_target` becomes `AgentError::InvalidTarget`. Any other non-success is a refusal too. A caller this process holds no live token for is offered no route at all, and their turn fails on the missing-credential path. Nothing ever falls back from a per-user credential to a shared one, and one caller's refusal leaves other callers running.

**5. Static-token servers are unchanged.** `from_config` returns `None` without gateway authentication, so the whole path is inert and those deployments keep their environment-configured providers.

**6. The desktop is unchanged.** `from_config` returns `None` for any profile but self-host.

## Notable design points

- `ProviderResolver` gains `resolve_for(owner)`, defaulting to `resolve()`, so every existing implementation and call site is untouched.
- The resolver's provider cache is keyed by owner. Two callers' route sets fingerprint identically — the fingerprint records only *that* a live token source exists, never whose — so a single shared slot would hand one caller another caller's credential. A test pins this.
- `RouteKind::Anthropic` now honors a route's token source. The adapter already supported one; only the gateway route kinds were wired to it.
- New `Store::chat_owner`, defaulting to `None`, lets the turn worker name a caller for an already-authorized chat id. An owner that cannot be named yields no per-caller credential, which fails the turn closed.

## Checks

- `cargo test -p tidebreak-server` — 1044 passed. The only failure was `code_terminals::create_write_read_and_two_cursors`, the known PTY-timing flake; it passes in isolation.
- `cargo test -p tidebreak-core -p tidebreak-router` — all passed.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets` — clean.

New coverage: 14 tests over the exchange client against a local fake gateway (wire contract, per-caller isolation, expiry re-mint, single-flight under eight concurrent turns, `invalid_grant`, `invalid_target`, mid-session refusal, unknown caller, verifier override, subpath deployments, unusable URLs), plus 7 over precedence and the cross-caller cache.