### PR TITLE
feat(outputs): show per-revision sources

### DIFF
--- a/crates/tidebreak-desktop/ui/src/MessageWebSources.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageWebSources.tsx
@@ -55,7 +55,7 @@ export function MessageWebSources({
           title={source.label}
           aria-label={source.label}
           className="inline-flex max-w-56 items-center gap-1 rounded-full border bg-card px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-          onClick={() => void openSource(source.url)}
+          onClick={() => void openWebSource(source.url)}
         >
           <DomainFavicon url={source.url} className="size-3" />
           <span className="truncate">{source.domain}</span>
@@ -75,7 +75,7 @@ export function MessageWebSources({
 }
 
 /** Native opener first; `window.open` only works in a plain browser tab. */
-async function openSource(url: string): Promise<void> {
+export async function openWebSource(url: string): Promise<void> {
   if (!(await openExternal(url).catch(() => false))) {
     window.open(url, "_blank", "noreferrer,noopener");
   }

--- a/crates/tidebreak-desktop/ui/src/deliverables.test.ts
+++ b/crates/tidebreak-desktop/ui/src/deliverables.test.ts
@@ -9,10 +9,13 @@ import {
   parseDeliverablePreview,
   parseDeliverablesCatalog,
   parseOutputExportResult,
+  parseOutputRevisionsCatalog,
 } from "./deliverables";
 
 const outputId = "550062d4-2528-5cc6-90f8-a788e119bf36";
 const revisionId = "72cb0277-5a3c-45ee-bda8-43534f74feb2";
+const citationId = "46abf484-8368-4c2d-b2ec-8b9ed77e202f";
+const documentId = "4571ebc0-69a7-4f8a-a9c7-936c50f0f022";
 
 beforeEach(() => invokeMock.mockReset());
 
@@ -246,6 +249,60 @@ describe("deliverable renderer projections", () => {
         destination: "/private/export.md",
       }),
     ).toThrow("Invalid output export response");
+  });
+
+  it("accepts only bounded, renderer-safe revision sources", () => {
+    const row = {
+      revisionId,
+      ordinal: 1,
+      sizeBytes: 42,
+      createdAt: "2026-07-24T00:00:00Z",
+      producedBy: "agent",
+      isCurrent: true,
+      sources: [
+        {
+          kind: "document",
+          citationId,
+          documentId,
+          locator: { kind: "lines", start: 4, end: 8 },
+        },
+        {
+          kind: "web",
+          url: "https://example.com/report",
+          label: "Research report",
+          domain: "example.com",
+        },
+      ],
+    };
+    expect(
+      parseOutputRevisionsCatalog({ outputId, revisions: [row] }, outputId)
+        .revisions[0]?.sources,
+    ).toEqual(row.sources);
+
+    expect(() =>
+      parseOutputRevisionsCatalog({
+        outputId,
+        revisions: [
+          {
+            ...row,
+            sources: [
+              {
+                kind: "web",
+                url: "javascript:alert(1)",
+                label: "Unsafe",
+                domain: "unsafe",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toThrow("Invalid output versions response");
+    expect(() =>
+      parseOutputRevisionsCatalog({
+        outputId,
+        revisions: [{ ...row, sources: Array(21).fill(row.sources[0]) }],
+      }),
+    ).toThrow("Invalid output versions response");
   });
 
   it("retries an ambiguous bridge response with the exact operation identity", async () => {

--- a/crates/tidebreak-desktop/ui/src/deliverables.ts
+++ b/crates/tidebreak-desktop/ui/src/deliverables.ts
@@ -1,5 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 
+import type { CitationLocator } from "@/api";
+
 /**
  * Conversation outputs are read and edited over the server's HTTP routes, the
  * same ones a headless client uses — only the native save dialog still goes
@@ -124,6 +126,9 @@ const MAX_PREVIEW_CHARACTERS = 100_000;
 const MAX_DELIVERABLE_BYTES = 512 * 1024;
 const MAX_BINARY_DELIVERABLE_BYTES = 16 * 1024 * 1024;
 const MAX_OUTPUT_REVISIONS = 100;
+const MAX_OUTPUT_REVISION_SOURCES = 20;
+const MAX_SOURCE_LABEL_CHARACTERS = 512;
+const MAX_SOURCE_URL_CHARACTERS = 2 * 1024;
 
 export function isTextDeliverableMediaType(
   value: string,
@@ -256,7 +261,22 @@ export type OutputRevisionInfo = {
   createdAt: string;
   producedBy: "agent" | "backgroundAgent" | "user";
   isCurrent: boolean;
+  sources: OutputRevisionSource[];
 };
+
+export type OutputRevisionSource =
+  | {
+      kind: "document";
+      citationId: string;
+      documentId: string;
+      locator: CitationLocator;
+    }
+  | {
+      kind: "web";
+      url: string;
+      label: string;
+      domain: string;
+    };
 
 export type OutputRevisionsCatalog = {
   outputId: string;
@@ -330,6 +350,7 @@ export function parseOutputRevisionsCatalog(
         "createdAt",
         "producedBy",
         "isCurrent",
+        "sources",
       ]) ||
       !isOpaqueId(row.revisionId) ||
       typeof row.ordinal !== "number" ||
@@ -344,10 +365,13 @@ export function parseOutputRevisionsCatalog(
       (row.producedBy !== "agent" &&
         row.producedBy !== "backgroundAgent" &&
         row.producedBy !== "user") ||
-      typeof row.isCurrent !== "boolean"
+      typeof row.isCurrent !== "boolean" ||
+      !Array.isArray(row.sources) ||
+      row.sources.length > MAX_OUTPUT_REVISION_SOURCES
     ) {
       throw new Error("Invalid output versions response");
     }
+    const sources = row.sources.map(parseOutputRevisionSource);
     return {
       revisionId: row.revisionId,
       ordinal: row.ordinal,
@@ -355,9 +379,103 @@ export function parseOutputRevisionsCatalog(
       createdAt: row.createdAt,
       producedBy: row.producedBy,
       isCurrent: row.isCurrent,
+      sources,
     };
   });
   return { outputId: value.outputId, revisions };
+}
+
+function parseOutputRevisionSource(value: unknown): OutputRevisionSource {
+  if (!isRecord(value)) throw new Error("Invalid output versions response");
+  if (value.kind === "document") {
+    if (
+      !isExactRecord(value, ["kind", "citationId", "documentId", "locator"]) ||
+      !isOpaqueId(value.citationId) ||
+      !isOpaqueId(value.documentId) ||
+      !isCitationLocator(value.locator)
+    ) {
+      throw new Error("Invalid output versions response");
+    }
+    return {
+      kind: "document",
+      citationId: value.citationId,
+      documentId: value.documentId,
+      locator: value.locator,
+    };
+  }
+  if (
+    value.kind !== "web" ||
+    !isExactRecord(value, ["kind", "url", "label", "domain"]) ||
+    !isWebSourceUrl(value.url) ||
+    !isBoundedSourceText(value.label) ||
+    !isBoundedSourceText(value.domain)
+  ) {
+    throw new Error("Invalid output versions response");
+  }
+  return {
+    kind: "web",
+    url: value.url,
+    label: value.label,
+    domain: value.domain,
+  };
+}
+
+function isCitationLocator(value: unknown): value is CitationLocator {
+  if (!isRecord(value) || typeof value.kind !== "string") return false;
+  const positiveInteger = (candidate: unknown): candidate is number =>
+    typeof candidate === "number" &&
+    Number.isSafeInteger(candidate) &&
+    candidate >= 1 &&
+    candidate <= 10_000_000;
+  switch (value.kind) {
+    case "document":
+      return isExactRecord(value, ["kind"]);
+    case "page":
+      return isExactRecord(value, ["kind", "page"]) && positiveInteger(value.page);
+    case "pages":
+    case "lines":
+      return (
+        isExactRecord(value, ["kind", "start", "end"]) &&
+        positiveInteger(value.start) &&
+        positiveInteger(value.end) &&
+        value.start <= value.end
+      );
+    case "sheet":
+      return (
+        isExactRecord(value, ["kind", "sheet", "cells"]) &&
+        typeof value.sheet === "string" &&
+        value.sheet.length > 0 &&
+        value.sheet.length <= 120 &&
+        !/\p{Cc}/u.test(value.sheet) &&
+        (value.cells === null ||
+          (typeof value.cells === "string" &&
+            value.cells.length > 0 &&
+            value.cells.length <= 32))
+      );
+    default:
+      return false;
+  }
+}
+
+function isWebSourceUrl(value: unknown): value is string {
+  if (typeof value !== "string" || value.length > MAX_SOURCE_URL_CHARACTERS) {
+    return false;
+  }
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isBoundedSourceText(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_SOURCE_LABEL_CHARACTERS &&
+    !/\p{Cc}/u.test(value)
+  );
 }
 
 export async function exportDeliverable(

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
@@ -7,7 +7,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DeliverablePreview, OutputRevisionInfo } from "@/deliverables";
 import { Toaster } from "@/components/ui/sonner";
 import { renderWithRouter } from "@/test/router";
+import { SourceNavProvider, type SourceNav } from "@/panel/SourceNav";
 import { OutputDetailRoot, type OutputDetailApis } from "./OutputDetailRoot";
+
+const hostMocks = vi.hoisted(() => ({ openExternal: vi.fn() }));
+vi.mock("@/host", async () => {
+  const actual = await vi.importActual<typeof import("@/host")>("@/host");
+  return { ...actual, openExternal: hostMocks.openExternal };
+});
 
 vi.mock("@/components/document/image-viewer", () => ({
   ImageViewer: () => <div>Image preview</div>,
@@ -25,10 +32,15 @@ vi.mock("@/document/DocumentViewer", async () => {
   };
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  hostMocks.openExternal.mockReset();
+});
 
 const outputId = "550062d4-2528-5cc6-90f8-a788e119bf36";
 const revisionId = "72cb0277-5a3c-45ee-bda8-43534f74feb2";
+const citationId = "46abf484-8368-4c2d-b2ec-8b9ed77e202f";
+const documentId = "4571ebc0-69a7-4f8a-a9c7-936c50f0f022";
 /** An output id this conversation does not own. */
 const absentOutputId = "ce116263-15b5-5df2-b472-269378e9da58";
 
@@ -55,6 +67,7 @@ function revisionRow(overrides: Partial<OutputRevisionInfo> = {}): OutputRevisio
     createdAt: "2026-07-24T00:00:00Z",
     producedBy: "agent",
     isCurrent: true,
+    sources: [],
     ...overrides,
   };
 }
@@ -96,10 +109,16 @@ function detailApis(overrides: Partial<OutputDetailApis> = {}): OutputDetailApis
   };
 }
 
-async function openOutput(apis: OutputDetailApis, id = outputId) {
+async function openOutput(
+  apis: OutputDetailApis,
+  id = outputId,
+  sourceNav: SourceNav | null = null,
+) {
   return renderWithRouter(
     <>
-      <OutputDetailRoot chatId="chat-1" outputId={id} apis={apis} />
+      <SourceNavProvider value={sourceNav}>
+        <OutputDetailRoot chatId="chat-1" outputId={id} apis={apis} />
+      </SourceNavProvider>
       <Toaster richColors />
     </>,
     { initialUrl: `/c/chat-1?tabs=outputs.${id}` },
@@ -172,6 +191,83 @@ describe("OutputDetailRoot", () => {
       screen.queryByRole("button", { name: "Version history" }),
     ).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Revert/ })).not.toBeInTheDocument();
+  });
+
+  it("shows the exact revision's document and web sources", async () => {
+    hostMocks.openExternal.mockResolvedValue(true);
+    const oldAgentRevisionId = "56c62f92-05d2-4830-8664-75dab007d087";
+    const userRevisionId = "8ac32ae1-c55f-4c11-820b-873912d144c2";
+    const apis = detailApis({
+      read: vi.fn().mockResolvedValue(preview({ revisionCount: 3 })),
+      listRevisions: vi.fn().mockResolvedValue({
+        outputId,
+        revisions: [
+          revisionRow({
+            ordinal: 3,
+            sources: [
+              {
+                kind: "document",
+                citationId,
+                documentId,
+                locator: { kind: "lines", start: 4, end: 8 },
+              },
+              {
+                kind: "web",
+                url: "https://example.com/current",
+                label: "Current research",
+                domain: "example.com",
+              },
+            ],
+          }),
+          revisionRow({
+            revisionId: oldAgentRevisionId,
+            ordinal: 2,
+            isCurrent: false,
+            sources: [
+              {
+                kind: "web",
+                url: "https://archive.example/earlier",
+                label: "Earlier research",
+                domain: "archive.example",
+              },
+            ],
+          }),
+          revisionRow({
+            revisionId: userRevisionId,
+            ordinal: 1,
+            producedBy: "user",
+            isCurrent: false,
+            sources: [],
+          }),
+        ],
+      }),
+    });
+    const openCitation = vi.fn();
+    const user = userEvent.setup();
+    await openOutput(apis, outputId, {
+      openCitation,
+      openDocument: vi.fn(),
+    });
+
+    expect(await screen.findByLabelText("Output sources")).toBeVisible();
+    expect(screen.getByText("Lines 4–8")).toBeVisible();
+    expect(screen.getByText("example.com")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Open document source 1" }));
+    expect(openCitation).toHaveBeenCalledWith({ documentId, citationId });
+    await user.click(screen.getByRole("button", { name: "Current research" }));
+    expect(hostMocks.openExternal).toHaveBeenCalledWith(
+      "https://example.com/current",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Version history" }));
+    await user.click(await screen.findByRole("button", { name: /v2/ }));
+    expect(await screen.findByText("archive.example")).toBeVisible();
+    expect(screen.queryByText("example.com")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Version history" }));
+    await user.click(await screen.findByRole("button", { name: /v1/ }));
+    await screen.findByText(/Viewing v1/);
+    expect(screen.queryByLabelText("Output sources")).not.toBeInTheDocument();
   });
 
   it("previews an old version and restores it as a new latest version", async () => {

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputDetailRoot.tsx
@@ -37,9 +37,12 @@ import {
   useNativePickerLatch,
 } from "@/NativePickerLatch";
 import { PanelFrame } from "@/panel/PanelFrame";
+import { useSourceNav } from "@/panel/SourceNav";
 import { usePanelNav } from "@/panel/usePanelNav";
+import { openWebSource } from "@/MessageWebSources";
 import { OutputContent } from "./OutputContent";
 import { outputTypeLabel } from "./outputFormat";
+import { OutputRevisionSources } from "./OutputRevisionSources";
 import { exportFailureMessage, friendlyOutputError } from "./OutputsView";
 
 export type OutputDetailApis = {
@@ -108,6 +111,7 @@ export function OutputDetailRoot({
   apis?: OutputDetailApis;
 }) {
   const { openPanel } = usePanelNav();
+  const sourceNav = useSourceNav();
   const [preview, setPreview] = useState<DeliverablePreview | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -147,10 +151,42 @@ export function OutputDetailRoot({
           setLoadError(friendlyOutputError(caught, "Could not preview that output."));
         }
       });
+    void apis
+      .listRevisions(chatId, outputId)
+      .then((catalog) => {
+        if (!cancelled) setRevisions(catalog.revisions);
+      })
+      .catch((caught) => {
+        if (!cancelled) {
+          setRevisions([]);
+          toast.error(
+            friendlyOutputError(
+              caught,
+              "Could not load this output's versions or sources.",
+            ),
+          );
+        }
+      });
     return () => {
       cancelled = true;
     };
   }, [apis, chatId, outputId]);
+
+  async function refreshRevisions() {
+    setRevisions(null);
+    try {
+      const catalog = await apis.listRevisions(chatId, outputId);
+      setRevisions(catalog.revisions);
+    } catch (caught) {
+      setRevisions([]);
+      toast.error(
+        friendlyOutputError(
+          caught,
+          "Could not load this output's versions or sources.",
+        ),
+      );
+    }
+  }
 
   async function onSave() {
     if (saving) return;
@@ -213,7 +249,7 @@ export function OutputDetailRoot({
         return;
       }
       setPreview(result.preview);
-      setRevisions(null);
+      void refreshRevisions();
       setEditor(null);
       setEditConflict(false);
       toast.success(
@@ -242,7 +278,7 @@ export function OutputDetailRoot({
     try {
       const next = await apis.read(chatId, outputId);
       setPreview(next);
-      setRevisions(null);
+      void refreshRevisions();
       setEditConflict(false);
       setEditor(
         next.truncated || !isEditableTextMediaType(next.mediaType)
@@ -256,18 +292,11 @@ export function OutputDetailRoot({
     }
   }
 
-  async function onHistoryOpenChange(open: boolean) {
+  function onHistoryOpenChange(open: boolean) {
     setHistoryOpen(open);
-    if (!open) return;
-    try {
-      const catalog = await apis.listRevisions(chatId, outputId);
-      setRevisions(catalog.revisions);
-    } catch (caught) {
-      setHistoryOpen(false);
-      toast.error(
-        friendlyOutputError(caught, "Could not load this output's versions."),
-      );
-    }
+    // An empty catalog is the failure sentinel: a valid output always has at
+    // least one revision. Opening history is the reader's explicit retry.
+    if (open && revisions?.length === 0) void refreshRevisions();
   }
 
   async function onViewRevision(revision: OutputRevisionInfo) {
@@ -296,7 +325,7 @@ export function OutputDetailRoot({
       const restoredOrdinal = previewRevision.ordinal;
       setPreviewRevision(null);
       setRevisionPreview(null);
-      setRevisions(null);
+      void refreshRevisions();
       const next = await apis.read(chatId, outputId);
       setPreview(next);
       toast.success(`Restored version ${restoredOrdinal} as the latest version.`);
@@ -308,6 +337,8 @@ export function OutputDetailRoot({
   }
 
   const viewing = previewRevision ? revisionPreview : preview;
+  const displayedRevision =
+    previewRevision ?? revisions?.find((revision) => revision.isCurrent) ?? null;
   const showHistory = (preview?.revisionCount ?? 0) > 1;
   // A truncated preview is not the whole file, so editing it would quietly drop
   // whatever the preview left out. Save As… still exports the complete file.
@@ -379,7 +410,7 @@ export function OutputDetailRoot({
             {showHistory && (
               <Popover
                 open={historyOpen}
-                onOpenChange={(open) => void onHistoryOpenChange(open)}
+                onOpenChange={onHistoryOpenChange}
               >
                 <WithTooltip label="Version history">
                   <PopoverTrigger asChild>
@@ -523,7 +554,24 @@ export function OutputDetailRoot({
           <div className="shrink-0 px-6 pt-4 text-xs text-muted-foreground">
             {outputTypeLabel(viewing.mediaType)}
           </div>
-          <OutputContent chatId={chatId} preview={viewing} />
+          <div className="flex min-h-0 flex-1 flex-col">
+            <OutputContent chatId={chatId} preview={viewing} />
+            {displayedRevision && (
+              <OutputRevisionSources
+                sources={displayedRevision.sources}
+                onOpenDocument={
+                  sourceNav
+                    ? (source) =>
+                        sourceNav.openCitation({
+                          documentId: source.documentId,
+                          citationId: source.citationId,
+                        })
+                    : undefined
+                }
+                onOpenWeb={(url) => void openWebSource(url)}
+              />
+            )}
+          </div>
         </>
       ) : (
         <p className="p-6 text-sm text-muted-foreground" role="status">

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputRevisionSources.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputRevisionSources.tsx
@@ -1,0 +1,68 @@
+import { ExternalLinkIcon, FileTextIcon } from "lucide-react";
+
+import { CitationLocatorLabel } from "@/AssistantSources";
+import { DomainFavicon } from "@/DomainFavicon";
+import type { OutputRevisionSource } from "@/deliverables";
+
+export function OutputRevisionSources({
+  sources,
+  onOpenDocument,
+  onOpenWeb,
+}: {
+  sources: readonly OutputRevisionSource[];
+  onOpenDocument?: (
+    source: Extract<OutputRevisionSource, { kind: "document" }>,
+  ) => void;
+  onOpenWeb?: (url: string) => void;
+}) {
+  if (sources.length === 0) return null;
+
+  return (
+    <section
+      className="shrink-0 border-t border-border-subtle bg-page-background px-6 py-3"
+      aria-label="Output sources"
+    >
+      <div className="mx-auto max-w-4xl">
+        <h2 className="mb-2 text-xs font-medium text-muted-foreground">Sources</h2>
+        <ol className="flex flex-wrap gap-1.5">
+          {sources.map((source, index) => (
+            <li key={sourceKey(source)}>
+              {source.kind === "document" ? (
+                <button
+                  type="button"
+                  className="inline-flex max-w-64 items-center gap-1.5 rounded-full border bg-card px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-default disabled:hover:bg-card disabled:hover:text-muted-foreground"
+                  aria-label={`Open document source ${index + 1}`}
+                  disabled={!onOpenDocument}
+                  onClick={() => onOpenDocument?.(source)}
+                >
+                  <FileTextIcon className="size-3.5 shrink-0" aria-hidden="true" />
+                  <span className="truncate">
+                    <CitationLocatorLabel locator={source.locator} />
+                  </span>
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  title={source.label}
+                  aria-label={source.label}
+                  className="inline-flex max-w-64 items-center gap-1.5 rounded-full border bg-card px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                  onClick={() => onOpenWeb?.(source.url)}
+                >
+                  <DomainFavicon url={source.url} className="size-3.5" />
+                  <span className="truncate">{source.domain}</span>
+                  <ExternalLinkIcon className="size-3 shrink-0" aria-hidden="true" />
+                </button>
+              )}
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+function sourceKey(source: OutputRevisionSource): string {
+  return source.kind === "document"
+    ? `document:${source.citationId}`
+    : `web:${source.url}`;
+}

--- a/crates/tidebreak-desktop/ui/src/stories/OutputRevisionSources.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/OutputRevisionSources.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import type { OutputRevisionSource } from "@/deliverables";
+import { OutputRevisionSources } from "@/outputs/OutputRevisionSources";
+
+function RevisionPanel({ sources }: { sources: OutputRevisionSource[] }) {
+  return (
+    <div className="flex h-80 flex-col overflow-hidden rounded-lg border bg-page-background">
+      <div className="min-h-0 flex-1 overflow-auto p-6">
+        <article className="mx-auto max-w-4xl text-sm">
+          <h1 className="mb-3 text-xl font-semibold">Quarterly revenue brief</h1>
+          <p>Revenue increased, led by enterprise expansion.</p>
+        </article>
+      </div>
+      <OutputRevisionSources
+        sources={sources}
+        onOpenDocument={fn()}
+        onOpenWeb={fn()}
+      />
+    </div>
+  );
+}
+
+const sourcedRevision: OutputRevisionSource[] = [
+  {
+    kind: "document",
+    citationId: "46abf484-8368-4c2d-b2ec-8b9ed77e202f",
+    documentId: "4571ebc0-69a7-4f8a-a9c7-936c50f0f022",
+    locator: { kind: "pages", start: 4, end: 6 },
+  },
+  {
+    kind: "web",
+    url: "https://www.sec.gov/example",
+    label: "Quarterly filing",
+    domain: "sec.gov",
+  },
+];
+
+const meta = {
+  title: "Outputs/Revision sources",
+  component: RevisionPanel,
+  args: { sources: sourcedRevision },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-4xl p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RevisionPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A foreground revision shows only the evidence its producing turn retrieved. */
+export const WithDocumentAndWebEvidence: Story = {};
+
+/** User edits and background-agent revisions do not borrow another turn's sources. */
+export const WithoutTurnEvidence: Story = {
+  args: { sources: [] },
+};

--- a/crates/tidebreak-server/src/routes/outputs.rs
+++ b/crates/tidebreak-server/src/routes/outputs.rs
@@ -18,6 +18,8 @@
 //! and all: this is a transport move, and a field rename here would be a second
 //! change wearing the first one's clothes.
 
+use std::collections::{HashMap, HashSet};
+
 use axum::extract::State;
 use axum::http::{header, HeaderValue};
 use axum::response::{IntoResponse, Response};
@@ -25,8 +27,10 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use tidebreak_core::{
-    deliverable_media_type, media_type_is_text, revision_byte_ceiling, AgentError, ChatId,
-    OutputId, OutputRecord, OutputRevision, OutputRevisionId,
+    deliverable_media_type, media_type_is_text, revision_byte_ceiling, AgentError,
+    AssistantCitationId, ChatId, ChatTranscriptSnapshot, CitationLocator, DocumentId, OutputId,
+    OutputRecord, OutputRevision, OutputRevisionId, ResultEntryKind, ToolCallRecord,
+    ToolCallStatus, ToolResultPreview, TurnId, WEB_SEARCH_TOOL,
 };
 
 use crate::error::ServerError;
@@ -43,6 +47,9 @@ const MAX_DELIVERABLES: usize = 100;
 /// Characters of text a preview carries. Bigger outputs are read through the
 /// content route.
 const MAX_PREVIEW_CHARACTERS: usize = 100_000;
+/// Most durable evidence references projected onto one revision. Document
+/// citations take precedence over web-search rows when a turn retrieved more.
+const MAX_OUTPUT_REVISION_SOURCES: usize = 20;
 
 /// Body ceiling for a user edit. The stored ceiling for a text output is 512
 /// KiB; the request carries that content JSON-escaped, so the transport limit
@@ -102,6 +109,30 @@ pub struct OutputRevisionInfo {
     /// `backgroundAgent` (a run), or `user` (an edit or a restore).
     produced_by: &'static str,
     is_current: bool,
+    /// Durable evidence retrieved by the foreground turn that produced this
+    /// revision. User and background-run revisions have no turn, so they carry
+    /// an empty list rather than borrowing evidence from another producer.
+    sources: Vec<OutputRevisionSource>,
+}
+
+/// One durable evidence reference belonging to a revision's producing turn.
+#[derive(Debug, Clone, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum OutputRevisionSource {
+    Document {
+        citation_id: AssistantCitationId,
+        document_id: DocumentId,
+        locator: CitationLocator,
+    },
+    Web {
+        url: String,
+        label: String,
+        domain: String,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -267,6 +298,15 @@ pub async fn list_chat_output_revisions(
         .await
         .map_err(ServerError::not_found)?;
     let revisions = state.store.list_output_revisions(output.id).await?;
+    let sources_by_turn = if revisions.iter().any(|revision| revision.turn_id.is_some()) {
+        let (transcript, tool_calls) = tokio::try_join!(
+            store.get_chat_transcript(chat_id),
+            store.list_tool_calls(chat_id),
+        )?;
+        output_revision_sources(transcript.as_ref(), &tool_calls)
+    } else {
+        HashMap::new()
+    };
     Ok(Json(OutputRevisionsCatalog {
         output_id: output.id,
         revisions: revisions
@@ -284,9 +324,106 @@ pub async fn list_chat_output_revisions(
                     "user"
                 },
                 is_current: revision.id == output.current_revision,
+                sources: revision
+                    .turn_id
+                    .and_then(|turn_id| sources_by_turn.get(&turn_id).cloned())
+                    .unwrap_or_default(),
             })
             .collect(),
     }))
+}
+
+#[derive(Default)]
+struct RevisionSources {
+    values: Vec<OutputRevisionSource>,
+    documents: HashSet<(DocumentId, CitationLocator)>,
+    web_urls: HashSet<String>,
+}
+
+/// Group the conversation's durable evidence by the exact turn that retrieved
+/// it. This is a read-time projection: citations and tool previews remain the
+/// authorities, so a revision can never invent or retain a second copy of a
+/// source that diverges from the transcript.
+fn output_revision_sources(
+    transcript: Option<&ChatTranscriptSnapshot>,
+    tool_calls: &[ToolCallRecord],
+) -> HashMap<TurnId, Vec<OutputRevisionSource>> {
+    let mut by_turn: HashMap<TurnId, RevisionSources> = HashMap::new();
+
+    if let Some(transcript) = transcript {
+        let message_turns = transcript
+            .messages
+            .iter()
+            .map(|message| (message.id, message.turn_id))
+            .collect::<HashMap<_, _>>();
+        for snapshot in &transcript.citations {
+            let Some(turn_id) = message_turns.get(&snapshot.message_id).copied() else {
+                continue;
+            };
+            let sources = by_turn.entry(turn_id).or_default();
+            let citation = &snapshot.citation;
+            let key = (citation.document_id, citation.locator.clone());
+            if sources.values.len() < MAX_OUTPUT_REVISION_SOURCES && sources.documents.insert(key) {
+                sources.values.push(OutputRevisionSource::Document {
+                    citation_id: citation.id,
+                    document_id: citation.document_id,
+                    locator: citation.locator.clone(),
+                });
+            }
+        }
+    }
+
+    // Document citations are inserted first on purpose. Search results fill
+    // the remaining bounded slots in durable call/result order.
+    for call in tool_calls {
+        if call.name != WEB_SEARCH_TOOL || call.status != ToolCallStatus::Completed {
+            continue;
+        }
+        let Some(ToolResultPreview::Entries { entries, .. }) = call.result_preview.as_ref() else {
+            continue;
+        };
+        let sources = by_turn.entry(call.turn_id).or_default();
+        for entry in entries {
+            if sources.values.len() >= MAX_OUTPUT_REVISION_SOURCES {
+                break;
+            }
+            if entry.kind != ResultEntryKind::Link {
+                continue;
+            }
+            let Some(url) = entry.url.as_deref() else {
+                continue;
+            };
+            let Some(domain) = web_domain(url) else {
+                continue;
+            };
+            if !sources.web_urls.insert(url.to_owned()) {
+                continue;
+            }
+            sources.values.push(OutputRevisionSource::Web {
+                url: url.to_owned(),
+                label: if entry.label.is_empty() {
+                    url.to_owned()
+                } else {
+                    entry.label.clone()
+                },
+                domain,
+            });
+        }
+    }
+
+    by_turn
+        .into_iter()
+        .map(|(turn_id, sources)| (turn_id, sources.values))
+        .collect()
+}
+
+fn web_domain(value: &str) -> Option<String> {
+    let parsed = url::Url::parse(value).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    let host = parsed.host_str()?;
+    Some(host.strip_prefix("www.").unwrap_or(host).to_owned())
 }
 
 /// `POST /chats/{chat_id}/outputs/{output_id}/revisions/{revision_id}/restore`

--- a/crates/tidebreak-server/src/tests/outputs.rs
+++ b/crates/tidebreak-server/src/tests/outputs.rs
@@ -1,7 +1,11 @@
 use super::*;
 
 use tidebreak_code_execution::ExecutionWorkspaceId;
-use tidebreak_core::{AgentRunId, OutputId, OutputRevisionId};
+use tidebreak_core::{
+    AgentRunId, AssistantCitationInput, CitationLocator, CreateOutput, DeliverableKind, DocumentId,
+    DocumentUpsert, MessageId, NewOutputRevision, OutputId, OutputRevisionId, ResultEntry,
+    ResultEntryKind, ToolResultPreview, TurnId,
+};
 
 /// GET one route with this test's bearer.
 async fn get(router: &Router, bearer: &str, uri: &str) -> axum::response::Response {
@@ -140,9 +144,11 @@ async fn a_published_output_is_listed_read_revised_restored_and_exported_over_ht
             .unwrap_or_else(|| panic!("revision {id} should still be in the history"))
     };
     assert_eq!(by_id(first_revision)["producedBy"], "backgroundAgent");
+    assert_eq!(by_id(first_revision)["sources"], serde_json::json!([]));
     assert_eq!(by_id(first_revision)["ordinal"], 1);
     assert_eq!(by_id(first_revision)["isCurrent"], false);
     assert_eq!(by_id(edited_revision)["producedBy"], "user");
+    assert_eq!(by_id(edited_revision)["sources"], serde_json::json!([]));
     assert_eq!(by_id(edited_revision)["isCurrent"], true);
 
     // Restoring is append-only: the earlier revision keeps its own bytes, and
@@ -225,4 +231,203 @@ async fn a_published_output_is_listed_read_revised_restored_and_exported_over_ht
         .status(),
         StatusCode::NOT_FOUND
     );
+}
+
+#[tokio::test]
+async fn a_foreground_revision_projects_only_its_turns_durable_evidence() {
+    let (router, token, store, dir) = test_app_without_turn_worker().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    store
+        .accept_turn(turn_id, chat.id, "fake", "write the sourced brief")
+        .await
+        .unwrap();
+
+    let now = chrono::Utc::now();
+    let document_id = DocumentId::new();
+    store
+        .upsert_document(&DocumentUpsert {
+            id: document_id,
+            project_id: None,
+            chat_id: Some(chat.id),
+            origin_uri: None,
+            media_type: "text/plain".into(),
+            title: Some("Quarterly filing".into()),
+            canonical_text: "Revenue increased in the quarter.".into(),
+            updated_at: now,
+        })
+        .await
+        .unwrap();
+    let citation = AssistantCitationInput {
+        document_id,
+        locator: CitationLocator::Lines { start: 1, end: 1 },
+    };
+    store
+        .append_assistant_message_with_citations(
+            &Message {
+                id: MessageId::new(),
+                chat_id: chat.id,
+                turn_id,
+                role: Role::Assistant,
+                content: tidebreak_core::format_citation_directive(
+                    "Revenue increased",
+                    document_id,
+                    &citation.locator,
+                ),
+                llm_content: None,
+                reasoning: Default::default(),
+                created_at: now,
+            },
+            std::slice::from_ref(&citation),
+        )
+        .await
+        .unwrap();
+
+    let web_call_id = CallId::new();
+    store
+        .accept_tool_call(&ToolCallRecord {
+            id: web_call_id,
+            chat_id: chat.id,
+            turn_id,
+            provider_id: "search-1".into(),
+            name: tidebreak_core::WEB_SEARCH_TOOL.into(),
+            arguments: serde_json::json!({"query": "quarterly revenue"}),
+            raw_arguments: None,
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Pending,
+            result: None,
+            result_preview: None,
+            provider_replay: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: now,
+            resolved_at: None,
+        })
+        .await
+        .unwrap();
+    let web_preview = ToolResultPreview::Entries {
+        entries: vec![ResultEntry::new(ResultEntryKind::Link, "SEC filing")
+            .with_detail("sec.gov")
+            .with_web_url("https://www.sec.gov/example")],
+        failures: Vec::new(),
+        elided: 0,
+    };
+    store
+        .resolve_server_tool_call_with_artifacts(
+            web_call_id,
+            &ToolCallResolution::Completed {
+                result: "search complete".into(),
+            },
+            now,
+            Some(&web_preview),
+        )
+        .await
+        .unwrap();
+
+    // A completed non-search tool can retain a link-shaped row, but it is not
+    // retrieval evidence for the output and must not be projected as a source.
+    let unrelated_call_id = CallId::new();
+    store
+        .accept_tool_call(&ToolCallRecord {
+            id: unrelated_call_id,
+            chat_id: chat.id,
+            turn_id,
+            provider_id: "read-1".into(),
+            name: "read_file".into(),
+            arguments: serde_json::json!({"path": "notes.md"}),
+            raw_arguments: None,
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Pending,
+            result: None,
+            result_preview: None,
+            provider_replay: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: now,
+            resolved_at: None,
+        })
+        .await
+        .unwrap();
+    let unrelated_preview = ToolResultPreview::Entries {
+        entries: vec![
+            ResultEntry::new(ResultEntryKind::Link, "Not a search source")
+                .with_web_url("https://example.com/not-evidence"),
+        ],
+        failures: Vec::new(),
+        elided: 0,
+    };
+    store
+        .resolve_server_tool_call_with_artifacts(
+            unrelated_call_id,
+            &ToolCallResolution::Completed {
+                result: "read complete".into(),
+            },
+            now,
+            Some(&unrelated_preview),
+        )
+        .await
+        .unwrap();
+
+    let output_id = OutputId::new();
+    let revision_id = OutputRevisionId::new();
+    let bytes = b"# Revenue\n\nRevenue increased.\n";
+    store
+        .create_output(&CreateOutput {
+            id: output_id,
+            chat_id: chat.id,
+            filename: "Revenue brief.md".into(),
+            kind: DeliverableKind::Text,
+            revision: NewOutputRevision {
+                id: revision_id,
+                byte_len: bytes.len() as u64,
+                sha256: [0; 32],
+                turn_id: Some(turn_id),
+                producing_run_id: None,
+                created_at: now,
+            },
+        })
+        .await
+        .unwrap();
+    let revision_path = dir.path().join("scratch").join(chat.id.to_string()).join(
+        tidebreak_core::output_revision_relative_path(output_id, revision_id),
+    );
+    std::fs::create_dir_all(revision_path.parent().unwrap()).unwrap();
+    std::fs::write(revision_path, bytes).unwrap();
+
+    let history: serde_json::Value = json_body(
+        get(
+            &router,
+            &bearer,
+            &format!("/chats/{}/outputs/{output_id}/revisions", chat.id),
+        )
+        .await,
+    )
+    .await;
+    let sources = history["revisions"][0]["sources"].as_array().unwrap();
+    assert_eq!(sources.len(), 2);
+    assert_eq!(sources[0]["kind"], "document");
+    assert_eq!(sources[0]["documentId"], document_id.to_string());
+    assert_eq!(
+        sources[0]["locator"],
+        serde_json::json!({
+            "kind": "lines",
+            "start": 1,
+            "end": 1,
+        })
+    );
+    assert_eq!(
+        sources[1],
+        serde_json::json!({
+            "kind": "web",
+            "url": "https://www.sec.gov/example",
+            "label": "SEC filing",
+            "domain": "sec.gov",
+        })
+    );
+    assert!(!history.to_string().contains("not-evidence"));
 }

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -67,8 +67,11 @@ The product store therefore owns an output record whose identity is an opaque
   foreground turn or a background run, never both — recorded in two mutually
   exclusive nullable references so existing turn-produced revisions are
   unchanged and a background run can now be attributed just as precisely. Only a
-  turn producer may carry retrieval source references, which resolve against
-  the turn's evidence. Revision rows are insert-only.
+  turn producer may carry retrieval source references. The revision API derives
+  those references from the producing turn's durable assistant citations and
+  completed web-search result rows, so the output layer cannot invent evidence
+  or retain a second copy that drifts from the transcript. User-authored and
+  background-run revisions carry no sources. Revision rows are insert-only.
 - Updating an output appends a revision and republishes the current one. The
   replaced revision keeps its own id and stays readable, so an update can no
   longer destroy the bytes it supersedes.
@@ -181,8 +184,7 @@ person can move back.
 ## Deliberate limits
 
 An export is a synchronous user action, so it is not automatically retried and
-does not yet have a durable export receipt. Office document generation,
-transcript-inline artifact cards, per-revision source references, and writing
-directly into connected folders remain later slices. Those additions should
-preserve the same rule: the model names a logical output, while a person or
-narrowly scoped capability chooses where host data is written.
+does not yet have a durable export receipt. Writing directly into connected
+folders remains a later slice. That addition should preserve the same rule: the
+model names a logical output, while a person or narrowly scoped capability
+chooses where host data is written.


### PR DESCRIPTION
## Summary

- derive each foreground output revision’s sources from the producing turn’s durable document citations and completed web-search results
- show the current or previewed revision’s document and web sources in the output detail panel, with internal citation navigation and safe external opening
- keep user-authored and background-agent revisions source-free, add bounded wire validation, tests, Storybook states, and update the deliverables contract

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tidebreak-server tests::outputs --locked`
- `pnpm exec vitest run src/deliverables.test.ts src/outputs/OutputDetailRoot.dom.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm storybook:build`

Closes #2326