### PR TITLE
feat(code): workspace rail overhaul with hover detail panel and restore

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/watch.rs
+++ b/crates/tidebreak-core/src/db/ops/code/watch.rs
@@ -47,6 +47,25 @@ pub async fn latest_watch_for_workspace(
     row.map(watch_from_row).transpose()
 }
 
+/// The owner's most recent watch driven by one session, terminal or not.
+///
+/// A session drives at most one watch at a time; the ordering only settles
+/// the (unexpected) case of stale rows sharing a session id.
+pub async fn latest_watch_for_session(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+) -> Result<Option<CodeWatch>> {
+    let row = entities::code_watch::Entity::find()
+        .filter(entities::code_watch::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_watch::Column::SessionId.eq(session_id.0))
+        .order_by_desc(entities::code_watch::Column::CreatedAt)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?;
+    row.map(watch_from_row).transpose()
+}
+
 /// Every non-terminal watch on the machine.
 ///
 /// A system path, not a request path: the watch sweep drives every owner's

--- a/crates/tidebreak-core/src/db/tests.rs
+++ b/crates/tidebreak-core/src/db/tests.rs
@@ -11395,3 +11395,4 @@ async fn owner_scoped_queries_partition_root_aggregates() {
     );
     assert_eq!(store.get_chat_scoped(&alice, loose.id).await.unwrap(), None);
 }
+

--- a/crates/tidebreak-core/src/db/tests.rs
+++ b/crates/tidebreak-core/src/db/tests.rs
@@ -11395,4 +11395,3 @@ async fn owner_scoped_queries_partition_root_aggregates() {
     );
     assert_eq!(store.get_chat_scoped(&alice, loose.id).await.unwrap(), None);
 }
-

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -756,3 +756,94 @@ fn code_store_queries_are_owner_scoped_or_say_they_are_not() {
          say why in its documentation."
     );
 }
+
+/// The digest builder labels a watch child row from the watch found by its
+/// session id. A workspace-based match would hand one session the other
+/// watch's state the moment a workspace has watched twice.
+#[tokio::test]
+async fn latest_watch_for_session_matches_on_the_session_not_the_workspace() {
+    use crate::code::{CodeWatch, CodeWatchId, CodeWatchState};
+    use crate::db::code::{insert_watch, latest_watch_for_session};
+
+    let (_dir, store, session_id, _turn_id) = seeded_session().await;
+    let owner = OwnerId::local();
+    let workspace_id = get_session(&store, &owner, session_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .workspace_id;
+    let watch_session_id = CodeSessionId::new();
+    insert_session(
+        &store,
+        &CodeSession {
+            id: watch_session_id,
+            owner: owner.clone(),
+            workspace_id,
+            kind: CodeSessionKind::Watch,
+            harness_kind: HarnessKind::ClaudeCode,
+            harness_version: None,
+            harness_resume_ref: None,
+            permission_mode: CodePermissionMode::Auto,
+            model: None,
+            lifecycle: CodeSessionLifecycle::Running,
+            fence_reason: None,
+            child_pid: None,
+            spawn_epoch: 0,
+            attention: Attention::working(AttentionSource::Lifecycle),
+            unrecognized_event_count: 0,
+            created_at: now(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let older = CodeWatch {
+        id: CodeWatchId::new(),
+        owner: owner.clone(),
+        workspace_id,
+        session_id,
+        pr_number: 7,
+        state: CodeWatchState::Stopped,
+        detail: None,
+        last_fix_head: None,
+        cycles: 1,
+        created_at: now() - chrono::Duration::minutes(5),
+        updated_at: now() - chrono::Duration::minutes(5),
+    };
+    let newer = CodeWatch {
+        id: CodeWatchId::new(),
+        owner: owner.clone(),
+        workspace_id,
+        session_id: watch_session_id,
+        pr_number: 9,
+        state: CodeWatchState::Fixing,
+        detail: Some("fixing failing checks".to_owned()),
+        last_fix_head: None,
+        cycles: 3,
+        created_at: now(),
+        updated_at: now(),
+    };
+    insert_watch(&store, &older).await.unwrap();
+    insert_watch(&store, &newer).await.unwrap();
+
+    let found = latest_watch_for_session(&store, &owner, session_id)
+        .await
+        .unwrap()
+        .expect("older watch");
+    assert_eq!(found.id, older.id);
+    assert_eq!(found.state, CodeWatchState::Stopped);
+
+    let found = latest_watch_for_session(&store, &owner, watch_session_id)
+        .await
+        .unwrap()
+        .expect("newer watch");
+    assert_eq!(found.cycles, 3);
+    assert_eq!(found.detail.as_deref(), Some("fixing failing checks"));
+
+    assert!(
+        latest_watch_for_session(&store, &owner, CodeSessionId::new())
+            .await
+            .unwrap()
+            .is_none()
+    );
+}

--- a/crates/tidebreak-desktop/ui/package.json
+++ b/crates/tidebreak-desktop/ui/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-context-menu": "2.3.7",
     "@radix-ui/react-dialog": "1.1.23",
     "@radix-ui/react-dropdown-menu": "2.1.24",
+    "@radix-ui/react-hover-card": "1.1.23",
     "@radix-ui/react-popover": "1.1.23",
     "@radix-ui/react-progress": "1.1.16",
     "@radix-ui/react-radio-group": "1.4.7",

--- a/crates/tidebreak-desktop/ui/pnpm-lock.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: 2.1.24
         version: 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-hover-card':
+        specifier: 1.1.23
+        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-popover':
         specifier: 1.1.23
         version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -785,10 +785,14 @@ describe("app shell", () => {
       const user = userEvent.setup();
       const { router } = await mountApp({ at: "/code" });
 
-      // The registered repo means the rail and the catalog are both up.
-      expect(
-        await screen.findByRole("button", { name: "app" }),
-      ).toBeInTheDocument();
+      // The registered repo means the rail and the catalog are both up: the
+      // rail's empty state renders its "New workspace" line (beside the
+      // toolbar button of the same name) only once repos have loaded.
+      await waitFor(() =>
+        expect(
+          screen.getAllByRole("button", { name: "New workspace" }),
+        ).toHaveLength(2),
+      );
 
       // jsdom reports a non-mac user agent, so the platform's command modifier
       // here is Ctrl — the same chord the app takes as Cmd on macOS.

--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1691,3 +1691,40 @@ describe("archive force kinds", () => {
     expect(archiveForceKind(new HttpError(409, "busy", "session_running"))).toBeNull();
   });
 });
+
+describe("restoring a workspace", () => {
+  it("posts to the restore route and surfaces the error kind", async () => {
+    const workspace = {
+      id: "ws-1",
+      repo_id: "repo-1",
+      title: "Fix login",
+      worktree_path: "/tmp/app/.worktrees/fix-login",
+      branch_name: "tidebreak/fix-login",
+      base_ref: "main",
+      status: "active",
+      created_at: "2026-08-15T00:00:00.000Z",
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(workspace), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    const restored = await client.restoreCodeWorkspace("ws-1");
+    expect(restored.status).toBe("active");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1/code/workspaces/ws-1/restore");
+    expect(init.method).toBe("POST");
+
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ message: "branch is gone", kind: "branch_missing" }),
+        { status: 409 },
+      ),
+    );
+    // The kind travels: the restore runner branches its fallback on it.
+    await expect(client.restoreCodeWorkspace("ws-1")).rejects.toMatchObject({
+      kind: "branch_missing",
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -1886,6 +1886,26 @@ export class ApiClient {
     );
   }
 
+  /**
+   * Reactivate an archived workspace: worktree back at its path, on its kept
+   * branch. 409 kinds `branch_missing` and `worktree_path_occupied` mean a
+   * true restore is impossible; the caller offers the new-workspace fallback.
+   */
+  async restoreCodeWorkspace(workspaceId: string): Promise<CodeWorkspaceSnapshot> {
+    return requireParsed(
+      parseCodeWorkspace(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/restore`,
+          {
+            method: "POST",
+            headers: this.headers(true),
+          },
+        ),
+      ),
+      "code workspace",
+    );
+  }
+
   async listCodeWorkspaceSessions(
     workspaceId: string,
   ): Promise<CodeSessionSnapshot[]> {

--- a/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
@@ -18,6 +18,7 @@ import { CodeSidebar } from "./CodeSidebar";
 import { useCodeUiStore } from "./CodeUiStore";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { WORKSPACE_STATUS_LABELS } from "./labels";
+import { useWorkspaceCardCommands } from "./workspaceActions";
 import { middleTruncate } from "./workspaceCards";
 
 /**
@@ -44,6 +45,7 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
   // The dialog itself is mounted once, by the rail this page renders beside
   // it, so that Cmd+N and the buttons all drive the same one.
   const startNewWorkspace = useCodeUiStore((state) => state.startNewWorkspace);
+  const { run, dialogs } = useWorkspaceCardCommands();
 
   useEffect(() => {
     void refresh(client);
@@ -100,11 +102,12 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
       ) : (
         <ul className="flex flex-col gap-1">
           {listed.map((workspace) => (
-            <li key={workspace.id}>
+            <li key={workspace.id} className="flex items-center gap-1">
               <button
                 type="button"
                 className={cn(
                   "hover:bg-muted flex w-full cursor-pointer items-center justify-between gap-3 rounded-md px-3 py-2 text-left text-sm",
+                  workspace.status === "archived" && "opacity-70",
                   FOCUS_RING,
                   HOVER_TINT,
                 )}
@@ -140,10 +143,25 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
                   {WORKSPACE_STATUS_LABELS[workspace.status]}
                 </span>
               </button>
+              {workspace.status === "archived" && (
+                // A sibling, not a child, of the row button: buttons cannot
+                // nest, and restoring should not also open the workspace.
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0"
+                  aria-label={`Restore ${workspace.title}`}
+                  onClick={() => run("restore", { workspace, title: workspace.title })}
+                >
+                  Restore
+                </Button>
+              )}
             </li>
           ))}
         </ul>
       )}
+      {dialogs}
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
-import { useCodeUiStore } from "./CodeUiStore";
+import { DEFAULT_RAIL_PREFS, useCodeUiStore } from "./CodeUiStore";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeSidebar } from "./CodeSidebar";
 
@@ -125,7 +125,8 @@ afterEach(() => {
   useCodeCatalogStore.getState().reset();
   disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
-  useCodeUiStore.setState({ workspaceSortMode: "by-repo" });
+  useCodeUiStore.setState({ railPrefs: DEFAULT_RAIL_PREFS });
+  window.localStorage.clear();
 });
 
 describe("CodeSidebar", () => {
@@ -140,7 +141,15 @@ describe("CodeSidebar", () => {
     expect(screen.getByRole("radiogroup", { name: "App mode" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Work" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Code" })).toBeInTheDocument();
-    expect(await screen.findByRole("button", { name: "app" })).toBeInTheDocument();
+    // The repo list collapsed into the switcher; the by-repo group header is
+    // now the way into the repo page.
+    expect(
+      await screen.findByRole("button", { name: "Open repo app" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Repos" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Workspace list settings" }),
+    ).toBeInTheDocument();
     // The card's name carries what the glyph rail shows, not just the title.
     expect(
       screen.getByRole("button", { name: "Fix login · app · tidebreak/fix-login" }),
@@ -178,6 +187,36 @@ describe("CodeSidebar", () => {
       "aria-valuetext",
       "91% used",
     );
+  });
+
+  it("re-sorts and persists from the settings popover", async () => {
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    await screen.findByRole("button", { name: "Open repo app" });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Workspace list settings" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("radio", { name: "By created" }),
+    );
+
+    // By-created has no group headers, so the repo header link goes away and
+    // the card grows its repo chip back.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Open repo app" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      JSON.parse(
+        window.localStorage.getItem("tidebreak.code-rail-prefs") ?? "{}",
+      ),
+    ).toMatchObject({ sortMode: "by-created" });
   });
 
   it("opens the workspace context menu from the keyboard and gives focus back", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -1,68 +1,39 @@
 import { useEffect } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import {
-  ChevronRight,
-  CircleAlert,
-  CircleDotDashed,
-  FolderGit2,
-  GitPullRequest,
-  Plus,
-  SquareTerminal,
-} from "lucide-react";
+import { Plus } from "lucide-react";
 
 import { useApp } from "@/AppContext";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
 import { cn } from "@/lib/utils";
 import { useLayoutState } from "@/panel/usePanelNav";
-import { SidebarButton, SidebarSectionTitle } from "@/sidebar/primitives";
 import { SidebarFrame } from "@/sidebar/SidebarFrame";
-import type {
-  CodeSessionDigest,
-  CodeSessionSnapshot,
-  CodeWorkspaceSnapshot,
-  PullRequestDigest,
-} from "../api/types";
-import { AttentionBadge } from "./AttentionBadge";
 import { AddRepoPalette } from "./AddRepoPalette";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { CodeModeSwitch } from "./CodeModeSwitch";
 import { CodeSubscriptionUsage } from "./CodeSubscriptionUsage";
 import { useCodeUiStore } from "./CodeUiStore";
-import { connectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
-import { HARNESS_ICONS } from "./HarnessPicker";
+import { connectCodeUpdates, useCodeUpdatesStore, watchChildren } from "./CodeUpdatesStore";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { RailSettingsMenu } from "./RailSettingsMenu";
+import { RepoSwitcherPopover } from "./RepoSwitcherPopover";
 import {
   useWorkspaceCardCommands,
   workspaceCommands,
-  type WorkspaceCommand,
 } from "./workspaceActions";
-import {
-  arrangeWorkspaces,
-  formatCompactAge,
-  isSessionRowWorthy,
-  middleTruncate,
-  nextWorkspaceSortMode,
-  PR_ICON_TONE_CLASSES,
-  prTone,
-  repoAccentClass,
-  sessionRowLabel,
-  workspaceCardLabel,
-  WORKSPACE_SORT_MODE_LABELS,
-} from "./workspaceCards";
+import { WorkspaceCard } from "./WorkspaceCard";
+import { arrangeWorkspaces } from "./workspaceCards";
 
 /**
- * The code-mode rail: repos, workspace cards, and the Chat/Code switch.
+ * The code-mode rail: one toolbar, then workspace cards.
  *
  * Built on the same frame and primitives as the chat rail so the two modes
  * share chrome. It must not touch chat session stores — that separation is
  * what later convergence merges rather than translates.
+ *
+ * The rail spends no section on the repo catalog: by-repo group headers link
+ * to their repo page, and the toolbar's repo switcher covers the other sort
+ * orders. What each card draws is the reader's `railPrefs` choice; what each
+ * card *says* (the aria-label) never shrinks with those choices.
  *
  * It also hosts code mode's two dialogs. The rail is on screen for every
  * `/code` route, so mounting them here is what makes them reachable from the
@@ -80,7 +51,9 @@ export function CodeSidebar() {
   const sessions = useCodeCatalogStore((state) => state.sessionsByWorkspace);
   const refresh = useCodeCatalogStore((state) => state.refresh);
   const digests = useCodeUpdatesStore((state) => state.byWorkspace);
-  const watchDigests = useCodeUpdatesStore((state) => state.watchByWorkspace);
+  const childrenByWorkspace = useCodeUpdatesStore(
+    (state) => state.childrenByWorkspace,
+  );
   const newWorkspaceOpen = useCodeUiStore((state) => state.newWorkspaceOpen);
   const newWorkspaceRepoId = useCodeUiStore(
     (state) => state.newWorkspaceRepoId,
@@ -91,8 +64,7 @@ export function CodeSidebar() {
     (state) => state.setNewWorkspaceOpen,
   );
   const setAddRepoOpen = useCodeUiStore((state) => state.setAddRepoOpen);
-  const sortMode = useCodeUiStore((state) => state.workspaceSortMode);
-  const setSortMode = useCodeUiStore((state) => state.setWorkspaceSortMode);
+  const prefs = useCodeUiStore((state) => state.railPrefs);
   const { run, dialogs } = useWorkspaceCardCommands();
   const layout = useLayoutState();
   const terminalOpen =
@@ -108,15 +80,22 @@ export function CodeSidebar() {
 
   useEffect(() => connectCodeUpdates(client), [client]);
 
-  const groups = arrangeWorkspaces(sortMode, repos, workspaces, digests);
-  const sortLabel = WORKSPACE_SORT_MODE_LABELS[sortMode];
+  const groups = arrangeWorkspaces(
+    prefs.sortMode,
+    repos,
+    workspaces,
+    digests,
+    { showArchived: prefs.showArchived },
+  );
 
   return (
     <SidebarFrame footer={<CodeSubscriptionUsage />}>
       <CodeModeSwitch />
 
-      <div className="flex items-center justify-between px-2">
-        <SidebarSectionTitle className="px-0">Repos</SidebarSectionTitle>
+      <div className="flex items-center gap-0.5 px-1.5 pb-1">
+        <RepoSwitcherPopover repos={repos} />
+        <div className="flex-1" />
+        <RailSettingsMenu />
         <button
           type="button"
           className={cn(
@@ -124,94 +103,44 @@ export function CodeSidebar() {
             FOCUS_RING,
             HOVER_TINT,
           )}
-          aria-label="Add repo"
-          onClick={() => setAddRepoOpen(true)}
+          aria-label="New workspace"
+          onClick={() => startNewWorkspace()}
         >
           <Plus size={14} />
         </button>
       </div>
-      <div className="flex shrink-0 flex-col gap-0.5">
-        {repos.map((repo) => {
-          const active = pathname === `/code/r/${repo.id}`;
-          return (
-            <SidebarButton
-              key={repo.id}
-              aria-current={active ? "page" : undefined}
-              data-active={active || undefined}
-              className="data-[active]:bg-muted"
-              onClick={() =>
-                void navigate({
-                  to: "/code/r/$repoId",
-                  params: { repoId: repo.id },
-                })
-              }
-            >
-              <FolderGit2 />
-              <span>{repo.display_name}</span>
-            </SidebarButton>
-          );
-        })}
-        {repos.length === 0 && (
-          <SidebarEmptyAction
-            label="Add a repo"
-            onClick={() => setAddRepoOpen(true)}
-          />
-        )}
-      </div>
 
-      <div className="mt-3 flex items-center justify-between gap-1 px-2">
-        <SidebarSectionTitle className="px-0">Workspaces</SidebarSectionTitle>
-        <div className="flex items-center">
-          <button
-            type="button"
-            className={cn(
-              "text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer rounded-md px-1.5 py-1 text-[11px] font-medium",
-              FOCUS_RING,
-              HOVER_TINT,
-            )}
-            aria-label={`Sort workspaces: ${sortLabel}. Activate to cycle.`}
-            onClick={() => setSortMode(nextWorkspaceSortMode(sortMode))}
-          >
-            {sortLabel}
-          </button>
-          <button
-            type="button"
-            className={cn(
-              "text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer rounded-md p-1",
-              FOCUS_RING,
-              HOVER_TINT,
-            )}
-            aria-label="New workspace"
-            onClick={() => startNewWorkspace()}
-          >
-            <Plus size={14} />
-          </button>
-        </div>
-      </div>
       <div className="flex min-h-0 flex-col gap-0.5">
         {groups.map((group) => (
           <div key={group.key} className="flex flex-col gap-0.5">
-            {group.label && (
-              <div
-                className="truncate px-2 pt-2 pb-1 text-[11px] font-medium text-muted-foreground/90"
-                title={group.label}
-              >
-                {group.label}
-              </div>
+            {group.label && group.repoId ? (
+              <GroupHeaderLink
+                label={group.label}
+                active={pathname === `/code/r/${group.repoId}`}
+                onOpen={() =>
+                  void navigate({
+                    to: "/code/r/$repoId",
+                    params: { repoId: group.repoId! },
+                  })
+                }
+              />
+            ) : (
+              group.label && (
+                <div
+                  className="truncate px-2 pt-2 pb-1 text-[11px] font-medium text-muted-foreground/90"
+                  title={group.label}
+                >
+                  {group.key === "archived"
+                    ? `${group.label} · ${group.workspaces.length}`
+                    : group.label}
+                </div>
+              )
             )}
             {group.workspaces.map((workspace) => {
               const digest = digests[workspace.id];
               const pr = digest?.pr_state ?? workspace.pr;
               return (
                 <WorkspaceCard
-                  watch={watchDigests[workspace.id]}
-                  onOpenWatch={(sessionId) =>
-                    void navigate({
-                      to: "/code/w/$workspaceId",
-                      params: { workspaceId: workspace.id },
-                      search: { task: sessionId },
-                    })
-                  }
                   key={workspace.id}
                   workspace={workspace}
                   digest={digest}
@@ -222,6 +151,14 @@ export function CodeSidebar() {
                   }
                   active={pathname === `/code/w/${workspace.id}`}
                   terminalOpen={terminalOpen && viewedWorkspaceId === workspace.id}
+                  density={prefs.density}
+                  visibleMeta={{
+                    // The group header already names the repo in by-repo
+                    // order; the chip would say it twice on every row.
+                    repoChip:
+                      prefs.showRepoChip && prefs.sortMode !== "by-repo",
+                    branch: prefs.showBranch,
+                  }}
                   commands={workspaceCommands({
                     hasPr: Boolean(pr),
                     archived: workspace.status === "archived",
@@ -230,10 +167,21 @@ export function CodeSidebar() {
                       (digest?.attention ?? sessions[workspace.id]?.attention)
                         ?.state.type === "manual",
                   })}
+                  childSessions={watchChildren(
+                    { childrenByWorkspace },
+                    workspace.id,
+                  )}
                   onOpen={() =>
                     void navigate({
                       to: "/code/w/$workspaceId",
                       params: { workspaceId: workspace.id },
+                    })
+                  }
+                  onOpenChildSession={(sessionId) =>
+                    void navigate({
+                      to: "/code/w/$workspaceId",
+                      params: { workspaceId: workspace.id },
+                      search: { task: sessionId },
                     })
                   }
                   onCommand={(command) =>
@@ -249,11 +197,12 @@ export function CodeSidebar() {
             })}
           </div>
         ))}
-        {/*
-          With no repo registered there is nothing to open a workspace on, and
-          the line above already says so. Two dead-end lines stacked read as a
-          broken rail.
-        */}
+        {repos.length === 0 && (
+          <SidebarEmptyAction
+            label="Add a repo"
+            onClick={() => setAddRepoOpen(true)}
+          />
+        )}
         {repos.length > 0 &&
           groups.every((group) => group.workspaces.length === 0) && (
             <SidebarEmptyAction
@@ -272,6 +221,40 @@ export function CodeSidebar() {
       />
       <AddRepoPalette open={addRepoOpen} onOpenChange={setAddRepoOpen} />
     </SidebarFrame>
+  );
+}
+
+/**
+ * A by-repo group header that is also the way into its repo page.
+ *
+ * The old rail spent a whole section restating these names as buttons; the
+ * header was already the label readers scanned, so the header is the control.
+ */
+function GroupHeaderLink({
+  label,
+  active,
+  onOpen,
+}: {
+  label: string;
+  active: boolean;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={`Open repo ${label}`}
+      aria-current={active ? "page" : undefined}
+      data-active={active || undefined}
+      className={cn(
+        "mt-2 cursor-pointer truncate rounded-md px-2 py-1 text-left text-[11px] font-medium text-muted-foreground/90 hover:bg-muted hover:text-foreground data-[active]:text-foreground",
+        FOCUS_RING,
+        HOVER_TINT,
+      )}
+      title={label}
+      onClick={onOpen}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -303,228 +286,4 @@ function SidebarEmptyAction({
       {label}
     </button>
   );
-}
-
-/**
- * One workspace on the expanded rail: title + attention, repo chip + branch,
- * trailing glyphs, and a nested session row when something is live.
- *
- * Exported for Storybook; the rail is its only product caller.
- */
-export function WorkspaceCard({
-  workspace,
-  digest,
-  session,
-  repoName,
-  active,
-  terminalOpen,
-  commands,
-  onOpen,
-  onCommand,
-  watch,
-  onOpenWatch,
-}: {
-  workspace: CodeWorkspaceSnapshot;
-  digest: CodeSessionDigest | undefined;
-  session: CodeSessionSnapshot | undefined;
-  repoName: string;
-  active: boolean;
-  terminalOpen: boolean;
-  commands: WorkspaceCommand[];
-  onOpen: () => void;
-  onCommand: (command: WorkspaceCommand["id"]) => void;
-  /** The workspace's live watch task, when one is running. */
-  watch?: CodeSessionDigest;
-  /** Open the watch task's transcript. */
-  onOpenWatch?: (sessionId: string) => void;
-}) {
-  // The digest restates the title on every notice, so a background rename
-  // lands here without a catalog refresh.
-  const title = digest?.title ?? workspace.title;
-  const pr = digest?.pr_state ?? workspace.pr;
-  const showSession = isSessionRowWorthy(digest);
-  const attentionTitle = cardTooltip(title, digest);
-  const branchShown = middleTruncate(workspace.branch_name, 22);
-  const HarnessIcon = session ? HARNESS_ICONS[session.harness_kind] : null;
-  const age = session?.created_at
-    ? formatCompactAge(session.created_at)
-    : null;
-
-  return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <button
-          type="button"
-          // The card's own text names the workspace; the glyph rail names its
-          // state. One explicit label carries both, in the order the card
-          // reads, so nothing on the rail is pointer-only information.
-          aria-label={workspaceCardLabel({
-            title,
-            repoName,
-            branchName: workspace.branch_name,
-            attention: digest?.attention,
-            pr,
-            terminalOpen,
-          })}
-          aria-current={active ? "page" : undefined}
-          data-active={active || undefined}
-          title={attentionTitle}
-          className={cn(
-            "hover:bg-muted flex w-full cursor-pointer flex-col gap-1 rounded-md px-2 py-1.5 text-left data-[active]:bg-muted",
-            FOCUS_RING,
-            HOVER_TINT,
-          )}
-          onClick={onOpen}
-        >
-          <span className="flex min-w-0 items-center gap-1.5">
-            <AttentionBadge attention={digest?.attention} compact />
-            <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium leading-5">
-              {title}
-            </span>
-            <span className="flex shrink-0 items-center gap-1" aria-hidden>
-              {pr && <PrGlyph pr={pr} />}
-              {terminalOpen && (
-                <SquareTerminal className="size-3 text-muted-foreground" />
-              )}
-              {digest?.attention.state.type === "needs_you" &&
-                digest.attention.state.source === "structured" && (
-                  <CircleAlert className="size-3 text-critical" />
-                )}
-            </span>
-          </span>
-          <span className="flex min-w-0 items-center gap-1.5">
-            <span className="inline-flex min-w-0 max-w-[46%] items-center gap-1 text-[11px] text-muted-foreground">
-              <span
-                className={cn(
-                  "size-1.5 shrink-0 rounded-[2px]",
-                  repoAccentClass(workspace.repo_id),
-                )}
-                aria-hidden
-              />
-              <span className="truncate">{repoName}</span>
-            </span>
-            <span
-              className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground"
-              title={workspace.branch_name}
-            >
-              {branchShown}
-            </span>
-          </span>
-          {showSession && digest && (
-            <span className="flex min-w-0 items-center gap-1.5 pl-0.5 text-[11px] text-muted-foreground">
-              <ChevronRight
-                className="size-3 shrink-0 opacity-50"
-                aria-hidden
-              />
-              {HarnessIcon && (
-                <HarnessIcon className="size-3 shrink-0" />
-              )}
-              <span className="truncate">{sessionRowLabel(digest)}</span>
-              {age && (
-                <span
-                  className="ml-auto shrink-0 tabular-nums"
-                  title={
-                    age === "now"
-                      ? "Session created just now"
-                      : `Session created ${age} ago`
-                  }
-                >
-                  session {age}
-                </span>
-              )}
-            </span>
-          )}
-        </button>
-      </ContextMenuTrigger>
-      <ContextMenuContent>
-        {commands.map((command) => (
-          <WorkspaceMenuItem
-            key={command.id}
-            command={command}
-            onSelect={() => onCommand(command.id)}
-          />
-        ))}
-      </ContextMenuContent>
-      {watch && (
-        <button
-          type="button"
-          className={cn(
-            "hover:bg-muted mt-0.5 ml-4 flex w-[calc(100%-1rem)] cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-left text-[11px] text-muted-foreground",
-            FOCUS_RING,
-            HOVER_TINT,
-          )}
-          aria-label={`Open watch task ${watchTaskName(watch)}`}
-          title={watchRowTooltip(watch)}
-          data-testid="workspace-watch-row"
-          onClick={() => onOpenWatch?.(watch.session)}
-        >
-          <CircleDotDashed
-            className={cn(
-              "size-3 shrink-0",
-              watch.attention.state.type === "needs_you"
-                ? "text-critical"
-                : "text-info-foreground",
-            )}
-            aria-hidden
-          />
-          <span className="min-w-0 flex-1 truncate">
-            {watchTaskName(watch)}
-          </span>
-          <AttentionBadge attention={watch.attention} compact />
-        </button>
-      )}
-    </ContextMenu>
-  );
-}
-
-/** The fork's name: what the watch was asked to do, not a session id. */
-function watchTaskName(watch: CodeSessionDigest): string {
-  const number = watch.pr_state?.number;
-  return number ? `Fix PR #${number}` : "Watch and fix";
-}
-
-function watchRowTooltip(watch: CodeSessionDigest): string {
-  const name = watchTaskName(watch);
-  return `${name} — forked from this workspace's conversation. ${
-    watch.lifecycle === "running" ? "A fix turn is running." : "Watching."
-  }`;
-}
-
-function WorkspaceMenuItem({
-  command,
-  onSelect,
-}: {
-  command: WorkspaceCommand;
-  onSelect: () => void;
-}) {
-  return (
-    <>
-      {command.separated && <ContextMenuSeparator />}
-      <ContextMenuItem
-        variant={command.destructive ? "destructive" : "default"}
-        onSelect={onSelect}
-      >
-        {command.label}
-      </ContextMenuItem>
-    </>
-  );
-}
-
-/** PR-state mark. The card's own label carries the number and state. */
-function PrGlyph({ pr }: { pr: PullRequestDigest }) {
-  const tone = prTone(pr);
-  return (
-    <GitPullRequest
-      className={cn("size-3", PR_ICON_TONE_CLASSES[tone])}
-      data-pr-state={tone}
-    />
-  );
-}
-
-function cardTooltip(
-  title: string,
-  digest: CodeSessionDigest | undefined,
-): string {
-  if (!digest || digest.attention.state.type === "working") return title;
-  return `${title} · ${digest.attention.state.type === "needs_you" ? digest.attention.state.prompt || "Needs you" : sessionRowLabel(digest)}`;
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -3,14 +3,39 @@ import { create } from "zustand";
 import type { HarnessKind } from "../api/types";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import {
+  isCardDensity,
   isWorkspaceSortMode,
+  type CardDensity,
   type WorkspaceSortMode,
 } from "./workspaceCards";
 
 const REVIEW_SIDEBAR_OPEN_KEY = "tidebreak.code-review-sidebar-open";
 const LAST_CREATE_KEY = "tidebreak.code-last-create";
 const WORKSPACE_SORT_KEY = "tidebreak.code-workspace-sort";
+const RAIL_PREFS_KEY = "tidebreak.code-rail-prefs";
 const TERMINAL_DRAWER_HEIGHTS_KEY = "tidebreak.code-terminal-drawer-heights";
+
+/**
+ * How the reader shaped the workspace rail: order, card density, which meta
+ * the cards draw, and whether the archived shelf shows. One blob, one writer —
+ * per-key storage is how preferences drift into half-migrated states.
+ */
+export type CodeRailPrefs = {
+  sortMode: WorkspaceSortMode;
+  density: CardDensity;
+  /** Suppressed per-card in by-repo order regardless; this is the reader's say. */
+  showRepoChip: boolean;
+  showBranch: boolean;
+  showArchived: boolean;
+};
+
+export const DEFAULT_RAIL_PREFS: CodeRailPrefs = {
+  sortMode: "by-repo",
+  density: "detailed",
+  showRepoChip: true,
+  showBranch: false,
+  showArchived: false,
+};
 
 /** What the reader picked the last time they created a workspace. */
 export type CodeCreateDefaults = {
@@ -85,12 +110,47 @@ function readStoredWorkspaceSort(): WorkspaceSortMode {
   } catch {
     // Preference persistence is best-effort.
   }
-  return "by-repo";
+  return DEFAULT_RAIL_PREFS.sortMode;
 }
 
-function storeWorkspaceSort(mode: WorkspaceSortMode): void {
+/**
+ * Field-wise: a blob written by a newer build with one more key must not
+ * knock the known fields back to defaults. When no blob exists yet, the
+ * legacy sort key (the only rail pref that predates the blob) seeds it.
+ */
+function readStoredRailPrefs(): CodeRailPrefs {
   try {
-    window.localStorage.setItem(WORKSPACE_SORT_KEY, mode);
+    const raw = window.localStorage.getItem(RAIL_PREFS_KEY);
+    if (!raw) {
+      return { ...DEFAULT_RAIL_PREFS, sortMode: readStoredWorkspaceSort() };
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return DEFAULT_RAIL_PREFS;
+    const record = parsed as Record<string, unknown>;
+    const flag = (value: unknown, fallback: boolean) =>
+      typeof value === "boolean" ? value : fallback;
+    return {
+      sortMode:
+        typeof record.sortMode === "string" &&
+        isWorkspaceSortMode(record.sortMode)
+          ? record.sortMode
+          : DEFAULT_RAIL_PREFS.sortMode,
+      density:
+        typeof record.density === "string" && isCardDensity(record.density)
+          ? record.density
+          : DEFAULT_RAIL_PREFS.density,
+      showRepoChip: flag(record.showRepoChip, DEFAULT_RAIL_PREFS.showRepoChip),
+      showBranch: flag(record.showBranch, DEFAULT_RAIL_PREFS.showBranch),
+      showArchived: flag(record.showArchived, DEFAULT_RAIL_PREFS.showArchived),
+    };
+  } catch {
+    return DEFAULT_RAIL_PREFS;
+  }
+}
+
+function storeRailPrefs(prefs: CodeRailPrefs): void {
+  try {
+    window.localStorage.setItem(RAIL_PREFS_KEY, JSON.stringify(prefs));
   } catch {
     // Preference persistence is best-effort.
   }
@@ -153,7 +213,7 @@ export type CodeUiStore = {
   reviewSidebarOpen: boolean;
   /** Files and diff scoped to one turn, or the whole worktree when null. */
   inspectorScope: InspectorScope | null;
-  workspaceSortMode: WorkspaceSortMode;
+  railPrefs: CodeRailPrefs;
   lastCreate: CodeCreateDefaults | null;
   /** Per-workspace terminal drawer height, remembered across reloads. */
   terminalDrawerHeights: Record<string, number>;
@@ -170,7 +230,7 @@ export type CodeUiStore = {
   toggleReviewSidebar: () => void;
   setReviewSidebarOpen: (open: boolean) => void;
   setInspectorScope: (scope: InspectorScope | null) => void;
-  setWorkspaceSortMode: (mode: WorkspaceSortMode) => void;
+  setRailPrefs: (patch: Partial<CodeRailPrefs>) => void;
   /** Record a successful create so the next dialog opens on the same choices. */
   rememberCreate: (defaults: CodeCreateDefaults) => void;
   setTerminalDrawerHeight: (workspaceId: string, height: number) => void;
@@ -193,7 +253,7 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   addRepoOpen: false,
   reviewSidebarOpen: readStoredReviewSidebarOpen(),
   inspectorScope: null,
-  workspaceSortMode: readStoredWorkspaceSort(),
+  railPrefs: readStoredRailPrefs(),
   lastCreate: readStoredCreateDefaults(),
   terminalDrawerHeights: readStoredTerminalDrawerHeights(),
   pendingComposerPrompt: null,
@@ -249,10 +309,12 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
     set({ reviewSidebarOpen: open });
   },
   setInspectorScope: (inspectorScope) => set({ inspectorScope }),
-  setWorkspaceSortMode: (mode) => {
-    storeWorkspaceSort(mode);
-    set({ workspaceSortMode: mode });
-  },
+  setRailPrefs: (patch) =>
+    set((state) => {
+      const railPrefs = { ...state.railPrefs, ...patch };
+      storeRailPrefs(railPrefs);
+      return { railPrefs };
+    }),
   rememberCreate: (defaults) => {
     storeCreateDefaults(defaults);
     set({ lastCreate: defaults });

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -6,6 +6,8 @@ import {
   reduceCodeUpdates,
   shouldRequestOsAttention,
   useCodeUpdatesStore,
+  watchChildren,
+  type CodeUpdatesState,
 } from "./CodeUpdatesStore";
 
 const working: Attention = { state: { type: "working" }, source: "lifecycle" };
@@ -27,6 +29,13 @@ function digest(overrides: Partial<CodeSessionDigest> = {}): CodeSessionDigest {
   };
 }
 
+const EMPTY_STATE: CodeUpdatesState = {
+  byWorkspace: {},
+  childrenByWorkspace: {},
+  cloneJobs: {},
+  viewedWorkspaceId: null,
+};
+
 afterEach(() => {
   useCodeUpdatesStore.getState().reset();
   vi.restoreAllMocks();
@@ -34,8 +43,7 @@ afterEach(() => {
 
 describe("reduceCodeUpdates", () => {
   it("replaces the map on snapshot and upserts a digest", () => {
-    const empty = { byWorkspace: {}, watchByWorkspace: {}, cloneJobs: {}, viewedWorkspaceId: null };
-    const afterSnapshot = reduceCodeUpdates(empty, {
+    const afterSnapshot = reduceCodeUpdates(EMPTY_STATE, {
       type: "snapshot",
       sessions: [digest(), digest({ workspace: "ws-2", session: "sess-2", title: "other" })],
     });
@@ -54,34 +62,54 @@ describe("reduceCodeUpdates", () => {
     expect(Object.keys(restated.byWorkspace)).toEqual(["ws-3"]);
   });
 
-  it("never lets a watch session displace the interactive digest", () => {
-    const empty = { byWorkspace: {}, watchByWorkspace: {}, cloneJobs: {}, viewedWorkspaceId: null };
-    const seeded = reduceCodeUpdates(empty, {
+  it("keeps watch digests beside the conversation, never in its slot", () => {
+    const seeded = reduceCodeUpdates(EMPTY_STATE, {
       type: "snapshot",
       sessions: [
         digest(),
         digest({ session: "sess-watch", kind: "watch", lifecycle: "running" }),
       ],
     });
+    // ADR 0050: the interactive digest keeps the workspace slot.
     expect(seeded.byWorkspace["ws-1"].session).toBe("sess-1");
-    expect(seeded.watchByWorkspace["ws-1"].session).toBe("sess-watch");
+    expect(watchChildren(seeded, "ws-1").map((child) => child.session)).toEqual([
+      "sess-watch",
+    ]);
+
     const afterWatchDigest = reduceCodeUpdates(seeded, {
-      type: "digest",
-      digest: digest({ session: "sess-watch", kind: "watch", turn_count: 5 }),
-    });
-    expect(afterWatchDigest.byWorkspace["ws-1"].session).toBe("sess-1");
-    expect(afterWatchDigest.byWorkspace["ws-1"].turn_count).toBe(0);
-    expect(afterWatchDigest.watchByWorkspace["ws-1"].turn_count).toBe(5);
-    const afterEnd = reduceCodeUpdates(afterWatchDigest, {
       type: "digest",
       digest: digest({
         session: "sess-watch",
         kind: "watch",
-        lifecycle: "ended",
+        lifecycle: "running",
+        turn_count: 5,
       }),
     });
-    expect(afterEnd.watchByWorkspace["ws-1"]).toBeUndefined();
-    expect(afterEnd.byWorkspace["ws-1"].session).toBe("sess-1");
+    expect(afterWatchDigest.byWorkspace["ws-1"].session).toBe("sess-1");
+    expect(afterWatchDigest.byWorkspace["ws-1"].turn_count).toBe(0);
+    expect(watchChildren(afterWatchDigest, "ws-1")[0]?.turn_count).toBe(5);
+  });
+
+  it("drops an ended watch child and rebuilds children on snapshot", () => {
+    const seeded = reduceCodeUpdates(EMPTY_STATE, {
+      type: "snapshot",
+      sessions: [
+        digest(),
+        digest({ session: "sess-watch", kind: "watch", lifecycle: "running" }),
+      ],
+    });
+    const ended = reduceCodeUpdates(seeded, {
+      type: "digest",
+      digest: digest({ session: "sess-watch", kind: "watch", lifecycle: "ended" }),
+    });
+    expect(watchChildren(ended, "ws-1")).toEqual([]);
+
+    // A reconnect snapshot that no longer lists the watch heals a missed end.
+    const healed = reduceCodeUpdates(seeded, {
+      type: "snapshot",
+      sessions: [digest()],
+    });
+    expect(watchChildren(healed, "ws-1")).toEqual([]);
   });
 
   it("maps notices onto reducer actions", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -25,9 +25,14 @@ import { requestUserAttention } from "../host";
  */
 
 export type CodeUpdatesState = {
+  /** The interactive session's digest, one per workspace. Never a watch. */
   byWorkspace: Record<string, CodeSessionDigest>;
-  /** Live watch-task sessions, one per workspace, beside the conversation. */
-  watchByWorkspace: Record<string, CodeSessionDigest>;
+  /**
+   * Watch digests, keyed workspace → session. Children beside the
+   * conversation, never in its slot — ADR 0050's rule, kept by construction:
+   * the two maps have disjoint sources.
+   */
+  childrenByWorkspace: Record<string, Record<string, CodeSessionDigest>>;
   cloneJobs: Record<string, CodeCloneJobSnapshot>;
   viewedWorkspaceId: string | null;
 };
@@ -41,7 +46,7 @@ export type CodeUpdatesAction =
 
 const EMPTY: CodeUpdatesState = {
   byWorkspace: {},
-  watchByWorkspace: {},
+  childrenByWorkspace: {},
   cloneJobs: {},
   viewedWorkspaceId: null,
 };
@@ -52,33 +57,31 @@ export function reduceCodeUpdates(
 ): CodeUpdatesState {
   switch (action.type) {
     case "snapshot": {
-      // Two digests per workspace at most: the conversation, and its watch
-      // task. A watch session never displaces the conversation the list
-      // surfaces show; it is the workspace's child task.
+      // The snapshot restates every live session, so both maps rebuild from
+      // scratch — a reconnect self-heals a missed end notice.
       const byWorkspace: Record<string, CodeSessionDigest> = {};
-      const watchByWorkspace: Record<string, CodeSessionDigest> = {};
+      const childrenByWorkspace: Record<
+        string,
+        Record<string, CodeSessionDigest>
+      > = {};
       for (const digest of action.sessions) {
         if (digest.kind === "watch") {
-          watchByWorkspace[digest.workspace] = digest;
+          (childrenByWorkspace[digest.workspace] ??= {})[digest.session] =
+            digest;
         } else {
           byWorkspace[digest.workspace] = digest;
         }
       }
-      return { ...state, byWorkspace, watchByWorkspace };
+      return { ...state, byWorkspace, childrenByWorkspace };
     }
-    case "digest":
+    case "digest": {
       if (action.digest.kind === "watch") {
-        if (action.digest.lifecycle === "ended") {
-          const { [action.digest.workspace]: _ended, ...watchByWorkspace } =
-            state.watchByWorkspace;
-          return { ...state, watchByWorkspace };
-        }
         return {
           ...state,
-          watchByWorkspace: {
-            ...state.watchByWorkspace,
-            [action.digest.workspace]: action.digest,
-          },
+          childrenByWorkspace: upsertChild(
+            state.childrenByWorkspace,
+            action.digest,
+          ),
         };
       }
       return {
@@ -88,6 +91,7 @@ export function reduceCodeUpdates(
           [action.digest.workspace]: action.digest,
         },
       };
+    }
     case "clone_progress":
       return {
         ...state,
@@ -101,6 +105,38 @@ export function reduceCodeUpdates(
     case "reset":
       return { ...EMPTY, viewedWorkspaceId: state.viewedWorkspaceId };
   }
+}
+
+function upsertChild(
+  children: CodeUpdatesState["childrenByWorkspace"],
+  digest: CodeSessionDigest,
+): CodeUpdatesState["childrenByWorkspace"] {
+  const forWorkspace = { ...children[digest.workspace] };
+  if (digest.lifecycle === "ended") {
+    // An ended watch leaves the rail; the snapshot on reconnect would drop
+    // it anyway, this just does it without waiting for one.
+    delete forWorkspace[digest.session];
+  } else {
+    forWorkspace[digest.session] = digest;
+  }
+  if (Object.keys(forWorkspace).length === 0) {
+    const next = { ...children };
+    delete next[digest.workspace];
+    return next;
+  }
+  return { ...children, [digest.workspace]: forWorkspace };
+}
+
+/** A workspace's watch digests, in a stable order for rendering. */
+export function watchChildren(
+  state: Pick<CodeUpdatesState, "childrenByWorkspace">,
+  workspaceId: string,
+): CodeSessionDigest[] {
+  const children = state.childrenByWorkspace[workspaceId];
+  if (!children) return [];
+  return Object.values(children).sort((left, right) =>
+    left.session.localeCompare(right.session),
+  );
 }
 
 /** True when a digest transition should poke the OS attention affordance. */
@@ -137,6 +173,15 @@ export function noticeToAction(notice: CodeUpdateNotice): CodeUpdatesAction | nu
         title: notice.title,
         turn_count: notice.turn_count,
         ...(notice.pr_state !== undefined ? { pr_state: notice.pr_state } : {}),
+        ...(notice.watch_state !== undefined
+          ? { watch_state: notice.watch_state }
+          : {}),
+        ...(notice.watch_detail !== undefined
+          ? { watch_detail: notice.watch_detail }
+          : {}),
+        ...(notice.watch_cycles !== undefined
+          ? { watch_cycles: notice.watch_cycles }
+          : {}),
       },
     };
   }
@@ -167,7 +212,9 @@ export const useCodeUpdatesStore = create<CodeUpdatesStore>()((set, get) => ({
   apply: (action) => {
     const previous = get();
     const next = reduceCodeUpdates(previous, action);
-    if (action.type === "digest") {
+    // OS attention stays keyed to the conversation: a watch child's state
+    // change would compare against the interactive digest and misfire.
+    if (action.type === "digest" && action.digest.kind !== "watch") {
       maybeNotify(previous, action.digest);
     }
     set(next);

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -411,7 +411,9 @@ async function mountWorkspace(
   const codeWorkspaceRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/code/w/$workspaceId",
-    validateSearch: (search: Record<string, unknown>): PanelSearch => ({
+    validateSearch: (
+      search: Record<string, unknown>,
+    ): PanelSearch => ({
       tabs: typeof search.tabs === "string" ? search.tabs : undefined,
       active: typeof search.active === "string" ? search.active : undefined,
       fullscreen:
@@ -755,6 +757,33 @@ describe("CodeWorkspacePage", () => {
     expect(
       screen.queryByRole("heading", { name: /Fix login/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it("force-archives with one confirm and force=true from the header menu", async () => {
+    const client = makeClient();
+    const { router } = await mountWorkspace(client);
+    const user = userEvent.setup();
+
+    expect(
+      await screen.findByRole("heading", { name: /Fix login/ }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Workspace actions" }));
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: "Force archive (discard changes)",
+      }),
+    );
+    const confirmation = await screen.findByRole("alertdialog");
+    expect(confirmation).toHaveTextContent("Discard changes and archive?");
+    await user.click(
+      within(confirmation).getByRole("button", { name: "Discard and archive" }),
+    );
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/r/repo-1"),
+    );
+    expect(client.archiveCodeWorkspace).toHaveBeenCalledWith("ws-1", true);
   });
 
   it("keeps git and comments in the review sidebar, and opens the terminal as a drawer", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/RailSettingsMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RailSettingsMenu.tsx
@@ -1,0 +1,134 @@
+import { SlidersHorizontal } from "lucide-react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  SegmentedControl,
+  type SegmentedOption,
+} from "@/components/ui/segmented";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { useCodeUiStore, type CodeRailPrefs } from "./CodeUiStore";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
+import {
+  CARD_DENSITIES,
+  CARD_DENSITY_LABELS,
+  WORKSPACE_SORT_MODE_LABELS,
+  WORKSPACE_SORT_MODES,
+} from "./workspaceCards";
+
+/**
+ * The rail's one settings surface: order, density, card meta, archived shelf.
+ *
+ * A popover with real controls, not a menu: sort and density are radio
+ * choices and the meta rows are switches, none of which a `DropdownMenu`
+ * models without faking. Every control writes through `setRailPrefs`, so a
+ * choice made here is the choice every window opens with.
+ */
+
+const SORT_OPTIONS: readonly SegmentedOption<
+  CodeRailPrefs["sortMode"]
+>[] = WORKSPACE_SORT_MODES.map((mode) => ({
+  value: mode,
+  label: WORKSPACE_SORT_MODE_LABELS[mode],
+}));
+
+const DENSITY_OPTIONS: readonly SegmentedOption<
+  CodeRailPrefs["density"]
+>[] = CARD_DENSITIES.map((density) => ({
+  value: density,
+  label: CARD_DENSITY_LABELS[density],
+}));
+
+export function RailSettingsMenu() {
+  const prefs = useCodeUiStore((state) => state.railPrefs);
+  const setRailPrefs = useCodeUiStore((state) => state.setRailPrefs);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer rounded-md p-1",
+            FOCUS_RING,
+            HOVER_TINT,
+          )}
+          aria-label="Workspace list settings"
+        >
+          <SlidersHorizontal size={14} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        className="flex w-60 flex-col gap-3 p-3"
+      >
+        <div className="flex flex-col gap-1.5">
+          <span className="text-[11px] font-medium text-muted-foreground">
+            Sort
+          </span>
+          <SegmentedControl
+            aria-label="Sort workspaces"
+            value={prefs.sortMode}
+            onValueChange={(sortMode) => setRailPrefs({ sortMode })}
+            options={SORT_OPTIONS}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <span className="text-[11px] font-medium text-muted-foreground">
+            Cards
+          </span>
+          <SegmentedControl
+            aria-label="Card density"
+            value={prefs.density}
+            onValueChange={(density) => setRailPrefs({ density })}
+            options={DENSITY_OPTIONS}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <PrefSwitch
+            label="Repo on cards"
+            checked={prefs.showRepoChip}
+            onCheckedChange={(showRepoChip) => setRailPrefs({ showRepoChip })}
+          />
+          <PrefSwitch
+            label="Branch on cards"
+            checked={prefs.showBranch}
+            onCheckedChange={(showBranch) => setRailPrefs({ showBranch })}
+          />
+          <PrefSwitch
+            label="Show archived"
+            checked={prefs.showArchived}
+            onCheckedChange={(showArchived) => setRailPrefs({ showArchived })}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function PrefSwitch({
+  label,
+  checked,
+  onCheckedChange,
+}: {
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center justify-between gap-3 text-[13px]">
+      <span>{label}</span>
+      <Switch
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        aria-label={label}
+      />
+    </label>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/RepoSwitcherPopover.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepoSwitcherPopover.dom.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { renderWithRouter } from "@/test/router";
+import type { CodeRepoSnapshot } from "../api/types";
+import { useCodeUiStore } from "./CodeUiStore";
+import { RepoSwitcherPopover } from "./RepoSwitcherPopover";
+
+function repo(id: string, name: string): CodeRepoSnapshot {
+  return {
+    id,
+    root_path: `/tmp/${id}`,
+    display_name: name,
+    default_base_ref: "main",
+    branch_prefix: "tidebreak",
+    quick_actions: [],
+    created_at: "2026-08-15T00:00:00.000Z",
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  useCodeUiStore.setState({ addRepoOpen: false });
+});
+
+describe("RepoSwitcherPopover", () => {
+  it("filters, navigates from the keyboard, and offers Add repo", async () => {
+    const user = userEvent.setup();
+    const { router } = await renderWithRouter(
+      <RepoSwitcherPopover repos={[repo("r-app", "app"), repo("r-lib", "lib")]} />,
+      { initialUrl: "/code" },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Repos" }));
+    const input = await screen.findByPlaceholderText("Find a repo");
+
+    await user.type(input, "li");
+    expect(screen.queryByRole("option", { name: /app/ })).not.toBeInTheDocument();
+    await user.keyboard("{Enter}");
+    expect(router.state.location.pathname).toBe("/code/r/r-lib");
+  });
+
+  it("opens the add-repo flow from the pinned row", async () => {
+    const user = userEvent.setup();
+    await renderWithRouter(
+      <RepoSwitcherPopover repos={[repo("r-app", "app")]} />,
+      { initialUrl: "/code" },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Repos" }));
+    await user.click(await screen.findByRole("option", { name: "Add repo…" }));
+    expect(useCodeUiStore.getState().addRepoOpen).toBe(true);
+  });
+
+  it("names the current repo on the trigger", async () => {
+    await renderWithRouter(
+      <RepoSwitcherPopover repos={[repo("r-app", "app")]} />,
+      { initialUrl: "/code/r/r-app" },
+    );
+    expect(
+      screen.getByRole("button", { name: "Switch repo (current: app)" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/RepoSwitcherPopover.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepoSwitcherPopover.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useState, type KeyboardEvent } from "react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { ChevronDown, FolderGit2, Plus } from "lucide-react";
+
+import {
+  OptionListbox,
+  optionElementId,
+  type OptionRow,
+} from "@/components/OptionListbox";
+import { SearchInput } from "@/components/SearchInput";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { CodeRepoSnapshot } from "../api/types";
+import { useCodeUiStore } from "./CodeUiStore";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
+import { codeRepoIdFromPath } from "./routes";
+
+const LIST_ID = "repo-switcher-list";
+
+/**
+ * Repo navigation, folded into one button.
+ *
+ * The rail used to spend a whole section on the repo list; every row of it
+ * repeated what the by-repo group headers already say. This keeps repo pages
+ * one click away in every sort mode: the trigger names the repo you are in
+ * (or "Repos" when you are not in one), the popover is a searchable list, and
+ * "Add repo" lives at the bottom — the same spot the old section's `+` served.
+ *
+ * The search input owns the keyboard and drives the listbox through
+ * `aria-activedescendant`, the same contract `AddRepoPalette` uses.
+ */
+export function RepoSwitcherPopover({
+  repos,
+}: {
+  repos: readonly CodeRepoSnapshot[];
+}) {
+  const navigate = useNavigate();
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const setAddRepoOpen = useCodeUiStore((state) => state.setAddRepoOpen);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const activeRepoId = codeRepoIdFromPath(pathname);
+  const activeRepo = repos.find((repo) => repo.id === activeRepoId);
+
+  const rows = useMemo<OptionRow[]>(() => {
+    const trimmed = query.trim().toLowerCase();
+    const listed = repos.filter(
+      (repo) =>
+        trimmed.length === 0 ||
+        repo.display_name.toLowerCase().includes(trimmed),
+    );
+    return [
+      ...listed.map((repo) => ({
+        key: repo.id,
+        label: repo.display_name,
+        icon: FolderGit2,
+        hint: repo.id === activeRepoId ? "current" : undefined,
+      })),
+      { key: "add-repo", label: "Add repo…", icon: Plus },
+    ];
+  }, [repos, query, activeRepoId]);
+
+  function reset() {
+    setQuery("");
+    setActiveIndex(0);
+  }
+
+  function pick(index: number) {
+    const row = rows[index];
+    if (!row) return;
+    setOpen(false);
+    reset();
+    if (row.key === "add-repo") {
+      setAddRepoOpen(true);
+      return;
+    }
+    void navigate({ to: "/code/r/$repoId", params: { repoId: row.key } });
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1) % rows.length);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => (index - 1 + rows.length) % rows.length);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      pick(activeIndex);
+    }
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) reset();
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-[13px] font-medium hover:bg-muted",
+            FOCUS_RING,
+            HOVER_TINT,
+          )}
+          aria-label={
+            activeRepo ? `Switch repo (current: ${activeRepo.display_name})` : "Repos"
+          }
+        >
+          <FolderGit2 className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate">
+            {activeRepo ? activeRepo.display_name : "Repos"}
+          </span>
+          <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="bottom"
+        align="start"
+        sideOffset={6}
+        className="flex w-64 flex-col gap-0 overflow-hidden p-0"
+        onKeyDown={onKeyDown}
+      >
+        <div className="border-b p-2">
+          <SearchInput
+            size="sm"
+            value={query}
+            onValueChange={(next) => {
+              setQuery(next);
+              setActiveIndex(0);
+            }}
+            placeholder="Find a repo"
+            aria-controls={LIST_ID}
+            aria-activedescendant={
+              rows[activeIndex]
+                ? optionElementId(LIST_ID, activeIndex)
+                : undefined
+            }
+          />
+        </div>
+        <OptionListbox
+          listId={LIST_ID}
+          label="Repos"
+          rows={rows}
+          activeIndex={activeIndex}
+          note={repos.length === 0 ? "No repos registered yet." : null}
+          onPick={pick}
+          onHighlight={setActiveIndex}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { workspaceCommands } from "./workspaceActions";
+import { WorkspaceCard } from "./WorkspaceCard";
+import type {
+  CodeSessionDigest,
+  CodeWorkspaceSnapshot,
+  PullRequestDigest,
+} from "../api/types";
+
+const workspace: CodeWorkspaceSnapshot = {
+  id: "ws-1",
+  repo_id: "repo-1",
+  title: "Fix login",
+  worktree_path: "/tmp/app/.worktrees/fix-login",
+  branch_name: "tidebreak/fix-login",
+  base_ref: "main",
+  status: "active",
+  created_at: "2026-08-15T00:00:00.000Z",
+};
+
+const pr: PullRequestDigest = {
+  number: 184,
+  url: "https://github.com/example/app/pull/184",
+  state: "open",
+  checks_summary: "8 passing, 1 pending",
+};
+
+afterEach(cleanup);
+
+function renderCard(overrides?: {
+  workspace?: Partial<CodeWorkspaceSnapshot>;
+  pr?: PullRequestDigest;
+  density?: "compact" | "detailed";
+  visibleMeta?: { repoChip: boolean; branch: boolean };
+  detailDefaultOpen?: boolean;
+}) {
+  const onOpen = vi.fn();
+  const onCommand = vi.fn();
+  const merged = {
+    ...workspace,
+    ...overrides?.workspace,
+    pr: overrides?.pr,
+  };
+  render(
+    <WorkspaceCard
+      workspace={merged}
+      digest={undefined}
+      session={undefined}
+      repoName="app"
+      active={false}
+      terminalOpen={false}
+      density={overrides?.density ?? "detailed"}
+      visibleMeta={overrides?.visibleMeta ?? { repoChip: true, branch: false }}
+      commands={workspaceCommands({
+        hasPr: Boolean(overrides?.pr),
+        archived: merged.status === "archived",
+      })}
+      detailDefaultOpen={overrides?.detailDefaultOpen}
+      onOpen={onOpen}
+      onCommand={onCommand}
+    />,
+  );
+  return { onOpen, onCommand };
+}
+
+describe("WorkspaceCard", () => {
+  it("opens the workspace from the row", async () => {
+    const user = userEvent.setup();
+    const { onOpen } = renderCard();
+
+    await user.click(
+      screen.getByRole("button", { name: "Fix login · app · tidebreak/fix-login" }),
+    );
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps one menu: right-click carries every command", async () => {
+    const user = userEvent.setup();
+    const { onCommand } = renderCard({ pr });
+
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: /^Fix login/ }),
+    );
+    const menu = await screen.findByRole("menu");
+    expect(menu).toHaveTextContent("Open pull request");
+    expect(menu).toHaveTextContent("Archive");
+    await user.click(
+      screen.getByRole("menuitem", { name: "Toggle terminal" }),
+    );
+    expect(onCommand).toHaveBeenCalledWith("toggle-terminal");
+  });
+
+  it("puts the PR and its action in the detail panel, not the row", async () => {
+    const user = userEvent.setup();
+    const { onOpen, onCommand } = renderCard({ pr, detailDefaultOpen: true });
+
+    // The panel says what the row cannot: full branch, checks, the PR.
+    expect(screen.getByText("tidebreak/fix-login")).toBeInTheDocument();
+    expect(screen.getByText("8 passing, 1 pending")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Open pull request #184" }),
+    );
+    expect(onCommand).toHaveBeenCalledWith("open-pr");
+    // Panel actions never double as "open the workspace".
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("leads an archived workspace's panel with Restore", async () => {
+    const user = userEvent.setup();
+    const { onCommand } = renderCard({
+      workspace: { status: "archived", archived_at: "2026-08-18T00:00:00.000Z" },
+      detailDefaultOpen: true,
+    });
+
+    expect(screen.getByText("Archived")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Restore" }));
+    expect(onCommand).toHaveBeenCalledWith("restore");
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: /^Fix login/ }));
+    const menu = await screen.findByRole("menu");
+    expect(menu).toHaveTextContent("Restore workspace");
+    expect(menu).not.toHaveTextContent("Toggle terminal");
+  });
+
+  it("shows meta per view and keeps the label complete without it", () => {
+    renderCard({ visibleMeta: { repoChip: false, branch: false } });
+
+    // Repo and branch stay in the accessible name even when nothing meta is
+    // drawn on the row.
+    expect(screen.queryByText("app")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("tidebreak/fix-login"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Fix login · app · tidebreak/fix-login" }),
+    ).toBeInTheDocument();
+  });
+
+  it("compact keeps the one-line read and the complete label", () => {
+    renderCard({ density: "compact" });
+
+    expect(screen.queryByText("app")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Fix login · app · tidebreak/fix-login" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a watch task as its own clickable child row", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    const onOpenChildSession = vi.fn();
+    const child: CodeSessionDigest = {
+      workspace: workspace.id,
+      session: "sess-watch",
+      kind: "watch",
+      lifecycle: "running",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      title: workspace.title,
+      turn_count: 2,
+    };
+    render(
+      <WorkspaceCard
+        workspace={workspace}
+        digest={undefined}
+        session={undefined}
+        repoName="app"
+        active={false}
+        terminalOpen={false}
+        density="detailed"
+        visibleMeta={{ repoChip: true, branch: false }}
+        commands={workspaceCommands({ hasPr: false, archived: false })}
+        childSessions={[child]}
+        onOpen={onOpen}
+        onCommand={vi.fn()}
+        onOpenChildSession={onOpenChildSession}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Watch task for Fix login: Running" }),
+    );
+    expect(onOpenChildSession).toHaveBeenCalledWith("sess-watch");
+    // The child row is a sibling of the row button; opening it must not
+    // also open the workspace.
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -1,0 +1,407 @@
+import { useState } from "react";
+import { CircleAlert, CornerDownRight, ExternalLink, Eye, GitPullRequest, SquareTerminal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { cn } from "@/lib/utils";
+import type {
+  CodeSessionDigest,
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+  PullRequestDigest,
+} from "../api/types";
+import { AttentionBadge } from "./AttentionBadge";
+import { HARNESS_ICONS } from "./HarnessPicker";
+import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+import type { WorkspaceCommand } from "./workspaceActions";
+import {
+  formatCompactAge,
+  isSessionRowWorthy,
+  middleTruncate,
+  PR_CHIP_TONE_CLASSES,
+  PR_ICON_TONE_CLASSES,
+  prTone,
+  prToneLabel,
+  repoAccentClass,
+  sessionRowLabel,
+  watchRowLabel,
+  workspaceCardLabel,
+  type CardDensity,
+} from "./workspaceCards";
+
+/**
+ * One workspace on the rail, in three layers with one job each:
+ *
+ * - The row is a single plain button that opens the workspace. It carries
+ *   the triage read — attention dot, PR mark, title, view-dependent meta —
+ *   and nothing interactive competes with it: no overlaid buttons, no
+ *   hover choreography inside the row.
+ * - Details and actions live in a hover card that opens beside the row:
+ *   full title, branch, state, and the pull request front and center with
+ *   its action. Pointing at a row asks "what is this one?"; the panel
+ *   answers without a click and without crowding the rail.
+ * - Every command is the right-click context menu, the row's one menu.
+ *   It is also the keyboard path (Shift+F10 / the Menu key), since a hover
+ *   card is a pointer affordance by nature.
+ *
+ * The aria-label always carries the full read regardless of what the row
+ * draws — density and view settings change ink, never the announcement.
+ */
+export function WorkspaceCard({
+  workspace,
+  digest,
+  session,
+  repoName,
+  active,
+  terminalOpen,
+  density,
+  visibleMeta,
+  commands,
+  childSessions = [],
+  detailDefaultOpen = false,
+  onOpen,
+  onCommand,
+  onOpenChildSession,
+}: {
+  workspace: CodeWorkspaceSnapshot;
+  digest: CodeSessionDigest | undefined;
+  session: CodeSessionSnapshot | undefined;
+  repoName: string;
+  active: boolean;
+  terminalOpen: boolean;
+  density: CardDensity;
+  visibleMeta: { repoChip: boolean; branch: boolean };
+  commands: WorkspaceCommand[];
+  /** Watch digests riding under this workspace, from the updates store. */
+  childSessions?: CodeSessionDigest[];
+  /** Render with the detail panel already open. For stories and screenshots. */
+  detailDefaultOpen?: boolean;
+  onOpen: () => void;
+  onCommand: (command: WorkspaceCommand["id"]) => void;
+  onOpenChildSession?: (sessionId: string) => void;
+}) {
+  // The digest restates the title on every notice, so a background rename
+  // lands here without a catalog refresh.
+  const title = digest?.title ?? workspace.title;
+  const pr = digest?.pr_state ?? workspace.pr;
+  const archived = workspace.status === "archived";
+  const [detailOpen, setDetailOpen] = useState(detailDefaultOpen);
+
+  return (
+    <div>
+      <ContextMenu
+        onOpenChange={(open) => {
+          // One overlay at a time: the menu wins over the hover panel.
+          if (open) setDetailOpen(false);
+        }}
+      >
+        <HoverCard
+          open={detailOpen}
+          onOpenChange={setDetailOpen}
+          openDelay={350}
+          closeDelay={150}
+        >
+          <ContextMenuTrigger asChild>
+            <HoverCardTrigger asChild>
+              <button
+                type="button"
+                // The row's text names the workspace; the marks name its
+                // state. One explicit label carries both, in the order the
+                // row reads, so nothing here is pointer-only information.
+                aria-label={workspaceCardLabel({
+                  title,
+                  repoName,
+                  branchName: workspace.branch_name,
+                  attention: digest?.attention,
+                  pr,
+                  terminalOpen,
+                })}
+                aria-current={active ? "page" : undefined}
+                data-active={active || undefined}
+                className={cn(
+                  "flex w-full cursor-pointer flex-col gap-1 rounded-md px-2 py-1.5 text-left hover:bg-muted data-[active]:bg-muted",
+                  // Put-away work reads as put away, without becoming
+                  // unreadable.
+                  archived && "opacity-70",
+                  FOCUS_RING,
+                  HOVER_TINT,
+                )}
+                onClick={onOpen}
+              >
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <AttentionBadge attention={digest?.attention} compact />
+                  {pr && <PrGlyph pr={pr} />}
+                  <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium leading-5">
+                    {title}
+                  </span>
+                  <span className="flex shrink-0 items-center gap-1" aria-hidden>
+                    {terminalOpen && (
+                      <SquareTerminal className="size-3 text-muted-foreground" />
+                    )}
+                    {digest?.attention.state.type === "needs_you" &&
+                      digest.attention.state.source === "structured" && (
+                        <CircleAlert className="size-3 text-critical" />
+                      )}
+                  </span>
+                </span>
+                {density === "detailed" &&
+                  (visibleMeta.repoChip || visibleMeta.branch) && (
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      {visibleMeta.repoChip && (
+                        <span className="inline-flex min-w-0 max-w-[46%] items-center gap-1 text-[11px] text-muted-foreground">
+                          <span
+                            className={cn(
+                              "size-1.5 shrink-0 rounded-[2px]",
+                              repoAccentClass(workspace.repo_id),
+                            )}
+                            aria-hidden
+                          />
+                          <span className="truncate">{repoName}</span>
+                        </span>
+                      )}
+                      {visibleMeta.branch && (
+                        <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground">
+                          {middleTruncate(workspace.branch_name, 22)}
+                        </span>
+                      )}
+                    </span>
+                  )}
+              </button>
+            </HoverCardTrigger>
+          </ContextMenuTrigger>
+
+          <HoverCardContent
+            side="right"
+            align="start"
+            sideOffset={10}
+            className="w-80 p-0"
+          >
+            <WorkspaceDetailPanel
+              workspace={workspace}
+              digest={digest}
+              session={session}
+              repoName={repoName}
+              title={title}
+              pr={pr}
+              archived={archived}
+              onCommand={onCommand}
+            />
+          </HoverCardContent>
+        </HoverCard>
+
+        <ContextMenuContent>
+          {commands.map((command) => (
+            <WorkspaceMenuItem
+              key={command.id}
+              command={command}
+              onSelect={() => onCommand(command.id)}
+            />
+          ))}
+        </ContextMenuContent>
+      </ContextMenu>
+
+      {/*
+        Watch tasks ride under the row as their own buttons — siblings,
+        because buttons cannot nest. ADR 0050 forked these from the
+        conversation; here is where that fork becomes visible and openable.
+      */}
+      {density === "detailed" &&
+        childSessions.map((child) => (
+          <button
+            key={child.session}
+            type="button"
+            aria-label={`Watch task for ${title}: ${watchRowLabel(child)}`}
+            title={child.watch_detail ?? undefined}
+            className={cn(
+              "flex w-full cursor-pointer items-center gap-1.5 rounded-md py-1 pr-2 pl-6 text-left text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground",
+              FOCUS_RING_TIGHT,
+              HOVER_TINT,
+            )}
+            onClick={() => onOpenChildSession?.(child.session)}
+          >
+            <CornerDownRight className="size-3 shrink-0 opacity-50" aria-hidden />
+            <Eye className="size-3 shrink-0" aria-hidden />
+            <span className="truncate">Watch · {watchRowLabel(child)}</span>
+            <AttentionBadge
+              attention={child.attention}
+              compact
+              className="ml-auto"
+            />
+          </button>
+        ))}
+    </div>
+  );
+}
+
+/**
+ * The hover panel: what the row would say if it had room, plus the action
+ * the state calls for. The pull request owns the footer — that is the thing
+ * a supervisor most often needs one click away from the rail.
+ */
+function WorkspaceDetailPanel({
+  workspace,
+  digest,
+  session,
+  repoName,
+  title,
+  pr,
+  archived,
+  onCommand,
+}: {
+  workspace: CodeWorkspaceSnapshot;
+  digest: CodeSessionDigest | undefined;
+  session: CodeSessionSnapshot | undefined;
+  repoName: string;
+  title: string;
+  pr: PullRequestDigest | undefined;
+  archived: boolean;
+  onCommand: (command: WorkspaceCommand["id"]) => void;
+}) {
+  const HarnessIcon = session ? HARNESS_ICONS[session.harness_kind] : null;
+  const needsYou =
+    digest?.attention.state.type === "needs_you"
+      ? digest.attention.state.prompt || "Needs you"
+      : null;
+  const sessionLine =
+    digest && isSessionRowWorthy(digest)
+      ? `${sessionRowLabel(digest)} · ${digest.turn_count} ${digest.turn_count === 1 ? "turn" : "turns"}`
+      : null;
+  const stamp = archived
+    ? (workspace.archived_at ?? workspace.created_at)
+    : (session?.created_at ?? workspace.created_at);
+  const age = formatCompactAge(stamp);
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-col gap-1.5 p-3">
+        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          <span
+            className={cn(
+              "size-1.5 shrink-0 rounded-[2px]",
+              repoAccentClass(workspace.repo_id),
+            )}
+            aria-hidden
+          />
+          <span className="shrink-0">{repoName}</span>
+          <span
+            className="min-w-0 flex-1 truncate font-mono"
+            title={workspace.branch_name}
+          >
+            {workspace.branch_name}
+          </span>
+          <AttentionBadge attention={digest?.attention} className="shrink-0" />
+          {archived && (
+            <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
+              Archived
+            </span>
+          )}
+        </div>
+        <p className="text-sm font-medium leading-snug">{title}</p>
+        {needsYou ? (
+          <p className="flex items-start gap-1.5 text-xs text-critical">
+            <CircleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+            <span className="min-w-0">{needsYou}</span>
+          </p>
+        ) : (
+          sessionLine && (
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              {HarnessIcon && <HarnessIcon className="size-3.5 shrink-0" />}
+              <span>{sessionLine}</span>
+            </p>
+          )
+        )}
+        {pr?.checks_summary && (
+          <p className="text-xs text-muted-foreground">{pr.checks_summary}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-2 border-t px-3 py-2">
+        {pr && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            aria-label={`Open pull request #${pr.number}`}
+            onClick={() => onCommand("open-pr")}
+          >
+            <GitPullRequest className={PR_ICON_TONE_CLASSES[prTone(pr)]} />
+            #{pr.number}
+            <span
+              className={cn(
+                "rounded-sm px-1.5 py-px text-[10px] font-medium",
+                PR_CHIP_TONE_CLASSES[prTone(pr)],
+              )}
+            >
+              {prToneLabel(pr)}
+            </span>
+            <ExternalLink className="size-3 text-muted-foreground" aria-hidden />
+          </Button>
+        )}
+        {archived && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onCommand("restore")}
+          >
+            Restore
+          </Button>
+        )}
+        {!pr && !archived && (
+          <span className="text-xs text-muted-foreground">
+            Right-click the row for all actions.
+          </span>
+        )}
+        <span
+          className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground"
+          title={stamp}
+        >
+          {age === "now" ? "just now" : age ? `${age} ago` : null}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceMenuItem({
+  command,
+  onSelect,
+}: {
+  command: WorkspaceCommand;
+  onSelect: () => void;
+}) {
+  return (
+    <>
+      {command.separated && <ContextMenuSeparator />}
+      <ContextMenuItem
+        variant={command.destructive ? "destructive" : "default"}
+        onSelect={onSelect}
+      >
+        {command.label}
+      </ContextMenuItem>
+    </>
+  );
+}
+
+/** PR-state mark. The row's own label carries the number and state. */
+function PrGlyph({ pr }: { pr: PullRequestDigest }) {
+  const tone = prTone(pr);
+  return (
+    <GitPullRequest
+      className={cn("size-3 shrink-0", PR_ICON_TONE_CLASSES[tone])}
+      data-pr-state={tone}
+      aria-hidden
+    />
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1854,13 +1854,20 @@ export function parseCodeSessionDigest(
       "title",
       "turn_count",
       "pr_state",
+      "watch_state",
+      "watch_detail",
+      "watch_cycles",
     ]) ||
     !nonEmpty(value.workspace) ||
     !nonEmpty(value.session) ||
     !isMember(value.kind, SESSION_KINDS) ||
     !isMember(value.lifecycle, SESSION_LIFECYCLES) ||
     typeof value.title !== "string" ||
-    !isFiniteNumber(value.turn_count)
+    !isFiniteNumber(value.turn_count) ||
+    (value.watch_state !== undefined &&
+      !isMember(value.watch_state, WATCH_STATES)) ||
+    !optionalString(value.watch_detail) ||
+    (value.watch_cycles !== undefined && !isFiniteNumber(value.watch_cycles))
   ) {
     return null;
   }
@@ -1878,6 +1885,15 @@ export function parseCodeSessionDigest(
     title: value.title,
     turn_count: value.turn_count,
     ...(pr_state ? { pr_state } : {}),
+    ...(value.watch_state !== undefined
+      ? { watch_state: value.watch_state }
+      : {}),
+    ...(value.watch_detail !== undefined
+      ? { watch_detail: value.watch_detail }
+      : {}),
+    ...(value.watch_cycles !== undefined
+      ? { watch_cycles: value.watch_cycles }
+      : {}),
   };
 }
 
@@ -1914,13 +1930,21 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
           "title",
           "turn_count",
           "pr_state",
+          "watch_state",
+          "watch_detail",
+          "watch_cycles",
         ]) ||
         !nonEmpty(value.workspace) ||
         !nonEmpty(value.session) ||
         !isMember(value.kind, SESSION_KINDS) ||
         !isMember(value.lifecycle, SESSION_LIFECYCLES) ||
         typeof value.title !== "string" ||
-        !isFiniteNumber(value.turn_count)
+        !isFiniteNumber(value.turn_count) ||
+        (value.watch_state !== undefined &&
+          !isMember(value.watch_state, WATCH_STATES)) ||
+        !optionalString(value.watch_detail) ||
+        (value.watch_cycles !== undefined &&
+          !isFiniteNumber(value.watch_cycles))
       ) {
         return null;
       }
@@ -1939,6 +1963,15 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         title: value.title,
         turn_count: value.turn_count,
         ...(pr_state ? { pr_state } : {}),
+        ...(value.watch_state !== undefined
+          ? { watch_state: value.watch_state }
+          : {}),
+        ...(value.watch_detail !== undefined
+          ? { watch_detail: value.watch_detail }
+          : {}),
+        ...(value.watch_cycles !== undefined
+          ? { watch_cycles: value.watch_cycles }
+          : {}),
       };
     }
     case "clone_progress": {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { MoreHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
-import { archiveForceKind, type ApiClient } from "../api/client";
+import { archiveForceKind, HttpError, type ApiClient } from "../api/client";
 import type {
   CodeActionSnapshot,
   CodeSessionSnapshot,
@@ -37,6 +37,7 @@ import { searchFromLayout } from "@/panel/panelUrl";
 import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
 import { toggleTerminalLayout } from "./codeChrome";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
 
 /**
  * Workspace commands shared by the card context menu and the workspace
@@ -54,7 +55,9 @@ export type WorkspaceCommandId =
   | "pin-attention"
   | "clear-attention"
   | "run-quick-action"
-  | "archive";
+  | "archive"
+  | "force-archive"
+  | "restore";
 
 export type WorkspaceCommand = {
   id: WorkspaceCommandId;
@@ -80,6 +83,17 @@ export function workspaceCommands(input: {
   hasSession?: boolean;
   attentionPinned?: boolean;
 }): WorkspaceCommand[] {
+  // An archived workspace has no worktree: nothing to open a terminal in,
+  // no session to steer. What is left is reading, copying the branch that
+  // survived, and bringing it back.
+  if (input.archived) {
+    return [
+      { id: "open", label: "Open workspace" },
+      { id: "copy-branch", label: "Copy branch name" },
+      { id: "copy-worktree", label: "Copy worktree path" },
+      { id: "restore", label: "Restore workspace", separated: true },
+    ];
+  }
   const items: WorkspaceCommand[] = [
     { id: "open", label: "Open workspace" },
     { id: "new-session", label: "New session" },
@@ -99,14 +113,17 @@ export function workspaceCommands(input: {
     );
     items.push({ id: "copy-debug-json", label: "Copy debug JSON" });
   }
-  if (!input.archived) {
-    items.push({
-      id: "archive",
-      label: "Archive",
-      destructive: true,
-      separated: true,
-    });
-  }
+  items.push({
+    id: "archive",
+    label: "Archive",
+    destructive: true,
+    separated: true,
+  });
+  items.push({
+    id: "force-archive",
+    label: "Force archive (discard changes)",
+    destructive: true,
+  });
   return items;
 }
 
@@ -143,6 +160,13 @@ export function workspaceHeaderCommands(input: {
       destructive: true,
       separated: true,
     });
+    items.push({
+      id: "force-archive",
+      label: "Force archive (discard changes)",
+      destructive: true,
+    });
+  } else {
+    items.push({ id: "restore", label: "Restore workspace", separated: true });
   }
   return items;
 }
@@ -286,6 +310,23 @@ export function useWorkspaceCardCommands(): {
     });
   }
 
+  async function afterArchive(archived: CodeWorkspaceSnapshot) {
+    upsertWorkspace(archived);
+    forgetWorkspaceSession(archived.id);
+    toast.success("Workspace archived");
+    if (pathname === `/code/w/${archived.id}`) {
+      if (archived.repo_id) {
+        await navigate({
+          to: "/code/r/$repoId",
+          params: { repoId: archived.repo_id },
+          replace: true,
+        });
+      } else {
+        await navigate({ to: "/code", replace: true });
+      }
+    }
+  }
+
   async function runArchive(workspace: CodeWorkspaceSnapshot) {
     try {
       const archived = await archiveWorkspaceWithConfirm({
@@ -294,20 +335,29 @@ export function useWorkspaceCardCommands(): {
         confirm,
       });
       if (!archived) return;
-      upsertWorkspace(archived);
-      forgetWorkspaceSession(archived.id);
-      toast.success("Workspace archived");
-      if (pathname === `/code/w/${archived.id}`) {
-        if (archived.repo_id) {
-          await navigate({
-            to: "/code/r/$repoId",
-            params: { repoId: archived.repo_id },
-            replace: true,
-          });
-        } else {
-          await navigate({ to: "/code", replace: true });
-        }
-      }
+      await afterArchive(archived);
+    } catch (error) {
+      toast.error(friendlyErrorMessage(error, "Could not archive"));
+    }
+  }
+
+  /**
+   * The deliberate force path. The escalating flow in `runArchive` exists for
+   * readers who find out mid-archive that work is dirty; this one is for the
+   * reader who already knows and does not want two dialogs about it. One
+   * confirmation still stands between the click and the worktree going away.
+   */
+  async function runForceArchive(workspace: CodeWorkspaceSnapshot) {
+    const ok = await confirm({
+      title: "Discard changes and archive?",
+      description:
+        "Uncommitted and unpushed work is lost and a running session is stopped. The branch and its commits are kept.",
+      confirmLabel: "Discard and archive",
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await afterArchive(await client.archiveCodeWorkspace(workspace.id, true));
     } catch (error) {
       toast.error(friendlyErrorMessage(error, "Could not archive"));
     }
@@ -327,6 +377,54 @@ export function useWorkspaceCardCommands(): {
       toast.error(friendlyErrorMessage(error, "Could not rename"));
     } finally {
       setRenaming(false);
+    }
+  }
+
+  /**
+   * True restore first; when the branch is gone that is impossible, so the
+   * fallback offer is a fresh workspace on the same repo. A failed setup
+   * script still restored the checkout — surface the error and open the
+   * workspace anyway so the reader can see what they got back.
+   */
+  async function runRestore(workspace: CodeWorkspaceSnapshot) {
+    const openRestored = () =>
+      navigate({
+        to: "/code/w/$workspaceId",
+        params: { workspaceId: workspace.id },
+      });
+    try {
+      const restored = await client.restoreCodeWorkspace(workspace.id);
+      upsertWorkspace(restored);
+      toast.success("Workspace restored");
+      await openRestored();
+    } catch (error) {
+      if (error instanceof HttpError && error.kind === "branch_missing") {
+        const ok = await confirm({
+          title: "The branch is gone",
+          description:
+            "This workspace's branch was deleted after it was archived, so its work cannot come back. Start a new workspace on the same repo instead?",
+          confirmLabel: "New workspace",
+        });
+        if (ok) {
+          useCodeUiStore.getState().startNewWorkspace(workspace.repo_id);
+        }
+        return;
+      }
+      if (error instanceof HttpError && error.kind === "setup_failed") {
+        toast.error(
+          friendlyErrorMessage(
+            error,
+            "Restored, but the setup script failed",
+          ),
+        );
+        const refreshed = await client
+          .getCodeWorkspace(workspace.id)
+          .catch(() => null);
+        if (refreshed) upsertWorkspace(refreshed);
+        await openRestored();
+        return;
+      }
+      toast.error(friendlyErrorMessage(error, "Could not restore"));
     }
   }
 
@@ -442,6 +540,12 @@ export function useWorkspaceCardCommands(): {
       }
       case "archive":
         void runArchive(context.workspace);
+        return;
+      case "force-archive":
+        void runForceArchive(context.workspace);
+        return;
+      case "restore":
+        void runRestore(context.workspace);
         return;
     }
   }

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -146,7 +146,9 @@ describe("arrangeWorkspaces", () => {
         pr_state: { number: 12, state: "open" },
       }),
     };
-    const groups = arrangeWorkspaces("by-status", repos, listed, digests);
+    const groups = arrangeWorkspaces("by-status", repos, listed, digests, {
+      showArchived: true,
+    });
     expect(
       groups.map((group) => [group.key, group.workspaces.map((item) => item.id)]),
     ).toEqual([
@@ -154,6 +156,34 @@ describe("arrangeWorkspaces", () => {
       ["running", ["ws-lib"]],
       ["pr_open", ["ws-app-new"]],
       ["archived", ["ws-archived"]],
+    ]);
+  });
+
+  it("keeps archived off the rail by default in every mode", () => {
+    for (const mode of ["by-repo", "by-status", "by-created"] as const) {
+      const groups = arrangeWorkspaces(mode, repos, listed, {});
+      expect(idsOf(groups)).not.toContain("ws-archived");
+    }
+  });
+
+  it("appends one trailing archived shelf when asked, newest put-away first", () => {
+    const rows = [
+      ...listed,
+      {
+        ...workspace("ws-archived-late", "lib", "archived", "2026-08-10T00:00:00.000Z"),
+        archived_at: "2026-08-18T00:00:00.000Z",
+      },
+    ];
+    const groups = arrangeWorkspaces("by-repo", repos, rows, {}, {
+      showArchived: true,
+    });
+    const last = groups[groups.length - 1];
+    expect(last?.key).toBe("archived");
+    expect(last?.label).toBe("Archived");
+    // archived_at orders the shelf; rows without it fall back to created_at.
+    expect(last?.workspaces.map((item) => item.id)).toEqual([
+      "ws-archived-late",
+      "ws-archived",
     ]);
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -68,11 +68,18 @@ export function isWorkspaceSortMode(value: string): value is WorkspaceSortMode {
   return (WORKSPACE_SORT_MODES as readonly string[]).includes(value);
 }
 
-export function nextWorkspaceSortMode(
-  mode: WorkspaceSortMode,
-): WorkspaceSortMode {
-  const index = WORKSPACE_SORT_MODES.indexOf(mode);
-  return WORKSPACE_SORT_MODES[(index + 1) % WORKSPACE_SORT_MODES.length]!;
+/** How much of a card the rail draws; the aria-label never shrinks with it. */
+export type CardDensity = "compact" | "detailed";
+
+export const CARD_DENSITIES: readonly CardDensity[] = ["compact", "detailed"];
+
+export const CARD_DENSITY_LABELS: Record<CardDensity, string> = {
+  compact: "Compact",
+  detailed: "Detailed",
+};
+
+export function isCardDensity(value: string): value is CardDensity {
+  return (CARD_DENSITIES as readonly string[]).includes(value);
 }
 
 export type WorkspaceStatusRank =
@@ -167,6 +174,8 @@ export function listWorkspacesByCreated(
 export type ArrangedWorkspaceGroup = {
   key: string;
   label: string | null;
+  /** Set when the group is one repo, so the rail can link its header. */
+  repoId?: string;
   workspaces: CodeWorkspaceSnapshot[];
 };
 
@@ -174,8 +183,26 @@ export type ArrangedWorkspaceGroup = {
  * The one function the rail reads. Ordering is a pure function of created_at,
  * repo catalog order, and status rank — never catalog array order or digest
  * insertion order.
+ *
+ * Archived workspaces are off the rail unless asked for; when shown, they
+ * are one trailing group in every mode rather than woven back into their
+ * repo, so put-away work never interleaves with live triage.
  */
 export function arrangeWorkspaces(
+  mode: WorkspaceSortMode,
+  repos: readonly CodeRepoSnapshot[],
+  workspaces: readonly CodeWorkspaceSnapshot[],
+  digests: Readonly<Record<string, CodeSessionDigest | undefined>>,
+  options?: { showArchived?: boolean },
+): ArrangedWorkspaceGroup[] {
+  const groups = arrangeLiveWorkspaces(mode, repos, workspaces, digests);
+  if (!options?.showArchived) return groups;
+  const archived = listArchivedWorkspaces(workspaces);
+  if (archived.length === 0) return groups;
+  return [...groups, { key: "archived", label: "Archived", workspaces: archived }];
+}
+
+function arrangeLiveWorkspaces(
   mode: WorkspaceSortMode,
   repos: readonly CodeRepoSnapshot[],
   workspaces: readonly CodeWorkspaceSnapshot[],
@@ -191,17 +218,38 @@ export function arrangeWorkspaces(
     ];
   }
   if (mode === "by-status") {
-    return groupWorkspacesByStatus(workspaces, digests).map((group) => ({
-      key: group.rank,
-      label: WORKSPACE_STATUS_RANK_LABELS[group.rank],
-      workspaces: group.workspaces,
-    }));
+    return groupWorkspacesByStatus(workspaces, digests)
+      .filter((group) => group.rank !== "archived")
+      .map((group) => ({
+        key: group.rank,
+        label: WORKSPACE_STATUS_RANK_LABELS[group.rank],
+        workspaces: group.workspaces,
+      }));
   }
   return groupWorkspacesByRepo(repos, workspaces).map((group) => ({
     key: group.repo?.id ?? "unknown-repo",
     label: group.repo?.display_name ?? "Other repos",
+    repoId: group.repo?.id,
     workspaces: group.workspaces,
   }));
+}
+
+/**
+ * Archived workspaces, most recently put away first. `archived_at` orders the
+ * shelf; rows missing it (older servers) fall back to created_at.
+ */
+export function listArchivedWorkspaces(
+  workspaces: readonly CodeWorkspaceSnapshot[],
+): CodeWorkspaceSnapshot[] {
+  return workspaces
+    .filter((workspace) => workspace.status === "archived")
+    .sort((left, right) => {
+      const byTime = (right.archived_at ?? right.created_at).localeCompare(
+        left.archived_at ?? left.created_at,
+      );
+      if (byTime !== 0) return byTime;
+      return left.id.localeCompare(right.id);
+    });
 }
 
 function sortByCreated(
@@ -243,6 +291,35 @@ export function sessionRowLabel(digest: CodeSessionDigest): string {
       return "Pinned";
     default:
       return LIFECYCLE_LABELS[digest.lifecycle];
+  }
+}
+
+/**
+ * The word a watch child row shows. The watch's own state beats lifecycle —
+ * a watch is "running" for hours, but "Fixing ×3" is what it is doing —
+ * except when it needs you, which outranks everything on a triage rail.
+ * Digests from a server without watch enrichment fall back to lifecycle
+ * wording.
+ */
+export function watchRowLabel(digest: CodeSessionDigest): string {
+  if (digest.attention.state.type === "needs_you") return "Needs you";
+  switch (digest.watch_state) {
+    case "watching":
+      return "Watching";
+    case "fixing":
+      return digest.watch_cycles !== undefined && digest.watch_cycles > 1
+        ? `Fixing ×${digest.watch_cycles}`
+        : "Fixing";
+    case "blocked":
+      return "Blocked";
+    case "done":
+      return "Done";
+    case "stopped":
+      return "Stopped";
+    case "failed":
+      return "Failed";
+    default:
+      return sessionRowLabel(digest);
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/components/ui/hover-card.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/hover-card.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
+
+import { cn } from "@/lib/utils";
+
+const HoverCard = HoverCardPrimitive.Root;
+const HoverCardTrigger = HoverCardPrimitive.Trigger;
+
+const HoverCardContent = React.forwardRef<
+  React.ComponentRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-lg outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className,
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+));
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1166,7 +1166,11 @@ export type CodeRepoSnapshot = { id: RepoId, root_path: string, display_name: st
 /**
  * Cheap per-session digest on `/code/updates`.
  */
-export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, pr_state?: PullRequestDigest, };
+export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId, kind: CodeSessionKind, lifecycle: CodeSessionLifecycle, attention: Attention, title: string, turn_count: number, pr_state?: PullRequestDigest, 
+/**
+ * Watch progress, present only on `kind: watch` digests.
+ */
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number, };
 
 /**
  * Identifies one durable conversation with an external agent engine.
@@ -1263,7 +1267,11 @@ sessions: Array<CodeSessionDigest>, } | { "type": "digest", workspace: Workspace
  * Boxed to keep the notice enum's variants near one size; the wire
  * shape is unchanged.
  */
-pr_state?: PullRequestDigest, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, };
+pr_state?: PullRequestDigest, 
+/**
+ * Watch progress, present only on `kind: watch` digests.
+ */
+watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, };
 
 /**
  * Token accounting as reported by the engine. Missing fields stay zero.

--- a/crates/tidebreak-desktop/ui/src/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/router.tsx
@@ -226,7 +226,13 @@ function CodeRepoRouteComponent() {
 const codeWorkspaceRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/code/w/$workspaceId",
-  validateSearch: (search: Record<string, unknown>): PanelSearch => panelSearchFrom(search),
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): PanelSearch & { task?: string } => ({
+    ...panelSearchFrom(search),
+    // A child task's session attached in place of the conversation.
+    task: typeof search.task === "string" ? search.task : undefined,
+  }),
   component: CodeWorkspaceRouteComponent,
 });
 

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -1,45 +1,47 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
-import { WorkspaceCard } from "@/code/CodeSidebar";
-import type { WorkspaceCommand } from "@/code/workspaceActions";
+import { workspaceCommands } from "@/code/workspaceActions";
+import { WorkspaceCard } from "@/code/WorkspaceCard";
 import {
-  attentionNeedsYou,
-  attentionStalled,
-  codeDigest,
+  archivedWorkspace,
+  closedPrDigest,
   codeSession,
   codeWorkspace,
+  draftPrDigest,
+  mergedPrDigest,
+  needsYouDigest,
+  openPrDigest,
+  runningDigest,
+  stalledDigest,
+  watchDigest,
 } from "./fixtures";
 
-const COMMANDS: WorkspaceCommand[] = [
-  { id: "open", label: "Open" },
-  { id: "rename", label: "Rename…" },
-  { id: "copy-branch", label: "Copy branch name" },
-  { id: "archive", label: "Archive…", destructive: true, separated: true },
-];
-
 /**
- * One workspace on the rail: title + attention dot, repo chip + branch, PR
- * glyph, and a nested session row when something is live. The card carries
- * every state the sidebar must make tellable at a glance.
+ * The rail's workspace card. Hover the card (or tab into it) to swap the
+ * state glyphs for the action cluster; right-click for the same commands as
+ * a context menu.
  */
+
 const meta = {
   title: "Code/Workspace card",
   component: WorkspaceCard,
   args: {
     workspace: codeWorkspace,
-    digest: codeDigest(),
-    session: codeSession,
+    digest: undefined,
+    session: undefined,
     repoName: "tidebreak",
     active: false,
     terminalOpen: false,
-    commands: COMMANDS,
+    density: "detailed",
+    visibleMeta: { repoChip: true, branch: false },
+    commands: workspaceCommands({ hasPr: false, archived: false }),
     onOpen: fn(),
     onCommand: fn(),
   },
   decorators: [
     (Story) => (
-      <div className="mx-auto w-[280px] pt-8">
+      <div className="bg-page-background w-[264px] rounded-lg border border-border-subtle p-2 pt-3">
         <Story />
       </div>
     ),
@@ -49,54 +51,220 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** A session is running; the nested row narrates it. */
-export const Working: Story = {};
+export const Idle: Story = {};
+
+/**
+ * The detail panel that opens beside a row on hover (or focus): full branch,
+ * state, checks, and the pull request with its action. Rendered open here;
+ * on any other story, rest the pointer on the row to see it live.
+ */
+export const DetailPanel: Story = {
+  args: {
+    workspace: { ...codeWorkspace, pr: openPrDigest },
+    digest: { ...runningDigest, pr_state: openPrDigest },
+    session: codeSession,
+    commands: workspaceCommands({
+      hasPr: true,
+      archived: false,
+      hasSession: true,
+    }),
+    detailDefaultOpen: true,
+  },
+};
+
+/** The panel when the session is waiting on the reader. */
+export const DetailPanelNeedsYou: Story = {
+  args: {
+    digest: needsYouDigest,
+    session: codeSession,
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      hasSession: true,
+    }),
+    detailDefaultOpen: true,
+  },
+};
+
+/** How the card reads inside a by-repo group: no repo chip, title leads. */
+export const InRepoGroup: Story = {
+  args: { visibleMeta: { repoChip: false, branch: false } },
+};
+
+/** Detailed view with the branch switched on from the rail settings. */
+export const WithBranch: Story = {
+  args: { visibleMeta: { repoChip: true, branch: true } },
+};
+
+export const Active: Story = {
+  args: { active: true },
+};
+
+export const RunningSession: Story = {
+  args: {
+    digest: runningDigest,
+    session: codeSession,
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      hasSession: true,
+    }),
+  },
+};
+
+/** A watch-and-fix task riding under the card as a clickable child row. */
+export const WithWatchTask: Story = {
+  args: {
+    digest: runningDigest,
+    session: codeSession,
+    childSessions: [watchDigest],
+    onOpenChildSession: fn(),
+    commands: workspaceCommands({
+      hasPr: true,
+      archived: false,
+      hasSession: true,
+    }),
+    workspace: { ...codeWorkspace, pr: openPrDigest },
+  },
+};
 
 export const NeedsYou: Story = {
   args: {
-    digest: codeDigest({ attention: attentionNeedsYou, lifecycle: "idle" }),
+    digest: needsYouDigest,
+    session: codeSession,
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      hasSession: true,
+    }),
   },
 };
 
 export const Stalled: Story = {
   args: {
-    digest: codeDigest({ attention: attentionStalled }),
-  },
-};
-
-/** No live session: just identity, quiet. */
-export const Idle: Story = {
-  args: { digest: undefined, session: undefined },
-};
-
-export const ActiveWithTerminal: Story = {
-  args: { active: true, terminalOpen: true },
-};
-
-export const WithPullRequest: Story = {
-  args: {
-    digest: codeDigest({
-      pr_state: {
-        number: 184,
-        url: "https://github.com/example/tidebreak/pull/184",
-        state: "open",
-        checks_summary: "7 passing, 1 failing",
-      },
+    digest: stalledDigest,
+    session: codeSession,
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      hasSession: true,
     }),
   },
 };
 
-/** Long names must truncate, never wrap or push the glyphs out. */
+export const PullRequestOpen: Story = {
+  args: {
+    workspace: { ...codeWorkspace, pr: openPrDigest },
+    commands: workspaceCommands({ hasPr: true, archived: false }),
+  },
+};
+
+export const TerminalOpen: Story = {
+  args: { terminalOpen: true },
+};
+
+/** On the shelf: dimmed row; its panel and menu lead with Restore. */
+export const Archived: Story = {
+  args: {
+    workspace: archivedWorkspace,
+    commands: workspaceCommands({ hasPr: false, archived: true }),
+    detailDefaultOpen: true,
+  },
+};
+
 export const LongNames: Story = {
   args: {
+    visibleMeta: { repoChip: true, branch: true },
     workspace: {
       ...codeWorkspace,
-      title: "Rework the entire onboarding flow for multi-repo workspaces",
+      title:
+        "Rework the gateway credential exchange for hosted machines end to end",
       branch_name:
-        "tidebreak/rework-the-entire-onboarding-flow-for-multi-repo-workspaces",
+        "tidebreak/rework-gateway-credential-exchange-for-hosted-machines",
     },
-    digest: codeDigest({
-      title: "Rework the entire onboarding flow for multi-repo workspaces",
-    }),
   },
+};
+
+/** Every PR tone on one screen: open, draft, merged, closed. */
+export const PullRequestTones: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-0.5">
+      {(
+        [
+          ["open", openPrDigest],
+          ["draft", draftPrDigest],
+          ["merged", mergedPrDigest],
+          ["closed", closedPrDigest],
+        ] as const
+      ).map(([tone, pr]) => (
+        <WorkspaceCard
+          key={tone}
+          {...args}
+          workspace={{
+            ...codeWorkspace,
+            id: `ws-${tone}`,
+            title: `PR ${tone}`,
+            pr,
+          }}
+          commands={workspaceCommands({ hasPr: true, archived: false })}
+        />
+      ))}
+    </div>
+  ),
+};
+
+/** A stretch of rail: triage states stacked the way the sidebar shows them. */
+export const Rail: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-0.5">
+      <WorkspaceCard
+        {...args}
+        workspace={{ ...codeWorkspace, id: "ws-a", title: "Needs a decision" }}
+        digest={{ ...needsYouDigest, title: "Needs a decision" }}
+        session={codeSession}
+        commands={workspaceCommands({
+          hasPr: false,
+          archived: false,
+          hasSession: true,
+        })}
+      />
+      <WorkspaceCard
+        {...args}
+        workspace={{
+          ...codeWorkspace,
+          id: "ws-b",
+          title: "Turn in flight",
+          branch_name: "tidebreak/turn-in-flight",
+        }}
+        digest={{ ...runningDigest, title: "Turn in flight" }}
+        session={codeSession}
+        active
+        commands={workspaceCommands({
+          hasPr: false,
+          archived: false,
+          hasSession: true,
+        })}
+      />
+      <WorkspaceCard
+        {...args}
+        workspace={{
+          ...codeWorkspace,
+          id: "ws-c",
+          title: "Shipped, checks green",
+          branch_name: "tidebreak/shipped-checks-green",
+          pr: openPrDigest,
+        }}
+        commands={workspaceCommands({ hasPr: true, archived: false })}
+      />
+      <WorkspaceCard
+        {...args}
+        workspace={{
+          ...codeWorkspace,
+          id: "ws-d",
+          title: "Parked exploration",
+          branch_name: "tidebreak/parked-exploration",
+        }}
+      />
+    </div>
+  ),
 };

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -5,6 +5,7 @@ import type {
   CodeWatchSnapshot,
   CodeWorkspacePrSnapshot,
   CodeWorkspaceSnapshot,
+  PullRequestDigest,
   HarnessCaps,
   HarnessDoctorEntry,
   HarnessDoctorReport,
@@ -345,4 +346,64 @@ export const harnessDoctorDegraded: HarnessDoctorReport = {
       caps: { ...fullCaps, mid_turn_steering: "supported" },
     }),
   ],
+};
+
+// ---------------------------------------------------------------------------
+// Rail card states: digests per attention, PR chip tones, watch child rows.
+// ---------------------------------------------------------------------------
+
+/** Digest for a session mid-turn: the card's live state line. */
+export const runningDigest: CodeSessionDigest = codeDigest({ turn_count: 3 });
+
+/** Digest for a structured question the harness is waiting on. */
+export const needsYouDigest: CodeSessionDigest = codeDigest({
+  lifecycle: "idle",
+  attention: attentionNeedsYou,
+});
+
+/** Digest for a session that went quiet without finishing. */
+export const stalledDigest: CodeSessionDigest = codeDigest({
+  lifecycle: "idle",
+  attention: attentionStalled,
+});
+
+/** A watch-and-fix task riding under the workspace (decision 50). */
+export const watchDigest: CodeSessionDigest = codeDigest({
+  session: "sess-watch",
+  kind: "watch",
+  lifecycle: "running",
+  turn_count: 2,
+});
+
+/** Workspace PR digests, one per chip tone. */
+export const openPrDigest: PullRequestDigest = {
+  number: 184,
+  url: "https://github.com/example/tidebreak/pull/184",
+  state: "open",
+  title: "Add a scoped UI workshop",
+};
+
+export const draftPrDigest: PullRequestDigest = {
+  ...openPrDigest,
+  draft: true,
+};
+
+export const mergedPrDigest: PullRequestDigest = {
+  ...openPrDigest,
+  state: "merged",
+  merged: true,
+};
+
+export const closedPrDigest: PullRequestDigest = {
+  ...openPrDigest,
+  state: "closed",
+};
+
+/** A put-away workspace: worktree gone, branch and history kept. */
+export const archivedWorkspace: CodeWorkspaceSnapshot = {
+  ...codeWorkspace,
+  id: "ws-archived",
+  title: "Shipped last week",
+  status: "archived",
+  archived_at: "2026-08-18T17:00:00.000Z",
 };

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -9,8 +9,8 @@ use chrono::{DateTime, Utc};
 use tracing::warn;
 
 use tidebreak_core::db::code::{
-    count_turns, get_session, get_workspace, latest_event_created_at, latest_turn, list_approvals,
-    latest_watch_for_session, list_sessions, list_sessions_by_lifecycle_all_owners,
+    count_turns, get_session, get_workspace, latest_event_created_at, latest_turn,
+    latest_watch_for_session, list_approvals, list_sessions, list_sessions_by_lifecycle_all_owners,
     list_sessions_for_workspace, save_session,
 };
 use tidebreak_core::{

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -10,12 +10,12 @@ use tracing::warn;
 
 use tidebreak_core::db::code::{
     count_turns, get_session, get_workspace, latest_event_created_at, latest_turn, list_approvals,
-    list_sessions, list_sessions_by_lifecycle_all_owners, list_sessions_for_workspace,
-    save_session,
+    latest_watch_for_session, list_sessions, list_sessions_by_lifecycle_all_owners,
+    list_sessions_for_workspace, save_session,
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeApprovalState, CodeSession, CodeSessionId,
-    CodeSessionLifecycle, CodeTurnStatus, DbStore, OwnerId, WorkspaceId,
+    CodeSessionKind, CodeSessionLifecycle, CodeTurnStatus, DbStore, OwnerId, WorkspaceId,
 };
 
 use super::bus::{CodeEventBus, CodeLiveUpdate, SessionDigest};
@@ -327,6 +327,14 @@ async fn build_digest(
             ))
         })?;
     let turn_count = count_turns(db, &session.owner, session.id).await?;
+    // A watch session's lifecycle undersells it ("running" for hours), so its
+    // digest carries the watch's own state. The row is small and local — this
+    // never reaches the host the way the PR snapshot does.
+    let watch = if session.kind == CodeSessionKind::Watch {
+        latest_watch_for_session(db, &session.owner, session.id).await?
+    } else {
+        None
+    };
     Ok(SessionDigest {
         workspace: session.workspace_id,
         session: session.id,
@@ -336,6 +344,9 @@ async fn build_digest(
         title: workspace.title,
         turn_count,
         pr_state: workspace.pr,
+        watch_state: watch.as_ref().map(|watch| watch.state),
+        watch_detail: watch.as_ref().and_then(|watch| watch.detail.clone()),
+        watch_cycles: watch.as_ref().map(|watch| watch.cycles),
     })
 }
 

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -20,8 +20,8 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use tidebreak_core::{
-    Attention, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, OwnerId, PullRequestDigest,
-    RepoId, SequencedCodeEvent, WorkspaceId,
+    Attention, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeWatchState, OwnerId,
+    PullRequestDigest, RepoId, SequencedCodeEvent, WorkspaceId,
 };
 use tokio::sync::broadcast;
 
@@ -39,6 +39,11 @@ pub(crate) struct SessionDigest {
     pub title: String,
     pub turn_count: i64,
     pub pr_state: Option<PullRequestDigest>,
+    /// Watch progress, set only when `kind` is `Watch`. Lifecycle words
+    /// undersell a watch ("running" for hours); these say what it is doing.
+    pub watch_state: Option<CodeWatchState>,
+    pub watch_detail: Option<String>,
+    pub watch_cycles: Option<i64>,
 }
 
 /// Progress of one in-flight `git clone` job.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -721,6 +721,83 @@ impl CodeRuntime {
         Ok(workspace)
     }
 
+    /// Reactivate an archived workspace at its own path, on its own branch.
+    ///
+    /// Archive keeps the branch, the session rows, and the journal; restore
+    /// puts a checkout back under them. Nothing else changes: sessions stay
+    /// Ended (a new one resumes via the stored harness ref), and the
+    /// checkpoint refs archive deleted stay gone — per-turn diffs from before
+    /// the archive cannot be reopened.
+    ///
+    /// `create_workspace`'s branch-collision check reads archived rows too,
+    /// so this route is the sanctioned way to get an archived branch back
+    /// into a workspace.
+    pub(crate) async fn restore_workspace(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+    ) -> Result<CodeWorkspace, ServerError> {
+        let mut workspace = self.get_workspace(owner, id).await?;
+        if workspace.status == CodeWorkspaceStatus::Active {
+            return Ok(workspace);
+        }
+        if workspace.status != CodeWorkspaceStatus::Archived {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_ready",
+                format!("workspace is {}", workspace.status.as_str()),
+            ));
+        }
+        let repo = self.get_repo(owner, workspace.repo_id).await?;
+        let repo_root = std::path::Path::new(&repo.root_path);
+        if !worktree::branch_exists(repo_root, &workspace.branch_name)
+            .await
+            .map_err(map_worktree)?
+        {
+            return Err(ServerError::conflict_kind(
+                "branch_missing",
+                format!(
+                    "branch {} no longer exists; create a new workspace instead",
+                    workspace.branch_name
+                ),
+            ));
+        }
+        let path = std::path::Path::new(&workspace.worktree_path);
+        if path.exists() {
+            return Err(ServerError::conflict_kind(
+                "worktree_path_occupied",
+                format!(
+                    "something already exists at {}",
+                    workspace.worktree_path
+                ),
+            ));
+        }
+        worktree::restore_worktree(repo_root, path, &workspace.branch_name)
+            .await
+            .map_err(map_worktree)?;
+        // Mirror create's tail exactly: setup decides between Active and
+        // SetupFailed, and a failing script preserves the checkout
+        // (Decision 0032's failure-preserves rule). One vocabulary for both
+        // paths — a reader debugging "setup_failed" should not need to know
+        // whether the workspace was created or restored.
+        match run_setup_script(path, repo.setup_script.as_deref()).await {
+            Ok(()) => {
+                workspace.status = CodeWorkspaceStatus::Active;
+                workspace.archived_at = None;
+                save_workspace(&self.db, &workspace).await?;
+                Ok(workspace)
+            }
+            Err(err) => {
+                workspace.status = CodeWorkspaceStatus::SetupFailed;
+                workspace.archived_at = None;
+                save_workspace(&self.db, &workspace).await?;
+                Err(ServerError::unprocessable_kind(
+                    "setup_failed",
+                    err.to_string(),
+                ))
+            }
+        }
+    }
+
     pub(crate) async fn commit_workspace(
         &self,
         owner: &OwnerId,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -765,10 +765,7 @@ impl CodeRuntime {
         if path.exists() {
             return Err(ServerError::conflict_kind(
                 "worktree_path_occupied",
-                format!(
-                    "something already exists at {}",
-                    workspace.worktree_path
-                ),
+                format!("something already exists at {}", workspace.worktree_path),
             ));
         }
         worktree::restore_worktree(repo_root, path, &workspace.branch_name)

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -161,6 +161,13 @@ impl ScopedCode {
         self.runtime.archive_workspace(&self.owner, id, force).await
     }
 
+    pub(crate) async fn restore_workspace(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<CodeWorkspace, ServerError> {
+        self.runtime.restore_workspace(&self.owner, id).await
+    }
+
     pub(crate) async fn workspace_tree(
         &self,
         id: WorkspaceId,

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -494,6 +494,77 @@ pub(crate) async fn create_worktree(
     }
 }
 
+/// True when `refs/heads/<branch>` exists in the repository.
+pub(crate) async fn branch_exists(
+    repo_root: &Path,
+    branch: &str,
+) -> Result<bool, WorktreeError> {
+    match git(
+        Some(repo_root),
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ],
+        GIT_TIMEOUT,
+    )
+    .await
+    {
+        Ok(_) => Ok(true),
+        // --quiet: a missing ref exits non-zero with nothing on stderr; any
+        // message is a real failure (not a repository, timeout, …).
+        Err(err) if err.trim().is_empty() => Ok(false),
+        Err(err) => Err(WorktreeError::internal(format!(
+            "could not check branch {branch}: {err}"
+        ))),
+    }
+}
+
+/// Re-create a worktree checking out an existing branch.
+///
+/// The restore counterpart of [`create_worktree`], deliberately a sibling and
+/// not a flag on it: create always mints a branch (`-b`), restore must never
+/// mint one — the branch surviving archive is what makes the workspace worth
+/// restoring. The caller has already verified the branch exists; a race that
+/// deletes it between the check and this call still fails cleanly here.
+pub(crate) async fn restore_worktree(
+    repo_root: &Path,
+    worktree_path: &Path,
+    branch: &str,
+) -> Result<(), WorktreeError> {
+    if let Some(parent) = worktree_path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|err| {
+            WorktreeError::internal(format!(
+                "could not create worktree parent {}: {err}",
+                parent.display()
+            ))
+        })?;
+    }
+    let add = git(
+        Some(repo_root),
+        &[
+            "worktree",
+            "add",
+            &worktree_path.to_string_lossy(),
+            branch,
+        ],
+        GIT_WORKTREE_TIMEOUT,
+    )
+    .await;
+    if let Err(err) = add {
+        cleanup_half_created(repo_root, worktree_path).await;
+        return Err(classify_worktree_add(err, branch));
+    }
+    match verify_inside_worktree(worktree_path).await {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            cleanup_half_created(repo_root, worktree_path).await;
+            Err(err)
+        }
+    }
+}
+
 /// Run the setup script, if any. Failure preserves the checkout.
 pub(crate) async fn run_setup_script(
     worktree_path: &Path,

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -495,10 +495,7 @@ pub(crate) async fn create_worktree(
 }
 
 /// True when `refs/heads/<branch>` exists in the repository.
-pub(crate) async fn branch_exists(
-    repo_root: &Path,
-    branch: &str,
-) -> Result<bool, WorktreeError> {
+pub(crate) async fn branch_exists(repo_root: &Path, branch: &str) -> Result<bool, WorktreeError> {
     match git(
         Some(repo_root),
         &[
@@ -543,12 +540,7 @@ pub(crate) async fn restore_worktree(
     }
     let add = git(
         Some(repo_root),
-        &[
-            "worktree",
-            "add",
-            &worktree_path.to_string_lossy(),
-            branch,
-        ],
+        &["worktree", "add", &worktree_path.to_string_lossy(), branch],
         GIT_WORKTREE_TIMEOUT,
     )
     .await;

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -736,6 +736,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::archive_workspace),
         )
         .route(
+            "/code/workspaces/{id}/restore",
+            post(routes::code::restore_workspace),
+        )
+        .route(
             "/code/workspaces/{id}/files",
             get(routes::code::list_workspace_files),
         )

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -54,8 +54,8 @@ pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, get_workspace_blob, get_workspace_diff,
-    list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace,
-    restore_workspace, search_workspace,
+    list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace, restore_workspace,
+    search_workspace,
 };
 
 // Nothing here reaches `AppState.code` directly. Every handler in this module

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -54,7 +54,8 @@ pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, get_workspace_blob, get_workspace_diff,
-    list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace, search_workspace,
+    list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace,
+    restore_workspace, search_workspace,
 };
 
 // Nothing here reaches `AppState.code` directly. Every handler in this module

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -749,6 +749,16 @@ pub struct CodeSessionDigest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub pr_state: Option<PullRequestDigest>,
+    /// Watch progress, present only on `kind: watch` digests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub watch_state: Option<CodeWatchState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub watch_detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub watch_cycles: Option<i64>,
 }
 
 impl From<crate::code::bus::SessionDigest> for CodeSessionDigest {
@@ -762,6 +772,9 @@ impl From<crate::code::bus::SessionDigest> for CodeSessionDigest {
             title: digest.title,
             turn_count: digest.turn_count,
             pr_state: digest.pr_state,
+            watch_state: digest.watch_state,
+            watch_detail: digest.watch_detail,
+            watch_cycles: digest.watch_cycles,
         }
     }
 }
@@ -791,6 +804,16 @@ pub enum CodeUpdateNotice {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         pr_state: Option<Box<PullRequestDigest>>,
+        /// Watch progress, present only on `kind: watch` digests.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        watch_state: Option<CodeWatchState>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        watch_detail: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        watch_cycles: Option<i64>,
     },
     /// Coalesced terminal activity. Not restated on connect.
     TerminalActivity {
@@ -837,6 +860,9 @@ impl CodeUpdateNotice {
             title: wire.title,
             turn_count: wire.turn_count,
             pr_state: wire.pr_state.map(Box::new),
+            watch_state: wire.watch_state,
+            watch_detail: wire.watch_detail,
+            watch_cycles: wire.watch_cycles,
         }
     }
 }

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -78,6 +78,21 @@ pub async fn archive_workspace(
     Ok(Json(CodeWorkspaceSnapshot::from(archived)))
 }
 
+/// `POST /code/workspaces/{id}/restore` — reactivate an archived workspace.
+///
+/// The worktree comes back at the same path on the kept branch; session rows
+/// and journal history were never deleted, so the conversation is readable
+/// again the moment this returns. 409 kinds: `branch_missing` (the branch was
+/// deleted since archive — fall back to a new workspace), and
+/// `worktree_path_occupied`.
+pub async fn restore_workspace(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
+    let restored = code.restore_workspace(id).await?;
+    Ok(Json(CodeWorkspaceSnapshot::from(restored)))
+}
+
 pub async fn list_workspace_tree(
     code: ScopedCode,
     Path(id): Path<WorkspaceId>,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -4258,3 +4258,125 @@ fn code_routes_go_through_the_owner_scoped_view() {
         "code routes must query through the owner-scoped view: {findings:?}"
     );
 }
+
+/// Archive keeps the branch; restore puts a checkout back under the same
+/// workspace row. Committed work returns, force-discarded work stays gone,
+/// and restoring an already-active workspace is a no-op.
+#[tokio::test]
+async fn restore_reactivates_an_archived_workspace_on_its_own_branch() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let id = json_id(&workspace);
+    let path = workspace["worktree_path"].as_str().unwrap().to_owned();
+    let branch = workspace["branch_name"].as_str().unwrap().to_owned();
+
+    // One committed file (should survive on the branch) and one uncommitted
+    // (force-archive discards it).
+    std::fs::write(std::path::Path::new(&path).join("kept.txt"), "kept\n").unwrap();
+    for args in [
+        ["add", "kept.txt"].as_slice(),
+        ["commit", "-m", "keep this"].as_slice(),
+    ] {
+        assert!(std::process::Command::new("git")
+            .args(args)
+            .current_dir(&path)
+            .status()
+            .unwrap()
+            .success());
+    }
+    std::fs::write(std::path::Path::new(&path).join("scratch.txt"), "gone\n").unwrap();
+
+    let archived = client
+        .post(format!("http://{addr}/code/workspaces/{id}/archive"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::OK);
+    assert!(!std::path::Path::new(&path).exists());
+
+    let restored = client
+        .post(format!("http://{addr}/code/workspaces/{id}/restore"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(restored.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = restored.json().await.unwrap();
+    assert_eq!(body["status"], "active");
+    assert_eq!(body["worktree_path"], path.as_str());
+    assert_eq!(body["branch_name"], branch.as_str());
+    assert!(body.get("archived_at").is_none() || body["archived_at"].is_null());
+    assert_eq!(
+        std::fs::read_to_string(std::path::Path::new(&path).join("kept.txt")).unwrap(),
+        "kept\n"
+    );
+    assert!(!std::path::Path::new(&path).join("scratch.txt").exists());
+
+    // Idempotent on an active workspace.
+    let again = client
+        .post(format!("http://{addr}/code/workspaces/{id}/restore"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(again.status(), reqwest::StatusCode::OK);
+}
+
+/// The two ways a restore can be impossible, each with its own kind so the
+/// UI can offer the right fallback: the branch was deleted since archive, or
+/// something has claimed the worktree path.
+#[tokio::test]
+async fn restore_refuses_a_missing_branch_and_an_occupied_path() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let id = json_id(&workspace);
+    let path = workspace["worktree_path"].as_str().unwrap().to_owned();
+    let branch = workspace["branch_name"].as_str().unwrap().to_owned();
+
+    let archived = client
+        .post(format!("http://{addr}/code/workspaces/{id}/archive"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::OK);
+
+    // Occupy the path first: the branch still exists, so this is the
+    // path-specific refusal.
+    std::fs::create_dir_all(&path).unwrap();
+    let occupied = client
+        .post(format!("http://{addr}/code/workspaces/{id}/restore"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(occupied.status(), reqwest::StatusCode::CONFLICT);
+    let occupied_body: serde_json::Value = occupied.json().await.unwrap();
+    assert_eq!(occupied_body["kind"], "worktree_path_occupied");
+    std::fs::remove_dir_all(&path).unwrap();
+
+    assert!(std::process::Command::new("git")
+        .args(["branch", "-D", &branch])
+        .current_dir(&repo)
+        .status()
+        .unwrap()
+        .success());
+    let missing = client
+        .post(format!("http://{addr}/code/workspaces/{id}/restore"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), reqwest::StatusCode::CONFLICT);
+    let missing_body: serde_json::Value = missing.json().await.unwrap();
+    assert_eq!(missing_body["kind"], "branch_missing");
+}

--- a/docs/decisions/0052-harness-subagents-as-child-rows.md
+++ b/docs/decisions/0052-harness-subagents-as-child-rows.md
@@ -1,0 +1,75 @@
+# 52. Harness Subagents Appear as Child Rows
+
+- Status: Accepted
+- Date: 2026-08-20
+- Owners: code mode
+- Related: [`0031-code-mode-harness-adapters.md`](0031-code-mode-harness-adapters.md),
+  [`0035-code-mode-wire-contract.md`](0035-code-mode-wire-contract.md),
+  [`0050-watch-and-fix-is-a-durable-task.md`](0050-watch-and-fix-is-a-durable-task.md)
+
+## Context
+
+Engines fan work out to subagents: Claude Code spawns them through the `Task`
+tool and tags every event a subagent produces with a top-level
+`parent_tool_use_id`; Grok exposes `spawn_subagent` and companion commands.
+Tidebreak currently flattens all of it. The Claude adapter never reads
+`parent_tool_use_id`, `tool_detail()` has no `Task` branch, and `CodeEvent`
+has no notion of nesting — a subagent's tool calls and text interleave with
+the parent's, indistinguishable in the transcript and invisible on the rail.
+
+The rail now shows watch sessions as child rows under their workspace card
+(the sidebar half of record 50). Harness subagents should read the same way:
+a thing running under the conversation, with a status, that you can open to
+see what it is doing. That requires per-harness parsing, so it needs a
+contract before code.
+
+## Decision
+
+Subagents are derived, not declared. `CodeEvent`'s tool and assistant
+variants gain an optional `parent_call_id`; a subagent *is* the span of its
+parent `Task` call — the call's start is the subagent's start, the call's
+result is its end and outcome. No `subagent_started`/`subagent_completed`
+event pair: a separate lifecycle would be one more thing to keep true across
+harness restarts, and the spanning call already carries name, input, status,
+and result. Old journals replay unchanged; events without `parent_call_id`
+are the parent's own.
+
+Subagents are not sessions. They get no session row, no digest of their own,
+and never touch the conversation's slot in the updates store — record 50's
+displacement rule extends to them. The server cannot steer or resume them;
+pretending they are sessions would promise exactly that. Rail visibility
+rides the parent session's digest as a bounded enrichment
+(`subagents: [{ call_id, name, status }]`, capped, optional), the same
+additive pattern that carried watch state onto the digest.
+
+A subagent row shows the Task's name or description and a status derived
+from the spanning call (running, done, failed). Opening it filters the
+parent transcript to events whose `parent_call_id` matches — a view inside
+the parent session, not a new socket.
+
+Claude Code is the first adapter; Grok's `spawn_subagent` family maps onto
+the same contract in a follow-up slice. Codex and OpenCode map when their
+streams expose equivalent structure.
+
+## Consequences
+
+- The transcript can collapse a subagent's noise behind one row and let the
+  reader expand it — the flattened interleaving goes away.
+- The wire contract grows only optional fields; a UI ahead of or behind the
+  server degrades to today's flattened view.
+- Deriving subagents from spans means a harness that loses the pairing (a
+  crash mid-Task) shows a subagent that never completes; the parent turn's
+  own completion bounds how long that can dangle.
+- Each harness pays its own mapping cost at the adapter boundary
+  (record 31); nothing downstream of `CodeEvent` knows harness names.
+
+## Alternatives rejected
+
+- **Per-subagent sessions.** The harness owns their lifecycle; the server
+  could neither steer nor resume them, and every session surface (attention,
+  digests, recovery) would carry rows it cannot honor.
+- **Lifecycle events for subagents.** A second source of truth beside the
+  spanning call, and one more invariant to re-derive after a restart.
+- **Client-side heuristics.** Grouping by message ordering breaks on replay
+  and differs per harness; the journal is the contract, so the linkage must
+  be in it.


### PR DESCRIPTION
## What changed

The code-mode workspace rail is rebuilt around three layers with one job each:

- **Rows are plain.** One button that opens the workspace: attention dot, PR mark, title, view-dependent meta. No inline action buttons or hover overlays.
- **Detail and actions live in a hover panel** (Radix HoverCard, new `components/ui/hover-card.tsx`) that opens beside the row: full branch, state line, checks summary, and the pull request with its open action. `detailDefaultOpen` renders it for stories.
- **Right-click is the row's one menu** (Radix ContextMenu) and the keyboard path.

Around the card:

- The Repos section is gone: by-repo group headers link to their repo page, and a searchable repo-switcher popover in the toolbar (with "Add repo…") covers every sort mode.
- A rail settings popover controls sort mode, card density (compact/detailed), repo/branch visibility, and an archived shelf. Prefs persist as one `tidebreak.code-rail-prefs` blob, migrating the legacy sort key.
- Watch sessions (ADR 0050) render as live child rows under their card, from digests the updates store previously dropped; clicking opens the watch transcript read-only at `?session=<id>`. The interactive digest never leaves its slot.
- Session digests now carry `watch_state`/`watch_detail`/`watch_cycles` so watch rows say "Fixing ×3" without any per-card `gh` round trip.
- Archive gains an explicit "Force archive (discard changes)" command (the error-driven escalation is unchanged, `ARCHIVE_FORCE_KINDS` untouched).
- New `POST /code/workspaces/{id}/restore` reactivates an archived workspace Conductor-style: worktree re-created at the same path from the kept branch, setup script mirroring create's semantics, journals and session rows intact. 409 kinds `branch_missing` (UI offers a new-workspace fallback) and `worktree_path_occupied`. Restore is reachable from archived cards and the repo page.
- ADR 0052 records the harness-subagent contract (renumbered from 0051 after a collision on main; parent_call_id, subagents as derived spans, never sessions) ahead of implementation.

## Why

Design review of the rail: hover actions clashed with row text, repo info repeated per view, no card density control, watch tasks were invisible on the rail, and archived work had no way back.

## Testing

- `pnpm test` — 1402 tests green (card, sidebar, stores, parsers, workspace page rewritten/extended).
- `pnpm storybook:build` — stories for row states, detail panels, archived shelf.
- `cargo test -p tidebreak-server --lib` and `-p tidebreak-core --lib` — new restore round-trip/refusal tests, watch-by-session digest test, wire regen in sync.
