### PR TITLE
fix(desktop): clear sent images and collapse transcript previews

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -389,6 +389,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         ),
       () => {
         setComposerDraft("");
+        images.clear();
         composerDraftActions.setFolders(chatId, []);
         voice.resetInputUsed();
       },
@@ -483,7 +484,11 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     const turnId = crypto.randomUUID();
     terminalHydrationGenerationRef.current += 1;
     const optimisticId = nextId();
-    if (fromComposer) setComposerDraft("");
+    const heldImages = fromComposer ? images.attachments : [];
+    if (fromComposer) {
+      setComposerDraft("");
+      images.clear();
+    }
     updateSession((session) => ({
       ...session,
       busy: true,
@@ -514,13 +519,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         voiceInputUsed,
       );
       // Only once the turn is durably accepted, and only for what the composer
-      // actually contributed. A refused send — an image the selected model
-      // cannot read, or a skill this install can no longer run — must leave the
-      // attachments and the pills where the reader can fix the problem and try
-      // again; a retry must not throw away attachments the reader has queued
-      // for their *next* message.
+      // actually contributed. Images already left the strip with the draft;
+      // files, skills, and folders wait so a refused send can still retry.
       if (fromComposer) {
-        images.clear();
         setComposerFiles(() => []);
         composerDraftActions.setSkills(chatId, []);
         composerDraftActions.setFolders(chatId, []);
@@ -528,9 +529,10 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       }
     } catch (err) {
       // Nothing was accepted, so the message has to go back to where it can be
-      // fixed and sent again: the text returns to the composer and the
-      // optimistic bubble — which no turn will ever answer — comes out of the
-      // transcript. Attachments are already left in place for the same reason.
+      // fixed and sent again: the text and images return to the composer and
+      // the optimistic bubble — which no turn will ever answer — comes out of
+      // the transcript.
+      if (fromComposer) images.restore(heldImages);
       updateSession((session) => ({
         ...session,
         busy: false,

--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -1430,7 +1430,9 @@ function ImageAttachmentChip({
         {attachment.previewUrl ? (
           // Shown from the bytes already in hand rather than fetched back from
           // the server, so the reader sees what they attached immediately.
-          <img className="size-full object-cover" src={attachment.previewUrl} alt="" />
+          // Contain, not cover: a wide dark screenshot cropped to a square
+          // reads as a black tile.
+          <img className="size-full object-contain" src={attachment.previewUrl} alt="" />
         ) : (
           <ImageIcon size={16} aria-hidden="true" />
         )}

--- a/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
@@ -574,10 +574,13 @@ describe("historical image attachments", () => {
         expect.any(AbortSignal),
       ),
     );
-    const image = await screen.findByRole("img", {
-      name: "Attached image 1: 320 by 240 pixels",
+    const toggle = await screen.findByRole("button", {
+      name: "Expand attached image 1: 320 by 240 pixels",
     });
-    expect(image).toHaveAttribute("src", "blob:transcript-image");
+    expect(toggle.querySelector("img")).toHaveAttribute(
+      "src",
+      "blob:transcript-image",
+    );
     expect(createObjectUrl).toHaveBeenCalledTimes(1);
 
     unmount();

--- a/crates/tidebreak-desktop/ui/src/TranscriptImageAttachments.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/TranscriptImageAttachments.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
 
@@ -36,9 +37,11 @@ describe("TranscriptImageAttachments served content type", () => {
       />,
     );
 
-    const rendered = await screen.findByRole("img", {
-      name: "Attached image 1: 320 by 240 pixels",
+    const toggle = await screen.findByRole("button", {
+      name: "Expand attached image 1: 320 by 240 pixels",
     });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    const rendered = toggle.querySelector("img");
     expect(rendered).toHaveAttribute("src", "blob:transcript-image");
   });
 
@@ -63,5 +66,38 @@ describe("TranscriptImageAttachments served content type", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("img")).toBeNull();
     expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("starts collapsed and expands on click", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:transcript-image"),
+      revokeObjectURL: vi.fn(),
+    });
+    const client = {
+      getChatImageAttachment: vi.fn(
+        async () => new Blob(["pixels"], { type: "image/png" }),
+      ),
+    };
+    render(
+      <TranscriptImageAttachments
+        client={client}
+        chatId="chat-1"
+        images={[image]}
+      />,
+    );
+
+    const toggle = await screen.findByRole("button", {
+      name: "Expand attached image 1: 320 by 240 pixels",
+    });
+    expect(toggle).not.toHaveClass("is-expanded");
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveClass("is-expanded");
+    expect(toggle).toHaveAccessibleName(
+      "Collapse attached image 1: 320 by 240 pixels",
+    );
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/TranscriptImageAttachments.tsx
+++ b/crates/tidebreak-desktop/ui/src/TranscriptImageAttachments.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ApiClient } from "./api";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
+import { cn } from "./lib/utils";
 
 type TranscriptImageAttachmentsProps = {
   client: Pick<ApiClient, "getChatImageAttachment">;
@@ -25,12 +26,19 @@ export function TranscriptImageAttachments({
           mediaType={image.mediaType}
           width={image.width}
           height={image.height}
-          label={`Attached image ${index + 1}: ${image.width} by ${image.height} pixels`}
+          label={imageLabel(index + 1, image.width, image.height)}
           unavailableLabel="Attached image unavailable"
         />
       ))}
     </div>
   );
+}
+
+function imageLabel(ordinal: number, width: number, height: number): string {
+  if (width > 0 && height > 0) {
+    return `attached image ${ordinal}: ${width} by ${height} pixels`;
+  }
+  return `attached image ${ordinal}`;
 }
 
 export function ChatImage({
@@ -54,6 +62,7 @@ export function ChatImage({
 }) {
   const [url, setUrl] = useState<string | null>(null);
   const [unavailable, setUnavailable] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     const abort = new AbortController();
@@ -84,13 +93,21 @@ export function ChatImage({
 
   if (url !== null) {
     return (
-      <img
-        className="message-image"
-        src={url}
-        alt={label}
-        width={width}
-        height={height}
-      />
+      <button
+        type="button"
+        className={cn("message-image-toggle", expanded && "is-expanded")}
+        aria-expanded={expanded}
+        aria-label={expanded ? `Collapse ${label}` : `Expand ${label}`}
+        onClick={() => setExpanded((open) => !open)}
+      >
+        <img
+          className="message-image"
+          src={url}
+          alt=""
+          {...(width > 0 ? { width } : {})}
+          {...(height > 0 ? { height } : {})}
+        />
+      </button>
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -17,6 +17,7 @@ import { CodeComposer, HarnessModelMenu } from "./CodeComposer";
 import { useCodeUiStore } from "./CodeUiStore";
 import { HttpError } from "../api/client";
 import { useComposerDrafts } from "../ComposerDrafts";
+import { readyImageAttachment } from "../ImageAttachments";
 import { OpenAIIcon, ProviderIcon } from "../ProviderIcons";
 import { useUiStore } from "../UiStore";
 
@@ -611,6 +612,67 @@ describe("CodeComposer", () => {
     expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "Send message" }));
     expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("drops attached images as soon as send starts", async () => {
+    const onSend = vi.fn(() => new Promise<void>(() => {}));
+    useComposerDrafts.getState().setImages("sess-1", [
+      readyImageAttachment("img-1", {
+        attachmentId: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+        fileName: "shot.png",
+        mediaType: "image/png",
+        width: 390,
+        height: 202,
+        byteLen: 1024,
+      }),
+    ]);
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        imageInput
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("shot.png")).toBeInTheDocument();
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "look at this" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => expect(onSend).toHaveBeenCalled());
+    expect(screen.queryByLabelText("Attached images")).toBeNull();
+  });
+
+  it("puts images back when send is refused", async () => {
+    const onSend = vi.fn().mockRejectedValue(new Error("Could not send that turn"));
+    useComposerDrafts.getState().setImages("sess-1", [
+      readyImageAttachment("img-1", {
+        attachmentId: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+        fileName: "shot.png",
+        mediaType: "image/png",
+        width: 390,
+        height: 202,
+        byteLen: 1024,
+      }),
+    ]);
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        imageInput
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "look at this" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+    expect(await screen.findByText("shot.png")).toBeInTheDocument();
+    expect(box).toHaveValue("look at this");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -640,18 +640,22 @@ export function CodeComposer({
         ? [{ blob_id: item.attachmentId, media_type: item.mediaType ?? "image/png" }]
         : [],
     );
+    const held = images.attachments;
     setDraft("");
     setNotice(null);
+    // Chips leave with the draft, not after the server answers. Waiting made
+    // a sent turn look like it had failed to take the images.
+    images.clear();
     try {
       const outcome =
         attachments.length > 0
           ? await onSend(message, attachments)
           : await onSend(message);
-      images.clear();
       if (outcome && outcome.kind === "queued") {
         setFollowUpQueued(true);
       }
     } catch (err) {
+      images.restore(held);
       setNotice({
         text:
           err instanceof HttpError && err.kind === "queue_full"

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -7,6 +7,7 @@ import { workspaceCommands } from "./workspaceActions";
 import { WorkspaceCard } from "./WorkspaceCard";
 import type {
   CodeSessionDigest,
+  CodeSessionSnapshot,
   CodeWorkspaceSnapshot,
   PullRequestDigest,
 } from "../api/types";
@@ -167,6 +168,38 @@ describe("WorkspaceCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("detailed idle cards still show the harness and lifecycle", () => {
+    const session: CodeSessionSnapshot = {
+      id: "sess-1",
+      workspace_id: workspace.id,
+      kind: "interactive",
+      harness_kind: "claude_code",
+      permission_mode: "ask",
+      lifecycle: "idle",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      unrecognized_event_count: 0,
+      created_at: "2026-08-15T00:00:00.000Z",
+    };
+    render(
+      <WorkspaceCard
+        workspace={workspace}
+        digest={undefined}
+        session={session}
+        repoName="app"
+        active={false}
+        terminalOpen={false}
+        density="detailed"
+        visibleMeta={{ repoChip: true, branch: false }}
+        commands={workspaceCommands({ hasPr: false, archived: false })}
+        onOpen={vi.fn()}
+        onCommand={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.getByTitle("Claude Code")).toBeInTheDocument();
+  });
+
   it("compact keeps the one-line read and the complete label", () => {
     renderCard({ density: "compact" });
 
@@ -177,8 +210,8 @@ describe("WorkspaceCard", () => {
   });
 
   it.each([
-    ["shell", "Shell running - 3 turns"],
-    ["monitor", "Monitoring - 3 turns"],
+    ["shell", "Shell running · 3 turns"],
+    ["monitor", "Monitoring · 3 turns"],
   ] as const)("renders %s activity as its own workspace state", (activity, label) => {
     const digest: CodeSessionDigest = {
       workspace: workspace.id,
@@ -208,6 +241,52 @@ describe("WorkspaceCard", () => {
 
     expect(screen.getByText(label)).toBeInTheDocument();
     expect(screen.queryByText(/Agent working/)).not.toBeInTheDocument();
+  });
+
+  it("detailed running cards lead with the harness mark and turn count", () => {
+    const digest: CodeSessionDigest = {
+      workspace: workspace.id,
+      session: "sess-1",
+      kind: "interactive",
+      lifecycle: "running",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      title: workspace.title,
+      turn_count: 1,
+      activity: "agent",
+    };
+    const session: CodeSessionSnapshot = {
+      id: "sess-1",
+      workspace_id: workspace.id,
+      kind: "interactive",
+      harness_kind: "claude_code",
+      permission_mode: "ask",
+      lifecycle: "running",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      unrecognized_event_count: 0,
+      created_at: "2026-08-15T00:00:00.000Z",
+    };
+    render(
+      <WorkspaceCard
+        workspace={workspace}
+        digest={digest}
+        session={session}
+        repoName="app"
+        active={false}
+        terminalOpen={false}
+        density="detailed"
+        visibleMeta={{ repoChip: true, branch: true }}
+        commands={workspaceCommands({
+          hasPr: false,
+          archived: false,
+          hasSession: true,
+        })}
+        onOpen={vi.fn()}
+        onCommand={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTitle("Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("Agent working · 1 turn")).toBeInTheDocument();
   });
 
   it("renders a watch task as its own clickable child row", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -32,6 +32,7 @@ import type {
 import { AttentionBadge } from "./AttentionBadge";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import { FOCUS_RING_INSET, HOVER_TINT } from "./interactive";
+import { HARNESS_LABELS, LIFECYCLE_LABELS } from "./labels";
 import type { WorkspaceCommand } from "./workspaceActions";
 import {
   workspaceWorkflowActionLabel,
@@ -370,10 +371,23 @@ function WorkspaceActivityLine({
     digest?.attention.state.type === "needs_you"
       ? digest.attention.state.prompt || "Needs you"
       : null;
-  const sessionLine =
-    digest && isSessionRowWorthy(digest)
-      ? `${sessionRowLabel(digest)} - ${digest.turn_count} ${digest.turn_count === 1 ? "turn" : "turns"}`
+  const worthyDigest =
+    digest && isSessionRowWorthy(digest) ? digest : undefined;
+  const statusLabel = needsYou
+    ? null
+    : worthyDigest
+      ? sessionRowLabel(worthyDigest)
+      : digest
+        ? LIFECYCLE_LABELS[digest.lifecycle]
+        : session
+          ? LIFECYCLE_LABELS[session.lifecycle]
+          : null;
+  const turnCount = digest?.turn_count;
+  const turnLabel =
+    !needsYou && turnCount !== undefined
+      ? `${turnCount} ${turnCount === 1 ? "turn" : "turns"}`
       : null;
+  const sessionLine = [statusLabel, turnLabel].filter(Boolean).join(" · ");
   const HarnessIcon = session ? HARNESS_ICONS[session.harness_kind] : null;
   const stamp = session?.created_at ?? workspace.created_at;
   const age = formatCompactAge(stamp);
@@ -386,12 +400,14 @@ function WorkspaceActivityLine({
     <div className="flex min-w-0 items-center gap-1.5 px-2.5 pb-2 pl-7 text-[11px] text-muted-foreground">
       {needsYou ? (
         <CircleAlert className="size-3 shrink-0 text-critical" aria-hidden />
+      ) : session && HarnessIcon ? (
+        <span title={HARNESS_LABELS[session.harness_kind]}>
+          <HarnessIcon className="size-3 shrink-0" aria-hidden />
+        </span>
       ) : terminalOnly ? (
         <SquareTerminal className="size-3 shrink-0" aria-hidden />
       ) : ActivityIcon ? (
         <ActivityIcon className="size-3 shrink-0" aria-hidden />
-      ) : HarnessIcon ? (
-        <HarnessIcon className="size-3 shrink-0" aria-hidden />
       ) : null}
       <span
         className={cn(
@@ -399,7 +415,7 @@ function WorkspaceActivityLine({
           needsYou && "text-critical-foreground",
         )}
       >
-        {needsYou ?? sessionLine ?? "Terminal open"}
+        {needsYou ?? (sessionLine || "Terminal open")}
       </span>
       {age && (
         <span className="shrink-0 tabular-nums">

--- a/crates/tidebreak-desktop/ui/src/stories/TranscriptImageAttachments.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TranscriptImageAttachments.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import { TranscriptImageAttachments } from "@/TranscriptImageAttachments";
+
+const PIXEL = new Blob(
+  [
+    Uint8Array.from(
+      atob(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+      ),
+      (character) => character.charCodeAt(0),
+    ),
+  ],
+  { type: "image/png" },
+);
+
+const images = [
+  {
+    attachmentId: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+    mediaType: "image/png",
+    width: 390,
+    height: 202,
+  },
+  {
+    attachmentId: "2d3e2b55-3a4c-4b2f-8e1b-3c7e6d5f4b32",
+    mediaType: "image/png",
+    width: 2102,
+    height: 416,
+  },
+];
+
+/**
+ * Sent images on a user turn. Default is a small thumbnail; click opens or
+ * closes a larger preview.
+ */
+const meta = {
+  title: "Chat/Transcript images",
+  component: TranscriptImageAttachments,
+  args: {
+    client: {
+      getChatImageAttachment: async () => PIXEL,
+    },
+    chatId: "chat-1",
+    images,
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-muted max-w-md rounded-xl p-3">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TranscriptImageAttachments>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Thumbnails: Story = {};
+
+export const Expanded: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = await canvas.findByRole("button", {
+      name: "Expand attached image 1: 390 by 202 pixels",
+    });
+    await userEvent.click(toggle);
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  },
+};
+
+export const Unavailable: Story = {
+  args: {
+    client: {
+      getChatImageAttachment: async () =>
+        new Blob(["nope"], { type: "application/octet-stream" }),
+    },
+    images: [images[0]],
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -128,10 +128,12 @@ export const Active: Story = {
   args: { active: true },
 };
 
+/** Harness mark, live activity, and turn count on the detailed status line. */
 export const RunningSession: Story = {
   args: {
     digest: runningDigest,
     session: codeSession,
+    visibleMeta: { repoChip: true, branch: true },
     commands: workspaceCommands({
       hasPr: false,
       archived: false,

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -658,24 +658,43 @@ body {
 }
 
 .message-image-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
-  gap: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
   margin-bottom: 0.55rem;
 }
 
-.message-image,
+.message-image-toggle {
+  display: block;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.message-image-toggle .message-image,
 .message-image-pending {
   display: block;
-  width: 100%;
-  max-width: 18rem;
-  max-height: 16rem;
+  width: auto;
+  height: 4.5rem;
+  max-width: 8rem;
   border-radius: 8px;
+  object-fit: contain;
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+}
+
+.message-image-toggle.is-expanded .message-image {
+  width: auto;
+  height: auto;
+  max-width: min(28rem, 100%);
+  max-height: 22rem;
   object-fit: contain;
 }
 
 .message-image-pending {
-  min-height: 6rem;
+  min-width: 6rem;
   padding: 0.75rem;
   color: var(--muted-foreground);
   background: color-mix(in oklch, var(--muted) 60%, transparent);

--- a/crates/tidebreak-desktop/ui/src/useImageAttachments.test.ts
+++ b/crates/tidebreak-desktop/ui/src/useImageAttachments.test.ts
@@ -265,4 +265,25 @@ describe("useImageAttachments", () => {
     expect(result.current.attachments).toEqual([]);
     expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview");
   });
+
+  it("puts ready chips back after a refused send without their local preview", async () => {
+    const { result } = renderHook(() => useImageAttachments(client, "chat-1"));
+
+    act(() => result.current.attachFiles([png()]));
+    await waitFor(() => expect(FakeUpload.opened).toHaveLength(1));
+    act(() => FakeUpload.opened[0].finish(201, PUBLISHED));
+    await waitFor(() =>
+      expect(result.current.attachments[0].status).toBe("ready"),
+    );
+    const held = result.current.attachments;
+
+    act(() => result.current.clear());
+    act(() => result.current.restore(held));
+    expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.attachments[0]).toMatchObject({
+      status: "ready",
+      previewUrl: null,
+      attachmentId: ATTACHMENT_ID,
+    });
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/useImageAttachments.ts
+++ b/crates/tidebreak-desktop/ui/src/useImageAttachments.ts
@@ -31,6 +31,12 @@ export type ImageAttachmentControls = {
   retry: (id: string) => void;
   /** Forget everything, once a turn has carried it. */
   clear: () => void;
+  /**
+   * Put a cleared strip back after a refused send. Local previews are gone —
+   * those object URLs were revoked with the clear — so ready chips fall back
+   * to name and geometry the way host-picked images always do.
+   */
+  restore: (items: readonly ImageAttachment[]) => void;
 };
 
 const NO_IMAGES: ImageAttachment[] = [];
@@ -261,6 +267,9 @@ export function useImageAttachments(
       }
       update(() => []);
       setError(null);
+    },
+    restore: (items) => {
+      update(() => items.map((item) => ({ ...item, previewUrl: null })));
     },
   };
 }


### PR DESCRIPTION
## Summary

- Drop composer image chips as soon as you send, and put them back if the turn is refused.
- Show sent images as small thumbnails you can click open and closed, instead of stretching a screenshot across the transcript.
- Keep the harness mark and a status line on detailed workspace cards, including Idle.

## Testing

- `pnpm exec tsc --noEmit`
- focused UI Vitest files for composer, transcript images, workspace cards, and image attachments
- `pnpm storybook:build`