### PR TITLE
feat(code): run several agents in one workspace

### DIFF
--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -631,7 +631,13 @@ mod tests {
         })
         .await
         .unwrap();
-        let handle = crate::code::session_worker::spawn_session_worker(session, engine, sink, None);
+        let handle = crate::code::session_worker::spawn_session_worker(
+            session,
+            engine,
+            sink,
+            None,
+            std::sync::Arc::new(tokio::sync::Mutex::new(())),
+        );
         let (reply, _turn) = tokio::sync::oneshot::channel();
         handle
             .commands

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -747,7 +747,7 @@ impl CodeRuntime {
                 ));
             }
         }
-        self.end_workspace_sessions(owner, id).await?;
+        let workers_stopped = self.end_workspace_sessions(owner, id).await?;
         remove_worktree(std::path::Path::new(&repo.root_path), path)
             .await
             .map_err(map_worktree)?;
@@ -772,13 +772,23 @@ impl CodeRuntime {
         workspace.status = CodeWorkspaceStatus::Archived;
         workspace.archived_at = Some(Utc::now());
         save_workspace(&self.db, &workspace).await?;
-        // The checkout is gone and every session on it has ended, so nothing
-        // can take this workspace's turn lock again. Restore mints a fresh
-        // one on the first session it starts.
-        self.worktree_turns
-            .lock()
-            .expect("worktree turn locks")
-            .remove(&workspace.id);
+        // Drop the turn lock only once every worker confirmed it was gone.
+        // The lock is an `Arc`, so forgetting it here does not disturb a
+        // worker that outlived its shutdown grace — it hands the *next* one a
+        // second lock over the same checkout, which is the one thing this is
+        // supposed to make impossible. Keeping the entry costs a map slot per
+        // archived workspace and keeps restore on the same lock.
+        if workers_stopped {
+            self.worktree_turns
+                .lock()
+                .expect("worktree turn locks")
+                .remove(&workspace.id);
+        } else {
+            tracing::warn!(
+                workspace = %workspace.id,
+                "code-mode: keeping the workspace turn lock; a worker outlived its shutdown"
+            );
+        }
         Ok(workspace)
     }
 
@@ -1250,58 +1260,91 @@ impl CodeRuntime {
             session.model = Some(model);
             let _ = save_session(&self.db, &session).await?;
         }
+        // A fenced sibling means an engine from a previous boot may still be
+        // alive in this checkout, outside every lock this process holds. The
+        // turn lock cannot see it, so nothing in the workspace writes until it
+        // is reaped (record 54).
+        if let Some(reason) = self.workspace_fence_reason(owner, &session).await? {
+            return Err(ServerError::conflict_kind("workspace_fenced", reason));
+        }
         // Queue-default (0009): a send while a turn is in flight parks one
         // follow-up. This does not consult mid_turn_steering — that cap
         // gates the separate /steer route only.
-        //
-        // A sibling session's turn counts as in flight too. The workspace's
-        // sessions share one checkout and take turns on it (record 54), so a
-        // send that would only wait on the turn lock parks here instead and
-        // the route answers promptly.
         let in_flight = session.lifecycle == CodeSessionLifecycle::Running
-            || get_open_turn(&self.db, owner, id).await?.is_some()
-            || self.workspace_turn_running(owner, &session).await?;
+            || get_open_turn(&self.db, owner, id).await?.is_some();
         if in_flight {
-            if !queue_follow_up(&handle, message, session.model.clone(), attachments) {
-                return Err(ServerError::conflict_kind(
-                    "queue_full",
-                    "a follow-up is already queued on this session",
-                ));
-            }
-            return Ok(SubmitTurnOutcome::Queued);
+            return self.park_follow_up(&handle, &session, message, attachments);
         }
         let (reply, rx) = oneshot::channel();
         handle
             .commands
             .send(WorkerCommand::RunTurn {
-                message,
+                message: message.clone(),
                 model: session.model.clone(),
-                attachments,
+                attachments: attachments.clone(),
                 reply,
             })
             .await
             .map_err(|_| ServerError::internal("session worker is gone"))?;
-        let turn = rx
+        let turn = match rx
             .await
             .map_err(|_| ServerError::internal("session worker dropped the turn"))?
-            .map_err(map_worker)?;
+        {
+            Ok(turn) => turn,
+            // A sibling holds the workspace's turn lock. Taking that lock is
+            // the reservation, so this is the first moment either send can
+            // know which one won — a check before the send would let two idle
+            // siblings both believe the checkout was free. The loser parks
+            // exactly as a busy session does, and the route answers now rather
+            // than holding the connection open for someone else's turn.
+            Err(WorkerError::WorktreeBusy) => {
+                return self.park_follow_up(&handle, &session, message, attachments);
+            }
+            Err(err) => return Err(map_worker(err)),
+        };
         Ok(SubmitTurnOutcome::Ran(Box::new(turn)))
     }
 
-    /// Whether another session in this session's workspace is mid-turn.
+    /// Park a message in the session's single follow-up slot (record 9).
+    fn park_follow_up(
+        &self,
+        handle: &WorkerHandle,
+        session: &CodeSession,
+        message: String,
+        attachments: Vec<tidebreak_core::CodeTurnAttachment>,
+    ) -> Result<SubmitTurnOutcome, ServerError> {
+        if !queue_follow_up(handle, message, session.model.clone(), attachments) {
+            return Err(ServerError::conflict_kind(
+                "queue_full",
+                "a follow-up is already queued on this session",
+            ));
+        }
+        Ok(SubmitTurnOutcome::Queued)
+    }
+
+    /// Why this session's workspace is closed to turns, if it is.
     ///
-    /// A pre-filter, not the guarantee: the turn lock in the worker is what
-    /// actually serializes the checkout. This only keeps a send that would
-    /// block on that lock from holding its route open (record 54).
-    async fn workspace_turn_running(
+    /// The turn lock lives in this process, so it can only order the workers
+    /// this process owns. A fenced session is the one case where that is not
+    /// enough: it means a harness child outlived a restart and may still be
+    /// writing to the checkout. Until it is reaped, no sibling may start a
+    /// turn there — otherwise the single-writer rule holds only for the
+    /// sessions we happen to know about.
+    async fn workspace_fence_reason(
         &self,
         owner: &OwnerId,
         session: &CodeSession,
-    ) -> Result<bool, ServerError> {
+    ) -> Result<Option<String>, ServerError> {
         let siblings = list_sessions_for_workspace(&self.db, owner, session.workspace_id).await?;
-        Ok(siblings.iter().any(|other| {
-            other.id != session.id && other.lifecycle == CodeSessionLifecycle::Running
-        }))
+        Ok(siblings
+            .iter()
+            .find(|other| other.id != session.id && other.lifecycle == CodeSessionLifecycle::Fenced)
+            .map(|fenced| {
+                format!(
+                    "another session in this workspace is fenced until it is reaped ({})",
+                    fenced.id
+                )
+            }))
     }
 
     pub(crate) async fn interrupt(&self, id: CodeSessionId) -> Result<(), ServerError> {
@@ -1664,11 +1707,17 @@ impl CodeRuntime {
         Ok(())
     }
 
+    /// End every session in a workspace.
+    ///
+    /// Returns whether every worker confirmed it stopped. A `false` means at
+    /// least one is still running somewhere with its own handle on the
+    /// workspace's turn lock.
     async fn end_workspace_sessions(
         &self,
         owner: &OwnerId,
         workspace_id: WorkspaceId,
-    ) -> Result<(), ServerError> {
+    ) -> Result<bool, ServerError> {
+        let mut all_stopped = true;
         let sessions = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
         for mut session in sessions {
             if session.lifecycle == CodeSessionLifecycle::Ended {
@@ -1688,7 +1737,7 @@ impl CodeRuntime {
             session.fence_reason = None;
             super::attention::persist_session(&self.db, &self.bus, &session).await?;
             if let Some(handle) = handle {
-                Self::shut_down_worker(session.id, handle).await;
+                all_stopped &= Self::shut_down_worker(session.id, handle).await;
             }
             // The outgoing worker still holds this epoch, so a persist during
             // the wait can overwrite Ended. Re-assert from a fresh load.
@@ -1703,7 +1752,7 @@ impl CodeRuntime {
                 ));
             }
         }
-        Ok(())
+        Ok(all_stopped)
     }
 
     /// Ask a superseded worker to stop, and wait for its command receiver to
@@ -1711,7 +1760,12 @@ impl CodeRuntime {
     /// enough; resending would only replay `interrupt` into an engine that is
     /// already stopping. The wait is bounded so a wedged engine cannot hold
     /// an archive or a reap open.
-    async fn shut_down_worker(id: CodeSessionId, handle: WorkerHandle) {
+    ///
+    /// Returns whether the worker confirmed it was gone. That answer matters
+    /// to the caller: a worker that outlived its grace still holds this
+    /// workspace's turn lock, so anything keyed on "the checkout is now
+    /// unowned" has to stay put.
+    async fn shut_down_worker(id: CodeSessionId, handle: WorkerHandle) -> bool {
         const GRACE: std::time::Duration = std::time::Duration::from_secs(5);
         let commands = handle.commands.clone();
         drop(handle);
@@ -1730,6 +1784,7 @@ impl CodeRuntime {
                 "code-mode: session worker did not stop in time; continuing without it"
             );
         }
+        stopped
     }
 
     async fn attach_and_spawn_worker(
@@ -2154,6 +2209,13 @@ fn map_worker(err: WorkerError) -> ServerError {
             ServerError::conflict_kind("steering_rejected", message)
         }
         WorkerError::Failed(message) => ServerError::internal(message),
+        // `submit_turn` intercepts this and parks the message instead, so
+        // reaching here means a caller took the turn path without handling
+        // contention. Answer as a conflict rather than a 500.
+        WorkerError::WorktreeBusy => ServerError::conflict_kind(
+            "workspace_busy",
+            "another session in this workspace is mid-turn",
+        ),
     }
 }
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -140,6 +140,14 @@ pub(crate) struct CodeRuntime {
     /// Last pin-install failure per kind. Cleared on a successful install.
     pin_install_errors: Mutex<HashMap<HarnessKind, String>>,
     workers: Mutex<HashMap<CodeSessionId, WorkerHandle>>,
+    /// One turn at a time per worktree, shared by every session in it.
+    ///
+    /// Sessions in a workspace share one checkout, so their turns cannot
+    /// overlap: two harnesses editing the same files, and two checkpoints
+    /// racing for `.git/index.lock`, is corruption rather than concurrency.
+    /// A worker takes the workspace's lock for the length of a turn, so a
+    /// sibling's turn starts after this one ends. See record 54.
+    worktree_turns: Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
     pr_cache: PrDigestCache,
     pub(crate) delivery_cache: DeliveryCache,
     pub(crate) clone_jobs: CloneJobs,
@@ -183,6 +191,7 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            worktree_turns: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
             delivery_cache: DeliveryCache::default(),
             clone_jobs: CloneJobs::default(),
@@ -251,6 +260,7 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            worktree_turns: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
             delivery_cache: DeliveryCache::default(),
             clone_jobs: CloneJobs::default(),
@@ -762,6 +772,13 @@ impl CodeRuntime {
         workspace.status = CodeWorkspaceStatus::Archived;
         workspace.archived_at = Some(Utc::now());
         save_workspace(&self.db, &workspace).await?;
+        // The checkout is gone and every session on it has ended, so nothing
+        // can take this workspace's turn lock again. Restore mints a fresh
+        // one on the first session it starts.
+        self.worktree_turns
+            .lock()
+            .expect("worktree turn locks")
+            .remove(&workspace.id);
         Ok(workspace)
     }
 
@@ -1038,11 +1055,11 @@ impl CodeRuntime {
 
     /// Shared create path for interactive sessions and watch sessions.
     ///
-    /// One active session per workspace *per kind*: a watch session shares
-    /// the worktree with the conversation it forked from, so the guard keeps
-    /// one of each rather than one in total. The watch sweep serializes fix
-    /// turns against interactive turns before submitting.
-    pub(super) async fn create_session_of_kind(
+    /// A workspace holds any number of interactive sessions and at most one
+    /// watch session, so the guard below covers watch only. The worktree they
+    /// share is protected by the per-workspace turn lock rather than by a cap
+    /// on conversations; see record 54.
+    pub(crate) async fn create_session_of_kind(
         &self,
         owner: &OwnerId,
         workspace_id: WorkspaceId,
@@ -1058,18 +1075,17 @@ impl CodeRuntime {
                 format!("workspace is {}", workspace.status.as_str()),
             ));
         }
-        let existing = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
-        if existing
-            .iter()
-            .any(|session| session.lifecycle != CodeSessionLifecycle::Ended && session.kind == kind)
-        {
-            return Err(ServerError::conflict_kind(
-                "session_exists",
-                match kind {
-                    CodeSessionKind::Interactive => "this workspace already has an active session",
-                    CodeSessionKind::Watch => "this workspace already has an active watch session",
-                },
-            ));
+        if kind == CodeSessionKind::Watch {
+            let existing = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
+            if existing.iter().any(|session| {
+                session.lifecycle != CodeSessionLifecycle::Ended
+                    && session.kind == CodeSessionKind::Watch
+            }) {
+                return Err(ServerError::conflict_kind(
+                    "session_exists",
+                    "this workspace already has an active watch session",
+                ));
+            }
         }
         let adapter = self.adapter(harness)?;
         #[cfg(not(test))]
@@ -1237,8 +1253,14 @@ impl CodeRuntime {
         // Queue-default (0009): a send while a turn is in flight parks one
         // follow-up. This does not consult mid_turn_steering — that cap
         // gates the separate /steer route only.
+        //
+        // A sibling session's turn counts as in flight too. The workspace's
+        // sessions share one checkout and take turns on it (record 54), so a
+        // send that would only wait on the turn lock parks here instead and
+        // the route answers promptly.
         let in_flight = session.lifecycle == CodeSessionLifecycle::Running
-            || get_open_turn(&self.db, owner, id).await?.is_some();
+            || get_open_turn(&self.db, owner, id).await?.is_some()
+            || self.workspace_turn_running(owner, &session).await?;
         if in_flight {
             if !queue_follow_up(&handle, message, session.model.clone(), attachments) {
                 return Err(ServerError::conflict_kind(
@@ -1264,6 +1286,22 @@ impl CodeRuntime {
             .map_err(|_| ServerError::internal("session worker dropped the turn"))?
             .map_err(map_worker)?;
         Ok(SubmitTurnOutcome::Ran(Box::new(turn)))
+    }
+
+    /// Whether another session in this session's workspace is mid-turn.
+    ///
+    /// A pre-filter, not the guarantee: the turn lock in the worker is what
+    /// actually serializes the checkout. This only keeps a send that would
+    /// block on that lock from holding its route open (record 54).
+    async fn workspace_turn_running(
+        &self,
+        owner: &OwnerId,
+        session: &CodeSession,
+    ) -> Result<bool, ServerError> {
+        let siblings = list_sessions_for_workspace(&self.db, owner, session.workspace_id).await?;
+        Ok(siblings.iter().any(|other| {
+            other.id != session.id && other.lifecycle == CodeSessionLifecycle::Running
+        }))
     }
 
     pub(crate) async fn interrupt(&self, id: CodeSessionId) -> Result<(), ServerError> {
@@ -1781,7 +1819,13 @@ impl CodeRuntime {
             attached.harness_resume_ref = Some(resume);
         }
         super::attention::persist_session(&self.db, &self.bus, &attached).await?;
-        let handle = spawn_session_worker(attached.clone(), engine, sink, Some(self.blobs.clone()));
+        let handle = spawn_session_worker(
+            attached.clone(),
+            engine,
+            sink,
+            Some(self.blobs.clone()),
+            self.worktree_turn_lock(attached.workspace_id),
+        );
         self.workers
             .lock()
             .expect("code workers")
@@ -1804,6 +1848,23 @@ impl CodeRuntime {
         Ok(attached)
     }
 
+    /// The turn lock for a workspace, minted on first use.
+    ///
+    /// Every session in the workspace hands the same `Arc` to its worker, so
+    /// the lock outlives any one session and a worker recovered after a
+    /// restart rejoins the same queue. See record 54.
+    pub(super) fn worktree_turn_lock(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Arc<tokio::sync::Mutex<()>> {
+        self.worktree_turns
+            .lock()
+            .expect("worktree turn locks")
+            .entry(workspace_id)
+            .or_default()
+            .clone()
+    }
+
     fn require_worker(&self, id: CodeSessionId) -> Result<WorkerHandle, ServerError> {
         self.workers
             .lock()
@@ -1812,8 +1873,7 @@ impl CodeRuntime {
             .map(|handle| WorkerHandle {
                 spawn_epoch: handle.spawn_epoch,
                 commands: handle.commands.clone(),
-                pending: handle.pending.clone(),
-                wake: handle.wake.clone(),
+                queue: handle.queue.clone(),
                 sink: handle.sink.clone(),
             })
             .ok_or_else(|| {

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -77,6 +77,13 @@ pub(crate) enum WorkerError {
     SteeringRejected(String),
     #[error("{0}")]
     Failed(String),
+    /// A sibling session holds the workspace's turn lock.
+    ///
+    /// Never reaches a caller. `submit_turn` parks the message and answers
+    /// `Queued`, so a send is never left holding its connection open for the
+    /// length of someone else's turn.
+    #[error("another session in this workspace is mid-turn")]
+    WorktreeBusy,
 }
 
 pub(crate) struct WorkerHandle {
@@ -107,6 +114,28 @@ impl TurnQueue {
             worktree,
         }
     }
+}
+
+/// Who is waiting on the other end of a turn, which decides how it waits.
+///
+/// A `Send` has an HTTP request open on it, so it may not block on a sibling's
+/// turn — it takes the lock or reports back that it could not. A `Queued` turn
+/// has already been acknowledged, so it can afford to wait.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TurnWait {
+    Send,
+    Queued,
+}
+
+/// The workspace's turn lock, and this caller's claim on waiting for it.
+///
+/// They travel together because neither answers anything alone: the lock says
+/// which checkout is being reserved, and the wait says what this caller is
+/// allowed to do when somebody else holds it.
+#[derive(Clone, Copy)]
+struct WorktreeTurn<'a> {
+    lock: &'a tokio::sync::Mutex<()>,
+    wait: TurnWait,
 }
 
 pub(crate) struct QueuedFollowUp {
@@ -438,7 +467,10 @@ async fn run_worker(
                         &sink,
                         blobs.as_deref(),
                         &mut commands,
-                        &queue.worktree,
+                        WorktreeTurn {
+                            lock: &queue.worktree,
+                            wait: TurnWait::Send,
+                        },
                         QueuedFollowUp {
                             message,
                             model,
@@ -491,6 +523,42 @@ async fn next_child_pid(changes: Option<&mut watch::Receiver<Option<i64>>>) -> O
         return std::future::pending().await;
     }
     *changes.borrow()
+}
+
+/// Wait for the workspace's turn lock, still answering control commands.
+///
+/// A queued turn can sit here for as long as a sibling's turn runs. Parking on
+/// a bare `lock()` would leave the worker deaf for that whole stretch: an
+/// interrupt sent while the message was still queued would be delivered to the
+/// engine only once the turn had started, which reads as the stop being
+/// ignored. Returns `None` when the turn should not start at all.
+async fn await_worktree_turn<'a>(
+    engine: &dyn HarnessSession,
+    worktree_turn: &'a tokio::sync::Mutex<()>,
+    commands: &mut mpsc::Receiver<WorkerCommand>,
+) -> Option<tokio::sync::MutexGuard<'a, ()>> {
+    loop {
+        tokio::select! {
+            guard = worktree_turn.lock() => return Some(guard),
+            command = commands.recv() => match command {
+                // Stopping something that has not started needs no engine
+                // call: dropping the turn here is the stop.
+                Some(WorkerCommand::Interrupt { reply }) => {
+                    let _ = reply.send(Ok(()));
+                    return None;
+                }
+                Some(WorkerCommand::Shutdown) | None => return None,
+                // There is no turn yet, so steering has nothing to steer and
+                // a second RunTurn is a conflict. `apply_control` answers both
+                // that way already.
+                Some(command) => {
+                    if apply_control(engine, command, None).await == ControlFlow::Shutdown {
+                        return None;
+                    }
+                }
+            },
+        }
+    }
 }
 
 async fn apply_control(
@@ -587,7 +655,10 @@ async fn drain_queued(
             sink,
             blobs,
             commands,
-            &queue.worktree,
+            WorktreeTurn {
+                lock: &queue.worktree,
+                wait: TurnWait::Queued,
+            },
             follow_up,
         )
         .await;
@@ -600,7 +671,7 @@ async fn drive_turn(
     sink: &LiveSink,
     blobs: Option<&dyn BlobStore>,
     commands: &mut mpsc::Receiver<WorkerCommand>,
-    worktree_turn: &tokio::sync::Mutex<()>,
+    worktree: WorktreeTurn<'_>,
     QueuedFollowUp {
         message,
         model,
@@ -624,11 +695,25 @@ async fn drive_turn(
     }
     let images = hydrate_turn_images(blobs, &attachments).await?;
 
-    // The workspace's checkout takes one turn at a time (record 54). Waiting
-    // here rather than refusing is what makes a second agent usable: the
-    // reader already sees the message as queued, and it runs when the sibling
-    // turn ends. Blobs are hydrated first so a decode never holds the tree.
-    let _worktree = worktree_turn.lock().await;
+    // The workspace's checkout takes one turn at a time (record 54). Taking
+    // the lock *is* the reservation: a pre-flight database read cannot be,
+    // because two idle siblings both pass it before either marks itself
+    // running. Blobs are hydrated first so a decode never holds the tree.
+    let _worktree = match worktree.wait {
+        // A send has its request open, so it never waits on a sibling's turn.
+        // The caller parks the message and answers `Queued` instead.
+        TurnWait::Send => worktree
+            .lock
+            .try_lock()
+            .map_err(|_| WorkerError::WorktreeBusy)?,
+        // Already acknowledged, so waiting costs nobody a connection. The wait
+        // still listens for control: an interrupt that arrives while a turn is
+        // queued has to stop it before it starts, not after.
+        TurnWait::Queued => match await_worktree_turn(engine, worktree.lock, commands).await {
+            Some(guard) => guard,
+            None => return Err(WorkerError::Conflict("the queued turn was stopped".into())),
+        },
+    };
     // Ending a session during that wait has to win. The lifecycle checks above
     // read a session that may be minutes stale by now.
     if session_was_ended(&sink.db, session).await {

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -82,10 +82,31 @@ pub(crate) enum WorkerError {
 pub(crate) struct WorkerHandle {
     pub spawn_epoch: i64,
     pub commands: mpsc::Sender<WorkerCommand>,
-    /// Single follow-up parked while a turn is running (queue-default).
-    pub pending: Arc<std::sync::Mutex<Option<QueuedFollowUp>>>,
-    pub wake: Arc<Notify>,
+    pub queue: TurnQueue,
     pub sink: Arc<LiveSink>,
+}
+
+/// How a worker gets its next turn, and when it may start one.
+///
+/// `pending` and `wake` are this session's own single follow-up slot
+/// (record 9). `worktree` is shared with every other session in the
+/// workspace, and holding it is what keeps two agents from editing one
+/// checkout at the same time (record 54).
+#[derive(Clone)]
+pub(crate) struct TurnQueue {
+    pending: Arc<std::sync::Mutex<Option<QueuedFollowUp>>>,
+    wake: Arc<Notify>,
+    worktree: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl TurnQueue {
+    fn new(worktree: Arc<tokio::sync::Mutex<()>>) -> Self {
+        Self {
+            pending: Arc::new(std::sync::Mutex::new(None)),
+            wake: Arc::new(Notify::new()),
+            worktree,
+        }
+    }
 }
 
 pub(crate) struct QueuedFollowUp {
@@ -324,30 +345,34 @@ impl HarnessEventSink for LiveSink {
     }
 }
 
+/// Start the worker for a session.
+///
+/// `worktree_turn` is the workspace's turn lock, shared with every other
+/// session in the same checkout. The worker holds it for the length of a
+/// turn, which is what keeps two agents from editing one worktree at once;
+/// see record 54.
 pub(crate) fn spawn_session_worker(
     session: CodeSession,
     engine: Box<dyn HarnessSession>,
     sink: Arc<LiveSink>,
     blobs: Option<Arc<dyn BlobStore>>,
+    worktree_turn: Arc<tokio::sync::Mutex<()>>,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel(8);
     let spawn_epoch = session.spawn_epoch;
-    let pending = Arc::new(std::sync::Mutex::new(None));
-    let wake = Arc::new(Notify::new());
+    let queue = TurnQueue::new(worktree_turn);
     tokio::spawn(run_worker(
         session,
         engine,
         sink.clone(),
-        pending.clone(),
-        wake.clone(),
+        queue.clone(),
         blobs,
         rx,
     ));
     WorkerHandle {
         spawn_epoch,
         commands: tx,
-        pending,
-        wake,
+        queue,
         sink,
     }
 }
@@ -359,7 +384,7 @@ pub(crate) fn queue_follow_up(
     model: Option<String>,
     attachments: Vec<tidebreak_core::CodeTurnAttachment>,
 ) -> bool {
-    let mut pending = handle.pending.lock().expect("code turn queue");
+    let mut pending = handle.queue.pending.lock().expect("code turn queue");
     if pending.is_some() {
         return false;
     }
@@ -368,7 +393,7 @@ pub(crate) fn queue_follow_up(
         model,
         attachments,
     });
-    handle.wake.notify_one();
+    handle.queue.wake.notify_one();
     true
 }
 
@@ -376,8 +401,7 @@ async fn run_worker(
     mut session: CodeSession,
     engine: Box<dyn HarnessSession>,
     sink: Arc<LiveSink>,
-    pending: Arc<std::sync::Mutex<Option<QueuedFollowUp>>>,
-    wake: Arc<Notify>,
+    queue: TurnQueue,
     blobs: Option<Arc<dyn BlobStore>>,
     mut commands: mpsc::Receiver<WorkerCommand>,
 ) {
@@ -394,13 +418,13 @@ async fn run_worker(
             &mut session,
             engine.as_ref(),
             &sink,
-            &pending,
+            &queue,
             blobs.as_deref(),
             &mut commands,
         )
         .await;
         tokio::select! {
-            _ = wake.notified() => {}
+            _ = queue.wake.notified() => {}
             command = commands.recv() => match command {
                 Some(WorkerCommand::RunTurn {
                     message,
@@ -414,6 +438,7 @@ async fn run_worker(
                         &sink,
                         blobs.as_deref(),
                         &mut commands,
+                        &queue.worktree,
                         QueuedFollowUp {
                             message,
                             model,
@@ -547,16 +572,25 @@ async fn drain_queued(
     session: &mut CodeSession,
     engine: &dyn HarnessSession,
     sink: &LiveSink,
-    pending: &Arc<std::sync::Mutex<Option<QueuedFollowUp>>>,
+    queue: &TurnQueue,
     blobs: Option<&dyn BlobStore>,
     commands: &mut mpsc::Receiver<WorkerCommand>,
 ) {
     loop {
-        let next = pending.lock().expect("code turn queue").take();
+        let next = queue.pending.lock().expect("code turn queue").take();
         let Some(follow_up) = next else {
             break;
         };
-        let _ = drive_turn(session, engine, sink, blobs, commands, follow_up).await;
+        let _ = drive_turn(
+            session,
+            engine,
+            sink,
+            blobs,
+            commands,
+            &queue.worktree,
+            follow_up,
+        )
+        .await;
     }
 }
 
@@ -566,6 +600,7 @@ async fn drive_turn(
     sink: &LiveSink,
     blobs: Option<&dyn BlobStore>,
     commands: &mut mpsc::Receiver<WorkerCommand>,
+    worktree_turn: &tokio::sync::Mutex<()>,
     QueuedFollowUp {
         message,
         model,
@@ -588,6 +623,18 @@ async fn drive_turn(
         return Err(WorkerError::Conflict("session has ended".into()));
     }
     let images = hydrate_turn_images(blobs, &attachments).await?;
+
+    // The workspace's checkout takes one turn at a time (record 54). Waiting
+    // here rather than refusing is what makes a second agent usable: the
+    // reader already sees the message as queued, and it runs when the sibling
+    // turn ends. Blobs are hydrated first so a decode never holds the tree.
+    let _worktree = worktree_turn.lock().await;
+    // Ending a session during that wait has to win. The lifecycle checks above
+    // read a session that may be minutes stale by now.
+    if session_was_ended(&sink.db, session).await {
+        return Err(WorkerError::Conflict("session has ended".into()));
+    }
+
     if let Some(model) = model.clone() {
         session.model = Some(model);
     }

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -409,7 +409,9 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
         )
         .await;
     }
-    // Another session's turn owns the worktree right now; wait.
+    // Another session's turn owns the worktree right now; wait. The turn lock
+    // in the worker is what actually serializes the checkout (record 54);
+    // skipping the cycle here avoids waking a harness that would only queue.
     let sessions = list_sessions_for_workspace(&runtime.db, &owner, watch.workspace_id).await?;
     if sessions
         .iter()

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1152,6 +1152,279 @@ async fn a_workspace_runs_several_agents_that_take_turns_on_one_worktree() {
     .expect("the queued sibling turn never ran");
 }
 
+/// Create `count` interactive sessions in one workspace, returning their ids.
+async fn create_sibling_sessions(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    workspace: &serde_json::Value,
+    count: usize,
+) -> Vec<String> {
+    let mut ids = Vec::new();
+    for _ in 0..count {
+        let created = client
+            .post(format!(
+                "http://{addr}/code/workspaces/{}/sessions",
+                json_id(workspace)
+            ))
+            .bearer_auth(token)
+            .json(&serde_json::json!({
+                "harness": "claude_code",
+                "permission_mode": "plan",
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            created.status(),
+            reqwest::StatusCode::CREATED,
+            "a sibling agent in one workspace must create"
+        );
+        let body: serde_json::Value = created.json().await.unwrap();
+        ids.push(json_id(&body).to_owned());
+    }
+    ids
+}
+
+#[tokio::test]
+async fn two_idle_siblings_sending_at_once_get_one_turn_and_one_queue() {
+    // Both sends leave before either session is marked Running, so no
+    // database read can tell them apart — the turn lock is the only thing
+    // that can, and taking it is the reservation. The reader sees one turn
+    // and one queued message; neither request is left open for the length of
+    // the other's turn.
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script()).with_delay(Duration::from_millis(400)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let ids = create_sibling_sessions(&client, addr, &token, &workspace, 2).await;
+
+    let send = |session_id: String, message: &'static str| {
+        let client = client.clone();
+        let token = token.clone();
+        tokio::spawn(async move {
+            let response = client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": message }))
+                .send()
+                .await
+                .unwrap();
+            let status = response.status();
+            let body: serde_json::Value = response.json().await.unwrap();
+            (status, body)
+        })
+    };
+    let first = send(ids[0].clone(), "first");
+    let second = send(ids[1].clone(), "second");
+    let (first, second) = tokio::time::timeout(Duration::from_secs(20), async {
+        (first.await.unwrap(), second.await.unwrap())
+    })
+    .await
+    .expect("a send blocked on the sibling's turn instead of queueing");
+
+    for (status, body) in [&first, &second] {
+        assert_eq!(*status, reqwest::StatusCode::ACCEPTED, "unexpected: {body}");
+    }
+    // A queued reply carries the parked message and its position; a turn
+    // reply carries the turn. Exactly one of each is the whole contract.
+    let queued = [&first, &second]
+        .into_iter()
+        .filter(|(_, body)| body.get("position").is_some())
+        .count();
+    assert_eq!(
+        queued, 1,
+        "one send must queue and one must run: {first:?} {second:?}"
+    );
+
+    // Both turns still land, one after the other, on the shared checkout.
+    let parsed: Vec<CodeSessionId> = ids.iter().map(|id| id.parse().unwrap()).collect();
+    tokio::time::timeout(Duration::from_secs(20), async {
+        loop {
+            let mut windows = Vec::new();
+            for id in &parsed {
+                let turns = tidebreak_core::db::code::list_turns(
+                    &runtime.db,
+                    &tidebreak_core::OwnerId::local(),
+                    *id,
+                )
+                .await
+                .unwrap();
+                match turns.first() {
+                    Some(turn) if turn.status == CodeTurnStatus::Completed => {
+                        windows.push((turn.started_at, turn.ended_at.expect("a completed turn")));
+                    }
+                    _ => break,
+                }
+            }
+            if windows.len() == parsed.len() {
+                windows.sort_by_key(|(started, _)| *started);
+                assert!(
+                    windows[1].0 >= windows[0].1,
+                    "the turns overlapped on one checkout: {windows:?}"
+                );
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("both turns never completed");
+}
+
+#[tokio::test]
+async fn interrupting_a_queued_turn_stops_it_before_it_reaches_the_worktree() {
+    // A queued turn waits for the sibling's turn to end, and that wait has to
+    // keep answering control. Otherwise a stop pressed while the message is
+    // still queued is delivered only once the turn has started, which reads
+    // as the stop being ignored.
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script()).with_delay(Duration::from_millis(2_000)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let ids = create_sibling_sessions(&client, addr, &token, &workspace, 2).await;
+
+    let holder_id = ids[0].clone();
+    let holder = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{holder_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "long" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    let first_parsed: CodeSessionId = ids[0].parse().unwrap();
+    wait_for_open_turn(&runtime, first_parsed).await;
+
+    let queued = client
+        .post(format!("http://{addr}/code/sessions/{}/turns", ids[1]))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "queued" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(queued.status(), reqwest::StatusCode::ACCEPTED);
+    assert!(
+        queued
+            .json::<serde_json::Value>()
+            .await
+            .unwrap()
+            .get("position")
+            .is_some(),
+        "the sibling send must queue while the worktree is held"
+    );
+
+    // By now the worker has taken the message out of its queue and is waiting
+    // on the checkout: parking happens before the send's response is written,
+    // so a whole HTTP round trip has passed since. The stop has to be
+    // answered from inside that wait, not after it.
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(1),
+        client
+            .post(format!("http://{addr}/code/sessions/{}/interrupt", ids[1]))
+            .bearer_auth(&token)
+            .send(),
+    )
+    .await
+    .expect("the stop waited for the sibling's turn instead of being answered")
+    .unwrap();
+    assert_eq!(stopped.status(), reqwest::StatusCode::ACCEPTED);
+
+    assert_eq!(
+        holder.await.unwrap().status(),
+        reqwest::StatusCode::ACCEPTED
+    );
+    let second_parsed: CodeSessionId = ids[1].parse().unwrap();
+    let turns = tidebreak_core::db::code::list_turns(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        second_parsed,
+    )
+    .await
+    .unwrap();
+    assert!(
+        turns.is_empty(),
+        "a stopped queued turn must never reach the worktree: {turns:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_fenced_session_closes_its_whole_workspace_to_turns() {
+    // A fence means an engine may still be alive in this checkout from before
+    // a restart, outside every lock this process holds. The turn lock cannot
+    // order a process it does not own, so no sibling writes until the reap.
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let ids = create_sibling_sessions(&client, addr, &token, &workspace, 2).await;
+
+    let owner = tidebreak_core::OwnerId::local();
+    let fenced_id: CodeSessionId = ids[0].parse().unwrap();
+    let mut row = tidebreak_core::db::code::get_session(&runtime.db, &owner, fenced_id)
+        .await
+        .unwrap()
+        .unwrap();
+    row.lifecycle = CodeSessionLifecycle::Fenced;
+    row.fence_reason = Some(FenceReason::OrphanAlive);
+    row.attention = Attention::new(
+        AttentionState::Fenced {
+            reason: FenceReason::OrphanAlive,
+        },
+        AttentionSource::Lifecycle,
+    );
+    tidebreak_core::db::code::save_session(&runtime.db, &row)
+        .await
+        .unwrap();
+
+    let refused = client
+        .post(format!("http://{addr}/code/sessions/{}/turns", ids[1]))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "while a sibling is fenced" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "workspace_fenced");
+
+    // Reaping the fenced session reopens the workspace.
+    let reaped = client
+        .post(format!("http://{addr}/code/sessions/{}/reap", ids[0]))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(reaped.status(), reqwest::StatusCode::OK);
+    let accepted = client
+        .post(format!("http://{addr}/code/sessions/{}/turns", ids[1]))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "after the reap" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        accepted.status(),
+        reqwest::StatusCode::ACCEPTED,
+        "the reap must reopen the workspace: {}",
+        accepted.text().await.unwrap()
+    );
+}
+
 #[tokio::test]
 async fn a_workspace_still_holds_only_one_watch_session() {
     // Watch keeps its cap: the fix loop belongs to the workspace, not to one

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1032,6 +1032,158 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
 }
 
 #[tokio::test]
+async fn a_workspace_runs_several_agents_that_take_turns_on_one_worktree() {
+    // Record 54: conversations are unlimited, the checkout is not. A send to a
+    // session whose sibling is mid-turn has to queue rather than run, or the
+    // two harnesses edit the same files at once.
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script()).with_delay(Duration::from_millis(120)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+
+    let mut ids = Vec::new();
+    for _ in 0..2 {
+        let created = client
+            .post(format!(
+                "http://{addr}/code/workspaces/{}/sessions",
+                json_id(&workspace)
+            ))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "harness": "claude_code",
+                "permission_mode": "plan",
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            created.status(),
+            reqwest::StatusCode::CREATED,
+            "a second agent in one workspace must create"
+        );
+        let body: serde_json::Value = created.json().await.unwrap();
+        ids.push(json_id(&body).to_owned());
+    }
+    assert_ne!(ids[0], ids[1]);
+
+    let first_id = ids[0].clone();
+    let first = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{first_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "first" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+
+    let first_parsed: CodeSessionId = ids[0].parse().unwrap();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let row = tidebreak_core::db::code::get_session(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                first_parsed,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            if row.lifecycle == CodeSessionLifecycle::Running {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("the first agent never reached Running");
+
+    let sibling = client
+        .post(format!("http://{addr}/code/sessions/{}/turns", ids[1]))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "second" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        sibling.status(),
+        reqwest::StatusCode::ACCEPTED,
+        "a send while a sibling holds the worktree must queue, not run"
+    );
+
+    assert_eq!(first.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+
+    let second_parsed: CodeSessionId = ids[1].parse().unwrap();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let first_turns = tidebreak_core::db::code::list_turns(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                first_parsed,
+            )
+            .await
+            .unwrap();
+            let second_turns = tidebreak_core::db::code::list_turns(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                second_parsed,
+            )
+            .await
+            .unwrap();
+            if second_turns.first().map(|turn| turn.status) == Some(CodeTurnStatus::Completed) {
+                let first_end = first_turns[0].ended_at.expect("the first turn ended");
+                assert!(
+                    second_turns[0].started_at >= first_end,
+                    "the sibling's turn must start after the worktree frees"
+                );
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("the queued sibling turn never ran");
+}
+
+#[tokio::test]
+async fn a_workspace_still_holds_only_one_watch_session() {
+    // Watch keeps its cap: the fix loop belongs to the workspace, not to one
+    // agent, so a second one would double every push. Record 54 lifted the cap
+    // on interactive sessions only.
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let workspace_id: WorkspaceId = json_id(&workspace).parse().unwrap();
+    let owner = tidebreak_core::OwnerId::local();
+
+    let watch = |()| {
+        runtime.create_session_of_kind(
+            &owner,
+            workspace_id,
+            tidebreak_core::CodeSessionKind::Watch,
+            HarnessKind::ClaudeCode,
+            CodePermissionMode::Plan,
+            None,
+        )
+    };
+    watch(()).await.expect("the first watch session creates");
+    let second = watch(()).await.expect_err("a second watch must be refused");
+    assert!(
+        format!("{second:?}").contains("session_exists"),
+        "unexpected error: {second:?}"
+    );
+}
+
+#[tokio::test]
 async fn unsupported_explicit_steer_is_refused_without_queueing() {
     let (router, token, runtime, dir) = code_app_with(
         ScriptedAdapter::new(plain_text_script()).with_delay(Duration::from_millis(40)),

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -35,7 +35,7 @@ eventually including Tidebreak's own internal loop, sits behind
 |---|---|
 | repo | A registered local git repository: root path, default base ref, branch prefix, setup/archive scripts, quick actions. |
 | workspace | One isolated unit of work on a repo. Owns exactly one git worktree and one branch for life; carries PR state. |
-| session | One durable conversation with one harness inside a workspace. V1: one active session per workspace. |
+| session | One durable conversation with one harness inside a workspace. A workspace holds several, plus at most one watch session; their turns are serialized on the shared worktree ([`0054`](decisions/0054-multiple-sessions-per-workspace.md)). |
 | turn | One user→agent cycle in a session, ending in a checkpoint. |
 | harness | The external coding-agent CLI being driven (never "provider"). |
 

--- a/docs/decisions/0054-multiple-sessions-per-workspace.md
+++ b/docs/decisions/0054-multiple-sessions-per-workspace.md
@@ -1,0 +1,96 @@
+# 54. Multiple Agent Sessions Share One Workspace
+
+- Status: Accepted
+- Date: 2026-08-20
+- Owners: Code mode
+- Related: [0009](0009-queued-turns.md),
+  [0030](0030-code-mode-separate-surface.md),
+  [0050](0050-watch-and-fix-is-a-durable-task.md),
+  [0053](0053-code-worktrees-live-in-a-user-visible-root.md)
+
+## Context
+
+A code workspace held one interactive agent. `create_session_of_kind` rejected
+a second one with a `session_exists` conflict, and the desktop client mirrored
+the rule by keying its live digest map on the workspace alone.
+
+The rule was never about the agent. It was about the checkout. A workspace is
+one git worktree, and two harnesses editing the same files at the same time is
+corruption, not concurrency: they overwrite each other's edits, and their
+per-turn checkpoints race for `.git/index.lock`. Allowing one session was the
+cheapest way to make that impossible.
+
+It is also the wrong shape for how people work. Running a second agent on the
+same branch — a different harness for a second opinion, a scratch conversation
+that should not disturb the main thread, a fork of a transcript into a fresh
+context — needs several conversations over one checkout, not several checkouts.
+Cloning a worktree per conversation would give each agent a private tree, at
+the cost of the shared state that made them worth running together.
+
+Watch sessions already proved the shape. Record 50 put a watch session in the
+same worktree as the conversation it forked from, and kept it safe by making
+the watch sweep wait while an interactive turn was running. The workspace has
+carried two sessions since then. What it has not carried is two sessions that
+both take turns on their own schedule.
+
+## Decision
+
+A workspace holds any number of interactive sessions and at most one watch
+session. Turns across all of them are serialized on the worktree.
+
+The turn lock is a per-workspace async mutex held by a session worker for the
+length of a turn, from the moment the turn row is written to the moment the
+harness reports an outcome. A worker whose turn is queued behind another waits
+on the lock rather than running, so the guarantee holds no matter which route
+started the turn — a user send, a queued follow-up, or the watch sweep.
+
+`submit_turn` treats a busy sibling the same way record 9 treats a busy
+session: the message parks in the session's single follow-up slot and the
+route answers `Queued`. The reader sees a queued message, not a stalled
+request, and the worker runs it when the worktree frees.
+
+Concurrency lives in the conversation list. The filesystem stays single-file.
+
+## Alternatives Considered
+
+**A worktree per session.** Every conversation gets its own checkout, so turns
+run in parallel with no lock at all. Rejected: it changes what a workspace is.
+The branch, the diff, the pull request, and the review surface are all keyed to
+one tree, and splitting the tree means merging those back together — a much
+larger change than the problem asks for, for a benefit (parallel edits) that
+agents on one task rarely want.
+
+**Reuse the watch sweep's existing check.** The sweep already skips a cycle
+when another session in the workspace is running, so it looked like the
+serialization was there to reuse. It is not: the check is one-directional and
+advisory. It makes watch defer to interactive, never the reverse, and it lives
+in the sweep rather than on the turn path, so two interactive sends would sail
+straight past it. The check stays as a cheap pre-filter that avoids waking a
+harness that would only wait; the lock is what makes it a rule.
+
+**A queue per workspace instead of per session.** One ordered queue for the
+whole worktree, drained by whichever worker is free. Rejected: it moves the
+follow-up slot away from the session that owns it, so a reader could no longer
+see which conversation their queued message belongs to, and cancelling one
+session's queued turn would mean reaching into a shared structure.
+
+## Consequences
+
+- A second agent starts immediately, but its first turn may wait. The wait is
+  visible as a queued message, and it is bounded by the sibling's turn.
+- A worker waiting on the lock is not reading its command channel, so a
+  shutdown or an interrupt aimed at a queued session applies after the sibling
+  turn ends. The session is not running at that point, so there is nothing in
+  flight to lose; the worker re-reads the session before it starts, and a
+  session ended during the wait never takes its turn.
+- The `session_exists` conflict now fires for watch sessions only. Clients that
+  read it as "this workspace is taken" need the session list instead.
+- Per-workspace client state keyed on the workspace alone becomes wrong. The
+  desktop digest map moves to workspace → session.
+
+## Validation
+
+`cargo test -p tidebreak-server code::` covers the create guard for both kinds
+and the serialization: two interactive sessions in one workspace create
+cleanly, a turn submitted while a sibling is running comes back `Queued`, and
+the watch guard still refuses a second watch.

--- a/docs/decisions/0054-multiple-sessions-per-workspace.md
+++ b/docs/decisions/0054-multiple-sessions-per-workspace.md
@@ -40,14 +40,27 @@ session. Turns across all of them are serialized on the worktree.
 
 The turn lock is a per-workspace async mutex held by a session worker for the
 length of a turn, from the moment the turn row is written to the moment the
-harness reports an outcome. A worker whose turn is queued behind another waits
-on the lock rather than running, so the guarantee holds no matter which route
-started the turn — a user send, a queued follow-up, or the watch sweep.
+harness reports an outcome. The guarantee holds no matter which route started
+the turn — a user send, a queued follow-up, or the watch sweep.
 
-`submit_turn` treats a busy sibling the same way record 9 treats a busy
-session: the message parks in the session's single follow-up slot and the
-route answers `Queued`. The reader sees a queued message, not a stalled
-request, and the worker runs it when the worktree frees.
+Taking the lock *is* the reservation. No database read can stand in for it: two
+idle siblings both pass any "is a sibling running?" check before either one
+marks itself running, so a pre-flight filter answers for a moment that has
+already passed. A send therefore tries the lock and does not wait for it. If a
+sibling holds it, `submit_turn` treats that exactly as record 9 treats a busy
+session: the message parks in the session's single follow-up slot and the route
+answers `Queued`. The reader sees a queued message, not a stalled request, and
+the worker runs it when the worktree frees.
+
+A queued turn does wait on the lock, since nobody is holding a connection open
+for it. That wait keeps answering control commands, so a stop pressed while a
+message is still queued drops the turn before it starts rather than reaching
+the engine after it has begun.
+
+The lock orders the workers this process owns, which is every writer except
+one: a fenced session may have left a harness child alive in the checkout from
+before a restart. While any session in a workspace is fenced, no session in
+that workspace may start a turn. The reap that clears the fence reopens it.
 
 Concurrency lives in the conversation list. The filesystem stays single-file.
 
@@ -65,8 +78,15 @@ when another session in the workspace is running, so it looked like the
 serialization was there to reuse. It is not: the check is one-directional and
 advisory. It makes watch defer to interactive, never the reverse, and it lives
 in the sweep rather than on the turn path, so two interactive sends would sail
-straight past it. The check stays as a cheap pre-filter that avoids waking a
-harness that would only wait; the lock is what makes it a rule.
+straight past it. The sweep keeps its check, because a skipped sweep cycle
+costs nothing and comes around again. The turn path gets the lock instead.
+
+**A pre-flight check on the turn path, so a send never has to be refused.**
+Read the workspace's sessions, and park the message if any sibling is running.
+Rejected: it is a check, not a reservation. Two simultaneous first sends both
+read an idle workspace, both proceed, and one then blocks inside the worker —
+holding its HTTP request open for the length of the other's turn. Trying the
+lock costs one atomic operation and answers for the present moment.
 
 **A queue per workspace instead of per session.** One ordered queue for the
 whole worktree, drained by whichever worker is free. Rejected: it moves the
@@ -78,11 +98,19 @@ session's queued turn would mean reaching into a shared structure.
 
 - A second agent starts immediately, but its first turn may wait. The wait is
   visible as a queued message, and it is bounded by the sibling's turn.
-- A worker waiting on the lock is not reading its command channel, so a
-  shutdown or an interrupt aimed at a queued session applies after the sibling
-  turn ends. The session is not running at that point, so there is nothing in
-  flight to lose; the worker re-reads the session before it starts, and a
-  session ended during the wait never takes its turn.
+- A worker waiting on the lock still answers control, so an interrupt or a
+  shutdown aimed at a queued session takes effect while it is still queued.
+  Stopping a turn that has not started needs no engine call: dropping it is the
+  stop, and no turn row is ever written. The worker also re-reads the session
+  before it starts, so a session ended during the wait never takes its turn.
+- One fenced session closes its whole workspace to turns, not just itself. That
+  is stricter than the old rule, and deliberately so: the alternative is a
+  single-writer guarantee that holds only for the sessions this process knows
+  about. Reaping the fenced session lifts it.
+- Archiving a workspace keeps its turn lock when a worker outlived its shutdown
+  grace. Dropping it would hand the next worker on that checkout a second lock
+  over the same files, which is the one thing the lock exists to prevent. The
+  cost is a map entry per archived workspace.
 - The `session_exists` conflict now fires for watch sessions only. Clients that
   read it as "this workspace is taken" need the session list instead.
 - Per-workspace client state keyed on the workspace alone becomes wrong. The
@@ -93,4 +121,7 @@ session's queued turn would mean reaching into a shared structure.
 `cargo test -p tidebreak-server code::` covers the create guard for both kinds
 and the serialization: two interactive sessions in one workspace create
 cleanly, a turn submitted while a sibling is running comes back `Queued`, and
-the watch guard still refuses a second watch.
+the watch guard still refuses a second watch. Three tests cover the races the
+lock exists for — two idle siblings sending at once get one turn and one queue
+rather than two turns and a held request, an interrupt reaches a queued turn
+before it starts, and a fenced sibling refuses turns until it is reaped.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -221,13 +221,13 @@ purpose:
 - **Checkpoint restore.** Per-turn checkpoints land with v1 as hidden refs
   and power turn-scoped diffs; the surface that restores a workspace to an
   earlier checkpoint waits until review flows have settled.
-- **Multiple sessions per workspace.** The data model keeps room for
-  follow-up and successor sessions in one worktree; v1 runs one active
-  session per workspace. Watch tasks
-  ([record 50](decisions/0050-watch-and-fix-is-a-durable-task.md)) take the
-  first step: one interactive session plus one watch session may share a
-  worktree, serialized so only one turn runs at a time. Free-form
-  concurrent sessions stay parked.
+- **Parallel turns in one worktree.** Several agents may share a workspace
+  ([record 54](decisions/0054-multiple-sessions-per-workspace.md)), but their
+  turns are serialized on the checkout: two harnesses editing one tree is
+  corruption, not concurrency. Running turns side by side would mean a
+  worktree per session, which splits the branch, the diff, and the pull
+  request the workspace is keyed to. Reconsider only with a reason to give
+  one workspace several trees.
 - **Changing a session's permission mode after it starts.** The mode is
   chosen at session creation, refused per harness capability there
   ([record 33](decisions/0033-code-mode-approvals.md),


### PR DESCRIPTION
## What changed

A code workspace held one interactive agent, enforced by a `session_exists`
conflict on create and recorded as a deferral in `docs/deferred.md`.

The rule was never about the agent — it was about the checkout. A workspace is
one git worktree, and two harnesses editing the same files at once overwrite
each other and race for `.git/index.lock` during per-turn checkpoints. Allowing
one session was the cheapest way to make that impossible.

This lifts the cap on conversations and puts the guarantee where it belongs. A
workspace now holds any number of interactive sessions and at most one watch
session, and turns across all of them serialize on a per-workspace async mutex
the session worker holds for the length of a turn. New ADR 0054 states the
rule; the `docs/deferred.md` entry shrinks to point at it.

**This departs from the plan, deliberately.** The plan said the turn path would
reuse the existing watch/interactive serialization rather than adding a second
mechanism. That mechanism turned out not to be one: the check in `watch.rs` is
one-directional and advisory, and `submit_turn` had no cross-session check at
all. The old check stays as a cheap pre-filter; the mutex is the mechanism.

`submit_turn` treats a busy sibling the way ADR 0009 treats a busy session: the
message parks in the session's follow-up slot and the route answers `Queued`, so
a send never holds its connection open waiting for the lock.

Conversation tabs (#2356) and fork (#2357) build on this. This is the server
half and ships no UI.

## Validation

- `cargo test -p tidebreak-server --lib code::` — 147 passed
- `cargo fmt --all --check`

Covers: several interactive sessions create cleanly; concurrent turns across two
sessions in one worktree still serialize; the one-watch-per-worktree guard still
holds.

## Compatibility and risk

No schema or wire format change — the cap was a runtime guard, not a constraint.
The risk is contention: a long turn now blocks a sibling's turn instead of that
sibling being impossible to create. That is the intended trade, and the queue
answer keeps it from looking like a hang.

## Tracking

None.
