### PR TITLE
fix(release): dispatch the server image build when a release publishes

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -21,18 +21,25 @@ run-name: >-
 #
 # Publishes happen on three triggers:
 #
-#   - a published, non-prerelease GitHub Release, which is the release cadence
-#     and the primary path. `release` events run this file from the default
-#     branch, not from the tag, so a hostile or stale tag YAML cannot publish;
+#   - a release, which is the release cadence and the primary path. release.yml
+#     dispatches this workflow with the tag it just published, because a release
+#     that job publishes raises no `release` event: the PATCH runs on
+#     GITHUB_TOKEN, and GitHub does not start a workflow run from an event that
+#     token created. The `release` trigger below stays declared for a release
+#     someone publishes by hand in the UI, which carries a user token and does
+#     fire. Both land here as the same build, and the per-tag concurrency group
+#     serializes them if a release ever arrives by both routes;
 #   - a weekly scheduled rebuild, so Debian security patches in the runtime
 #     base flush through even when nothing in-repo changes;
 #   - manual dispatch, for retries and backfills. Dispatch takes an optional
 #     release tag; with none, it rebuilds the current latest release, exactly
 #     like the schedule does.
 #
-# Publication source is the default branch only. Manual dispatch and the weekly
-# schedule must run this workflow from that branch, and every publish refuses a
-# revision that is not an ancestor of it. The build checkout does not persist
+# No trigger runs this file from the release tag. `release` events and dispatch
+# both run it from the default branch, so a hostile or stale tag YAML cannot
+# publish. Manual dispatch and the weekly schedule must run this workflow from
+# that branch too, and every publish refuses a revision that is not an ancestor
+# of it. The build checkout does not persist
 # credentials, and deploy/self-host/Dockerfile.dockerignore keeps `.git` and
 # every untracked non-source path out of the `COPY . .` context.
 #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2424,6 +2424,22 @@ jobs:
             '.published_at | select(type == "string" and length > 0)' \
             <<<"$release_json")"
           echo "published_at=$published_at" >> "$GITHUB_OUTPUT"
+      - name: Publish the server image for this release
+        if: ${{ needs.validate.outputs.draft == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          # publish-server-image.yml declares `on: release: [published]`, but
+          # that trigger cannot fire for a release this job publishes: the
+          # PATCH above runs on GITHUB_TOKEN, and GitHub does not start a
+          # workflow run from an event that token created. workflow_dispatch is
+          # one of the two exceptions to that rule, so dispatch it explicitly.
+          # The release trigger stays declared for a release someone publishes
+          # by hand in the UI, which carries a user token and does fire.
+          gh workflow run publish-server-image.yml \
+            --repo "$GITHUB_REPOSITORY" --ref main --field "release_tag=$RELEASE_TAG"
+
       - name: Refresh the next release draft
         if: ${{ needs.validate.outputs.draft == 'true' }}
         env:

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -287,6 +287,45 @@ test("release-drafter retains a stable draft tag after formatting", () => {
   assert.match(draftJob, /jq -r \.action/);
 });
 
+test("publishing a release dispatches the server image build", () => {
+  // A release this workflow publishes raises no `release` event, because the
+  // PATCH that publishes it runs on GITHUB_TOKEN. Relying on the declared
+  // `release` trigger alone shipped a release with no server image and no
+  // failed run to notice. The dispatch is the working path; assert it stays.
+  const finalizeJob = workflowJob(workflows["release.yml"], "finalize_release");
+  assert.match(finalizeJob, /actions: write/);
+  const dispatchAt = finalizeJob.indexOf(
+    "gh workflow run publish-server-image.yml",
+  );
+  assert.notEqual(
+    dispatchAt,
+    -1,
+    "finalize_release must dispatch the server image build",
+  );
+  assert.match(
+    finalizeJob.slice(dispatchAt, dispatchAt + 200),
+    /--field "release_tag=\$RELEASE_TAG"/,
+  );
+
+  // Dispatch only on the draft-to-published transition. Re-running the release
+  // workflow against an already-published release must not rebuild an image,
+  // because a version tag that exists on GHCR fails the publish.
+  const dispatchStep = finalizeJob.slice(
+    finalizeJob.lastIndexOf("- name:", dispatchAt),
+    dispatchAt,
+  );
+  assert.match(
+    dispatchStep,
+    /if: \$\{\{ needs\.validate\.outputs\.draft == 'true' \}\}/,
+  );
+
+  // The declared trigger stays for a release published by hand in the UI.
+  assert.match(
+    workflows["publish-server-image.yml"],
+    /^on:\n {2}release:\n {4}types: \[published\]$/m,
+  );
+});
+
 test("workflow container images are pinned by digest", () => {
   for (const [name, source] of Object.entries(workflows)) {
     for (const match of source.matchAll(/^\s*image:\s*([^\s#]+)/gm)) {


### PR DESCRIPTION
## What broke

`publish-server-image.yml` declares `on: release: [published]` and its header calls that "the release cadence and the primary path." That trigger cannot fire for a release `release.yml` publishes. The `PATCH` that flips the draft runs on `GITHUB_TOKEN`, and GitHub does not start a workflow run from an event that token created.

v0.57.0 published this morning and no image build ran. Nothing failed, so nothing reported it. The release had no `ghcr.io/brightwave-inc/tidebreak-server` image until a manual dispatch built one, and every future release would have been silent in the same way.

## The fix

`finalize_release` dispatches `publish-server-image.yml` with the tag it just published. `workflow_dispatch` is one of the two events `GITHUB_TOKEN` may raise, and the same job already dispatches `release-draft.yml` this way, so the mechanism is proven in this repository and the job already holds `actions: write`.

The step carries the same `draft == 'true'` guard as its neighbor. Re-running the release workflow against an already-published release must not rebuild an image, because a version tag that already exists on GHCR fails the publish.

The `release` trigger stays declared. A release someone publishes by hand in the UI carries a user token and does fire it. Both routes land as the same build, and the per-tag concurrency group serializes them.

## Test

`workflow-security.test.mjs` gains a case asserting the dispatch, its tag argument, its draft guard, and that the declared trigger survives. Removing the dispatch line fails it. The header comment in `publish-server-image.yml` now describes the trigger that actually works.

37 tests pass.