### PR TITLE
feat(code): move new worktrees to a configurable, user-visible root

### DIFF
--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -127,6 +127,19 @@ pub struct Config {
     /// [`Config::bind_addr`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub listen_addr: Option<SocketAddr>,
+    /// Where new code-mode worktrees land when no `code_worktree_root` setting
+    /// is stored.
+    ///
+    /// Worktrees hold uncommitted work on real branches, so a windowed
+    /// embedding points this at a visible place in the user's home directory —
+    /// the desktop app uses `~/Tidebreak/workspaces` — rather than letting user
+    /// work sit in disposable app data. Embeddings that leave it absent (the
+    /// CLI, self-host, tests) keep worktrees under
+    /// `{data_dir}/code/worktrees`, which is the right answer for a headless
+    /// deployment whose data directory *is* its user-visible location. Either
+    /// way the stored setting wins once an operator sets one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_worktree_root_default: Option<PathBuf>,
 }
 
 /// The bind every profile uses when no address is configured: loopback, and
@@ -191,6 +204,7 @@ impl Config {
             auth_gateway_verifier_url: None,
             public_url: None,
             listen_addr: None,
+            code_worktree_root_default: None,
         }
     }
 
@@ -292,6 +306,7 @@ impl Config {
             auth_gateway_verifier_url,
             public_url,
             listen_addr,
+            code_worktree_root_default: None,
         })
     }
 

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -535,6 +535,17 @@ fn home_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         .map_err(|e| format!("resolve home dir: {e}"))
 }
 
+/// Default root for code worktrees: `~/Tidebreak/workspaces`.
+///
+/// Not created here. The server creates each worktree's parents when it adds
+/// one, so an install that never opens code mode leaves no empty folder in the
+/// user's home directory.
+fn worktree_root_default(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    Ok(home_dir(app)?
+        .join(channel::PRODUCTION_PRODUCT_NAME)
+        .join("workspaces"))
+}
+
 /// Resolve the directory Tauri stages bundle resources into.
 ///
 /// Packaged builds use Tauri's normal resource path (`Contents/Resources` on
@@ -845,6 +856,14 @@ async fn boot_server(
         .clone()
         .expect("skills dir was just set");
     config.exec_plugins_dir = Some(exec_plugins_dir(&app, &skills_dir)?);
+    // Code worktrees hold uncommitted work on real branches, so they land in a
+    // visible folder in the user's home directory rather than in app data,
+    // which uninstall and "reset app data" flows treat as disposable. Every
+    // channel shares the one root on purpose: the app identifier keys app data
+    // precisely so three builds cannot corrupt each other's *state*, and a dev
+    // build growing its own second copy of the user's work is the problem, not
+    // the protection. The stored `code_worktree_root` setting overrides this.
+    config.code_worktree_root_default = Some(worktree_root_default(&app)?);
     // The effective identifier — including the debug and staging overrides —
     // keys the macOS managed-preferences (MDM) domain the server reads policy from.
     config.bundle_id = Some(app.config().identifier.clone());

--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -78,6 +78,10 @@ const listCodeRepos = vi.fn(async () => [
 ]);
 const listCodeWorkspaces = vi.fn(async () => [] as unknown[]);
 const getHarnessDoctor = vi.fn(async () => ({ harnesses: [] }));
+const getCodeWorktreeRoot = vi.fn(async () => ({
+  effective_root: "/Users/sam/Tidebreak/workspaces",
+  default_root: "/Users/sam/Tidebreak/workspaces",
+}));
 const listCodeHarnessModels = vi.fn(async () => ({
   kind: "claude_code" as const,
   models: [],
@@ -141,6 +145,7 @@ vi.mock("./api", () => ({
     listCodeRepos = listCodeRepos;
     listCodeWorkspaces = listCodeWorkspaces;
     getHarnessDoctor = getHarnessDoctor;
+    getCodeWorktreeRoot = getCodeWorktreeRoot;
     listCodeHarnessModels = listCodeHarnessModels;
     openCodeUpdates = vi.fn(() => ({
       close() {},

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -98,6 +98,7 @@ import {
   type CodePrMergeMethod,
   type CodeWorkspaceSnapshot,
   type CodeCloneDefaults,
+  type CodeWorktreeRoot,
   type CodeCloneJobSnapshot,
   type CodeHarnessInstallSnapshot,
   type CodeSubscriptionUsage,
@@ -123,6 +124,7 @@ import {
 import {
   parseCodeApproval,
   parseCodeCloneDefaults,
+  parseCodeWorktreeRoot,
   parseCodeCloneJob,
   parseCodeHarnessInstall,
   parseCodeRepo,
@@ -1759,6 +1761,32 @@ export class ApiClient {
         }),
       ),
       "clone job",
+    );
+  }
+
+  async getCodeWorktreeRoot(): Promise<CodeWorktreeRoot> {
+    return requireParsed(
+      parseCodeWorktreeRoot(
+        await this.json("/code/worktree-root", { headers: this.headers() }),
+      ),
+      "worktree root",
+    );
+  }
+
+  /**
+   * Move the root new worktrees are created under. A null root restores the
+   * default. Worktrees already on disk keep the path they were created at.
+   */
+  async setCodeWorktreeRoot(root: string | null): Promise<CodeWorktreeRoot> {
+    return requireParsed(
+      parseCodeWorktreeRoot(
+        await this.json("/code/worktree-root", {
+          method: "PUT",
+          headers: this.headers(true),
+          body: JSON.stringify({ root }),
+        }),
+      ),
+      "worktree root",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -138,6 +138,7 @@ import {
   type CodeCloneDefaults as WireCodeCloneDefaults,
   type CodeCloneJobSnapshot as WireCodeCloneJobSnapshot,
   type CodeHarnessInstallSnapshot as WireCodeHarnessInstallSnapshot,
+  type CodeWorktreeRoot as WireCodeWorktreeRoot,
   type CodeTerminalActivityNotice as WireCodeTerminalActivityNotice,
   type PullRequestDigest as WirePullRequestDigest,
   type PullRequestCheck as WirePullRequestCheck,
@@ -1104,6 +1105,8 @@ export type CodeCloneDefaults = WireCodeCloneDefaults;
 export type CodeCloneJobSnapshot = WireCodeCloneJobSnapshot;
 /** Where the warm install of one pinned engine stands. */
 export type CodeHarnessInstallSnapshot = WireCodeHarnessInstallSnapshot;
+/** Where new code worktrees land, and what clearing the setting returns to. */
+export type CodeWorktreeRoot = WireCodeWorktreeRoot;
 
 /** Subscription quota windows exposed by Model Gateway or a direct harness. */
 export type CodeSubscriptionUsage = {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -13,6 +13,7 @@ import {
   parseCodeSessionList,
   parseCodeSubscriptionUsage,
   parseCodeUpdateNotice,
+  parseCodeWorktreeRoot,
   parseCodeTerminal,
   parseCodeTerminalList,
   parseCodeTerminalRead,
@@ -599,6 +600,41 @@ describe("liveCodeSession", () => {
     expect(watch && live).toBeTruthy();
     expect(liveCodeSession([watch!, live!])?.id).toBe("sess-1");
     expect(liveCodeSession([watch!])).toBeNull();
+  });
+});
+
+describe("worktree root parser", () => {
+  it("keeps an absent root absent and refuses a wrong shape", () => {
+    expect(
+      parseCodeWorktreeRoot({
+        effective_root: "/Users/sam/Tidebreak/workspaces",
+        default_root: "/Users/sam/Tidebreak/workspaces",
+      }),
+    ).toEqual({
+      effective_root: "/Users/sam/Tidebreak/workspaces",
+      default_root: "/Users/sam/Tidebreak/workspaces",
+    });
+    expect(
+      parseCodeWorktreeRoot({
+        root: "/Volumes/work/trees",
+        effective_root: "/Volumes/work/trees",
+        default_root: "/Users/sam/Tidebreak/workspaces",
+      }),
+    ).toEqual({
+      root: "/Volumes/work/trees",
+      effective_root: "/Volumes/work/trees",
+      default_root: "/Users/sam/Tidebreak/workspaces",
+    });
+    expect(
+      parseCodeWorktreeRoot({ effective_root: "/tmp/trees" }),
+    ).toBeNull();
+    expect(
+      parseCodeWorktreeRoot({
+        root: 7,
+        effective_root: "/tmp/trees",
+        default_root: "/tmp/trees",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -49,6 +49,7 @@ import type {
   CodeCloneDefaults,
   CodeCloneJobSnapshot,
   CodeHarnessInstallSnapshot,
+  CodeWorktreeRoot,
   CodeSubscriptionUsage,
   PullRequestDigest,
   PullRequestComment,
@@ -93,6 +94,7 @@ import type {
   CodeCloneDefaults as WireCodeCloneDefaults,
   CodeCloneJobSnapshot as WireCodeCloneJobSnapshot,
   CodeHarnessInstallSnapshot as WireCodeHarnessInstallSnapshot,
+  CodeWorktreeRoot as WireCodeWorktreeRoot,
 } from "../generated/wire";
 
 /**
@@ -348,6 +350,29 @@ export function parseCodeCloneDefaults(
     ...(value.gh_authenticated !== undefined
       ? { gh_authenticated: value.gh_authenticated }
       : {}),
+  };
+}
+
+export function parseCodeWorktreeRoot(
+  value: unknown,
+): CodeWorktreeRoot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeWorktreeRoot>(value, [
+      "root",
+      "effective_root",
+      "default_root",
+    ]) ||
+    !optionalString(value.root) ||
+    typeof value.effective_root !== "string" ||
+    typeof value.default_root !== "string"
+  ) {
+    return null;
+  }
+  return {
+    effective_root: value.effective_root,
+    default_root: value.default_root,
+    ...(value.root !== undefined ? { root: value.root } : {}),
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1422,6 +1422,16 @@ export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "arch
 export type CodeWorkspaceTree = { paths: Array<string>, truncated: boolean, };
 
 /**
+ * Where new worktrees land: `GET`/`PUT /code/worktree-root`.
+ *
+ * `root` is the stored setting and is absent while the deployment runs on its
+ * default. `effective_root` is what the next workspace uses, and
+ * `default_root` is what clearing the setting returns to — so a reader can
+ * tell a chosen path from an inherited one without repeating the rule.
+ */
+export type CodeWorktreeRoot = { root?: string, effective_root: string, default_root: string, };
+
+/**
  * What one on-demand compaction did.
  */
 export type CompactionRun = { 
@@ -3330,6 +3340,11 @@ export type RootAttachmentOrigin = "project_default" | "conversation";
  * One journaled event on the per-session WebSocket.
  */
 export type SequencedCodeEventFrame = { seq: number, event: CodeEvent, replayed?: boolean, };
+
+/**
+ * Body of `PUT /code/worktree-root`. A null or blank root clears the setting.
+ */
+export type SetCodeWorktreeRootBody = { root: string | null, };
 
 /**
  * Runtime settings a client can read. The API key itself is never returned —

--- a/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import type { ApiClient } from "../api/client";
-import type { HarnessDoctorReport } from "../api/types";
+import type { CodeWorktreeRoot, HarnessDoctorReport } from "../api/types";
 import { DoctorList } from "@/code/DoctorList";
+import { hasNativeHost, pickCodeDirectory } from "@/host";
+import { friendlyErrorMessage } from "@/lib/utils";
 import { SettingsError, SettingsPanel } from "./primitives";
+import { WorktreeRootSection } from "./WorktreeRootSection";
 
 /**
- * Settings: the coding-harness doctor.
+ * Settings: the coding-harness doctor, and where workspaces land on disk.
  *
  * Found, path, version, tier, capabilities, auth, remediation, and
  * unrecognized-event counts live here so a reader can repair an engine
- * without opening a workspace.
+ * without opening a workspace. The workspace folder sits above them because it
+ * decides where the user's own code ends up, which matters before any engine
+ * runs.
  */
 
 export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
@@ -18,6 +24,11 @@ export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [worktreeRoot, setWorktreeRoot] = useState<CodeWorktreeRoot | null>(
+    null,
+  );
+  const [rootDraft, setRootDraft] = useState("");
+  const [savingRoot, setSavingRoot] = useState(false);
 
   async function load(refresh: boolean) {
     if (refresh) setRefreshing(true);
@@ -41,13 +52,68 @@ export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client]);
 
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const next = await client.getCodeWorktreeRoot();
+        if (cancelled) return;
+        setWorktreeRoot(next);
+        setRootDraft(next.root ?? "");
+      } catch (err) {
+        if (!cancelled) setError(String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  async function saveRoot(root: string | null) {
+    setSavingRoot(true);
+    setError(null);
+    try {
+      const next = await client.setCodeWorktreeRoot(root);
+      setWorktreeRoot(next);
+      setRootDraft(next.root ?? "");
+      toast.success(
+        root === null
+          ? "New workspaces use the default folder"
+          : "New workspaces land in the new folder",
+      );
+    } catch (err) {
+      setError(friendlyErrorMessage(err, "Could not set the workspace folder"));
+    } finally {
+      setSavingRoot(false);
+    }
+  }
+
   return (
     <SettingsPanel
       title="Coding harnesses"
-      description="Engines installed on this machine, their versions, and what they can do."
+      description="Engines installed on this machine, what they can do, and where the workspaces they run in live."
       busy={loading || refreshing}
     >
       {error && <SettingsError>{error}</SettingsError>}
+      {worktreeRoot && (
+        <WorktreeRootSection
+          value={rootDraft}
+          effectiveRoot={worktreeRoot.effective_root}
+          defaultRoot={worktreeRoot.default_root}
+          inherited={worktreeRoot.root === undefined}
+          busy={savingRoot}
+          canBrowse={hasNativeHost()}
+          onChange={setRootDraft}
+          onBrowse={() => {
+            void (async () => {
+              const picked = await pickCodeDirectory();
+              if (picked) setRootDraft(picked);
+            })();
+          }}
+          onSave={() => void saveRoot(rootDraft.trim())}
+          onReset={() => void saveRoot(null)}
+        />
+      )}
       {report && (
         <DoctorList
           report={report}

--- a/crates/tidebreak-desktop/ui/src/settings/WorktreeRootSection.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/WorktreeRootSection.tsx
@@ -1,0 +1,93 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { SettingsField, SettingsSection } from "./primitives";
+
+/**
+ * Where new code workspaces put their worktrees.
+ *
+ * A worktree holds uncommitted work on a real branch, so this path is the
+ * user's, not the app's — the field leads with the folder that is in force and
+ * says plainly what changing it does and does not do. Presentational: the
+ * panel owns loading, saving, and the native picker.
+ */
+export function WorktreeRootSection({
+  value,
+  effectiveRoot,
+  defaultRoot,
+  inherited,
+  busy,
+  canBrowse,
+  onChange,
+  onBrowse,
+  onSave,
+  onReset,
+}: {
+  /** The draft in the field, which may differ from what is saved. */
+  value: string;
+  /** The root the next workspace uses right now. */
+  effectiveRoot: string;
+  /** What resetting returns to. */
+  defaultRoot: string;
+  /** True while no root is stored and the default is in force. */
+  inherited: boolean;
+  busy: boolean;
+  canBrowse: boolean;
+  onChange: (value: string) => void;
+  onBrowse: () => void;
+  onSave: () => void;
+  onReset: () => void;
+}) {
+  const dirty = value.trim() !== (inherited ? "" : effectiveRoot);
+  return (
+    <SettingsSection
+      title="Workspace folder"
+      description="Every new workspace gets a git worktree under this folder. Workspaces that already exist keep the folder they were created in."
+    >
+      <SettingsField
+        label="Folder"
+        hint={
+          inherited
+            ? `Using the default, ${defaultRoot}.`
+            : `Reset to use the default, ${defaultRoot}.`
+        }
+      >
+        <div className="flex gap-2">
+          <Input
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            placeholder={defaultRoot}
+            disabled={busy}
+            spellCheck={false}
+          />
+          {canBrowse && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onBrowse}
+              disabled={busy}
+            >
+              Browse
+            </Button>
+          )}
+        </div>
+      </SettingsField>
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          onClick={onSave}
+          disabled={busy || !dirty || !value.trim()}
+        >
+          {busy ? "Saving…" : "Save"}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onReset}
+          disabled={busy || inherited}
+        >
+          Reset to default
+        </Button>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/WorktreeRootSection.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorktreeRootSection.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { WorktreeRootSection } from "@/settings/WorktreeRootSection";
+
+/**
+ * Where new workspaces put their worktrees. The states that matter are whether
+ * the folder is the default or one the user chose, and whether a save is in
+ * flight — a reader has to be able to tell an inherited path from a decision.
+ */
+const meta = {
+  title: "Settings/Workspace folder",
+  component: WorktreeRootSection,
+  args: {
+    value: "",
+    effectiveRoot: "/Users/sam/Tidebreak/workspaces",
+    defaultRoot: "/Users/sam/Tidebreak/workspaces",
+    inherited: true,
+    busy: false,
+    canBrowse: true,
+    onChange: fn(),
+    onBrowse: fn(),
+    onSave: fn(),
+    onReset: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-3xl pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WorktreeRootSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Nothing chosen yet: the default is in force and Reset has nothing to do. */
+export const Default: Story = {};
+
+/** A folder the user picked, with Reset live. */
+export const CustomFolder: Story = {
+  args: {
+    value: "/Volumes/work/trees",
+    effectiveRoot: "/Volumes/work/trees",
+    inherited: false,
+  },
+};
+
+/** An edited draft, before it is saved. */
+export const Edited: Story = {
+  args: {
+    value: "/Volumes/work/trees-2",
+    effectiveRoot: "/Volumes/work/trees",
+    inherited: false,
+  },
+};
+
+/** Mid-save: every control is inert until the server answers. */
+export const Saving: Story = {
+  args: {
+    value: "/Volumes/work/trees",
+    effectiveRoot: "/Users/sam/Tidebreak/workspaces",
+    inherited: true,
+    busy: true,
+  },
+};
+
+/** A browser session, or a headless deployment: no native folder picker. */
+export const WithoutPicker: Story = {
+  args: { canBrowse: false },
+};
+
+/** A headless deployment, where the default stays inside the data directory. */
+export const HeadlessDefault: Story = {
+  args: {
+    effectiveRoot: "/srv/tidebreak/code/worktrees",
+    defaultRoot: "/srv/tidebreak/code/worktrees",
+  },
+};

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -76,19 +76,20 @@ impl CloneJob {
     }
 }
 
-/// Directory a given owner's clones land in, under the deployment's shared
-/// clone parent.
+/// Directory a given owner's checkouts land in, under a deployment-wide
+/// parent: the clone parent here, and the worktree root in
+/// [`super::worktree_root`].
 ///
-/// The parent directory is one deployment-wide setting, so without a per-owner
-/// segment two users cloning the same remote would both target
+/// Each of those parents is one setting shared by every principal, so without
+/// a per-owner segment two users cloning the same remote would both target
 /// `<parent>/<name>` and the second would be refused — or worse, adopt the
-/// first user's checkout. The local profile keeps cloning straight into the
+/// first user's checkout. The local profile keeps writing straight into the
 /// parent, because there is exactly one owner and its paths are the ones users
 /// already have.
 ///
 /// Owner keys are visible ASCII and may contain characters that are not safe
 /// in a path segment, so everything outside a conservative set is replaced.
-pub(crate) fn owner_clone_dir(parent: &Path, owner: &OwnerId) -> PathBuf {
+pub(crate) fn owner_dir(parent: &Path, owner: &OwnerId) -> PathBuf {
     if owner.is_local() {
         return parent.to_path_buf();
     }
@@ -166,7 +167,7 @@ impl CodeRuntime {
                 "name must be a single path segment",
             ));
         }
-        let target = owner_clone_dir(&parent, owner).join(&name);
+        let target = owner_dir(&parent, owner).join(&name);
         if target.exists() {
             return Err(ServerError::conflict_kind(
                 "clone_target_exists",

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod terminal;
 pub(crate) mod titling;
 pub(crate) mod watch;
 pub(crate) mod worktree;
+pub(crate) mod worktree_root;
 
 pub(crate) use runtime::CodeRuntime;
 pub(crate) use scoped::ScopedCode;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -126,6 +126,9 @@ pub(crate) struct CodeRuntime {
     pub bus: Arc<CodeEventBus>,
     pub adapters: AdapterRegistry,
     pub data_dir: PathBuf,
+    /// Visible worktree root this embedding names, if any. The stored
+    /// `code_worktree_root` setting overrides it; see [`super::worktree_root`].
+    pub(crate) worktree_root_default: Option<PathBuf>,
     pub blobs: Arc<dyn tidebreak_core::BlobStore>,
     pub approvals: Arc<ApprovalBridge>,
     host: HostEnv,
@@ -158,6 +161,7 @@ impl CodeRuntime {
     pub(crate) fn new(
         db: Arc<DbStore>,
         data_dir: PathBuf,
+        worktree_root_default: Option<PathBuf>,
         host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     ) -> Self {
         Self {
@@ -166,6 +170,7 @@ impl CodeRuntime {
             adapters: builtin_registry(),
             blobs: Arc::new(tidebreak_core::FsBlobStore::new(data_dir.join("blobs"))),
             data_dir: data_dir.clone(),
+            worktree_root_default,
             approvals: ApprovalBridge::new(),
             host: HostEnv {
                 data_dir: Some(data_dir),
@@ -235,6 +240,7 @@ impl CodeRuntime {
             adapters,
             blobs: Arc::new(tidebreak_core::FsBlobStore::new(data_dir.join("blobs"))),
             data_dir,
+            worktree_root_default: None,
             approvals: ApprovalBridge::new(),
             host: HostEnv::from_process(),
             host_tool_broker: None,
@@ -597,7 +603,12 @@ impl CodeRuntime {
                 from_title
             }
         };
-        let path = worktree_dir(&self.data_dir, repo_id, id, &repo_slug, &workspace_slug);
+        // Resolved per creation, not cached: the root is a setting an operator
+        // can change while the process runs, and it decides only where the
+        // *next* worktree lands. Existing workspaces keep the absolute path on
+        // their row (`super::worktree_root`).
+        let root = self.owner_worktree_root(owner).await?;
+        let path = worktree_dir(&root, id, &repo_slug, &workspace_slug);
         let display_title = if title.is_empty() {
             workspace_slug.clone()
         } else {
@@ -2306,7 +2317,7 @@ mod managed_node_wait_tests {
         ))
         .await
         .expect("db");
-        let runtime = CodeRuntime::new(Arc::new(db), data_dir.path().to_path_buf(), None);
+        let runtime = CodeRuntime::new(Arc::new(db), data_dir.path().to_path_buf(), None, None);
 
         assert_eq!(
             runtime.managed_node_root(false).await.expect("node root"),

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -119,6 +119,19 @@ impl ScopedCode {
         self.runtime.get_clone_job(id)
     }
 
+    pub(crate) async fn worktree_root(
+        &self,
+    ) -> Result<crate::routes::code::CodeWorktreeRoot, ServerError> {
+        self.runtime.worktree_root_snapshot().await
+    }
+
+    pub(crate) async fn set_worktree_root(
+        &self,
+        root: Option<&str>,
+    ) -> Result<crate::routes::code::CodeWorktreeRoot, ServerError> {
+        self.runtime.set_worktree_root(root).await
+    }
+
     // ------------------------------------------------------------------
     // Workspaces.
     // ------------------------------------------------------------------

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -696,30 +696,48 @@ pub(crate) fn branch_name(prefix: &str, title: &str, seed: u128) -> String {
     format!("{prefix}{slug}")
 }
 
-/// Path `<data_dir>/code/worktrees/<repo-slug>/<workspace-slug>/`.
-/// `<data_dir>/code/worktrees/<repo-id>-<slug>/<workspace-id>-<slug>/`.
+/// Path `<root>/<repo-slug>/<workspace-slug>-<short-id>/`.
 ///
-/// Ids are the uniqueness key so two clones of the same project cannot share
-/// a directory. Slugs stay only as a human-readable suffix.
+/// The readable name leads and the id trails, because these paths are read by
+/// people: they appear in terminal prompts, editor titles, and every `cd` an
+/// agent narrates. The workspace id still carries uniqueness — two workspaces
+/// on one repo may share a title, and a title may be empty — so it stays as a
+/// short suffix rather than the leading segment it used to be.
+///
+/// The repo segment is the slug alone. Workspace ids are unique across every
+/// repo, so two repos that share a name share a folder without ever sharing a
+/// worktree.
 pub(crate) fn worktree_dir(
-    data_dir: &Path,
-    repo_id: tidebreak_core::RepoId,
+    root: &Path,
     workspace_id: tidebreak_core::WorkspaceId,
     repo_slug: &str,
     workspace_slug: &str,
 ) -> PathBuf {
-    data_dir
-        .join("code")
-        .join("worktrees")
-        .join(dir_name(repo_id, repo_slug))
-        .join(dir_name(workspace_id, workspace_slug))
+    root.join(dir_segment(repo_slug, "repo")).join(format!(
+        "{}-{}",
+        dir_segment(workspace_slug, "workspace"),
+        short_id(workspace_id.as_uuid())
+    ))
 }
 
-fn dir_name(id: impl std::fmt::Display, slug: &str) -> String {
+/// The default worktree root for an embedding that names no visible one:
+/// `<data_dir>/code/worktrees`, where every worktree lived before the root
+/// became configurable.
+pub(crate) fn data_dir_worktree_root(data_dir: &Path) -> PathBuf {
+    data_dir.join("code").join("worktrees")
+}
+
+/// First eight hex digits of a UUID — enough to separate the workspaces one
+/// person runs, short enough to keep the path readable.
+pub(crate) fn short_id(id: &uuid::Uuid) -> String {
+    id.simple().to_string()[..8].to_owned()
+}
+
+fn dir_segment<'a>(slug: &'a str, fallback: &'a str) -> &'a str {
     if slug.is_empty() {
-        id.to_string()
+        fallback
     } else {
-        format!("{id}-{slug}")
+        slug
     }
 }
 
@@ -1002,8 +1020,7 @@ mod tests {
 
     fn scratch_worktree(data: &Path, label: &str) -> PathBuf {
         worktree_dir(
-            data,
-            tidebreak_core::RepoId::new(),
+            &data_dir_worktree_root(data),
             tidebreak_core::WorkspaceId::new(),
             "demo",
             label,
@@ -1212,17 +1229,38 @@ mod tests {
         assert!(bounded_truncated);
     }
 
+    /// The path a person reads: the repo folder and the workspace name lead,
+    /// and the id is the short suffix that keeps two same-named workspaces
+    /// apart. Two workspaces never share a directory even on one repo, and the
+    /// root is whatever the deployment configured.
     #[test]
-    fn worktree_paths_are_keyed_on_ids() {
-        let data = std::path::Path::new("/tmp/data");
-        let repo_a = tidebreak_core::RepoId::new();
-        let repo_b = tidebreak_core::RepoId::new();
-        let ws = tidebreak_core::WorkspaceId::new();
-        let left = worktree_dir(data, repo_a, ws, "origin", "first");
-        let right = worktree_dir(data, repo_b, ws, "origin", "first");
+    fn worktree_paths_read_name_first_and_stay_unique() {
+        let root = std::path::Path::new("/Users/sam/Tidebreak/workspaces");
+        let first = tidebreak_core::WorkspaceId::new();
+        let second = tidebreak_core::WorkspaceId::new();
+        let left = worktree_dir(root, first, "tidebreak", "fix-login");
+        let right = worktree_dir(root, second, "tidebreak", "fix-login");
         assert_ne!(left, right);
-        assert!(left.to_string_lossy().contains(&repo_a.to_string()));
-        assert!(right.to_string_lossy().contains(&repo_b.to_string()));
+        assert_eq!(left.parent(), Some(root.join("tidebreak").as_path()));
+        let leaf = left.file_name().unwrap().to_string_lossy().into_owned();
+        assert_eq!(leaf, format!("fix-login-{}", short_id(first.as_uuid())));
+        // An untitled workspace on a nameless repo still resolves to two
+        // segments rather than collapsing into the root.
+        let bare = worktree_dir(root, first, "", "");
+        assert_eq!(
+            bare,
+            root.join("repo")
+                .join(format!("workspace-{}", short_id(first.as_uuid())))
+        );
+    }
+
+    /// The headless default keeps every worktree where it has always lived.
+    #[test]
+    fn the_data_dir_root_is_unchanged() {
+        assert_eq!(
+            data_dir_worktree_root(std::path::Path::new("/srv/tidebreak")),
+            std::path::Path::new("/srv/tidebreak/code/worktrees")
+        );
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/worktree_root.rs
+++ b/crates/tidebreak-server/src/code/worktree_root.rs
@@ -1,0 +1,139 @@
+//! Where new code-mode worktrees land: one deployment setting, resolved.
+//!
+//! A worktree is user work — uncommitted code on a real branch — so it does
+//! not belong in the disposable app-data directory the database and logs live
+//! in. The root is therefore a setting an operator can point anywhere, with a
+//! visible default supplied by the embedding
+//! ([`tidebreak_core::Config::code_worktree_root_default`]) and the old
+//! `<data_dir>/code/worktrees` as the fallback for headless deployments.
+//!
+//! The setting decides where the *next* workspace is created. Every existing
+//! workspace keeps the absolute `worktree_path` recorded on its row: a git
+//! worktree stores absolute paths in both its own `.git` file and the repo's
+//! `.git/worktrees/*` entry, so moving one is a repair pass, not a rename.
+//! Changing the root never touches a tree already on disk.
+
+use std::path::{Path, PathBuf};
+
+use tidebreak_core::{OwnerId, Store};
+
+use super::clone::owner_dir;
+use super::runtime::CodeRuntime;
+use super::worktree::data_dir_worktree_root;
+use crate::error::ServerError;
+use crate::routes::code::CodeWorktreeRoot;
+
+/// Deployment-wide setting naming the root. Absent means "use the default".
+pub(crate) const WORKTREE_ROOT_SETTING: &str = "code_worktree_root";
+
+impl CodeRuntime {
+    /// The root the next workspace on this deployment is created under, before
+    /// the per-owner segment.
+    pub(crate) async fn worktree_root(&self) -> Result<PathBuf, ServerError> {
+        Ok(match read_worktree_root(&*self.db).await? {
+            Some(root) => PathBuf::from(root),
+            None => self.default_worktree_root(),
+        })
+    }
+
+    /// The root one owner's worktrees land under.
+    ///
+    /// The setting is one deployment-wide path, so a multi-user machine needs
+    /// the same per-owner segment clones take ([`owner_dir`]) — otherwise two
+    /// users' repositories of the same name share a folder. The local profile
+    /// has exactly one owner and keeps the root itself.
+    pub(crate) async fn owner_worktree_root(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<PathBuf, ServerError> {
+        Ok(owner_dir(&self.worktree_root().await?, owner))
+    }
+
+    /// What the root falls back to with no setting stored: the visible
+    /// location the embedding named, or the app-data directory it always used.
+    pub(crate) fn default_worktree_root(&self) -> PathBuf {
+        self.worktree_root_default
+            .clone()
+            .unwrap_or_else(|| data_dir_worktree_root(&self.data_dir))
+    }
+
+    /// `GET /code/worktree-root`.
+    pub(crate) async fn worktree_root_snapshot(&self) -> Result<CodeWorktreeRoot, ServerError> {
+        let stored = read_worktree_root(&*self.db).await?;
+        let default_root = self.default_worktree_root().display().to_string();
+        Ok(CodeWorktreeRoot {
+            effective_root: stored.clone().unwrap_or_else(|| default_root.clone()),
+            root: stored,
+            default_root,
+        })
+    }
+
+    /// `PUT /code/worktree-root`. An absent or blank root clears the setting,
+    /// returning the deployment to its default.
+    pub(crate) async fn set_worktree_root(
+        &self,
+        root: Option<&str>,
+    ) -> Result<CodeWorktreeRoot, ServerError> {
+        match root.map(str::trim).filter(|value| !value.is_empty()) {
+            None => self.db.delete_setting(WORKTREE_ROOT_SETTING).await?,
+            Some(root) => {
+                let root = PathBuf::from(root);
+                validate_worktree_root(&root).await?;
+                self.db
+                    .set_setting(
+                        WORKTREE_ROOT_SETTING,
+                        &serde_json::json!(root.display().to_string()),
+                    )
+                    .await?;
+            }
+        }
+        self.worktree_root_snapshot().await
+    }
+}
+
+/// Refuse a root the deployment cannot create worktrees under, at the moment
+/// it is set rather than at the first workspace that fails.
+///
+/// The directory need not exist yet — creating it is part of accepting it, so
+/// the folder shows up where the user asked for it instead of appearing with
+/// the first workspace.
+async fn validate_worktree_root(root: &Path) -> Result<(), ServerError> {
+    if !root.is_absolute() {
+        return Err(ServerError::bad_request_kind(
+            "worktree_root_relative",
+            format!("worktree root {} must be an absolute path", root.display()),
+        ));
+    }
+    match tokio::fs::metadata(root).await {
+        Ok(meta) if meta.is_dir() => Ok(()),
+        Ok(_) => Err(ServerError::bad_request_kind(
+            "worktree_root_not_dir",
+            format!("worktree root {} is not a directory", root.display()),
+        )),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            tokio::fs::create_dir_all(root).await.map_err(|err| {
+                ServerError::bad_request_kind(
+                    "worktree_root_unusable",
+                    format!("could not create worktree root {}: {err}", root.display()),
+                )
+            })
+        }
+        Err(err) => Err(ServerError::bad_request_kind(
+            "worktree_root_unusable",
+            format!("could not read worktree root {}: {err}", root.display()),
+        )),
+    }
+}
+
+async fn read_worktree_root(store: &dyn Store) -> Result<Option<String>, ServerError> {
+    Ok(store
+        .get_setting(WORKTREE_ROOT_SETTING)
+        .await?
+        .and_then(|value| {
+            value
+                .as_str()
+                .map(str::trim)
+                .filter(|root| !root.is_empty())
+                .map(ToOwned::to_owned)
+        }))
+}

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -450,13 +450,14 @@ pub fn app(state: AppState) -> Router {
             "/voice-transcription/install",
             post(routes::post_voice_transcription_install),
         )
-        // Code mode's two deployment-plane routes. Installing a pinned harness
-        // writes a binary to this machine, and the clone parent directory is
-        // one shared setting that decides where every principal's checkouts
-        // land on its disk — both change what the deployment *is*, so neither
-        // belongs to a member (decisions 6 and 48 step 1). Reading and
-        // cloning into that directory stay on the member plane: those produce
-        // owner-scoped rows and owner-keyed checkouts.
+        // Code mode's deployment-plane routes. Installing a pinned harness
+        // writes a binary to this machine, and the clone parent and worktree
+        // root are shared settings that decide where every principal's
+        // checkouts and worktrees land on its disk — all of them change what
+        // the deployment *is*, so none belongs to a member (decisions 6 and 48
+        // step 1). Creating workspaces under those directories stays on the
+        // member plane: that produces owner-scoped rows and owner-keyed
+        // checkouts.
         .route(
             "/code/harnesses/refresh",
             post(routes::code::refresh_harnesses),
@@ -468,6 +469,10 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/code/repos/clone-defaults",
             get(routes::code::clone_defaults),
+        )
+        .route(
+            "/code/worktree-root",
+            get(routes::code::get_worktree_root).put(routes::code::set_worktree_root),
         )
         .route_layer(axum::middleware::from_fn(auth::require_admin));
 
@@ -1458,6 +1463,7 @@ async fn bind_inner(
     let code = Arc::new(code::CodeRuntime::new(
         db,
         state.config.data_dir.clone(),
+        state.config.code_worktree_root_default.clone(),
         code_host_tool_broker,
     ));
     // Recovery runs after the bind, below: the workers it re-attaches need the

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! Every route here is owner-scoped through `ScopedCode`. The routes that
 //! change what the machine *is* — installing pinned harness binaries, and the
-//! clone-parent-directory setting every principal shares — are registered on
-//! the deployment-plane router in `crate::lib` instead, behind `require_admin`.
+//! clone-parent and worktree-root directories every principal shares — are
+//! registered on the deployment-plane router in `crate::lib` instead, behind
+//! `require_admin`.
 
 mod approvals;
 mod git;
@@ -49,15 +50,16 @@ pub(crate) use types::{
     CodeSessionDigest, CodeSessionSnapshot, CodeTerminalActivityNotice, CodeTerminalRead,
     CodeTerminalSnapshot, CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff,
     CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSearch, CodeWorkspaceSearchMatch,
-    CodeWorkspaceSnapshot, CodeWorkspaceTree, HarnessDoctorReport, HarnessModelList,
-    MergeCodePrBody, QueuedCodeTurn, SequencedCodeEventFrame,
+    CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot, HarnessDoctorReport,
+    HarnessModelList, MergeCodePrBody, QueuedCodeTurn, SequencedCodeEventFrame,
+    SetCodeWorktreeRootBody,
 };
 pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, get_workspace_blob, get_workspace_diff,
-    list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace, restore_workspace,
-    search_workspace,
+    get_worktree_root, list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace,
+    restore_workspace, search_workspace, set_worktree_root,
 };
 
 // Nothing here reaches `AppState.code` directly. Every handler in this module

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -294,6 +294,29 @@ pub struct CodeCloneDefaults {
     pub gh_remediation: String,
 }
 
+/// Where new worktrees land: `GET`/`PUT /code/worktree-root`.
+///
+/// `root` is the stored setting and is absent while the deployment runs on its
+/// default. `effective_root` is what the next workspace uses, and
+/// `default_root` is what clearing the setting returns to — so a reader can
+/// tell a chosen path from an inherited one without repeating the rule.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeWorktreeRoot {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub root: Option<String>,
+    pub effective_root: String,
+    pub default_root: String,
+}
+
+/// Body of `PUT /code/worktree-root`. A null or blank root clears the setting.
+#[derive(Debug, Deserialize, Serialize, TS)]
+#[serde(deny_unknown_fields)]
+pub struct SetCodeWorktreeRootBody {
+    #[serde(default)]
+    pub root: Option<String>,
+}
+
 /// Body of `POST /code/repos`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -10,10 +10,28 @@ use crate::state::AppState;
 use super::types::{
     ArchiveWorkspaceBody, CodeFileChange, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
     CodeWorkspaceSearch, CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot, CodeWorkspaceTree,
-    CreateWorkspaceBody, ListWorkspacesQuery, PatchWorkspaceBody, WorkspaceBlobQuery,
-    WorkspaceDiffQuery, WorkspaceFilesQuery, WorkspaceSearchQuery, WorkspaceTreeQuery,
+    CodeWorktreeRoot, CreateWorkspaceBody, ListWorkspacesQuery, PatchWorkspaceBody,
+    SetCodeWorktreeRootBody, WorkspaceBlobQuery, WorkspaceDiffQuery, WorkspaceFilesQuery,
+    WorkspaceSearchQuery, WorkspaceTreeQuery,
 };
 use tidebreak_core::WorkspaceId;
+
+/// `GET /code/worktree-root`: where the next workspace's worktree lands.
+pub async fn get_worktree_root(code: ScopedCode) -> Result<Json<CodeWorktreeRoot>, ServerError> {
+    Ok(Json(code.worktree_root().await?))
+}
+
+/// `PUT /code/worktree-root`.
+///
+/// New workspaces only. Worktrees already on disk keep the absolute path
+/// stored on their row, because a git worktree records absolute paths in two
+/// places that a move would have to repair.
+pub async fn set_worktree_root(
+    code: ScopedCode,
+    Json(body): Json<SetCodeWorktreeRootBody>,
+) -> Result<Json<CodeWorktreeRoot>, ServerError> {
+    Ok(Json(code.set_worktree_root(body.root.as_deref()).await?))
+}
 
 pub async fn create_workspace(
     code: ScopedCode,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -2102,11 +2102,139 @@ async fn two_repos_with_the_same_name_get_distinct_worktrees() {
     assert_eq!(repo_b["display_name"], "origin");
     let path_a = ws_a["worktree_path"].as_str().unwrap();
     let path_b = ws_b["worktree_path"].as_str().unwrap();
+    // Same repo name, so the same repo folder — the workspace id suffix is
+    // what keeps the two checkouts apart.
     assert_ne!(path_a, path_b);
-    assert!(path_a.contains(json_id(&repo_a)));
-    assert!(path_b.contains(json_id(&repo_b)));
+    assert!(path_a.contains(&json_id(&ws_a)[..8]));
+    assert!(path_b.contains(&json_id(&ws_b)[..8]));
     assert!(std::path::Path::new(path_a).join("README.md").is_file());
     assert!(std::path::Path::new(path_b).join("README.md").is_file());
+}
+
+/// The worktree root is a setting, and moving it moves only what comes next.
+///
+/// The two halves are one test because the second is meaningless without the
+/// first: a root that new workspaces honour but old ones silently follow would
+/// leave every existing checkout pointing at nothing.
+#[tokio::test]
+async fn the_worktree_root_moves_new_workspaces_and_leaves_existing_ones() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (repo_body, before) = register_and_workspace(&client, addr, &token, &repo).await;
+    let before_path = before["worktree_path"].as_str().unwrap().to_owned();
+    // The default is the data directory until a root is set.
+    let defaults = client
+        .get(format!("http://{addr}/code/worktree-root"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert!(defaults["root"].is_null());
+    assert_eq!(defaults["effective_root"], defaults["default_root"]);
+    assert!(before_path.starts_with(defaults["default_root"].as_str().unwrap()));
+
+    // A root that does not exist yet is created rather than refused.
+    let chosen = dir.path().join("visible").join("workspaces");
+    let moved = client
+        .put(format!("http://{addr}/code/worktree-root"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "root": chosen }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(moved.status(), reqwest::StatusCode::OK);
+    let moved: serde_json::Value = moved.json().await.unwrap();
+    assert_eq!(moved["root"], moved["effective_root"]);
+    assert!(chosen.is_dir());
+
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "second change",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let after: serde_json::Value = created.json().await.unwrap();
+    let after_path = after["worktree_path"].as_str().unwrap();
+    assert!(
+        after_path.starts_with(chosen.to_str().unwrap()),
+        "{after_path}"
+    );
+    // Readable name first, id last.
+    assert!(after_path.ends_with(&format!("second-change-{}", &json_id(&after)[..8])));
+    assert!(std::path::Path::new(after_path).join("README.md").is_file());
+
+    // The workspace created before the move keeps the path on its row, and the
+    // checkout is still there.
+    let reread = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}",
+            json_id(&before)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(reread["worktree_path"], before_path);
+    assert!(std::path::Path::new(&before_path)
+        .join("README.md")
+        .is_file());
+
+    // Clearing the setting returns the deployment to its default and, again,
+    // touches nothing on disk.
+    let cleared = client
+        .put(format!("http://{addr}/code/worktree-root"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "root": null }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert!(cleared["root"].is_null());
+    assert_eq!(cleared["effective_root"], cleared["default_root"]);
+}
+
+/// A root the deployment cannot write worktrees under is refused when it is
+/// set, not at the first workspace that fails.
+#[tokio::test]
+async fn the_worktree_root_refuses_a_relative_path_and_a_file() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+
+    let relative = client
+        .put(format!("http://{addr}/code/worktree-root"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "root": "workspaces" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(relative.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let file = dir.path().join("not-a-directory");
+    std::fs::write(&file, b"x").unwrap();
+    let refused = client
+        .put(format!("http://{addr}/code/worktree-root"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "root": file }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -4238,6 +4366,21 @@ async fn code_deployment_plane_routes_refuse_a_member() {
         .unwrap();
     assert_eq!(admin.status(), reqwest::StatusCode::OK);
 
+    let member_root = client
+        .get(format!("http://{addr}/code/worktree-root"))
+        .bearer_auth(BOB_TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(member_root.status(), reqwest::StatusCode::FORBIDDEN);
+    let admin_root = client
+        .get(format!("http://{addr}/code/worktree-root"))
+        .bearer_auth(ALICE_TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(admin_root.status(), reqwest::StatusCode::OK);
+
     let member_refresh = client
         .post(format!("http://{addr}/code/harnesses/refresh"))
         .bearer_auth(BOB_TOKEN)
@@ -4261,26 +4404,26 @@ async fn code_deployment_plane_routes_refuse_a_member() {
 /// the second clone from landing on the first one's checkout.
 #[test]
 fn clone_targets_are_keyed_by_owner() {
-    use crate::code::clone::owner_clone_dir;
+    use crate::code::clone::owner_dir;
     let parent = std::path::Path::new("/srv/checkouts");
     // The local profile is single-user and keeps the paths people already have.
     assert_eq!(
-        owner_clone_dir(parent, &tidebreak_core::OwnerId::local()),
+        owner_dir(parent, &tidebreak_core::OwnerId::local()),
         parent.to_path_buf()
     );
-    let alice = owner_clone_dir(parent, &tidebreak_core::OwnerId::new("alice").unwrap());
-    let bob = owner_clone_dir(parent, &tidebreak_core::OwnerId::new("bob").unwrap());
+    let alice = owner_dir(parent, &tidebreak_core::OwnerId::new("alice").unwrap());
+    let bob = owner_dir(parent, &tidebreak_core::OwnerId::new("bob").unwrap());
     assert_ne!(alice, bob);
     assert_eq!(alice, parent.join("alice"));
     // An owner key is visible ASCII, so it may carry separators and dots that
     // must not escape the parent or resolve to it.
-    let hostile = owner_clone_dir(
+    let hostile = owner_dir(
         parent,
         &tidebreak_core::OwnerId::new("../../etc/passwd").unwrap(),
     );
     assert_eq!(hostile.parent(), Some(parent));
     assert!(hostile.starts_with(parent));
-    let dots = owner_clone_dir(parent, &tidebreak_core::OwnerId::new("..").unwrap());
+    let dots = owner_dir(parent, &tidebreak_core::OwnerId::new("..").unwrap());
     assert_eq!(dots, parent.join("owner"));
 }
 

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -440,6 +440,9 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodeCloneJobSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeHarnessInstallSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeCloneDefaults>(&cfg, &mut out);
+        // Where new worktrees land, and the body that moves it.
+        generate::collect_from::<crate::routes::code::CodeWorktreeRoot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::SetCodeWorktreeRootBody>(&cfg, &mut out);
         out
     }
 

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -271,6 +271,7 @@ carries the whole `rawInput`, so it has nothing to correct.
 ```
 POST/GET        /code/repos                GET/PATCH/DELETE /code/repos/{id}
 GET             /code/harnesses            doctor    POST /code/harnesses/refresh
+GET/PUT         /code/worktree-root        {root}    where new worktrees land (admin)
 
 POST/GET        /code/workspaces           {repo_id, base_ref?, title?}
 GET/PATCH       /code/workspaces/{id}
@@ -304,6 +305,23 @@ POST            /code/workspaces/{id}/terminals/{tid}/write | /resize
 The session worker is the only journal writer for its session, under a
 lease and the spawn epoch; routes submit work and read state, they never
 write the journal directly.
+
+### Where worktrees live
+
+A workspace's worktree is created at
+`<root>/<repo-slug>/<workspace-slug>-<short-id>/`, where `<root>` is the
+`code_worktree_root` setting, or — with none stored — the visible default the
+embedding named (`~/Tidebreak/workspaces` on the desktop) or
+`<data_dir>/code/worktrees` for a headless deployment. The readable name leads
+because people read these paths; the id trails to keep two same-named
+workspaces apart. A multi-user deployment inserts the same per-owner segment
+clones use.
+
+The root decides where the *next* worktree is created. Every existing workspace
+keeps the absolute `worktree_path` on its row: git records absolute paths in
+both the worktree's `.git` file and the repository's `.git/worktrees/*` entry,
+so moving one is a `git worktree repair` pass rather than a rename. Moving the
+root therefore never touches a checkout already on disk.
 
 Pull-request operations shell out to the user's `gh` (auth observed, never
 brokered — the [`0034`](decisions/0034-harness-discovery-credentials.md)

--- a/docs/decisions/0053-code-worktrees-live-in-a-user-visible-root.md
+++ b/docs/decisions/0053-code-worktrees-live-in-a-user-visible-root.md
@@ -1,0 +1,139 @@
+# 53. Code Worktrees Live in a User-Visible, Configurable Root
+
+- Status: Accepted
+- Date: 2026-08-20
+- Owners: code mode
+- Related: [`0032-code-workspaces-worktrees-checkpoints.md`](0032-code-workspaces-worktrees-checkpoints.md),
+  [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),
+  [`0045-run-code-mode-on-windows.md`](0045-run-code-mode-on-windows.md),
+  [`docs/code-mode.md`](../code-mode.md)
+
+## Context
+
+[`0032`](0032-code-workspaces-worktrees-checkpoints.md) rooted every worktree
+under the Tidebreak data directory, and
+[`0045`](0045-run-code-mode-on-windows.md) restated that Windows introduces no
+user-selectable location. On the desktop that data directory is platform app
+data keyed by the bundle identifier, so a workspace lands in
+`~/Library/Application Support/io.brightwave.tidebreak[.dev|.staging]/code/worktrees/<repoId>-<slug>/<workspaceId>-<slug>/`.
+
+Four facts make that the wrong home, and none of them was known to be wrong
+when 0032 was written — worktrees were an implementation detail then, and they
+are user work now:
+
+- A worktree holds uncommitted changes on a real branch. App data is
+  conventionally disposable: uninstall flows and "reset app data" delete it,
+  and a user consenting to either is not consenting to lose a day's work.
+- `~/Library` is hidden in Finder and in file dialogs, and the UUID-prefixed
+  segments make the paths long and unreadable everywhere they show up — shell
+  prompts, editor titles, and every `cd` an agent narrates.
+- The bundle identifier keys the path, so each channel grows its own tree; a
+  development machine carries three copies of the same person's work.
+- Everything an agent builds inside — one current tree is 2.4 GB, mostly
+  `node_modules` — is backed up as application state.
+
+The database, logs, blobs, and managed tools are correctly placed. Only the
+worktrees are misfiled. Clone destinations already solved the same problem with
+the `code_clone_parent_dir` setting, which is the pattern to copy rather than
+invent.
+
+## Decision
+
+**The root is a setting.** `code_worktree_root` is one deployment-wide setting,
+read and written on the deployment plane behind `require_admin` — the same
+plane the clone parent lives on, for the same reason: it decides where every
+principal's work lands on this machine. A multi-user deployment inserts the
+per-owner path segment clones already use, so two users' same-named
+repositories cannot share a folder.
+
+**The default depends on the embedding, not the profile.** The boot config
+carries `code_worktree_root_default`. The desktop app sets it to
+`~/Tidebreak/workspaces` — one root for all three channels, because a dev build
+growing a second copy of the user's work is the problem, not the protection.
+Embeddings that leave it absent — the CLI, self-host, tests — keep
+`<data_dir>/code/worktrees`, which is right for a headless deployment whose
+data directory *is* the operator-visible location and whose `TIDEBREAK_DATA_DIR`
+is already a deliberate choice. A stored setting overrides either.
+
+**Names lead, ids trail.** A worktree is created at
+`<root>/<repo-slug>/<workspace-slug>-<short-id>/`. The workspace id, shortened
+to eight hex digits, is a suffix rather than the leading segment: it still
+carries uniqueness — titles repeat and may be empty — but it no longer costs
+the reader the first thing they see. The repo segment is the slug alone;
+workspace ids are unique across every repo, so two repos that share a name
+share a folder without ever sharing a worktree.
+
+**The root applies to new workspaces only.** A git worktree records absolute
+paths in two places — its own `.git` file and the repository's
+`.git/worktrees/*` entry — so relocating one is a `git worktree repair` pass,
+not a rename. Every existing workspace keeps the absolute `worktree_path` on
+its row and its checkout stays exactly where it is. Nothing recomputes a path
+for a row that already has one.
+
+Deliberately excluded: a mover or repair pass for existing trees, a per-repo
+override (still deferred), and any change to where the database, blobs, logs,
+or managed tools live.
+
+## Alternatives Considered
+
+**Do nothing.** Rejected: the location is not a cosmetic complaint. Losing
+uncommitted branches to a documented "reset app data" step is a data-loss path,
+and it is reached by a user doing something the platform tells them is safe.
+
+**Move existing worktrees and repair them on first boot.** Rejected for this
+change. `git worktree repair` is the correct mechanism, but a boot-time pass
+that moves every user's checkouts — across channels, with sessions possibly
+mid-turn and agent processes holding open files — is a much larger risk than
+the problem it closes. The setting makes the migration possible later; leaving
+existing trees in place makes this change safe now. A user who wants an old
+workspace in the new root can archive it and create a new one.
+
+**Derive the default from `Profile::Desktop`.** Rejected: the CLI runs the
+desktop profile too, and a headless `tidebreak serve` should not start writing
+into `~/Tidebreak`. The embedding that owns a window is the one that knows a
+visible home directory is the right answer, so the embedding names it.
+
+**Put worktrees beside the clone parent (`<clone-parent>/../worktrees`).**
+Rejected: the clone parent is wherever the user keeps source checkouts, which
+is often a directory they curate; deriving a sibling from it would put
+Tidebreak-managed trees inside someone's `~/src` layout without asking.
+
+## Consequences
+
+Two conventions now exist on one machine: workspaces created before this change
+sit in app data, and workspaces created after sit in the visible root. The
+paths are absolute and stored, so both keep working, but a user's workspace list
+spans two locations until the old ones are archived. That is the accepted cost
+of not writing a mover.
+
+`~/Tidebreak/workspaces` is a directory Tidebreak creates in the user's home.
+It is created when the first worktree lands, not at boot, so an install that
+never opens code mode leaves nothing behind.
+
+Worktrees are no longer inside the data directory the desktop marks private to
+the host broker, so a user *can* now attach a workspace folder as a chat-mode
+folder. That is a user choice about their own source tree, and the same choice
+they already have for any clone.
+
+Revisit if the two-location split proves confusing enough to justify the repair
+pass, or if a per-repo override lands and the deployment-wide root stops being
+the only answer.
+
+## Validation
+
+- Path construction: the readable segments lead, the short id is the suffix,
+  and two workspaces on one repo with the same title resolve to different
+  directories.
+- The headless default is byte-for-byte the old `<data_dir>/code/worktrees`, so
+  an existing self-host deployment sees no move.
+- End to end: create a workspace, move the root, create a second workspace, and
+  assert the first workspace's stored path and its checkout are both unchanged
+  while the second lands under the new root. A wrong implementation that
+  recomputed paths on read would pass a test that only checked the new
+  workspace, which is why the assertion on the *old* row is the load-bearing
+  one.
+- Setting a root that does not exist creates it; a relative path and a path
+  that names a file are refused when set, not at the first workspace that
+  fails.
+- The route is admin-gated by registration: a member is refused, an admin is
+  not.


### PR DESCRIPTION
Fixes #2317.

## What changed

Code worktrees left platform app data. A worktree holds uncommitted work on a
real branch, so it does not belong in a directory that uninstall and "reset app
data" flows treat as disposable — and `~/Library` is hidden, UUID-prefixed, and
duplicated per channel.

New worktrees now land at `<root>/<repo-slug>/<workspace-slug>-<short-id>/`:
the readable name leads, and eight hex digits of the workspace id trail as the
uniqueness suffix. The repo segment is the slug alone; workspace ids are unique
across repos, so two same-named repos share a folder without ever sharing a
worktree.

`<root>` comes from a new deployment-wide `code_worktree_root` setting, built on
the `code_clone_parent_dir` pattern it sits beside: one shared value, read and
written on the admin plane (`GET`/`PUT /code/worktree-root`), with the same
per-owner path segment a multi-user machine needs. Setting a root that does not
exist creates it; a relative path or a path that names a file is refused when
set, not at the first workspace that fails.

## The default, and why

- **Desktop:** `~/Tidebreak/workspaces`, supplied through a new
  `Config::code_worktree_root_default` boot field. All three channels share the
  one root on purpose — the issue counts three trees on a dev machine as part of
  the problem, and app-data keying exists to protect app *state*, not to fork
  the user's work.
- **Headless (CLI, self-host, tests):** unchanged `<data_dir>/code/worktrees`.
  A headless deployment's data directory is already an operator-chosen, visible
  location, and `TIDEBREAK_DATA_DIR` is already the lever. Keying off
  `Profile::Desktop` would have caught the CLI too, so the embedding names the
  default instead of the profile implying it.
- A stored setting overrides either.

## Migration: none, by design

Existing workspaces keep the absolute `worktree_path` on their row and their
checkouts stay exactly where they are. Nothing recomputes a path for a row that
already has one — `restore_worktree` and every other caller read the stored
path, and `worktree_dir` is now reached only from `create_workspace`.

No mover and no `git worktree repair` pass. Git records absolute paths in both
the worktree's `.git` file and the repo's `.git/worktrees/*` entry, so a
boot-time relocation across channels, with sessions possibly mid-turn, is a much
larger risk than the problem it closes. The cost is accepted and stated: a
machine can carry workspaces in two locations until the old ones are archived.

## UI

Settings → Coding harnesses gains a "Workspace folder" section: the folder in
force, a native Browse button, Save, and Reset to default, with the default
named in the hint either way. Stories cover inherited, custom, edited, saving,
no-picker, and headless-default states.

## Checks

- `cargo fmt --all --check` — pass
- `cargo clippy -p tidebreak-server -p tidebreak-core --all-targets -- -D warnings` — pass
- `cargo test -p tidebreak-server --lib code::` — 130 passed
- `cargo test -p tidebreak-server --lib code_clone` / `worktree` / `wire_types` — pass
- `cargo test -p tidebreak-core --lib config` — pass
- `pnpm exec tsc --noEmit` — pass
- `pnpm exec vitest run src/code/parsers.test.ts src/AppShell.dom.test.tsx src/WireFixtures.test.ts` — 67 passed
- `pnpm storybook:build` — pass

New tests pin the two contracts worth pinning: path construction (name first,
id last, unique per workspace, headless root byte-identical to the old one), and
end to end that moving the root moves the next workspace while the previous
workspace's stored path and checkout are untouched. The assertion on the *old*
row is the load-bearing one — an implementation that recomputed paths on read
would pass a test that only checked the new workspace.
