### PR TITLE
feat(web-search): search through the chat's own model provider

### DIFF
--- a/crates/tidebreak-desktop/ui/src/WebSearchProviderRequiredCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/WebSearchProviderRequiredCard.tsx
@@ -11,6 +11,12 @@ import { Button } from "@/components/ui/button";
  * reads the same as a consent prompt or a clarifying question. The tool group
  * above already names and labels the search, so the card carries no icon of its
  * own.
+ *
+ * Reaching this card is narrower than it used to be: Claude, GPT, and Gemini
+ * chats search through their own model provider, so what is left here is a chat
+ * on a model whose provider cannot search — a self-hosted or pass-through
+ * route — or a host pinned to `host` mode with no key. Naming a second remedy
+ * matters, because for most readers switching models is the faster one.
  */
 export function WebSearchProviderRequiredCard() {
   const titleId = useId();
@@ -23,7 +29,7 @@ export function WebSearchProviderRequiredCard() {
     <AttentionCard
       title="Web search needs a provider"
       titleId={titleId}
-      subtitle="Choose a web search provider and add its API key in Settings."
+      subtitle="Add a web search provider in Settings, or switch this chat to a Claude, GPT, or Gemini model to search through it directly."
     >
       <div className="flex flex-wrap gap-2">
         <Button

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -4040,7 +4040,7 @@ export type WebSearchMode = "automatic" | "vendor" | "host" | "off";
  * A configured web-search backend. The stable string also selects its secret
  * reference; it is intentionally not a model-controlled argument.
  */
-export type WebSearchProviderKind = "exa" | "tavily" | "brave" | "searxng";
+export type WebSearchProviderKind = "exa" | "tavily" | "brave" | "searxng" | "model_provider";
 
 /**
  * Identifies one isolated workspace (worktree + branch) on a repo.

--- a/crates/tidebreak-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
@@ -205,4 +205,46 @@ describe("WebSearchPanel", () => {
     await screen.findByRole("alert");
     expect(putWebSearchConfig).not.toHaveBeenCalled();
   });
+
+  /**
+   * The verdict is the one place the panel says whether search will actually
+   * run. Automatic falls back to the chat's own model provider, so an install
+   * with no key is working rather than broken — reporting it as unconfigured
+   * sends the reader to buy an API key they do not need.
+   */
+  it("reports automatic as working when only the model's own search is left", async () => {
+    const { client } = clientFor({
+      has_credential: false,
+      available: false,
+      timeout_ms: 20_000,
+      mode: "automatic",
+    });
+
+    render(<WebSearchPanel client={client} />);
+
+    expect(await screen.findByText(/Built-in search only/)).toBeTruthy();
+    expect(
+      screen.getByText(/searches through the model it is running on/),
+    ).toBeTruthy();
+  });
+
+  /**
+   * Explicit host mode is the one state that still strands a chat: the operator
+   * ruled out the model provider, so an unkeyed engine really does mean no
+   * search, and the panel must keep saying so.
+   */
+  it("still reports explicit host mode without a key as unconfigured", async () => {
+    const { client } = clientFor({
+      provider: "exa",
+      has_credential: false,
+      available: false,
+      timeout_ms: 20_000,
+      mode: "host",
+    });
+
+    render(<WebSearchPanel client={client} />);
+
+    expect(await screen.findByText(/Not configured/)).toBeTruthy();
+    expect(screen.getByText(/needs an API key/)).toBeTruthy();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -185,11 +185,11 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
 
           <SettingsSection
             title="Search mode"
-            description="Which search work gets. Automatic uses your model provider's built-in search when the selected model supports it, and the provider configured below otherwise."
+            description="Which search work gets. Automatic prefers the provider configured below, and falls back to the model's own search when no provider here is ready."
           >
             <SettingsField
               label="Search mode"
-              hint="Built-in search runs inside the model provider's own infrastructure and is billed through that provider's API key, not through the providers below."
+              hint="Built-in search runs on the model's own provider and is billed through that provider's key or subscription, not through the providers below. Claude, GPT, and Gemini models can search this way."
             >
               <Select
                 value={mode}
@@ -319,6 +319,10 @@ function providerLabel(provider: WebSearchProviderKind): string {
       return "Brave Search";
     case "searxng":
       return "SearXNG";
+    case "model_provider":
+      // Never selectable here — it follows the chat's model rather than this
+      // configuration — but a hand-edited setting should still read as prose.
+      return "your model provider";
     default:
       return provider;
   }
@@ -343,16 +347,16 @@ function webSearchState(config: WebSearchConfigInfo | null): {
       kind: "ready",
       label: "Built-in search",
       description:
-        "Work searches through the model provider. A model without built-in search cannot search at all.",
+        "Work searches through the model it is running on. Claude, GPT, and Gemini models can; a model on another provider cannot search at all.",
     };
   }
   if (!config?.provider) {
     return config?.mode === "automatic"
       ? {
-          kind: "not-configured",
+          kind: "ready",
           label: "Built-in search only",
           description:
-            "No provider is selected here, so only models with built-in search can search.",
+            "No provider is selected here, so work searches through the model it is running on. Claude, GPT, and Gemini models can.",
         }
       : {
           kind: "disabled",
@@ -370,16 +374,22 @@ function webSearchState(config: WebSearchConfigInfo | null): {
       label: "Ready",
       description:
         config.mode === "automatic"
-          ? `${selected} Models with built-in search use that instead.`
+          ? `${selected} Automatic prefers it over any model's built-in search.`
           : selected,
     };
   }
+  const missing =
+    config.provider === SEARXNG_PROVIDER
+      ? `${providerLabel(config.provider)} is selected but needs an instance URL.`
+      : `${providerLabel(config.provider)} is selected but needs an API key.`;
   return {
-    kind: "not-configured",
-    label: "Not configured",
+    // Automatic still searches: it falls back to the model's own provider
+    // rather than leaving work with a tool nothing answers.
+    kind: config.mode === "automatic" ? "ready" : "not-configured",
+    label: config.mode === "automatic" ? "Built-in search" : "Not configured",
     description:
-      config.provider === SEARXNG_PROVIDER
-        ? `${providerLabel(config.provider)} is selected but needs an instance URL.`
-        : `${providerLabel(config.provider)} is selected but needs an API key.`,
+      config.mode === "automatic"
+        ? `${missing} Until then, work searches through the model it is running on.`
+        : missing,
   };
 }

--- a/crates/tidebreak-desktop/ui/src/stories/WebSearchPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WebSearchPanel.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { ApiClient, WebSearchConfigInfo } from "@/api";
+import { WebSearchPanel } from "@/settings/WebSearchPanel";
+import {
+  webSearchCredentials,
+  webSearchHostOnlyUnconfigured,
+  webSearchKeyMissing,
+  webSearchNoProvider,
+  webSearchOff,
+  webSearchReady,
+  webSearchVendorOnly,
+} from "./fixtures";
+
+/**
+ * A client that answers the panel's two reads and refuses to write.
+ *
+ * The panel resolves its whole verdict from what these return, so a fixture per
+ * config is enough to render every state. Writes are absent on purpose: a story
+ * that could mutate settings would be a story that behaves differently the
+ * second time it is opened.
+ */
+function stubClient(config: WebSearchConfigInfo): ApiClient {
+  return {
+    getWebSearchConfig: async () => config,
+    listWebSearchCredentials: async () => ({
+      credentials: webSearchCredentials,
+    }),
+  } as unknown as ApiClient;
+}
+
+/**
+ * Web-search settings. The states that matter here are the verdicts, because
+ * the verdict is the only place the panel says who will actually run a search —
+ * an engine keyed on this host, or the model the chat is already talking to.
+ */
+const meta = {
+  title: "Settings/Web search",
+  component: WebSearchPanel,
+  args: { client: stubClient(webSearchReady) },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WebSearchPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The operator's own engine, keyed and preferred over any built-in search. */
+export const ConfiguredEngine: Story = {};
+
+/**
+ * Nothing configured, automatic mode — the common install.
+ *
+ * This is the state behind the original bug: it used to report "built-in search
+ * only" as a *problem*, because a GPT or Gemini chat had no search at all. Now
+ * it is a working configuration and reads as one.
+ */
+export const NoProviderConfigured: Story = {
+  args: { client: stubClient(webSearchNoProvider) },
+};
+
+/**
+ * An engine selected but never keyed. Automatic does not strand the reader
+ * here: it says what is missing and what happens until it is supplied.
+ */
+export const SelectedEngineMissingItsKey: Story = {
+  args: { client: stubClient(webSearchKeyMissing) },
+};
+
+/** Deliberately no host engine: every search goes to the chat's own model. */
+export const BuiltInSearchOnly: Story = {
+  args: { client: stubClient(webSearchVendorOnly) },
+};
+
+/**
+ * The one state that can still strand a chat. Explicit host mode never falls
+ * back to the model provider, so an unkeyed engine here means no search — which
+ * is the operator's choice, and is reported as unconfigured rather than ready.
+ */
+export const HostOnlyWithoutAKey: Story = {
+  args: { client: stubClient(webSearchHostOnlyUnconfigured) },
+};
+
+/** Search turned off outright: the tool is never offered. */
+export const Off: Story = {
+  args: { client: stubClient(webSearchOff) },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -19,6 +19,8 @@ import type {
   PendingUserQuestions,
   TaskPlan,
   ToolActionPreview,
+  WebSearchConfigInfo,
+  WebSearchCredentialReadiness,
 } from "@/api";
 import type { CodeDeliveryNotification } from "@/code/CodeDeliveryStore";
 
@@ -871,4 +873,53 @@ export const deliveryNotifications: CodeDeliveryNotification[] = [
       number: 2247,
     },
   },
+];
+
+/**
+ * Web-search settings, one entry per verdict the panel can reach.
+ *
+ * The interesting axis is not "configured or not" but who ends up searching:
+ * an engine on this host, or the model the chat is already running on. Every
+ * entry below is a state a reader can actually land in.
+ */
+export const webSearchNoProvider: WebSearchConfigInfo = {
+  mode: "automatic",
+  timeout_ms: 20000,
+  has_credential: false,
+  available: false,
+};
+
+export const webSearchKeyMissing: WebSearchConfigInfo = {
+  ...webSearchNoProvider,
+  provider: "brave",
+};
+
+export const webSearchReady: WebSearchConfigInfo = {
+  mode: "automatic",
+  provider: "brave",
+  timeout_ms: 20000,
+  has_credential: true,
+  available: true,
+};
+
+export const webSearchVendorOnly: WebSearchConfigInfo = {
+  ...webSearchNoProvider,
+  mode: "vendor",
+};
+
+export const webSearchHostOnlyUnconfigured: WebSearchConfigInfo = {
+  ...webSearchNoProvider,
+  mode: "host",
+  provider: "exa",
+};
+
+export const webSearchOff: WebSearchConfigInfo = {
+  ...webSearchNoProvider,
+  mode: "off",
+};
+
+export const webSearchCredentials: WebSearchCredentialReadiness[] = [
+  { provider: "exa", has_credential: false },
+  { provider: "tavily", has_credential: false },
+  { provider: "brave", has_credential: true },
 ];

--- a/crates/tidebreak-router/src/openai.rs
+++ b/crates/tidebreak-router/src/openai.rs
@@ -348,9 +348,24 @@ pub(crate) fn build_request_json_for(
     req: &ChatRequest,
     profile: ResponsesProfile,
 ) -> Result<Value> {
-    if profile == ResponsesProfile::OpenAi && req.vendor_web_search.is_some() {
+    // Responses has no wire field for `VendorWebSearch::max_uses`, so a request
+    // that hands the model a hosted search alongside its own tools spends an
+    // unbounded number of searches inside one agent turn. That shape stays
+    // refused.
+    //
+    // A request carrying no tools of its own is the other case: it is one
+    // dedicated search the host issued and will not continue, so the host counts
+    // the calls and the budget is enforced before egress rather than on the
+    // wire. This is the same predicate the Gemini adapter already applies in
+    // `declares_search_grounding`, for the same reason.
+    if profile == ResponsesProfile::OpenAi
+        && req.vendor_web_search.is_some()
+        && !req.tools.is_empty()
+    {
         return Err(AgentError::Provider(
-            "Responses API cannot enforce the vendor web-search max_uses budget".into(),
+            "Responses API cannot enforce the vendor web-search max_uses budget \
+             alongside host tools"
+                .into(),
         ));
     }
 
@@ -388,9 +403,9 @@ pub(crate) fn build_request_json_for(
     }
     // xAI's vendor search is a hosted tool, declared alongside the function
     // tools rather than instead of them: the model may still call anything the
-    // host advertised in the same response. OpenAI requests carrying this
-    // capability are rejected above because that endpoint cannot enforce the
-    // mandatory per-turn `max_uses` budget before provider egress.
+    // host advertised in the same response. An OpenAI request reaches here only
+    // when it carries no tools of its own — the guard above refused the mixed
+    // shape — so on that profile this is the sole tool on the request.
     if req.vendor_web_search.is_some() {
         let vendor_tool = json!({ "type": VENDOR_WEB_SEARCH_TOOL });
         match body["tools"].as_array_mut() {
@@ -1364,6 +1379,35 @@ mod tests {
             .unwrap()
             .iter()
             .any(|item| item["name"] == "web_search"));
+    }
+
+    /// The dedicated search sub-request the host issues on the model's behalf.
+    ///
+    /// It is the mixed shape that Responses cannot bound, not the hosted tool
+    /// itself: with no other tool on the request there is nothing for the model
+    /// to continue into, so the host's own call count is the budget. Refusing
+    /// this shape too would leave OpenAI models unable to search at all.
+    #[test]
+    fn openai_accepts_a_hosted_search_on_a_request_carrying_no_other_tools() {
+        let req = ChatRequest {
+            model: "gpt-5.6-sol".into(),
+            messages: vec![ChatMessage::text(Role::User, "who won the match")],
+            tools: Vec::new(),
+            vendor_web_search: Some(VendorWebSearch { max_uses: 1 }),
+            ..Default::default()
+        };
+
+        let body = build_request_json(&req)
+            .expect("a tool-free search sub-request is the shape the host can bound");
+        assert_eq!(body["tools"], json!([{"type":"web_search"}]));
+
+        // Nothing to collide with: the rename only exists to keep one request
+        // from carrying two different tools named `web_search`.
+        assert!(!body["input"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["name"] == "web_search_prior"));
     }
 
     #[test]

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1402,7 +1402,12 @@ async fn bind_inner(
         .with_office_converter(office_converter)
         .with_host_tool_broker(host_tool_broker),
     );
-    let foreground_web_search = web_search::foreground_tool(store.clone(), secrets.clone());
+    let foreground_web_search = web_search::foreground_tool(
+        store.clone(),
+        secrets.clone(),
+        resolver.clone(),
+        boot_default_model(),
+    );
     let web_extract = web_search::foreground_extract_tool(store.clone(), secrets.clone());
     // Computer use exists only where there is a display to capture and a
     // trusted client to drive it: the desktop profile on macOS, where the
@@ -1582,6 +1587,8 @@ async fn bind_inner(
         sandbox_web_search_worker::SandboxWebSearchWorker::with_attempts(
             state.store.clone(),
             state.secrets.clone(),
+            state.resolver.clone(),
+            state.agent_config.model.clone(),
             state.agent_run_wake.clone(),
             state.sandbox_attempts.clone(),
             sandbox_web_search_worker::SandboxWebSearchWorkerConfig::default(),
@@ -1910,12 +1917,21 @@ fn agent_deps_with_cancellation_acceleration(
     // an explicit ordered wait parks only when results are needed. The bounded
     // sandbox worker below never receives either orchestration definition.
     tools.register_foreground_agent_orchestration();
-    let model = std::env::var("TIDEBREAK_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+    let model = boot_default_model();
     let agent_config = AgentConfig {
         model,
         ..AgentConfig::default()
     };
     (tools, agent_config)
+}
+
+/// The model this process launched with.
+///
+/// Read in two places — the boot agent config, and the web-search resolver's
+/// last fallback when neither a chat nor the global `chat` role names a model —
+/// so it lives in one.
+fn boot_default_model() -> String {
+    std::env::var("TIDEBREAK_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string())
 }
 
 /// Register the computer-use contracts as validated client tools.

--- a/crates/tidebreak-server/src/model_registry.rs
+++ b/crates/tidebreak-server/src/model_registry.rs
@@ -187,6 +187,26 @@ impl ModelSpec {
         !self.reasoning_efforts.is_empty()
     }
 
+    /// Whether this model's provider can serve a dedicated web-search
+    /// sub-request: one tool-free call that carries only the provider's own
+    /// hosted search and returns what it cited.
+    ///
+    /// This is deliberately not [`Self::supports_vendor_web_search`], which
+    /// answers a different question — whether the routing adapter hands the
+    /// model a hosted search *during an agent turn*, alongside the host's own
+    /// tools. Both OpenAI and Gemini keep that false, and for good reason:
+    /// neither endpoint can bound how many searches one turn spends. A
+    /// sub-request has no such problem. The host issues it, gets one answer
+    /// back, and never continues it, so the host's own call count is the
+    /// budget.
+    ///
+    /// Anthropic is absent because it needs nothing here: its rows already
+    /// carry a native in-turn search, which is strictly better than a
+    /// round-trip through a second call.
+    pub fn supports_search_subrequest(&self) -> bool {
+        matches!(self.provider, ProviderKind::Openai | ProviderKind::Gemini)
+    }
+
     /// Whether this OpenAI row may run under ChatGPT / Codex subscription auth.
     ///
     /// ChatGPT OAuth routes inference through the Codex backend, which rejects

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -794,6 +794,16 @@ pub struct ResolvedModelPolicy {
     /// search instead of the host's. Asserts that the routing adapter emits the
     /// vendor tool, so it is never inherited by a pass-through route.
     pub supports_vendor_web_search: bool,
+    /// Whether the host may search on this model's behalf with a dedicated,
+    /// tool-free sub-request to its provider.
+    ///
+    /// Separate from [`Self::supports_vendor_web_search`] because it is a
+    /// different call: the host issues it, bounds it by counting its own calls,
+    /// and never continues it. See
+    /// [`ModelSpec::supports_search_subrequest`](crate::model_registry::ModelSpec::supports_search_subrequest).
+    /// Never inherited by a pass-through route, for the same reason the vendor
+    /// flag is not — the claim is about the adapter, not the vendor.
+    pub supports_search_subrequest: bool,
     /// The reasoning-effort levels this model accepts, ascending. Empty when
     /// the model takes no effort control.
     pub reasoning_efforts: Vec<ReasoningEffort>,
@@ -827,6 +837,7 @@ impl ResolvedModelPolicy {
             supports_structured_output: spec.supports_structured_output(),
             supports_reasoning: spec.supports_reasoning,
             supports_vendor_web_search: spec.supports_vendor_web_search,
+            supports_search_subrequest: spec.supports_search_subrequest(),
             reasoning_efforts: spec.reasoning_efforts.to_vec(),
         }
     }
@@ -902,6 +913,9 @@ impl ResolvedModelPolicy {
             // shape that would enable one is the vendor's own, and this route
             // does not speak it. Deliberately not inherited by `gateway_for`.
             supports_vendor_web_search: false,
+            // Same reasoning, same answer: a search sub-request is the vendor's
+            // own request shape, which this route does not speak.
+            supports_search_subrequest: false,
             reasoning_efforts: if first_party_xai {
                 model.reasoning_efforts.clone()
             } else {

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
@@ -443,7 +443,7 @@ impl SandboxAgentRunWorker {
                     .await;
             }
         }
-        let supports_vendor_web_search = if self.resolver.enforces_model_registry() {
+        let search_capabilities = if self.resolver.enforces_model_registry() {
             let Some(policy) =
                 crate::providers::resolve_model_policy(&*self.store, &model, true).await?
             else {
@@ -456,13 +456,16 @@ impl SandboxAgentRunWorker {
                     "managed gateway execution requires a frozen model identity",
                 ));
             }
-            let supports_vendor_web_search = policy.supports_vendor_web_search;
+            let capabilities = (
+                policy.supports_vendor_web_search,
+                policy.supports_search_subrequest,
+            );
             crate::providers::apply_model_policy(
                 &mut agent_config,
                 &policy,
                 chat.reasoning_effort,
             )?;
-            supports_vendor_web_search
+            capabilities
         } else {
             crate::providers::apply_free_form_model(
                 &mut agent_config,
@@ -471,8 +474,9 @@ impl SandboxAgentRunWorker {
             )?;
             // A model reached without the registry claims nothing, here as
             // everywhere else: no row asserts that its adapter emits a
-            // provider-executed search, so this run is not offered one.
-            false
+            // provider-executed search, or that its provider would accept a
+            // search sub-request, so this run is offered neither.
+            (false, false)
         };
         // One host setting governs both surfaces. A background run is the
         // conversation's own work delegated to a child, so the operator's
@@ -481,7 +485,8 @@ impl SandboxAgentRunWorker {
         agent_config.web_search = crate::web_search::resolve_turn_web_search(
             &*self.store,
             &*self.secrets,
-            supports_vendor_web_search,
+            search_capabilities.0,
+            search_capabilities.1,
         )
         .await?;
         // Same source the foreground turn freezes into its operating prompt:

--- a/crates/tidebreak-server/src/sandbox_web_search_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_web_search_worker.rs
@@ -15,7 +15,8 @@ use async_trait::async_trait;
 #[cfg(test)]
 use chrono::Utc;
 use tidebreak_core::{
-    AgentError, ClaimSandboxToolCallOutcome, Result, SandboxToolCall, Store, ToolCallResolution,
+    AgentError, ChatId, ClaimSandboxToolCallOutcome, Result, SandboxToolCall, Store,
+    ToolCallResolution,
 };
 use tokio::sync::Notify;
 
@@ -32,8 +33,13 @@ pub(crate) trait SandboxWebSearch: Send + Sync {
     /// Resolve host policy and credentials without sending a request. The
     /// worker revalidates its durable lease after this await and immediately
     /// before it calls `WebSearchProvider::search`.
+    ///
+    /// The chat decides which backend answers when the host searches through
+    /// the conversation's own model provider, so a background call resolves
+    /// against the chat it belongs to rather than against host settings alone.
     async fn resolve(
         &self,
+        chat: ChatId,
     ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError>;
 }
 
@@ -48,16 +54,25 @@ pub(crate) enum SandboxWebSearchError {
 struct HostSandboxWebSearch {
     store: Arc<dyn Store>,
     secrets: Arc<dyn tidebreak_core::SecretProvider>,
+    providers: Arc<dyn crate::resolver::ProviderResolver>,
+    default_model: String,
 }
 
 #[async_trait]
 impl SandboxWebSearch for HostSandboxWebSearch {
     async fn resolve(
         &self,
+        chat: ChatId,
     ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError> {
-        web_search::resolve_provider(&*self.store, &*self.secrets)
-            .await
-            .map_err(|_| SandboxWebSearchError::Failed)
+        web_search::resolve_provider(
+            &*self.store,
+            &*self.secrets,
+            Some(chat),
+            Some(&self.providers),
+            &self.default_model,
+        )
+        .await
+        .map_err(|_| SandboxWebSearchError::Failed)
     }
 }
 
@@ -117,13 +132,20 @@ impl SandboxWebSearchWorker {
     pub(crate) fn with_attempts(
         store: Arc<dyn Store>,
         secrets: Arc<dyn tidebreak_core::SecretProvider>,
+        providers: Arc<dyn crate::resolver::ProviderResolver>,
+        default_model: String,
         wake: Arc<Notify>,
         attempts: Arc<SandboxAttemptGuard>,
         config: SandboxWebSearchWorkerConfig,
     ) -> Self {
         Self::with_search_and_attempts(
             store.clone(),
-            Arc::new(HostSandboxWebSearch { store, secrets }),
+            Arc::new(HostSandboxWebSearch {
+                store,
+                secrets,
+                providers,
+                default_model,
+            }),
             wake,
             attempts,
             config,
@@ -262,7 +284,7 @@ impl SandboxWebSearchWorker {
         let resolution = match parse_web_search_request(&call) {
             Err(resolution) => resolution,
             Ok(request) => match {
-                let resolve = self.search.resolve();
+                let resolve = self.search.resolve(call.chat_id);
                 tokio::pin!(resolve);
                 tokio::select! {
                     resolved = &mut resolve => Some(resolved),
@@ -504,6 +526,7 @@ mod tests {
     impl SandboxWebSearch for BlockingResolution {
         async fn resolve(
             &self,
+            _chat: ChatId,
         ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError>
         {
             let _drop = DropMarker(self.dropped.clone());
@@ -552,6 +575,7 @@ mod tests {
     impl SandboxWebSearch for FakeSearch {
         async fn resolve(
             &self,
+            _chat: ChatId,
         ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError>
         {
             self.resolution.clone()

--- a/crates/tidebreak-server/src/tests/documents.rs
+++ b/crates/tidebreak-server/src/tests/documents.rs
@@ -1586,7 +1586,16 @@ async fn agent_deps_for_test(
     let store_for_gateway = store.clone();
     agent_deps(
         Arc::new(UnavailableCodeExecution),
-        web_search::foreground_tool(store.clone(), Arc::new(MemSecrets::default())),
+        web_search::foreground_tool(
+            store.clone(),
+            Arc::new(MemSecrets::default()),
+            // This suite exercises extraction and document capture, never a
+            // search: an unconfigured route is the honest stand-in.
+            Arc::new(FixedResolver(Arc::new(
+                crate::provider::UnconfiguredProvider,
+            ))),
+            "claude-opus-5".to_string(),
+        ),
         web_search::foreground_extract_tool(extract_store, Arc::new(MemSecrets::default())),
         store,
         dir.join("profile-data"),

--- a/crates/tidebreak-server/src/tests/workers.rs
+++ b/crates/tidebreak-server/src/tests/workers.rs
@@ -2937,7 +2937,10 @@ struct FixedWebSearchResolver {
 
 #[async_trait]
 impl WebSearchResolver for FixedWebSearchResolver {
-    async fn resolve(&self) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError> {
+    async fn resolve(
+        &self,
+        _chat: Option<tidebreak_core::ChatId>,
+    ) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError> {
         Ok(Some(self.provider.clone()))
     }
 }

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -791,6 +791,9 @@ impl TurnWorker {
                 model_policy
                     .as_ref()
                     .is_some_and(|policy| policy.supports_vendor_web_search),
+                model_policy
+                    .as_ref()
+                    .is_some_and(|policy| policy.supports_search_subrequest),
             )
             .await?
         } else {

--- a/crates/tidebreak-server/src/web_search/host.rs
+++ b/crates/tidebreak-server/src/web_search/host.rs
@@ -9,12 +9,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::{
-    BraveProvider, ExaProvider, ExtractedPageSink, ExtractedPageSinkError, NativeExtractor,
-    OutboundOrigin, PageExtractor, ReqwestHttpClient, ReqwestPageFetcher, SearxngBaseUrl,
-    SearxngProvider, StoredExtractedPage, TavilyProvider, TokioHostResolver, WebExtractFailure,
-    WebExtractRequest, WebExtractResponse, WebExtractTool, WebSearchCredential,
-    WebSearchCredentialState, WebSearchCredentials, WebSearchProvider, WebSearchProviderKind,
-    WebSearchResolver, WebSearchResolverError, WebSearchTool,
+    BraveProvider, ExaProvider, ExtractedPageSink, ExtractedPageSinkError, ModelProviderSearch,
+    NativeExtractor, OutboundOrigin, PageExtractor, ReqwestHttpClient, ReqwestPageFetcher,
+    SearchModel, SearxngBaseUrl, SearxngProvider, StoredExtractedPage, TavilyProvider,
+    TokioHostResolver, WebExtractFailure, WebExtractRequest, WebExtractResponse, WebExtractTool,
+    WebSearchCredential, WebSearchCredentialState, WebSearchCredentials, WebSearchProvider,
+    WebSearchProviderKind, WebSearchResolver, WebSearchResolverError, WebSearchTool,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -25,6 +25,8 @@ use tidebreak_core::{
 };
 
 use crate::error::ServerError;
+use crate::model_roles::{self, ModelRole};
+use crate::resolver::ProviderResolver;
 
 const NETWORK_OFF_ERROR_CODE: &str = "chat_network_off";
 const NETWORK_OFF_MESSAGE: &str =
@@ -324,6 +326,8 @@ fn host_is_available(config: &WebSearchConfig, has_credential: bool) -> bool {
     match config.provider {
         // Nothing to authenticate with; the instance URL is what it needs.
         Some(WebSearchProviderKind::Searxng) => config.searxng_base_url().is_some(),
+        // Not selectable here, so reaching this arm means hand-edited storage.
+        Some(WebSearchProviderKind::ModelProvider) => false,
         Some(_) => has_credential,
         None => false,
     }
@@ -333,17 +337,27 @@ fn host_is_available(config: &WebSearchConfig, has_credential: bool) -> bool {
 /// capabilities.
 ///
 /// `supports_vendor` is the resolved model row's claim that the routing adapter
-/// emits a provider-executed search for it — not that the vendor documents one
-/// — so a model reached over a pass-through route resolves as if it had none.
+/// emits a provider-executed search *during the turn* — not that the vendor
+/// documents one — so a model reached over a pass-through route resolves as if
+/// it had none.
+///
+/// `supports_subrequest` is the weaker, more widely available claim: the host
+/// can search on this model's behalf with one dedicated call to its provider.
+/// It resolves to [`TurnWebSearch::Host`], because that is what it is — the
+/// model is offered the host's own tool, and the host decides what runs behind
+/// it. Where a model has both, the in-turn search wins: it costs no extra
+/// round-trip and the model steers it directly.
 ///
 /// Nothing here consults the chat's permission mode. A vendor search is
 /// provider-internal: it makes no egress from this host, reaches no new party
 /// with the conversation's data, and is already finished by the time Tidebreak
-/// sees it, so there is no decision an approval card could still gate.
+/// sees it, so there is no decision an approval card could still gate. A
+/// sub-request reaches the same party the conversation is already with.
 pub async fn resolve_turn_web_search(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
     supports_vendor: bool,
+    supports_subrequest: bool,
 ) -> Result<TurnWebSearch> {
     let config = read_config(store).await?;
     let vendor = || {
@@ -358,6 +372,10 @@ pub async fn resolve_turn_web_search(
         // configuration error it always has.
         WebSearchMode::Host => TurnWebSearch::Host,
         WebSearchMode::Vendor if supports_vendor => vendor(),
+        // The model's own provider, reached through the host's tool because
+        // that is the only shape its endpoint will accept alongside an agent
+        // turn's tools.
+        WebSearchMode::Vendor if supports_subrequest => TurnWebSearch::Host,
         WebSearchMode::Vendor => TurnWebSearch::Off,
         WebSearchMode::Automatic => {
             let has_credential = host_has_credential(&config, secrets).await;
@@ -546,25 +564,112 @@ async fn required_credential(
     }
 }
 
-/// Resolve the explicitly selected provider for host execution. The returned
+/// The model one chat would search through, when its provider can serve a
+/// dedicated search sub-request.
+///
+/// `None` covers every reason a chat has no such route: an unreadable or
+/// unregistered selection, a pass-through endpoint that cannot promise the
+/// vendor's request shape, and a provider with no hosted search at all
+/// (Anthropic, whose rows carry a native in-turn search instead).
+///
+/// The selection is read the way a new execution reads it — the chat's own
+/// override, then the global `chat` role selection, then the process default —
+/// so the search runs on the model the reader believes they are talking to.
+async fn chat_search_model(
+    store: &dyn Store,
+    chat: ChatId,
+    default_model: &str,
+) -> Option<SearchModel> {
+    let selected = match store
+        .get_chat(chat)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|chat| chat.model)
+    {
+        Some(model) => model,
+        None => model_roles::read_selection(store, ModelRole::Chat)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| default_model.to_owned()),
+    };
+    let policy = crate::providers::resolve_model_policy(store, &selected, true)
+        .await
+        .ok()
+        .flatten()?;
+    if !policy.supports_search_subrequest {
+        return None;
+    }
+    Some(SearchModel {
+        provider: Some(tidebreak_core::ProviderId::new(policy.provider.as_str())),
+        model: policy.route_model.clone(),
+        reasoning_model: policy.supports_reasoning,
+        reasoning_efforts: policy.reasoning_efforts.clone(),
+    })
+}
+
+/// Resolve the provider that will run one chat's host-side search. The returned
 /// provider is inert until its `search` method is called.
 ///
-/// Every path fails closed as `Ok(None)`: mode that never runs on this host
-/// (`off` / `vendor`), a missing key for the providers that need one, and a
-/// missing instance URL for the one that does not. Credentials left in the
-/// keychain after search is turned off must not keep host search live.
+/// Two backends can answer, and which one does is the operator's mode:
+///
+/// - `host` takes the configured engine and nothing else. An operator who named
+///   Brave meant Brave, and quietly searching through their model provider
+///   instead would send queries somewhere they did not choose.
+/// - `vendor` takes the chat's model provider and nothing else, by the mirror of
+///   the same argument.
+/// - `automatic` prefers the configured engine, because it is the deliberate
+///   choice, and falls back to the model provider so a host with no key still
+///   searches.
+///
+/// Every path fails closed as `Ok(None)`: `off`, a missing key for the engines
+/// that need one, a missing instance URL for the one that does not, and a chat
+/// whose model has no search sub-request. Credentials left in the keychain after
+/// search is turned off must not keep host search live.
 pub async fn resolve_provider(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
+    chat: Option<ChatId>,
+    providers: Option<&Arc<dyn ProviderResolver>>,
+    default_model: &str,
 ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, ServerError> {
     let config = read_config(store).await?;
     config.validate()?;
-    // Host adapters only serve Host and Automatic. Vendor search never touches
-    // this path, and Off means no search at all — including when a prior key
-    // is still stored and a stale tool call still reaches the registry.
-    if matches!(config.mode, WebSearchMode::Off | WebSearchMode::Vendor) {
+    if matches!(config.mode, WebSearchMode::Off) {
         return Ok(None);
     }
+
+    // Resolved first so `automatic` can fall through to it, and so `vendor` has
+    // its only candidate. Building it makes no request: the model provider is
+    // as inert here as a bound HTTP client is.
+    let model_backed = async {
+        if matches!(config.mode, WebSearchMode::Host) {
+            return None;
+        }
+        let providers = providers?;
+        let model = chat_search_model(store, chat?, default_model).await?;
+        let backend: Arc<dyn WebSearchProvider> =
+            Arc::new(ModelProviderSearch::new(providers.resolve().await, model));
+        Some(backend)
+    };
+
+    if matches!(config.mode, WebSearchMode::Vendor) {
+        return Ok(model_backed.await);
+    }
+
+    let configured = configured_provider(secrets, &config).await?;
+    Ok(match configured {
+        Some(provider) => Some(provider),
+        None => model_backed.await,
+    })
+}
+
+/// The engine the operator selected and credentialed, if it is usable.
+async fn configured_provider(
+    secrets: &dyn SecretProvider,
+    config: &WebSearchConfig,
+) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, ServerError> {
     let Some(kind) = config.provider else {
         return Ok(None);
     };
@@ -580,6 +685,9 @@ pub async fn resolve_provider(
             let client = bound_client(base_url.origin(), config.timeout_ms)?;
             Arc::new(SearxngProvider::new(client, base_url))
         }
+        // Never an operator selection: it is chosen by mode, above, because the
+        // backend follows the chat rather than the configuration.
+        WebSearchProviderKind::ModelProvider => return Ok(None),
         kind => {
             let Some(credential) = required_credential(secrets, kind).await? else {
                 return Ok(None);
@@ -596,8 +704,11 @@ pub async fn resolve_provider(
                 WebSearchProviderKind::Brave => {
                     Arc::new(BraveProvider::new(client, credential).map_err(|_| unavailable())?)
                 }
-                // Handled above; `OutboundOrigin::fixed` has already refused it.
-                WebSearchProviderKind::Searxng => return Ok(None),
+                // Handled above; `OutboundOrigin::fixed` has already refused
+                // both.
+                WebSearchProviderKind::Searxng | WebSearchProviderKind::ModelProvider => {
+                    return Ok(None)
+                }
             }
         }
     };
@@ -607,16 +718,33 @@ pub async fn resolve_provider(
 struct HostWebSearchResolver {
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
+    /// The model router, when this resolver serves search.
+    ///
+    /// `None` for extraction, which the model-backed backend cannot do: it
+    /// searches by asking a model what it found, and there is no equivalent for
+    /// "read exactly this page." Extraction routes to the configured engine or
+    /// to the native fetcher, exactly as it did before this backend existed.
+    providers: Option<Arc<dyn ProviderResolver>>,
+    /// The model this process launched with — the last fallback when neither
+    /// the chat nor the global `chat` role names one.
+    default_model: String,
 }
 
 #[async_trait]
 impl WebSearchResolver for HostWebSearchResolver {
     async fn resolve(
         &self,
+        chat: Option<ChatId>,
     ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError> {
-        resolve_provider(&*self.store, &*self.secrets)
-            .await
-            .map_err(|_| WebSearchResolverError)
+        resolve_provider(
+            &*self.store,
+            &*self.secrets,
+            chat,
+            self.providers.as_ref(),
+            &self.default_model,
+        )
+        .await
+        .map_err(|_| WebSearchResolverError)
     }
 }
 
@@ -627,12 +755,16 @@ impl WebSearchResolver for HostWebSearchResolver {
 pub(crate) fn foreground_tool(
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
+    providers: Arc<dyn ProviderResolver>,
+    default_model: String,
 ) -> Box<dyn Tool> {
     Box::new(ChatNetworkPolicyTool::new(
         store.clone(),
         Box::new(WebSearchTool::new(Arc::new(HostWebSearchResolver {
             store,
             secrets,
+            providers: Some(providers),
+            default_model,
         }))),
     ))
 }
@@ -746,6 +878,9 @@ pub(crate) fn foreground_extract_tool(
         Arc::new(HostWebSearchResolver {
             store: store.clone(),
             secrets,
+            // Search-only backend, so extraction never routes to it.
+            providers: None,
+            default_model: String::new(),
         }),
         Some(Arc::new(HostNativePageExtractor {
             store: store.clone(),
@@ -800,6 +935,47 @@ mod tests {
         .await
         .unwrap();
         (store, dir)
+    }
+
+    /// Resolution with no chat and no model router: the configured engine, or
+    /// nothing. This is what `resolve_provider` meant before it learned to
+    /// search through a chat's own model provider, and what every test written
+    /// against that behaviour still means.
+    async fn resolve_configured(
+        store: &dyn Store,
+        secrets: &dyn SecretProvider,
+    ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, ServerError> {
+        resolve_provider(store, secrets, None, None, "").await
+    }
+
+    /// A resolver standing in for the model router. It is never asked to
+    /// stream here — building the backend is all these tests observe — so an
+    /// unconfigured route is the honest fake.
+    struct TestModelRouter;
+
+    #[async_trait]
+    impl ProviderResolver for TestModelRouter {
+        async fn resolve(&self) -> Arc<dyn tidebreak_core::ModelProvider> {
+            Arc::new(crate::provider::UnconfiguredProvider)
+        }
+    }
+
+    /// Store a chat pinned to `model`, and return the router to resolve against.
+    async fn chat_on(store: &DbStore, model: &str) -> (ChatId, Arc<dyn ProviderResolver>) {
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: Some(model.to_owned()),
+            reasoning_effort: None,
+            permission_mode: None,
+            network_policy: NetworkPolicy::Open,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        (chat.id, Arc::new(TestModelRouter))
     }
 
     struct UnexpectedNetworkTool;
@@ -915,7 +1091,10 @@ mod tests {
         assert_eq!(info.provider, Some(WebSearchProviderKind::Exa));
         assert!(!info.has_credential);
         assert!(!info.available);
-        assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
+        assert!(matches!(
+            resolve_configured(&store, &secrets).await,
+            Ok(None)
+        ));
         assert!(secrets.0.lock().unwrap().is_empty());
     }
 
@@ -937,7 +1116,10 @@ mod tests {
         let info = update_config(&store, &secrets, select(None)).await.unwrap();
         assert_eq!(info.provider, Some(WebSearchProviderKind::Searxng));
         assert!(!info.available);
-        assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
+        assert!(matches!(
+            resolve_configured(&store, &secrets).await,
+            Ok(None)
+        ));
 
         // A malformed instance URL is rejected at PUT time rather than
         // silently widening where the transport may dial.
@@ -966,7 +1148,7 @@ mod tests {
         assert!(!info.has_credential);
         assert!(info.available);
         assert!(matches!(
-            resolve_provider(&store, &secrets).await,
+            resolve_configured(&store, &secrets).await,
             Ok(Some(_))
         ));
         // Nothing about a credential-free provider touches the keychain, and
@@ -1000,7 +1182,10 @@ mod tests {
         assert_eq!(info.provider, None);
         assert!(!info.has_credential);
         assert!(!info.available);
-        assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
+        assert!(matches!(
+            resolve_configured(&store, &secrets).await,
+            Ok(None)
+        ));
     }
 
     /// The whole point of the mode: which search a turn gets, decided from
@@ -1009,7 +1194,8 @@ mod tests {
     async fn turn_resolution_prefers_a_usable_host_and_falls_back_to_the_vendor() {
         let (store, _dir) = test_store().await;
         let secrets = TestSecrets::default();
-        let resolve = |supports_vendor| resolve_turn_web_search(&store, &secrets, supports_vendor);
+        let resolve =
+            |supports_vendor| resolve_turn_web_search(&store, &secrets, supports_vendor, false);
         let vendor = TurnWebSearch::Vendor(VendorWebSearch {
             max_uses: VendorWebSearch::DEFAULT_MAX_USES,
         });
@@ -1056,6 +1242,164 @@ mod tests {
         assert_eq!(resolve(true).await.unwrap(), TurnWebSearch::Off);
     }
 
+    /// The screenshot this whole path exists to fix: automatic mode, no key
+    /// stored, a chat on a model whose provider has no in-turn search. Before
+    /// the sub-request backend the turn held a host tool with nothing behind
+    /// it, and the reader got "web search needs a provider".
+    #[tokio::test]
+    async fn a_model_with_only_a_sub_request_still_gets_a_working_host_tool() {
+        let (store, _dir) = test_store().await;
+        let secrets = TestSecrets::default();
+        let resolve =
+            |vendor, subrequest| resolve_turn_web_search(&store, &secrets, vendor, subrequest);
+
+        // Automatic with nothing configured: the tool is offered either way,
+        // but now something answers it.
+        assert_eq!(resolve(false, true).await.unwrap(), TurnWebSearch::Host);
+
+        // Vendor mode is where the difference is visible. It used to mean
+        // "off" for these models, because they claim no in-turn search.
+        update_config(
+            &store,
+            &secrets,
+            WebSearchConfigUpdate {
+                provider: None,
+                mode: Some(WebSearchMode::Vendor),
+                timeout_ms: None,
+                searxng_base_url: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(resolve(false, true).await.unwrap(), TurnWebSearch::Host);
+        assert_eq!(resolve(false, false).await.unwrap(), TurnWebSearch::Off);
+
+        // A model with both keeps the in-turn search: it costs no extra
+        // round-trip and the model steers it directly.
+        assert_eq!(
+            resolve(true, true).await.unwrap(),
+            TurnWebSearch::Vendor(VendorWebSearch {
+                max_uses: VendorWebSearch::DEFAULT_MAX_USES,
+            })
+        );
+    }
+
+    /// An operator who named an engine meant that engine. Falling back to the
+    /// chat's model provider would send their queries somewhere they did not
+    /// choose, which is the one thing explicit host mode rules out.
+    #[tokio::test]
+    async fn host_mode_never_resolves_the_model_backed_backend() {
+        let (store, _dir) = test_store().await;
+        let secrets = TestSecrets::default();
+        let (chat, router) = chat_on(&store, "openai::gpt-5.6-sol").await;
+
+        for mode in [WebSearchMode::Host, WebSearchMode::Off] {
+            update_config(
+                &store,
+                &secrets,
+                WebSearchConfigUpdate {
+                    provider: None,
+                    mode: Some(mode),
+                    timeout_ms: None,
+                    searxng_base_url: None,
+                },
+            )
+            .await
+            .unwrap();
+
+            let resolved = resolve_provider(&store, &secrets, Some(chat), Some(&router), "")
+                .await
+                .unwrap();
+            assert!(resolved.is_none(), "{mode:?} resolved a backend");
+        }
+
+        // Vendor mode is the same chat and the same router, and it does
+        // resolve — so the refusals above are the mode, not a broken fixture.
+        update_config(
+            &store,
+            &secrets,
+            WebSearchConfigUpdate {
+                provider: None,
+                mode: Some(WebSearchMode::Vendor),
+                timeout_ms: None,
+                searxng_base_url: None,
+            },
+        )
+        .await
+        .unwrap();
+        let resolved = resolve_provider(&store, &secrets, Some(chat), Some(&router), "")
+            .await
+            .unwrap()
+            .expect("vendor mode resolves the chat's own model provider");
+        assert_eq!(resolved.kind(), WebSearchProviderKind::ModelProvider);
+    }
+
+    /// Anthropic rows carry a native in-turn search, so they need nothing here
+    /// — and a chat on one must not quietly acquire a second, worse search
+    /// path built on an extra round-trip.
+    #[tokio::test]
+    async fn a_chat_whose_model_has_no_sub_request_resolves_nothing() {
+        let (store, _dir) = test_store().await;
+        let secrets = TestSecrets::default();
+        let (chat, router) = chat_on(&store, "anthropic::claude-opus-5").await;
+        update_config(
+            &store,
+            &secrets,
+            WebSearchConfigUpdate {
+                provider: None,
+                mode: Some(WebSearchMode::Vendor),
+                timeout_ms: None,
+                searxng_base_url: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let resolved = resolve_provider(&store, &secrets, Some(chat), Some(&router), "")
+            .await
+            .unwrap();
+
+        assert!(resolved.is_none());
+    }
+
+    /// Automatic prefers what the operator configured, and only falls through
+    /// to the model provider when this host has nothing to run.
+    #[tokio::test]
+    async fn automatic_prefers_a_usable_engine_over_the_model_provider() {
+        let (store, _dir) = test_store().await;
+        let secrets = TestSecrets::default();
+        let (chat, router) = chat_on(&store, "openai::gpt-5.6-sol").await;
+        update_config(
+            &store,
+            &secrets,
+            WebSearchConfigUpdate {
+                provider: Some(Some(WebSearchProviderKind::Exa)),
+                mode: Some(WebSearchMode::Automatic),
+                timeout_ms: None,
+                searxng_base_url: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Selected but unusable: no key, so the model provider answers.
+        let resolved = resolve_provider(&store, &secrets, Some(chat), Some(&router), "")
+            .await
+            .unwrap()
+            .expect("an unusable engine falls through");
+        assert_eq!(resolved.kind(), WebSearchProviderKind::ModelProvider);
+
+        // With the key in place the operator's choice wins again.
+        write_credential(&secrets, WebSearchProviderKind::Exa, "key")
+            .await
+            .unwrap();
+        let resolved = resolve_provider(&store, &secrets, Some(chat), Some(&router), "")
+            .await
+            .unwrap()
+            .expect("a credentialed engine resolves");
+        assert_eq!(resolved.kind(), WebSearchProviderKind::Exa);
+    }
+
     /// `PUT { "provider": null }` is the documented disable and what
     /// `settings web-search select off` sends. It must turn search off for the
     /// turn surface, not leave mode automatic so a vendor-capable model still
@@ -1080,7 +1424,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            resolve_turn_web_search(&store, &secrets, true)
+            resolve_turn_web_search(&store, &secrets, true, false)
                 .await
                 .unwrap(),
             TurnWebSearch::Host
@@ -1103,19 +1447,22 @@ mod tests {
         assert_eq!(info.mode, WebSearchMode::Off);
         assert!(!info.available);
         assert_eq!(
-            resolve_turn_web_search(&store, &secrets, true)
+            resolve_turn_web_search(&store, &secrets, true, false)
                 .await
                 .unwrap(),
             TurnWebSearch::Off
         );
         assert_eq!(
-            resolve_turn_web_search(&store, &secrets, false)
+            resolve_turn_web_search(&store, &secrets, false, false)
                 .await
                 .unwrap(),
             TurnWebSearch::Off
         );
         // A leftover key must not keep host search live under Off.
-        assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
+        assert!(matches!(
+            resolve_configured(&store, &secrets).await,
+            Ok(None)
+        ));
 
         // Selecting a provider again without an explicit mode restores a
         // usable default rather than leaving Off stuck under a selection.
@@ -1133,7 +1480,7 @@ mod tests {
         .unwrap();
         assert_eq!(info.mode, WebSearchMode::Automatic);
         assert_eq!(
-            resolve_turn_web_search(&store, &secrets, true)
+            resolve_turn_web_search(&store, &secrets, true, false)
                 .await
                 .unwrap(),
             TurnWebSearch::Host
@@ -1171,12 +1518,15 @@ mod tests {
         assert!(info.has_credential);
         assert!(!info.available);
         assert_eq!(
-            resolve_turn_web_search(&store, &secrets, true)
+            resolve_turn_web_search(&store, &secrets, true, false)
                 .await
                 .unwrap(),
             TurnWebSearch::Off
         );
-        assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
+        assert!(matches!(
+            resolve_configured(&store, &secrets).await,
+            Ok(None)
+        ));
     }
 
     /// A configuration written before the mode existed keeps the behavior it

--- a/crates/tidebreak-server/src/web_search/mod.rs
+++ b/crates/tidebreak-server/src/web_search/mod.rs
@@ -16,6 +16,7 @@ mod extract_source;
 mod fetch_policy;
 mod host;
 mod http;
+mod model_provider;
 mod native;
 mod searxng;
 mod tavily;
@@ -40,6 +41,7 @@ pub use http::{
     HttpClient, HttpGetRequest, HttpRequest, HttpResponse, OutboundOrigin, ReqwestHttpClient,
     MAX_HTTP_RESPONSE_BYTES,
 };
+pub use model_provider::{ModelProviderSearch, SearchModel};
 pub use native::{
     HostAddressResolver, NativeExtractError, NativeExtraction, NativeExtractor, PageFetchResponse,
     PageFetchTransport, ReqwestPageFetcher, TokioHostResolver, MAX_EXTRACT_CONTENT_CHARS,

--- a/crates/tidebreak-server/src/web_search/model_provider.rs
+++ b/crates/tidebreak-server/src/web_search/model_provider.rs
@@ -163,6 +163,13 @@ impl WebSearchProvider for ModelProviderSearch {
                         continue;
                     }
                     results.extend(cited_results(&output, &request));
+                    // One sub-request can run more than one search: a reasoning
+                    // model browses with `open_page` and `find_in_page` as well
+                    // as `search`, and each finished item arrives as its own
+                    // call. The caller asked for `max_results` in total, not per
+                    // item, so the cap belongs here rather than inside the
+                    // per-call mapping.
+                    results.truncate(request.max_results);
                 }
                 // A refusal is the model declining to answer, which is not the
                 // same as a search that found nothing: reporting it as an empty
@@ -228,7 +235,6 @@ fn cited_results(output: &Value, request: &WebSearchRequest) -> Vec<WebSearchRes
                 request.end_published_at,
             )
         })
-        .take(request.max_results)
         .collect()
 }
 
@@ -236,7 +242,83 @@ fn cited_results(output: &Value, request: &WebSearchRequest) -> Vec<WebSearchRes
 mod tests {
     use super::*;
     use crate::web_search::SearchDomain;
+    use futures::stream::{self, BoxStream};
     use serde_json::json;
+
+    /// A provider that answers with a scripted run of hosted-search calls.
+    struct ScriptedSearches(Vec<Value>);
+
+    #[async_trait]
+    impl ModelProvider for ScriptedSearches {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("scripted")
+        }
+
+        async fn stream(
+            &self,
+            _req: ChatRequest,
+        ) -> tidebreak_core::Result<BoxStream<'static, ProviderEvent>> {
+            let events: Vec<ProviderEvent> = self
+                .0
+                .iter()
+                .map(|output| ProviderEvent::ProviderExecutedToolCall {
+                    name: VENDOR_WEB_SEARCH_TOOL.to_owned(),
+                    input: json!({"query": "q"}),
+                    output: output.clone(),
+                    is_error: false,
+                    replay: None,
+                })
+                .collect();
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    fn search_over(outputs: Vec<Value>) -> ModelProviderSearch {
+        ModelProviderSearch::new(
+            Arc::new(ScriptedSearches(outputs)),
+            SearchModel {
+                provider: Some(ProviderId::new("openai")),
+                model: "gpt-5.6-sol".into(),
+                reasoning_model: true,
+                reasoning_efforts: vec![ReasoningEffort::Low],
+            },
+        )
+    }
+
+    fn cited(urls: &[&str]) -> Value {
+        json!({
+            "provider": "openai",
+            "results": urls
+                .iter()
+                .map(|url| json!({"url": url, "title": "T", "snippet": ""}))
+                .collect::<Vec<_>>(),
+        })
+    }
+
+    /// `max_results` is a total, not a per-call allowance.
+    ///
+    /// One sub-request can finish several hosted searches — a reasoning model
+    /// browses with `open_page` and `find_in_page` as well as `search`, and each
+    /// arrives as its own call. Capping inside the per-call mapping would let a
+    /// three-result request answer with nine, which no other backend does and
+    /// which the caller pays for in context.
+    #[tokio::test]
+    async fn several_searches_in_one_sub_request_still_honour_max_results() {
+        let search = search_over(vec![
+            cited(&["https://a.test/1", "https://a.test/2"]),
+            cited(&["https://b.test/1", "https://b.test/2"]),
+            cited(&["https://c.test/1"]),
+        ]);
+
+        let response = search
+            .search(WebSearchRequest::new("news", 3).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.results.len(), 3);
+        assert_eq!(response.results[0].url, "https://a.test/1");
+        assert_eq!(response.results[2].url, "https://b.test/1");
+    }
 
     fn request(query: &str) -> WebSearchRequest {
         WebSearchRequest::new(query, 5).unwrap()

--- a/crates/tidebreak-server/src/web_search/model_provider.rs
+++ b/crates/tidebreak-server/src/web_search/model_provider.rs
@@ -1,0 +1,326 @@
+//! Searching through the chat's own model provider.
+//!
+//! Every other backend in this module is a search engine with an address and a
+//! key. This one has neither: it hands one query to the provider the chat is
+//! already talking to, on that provider's own credential or subscription, and
+//! reads back what the answer cited.
+//!
+//! The request is deliberately tool-free. That is not an implementation detail
+//! — it is the whole reason this path is allowed to exist. Both the OpenAI and
+//! the Gemini adapters refuse to declare a hosted search alongside the host's
+//! own function tools, because neither endpoint can bound how many searches one
+//! agent turn would then spend (`openai.rs`'s profile guard,
+//! `gemini.rs`'s `declares_search_grounding`). A sub-request has no such
+//! problem: the host issues exactly one, never continues it, and counts its own
+//! calls. The budget moves off the wire and onto this host, where it can
+//! actually be enforced.
+//!
+//! What comes back is thinner than a search engine's answer. Both providers
+//! report citations as title and URL with no page excerpt, so results carry no
+//! snippet and the agent follows up with `web_extract` for anything it needs to
+//! read. Domain filters are honoured the same way Brave and SearXNG honour
+//! them: passed as query operators, then enforced here on the results.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::Value;
+use tidebreak_core::provider::VendorWebSearch;
+use tidebreak_core::{
+    ChatMessage, ChatRequest, ModelProvider, PromptCacheMode, ProviderEvent, ProviderId,
+    ReasoningEffort, Role,
+};
+
+use super::types::{domain_scoped_query, result_within_domains, result_within_published_window};
+use crate::web_search::{
+    WebSearchError, WebSearchProvider, WebSearchProviderKind, WebSearchRequest, WebSearchResponse,
+    WebSearchResult, MAX_QUERY_CHARS,
+};
+
+/// The tool name both adapters report a provider-executed search under.
+const VENDOR_WEB_SEARCH_TOOL: &str = "web_search";
+
+/// Searches the provider may run inside the one sub-request.
+///
+/// Anthropic is the only route that reads this as a wire budget; OpenAI has no
+/// field for it and Gemini ignores it. It is declared honestly anyway, because
+/// the number that actually bounds this path is the host's own call count, and
+/// one call is what one host tool call buys.
+const SEARCHES_PER_SUBREQUEST: u32 = 1;
+
+/// Upper bound on tokens one search sub-request generates.
+///
+/// The answer's prose is discarded — only its citations are read — so this
+/// needs to cover a short summary and nothing more. It still has to leave a
+/// reasoning model room to think before it cites, which is why it is not
+/// smaller.
+const SEARCH_MAX_OUTPUT_TOKENS: u32 = 2_048;
+
+/// What the sub-request asks for.
+///
+/// It asks for prose rather than a list because the citations, not the text,
+/// are the product: a model told to answer in a structured shape tends to stop
+/// citing. The instruction not to answer from memory is what stops a model
+/// treating a "latest" question as something it already knows — the failure
+/// this whole path exists to prevent.
+const SEARCH_SYSTEM_PROMPT: &str = "\
+You are a search tool. Search the web for what the user asks about and answer \
+in one short paragraph, citing every source you used. Never answer from prior \
+knowledge without searching: your knowledge is stale and the caller wants what \
+the web says now.";
+
+/// The model one search sub-request runs on.
+#[derive(Clone, Debug)]
+pub struct SearchModel {
+    /// Provider route, as the router's own hint.
+    pub provider: Option<ProviderId>,
+    /// Provider model identifier.
+    pub model: String,
+    /// Whether the route takes a reasoning-model request shape.
+    pub reasoning_model: bool,
+    /// Effort levels the model accepts, ascending; empty when it exposes none.
+    pub reasoning_efforts: Vec<ReasoningEffort>,
+}
+
+impl SearchModel {
+    /// The cheapest effort this model will accept.
+    ///
+    /// A search sub-request is a lookup, not a problem: it reads results and
+    /// cites them. Running it at the chat's own effort would spend reasoning
+    /// tokens on a call whose prose is discarded. `clamp_to` degrades to the
+    /// nearest supported level, so a model whose floor is higher than `None`
+    /// still gets a level it accepts.
+    fn effort(&self) -> Option<ReasoningEffort> {
+        ReasoningEffort::None.clamp_to(&self.reasoning_efforts)
+    }
+}
+
+/// Searches by asking the chat's own model provider.
+pub struct ModelProviderSearch {
+    providers: Arc<dyn ModelProvider>,
+    model: SearchModel,
+}
+
+impl ModelProviderSearch {
+    #[must_use]
+    pub fn new(providers: Arc<dyn ModelProvider>, model: SearchModel) -> Self {
+        Self { providers, model }
+    }
+
+    fn request(&self, search: &WebSearchRequest) -> ChatRequest {
+        ChatRequest {
+            provider: self.model.provider.clone(),
+            model: self.model.model.clone(),
+            reasoning_model: self.model.reasoning_model,
+            system: Some(SEARCH_SYSTEM_PROMPT.to_owned()),
+            messages: vec![ChatMessage::text(
+                Role::User,
+                domain_scoped_query(&search.query, &search.domains, MAX_QUERY_CHARS),
+            )],
+            // The empty tool list is what makes this shape legal on both
+            // adapters. Adding a tool here would put the request back into the
+            // unbounded agent-turn shape they refuse.
+            tools: Vec::new(),
+            max_tokens: Some(SEARCH_MAX_OUTPUT_TOKENS),
+            temperature: None,
+            reasoning_effort: self.model.effort(),
+            vendor_web_search: Some(VendorWebSearch {
+                max_uses: SEARCHES_PER_SUBREQUEST,
+            }),
+            // One call, one prompt nothing else re-sends: a cache write here
+            // would be a premium paid for an entry that expires unread.
+            prompt_cache: PromptCacheMode::OneShot,
+            ..Default::default()
+        }
+    }
+}
+
+#[async_trait]
+impl WebSearchProvider for ModelProviderSearch {
+    fn kind(&self) -> WebSearchProviderKind {
+        WebSearchProviderKind::ModelProvider
+    }
+
+    async fn search(&self, request: WebSearchRequest) -> Result<WebSearchResponse, WebSearchError> {
+        request.validate()?;
+        let mut stream = self
+            .providers
+            .stream(self.request(&request))
+            .await
+            .map_err(|error| WebSearchError::Transport(error.to_string()))?;
+
+        let mut results = Vec::new();
+        while let Some(event) = stream.next().await {
+            match event {
+                ProviderEvent::ProviderExecutedToolCall {
+                    name,
+                    output,
+                    is_error,
+                    ..
+                } if name == VENDOR_WEB_SEARCH_TOOL => {
+                    if is_error {
+                        continue;
+                    }
+                    results.extend(cited_results(&output, &request));
+                }
+                // A refusal is the model declining to answer, which is not the
+                // same as a search that found nothing: reporting it as an empty
+                // result set would tell the agent the web is silent on the
+                // subject.
+                ProviderEvent::Refusal { .. } => {
+                    return Err(WebSearchError::Transport("the model refused".into()))
+                }
+                ProviderEvent::Failed { .. } => {
+                    return Err(WebSearchError::Transport(
+                        "the search sub-request failed".into(),
+                    ))
+                }
+                // Everything else is the prose answer, its reasoning, and its
+                // accounting. Only the citations are the product here.
+                _ => {}
+            }
+        }
+
+        Ok(WebSearchResponse::new(self.kind(), results))
+    }
+}
+
+/// Read one provider-executed search's normalized output into host results.
+///
+/// Both adapters already emit `{ provider, results: [{ url, title, snippet }] }`
+/// — the shape the host's own `web_search` tool produces — so this reads that
+/// contract rather than either provider's wire format. A row that fails the
+/// host's own validation is dropped rather than failing the search: the
+/// remaining citations are still worth returning.
+fn cited_results(output: &Value, request: &WebSearchRequest) -> Vec<WebSearchResult> {
+    let Some(rows) = output.get("results").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    rows.iter()
+        .filter_map(|row| {
+            let url = row.get("url").and_then(Value::as_str)?;
+            let title = row.get("title").and_then(Value::as_str).unwrap_or_default();
+            let snippet = row
+                .get("snippet")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            WebSearchResult::new(
+                url,
+                title,
+                snippet,
+                None,
+                None,
+                // Neither provider dates a citation. `result_within_published_window`
+                // keeps undated results, so a publication window narrows nothing
+                // here rather than emptying the answer.
+                None,
+                None,
+                std::collections::BTreeMap::new(),
+            )
+            .ok()
+        })
+        .filter(|result| result_within_domains(&result.url, &request.domains))
+        .filter(|result| {
+            result_within_published_window(
+                result.published_at,
+                request.start_published_at,
+                request.end_published_at,
+            )
+        })
+        .take(request.max_results)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::web_search::SearchDomain;
+    use serde_json::json;
+
+    fn request(query: &str) -> WebSearchRequest {
+        WebSearchRequest::new(query, 5).unwrap()
+    }
+
+    #[test]
+    fn citations_become_host_results() {
+        let output = json!({
+            "provider": "openai",
+            "results": [
+                {"url": "https://example.com/a", "title": "A", "snippet": ""},
+                {"url": "https://example.org/b", "title": "B", "snippet": "excerpt"},
+            ],
+        });
+
+        let results = cited_results(&output, &request("news"));
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].url, "https://example.com/a");
+        assert_eq!(results[0].title, "A");
+        // Absent excerpts stay absent rather than becoming invented text.
+        assert_eq!(results[0].snippet, "");
+        assert_eq!(results[1].snippet, "excerpt");
+    }
+
+    /// The filter has to be real here for the same reason it is real for Brave:
+    /// the `site:` operators in the query are a hint the provider may ignore.
+    #[test]
+    fn results_outside_the_requested_domains_are_dropped() {
+        let output = json!({
+            "provider": "gemini",
+            "results": [
+                {"url": "https://example.com/a", "title": "A", "snippet": ""},
+                {"url": "https://docs.example.com/b", "title": "B", "snippet": ""},
+                {"url": "https://elsewhere.test/c", "title": "C", "snippet": ""},
+            ],
+        });
+        let request = request("news")
+            .with_domains(vec![SearchDomain::parse("example.com").unwrap()])
+            .unwrap();
+
+        let results = cited_results(&output, &request);
+
+        // The host itself and its subdomain, but not the unrelated origin.
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[1].url, "https://docs.example.com/b");
+    }
+
+    /// A search that cited nothing ran and found nothing. It is not a failure,
+    /// and it must not become one: the agent's next move differs entirely.
+    #[test]
+    fn an_answer_that_cited_nothing_yields_no_results() {
+        let empty = json!({"provider": "openai", "results": []});
+        assert!(cited_results(&empty, &request("news")).is_empty());
+
+        let malformed = json!({"provider": "openai"});
+        assert!(cited_results(&malformed, &request("news")).is_empty());
+    }
+
+    /// The tool-free shape is the contract that both provider adapters check.
+    /// A tool appearing on this request would put it back into the shape they
+    /// refuse, and the failure would surface as a dead search rather than as
+    /// anything that names this call.
+    #[test]
+    fn the_sub_request_carries_no_tools_and_asks_for_one_search() {
+        let providers: Arc<dyn ModelProvider> = Arc::new(crate::provider::UnconfiguredProvider);
+        let search = ModelProviderSearch::new(
+            providers,
+            SearchModel {
+                provider: Some(ProviderId::new("openai")),
+                model: "gpt-5.6-sol".into(),
+                reasoning_model: true,
+                reasoning_efforts: vec![ReasoningEffort::Low, ReasoningEffort::High],
+            },
+        );
+
+        let built = search.request(&request("who won"));
+
+        assert!(built.tools.is_empty());
+        assert_eq!(
+            built.vendor_web_search,
+            Some(VendorWebSearch { max_uses: 1 })
+        );
+        // Lowest level the model accepts, not the chat's own.
+        assert_eq!(built.reasoning_effort, Some(ReasoningEffort::Low));
+    }
+}

--- a/crates/tidebreak-server/src/web_search/tool.rs
+++ b/crates/tidebreak-server/src/web_search/tool.rs
@@ -5,8 +5,8 @@ use chrono::Utc;
 use serde_json::Value;
 use thiserror::Error;
 use tidebreak_core::{
-    ApprovalClass, ResultEntry, ResultEntryKind, Tool, ToolCtx, ToolErrorCategory, ToolOutput,
-    ToolSpec, WebExtractArgs, WebSearchArgs,
+    ApprovalClass, ChatId, ResultEntry, ResultEntryKind, Tool, ToolCtx, ToolErrorCategory,
+    ToolOutput, ToolSpec, WebExtractArgs, WebSearchArgs,
 };
 use url::Url;
 
@@ -30,9 +30,17 @@ pub struct WebSearchResolverError;
 /// Resolve the provider selected by current host policy without performing
 /// egress. Implementations may load settings and credentials on every call so
 /// configuration changes take effect without rebuilding the tool registry.
+///
+/// The chat is part of the question, not context for logging: one backend
+/// searches through the chat's own model provider, so which provider answers
+/// depends on which model the chat is on. `None` means the caller cannot name a
+/// chat, which resolves to the configured engine or to nothing.
 #[async_trait]
 pub trait WebSearchResolver: Send + Sync {
-    async fn resolve(&self) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError>;
+    async fn resolve(
+        &self,
+        chat: Option<ChatId>,
+    ) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError>;
 }
 
 /// Decode and validate the one canonical model-facing argument shape.
@@ -77,12 +85,12 @@ impl Tool for WebSearchTool {
         ApprovalClass::Sensitive
     }
 
-    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> tidebreak_core::Result<ToolOutput> {
+    async fn execute(&self, ctx: &ToolCtx, args: Value) -> tidebreak_core::Result<ToolOutput> {
         let request = match request_from_tool_arguments(args) {
             Ok(request) => request,
             Err(_) => return Ok(ToolOutput::error("Web search arguments are invalid.")),
         };
-        let provider = match self.resolver.resolve().await {
+        let provider = match self.resolver.resolve(Some(ctx.chat_id)).await {
             Ok(Some(provider)) => provider,
             Ok(None) => {
                 return Ok(ToolOutput::failed(
@@ -218,7 +226,7 @@ impl Tool for WebExtractTool {
                 ))
             }
         };
-        let provider = match self.resolver.resolve().await {
+        let provider = match self.resolver.resolve(Some(ctx.chat_id)).await {
             Ok(provider) => provider,
             Err(_) => return Ok(ToolOutput::error("Web page extraction could not complete.")),
         };
@@ -324,6 +332,7 @@ mod tests {
     impl WebSearchResolver for FakeResolver {
         async fn resolve(
             &self,
+            _chat: Option<ChatId>,
         ) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError> {
             if self.fail {
                 Err(WebSearchResolverError)

--- a/crates/tidebreak-server/src/web_search/types.rs
+++ b/crates/tidebreak-server/src/web_search/types.rs
@@ -58,6 +58,16 @@ pub enum WebSearchProviderKind {
     Tavily,
     Brave,
     Searxng,
+    /// The chat's own model provider, searched through one dedicated
+    /// sub-request rather than a third-party engine.
+    ///
+    /// Unlike every other kind, this one names no fixed vendor: which provider
+    /// runs the search depends on the model the chat is on. That is exactly why
+    /// it is never operator-selectable — a fixed "active provider" choice
+    /// cannot express a backend that changes per chat — so it is absent from
+    /// the settings dropdown and from `CREDENTIAL_PROVIDERS`. It is here so a
+    /// response can still say who searched.
+    ModelProvider,
 }
 
 impl WebSearchProviderKind {
@@ -65,7 +75,13 @@ impl WebSearchProviderKind {
     ///
     /// Anything that has to enumerate providers reads this rather than
     /// spelling out a list that a new variant would silently fall out of.
-    pub const ALL: [Self; 4] = [Self::Exa, Self::Tavily, Self::Brave, Self::Searxng];
+    pub const ALL: [Self; 5] = [
+        Self::Exa,
+        Self::Tavily,
+        Self::Brave,
+        Self::Searxng,
+        Self::ModelProvider,
+    ];
 
     #[must_use]
     pub const fn as_str(self) -> &'static str {
@@ -74,6 +90,7 @@ impl WebSearchProviderKind {
             Self::Tavily => "tavily",
             Self::Brave => "brave",
             Self::Searxng => "searxng",
+            Self::ModelProvider => "model_provider",
         }
     }
 
@@ -93,17 +110,26 @@ impl WebSearchProviderKind {
             // A self-hosted instance the operator runs. There is no vendor
             // account behind it and so no key.
             Self::Searxng => None,
+            // Authenticated as the chat's model provider already is, by that
+            // provider's own credential or subscription. There is no separate
+            // web-search account to hold a key for.
+            Self::ModelProvider => None,
         }
     }
 
-    /// Fixed search endpoint, or `None` for a provider whose address is host
-    /// configuration because it has no single hosted address to pin.
+    /// Fixed search endpoint, or `None` for a provider this host does not dial
+    /// at a constant address of its own.
     pub(crate) const fn search_url(self) -> Option<&'static str> {
         match self {
             Self::Exa => Some("https://api.exa.ai/search"),
             Self::Tavily => Some("https://api.tavily.com/search"),
             Self::Brave => Some("https://api.search.brave.com/res/v1/web/search"),
+            // Self-hosted: the operator supplies the address.
             Self::Searxng => None,
+            // Not an endpoint this module dials at all. The request goes out
+            // through the model router, on the route that provider already
+            // owns.
+            Self::ModelProvider => None,
         }
     }
 
@@ -117,7 +143,7 @@ impl WebSearchProviderKind {
         match self {
             Self::Exa => Some("https://api.exa.ai/contents"),
             Self::Tavily => Some("https://api.tavily.com/extract"),
-            Self::Brave | Self::Searxng => None,
+            Self::Brave | Self::Searxng | Self::ModelProvider => None,
         }
     }
 
@@ -132,13 +158,17 @@ impl WebSearchProviderKind {
     /// [`OutboundOrigin`](crate::web_search::OutboundOrigin) — it is just an origin fixed
     /// at construction from validated host configuration rather than a
     /// constant.
+    ///
+    /// Also `None` for the model-provider backend, which makes no egress of its
+    /// own: it hands the search to the model router, whose routes are bound
+    /// where provider credentials are.
     #[must_use]
     pub const fn outbound_domain(self) -> Option<&'static str> {
         match self {
             Self::Exa => Some("api.exa.ai"),
             Self::Tavily => Some("api.tavily.com"),
             Self::Brave => Some("api.search.brave.com"),
-            Self::Searxng => None,
+            Self::Searxng | Self::ModelProvider => None,
         }
     }
 }


### PR DESCRIPTION
## What changed

A chat on GPT-5.6 Sol asked a question that needed the live web and got "Web search needs a provider", even with a ChatGPT subscription that includes search — because the OpenAI adapter refused any request carrying a hosted search (Responses has no wire field for the per-turn `max_uses` budget) and the Gemini adapter only grounds a request carrying no tools of its own. This adds a `WebSearchProvider` backend whose transport is one dedicated, tool-free sub-request to the chat's own model provider, so the host counts the calls and the budget is enforced before egress instead of on the wire; the OpenAI guard narrows to requests that carry *other* tools — the same predicate `declares_search_grounding` already applies — and Gemini needs no adapter change. Settings copy and the attention card are updated to match, including a pre-existing inversion where the panel claimed automatic mode prefers built-in search over the configured engine (it has always preferred the engine).

## Validation

`cargo test -p tidebreak-router --lib` (176), `cargo test -p tidebreak-server --lib` (1074), `pnpm vitest run` (1467 across 205 files), `storybook:build`, plus `cargo clippy` and `cargo fmt --check` clean. **Not verified locally:** the end-to-end dev run — two facts were read from the adapters rather than confirmed against live APIs, namely that the Codex backend accepts the hosted `web_search` tool under subscription auth, and that a tool-free `googleSearch` request behaves as the Gemini adapter expects. Unrelated flakiness exists on `main` and reproduces without this change: `code_terminals::create_write_read_and_two_cursors` and `configuration::api_key_put_configures_it_and_delete_reverts` each failed once under parallel load and pass in isolation.

## Compatibility and risk

Wire change: `WebSearchProviderKind` gains a `model_provider` variant (`wire.ts` regenerated); it is never operator-selectable and is absent from `CREDENTIAL_PROVIDERS` and the settings dropdown. No `supports_vendor_web_search` row moves, so in-turn search on Anthropic and the agent-turn path for OpenAI/Gemini are untouched, and explicit `host` mode still never falls back to a model provider. Known gap carried, not introduced: Gemini's Search Suggestions markup (`attribution_html`) is dropped on this path exactly as it already is on the native one, and Google requires displaying it with grounded results — worth a follow-up that fixes both paths.