### PR TITLE
feat(code): complete the workspace tab keymap

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -24,7 +24,11 @@ import {
 } from "./ChatDeletion";
 import { useChatListStore } from "./ChatListStore";
 import {
+  centerTabCount,
   closeFocusedCodeTab,
+  selectCenterTab,
+  splitFocusedEditor,
+  stepCenterTab,
   toggleTerminalLayout,
 } from "./code/codeChrome";
 import { CodeDeliveryMonitor } from "./code/CodeDeliveryMonitor";
@@ -35,6 +39,7 @@ import {
   shellShortcutMode,
 } from "./code/routes";
 import { layoutFromSearch, searchFromLayout, type PanelSearch } from "./panel/panelUrl";
+import type { LayoutState } from "./panel/panelTypes";
 import { connectOutputs } from "./deliverables";
 import { useProjectListStore } from "./ProjectListStore";
 import { useComposerDrafts } from "./ComposerDrafts";
@@ -53,6 +58,7 @@ import { WindowDragStrip } from "./WindowDragStrip";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
 import {
+  numberedTabIndex,
   useShellShortcuts,
   type ShellShortcutHandlers,
   type ShellShortcutMode,
@@ -66,6 +72,19 @@ function focusComposer(): void {
   document
     .querySelector<HTMLTextAreaElement>("[data-composer-input]")
     ?.focus();
+}
+
+/**
+ * Whether a Monaco editor has the keyboard.
+ *
+ * Monaco binds its own Cmd+F to a find widget that searches the open file,
+ * which is what a reader inside a file means by the chord. The container class
+ * is Monaco's own and is on every instance, so this asks the DOM rather than
+ * tracking which of several editors last mounted.
+ */
+function isMonacoFocused(): boolean {
+  const active = document.activeElement;
+  return active instanceof Element && active.closest(".monaco-editor") !== null;
 }
 
 // Store actions are stable for the store's lifetime; these handles are for
@@ -167,6 +186,32 @@ export function AppShell() {
     };
   }, [navigate]);
 
+  /**
+   * Put the workspace's layout through one change and write it back.
+   *
+   * Every tab chord is the same three steps — read the layout out of the URL,
+   * hand it to one of the pure functions in `codeChrome`, navigate to the
+   * result — so they share this. Returning `false` declines the key: off a
+   * workspace there is no strip to act on, and a change that returned the
+   * layout untouched is one the strip could not make, so the key belongs to
+   * whatever is focused instead.
+   */
+  function applyCodeLayout(
+    change: (layout: LayoutState) => LayoutState,
+  ): boolean | void {
+    const { pathname, search } = router.state.location;
+    const workspaceId = codeWorkspaceIdFromPath(pathname);
+    if (!workspaceId) return false;
+    const layout = layoutFromSearch(search as PanelSearch);
+    const next = change(layout);
+    if (next === layout) return false;
+    void navigate({
+      to: "/code/w/$workspaceId",
+      params: { workspaceId },
+      search: searchFromLayout(next),
+    });
+  }
+
   // Shell shortcuts are defined here because these actions outlive any one
   // route: toggling the frame, starting a chat, reaching the composer, and
   // scaling the window all work wherever the reader is. Mode-scoped ones act
@@ -190,30 +235,32 @@ export function AppShell() {
     "toggle-code-review": () => {
       useCodeUiStore.getState().toggleReviewSidebar();
     },
-    "toggle-code-terminal": () => {
-      const { pathname, search } = router.state.location;
-      const workspaceId = codeWorkspaceIdFromPath(pathname);
-      if (!workspaceId) return;
-      const next = toggleTerminalLayout(layoutFromSearch(search as PanelSearch));
-      void navigate({
-        to: "/code/w/$workspaceId",
-        params: { workspaceId },
-        search: searchFromLayout(next),
-      });
+    "toggle-code-terminal": () => applyCodeLayout(toggleTerminalLayout),
+    "code-quick-open": () => {
+      const { pathname } = router.state.location;
+      if (!codeWorkspaceIdFromPath(pathname)) return false;
+      useCodeUiStore.getState().requestQuickOpen();
     },
-    "close-tab": () => {
-      const { pathname, search } = router.state.location;
-      const workspaceId = codeWorkspaceIdFromPath(pathname);
-      if (!workspaceId) return false;
-      const layout = layoutFromSearch(search as PanelSearch);
-      const next = closeFocusedCodeTab(layout);
-      if (!next) return false;
-      void navigate({
-        to: "/code/w/$workspaceId",
-        params: { workspaceId },
-        search: searchFromLayout(next),
-      });
+    "code-find": () => {
+      // Monaco owns Cmd+F while it has focus, and its find widget is the
+      // better answer inside a file than a filename search is. Declining the
+      // key hands it back to the editor rather than to the shell.
+      if (isMonacoFocused()) return false;
+      const { pathname } = router.state.location;
+      if (!codeWorkspaceIdFromPath(pathname)) return false;
+      useCodeUiStore.getState().requestFilesSearch();
     },
+    "code-prev-tab": () => applyCodeLayout((l) => stepCenterTab(l, -1)),
+    "code-next-tab": () => applyCodeLayout((l) => stepCenterTab(l, 1)),
+    "code-select-tab": (event) =>
+      applyCodeLayout((layout) => {
+        const position = numberedTabIndex(event.code, centerTabCount(layout));
+        return position === null ? layout : selectCenterTab(layout, position);
+      }),
+    "code-split-editor": () => applyCodeLayout(splitFocusedEditor),
+    // A closed tab is the one case the pure function reports with `null`, since
+    // "nothing here to close" is not the same as "closing changed nothing".
+    "close-tab": () => applyCodeLayout((l) => closeFocusedCodeTab(l) ?? l),
     "focus-composer": focusComposer,
     "zoom-in": zoom.zoomIn,
     "zoom-out": zoom.zoomOut,

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   groupedShellShortcuts,
   isEditableTarget,
+  numberedTabIndex,
   resolveShellShortcut,
   SHELL_SHORTCUTS,
   shortcutKeycaps,
@@ -243,6 +244,21 @@ describe("shortcut help", () => {
       expect(listed).toHaveLength(live.length);
       expect(new Set(listed)).toEqual(new Set(live));
     }
+  });
+});
+
+describe("numbered tabs", () => {
+  it("sends 9 to the last tab and ignores digits past the strip", () => {
+    // Browsers count from one and keep the last digit for the end of the
+    // strip however long it is, so 9 is "the last" rather than "the ninth".
+    expect(numberedTabIndex("Digit1", 4)).toBe(0);
+    expect(numberedTabIndex("Digit4", 4)).toBe(3);
+    expect(numberedTabIndex("Digit9", 4)).toBe(3);
+    // A digit past the end does nothing, rather than quietly meaning the end:
+    // that would make every unused digit a second way to say 9.
+    expect(numberedTabIndex("Digit5", 4)).toBeNull();
+    expect(numberedTabIndex("Numpad2", 4)).toBe(1);
+    expect(numberedTabIndex("Digit1", 0)).toBeNull();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -16,6 +16,12 @@ export type ShellShortcutAction =
   | "code-new-workspace"
   | "toggle-code-review"
   | "toggle-code-terminal"
+  | "code-quick-open"
+  | "code-find"
+  | "code-prev-tab"
+  | "code-next-tab"
+  | "code-select-tab"
+  | "code-split-editor"
   | "close-tab"
   | "focus-composer"
   | "zoom-in"
@@ -168,6 +174,85 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     codes: ["KeyJ"],
     mod: true,
     description: "Show or hide the terminal",
+    group: "Code",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    // The tab strip's plus control opens the file picker first, so the chord
+    // that means "new tab" everywhere else opens the same thing here rather
+    // than a blank tab there is nothing to put in.
+    id: "code-quick-open",
+    codes: ["KeyT"],
+    mod: true,
+    description: "New tab: open a file by name",
+    group: "Code",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "code-quick-open",
+    codes: ["KeyP"],
+    mod: true,
+    description: "Open a file by name",
+    group: "Code",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "code-find",
+    codes: ["KeyF"],
+    mod: true,
+    description: "Search the worktree files",
+    group: "Code",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    // Cmd+Shift+[ and ] are the browser's tab-cycling chords. Shift is held,
+    // so the key the keyboard reports is the shifted glyph; both are listed
+    // and the unshifted one leads, because that is the label on the keycap.
+    id: "code-prev-tab",
+    keys: ["[", "{"],
+    mod: true,
+    shift: true,
+    description: "Previous tab",
+    group: "Code",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "code-next-tab",
+    keys: ["]", "}"],
+    mod: true,
+    shift: true,
+    description: "Next tab",
+    group: "Code",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "code-select-tab",
+    codes: [
+      "Digit1", "Digit2", "Digit3", "Digit4", "Digit5",
+      "Digit6", "Digit7", "Digit8", "Digit9",
+      "Numpad1", "Numpad2", "Numpad3", "Numpad4", "Numpad5",
+      "Numpad6", "Numpad7", "Numpad8", "Numpad9",
+    ],
+    mod: true,
+    description: "Go to a tab by number, or 9 for the last",
+    group: "Code",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    // The chord VS Code uses for the same move. The strip needs two controls
+    // for it because a button sits on one side and can only point one way; a
+    // chord reads which group has focus and sends that tab the other way.
+    id: "code-split-editor",
+    keys: ["\\"],
+    mod: true,
+    description: "Move the focused tab to the other editor group",
     group: "Code",
     scope: "code",
     allowInEditable: true,
@@ -403,9 +488,33 @@ function hasOpenModalDialog(doc: Document): boolean {
   );
 }
 
+/**
+ * The tab a numbered chord names, or `null` when the strip is not that long.
+ *
+ * Browsers count from one and reserve the last digit for the last tab however
+ * many there are, so 9 means "the end" rather than "the ninth". `count` is
+ * what the strip actually holds, so 4 on a three-tab strip does nothing
+ * instead of silently jumping to the end.
+ */
+export function numberedTabIndex(code: string, count: number): number | null {
+  const digit = Number(code.replace(/^(Digit|Numpad)/, ""));
+  if (!Number.isInteger(digit) || digit < 1 || digit > 9) return null;
+  if (count <= 0) return null;
+  if (digit === 9) return count - 1;
+  return digit <= count ? digit - 1 : null;
+}
+
+/**
+ * What a shortcut does, given the event that triggered it.
+ *
+ * The event is passed rather than swallowed because one definition can stand
+ * for a family of chords: Cmd+1 through Cmd+9 are one action whose argument is
+ * the digit, and only the event knows which key was struck. Returning `false`
+ * declines the key and lets it through to whatever is focused.
+ */
 export type ShellShortcutHandlers = Record<
   ShellShortcutAction,
-  () => boolean | void
+  (event: KeyboardEvent) => boolean | void
 >;
 
 /**
@@ -440,7 +549,7 @@ export function useShellShortcuts(
         mode: modeRef.current(),
       });
       if (!def) return;
-      const handled = handlersRef.current[def.id]();
+      const handled = handlersRef.current[def.id](event);
       if (handled === false) return;
       event.preventDefault();
     }

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -107,6 +107,9 @@ export function CodeInspector({
     : (digest?.pr_state ?? workspace?.pr);
   const scope = useCodeUiStore((state) => state.inspectorScope);
   const setInspectorScope = useCodeUiStore((state) => state.setInspectorScope);
+  const filesSearchPending = useCodeUiStore(
+    (state) => state.filesSearchPending,
+  );
   const [tab, setTab] = useState<InspectorTab>(scope ? "source" : "files");
   const [file, setFile] = useState<string | undefined>();
   const turnId = scope?.turnId;
@@ -122,6 +125,13 @@ export function CodeInspector({
     setTab(requestedTab.tab);
     onRequestedTabHandled?.(requestedTab.revision);
   }, [onRequestedTabHandled, requestedTab]);
+
+  // Search lives on the Files tab, so the find chord has to land there first.
+  // The panel itself clears the flag once it has the caret; this only moves
+  // the tab, which is a no-op when Files is already up.
+  useEffect(() => {
+    if (filesSearchPending) setTab("files");
+  }, [filesSearchPending]);
 
   function openFile(next: string, line?: number) {
     if (onOpenFile) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.dom.test.tsx
@@ -1,11 +1,48 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CodeQuickOpen, rankQuickOpenPaths } from "./CodeQuickOpen";
 
 afterEach(cleanup);
+
+type QuickOpenProps = ComponentProps<typeof CodeQuickOpen>;
+
+/**
+ * Render the picker with a request counter the test can bump.
+ *
+ * The chords that reach it live in the shell keymap, so the component's only
+ * entry point is this counter — the one the New tab control increments and the
+ * one the keymap raises. `open()` stands in for either.
+ */
+function mountQuickOpen(props: Omit<QuickOpenProps, "openRequest">) {
+  let current = props;
+  let openRequest = 0;
+  const { rerender } = render(
+    <CodeQuickOpen {...current} openRequest={openRequest} />,
+  );
+  const draw = () =>
+    rerender(<CodeQuickOpen {...current} openRequest={openRequest} />);
+  return {
+    open: () => {
+      openRequest += 1;
+      draw();
+    },
+    /** Change what the picker is looking at, without reopening it. */
+    update: (next: Partial<QuickOpenProps>) => {
+      current = { ...current, ...next };
+      draw();
+    },
+  };
+}
 
 describe("CodeQuickOpen", () => {
   it("ranks fuzzy filename matches ahead of looser matches", () => {
@@ -20,7 +57,7 @@ describe("CodeQuickOpen", () => {
     ).toEqual(["src/index.ts", "tests/index.ts"]);
   });
 
-  it("opens in the center on Cmd+P and supports arrow-and-enter selection", async () => {
+  it("opens on request, then picks with the arrows and enter", async () => {
     const onOpenFile = vi.fn();
     const client = {
       listCodeWorkspaceTree: vi.fn(async () => ({
@@ -28,16 +65,15 @@ describe("CodeQuickOpen", () => {
         truncated: false,
       })),
     };
-    render(
-      <CodeQuickOpen
-        client={client}
-        workspaceId="ws-1"
-        contentRevision={0}
-        onOpenFile={onOpenFile}
-      />,
-    );
+    const ui = mountQuickOpen({
+      client,
+      workspaceId: "ws-1",
+      contentRevision: 0,
+      onOpenFile,
+    });
 
-    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    ui.open();
     const input = await screen.findByRole("combobox", { name: "Search files by name" });
     expect(input).toHaveFocus();
     expect(client.listCodeWorkspaceTree).toHaveBeenCalledWith("ws-1", {
@@ -54,40 +90,6 @@ describe("CodeQuickOpen", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("opens when the visible new-tab control increments its request", async () => {
-    const client = {
-      listCodeWorkspaceTree: vi.fn(async () => ({
-        paths: ["src/main.rs"],
-        truncated: false,
-      })),
-    };
-    const { rerender } = render(
-      <CodeQuickOpen
-        client={client}
-        workspaceId="ws-1"
-        contentRevision={0}
-        onOpenFile={vi.fn()}
-        openRequest={0}
-      />,
-    );
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    rerender(
-      <CodeQuickOpen
-        client={client}
-        workspaceId="ws-1"
-        contentRevision={0}
-        onOpenFile={vi.fn()}
-        openRequest={1}
-      />,
-    );
-
-    expect(
-      await screen.findByRole("combobox", { name: "Search files by name" }),
-    ).toHaveFocus();
-    expect(client.listCodeWorkspaceTree).toHaveBeenCalledTimes(1);
-  });
-
   it("reuses the file list until the worktree revision changes", async () => {
     const user = userEvent.setup();
     const client = {
@@ -96,37 +98,28 @@ describe("CodeQuickOpen", () => {
         truncated: false,
       })),
     };
-    const { rerender } = render(
-      <CodeQuickOpen
-        client={client}
-        workspaceId="ws-1"
-        contentRevision={0}
-        onOpenFile={vi.fn()}
-      />,
-    );
+    const ui = mountQuickOpen({
+      client,
+      workspaceId: "ws-1",
+      contentRevision: 0,
+      onOpenFile: vi.fn(),
+    });
 
-    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    ui.open();
     expect(
       await screen.findByRole("option", { name: "src/main.rs" }),
     ).toBeInTheDocument();
     await user.keyboard("{Escape}");
 
-    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    ui.open();
     expect(
       await screen.findByRole("option", { name: "src/main.rs" }),
     ).toBeInTheDocument();
     expect(client.listCodeWorkspaceTree).toHaveBeenCalledTimes(1);
     await user.keyboard("{Escape}");
 
-    rerender(
-      <CodeQuickOpen
-        client={client}
-        workspaceId="ws-1"
-        contentRevision={1}
-        onOpenFile={vi.fn()}
-      />,
-    );
-    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    ui.update({ contentRevision: 1 });
+    ui.open();
     await waitFor(() =>
       expect(client.listCodeWorkspaceTree).toHaveBeenCalledTimes(2),
     );
@@ -147,30 +140,22 @@ describe("CodeQuickOpen", () => {
             }),
         ),
     };
-    const { rerender } = render(
-      <CodeQuickOpen
-        client={client}
-        workspaceId="ws-1"
-        contentRevision={0}
-        onOpenFile={vi.fn()}
-      />,
-    );
-    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    const ui = mountQuickOpen({
+      client,
+      workspaceId: "ws-1",
+      contentRevision: 0,
+      onOpenFile: vi.fn(),
+    });
+
+    ui.open();
     expect(
       await screen.findByRole("option", { name: "old.ts" }),
     ).toBeInTheDocument();
 
-    rerender(
-      <CodeQuickOpen
-        client={client}
-        workspaceId="ws-2"
-        contentRevision={0}
-        onOpenFile={vi.fn()}
-      />,
-    );
+    ui.update({ workspaceId: "ws-2" });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    fireEvent.keyDown(window, { key: "p", metaKey: true });
+    ui.open();
     expect(screen.queryByRole("option", { name: "old.ts" })).not.toBeInTheDocument();
     resolveSecond?.({ paths: ["new.ts"], truncated: false });
     expect(

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
@@ -22,7 +22,13 @@ import { friendlyErrorMessage } from "@/lib/utils";
 const QUICK_OPEN_LIMIT = 5000;
 const VISIBLE_RESULTS = 12;
 
-/** Centered, keyboard-first filename quick open for Cmd/Ctrl+P. */
+/**
+ * Centered, keyboard-first filename quick open.
+ *
+ * The chords that reach it — Cmd+T and Cmd+P — are in the shell keymap rather
+ * than a listener here, so they appear in the shortcuts dialog and respect the
+ * guard that keeps every shell chord out of an open dialog.
+ */
 export function CodeQuickOpen({
   client,
   workspaceId,
@@ -34,7 +40,7 @@ export function CodeQuickOpen({
   workspaceId: string;
   contentRevision: number;
   onOpenFile: (path: string) => void;
-  /** Increment to open the picker from a visible New tab control. */
+  /** Increment to open the picker: a New tab control, or the shell keymap. */
   openRequest?: number;
 }) {
   const [open, setOpen] = useState(false);
@@ -51,17 +57,6 @@ export function CodeQuickOpen({
     setOpenWorkspaceId(workspaceId);
     setOpen(true);
   }, [workspaceId]);
-
-  useEffect(() => {
-    function onQuickOpen(event: KeyboardEvent) {
-      if (event.key.toLowerCase() !== "p") return;
-      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return;
-      event.preventDefault();
-      reveal();
-    }
-    window.addEventListener("keydown", onQuickOpen);
-    return () => window.removeEventListener("keydown", onQuickOpen);
-  }, [reveal]);
 
   useEffect(() => {
     if (openRequest > 0) reveal();

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -242,6 +242,24 @@ export type CodeUiStore = {
   runComposerPrompt: (scope: string, prompt: string) => boolean;
   takeComposerPrompt: (scope: string) => PendingComposerPrompt | null;
   finishComposerAction: (scope: string) => void;
+  /**
+   * Asks raised by the shell keymap that only a workspace surface can carry
+   * out.
+   *
+   * The shortcut listener lives above the route, so it cannot reach into the
+   * workspace's own state; it raises a flag here and the surface that owns the
+   * affordance takes it, the same way a queued composer prompt is taken. A
+   * flag rather than a counter because the ask does not queue — pressing the
+   * chord twice before the panel mounts is still one ask — and taking it is
+   * what keeps a later remount from repeating it.
+   */
+  quickOpenPending: boolean;
+  filesSearchPending: boolean;
+  requestQuickOpen: () => void;
+  takeQuickOpen: () => boolean;
+  /** Opens the review sidebar too: search is dead while that rail is hidden. */
+  requestFilesSearch: () => void;
+  takeFilesSearch: () => boolean;
 };
 
 export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
@@ -255,6 +273,23 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   terminalDrawerHeights: readStoredTerminalDrawerHeights(),
   pendingComposerPrompt: null,
   composerActionScope: null,
+  quickOpenPending: false,
+  filesSearchPending: false,
+  requestQuickOpen: () => set({ quickOpenPending: true }),
+  takeQuickOpen: () => {
+    if (!get().quickOpenPending) return false;
+    set({ quickOpenPending: false });
+    return true;
+  },
+  requestFilesSearch: () => {
+    storeReviewSidebarOpen(true);
+    set({ reviewSidebarOpen: true, filesSearchPending: true });
+  },
+  takeFilesSearch: () => {
+    if (!get().filesSearchPending) return false;
+    set({ filesSearchPending: false });
+    return true;
+  },
   offerComposerPrompt: (scope, prompt) =>
     set({ pendingComposerPrompt: { scope, text: prompt, submit: false } }),
   runComposerPrompt: (scope, prompt) => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -188,6 +188,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const setReviewSidebarOpen = useCodeUiStore(
     (state) => state.setReviewSidebarOpen,
   );
+  const quickOpenPending = useCodeUiStore((state) => state.quickOpenPending);
   const shortcutHints = useCodeShortcutHints();
   const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(
     null,
@@ -438,6 +439,17 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     setQuickOpenTarget(region);
     setQuickOpenRequest((request) => request + 1);
   }
+
+  // The shell keymap raises the ask above the route; the workspace is what can
+  // answer it. Taking the flag is what stops a remount from reopening the
+  // picker over whatever the reader moved on to.
+  const splitFocused =
+    Boolean(layout.editorSplit?.focused) && chrome.splitEditors.tabs.length > 0;
+  useEffect(() => {
+    if (!quickOpenPending) return;
+    if (!useCodeUiStore.getState().takeQuickOpen()) return;
+    requestNewTab(splitFocused ? "secondary" : "primary");
+  }, [quickOpenPending, splitFocused]);
 
   /** Attach a child task's transcript (or the conversation when undefined). */
   function openWorkspaceTask(sessionId: string | undefined) {

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.dom.test.tsx
@@ -1,8 +1,16 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { useCodeUiStore } from "./CodeUiStore";
 import { FilesPanel } from "./FilesPanel";
 
 afterEach(() => {
@@ -207,13 +215,15 @@ describe("FilesPanel", () => {
     expect(onOpenFile).toHaveBeenCalledWith("src/lib.rs", 12);
   });
 
-  it("focuses content search on Cmd+F and sends include and exclude globs", async () => {
+  it("takes a pending find ask and sends include and exclude globs", async () => {
     const client = makeClient();
     render(
       <FilesPanel client={client} workspaceId="ws-1" onOpenFile={vi.fn()} />,
     );
     expect(await screen.findByText("README.md")).toBeInTheDocument();
-    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    // The find chord is a flag raised by the shell keymap, not a key this
+    // panel listens for: that is what lets Cmd+F work with the rail closed.
+    act(() => useCodeUiStore.getState().requestFilesSearch());
     const search = screen.getByRole("searchbox", { name: "Search file contents" });
     expect(search).toHaveFocus();
     await userEvent.setup().type(search, "crisp");

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -18,6 +18,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { CodeFileIcon } from "./CodeFileIcon";
+import { useCodeUiStore } from "./CodeUiStore";
 import {
   ancestorPaths,
   buildFileTree,
@@ -64,6 +65,9 @@ export function FilesPanel({
   const [focusedPath, setFocusedPath] = useState<string | null>(null);
   const searchInput = useRef<HTMLInputElement>(null);
   const root = useRef<HTMLDivElement>(null);
+  const filesSearchPending = useCodeUiStore(
+    (state) => state.filesSearchPending,
+  );
   const rowRefs = useRef(new Map<string, HTMLLIElement>());
 
   const loadTree = useCallback(
@@ -176,19 +180,16 @@ export function FilesPanel({
     });
   }
 
+  // The find chord is raised as a flag by the shell keymap, above the route
+  // that owns this panel. Taking it here rather than watching for the key
+  // means search still answers Cmd+F when the review rail was closed: the
+  // store opens the rail, this panel mounts, and the ask is still waiting.
   useEffect(() => {
-    function onFind(event: KeyboardEvent) {
-      if (event.key !== "f" && event.key !== "F") return;
-      if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
-      const pane = root.current;
-      if (!pane || pane.closest("[data-state='inactive']")) return;
-      event.preventDefault();
-      searchInput.current?.focus();
-      searchInput.current?.select();
-    }
-    window.addEventListener("keydown", onFind);
-    return () => window.removeEventListener("keydown", onFind);
-  }, []);
+    if (!filesSearchPending) return;
+    if (!useCodeUiStore.getState().takeFilesSearch()) return;
+    searchInput.current?.focus();
+    searchInput.current?.select();
+  }, [filesSearchPending]);
 
   const searchMode = Boolean(query.trim());
   const ready = tree !== null;

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.test.ts
@@ -9,6 +9,9 @@ import {
   closeFocusedCodeTab,
   closeOtherEditorTabs,
   codeBrowserIds,
+  centerTabCount,
+  selectCenterTab,
+  stepCenterTab,
   focusCodeChromeTab,
   focusConversation,
   focusEditorTab,
@@ -17,6 +20,7 @@ import {
   openCodeEditor,
   removedCodeBrowserIds,
   splitCodeChromeLayout,
+  splitFocusedEditor,
   toggleTerminalLayout,
 } from "./codeChrome";
 
@@ -345,6 +349,102 @@ describe("code chrome layout", () => {
     expect(mergeEditorSplit(split).tabs.filter((tab) => tab.type === "file")).toEqual([
       { type: "file", path: "src/lib.rs" },
     ]);
+  });
+
+  it("counts the main agent as the first numbered tab", () => {
+    // Cmd+1 names a position on screen, and position one is the main agent —
+    // the tab the strip always draws first and the URL never stores as one.
+    const layout = {
+      tabs: [
+        { type: "file" as const, path: "src/lib.rs" },
+        { type: "diff" as const, path: "src/main.rs" },
+        { type: "terminal" as const },
+      ],
+      activeIndex: 0,
+      fullscreen: false,
+      conversationFocused: false,
+    };
+
+    expect(centerTabCount(layout)).toBe(3);
+    expect(selectCenterTab(layout, 0).conversationFocused).toBe(true);
+    const second = selectCenterTab(layout, 2);
+    expect(second.conversationFocused).toBe(false);
+    expect(second.tabs[second.activeIndex]).toEqual({
+      type: "diff",
+      path: "src/main.rs",
+    });
+    // The terminal is a drawer, not a tab, so it is not position four.
+    expect(selectCenterTab(layout, 3)).toBe(layout);
+  });
+
+  it("numbers the split group on its own, with no main agent in it", () => {
+    // The right-hand group draws editor tabs only, so its first position is a
+    // file rather than the conversation the left group leads with.
+    const layout = {
+      tabs: [{ type: "file" as const, path: "src/lib.rs" }],
+      activeIndex: 0,
+      fullscreen: false,
+      conversationFocused: false,
+      editorSplit: {
+        tabs: [
+          { type: "file" as const, path: "README.md" },
+          { type: "file" as const, path: "Cargo.toml" },
+        ],
+        activeIndex: 0,
+        focused: true,
+      },
+    };
+
+    expect(centerTabCount(layout)).toBe(2);
+    expect(selectCenterTab(layout, 1).editorSplit?.activeIndex).toBe(1);
+  });
+
+  it("wraps when cycling past either end of the strip", () => {
+    const layout = {
+      tabs: [
+        { type: "file" as const, path: "src/lib.rs" },
+        { type: "diff" as const, path: "src/main.rs" },
+      ],
+      activeIndex: 0,
+      fullscreen: false,
+      conversationFocused: true,
+    };
+
+    // Back from the main agent lands on the last tab, not on nothing.
+    expect(stepCenterTab(layout, -1).activeIndex).toBe(1);
+    expect(stepCenterTab(layout, 1).activeIndex).toBe(0);
+    // A strip of one is the conversation alone; cycling has nowhere to go.
+    expect(stepCenterTab(EMPTY_LAYOUT, 1)).toBe(EMPTY_LAYOUT);
+  });
+
+  it("sends the focused tab whichever way it can go", () => {
+    const layout = {
+      tabs: [
+        { type: "file" as const, path: "src/lib.rs" },
+        { type: "diff" as const, path: "src/main.rs" },
+      ],
+      activeIndex: 1,
+      fullscreen: false,
+    };
+
+    // From the left group the only direction is right.
+    const split = splitFocusedEditor(layout);
+    expect(split.tabs).toHaveLength(1);
+    expect(split.editorSplit?.tabs).toEqual([
+      { type: "diff", path: "src/main.rs" },
+    ]);
+    expect(split.editorSplit?.focused).toBe(true);
+
+    // And from the right group, back again: one chord, both directions.
+    expect(splitFocusedEditor(split).editorSplit?.tabs ?? []).toHaveLength(0);
+    expect(splitFocusedEditor(split).tabs).toHaveLength(2);
+
+    // The conversation is not a tab the split can hold, and an empty strip has
+    // nothing to send. Both decline by returning the layout untouched, which is
+    // what tells the shell to let the key through.
+    const onConversation = { ...layout, conversationFocused: true };
+    expect(splitFocusedEditor(onConversation)).toBe(onConversation);
+    expect(splitFocusedEditor(EMPTY_LAYOUT)).toBe(EMPTY_LAYOUT);
   });
 
   it("closes the editor tab that owns focus for the shell shortcut", () => {

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -122,6 +122,74 @@ export function closeFocusedCodeTab(layout: LayoutState): LayoutState | null {
   return null;
 }
 
+/**
+ * The center strip the keyboard acts on, as one ordered list.
+ *
+ * A chord names a position on screen, so this counts what the reader can see
+ * rather than what the URL stores: the main agent is position 0 of the primary
+ * strip and file tabs follow it, and when the right-hand split holds focus the
+ * strip is that group alone — it draws no main-agent tab.
+ */
+function centerStrip(layout: LayoutState): {
+  region: CodeEditorRegion;
+  /** Whether position 0 is the conversation rather than an editor tab. */
+  hasConversation: boolean;
+  count: number;
+  position: number;
+} {
+  const chrome = splitCodeChromeLayout(layout);
+  if (layout.editorSplit?.focused && chrome.splitEditors.tabs.length > 0) {
+    return {
+      region: "secondary",
+      hasConversation: false,
+      count: chrome.splitEditors.tabs.length,
+      position: chrome.splitEditors.activeIndex,
+    };
+  }
+  const editors = chrome.editors.tabs.length;
+  const onConversation =
+    editors === 0 || Boolean(chrome.editors.conversationFocused);
+  return {
+    region: "primary",
+    hasConversation: true,
+    count: editors + 1,
+    position: onConversation ? 0 : chrome.editors.activeIndex + 1,
+  };
+}
+
+/** How many tabs the focused center strip draws, counting the main agent. */
+export function centerTabCount(layout: LayoutState): number {
+  return centerStrip(layout).count;
+}
+
+/** Bring the center strip's `position`th tab forward, counting from zero. */
+export function selectCenterTab(
+  layout: LayoutState,
+  position: number,
+): LayoutState {
+  const strip = centerStrip(layout);
+  if (position < 0 || position >= strip.count) return layout;
+  if (!strip.hasConversation) {
+    return focusEditorTab(layout, position, strip.region);
+  }
+  if (position === 0) return focusConversation(layout);
+  return focusEditorTab(layout, position - 1, strip.region);
+}
+
+/**
+ * Step through the center strip, wrapping at both ends.
+ *
+ * Cycling wraps because that is what the chord does in every browser, and
+ * because a strip short enough to cycle by hand is one the reader can see the
+ * whole of — stopping at the end would read as the key having failed.
+ */
+export function stepCenterTab(layout: LayoutState, delta: number): LayoutState {
+  const strip = centerStrip(layout);
+  if (strip.count <= 1) return layout;
+  const next = (strip.position + delta + strip.count) % strip.count;
+  return selectCenterTab(layout, next);
+}
+
 /** Show the conversation while keeping file and diff tabs open. */
 export function focusConversation(layout: LayoutState): LayoutState {
   return {
@@ -402,6 +470,36 @@ export function moveEditorTab(
     without,
     target as CodeEditorPanel,
     "primary",
+  );
+}
+
+/**
+ * Send the focused tab to the other editor group.
+ *
+ * The strip draws this as two separate controls — a split button on the left
+ * group, "Move to main group" on the right — because a button sits on one side
+ * and can only mean one thing. A chord has no side, so it reads which group
+ * holds focus and moves that tab the only way it can go. Returns the layout
+ * unchanged when the conversation holds focus: a conversation is not a tab the
+ * split can hold.
+ */
+export function splitFocusedEditor(layout: LayoutState): LayoutState {
+  const chrome = splitCodeChromeLayout(layout);
+  if (layout.editorSplit?.focused && chrome.splitEditors.tabs.length > 0) {
+    return moveEditorTab(
+      layout,
+      "secondary",
+      chrome.splitEditors.activeIndex,
+      "primary",
+    );
+  }
+  if (chrome.editors.tabs.length === 0) return layout;
+  if (chrome.editors.conversationFocused) return layout;
+  return moveEditorTab(
+    layout,
+    "primary",
+    chrome.editors.activeIndex,
+    "secondary",
   );
 }
 


### PR DESCRIPTION
## What changed

The center tab strip had Cmd+W and little else, and two of the bindings it did
have were invisible.

Cmd+P and Cmd+F were private `window` listeners rather than entries in
`SHELL_SHORTCUTS`, so they were missing from the Cmd+/ dialog and skipped the
modal and editable guards every other chord goes through. Cmd+F was worse than
missing: `FilesPanel` only mounts inside the review sidebar, so search was
silently dead whenever that sidebar was closed.

Everything now lives in the one table, so the help dialog and the listener stay
derived from a single source:

| Chord | Action |
|---|---|
| Cmd+T | `code-quick-open` |
| Cmd+P | `code-quick-open` |
| Cmd+F | `code-find` |
| Cmd+Shift+[ / ] | `code-prev-tab` / `code-next-tab` |
| Cmd+1–9 | `code-select-tab` |

Two behaviors needed care:

- **Cmd+F works with the review sidebar closed.** It routes through
  `useCodeUiStore`, which opens the sidebar on the files tab and then focuses
  its search input. `FilesPanel` drops its private listener and reacts to a
  focus request instead.
- **Monaco keeps its own find.** The handler returns `false` when the active
  element is inside a Monaco instance, which `useShellShortcuts` already treats
  as "not handled" and lets through — the same escape hatch `close-tab` uses.

Cmd+9 selects the last tab rather than the ninth, matching browsers. Selection
and cycling reuse `focusEditorTab` and `focusCodeChromeTab`; the layout algebra
does not change.

## Validation

- `pnpm exec vitest run src/ShellShortcuts.test.ts src/code/codeChrome.test.ts` — 33 passed
- `pnpm exec tsc --noEmit`

Not verified locally: pressing the chords in the running app. Worth checking
Cmd+F once with the review sidebar closed and once inside Monaco.

## Compatibility and risk

None. No wire or persisted format changes.

## Tracking

None.
