### PR TITLE
feat(code): fork an agent into a new tab

### DIFF
--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import {
   ArrowUpRight,
+  FileText,
   FolderOpen,
   Image as ImageIcon,
   Mic,
@@ -196,6 +197,25 @@ export type ComposerFiles = {
   onRemove: (documentId: string) => void;
 };
 
+/**
+ * A file that already sits in the agent's working directory.
+ *
+ * Nothing is uploaded and no document is created: the chip carries a path,
+ * and the surface names that path in the message it sends. Chat has no such
+ * files, so only code mode passes these.
+ */
+export type ComposerWorkspaceFile = {
+  /** Workspace-relative, which is what the engine is told to read. */
+  path: string;
+  /** One short line under the path — what the file holds, or how big it is. */
+  detail?: string;
+};
+
+export type ComposerWorkspaceFiles = {
+  items: readonly ComposerWorkspaceFile[];
+  onRemove: (path: string) => void;
+};
+
 export type ComposerFolders = {
   items: ChatFolderAccess[];
   /**
@@ -306,6 +326,8 @@ export type ComposerProps = {
   slash?: ComposerSlash;
   images?: ComposerImages;
   files?: ComposerFiles;
+  /** Paths the agent can already read, shown as chips and named on send. */
+  workspaceFiles?: ComposerWorkspaceFiles;
   folders?: ComposerFolders;
   /**
    * Workspace-relative paths `@` can insert as plain text. The parent fetches
@@ -352,6 +374,7 @@ export function Composer({
   slash,
   images,
   files,
+  workspaceFiles,
   folders,
   pathMentions,
   voice,
@@ -918,6 +941,20 @@ export function Composer({
           ))}
         </ul>
       )}
+      {workspaceFiles && workspaceFiles.items.length > 0 && (
+        <ul
+          className="m-0 flex list-none flex-wrap gap-2 p-0"
+          aria-label="Attached workspace files"
+        >
+          {workspaceFiles.items.map((file) => (
+            <WorkspaceFileChip
+              key={file.path}
+              file={file}
+              onRemove={() => workspaceFiles.onRemove(file.path)}
+            />
+          ))}
+        </ul>
+      )}
       {folderChips.length > 0 && folders && (
         <ul
           className="m-0 flex list-none flex-wrap gap-2 p-0"
@@ -1386,6 +1423,50 @@ function FileAttachmentChip({
         type="button"
         className="absolute right-0.5 top-0.5 inline-flex items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground"
         aria-label={`Remove ${file.displayName}`}
+        onClick={onRemove}
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    </li>
+  );
+}
+
+/**
+ * One file the agent can already open, named by path.
+ *
+ * A path, not a thumbnail: the bytes are in the worktree before the turn
+ * starts, so the chip's job is to show the reader which file the message is
+ * about to point at, and to let them take it back off.
+ */
+function WorkspaceFileChip({
+  file,
+  onRemove,
+}: {
+  file: ComposerWorkspaceFile;
+  onRemove: () => void;
+}) {
+  const name = file.path.slice(file.path.lastIndexOf("/") + 1);
+  const folder = file.path.slice(0, file.path.length - name.length - 1);
+  return (
+    <li className="relative flex min-w-0 max-w-full items-center gap-2 rounded-lg border border-border bg-muted/50 py-1.5 pl-2 pr-7 text-muted-foreground">
+      <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-md bg-background">
+        <FileText className="size-4" aria-hidden="true" />
+      </span>
+      <span className="grid min-w-0 gap-px">
+        <strong
+          className="max-w-[14rem] truncate text-xs font-semibold text-foreground"
+          title={file.path}
+        >
+          {name}
+        </strong>
+        <small className="max-w-[14rem] truncate text-[0.68rem]">
+          {file.detail ?? folder}
+        </small>
+      </span>
+      <button
+        type="button"
+        className="absolute right-0.5 top-0.5 inline-flex items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground"
+        aria-label={`Remove ${name}`}
         onClick={onRemove}
       >
         <X size={14} aria-hidden="true" />

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -99,6 +99,7 @@ import {
   type CodeWorkspaceSnapshot,
   type CodeCloneDefaults,
   type CodeWorktreeRoot,
+  type CodeForkTranscript,
   type CodeCloneJobSnapshot,
   type CodeHarnessInstallSnapshot,
   type CodeSubscriptionUsage,
@@ -137,6 +138,7 @@ import {
   parseCodeApproval,
   parseCodeCloneDefaults,
   parseCodeWorktreeRoot,
+  parseCodeForkTranscript,
   parseCodeCloneJob,
   parseCodeHarnessInstall,
   parseCodeRepo,
@@ -2459,6 +2461,25 @@ export class ApiClient {
         ),
       ),
       "code workspace diff",
+    );
+  }
+
+  /**
+   * Write one session's transcript into its worktree, for a fork to read.
+   *
+   * The child session is created separately: this call only produces the
+   * file, so the reader still picks the engine and edits the framing before
+   * anything is sent.
+   */
+  async forkCodeSession(sessionId: string): Promise<CodeForkTranscript> {
+    return requireParsed(
+      parseCodeForkTranscript(
+        await this.json(`/code/sessions/${encodeURIComponent(sessionId)}/fork`, {
+          method: "POST",
+          headers: this.headers(),
+        }),
+      ),
+      "code fork transcript",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -167,6 +167,7 @@ import {
   type CodeCloneJobSnapshot as WireCodeCloneJobSnapshot,
   type CodeHarnessInstallSnapshot as WireCodeHarnessInstallSnapshot,
   type CodeWorktreeRoot as WireCodeWorktreeRoot,
+  type CodeForkTranscript as WireCodeForkTranscript,
   type CodeTerminalActivityNotice as WireCodeTerminalActivityNotice,
   type PullRequestDigest as WirePullRequestDigest,
   type PullRequestCheck as WirePullRequestCheck,
@@ -1165,6 +1166,8 @@ export type CodeCloneJobSnapshot = WireCodeCloneJobSnapshot;
 export type CodeHarnessInstallSnapshot = WireCodeHarnessInstallSnapshot;
 /** Where new code worktrees land, and what clearing the setting returns to. */
 export type CodeWorktreeRoot = WireCodeWorktreeRoot;
+/** The transcript file a fork wrote into the worktree, ready to hand on. */
+export type CodeForkTranscript = WireCodeForkTranscript;
 
 /** Subscription quota windows exposed by Model Gateway or a direct harness. */
 export type CodeSubscriptionUsage = {

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -17,6 +17,7 @@ import {
   FileCode,
   FileDiff,
   GitBranch,
+  GitFork,
   GitPullRequest,
   Globe2,
   SquareTerminal,
@@ -104,6 +105,7 @@ export function CodeCenterTabs({
   onSelectConversation,
   onNewConversation,
   onCloseConversation,
+  onForkConversation,
   onSelectEditor,
   onCloseEditor,
   onCloseAllEditors,
@@ -134,6 +136,8 @@ export function CodeCenterTabs({
   /** Offer "New agent" in the plus menu. */
   onNewConversation?: () => void;
   onCloseConversation?: (sessionId: string | null) => void;
+  /** Copy this agent's transcript into the worktree and open a new agent on it. */
+  onForkConversation?: (sessionId: string) => void;
   onSelectEditor: (index: number) => void;
   onCloseEditor: (index: number) => void;
   onCloseAllEditors: () => void;
@@ -218,6 +222,7 @@ export function CodeCenterTabs({
     >
       {conversations.map((conversation, index) => {
         const active = conversation === activeConversation;
+        const forkable = conversation.id;
         const Icon = conversation.harness
           ? HARNESS_ICONS[conversation.harness]
           : Bot;
@@ -283,6 +288,19 @@ export function CodeCenterTabs({
               </div>
             </ContextMenuTrigger>
             <TabContextMenuContent label={conversation.label}>
+              {/* A draft has no transcript yet, so it has nothing to fork. */}
+              {onForkConversation && forkable !== null && (
+                <>
+                  <ContextMenuItem
+                    className="gap-3 py-2"
+                    onSelect={() => onForkConversation(forkable)}
+                  >
+                    <GitFork />
+                    Fork this agent
+                  </ContextMenuItem>
+                  <ContextMenuSeparator />
+                </>
+              )}
               <ContextMenuItem
                 className="gap-3 py-2"
                 disabled={editorTabs.length === 0}

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -9,7 +9,8 @@ import type {
 } from "../api/types";
 import { useApp } from "@/AppContext";
 import { HttpError } from "../api/client";
-import { Composer } from "../Composer";
+import { Composer, type ComposerWorkspaceFiles } from "../Composer";
+import { messageWithWorkspaceFiles } from "./fork";
 import { IMAGE_MEDIA_TYPES } from "../ImageAttachments";
 import { useImageAttachments } from "../useImageAttachments";
 import { reasoningEffortOptions } from "../ModelMenu";
@@ -461,6 +462,7 @@ export function CodeComposer({
   slashCommands,
   searchPaths,
   imageInput = false,
+  workspaceFiles,
   onSend,
   onSteer,
   onInterrupt,
@@ -503,6 +505,11 @@ export function CodeComposer({
   searchPaths?: (query: string) => Promise<readonly string[]>;
   /** The doctor said this engine consumes images on its input path. */
   imageInput?: boolean;
+  /**
+   * Files already in the worktree, shown as chips and named after the
+   * message. A fork's transcript arrives this way.
+   */
+  workspaceFiles?: ComposerWorkspaceFiles;
   onSend: (
     message: string,
     attachments?: readonly { blob_id: string; media_type: string }[],
@@ -622,8 +629,11 @@ export function CodeComposer({
   }, [lastTurnBeganId]);
 
   async function submit() {
-    const message = draft.trim();
-    if (!message || disabled) return;
+    const typed = draft.trim();
+    if (!typed || disabled) return;
+    // The chips ride out with the message: the engine reads the paths from
+    // its own working directory, so nothing is uploaded.
+    const message = messageWithWorkspaceFiles(typed, workspaceFiles?.items ?? []);
     const pending = images.attachments.filter(
       (item) => item.status === "queued" || item.status === "uploading",
     );
@@ -821,6 +831,7 @@ export function CodeComposer({
               }
             : undefined
         }
+        workspaceFiles={workspaceFiles}
         onDraftChange={(value) => {
           draftRef.current = value;
           setSteerError(null);

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -29,6 +29,7 @@ import type { ApiClient } from "../api/client";
 import type {
   Attention,
   CodeApprovalSnapshot,
+  CodeForkTranscript,
   CodePermissionMode,
   CodeRepoSnapshot,
   CodeSessionSnapshot,
@@ -118,6 +119,7 @@ import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { CodeInspector, PrTab, type InspectorTab } from "./CodeInspector";
 import { DiffOverview } from "./DiffOverview";
 import { useCodeUiStore } from "./CodeUiStore";
+import { FORK_FRAMING, forkTranscriptFile } from "./fork";
 import {
   useCodeUpdatesStore,
   useConversationDigests,
@@ -243,6 +245,13 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
    * has not heard of yet, and clearing it would drop a good link on reload.
    */
   const [sessionsLoaded, setSessionsLoaded] = useState(false);
+  /**
+   * The transcript a fork wrote, waiting for the draft agent to send it.
+   *
+   * It survives an engine change and a rewritten framing line, and clears
+   * once a session starts or the reader closes the draft.
+   */
+  const [forkSource, setForkSource] = useState<CodeForkTranscript | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const [quickOpenRequest, setQuickOpenRequest] = useState(0);
@@ -448,6 +457,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       setSessions((current) => [...current, created]);
       setActiveSessionId(created.id);
       setDraftAgent(false);
+      setForkSource(null);
       // The first agent stays at a clean URL; a sibling names itself so a
       // reload comes back to the tab the reader was on.
       if (conversations.length > 0) openWorkspaceTask(created.id);
@@ -484,6 +494,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         hasSession: Boolean(session),
         attentionPinned:
           (digest?.attention ?? session?.attention)?.state.type === "manual",
+        // A watch child is the harness's own run, not a conversation to
+        // continue, so only an interactive agent offers a fork.
+        canFork: session?.kind === "interactive",
         quickActions: repo?.quick_actions ?? [],
       })
     : [];
@@ -590,7 +603,27 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
 
   /** Add a tab for an agent the reader has not filled in yet. */
   function newConversation() {
+    setForkSource(null);
     selectConversation(null);
+  }
+
+  /**
+   * Hand one agent's transcript to a fresh one.
+   *
+   * The server writes the file into the worktree, so the child reads it from
+   * its own working directory whatever engine it turns out to be. Nothing is
+   * sent here: the draft tab opens with the transcript attached and a framing
+   * line the reader edits first.
+   */
+  async function forkConversation(sessionId: string) {
+    try {
+      const written = await client.forkCodeSession(sessionId);
+      setForkSource(written);
+      selectConversation(null);
+      useCodeUiStore.getState().offerComposerPrompt(workspaceId, FORK_FRAMING);
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not fork this agent"));
+    }
   }
 
   /**
@@ -602,6 +635,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   function closeConversation(sessionId: string | null) {
     if (sessionId !== null) return;
     setDraftAgent(false);
+    setForkSource(null);
     const first = conversations[0];
     if (first) selectConversation(first.id);
     else setActiveSessionId(null);
@@ -791,6 +825,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         onSelectConversation={selectConversation}
         onNewConversation={newConversation}
         onCloseConversation={closeConversation}
+        onForkConversation={(sessionId) => void forkConversation(sessionId)}
         onSelectEditor={(index) =>
           setWorkspaceLayout(focusEditorTab(layout, index, "primary"))
         }
@@ -880,6 +915,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                   defaultModelKey={defaultModelKey}
                   onStart={(harness, mode, message, model) =>
                     startSession(harness, mode, message, model)
+                  }
+                  workspaceFiles={
+                    forkSource
+                      ? {
+                          items: [forkTranscriptFile(forkSource)],
+                          onRemove: () => setForkSource(null),
+                        }
+                      : undefined
                   }
                 />
               )}
@@ -1113,14 +1156,18 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                 repoName: repoName ?? undefined,
                 worktreePath: workspace.worktree_path,
               }}
-              onCommand={(command) =>
+              onCommand={(command) => {
+                if (command.id === "fork-agent") {
+                  if (session) void forkConversation(session.id);
+                  return;
+                }
                 run(command.id, {
                   workspace,
                   title: title ?? workspace.title,
                   session: session ?? undefined,
                   actionName: command.actionName,
-                })
-              }
+                });
+              }}
             />
           ) : undefined
         }

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -7,6 +7,7 @@ import type {
   HarnessKind,
   ModelInfo,
 } from "../api/types";
+import type { ComposerWorkspaceFiles } from "@/Composer";
 import { CodeComposer } from "./CodeComposer";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { HarnessPicker } from "./HarnessPicker";
@@ -45,6 +46,7 @@ export function StartSessionPrompt({
   client,
   catalogModels = NO_CATALOG_MODELS,
   defaultModelKey = null,
+  workspaceFiles,
 }: {
   workspaceId: string;
   harnesses: HarnessDoctorEntry[];
@@ -60,6 +62,8 @@ export function StartSessionPrompt({
   client?: Pick<ApiClient, "listCodeHarnessModels">;
   catalogModels?: ModelInfo[];
   defaultModelKey?: string | null;
+  /** Worktree files the first message names — a fork's transcript. */
+  workspaceFiles?: ComposerWorkspaceFiles;
 }) {
   const [picked, setPicked] = useState<HarnessKind | null>(null);
   const [model, setModel] = useState<string | undefined>();
@@ -165,6 +169,7 @@ export function StartSessionPrompt({
           modelOptions={modelOptions}
           modelLoading={modelLoading}
           promptScope={workspaceId}
+          workspaceFiles={workspaceFiles}
           onModelChange={setModel}
           onModeChange={onSelectMode}
           onSend={async (message) => {

--- a/crates/tidebreak-desktop/ui/src/code/fork.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/fork.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { forkTranscriptFile, messageWithWorkspaceFiles } from "./fork";
+
+describe("messageWithWorkspaceFiles", () => {
+  it("leaves a message alone when nothing is attached", () => {
+    expect(messageWithWorkspaceFiles("Keep going.", [])).toBe("Keep going.");
+  });
+
+  /**
+   * The paths are the whole handoff: the child reads them from its own working
+   * directory, so a dropped or reworded path breaks the fork silently.
+   */
+  it("names every attached path after the message", () => {
+    expect(
+      messageWithWorkspaceFiles("Read this first.", [
+        { path: ".tidebreak/forks/a.md" },
+        { path: "docs/plan.md", detail: "ignored here" },
+      ]),
+    ).toBe(
+      "Read this first.\n\nFiles in this worktree:\n" +
+        "- `.tidebreak/forks/a.md`\n- `docs/plan.md`",
+    );
+  });
+});
+
+describe("forkTranscriptFile", () => {
+  it("says how much of the parent the child is getting", () => {
+    expect(
+      forkTranscriptFile({
+        path: ".tidebreak/forks/s1.md",
+        byte_len: 2_048,
+        turns: 12,
+        truncated: false,
+      }),
+    ).toEqual({
+      path: ".tidebreak/forks/s1.md",
+      detail: "Transcript, 12 turns",
+    });
+  });
+
+  /** A truncated file must not read as the whole conversation. */
+  it("marks a transcript whose oldest turns were dropped", () => {
+    expect(
+      forkTranscriptFile({
+        path: ".tidebreak/forks/s2.md",
+        byte_len: 524_288,
+        turns: 1,
+        truncated: true,
+      }).detail,
+    ).toBe("Transcript, most recent 1 turn");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/fork.ts
+++ b/crates/tidebreak-desktop/ui/src/code/fork.ts
@@ -1,0 +1,44 @@
+import type { ComposerWorkspaceFile } from "@/Composer";
+import type { CodeForkTranscript } from "../api/types";
+
+/**
+ * Forking one agent into another: what the child is handed, and how.
+ *
+ * The server writes the parent's transcript into the worktree, so the child
+ * needs a path rather than bytes. That path travels as a composer chip and is
+ * named on the way out, which keeps the framing line the reader's to edit.
+ */
+
+/** The opening line a fork seeds, editable before it is sent. */
+export const FORK_FRAMING =
+  "Read the attached transcript first, then pick up where that agent left off.";
+
+/** The transcript chip for a fork the server has already written. */
+export function forkTranscriptFile(
+  transcript: CodeForkTranscript,
+): ComposerWorkspaceFile {
+  const turns = `${transcript.turns} ${transcript.turns === 1 ? "turn" : "turns"}`;
+  return {
+    path: transcript.path,
+    detail: transcript.truncated
+      ? `Transcript, most recent ${turns}`
+      : `Transcript, ${turns}`,
+  };
+}
+
+/**
+ * Name the worktree files a message points at, after the message itself.
+ *
+ * The engine reads them from disk, so the prompt carries paths and nothing
+ * else. An empty list leaves the message exactly as the reader wrote it.
+ */
+export function messageWithWorkspaceFiles(
+  message: string,
+  files: readonly ComposerWorkspaceFile[],
+): string {
+  if (files.length === 0) return message;
+  const list = files.map((file) => `- \`${file.path}\``).join("\n");
+  const body = `Files in this worktree:\n${list}`;
+  const text = message.trim();
+  return text.length === 0 ? body : `${text}\n\n${body}`;
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -76,6 +76,7 @@ import type {
   PullRequestCommentKind,
   CodePrCommentsSnapshot,
   QueuedCodeTurn,
+  CodeForkTranscript,
 } from "../api/types";
 import type {
   CodeEvent as WireCodeEvent,
@@ -128,6 +129,7 @@ import type {
   CodeDeliverySourceError as WireCodeDeliverySourceError,
   CodeDeliveryWorkflowJob as WireCodeDeliveryWorkflowJob,
   CodeDeliveryWorkspaceLink as WireCodeDeliveryWorkspaceLink,
+  CodeForkTranscript as WireCodeForkTranscript,
   CodeGitHubCapability as WireCodeGitHubCapability,
   CodeGitHubRepositoryRef as WireCodeGitHubRepositoryRef,
   CodeGitHubRepositoryTarget as WireCodeGitHubRepositoryTarget,
@@ -1084,6 +1086,32 @@ export function parseCodeCloneDefaults(
     ...(value.gh_authenticated !== undefined
       ? { gh_authenticated: value.gh_authenticated }
       : {}),
+  };
+}
+
+export function parseCodeForkTranscript(
+  value: unknown,
+): CodeForkTranscript | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeForkTranscript>(value, [
+      "path",
+      "byte_len",
+      "turns",
+      "truncated",
+    ]) ||
+    typeof value.path !== "string" ||
+    typeof value.byte_len !== "number" ||
+    typeof value.turns !== "number" ||
+    typeof value.truncated !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    path: value.path,
+    byte_len: value.byte_len,
+    turns: value.turns,
+    truncated: value.truncated,
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -54,6 +54,8 @@ export type WorkspaceCommandId =
   | "toggle-terminal"
   | "pin-attention"
   | "clear-attention"
+  /** Handled by the workspace page, which owns the tab the fork opens into. */
+  | "fork-agent"
   | "run-quick-action"
   | "archive"
   | "force-archive"
@@ -136,6 +138,8 @@ export function workspaceHeaderCommands(input: {
   hasSession: boolean;
   attentionPinned: boolean;
   quickActions: readonly { name: string }[];
+  /** The shown agent has a transcript worth handing to a sibling. */
+  canFork?: boolean;
 }): WorkspaceCommand[] {
   const items: WorkspaceCommand[] = [{ id: "rename", label: "Rename…" }];
   if (input.hasSession) {
@@ -144,6 +148,9 @@ export function workspaceHeaderCommands(input: {
         ? { id: "clear-attention", label: "Clear attention" }
         : { id: "pin-attention", label: "Pin attention" },
     );
+    if (input.canFork) {
+      items.push({ id: "fork-agent", label: "Fork this agent" });
+    }
     items.push({ id: "copy-debug-json", label: "Copy debug JSON" });
   }
   if (!input.archived) {

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1241,7 +1241,8 @@ export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: n
  */
 export type CodeForkTranscript = { path: string, byte_len: number, turns: number, 
 /**
- * True when the oldest turns were dropped to fit the size cap.
+ * True when anything was left out to fit the size cap: the oldest
+ * turns, or the end of a turn too large on its own.
  */
 truncated: boolean, };
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1233,6 +1233,19 @@ export type CodeExecutionUnavailableReason = "unsupported_platform" | "missing_s
 export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: number, deletions: number, previous_path?: string, };
 
 /**
+ * A written fork transcript: `POST /code/sessions/{id}/fork`.
+ *
+ * `path` is worktree-relative, which is what the child agent needs: the file
+ * already sits in its working directory, so the prompt names a path rather
+ * than carrying the bytes.
+ */
+export type CodeForkTranscript = { path: string, byte_len: number, turns: number, 
+/**
+ * True when the oldest turns were dropped to fit the size cap.
+ */
+truncated: boolean, };
+
+/**
  * Whether the local GitHub CLI can serve delivery requests.
  */
 export type CodeGitHubCapability = { found: boolean, authenticated?: boolean, viewer_login?: string, remediation: string, };

--- a/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeCenterTabs.stories.tsx
@@ -61,6 +61,7 @@ function TabStrip({
         }}
         onNewConversation={region === "primary" ? fn() : undefined}
         onCloseConversation={fn()}
+        onForkConversation={fn()}
         onSelectEditor={(index) => {
           setChatFocused(false);
           setActive(index);
@@ -80,8 +81,7 @@ function TabStrip({
         region={region}
         browserTitles={{ "browser-1": "Storybook — Tidebreak" }}
       />
-    </DndContext>
-  );
+    </DndContext>  );
 }
 
 const meta = {
@@ -134,6 +134,14 @@ export const ManyConversations: Story = {
       },
     ],
   },
+};
+
+/**
+ * Right-click an agent's tab to fork it: the transcript goes into the
+ * worktree and a new agent opens on it. A draft has nothing to fork yet.
+ */
+export const ForkFromTabMenu: Story = {
+  args: { conversations: MAIN_AGENT },
 };
 
 /** A new agent the reader has opened but not started: the one closable tab. */

--- a/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 import {
@@ -8,6 +8,9 @@ import {
   RouterProvider,
 } from "@tanstack/react-router";
 
+import type { ComposerWorkspaceFiles } from "@/Composer";
+import { useCodeUiStore } from "@/code/CodeUiStore";
+import { FORK_FRAMING, forkTranscriptFile } from "@/code/fork";
 import { StartSessionPrompt } from "@/code/StartSessionPrompt";
 import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
 
@@ -28,10 +31,18 @@ function withRouter(children: ReactNode) {
 function StartSession({
   harnesses,
   starting = false,
+  workspaceFiles,
 }: {
   harnesses: typeof harnessDoctor.harnesses;
   starting?: boolean;
+  workspaceFiles?: ComposerWorkspaceFiles;
 }) {
+  // A fork seeds the framing line the same way the workspace page does, so
+  // the story shows the state the reader actually lands in.
+  useEffect(() => {
+    if (!workspaceFiles) return;
+    useCodeUiStore.getState().offerComposerPrompt("ws-1", FORK_FRAMING);
+  }, [workspaceFiles]);
   return (
     <StartSessionPrompt
       workspaceId="ws-1"
@@ -40,6 +51,7 @@ function StartSession({
       selectedMode={null}
       onSelectMode={fn()}
       onStart={fn()}
+      workspaceFiles={workspaceFiles}
     />
   );
 }
@@ -68,4 +80,42 @@ export const Starting: Story = {
 /** Engines that need install or sign-in before a session can start. */
 export const NeedsSetup: Story = {
   args: { harnesses: harnessDoctorDegraded.harnesses },
+};
+
+/**
+ * A fork: the parent's transcript is already in the worktree, so the child
+ * gets a path rather than an upload, and the framing line stays editable.
+ * Any engine can be the one that reads it.
+ */
+export const ForkedFromAnotherAgent: Story = {
+  args: {
+    workspaceFiles: {
+      items: [
+        forkTranscriptFile({
+          path: ".tidebreak/forks/9c1f4a2e.md",
+          byte_len: 48_120,
+          turns: 14,
+          truncated: false,
+        }),
+      ],
+      onRemove: fn(),
+    },
+  },
+};
+
+/** A long parent: the oldest turns did not fit, and the chip says so. */
+export const ForkedFromALongSession: Story = {
+  args: {
+    workspaceFiles: {
+      items: [
+        forkTranscriptFile({
+          path: ".tidebreak/forks/3b70de55.md",
+          byte_len: 524_288,
+          turns: 6,
+          truncated: true,
+        }),
+      ],
+      onRemove: fn(),
+    },
+  },
 };

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -1,0 +1,496 @@
+//! Fork: the parent session's transcript, written into the worktree as
+//! markdown so a sibling agent of any engine can read it.
+//!
+//! Pure serialization of what the journal already holds. No model call and no
+//! summary — a generated one would be a second thing to be wrong, and the
+//! point of the file is that the child sees what the parent saw.
+//!
+//! The file lands in `.tidebreak/forks/` beside a `.gitignore` holding `*`,
+//! which is what keeps it out of `git status` without touching the repo's
+//! tracked ignore file or the shared `.git/info/exclude` that every other
+//! worktree of the same repository reads.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use tidebreak_core::{
+    CodeEvent, CodeSession, CodeTurn, CodeTurnId, HarnessKind, SequencedCodeEvent, ToolDetail,
+    ToolOutcome,
+};
+
+/// Directory holding fork transcripts, relative to the worktree root.
+pub(crate) const FORKS_DIR: &str = ".tidebreak/forks";
+
+/// Largest transcript written, in bytes.
+///
+/// A long session can hold megabytes of assistant text. The child needs
+/// recent context far more than it needs the first turn, so the oldest turns
+/// are dropped to fit and the header says so.
+const MAX_TRANSCRIPT_BYTES: usize = 512 * 1024;
+
+/// A written fork transcript, as the route reports it.
+pub(crate) struct WrittenTranscript {
+    /// Worktree-relative path, in the form the composer shows and the engine
+    /// opens.
+    pub(crate) path: String,
+    /// Bytes on disk.
+    pub(crate) byte_len: u64,
+    /// Turns the file actually contains.
+    pub(crate) turns: u32,
+    /// True when older turns were dropped to fit [`MAX_TRANSCRIPT_BYTES`].
+    pub(crate) truncated: bool,
+}
+
+/// Render one session's transcript and write it under the worktree.
+pub(crate) async fn write_transcript(
+    worktree: &Path,
+    session: &CodeSession,
+    turns: &[CodeTurn],
+    events: &[SequencedCodeEvent],
+) -> std::io::Result<WrittenTranscript> {
+    let rendered = render_transcript(session, turns, events);
+    let dir = worktree.join(FORKS_DIR);
+    tokio::fs::create_dir_all(&dir).await?;
+    ignore_scratch_dir(worktree).await?;
+    let path = dir.join(format!("{}.md", session.id));
+    tokio::fs::write(&path, rendered.markdown.as_bytes()).await?;
+    Ok(WrittenTranscript {
+        path: format!("{FORKS_DIR}/{}.md", session.id),
+        byte_len: rendered.markdown.len() as u64,
+        turns: rendered.turns,
+        truncated: rendered.truncated,
+    })
+}
+
+/// Make `.tidebreak/` ignore itself.
+///
+/// A `.gitignore` holding `*` hides the directory and the ignore file with
+/// it. Writing here mutates nothing the reader tracks and nothing shared with
+/// their other worktrees, which the alternatives — the repository's own
+/// `.gitignore`, or `.git/info/exclude` — both do.
+async fn ignore_scratch_dir(worktree: &Path) -> std::io::Result<()> {
+    let scratch: PathBuf = worktree.join(".tidebreak");
+    let marker = scratch.join(".gitignore");
+    if tokio::fs::try_exists(&marker).await? {
+        return Ok(());
+    }
+    tokio::fs::write(&marker, "*\n").await
+}
+
+/// A rendered transcript and what had to be left out of it.
+struct RenderedTranscript {
+    markdown: String,
+    turns: u32,
+    truncated: bool,
+}
+
+/// Serialize a session as markdown, newest turns kept when it will not fit.
+fn render_transcript(
+    session: &CodeSession,
+    turns: &[CodeTurn],
+    events: &[SequencedCodeEvent],
+) -> RenderedTranscript {
+    let engine = harness_label(session.harness_kind);
+    let mut sections: Vec<String> = Vec::with_capacity(turns.len());
+    for turn in turns {
+        sections.push(render_turn(turn, events, engine));
+    }
+
+    // Budget from the end: the last turn is the one the child most needs.
+    let mut kept = 0usize;
+    let mut used = 0usize;
+    for section in sections.iter().rev() {
+        if used + section.len() > MAX_TRANSCRIPT_BYTES && kept > 0 {
+            break;
+        }
+        used += section.len();
+        kept += 1;
+    }
+    let dropped = sections.len() - kept;
+
+    let mut out = String::with_capacity(used + 512);
+    let _ = writeln!(out, "# Transcript of a {engine} session");
+    out.push('\n');
+    let _ = writeln!(
+        out,
+        "Recorded from the session started {}. {} turn{}{}.",
+        session.created_at.to_rfc3339(),
+        turns.len(),
+        if turns.len() == 1 { "" } else { "s" },
+        if dropped > 0 {
+            format!(", of which the {dropped} oldest are not included here")
+        } else {
+            String::new()
+        }
+    );
+    out.push('\n');
+    out.push_str(
+        "Messages and tool calls are as the engine reported them. Work a \
+         subagent did inside a `Task` call is summarized by that call rather \
+         than transcribed.\n",
+    );
+
+    for section in &sections[dropped..] {
+        out.push('\n');
+        out.push_str(section);
+    }
+
+    RenderedTranscript {
+        markdown: out,
+        turns: kept as u32,
+        truncated: dropped > 0,
+    }
+}
+
+/// One turn: what the reader asked, then what the engine said and did.
+fn render_turn(turn: &CodeTurn, events: &[SequencedCodeEvent], engine: &str) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "## Turn {} — you\n", turn.ordinal);
+    let asked = turn.user_input.trim();
+    let _ = writeln!(
+        out,
+        "{}\n",
+        if asked.is_empty() { "_(empty)_" } else { asked }
+    );
+
+    let lines = turn_lines(turn.id, events);
+    if lines.is_empty() {
+        return out;
+    }
+    let _ = writeln!(out, "## Turn {} — {engine}\n", turn.ordinal);
+    for line in lines {
+        let _ = writeln!(out, "{line}\n");
+    }
+    out
+}
+
+/// The engine's own messages and tool calls for one turn, in journal order.
+///
+/// Scoped by walking from this turn's `TurnStarted` to the next one: a turn
+/// id appears on the boundary events, not on every event inside it.
+fn turn_lines(turn_id: CodeTurnId, events: &[SequencedCodeEvent]) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+    let mut inside = false;
+    // A tool call opens and closes on separate events, and the closing one
+    // carries the outcome plus a detail that may say more than the opening
+    // one did. Hold the call's name, detail, and line index until then.
+    let mut open: Vec<(String, usize, String, ToolDetail)> = Vec::new();
+
+    for entry in events {
+        match &entry.event {
+            CodeEvent::TurnStarted { turn_id: started } => {
+                if inside {
+                    break;
+                }
+                inside = *started == turn_id;
+            }
+            _ if !inside => {}
+            CodeEvent::AssistantMessage {
+                text,
+                parent_call_id,
+            } => {
+                if parent_call_id.is_none() && !text.trim().is_empty() {
+                    lines.push(text.trim().to_owned());
+                }
+            }
+            CodeEvent::UserSteered { text } => {
+                if !text.trim().is_empty() {
+                    lines.push(format!("**You, mid-turn:** {}", text.trim()));
+                }
+            }
+            CodeEvent::ToolStarted {
+                call_id,
+                name,
+                detail,
+                parent_call_id,
+            } => {
+                if parent_call_id.is_some() {
+                    continue;
+                }
+                open.push((call_id.clone(), lines.len(), name.clone(), detail.clone()));
+                lines.push(tool_line(name, detail, None));
+            }
+            CodeEvent::ToolCompleted {
+                call_id,
+                outcome,
+                detail,
+                parent_call_id,
+                ..
+            } => {
+                if parent_call_id.is_some() {
+                    continue;
+                }
+                let Some(found) = open.iter().position(|(id, ..)| id == call_id) else {
+                    continue;
+                };
+                let (_, at, name, started) = open.remove(found);
+                let Some(line) = lines.get_mut(at) else {
+                    continue;
+                };
+                *line = format!(
+                    "{}{}",
+                    tool_line(&name, &started, detail.as_ref()),
+                    match outcome {
+                        ToolOutcome::Succeeded => "",
+                        ToolOutcome::Failed => " (failed)",
+                        ToolOutcome::Denied => " (denied)",
+                    }
+                );
+            }
+            CodeEvent::TurnFailed { error } => {
+                lines.push(format!("**The turn failed:** {}", error.message.trim()));
+            }
+            CodeEvent::TurnInterrupted => lines.push("**The turn was interrupted.**".to_owned()),
+            _ => {}
+        }
+    }
+    lines
+}
+
+/// A tool call as one line: what it was, and what it was pointed at.
+///
+/// An engine can open a call before its arguments finish streaming, so the
+/// detail on the completion replaces the opening one when it scores higher —
+/// [`ToolDetail::specificity`]'s rule, so a correction never downgrades a
+/// line that already names its subject.
+fn tool_line(name: &str, started: &ToolDetail, completed: Option<&ToolDetail>) -> String {
+    let chosen = match completed {
+        Some(later) if later.specificity() > started.specificity() => later,
+        _ => started,
+    };
+    let subject = chosen.subject().trim();
+    if subject.is_empty() {
+        format!("- `{name}`")
+    } else {
+        format!("- `{name}` — {}", one_line(subject))
+    }
+}
+
+/// Collapse a subject onto one line so a bullet stays a bullet.
+fn one_line(value: &str) -> String {
+    let flattened = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flattened.chars().count() <= 160 {
+        return flattened;
+    }
+    let cut: String = flattened.chars().take(159).collect();
+    format!("{cut}…")
+}
+
+/// The engine's name as a person writes it.
+fn harness_label(kind: HarnessKind) -> &'static str {
+    match kind {
+        HarnessKind::ClaudeCode => "Claude Code",
+        HarnessKind::Codex => "Codex CLI",
+        HarnessKind::Opencode => "opencode",
+        HarnessKind::Grok => "Grok CLI",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidebreak_core::{
+        Attention, AttentionSource, BoundedError, CodePermissionMode, CodeSessionId,
+        CodeSessionKind, CodeSessionLifecycle, CodeTurnStatus, OwnerId, WorkspaceId,
+    };
+
+    fn session() -> CodeSession {
+        CodeSession {
+            id: CodeSessionId::new(),
+            owner: OwnerId::local(),
+            workspace_id: WorkspaceId::new(),
+            kind: CodeSessionKind::Interactive,
+            harness_kind: HarnessKind::ClaudeCode,
+            harness_version: None,
+            harness_resume_ref: None,
+            permission_mode: CodePermissionMode::Plan,
+            model: None,
+            lifecycle: CodeSessionLifecycle::Idle,
+            fence_reason: None,
+            child_pid: None,
+            spawn_epoch: 0,
+            attention: Attention::working(AttentionSource::Lifecycle),
+            unrecognized_event_count: 0,
+            subagents: Vec::new(),
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    fn turn(session_id: CodeSessionId, ordinal: i64, asked: &str) -> CodeTurn {
+        CodeTurn {
+            id: CodeTurnId::new(),
+            session_id,
+            ordinal,
+            status: CodeTurnStatus::Completed,
+            user_input: asked.to_owned(),
+            user_input_blob_id: None,
+            attachments: Vec::new(),
+            checkpoint_ref: None,
+            diffstat: None,
+            usage: None,
+            narrative: None,
+            started_at: chrono::Utc::now(),
+            ended_at: None,
+        }
+    }
+
+    fn seq(events: Vec<CodeEvent>) -> Vec<SequencedCodeEvent> {
+        events
+            .into_iter()
+            .enumerate()
+            .map(|(at, event)| SequencedCodeEvent {
+                seq: at as i64 + 1,
+                event,
+            })
+            .collect()
+    }
+
+    /// The contract the child reads: its own turns, in order, and nobody
+    /// else's. Scoping by `TurnStarted` boundaries is the only thing keeping
+    /// turn two's work out of turn one's section.
+    #[test]
+    fn renders_each_turn_with_only_its_own_events() {
+        let session = session();
+        let first = turn(session.id, 1, "fix the failing auth test");
+        let second = turn(session.id, 2, "now push it");
+        let events = seq(vec![
+            CodeEvent::TurnStarted { turn_id: first.id },
+            CodeEvent::AssistantMessage {
+                text: "Looking at the test now.".to_owned(),
+                parent_call_id: None,
+            },
+            CodeEvent::ToolStarted {
+                call_id: "call-1".to_owned(),
+                name: "Bash".to_owned(),
+                detail: ToolDetail::Other {
+                    summary: String::new(),
+                },
+                parent_call_id: None,
+            },
+            CodeEvent::ToolCompleted {
+                call_id: "call-1".to_owned(),
+                outcome: ToolOutcome::Failed,
+                preview: "1 failed".to_owned(),
+                detail: Some(ToolDetail::Command {
+                    cmd: "cargo test -p auth".to_owned(),
+                    cwd: String::new(),
+                }),
+                parent_call_id: None,
+            },
+            CodeEvent::TurnStarted { turn_id: second.id },
+            CodeEvent::AssistantMessage {
+                text: "Pushed.".to_owned(),
+                parent_call_id: None,
+            },
+        ]);
+
+        let rendered = render_transcript(&session, &[first, second], &events);
+        let markdown = rendered.markdown;
+
+        assert_eq!(rendered.turns, 2);
+        assert!(!rendered.truncated);
+        assert!(markdown.contains("# Transcript of a Claude Code session"));
+        assert!(markdown.contains("fix the failing auth test"));
+        assert!(markdown.contains("Looking at the test now."));
+        // The completion's detail names the command the start could not.
+        assert!(markdown.contains("- `Bash` — cargo test -p auth (failed)"));
+        // Turn two's message must not have leaked into turn one's section.
+        let turn_two = markdown.find("## Turn 2 — you").expect("turn two heading");
+        assert!(markdown.find("Pushed.").expect("second message") > turn_two);
+    }
+
+    /// Subagent chatter belongs to the subagent. The parent's `Task` call is
+    /// what the child needs to see, not the thousand lines inside it.
+    #[test]
+    fn leaves_subagent_events_to_the_task_call_that_ran_them() {
+        let session = session();
+        let only = turn(session.id, 1, "audit the crate");
+        let events = seq(vec![
+            CodeEvent::TurnStarted { turn_id: only.id },
+            CodeEvent::ToolStarted {
+                call_id: "task-1".to_owned(),
+                name: "Task".to_owned(),
+                detail: ToolDetail::Other {
+                    summary: "audit".to_owned(),
+                },
+                parent_call_id: None,
+            },
+            CodeEvent::AssistantMessage {
+                text: "subagent thinking out loud".to_owned(),
+                parent_call_id: Some("task-1".to_owned()),
+            },
+            CodeEvent::ToolCompleted {
+                call_id: "task-1".to_owned(),
+                outcome: ToolOutcome::Succeeded,
+                preview: "done".to_owned(),
+                detail: None,
+                parent_call_id: None,
+            },
+        ]);
+
+        let markdown = render_transcript(&session, &[only], &events).markdown;
+        assert!(markdown.contains("- `Task` — audit"));
+        assert!(!markdown.contains("subagent thinking out loud"));
+    }
+
+    /// A failed turn is the most useful thing a fork can know, so it survives
+    /// into the file rather than reading as silence.
+    #[test]
+    fn keeps_a_failure_visible() {
+        let session = session();
+        let only = turn(session.id, 1, "deploy it");
+        let events = seq(vec![
+            CodeEvent::TurnStarted { turn_id: only.id },
+            CodeEvent::TurnFailed {
+                error: BoundedError {
+                    message: "the engine exited".to_owned(),
+                },
+            },
+        ]);
+
+        let markdown = render_transcript(&session, &[only], &events).markdown;
+        assert!(markdown.contains("**The turn failed:** the engine exited"));
+    }
+
+    /// Over budget, the oldest turns go and the header says how many. The
+    /// child needs the end of the conversation, not the start of it.
+    #[test]
+    fn drops_the_oldest_turns_to_fit_and_says_so() {
+        let session = session();
+        let bulk = "x".repeat(200 * 1024);
+        let turns: Vec<CodeTurn> = (1..=5)
+            .map(|ordinal| turn(session.id, ordinal, &bulk))
+            .collect();
+
+        let rendered = render_transcript(&session, &turns, &[]);
+        assert!(rendered.truncated);
+        assert_eq!(rendered.turns, 2);
+        assert!(rendered.markdown.contains("the 3 oldest are not included"));
+        assert!(rendered.markdown.contains("## Turn 5 — you"));
+        assert!(!rendered.markdown.contains("## Turn 1 — you"));
+    }
+
+    /// The file has to be readable by the child engine and invisible to
+    /// `git status`, which is the whole reason for the `*` marker beside it.
+    #[tokio::test]
+    async fn writes_the_file_into_a_self_ignoring_directory() {
+        let worktree = tempfile::tempdir().expect("tempdir");
+        let session = session();
+        let only = turn(session.id, 1, "hello");
+
+        let written = write_transcript(worktree.path(), &session, &[only], &[])
+            .await
+            .expect("write");
+
+        assert_eq!(written.path, format!("{FORKS_DIR}/{}.md", session.id));
+        assert_eq!(written.turns, 1);
+        assert!(!written.truncated);
+        let on_disk = std::fs::read_to_string(worktree.path().join(&written.path)).expect("read");
+        assert_eq!(written.byte_len, on_disk.len() as u64);
+        assert!(on_disk.contains("hello"));
+        assert_eq!(
+            std::fs::read_to_string(worktree.path().join(".tidebreak/.gitignore")).expect("marker"),
+            "*\n"
+        );
+    }
+}

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -21,11 +21,13 @@ use tidebreak_core::{
 /// Directory holding fork transcripts, relative to the worktree root.
 pub(crate) const FORKS_DIR: &str = ".tidebreak/forks";
 
-/// Largest transcript written, in bytes.
+/// Largest transcript written, in bytes. Bounds the whole file, header
+/// included.
 ///
 /// A long session can hold megabytes of assistant text. The child needs
 /// recent context far more than it needs the first turn, so the oldest turns
-/// are dropped to fit and the header says so.
+/// are dropped to fit and the header says so. One turn can be over the cap by
+/// itself, so that one is cut rather than written past it.
 const MAX_TRANSCRIPT_BYTES: usize = 512 * 1024;
 
 /// A written fork transcript, as the route reports it.
@@ -37,11 +39,18 @@ pub(crate) struct WrittenTranscript {
     pub(crate) byte_len: u64,
     /// Turns the file actually contains.
     pub(crate) turns: u32,
-    /// True when older turns were dropped to fit [`MAX_TRANSCRIPT_BYTES`].
+    /// True when anything was left out to fit [`MAX_TRANSCRIPT_BYTES`]:
+    /// older turns, or the end of a turn too large on its own.
     pub(crate) truncated: bool,
 }
 
 /// Render one session's transcript and write it under the worktree.
+///
+/// A session can be forked again over a file the last child is already
+/// reading, so the write is published by rename: a reader sees one whole
+/// version or another and never the middle of one. Each write stages its own
+/// sibling file, so two forks racing on one session cannot mix their bytes —
+/// the later rename simply wins.
 pub(crate) async fn write_transcript(
     worktree: &Path,
     session: &CodeSession,
@@ -53,13 +62,38 @@ pub(crate) async fn write_transcript(
     tokio::fs::create_dir_all(&dir).await?;
     ignore_scratch_dir(worktree).await?;
     let path = dir.join(format!("{}.md", session.id));
-    tokio::fs::write(&path, rendered.markdown.as_bytes()).await?;
+    publish(&path, rendered.markdown.as_bytes()).await?;
     Ok(WrittenTranscript {
         path: format!("{FORKS_DIR}/{}.md", session.id),
         byte_len: rendered.markdown.len() as u64,
         turns: rendered.turns,
         truncated: rendered.truncated,
     })
+}
+
+/// Put bytes at `path` in one step, leaving nothing behind if it fails.
+///
+/// The staged name carries a fresh id rather than a fixed `.part` suffix, so
+/// concurrent writers stage separately and neither can be caught writing over
+/// the other's half-written file.
+async fn publish(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::other("the transcript path names no file"))?;
+    let staged = path.with_file_name(format!(
+        "{}.{}.part",
+        name.to_string_lossy(),
+        uuid::Uuid::new_v4()
+    ));
+    let written = tokio::fs::write(&staged, bytes).await;
+    let published = match written {
+        Ok(()) => tokio::fs::rename(&staged, path).await,
+        Err(err) => Err(err),
+    };
+    if published.is_err() {
+        let _ = tokio::fs::remove_file(&staged).await;
+    }
+    published
 }
 
 /// Make `.tidebreak/` ignore itself.
@@ -85,6 +119,10 @@ struct RenderedTranscript {
 }
 
 /// Serialize a session as markdown, newest turns kept when it will not fit.
+///
+/// The result is never larger than [`MAX_TRANSCRIPT_BYTES`]. Turns are kept
+/// from the newest back; the header counts against the same budget, and a
+/// turn that is over the budget by itself is cut instead of overrunning it.
 fn render_transcript(
     session: &CodeSession,
     turns: &[CodeTurn],
@@ -96,27 +134,57 @@ fn render_transcript(
         sections.push(render_turn(turn, events, engine));
     }
 
+    // The header is part of the file, so it is part of the budget. Its length
+    // depends on how many turns are dropped, which is what the budget decides
+    // — so reserve the longest it can be, the one that drops every turn.
+    let reserved = header(session, turns.len(), turns.len(), engine).len();
+    let budget = MAX_TRANSCRIPT_BYTES.saturating_sub(reserved);
+
     // Budget from the end: the last turn is the one the child most needs.
+    // Each section costs the blank line that separates it, too.
     let mut kept = 0usize;
     let mut used = 0usize;
-    for section in sections.iter().rev() {
-        if used + section.len() > MAX_TRANSCRIPT_BYTES && kept > 0 {
-            break;
+    let mut clipped = false;
+    for section in sections.iter_mut().rev() {
+        if used + section.len() + 1 > budget {
+            if kept > 0 {
+                break;
+            }
+            // One turn is over the cap on its own. The child gets the start
+            // of it rather than a file that ignores the bound.
+            clip(section, budget.saturating_sub(1));
+            clipped = true;
         }
-        used += section.len();
+        used += section.len() + 1;
         kept += 1;
     }
     let dropped = sections.len() - kept;
 
-    let mut out = String::with_capacity(used + 512);
+    let mut out = String::with_capacity(reserved + used);
+    out.push_str(&header(session, turns.len(), dropped, engine));
+    for section in &sections[dropped..] {
+        out.push('\n');
+        out.push_str(section);
+    }
+
+    RenderedTranscript {
+        markdown: out,
+        turns: kept as u32,
+        truncated: dropped > 0 || clipped,
+    }
+}
+
+/// The file's opening: where the transcript came from, and what is missing.
+fn header(session: &CodeSession, total: usize, dropped: usize, engine: &str) -> String {
+    let mut out = String::new();
     let _ = writeln!(out, "# Transcript of a {engine} session");
     out.push('\n');
     let _ = writeln!(
         out,
         "Recorded from the session started {}. {} turn{}{}.",
         session.created_at.to_rfc3339(),
-        turns.len(),
-        if turns.len() == 1 { "" } else { "s" },
+        total,
+        if total == 1 { "" } else { "s" },
         if dropped > 0 {
             format!(", of which the {dropped} oldest are not included here")
         } else {
@@ -129,16 +197,26 @@ fn render_transcript(
          subagent did inside a `Task` call is summarized by that call rather \
          than transcribed.\n",
     );
+    out
+}
 
-    for section in &sections[dropped..] {
-        out.push('\n');
-        out.push_str(section);
+/// Cut a section to `budget` bytes, on a character boundary, and say so.
+///
+/// The head is what survives: it holds the heading and the ask, without which
+/// the section stops being readable markdown at all. Cutting from the front
+/// would save the engine's last words and lose the question they answer.
+fn clip(section: &mut String, budget: usize) {
+    const CUT: &str = "\n_(the rest of this turn was too large to include)_\n";
+    if section.len() <= budget {
+        return;
     }
-
-    RenderedTranscript {
-        markdown: out,
-        turns: kept as u32,
-        truncated: dropped > 0,
+    let mut end = budget.saturating_sub(CUT.len()).min(section.len());
+    while end > 0 && !section.is_char_boundary(end) {
+        end -= 1;
+    }
+    section.truncate(end);
+    if budget > CUT.len() {
+        section.push_str(CUT);
     }
 }
 
@@ -468,6 +546,126 @@ mod tests {
         assert!(rendered.markdown.contains("the 3 oldest are not included"));
         assert!(rendered.markdown.contains("## Turn 5 — you"));
         assert!(!rendered.markdown.contains("## Turn 1 — you"));
+    }
+
+    /// The cap bounds the file, not the turns inside it, so the header has to
+    /// come out of the same budget. Two turns that together sit just under it
+    /// leave no room for the paragraph saying where the transcript came from.
+    #[test]
+    fn counts_the_header_against_the_cap() {
+        let session = session();
+        let bulk = "x".repeat(MAX_TRANSCRIPT_BYTES / 2 - 40);
+        let turns: Vec<CodeTurn> = (1..=2)
+            .map(|ordinal| turn(session.id, ordinal, &bulk))
+            .collect();
+
+        let rendered = render_transcript(&session, &turns, &[]);
+        assert!(
+            rendered.markdown.len() <= MAX_TRANSCRIPT_BYTES,
+            "{} bytes is over the cap",
+            rendered.markdown.len()
+        );
+        assert_eq!(rendered.turns, 1);
+        assert!(rendered.truncated);
+    }
+
+    /// One turn can be larger than the whole budget on its own — a single ask
+    /// with a pasted log in it. Dropping turns cannot help there, so the turn
+    /// itself is cut, and the file says where.
+    #[test]
+    fn cuts_a_turn_that_is_over_the_cap_by_itself() {
+        let session = session();
+        let bulk = "x".repeat(MAX_TRANSCRIPT_BYTES * 2);
+        let only = turn(session.id, 1, &bulk);
+
+        let rendered = render_transcript(&session, &[only], &[]);
+        assert!(
+            rendered.markdown.len() <= MAX_TRANSCRIPT_BYTES,
+            "{} bytes is over the cap",
+            rendered.markdown.len()
+        );
+        assert_eq!(rendered.turns, 1);
+        assert!(rendered.truncated);
+        assert!(rendered.markdown.contains("## Turn 1 — you"));
+        assert!(rendered
+            .markdown
+            .contains("the rest of this turn was too large to include"));
+    }
+
+    /// Multi-byte text must not be cut through a character. A file the child
+    /// engine cannot decode is worse than one that stops early.
+    #[test]
+    fn cuts_on_a_character_boundary() {
+        let session = session();
+        let only = turn(session.id, 1, &"日".repeat(MAX_TRANSCRIPT_BYTES));
+
+        let rendered = render_transcript(&session, &[only], &[]);
+        assert!(rendered.markdown.len() <= MAX_TRANSCRIPT_BYTES);
+        assert!(rendered.truncated);
+        // Round-tripping through bytes proves nothing was cut mid-character:
+        // `String` would not hold it otherwise.
+        assert_eq!(
+            String::from_utf8(rendered.markdown.clone().into_bytes()).expect("valid utf-8"),
+            rendered.markdown
+        );
+    }
+
+    /// A session can be forked again while the last child still has the file
+    /// open. Every read has to land on a whole document, which is what the
+    /// stage-then-rename is for — a plain write truncates in place first.
+    #[tokio::test]
+    async fn a_reader_never_catches_a_re_fork_mid_write() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let worktree = tempfile::tempdir().expect("tempdir");
+        let session = session();
+        let short = vec![turn(session.id, 1, "hello")];
+        let long: Vec<CodeTurn> = (1..=20)
+            .map(|ordinal| turn(session.id, ordinal, &"x".repeat(8 * 1024)))
+            .collect();
+        write_transcript(worktree.path(), &session, &short, &[])
+            .await
+            .expect("first write");
+        let path = worktree
+            .path()
+            .join(format!("{FORKS_DIR}/{}.md", session.id));
+
+        let done = Arc::new(AtomicBool::new(false));
+        let reader = {
+            let path = path.clone();
+            let done = Arc::clone(&done);
+            tokio::task::spawn_blocking(move || {
+                let mut reads = 0usize;
+                while !done.load(Ordering::Relaxed) {
+                    let seen = std::fs::read_to_string(&path).expect("the file is always there");
+                    assert!(
+                        seen.starts_with("# Transcript of a Claude Code session"),
+                        "a reader caught {} bytes mid-write",
+                        seen.len()
+                    );
+                    reads += 1;
+                }
+                reads
+            })
+        };
+
+        for _ in 0..20 {
+            for turns in [&long, &short] {
+                write_transcript(worktree.path(), &session, turns, &[])
+                    .await
+                    .expect("re-fork");
+            }
+        }
+        done.store(true, Ordering::Relaxed);
+        assert!(reader.await.expect("reader") > 0, "the reader never ran");
+
+        // Nothing staged is left behind for the child engine to trip over.
+        let left: Vec<String> = std::fs::read_dir(worktree.path().join(FORKS_DIR))
+            .expect("forks dir")
+            .map(|entry| entry.expect("entry").file_name().to_string_lossy().into())
+            .collect();
+        assert_eq!(left, vec![format!("{}.md", session.id)]);
     }
 
     /// The file has to be readable by the child engine and invisible to

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod bus;
 pub(crate) mod checkpoint;
 pub(crate) mod clone;
 pub(crate) mod delivery;
+pub(crate) mod fork;
 pub(crate) mod gh;
 pub(crate) mod harness_install;
 pub(crate) mod recovery;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -35,6 +35,7 @@ use super::checkpoint::{
 };
 use super::clone::CloneJobs;
 use super::delivery::DeliveryCache;
+use super::fork;
 use super::gh::{
     self, ActionOutcome, CommitOutcome, GhError, PrDigestCache, PushOutcome, WorkspaceGitStatus,
 };
@@ -1570,6 +1571,33 @@ impl CodeRuntime {
         let turns = list_turns(&self.db, owner, session_id).await?;
         let events = list_events(&self.db, owner, session_id, 0).await?;
         Ok((session, turns, events))
+    }
+
+    /// Write this session's transcript into its worktree for a fork to read.
+    ///
+    /// The child is a sibling session in the same worktree, so the file only
+    /// has to exist where the engine already works. Nothing is handed over
+    /// here: the caller creates the child and names the path in its first
+    /// message.
+    pub(crate) async fn fork_transcript(
+        &self,
+        owner: &OwnerId,
+        session_id: CodeSessionId,
+    ) -> Result<fork::WrittenTranscript, ServerError> {
+        let session = self.get_session(owner, session_id).await?;
+        let workspace = self
+            .require_live_workspace(owner, session.workspace_id)
+            .await?;
+        let turns = list_turns(&self.db, owner, session_id).await?;
+        let events = list_events(&self.db, owner, session_id, 0).await?;
+        fork::write_transcript(
+            std::path::Path::new(&workspace.worktree_path),
+            &session,
+            &turns,
+            &events,
+        )
+        .await
+        .map_err(|err| ServerError::internal(format!("could not write the fork transcript: {err}")))
     }
 
     pub(crate) async fn workspace_tree(

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -427,6 +427,13 @@ impl ScopedCode {
         self.runtime.list_session_turns(&self.owner, id).await
     }
 
+    pub(crate) async fn fork_transcript(
+        &self,
+        id: CodeSessionId,
+    ) -> Result<super::fork::WrittenTranscript, ServerError> {
+        self.runtime.fork_transcript(&self.owner, id).await
+    }
+
     pub(crate) async fn session_debug(
         &self,
         id: CodeSessionId,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -857,6 +857,7 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::interrupt_session),
         )
         .route("/code/sessions/{id}/reap", post(routes::code::reap_session))
+        .route("/code/sessions/{id}/fork", post(routes::code::fork_session))
         .route(
             "/code/sessions/{id}/debug",
             get(routes::code::get_session_debug),

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -42,9 +42,9 @@ pub(crate) use repos::{
 };
 pub(crate) use session_events::session_events;
 pub(crate) use sessions::{
-    create_session, get_session_debug, get_session_image, interrupt_session, list_session_turns,
-    list_workspace_sessions, publish_session_image, reap_session, set_attention, steer_session,
-    submit_turn,
+    create_session, fork_session, get_session_debug, get_session_image, interrupt_session,
+    list_session_turns, list_workspace_sessions, publish_session_image, reap_session,
+    set_attention, steer_session, submit_turn,
 };
 pub(crate) use terminals::{
     close_terminal, close_workspace_terminals, create_terminal, list_terminals, read_terminal,
@@ -57,14 +57,14 @@ pub(crate) use types::{
     CodeDeliveryPullRequestActionBody, CodeDeliveryPullRequestDetail, CodeDeliveryPullRequestQuery,
     CodeDeliveryPullRequestTarget, CodeDeliveryPullRequestsPage, CodeDeliveryRepositoriesSnapshot,
     CodeDeliveryRunActionBody, CodeDeliveryRunDetail, CodeDeliveryRunQuery, CodeDeliveryRunTarget,
-    CodeDeliveryRunsPage, CodeFileChange, CodeHarnessInstallSnapshot, CodePrCommentsSnapshot,
-    CodePushSnapshot, CodeRepoSnapshot, CodeSessionDebug, CodeSessionDigest, CodeSessionSnapshot,
-    CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTurnSnapshot,
-    CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
-    CodeWorkspacePrSnapshot, CodeWorkspaceSearch, CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot,
-    CodeWorkspaceTree, CodeWorktreeRoot, HarnessDoctorReport, HarnessModelList, MergeCodePrBody,
-    QueuedCodeTurn, ResolveCodeDeliveryRepositoriesBody, SequencedCodeEventFrame,
-    SetCodeWorktreeRootBody,
+    CodeDeliveryRunsPage, CodeFileChange, CodeForkTranscript, CodeHarnessInstallSnapshot,
+    CodePrCommentsSnapshot, CodePushSnapshot, CodeRepoSnapshot, CodeSessionDebug,
+    CodeSessionDigest, CodeSessionSnapshot, CodeTerminalActivityNotice, CodeTerminalRead,
+    CodeTerminalSnapshot, CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff,
+    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSearch, CodeWorkspaceSearchMatch,
+    CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot, HarnessDoctorReport,
+    HarnessModelList, MergeCodePrBody, QueuedCodeTurn, ResolveCodeDeliveryRepositoriesBody,
+    SequencedCodeEventFrame, SetCodeWorktreeRootBody,
 };
 pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -12,7 +12,7 @@ use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 
 use super::types::{
-    CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuedCodeTurn,
+    CodeForkTranscript, CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuedCodeTurn,
     SequencedCodeEventFrame, SetAttentionBody, SteerBody, SubmitTurnBody,
 };
 use crate::code::runtime::SubmitTurnOutcome;
@@ -82,6 +82,27 @@ pub async fn submit_turn(
         )
             .into_response()),
     }
+}
+
+/// `POST /code/sessions/{id}/fork` — write this session's transcript into the
+/// worktree and report where it landed.
+///
+/// Creating the child session is a separate call: forking is a file, and the
+/// reader picks the engine and edits the framing before anything is sent.
+pub async fn fork_session(
+    code: ScopedCode,
+    Path(id): Path<CodeSessionId>,
+) -> Result<(StatusCode, Json<CodeForkTranscript>), ServerError> {
+    let written = code.fork_transcript(id).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CodeForkTranscript {
+            path: written.path,
+            byte_len: written.byte_len,
+            turns: written.turns,
+            truncated: written.truncated,
+        }),
+    ))
 }
 
 pub async fn get_session_debug(

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -294,6 +294,20 @@ pub struct CodeCloneDefaults {
     pub gh_remediation: String,
 }
 
+/// A written fork transcript: `POST /code/sessions/{id}/fork`.
+///
+/// `path` is worktree-relative, which is what the child agent needs: the file
+/// already sits in its working directory, so the prompt names a path rather
+/// than carrying the bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeForkTranscript {
+    pub path: String,
+    pub byte_len: u64,
+    pub turns: u32,
+    /// True when the oldest turns were dropped to fit the size cap.
+    pub truncated: bool,
+}
+
 /// Where new worktrees land: `GET`/`PUT /code/worktree-root`.
 ///
 /// `root` is the stored setting and is absent while the deployment runs on its

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -304,7 +304,8 @@ pub struct CodeForkTranscript {
     pub path: String,
     pub byte_len: u64,
     pub turns: u32,
-    /// True when the oldest turns were dropped to fit the size cap.
+    /// True when anything was left out to fit the size cap: the oldest
+    /// turns, or the end of a turn too large on its own.
     pub truncated: bool,
 }
 

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -465,6 +465,7 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodeCloneDefaults>(&cfg, &mut out);
         // Where new worktrees land, and the body that moves it.
         generate::collect_from::<crate::routes::code::CodeWorktreeRoot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeForkTranscript>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::SetCodeWorktreeRootBody>(&cfg, &mut out);
         out
     }


### PR DESCRIPTION
> Stacked on #2356, which is stacked on #2355. Review those first; this diff is
> against #2356's branch and retargets as they land.

## What changed

Forking hands one agent's transcript to a fresh one, in a new tab, on whatever
engine the reader picks.

Because the child can be any harness, the handoff has to be something any
harness can read. The server renders the parent's turns to markdown and writes
them into the worktree at `.tidebreak/forks/<session-id>.md`. Pure serialization
of what the journal already holds — no model call and no summary, because a
generated one would be a second thing to be wrong, and the point of the file is
that the child sees what the parent saw.

`.tidebreak/` carries a `.gitignore` holding `*`, so it hides itself and the
ignore file with it. That is what keeps the transcript out of `git status`
without touching the repository's tracked ignore file or the `.git/info/exclude`
that every other worktree of the same repository reads. A long session drops its
oldest turns to fit 512 KiB and the header says so: the child needs recent
context far more than it needs the first turn.

`POST /code/sessions/{id}/fork` writes the file and reports where it landed.
Creating the child is a separate call, so the reader chooses the engine and edits
the framing line before anything is sent.

**The child receives a path, not bytes.** `Composer` gains a workspace-file chip
for exactly this: nothing is uploaded and no document is created, and the surface
names the path after the message it sends. This is a new concept rather than a
reuse of `ComposerFiles`, whose items are `ImportedDocument`s with a
`documentId` a worktree file does not have. Removing the chip removes the
reference, so the framing line stays the reader's to write.

Fork is on the conversation tab's context menu and in the workspace header,
offered for interactive agents only — a watch child is the harness's own run, not
a conversation to continue.

## Validation

- `cargo test -p tidebreak-server --lib code::` — 152 passed, 5 of them new in `code::fork`
- `cargo fmt --all --check`
- `pnpm test` — 206 files, 1473 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm storybook:build`

Server tests cover the self-ignoring directory, per-turn event scoping, subagent
events staying with the task call that ran them, a visible failure, and dropping
the oldest turns to fit. Stories cover a composer seeded with a transcript chip,
a truncated one, and the tab menu.

Not verified locally: an end-to-end fork against a real worktree. Worth
confirming the file exists on disk and that the child's first message names it.

## Compatibility and risk

Adds one route and one wire type (`CodeForkTranscript`); `wire.ts` is
regenerated. The server writes a file inside the worktree, which is new — it is
confined to `.tidebreak/`, ignored, and named by session id, so a re-fork
overwrites its own file and nothing else.

## Tracking

None.
