### PR TITLE
fix(desktop): keep the code tool line on one row

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -87,12 +87,16 @@ export function ToolCardShell({
           {icon}
         </span>
         <span className={cn("min-w-0 flex-1", titleClassName)}>
-          <span
-            className={cn(typeof title === "string" && "block truncate")}
-            title={typeof title === "string" ? title : undefined}
-          >
-            {title}
-          </span>
+          {typeof title === "string" ? (
+            <span className="block truncate" title={title}>
+              {title}
+            </span>
+          ) : (
+            // Rendered directly so a `titleClassName` flex layout reaches the
+            // host's own title children; an inline wrapper here forces a
+            // block-level child (e.g. MiddleTruncate) onto its own line.
+            title
+          )}
         </span>
         <span className="text-muted-foreground ml-auto flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums">
           {trailing}

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -79,6 +79,36 @@ describe("CodeTranscript", () => {
     expect(screen.getByText("unrecognized event dropped")).toBeInTheDocument();
   });
 
+  it("shows the command beside the verb, without its worktree cd prefix", () => {
+    const item: CodeTranscriptItem = {
+      kind: "tool",
+      id: "tool-cd",
+      turnId: "t1",
+      callId: "c2",
+      name: "Bash",
+      detail: {
+        kind: "command",
+        cmd: 'cd "/Users/me/Library/Application Support/dev/worktrees/abc" && cargo test -p core',
+        cwd: "/tmp",
+      },
+      status: "succeeded",
+      preview: "",
+      startedAt: "2026-08-15T12:00:00.000Z",
+      durationMs: 900,
+    };
+    render(<CodeTranscript items={[item]} />);
+    // The leading `cd <worktree> &&` repeats the session's own directory on
+    // every row and pushes the real command into the truncated middle.
+    const subject = screen.getByText("cargo test -p core");
+    expect(screen.queryByText(/Application Support/)).toBeNull();
+    // The verb and the command are direct children of the flex title row.
+    // An inline wrapper span here once pushed the command onto its own line
+    // and broke middle truncation (#2282 regression).
+    const verb = screen.getByText("Command run");
+    expect(subject.parentElement).toBe(verb.parentElement);
+    expect(verb.parentElement?.className).toContain("flex");
+  });
+
   it("announces the turn's lifecycle and nothing that streams", () => {
     // A tool line changes on every streamed byte. Wrapping it in a live region
     // reads the whole session out, over and over, and buries the one thing a

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -641,9 +641,24 @@ function toolSubject(detail: ToolDetail, name: string): string {
  * serialization verbatim leaves ordinary globs looking like
  * `'"'!node_modules'"'`. Decode the outer double-quoted `-lc` argument for
  * display only; the command is never executed from this value.
+ *
+ * Headless engines also lead every command with `cd <worktree> && `, so a
+ * session's rows all open with the same long path and the part worth reading
+ * is pushed into the truncated middle. Drop that leading `cd` for display —
+ * the worktree is the session's own directory, so it says nothing the row
+ * does not already mean.
  */
 function humanizeShellCommand(command: string): string {
-  const trimmed = command.trim();
+  const unwrapped = unwrapShellLauncher(command.trim());
+  const stripped = unwrapped.replace(
+    /^cd\s+(?:"[^"]*"|'[^']*'|[^\s;&|]+)\s*&&\s*/,
+    "",
+  );
+  // A bare `cd <path>` is the whole command; stripping it would leave nothing.
+  return stripped.trim() || unwrapped;
+}
+
+function unwrapShellLauncher(trimmed: string): string {
   const wrapped = trimmed.match(
     /^\/(?:usr\/)?bin\/(?:zsh|bash|sh) -lc "([\s\S]*)"$/,
   );

--- a/crates/tidebreak-desktop/ui/src/stories/CodeToolCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeToolCard.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CodeToolCard } from "@/code/CodeTranscript";
+
+/**
+ * The code transcript's boxless tool line: verb, mono subject, and trailing
+ * meta on one row. The states that matter are the ones that stress that row —
+ * a worktree-prefixed command long enough to force middle truncation, a
+ * running call streaming its tail, and the failed line that opens itself.
+ */
+const meta = {
+  title: "Code/Tool line",
+  component: CodeToolCard,
+  args: {
+    name: "Bash",
+    detail: { kind: "command", cmd: "cargo test -p tidebreak-core", cwd: "/repo" },
+    status: "succeeded",
+    preview: "",
+    startedAt: "2026-08-15T12:00:00.000Z",
+    durationMs: 1_800,
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CodeToolCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Succeeded: Story = {};
+
+/**
+ * Headless engines lead every command with `cd <worktree> && `. The line
+ * drops that prefix and middle-truncates what is left, so the verb, the
+ * command's head and tail, and the trailing meta all stay on one row.
+ */
+export const LongWorktreeCommand: Story = {
+  args: {
+    detail: {
+      kind: "command",
+      cmd: 'cd "/Users/me/Library/Application Support/io.example.dev/code/worktrees/3d751509-02de-4f33" && pnpm vitest run src/code/CodeTranscript.dom.test.tsx --reporter=dot',
+      cwd: "/repo",
+    },
+    durationMs: 6_100,
+  },
+};
+
+/** A running call streams the last lines of output without growing the row. */
+export const Running: Story = {
+  args: {
+    status: "running",
+    durationMs: null,
+    preview: "Compiling tidebreak-core v0.4.2\nCompiling tidebreak-harness v0.4.2\n",
+  },
+};
+
+/** Failure opens itself: the output and exit code are the point. */
+export const Failed: Story = {
+  args: {
+    status: "failed",
+    durationMs: 4_400,
+    preview:
+      "error[E0308]: mismatched types\n  --> src/lib.rs:41:9\n   |\n41 |         Ok(())\n   |         ^^^^^^ expected `Turn`, found `()`\n\nexit code 1",
+  },
+};
+
+export const Denied: Story = {
+  args: {
+    status: "denied",
+    durationMs: null,
+    preview: "The reader denied this command.",
+  },
+};
+
+export const FileRead: Story = {
+  args: {
+    name: "Read",
+    detail: { kind: "file_read", path: "crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx" },
+    durationMs: 300,
+  },
+};
+
+export const Search: Story = {
+  args: {
+    name: "Grep",
+    detail: { kind: "search", query: "humanizeShellCommand" },
+    preview: "src/code/CodeTranscript.tsx:651",
+    durationMs: 500,
+  },
+};


### PR DESCRIPTION
## What changed

The card unification (#2282) wrapped every `ToolCardShell` title in an inline span. Code mode passes its title as two elements — the bold verb and the `MiddleTruncate` command — with a flex `titleClassName`, but that class landed on the outer span while the elements sat inside the plain inline wrapper. The block-level `MiddleTruncate` broke onto its own line, its nowrap text stopped the row from shrinking, middle truncation died, and the duration/exit/status meta floated mid-row.

- `ToolCardShell` now renders a non-string title directly inside the flex container, so the host's title layout reaches its children. String titles (work/chat cards, agent timeline) keep the old wrapper.
- `humanizeShellCommand` also strips the leading `cd "<worktree>" && ` for display. Headless engines lead every command with the session's own directory, which buried the real command in the truncated middle. Display only; a bare `cd <path>` is left alone.

## Tests

- Regression test in `CodeTranscript.dom.test.tsx`: the verb and command must be direct children of the flex title row, and the cd prefix must not render.
- New `CodeToolCard.stories.tsx` covering the tool line's states, including the long worktree-prefixed command that would have caught this.
- `pnpm test` on the five suites touching the shell and its consumers (79 pass), `tsc --noEmit` clean, `pnpm storybook:build` clean.