### PR TITLE
docs: point agents at the GitHub project board

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,18 @@ is React/TypeScript under `crates/tidebreak-desktop/ui`.
   ready PR lands when its lanes go green.
 - This is a public repository. No secrets, no private design docs.
 
+## GitHub tracking
+
+The [Tidebreak GitHub Project](https://github.com/orgs/brightwave-inc/projects/5)
+is the board. Milestones are delivery buckets. Parked product ideas stay in
+[`docs/deferred.md`](docs/deferred.md) until a slice is buildable; do not copy
+that list onto the board.
+
+- Open an issue only for a bounded outcome with an owner. Do not file per-file
+  or per-session tasks.
+- Multi-slice work uses an `epic` parent. Children are the slices, not the
+  files inside them.
+
 ## Desktop UI workflow
 
 - When adding or changing a reusable visual component or a meaningful UI state,
@@ -40,6 +52,7 @@ is React/TypeScript under `crates/tidebreak-desktop/ui`.
 ## Pointers
 
 - Humans and commit/PR titles: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Board: [Tidebreak GitHub Project](https://github.com/orgs/brightwave-inc/projects/5)
 - Decisions: [`docs/decisions/`](docs/decisions)
 - Parked scope: [`docs/deferred.md`](docs/deferred.md)
 - Releases: [`docs/releases.md`](docs/releases.md)


### PR DESCRIPTION
## What changed

Point coding agents at the [Tidebreak GitHub Project](https://github.com/orgs/brightwave-inc/projects/5). `CLAUDE.md` (`Agents.md` is a symlink to that file) now says:

- The project is the board; milestones are delivery buckets.
- Parked product ideas stay in `docs/deferred.md` until a slice is buildable.
- Open an issue only for a bounded outcome with an owner. Do not file per-file or per-session tasks.
- Multi-slice work uses an `epic` parent; children are the slices.

## Validation

Docs-only change. No tests.

## Compatibility and risk

None.

## Tracking

No issue. This is the tracking setup itself.