### PR TITLE
perf(code): warm harness installs and stop re-probing on every create

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -99,6 +99,7 @@ import {
   type CodeWorkspaceSnapshot,
   type CodeCloneDefaults,
   type CodeCloneJobSnapshot,
+  type CodeHarnessInstallSnapshot,
   type CodeSubscriptionUsage,
   type HarnessDoctorReport,
   type HarnessKind,
@@ -123,6 +124,7 @@ import {
   parseCodeApproval,
   parseCodeCloneDefaults,
   parseCodeCloneJob,
+  parseCodeHarnessInstall,
   parseCodeRepo,
   parseCodeSession,
   parseCodeSessionList,
@@ -1800,6 +1802,27 @@ export class ApiClient {
         ),
       ),
       "harness models",
+    );
+  }
+
+  /**
+   * Warm the pinned install of one engine ahead of a session create.
+   *
+   * Answers as soon as the server knows where the install stands; the phases
+   * that follow arrive on `WS /code/updates`. Safe to call repeatedly — an
+   * installed pin answers `ready` and one already running is not restarted.
+   */
+  async startHarnessInstall(
+    kind: HarnessKind,
+  ): Promise<CodeHarnessInstallSnapshot> {
+    return requireParsed(
+      parseCodeHarnessInstall(
+        await this.json(
+          `/code/harnesses/${encodeURIComponent(kind)}/install`,
+          { method: "POST", headers: this.headers() },
+        ),
+      ),
+      "harness install",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -137,6 +137,7 @@ import {
   type CodeUpdateNotice as WireCodeUpdateNotice,
   type CodeCloneDefaults as WireCodeCloneDefaults,
   type CodeCloneJobSnapshot as WireCodeCloneJobSnapshot,
+  type CodeHarnessInstallSnapshot as WireCodeHarnessInstallSnapshot,
   type CodeTerminalActivityNotice as WireCodeTerminalActivityNotice,
   type PullRequestDigest as WirePullRequestDigest,
   type PullRequestCheck as WirePullRequestCheck,
@@ -1101,6 +1102,8 @@ export type CodeSessionDigest = WireCodeSessionDigest;
 export type CodeUpdateNotice = WireCodeUpdateNotice;
 export type CodeCloneDefaults = WireCodeCloneDefaults;
 export type CodeCloneJobSnapshot = WireCodeCloneJobSnapshot;
+/** Where the warm install of one pinned engine stands. */
+export type CodeHarnessInstallSnapshot = WireCodeHarnessInstallSnapshot;
 
 /** Subscription quota windows exposed by Model Gateway or a direct harness. */
 export type CodeSubscriptionUsage = {

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -52,6 +52,7 @@ type CodeCatalogStore = CodeCatalogState & {
   refreshDoctor: (
     client: Pick<ApiClient, "refreshHarnessDoctor">,
   ) => Promise<void>;
+  reloadDoctor: (client: Pick<ApiClient, "getHarnessDoctor">) => Promise<void>;
   ensureHarnessModels: (
     client: Pick<ApiClient, "listCodeHarnessModels">,
     kind: HarnessKind,
@@ -147,6 +148,13 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
   refreshDoctor: async (client) => {
     const doctor = await client.refreshHarnessDoctor();
     set({ doctor });
+  },
+  // The memoized read, for picking up an engine a warm install just put on
+  // disk. `refreshDoctor` is the doctor's own button: it re-probes every
+  // engine and installs every pin, which is far more than reading one result
+  // that already exists.
+  reloadDoctor: async (client) => {
+    set({ doctor: await client.getHarnessDoctor() });
   },
   ensureHarnessModels: (client, kind) =>
     loadHarnessModels(client, kind, get, false),

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -33,6 +33,7 @@ const EMPTY_STATE: CodeUpdatesState = {
   byWorkspace: {},
   childrenByWorkspace: {},
   cloneJobs: {},
+  harnessInstalls: {},
   viewedWorkspaceId: null,
 };
 
@@ -165,6 +166,40 @@ describe("reduceCodeUpdates", () => {
         percent: 40,
         done: false,
       },
+    });
+    expect(
+      noticeToAction({
+        type: "harness_install",
+        kind: "claude_code",
+        version: "2.1.234",
+        phase: "installing",
+        done: false,
+      }),
+    ).toEqual({
+      type: "harness_install",
+      install: {
+        kind: "claude_code",
+        version: "2.1.234",
+        phase: "installing",
+        done: false,
+      },
+    });
+  });
+
+  it("keeps one install state per engine", () => {
+    const installing = reduceCodeUpdates(EMPTY_STATE, {
+      type: "harness_install",
+      install: { kind: "codex", phase: "installing", done: false },
+    });
+    expect(installing.harnessInstalls.codex?.phase).toBe("installing");
+    const ready = reduceCodeUpdates(installing, {
+      type: "harness_install",
+      install: { kind: "codex", phase: "ready", done: true },
+    });
+    expect(ready.harnessInstalls.codex).toEqual({
+      kind: "codex",
+      phase: "ready",
+      done: true,
     });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -4,9 +4,11 @@ import type { ApiClient } from "../api/client";
 import type {
   Attention,
   CodeCloneJobSnapshot,
+  CodeHarnessInstallSnapshot,
   CodeSessionDigest,
   CodeSessionLifecycle,
   CodeUpdateNotice,
+  HarnessKind,
   PullRequestDigest,
 } from "../api/types";
 import {
@@ -34,6 +36,13 @@ export type CodeUpdatesState = {
    */
   childrenByWorkspace: Record<string, Record<string, CodeSessionDigest>>;
   cloneJobs: Record<string, CodeCloneJobSnapshot>;
+  /**
+   * Warm harness installs, keyed by engine. The New Workspace dialog starts
+   * them and reads their phase from here; nothing else depends on them, and a
+   * reconnect drops them because the doctor report is the durable answer for
+   * what is installed.
+   */
+  harnessInstalls: Partial<Record<HarnessKind, CodeHarnessInstallSnapshot>>;
   viewedWorkspaceId: string | null;
 };
 
@@ -41,6 +50,7 @@ export type CodeUpdatesAction =
   | { type: "snapshot"; sessions: CodeSessionDigest[] }
   | { type: "digest"; digest: CodeSessionDigest }
   | { type: "clone_progress"; job: CodeCloneJobSnapshot }
+  | { type: "harness_install"; install: CodeHarnessInstallSnapshot }
   | { type: "view"; workspaceId: string | null }
   | { type: "reset" };
 
@@ -48,6 +58,7 @@ const EMPTY: CodeUpdatesState = {
   byWorkspace: {},
   childrenByWorkspace: {},
   cloneJobs: {},
+  harnessInstalls: {},
   viewedWorkspaceId: null,
 };
 
@@ -98,6 +109,14 @@ export function reduceCodeUpdates(
         cloneJobs: {
           ...state.cloneJobs,
           [action.job.id]: action.job,
+        },
+      };
+    case "harness_install":
+      return {
+        ...state,
+        harnessInstalls: {
+          ...state.harnessInstalls,
+          [action.install.kind]: action.install,
         },
       };
     case "view":
@@ -198,6 +217,18 @@ export function noticeToAction(notice: CodeUpdateNotice): CodeUpdatesAction | nu
         ...(notice.percent !== undefined ? { percent: notice.percent } : {}),
         ...(notice.error !== undefined ? { error: notice.error } : {}),
         ...(notice.repo_id !== undefined ? { repo_id: notice.repo_id } : {}),
+      },
+    };
+  }
+  if (notice.type === "harness_install") {
+    return {
+      type: "harness_install",
+      install: {
+        kind: notice.kind,
+        phase: notice.phase,
+        done: notice.done,
+        ...(notice.version !== undefined ? { version: notice.version } : {}),
+        ...(notice.error !== undefined ? { error: notice.error } : {}),
       },
     };
   }

--- a/crates/tidebreak-desktop/ui/src/code/HarnessInstallNote.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessInstallNote.tsx
@@ -1,0 +1,45 @@
+import { Loader2, TriangleAlert } from "lucide-react";
+
+import type { CodeHarnessInstallSnapshot } from "../api/types";
+import { HARNESS_LABELS } from "./labels";
+
+/**
+ * What a warm harness install is doing, under the engine picker.
+ *
+ * A pinned engine is a 37-297MB npm install the first time its version is
+ * used. Create used to pay for it with nothing on screen, so the surface that
+ * knows which engine is next starts the install and says so here. Ready
+ * installs render nothing: the picker already shows a usable engine.
+ */
+export function HarnessInstallNote({
+  install,
+}: {
+  install: CodeHarnessInstallSnapshot | undefined;
+}) {
+  if (!install || (install.done && !install.error)) return null;
+  const label = HARNESS_LABELS[install.kind];
+  const version = install.version ? ` ${install.version}` : "";
+  if (install.error) {
+    return (
+      <p className="text-destructive flex items-start gap-1.5 text-xs">
+        <TriangleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+        <span>
+          {label}
+          {version} could not be installed. {install.error}
+        </span>
+      </p>
+    );
+  }
+  return (
+    <p
+      className="text-muted-foreground flex items-center gap-1.5 text-xs"
+      role="status"
+    >
+      <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden="true" />
+      <span>
+        Installing {label}
+        {version}. First use downloads the engine.
+      </span>
+    </p>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -33,7 +33,9 @@ import { friendlyErrorMessage } from "@/lib/utils";
 import { usesCommandModifier } from "@/ShellShortcuts";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { HarnessModelMenu } from "./CodeComposer";
+import { HarnessInstallNote } from "./HarnessInstallNote";
 import { HarnessPicker } from "./HarnessPicker";
 import {
   autoIsUnsupervised,
@@ -113,6 +115,8 @@ export function NewWorkspaceDialog({
   const ensureHarnessModels = useCodeCatalogStore(
     (state) => state.ensureHarnessModels,
   );
+  const reloadDoctor = useCodeCatalogStore((state) => state.reloadDoctor);
+  const harnessInstalls = useCodeUpdatesStore((state) => state.harnessInstalls);
   const lastCreate = useCodeUiStore((state) => state.lastCreate);
   const rememberCreate = useCodeUiStore((state) => state.rememberCreate);
   const [repoId, setRepoId] = useState("");
@@ -164,6 +168,45 @@ export function NewWorkspaceDialog({
     // mid-open — a workspace created elsewhere must not move this form.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, defaultRepoId, repos]);
+
+  // A pin this machine has never installed is minutes of npm. Warming it
+  // when the dialog opens — and again when the engine changes — moves that
+  // off create, where it was a silent stall. The doctor entry is the only
+  // trigger: an engine already on disk is never asked for.
+  const doctorEntry = allHarnesses.find((item) => item.kind === harness);
+  const needsInstall = Boolean(doctorEntry && !doctorEntry.found);
+  const install = harnessInstalls[harness];
+
+  useEffect(() => {
+    if (!open || !needsInstall) return;
+    let cancelled = false;
+    void client.startHarnessInstall(harness).then(
+      (snapshot) => {
+        // The answer is immediate; the phases after it arrive on the updates
+        // socket. Applying it here means the note shows even on the profile
+        // that never opened one.
+        if (!cancelled) {
+          useCodeUpdatesStore
+            .getState()
+            .apply({ type: "harness_install", install: snapshot });
+        }
+      },
+      // Nothing is broken yet: create still reports `harness_not_found` with
+      // the reason, and a member of a shared deployment may not install at
+      // all. A toast on dialog open would be noise either way.
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [client, harness, needsInstall, open]);
+
+  useEffect(() => {
+    // A finished install leaves the doctor report saying "Not installed", so
+    // the engine would stay unpickable until something re-read it.
+    if (!open || !needsInstall || !install?.done || install.error) return;
+    void reloadDoctor(client).catch(() => {});
+  }, [client, install, needsInstall, open, reloadDoctor]);
 
   const selectedRepo = repos.find((repo) => repo.id === repoId);
   const selectedHarness = readyHarnesses.find((entry) => entry.kind === harness);
@@ -335,6 +378,7 @@ export function NewWorkspaceDialog({
               }}
               disabled={creating}
             />
+            <HarnessInstallNote install={install} />
           </div>
           <div className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Model</span>

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -643,4 +643,30 @@ describe("clone wire parsers", () => {
       repo_id: "repo-1",
     });
   });
+
+  it("accepts a harness_install update notice and refuses an unknown engine", () => {
+    expect(
+      parseCodeUpdateNotice({
+        type: "harness_install",
+        kind: "claude_code",
+        version: "2.1.234",
+        phase: "installing",
+        done: false,
+      }),
+    ).toEqual({
+      type: "harness_install",
+      kind: "claude_code",
+      version: "2.1.234",
+      phase: "installing",
+      done: false,
+    });
+    expect(
+      parseCodeUpdateNotice({
+        type: "harness_install",
+        kind: "not_an_engine",
+        phase: "installing",
+        done: false,
+      }),
+    ).toBeNull();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -48,6 +48,7 @@ import type {
   CodeUpdateNotice,
   CodeCloneDefaults,
   CodeCloneJobSnapshot,
+  CodeHarnessInstallSnapshot,
   CodeSubscriptionUsage,
   PullRequestDigest,
   PullRequestComment,
@@ -91,6 +92,7 @@ import type {
   CodeUpdateNotice as WireCodeUpdateNotice,
   CodeCloneDefaults as WireCodeCloneDefaults,
   CodeCloneJobSnapshot as WireCodeCloneJobSnapshot,
+  CodeHarnessInstallSnapshot as WireCodeHarnessInstallSnapshot,
 } from "../generated/wire";
 
 /**
@@ -288,6 +290,35 @@ export function parseCodeCloneJob(value: unknown): CodeCloneJobSnapshot | null {
     ...(value.percent !== undefined ? { percent: value.percent } : {}),
     ...(value.error !== undefined ? { error: value.error } : {}),
     ...(value.repo_id !== undefined ? { repo_id: value.repo_id } : {}),
+  };
+}
+
+export function parseCodeHarnessInstall(
+  value: unknown,
+): CodeHarnessInstallSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeHarnessInstallSnapshot>(value, [
+      "kind",
+      "version",
+      "phase",
+      "done",
+      "error",
+    ]) ||
+    !isMember(value.kind, HARNESS_KINDS) ||
+    typeof value.phase !== "string" ||
+    typeof value.done !== "boolean" ||
+    !optionalString(value.version) ||
+    !optionalString(value.error)
+  ) {
+    return null;
+  }
+  return {
+    kind: value.kind,
+    phase: value.phase,
+    done: value.done,
+    ...(value.version !== undefined ? { version: value.version } : {}),
+    ...(value.error !== undefined ? { error: value.error } : {}),
   };
 }
 
@@ -2064,6 +2095,29 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         ...(value.percent !== undefined ? { percent: value.percent } : {}),
         ...(value.error !== undefined ? { error: value.error } : {}),
         ...(value.repo_id !== undefined ? { repo_id: value.repo_id } : {}),
+      };
+    }
+    case "harness_install": {
+      if (
+        !onlyKeys<Extract<WireCodeUpdateNotice, { type: "harness_install" }>>(
+          value,
+          ["type", "kind", "version", "phase", "done", "error"],
+        ) ||
+        !isMember(value.kind, HARNESS_KINDS) ||
+        typeof value.phase !== "string" ||
+        typeof value.done !== "boolean" ||
+        !optionalString(value.version) ||
+        !optionalString(value.error)
+      ) {
+        return null;
+      }
+      return {
+        type: "harness_install",
+        kind: value.kind,
+        phase: value.phase,
+        done: value.done,
+        ...(value.version !== undefined ? { version: value.version } : {}),
+        ...(value.error !== undefined ? { error: value.error } : {}),
       };
     }
     case "terminal_activity": {

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1141,6 +1141,20 @@ export type CodeExecutionUnavailableReason = "unsupported_platform" | "missing_s
 export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: number, deletions: number, previous_path?: string, };
 
 /**
+ * State of one warm harness install, returned by
+ * `POST /code/harnesses/{kind}/install` and restated on the live bus.
+ *
+ * `phase` is `installing`, `ready`, or `failed`. npm reports no usable
+ * percentage to a pipe, so there is no bar to show — only which of the three
+ * the engine is in.
+ */
+export type CodeHarnessInstallSnapshot = { kind: HarnessKind, 
+/**
+ * The pinned version being installed.
+ */
+version?: string, phase: string, done: boolean, error?: string, };
+
+/**
  * How an external agent-engine session handles mutations and approvals.
  *
  * Each adapter maps these onto the engine's native flags. A mode the
@@ -1322,7 +1336,7 @@ watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
  * Harness subagents on this session, present only when any were
  * observed (decision 52).
  */
-subagents?: Array<CodeSubagentSummary>, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, };
+subagents?: Array<CodeSubagentSummary>, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, } | { "type": "harness_install", kind: HarnessKind, version?: string, phase: string, done: boolean, error?: string, };
 
 /**
  * Token accounting as reported by the engine. Missing fields stay zero.

--- a/crates/tidebreak-desktop/ui/src/stories/HarnessInstallNote.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HarnessInstallNote.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { HarnessInstallNote } from "@/code/HarnessInstallNote";
+
+/**
+ * The install line under the engine picker in New workspace.
+ *
+ * A pinned engine that this machine has never installed is a 37-297MB npm
+ * install. It runs ahead of create now, so the dialog says what is happening
+ * instead of stalling on the Create button.
+ */
+const meta = {
+  title: "Code/Harness install note",
+  component: HarnessInstallNote,
+  args: {
+    install: {
+      kind: "claude_code",
+      version: "2.1.234",
+      phase: "installing",
+      done: false,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-sm pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HarnessInstallNote>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The install is running. */
+export const Installing: Story = {};
+
+/** The install failed; the reason stays on screen rather than in a toast. */
+export const Failed: Story = {
+  args: {
+    install: {
+      kind: "codex",
+      version: "0.147.0",
+      phase: "failed",
+      done: true,
+      error: "npm install @openai/codex@0.147.0 timed out",
+    },
+  },
+};
+
+/** Installed engines render nothing — the picker already shows them. */
+export const Ready: Story = {
+  args: {
+    install: {
+      kind: "claude_code",
+      version: "2.1.234",
+      phase: "ready",
+      done: true,
+    },
+  },
+};
+
+/** Nothing was ever started for this engine. */
+export const Absent: Story = {
+  args: { install: undefined },
+};

--- a/crates/tidebreak-harness/src/pin.rs
+++ b/crates/tidebreak-harness/src/pin.rs
@@ -3,8 +3,10 @@
 //! Each engine is an exact npm package version. Probe and launch use that
 //! copy. The user's PATH is not the engine (decision 0041).
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -109,6 +111,27 @@ pub fn managed_binary(data_dir: &Path, kind: HarnessKind) -> Option<PathBuf> {
     is_absolute_executable(&binary).then_some(binary)
 }
 
+/// One lock per install directory, so two callers cannot npm-install into it
+/// at once.
+///
+/// A pin now has two installers — the warm install the New Workspace dialog
+/// starts, and the create path's own fallback — and npm has no guard of its
+/// own for two processes writing one `node_modules`. The marker is written
+/// only after a successful install, so a torn tree left by an interleaved run
+/// would be blessed by the next marker write rather than reinstalled. Keying
+/// on the directory rather than the kind keeps two data directories (tests,
+/// profiles) from serializing against each other.
+fn install_lock(dir: &Path) -> Arc<tokio::sync::Mutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<tokio::sync::Mutex<()>>>>> = OnceLock::new();
+    LOCKS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("harness install locks")
+        .entry(dir.to_path_buf())
+        .or_default()
+        .clone()
+}
+
 /// Install the pin with the host-verified managed Node runtime's npm if it is
 /// not present.
 ///
@@ -116,6 +139,9 @@ pub fn managed_binary(data_dir: &Path, kind: HarnessKind) -> Option<PathBuf> {
 /// is the digest-gated host-tool broker). This crate deliberately does not
 /// scan `{data_dir}/tools/node`: a sibling directory that merely looks like a
 /// Node install must never become executable code by being newest on disk.
+///
+/// Concurrent calls for one pin are serialized: the first installs and the
+/// rest return the binary it produced.
 pub async fn ensure_installed(
     data_dir: &Path,
     kind: HarnessKind,
@@ -128,6 +154,12 @@ pub async fn ensure_installed(
     }
     let pin = pin_for(kind).ok_or_else(|| format!("{kind} has no pin"))?;
     let dir = install_dir(data_dir, pin);
+    let lock = install_lock(&dir);
+    let _guard = lock.lock().await;
+    // Another caller may have installed this pin while this one waited.
+    if let Some(existing) = managed_binary(data_dir, kind) {
+        return Ok(existing);
+    }
     tokio::fs::create_dir_all(&dir)
         .await
         .map_err(|err| format!("could not create harness install dir: {err}"))?;
@@ -281,5 +313,36 @@ mod tests {
             .block_on(ensure_installed(tmp.path(), HarnessKind::ClaudeCode, None))
             .unwrap_err();
         assert!(err.contains("managed Node"), "{err}");
+    }
+
+    /// The warm install and the create path's fallback can ask for one pin at
+    /// the same time. Only one of them may be inside the install directory.
+    #[tokio::test]
+    async fn one_pin_directory_admits_one_installer_at_a_time() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pin = pin_for(HarnessKind::ClaudeCode).unwrap();
+        let dir = install_dir(tmp.path(), pin);
+        let inside = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let peak = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let installers = (0..4).map(|_| {
+            let (dir, inside, peak) = (dir.clone(), Arc::clone(&inside), Arc::clone(&peak));
+            tokio::spawn(async move {
+                let lock = install_lock(&dir);
+                let _guard = lock.lock().await;
+                let now = inside.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                peak.fetch_max(now, std::sync::atomic::Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                inside.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            })
+        });
+        for installer in installers.collect::<Vec<_>>() {
+            installer.await.unwrap();
+        }
+
+        assert_eq!(peak.load(std::sync::atomic::Ordering::SeqCst), 1);
+        // A second pin is not held up by the first.
+        let other = install_dir(tmp.path(), pin_for(HarnessKind::Codex).unwrap());
+        assert!(!Arc::ptr_eq(&install_lock(&dir), &install_lock(&other)));
     }
 }

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -21,7 +21,8 @@ use std::sync::Mutex;
 
 use tidebreak_core::{
     Attention, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeSubagentSummary,
-    CodeWatchState, OwnerId, PullRequestDigest, RepoId, SequencedCodeEvent, WorkspaceId,
+    CodeWatchState, HarnessKind, OwnerId, PullRequestDigest, RepoId, SequencedCodeEvent,
+    WorkspaceId,
 };
 use tokio::sync::broadcast;
 
@@ -60,6 +61,16 @@ pub(crate) struct CloneProgress {
     pub repo_id: Option<RepoId>,
 }
 
+/// Progress of one warm harness install.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HarnessInstallProgress {
+    pub kind: HarnessKind,
+    pub version: Option<String>,
+    pub phase: String,
+    pub done: bool,
+    pub error: Option<String>,
+}
+
 /// One unsequenced notice on the install-wide updates channel.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum CodeLiveUpdate {
@@ -68,6 +79,9 @@ pub(crate) enum CodeLiveUpdate {
     Digest(Box<SessionDigest>),
     /// Clone job progress. Not restated on connect.
     CloneProgress(CloneProgress),
+    /// Warm harness install progress. Not restated on connect; the doctor
+    /// report is the durable answer for what is installed.
+    HarnessInstall(HarnessInstallProgress),
 }
 
 /// Per-session broadcast channels for live journal events, plus one digest

--- a/crates/tidebreak-server/src/code/harness_install.rs
+++ b/crates/tidebreak-server/src/code/harness_install.rs
@@ -1,0 +1,202 @@
+//! Warm installs of pinned harness binaries, off the session-create path.
+//!
+//! A cold pin is an `npm install` of 37-297MB. Paying for it inside
+//! `POST /code/workspaces/{id}/sessions` turns create into a minutes-long
+//! stall with nothing on screen, so the surface that knows which engine is
+//! about to be used starts the install ahead of need and watches it the way
+//! it watches a clone: a detached task, progress on the owner's live bus, and
+//! a snapshot returned to whoever asked for it.
+//!
+//! The create path keeps its own ensure. Correctness does not depend on the
+//! warm install having run — or having succeeded — and the per-pin lock in
+//! `tidebreak_harness` means a create that arrives mid-install waits for that
+//! install instead of starting a second one.
+//!
+//! npm reports no usable percentage to a pipe, so this reports phases rather
+//! than a bar: `installing`, then `ready` or `failed`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tidebreak_core::{HarnessKind, OwnerId};
+
+use super::bus::{CodeLiveUpdate, HarnessInstallProgress};
+use super::runtime::CodeRuntime;
+use crate::error::ServerError;
+use crate::routes::code::CodeHarnessInstallSnapshot;
+
+/// The pin is on disk and its probe is warm.
+const PHASE_READY: &str = "ready";
+/// `npm install` is running.
+const PHASE_INSTALLING: &str = "installing";
+/// The install failed; `error` says how.
+const PHASE_FAILED: &str = "failed";
+
+/// In-memory warm-install state for this process, one entry per engine. Not
+/// journaled: a restart drops it and the next dialog asks again.
+#[derive(Debug, Default)]
+pub(crate) struct HarnessInstallJobs {
+    jobs: Mutex<HashMap<HarnessKind, HarnessInstallJob>>,
+}
+
+#[derive(Debug, Clone)]
+struct HarnessInstallJob {
+    kind: HarnessKind,
+    version: Option<String>,
+    phase: &'static str,
+    done: bool,
+    error: Option<String>,
+}
+
+impl HarnessInstallJobs {
+    fn get(&self, kind: HarnessKind) -> Option<HarnessInstallJob> {
+        self.jobs
+            .lock()
+            .expect("harness install jobs")
+            .get(&kind)
+            .cloned()
+    }
+
+    fn insert(&self, job: HarnessInstallJob) {
+        self.jobs
+            .lock()
+            .expect("harness install jobs")
+            .insert(job.kind, job);
+    }
+
+    /// Take the install slot for `job`'s engine, or report the install
+    /// already in it. One lock covers the check and the claim, so two
+    /// requests that arrive together produce one install.
+    fn claim(&self, job: HarnessInstallJob) -> Option<HarnessInstallJob> {
+        let mut jobs = self.jobs.lock().expect("harness install jobs");
+        match jobs.get(&job.kind) {
+            Some(running) if !running.done && running.version == job.version => {
+                Some(running.clone())
+            }
+            _ => {
+                jobs.insert(job.kind, job);
+                None
+            }
+        }
+    }
+}
+
+impl HarnessInstallJob {
+    fn to_snapshot(&self) -> CodeHarnessInstallSnapshot {
+        CodeHarnessInstallSnapshot {
+            kind: self.kind,
+            version: self.version.clone(),
+            phase: self.phase.to_owned(),
+            done: self.done,
+            error: self.error.clone(),
+        }
+    }
+}
+
+impl CodeRuntime {
+    /// Start — or report — the install of `kind`'s pin.
+    ///
+    /// Answers immediately in every case: the pin is already installed, an
+    /// install this process started is still running, or a fresh one is now
+    /// detached. Two callers never produce two installs.
+    pub(crate) fn start_harness_install(
+        self: &Arc<Self>,
+        owner: &OwnerId,
+        kind: HarnessKind,
+    ) -> Result<CodeHarnessInstallSnapshot, ServerError> {
+        let pin = tidebreak_harness::pin_for(kind).ok_or_else(|| {
+            ServerError::unprocessable_kind(
+                "harness_unavailable",
+                format!("{kind} has no pinned version to install"),
+            )
+        })?;
+        let version = Some(pin.version.to_owned());
+        if tidebreak_harness::managed_binary(&self.data_dir, kind).is_some() {
+            let job = HarnessInstallJob {
+                kind,
+                version,
+                phase: PHASE_READY,
+                done: true,
+                error: None,
+            };
+            self.harness_installs.insert(job.clone());
+            return Ok(job.to_snapshot());
+        }
+        let job = HarnessInstallJob {
+            kind,
+            version,
+            phase: PHASE_INSTALLING,
+            done: false,
+            error: None,
+        };
+        if let Some(running) = self.harness_installs.claim(job.clone()) {
+            return Ok(running.to_snapshot());
+        }
+        self.publish_harness_install(owner, &job);
+
+        let runtime = Arc::clone(self);
+        let owner = owner.clone();
+        tokio::spawn(async move {
+            runtime.run_harness_install(&owner, kind).await;
+        });
+        Ok(job.to_snapshot())
+    }
+
+    async fn run_harness_install(self: Arc<Self>, owner: &OwnerId, kind: HarnessKind) {
+        // `false`, like the create path: ensure the managed Node runtime and
+        // wait for it. A retry here would re-trigger a Node install because a
+        // dialog opened.
+        match self.ensure_pinned_harness(kind, false).await {
+            Ok(binary) => {
+                self.record_pin_install(kind, Ok(()));
+                // The doctor's memoized probe was taken before this install
+                // and says the engine is missing. Drop it and take the cold
+                // probe here, so create pays for neither.
+                self.invalidate_moved_probe(kind, &binary);
+                if let Ok(adapter) = self.adapter(kind) {
+                    self.probe(adapter.as_ref()).await;
+                }
+                self.finish_harness_install(owner, kind, Ok(()));
+            }
+            Err(error) => {
+                self.record_pin_install(kind, Err(error.clone()));
+                self.finish_harness_install(owner, kind, Err(error));
+            }
+        }
+    }
+
+    fn finish_harness_install(
+        &self,
+        owner: &OwnerId,
+        kind: HarnessKind,
+        result: Result<(), String>,
+    ) {
+        let previous = self.harness_installs.get(kind);
+        let job = HarnessInstallJob {
+            kind,
+            version: previous.and_then(|job| job.version),
+            phase: if result.is_ok() {
+                PHASE_READY
+            } else {
+                PHASE_FAILED
+            },
+            done: true,
+            error: result.err(),
+        };
+        self.harness_installs.insert(job.clone());
+        self.publish_harness_install(owner, &job);
+    }
+
+    fn publish_harness_install(&self, owner: &OwnerId, job: &HarnessInstallJob) {
+        self.bus.publish_update(
+            owner,
+            CodeLiveUpdate::HarnessInstall(HarnessInstallProgress {
+                kind: job.kind,
+                version: job.version.clone(),
+                phase: job.phase.to_owned(),
+                done: job.done,
+                error: job.error.clone(),
+            }),
+        );
+    }
+}

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod bus;
 pub(crate) mod checkpoint;
 pub(crate) mod clone;
 pub(crate) mod gh;
+pub(crate) mod harness_install;
 pub(crate) mod recovery;
 pub(crate) mod runtime;
 pub(crate) mod scoped;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1,7 +1,7 @@
 //! Process-wide code-mode runtime: adapters, workers, worktrees, recovery.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -37,6 +37,7 @@ use super::clone::CloneJobs;
 use super::gh::{
     self, ActionOutcome, CommitOutcome, GhError, PrDigestCache, PushOutcome, WorkspaceGitStatus,
 };
+use super::harness_install::HarnessInstallJobs;
 use super::recovery::{self, RecoveryAction};
 use super::session_worker::{
     attach_engine, journal_event, queue_follow_up, spawn_session_worker, WorkerCommand,
@@ -89,6 +90,17 @@ async fn wait_for_managed_node(
     }
 }
 
+/// Whether a memoized probe still describes the pinned binary on disk.
+///
+/// A probe observes exactly one file, and the pin version is a segment of
+/// that file's path (`{data_dir}/tools/harnesses/{kind}/{version}/…`), so one
+/// path comparison covers both halves of what the probe depends on: the
+/// resolved binary and the pin it came from. A probe that found nothing
+/// describes no install and is always stale.
+fn probe_describes(cached: Option<&HarnessProbe>, installed: &Path) -> bool {
+    cached.is_some_and(|probe| probe.found && probe.binary_path.as_deref() == Some(installed))
+}
+
 /// Optional metadata on `POST /code/repos`. Every field left `None` takes
 /// the value [`CodeRuntime::register_repo`] derives from the checkout.
 #[derive(Debug, Default)]
@@ -126,6 +138,8 @@ pub(crate) struct CodeRuntime {
     workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
     pr_cache: PrDigestCache,
     pub(crate) clone_jobs: CloneJobs,
+    /// Warm harness installs started ahead of a session create.
+    pub(super) harness_installs: HarnessInstallJobs,
     #[cfg(test)]
     pub(crate) gh_search_path: Mutex<Option<String>>,
     stall_sweep: Mutex<Option<super::attention::StallSweepGuard>>,
@@ -164,6 +178,7 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
             clone_jobs: CloneJobs::default(),
+            harness_installs: HarnessInstallJobs::default(),
             #[cfg(test)]
             gh_search_path: Mutex::new(None),
             stall_sweep: Mutex::new(None),
@@ -229,6 +244,7 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
             clone_jobs: CloneJobs::default(),
+            harness_installs: HarnessInstallJobs::default(),
             #[cfg(test)]
             gh_search_path: Mutex::new(None),
             stall_sweep: Mutex::new(None),
@@ -354,6 +370,19 @@ impl CodeRuntime {
         self.probes.lock().expect("harness probes").clear();
     }
 
+    /// Drop the memoized probe for `kind` only when the install it was taken
+    /// against is not the one now on disk.
+    ///
+    /// Session create used to invalidate unconditionally, which charged every
+    /// create a cold probe — a login shell plus a Node CLI start — to observe
+    /// a binary that had not moved since the last one.
+    pub(super) fn invalidate_moved_probe(&self, kind: HarnessKind, installed: &Path) {
+        let mut probes = self.probes.lock().expect("harness probes");
+        if !probe_describes(probes.get(&kind), installed) {
+            probes.remove(&kind);
+        }
+    }
+
     #[cfg_attr(test, allow(dead_code))]
     async fn managed_node_root(&self, retry: bool) -> Result<PathBuf, String> {
         match self.host_tool_broker.as_deref() {
@@ -375,7 +404,7 @@ impl CodeRuntime {
     }
 
     #[cfg_attr(test, allow(dead_code))]
-    async fn ensure_pinned_harness(
+    pub(super) async fn ensure_pinned_harness(
         &self,
         kind: HarnessKind,
         retry_node: bool,
@@ -1030,15 +1059,23 @@ impl CodeRuntime {
         let adapter = self.adapter(harness)?;
         #[cfg(not(test))]
         {
-            if let Err(err) = self.ensure_pinned_harness(harness, false).await {
-                self.record_pin_install(harness, Err(err.clone()));
-                return Err(ServerError::unprocessable_kind(
-                    "harness_not_found",
-                    format!("{harness} could not be installed: {err}"),
-                ));
+            // The warm install the dialog starts usually got here first, in
+            // which case this is a marker read. It stays on the create path
+            // regardless: correctness must not depend on the warm path having
+            // run, and a pin installed here is serialized against that one.
+            match self.ensure_pinned_harness(harness, false).await {
+                Ok(binary) => {
+                    self.record_pin_install(harness, Ok(()));
+                    self.invalidate_moved_probe(harness, &binary);
+                }
+                Err(err) => {
+                    self.record_pin_install(harness, Err(err.clone()));
+                    return Err(ServerError::unprocessable_kind(
+                        "harness_not_found",
+                        format!("{harness} could not be installed: {err}"),
+                    ));
+                }
             }
-            self.record_pin_install(harness, Ok(()));
-            self.probes.lock().expect("harness probes").remove(&harness);
         }
         let probe = self.probe(adapter.as_ref()).await;
         if !probe.found {
@@ -2048,6 +2085,51 @@ fn map_worker(err: WorkerError) -> ServerError {
 impl From<WorktreeError> for ServerError {
     fn from(err: WorktreeError) -> Self {
         map_worktree(err)
+    }
+}
+
+#[cfg(test)]
+mod probe_freshness_tests {
+    use super::*;
+
+    fn probe_at(path: Option<&str>) -> HarnessProbe {
+        HarnessProbe {
+            found: path.is_some(),
+            binary_path: path.map(PathBuf::from),
+            version: Some("2.1.234".into()),
+            authenticated: Some(true),
+            stderr: String::new(),
+            env: Vec::new(),
+            commands: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_probe_of_the_installed_binary_is_still_current() {
+        let installed =
+            Path::new("/data/tools/harnesses/claude_code/2.1.234/node_modules/.bin/claude");
+        assert!(probe_describes(
+            Some(&probe_at(installed.to_str())),
+            installed
+        ));
+    }
+
+    #[test]
+    fn a_pin_bump_moves_the_path_and_stales_the_probe() {
+        let previous = probe_at(Some(
+            "/data/tools/harnesses/claude_code/2.1.233/node_modules/.bin/claude",
+        ));
+        assert!(!probe_describes(
+            Some(&previous),
+            Path::new("/data/tools/harnesses/claude_code/2.1.234/node_modules/.bin/claude")
+        ));
+    }
+
+    #[test]
+    fn no_probe_and_a_probe_that_found_nothing_are_both_stale() {
+        let installed = Path::new("/data/tools/harnesses/codex/0.147.0/node_modules/.bin/codex");
+        assert!(!probe_describes(None, installed));
+        assert!(!probe_describes(Some(&probe_at(None)), installed));
     }
 }
 

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -35,7 +35,9 @@ use super::runtime::{CodeRuntime, RepoRegistration, SubmitTurnOutcome};
 use super::worktree;
 use crate::error::ServerError;
 use crate::principal::AuthContext;
-use crate::routes::code::types::{CodeCloneDefaults, CodeCloneJobSnapshot};
+use crate::routes::code::types::{
+    CodeCloneDefaults, CodeCloneJobSnapshot, CodeHarnessInstallSnapshot,
+};
 use crate::state::AppState;
 
 /// Code mode as one authenticated principal may see it.
@@ -465,6 +467,19 @@ impl ScopedCode {
 
     pub(crate) fn invalidate_probes(&self) {
         self.runtime.invalidate_probes();
+    }
+
+    /// Warm the pinned install of one engine. See
+    /// [`CodeRuntime::start_harness_install`].
+    ///
+    /// Progress reaches this principal's `/code/updates` socket; the binary it
+    /// writes belongs to the machine, which is why the route sits on the
+    /// deployment plane beside the doctor's refresh.
+    pub(crate) fn start_harness_install(
+        &self,
+        kind: HarnessKind,
+    ) -> Result<CodeHarnessInstallSnapshot, ServerError> {
+        self.runtime.start_harness_install(&self.owner, kind)
     }
 
     #[cfg(not(test))]

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -462,6 +462,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::refresh_harnesses),
         )
         .route(
+            "/code/harnesses/{kind}/install",
+            post(routes::code::install_harness),
+        )
+        .route(
             "/code/repos/clone-defaults",
             get(routes::code::clone_defaults),
         )

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -4,7 +4,10 @@ use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::Json;
 
-use super::types::{HarnessDoctorEntry, HarnessDoctorReport, HarnessModel, HarnessModelList};
+use super::types::{
+    CodeHarnessInstallSnapshot, HarnessDoctorEntry, HarnessDoctorReport, HarnessModel,
+    HarnessModelList,
+};
 use tidebreak_core::HarnessKind;
 
 /// The doctor surface, served from the memoized probes (decision 0034).
@@ -20,6 +23,21 @@ pub async fn refresh_harnesses(code: ScopedCode) -> Result<Json<HarnessDoctorRep
     code.refresh_pinned_harnesses().await;
     code.invalidate_probes();
     Ok(Json(doctor(&code).await?))
+}
+
+/// Start the pinned install of one engine ahead of a session create, and
+/// report where that install stands.
+///
+/// The New Workspace dialog calls this when it opens and when the engine
+/// changes. A cold pin is minutes of `npm install`; on the create path that
+/// is a silent stall, so it runs here instead and reports on
+/// `WS /code/updates`. Answers immediately in every case — already installed,
+/// already running, or now started — and never installs twice for one pin.
+pub async fn install_harness(
+    code: ScopedCode,
+    Path(kind): Path<HarnessKind>,
+) -> Result<Json<CodeHarnessInstallSnapshot>, ServerError> {
+    Ok(Json(code.start_harness_install(kind)?))
 }
 
 /// Models this harness currently lists. Not on the doctor path.

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -24,7 +24,9 @@ pub(crate) use git::{
     merge_workspace_pr, push_workspace, refresh_workspace_pr, run_workspace_action,
     start_workspace_watch, stop_workspace_watch,
 };
-pub(crate) use harnesses::{list_harness_models, list_harnesses, refresh_harnesses};
+pub(crate) use harnesses::{
+    install_harness, list_harness_models, list_harnesses, refresh_harnesses,
+};
 pub(crate) use repos::{
     clone_defaults, create_repo, delete_repo, get_clone_job, get_repo, list_repos, patch_repo,
     start_clone,
@@ -42,13 +44,13 @@ pub(crate) use terminals::{
 #[allow(unused_imports)]
 pub(crate) use types::{
     CodeActionSnapshot, CodeApprovalDecisionBody, CodeApprovalSnapshot, CodeCloneDefaults,
-    CodeCloneJobSnapshot, CodeCommitSnapshot, CodeFileChange, CodePrCommentsSnapshot,
-    CodePushSnapshot, CodeRepoSnapshot, CodeSessionDebug, CodeSessionDigest, CodeSessionSnapshot,
-    CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTurnSnapshot,
-    CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
-    CodeWorkspacePrSnapshot, CodeWorkspaceSearch, CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot,
-    CodeWorkspaceTree, HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
-    SequencedCodeEventFrame,
+    CodeCloneJobSnapshot, CodeCommitSnapshot, CodeFileChange, CodeHarnessInstallSnapshot,
+    CodePrCommentsSnapshot, CodePushSnapshot, CodeRepoSnapshot, CodeSessionDebug,
+    CodeSessionDigest, CodeSessionSnapshot, CodeTerminalActivityNotice, CodeTerminalRead,
+    CodeTerminalSnapshot, CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff,
+    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSearch, CodeWorkspaceSearchMatch,
+    CodeWorkspaceSnapshot, CodeWorkspaceTree, HarnessDoctorReport, HarnessModelList,
+    MergeCodePrBody, QueuedCodeTurn, SequencedCodeEventFrame,
 };
 pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -261,6 +261,26 @@ pub struct CodeCloneJobSnapshot {
     pub repo_id: Option<RepoId>,
 }
 
+/// State of one warm harness install, returned by
+/// `POST /code/harnesses/{kind}/install` and restated on the live bus.
+///
+/// `phase` is `installing`, `ready`, or `failed`. npm reports no usable
+/// percentage to a pipe, so there is no bar to show — only which of the three
+/// the engine is in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeHarnessInstallSnapshot {
+    pub kind: HarnessKind,
+    /// The pinned version being installed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub version: Option<String>,
+    pub phase: String,
+    pub done: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub error: Option<String>,
+}
+
 /// Remembered clone destination plus observed `gh` status.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub struct CodeCloneDefaults {
@@ -847,9 +867,31 @@ pub enum CodeUpdateNotice {
         #[ts(optional)]
         repo_id: Option<RepoId>,
     },
+    /// Progress of one warm harness install. Not restated on connect.
+    HarnessInstall {
+        kind: HarnessKind,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        version: Option<String>,
+        phase: String,
+        done: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        error: Option<String>,
+    },
 }
 
 impl CodeUpdateNotice {
+    pub(crate) fn harness_install(progress: crate::code::bus::HarnessInstallProgress) -> Self {
+        Self::HarnessInstall {
+            kind: progress.kind,
+            version: progress.version,
+            phase: progress.phase,
+            done: progress.done,
+            error: progress.error,
+        }
+    }
+
     pub(crate) fn clone_progress(progress: crate::code::bus::CloneProgress) -> Self {
         Self::CloneProgress {
             job: progress.job,

--- a/crates/tidebreak-server/src/routes/code/updates.rs
+++ b/crates/tidebreak-server/src/routes/code/updates.rs
@@ -99,6 +99,14 @@ async fn stream_updates(
                         break;
                     }
                 }
+                Ok(CodeLiveUpdate::HarnessInstall(progress)) => {
+                    if send_notice(&mut socket, &CodeUpdateNotice::harness_install(progress))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
                 Err(RecvError::Lagged(_)) => {
                     match list_digests(&runtime.db, &owner).await {
                         Ok(sessions) => {

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -438,6 +438,7 @@ mod tests {
         generate::collect_from::<crate::routes::code::MergeCodePrBody>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeActionSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeCloneJobSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeHarnessInstallSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeCloneDefaults>(&cfg, &mut out);
         out
     }


### PR DESCRIPTION
Fixes #2318

## What changed

**Warm installs, off the request path.** `POST /code/harnesses/{kind}/install` starts `ensure_installed` for one engine in a detached task and reports progress on the owner's `WS /code/updates`, mirroring how `git clone` progress works. Phases are `installing`, then `ready` or `failed` — npm reports no usable percentage to a pipe, so there is no bar to fake. The route answers immediately in all three cases (already installed, already running, now started) and never starts two installs for one pin. It sits on the deployment plane beside `/code/harnesses/refresh`, because installing a pin writes a binary to the machine.

On success the task also invalidates the stale probe and takes the cold one itself, so create pays for neither the install nor the ~1s engine startup.

**Dialog wiring.** The New Workspace dialog fires the call when it opens and when the engine changes, but only when the doctor says that engine is not installed — an engine already on disk is never asked for, and a member of a shared deployment never hits an admin route for nothing. A new `HarnessInstallNote` renders the phase under the engine picker instead of the previous silent stall, and a finished install re-reads the doctor (`GET /code/harnesses`, not the doctor's own install-everything refresh) so the engine turns selectable.

**One installer per pin.** `tidebreak_harness::ensure_installed` now takes a per-install-directory async lock and re-checks the marker after acquiring it. npm has no guard for two writers in one `node_modules`, and the marker is written only after a successful install, so a torn tree from an interleaved run would have been blessed by the next marker write. Keyed on the directory, so two data directories do not serialize against each other.

**Probe only when it can have changed.** `create_session_of_kind` used to drop the memoized probe unconditionally. It now drops it only when the resolved binary path differs from the one just ensured. The pin version is a path segment (`tools/harnesses/{kind}/{version}/…`), so one comparison covers both the binary and the pin. A probe that found nothing, or no cached probe, is still stale; a failed or empty probe still surfaces `harness_not_found`. The `#[cfg(not(test))]` block around the ensure is unchanged in shape, so test behavior is intact.

## Tests

- `tidebreak-harness`: one pin directory admits one installer at a time, and a second pin is not held up by the first.
- `tidebreak-server`: the probe-freshness contract — same path stays cached, a pin bump stales it, and no-probe / found-nothing are both stale.
- UI: the `harness_install` notice validator (including refusing an unknown engine) and the one-install-per-engine reducer.
- Storybook: `Code/Harness install note` covers installing, failed, ready, and absent.

## Checks

`cargo fmt --all --check`, `cargo clippy -p tidebreak-server -p tidebreak-harness --all-targets -- -D warnings`, `cargo test -p tidebreak-server code::` (130 passed), `cargo test -p tidebreak-harness` (2 pre-existing failures in `child::unix_process_tree_tests`, identical on a clean tree in this sandbox), `pnpm test` (1412 passed), `tsc --noEmit`, `pnpm storybook:build`.

## Left out

Boot-time warming after a pin bump. The dialog is the surface the issue names, and warming every engine at launch spends four installs on engines a launch may never use. Other create surfaces (the CLI, watch sessions) still take the install on the request path, where the existing ensure covers them.