### PR TITLE
fix(self-host): make the server image report its release

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -259,13 +259,22 @@ jobs:
         run: |
           docker build \
             --file deploy/self-host/Dockerfile \
+            --build-arg "TIDEBREAK_VERSION=$VERSION" \
             --tag "$SERVER_REPOSITORY:$VERSION-${{ matrix.arch }}" \
             .
 
       - name: Smoke test the built binary
         run: |
-          docker run --rm --entrypoint /usr/local/bin/tidebreak \
-            "$SERVER_REPOSITORY:$VERSION-${{ matrix.arch }}" --version
+          # Proves the binary executes on this architecture, and that it
+          # carries the release it claims to. A published image whose version
+          # is a guess is worse than one that cannot answer.
+          reported="$(docker run --rm --entrypoint /usr/local/bin/tidebreak \
+            "$SERVER_REPOSITORY:$VERSION-${{ matrix.arch }}" --version)"
+          echo "$reported"
+          [[ "$reported" = "tidebreak $VERSION" ]] || {
+            echo "Expected 'tidebreak $VERSION'." >&2
+            exit 1
+          }
 
       - name: Push the per-architecture tag
         run: docker push "$SERVER_REPOSITORY:$VERSION-${{ matrix.arch }}"

--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -85,8 +85,21 @@ mod setup;
 use print::OutputFormat;
 use setup::{Command as SetupCommand, SecretSource};
 
+/// What `--version` reports.
+///
+/// The workspace manifest stays at `0.0.0`: release numbering lives on the Git
+/// tag and the desktop bundle, not in Cargo. A release build passes the tag
+/// through `TIDEBREAK_VERSION` so the published binary states the release it
+/// came from. A build without it says so plainly rather than claiming a
+/// version it does not have.
+const VERSION: &str = match option_env!("TIDEBREAK_VERSION") {
+    Some(version) => version,
+    None => "0.0.0-unreleased",
+};
+
 const USAGE: &str = "\
 usage: tidebreak serve
+       tidebreak --version
        tidebreak mcp <workspace>
        tidebreak rehome-secrets
        tidebreak -p <prompt> [--chat <id>] [--output-format text|json]
@@ -204,6 +217,18 @@ async fn run() -> Result<i32> {
                 usage_error("serve does not accept arguments");
             }
             serve().await.map(|()| 0)
+        }
+        Some(command) if command == OsStr::new("--version") => {
+            // A published container has no other way to say what it is: the
+            // image tag can be moved, and `serve` needs a database before it
+            // reports anything. This is also the smoke test the server image
+            // publish runs against a freshly built binary.
+            server_flags.refuse("--version");
+            if args.next().is_some() {
+                usage_error("--version does not accept arguments");
+            }
+            println!("tidebreak {VERSION}");
+            Ok(0)
         }
         Some(command) if command == OsStr::new("mcp") => {
             server_flags.refuse("mcp");

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -33,6 +33,13 @@ WORKDIR /src
 # every path the workspace manifests reference.
 COPY . .
 
+# The release this image carries, reported by `tidebreak --version`. The
+# workspace manifest stays at 0.0.0, so without this the binary cannot state
+# which release it is. The default is the honest answer for a local build; the
+# publish workflow passes the release tag. Docker exposes an ARG to the RUN
+# below as an environment variable, which is where `option_env!` reads it.
+ARG TIDEBREAK_VERSION="0.0.0-unreleased"
+
 # `--features tidebreak-server/postgres` reaches through the CLI into the
 # server crate's feature, because the feature lives there and the CLI takes
 # tidebreak-server with default features. Without it the self-host boot has no

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -771,6 +771,21 @@ test("the self-host runtime installs packages from an immutable Debian snapshot"
   );
 });
 
+test("the published server image states the release it carries", () => {
+  // The workspace manifest stays at 0.0.0, so the release tag reaches the
+  // binary only through this build argument. Without it `--version` answers
+  // "0.0.0-unreleased" and the smoke test below catches the mismatch.
+  assert.match(selfHostDockerfile, /^ARG TIDEBREAK_VERSION="0\.0\.0-unreleased"$/m);
+
+  const buildJob = workflowJob(workflows["publish-server-image.yml"], "build");
+  assert.match(buildJob, /--build-arg "TIDEBREAK_VERSION=\$VERSION"/);
+
+  // Asserting the reported string, not just a zero exit. The smoke test that
+  // shipped ran `--version` against a binary with no such flag; it would have
+  // failed on any build, and did on the first one that compiled.
+  assert.match(buildJob, /\[\[ "\$reported" = "tidebreak \$VERSION" \]\]/);
+});
+
 test(
   "BuildKit admits only exact source inputs from allowed source paths",
   { skip: process.env.TIDEBREAK_SKIP_DOCKER_CONTEXT_PROBE === "1" },


### PR DESCRIPTION
## What broke

The server image publish smoke-tests the built binary with `tidebreak --version`. The CLI has no such flag. The binary printed its usage text and exited 2, so the step could never have passed on any build.

It went unnoticed because the first publish attempt died at compile with the dockerignore bug (#2299), and today's dispatch for v0.57.0 was the first build ever to reach the smoke test. It failed there, with both architectures compiled and one push away from done.

## The fix

Add `--version`, and give it something true to say.

The workspace manifest is pinned at `0.0.0` because release numbering lives on the Git tag and the desktop bundle, not in Cargo. Reporting `CARGO_PKG_VERSION` would make the smoke test pass while printing `tidebreak 0.0.0` for every release, which is worse than not answering. So the tag reaches the binary through a `TIDEBREAK_VERSION` build argument that the publish workflow passes and `option_env!` reads at compile time. A build that passes nothing reports `0.0.0-unreleased`.

The smoke test asserts the reported string rather than a zero exit:

```
reported="$(docker run --rm --entrypoint /usr/local/bin/tidebreak "$SERVER_REPOSITORY:$VERSION-$arch" --version)"
[[ "$reported" = "tidebreak $VERSION" ]] || exit 1
```

That is the difference between checking the binary runs and checking it is the release it claims to be. A deployment pins this image by digest; being able to ask a running pod what it is has value beyond the smoke test.

## Test

`workflow-security.test.mjs` gains a case covering the build argument, the Dockerfile's `ARG` default, and the string assertion.

Verified against `cargo` builds:

- unstamped build reports `tidebreak 0.0.0-unreleased`
- `TIDEBREAK_VERSION=0.57.0` build reports `tidebreak 0.57.0`
- `--version extra` exits 2 with the usage text

Verified end to end against the staged Docker context, which is the path that failed today:

```
docker build --build-arg TIDEBREAK_VERSION=0.57.0 ...   # exit 0
docker run --rm --entrypoint /usr/local/bin/tidebreak tidebreak-self-host:verify --version
tidebreak 0.57.0
```

Clippy is clean and 37 workflow tests pass.

## Related

Stacks with #2306, which fixes the trigger that should have started this build in the first place. Both are needed before a release publishes an image without a human dispatching it.