### PR TITLE
fix(code): give agent status one color per state

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
@@ -44,11 +44,25 @@ const cases: Array<{ attention: Attention; label: string; type: string }> = [
 ];
 
 describe("AttentionBadge", () => {
-  it("renders nothing for Working", () => {
+  it("renders no pill for Working", () => {
     const { container } = render(
       <AttentionBadge attention={{ state: { type: "working" }, source: "lifecycle" }} />,
     );
     expect(container).toBeEmptyDOMElement();
+  });
+
+  // A compact dot is often a row's only state. Working drawing as nothing here
+  // made a busy agent look idle, which is the one confusion worth a test.
+  it("renders a moving dot for Working when compact", () => {
+    render(
+      <AttentionBadge
+        compact
+        attention={{ state: { type: "working" }, source: "lifecycle" }}
+      />,
+    );
+    const dot = screen.getByLabelText("Working");
+    expect(dot).toHaveAttribute("data-attention", "working");
+    expect(dot).toHaveClass("animate-pulse");
   });
 
   it.each(cases)("renders $type with its label", ({ attention, label, type }) => {

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
@@ -3,13 +3,38 @@ import { cn } from "@/lib/utils";
 
 import type { Attention } from "../api/types";
 import { attentionLabel, attentionTooltip } from "./labels";
+import {
+  attentionStatusTone,
+  STATUS_DOT,
+  STATUS_MOTION,
+  type StatusTone,
+} from "./statusTone";
 
 /**
  * Status affordance for a server-computed attention state.
  *
  * NeedsYou is strongest. Stalled and Fenced are distinct warnings.
- * DoneUnreviewed is a quiet mark. Working has no badge.
+ * DoneUnreviewed is a quiet mark.
+ *
+ * Working is a dot but not a pill. The compact dot is often the only state a
+ * row carries, and an agent mid-turn used to draw there as nothing at all —
+ * indistinguishable from an idle one, for the state a reader most wants to
+ * see. The full badge always sits beside text that names the state already, so
+ * a "Working" pill there would only repeat it.
  */
+
+const BADGE_VARIANTS: Record<
+  StatusTone,
+  "outline" | "success" | "warning" | "critical" | "info" | "merged"
+> = {
+  neutral: "outline",
+  running: "info",
+  ready: "success",
+  pending: "info",
+  warning: "warning",
+  critical: "critical",
+  merged: "merged",
+};
 
 export function AttentionBadge({
   attention,
@@ -20,19 +45,18 @@ export function AttentionBadge({
   compact?: boolean;
   className?: string;
 }) {
-  if (!attention || attention.state.type === "working") return null;
+  if (!attention) return null;
+  if (attention.state.type === "working" && !compact) return null;
   const label = attentionLabel(attention);
   const tooltip = attentionTooltip(attention);
-  const tone = attentionTone(attention);
+  const tone = attentionStatusTone(attention);
   if (compact) {
     return (
       <span
         className={cn(
           "inline-block size-2 shrink-0 rounded-full",
-          tone === "critical" && "bg-critical-foreground-muted",
-          tone === "warning" && "bg-warning-foreground-muted",
-          tone === "subtle" && "bg-muted-foreground/60",
-          tone === "info" && "bg-info-foreground-muted",
+          STATUS_DOT[tone],
+          STATUS_MOTION[tone],
           className,
         )}
         // A dot with no text is only a state if something says which one. On a
@@ -47,15 +71,7 @@ export function AttentionBadge({
   }
   return (
     <Badge
-      variant={
-        tone === "critical"
-          ? "critical"
-          : tone === "warning"
-            ? "warning"
-            : tone === "info"
-              ? "info"
-              : "outline"
-      }
+      variant={BADGE_VARIANTS[tone]}
       size="sm"
       className={className}
       aria-label={label}
@@ -65,22 +81,4 @@ export function AttentionBadge({
       {label}
     </Badge>
   );
-}
-
-function attentionTone(
-  attention: Attention,
-): "critical" | "warning" | "subtle" | "info" {
-  switch (attention.state.type) {
-    case "needs_you":
-      return "critical";
-    case "stalled":
-    case "fenced":
-      return "warning";
-    case "manual":
-      return "info";
-    case "done_unreviewed":
-      return "subtle";
-    default:
-      return "subtle";
-  }
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeFileIcon.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeFileIcon.tsx
@@ -82,6 +82,11 @@ const DATA_EXTENSIONS = new Set(["db", "sqlite", "sqlite3", "sql"]);
  * A quiet file-type glyph shared by file navigation and changed-file trees.
  * The color is an identity cue, never a status cue; callers can override it
  * with `className` when Git state is the more important signal.
+ *
+ * Tones come from the `--icon-*` identity family, which the inbox and tool
+ * glyphs already use, and never from the status ramp — a `.json` file is not a
+ * warning, and a changed-file tree draws Git state in the same view. The
+ * family is theme-aware, which the raw palette classes it replaced were not.
  */
 export function CodeFileIcon({
   path,
@@ -108,7 +113,7 @@ export function fileIconSpec(path: string): FileIconSpec {
   if (name.startsWith("readme")) {
     return {
       icon: BookOpenText,
-      tone: "text-info-foreground",
+      tone: "text-icon-cyan",
       kind: "readme",
     };
   }
@@ -127,7 +132,7 @@ export function fileIconSpec(path: string): FileIconSpec {
   ) {
     return {
       icon: Package,
-      tone: "text-warning-foreground",
+      tone: "text-icon-rose",
       kind: "package",
     };
   }
@@ -141,12 +146,12 @@ export function fileIconSpec(path: string): FileIconSpec {
   if (extension === "json" || extension === "jsonc") {
     return {
       icon: FileJson,
-      tone: "text-warning-foreground",
+      tone: "text-icon-amber",
       kind: "json",
     };
   }
   if (CODE_EXTENSIONS.has(extension)) {
-    return { icon: FileCode2, tone: "text-info-foreground", kind: "code" };
+    return { icon: FileCode2, tone: "text-icon-blue", kind: "code" };
   }
   if (TEXT_EXTENSIONS.has(extension)) {
     return { icon: FileText, tone: "text-muted-foreground", kind: "text" };
@@ -154,24 +159,24 @@ export function fileIconSpec(path: string): FileIconSpec {
   if (CONFIG_EXTENSIONS.has(extension) || name.startsWith(".env")) {
     return {
       icon: FileCog,
-      tone: "text-warning-foreground",
+      tone: "text-icon-amber",
       kind: "config",
     };
   }
   if (IMAGE_EXTENSIONS.has(extension)) {
-    return { icon: FileImage, tone: "text-violet-500", kind: "image" };
+    return { icon: FileImage, tone: "text-icon-violet", kind: "image" };
   }
   if (STYLE_EXTENSIONS.has(extension)) {
-    return { icon: Palette, tone: "text-pink-500", kind: "style" };
+    return { icon: Palette, tone: "text-icon-rose", kind: "style" };
   }
   if (DATA_EXTENSIONS.has(extension)) {
-    return { icon: Database, tone: "text-teal-500", kind: "data" };
+    return { icon: Database, tone: "text-icon-cyan", kind: "data" };
   }
   if (extension === "html" || extension === "xml") {
-    return { icon: Braces, tone: "text-orange-500", kind: "markup" };
+    return { icon: Braces, tone: "text-icon-amber", kind: "markup" };
   }
   if (extension === "woff" || extension === "woff2" || extension === "ttf") {
-    return { icon: FileType2, tone: "text-violet-500", kind: "font" };
+    return { icon: FileType2, tone: "text-icon-violet", kind: "font" };
   }
   return { icon: File, tone: "text-muted-foreground", kind: "file" };
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -53,6 +53,7 @@ import {
   type ShellShortcutAction,
 } from "@/ShellShortcuts";
 import { AttentionBadge } from "./AttentionBadge";
+import { STATUS_MARK } from "./statusTone";
 import {
   codeBrowserIds,
   closeAllEditorTabs,
@@ -1777,7 +1778,7 @@ function WatchTaskBar({
       <CircleDotDashed
         className={cn(
           "size-3.5 shrink-0",
-          watch?.state === "blocked" ? "text-warning" : "text-info-foreground",
+          watch?.state === "blocked" ? STATUS_MARK.warning : STATUS_MARK.pending,
         )}
         aria-hidden
       />

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -38,8 +38,14 @@ import {
   workspaceWorkflowActionLabel,
   workspaceWorkflowModel,
   type WorkspaceWorkflowAction,
-  type WorkspaceWorkflowTone,
 } from "./workspaceWorkflow";
+import {
+  digestStatusTone,
+  STATUS_MARK,
+  STATUS_MOTION,
+  STATUS_TEXT,
+  type StatusTone,
+} from "./statusTone";
 import {
   formatCompactAge,
   isSessionRowWorthy,
@@ -148,7 +154,9 @@ export function WorkspaceCard({
                 )}
                 {digest?.attention.state.type === "needs_you" &&
                   digest.attention.state.source === "structured" && (
-                    <CircleAlert className="size-3 text-critical" />
+                    <CircleAlert
+                      className={cn("size-3", STATUS_MARK.critical)}
+                    />
                   )}
               </span>
             </span>
@@ -221,9 +229,7 @@ export function WorkspaceCard({
                 key={subagent.call_id}
                 label={subagent.name}
                 status={SUBAGENT_STATUS_LABELS[subagent.status]}
-                statusTone={
-                  subagent.status === "failed" ? "critical" : "neutral"
-                }
+                statusTone={SUBAGENT_STATUS_TONES[subagent.status]}
                 ariaLabel={`Subagent for ${title}: ${subagent.name}, ${SUBAGENT_STATUS_LABELS[subagent.status]}`}
                 icon={<Bot />}
                 onClick={() => onOpenSubagent?.(subagent.call_id)}
@@ -241,12 +247,10 @@ const SUBAGENT_STATUS_LABELS: Record<CodeSubagentStatus, string> = {
   failed: "Failed",
 };
 
-const TONE_CLASS: Record<WorkspaceWorkflowTone, string> = {
-  neutral: "text-muted-foreground",
-  ready: "text-success-foreground",
-  pending: "text-info-foreground",
-  warning: "text-warning-foreground",
-  critical: "text-critical-foreground",
+const SUBAGENT_STATUS_TONES: Record<CodeSubagentStatus, StatusTone> = {
+  running: "running",
+  done: "neutral",
+  failed: "critical",
 };
 
 function WorkspaceStateLine({
@@ -305,7 +309,7 @@ function WorkspaceStateLine({
             type="button"
             className={cn(
               "flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-[11px] font-medium hover:bg-muted",
-              TONE_CLASS[model.tone],
+              STATUS_TEXT[model.tone],
               FOCUS_RING_INSET,
               HOVER_TINT,
             )}
@@ -395,24 +399,37 @@ function WorkspaceActivityLine({
   const terminalOnly = terminalOpen && !needsYou && !sessionLine;
   if (!needsYou && !sessionLine && !terminalOnly) return null;
   const ActivityIcon = digest ? sessionActivityIcon(digest) : null;
+  const running = digestStatusTone(digest) === "running";
 
   return (
     <div className="flex min-w-0 items-center gap-1.5 px-2.5 pb-2 pl-7 text-[11px] text-muted-foreground">
       {needsYou ? (
-        <CircleAlert className="size-3 shrink-0 text-critical" aria-hidden />
+        <CircleAlert
+          className={cn("size-3 shrink-0", STATUS_TEXT.critical)}
+          aria-hidden
+        />
       ) : session && HarnessIcon ? (
+        // A brand mark, so it keeps its own identity: the running tone goes
+        // on the label beside it, never on the engine's logo.
         <span title={HARNESS_LABELS[session.harness_kind]}>
           <HarnessIcon className="size-3 shrink-0" aria-hidden />
         </span>
       ) : terminalOnly ? (
         <SquareTerminal className="size-3 shrink-0" aria-hidden />
       ) : ActivityIcon ? (
-        <ActivityIcon className="size-3 shrink-0" aria-hidden />
+        <ActivityIcon
+          className={cn(
+            "size-3 shrink-0",
+            running && [STATUS_TEXT.running, STATUS_MOTION.running],
+          )}
+          aria-hidden
+        />
       ) : null}
       <span
         className={cn(
           "min-w-0 flex-1 truncate",
-          needsYou && "text-critical-foreground",
+          needsYou && STATUS_TEXT.critical,
+          running && STATUS_TEXT.running,
         )}
       >
         {needsYou ?? (sessionLine || "Terminal open")}
@@ -459,7 +476,7 @@ function WorkspaceChildRow({
 }: {
   label: string;
   status?: string;
-  statusTone?: "neutral" | "critical";
+  statusTone?: StatusTone;
   ariaLabel: string;
   icon: ReactNode;
   attention?: CodeSessionDigest["attention"];
@@ -482,12 +499,7 @@ function WorkspaceChildRow({
       </span>
       <span className="min-w-0 flex-1 truncate">{label}</span>
       {status && (
-        <span
-          className={cn(
-            "shrink-0",
-            statusTone === "critical" && "text-critical",
-          )}
-        >
+        <span className={cn("shrink-0", STATUS_TEXT[statusTone])}>
           {status}
         </span>
       )}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -38,16 +38,8 @@ import {
   workspaceWorkflowActionLabel,
   workspaceWorkflowModel,
   type WorkspaceWorkflowAction,
-  type WorkspaceWorkflowTone,
 } from "./workspaceWorkflow";
-
-const TONE_CLASS: Record<WorkspaceWorkflowTone, string> = {
-  neutral: "text-foreground-subtle",
-  ready: "text-success",
-  pending: "text-info-foreground",
-  warning: "text-warning",
-  critical: "text-critical",
-};
+import { STATUS_MARK, STATUS_TEXT } from "./statusTone";
 
 /**
  * Compact workspace workflow control for the top chrome.
@@ -239,12 +231,12 @@ export function WorkspaceWorkflowControl({
           >
             {model.pr ? (
               <GitPullRequest
-                className={cn("size-3.5 shrink-0", TONE_CLASS[model.tone])}
+                className={cn("size-3.5 shrink-0", STATUS_MARK[model.tone])}
                 aria-hidden
               />
             ) : (
               <GitBranch
-                className={cn("size-3.5 shrink-0", TONE_CLASS[model.tone])}
+                className={cn("size-3.5 shrink-0", STATUS_MARK[model.tone])}
                 aria-hidden
               />
             )}
@@ -281,7 +273,7 @@ export function WorkspaceWorkflowControl({
             <span
               className={cn(
                 "mt-0.5 grid size-6 shrink-0 place-items-center rounded-md bg-muted/60",
-                TONE_CLASS[model.tone],
+                STATUS_MARK[model.tone],
               )}
             >
               {model.pr ? (
@@ -384,8 +376,8 @@ export function WorkspaceWorkflowControl({
                       className={cn(
                         "shrink-0 text-[11px] font-medium",
                         check.bucket === "fail"
-                          ? "text-critical"
-                          : "text-info-foreground",
+                          ? STATUS_TEXT.critical
+                          : STATUS_TEXT.pending,
                       )}
                     >
                       {check.bucket === "fail" ? "Failed" : "Pending"}
@@ -470,8 +462,8 @@ export function WorkspaceWorkflowControl({
             <CircleDotDashed
               className={cn(
                 watch.state === "blocked"
-                  ? "text-warning"
-                  : "text-info-foreground",
+                  ? STATUS_MARK.warning
+                  : STATUS_MARK.pending,
               )}
               aria-hidden
             />

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import type { Attention, CodeSessionDigest } from "../api/types";
+import {
+  attentionStatusTone,
+  digestStatusTone,
+  STATUS_MOTION,
+} from "./statusTone";
+
+function digest(
+  attention: Attention["state"],
+  lifecycle: CodeSessionDigest["lifecycle"],
+): CodeSessionDigest {
+  return {
+    attention: { state: attention, source: "lifecycle" },
+    lifecycle,
+  } as CodeSessionDigest;
+}
+
+describe("attentionStatusTone", () => {
+  // Working used to have no tone at all, which is what made a busy agent and
+  // an idle one look the same. The tone it gets has to be one that moves.
+  it("gives Working a tone that carries motion", () => {
+    const tone = attentionStatusTone({
+      state: { type: "working" },
+      source: "lifecycle",
+    });
+    expect(tone).toBe("running");
+    expect(STATUS_MOTION[tone]).toBeTruthy();
+  });
+
+  it("separates the two warnings from the one critical", () => {
+    const tone = (state: Attention["state"]) =>
+      attentionStatusTone({ state, source: "lifecycle" });
+    expect(
+      tone({ type: "needs_you", prompt: "", source: "structured" }),
+    ).toBe("critical");
+    expect(tone({ type: "stalled", idle_secs: 90 })).toBe("warning");
+    expect(tone({ type: "fenced", reason: { type: "orphan_alive" } })).toBe(
+      "warning",
+    );
+    expect(tone({ type: "done_unreviewed" })).toBe("neutral");
+  });
+});
+
+describe("digestStatusTone", () => {
+  it("lets attention outrank a running lifecycle", () => {
+    // A session stays `running` while it waits on you, and the waiting is the
+    // part worth coloring. Pulsing here would contradict the label beside it.
+    expect(
+      digestStatusTone(
+        digest(
+          { type: "needs_you", prompt: "", source: "structured" },
+          "running",
+        ),
+      ),
+    ).toBe("critical");
+    expect(
+      digestStatusTone(digest({ type: "stalled", idle_secs: 90 }, "running")),
+    ).toBe("warning");
+  });
+
+  it("runs only when working and running agree", () => {
+    expect(digestStatusTone(digest({ type: "working" }, "running"))).toBe(
+      "running",
+    );
+    expect(digestStatusTone(digest({ type: "working" }, "ended"))).toBe(
+      "neutral",
+    );
+    expect(digestStatusTone(undefined)).toBe("neutral");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.ts
@@ -1,0 +1,135 @@
+import type { Attention, CodeSessionDigest } from "../api/types";
+
+/**
+ * The one place code mode turns a state into a color.
+ *
+ * Two things were being decided together and kept coming out differently. A
+ * *tone* is what a state means — ready, warning, critical. A *rung* is which
+ * shade of that tone a given surface should paint, and it follows from what is
+ * being drawn: a word, a standalone glyph, a filled dot, a pill. Every surface
+ * used to pick both for itself, so the same state drew as `text-critical` on
+ * one row of a workspace card and `text-critical-foreground` on the next, and
+ * the card and the workflow control disagreed on four of five tones.
+ *
+ * Surfaces now choose a tone and say what they are painting. The rung is not
+ * theirs to pick.
+ *
+ * Status tones are reserved for status. File types, repo swatches, and engine
+ * badges are identity, not state: those use the `--icon-*` family instead, so
+ * a `.json` file never reads as a warning.
+ */
+
+/**
+ * The status vocabulary. A superset of `WorkspaceWorkflowTone` sharing its
+ * member names, so a workflow model's tone indexes these maps directly.
+ */
+export type StatusTone =
+  | "neutral"
+  | "running"
+  | "ready"
+  | "pending"
+  | "warning"
+  | "critical"
+  | "merged";
+
+/**
+ * Label text, and icons sitting inline beside it. The `-foreground` rung is
+ * the readable one: it carries the hue at text contrast rather than at the
+ * full-strength value a lone glyph needs.
+ */
+export const STATUS_TEXT: Record<StatusTone, string> = {
+  neutral: "text-muted-foreground",
+  running: "text-info-foreground",
+  ready: "text-success-foreground",
+  pending: "text-info-foreground",
+  warning: "text-warning-foreground",
+  critical: "text-critical-foreground",
+  merged: "text-merged-foreground",
+};
+
+/**
+ * A glyph carrying the state on its own — a PR mark, an alert circle. Nothing
+ * next to it says what it is, so it takes the full-strength value.
+ */
+export const STATUS_MARK: Record<StatusTone, string> = {
+  neutral: "text-muted-foreground",
+  running: "text-info",
+  ready: "text-success",
+  pending: "text-info",
+  warning: "text-warning",
+  critical: "text-critical",
+  merged: "text-merged",
+};
+
+/** A filled dot. Same reasoning as a mark, in a background rather than ink. */
+export const STATUS_DOT: Record<StatusTone, string> = {
+  neutral: "bg-muted-foreground/60",
+  running: "bg-info",
+  ready: "bg-success",
+  pending: "bg-info",
+  warning: "bg-warning",
+  critical: "bg-critical",
+  merged: "bg-merged",
+};
+
+/** A pill: a tinted field with text that has to stay legible on it. */
+export const STATUS_CHIP: Record<StatusTone, string> = {
+  neutral: "bg-muted text-muted-foreground",
+  running: "bg-info-background text-info-foreground-muted",
+  ready: "bg-success-background text-success-foreground-muted",
+  pending: "bg-info-background text-info-foreground-muted",
+  warning: "bg-warning-background text-warning-foreground-muted",
+  critical: "bg-critical-background text-critical-foreground-muted",
+  merged: "bg-merged-background text-merged-foreground-muted",
+};
+
+/**
+ * Motion, for the tones that mean something is happening right now.
+ *
+ * Running and pending share the info ramp because both are in flight, and hue
+ * alone cannot separate them. Movement can: a running agent is doing work this
+ * second, while a pending check is only waiting to be told. Callers spread this
+ * onto the same element they tone.
+ */
+export const STATUS_MOTION: Partial<Record<StatusTone, string>> = {
+  running: "animate-pulse",
+};
+
+/**
+ * What an attention state means, as a color.
+ *
+ * `working` is a tone here rather than the absence of one. It used to render
+ * nothing at all, which left the single most common live state — an agent
+ * mid-turn — looking exactly like an idle one.
+ */
+export function attentionStatusTone(attention: Attention): StatusTone {
+  switch (attention.state.type) {
+    case "working":
+      return "running";
+    case "needs_you":
+      return "critical";
+    case "stalled":
+    case "fenced":
+      return "warning";
+    case "manual":
+      return "pending";
+    case "done_unreviewed":
+      return "neutral";
+  }
+}
+
+/**
+ * A whole session's tone: what it wants from the reader, or that it is busy.
+ *
+ * Attention outranks lifecycle. A session can be `running` and still need an
+ * answer, and the need is the thing worth coloring.
+ */
+export function digestStatusTone(
+  digest: CodeSessionDigest | undefined,
+): StatusTone {
+  if (!digest) return "neutral";
+  if (digest.attention.state.type !== "working") {
+    return attentionStatusTone(digest.attention);
+  }
+  return digest.lifecycle === "running" ? "running" : "neutral";
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -5,6 +5,7 @@ import type {
   CodeWorkspaceSnapshot,
 } from "../api/types";
 import { attentionLabel, LIFECYCLE_LABELS } from "./labels";
+import { STATUS_CHIP, STATUS_MARK, type StatusTone } from "./statusTone";
 
 /**
  * Pure presentation logic for workspace cards: grouping by repo, the state
@@ -465,23 +466,43 @@ export function prToneLabel(
   }
 }
 
-/** Icon (text) classes per tone, for the PR mark itself. */
-export const PR_ICON_TONE_CLASSES: Record<PrChipTone, string> = {
-  open: "text-success",
-  draft: "text-muted-foreground",
-  merged: "text-purple-600 dark:text-purple-400",
-  closed: "text-critical",
-  other: "text-muted-foreground",
+/**
+ * The PR vocabulary as a view of the shared status one. A PR chip is a status
+ * chip; keeping its own color table is what let merged drift onto a hardcoded
+ * purple while every other tone rode the theme.
+ */
+const PR_STATUS_TONES: Record<PrChipTone, StatusTone> = {
+  open: "ready",
+  draft: "neutral",
+  merged: "merged",
+  closed: "critical",
+  other: "neutral",
 };
 
-/**
- * Chip classes per tone. Open, draft, and closed ride the semantic theme
- * tokens; merged has no token, so it pins GitHub's purple in both themes.
- */
-export const PR_CHIP_TONE_CLASSES: Record<PrChipTone, string> = {
-  open: "bg-success-background text-success-foreground-muted",
-  draft: "bg-muted text-muted-foreground",
-  merged: "bg-purple-100 text-purple-700 dark:bg-purple-500/20 dark:text-purple-300",
-  closed: "bg-critical-background text-critical-foreground-muted",
-  other: "bg-muted text-muted-foreground",
-};
+/** The status tone a PR carries, for callers painting a surface of their own. */
+export function prStatusTone(pr: {
+  state: string;
+  draft?: boolean;
+}): StatusTone {
+  return PR_STATUS_TONES[prTone(pr)];
+}
+
+function prToneClasses(
+  rungs: Record<StatusTone, string>,
+): Record<PrChipTone, string> {
+  return {
+    open: rungs[PR_STATUS_TONES.open],
+    draft: rungs[PR_STATUS_TONES.draft],
+    merged: rungs[PR_STATUS_TONES.merged],
+    closed: rungs[PR_STATUS_TONES.closed],
+    other: rungs[PR_STATUS_TONES.other],
+  };
+}
+
+/** Icon (text) classes per tone, for the PR mark itself. */
+export const PR_ICON_TONE_CLASSES: Record<PrChipTone, string> =
+  prToneClasses(STATUS_MARK);
+
+/** Chip classes per tone. */
+export const PR_CHIP_TONE_CLASSES: Record<PrChipTone, string> =
+  prToneClasses(STATUS_CHIP);

--- a/crates/tidebreak-desktop/ui/src/components/ui/badge.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/badge.tsx
@@ -21,6 +21,8 @@ const badgeVariants = cva(
         critical:
           "border-transparent bg-critical-background text-critical-foreground-muted",
         info: "border-transparent bg-info-background text-info-foreground-muted",
+        merged:
+          "border-transparent bg-merged-background text-merged-foreground-muted",
       },
       size: {
         default: "px-2.5 py-0.5 font-semibold",

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -8,6 +8,7 @@ import {
   closedPrDigest,
   codeSession,
   codeWorkspace,
+  doneDigest,
   draftPrDigest,
   mergedPrDigest,
   monitorDigest,
@@ -280,6 +281,47 @@ export const PullRequestTones: Story = {
             pr,
           }}
           commands={workspaceCommands({ hasPr: true, archived: false })}
+        />
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * The status ramp on one screen, which is the only way to catch a tone drawn
+ * at the wrong strength. Read down the glyph rail: working moves, needs-you is
+ * the one red, stalled is amber, done is quiet, and merged is purple rather
+ * than a second shade of green. Check this in both themes.
+ */
+export const StatusTones: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-0.5">
+      {(
+        [
+          ["Working", runningDigest, undefined],
+          ["Needs you", needsYouDigest, undefined],
+          ["Stalled", stalledDigest, undefined],
+          ["Done, unreviewed", doneDigest, undefined],
+          ["PR merged", undefined, mergedPrDigest],
+          ["Idle", undefined, undefined],
+        ] as const
+      ).map(([label, digest, pr]) => (
+        <WorkspaceCard
+          {...args}
+          key={label}
+          workspace={{
+            ...codeWorkspace,
+            id: `ws-${label}`,
+            title: label,
+            pr,
+          }}
+          digest={digest && { ...digest, title: label }}
+          session={digest ? codeSession : undefined}
+          commands={workspaceCommands({
+            hasPr: Boolean(pr),
+            archived: false,
+            hasSession: Boolean(digest),
+          })}
         />
       ))}
     </div>

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -390,6 +390,13 @@ export const stalledDigest: CodeSessionDigest = codeDigest({
   attention: attentionStalled,
 });
 
+/** Digest for a finished turn nobody has looked at yet. */
+export const doneDigest: CodeSessionDigest = codeDigest({
+  lifecycle: "idle",
+  attention: attentionDoneUnreviewed,
+  turn_count: 6,
+});
+
 /** A watch-and-fix task riding under the workspace (decision 50). */
 export const watchDigest: CodeSessionDigest = codeDigest({
   session: "sess-watch",

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -71,6 +71,14 @@
   --info-foreground-muted: color-mix(in oklch, var(--info-foreground) 75%, transparent);
   --info-background: oklch(0.951 0.026 236.824);
   --info-border: oklch(0.391 0.09 240.876);
+  /* Merged is a status, not a brand color: a merged PR is a settled outcome
+     distinct from both success and closed. GitHub's purple, on the same rungs
+     as the ramps above so it can be used interchangeably with them. */
+  --merged: oklch(0.541 0.281 293.009);
+  --merged-foreground: oklch(0.432 0.232 292.759);
+  --merged-foreground-muted: color-mix(in oklch, var(--merged-foreground) 75%, transparent);
+  --merged-background: oklch(0.943 0.029 294.588);
+  --merged-border: oklch(0.432 0.232 292.759);
 
   /* Citations retain a visible highlight without introducing a second accent. */
   --brand-accent: oklch(0.9 0 0);
@@ -184,6 +192,11 @@
   --info-foreground-muted: color-mix(in oklch, var(--info-foreground) 75%, transparent);
   --info-background: oklch(0.391 0.09 240.876);
   --info-border: oklch(0.746 0.16 232.661);
+  --merged: oklch(0.702 0.183 293.541);
+  --merged-foreground: oklch(0.943 0.029 294.588);
+  --merged-foreground-muted: color-mix(in oklch, var(--merged-foreground) 75%, transparent);
+  --merged-background: oklch(0.432 0.232 292.759);
+  --merged-border: oklch(0.702 0.183 293.541);
 
   --brand-accent: oklch(0.32 0 0);
   --citation-mark: oklch(0.34 0 0);
@@ -261,6 +274,12 @@
   --color-info-foreground-muted: var(--info-foreground-muted);
   --color-info-background: var(--info-background);
   --color-info-border: var(--info-border);
+
+  --color-merged: var(--merged);
+  --color-merged-foreground: var(--merged-foreground);
+  --color-merged-foreground-muted: var(--merged-foreground-muted);
+  --color-merged-background: var(--merged-background);
+  --color-merged-border: var(--merged-border);
 
   --color-brand-accent: var(--brand-accent);
 


### PR DESCRIPTION
## What changed

Status color said different things in different places, and said nothing at all
about the state agents are in most of the time.

- **Running gets a color.** `AttentionBadge` returned `null` for `working`, so a
  busy agent was indistinguishable from an idle one on the rail. It now renders
  an `info`-ramp dot with `animate-pulse`. Motion, not hue, is what separates
  "working right now" from "waiting on you" — both belong on the info ramp, and
  only one of them is urgent.
- **One rung per role.** New `src/code/statusTone.ts` is the single source of
  truth, replacing four private derivations: `attentionTone` in
  `AttentionBadge.tsx`, `TONE_CLASS` in `WorkspaceCard.tsx`, and the two PR maps
  in `workspaceCards.ts`. Three maps pick a rung by what is being painted —
  `STATUS_TEXT` for labels, `STATUS_MARK` for standalone dots, `STATUS_CHIP` for
  pills — so the same needs-you state can no longer land on `text-critical` in
  one line of a card and `text-critical-foreground` in the next.
- **`merged` becomes a token.** `--merged` and its ramp join both themes in
  `styles.css`, keeping GitHub's purple hue and dropping the last hardcoded
  `purple-100/700/500/300` from `workspaceCards.ts`.
- **File types leave the status ramp.** `CodeFileIcon` painted file *types* with
  `text-warning-foreground` and `text-info-foreground`, so a `.json` file read as
  a warning. Those move to identity colors from the same family as
  `REPO_ACCENT_CLASSES`.

The workspace activity line keeps the engine's brand logo as its leading icon.
A running agent reads as running from its label tone and the pulsing badge
instead — tinting a Claude or OpenAI mark with a status ramp would make the
logo mean something it does not mean.

## Validation

- `pnpm exec vitest run src/code/statusTone.test.ts src/code/workspaceCards.test.ts src/code/WorkspaceCard.dom.test.tsx` — 40 passed
- `pnpm exec tsc --noEmit`
- `pnpm storybook:build`

Not verified locally: the light/dark sweep. The `WorkspaceCard` story now covers
running, needs-you, stalled, done, and PR-merged side by side, which is where to
look.

## Compatibility and risk

None. No wire or persisted format changes; the new CSS variables are additive.

## Tracking

None.
