### PR TITLE
feat(code): give every agent its own tab

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -8,6 +8,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import {
   ArrowRightFromLine,
+  Bot,
   ChevronLeft,
   ChevronRight,
   CircleX,
@@ -20,7 +21,6 @@ import {
   Globe2,
   SquareTerminal,
   ListX,
-  MessageSquare,
   MoveLeft,
   MoveRight,
   PanelRightClose,
@@ -40,22 +40,48 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { panelKey, type PanelContent } from "@/panel/panelTypes";
+import type { Attention, HarnessKind } from "../api/types";
+import { AttentionBadge } from "./AttentionBadge";
 import { editorStripDropId, editorTabDragId } from "./editorDrag";
+import { HARNESS_ICONS } from "./HarnessPicker";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 
 /** Ids the strip and the two center panels agree on, so tabs name panels. */
-export const CHAT_TAB_ID = "code-center-tab-chat";
 export const CHAT_PANEL_ID = "code-center-panel-chat";
 export const EDITOR_PANEL_ID = "code-center-panel-editor-primary";
 export const SPLIT_EDITOR_PANEL_ID = "code-center-panel-editor-secondary";
 const editorTabId = (region: CenterTabRegion, index: number) =>
   `code-center-tab-editor-${region}-${index}`;
 
+/** The tab that labels the chat panel. `null` names the unstarted agent. */
+export function conversationTabId(sessionId: string | null): string {
+  return `code-center-tab-chat-${sessionId ?? "new"}`;
+}
+
 export type CenterTabRegion = "primary" | "secondary";
+
+const NO_CONVERSATIONS: readonly CodeConversationTab[] = [];
+
+/**
+ * One agent's tab in the center strip.
+ *
+ * `id` is null for an agent the reader has asked for but not started yet, so
+ * the strip can show the draft in place before a session exists.
+ */
+export type CodeConversationTab = {
+  id: string | null;
+  label: string;
+  /** Absent on a draft, which has no engine until the reader picks one. */
+  harness?: HarnessKind;
+  attention?: Attention;
+  /** Only a draft closes here: ending a live agent is a server action. */
+  closable?: boolean;
+};
 
 /** Which tab labels the editor panel right now. */
 export function centerEditorTabId(
@@ -66,14 +92,18 @@ export function centerEditorTabId(
 }
 
 /**
- * Center strip: the main agent is always first and cannot close. File and diff
- * tabs sit beside it, and the plus control opens a new file tab.
+ * Center strip: the workspace's agents come first, then its file and diff
+ * tabs, then the plus control that opens either.
  */
 export function CodeCenterTabs({
   editorTabs,
   editorActiveIndex,
   conversationFocused,
-  onSelectChat,
+  conversations = NO_CONVERSATIONS,
+  activeConversationId = null,
+  onSelectConversation,
+  onNewConversation,
+  onCloseConversation,
   onSelectEditor,
   onCloseEditor,
   onCloseAllEditors,
@@ -89,7 +119,6 @@ export function CodeCenterTabs({
   onNewTerminal,
   browserTitles = {},
   region = "primary",
-  showMainAgent = true,
   onMoveEditorToOtherGroup,
   onMoveEditor,
   onSplitActive,
@@ -98,7 +127,13 @@ export function CodeCenterTabs({
   editorTabs: PanelContent[];
   editorActiveIndex: number;
   conversationFocused: boolean;
-  onSelectChat: () => void;
+  /** The workspace's agents, oldest first. Empty in a split group. */
+  conversations?: readonly CodeConversationTab[];
+  activeConversationId?: string | null;
+  onSelectConversation?: (sessionId: string | null) => void;
+  /** Offer "New agent" in the plus menu. */
+  onNewConversation?: () => void;
+  onCloseConversation?: (sessionId: string | null) => void;
   onSelectEditor: (index: number) => void;
   onCloseEditor: (index: number) => void;
   onCloseAllEditors: () => void;
@@ -120,7 +155,6 @@ export function CodeCenterTabs({
   onNewTerminal?: () => void;
   browserTitles?: Readonly<Record<string, string>>;
   region?: CenterTabRegion;
-  showMainAgent?: boolean;
   onMoveEditorToOtherGroup?: (index: number) => void;
   /**
    * Reorder within this strip. Dragging does the same thing, so this is the
@@ -134,9 +168,13 @@ export function CodeCenterTabs({
   const { setNodeRef: setStripRef } = useDroppable({
     id: editorStripDropId(region),
   });
-  const tabOffset = showMainAgent ? 1 : 0;
+  const tabOffset = conversations.length;
   const panelId =
     region === "primary" ? EDITOR_PANEL_ID : SPLIT_EDITOR_PANEL_ID;
+  const activeConversation = conversationFocused
+    ? (conversations.find((entry) => entry.id === activeConversationId) ??
+      conversations[0])
+    : undefined;
 
   /**
    * The tabs pattern: one tab stop for the strip, arrows to move between
@@ -146,7 +184,8 @@ export function CodeCenterTabs({
   function select(position: number) {
     const last = editorTabs.length + tabOffset - 1;
     const wrapped = position < 0 ? last : position > last ? 0 : position;
-    if (showMainAgent && wrapped === 0) onSelectChat();
+    const conversation = conversations[wrapped];
+    if (conversation) onSelectConversation?.(conversation.id);
     else onSelectEditor(wrapped - tabOffset);
     tabRefs.current[wrapped]?.focus();
   }
@@ -177,46 +216,85 @@ export function CodeCenterTabs({
       aria-label={region === "primary" ? "Workspace center" : "Workspace split"}
       data-region={region}
     >
-      {showMainAgent && (
-        <ContextMenu>
-          <ContextMenuTrigger asChild>
-            <button
-              type="button"
-              role="tab"
-              id={CHAT_TAB_ID}
-              aria-selected={conversationFocused}
-              aria-controls={CHAT_PANEL_ID}
-              tabIndex={conversationFocused ? 0 : -1}
-              ref={(node) => {
-                tabRefs.current[0] = node;
-              }}
-              className={cn(
-                "flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg px-2.5 text-xs font-medium transition-[background-color,color,box-shadow,transform] duration-150 active:translate-y-px",
-                FOCUS_RING_TIGHT,
-                HOVER_TINT,
-                conversationFocused
-                  ? "bg-background text-foreground shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_7%,transparent),inset_0_0_0_1px_var(--border-subtle)]"
-                  : "text-muted-foreground hover:bg-background/65 hover:text-foreground",
-              )}
-              onClick={onSelectChat}
-              onKeyDown={(event) => onKeyDown(event, 0)}
-            >
-              <MessageSquare className="size-3.5" />
-              Main agent
-            </button>
-          </ContextMenuTrigger>
-          <TabContextMenuContent label="Main agent">
-            <ContextMenuItem
-              className="gap-3 py-2"
-              disabled={editorTabs.length === 0}
-              onSelect={onCloseEveryEditor ?? onCloseAllEditors}
-            >
-              <ListX />
-              Close other tabs
-            </ContextMenuItem>
-          </TabContextMenuContent>
-        </ContextMenu>
-      )}
+      {conversations.map((conversation, index) => {
+        const active = conversation === activeConversation;
+        const Icon = conversation.harness
+          ? HARNESS_ICONS[conversation.harness]
+          : Bot;
+        return (
+          <ContextMenu key={conversation.id ?? "new"}>
+            <ContextMenuTrigger asChild>
+              {/* The close control is a second control on the same row, so
+                  the pair stays transparent to assistive tech. */}
+              <div
+                role="presentation"
+                className={cn(
+                  "flex h-8 min-w-0 shrink-0 items-center rounded-lg transition-[background-color,box-shadow] duration-150",
+                  conversation.closable && "pr-1",
+                  HOVER_TINT,
+                  active
+                    ? "bg-background shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_7%,transparent),inset_0_0_0_1px_var(--border-subtle)]"
+                    : "hover:bg-background/65",
+                )}
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  id={conversationTabId(conversation.id)}
+                  aria-selected={active}
+                  aria-controls={CHAT_PANEL_ID}
+                  tabIndex={active ? 0 : -1}
+                  ref={(node) => {
+                    tabRefs.current[index] = node;
+                  }}
+                  className={cn(
+                    "flex h-full min-w-0 cursor-pointer items-center gap-1.5 rounded-lg px-2.5 text-xs font-medium transition-[color,transform] duration-150 active:translate-y-px",
+                    FOCUS_RING_TIGHT,
+                    HOVER_TINT,
+                    active
+                      ? "text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                  onClick={() => onSelectConversation?.(conversation.id)}
+                  onKeyDown={(event) => onKeyDown(event, index)}
+                >
+                  <Icon className="size-3.5 shrink-0" />
+                  <span className="max-w-40 truncate">
+                    {conversation.label}
+                  </span>
+                  {/* The dot is the agent's own state, not the tab's, so it
+                      shows on the tabs the reader is not looking at too. */}
+                  <AttentionBadge attention={conversation.attention} compact />
+                </button>
+                {conversation.closable && (
+                  <button
+                    type="button"
+                    className={cn(
+                      "text-muted-foreground hover:bg-muted hover:text-foreground grid size-5 shrink-0 cursor-pointer place-items-center rounded-md",
+                      FOCUS_RING_TIGHT,
+                      HOVER_TINT,
+                    )}
+                    onClick={() => onCloseConversation?.(conversation.id)}
+                  >
+                    <X className="size-3" />
+                    <span className="sr-only">{`Close ${conversation.label}`}</span>
+                  </button>
+                )}
+              </div>
+            </ContextMenuTrigger>
+            <TabContextMenuContent label={conversation.label}>
+              <ContextMenuItem
+                className="gap-3 py-2"
+                disabled={editorTabs.length === 0}
+                onSelect={onCloseEveryEditor ?? onCloseAllEditors}
+              >
+                <ListX />
+                Close other tabs
+              </ContextMenuItem>
+            </TabContextMenuContent>
+          </ContextMenu>
+        );
+      })}
       <SortableContext
         items={editorTabs.map((panel) => editorTabDragId(region, panel))}
         strategy={horizontalListSortingStrategy}
@@ -266,6 +344,15 @@ export function CodeCenterTabs({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-44">
+          {onNewConversation && (
+            <>
+              <DropdownMenuItem onSelect={onNewConversation}>
+                <Bot />
+                New agent
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
           <DropdownMenuItem onSelect={onNewTab}>
             <FileCode />
             Open file…

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -56,7 +56,7 @@ import { FilesPanel } from "./FilesPanel";
 import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { MiddleTruncate } from "./MiddleTruncate";
 import { prWorkflowStatus, type PrWorkflowState } from "./prActions";
-import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { useWorkspaceDigest } from "./CodeUpdatesStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
 
@@ -99,7 +99,7 @@ export function CodeInspector({
   onOpenDiff?: (path: string) => void;
   onClose?: () => void;
 }) {
-  const digest = useCodeUpdatesStore((state) => state.byWorkspace[workspaceId]);
+  const digest = useWorkspaceDigest(workspaceId);
   const pr = prResource
     ? prResource.data === null
       ? (digest?.pr_state ?? workspace?.pr)

--- a/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/utils";
 import { RouteFrame } from "@/RouteFrame";
 import { AttentionBadge } from "./AttentionBadge";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
-import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { useWorkspaceDigests } from "./CodeUpdatesStore";
 import { CodeSidebar } from "./CodeSidebar";
 import { useCodeUiStore } from "./CodeUiStore";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
@@ -41,7 +41,7 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
   const repos = useCodeCatalogStore((state) => state.repos);
   const workspaces = useCodeCatalogStore((state) => state.workspaces);
   const refresh = useCodeCatalogStore((state) => state.refresh);
-  const digests = useCodeUpdatesStore((state) => state.byWorkspace);
+  const digests = useWorkspaceDigests();
   // The dialog itself is mounted once, by the rail this page renders beside
   // it, so that Cmd+N and the buttons all drive the same one.
   const startNewWorkspace = useCodeUiStore((state) => state.startNewWorkspace);

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -20,6 +20,7 @@ import { useCodeUiStore } from "./CodeUiStore";
 import {
   connectCodeUpdates,
   useCodeUpdatesStore,
+  useWorkspaceDigests,
   watchChildren,
 } from "./CodeUpdatesStore";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
@@ -62,7 +63,7 @@ export function CodeSidebar() {
   const workspaces = useCodeCatalogStore((state) => state.workspaces);
   const sessions = useCodeCatalogStore((state) => state.sessionsByWorkspace);
   const refresh = useCodeCatalogStore((state) => state.refresh);
-  const digests = useCodeUpdatesStore((state) => state.byWorkspace);
+  const digests = useWorkspaceDigests();
   const childrenByWorkspace = useCodeUpdatesStore(
     (state) => state.childrenByWorkspace,
   );

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -7,6 +7,7 @@ import {
   shouldRequestOsAttention,
   useCodeUpdatesStore,
   watchChildren,
+  workspaceDigest,
   type CodeUpdatesState,
 } from "./CodeUpdatesStore";
 
@@ -30,7 +31,7 @@ function digest(overrides: Partial<CodeSessionDigest> = {}): CodeSessionDigest {
 }
 
 const EMPTY_STATE: CodeUpdatesState = {
-  byWorkspace: {},
+  conversationsByWorkspace: {},
   childrenByWorkspace: {},
   cloneJobs: {},
   harnessInstalls: {},
@@ -48,19 +49,64 @@ describe("reduceCodeUpdates", () => {
       type: "snapshot",
       sessions: [digest(), digest({ workspace: "ws-2", session: "sess-2", title: "other" })],
     });
-    expect(Object.keys(afterSnapshot.byWorkspace)).toEqual(["ws-1", "ws-2"]);
+    expect(Object.keys(afterSnapshot.conversationsByWorkspace)).toEqual([
+      "ws-1",
+      "ws-2",
+    ]);
     const afterDigest = reduceCodeUpdates(afterSnapshot, {
       type: "digest",
       digest: digest({ turn_count: 2, attention: need }),
     });
-    expect(afterDigest.byWorkspace["ws-1"].turn_count).toBe(2);
-    expect(afterDigest.byWorkspace["ws-1"].attention).toEqual(need);
-    expect(afterDigest.byWorkspace["ws-2"].title).toBe("other");
+    const first = afterDigest.conversationsByWorkspace["ws-1"]["sess-1"];
+    expect(first.turn_count).toBe(2);
+    expect(first.attention).toEqual(need);
+    expect(
+      afterDigest.conversationsByWorkspace["ws-2"]["sess-2"].title,
+    ).toBe("other");
     const restated = reduceCodeUpdates(afterDigest, {
       type: "snapshot",
       sessions: [digest({ workspace: "ws-3", session: "sess-3" })],
     });
-    expect(Object.keys(restated.byWorkspace)).toEqual(["ws-3"]);
+    expect(Object.keys(restated.conversationsByWorkspace)).toEqual(["ws-3"]);
+  });
+
+  it("keeps every agent in one workspace and collapses them for a card", () => {
+    const seeded = reduceCodeUpdates(EMPTY_STATE, {
+      type: "snapshot",
+      sessions: [
+        digest({ session: "sess-1" }),
+        digest({ session: "sess-2", lifecycle: "running" }),
+      ],
+    });
+    // Record 54: several agents share one worktree, so the map keeps them all.
+    expect(Object.keys(seeded.conversationsByWorkspace["ws-1"])).toEqual([
+      "sess-1",
+      "sess-2",
+    ]);
+    // A running agent outranks an idle one on the card.
+    expect(workspaceDigest(seeded, "ws-1")?.session).toBe("sess-2");
+
+    const asked = reduceCodeUpdates(seeded, {
+      type: "digest",
+      digest: digest({ session: "sess-1", attention: need }),
+    });
+    // A waiting agent outranks a running one: it is the one that needs a person.
+    expect(workspaceDigest(asked, "ws-1")?.session).toBe("sess-1");
+    expect(workspaceDigest(asked, "ws-missing")).toBeUndefined();
+  });
+
+  it("keeps an ended conversation so its title and PR survive", () => {
+    const seeded = reduceCodeUpdates(EMPTY_STATE, {
+      type: "snapshot",
+      sessions: [digest()],
+    });
+    const ended = reduceCodeUpdates(seeded, {
+      type: "digest",
+      digest: digest({ lifecycle: "ended" }),
+    });
+    expect(ended.conversationsByWorkspace["ws-1"]["sess-1"].lifecycle).toBe(
+      "ended",
+    );
   });
 
   it("keeps watch digests beside the conversation, never in its slot", () => {
@@ -71,8 +117,10 @@ describe("reduceCodeUpdates", () => {
         digest({ session: "sess-watch", kind: "watch", lifecycle: "running" }),
       ],
     });
-    // ADR 0050: the interactive digest keeps the workspace slot.
-    expect(seeded.byWorkspace["ws-1"].session).toBe("sess-1");
+    // ADR 0050: a watch is a child, never one of the conversations.
+    expect(Object.keys(seeded.conversationsByWorkspace["ws-1"])).toEqual([
+      "sess-1",
+    ]);
     expect(watchChildren(seeded, "ws-1").map((child) => child.session)).toEqual([
       "sess-watch",
     ]);
@@ -86,8 +134,12 @@ describe("reduceCodeUpdates", () => {
         turn_count: 5,
       }),
     });
-    expect(afterWatchDigest.byWorkspace["ws-1"].session).toBe("sess-1");
-    expect(afterWatchDigest.byWorkspace["ws-1"].turn_count).toBe(0);
+    expect(
+      Object.keys(afterWatchDigest.conversationsByWorkspace["ws-1"]),
+    ).toEqual(["sess-1"]);
+    expect(
+      afterWatchDigest.conversationsByWorkspace["ws-1"]["sess-1"].turn_count,
+    ).toBe(0);
     expect(watchChildren(afterWatchDigest, "ws-1")[0]?.turn_count).toBe(5);
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { create } from "zustand";
 
 import type { ApiClient } from "../api/client";
@@ -26,15 +27,28 @@ import { requestUserAttention } from "../host";
  * cheap.
  */
 
+/** Digests for one kind of session, keyed workspace → session. */
+export type DigestsByWorkspace = Record<
+  string,
+  Record<string, CodeSessionDigest>
+>;
+
 export type CodeUpdatesState = {
-  /** The interactive session's digest, one per workspace. Never a watch. */
-  byWorkspace: Record<string, CodeSessionDigest>;
+  /**
+   * Conversation digests, keyed workspace → session. Never a watch.
+   *
+   * A workspace runs several agents (record 54), so it names a set rather
+   * than one digest. List surfaces collapse the set through
+   * `workspaceDigest`; the workspace page reads all of it to label its
+   * conversation tabs.
+   */
+  conversationsByWorkspace: DigestsByWorkspace;
   /**
    * Watch digests, keyed workspace → session. Children beside the
-   * conversation, never in its slot — ADR 0050's rule, kept by construction:
+   * conversations, never among them — ADR 0050's rule, kept by construction:
    * the two maps have disjoint sources.
    */
-  childrenByWorkspace: Record<string, Record<string, CodeSessionDigest>>;
+  childrenByWorkspace: DigestsByWorkspace;
   cloneJobs: Record<string, CodeCloneJobSnapshot>;
   /**
    * Warm harness installs, keyed by engine. The New Workspace dialog starts
@@ -55,7 +69,7 @@ export type CodeUpdatesAction =
   | { type: "reset" };
 
 const EMPTY: CodeUpdatesState = {
-  byWorkspace: {},
+  conversationsByWorkspace: {},
   childrenByWorkspace: {},
   cloneJobs: {},
   harnessInstalls: {},
@@ -70,37 +84,40 @@ export function reduceCodeUpdates(
     case "snapshot": {
       // The snapshot restates every live session, so both maps rebuild from
       // scratch — a reconnect self-heals a missed end notice.
-      const byWorkspace: Record<string, CodeSessionDigest> = {};
-      const childrenByWorkspace: Record<
-        string,
-        Record<string, CodeSessionDigest>
-      > = {};
+      const conversationsByWorkspace: DigestsByWorkspace = {};
+      const childrenByWorkspace: DigestsByWorkspace = {};
       for (const digest of action.sessions) {
-        if (digest.kind === "watch") {
-          (childrenByWorkspace[digest.workspace] ??= {})[digest.session] =
-            digest;
-        } else {
-          byWorkspace[digest.workspace] = digest;
-        }
+        const map =
+          digest.kind === "watch"
+            ? childrenByWorkspace
+            : conversationsByWorkspace;
+        (map[digest.workspace] ??= {})[digest.session] = digest;
       }
-      return { ...state, byWorkspace, childrenByWorkspace };
+      return { ...state, conversationsByWorkspace, childrenByWorkspace };
     }
     case "digest": {
       if (action.digest.kind === "watch") {
         return {
           ...state,
-          childrenByWorkspace: upsertChild(
+          // An ended watch leaves the rail. The snapshot on reconnect would
+          // drop it anyway; this does it without waiting for one.
+          childrenByWorkspace: upsertDigest(
             state.childrenByWorkspace,
             action.digest,
+            true,
           ),
         };
       }
       return {
         ...state,
-        byWorkspace: {
-          ...state.byWorkspace,
-          [action.digest.workspace]: action.digest,
-        },
+        // An ended conversation stays. Its tab is already gone — the strip
+        // reads the session list, not this map — and the workspace header
+        // keeps a title and a PR from it until the next snapshot.
+        conversationsByWorkspace: upsertDigest(
+          state.conversationsByWorkspace,
+          action.digest,
+          false,
+        ),
       };
     }
     case "clone_progress":
@@ -126,24 +143,112 @@ export function reduceCodeUpdates(
   }
 }
 
-function upsertChild(
-  children: CodeUpdatesState["childrenByWorkspace"],
+function upsertDigest(
+  map: DigestsByWorkspace,
   digest: CodeSessionDigest,
-): CodeUpdatesState["childrenByWorkspace"] {
-  const forWorkspace = { ...children[digest.workspace] };
-  if (digest.lifecycle === "ended") {
-    // An ended watch leaves the rail; the snapshot on reconnect would drop
-    // it anyway, this just does it without waiting for one.
+  dropEnded: boolean,
+): DigestsByWorkspace {
+  const forWorkspace = { ...map[digest.workspace] };
+  if (dropEnded && digest.lifecycle === "ended") {
     delete forWorkspace[digest.session];
   } else {
     forWorkspace[digest.session] = digest;
   }
   if (Object.keys(forWorkspace).length === 0) {
-    const next = { ...children };
+    const next = { ...map };
     delete next[digest.workspace];
     return next;
   }
-  return { ...children, [digest.workspace]: forWorkspace };
+  return { ...map, [digest.workspace]: forWorkspace };
+}
+
+/**
+ * The one digest a list surface should show for a workspace.
+ *
+ * A card is a row per workspace, not per agent, so several conversations
+ * collapse to the one that most wants a person: a need first, then a running
+ * engine, then anything still live. Title and PR state come from the
+ * workspace itself, so every sibling agrees on them and this choice only
+ * decides whose attention the card reports.
+ */
+export function workspaceDigest(
+  state: Pick<CodeUpdatesState, "conversationsByWorkspace">,
+  workspaceId: string,
+): CodeSessionDigest | undefined {
+  const conversations = state.conversationsByWorkspace[workspaceId];
+  if (!conversations) return undefined;
+  let best: CodeSessionDigest | undefined;
+  for (const digest of Object.values(conversations)) {
+    if (!best || digestUrgency(digest) < digestUrgency(best)) best = digest;
+  }
+  return best;
+}
+
+function digestUrgency(digest: CodeSessionDigest): number {
+  if (digest.lifecycle === "ended") return 4;
+  if (digest.attention.state.type === "needs_you") return 0;
+  if (digest.lifecycle === "running") return 1;
+  if (digest.attention.state.type === "done_unreviewed") return 2;
+  return 3;
+}
+
+/** One digest per workspace, for the rail and the card lists. */
+export function useWorkspaceDigests(): Record<string, CodeSessionDigest> {
+  const conversations = useCodeUpdatesStore(
+    (state) => state.conversationsByWorkspace,
+  );
+  return useMemo(() => {
+    const digests: Record<string, CodeSessionDigest> = {};
+    for (const workspaceId of Object.keys(conversations)) {
+      const digest = workspaceDigest(
+        { conversationsByWorkspace: conversations },
+        workspaceId,
+      );
+      if (digest) digests[workspaceId] = digest;
+    }
+    return digests;
+  }, [conversations]);
+}
+
+/** The digest that speaks for one workspace, for a header or an inspector. */
+export function useWorkspaceDigest(
+  workspaceId: string,
+): CodeSessionDigest | undefined {
+  return useCodeUpdatesStore((state) => workspaceDigest(state, workspaceId));
+}
+
+/**
+ * The live digest for one session, whichever map holds it.
+ *
+ * A workspace page shows one session at a time and may be showing a watch
+ * child, so it asks by id rather than taking the workspace's representative.
+ */
+export function useSessionDigest(
+  workspaceId: string,
+  sessionId: string | null,
+): CodeSessionDigest | undefined {
+  return useCodeUpdatesStore((state) =>
+    sessionId
+      ? (state.conversationsByWorkspace[workspaceId]?.[sessionId] ??
+        state.childrenByWorkspace[workspaceId]?.[sessionId])
+      : undefined,
+  );
+}
+
+const NO_DIGESTS: Record<string, CodeSessionDigest> = {};
+
+/**
+ * Every conversation digest in one workspace, keyed by session.
+ *
+ * The workspace page labels a tab per agent, so it needs each agent's own
+ * state rather than the one the card collapses to.
+ */
+export function useConversationDigests(
+  workspaceId: string,
+): Record<string, CodeSessionDigest> {
+  return useCodeUpdatesStore(
+    (state) => state.conversationsByWorkspace[workspaceId] ?? NO_DIGESTS,
+  );
 }
 
 /** A workspace's watch digests, in a stable order for rendering. */
@@ -261,7 +366,9 @@ export const useCodeUpdatesStore = create<CodeUpdatesStore>()((set, get) => ({
 }));
 
 function maybeNotify(previous: CodeUpdatesState, digest: CodeSessionDigest): void {
-  const prior = previous.byWorkspace[digest.workspace]?.attention;
+  const prior =
+    previous.conversationsByWorkspace[digest.workspace]?.[digest.session]
+      ?.attention;
   if (
     shouldRequestOsAttention(
       prior,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -213,7 +213,7 @@ function makeClient() {
     listCodeWorkspaceSessions: vi.fn(
       async (): Promise<(typeof SESSION)[]> => [],
     ),
-    listCodeSessionTurns: vi.fn(async () => [TURN]),
+    listCodeSessionTurns: vi.fn(async (_sessionId: string) => [TURN]),
     listCodeApprovals: vi.fn(async () => []),
     openCodeEvents: vi.fn(
       (
@@ -1042,6 +1042,72 @@ describe("CodeWorkspacePage", () => {
       screen.getByRole("tablist", { name: "Workspace center" }),
     ).toBeInTheDocument();
     expect(chatTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("gives every agent in the workspace its own tab and switches between them", async () => {
+    const client = makeClient();
+    const second: CodeSessionSnapshot = {
+      ...SESSION,
+      id: "sess-2",
+      harness_kind: "codex",
+      created_at: "2026-08-15T01:00:00.000Z",
+    };
+    // The list arrives newest first; the strip reads oldest first, so the
+    // agent the workspace started with keeps the left-hand slot.
+    client.listCodeWorkspaceSessions.mockResolvedValue([second, SESSION]);
+    client.listCodeSessionTurns.mockImplementation(async (sessionId: string) =>
+      sessionId === "sess-1"
+        ? [TURN]
+        : [{ ...TURN, id: "turn-2", session_id: "sess-2", user_input: "run the tests" }],
+    );
+    const user = userEvent.setup();
+    const { router } = await mountWorkspace(client);
+
+    const main = await screen.findByRole("tab", { name: "Main agent" });
+    const codex = screen.getByRole("tab", { name: "Codex CLI" });
+    expect(main).toHaveAttribute("aria-selected", "true");
+    expect(
+      await screen.findByRole("article", { name: "You" }),
+    ).toHaveTextContent("list the files");
+
+    await user.click(codex);
+    expect(codex).toHaveAttribute("aria-selected", "true");
+    // The URL names the sibling so a reload comes back to the same agent.
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({ task: "sess-2" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("article", { name: "You" })).toHaveTextContent(
+        "run the tests",
+      ),
+    );
+  });
+
+  it("opens a draft tab for a second agent and closes it again", async () => {
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    await screen.findByRole("tab", { name: "Main agent" });
+    await user.click(screen.getByRole("button", { name: "New tab" }));
+    await user.click(await screen.findByRole("menuitem", { name: "New agent" }));
+
+    const draft = await screen.findByRole("tab", { name: "New agent" });
+    expect(draft).toHaveAttribute("aria-selected", "true");
+    // Nothing is running behind a draft, so the picker takes the panel.
+    expect(
+      await screen.findByRole("button", { name: "Send message" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close New agent" }));
+    expect(
+      screen.queryByRole("tab", { name: "New agent" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Main agent" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   it("starts on the main-agent tab and opens a file from the visible new-tab control", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -1083,6 +1083,51 @@ describe("CodeWorkspacePage", () => {
     );
   });
 
+  it("falls back to the main agent when ?task names a session that is gone", async () => {
+    // A link outlives the agent it points at. Landing on one must not leave the
+    // page showing nothing, and must not leave the URL still claiming it.
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    const { router } = await mountWorkspace(
+      client,
+      "/code/w/ws-1?task=sess-never-existed",
+    );
+
+    const main = await screen.findByRole("tab", { name: "Main agent" });
+    expect(main).toHaveAttribute("aria-selected", "true");
+    expect(
+      await screen.findByRole("article", { name: "You" }),
+    ).toHaveTextContent("list the files");
+    await waitFor(() =>
+      expect(router.state.location.search).not.toHaveProperty("task"),
+    );
+  });
+
+  it("falls back to the main agent when ?task names an ended session", async () => {
+    // Ended is the common case: the reader stopped the agent, then reloaded.
+    // The session is still listed, so existence alone is not enough to select.
+    const client = makeClient();
+    const ended: CodeSessionSnapshot = {
+      ...SESSION,
+      id: "sess-2",
+      harness_kind: "codex",
+      lifecycle: "ended",
+      created_at: "2026-08-15T01:00:00.000Z",
+    };
+    client.listCodeWorkspaceSessions.mockResolvedValue([ended, SESSION]);
+    const { router } = await mountWorkspace(client, "/code/w/ws-1?task=sess-2");
+
+    const main = await screen.findByRole("tab", { name: "Main agent" });
+    expect(main).toHaveAttribute("aria-selected", "true");
+    // An ended agent keeps no tab, so there is nothing to switch back to.
+    expect(
+      screen.queryByRole("tab", { name: "Codex CLI" }),
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(router.state.location.search).not.toHaveProperty("task"),
+    );
+  });
+
   it("opens a draft tab for a second agent and closes it again", async () => {
     const client = makeClient();
     client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -235,6 +235,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   );
   /** True while the reader is filling in a new agent that has no session yet. */
   const [draftAgent, setDraftAgent] = useState(false);
+  /**
+   * True once the server's session list has arrived for this workspace.
+   *
+   * `?task=` can only be judged against a loaded list. Before it lands, a
+   * param that names nothing looks exactly like one naming a session the page
+   * has not heard of yet, and clearing it would drop a good link on reload.
+   */
+  const [sessionsLoaded, setSessionsLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const [quickOpenRequest, setQuickOpenRequest] = useState(0);
@@ -341,21 +349,40 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   }, [rememberedSession]);
 
   // `?task=` names the session to show: a sibling agent, or a watch child
-  // opened from the rail. It wins over the default selection below.
-  useEffect(() => {
-    if (!taskParam) return;
-    if (!sessions.some((entry) => entry.id === taskParam)) return;
-    setActiveSessionId(taskParam);
-    setDraftAgent(false);
+  // opened from the rail. The param is a request, not a fact — a link outlives
+  // the agent it points at, so it holds only while that agent is still here
+  // and still live.
+  const namedTask = useMemo(() => {
+    if (!taskParam) return null;
+    const found = sessions.find((entry) => entry.id === taskParam);
+    return found && found.lifecycle !== "ended" ? found : null;
   }, [sessions, taskParam]);
 
-  // Nothing named, or the shown session ended: fall back to the first agent.
+  // A param that names nothing showable is stale: the agent ended, or the link
+  // came from somewhere else. Drop it, so the fallback below runs and the URL
+  // stops naming an agent that is not there. Replace rather than push, so Back
+  // does not lead to the same dead link.
   useEffect(() => {
-    if (taskParam || draftAgent) return;
-    const shown = sessions.some((entry) => entry.id === activeSessionId);
+    if (!sessionsLoaded || !taskParam || namedTask) return;
+    openWorkspaceTask(undefined, { replace: true });
+  }, [namedTask, sessionsLoaded, taskParam]);
+
+  // A named session wins over the default selection below.
+  useEffect(() => {
+    if (!namedTask) return;
+    setActiveSessionId(namedTask.id);
+    setDraftAgent(false);
+  }, [namedTask]);
+
+  // Nothing named, or the shown agent ended: fall back to the first one. The
+  // check reads the live conversations, not every session, so an agent that
+  // ended under the reader does not stay selected.
+  useEffect(() => {
+    if (namedTask || draftAgent) return;
+    const shown = conversations.some((entry) => entry.id === activeSessionId);
     if (activeSessionId && shown) return;
     setActiveSessionId(conversations[0]?.id ?? null);
-  }, [activeSessionId, conversations, draftAgent, sessions, taskParam]);
+  }, [activeSessionId, conversations, draftAgent, namedTask]);
 
   useEffect(() => {
     return () => {
@@ -367,6 +394,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   useEffect(() => {
     let cancelled = false;
     setError(null);
+    setSessionsLoaded(false);
     void (async () => {
       try {
         const [next, listed] = await Promise.all([
@@ -378,6 +406,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         const catalogState = useCodeCatalogStore.getState();
         catalogState.upsertWorkspace(next);
         setSessions(listed);
+        setSessionsLoaded(true);
         // The card and the rail show one agent per workspace, so the catalog
         // remembers the first — the one the workspace was started with.
         const first = liveCodeSessions(listed)[0];
@@ -518,11 +547,20 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     requestNewTab(splitFocused ? "secondary" : "primary");
   }, [quickOpenPending, splitFocused]);
 
-  /** Attach a child task's transcript (or the conversation when undefined). */
-  function openWorkspaceTask(sessionId: string | undefined) {
+  /**
+   * Attach a child task's transcript (or the conversation when undefined).
+   *
+   * `replace` is for corrections rather than choices: clearing a stale param
+   * should not leave a history entry the reader can walk back into.
+   */
+  function openWorkspaceTask(
+    sessionId: string | undefined,
+    options?: { replace?: boolean },
+  ) {
     void navigate({
       to: "/code/w/$workspaceId",
       params: { workspaceId },
+      replace: options?.replace ?? false,
       search: (current: Record<string, unknown>) => ({
         ...current,
         task: sessionId,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -93,8 +93,9 @@ import {
   centerTabParts,
   CenterTabIcon,
   CHAT_PANEL_ID,
-  CHAT_TAB_ID,
   CodeCenterTabs,
+  type CodeConversationTab,
+  conversationTabId,
   EDITOR_PANEL_ID,
   SPLIT_EDITOR_PANEL_ID,
 } from "./CodeCenterTabs";
@@ -117,8 +118,12 @@ import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { CodeInspector, PrTab, type InspectorTab } from "./CodeInspector";
 import { DiffOverview } from "./DiffOverview";
 import { useCodeUiStore } from "./CodeUiStore";
-import { useCodeUpdatesStore } from "./CodeUpdatesStore";
-import { liveCodeSession } from "./parsers";
+import {
+  useCodeUpdatesStore,
+  useConversationDigests,
+  useSessionDigest,
+} from "./CodeUpdatesStore";
+import { liveCodeSessions } from "./parsers";
 import { CodeComposer } from "./CodeComposer";
 import { CodeQuickOpen } from "./CodeQuickOpen";
 import { WorkspaceWorkflowControl } from "./WorkspaceWorkflowControl";
@@ -160,6 +165,7 @@ import {
   gatewayCodeModels,
   harnessCodeModels,
   harnessHonorsTurnModel,
+  HARNESS_LABELS,
   LIFECYCLE_LABELS,
   sessionLifecycleTooltip,
 } from "./labels";
@@ -214,9 +220,21 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     null,
   );
   const [repo, setRepo] = useState<CodeRepoSnapshot | null>(null);
-  const [session, setSession] = useState<CodeSessionSnapshot | null>(
-    catalog.sessionsByWorkspace[workspaceId] ?? null,
+  /**
+   * Every session the server knows about here, conversations and watches alike.
+   *
+   * A workspace runs several agents (record 54), so the page holds the list and
+   * picks one to show rather than tracking a single session.
+   */
+  const [sessions, setSessions] = useState<CodeSessionSnapshot[]>(() => {
+    const remembered = catalog.sessionsByWorkspace[workspaceId];
+    return remembered ? [remembered] : [];
+  });
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(
+    catalog.sessionsByWorkspace[workspaceId]?.id ?? null,
   );
+  /** True while the reader is filling in a new agent that has no session yet. */
+  const [draftAgent, setDraftAgent] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const [quickOpenRequest, setQuickOpenRequest] = useState(0);
@@ -242,7 +260,13 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const [browserTitles, setBrowserTitles] = useState<Record<string, string>>(
     () => storedBrowserTitles(layout),
   );
-  const digest = useCodeUpdatesStore((state) => state.byWorkspace[workspaceId]);
+  const conversations = useMemo(() => liveCodeSessions(sessions), [sessions]);
+  const session = useMemo(
+    () => sessions.find((entry) => entry.id === activeSessionId) ?? null,
+    [activeSessionId, sessions],
+  );
+  const digest = useSessionDigest(workspaceId, session?.id ?? null);
+  const conversationDigests = useConversationDigests(workspaceId);
   const setViewedWorkspace = useCodeUpdatesStore(
     (state) => state.setViewedWorkspace,
   );
@@ -305,10 +329,33 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     return () => setViewedWorkspace(null);
   }, [setViewedWorkspace, workspaceId]);
 
+  // A session started elsewhere — the new-workspace dialog, say — reaches the
+  // page through the catalog before the list request comes back.
   useEffect(() => {
-    if (taskParam) return;
-    if (rememberedSession) setSession(rememberedSession);
-  }, [rememberedSession, taskParam]);
+    if (!rememberedSession) return;
+    setSessions((current) =>
+      current.some((entry) => entry.id === rememberedSession.id)
+        ? current
+        : [...current, rememberedSession],
+    );
+  }, [rememberedSession]);
+
+  // `?task=` names the session to show: a sibling agent, or a watch child
+  // opened from the rail. It wins over the default selection below.
+  useEffect(() => {
+    if (!taskParam) return;
+    if (!sessions.some((entry) => entry.id === taskParam)) return;
+    setActiveSessionId(taskParam);
+    setDraftAgent(false);
+  }, [sessions, taskParam]);
+
+  // Nothing named, or the shown session ended: fall back to the first agent.
+  useEffect(() => {
+    if (taskParam || draftAgent) return;
+    const shown = sessions.some((entry) => entry.id === activeSessionId);
+    if (activeSessionId && shown) return;
+    setActiveSessionId(conversations[0]?.id ?? null);
+  }, [activeSessionId, conversations, draftAgent, sessions, taskParam]);
 
   useEffect(() => {
     return () => {
@@ -322,7 +369,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     setError(null);
     void (async () => {
       try {
-        const [next, sessions] = await Promise.all([
+        const [next, listed] = await Promise.all([
           client.getCodeWorkspace(workspaceId),
           client.listCodeWorkspaceSessions(workspaceId),
         ]);
@@ -330,23 +377,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         setWorkspace(next);
         const catalogState = useCodeCatalogStore.getState();
         catalogState.upsertWorkspace(next);
-        const live = liveCodeSession(sessions);
-        if (live) catalogState.rememberSession(live);
-        // `?task=` attaches a child task's transcript — today, the watch
-        // session — instead of the conversation.
-        const named = taskParam
-          ? sessions.find(
-              (candidate) =>
-                candidate.id === taskParam && candidate.lifecycle !== "ended",
-            )
-          : undefined;
-        if (named) {
-          setSession(named);
-        } else if (live) {
-          setSession(live);
-        } else if (!catalogState.sessionsByWorkspace[workspaceId]) {
-          setSession(null);
-        }
+        setSessions(listed);
+        // The card and the rail show one agent per workspace, so the catalog
+        // remembers the first — the one the workspace was started with.
+        const first = liveCodeSessions(listed)[0];
+        if (first) catalogState.rememberSession(first);
         const nextRepo = await client.getCodeRepo(next.repo_id);
         if (!cancelled) setRepo(nextRepo);
       } catch (err) {
@@ -358,7 +393,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     return () => {
       cancelled = true;
     };
-  }, [client, workspaceId, reloadToken, taskParam]);
+  }, [client, workspaceId, reloadToken]);
 
   async function startSession(
     harness: HarnessKind,
@@ -380,8 +415,13 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         permission_mode: permissionMode,
         model: posted,
       });
-      catalog.rememberSession(created);
-      setSession(created);
+      if (conversations.length === 0) catalog.rememberSession(created);
+      setSessions((current) => [...current, created]);
+      setActiveSessionId(created.id);
+      setDraftAgent(false);
+      // The first agent stays at a clean URL; a sibling names itself so a
+      // reload comes back to the tab the reader was on.
+      if (conversations.length > 0) openWorkspaceTask(created.id);
       await client.submitCodeTurn(created.id, message);
     } catch (err) {
       toast.error(friendlyErrorMessage(err, "Could not start a session"));
@@ -395,7 +435,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     try {
       const next = await client.reapCodeSession(session.id);
       catalog.rememberSession(next);
-      setSession(next);
+      setSessions((current) =>
+        current.map((entry) => (entry.id === next.id ? next : entry)),
+      );
     } catch (err) {
       toast.error(friendlyErrorMessage(err, "Could not reap the session"));
     }
@@ -489,6 +531,44 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     });
   }
 
+  /**
+   * Show one of the workspace's agents, or the unstarted draft when null.
+   *
+   * Selection lives in `?task=` so a reload or a shared link returns to the
+   * same agent. The first one is the workspace's default, so it stays unnamed.
+   */
+  function selectConversation(sessionId: string | null) {
+    setWorkspaceLayout(focusConversation(layout));
+    if (sessionId === null) {
+      setDraftAgent(true);
+      setActiveSessionId(null);
+      openWorkspaceTask(undefined);
+      return;
+    }
+    setDraftAgent(false);
+    setActiveSessionId(sessionId);
+    openWorkspaceTask(sessionId === conversations[0]?.id ? undefined : sessionId);
+  }
+
+  /** Add a tab for an agent the reader has not filled in yet. */
+  function newConversation() {
+    selectConversation(null);
+  }
+
+  /**
+   * Close a conversation tab.
+   *
+   * Only the draft closes here. A started agent holds a worktree and a running
+   * engine, so ending one is a server action rather than a tab control.
+   */
+  function closeConversation(sessionId: string | null) {
+    if (sessionId !== null) return;
+    setDraftAgent(false);
+    const first = conversations[0];
+    if (first) selectConversation(first.id);
+    else setActiveSessionId(null);
+  }
+
   /** Filter the parent transcript to one harness-owned child. */
   function openWorkspaceSubagent(callId: string | undefined) {
     void navigate({
@@ -531,6 +611,41 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       .then(() => toast.success("Copied path"))
       .catch(() => toast.error("Could not copy path"));
   }
+
+  /**
+   * The agent tab the strip should mark selected.
+   *
+   * A watch child opened from the rail is a drill-in with its own back bar, not
+   * a peer tab, so the first agent stays selected underneath it.
+   */
+  const activeConversationId = draftAgent
+    ? null
+    : (conversations.find((entry) => entry.id === session?.id)?.id ??
+      conversations[0]?.id ??
+      null);
+  const conversationTabs = useMemo<CodeConversationTab[]>(() => {
+    const tabs: CodeConversationTab[] = conversations.map((entry, index) => ({
+      id: entry.id,
+      label: conversationTabLabel(entry, index, conversations),
+      harness: entry.harness_kind,
+      attention: conversationDigests[entry.id]?.attention,
+    }));
+    // A draft has no engine yet, so it wears the generic agent glyph. It is
+    // also the one closable tab: nothing is running behind it. A workspace
+    // with no agents at all still gets one, so the strip always names the
+    // panel below it.
+    if (draftAgent || tabs.length === 0) {
+      tabs.push({
+        id: null,
+        label: tabs.length === 0 ? "Main agent" : "New agent",
+        closable: tabs.length > 0,
+      });
+    }
+    return tabs;
+  }, [conversationDigests, conversations, draftAgent]);
+
+  /** The picker shows for a first agent and for every one added after it. */
+  const startingNewAgent = draftAgent || !session;
 
   const editorTabs = chrome.editors.tabs;
   const showingChat =
@@ -633,7 +748,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         browserTitles={browserTitles}
         editorActiveIndex={chrome.editors.activeIndex}
         conversationFocused={showingChat}
-        onSelectChat={() => setWorkspaceLayout(focusConversation(layout))}
+        conversations={conversationTabs}
+        activeConversationId={activeConversationId}
+        onSelectConversation={selectConversation}
+        onNewConversation={newConversation}
+        onCloseConversation={closeConversation}
         onSelectEditor={(index) =>
           setWorkspaceLayout(focusEditorTab(layout, index, "primary"))
         }
@@ -686,7 +805,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         className={cn("min-h-0 flex-1", !showingChat && "hidden")}
         id={CHAT_PANEL_ID}
         role="tabpanel"
-        aria-labelledby={CHAT_TAB_ID}
+        aria-labelledby={conversationTabId(activeConversationId)}
       >
         <PanelLayout
           layout={chrome.panels}
@@ -711,7 +830,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                   </Button>
                 </div>
               )}
-              {!session && workspace?.status === "active" && (
+              {startingNewAgent && workspace?.status === "active" && (
                 <StartSessionPrompt
                   workspaceId={workspaceId}
                   harnesses={doctorHarnesses}
@@ -726,7 +845,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                   }
                 />
               )}
-              {session && (
+              {session && !draftAgent && (
                 <CodeSessionPane
                   key={session.id}
                   session={session}
@@ -775,12 +894,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     >
       <CodeCenterTabs
         region="secondary"
-        showMainAgent={false}
         editorTabs={splitEditorTabs}
         browserTitles={browserTitles}
         editorActiveIndex={chrome.splitEditors.activeIndex}
         conversationFocused={false}
-        onSelectChat={() => undefined}
         onSelectEditor={(index) =>
           setWorkspaceLayout(focusEditorTab(layout, index, "secondary"))
         }
@@ -1885,4 +2002,25 @@ function WatchTaskBar({
       </Button>
     </div>
   );
+}
+
+/**
+ * A tab label for one of a workspace's agents.
+ *
+ * The first agent is the one the workspace was started with, so it keeps the
+ * name the rest of the surface uses. The others are named by engine, numbered
+ * only when the same engine runs more than once.
+ */
+function conversationTabLabel(
+  session: CodeSessionSnapshot,
+  index: number,
+  sessions: readonly CodeSessionSnapshot[],
+): string {
+  if (index === 0) return "Main agent";
+  const label = HARNESS_LABELS[session.harness_kind];
+  const same = sessions.filter(
+    (entry, at) => at > 0 && entry.harness_kind === session.harness_kind,
+  );
+  if (same.length < 2) return label;
+  return `${label} ${same.indexOf(session) + 1}`;
 }

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  liveCodeSession,
+  liveCodeSessions,
   parseCodeAction,
   parseCodeApproval,
   parseCodeCloneDefaults,
@@ -673,20 +673,31 @@ describe("parseCodeEvent", () => {
   });
 });
 
-describe("liveCodeSession", () => {
-  it("prefers the newest non-ended session", () => {
+describe("liveCodeSessions", () => {
+  it("drops ended sessions and orders the rest oldest first", () => {
     const ended = parseCodeSession({
       ...SESSION,
       id: "old",
       lifecycle: "ended",
+      created_at: "2026-08-15T09:00:00.000Z",
+    });
+    const later = parseCodeSession({
+      ...SESSION,
+      id: "sess-2",
+      created_at: "2026-08-15T13:00:00.000Z",
     });
     const live = parseCodeSession(SESSION);
-    expect(ended && live).toBeTruthy();
-    expect(liveCodeSession([ended!, live!])?.id).toBe("sess-1");
-    expect(liveCodeSession([ended!])).toBeNull();
+    expect(ended && later && live).toBeTruthy();
+    // The list arrives newest first; the tab strip reads left to right in the
+    // order the agents were started.
+    expect(liveCodeSessions([later!, live!, ended!]).map((s) => s.id)).toEqual([
+      "sess-1",
+      "sess-2",
+    ]);
+    expect(liveCodeSessions([ended!])).toEqual([]);
   });
 
-  it("never attaches a watch session to the workspace page", () => {
+  it("never offers a watch session as a conversation", () => {
     const watch = parseCodeSession({
       ...SESSION,
       id: "watch-1",
@@ -694,8 +705,10 @@ describe("liveCodeSession", () => {
     });
     const live = parseCodeSession(SESSION);
     expect(watch && live).toBeTruthy();
-    expect(liveCodeSession([watch!, live!])?.id).toBe("sess-1");
-    expect(liveCodeSession([watch!])).toBeNull();
+    expect(liveCodeSessions([watch!, live!]).map((s) => s.id)).toEqual([
+      "sess-1",
+    ]);
+    expect(liveCodeSessions([watch!])).toEqual([]);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1629,16 +1629,26 @@ export function parseCodeSessionList(
   return sessions;
 }
 
-/** The one session a workspace page should attach, if any. */
-export function liveCodeSession(
+/**
+ * The conversations a workspace page should offer, oldest first.
+ *
+ * A workspace runs several agents (record 54). The list arrives newest first,
+ * but the tab strip reads left to right in the order the agents were started,
+ * so the first one keeps its place and a new one appends to the right.
+ */
+export function liveCodeSessions(
   sessions: readonly CodeSessionSnapshot[],
-): CodeSessionSnapshot | null {
-  return (
-    sessions.find(
+): CodeSessionSnapshot[] {
+  return sessions
+    .filter(
       (session) =>
         session.kind === "interactive" && session.lifecycle !== "ended",
-    ) ?? null
-  );
+    )
+    .sort(
+      (left, right) =>
+        left.created_at.localeCompare(right.created_at) ||
+        left.id.localeCompare(right.id),
+    );
 }
 
 export function parseCodeTurn(value: unknown): CodeTurnSnapshot | null {

--- a/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
@@ -3,23 +3,38 @@ import { DndContext } from "@dnd-kit/core";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
-import { CodeCenterTabs } from "@/code/CodeCenterTabs";
+import {
+  CodeCenterTabs,
+  type CodeConversationTab,
+} from "@/code/CodeCenterTabs";
 import type { PanelContent } from "@/panel/panelTypes";
 
+import {
+  attentionDoneUnreviewed,
+  attentionNeedsYou,
+  attentionWorking,
+} from "./fixtures";
+
+const MAIN_AGENT: CodeConversationTab[] = [
+  { id: "session-1", label: "Main agent", harness: "claude_code" },
+];
+
 /**
- * The center tab strip: the persistent Main agent tab, editor tabs, and the
- * single `+` that offers everything the center can open — a file, the
- * all-changes diff, a browser, or the terminal — instead of jumping straight
- * into the file picker.
+ * The center tab strip: one tab per agent in the workspace, then editor tabs,
+ * then the single `+` that offers everything the center can open — another
+ * agent, a file, the all-changes diff, a browser, or the terminal — instead of
+ * jumping straight into the file picker.
  */
 function TabStrip({
   editorTabs,
+  conversations = MAIN_AGENT,
   withBrowser = true,
   withDiff = true,
   withTerminal = true,
   region = "primary" as const,
 }: {
   editorTabs: PanelContent[];
+  conversations?: CodeConversationTab[];
   withBrowser?: boolean;
   withDiff?: boolean;
   withTerminal?: boolean;
@@ -27,6 +42,9 @@ function TabStrip({
 }) {
   const [active, setActive] = useState(editorTabs.length > 0 ? 0 : -1);
   const [chatFocused, setChatFocused] = useState(editorTabs.length === 0);
+  const [conversation, setConversation] = useState<string | null>(
+    conversations[0]?.id ?? null,
+  );
   // Tabs drag through dnd-kit, which addresses everything from the context the
   // page provides. Without one here the strip would render but sit inert.
   return (
@@ -35,7 +53,14 @@ function TabStrip({
         editorTabs={editorTabs}
         editorActiveIndex={active}
         conversationFocused={chatFocused}
-        onSelectChat={() => setChatFocused(true)}
+        conversations={region === "primary" ? conversations : []}
+        activeConversationId={conversation}
+        onSelectConversation={(id) => {
+          setChatFocused(true);
+          setConversation(id);
+        }}
+        onNewConversation={region === "primary" ? fn() : undefined}
+        onCloseConversation={fn()}
         onSelectEditor={(index) => {
           setChatFocused(false);
           setActive(index);
@@ -53,7 +78,6 @@ function TabStrip({
         onNewTerminal={withTerminal ? fn() : undefined}
         onSplitActive={fn()}
         region={region}
-        showMainAgent={region === "primary"}
         browserTitles={{ "browser-1": "Storybook — Tidebreak" }}
       />
     </DndContext>
@@ -79,8 +103,48 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** Conversation alone; the `+` menu is the whole affordance. */
+/** One agent alone; the `+` menu is the whole affordance. */
 export const ConversationOnly: Story = {};
+
+/**
+ * Several agents in one worktree, each showing its own state: one waiting on a
+ * reply, one still working, one idle. The dots are the agents' states, so they
+ * stay readable on the tabs nobody is looking at.
+ */
+export const ManyConversations: Story = {
+  args: {
+    conversations: [
+      {
+        id: "session-1",
+        label: "Main agent",
+        harness: "claude_code",
+        attention: attentionNeedsYou,
+      },
+      {
+        id: "session-2",
+        label: "Codex",
+        harness: "codex",
+        attention: attentionWorking,
+      },
+      {
+        id: "session-3",
+        label: "opencode",
+        harness: "opencode",
+        attention: attentionDoneUnreviewed,
+      },
+    ],
+  },
+};
+
+/** A new agent the reader has opened but not started: the one closable tab. */
+export const DraftConversation: Story = {
+  args: {
+    conversations: [
+      ...MAIN_AGENT,
+      { id: null, label: "New agent", closable: true },
+    ],
+  },
+};
 
 export const FilesOpen: Story = {
   args: {
@@ -112,7 +176,7 @@ export const WithBrowserTab: Story = {
   },
 };
 
-/** A split's right-hand group: no Main agent tab, close-group affordance. */
+/** A split's right-hand group: no agent tabs, close-group affordance. */
 export const SecondaryGroup: Story = {
   args: {
     region: "secondary",


### PR DESCRIPTION
> Stacked on #2355. Review that first; this diff is against its branch and
> retargets to `main` once it lands.

## What changed

A workspace can now run several agents (ADR 0054), so the center strip shows one
tab per agent instead of a single fixed "Main agent". Each tab carries its
engine's icon and its own attention dot, so an agent that needs a person is
visible from the tab nobody is looking at.

`CodeUpdatesStore` keeps a digest per session rather than one per workspace,
mirroring the `childrenByWorkspace` map already beside it. List surfaces collapse
the set through `workspaceDigest`, which picks the agent that most wants a
person — a need first, then a running engine, then anything still live — so a
card still speaks with one voice. The workspace page reads all of it to label the
tabs. `liveCodeSession` becomes `liveCodeSessions`, ordered oldest first, so the
first agent keeps the left-hand slot and a new one appends to the right.

Selection lives in the `?task=` search param the watch rail already uses, so a
reload returns to the same agent. "New agent" in the plus menu opens a draft tab
showing the existing start picker; starting it creates a sibling session in the
same worktree.

**One thing the plan asked for is not here.** The plan said each conversation tab
would be closable. Only the unstarted draft tab is. Ending a started agent needs
a server route that does not exist yet, so that control waits for one rather than
shipping as a button that half works.

## Validation

- `pnpm exec vitest run src/code/parsers.test.ts src/code/CodeUpdatesStore.test.ts src/code/CodeWorkspacePage.dom.test.tsx` — 87 passed
- `pnpm exec tsc --noEmit`
- `pnpm storybook:build`

Stories cover three agents in one workspace, one running, one needing you, one
idle, plus the draft tab.

Not verified locally: two agents streaming at once against a real server. Worth
confirming both stream and that their turns serialize.

## Compatibility and risk

No wire format change — the digest notice already carried `session`, and only the
client's indexing of it changes. A reconnect restates a full snapshot, so a
missed notice self-heals.

## Tracking

None.
