### PR TITLE
chore: add a from-anywhere Storybook launcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,9 @@ is React/TypeScript under `crates/tidebreak-desktop/ui`.
 - Show the states that matter for evaluation, including loading, empty, success,
   failure, and compact variants when they apply. Reuse the typed Storybook
   fixtures instead of duplicating ad hoc sample data.
-- Run `pnpm storybook` from `crates/tidebreak-desktop/ui` while developing UI,
-  and run `pnpm storybook:build` before publishing relevant UI changes.
+- Run `scripts/storybook.sh` while developing UI, and run
+  `pnpm --dir crates/tidebreak-desktop/ui storybook:build` before publishing
+  relevant UI changes.
 
 ## Pointers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,10 @@ Desktop builds require CMake to compile the pinned whisper.cpp local voice engin
 # Arguments are forwarded to `cargo tauri dev`.
 scripts/dev.sh
 
+# Run Storybook for the desktop UI: installs the UI dependencies, then starts
+# the Storybook dev server. Arguments are forwarded to `pnpm storybook`.
+scripts/storybook.sh
+
 # Build everything
 cargo build --workspace
 

--- a/scripts/storybook.sh
+++ b/scripts/storybook.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Install the desktop UI dependencies and start Storybook.
+#
+# Storybook lives in crates/tidebreak-desktop/ui, which is not the directory
+# you are usually in, and skipping the install leaves it on a stale
+# dependency tree. This does both, from anywhere in the repo.
+#
+#   scripts/storybook.sh # the usual Storybook dev server
+#
+# Every argument is forwarded to `pnpm storybook`.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(dirname "$script_dir")"
+ui_dir="$repo_root/crates/tidebreak-desktop/ui"
+
+if ! command -v pnpm >/dev/null; then
+  echo "Missing prerequisites:" >&2
+  echo "  - pnpm — https://pnpm.io/installation" >&2
+  exit 1
+fi
+
+echo "==> Installing UI dependencies"
+pnpm --dir "$ui_dir" install
+
+echo "==> Starting Storybook"
+exec pnpm --dir "$ui_dir" storybook "$@"


### PR DESCRIPTION
## Summary

Storybook lives in `crates/tidebreak-desktop/ui`. Running it from the repo root used to mean two commands, and skipping `pnpm install` leaves a stale tree.

`scripts/storybook.sh` matches `scripts/dev.sh`: it installs UI dependencies, then starts Storybook, from anywhere in the repo. Extra arguments go to `pnpm storybook`.

`CONTRIBUTING.md` and `CLAUDE.md` point at the script. `storybook:build` stays a `pnpm --dir` command.

## Test plan

- [ ] From the repo root, `scripts/storybook.sh` starts Storybook.
- [ ] From another directory in the repo, the same script starts Storybook.