### PR TITLE
fix(desktop): let the content policy reach a remote machine

### DIFF
--- a/crates/tidebreak-desktop/tauri.conf.json
+++ b/crates/tidebreak-desktop/tauri.conf.json
@@ -28,7 +28,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; img-src 'self' asset: blob: data: https://github.com https://avatars.githubusercontent.com; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; worker-src 'self' blob:; frame-src http://127.0.0.1:* http://localhost:*; object-src 'none'"
+      "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:* https: wss:; img-src 'self' asset: blob: data: https://github.com https://avatars.githubusercontent.com; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; worker-src 'self' blob:; frame-src http://127.0.0.1:* http://localhost:*; object-src 'none'"
     }
   },
   "plugins": {

--- a/crates/tidebreak-desktop/ui/src/tauriSecurityPolicy.test.ts
+++ b/crates/tidebreak-desktop/ui/src/tauriSecurityPolicy.test.ts
@@ -1,16 +1,28 @@
 import { readFileSync } from "node:fs";
 import { expect, it } from "vitest";
 
-it("allows only the approved GitHub avatar hosts in the desktop image policy", () => {
+function directive(name: string): string | undefined {
   const config = JSON.parse(
     readFileSync(new URL("../../tauri.conf.json", import.meta.url), "utf8"),
   ) as { app: { security: { csp: string } } };
-  const imagePolicy = config.app.security.csp
+  return config.app.security.csp
     .split(";")
-    .map((directive) => directive.trim())
-    .find((directive) => directive.startsWith("img-src "));
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(`${name} `));
+}
 
-  expect(imagePolicy).toBe(
+it("allows only the approved GitHub avatar hosts in the desktop image policy", () => {
+  expect(directive("img-src")).toBe(
     "img-src 'self' asset: blob: data: https://github.com https://avatars.githubusercontent.com",
   );
+});
+
+it("lets the connection policy reach a remote machine over TLS", () => {
+  // The policy is compiled into the binary, and the remote machine is whatever
+  // address the operator attaches, so the scheme is the narrowest form this
+  // can take. Losing either token blocks every request to a remote machine.
+  const connectPolicy = directive("connect-src");
+
+  expect(connectPolicy).toContain(" https:");
+  expect(connectPolicy).toContain(" wss:");
 });


### PR DESCRIPTION
## What changed

`connect-src` in the desktop content security policy allowed only `'self'`, the IPC scheme, and four loopback patterns. Add `https:` and `wss:` so the app can reach a machine attached at a remote address.

## Why

The embedded server binds loopback, so a local machine has always been in policy. A remote machine is not. Every call the attach path makes from the webview is governed by `connect-src`:

- `ApiClient`'s `fetch` calls in `crates/tidebreak-desktop/ui/src/api/client.ts`
- the three `new WebSocket(...)` call sites in the same file

The Rust-side connect probe in `remote.rs` uses `reqwest` and is not governed by the policy, so the address check passed and only the session failed. WebKit reports a policy-blocked request as `TypeError: Load failed`, which is the same string a network failure produces, so there was no usable diagnostic.

Verified against a deployed server: with the policy patched, a release build's WebKit networking process holds an established TLS socket to the remote host, and the app attaches and runs turns. Under the shipped policy that socket cannot exist.

## Why not a narrower policy

The policy is compiled into the binary at build time, and the remote address is whatever the operator types into the machine panel, so there is no host to name. Scheme-level is the narrowest form available. Plaintext `http:` stays limited to loopback, so a remote machine still has to serve TLS.

## Tests

`crates/tidebreak-desktop/ui/src/tauriSecurityPolicy.test.ts` now pins both tokens alongside the existing image-policy assertion. Refactored the config read into a shared `directive()` helper.

    ✓ src/tauriSecurityPolicy.test.ts (2 tests)