### PR TITLE
fix(server): stop idle agent polling from starving the SQLite pool

### DIFF
--- a/crates/tidebreak-core/src/db/mod.rs
+++ b/crates/tidebreak-core/src/db/mod.rs
@@ -99,6 +99,43 @@ struct DocumentSummaryRow {
     updated_at: chrono::DateTime<Utc>,
 }
 
+/// How long a SQLite writer waits for the write lock before it gives up.
+///
+/// sqlx defaults to 5s, which a real turn write can exceed while a fleet runs;
+/// waiting is better than surfacing "database is locked" to the caller.
+#[cfg(feature = "sqlite")]
+const SQLITE_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Apply the write policy that a `PRAGMA` at connect time cannot.
+///
+/// Constraint: `synchronous` and `busy_timeout` are per-connection settings,
+/// so a pool larger than one connection only honours them if they ride the
+/// connect options. `journal_mode` is the exception — it is a persistent
+/// file-level setting, which is why WAL stays a one-shot `PRAGMA` below.
+///
+/// `synchronous=NORMAL` is the standard WAL pairing: WAL already keeps a
+/// commit durable across a process crash, and the default `FULL` buys
+/// durability across a power loss by fsyncing every commit — expensive on
+/// macOS, and it lengthens every write while SQLite's single writer is the
+/// contended resource (#2316).
+///
+/// SeaORM only applies this hook to the SQLite driver, so it is a no-op for a
+/// Postgres self-host.
+#[cfg(feature = "sqlite")]
+fn with_sqlite_write_policy(mut options: ConnectOptions) -> ConnectOptions {
+    options.map_sqlx_sqlite_opts(|sqlite| {
+        sqlite
+            .synchronous(sea_orm::sqlx::sqlite::SqliteSynchronous::Normal)
+            .busy_timeout(SQLITE_BUSY_TIMEOUT)
+    });
+    options
+}
+
+#[cfg(not(feature = "sqlite"))]
+fn with_sqlite_write_policy(options: ConnectOptions) -> ConnectOptions {
+    options
+}
+
 impl DbStore {
     /// Connect to `url` and run migrations. For a SQLite file that should be
     /// created if missing, include `?mode=rwc` (e.g.
@@ -113,6 +150,7 @@ impl DbStore {
     /// hosts and integration fixtures that need deliberate pool sizing or
     /// timeout policy rather than SeaORM's defaults.
     pub async fn connect_with_options(options: ConnectOptions) -> Result<Self> {
+        let options = with_sqlite_write_policy(options);
         let conn = Database::connect(options).await.map_err(store_err)?;
         // WAL lets a reader (e.g. the UI listing chats) proceed concurrently
         // with a writer (a turn appending messages). SQLite-only; it's a

--- a/crates/tidebreak-core/src/db/ops/agent_run.rs
+++ b/crates/tidebreak-core/src/db/ops/agent_run.rs
@@ -662,6 +662,21 @@ pub(in crate::db) async fn claim_agent_run(
         max_running_per_chat,
     )?;
 
+    // Idle fast path. Every branch of the scan below acts only on a background
+    // run in one of `SCANNABLE_CLAIM_STATUSES`, so when none exists the scan
+    // has nothing to decide — but the durable claim lock it would take to
+    // discover that is an `UPDATE`, which makes an idle poll a write
+    // transaction on SQLite's single writer. Fleet-wide, those polls serialize
+    // behind real turn writes, hold their pooled connection while they wait,
+    // and starve every other request in the process (#2316).
+    //
+    // Reading it outside the lock is safe: the locked scan below stays the
+    // authority for every decision, and a run that appears right after this
+    // check is claimed by the next poll (the worker also wakes on notify).
+    if !any_scannable_agent_run_on(&store.conn).await? {
+        return Ok(None);
+    }
+
     loop {
         let transaction = store.conn.begin().await.map_err(store_err)?;
         acquire_agent_run_claim_lock(&transaction).await?;
@@ -1270,6 +1285,49 @@ pub(in crate::db) async fn reclaim_container_agent_run(
 /// is enough; past it the row only exists to be swept.
 const EMPTY_CLAIM_SCAN_RETENTION: chrono::Duration = chrono::Duration::hours(1);
 
+/// How often an empty scan is allowed to write a no-work receipt.
+///
+/// Constraint: a receipt per empty scan puts one delete and one insert on
+/// SQLite's single writer every few seconds per worker, which is what
+/// serializes idle polling behind real turn writes and drains the pool
+/// (#2316). One receipt per window keeps the table bounded and keeps the
+/// evidence that scans ran (#1455) at a cost the write path does not notice.
+///
+/// What it gives up is exact-retry replay for a token whose scan skipped the
+/// write. That is safe: a retry that finds work instead claims it under the
+/// same token, which is a valid outcome for a request whose response was
+/// lost, and no caller retries an empty scan with the same token today —
+/// every worker draws a fresh one per poll.
+const EMPTY_CLAIM_SCAN_WRITE_CADENCE: chrono::Duration = chrono::Duration::minutes(5);
+
+/// Statuses the claim scan can act on.
+///
+/// Constraint: keep this the union of the statuses the branches of
+/// [`claim_agent_run`] filter on. It is what lets an idle poll answer "nothing
+/// to do" from a read instead of a write transaction. `needs_input` is
+/// deliberately absent: it is not terminal, but no scan branch advances it.
+const SCANNABLE_CLAIM_STATUSES: [&str; 5] = [
+    AgentRunStatus::Queued.as_str(),
+    AgentRunStatus::Running.as_str(),
+    AgentRunStatus::Cancelling.as_str(),
+    AgentRunStatus::Waiting.as_str(),
+    AgentRunStatus::RetryWait.as_str(),
+];
+
+/// Whether any background run is in a state the claim scan could act on.
+async fn any_scannable_agent_run_on<C>(conn: &C) -> Result<bool>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    Ok(entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Tier.eq(AgentRunTier::Background.as_str()))
+        .filter(entities::agent_run::Column::Status.is_in(SCANNABLE_CLAIM_STATUSES))
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some())
+}
+
 async fn record_empty_claim_scan_on<C>(
     conn: &C,
     lease_token: uuid::Uuid,
@@ -1278,6 +1336,36 @@ async fn record_empty_claim_scan_on<C>(
 where
     C: sea_orm::ConnectionTrait,
 {
+    // A saturated fleet reaches this branch on every poll of every worker, so
+    // keep the write to one receipt per cadence window and let the other scans
+    // stay read-only (#2316). Existence reads decide it, and they short-circuit
+    // on the first row instead of sorting the table — which matters on a
+    // database that accreted receipts before #1455 was fixed.
+    let current_receipt = entities::agent_run_claim::Entity::find()
+        .filter(entities::agent_run_claim::Column::AgentRunId.is_null())
+        .filter(
+            entities::agent_run_claim::Column::ClaimedAt.gt(now - EMPTY_CLAIM_SCAN_WRITE_CADENCE),
+        )
+        .one(conn)
+        .await
+        .map_err(store_err)?;
+    if current_receipt.is_some() {
+        // A receipt for this window already stands. Write anyway if the sweep
+        // has something to take, so a database carrying old receipts converges
+        // on one delete rather than keeping them forever.
+        let sweepable = entities::agent_run_claim::Entity::find()
+            .filter(entities::agent_run_claim::Column::AgentRunId.is_null())
+            .filter(
+                entities::agent_run_claim::Column::ClaimedAt.lt(now - EMPTY_CLAIM_SCAN_RETENTION),
+            )
+            .one(conn)
+            .await
+            .map_err(store_err)?;
+        if sweepable.is_none() {
+            return Ok(());
+        }
+    }
+
     // An idle worker polls every few seconds and would otherwise accrete one
     // NULL-run receipt per empty scan forever (#1455). Prune expired ones
     // before inserting the new one so the table stays bounded by the
@@ -2020,13 +2108,7 @@ where
     entities::agent_run::Entity::find()
         .filter(entities::agent_run::Column::Tier.eq(AgentRunTier::Background.as_str()))
         .filter(entities::agent_run::Column::Id.in_subquery(admitted_child_id_subquery()))
-        .filter(entities::agent_run::Column::Status.is_in([
-            AgentRunStatus::Queued.as_str(),
-            AgentRunStatus::Running.as_str(),
-            AgentRunStatus::Cancelling.as_str(),
-            AgentRunStatus::Waiting.as_str(),
-            AgentRunStatus::RetryWait.as_str(),
-        ]))
+        .filter(entities::agent_run::Column::Status.is_in(SCANNABLE_CLAIM_STATUSES))
         .filter(entities::agent_run::Column::DeadlineAt.lte(now))
         .filter(entities::agent_run::Column::UpdatedAt.lte(now))
         .order_by_asc(entities::agent_run::Column::DeadlineAt)

--- a/crates/tidebreak-core/src/db/tests/agent_run.rs
+++ b/crates/tidebreak-core/src/db/tests/agent_run.rs
@@ -1275,7 +1275,46 @@ async fn sandbox_claims_are_exact_reclaimable_and_heartbeatable() {
 }
 
 #[tokio::test]
-async fn idle_polling_does_not_accrete_empty_claim_scan_rows() {
+async fn idle_polling_does_not_touch_the_write_path() {
+    let (_dir, store) = temp_store().await;
+
+    // Stand in for a receipt an earlier empty poll left behind (#1455).
+    let stale_token = uuid::Uuid::new_v4();
+    crate::db::entities::agent_run_claim::ActiveModel {
+        token: Set(stale_token),
+        agent_run_id: Set(None),
+        attempt_count: Set(None),
+        claim_count: Set(None),
+        claimed_at: Set(Utc::now() - Duration::hours(2)),
+        lease_expires_at: Set(None),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+
+    // Nothing is claimable, which is what an idle worker's poll sees.
+    for _ in 0..3 {
+        assert!(store
+            .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 4, 2)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    // No write at all — not even the sweep. An idle poll must not take the
+    // single SQLite writer away from real work (#2316); the sweep rides the
+    // next scan that has a reason to write.
+    let remaining = crate::db::entities::agent_run_claim::Entity::find()
+        .filter(crate::db::entities::agent_run_claim::Column::AgentRunId.is_null())
+        .all(&store.conn)
+        .await
+        .unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].token, stale_token);
+}
+
+#[tokio::test]
+async fn saturated_polling_does_not_accrete_empty_claim_scan_rows() {
     let (_dir, store) = temp_store().await;
 
     // Stand in for a receipt an idle worker's earlier empty poll would have
@@ -1294,22 +1333,62 @@ async fn idle_polling_does_not_accrete_empty_claim_scan_rows() {
     .await
     .unwrap();
 
-    // An idle worker poll with nothing to claim.
+    // Fill the single scheduler slot so every later poll scans and finds
+    // nothing claimable — the shape a running fleet holds for minutes.
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    admit_sandbox_for_test(&store, chat.id, "occupy the only slot").await;
     assert!(store
-        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 4, 2)
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(5), 1, 1)
         .await
         .unwrap()
-        .is_none());
+        .is_some());
+
+    for _ in 0..3 {
+        assert!(store
+            .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(5), 1, 1)
+            .await
+            .unwrap()
+            .is_none());
+    }
 
     let remaining = crate::db::entities::agent_run_claim::Entity::find()
         .filter(crate::db::entities::agent_run_claim::Column::AgentRunId.is_null())
         .all(&store.conn)
         .await
         .unwrap();
-    // The stale receipt was swept; only the poll's own fresh receipt remains,
-    // so an idle worker no longer accretes rows without bound.
+    // The stale receipt was swept, and the three scans wrote one receipt
+    // between them rather than one each: the table stays bounded (#1455) and
+    // polling stays off the write path (#2316).
     assert_eq!(remaining.len(), 1);
     assert_ne!(remaining[0].token, stale_token);
+
+    // A receipt that ages past retention while a current one stands still gets
+    // swept, so a database that accreted receipts before #1455 converges
+    // instead of carrying them forever.
+    let aged_token = uuid::Uuid::new_v4();
+    crate::db::entities::agent_run_claim::ActiveModel {
+        token: Set(aged_token),
+        agent_run_id: Set(None),
+        attempt_count: Set(None),
+        claim_count: Set(None),
+        claimed_at: Set(Utc::now() - Duration::hours(3)),
+        lease_expires_at: Set(None),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(5), 1, 1)
+        .await
+        .unwrap()
+        .is_none());
+    let swept = crate::db::entities::agent_run_claim::Entity::find()
+        .filter(crate::db::entities::agent_run_claim::Column::AgentRunId.is_null())
+        .all(&store.conn)
+        .await
+        .unwrap();
+    assert!(swept.iter().all(|receipt| receipt.token != aged_token));
 }
 
 #[tokio::test]

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -33,6 +33,9 @@ tidebreak-mcp = { path = "../tidebreak-mcp" }
 tidebreak-router = { path = "../tidebreak-router" }
 tidebreak-sandbox-protocol = { path = "../tidebreak-sandbox-protocol" }
 axum = { workspace = true }
+# Pool sizing for the store this host opens (`host_connect_options`); the
+# driver features come from `tidebreak-core`.
+sea-orm = { workspace = true }
 # `rt-multi-thread` backs the durable operation log's synchronous `OperationStore`
 # bridge (`tokio::task::block_in_place`); the host runs on a multi-thread runtime.
 tokio = { workspace = true, features = ["net", "process", "rt", "rt-multi-thread", "sync", "macros", "time"] }
@@ -112,7 +115,6 @@ winreg = "=0.56.0"
 # so the sandbox-resident driver tests can drive the actual sandbox side over a
 # loopback socket, with only Docker and the host model mocked.
 tidebreak-sandbox-agent = { path = "../tidebreak-sandbox-agent" }
-sea-orm = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 tower = { version = "=0.5.3", features = ["util"] }
 tokio-tungstenite = { workspace = true }

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -53,7 +53,7 @@ impl SchemaMarker {
 
 pub(super) async fn connect(config: &Config) -> Result<DbStore> {
     connect_with(config, |database_url| async move {
-        DbStore::connect(&database_url).await
+        DbStore::connect_with_options(crate::host_connect_options(&database_url)).await
     })
     .await
 }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1967,7 +1967,10 @@ async fn connect_db(config: &Config) -> Result<Arc<DbStore>> {
             // authenticator is configured before the shared store exists.
             // State assembly constructs the live verifier used by requests.
             auth::PrincipalAuthenticator::from_config(config)?;
-            let store = tidebreak_core::DbStore::connect(&config.database_url()?).await?;
+            let store = tidebreak_core::DbStore::connect_with_options(host_connect_options(
+                &config.database_url()?,
+            ))
+            .await?;
             Ok(Arc::new(store))
         }
         // An unknown future profile has chosen neither a store nor an
@@ -1976,6 +1979,37 @@ async fn connect_db(config: &Config) -> Result<Arc<DbStore>> {
             "no store backend is wired for this profile",
         )),
     }
+}
+
+/// How many pooled connections a host process opens.
+///
+/// Constraint: SeaORM gives a SQLite pool one connection unless it is told
+/// otherwise, so a single slow write blocks every other request in the
+/// process — including the four sequential store calls that create a
+/// workspace, which is how a ~0.3s `git worktree add` turned into minutes
+/// (#2316). WAL lets readers run beside the writer, so a modest pool is
+/// enough for interactive requests to pass a stalled one. Keep it fixed: this
+/// is a floor for responsiveness, not a tuning surface.
+const HOST_MAX_CONNECTIONS: u32 = 8;
+
+/// How long a request waits for a pooled connection before it fails.
+///
+/// Explicit rather than inherited: waits at exactly sqlx's 30s default are
+/// what the starved pool looked like in the logs, and a caller that has
+/// waited this long is better served by an error it can report than by a
+/// dialog that never resolves.
+const HOST_ACQUIRE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Build the connect options every host store opens with.
+pub(crate) fn host_connect_options(url: &str) -> sea_orm::ConnectOptions {
+    let mut options = sea_orm::ConnectOptions::new(url.to_owned());
+    options
+        .max_connections(HOST_MAX_CONNECTIONS)
+        // Keep one connection warm so an idle profile does not pay reconnect
+        // latency on the first interactive request.
+        .min_connections(1)
+        .acquire_timeout(HOST_ACQUIRE_TIMEOUT);
+    options
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What changed

Creating a workspace could take minutes even though `git worktree add` takes ~0.3s. Every store call in the chain waited ~30s for a database connection. Three things compounded, and this fixes all three.

**Idle polling was a write.** An empty agent-run claim scan performed a prune delete plus a NULL-run receipt insert. Workers poll every few seconds, SQLite has a single writer, and each stalled poll held a pooled connection while it waited.

- A scan that finds no background run in a state it could act on now returns from one read, before it takes the durable claim lock — that lock is an `UPDATE`, so taking it is what made an idle poll a write transaction. The locked scan stays the authority for every decision; a run that appears right after the check is claimed by the next poll, and the worker also wakes on notify.
- When runs exist but nothing is claimable (a saturated fleet), the no-work receipt is written once per five-minute window instead of once per poll, and the retention sweep rides the same write. A receipt that ages past retention still forces one write, so a database that accreted receipts before #1455 converges instead of carrying them forever.
- The table stays bounded and the evidence that scans ran survives, so #1455 stays fixed. What it gives up is exact-retry replay for a token whose scan skipped the write: a retry that finds work claims it under the same token, which is a valid outcome for a request whose response was lost, and every worker draws a fresh token per poll today.

**The pool was one connection.** SeaORM gives a SQLite pool a single connection unless it is told otherwise, so one slow write blocked every other request in the process — including the four sequential store calls that create a workspace. Host processes now open 8 connections with an explicit 30s acquire timeout (the value the starved waits were already hitting, now chosen rather than inherited).

**Every commit fsynced.** SQLite connections now open with `synchronous=NORMAL`, the standard WAL pairing, and a 15s busy timeout. Both are per-connection settings, so they ride the connect options; a `PRAGMA` run once at connect would only reach one pooled connection. `journal_mode=WAL` stays a one-shot `PRAGMA` because it is a persistent file-level setting.

## Tests

- `idle_polling_does_not_touch_the_write_path` — repeated polls with nothing claimable leave the claim table byte-identical, including the sweep.
- `saturated_polling_does_not_accrete_empty_claim_scan_rows` — replaces the #1455 test with the fleet shape it now has to hold: three empty scans write one receipt between them, the stale receipt is swept, and a receipt that later ages past retention is swept too.

Local: `cargo test -p tidebreak-core --lib` (682 passed), `cargo test -p tidebreak-server --lib tests::` (1046 passed, one pre-existing PTY flake that passes alone), `cargo fmt --all --check`, and `cargo clippy -p tidebreak-core -p tidebreak-server --all-targets -- -D warnings` all clean.

## Notes for review

- `sea-orm` moves from a dev-dependency to a dependency of `tidebreak-server` so the pool sizing lives at the host call sites. Same workspace pin; the lockfile is unchanged.
- Raising the desktop pool above one connection means writers can now contend inside SQLite rather than inside the pool. The contended paths take the advisory lock as their first statement, so they write before they read and the busy handler covers them; a read-then-write transaction could still see `SQLITE_BUSY_SNAPSHOT`. The issue's remaining lever — a dedicated writer connection so readers never queue behind the write lock — would settle that and is left for a follow-up.

Fixes #2316
