### PR TITLE
fix(code): move editor tab drag onto pointer events

### DIFF
--- a/crates/tidebreak-desktop/ui/package.json
+++ b/crates/tidebreak-desktop/ui/package.json
@@ -15,6 +15,9 @@
     "tauri": "cargo tauri"
   },
   "dependencies": {
+    "@dnd-kit/core": "6.3.1",
+    "@dnd-kit/sortable": "10.0.0",
+    "@dnd-kit/utilities": "3.2.2",
     "@dukelib/sheets-wasm": "0.1.23",
     "@embedpdf/core": "2.15.0",
     "@embedpdf/engines": "2.15.0",

--- a/crates/tidebreak-desktop/ui/pnpm-lock.yaml
+++ b/crates/tidebreak-desktop/ui/pnpm-lock.yaml
@@ -13,6 +13,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: 6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: 10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: 3.2.2
+        version: 3.2.2(react@19.2.7)
       '@dukelib/sheets-wasm':
         specifier: 0.1.23
         version: 0.1.23
@@ -458,6 +467,28 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dukelib/sheets-wasm@0.1.23':
     resolution: {integrity: sha512-E/vHXR2I/EodNCpyVcFq0p8/u5qxmKxatUZvB7bsFfghUPQ2GMxg81MBFjOEQtLKXnzR7xjXOyzPzBTLbv2e1g==}
@@ -4829,6 +4860,31 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.7)
+      react: 19.2.7
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
 
   '@dukelib/sheets-wasm@0.1.23': {}
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -1,11 +1,15 @@
+import { useRef, type KeyboardEvent, type ReactNode } from "react";
+import { useDroppable } from "@dnd-kit/core";
 import {
-  useRef,
-  type DragEvent,
-  type KeyboardEvent,
-  type ReactNode,
-} from "react";
+  SortableContext,
+  horizontalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import {
   ArrowRightFromLine,
+  ChevronLeft,
+  ChevronRight,
   CircleX,
   Columns2,
   Copy,
@@ -40,7 +44,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { panelKey, type PanelContent } from "@/panel/panelTypes";
-import { writeEditorTabDrag } from "./editorDrag";
+import { editorStripDropId, editorTabDragId } from "./editorDrag";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 
 /** Ids the strip and the two center panels agree on, so tabs name panels. */
@@ -87,10 +91,9 @@ export function CodeCenterTabs({
   region = "primary",
   showMainAgent = true,
   onMoveEditorToOtherGroup,
+  onMoveEditor,
   onSplitActive,
   onCloseGroup,
-  onDragEditorStart,
-  onDragEditorEnd,
 }: {
   editorTabs: PanelContent[];
   editorActiveIndex: number;
@@ -119,12 +122,18 @@ export function CodeCenterTabs({
   region?: CenterTabRegion;
   showMainAgent?: boolean;
   onMoveEditorToOtherGroup?: (index: number) => void;
+  /**
+   * Reorder within this strip. Dragging does the same thing, so this is the
+   * path for anyone not using a pointer.
+   */
+  onMoveEditor?: (from: number, to: number) => void;
   onSplitActive?: () => void;
   onCloseGroup?: () => void;
-  onDragEditorStart?: (index: number) => void;
-  onDragEditorEnd?: () => void;
 }) {
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const { setNodeRef: setStripRef } = useDroppable({
+    id: editorStripDropId(region),
+  });
   const tabOffset = showMainAgent ? 1 : 0;
   const panelId =
     region === "primary" ? EDITOR_PANEL_ID : SPLIT_EDITOR_PANEL_ID;
@@ -162,6 +171,9 @@ export function CodeCenterTabs({
     <div
       className="workspace-pane-tabs flex h-11 shrink-0 items-center gap-1 overflow-x-auto border-b border-border-subtle bg-page-background/55 px-2"
       role="tablist"
+      // The strip takes drops on its own account, so releasing past the last
+      // tab still lands in this group instead of falling through to nothing.
+      ref={setStripRef}
       aria-label={region === "primary" ? "Workspace center" : "Workspace split"}
       data-region={region}
     >
@@ -205,152 +217,37 @@ export function CodeCenterTabs({
           </TabContextMenuContent>
         </ContextMenu>
       )}
-      {editorTabs.map((panel, index) => {
-        const active = !conversationFocused && index === editorActiveIndex;
-        const { name, suffix } = centerTabParts(panel, browserTitles);
-        const label = suffix ? `${name} ${suffix}` : name;
-        const path =
-          panel.type === "file" || panel.type === "diff"
-            ? panel.path
-            : undefined;
-        return (
-          <ContextMenu key={panelKey(panel)}>
-            <ContextMenuTrigger asChild>
-              {/* A tablist owns tabs. The close control is a second control on
-                  the same row, so this pair is transparent to assistive tech. */}
-              <div
-                role="presentation"
-                draggable
-                className={cn(
-                  "flex h-8 min-w-0 shrink-0 cursor-grab items-center rounded-lg pr-1 transition-[background-color,box-shadow,transform] duration-150 active:cursor-grabbing active:translate-y-px",
-                  HOVER_TINT,
-                  active
-                    ? "bg-background shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_7%,transparent),inset_0_0_0_1px_var(--border-subtle)]"
-                    : "hover:bg-background/65",
-                )}
-                onDragStart={(event: DragEvent<HTMLDivElement>) => {
-                  writeEditorTabDrag(event.dataTransfer, { region, index });
-                  onDragEditorStart?.(index);
-                }}
-                onDragEnd={onDragEditorEnd}
-              >
-                <button
-                  type="button"
-                  role="tab"
-                  id={editorTabId(region, index)}
-                  aria-label={label}
-                  aria-selected={active}
-                  aria-controls={panelId}
-                  tabIndex={active ? 0 : -1}
-                  ref={(node) => {
-                    tabRefs.current[index + tabOffset] = node;
-                  }}
-                  className={cn(
-                    "flex h-full min-w-0 cursor-pointer items-center gap-1.5 rounded-lg pr-1 pl-2.5 text-xs font-medium",
-                    FOCUS_RING_TIGHT,
-                    HOVER_TINT,
-                    active ? "text-foreground" : "text-muted-foreground",
-                  )}
-                  onClick={() => onSelectEditor(index)}
-                  onKeyDown={(event) =>
-                    onKeyDown(event, index + tabOffset)
-                  }
-                >
-                  {panel.type === "diff" ? (
-                    <FileDiff className="size-3.5 shrink-0" />
-                  ) : panel.type === "browser" ? (
-                    <Globe2 className="size-3.5 shrink-0" />
-                  ) : panel.type === "source_control" ? (
-                    <GitBranch className="size-3.5 shrink-0" />
-                  ) : panel.type === "pr" ? (
-                    <GitPullRequest className="size-3.5 shrink-0" />
-                  ) : (
-                    <FileCode className="size-3.5 shrink-0" />
-                  )}
-                  <span
-                    className="flex min-w-0 items-baseline gap-1"
-                    title={centerTabTitle(panel, browserTitles)}
-                  >
-                    <span className="max-w-40 truncate">{name}</span>
-                    {/* The suffix stays outside the truncating name. */}
-                    {suffix && <span className="shrink-0">{suffix}</span>}
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  className={cn(
-                    "text-muted-foreground hover:bg-muted hover:text-foreground grid size-5 shrink-0 cursor-pointer place-items-center rounded-md",
-                    FOCUS_RING_TIGHT,
-                    HOVER_TINT,
-                  )}
-                  onClick={() => onCloseEditor(index)}
-                >
-                  <X className="size-3" />
-                  <span className="sr-only">{`Close ${label}`}</span>
-                </button>
-              </div>
-            </ContextMenuTrigger>
-            <TabContextMenuContent label={label}>
-              {path && (
-                <>
-                  <ContextMenuItem
-                    className="gap-3 py-2"
-                    onSelect={() => onCopyPath(path)}
-                  >
-                    <Copy />
-                    Copy path
-                  </ContextMenuItem>
-                  <ContextMenuSeparator />
-                </>
-              )}
-              {onMoveEditorToOtherGroup && (
-                <>
-                  <ContextMenuItem
-                    className="gap-3 py-2"
-                    onSelect={() => onMoveEditorToOtherGroup(index)}
-                  >
-                    {region === "primary" ? <MoveRight /> : <MoveLeft />}
-                    {region === "primary"
-                      ? "Move to split right"
-                      : "Move to main group"}
-                  </ContextMenuItem>
-                  <ContextMenuSeparator />
-                </>
-              )}
-              <ContextMenuItem
-                className="gap-3 py-2"
-                onSelect={() => onCloseEditor(index)}
-              >
-                <X />
-                Close tab
-              </ContextMenuItem>
-              <ContextMenuItem
-                className="gap-3 py-2"
-                disabled={editorTabs.length <= 1}
-                onSelect={() => onCloseOtherEditors(index)}
-              >
-                <ListX />
-                Close other tabs
-              </ContextMenuItem>
-              <ContextMenuItem
-                className="gap-3 py-2"
-                disabled={index === editorTabs.length - 1}
-                onSelect={() => onCloseEditorsToRight(index)}
-              >
-                <ArrowRightFromLine />
-                Close tabs to the right
-              </ContextMenuItem>
-              <ContextMenuItem
-                className="gap-3 py-2"
-                onSelect={onCloseAllEditors}
-              >
-                <CircleX />
-                Close all tabs
-              </ContextMenuItem>
-            </TabContextMenuContent>
-          </ContextMenu>
-        );
-      })}
+      <SortableContext
+        items={editorTabs.map((panel) => editorTabDragId(region, panel))}
+        strategy={horizontalListSortingStrategy}
+      >
+        {editorTabs.map((panel, index) => (
+          <EditorTab
+            key={panelKey(panel)}
+            panel={panel}
+            index={index}
+            region={region}
+            panelId={panelId}
+            active={!conversationFocused && index === editorActiveIndex}
+            tabCount={editorTabs.length}
+            browserTitles={browserTitles}
+            tabRef={(node) => {
+              tabRefs.current[index + tabOffset] = node;
+            }}
+            onSelect={() => onSelectEditor(index)}
+            onKeyDown={(event) => onKeyDown(event, index + tabOffset)}
+            onClose={() => onCloseEditor(index)}
+            onCloseOthers={() => onCloseOtherEditors(index)}
+            onCloseToRight={() => onCloseEditorsToRight(index)}
+            onCloseAll={onCloseAllEditors}
+            onCopyPath={onCopyPath}
+            onMoveToOtherGroup={
+              onMoveEditorToOtherGroup && (() => onMoveEditorToOtherGroup(index))
+            }
+            onMove={onMoveEditor && ((to: number) => onMoveEditor(index, to))}
+          />
+        ))}
+      </SortableContext>
       {/* One + for everything the center can open. A bare click must say
           what it will do, so the button offers the choices instead of
           jumping into the file picker. */}
@@ -438,6 +335,209 @@ export function CodeCenterTabs({
   );
 }
 
+/**
+ * One draggable tab.
+ *
+ * Its own component because `useSortable` is a hook, and the strip renders a
+ * list. The sortable id is the tab's panel key rather than its position, so a
+ * tab keeps its identity while the ones around it shuffle underneath it.
+ */
+function EditorTab({
+  panel,
+  index,
+  region,
+  panelId,
+  active,
+  tabCount,
+  browserTitles,
+  tabRef,
+  onSelect,
+  onKeyDown: onTabKeyDown,
+  onClose,
+  onCloseOthers,
+  onCloseToRight,
+  onCloseAll,
+  onCopyPath,
+  onMoveToOtherGroup,
+  onMove,
+}: {
+  panel: PanelContent;
+  index: number;
+  region: CenterTabRegion;
+  panelId: string;
+  active: boolean;
+  tabCount: number;
+  browserTitles: Readonly<Record<string, string>>;
+  tabRef: (node: HTMLButtonElement | null) => void;
+  onSelect: () => void;
+  onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
+  onClose: () => void;
+  onCloseOthers: () => void;
+  onCloseToRight: () => void;
+  onCloseAll: () => void;
+  onCopyPath: (path: string) => void;
+  onMoveToOtherGroup?: (() => void) | undefined;
+  onMove?: ((to: number) => void) | undefined;
+}) {
+  const { name, suffix } = centerTabParts(panel, browserTitles);
+  const label = suffix ? `${name} ${suffix}` : name;
+  const path =
+    panel.type === "file" || panel.type === "diff" ? panel.path : undefined;
+  // `attributes` is left off on purpose: it turns its element into a focusable
+  // button, and this wrapper is presentational — the tab inside it is what the
+  // reader focuses. Reordering by keyboard would collide with the tablist's own
+  // arrow keys, so the context menu carries that job instead.
+  const { listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: editorTabDragId(region, panel) });
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        {/* A tablist owns tabs. The close control is a second control on
+            the same row, so this pair is transparent to assistive tech. */}
+        <div
+          role="presentation"
+          ref={setNodeRef}
+          style={{ transform: CSS.Translate.toString(transform), transition }}
+          className={cn(
+            "flex h-8 min-w-0 shrink-0 touch-none cursor-grab items-center rounded-lg pr-1 transition-[background-color,box-shadow,transform] duration-150 active:cursor-grabbing active:translate-y-px",
+            HOVER_TINT,
+            active
+              ? "bg-background shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_7%,transparent),inset_0_0_0_1px_var(--border-subtle)]"
+              : "hover:bg-background/65",
+            // The overlay draws the tab that is moving, so the original stays
+            // in place as a gap rather than a second copy of itself.
+            isDragging && "opacity-40",
+          )}
+          {...listeners}
+        >
+          <button
+            type="button"
+            role="tab"
+            id={editorTabId(region, index)}
+            aria-label={label}
+            aria-selected={active}
+            aria-controls={panelId}
+            tabIndex={active ? 0 : -1}
+            ref={tabRef}
+            className={cn(
+              "flex h-full min-w-0 cursor-pointer items-center gap-1.5 rounded-lg pr-1 pl-2.5 text-xs font-medium",
+              FOCUS_RING_TIGHT,
+              HOVER_TINT,
+              active ? "text-foreground" : "text-muted-foreground",
+            )}
+            onClick={onSelect}
+            onKeyDown={onTabKeyDown}
+          >
+            <CenterTabIcon panel={panel} />
+            <span
+              className="flex min-w-0 items-baseline gap-1"
+              title={centerTabTitle(panel, browserTitles)}
+            >
+              <span className="max-w-40 truncate">{name}</span>
+              {/* The suffix stays outside the truncating name. */}
+              {suffix && <span className="shrink-0">{suffix}</span>}
+            </span>
+          </button>
+          <button
+            type="button"
+            // Pressing close and drifting a few pixels should still close the
+            // tab, not carry it somewhere. The sensor reads this flag.
+            data-no-drag="true"
+            className={cn(
+              "text-muted-foreground hover:bg-muted hover:text-foreground grid size-5 shrink-0 cursor-pointer place-items-center rounded-md",
+              FOCUS_RING_TIGHT,
+              HOVER_TINT,
+            )}
+            onClick={onClose}
+          >
+            <X className="size-3" />
+            <span className="sr-only">{`Close ${label}`}</span>
+          </button>
+        </div>
+      </ContextMenuTrigger>
+      <TabContextMenuContent label={label}>
+        {path && (
+          <>
+            <ContextMenuItem className="gap-3 py-2" onSelect={() => onCopyPath(path)}>
+              <Copy />
+              Copy path
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        )}
+        {onMove && (
+          <>
+            <ContextMenuItem
+              className="gap-3 py-2"
+              disabled={index === 0}
+              onSelect={() => onMove(index - 1)}
+            >
+              <ChevronLeft />
+              Move left
+            </ContextMenuItem>
+            <ContextMenuItem
+              className="gap-3 py-2"
+              disabled={index === tabCount - 1}
+              onSelect={() => onMove(index + 1)}
+            >
+              <ChevronRight />
+              Move right
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        )}
+        {onMoveToOtherGroup && (
+          <>
+            <ContextMenuItem className="gap-3 py-2" onSelect={onMoveToOtherGroup}>
+              {region === "primary" ? <MoveRight /> : <MoveLeft />}
+              {region === "primary" ? "Move to split right" : "Move to main group"}
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        )}
+        <ContextMenuItem className="gap-3 py-2" onSelect={onClose}>
+          <X />
+          Close tab
+        </ContextMenuItem>
+        <ContextMenuItem
+          className="gap-3 py-2"
+          disabled={tabCount <= 1}
+          onSelect={onCloseOthers}
+        >
+          <ListX />
+          Close other tabs
+        </ContextMenuItem>
+        <ContextMenuItem
+          className="gap-3 py-2"
+          disabled={index === tabCount - 1}
+          onSelect={onCloseToRight}
+        >
+          <ArrowRightFromLine />
+          Close tabs to the right
+        </ContextMenuItem>
+        <ContextMenuItem className="gap-3 py-2" onSelect={onCloseAll}>
+          <CircleX />
+          Close all tabs
+        </ContextMenuItem>
+      </TabContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+/** The mark that says what kind of thing a tab holds. */
+export function CenterTabIcon({ panel }: { panel: PanelContent }) {
+  if (panel.type === "diff") return <FileDiff className="size-3.5 shrink-0" />;
+  if (panel.type === "browser") return <Globe2 className="size-3.5 shrink-0" />;
+  if (panel.type === "source_control") {
+    return <GitBranch className="size-3.5 shrink-0" />;
+  }
+  if (panel.type === "pr") {
+    return <GitPullRequest className="size-3.5 shrink-0" />;
+  }
+  return <FileCode className="size-3.5 shrink-0" />;
+}
+
 function TabContextMenuContent({
   label,
   children,
@@ -468,7 +568,7 @@ function centerTabTitle(
  * A tab's label, split into the part that may truncate and the part that may
  * not.
  */
-function centerTabParts(
+export function centerTabParts(
   panel: PanelContent,
   browserTitles: Readonly<Record<string, string>>,
 ): {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -33,7 +33,6 @@ import { resetCodeSessionRegistry } from "./CodeSessionRegistry";
 import { useCodeUiStore } from "./CodeUiStore";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeWorkspacePage } from "./CodeWorkspacePage";
-import { CODE_EDITOR_DRAG_TYPE } from "./editorDrag";
 import {
   readStoredBrowserSession,
   seedBrowserSession,
@@ -404,6 +403,30 @@ function appContext(client: ReturnType<typeof makeClient>): AppContextValue {
     }),
     restartForUpdate: async () => {},
   };
+}
+
+/**
+ * Press `element` and drag it `distance` pixels to the right.
+ *
+ * Pointer events, deliberately: dnd-kit's sensor listens for them and never
+ * touches the native drag path, so this is the same sequence the webview
+ * delivers. The move has to clear the sensor's 4px activation distance, and it
+ * goes to the document because that is where the sensor listens once a press
+ * has started.
+ */
+function dragBy(element: Element, distance: number) {
+  fireEvent.pointerDown(element, {
+    isPrimary: true,
+    button: 0,
+    pointerId: 1,
+    clientX: 0,
+    clientY: 0,
+  });
+  fireEvent.pointerMove(document, {
+    pointerId: 1,
+    clientX: distance,
+    clientY: 0,
+  });
 }
 
 /**
@@ -1452,7 +1475,7 @@ describe("CodeWorkspacePage", () => {
     expect(browserMocks.close).toHaveBeenCalledExactlyOnceWith("browser-1");
   });
 
-  it("moves and drags file tabs into a reloadable split group from the transfer payload", async () => {
+  it("moves file tabs into a reloadable split group and back", async () => {
     const client = makeClient();
     const user = userEvent.setup();
     const { router } = await mountWorkspace(
@@ -1489,38 +1512,75 @@ describe("CodeWorkspacePage", () => {
       screen.queryByRole("tablist", { name: "Workspace split" }),
     ).not.toBeInTheDocument();
 
-    const libTab = screen.getByRole("tab", { name: "lib.rs" });
-    const dragPayload = new Map<string, string>();
-    const dataTransfer = {
-      effectAllowed: "none",
-      dropEffect: "none",
-      types: [] as string[],
-      setData: vi.fn((type: string, value: string) => {
-        dragPayload.set(type, value);
-        if (!dataTransfer.types.includes(type)) dataTransfer.types.push(type);
-      }),
-      getData: vi.fn((type: string) => dragPayload.get(type) ?? ""),
-    };
-    fireEvent.dragStart(libTab, { dataTransfer });
-    // The preview state still says lib.rs. The durable transfer payload now
-    // says main.rs, proving the drop resolves the actual drag data instead of
-    // trusting the source component's transient React state.
-    dataTransfer.setData(
-      CODE_EDITOR_DRAG_TYPE,
-      JSON.stringify({ region: "primary", index: 1 }),
-    );
-    const dropZone = await screen.findByTestId("split-drop-zone");
-    fireEvent.dragOver(dropZone, { dataTransfer });
-    fireEvent.drop(dropZone, { dataTransfer });
-
-    expect(
-      await screen.findByRole("tablist", { name: "Workspace split" }),
-    ).toBeInTheDocument();
+    // The split zone belongs to a drag, so it is not on screen without one.
+    expect(screen.queryByTestId("split-drop-zone")).not.toBeInTheDocument();
     await waitFor(() =>
       expect(router.state.location.search).toMatchObject({
-        split: "file.src%2Fmain.rs",
+        tabs: "file.src%2Flib.rs,file.src%2Fmain.rs",
       }),
     );
+  });
+
+  it("reorders a tab from its context menu, without a pointer drag", async () => {
+    const client = makeClient();
+    const user = userEvent.setup();
+    const { router } = await mountWorkspace(
+      client,
+      "/code/w/ws-1?tabs=file.src%252Flib.rs,file.src%252Fmain.rs&active=file.src%252Fmain.rs",
+    );
+
+    // Dragging reorders too, but a pointer is the only way to reach it. This
+    // menu is the same move for anyone on a keyboard, which is why the tab
+    // wrapper stays out of the tab order rather than becoming a second stop.
+    const libTab = await screen.findByRole("tab", { name: "lib.rs" });
+    fireEvent.contextMenu(libTab);
+    await user.click(await screen.findByRole("menuitem", { name: "Move right" }));
+
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        tabs: "file.src%2Fmain.rs,file.src%2Flib.rs",
+      }),
+    );
+  });
+
+  // The reported bug was that a drag never started: the strip was the only
+  // HTML5 drag source in the app, and WebKit would not begin an ancestor's
+  // drag from the inner `<button role="tab">` the reader actually presses.
+  // These two cover that gesture from the pointer down. Where it lands is a
+  // separate question, and the pure rules in `editorDrag` answer it: dnd-kit
+  // resolves a target from element rects, and jsdom reports every rect as
+  // zero, so asserting a drop here would prove nothing.
+  it("starts a tab drag from a pointer press on the tab itself", async () => {
+    const client = makeClient();
+    await mountWorkspace(
+      client,
+      "/code/w/ws-1?tabs=file.src%252Flib.rs,file.src%252Fmain.rs&active=file.src%252Fmain.rs",
+    );
+
+    const mainTab = await screen.findByRole("tab", { name: "main.rs" });
+    expect(screen.queryByTestId("split-drop-zone")).not.toBeInTheDocument();
+
+    dragBy(mainTab, 40);
+
+    // The zone renders only while a drag is live, so its presence is the drag.
+    expect(await screen.findByTestId("split-drop-zone")).toBeInTheDocument();
+  });
+
+  it("does not start a tab drag from a press on the close control", async () => {
+    const client = makeClient();
+    await mountWorkspace(
+      client,
+      "/code/w/ws-1?tabs=file.src%252Flib.rs,file.src%252Fmain.rs&active=file.src%252Fmain.rs",
+    );
+
+    await screen.findByRole("tab", { name: "main.rs" });
+    const close = screen.getByRole("button", { name: "Close main.rs" });
+
+    dragBy(close, 40);
+
+    // A press that drifts a few pixels should still close the tab rather than
+    // carry it somewhere, which is what the sensor's opt-out marker buys.
+    expect(screen.queryByTestId("split-drop-zone")).not.toBeInTheDocument();
   });
 
   it("keeps the jump-to-latest pill out of the tab order until it is on screen", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1,4 +1,17 @@
 import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCenter,
+  pointerWithin,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+  type PointerSensorOptions,
+} from "@dnd-kit/core";
+import {
   lazy,
   Suspense,
   useCallback,
@@ -6,6 +19,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
 import { ArrowDown, Bot, CircleDotDashed } from "lucide-react";
@@ -68,12 +82,15 @@ import {
   moveEditorTab,
   openCodeEditor,
   removedCodeBrowserIds,
+  reorderEditorTab,
   splitCodeChromeLayout,
   openTerminalLayout,
   toggleTerminalLayout,
 } from "./codeChrome";
 import {
   centerEditorTabId,
+  centerTabParts,
+  CenterTabIcon,
   CHAT_PANEL_ID,
   CHAT_TAB_ID,
   CodeCenterTabs,
@@ -117,9 +134,11 @@ import {
   type CodeTranscriptItem,
 } from "./CodeSessionReducer";
 import {
-  hasEditorTabDrag,
-  readEditorTabDrag,
-  type EditorTabDrag,
+  dropEditorTab,
+  findEditorPanel,
+  isEditorStripDropId,
+  offersSplitDrop,
+  EDITOR_SPLIT_DROP_ID,
 } from "./editorDrag";
 import { FOCUS_RING } from "./interactive";
 import { StartSessionPrompt } from "./StartSessionPrompt";
@@ -205,10 +224,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     tab: InspectorTab;
     revision: number;
   } | null>(null);
-  const [draggedEditor, setDraggedEditor] = useState<{
-    region: CodeEditorRegion;
-    index: number;
-  } | null>(null);
+  const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
+  const tabDragSensors = useSensors(
+    // Four pixels of travel before a press becomes a drag, so a click still
+    // selects the tab it landed on.
+    useSensor(TabPointerSensor, { activationConstraint: { distance: 4 } }),
+  );
   const [starting, setStarting] = useState(false);
   const [createMode, setCreateMode] = useState<CodePermissionMode | null>(null);
   const [fileReveal, setFileReveal] = useState<{
@@ -479,21 +500,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     );
   }, []);
 
-  function dropDraggedEditor(
-    region: CodeEditorRegion,
-    transfer?: Pick<DataTransfer, "getData">,
-  ): boolean {
-    const drag: EditorTabDrag | null = transfer
-      ? readEditorTabDrag(transfer)
-      : draggedEditor;
-    if (!drag) return false;
-    setDraggedEditor(null);
-    if (drag.region !== region) {
-      setWorkspaceLayout(
-        moveEditorTab(layout, drag.region, drag.index, region),
-      );
-    }
-    return true;
+  function finishTabDrag(event: DragEndEvent) {
+    setDraggedTabId(null);
+    const next = dropEditorTab(
+      layout,
+      String(event.active.id),
+      event.over ? String(event.over.id) : null,
+    );
+    if (next) setWorkspaceLayout(next);
   }
 
   function copyEditorPath(path: string) {
@@ -597,16 +611,6 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     <div
       className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
       data-testid="primary-editor-group"
-      onDragOver={(event) => {
-        if (!draggedEditor && !hasEditorTabDrag(event.dataTransfer)) return;
-        event.preventDefault();
-        event.dataTransfer.dropEffect = "move";
-      }}
-      onDrop={(event) => {
-        if (dropDraggedEditor("primary", event.dataTransfer)) {
-          event.preventDefault();
-        }
-      }}
     >
       <CodeCenterTabs
         editorTabs={editorTabs}
@@ -648,6 +652,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onMoveEditorToOtherGroup={(index) =>
           setWorkspaceLayout(moveEditorTab(layout, "primary", index, "secondary"))
         }
+        onMoveEditor={(from, to) =>
+          setWorkspaceLayout(reorderEditorTab(layout, "primary", from, to))
+        }
         onSplitActive={() =>
           setWorkspaceLayout(
             moveEditorTab(
@@ -658,10 +665,6 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             ),
           )
         }
-        onDragEditorStart={(index) =>
-          setDraggedEditor({ region: "primary", index })
-        }
-        onDragEditorEnd={() => setDraggedEditor(null)}
       />
       <div
         className={cn("min-h-0 flex-1", !showingChat && "hidden")}
@@ -753,16 +756,6 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     <div
       className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
       data-testid="secondary-editor-group"
-      onDragOver={(event) => {
-        if (!draggedEditor && !hasEditorTabDrag(event.dataTransfer)) return;
-        event.preventDefault();
-        event.dataTransfer.dropEffect = "move";
-      }}
-      onDrop={(event) => {
-        if (dropDraggedEditor("secondary", event.dataTransfer)) {
-          event.preventDefault();
-        }
-      }}
     >
       <CodeCenterTabs
         region="secondary"
@@ -807,11 +800,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onMoveEditorToOtherGroup={(index) =>
           setWorkspaceLayout(moveEditorTab(layout, "secondary", index, "primary"))
         }
-        onCloseGroup={() => setWorkspaceLayout(mergeEditorSplit(layout))}
-        onDragEditorStart={(index) =>
-          setDraggedEditor({ region: "secondary", index })
+        onMoveEditor={(from, to) =>
+          setWorkspaceLayout(reorderEditorTab(layout, "secondary", from, to))
         }
-        onDragEditorEnd={() => setDraggedEditor(null)}
+        onCloseGroup={() => setWorkspaceLayout(mergeEditorSplit(layout))}
       />
       {editorPanel(
         activeSplitEditor,
@@ -821,53 +813,51 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     </div>
   ) : null;
 
+  const draggedPanel = draggedTabId
+    ? findEditorPanel(layout, draggedTabId)
+    : null;
+
   const workspaceMain = (
     <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
-        {hasEditorSplit ? (
-          <ResizablePanelGroup
-            direction="horizontal"
-            className="h-full min-h-0"
-          >
-            <ResizablePanel defaultSize={55} minSize={25} className="min-w-0">
-              {primaryEditorGroup}
-            </ResizablePanel>
-            <ResizableHandle />
-            <ResizablePanel defaultSize={45} minSize={25} className="min-w-0">
-              {splitEditorGroup}
-            </ResizablePanel>
-          </ResizablePanelGroup>
-        ) : (
-          primaryEditorGroup
-        )}
-        {draggedEditor?.region === "primary" && !hasEditorSplit && (
-          <div
-            data-testid="split-drop-zone"
-            className="workspace-split-drop-zone absolute inset-y-3 right-3 z-10 flex w-[min(40%,22rem)] flex-col items-center justify-center gap-2 rounded-xl border border-border bg-background/92 px-6 text-center shadow-lg backdrop-blur-md"
-            onDragOver={(event) => {
-              if (!draggedEditor && !hasEditorTabDrag(event.dataTransfer)) return;
-              event.preventDefault();
-              event.dataTransfer.dropEffect = "move";
-            }}
-            onDrop={(event) => {
-              if (dropDraggedEditor("secondary", event.dataTransfer)) {
-                event.preventDefault();
-              }
-            }}
-          >
-            <span className="grid size-9 place-items-center rounded-lg bg-muted text-foreground">
-              <span className="grid grid-cols-2 gap-0.5" aria-hidden>
-                <span className="h-4 w-2 rounded-[2px] bg-foreground/25" />
-                <span className="h-4 w-2 rounded-[2px] bg-foreground" />
-              </span>
+      <DndContext
+        sensors={tabDragSensors}
+        collisionDetection={tabDropTarget}
+        onDragStart={(event) => setDraggedTabId(String(event.active.id))}
+        onDragCancel={() => setDraggedTabId(null)}
+        onDragEnd={finishTabDrag}
+      >
+        <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
+          {hasEditorSplit ? (
+            <ResizablePanelGroup
+              direction="horizontal"
+              className="h-full min-h-0"
+            >
+              <ResizablePanel defaultSize={55} minSize={25} className="min-w-0">
+                {primaryEditorGroup}
+              </ResizablePanel>
+              <ResizableHandle />
+              <ResizablePanel defaultSize={45} minSize={25} className="min-w-0">
+                {splitEditorGroup}
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          ) : (
+            primaryEditorGroup
+          )}
+          {draggedTabId && offersSplitDrop(layout, draggedTabId) && (
+            <SplitDropZone />
+          )}
+        </div>
+        {/* The strip scrolls, so a transformed child would be clipped by it.
+            The overlay draws the moving tab above everything instead. */}
+        <DragOverlay dropAnimation={null}>
+          {draggedPanel ? (
+            <span className="flex h-8 items-center gap-1.5 rounded-lg bg-background px-2.5 text-xs font-medium text-foreground shadow-lg">
+              <CenterTabIcon panel={draggedPanel} />
+              {centerTabParts(draggedPanel, browserTitles).name}
             </span>
-            <span className="text-sm font-semibold">Open beside the agent</span>
-            <span className="max-w-44 text-xs leading-relaxed text-muted-foreground">
-              Drop here to create a working pane on the right.
-            </span>
-          </div>
-        )}
-      </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
       {chrome.terminal && (
         <TerminalDrawer
           client={client}
@@ -1017,6 +1007,74 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         </div>
       )}
     </>
+  );
+}
+
+/**
+ * The pointer sensor, minus the controls that live inside a tab.
+ *
+ * A tab's close button sits within the draggable, so without this a press that
+ * drifts a few pixels would pick the tab up rather than close it. A control
+ * opts itself out by carrying the marker attribute.
+ */
+class TabPointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: "onPointerDown" as const,
+      handler: (
+        { nativeEvent: event }: ReactPointerEvent,
+        { onActivation }: PointerSensorOptions,
+      ) => {
+        if (!event.isPrimary || event.button !== 0) return false;
+        const target = event.target;
+        if (!(target instanceof Element)) return true;
+        if (target.closest('[data-no-drag="true"]')) return false;
+        onActivation?.({ event });
+        return true;
+      },
+    },
+  ];
+}
+
+/**
+ * The drop target under the pointer, with the nearest one as a fallback.
+ *
+ * A strip contains its tabs and overlaps the split zone, so it collides on
+ * every drop that lands on either. Dropping it whenever something more specific
+ * was hit is what makes a tab a reorder and the strip's open space an append.
+ * The nearest-center fallback covers the frames where a fast drag has the
+ * pointer outside every registered box.
+ */
+const tabDropTarget: CollisionDetection = (args) => {
+  const under = pointerWithin(args);
+  const collisions = under.length > 0 ? under : closestCenter(args);
+  const specific = collisions.filter(
+    (collision) => !isEditorStripDropId(String(collision.id)),
+  );
+  return specific.length > 0 ? specific : collisions;
+};
+
+/** The mid-drag target that offers to open the tab beside the conversation. */
+function SplitDropZone() {
+  const { isOver, setNodeRef } = useDroppable({ id: EDITOR_SPLIT_DROP_ID });
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid="split-drop-zone"
+      data-over={isOver ? "true" : undefined}
+      className="workspace-split-drop-zone absolute inset-y-3 right-3 z-10 flex w-[min(40%,22rem)] flex-col items-center justify-center gap-2 rounded-xl border border-border bg-background/92 px-6 text-center shadow-lg backdrop-blur-md data-[over=true]:border-ring data-[over=true]:bg-accent/60"
+    >
+      <span className="grid size-9 place-items-center rounded-lg bg-muted text-foreground">
+        <span className="grid grid-cols-2 gap-0.5" aria-hidden>
+          <span className="h-4 w-2 rounded-[2px] bg-foreground/25" />
+          <span className="h-4 w-2 rounded-[2px] bg-foreground" />
+        </span>
+      </span>
+      <span className="text-sm font-semibold">Open beside the agent</span>
+      <span className="max-w-44 text-xs leading-relaxed text-muted-foreground">
+        Drop here to create a working pane on the right.
+      </span>
+    </div>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codeChrome.ts
@@ -366,6 +366,75 @@ export function openCodeEditor(
   );
 }
 
+/**
+ * Reorder one group's tabs, keeping whatever was active active.
+ *
+ * Positions count editor tabs only, because that is what the strip draws. The
+ * terminal lives in the same array but renders as a drawer, so it holds its
+ * slot while the tabs around it shuffle — otherwise dragging a tab past it
+ * would move the drawer.
+ */
+export function reorderEditorTab(
+  layout: LayoutState,
+  region: CodeEditorRegion,
+  from: number,
+  to: number,
+): LayoutState {
+  if (from === to) return layout;
+
+  if (region === "secondary") {
+    const split = layout.editorSplit;
+    if (!split) return layout;
+    const tabs = moveWithin(split.tabs, from, to);
+    if (!tabs) return layout;
+    const active = split.tabs[split.activeIndex];
+    return {
+      ...layout,
+      editorSplit: { ...split, tabs, activeIndex: keyIndex(tabs, active) },
+    };
+  }
+
+  const moved = moveWithin(layout.tabs.filter(isEditorTab), from, to);
+  if (!moved) return layout;
+  const active = layout.tabs[layout.activeIndex];
+  let next = 0;
+  const tabs = layout.tabs.map((tab) =>
+    isEditorTab(tab) ? (moved[next++] ?? tab) : tab,
+  );
+  return { ...layout, tabs, activeIndex: keyIndex(tabs, active) };
+}
+
+/**
+ * The list with one item lifted out and put back at `to`.
+ *
+ * Null when either position is off the end, which is how a drop onto something
+ * that is no longer there reports itself.
+ */
+function moveWithin<T>(
+  items: readonly T[],
+  from: number,
+  to: number,
+): T[] | null {
+  if (from < 0 || from >= items.length) return null;
+  if (to < 0 || to >= items.length) return null;
+  const next = [...items];
+  const [item] = next.splice(from, 1);
+  if (item === undefined) return null;
+  next.splice(to, 0, item);
+  return next;
+}
+
+/** Where a tab ended up after the shuffle; 0 if there is nothing to follow. */
+function keyIndex(
+  tabs: readonly PanelContent[],
+  tab: PanelContent | undefined,
+): number {
+  if (!tab) return 0;
+  const key = panelKey(tab);
+  const at = tabs.findIndex((candidate) => panelKey(candidate) === key);
+  return at < 0 ? 0 : at;
+}
+
 /** Move an existing file/diff tab between the two visible editor groups. */
 export function moveEditorTab(
   layout: LayoutState,

--- a/crates/tidebreak-desktop/ui/src/code/editorDrag.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/editorDrag.test.ts
@@ -1,91 +1,116 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+
+import type { LayoutState, PanelContent } from "@/panel/panelTypes";
 
 import {
-  CODE_EDITOR_DRAG_TYPE,
-  hasEditorTabDrag,
-  readEditorTabDrag,
-  writeEditorTabDrag,
+  dropEditorTab,
+  editorStripDropId,
+  editorTabDragId,
+  findEditorPanel,
+  offersSplitDrop,
+  EDITOR_SPLIT_DROP_ID,
 } from "./editorDrag";
 
-function transfer() {
-  const data = new Map<string, string>();
-  const value = {
-    effectAllowed: "none",
-    types: [] as string[],
-    setData: vi.fn((type: string, payload: string) => {
-      data.set(type, payload);
-      if (!value.types.includes(type)) value.types.push(type);
-    }),
-    getData: vi.fn((type: string) => data.get(type) ?? ""),
+const lib: PanelContent = { type: "file", path: "src/lib.rs" };
+const main: PanelContent = { type: "file", path: "src/main.rs" };
+const diff: PanelContent = { type: "diff", path: "src/main.rs" };
+
+/** A left group holding three tabs, with the terminal drawer among them. */
+function layout(overrides: Partial<LayoutState> = {}): LayoutState {
+  return {
+    tabs: [lib, { type: "terminal" }, main, diff],
+    activeIndex: 0,
+    fullscreen: false,
+    ...overrides,
   };
-  return value;
 }
 
-describe("editor tab drag payload", () => {
-  it("round-trips the tab through the private transfer type", () => {
-    const data = transfer();
+const tabId = (region: "primary" | "secondary", panel: PanelContent) =>
+  editorTabDragId(region, panel);
 
-    writeEditorTabDrag(data as unknown as DataTransfer, {
-      region: "primary",
-      index: 2,
-    });
-
-    expect(data.effectAllowed).toBe("move");
-    expect(data.setData).toHaveBeenCalledWith(
-      CODE_EDITOR_DRAG_TYPE,
-      JSON.stringify({ region: "primary", index: 2 }),
+describe("editor tab drops", () => {
+  it("reorders within a group without moving the terminal", () => {
+    const next = dropEditorTab(
+      layout(),
+      tabId("primary", lib),
+      tabId("primary", diff),
     );
-    expect(hasEditorTabDrag(data as unknown as DataTransfer)).toBe(true);
-    expect(readEditorTabDrag(data)).toEqual({ region: "primary", index: 2 });
+
+    // The drawer holds its slot while the tabs around it shuffle.
+    expect(next?.tabs).toEqual([main, { type: "terminal" }, diff, lib]);
+    // And the tab that was active still is, wherever it ended up.
+    expect(next?.activeIndex).toBe(3);
   });
 
-  it("accepts the plain-text compatibility payload", () => {
+  it("appends when the drop lands on the strip's open space", () => {
+    const next = dropEditorTab(
+      layout(),
+      tabId("primary", lib),
+      editorStripDropId("primary"),
+    );
+
+    expect(next?.tabs).toEqual([main, { type: "terminal" }, diff, lib]);
+  });
+
+  it("creates the split from the zone, and reads back across it", () => {
+    const split = dropEditorTab(
+      layout(),
+      tabId("primary", diff),
+      EDITOR_SPLIT_DROP_ID,
+    );
+    expect(split?.editorSplit?.tabs).toEqual([diff]);
+    expect(split?.tabs).toEqual([lib, { type: "terminal" }, main]);
+
+    // Dropping it on the left strip sends it home again.
+    const back = dropEditorTab(
+      split!,
+      tabId("secondary", diff),
+      editorStripDropId("primary"),
+    );
+    expect(back?.editorSplit?.tabs ?? []).toEqual([]);
+    expect(back?.tabs).toContainEqual(diff);
+  });
+
+  it("reports every no-op drag as null", () => {
+    const state = layout();
+    // Released over open air, and dropped back onto itself.
+    expect(dropEditorTab(state, tabId("primary", lib), null)).toBeNull();
     expect(
-      readEditorTabDrag({
-        getData: (type) =>
-          type === "text/plain"
-            ? "tidebreak-editor-tab:secondary:4"
-            : "",
-      }),
-    ).toEqual({ region: "secondary", index: 4 });
-  });
-
-  it("keeps the text fallback when a webview rejects custom MIME data", () => {
-    const data = new Map<string, string>();
-    const value = {
-      effectAllowed: "none",
-      types: [] as string[],
-      setData: vi.fn((type: string, payload: string) => {
-        if (type === CODE_EDITOR_DRAG_TYPE) throw new Error("unsupported type");
-        data.set(type, payload);
-        value.types.push(type);
-      }),
-      getData: vi.fn((type: string) => data.get(type) ?? ""),
-    };
-
-    expect(() =>
-      writeEditorTabDrag(value as unknown as DataTransfer, {
-        region: "primary",
-        index: 3,
-      }),
-    ).not.toThrow();
-    expect(hasEditorTabDrag(value as unknown as DataTransfer)).toBe(true);
-    expect(readEditorTabDrag(value)).toEqual({ region: "primary", index: 3 });
-  });
-
-  it("rejects malformed and negative indexes", () => {
-    expect(
-      readEditorTabDrag({
-        getData: (type) =>
-          type === CODE_EDITOR_DRAG_TYPE
-            ? JSON.stringify({ region: "primary", index: -1 })
-            : "not-a-tab",
-      }),
+      dropEditorTab(state, tabId("primary", lib), tabId("primary", lib)),
     ).toBeNull();
+    // Aimed at a tab that closed underneath the drag.
     expect(
-      readEditorTabDrag({
-        getData: (type) => (type === "text/plain" ? "primary:1" : ""),
-      }),
+      dropEditorTab(state, tabId("primary", lib), tabId("primary", {
+        type: "file",
+        path: "src/gone.rs",
+      })),
     ).toBeNull();
+    // Dragging something that is not one of ours, onto something that is not
+    // one of our targets.
+    expect(dropEditorTab(state, "sidebar-item", "trash")).toBeNull();
+    // The split zone only ever takes a left-group tab.
+    expect(
+      dropEditorTab(state, tabId("secondary", lib), EDITOR_SPLIT_DROP_ID),
+    ).toBeNull();
+  });
+
+  it("offers the split zone only while there is a split to create", () => {
+    const state = layout();
+    expect(offersSplitDrop(state, tabId("primary", lib))).toBe(true);
+    expect(offersSplitDrop(state, tabId("secondary", lib))).toBe(false);
+
+    const split = dropEditorTab(
+      state,
+      tabId("primary", diff),
+      EDITOR_SPLIT_DROP_ID,
+    );
+    expect(offersSplitDrop(split!, tabId("primary", lib))).toBe(false);
+  });
+
+  it("finds the panel the overlay draws, and only while it exists", () => {
+    const state = layout();
+    expect(findEditorPanel(state, tabId("primary", main))).toEqual(main);
+    expect(findEditorPanel(state, tabId("secondary", main))).toBeNull();
+    expect(findEditorPanel(state, editorStripDropId("primary"))).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/editorDrag.ts
+++ b/crates/tidebreak-desktop/ui/src/code/editorDrag.ts
@@ -1,88 +1,162 @@
-import type { CodeEditorRegion } from "./codeChrome";
+import {
+  panelKey,
+  type LayoutState,
+  type PanelContent,
+} from "@/panel/panelTypes";
+
+import {
+  isEditorTab,
+  moveEditorTab,
+  reorderEditorTab,
+  splitCodeChromeLayout,
+  type CodeEditorRegion,
+} from "./codeChrome";
 
 /**
- * Private drag type for editor tabs.
+ * Identity and drop rules for dragging editor tabs.
  *
- * The previous split implementation only remembered the tab in React state.
- * A drop that arrived after that state had cleared looked exactly like an
- * unrelated drop and silently did nothing. The transfer itself is now the
- * source of truth; component state is only used to draw the preview.
+ * dnd-kit addresses everything by a single string id, so the ids are the whole
+ * protocol: one per tab, one per strip, and one for the split zone. A tab's id
+ * carries its region and its panel key rather than its position, because a
+ * position changes under the drag and a key does not.
+ *
+ * Nothing here touches `dataTransfer`. Native HTML5 drag never started reliably
+ * in the desktop webview — the pointer path replaces it — so a drop no longer
+ * has to survive a serialization round trip.
  */
-export const CODE_EDITOR_DRAG_TYPE = "application/x-tidebreak-editor-tab";
-const CODE_EDITOR_DRAG_TEXT_PREFIX = "tidebreak-editor-tab";
 
-export type EditorTabDrag = {
-  region: CodeEditorRegion;
-  index: number;
-};
+const TAB_PREFIX = "editor-tab:";
+const STRIP_PREFIX = "editor-strip:";
 
-export function writeEditorTabDrag(
-  transfer: DataTransfer,
-  drag: EditorTabDrag,
-): void {
-  transfer.effectAllowed = "move";
-  // Some desktop webviews reject or strip custom MIME payloads. Keep both
-  // writes independent so either representation can carry the tab through.
-  try {
-    transfer.setData(CODE_EDITOR_DRAG_TYPE, JSON.stringify(drag));
-  } catch {
-    // The namespaced text payload below remains available.
-  }
-  try {
-    transfer.setData(
-      "text/plain",
-      `${CODE_EDITOR_DRAG_TEXT_PREFIX}:${drag.region}:${drag.index}`,
-    );
-  } catch {
-    // React drag state can still draw and handle the in-flight preview.
-  }
-}
+/** The zone that appears mid-drag, offering to open the tab beside the chat. */
+export const EDITOR_SPLIT_DROP_ID = "editor-split-zone";
 
-export function hasEditorTabDrag(transfer: DataTransfer): boolean {
-  const types = Array.from(transfer.types ?? []);
-  return (
-    types.includes(CODE_EDITOR_DRAG_TYPE) || types.includes("text/plain")
-  );
-}
-
-export function readEditorTabDrag(
-  transfer: Pick<DataTransfer, "getData">,
-): EditorTabDrag | null {
-  const encoded = readTransferData(transfer, CODE_EDITOR_DRAG_TYPE);
-  if (encoded) {
-    try {
-      const parsed: unknown = JSON.parse(encoded);
-      if (isEditorTabDrag(parsed)) return parsed;
-    } catch {
-      // Fall through to the compatibility payload below.
-    }
-  }
-
-  const fallback = readTransferData(transfer, "text/plain");
-  const match = new RegExp(
-    `^${CODE_EDITOR_DRAG_TEXT_PREFIX}:(primary|secondary):(\\d+)$`,
-  ).exec(fallback);
-  if (!match) return null;
-  return { region: match[1] as CodeEditorRegion, index: Number(match[2]) };
-}
-
-function readTransferData(
-  transfer: Pick<DataTransfer, "getData">,
-  type: string,
+/** The id of a tab, stable while it moves. Panel keys may hold colons. */
+export function editorTabDragId(
+  region: CodeEditorRegion,
+  panel: PanelContent,
 ): string {
-  try {
-    return transfer.getData(type);
-  } catch {
-    return "";
-  }
+  return `${TAB_PREFIX}${region}:${panelKey(panel)}`;
 }
 
-function isEditorTabDrag(value: unknown): value is EditorTabDrag {
-  if (!value || typeof value !== "object") return false;
-  const candidate = value as Partial<EditorTabDrag>;
-  return (
-    (candidate.region === "primary" || candidate.region === "secondary") &&
-    Number.isInteger(candidate.index) &&
-    (candidate.index ?? -1) >= 0
-  );
+/** The id of a whole strip, so a drop on its empty space still lands. */
+export function editorStripDropId(region: CodeEditorRegion): string {
+  return `${STRIP_PREFIX}${region}`;
+}
+
+/** Whether an id names a whole strip rather than one tab or the split zone. */
+export function isEditorStripDropId(id: string): boolean {
+  return id.startsWith(STRIP_PREFIX);
+}
+
+/** The region an id belongs to, or null when the id is not one of ours. */
+export function editorDragRegion(id: string): CodeEditorRegion | null {
+  const rest = id.startsWith(TAB_PREFIX)
+    ? id.slice(TAB_PREFIX.length)
+    : id.startsWith(STRIP_PREFIX)
+      ? id.slice(STRIP_PREFIX.length)
+      : null;
+  if (rest === null) return null;
+  if (rest === "primary" || rest.startsWith("primary:")) return "primary";
+  if (rest === "secondary" || rest.startsWith("secondary:")) return "secondary";
+  return null;
+}
+
+/** The panel key inside a tab id, or null for a strip or the split zone. */
+function editorDragKey(id: string): string | null {
+  if (!id.startsWith(TAB_PREFIX)) return null;
+  const rest = id.slice(TAB_PREFIX.length);
+  const at = rest.indexOf(":");
+  return at < 0 ? null : rest.slice(at + 1);
+}
+
+/** Which tabs a region draws, in the order the strip draws them. */
+function regionTabs(
+  layout: LayoutState,
+  region: CodeEditorRegion,
+): PanelContent[] {
+  return region === "primary"
+    ? layout.tabs.filter(isEditorTab)
+    : [...(layout.editorSplit?.tabs ?? [])];
+}
+
+function indexOfKey(tabs: readonly PanelContent[], key: string): number {
+  return tabs.findIndex((tab) => panelKey(tab) === key);
+}
+
+/**
+ * The layout a finished drag produces, or null when it changes nothing.
+ *
+ * Null covers every way a drag can end without a move: released over open air,
+ * dropped back where it started, or aimed at a tab that closed underneath it.
+ * The caller treats null as "leave the layout alone" rather than as an error,
+ * because from the reader's side those are all the same gesture.
+ */
+export function dropEditorTab(
+  layout: LayoutState,
+  activeId: string,
+  overId: string | null,
+): LayoutState | null {
+  if (!overId || activeId === overId) return null;
+  const from = editorDragRegion(activeId);
+  const key = editorDragKey(activeId);
+  if (!from || key === null) return null;
+  const fromIndex = indexOfKey(regionTabs(layout, from), key);
+  if (fromIndex < 0) return null;
+
+  if (overId === EDITOR_SPLIT_DROP_ID) {
+    if (from === "secondary") return null;
+    return moveEditorTab(layout, from, fromIndex, "secondary");
+  }
+
+  const to = editorDragRegion(overId);
+  if (!to) return null;
+
+  if (to !== from) {
+    // Across groups the tab joins the end of the other strip. dnd-kit knows
+    // which tab the pointer is over, but a cross-group drop reads as "put this
+    // over there" rather than as an ordering, and the reader can drag again to
+    // place it.
+    return moveEditorTab(layout, from, fromIndex, to);
+  }
+
+  const tabs = regionTabs(layout, to);
+  const overKey = editorDragKey(overId);
+  // A drop with no tab under it landed on the strip itself, which within a
+  // group means the open space past the last tab.
+  const toIndex =
+    overKey === null ? tabs.length - 1 : indexOfKey(tabs, overKey);
+  if (toIndex < 0 || toIndex === fromIndex) return null;
+  return reorderEditorTab(layout, from, fromIndex, toIndex);
+}
+
+/**
+ * Whether the split zone should be offered for the tab being dragged.
+ *
+ * Only a left-group tab can create the split, and only while there is no split
+ * to create — once the right group exists, that group is itself the target.
+ */
+export function offersSplitDrop(
+  layout: LayoutState,
+  activeId: string,
+): boolean {
+  if (editorDragRegion(activeId) !== "primary") return false;
+  return splitCodeChromeLayout(layout).splitEditors.tabs.length === 0;
+}
+
+/**
+ * The tab an id names, or null once that tab has closed under the drag.
+ *
+ * The overlay needs the panel itself, not its position, so that the ghost keeps
+ * drawing the right label while the tabs beneath it shuffle.
+ */
+export function findEditorPanel(
+  layout: LayoutState,
+  id: string,
+): PanelContent | null {
+  const region = editorDragRegion(id);
+  const key = editorDragKey(id);
+  if (!region || key === null) return null;
+  const at = indexOfKey(regionTabs(layout, region), key);
+  return at < 0 ? null : (regionTabs(layout, region)[at] ?? null);
 }

--- a/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { DndContext } from "@dnd-kit/core";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
@@ -26,32 +27,36 @@ function TabStrip({
 }) {
   const [active, setActive] = useState(editorTabs.length > 0 ? 0 : -1);
   const [chatFocused, setChatFocused] = useState(editorTabs.length === 0);
+  // Tabs drag through dnd-kit, which addresses everything from the context the
+  // page provides. Without one here the strip would render but sit inert.
   return (
-    <CodeCenterTabs
-      editorTabs={editorTabs}
-      editorActiveIndex={active}
-      conversationFocused={chatFocused}
-      onSelectChat={() => setChatFocused(true)}
-      onSelectEditor={(index) => {
-        setChatFocused(false);
-        setActive(index);
-      }}
-      onCloseEditor={fn()}
-      onCloseAllEditors={fn()}
-      onCloseOtherEditors={fn()}
-      onCloseEditorsToRight={fn()}
-      onCopyPath={fn()}
-      onNewTab={fn()}
-      onNewBrowser={withBrowser ? fn() : undefined}
-      onNewDiff={withDiff ? fn() : undefined}
-      onNewSourceControl={withDiff ? fn() : undefined}
-      onNewPr={withDiff ? fn() : undefined}
-      onNewTerminal={withTerminal ? fn() : undefined}
-      onSplitActive={fn()}
-      region={region}
-      showMainAgent={region === "primary"}
-      browserTitles={{ "browser-1": "Storybook — Tidebreak" }}
-    />
+    <DndContext>
+      <CodeCenterTabs
+        editorTabs={editorTabs}
+        editorActiveIndex={active}
+        conversationFocused={chatFocused}
+        onSelectChat={() => setChatFocused(true)}
+        onSelectEditor={(index) => {
+          setChatFocused(false);
+          setActive(index);
+        }}
+        onCloseEditor={fn()}
+        onCloseAllEditors={fn()}
+        onCloseOtherEditors={fn()}
+        onCloseEditorsToRight={fn()}
+        onCopyPath={fn()}
+        onNewTab={fn()}
+        onNewBrowser={withBrowser ? fn() : undefined}
+        onNewDiff={withDiff ? fn() : undefined}
+        onNewSourceControl={withDiff ? fn() : undefined}
+        onNewPr={withDiff ? fn() : undefined}
+        onNewTerminal={withTerminal ? fn() : undefined}
+        onSplitActive={fn()}
+        region={region}
+        showMainAgent={region === "primary"}
+        browserTitles={{ "browser-1": "Storybook — Tidebreak" }}
+      />
+    </DndContext>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -334,7 +334,7 @@ function transcriptFrames(
       event: {
         type: "assistant_message",
         text:
-          "The split interaction now carries a typed payload in DataTransfer, so the drop target can recover the dragged tab without trusting transient React state. I also enlarged the target and made its destination explicit: “Open beside the agent.”",
+          "Tabs now move on pointer events rather than native drag, so a drag starts every time in the desktop webview. Dropping one on another tab reorders the strip; dropping it on the right-hand target opens it beside the agent.",
       },
     },
     {
@@ -371,12 +371,12 @@ function transcriptFrames(
         type: "tool_completed",
         call_id: `${spec.callId}-search`,
         outcome: "succeeded",
-        preview: "Found the typed transfer payload in the editor tab strip.",
+        preview: "Found the pointer sensor wiring in the editor tab strip.",
         parent_call_id: spec.callId,
       });
       emit({
         type: "assistant_message",
-        text: "The typed drag payload is intact. I’m checking the focus handoff before I report back.",
+        text: "The pointer sensor picks the tab up cleanly. I’m checking the focus handoff before I report back.",
         parent_call_id: spec.callId,
       });
       break;
@@ -841,21 +841,31 @@ function subagentUrl(scenario: SubagentScenario): string {
   return `${conversationUrl}?subagent=${encodeURIComponent(spec.callId)}`;
 }
 
-function dragTransfer(): DataTransfer {
-  const payload = new Map<string, string>();
-  const transfer = {
-    effectAllowed: "none",
-    dropEffect: "none",
-    types: [] as string[],
-    setData(type: string, value: string) {
-      payload.set(type, value);
-      if (!transfer.types.includes(type)) transfer.types.push(type);
-    },
-    getData(type: string) {
-      return payload.get(type) ?? "";
-    },
-  };
-  return transfer as unknown as DataTransfer;
+/**
+ * Press a tab and drag it far enough to count as a drag.
+ *
+ * Tabs move on pointer events, so the gesture is a real press and a real move
+ * rather than a synthetic `dragstart`. The move has to clear the sensor's
+ * four-pixel activation distance, which is what keeps a click a click.
+ */
+function startTabDrag(tab: Element) {
+  // The press lands on the tab itself, not the draggable wrapper around it.
+  // That is the gesture that used to fail: WebKit would not begin an
+  // ancestor's native drag from the inner button, so the drag never started.
+  const box = tab.getBoundingClientRect();
+  const from = { x: box.left + box.width / 2, y: box.top + box.height / 2 };
+  fireEvent.pointerDown(tab, {
+    pointerId: 1,
+    isPrimary: true,
+    button: 0,
+    clientX: from.x,
+    clientY: from.y,
+  });
+  fireEvent.pointerMove(document, {
+    pointerId: 1,
+    clientX: from.x + 40,
+    clientY: from.y,
+  });
 }
 
 const conversationUrl = workspaceUrl();
@@ -941,8 +951,7 @@ export const ActiveDragTarget: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const tab = await canvas.findByRole("tab", { name: "WorkspaceCard.tsx" });
-    const draggable = tab.closest('[draggable="true"]') ?? tab;
-    fireEvent.dragStart(draggable, { dataTransfer: dragTransfer() });
+    startTabDrag(tab);
     await expect(await canvas.findByTestId("split-drop-zone")).toBeVisible();
   },
 };
@@ -966,7 +975,7 @@ export const RunningSubagent: Story = {
     await expect(context).toHaveTextContent("Running");
     await expect(
       await canvas.findByText(
-        "The typed drag payload is intact. I’m checking the focus handoff before I report back.",
+        "The pointer sensor picks the tab up cleanly. I’m checking the focus handoff before I report back.",
       ),
     ).toBeVisible();
   },

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -26,8 +26,8 @@ a stale one.
 ## Summary
 
 - Rust crates: 827
-- Desktop UI production packages: 521
-- Distinct license texts: 574
+- Desktop UI production packages: 525
+- Distinct license texts: 575
 - Packages with no declared license: 0
 - Packages with a curated license: 28
 
@@ -5050,6 +5050,30 @@ License identifiers named across all declared expressions:
 - License: `MIT`
 - Repository: git+https://github.com/chenglou/pretext.git
 - License text: `LICENSE` ([L-7f2fadc433d1](#l-7f2fadc433d1))
+
+### @dnd-kit/accessibility 3.1.1
+
+- License: `MIT`
+- Repository: git+https://github.com/clauderic/dnd-kit.git
+- License text: `LICENSE` ([L-6fdf84a73d06](#l-6fdf84a73d06))
+
+### @dnd-kit/core 6.3.1
+
+- License: `MIT`
+- Repository: git+https://github.com/clauderic/dnd-kit.git
+- License text: `LICENSE` ([L-6fdf84a73d06](#l-6fdf84a73d06))
+
+### @dnd-kit/sortable 10.0.0
+
+- License: `MIT`
+- Repository: git+https://github.com/clauderic/dnd-kit.git
+- License text: `LICENSE` ([L-6fdf84a73d06](#l-6fdf84a73d06))
+
+### @dnd-kit/utilities 3.2.2
+
+- License: `MIT`
+- Repository: git+https://github.com/clauderic/dnd-kit.git
+- License text: `LICENSE` ([L-6fdf84a73d06](#l-6fdf84a73d06))
 
 ### @dukelib/sheets-wasm 0.1.23
 
@@ -21289,6 +21313,32 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
+
+### L-6fdf84a73d06
+
+```
+MIT License
+
+Copyright (c) 2021, Claudéric Demers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### L-7001906d3fe6


### PR DESCRIPTION
## What changed

Tab dragging moves from native HTML5 drag to pointer events, via dnd-kit.

The strip was the only HTML5 drag source in the app, so there was never any
evidence that path worked here. Two suspects, and no way to separate them:
Tauri's `dragDropEnabled: true`, which `documents.rs:412` needs for Finder
drops, and WebKit refusing to begin an ancestor's drag from the inner
`<button role="tab">` a reader actually presses. dnd-kit's `PointerSensor`
listens for pointer events and never touches the native drag path, so both
suspects stop mattering and `dragDropEnabled` can stay on.

- One `DndContext` in `CodeWorkspacePage.tsx` wraps both strips and the split
  zone. `SortableContext` per region; each tab is a `useSortable`.
- `TabPointerSensor` subclasses `PointerSensor` to ignore presses that start on
  a control marked `data-no-drag`, so pressing close and drifting a few pixels
  still closes the tab. Activation distance is 4px, so a click still selects.
- The split zone is a `useDroppable`, rendered only while a drag is live.
- `DragOverlay` draws the moving tab. Required, not decorative: the strip is
  `overflow-x-auto` and would clip a transformed child.
- `editorDrag.ts` is rewritten rather than deleted. It used to harden a private
  MIME payload so a drop could survive `dataTransfer`; there is no
  `dataTransfer` now, so it holds the dnd-kit id protocol instead — one id per
  tab, per strip, and for the split zone — plus the pure `dropEditorTab` rules
  that turn a finished drag into a layout.
- Reordering within a strip is new. It was not possible before at all.

**Move left / move right on the tab context menu.** Reordering by drag is
pointer-only: `useSortable`'s `attributes` are deliberately left off, because
making each tab wrapper a second focusable stop would collide with the
tablist's own arrow keys. The menu carries the same move for anyone on a
keyboard, alongside the "move to split right" entry that was already there.

Three exact-pinned dependencies, matching the lockfile:
`@dnd-kit/core` 6.3.1, `@dnd-kit/sortable` 10.0.0, `@dnd-kit/utilities` 3.2.2
(`@dnd-kit/accessibility` 3.1.1 arrives transitively). All four are recorded in
the third-party notices.

Atlassian's Pragmatic drag-and-drop was rejected: it is built *on* HTML5 DnD
and would hit the same wall. `@dnd-kit/react` 0.5.0 was rejected as pre-1.0.

## Validation

`pnpm test`, `pnpm exec tsc --noEmit`, and `pnpm storybook:build` pass.

Three new tests in `CodeWorkspacePage.dom.test.tsx` cover the gesture itself,
which is what actually regressed:

- A pointer press **on the inner tab button** plus a move past the activation
  distance starts a drag. This is the exact thing WebKit would not do.
- The same sequence on the close control does not start one.
- Move right in the context menu reorders the strip.

The first two discriminate against each other, so neither is vacuous.

**What this does not prove.** dnd-kit resolves a drop target from element
rects, and jsdom reports every rect as zero, so no automated test here can
assert where a tab lands. That half is covered by the pure `dropEditorTab`
rules in `editorDrag.test.ts`, which are the real contract. Two things still
want a human in the running app: that the pointer path behaves the same inside
WKWebView as it does in jsdom, and that Finder drops into the composer still
work with `dragDropEnabled: true`.

## Compatibility and risk

No wire, schema, or persisted-layout change; the layout algebra in
`code/codeChrome.ts` is untouched. The blast radius is the center tab strip.
Worst case is that dragging is no better than it was, which is to say not
working — the pointer path is additive over a native path that never fired.

## Tracking

Part of a six-PR stack. Independent of the others.
