### PR TITLE
feat(desktop): improve work and code null states

### DIFF
--- a/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import {
   AppWindow,
+  ArrowUpRight,
   GitBranch,
   Globe,
   Scale,
@@ -37,7 +38,6 @@ export type StarterPromptOptions = {
 
 type StarterPrompt = {
   icon: typeof Sparkles;
-  iconClass: string;
   label: string;
   description: string;
   prompt: string;
@@ -54,7 +54,6 @@ type StarterPrompt = {
 const STARTER_PROMPTS: StarterPrompt[] = [
   {
     icon: Globe,
-    iconClass: "text-icon-cyan",
     label: "Brief this week's AI news",
     description: "Search the web, then write a sourced briefing.",
     prompt:
@@ -63,7 +62,6 @@ const STARTER_PROMPTS: StarterPrompt[] = [
   },
   {
     icon: Scale,
-    iconClass: "text-icon-amber",
     label: "Compare two public products",
     description: "Search, tabulate, and recommend with citations.",
     prompt:
@@ -72,7 +70,6 @@ const STARTER_PROMPTS: StarterPrompt[] = [
   },
   {
     icon: AppWindow,
-    iconClass: "text-icon-blue",
     label: "Build a local planner",
     description: "Create a small app in this workspace.",
     prompt:
@@ -80,7 +77,6 @@ const STARTER_PROMPTS: StarterPrompt[] = [
   },
   {
     icon: GitBranch,
-    iconClass: "text-icon-violet",
     label: "Research in parallel",
     description: "Split a briefing across background tasks.",
     prompt:
@@ -102,7 +98,46 @@ export function promptTitle(name: string): string {
 }
 
 const CARD_CLASS =
-  "flex items-center gap-2.5 rounded-lg border border-border-subtle bg-background px-3 py-2.5 text-left text-[0.85rem] font-medium text-foreground transition-colors duration-150 hover:border-border hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/25 active:translate-y-px [&_svg]:flex-none";
+  "group flex min-h-[5.25rem] items-start gap-3 rounded-xl bg-muted/35 px-4 py-3.5 text-left text-sm text-foreground ring-1 ring-inset ring-border-subtle transition-[transform,background-color,box-shadow] duration-200 hover:-translate-y-0.5 hover:bg-muted/60 hover:shadow-sm focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/25 active:translate-y-0";
+
+function PromptCard({
+  icon: Icon,
+  label,
+  description,
+  first,
+  onClick,
+}: {
+  icon: typeof Sparkles;
+  label: string;
+  description?: string;
+  first: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={CARD_CLASS}
+      data-first-task-target={first ? "starter-choice" : undefined}
+      onClick={onClick}
+    >
+      <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-background text-muted-foreground shadow-[inset_0_0_0_1px_var(--border-subtle)] transition-colors duration-200 group-hover:text-foreground">
+        <Icon size={17} strokeWidth={1.75} />
+      </span>
+      <span className="min-w-0 flex-1 pt-0.5">
+        <span className="block font-medium tracking-[-0.01em]">{label}</span>
+        {description && (
+          <span className="mt-0.5 block text-[0.8rem] leading-5 font-normal text-muted-foreground">
+            {description}
+          </span>
+        )}
+      </span>
+      <ArrowUpRight
+        aria-hidden="true"
+        className="mt-1 size-4 shrink-0 text-muted-foreground/45 transition-[color,transform] duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-foreground"
+      />
+    </button>
+  );
+}
 
 export function WelcomeState({
   onSelectPrompt,
@@ -193,78 +228,69 @@ export function WelcomeState({
 
   return (
     <section className="welcome" aria-label="Start work">
-      <span className="welcome-mark" aria-hidden="true">
-        <Logomark />
-      </span>
-      <div className="welcome-copy">
-        <h2>{heading}</h2>
-        <p>{description}</p>
-        {managedExecutionOnly && <p>{MANAGED_EXECUTION_DISCLOSURE}</p>}
+      <div className="welcome-intro">
+        <span className="welcome-mark" aria-hidden="true">
+          <Logomark />
+        </span>
+        <div className="welcome-copy">
+          <h2>{heading}</h2>
+          <p>{description}</p>
+          {managedExecutionOnly && (
+            <p className="welcome-disclosure">
+              {MANAGED_EXECUTION_DISCLOSURE}
+            </p>
+          )}
+        </div>
       </div>
       {onStartWalkthrough && (
-        <Button type="button" size="sm" onClick={onStartWalkthrough}>
+        <Button
+          className="self-center"
+          type="button"
+          size="sm"
+          onClick={onStartWalkthrough}
+        >
           Set up your first task
         </Button>
       )}
-      {onSelectPrompt && libraryPrompts.length > 0 && (
+      {onSelectPrompt && (
         <div className="welcome-prompts" data-first-task-target="starters">
-          {libraryPrompts.map((prompt, index) => (
-            <button
-              key={prompt.name}
-              type="button"
-              className={CARD_CLASS}
-              data-first-task-target={index === 0 ? "starter-choice" : undefined}
-              onClick={() => insertLibraryPrompt(prompt.name)}
-            >
-              <Sparkles size={16} className="text-muted-foreground" />
-              <span className="min-w-0">
-                <span className="block">{promptTitle(prompt.name)}</span>
-                {prompt.description && (
-                  <span className="block text-[0.78rem] font-normal text-muted-foreground">
-                    {prompt.description}
-                  </span>
-                )}
-              </span>
-            </button>
-          ))}
-        </div>
-      )}
-      {onSelectPrompt && libraryPrompts.length === 0 && (
-        <div className="welcome-prompts" data-first-task-target="starters">
-          {STARTER_PROMPTS.map(
-            (
-              {
-                icon: Icon,
-                iconClass,
-                label,
-                description,
-                prompt,
-                enableInternet,
-              },
-              index,
-            ) => (
-              <button
-                key={label}
-                type="button"
-                className={CARD_CLASS}
-                data-first-task-target={index === 0 ? "starter-choice" : undefined}
-                onClick={() =>
-                  onSelectPrompt(
+          {libraryPrompts.length > 0
+            ? libraryPrompts.map((prompt, index) => (
+                <PromptCard
+                  key={prompt.name}
+                  icon={Sparkles}
+                  label={promptTitle(prompt.name)}
+                  description={prompt.description}
+                  first={index === 0}
+                  onClick={() => insertLibraryPrompt(prompt.name)}
+                />
+              ))
+            : STARTER_PROMPTS.map(
+                (
+                  {
+                    icon,
+                    label,
+                    description,
                     prompt,
-                    enableInternet ? { enableInternet: true } : undefined,
-                  )
-                }
-              >
-                <Icon size={16} className={iconClass} />
-                <span className="min-w-0">
-                  <span className="block">{label}</span>
-                  <span className="block text-[0.78rem] font-normal text-muted-foreground">
-                    {description}
-                  </span>
-                </span>
-              </button>
-            ),
-          )}
+                    enableInternet,
+                  },
+                  index,
+                ) => (
+                  <PromptCard
+                    key={label}
+                    icon={icon}
+                    label={label}
+                    description={description}
+                    first={index === 0}
+                    onClick={() =>
+                      onSelectPrompt(
+                        prompt,
+                        enableInternet ? { enableInternet: true } : undefined,
+                      )
+                    }
+                  />
+                ),
+              )}
         </div>
       )}
     </section>

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
@@ -143,7 +143,7 @@ describe("CodeHome", () => {
     );
 
     expect(screen.getByRole("status")).toHaveTextContent("Loading…");
-    expect(screen.queryByText("No repos yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Start with a repository")).not.toBeInTheDocument();
   });
 
   it("keeps loading after empty repos until the doctor arrives", async () => {
@@ -164,13 +164,15 @@ describe("CodeHome", () => {
     });
 
     expect(screen.getByRole("status")).toHaveTextContent("Loading…");
-    expect(screen.queryByText("No repos yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Start with a repository")).not.toBeInTheDocument();
   });
 
   it("shows the empty state once repos are empty and a harness is ready", async () => {
     await renderHome();
 
-    expect(await screen.findByText("No repos yet")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Start with a repository" }),
+    ).toBeInTheDocument();
     const main = document.querySelector(".main");
     expect(main).not.toBeNull();
     expect(
@@ -191,7 +193,7 @@ describe("CodeHome", () => {
     expect(
       await screen.findByRole("heading", { name: "Install a coding harness" }),
     ).toBeInTheDocument();
-    expect(screen.queryByText("No repos yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Start with a repository")).not.toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
@@ -210,7 +212,7 @@ describe("CodeHome", () => {
     });
 
     expect(await screen.findByRole("heading", { name: "Repos" })).toBeInTheDocument();
-    expect(screen.queryByText("No repos yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Start with a repository")).not.toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { FolderGit2, GitBranch, Plus, Sparkles } from "lucide-react";
 
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
 import {
   Empty,
-  EmptyContent,
-  EmptyDescription,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
@@ -75,13 +74,21 @@ function CodeHomeBody() {
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-8">
-      <div>
-        <h1 className="text-2xl font-medium tracking-tight">Code</h1>
-        <p className="text-muted-foreground text-sm">
-          Register a local git repository, then open isolated workspaces on it.
-        </p>
-      </div>
+    <div
+      className={cn(
+        "mx-auto flex min-h-full w-full flex-col gap-8 px-6 py-8",
+        showEmpty ? "max-w-5xl" : "max-w-3xl",
+      )}
+    >
+      {!showEmpty && (
+        <header>
+          <h1 className="text-2xl font-medium tracking-tight">Code</h1>
+          <p className="text-muted-foreground text-sm">
+            Register a local git repository, then open isolated workspaces on
+            it.
+          </p>
+        </header>
+      )}
       {error && <p className="text-sm text-critical">{error}</p>}
       {showLoading && (
         <Empty role="status">
@@ -109,22 +116,9 @@ function CodeHomeBody() {
         </section>
       )}
       {showEmpty && (
-        // Nothing is registered, so the page has exactly one thing to say.
-        // A "Repos" heading over an empty list, under a second heading that
-        // repeats the same instruction, is two sections carrying one message.
-        <Empty>
-          <EmptyHeader>
-            <EmptyTitle>No repos yet</EmptyTitle>
-            <EmptyDescription>
-              Browse a local folder, or clone from a git URL or GitHub.
-            </EmptyDescription>
-          </EmptyHeader>
-          <EmptyContent>
-            <Button type="button" onClick={() => setAddOpen(true)}>
-              Add repo
-            </Button>
-          </EmptyContent>
-        </Empty>
+        <div className="flex flex-1 items-center">
+          <CodeRepoEmptyState onAddRepo={() => setAddOpen(true)} />
+        </div>
       )}
       {showRepos && (
         <section className="flex flex-col gap-3">
@@ -174,5 +168,85 @@ function CodeHomeBody() {
       )}
       <AddRepoPalette open={addOpen} onOpenChange={setAddOpen} />
     </div>
+  );
+}
+
+const CODE_ONBOARDING_STEPS = [
+  {
+    icon: FolderGit2,
+    title: "Add a repository",
+    description: "Browse a local folder or clone from a git URL or GitHub.",
+  },
+  {
+    icon: GitBranch,
+    title: "Open a workspace",
+    description: "Give the task an isolated branch and working directory.",
+  },
+  {
+    icon: Sparkles,
+    title: "Start the work",
+    description: "Choose a coding agent and hand it a concrete task.",
+  },
+];
+
+/**
+ * The settled first-run state for code mode.
+ *
+ * Kept presentational so Storybook can show the page without waiting on the
+ * repo catalog and harness doctor that decide when production reaches it.
+ */
+export function CodeRepoEmptyState({ onAddRepo }: { onAddRepo: () => void }) {
+  return (
+    <section
+      className="grid w-full items-center gap-12 py-10 md:grid-cols-[minmax(0,1.15fr)_minmax(16rem,0.85fr)] md:gap-16 md:py-16"
+      aria-labelledby="code-empty-title"
+    >
+      <div className="max-w-xl">
+        <div className="mb-5 flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          <FolderGit2 aria-hidden="true" className="size-4" />
+          <span>Code mode</span>
+        </div>
+        <h1
+          id="code-empty-title"
+          className="max-w-lg text-3xl leading-[1.08] font-semibold tracking-[-0.04em] text-balance sm:text-4xl"
+        >
+          Start with a repository
+        </h1>
+        <p className="mt-4 max-w-lg text-[0.95rem] leading-6 text-muted-foreground text-pretty">
+          Register a local checkout or clone one from a remote. Tidebreak uses
+          it to create isolated workspaces for agent tasks.
+        </p>
+        <div className="mt-7 flex flex-wrap items-center gap-3">
+          <Button type="button" size="lg" onClick={onAddRepo}>
+            <Plus aria-hidden="true" />
+            Add repo
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            Local folder, git URL, or GitHub
+          </span>
+        </div>
+      </div>
+
+      <ol
+        className="relative flex flex-col before:absolute before:top-5 before:bottom-5 before:left-[1.125rem] before:w-px before:bg-border-subtle before:content-['']"
+        aria-label="How code mode starts"
+      >
+        {CODE_ONBOARDING_STEPS.map(({ icon: Icon, title, description }) => (
+          <li key={title} className="relative flex gap-4 pb-7 last:pb-0">
+            <span className="z-10 grid size-9 shrink-0 place-items-center rounded-full border border-border-subtle bg-background text-muted-foreground shadow-xs">
+              <Icon aria-hidden="true" className="size-4" strokeWidth={1.75} />
+            </span>
+            <span className="min-w-0 pt-0.5">
+              <span className="block text-sm font-medium tracking-[-0.01em]">
+                {title}
+              </span>
+              <span className="mt-0.5 block text-[0.8rem] leading-5 text-muted-foreground text-pretty">
+                {description}
+              </span>
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/stories/NullStates.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NullStates.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { WelcomeState } from "@/WelcomeState";
+import { CodeRepoEmptyState } from "@/code/CodeHome";
+
+type NullStatePreviewProps = {
+  mode: "work" | "code";
+  onAddRepo: () => void;
+  onSelectPrompt: (prompt: string) => void;
+};
+
+function NullStatePreview({
+  mode,
+  onAddRepo,
+  onSelectPrompt,
+}: NullStatePreviewProps) {
+  if (mode === "code") {
+    return (
+      <main className="content-container flex h-full min-h-0 w-full overflow-auto">
+        <div className="mx-auto flex min-h-full w-full max-w-5xl items-center px-6 py-8">
+          <CodeRepoEmptyState onAddRepo={onAddRepo} />
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="content-container flex h-full min-h-0 w-full items-center justify-center overflow-auto px-[clamp(1rem,5vw,5rem)] py-10">
+      <WelcomeState onSelectPrompt={onSelectPrompt} />
+    </main>
+  );
+}
+
+const meta = {
+  title: "Modes/Null states",
+  component: NullStatePreview,
+  parameters: { layout: "fullscreen" },
+  args: {
+    mode: "work",
+    onAddRepo: fn(),
+    onSelectPrompt: fn(),
+  },
+  argTypes: {
+    mode: { control: "inline-radio", options: ["work", "code"] },
+  },
+} satisfies Meta<typeof NullStatePreview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Work mode before the first message, with complete editable starters. */
+export const WorkMode: Story = {};
+
+/** Code mode before any repository has been registered. */
+export const CodeMode: Story = {
+  args: { mode: "code" },
+};
+
+/** The work-mode stack at the narrowest supported conversation width. */
+export const WorkModeCompact: Story = {
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -461,17 +461,32 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  gap: 2rem;
   width: 100%;
-  max-width: 34rem;
+  max-width: 46rem;
+  padding-block: 1rem;
   text-align: center;
 }
 
+.welcome-intro {
+  display: flex;
+  max-width: 42rem;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.15rem;
+}
+
+.welcome-mark {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .welcome-mark svg {
-  width: 2.25rem;
+  width: 2.75rem;
   height: auto;
   color: var(--ink);
-  opacity: 0.9;
+  opacity: 0.88;
 }
 
 .welcome-copy {
@@ -494,15 +509,53 @@ body {
   font-size: 0.95rem;
 }
 
+.welcome .welcome-copy {
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.welcome .welcome-copy h2 {
+  font-size: clamp(1.7rem, 3vw, 2rem);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
+  text-wrap: balance;
+}
+
+.welcome .welcome-copy p {
+  max-width: 40rem;
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+.welcome .welcome-copy .welcome-disclosure {
+  margin-top: 0.35rem;
+  max-width: 38rem;
+  font-size: 0.8rem;
+}
+
 .welcome-prompts {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
+  gap: 0.7rem;
   width: 100%;
-  margin-top: 0.25rem;
 }
 
 @media (max-width: 720px) {
+  .welcome {
+    gap: 1.5rem;
+    padding-block: 1.5rem;
+  }
+
+  .welcome-intro {
+    gap: 0.9rem;
+  }
+
+  .welcome-mark svg {
+    width: 2rem;
+  }
+
   .welcome-prompts {
     grid-template-columns: minmax(0, 1fr);
   }


### PR DESCRIPTION
## Summary

- Center and simplify the work-mode null state while keeping starter tasks easy to scan.
- Replace the generic code-mode empty box with a focused repository onboarding flow.
- Add Storybook coverage for work, code, and compact work-mode null states.

## Testing

- `pnpm exec vitest run src/WelcomeState.test.tsx src/WelcomeState.dom.test.tsx src/code/CodeHome.dom.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm storybook:build`