### PR TITLE
feat(browser): add responsive viewport controls for embedded browser

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, type FormEvent, type ReactNode } from "react";
+import { cloneElement, isValidElement, useEffect, useId, useRef, useState, type FormEvent, type ReactElement, type ReactNode, type RefObject } from "react";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -38,6 +38,26 @@ import { browserSecurity, MAX_BROWSER_URL_CHARS } from "./browserNavigation";
 import type { BrowserSession } from "./browserSession";
 
 type BrowserEngine = NonNullable<BrowserHostSnapshot["engine"]>;
+
+const COMPACT_TOOLBAR_WIDTH = 420;
+
+/**
+ * Observes a container element and returns true while its inline-size
+ * is less than `breakpoint`.  False for zero-size or disconnected elements.
+ */
+function useCompactToolbar(ref: RefObject<HTMLDivElement | null>, breakpoint: number): boolean {
+  const [compact, setCompact] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const check = () => setCompact(el.clientWidth < breakpoint);
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    check();
+    return () => observer.disconnect();
+  }, [ref, breakpoint]);
+  return compact;
+}
 
 export function BrowserToolbar({
   session,
@@ -87,8 +107,10 @@ export function BrowserToolbar({
   viewportControl?: ReactNode;
 }) {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const toolbarRef = useRef<HTMLDivElement | null>(null);
   const addressErrorId = useId();
   const securityId = useId();
+  const compactToolbar = useCompactToolbar(toolbarRef, COMPACT_TOOLBAR_WIDTH);
   const security = session.url ? browserSecurity(session.url) : null;
 
   useEffect(() => {
@@ -102,7 +124,7 @@ export function BrowserToolbar({
 
   return (
     <header className="relative z-[1] shrink-0 border-b border-border-subtle bg-page-background/88 backdrop-blur-md">
-      <div className="flex min-w-0 items-center gap-1.5 px-2 py-1.5">
+      <div ref={toolbarRef} className="flex min-w-0 items-center gap-1.5 px-2 py-1.5">
         <nav
           aria-label="Browser navigation"
           className="flex shrink-0 items-center rounded-lg border border-border-subtle bg-background/72 p-0.5 shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_5%,transparent)]"
@@ -193,12 +215,17 @@ export function BrowserToolbar({
         <BrowserAgentAccessControl
           engine={engine}
           access={agentAccess}
+          compact={compactToolbar}
           onShare={onShareAgent}
           onRevoke={onRevokeAgent}
         />
 
         {viewportControl && (
-          <div className="shrink-0">{viewportControl}</div>
+          <div className="shrink-0">
+            {isValidElement(viewportControl)
+              ? cloneElement(viewportControl as ReactElement<{ compact?: boolean }>, { compact: compactToolbar })
+              : viewportControl}
+          </div>
         )}
 
         <DropdownMenu onOpenChange={onOverlayOpenChange}>
@@ -290,11 +317,13 @@ export function BrowserToolbar({
 function BrowserAgentAccessControl({
   engine,
   access,
+  compact = false,
   onShare,
   onRevoke,
 }: {
   engine?: BrowserEngine;
   access?: BrowserAgentAccess;
+  compact?: boolean;
   onShare?: () => void;
   onRevoke?: () => void;
 }) {
@@ -372,10 +401,11 @@ function BrowserAgentAccessControl({
       variant="outline"
       size="xs"
       className="h-7 bg-background/72 text-[10px]"
+      aria-label="Share with agent"
       onClick={onShare}
     >
       <Bot />
-      Share with agent
+      {!compact && "Share with agent"}
     </Button>
   ) : null;
 }

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, type FormEvent } from "react";
+import { useEffect, useId, useRef, type FormEvent, type ReactNode } from "react";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -61,6 +61,7 @@ export function BrowserToolbar({
   onSelectHistory,
   onOpenExternal,
   onOverlayOpenChange,
+  viewportControl,
 }: {
   session: BrowserSession;
   address: string;
@@ -83,6 +84,7 @@ export function BrowserToolbar({
   onSelectHistory: (index: number) => void;
   onOpenExternal: () => void;
   onOverlayOpenChange: (open: boolean) => void;
+  viewportControl?: ReactNode;
 }) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const addressErrorId = useId();
@@ -194,6 +196,10 @@ export function BrowserToolbar({
           onShare={onShareAgent}
           onRevoke={onRevokeAgent}
         />
+
+        {viewportControl && (
+          <div className="shrink-0">{viewportControl}</div>
+        )}
 
         <DropdownMenu onOpenChange={onOverlayOpenChange}>
           <WithTooltip label="History">

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -1,4 +1,15 @@
-import { cloneElement, isValidElement, useEffect, useId, useRef, useState, type FormEvent, type ReactElement, type ReactNode, type RefObject } from "react";
+import {
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactElement,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -24,6 +35,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
@@ -45,12 +57,18 @@ const COMPACT_TOOLBAR_WIDTH = 420;
  * Observes a container element and returns true while its inline-size
  * is less than `breakpoint`.  False for zero-size or disconnected elements.
  */
-function useCompactToolbar(ref: RefObject<HTMLDivElement | null>, breakpoint: number): boolean {
+function useCompactToolbar(
+  ref: RefObject<HTMLDivElement | null>,
+  breakpoint: number,
+): boolean {
   const [compact, setCompact] = useState(false);
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    const check = () => setCompact(el.clientWidth < breakpoint);
+    const check = () => {
+      const width = el.clientWidth;
+      setCompact(width > 0 && width < breakpoint);
+    };
     const observer = new ResizeObserver(check);
     observer.observe(el);
     check();
@@ -124,7 +142,14 @@ export function BrowserToolbar({
 
   return (
     <header className="relative z-[1] shrink-0 border-b border-border-subtle bg-page-background/88 backdrop-blur-md">
-      <div ref={toolbarRef} className="flex min-w-0 items-center gap-1.5 px-2 py-1.5">
+      <div
+        ref={toolbarRef}
+        data-compact={compactToolbar || undefined}
+        className={cn(
+          "flex min-w-0 items-center py-1.5",
+          compactToolbar ? "gap-1 px-1.5" : "gap-1.5 px-2",
+        )}
+      >
         <nav
           aria-label="Browser navigation"
           className="flex shrink-0 items-center rounded-lg border border-border-subtle bg-background/72 p-0.5 shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_5%,transparent)]"
@@ -172,10 +197,14 @@ export function BrowserToolbar({
           </WithTooltip>
         </nav>
 
-        <form className="min-w-0 flex-1" onSubmit={submit}>
+        <form
+          className={cn("flex-1", compactToolbar ? "min-w-20" : "min-w-0")}
+          onSubmit={submit}
+        >
           <label
             className={cn(
-              "flex h-8 min-w-0 items-center gap-2 rounded-lg border border-border-subtle bg-background/88 px-2.5 text-xs",
+              "flex h-8 min-w-0 items-center rounded-lg border border-border-subtle bg-background/88 text-xs",
+              compactToolbar ? "gap-1.5 px-2" : "gap-2 px-2.5",
               "shadow-[inset_0_1px_0_color-mix(in_oklch,var(--foreground)_3%,transparent),0_1px_2px_color-mix(in_oklch,var(--foreground)_4%,transparent)]",
               "transition-[border-color,box-shadow,background-color] duration-150 focus-within:border-ring focus-within:bg-background focus-within:ring-3 focus-within:ring-ring/20",
               addressError && "border-critical-border ring-2 ring-critical/10",
@@ -206,9 +235,9 @@ export function BrowserToolbar({
             />
             {session.loadState === "loading" ? (
               <LoaderCircle className="size-3.5 shrink-0 animate-spin text-muted-foreground motion-reduce:animate-none" />
-            ) : (
+            ) : !compactToolbar ? (
               <Search className="size-3.5 shrink-0 text-muted-foreground/70" />
-            )}
+            ) : null}
           </label>
         </form>
 
@@ -218,6 +247,7 @@ export function BrowserToolbar({
           compact={compactToolbar}
           onShare={onShareAgent}
           onRevoke={onRevokeAgent}
+          onOverlayOpenChange={onOverlayOpenChange}
         />
 
         {viewportControl && (
@@ -234,7 +264,7 @@ export function BrowserToolbar({
               <Button
                 type="button"
                 variant="ghost"
-                size="icon-sm"
+                size={compactToolbar ? "icon-xs" : "icon-sm"}
                 disabled={session.history.length === 0}
               >
                 <History />
@@ -283,7 +313,7 @@ export function BrowserToolbar({
           <Button
             type="button"
             variant="ghost"
-            size="icon-sm"
+            size={compactToolbar ? "icon-xs" : "icon-sm"}
             disabled={!session.url}
             onClick={onOpenExternal}
           >
@@ -320,15 +350,29 @@ function BrowserAgentAccessControl({
   compact = false,
   onShare,
   onRevoke,
+  onOverlayOpenChange,
 }: {
   engine?: BrowserEngine;
   access?: BrowserAgentAccess;
   compact?: boolean;
   onShare?: () => void;
   onRevoke?: () => void;
+  onOverlayOpenChange?: (open: boolean) => void;
 }) {
   if (!engine?.capabilities.semanticSnapshot || !access?.origin) return null;
   const originLabel = browserOriginLabel(access.origin);
+
+  if (compact && (access.paused || access.shared)) {
+    return (
+      <CompactAgentAccessControl
+        access={access}
+        originLabel={originLabel}
+        onShare={onShare}
+        onRevoke={onRevoke}
+        onOpenChange={onOverlayOpenChange}
+      />
+    );
+  }
 
   if (access.paused) {
     return (
@@ -399,7 +443,7 @@ function BrowserAgentAccessControl({
     <Button
       type="button"
       variant="outline"
-      size="xs"
+      size={compact ? "icon-xs" : "xs"}
       className="h-7 bg-background/72 text-[10px]"
       aria-label="Share with agent"
       onClick={onShare}
@@ -408,6 +452,90 @@ function BrowserAgentAccessControl({
       {!compact && "Share with agent"}
     </Button>
   ) : null;
+}
+
+function CompactAgentAccessControl({
+  access,
+  originLabel,
+  onShare,
+  onRevoke,
+  onOpenChange,
+}: {
+  access: BrowserAgentAccess;
+  originLabel: string;
+  onShare?: () => void;
+  onRevoke?: () => void;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const paused = access.paused;
+  const statusLabel = paused
+    ? `Agent paused before ${access.origin}`
+    : `Shared with agent: ${access.origin}`;
+  const displayLabel = paused
+    ? "Agent paused"
+    : access.scope === "loopback_workspace"
+      ? "Local sites shared"
+      : `${originLabel} shared`;
+  const Icon = paused ? Pause : ShieldCheck;
+
+  return (
+    <div className="shrink-0">
+      <span className="sr-only" role="status">
+        {statusLabel}
+      </span>
+      <DropdownMenu onOpenChange={onOpenChange}>
+        <WithTooltip label={displayLabel}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className={cn(
+                "size-7",
+                paused
+                  ? "border border-warning-border/70 bg-warning-background/72 text-warning-foreground hover:bg-warning-background hover:text-warning-foreground"
+                  : "bg-success-background/65 text-success-foreground hover:bg-success-background hover:text-success-foreground",
+              )}
+              aria-label={statusLabel}
+            >
+              <Icon />
+            </Button>
+          </DropdownMenuTrigger>
+        </WithTooltip>
+        <DropdownMenuContent
+          align="end"
+          aria-label="Agent access"
+          className="w-56"
+        >
+          <DropdownMenuItem
+            disabled
+            className="gap-2 data-disabled:opacity-100"
+          >
+            <Icon />
+            <span className="min-w-0">
+              <span className="block text-xs font-medium">{displayLabel}</span>
+              <span className="block truncate text-[11px] text-muted-foreground">
+                {originLabel}
+              </span>
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          {paused && onShare && (
+            <DropdownMenuItem onSelect={onShare}>
+              <Bot />
+              Review &amp; resume
+            </DropdownMenuItem>
+          )}
+          {access.shared && onRevoke && (
+            <DropdownMenuItem variant="destructive" onSelect={onRevoke}>
+              <X />
+              Stop sharing
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
 }
 
 function browserOriginLabel(origin: string): string {

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -366,15 +366,24 @@ function BrowserAgentAccessControl({
   onAgentAccessOpenChange?: (open: boolean) => void;
   agentAccessOpen?: boolean;
 }) {
-  // Close the compact Agent access menu when the toolbar grows past the
-  // compact breakpoint. Radix does not call onOpenChange(false) when its
-  // root is conditionally unmounted, so without this the parent visibility
-  // source would stay latched true and the native view would stay hidden.
+  // Close the compact Agent access menu whenever the compact dropdown
+  // unmounts. Radix does not call onOpenChange(false) when its root is
+  // conditionally removed from the tree, so without this the parent
+  // visibility source would stay latched true and the native WKWebView
+  // would stay hidden. The dropdown is mounted only while the capability
+  // guard, an origin, compact width, and a paused-or-shared state all
+  // hold; any of those becoming false unmounts it.
+  const compactMenuMounted = Boolean(
+    engine?.capabilities.semanticSnapshot &&
+      access?.origin &&
+      compact &&
+      (access?.paused || access?.shared),
+  );
   useEffect(() => {
-    if (!compact && agentAccessOpen) {
+    if (agentAccessOpen && !compactMenuMounted) {
       onAgentAccessOpenChange?.(false);
     }
-  }, [compact, agentAccessOpen, onAgentAccessOpenChange]);
+  }, [compactMenuMounted, agentAccessOpen, onAgentAccessOpenChange]);
 
   if (!engine?.capabilities.semanticSnapshot || !access?.origin) return null;
   const originLabel = browserOriginLabel(access.origin);

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -366,13 +366,13 @@ function BrowserAgentAccessControl({
   onAgentAccessOpenChange?: (open: boolean) => void;
   agentAccessOpen?: boolean;
 }) {
-  // Close the compact Agent access menu when the toolbar grows past the
-  // compact breakpoint. Radix does not call onOpenChange(false) when its
+ // Close the compact Agent access menu when the toolbar grows past the
+ // compact breakpoint. Radix does not call onOpenChange(false) when its
   // root is conditionally unmounted, so without this the parent visibility
   // source would stay latched true and the native view would stay hidden.
-  useEffect(() => {
-    if (!compact && agentAccessOpen) {
-      onAgentAccessOpenChange?.(false);
+ useEffect(() => {
+   if (!compact && agentAccessOpen) {
+     onAgentAccessOpenChange?.(false);
     }
   }, [compact, agentAccessOpen, onAgentAccessOpenChange]);
 

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -99,6 +99,8 @@ export function BrowserToolbar({
   onSelectHistory,
   onOpenExternal,
   onOverlayOpenChange,
+  onAgentAccessOpenChange,
+  agentAccessOpen = false,
   viewportControl,
 }: {
   session: BrowserSession;
@@ -122,6 +124,8 @@ export function BrowserToolbar({
   onSelectHistory: (index: number) => void;
   onOpenExternal: () => void;
   onOverlayOpenChange: (open: boolean) => void;
+  onAgentAccessOpenChange?: (open: boolean) => void;
+  agentAccessOpen?: boolean;
   viewportControl?: ReactNode;
 }) {
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -247,7 +251,8 @@ export function BrowserToolbar({
           compact={compactToolbar}
           onShare={onShareAgent}
           onRevoke={onRevokeAgent}
-          onOverlayOpenChange={onOverlayOpenChange}
+          onAgentAccessOpenChange={onAgentAccessOpenChange}
+          agentAccessOpen={agentAccessOpen}
         />
 
         {viewportControl && (
@@ -350,15 +355,27 @@ function BrowserAgentAccessControl({
   compact = false,
   onShare,
   onRevoke,
-  onOverlayOpenChange,
+  onAgentAccessOpenChange,
+  agentAccessOpen = false,
 }: {
   engine?: BrowserEngine;
   access?: BrowserAgentAccess;
   compact?: boolean;
   onShare?: () => void;
   onRevoke?: () => void;
-  onOverlayOpenChange?: (open: boolean) => void;
+  onAgentAccessOpenChange?: (open: boolean) => void;
+  agentAccessOpen?: boolean;
 }) {
+  // Close the compact Agent access menu when the toolbar grows past the
+  // compact breakpoint. Radix does not call onOpenChange(false) when its
+  // root is conditionally unmounted, so without this the parent visibility
+  // source would stay latched true and the native view would stay hidden.
+  useEffect(() => {
+    if (!compact && agentAccessOpen) {
+      onAgentAccessOpenChange?.(false);
+    }
+  }, [compact, agentAccessOpen, onAgentAccessOpenChange]);
+
   if (!engine?.capabilities.semanticSnapshot || !access?.origin) return null;
   const originLabel = browserOriginLabel(access.origin);
 
@@ -369,7 +386,8 @@ function BrowserAgentAccessControl({
         originLabel={originLabel}
         onShare={onShare}
         onRevoke={onRevoke}
-        onOpenChange={onOverlayOpenChange}
+        open={agentAccessOpen}
+        onOpenChangeControlled={onAgentAccessOpenChange}
       />
     );
   }
@@ -459,13 +477,15 @@ function CompactAgentAccessControl({
   originLabel,
   onShare,
   onRevoke,
-  onOpenChange,
+  open = false,
+  onOpenChangeControlled,
 }: {
   access: BrowserAgentAccess;
   originLabel: string;
   onShare?: () => void;
   onRevoke?: () => void;
-  onOpenChange?: (open: boolean) => void;
+  open?: boolean;
+  onOpenChangeControlled?: (open: boolean) => void;
 }) {
   const paused = access.paused;
   const statusLabel = paused
@@ -483,7 +503,10 @@ function CompactAgentAccessControl({
       <span className="sr-only" role="status">
         {statusLabel}
       </span>
-      <DropdownMenu onOpenChange={onOpenChange}>
+      <DropdownMenu
+        open={open}
+        onOpenChange={onOpenChangeControlled}
+      >
         <WithTooltip label={displayLabel}>
           <DropdownMenuTrigger asChild>
             <Button

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -366,13 +366,13 @@ function BrowserAgentAccessControl({
   onAgentAccessOpenChange?: (open: boolean) => void;
   agentAccessOpen?: boolean;
 }) {
- // Close the compact Agent access menu when the toolbar grows past the
- // compact breakpoint. Radix does not call onOpenChange(false) when its
+  // Close the compact Agent access menu when the toolbar grows past the
+  // compact breakpoint. Radix does not call onOpenChange(false) when its
   // root is conditionally unmounted, so without this the parent visibility
   // source would stay latched true and the native view would stay hidden.
- useEffect(() => {
-   if (!compact && agentAccessOpen) {
-     onAgentAccessOpenChange?.(false);
+  useEffect(() => {
+    if (!compact && agentAccessOpen) {
+      onAgentAccessOpenChange?.(false);
     }
   }, [compact, agentAccessOpen, onAgentAccessOpenChange]);
 

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.dom.test.tsx
@@ -239,6 +239,16 @@ describe("BrowserViewportControl", () => {
     ).toBeVisible();
   });
 
+  it("names the open popover dialog for assistive technology", async () => {
+    renderControl();
+    const user = userEvent.setup();
+    const trigger = screen.getByRole("button", { name: /Viewport: Fit/i });
+
+    await user.click(trigger);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-label", "Viewport size");
+  });
+
   it("syncs the custom width field when the viewport changes externally", async () => {
     const { rerender } = renderControl({
       viewport: { preset: "custom", customWidth: 500 },

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.dom.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BrowserViewportControl } from "./BrowserViewportControl";
+import {
+  DEFAULT_CUSTOM_WIDTH,
+  DEFAULT_VIEWPORT,
+  MAX_CUSTOM_WIDTH,
+  MIN_CUSTOM_WIDTH,
+} from "./browserViewport";
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+function renderControl(
+  overrides: Partial<Parameters<typeof BrowserViewportControl>[0]> = {},
+) {
+  const onViewportChange = vi.fn();
+  const result = render(
+    <BrowserViewportControl
+      viewport={DEFAULT_VIEWPORT}
+      renderedWidth={null}
+      onViewportChange={onViewportChange}
+      {...overrides}
+    />,
+  );
+  return { ...result, onViewportChange };
+}
+
+async function openPopoverAndSetCustomWidth(
+  user: ReturnType<typeof userEvent.setup>,
+  value: string,
+) {
+  await user.click(screen.getByRole("button", { name: /Viewport: Fit/i }));
+  const input = screen.getByRole("spinbutton", {
+    name: "Custom viewport width in pixels",
+  });
+  await user.clear(input);
+  await user.type(input, value);
+  fireEvent.submit(input.closest("form")!);
+}
+
+describe("BrowserViewportControl", () => {
+  it("renders the active preset label and rendered width in the trigger", () => {
+    renderControl({
+      viewport: { preset: "desktop", customWidth: 800 },
+      renderedWidth: 1440,
+    });
+    const trigger = screen.getByRole("button", {
+      name: /Viewport: Desktop 1440, rendered at 1440px/i,
+    });
+    expect(trigger).toBeVisible();
+    expect(trigger).toHaveTextContent("Desktop 1440");
+    expect(trigger).toHaveTextContent("1440px");
+  });
+
+  it("disables the trigger when disabled", () => {
+    renderControl({ disabled: true });
+    expect(
+      screen.getByRole("button", { name: /Viewport: Fit/i }),
+    ).toBeDisabled();
+  });
+
+  it("switches to the desktop preset on selection", async () => {
+    const { onViewportChange } = renderControl();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /Viewport: Fit/i }));
+    await user.click(screen.getByRole("radio", { name: /Desktop/i }));
+
+    expect(onViewportChange).toHaveBeenCalledWith(
+      expect.objectContaining({ preset: "desktop" }),
+    );
+  });
+
+  it("switches to the tablet and mobile presets", async () => {
+    const { onViewportChange } = renderControl();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /Viewport: Fit/i }));
+    await user.click(screen.getByRole("radio", { name: /Tablet/i }));
+    expect(onViewportChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ preset: "tablet" }),
+    );
+
+    await user.click(screen.getByRole("radio", { name: /Mobile/i }));
+    expect(onViewportChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ preset: "mobile" }),
+    );
+  });
+
+  it("marks the active preset as checked", async () => {
+    renderControl({
+      viewport: { preset: "tablet", customWidth: 800 },
+    });
+    const trigger = screen.getByRole("button", { name: /Viewport: Tablet/i });
+    const user = userEvent.setup();
+    await user.click(trigger);
+
+    const tablet = screen.getByRole("radio", { name: /Tablet/i });
+    expect(tablet).toHaveAttribute("aria-checked", "true");
+    const desktop = screen.getByRole("radio", { name: /Desktop/i });
+    expect(desktop).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("validates and commits custom width input", async () => {
+    const { onViewportChange } = renderControl();
+    const user = userEvent.setup();
+
+    await openPopoverAndSetCustomWidth(user, "320");
+
+    expect(onViewportChange).toHaveBeenCalledWith(
+      expect.objectContaining({ preset: "custom", customWidth: 320 }),
+    );
+  });
+
+  it("clamps below-minimum custom width and shows an error", async () => {
+    const { onViewportChange } = renderControl();
+    const user = userEvent.setup();
+
+    await openPopoverAndSetCustomWidth(user, "50");
+
+    expect(onViewportChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preset: "custom",
+        customWidth: MIN_CUSTOM_WIDTH,
+      }),
+    );
+    expect(
+      screen.getByText(
+        `Width must be between ${MIN_CUSTOM_WIDTH} and ${MAX_CUSTOM_WIDTH}`,
+      ),
+    ).toBeVisible();
+  });
+
+  it("clamps above-maximum custom width and shows an error", async () => {
+    const { onViewportChange } = renderControl();
+    const user = userEvent.setup();
+
+    await openPopoverAndSetCustomWidth(user, "99999");
+
+    expect(onViewportChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preset: "custom",
+        customWidth: MAX_CUSTOM_WIDTH,
+      }),
+    );
+    expect(
+      screen.getByText(
+        `Width must be between ${MIN_CUSTOM_WIDTH} and ${MAX_CUSTOM_WIDTH}`,
+      ),
+    ).toBeVisible();
+  });
+
+  it("rejects non-numeric input with an error", async () => {
+    const { onViewportChange } = renderControl();
+    const user = userEvent.setup();
+
+    await openPopoverAndSetCustomWidth(user, "abc");
+
+    expect(screen.getByText("Enter a number")).toBeVisible();
+    // Should not call onViewportChange for invalid input
+    expect(onViewportChange).not.toHaveBeenCalled();
+  });
+
+  it("shows the valid range hint", async () => {
+    renderControl();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Viewport: Fit/i }));
+    expect(
+      screen.getByText(`${MIN_CUSTOM_WIDTH}–${MAX_CUSTOM_WIDTH} px`),
+    ).toBeVisible();
+  });
+
+  it("syncs the custom width field when the viewport changes externally", () => {
+    const { rerender } = renderControl({
+      viewport: { preset: "custom", customWidth: 500 },
+    });
+
+    // External change — e.g. preset switch resets customWidth
+    rerender(
+      <BrowserViewportControl
+        viewport={{ preset: "custom", customWidth: DEFAULT_CUSTOM_WIDTH }}
+        renderedWidth={null}
+        onViewportChange={vi.fn()}
+      />,
+    );
+    const input = screen.queryByRole("spinbutton", {
+      name: "Custom viewport width in pixels",
+    });
+    if (input) {
+      expect(input).toHaveValue(String(DEFAULT_CUSTOM_WIDTH));
+    }
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.dom.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { useState } from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -46,6 +47,22 @@ async function openPopoverAndSetCustomWidth(
   await user.clear(input);
   await user.type(input, value);
   fireEvent.submit(input.closest("form")!);
+  return input;
+}
+
+function StatefulControl({
+  initialViewport = DEFAULT_VIEWPORT,
+}: {
+  initialViewport?: typeof DEFAULT_VIEWPORT;
+}) {
+  const [viewport, setViewport] = useState(initialViewport);
+  return (
+    <BrowserViewportControl
+      viewport={viewport}
+      renderedWidth={null}
+      onViewportChange={setViewport}
+    />
+  );
 }
 
 describe("BrowserViewportControl", () => {
@@ -111,6 +128,56 @@ describe("BrowserViewportControl", () => {
     expect(desktop).toHaveAttribute("aria-checked", "false");
   });
 
+  it("focuses the active preset when opened from the keyboard", async () => {
+    renderControl({
+      viewport: { preset: "tablet", customWidth: 800 },
+    });
+    const user = userEvent.setup();
+    const trigger = screen.getByRole("button", { name: /Viewport: Tablet/i });
+
+    trigger.focus();
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByRole("radio", { name: "Tablet" })).toHaveFocus();
+  });
+
+  it("moves selection and focus with arrows, Home, and End", async () => {
+    render(<StatefulControl />);
+    const user = userEvent.setup();
+    const trigger = screen.getByRole("button", { name: /Viewport: Fit/i });
+
+    trigger.focus();
+    await user.keyboard("{Enter}");
+
+    const fit = screen.getByRole("radio", { name: "Fit" });
+    const desktop = screen.getByRole("radio", { name: "Desktop" });
+    const tablet = screen.getByRole("radio", { name: "Tablet" });
+    const custom = screen.getByRole("radio", { name: "Custom" });
+    expect(fit).toHaveFocus();
+
+    await user.keyboard("{ArrowRight}");
+    expect(desktop).toHaveFocus();
+    expect(desktop).toHaveAttribute("aria-checked", "true");
+
+    await user.keyboard("{ArrowDown}");
+    expect(tablet).toHaveFocus();
+    expect(tablet).toHaveAttribute("aria-checked", "true");
+
+    await user.keyboard("{ArrowLeft}");
+    expect(desktop).toHaveFocus();
+
+    await user.keyboard("{ArrowUp}");
+    expect(fit).toHaveFocus();
+
+    await user.keyboard("{End}");
+    expect(custom).toHaveFocus();
+    expect(custom).toHaveAttribute("aria-checked", "true");
+
+    await user.keyboard("{Home}");
+    expect(fit).toHaveFocus();
+    expect(fit).toHaveAttribute("aria-checked", "true");
+  });
+
   it("validates and commits custom width input", async () => {
     const { onViewportChange } = renderControl();
     const user = userEvent.setup();
@@ -122,18 +189,14 @@ describe("BrowserViewportControl", () => {
     );
   });
 
-  it("clamps below-minimum custom width and shows an error", async () => {
+  it("rejects a below-minimum custom width without applying it", async () => {
     const { onViewportChange } = renderControl();
     const user = userEvent.setup();
 
-    await openPopoverAndSetCustomWidth(user, "50");
+    const input = await openPopoverAndSetCustomWidth(user, "50");
 
-    expect(onViewportChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        preset: "custom",
-        customWidth: MIN_CUSTOM_WIDTH,
-      }),
-    );
+    expect(onViewportChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue(50);
     expect(
       screen.getByText(
         `Width must be between ${MIN_CUSTOM_WIDTH} and ${MAX_CUSTOM_WIDTH}`,
@@ -141,18 +204,14 @@ describe("BrowserViewportControl", () => {
     ).toBeVisible();
   });
 
-  it("clamps above-maximum custom width and shows an error", async () => {
+  it("rejects an above-maximum custom width without applying it", async () => {
     const { onViewportChange } = renderControl();
     const user = userEvent.setup();
 
-    await openPopoverAndSetCustomWidth(user, "99999");
+    const input = await openPopoverAndSetCustomWidth(user, "99999");
 
-    expect(onViewportChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        preset: "custom",
-        customWidth: MAX_CUSTOM_WIDTH,
-      }),
-    );
+    expect(onViewportChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue(99999);
     expect(
       screen.getByText(
         `Width must be between ${MIN_CUSTOM_WIDTH} and ${MAX_CUSTOM_WIDTH}`,
@@ -180,10 +239,18 @@ describe("BrowserViewportControl", () => {
     ).toBeVisible();
   });
 
-  it("syncs the custom width field when the viewport changes externally", () => {
+  it("syncs the custom width field when the viewport changes externally", async () => {
     const { rerender } = renderControl({
       viewport: { preset: "custom", customWidth: 500 },
     });
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: /Viewport: Custom 500/i }),
+    );
+    const input = screen.getByRole("spinbutton", {
+      name: "Custom viewport width in pixels",
+    });
+    expect(input).toHaveValue(500);
 
     // External change — e.g. preset switch resets customWidth
     rerender(
@@ -193,11 +260,6 @@ describe("BrowserViewportControl", () => {
         onViewportChange={vi.fn()}
       />,
     );
-    const input = screen.queryByRole("spinbutton", {
-      name: "Custom viewport width in pixels",
-    });
-    if (input) {
-      expect(input).toHaveValue(String(DEFAULT_CUSTOM_WIDTH));
-    }
+    expect(input).toHaveValue(DEFAULT_CUSTOM_WIDTH);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
@@ -107,8 +107,8 @@ export function BrowserViewportControl({
           <Button
             type="button"
             variant="ghost"
-            size={compact ? "icon-sm" : "xs"}
-            className={compact ? "h-7" : "h-7 gap-1.5 px-2 text-[10px] font-medium"}
+            size={compact ? "icon-xs" : "xs"}
+            className={compact ? "size-7" : "h-7 gap-1.5 px-2 text-[10px] font-medium"}
             disabled={disabled}
             aria-label={triggerAriaLabel}
           >

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
@@ -4,6 +4,8 @@ import {
   useRef,
   useState,
   type FormEvent,
+  type KeyboardEvent,
+  type RefObject,
 } from "react";
 import {
   MonitorSmartphone,
@@ -32,25 +34,21 @@ import {
   VIEWPORT_PRESET_LABELS,
 } from "./browserViewport";
 
-const PRESET_ORDER: BrowserViewportPreset[] = [
+const PRESET_ORDER = [
   "fit",
   "desktop",
   "tablet",
   "mobile",
-];
+  "custom",
+] as const satisfies readonly BrowserViewportPreset[];
 
-const PRESET_ICONS: Record<
-  Exclude<BrowserViewportPreset, "custom">,
-  typeof MonitorSmartphone
-> = {
+const PRESET_ICONS: Record<BrowserViewportPreset, typeof MonitorSmartphone> = {
   fit: Maximize,
   desktop: MonitorSmartphone,
   tablet: Tablet,
   mobile: Smartphone,
+  custom: SlidersHorizontal,
 };
-
-const PRESET_ICON_FOR = (preset: BrowserViewportPreset) =>
-  preset === "custom" ? SlidersHorizontal : PRESET_ICONS[preset];
 
 export type BrowserViewportControlProps = {
   viewport: BrowserViewport;
@@ -76,6 +74,7 @@ export function BrowserViewportControl({
   disabled = false,
 }: BrowserViewportControlProps) {
   const [open, setOpen] = useState(false);
+  const activeRadioRef = useRef<HTMLButtonElement | null>(null);
   const triggerLabelId = useId();
   const label = viewportLabel(viewport);
   const widthText =
@@ -117,11 +116,15 @@ export function BrowserViewportControl({
       <PopoverContent
         align="end"
         className="w-60 p-2"
-        onOpenAutoFocus={(event) => event.preventDefault()}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          activeRadioRef.current?.focus();
+        }}
       >
         <ViewportPresetList
           viewport={viewport}
           onSelectPreset={selectPreset}
+          activeRadioRef={activeRadioRef}
         />
         <div className="my-1.5 h-px bg-border-subtle" />
         <CustomWidthField
@@ -137,18 +140,56 @@ export function BrowserViewportControl({
 function ViewportPresetList({
   viewport,
   onSelectPreset,
+  activeRadioRef,
 }: {
   viewport: BrowserViewport;
   onSelectPreset: (preset: BrowserViewportPreset) => void;
+  activeRadioRef: RefObject<HTMLButtonElement | null>;
 }) {
+  const refs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  function selectAt(index: number) {
+    const preset = PRESET_ORDER[index];
+    if (!preset) return;
+    onSelectPreset(preset);
+    refs.current[index]?.focus();
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    const last = PRESET_ORDER.length - 1;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      selectAt(index === last ? 0 : index + 1);
+      return;
+    }
+    if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      selectAt(index === 0 ? last : index - 1);
+      return;
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      selectAt(0);
+      return;
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      selectAt(last);
+    }
+  }
+
   return (
     <div role="radiogroup" aria-label="Viewport presets">
-      {PRESET_ORDER.map((preset) => {
-        const Icon = PRESET_ICON_FOR(preset);
+      {PRESET_ORDER.map((preset, index) => {
+        const Icon = PRESET_ICONS[preset];
         const active = viewport.preset === preset;
         return (
           <button
             key={preset}
+            ref={(node) => {
+              refs.current[index] = node;
+              if (active) activeRadioRef.current = node;
+            }}
             type="button"
             role="radio"
             aria-checked={active}
@@ -163,6 +204,7 @@ function ViewportPresetList({
                 : "text-muted-foreground hover:text-foreground",
             )}
             onClick={() => onSelectPreset(preset)}
+            onKeyDown={(event) => onKeyDown(event, index)}
           >
             <Icon className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="flex-1 truncate">{VIEWPORT_PRESET_LABELS[preset]}</span>
@@ -211,9 +253,9 @@ function CustomWidthField({
       setError(
         `Width must be between ${MIN_CUSTOM_WIDTH} and ${MAX_CUSTOM_WIDTH}`,
       );
-    } else {
-      setError(null);
+      return;
     }
+    setError(null);
     onViewportChange({ preset: "custom", customWidth: clamped });
     setDraft(String(clamped));
     inputRef.current?.focus();

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
@@ -1,0 +1,276 @@
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
+import {
+  MonitorSmartphone,
+  Smartphone,
+  Tablet,
+  Maximize,
+  SlidersHorizontal,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { FOCUS_RING_TIGHT, HOVER_TINT } from "../interactive";
+import {
+  type BrowserViewport,
+  type BrowserViewportPreset,
+  clampCustomWidth,
+  MAX_CUSTOM_WIDTH,
+  MIN_CUSTOM_WIDTH,
+  viewportLabel,
+  VIEWPORT_PRESET_LABELS,
+} from "./browserViewport";
+
+const PRESET_ORDER: BrowserViewportPreset[] = [
+  "fit",
+  "desktop",
+  "tablet",
+  "mobile",
+];
+
+const PRESET_ICONS: Record<
+  Exclude<BrowserViewportPreset, "custom">,
+  typeof MonitorSmartphone
+> = {
+  fit: Maximize,
+  desktop: MonitorSmartphone,
+  tablet: Tablet,
+  mobile: Smartphone,
+};
+
+const PRESET_ICON_FOR = (preset: BrowserViewportPreset) =>
+  preset === "custom" ? SlidersHorizontal : PRESET_ICONS[preset];
+
+export type BrowserViewportControlProps = {
+  viewport: BrowserViewport;
+  /** Actual rendered width in CSS px, for legibility without a second control. */
+  renderedWidth: number | null;
+  onViewportChange: (viewport: BrowserViewport) => void;
+  disabled?: boolean;
+};
+
+/**
+ * Compact viewport selector for the browser toolbar.
+ *
+ * A single popover button carries Fit + desktop/tablet/mobile presets and a
+ * bounded custom-width field. The trigger label shows the active preset and
+ * its effective width so the user never needs a second readout. Custom-width
+ * validation is inline and non-blocking. Uses a popover (not a dropdown menu)
+ * so the custom-width form stays interactive without auto-closing on submit.
+ */
+export function BrowserViewportControl({
+  viewport,
+  renderedWidth,
+  onViewportChange,
+  disabled = false,
+}: BrowserViewportControlProps) {
+  const [open, setOpen] = useState(false);
+  const triggerLabelId = useId();
+  const label = viewportLabel(viewport);
+  const widthText =
+    renderedWidth !== null && renderedWidth > 0
+      ? `${Math.round(renderedWidth)}px`
+      : null;
+  const triggerAriaLabel = `Viewport: ${label}${
+    widthText ? `, rendered at ${widthText}` : ""
+  }`;
+
+  function selectPreset(preset: BrowserViewportPreset) {
+    onViewportChange({ ...viewport, preset });
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <WithTooltip label="Viewport size">
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="h-7 gap-1.5 px-2 text-[10px] font-medium"
+            disabled={disabled}
+            aria-label={triggerAriaLabel}
+          >
+            <SlidersHorizontal className="size-3.5 shrink-0 text-muted-foreground" />
+            <span id={triggerLabelId} className="max-w-24 truncate">
+              {label}
+            </span>
+            {widthText && (
+              <span className="shrink-0 text-muted-foreground/70">
+                {widthText}
+              </span>
+            )}
+          </Button>
+        </PopoverTrigger>
+      </WithTooltip>
+      <PopoverContent
+        align="end"
+        className="w-60 p-2"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <ViewportPresetList
+          viewport={viewport}
+          onSelectPreset={selectPreset}
+        />
+        <div className="my-1.5 h-px bg-border-subtle" />
+        <CustomWidthField
+          viewport={viewport}
+          onViewportChange={onViewportChange}
+          controlGroupId={triggerLabelId}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ViewportPresetList({
+  viewport,
+  onSelectPreset,
+}: {
+  viewport: BrowserViewport;
+  onSelectPreset: (preset: BrowserViewportPreset) => void;
+}) {
+  return (
+    <div role="radiogroup" aria-label="Viewport presets">
+      {PRESET_ORDER.map((preset) => {
+        const Icon = PRESET_ICON_FOR(preset);
+        const active = viewport.preset === preset;
+        return (
+          <button
+            key={preset}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={VIEWPORT_PRESET_LABELS[preset]}
+            tabIndex={active ? 0 : -1}
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium",
+              FOCUS_RING_TIGHT,
+              HOVER_TINT,
+              active
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+            onClick={() => onSelectPreset(preset)}
+          >
+            <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="flex-1 truncate">{VIEWPORT_PRESET_LABELS[preset]}</span>
+            {active && (
+              <span
+                aria-hidden
+                className="size-1.5 rounded-full bg-primary"
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function CustomWidthField({
+  viewport,
+  onViewportChange,
+  controlGroupId,
+}: {
+  viewport: BrowserViewport;
+  onViewportChange: (viewport: BrowserViewport) => void;
+  controlGroupId: string;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const errorId = useId();
+  const [draft, setDraft] = useState(String(viewport.customWidth));
+  const [error, setError] = useState<string | null>(null);
+
+  // Keep the draft in sync when the viewport changes externally (preset switch).
+  useEffect(() => {
+    setDraft(String(viewport.customWidth));
+    setError(null);
+  }, [viewport.customWidth]);
+
+  function commit(event: FormEvent) {
+    event.preventDefault();
+    const parsed = Number.parseInt(draft, 10);
+    if (!Number.isFinite(parsed)) {
+      setError("Enter a number");
+      return;
+    }
+    const clamped = clampCustomWidth(parsed);
+    if (parsed < MIN_CUSTOM_WIDTH || parsed > MAX_CUSTOM_WIDTH) {
+      setError(
+        `Width must be between ${MIN_CUSTOM_WIDTH} and ${MAX_CUSTOM_WIDTH}`,
+      );
+    } else {
+      setError(null);
+    }
+    onViewportChange({ preset: "custom", customWidth: clamped });
+    setDraft(String(clamped));
+    inputRef.current?.focus();
+  }
+
+  return (
+    <form
+      onSubmit={commit}
+      className="px-1 py-0.5"
+      aria-labelledby={`${controlGroupId}-custom-label`}
+    >
+      <div className="flex items-center gap-2">
+        <label
+          id={`${controlGroupId}-custom-label`}
+          htmlFor={`${controlGroupId}-custom-input`}
+          className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground"
+        >
+          <SlidersHorizontal className="size-3" />
+          Custom width
+        </label>
+        <input
+          ref={inputRef}
+          id={`${controlGroupId}-custom-input`}
+          type="number"
+          inputMode="numeric"
+          min={MIN_CUSTOM_WIDTH}
+          max={MAX_CUSTOM_WIDTH}
+          step={8}
+          value={draft}
+          aria-label="Custom viewport width in pixels"
+          aria-invalid={Boolean(error)}
+          aria-describedby={error ? errorId : undefined}
+          className={cn(
+            "h-7 w-20 rounded-md border bg-background px-2 text-xs font-medium tabular-nums outline-none",
+            "focus:border-ring focus:ring-2 focus:ring-ring/20",
+            error && "border-critical-border ring-1 ring-critical/10",
+          )}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            if (error) setError(null);
+          }}
+          onFocus={(event) => event.currentTarget.select()}
+        />
+        <span className="text-[10px] text-muted-foreground/70">px</span>
+      </div>
+      {error && (
+        <p
+          id={errorId}
+          role="alert"
+          className="mt-1 text-[10px] text-critical-foreground"
+        >
+          {error}
+        </p>
+      )}
+      <p className="mt-1 text-[10px] text-muted-foreground/60">
+        {MIN_CUSTOM_WIDTH}–{MAX_CUSTOM_WIDTH} px
+      </p>
+    </form>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
@@ -58,6 +58,8 @@ export type BrowserViewportControlProps = {
   /** Notify the native surface while this app-owned popover covers it. */
   onOverlayOpenChange?: (open: boolean) => void;
   disabled?: boolean;
+  /** Icon-only trigger for narrow toolbar containers. */
+  compact?: boolean;
 };
 
 /**
@@ -75,6 +77,7 @@ export function BrowserViewportControl({
   onViewportChange,
   onOverlayOpenChange,
   disabled = false,
+  compact = false,
 }: BrowserViewportControlProps) {
   const [open, setOpen] = useState(false);
   const activeRadioRef = useRef<HTMLButtonElement | null>(null);
@@ -104,19 +107,23 @@ export function BrowserViewportControl({
           <Button
             type="button"
             variant="ghost"
-            size="xs"
-            className="h-7 gap-1.5 px-2 text-[10px] font-medium"
+            size={compact ? "icon-sm" : "xs"}
+            className={compact ? "h-7" : "h-7 gap-1.5 px-2 text-[10px] font-medium"}
             disabled={disabled}
             aria-label={triggerAriaLabel}
           >
             <SlidersHorizontal className="size-3.5 shrink-0 text-muted-foreground" />
-            <span id={triggerLabelId} className="max-w-24 truncate">
-              {label}
-            </span>
-            {widthText && (
-              <span className="shrink-0 text-muted-foreground/70">
-                {widthText}
-              </span>
+            {!compact && (
+              <>
+                <span id={triggerLabelId} className="max-w-24 truncate">
+                  {label}
+                </span>
+                {widthText && (
+                  <span className="shrink-0 text-muted-foreground/70">
+                    {widthText}
+                  </span>
+                )}
+              </>
             )}
           </Button>
         </PopoverTrigger>
@@ -124,6 +131,7 @@ export function BrowserViewportControl({
       <PopoverContent
         align="end"
         className="w-60 p-2"
+        aria-label="Viewport size"
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           activeRadioRef.current?.focus();

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
@@ -55,6 +55,8 @@ export type BrowserViewportControlProps = {
   /** Actual rendered width in CSS px, for legibility without a second control. */
   renderedWidth: number | null;
   onViewportChange: (viewport: BrowserViewport) => void;
+  /** Notify the native surface while this app-owned popover covers it. */
+  onOverlayOpenChange?: (open: boolean) => void;
   disabled?: boolean;
 };
 
@@ -71,6 +73,7 @@ export function BrowserViewportControl({
   viewport,
   renderedWidth,
   onViewportChange,
+  onOverlayOpenChange,
   disabled = false,
 }: BrowserViewportControlProps) {
   const [open, setOpen] = useState(false);
@@ -89,8 +92,13 @@ export function BrowserViewportControl({
     onViewportChange({ ...viewport, preset });
   }
 
+  function setPopoverOpen(nextOpen: boolean) {
+    setOpen(nextOpen);
+    onOverlayOpenChange?.(nextOpen);
+  }
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={setPopoverOpen}>
       <WithTooltip label="Viewport size">
         <PopoverTrigger asChild>
           <Button

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -343,9 +343,15 @@ describe("CodeBrowserTab", () => {
         host={runtime.host}
       />,
     );
-    await waitFor(() =>
-      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
-    );
+    await waitFor(() => {
+      const createAction = runtime.calls.find(({ action }) => action.type === "create");
+      expect(createAction?.action).toEqual({
+        type: "create",
+        url: expect.stringContaining("https://example.com"),
+        bounds: expect.objectContaining({ width: 840 }),
+        visible: false,
+      });
+    });
 
     view.unmount();
     releaseCreate?.();
@@ -373,9 +379,17 @@ describe("CodeBrowserTab", () => {
         host={runtime.host}
       />,
     );
-    await waitFor(() =>
-      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
-    );
+    await waitFor(() => {
+      const createAction = runtime.calls.find(({ action }) => action.type === "create");
+      expect(createAction).toBeDefined();
+      // The create payload itself must be hidden unconditionally.
+      expect(createAction?.action).toEqual({
+        type: "create",
+        url: expect.stringContaining("https://example.com"),
+        bounds: expect.objectContaining({ width: 840 }),
+        visible: false,
+      });
+    });
 
     view.rerender(
       <CodeBrowserTab
@@ -395,6 +409,7 @@ describe("CodeBrowserTab", () => {
         action: { type: "set_visible", visible: false },
       }),
     );
+    // No early reveal should have been issued.
     expect(runtime.calls).not.toContainEqual({
       workspaceId: "workspace-1",
       browserId: "browser-1",
@@ -784,6 +799,85 @@ describe("CodeBrowserTab", () => {
     );
   });
 
+  it("applies the current viewport bounds when a viewport change races a pending snapshot", async () => {
+    // Simulate: remount with Fit (840 px pane), fire ResizeObserver to change
+    // surface to Mobile 390 while snapshot is still pending, resolve snapshot,
+    // and assert the final set_bounds uses the centered 390 px rectangle, not
+    // the stale 840 px pre-await capture.
+    let releaseSnapshot: (() => void) | undefined;
+    const snapshotGate = new Promise<void>((resolve) => {
+      releaseSnapshot = resolve;
+    });
+    const runtime = browserHost({ existing: true, createGate: snapshotGate });
+    // Modify command to gate snapshot instead of create:
+    runtime.host.command = vi.fn(async (workspaceId, browserId, action) => {
+      runtime.calls.push({ workspaceId, browserId, action });
+      if (action.type === "snapshot") {
+        await snapshotGate;
+        return {
+          exists: true,
+          workspaceId,
+          browserId,
+          url: "https://example.com/restored",
+          title: "Restored page",
+          loadState: "ready" as const,
+        };
+      }
+      return {
+        exists: true,
+        workspaceId,
+        browserId,
+        url: "url" in action ? (action as { url: string }).url : "https://example.com/restored",
+      } satisfies BrowserHostSnapshot;
+    });
+
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com/one"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "snapshot")).toBe(true),
+    );
+
+    // Simulate ResizeObserver firing with Mobile 390 centered bounds
+    // before the snapshot resolves.
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 225,
+      y: 180,
+      width: 390,
+      height: 560,
+      top: 180,
+      right: 615,
+      bottom: 740,
+      left: 225,
+      toJSON: () => ({}),
+    });
+
+    // Let ResizeObserver run one frame (it won't set_bounds because nativeReady is still false)
+    await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    // The resize path should have skipped — no set_bounds yet
+    expect(runtime.calls.filter(({ action }) => action.type === "set_bounds")).toHaveLength(0);
+
+    // Now release the snapshot
+    releaseSnapshot?.();
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "set_bounds")).toBe(true),
+    );
+
+    // The final set_bounds must use the live 390px centered surface, not the
+    // 840px pre-await capture.
+    const boundsCalls = runtime.calls.filter(({ action }) => action.type === "set_bounds");
+    expect(boundsCalls).toHaveLength(1);
+    expect(boundsCalls[0].action).toEqual({
+      type: "set_bounds",
+      bounds: { x: 225, y: 180, width: 390, height: 560 },
+    });
+  });
+
   it("renders a retryable failure without losing the requested address", async () => {
     const runtime = browserHost({ createError: "native view failed" });
     render(
@@ -940,5 +1034,66 @@ describe("CodeBrowserTab", () => {
         action: { type: "set_visible", visible: false },
       }),
     );
+  });
+});
+
+
+describe("BrowserToolbar compact", () => {
+  it("keeps all controls visible and keyboard-reachable at 320 px", async () => {
+    const { host, calls } = browserHost();
+
+    const { container } = render(
+      <div style={{ width: 320 }}>
+        <CodeBrowserTab
+          workspaceId="workspace-1"
+          browserId="browser-1"
+          initialUrl="https://example.com"
+          host={host}
+        />
+      </div>,
+    );
+    await waitFor(() =>
+      expect(calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    // The inner flex row should not overflow.
+    const row = container.querySelector('.flex.min-w-0.items-center') as HTMLElement | null;
+    expect(row).not.toBeNull();
+    if (row) {
+      expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth);
+    }
+
+    // Every essential control must be present.
+    expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Forward" })).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Address or search" })).toBeVisible();
+    expect(screen.getByRole("button", { name: /Viewport:/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: "History" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Open externally" })).toBeVisible();
+  });
+
+  it("keeps all controls visible and keyboard-reachable at 390 px", async () => {
+    const { host, calls } = browserHost();
+    render(
+      <div style={{ width: 390 }}>
+        <CodeBrowserTab
+          workspaceId="workspace-1"
+          browserId="browser-1"
+          initialUrl="https://example.com"
+          host={host}
+        />
+      </div>,
+    );
+    await waitFor(() =>
+      expect(calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    // Every essential control must be present.
+    expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Forward" })).toBeVisible();
+    expect(screen.getByRole("textbox", { name: "Address or search" })).toBeVisible();
+    expect(screen.getByRole("button", { name: /Viewport:/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: "History" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Open externally" })).toBeVisible();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -62,6 +63,7 @@ function browserHost(options?: {
   createGate?: Promise<void>;
   createError?: string;
   existing?: boolean;
+  snapshotGate?: Promise<void>;
   runtime?: Partial<BrowserHostSnapshot>;
 }): {
   host: CodeBrowserHost;
@@ -83,6 +85,7 @@ function browserHost(options?: {
     command: vi.fn(async (workspaceId, browserId, action) => {
       calls.push({ workspaceId, browserId, action });
       if (action.type === "snapshot") {
+        if (options?.snapshotGate) await options.snapshotGate;
         return options?.existing
           ? {
               exists: true,
@@ -119,8 +122,14 @@ function browserHost(options?: {
   };
 }
 
+let mockedClientWidth = 1024;
+
 beforeEach(() => {
   window.localStorage.clear();
+  mockedClientWidth = 1024;
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(
+    () => mockedClientWidth,
+  );
   vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
     x: 120,
     y: 180,
@@ -364,6 +373,89 @@ describe("CodeBrowserTab", () => {
       }),
     );
   });
+
+  it.each([
+    { label: "newly created", existing: false },
+    { label: "restored", existing: true },
+  ])(
+    "does not reveal a $label native view after its queued reveal is unmounted",
+    async ({ existing }) => {
+      let releaseReady: (() => void) | undefined;
+      const readyGate = new Promise<void>((resolve) => {
+        releaseReady = resolve;
+      });
+      const queuedFrames: Array<{
+        callback: FrameRequestCallback;
+        id: number;
+      }> = [];
+      const cancelledFrames = new Set<number>();
+      let nextFrame = 1;
+      vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+        const id = nextFrame++;
+        queuedFrames.push({ callback, id });
+        return id;
+      });
+      vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+        cancelledFrames.add(id);
+      });
+
+      const runtime = browserHost({
+        existing,
+        ...(existing
+          ? { snapshotGate: readyGate }
+          : { createGate: readyGate }),
+      });
+      const view = render(
+        <CodeBrowserTab
+          workspaceId="workspace-1"
+          browserId="browser-1"
+          initialUrl="https://example.com"
+          host={runtime.host}
+        />,
+      );
+      await waitFor(() =>
+        expect(runtime.calls.some(({ action }) =>
+          action.type === (existing ? "snapshot" : "create")
+        )).toBe(true),
+      );
+
+      const framesBeforeReady = queuedFrames.length;
+      await act(async () => releaseReady?.());
+      await waitFor(() =>
+        expect(queuedFrames.length).toBeGreaterThan(framesBeforeReady),
+      );
+      const revealFrame = queuedFrames.at(-1);
+      expect(revealFrame).toBeDefined();
+      expect(runtime.calls).not.toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: true },
+      });
+
+      view.unmount();
+      await waitFor(() =>
+        expect(runtime.calls).toContainEqual({
+          workspaceId: "workspace-1",
+          browserId: "browser-1",
+          action: { type: "set_visible", visible: false },
+        }),
+      );
+      expect(cancelledFrames).toContain(revealFrame!.id);
+      const finalHideIndex = runtime.calls
+        .map(({ action }) =>
+          action.type === "set_visible" && action.visible === false
+        )
+        .lastIndexOf(true);
+
+      await act(async () => revealFrame!.callback(16));
+
+      expect(runtime.calls.slice(finalHideIndex + 1)).not.toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: true },
+      });
+    },
+  );
 
   it("keeps a native view hidden when an overlay opens while creation is in flight", async () => {
     let releaseCreate: (() => void) | undefined;
@@ -1037,63 +1129,144 @@ describe("CodeBrowserTab", () => {
   });
 });
 
-
 describe("BrowserToolbar compact", () => {
-  it("keeps all controls visible and keyboard-reachable at 320 px", async () => {
-    const { host, calls } = browserHost();
-
+  it("keeps the unshared action and essential controls keyboard-reachable at 320 px", async () => {
+    mockedClientWidth = 320;
+    const runtime = browserHost({
+      runtime: {
+        engine: inspectEngine,
+        agentAccess: agentAccess(),
+      },
+    });
+    const user = userEvent.setup();
     const { container } = render(
-      <div style={{ width: 320 }}>
-        <CodeBrowserTab
-          workspaceId="workspace-1"
-          browserId="browser-1"
-          initialUrl="https://example.com"
-          host={host}
-        />
-      </div>,
-    );
-    await waitFor(() =>
-      expect(calls.some(({ action }) => action.type === "create")).toBe(true),
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
     );
 
-    // The inner flex row should not overflow.
-    const row = container.querySelector('.flex.min-w-0.items-center') as HTMLElement | null;
-    expect(row).not.toBeNull();
-    if (row) {
-      expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth);
-    }
-
-    // Every essential control must be present.
+    const share = await screen.findByRole("button", { name: "Share with agent" });
+    expect(container.querySelector('[data-compact="true"]')).not.toBeNull();
     expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Forward" })).toBeVisible();
     expect(screen.getByRole("textbox", { name: "Address or search" })).toBeVisible();
     expect(screen.getByRole("button", { name: /Viewport:/i })).toBeVisible();
     expect(screen.getByRole("button", { name: "History" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Open externally" })).toBeVisible();
+
+    share.focus();
+    await user.keyboard("{Enter}");
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "share_with_agent" },
+      }),
+    );
   });
 
-  it("keeps all controls visible and keyboard-reachable at 390 px", async () => {
-    const { host, calls } = browserHost();
+  it("exposes shared status and revoke through one keyboard-operated control at 320 px", async () => {
+    mockedClientWidth = 320;
+    const runtime = browserHost({
+      runtime: {
+        engine: inspectEngine,
+        agentAccess: agentAccess({
+          shared: true,
+          scope: "origin",
+          canObserve: true,
+          canControl: true,
+        }),
+      },
+    });
+    const user = userEvent.setup();
     render(
-      <div style={{ width: 390 }}>
-        <CodeBrowserTab
-          workspaceId="workspace-1"
-          browserId="browser-1"
-          initialUrl="https://example.com"
-          host={host}
-        />
-      </div>,
-    );
-    await waitFor(() =>
-      expect(calls.some(({ action }) => action.type === "create")).toBe(true),
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
     );
 
-    // Every essential control must be present.
-    expect(screen.getByRole("button", { name: "Back" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Forward" })).toBeVisible();
-    expect(screen.getByRole("textbox", { name: "Address or search" })).toBeVisible();
-    expect(screen.getByRole("button", { name: /Viewport:/i })).toBeVisible();
-    expect(screen.getByRole("button", { name: "History" })).toBeVisible();
-    expect(screen.getByRole("button", { name: "Open externally" })).toBeVisible();
+    const access = await screen.findByRole("button", {
+      name: "Shared with agent: https://example.com",
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Shared with agent: https://example.com",
+    );
+    access.focus();
+    await user.keyboard("{Enter}");
+    const revoke = screen.getByRole("menuitem", { name: "Stop sharing" });
+    expect(revoke).toHaveFocus();
+    await user.keyboard("{Enter}");
+
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "revoke_agent_access" },
+      }),
+    );
+  });
+
+  it("exposes paused status, resume, and revoke through one keyboard-operated control at 390 px", async () => {
+    mockedClientWidth = 390;
+    const runtime = browserHost({
+      runtime: {
+        engine: inspectEngine,
+        agentAccess: agentAccess({
+          shared: true,
+          paused: true,
+          halted: true,
+          origin: "https://accounts.example.org",
+          scope: "origin",
+        }),
+      },
+    });
+    const user = userEvent.setup();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+
+    const access = await screen.findByRole("button", {
+      name: "Agent paused before https://accounts.example.org",
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Agent paused before https://accounts.example.org",
+    );
+    access.focus();
+    await user.keyboard("{Enter}");
+    const resume = screen.getByRole("menuitem", { name: "Review & resume" });
+    expect(resume).toHaveFocus();
+    await user.keyboard("{Enter}");
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "share_with_agent" },
+      }),
+    );
+
+    access.focus();
+    await user.keyboard("{Enter}");
+    await user.keyboard("{ArrowDown}");
+    const revoke = screen.getByRole("menuitem", { name: "Stop sharing" });
+    expect(revoke).toHaveFocus();
+    await user.keyboard("{Enter}");
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "revoke_agent_access" },
+      }),
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -1269,4 +1269,133 @@ describe("BrowserToolbar compact", () => {
       }),
     );
   });
+
+  it("closes the compact Agent access menu and restores the native view when the toolbar grows past 420 px", async () => {
+    // Regression: opening the compact Agent access DropdownMenu calls the
+    // parent obscuration callback true. Resizing to >=420 switches to the
+    // wide branch and unmounts Radix without onOpenChange(false), leaving
+    // the native WKWebView hidden. This test verifies a distinct
+    // agentAccessOpen visibility source is closed explicitly on compact->wide
+    // transitions and the native view is subsequently revealed.
+
+    // Capture ResizeObserver callbacks so we can manually fire a resize event
+    // after changing the mocked clientWidth. The global stub in setup.ts fires
+    // once synchronously on observe; we replicate that and store the callback.
+    const observerCallbacks: Array<ResizeObserverCallback> = [];
+    vi.stubGlobal("ResizeObserver", class {
+      constructor(callback: ResizeObserverCallback) {
+        observerCallbacks.push(callback);
+      }
+      observe(target: Element) {
+        const entry = {
+          target,
+          contentRect: { width: 1024, height: 768, top: 0, left: 0, right: 1024, bottom: 768, x: 0, y: 0 },
+          borderBoxSize: [{ inlineSize: 1024, blockSize: 768 }],
+          contentBoxSize: [{ inlineSize: 1024, blockSize: 768 }],
+          devicePixelContentBoxSize: [{ inlineSize: 1024, blockSize: 768 }],
+        } as unknown as ResizeObserverEntry;
+        const cb = observerCallbacks.at(-1)!;
+        cb([entry], this as unknown as ResizeObserver);
+      }
+      unobserve() {}
+      disconnect() {}
+    });
+
+    mockedClientWidth = 390;
+    const runtime = browserHost({
+      runtime: {
+        engine: inspectEngine,
+        agentAccess: agentAccess({
+          shared: true,
+          scope: "origin",
+          canObserve: true,
+          canControl: true,
+        }),
+      },
+    });
+    const user = userEvent.setup();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+
+    // Wait for the native surface to be created and revealed
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: true },
+      }),
+    );
+
+    // Clear calls before opening the menu so we can verify the hide command
+    runtime.calls.splice(0);
+
+    // Open the compact Agent access menu
+    const access = screen.getByRole("button", {
+      name: "Shared with agent: https://example.com",
+    });
+    await user.click(access);
+    // The menu should be open
+    expect(screen.getByRole("menuitem", { name: "Stop sharing" })).toBeVisible();
+
+    // The native view should be hidden while the menu is open
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: false },
+      }),
+    );
+
+    // Simulate resizing from 390px to 1024px (past the 420px breakpoint).
+    // Fire the ResizeObserver callback for the toolbar observer so
+    // useCompactToolbar re-reads clientWidth and switches to wide mode.
+    runtime.calls.splice(0);
+    mockedClientWidth = 1024;
+    const toolbarObserverCallback = observerCallbacks[0];
+    expect(toolbarObserverCallback).toBeDefined();
+    const resizeEntry = {
+      target: null as unknown as Element,
+      contentRect: { width: 1024, height: 768, top: 0, left: 0, right: 1024, bottom: 768, x: 0, y: 0 },
+      borderBoxSize: [{ inlineSize: 1024, blockSize: 768 }],
+      contentBoxSize: [{ inlineSize: 1024, blockSize: 768 }],
+      devicePixelContentBoxSize: [{ inlineSize: 1024, blockSize: 768 }],
+    } as unknown as ResizeObserverEntry;
+    await act(async () => {
+      toolbarObserverCallback([resizeEntry], {} as ResizeObserver);
+    });
+
+    // The compact->wide effect should have closed agentAccessOpen, which
+    // makes the native view visible again. Flush the reveal frame and verify.
+    await act(async () => {
+      await new Promise<void>((resolve) =>
+        window.requestAnimationFrame(() => resolve()),
+      );
+    });
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: true },
+      }),
+    );
+
+    // The compact menu trigger should no longer be present (wide branch renders inline)
+    expect(
+      screen.queryByRole("button", { name: "Shared with agent: https://example.com" }),
+    ).toBeNull();
+    // The wide-branch inline "Stop sharing" button should be present instead
+    expect(screen.getByRole("button", { name: "Stop sharing" })).toBeVisible();
+
+    vi.unstubAllGlobals();
+  });
+
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -297,6 +297,49 @@ describe("CodeBrowserTab", () => {
     );
   });
 
+  it("keeps a native view hidden when an overlay opens while creation is in flight", async () => {
+    let releaseCreate: (() => void) | undefined;
+    const createGate = new Promise<void>((resolve) => {
+      releaseCreate = resolve;
+    });
+    const runtime = browserHost({ createGate });
+    const view = render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    view.rerender(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+        obscured
+      />,
+    );
+    releaseCreate?.();
+
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: false },
+      }),
+    );
+    expect(runtime.calls).not.toContainEqual({
+      workspaceId: "workspace-1",
+      browserId: "browser-1",
+      action: { type: "set_visible", visible: true },
+    });
+  });
+
   it("replaces the native session when the same panel slot selects another browser tab", async () => {
     const runtime = browserHost();
     const view = render(

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -267,6 +267,68 @@ describe("CodeBrowserTab", () => {
     );
   });
 
+  it("keeps the native surface hidden until every overlay has closed", async () => {
+    const runtime = browserHost();
+    const view = render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    runtime.calls.splice(0);
+    await userEvent.click(screen.getByRole("button", { name: /Viewport: Fit/i }));
+    expect(await screen.findByRole("radio", { name: "Fit" })).toBeVisible();
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: false },
+      }),
+    );
+
+    runtime.calls.splice(0);
+    view.rerender(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+        obscured
+      />,
+    );
+    await userEvent.keyboard("{Escape}");
+    await new Promise<void>((resolve) =>
+      window.requestAnimationFrame(() => resolve()),
+    );
+    expect(runtime.calls).not.toContainEqual({
+      workspaceId: "workspace-1",
+      browserId: "browser-1",
+      action: { type: "set_visible", visible: true },
+    });
+
+    view.rerender(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: true },
+      }),
+    );
+  });
+
   it("hides a native view that finishes creating after its tab unmounts", async () => {
     let releaseCreate: (() => void) | undefined;
     const createGate = new Promise<void>((resolve) => {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -1398,4 +1398,111 @@ describe("BrowserToolbar compact", () => {
     vi.unstubAllGlobals();
   });
 
+  it("closes the compact Agent access menu and restores the native view when agent access is revoked while the menu is open", async () => {
+    // Regression: a host event revokes agent access while the compact
+    // Agent access DropdownMenu is open. BrowserAgentAccessControl returns
+    // null, Radix unmounts without onOpenChange(false), and agentAccessOpen
+    // would stay latched true, keeping the native WKWebView hidden.
+
+    const observerCallbacks: Array<ResizeObserverCallback> = [];
+    vi.stubGlobal("ResizeObserver", class {
+      constructor(callback: ResizeObserverCallback) {
+        observerCallbacks.push(callback);
+      }
+      observe(target: Element) {
+        const entry = {
+          target,
+          contentRect: { width: 390, height: 768, top: 0, left: 0, right: 390, bottom: 768, x: 0, y: 0 },
+          borderBoxSize: [{ inlineSize: 390, blockSize: 768 }],
+          contentBoxSize: [{ inlineSize: 390, blockSize: 768 }],
+          devicePixelContentBoxSize: [{ inlineSize: 390, blockSize: 768 }],
+        } as unknown as ResizeObserverEntry;
+        const cb = observerCallbacks.at(-1)!;
+        cb([entry], this as unknown as ResizeObserver);
+      }
+      unobserve() {}
+      disconnect() {}
+    });
+
+    mockedClientWidth = 390;
+    const runtime = browserHost({
+      runtime: {
+        engine: inspectEngine,
+        agentAccess: agentAccess({
+          shared: true,
+          scope: "origin",
+          canObserve: true,
+          canControl: true,
+        }),
+      },
+    });
+    const user = userEvent.setup();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+
+    // Wait for create and initial reveal
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: true },
+      }),
+    );
+
+    // Open the compact Agent access menu
+    const access = screen.getByRole("button", {
+      name: "Shared with agent: https://example.com",
+    });
+    await user.click(access);
+    expect(screen.getByRole("menuitem", { name: "Stop sharing" })).toBeVisible();
+
+    // Native view should be hidden while the menu is open
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: false },
+      }),
+    );
+
+    // Emit a host event that revokes agent access — origin becomes undefined.
+    // The event handler merges agentAccess into runtime state, and
+    // BrowserAgentAccessControl returns null when origin is falsy.
+    runtime.calls.splice(0);
+    await act(async () => {
+      runtime.emit({
+        type: "navigation_finished",
+        url: "https://example.com",
+        browserId: "browser-1",
+        workspaceId: "workspace-1",
+        agentAccess: { ...agentAccess(), shared: false, origin: undefined },
+      });
+    });
+
+    // The effect should close agentAccessOpen, restoring native visibility.
+    await act(async () => {
+      await new Promise<void>((resolve) =>
+        window.requestAnimationFrame(() => resolve()),
+      );
+    });
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: true },
+      }),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -1474,9 +1474,13 @@ describe("BrowserToolbar compact", () => {
       }),
     );
 
-    // Emit a host event that revokes agent access — origin becomes undefined.
-    // The event handler merges agentAccess into runtime state, and
-    // BrowserAgentAccessControl returns null when origin is falsy.
+    // Emit a host event that revokes agent access. The real host keeps the
+    // current HTTP origin (origin stays https://example.com) while paused
+    // and shared both become false. The compact Agent access dropdown is
+    // mounted only while compact && (paused || shared); with both false it
+    // unmounts without Radix calling onOpenChange(false). The mounted
+    // predicate effect in BrowserAgentAccessControl must close
+    // agentAccessOpen, restoring native visibility.
     runtime.calls.splice(0);
     await act(async () => {
       runtime.emit({
@@ -1484,11 +1488,19 @@ describe("BrowserToolbar compact", () => {
         url: "https://example.com",
         browserId: "browser-1",
         workspaceId: "workspace-1",
-        agentAccess: { ...agentAccess(), shared: false, origin: undefined },
+        agentAccess: { ...agentAccess(), shared: false, paused: false },
       });
     });
 
-    // The effect should close agentAccessOpen, restoring native visibility.
+    // The compact menu trigger should no longer be present; the wide-branch
+    // "Share with agent" button renders instead since neither paused nor
+    // shared is true.
+    expect(
+      screen.queryByRole("button", { name: "Shared with agent: https://example.com" }),
+    ).toBeNull();
+
+    // The mounted-predicate effect should close agentAccessOpen, restoring
+    // native visibility.
     await act(async () => {
       await new Promise<void>((resolve) =>
         window.requestAnimationFrame(() => resolve()),

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -717,4 +717,123 @@ describe("CodeBrowserTab", () => {
     ).toBeInTheDocument();
     fireEvent.submit(screen.getByRole("textbox", { name: "Address or search" }).closest("form")!);
   });
+
+  it("renders the viewport control in the toolbar and disables it without a URL", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        host={runtime.host}
+      />,
+    );
+    const viewportButton = screen.getByRole("button", { name: /Viewport: Fit/i });
+    expect(viewportButton).toBeDisabled();
+  });
+
+  it("enables the viewport control once a page loads", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+    const viewportButton = await screen.findByRole("button", { name: /Viewport: Fit/i });
+    expect(viewportButton).toBeEnabled();
+  });
+
+  it("updates the viewport trigger label when the preset changes", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    // Initially shows Fit
+    expect(screen.getByRole("button", { name: /Viewport: Fit/i })).toBeEnabled();
+
+    // Open the viewport popover and switch to mobile
+    await userEvent.click(screen.getByRole("button", { name: /Viewport: Fit/i }));
+    await userEvent.click(screen.getByRole("radio", { name: /Mobile/i }));
+
+    // The trigger label should now show Mobile
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Viewport: Mobile 390/i })).toBeVisible(),
+    );
+  });
+
+  it("persists the viewport preference to localStorage", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Viewport: Fit/i }));
+    await userEvent.click(screen.getByRole("radio", { name: /Tablet/i }));
+
+    await waitFor(() => {
+      const raw = window.localStorage.getItem("tidebreak.code-browser-viewport.v1");
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw!);
+      expect(parsed.preset).toBe("tablet");
+    });
+  });
+
+  it("hides the viewport control trigger alongside the native surface when obscured", async () => {
+    const runtime = browserHost();
+    const view = render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+
+    // The viewport control button should be present before obscuring
+    expect(screen.getByRole("button", { name: /Viewport: Fit/i })).toBeInTheDocument();
+
+    view.rerender(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+        obscured
+      />,
+    );
+
+    // The set_visible false command should fire
+    await waitFor(() =>
+      expect(runtime.calls).toContainEqual({
+        workspaceId: "workspace-1",
+        browserId: "browser-1",
+        action: { type: "set_visible", visible: false },
+      }),
+    );
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -130,19 +130,22 @@ function CodeBrowserTabSession({
     session.loadState !== "failed";
   const visibleRef = useRef(visible);
 
- sessionRef.current = session;
- visibleRef.current = visible;
+  sessionRef.current = session;
+  visibleRef.current = visible;
 
   // Reset agentAccessOpen when agent access is revoked or becomes unavailable
-  // while its compact menu is open. Radix does not call onOpenChange(false)
-  // when BrowserAgentAccessControl returns null due to the early exit, so
-  // without this agentAccessOpen would stay latched true and the native
-  // WKWebView would stay hidden permanently.
+  // while its compact menu is open. Mirror BrowserAgentAccessControl's render
+  // guard: Radix does not call onOpenChange(false) when the control returns
+  // null, so without this the native WKWebView would stay hidden permanently.
+  const agentAccessAvailable = Boolean(
+    runtime?.engine?.capabilities.semanticSnapshot &&
+      runtime?.agentAccess?.origin,
+  );
   useEffect(() => {
-    if (agentAccessOpen && !runtime?.agentAccess?.origin) {
+    if (agentAccessOpen && !agentAccessAvailable) {
       setAgentAccessOpen(false);
     }
-  }, [agentAccessOpen, runtime?.agentAccess?.origin]);
+  }, [agentAccessAvailable, agentAccessOpen]);
 
   const updateSession = useCallback(
     (update: (current: BrowserSession) => BrowserSession) => {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -154,12 +154,17 @@ function CodeBrowserTabSession({
     [browserId, workspaceId],
   );
 
-  const settleCreatedNativeView = useCallback(async () => {
+  /**
+   * Shared post-ready reconciliation for create and existing-view paths.
+   *
+   * Reads the live viewport-surface bounds (not a stale pre-await capture),
+   * applies them, then reveals the native surface through the existing
+   * cancellable one-animation-frame mechanism so an in-flight overlay
+   * handoff is never overpainted.  Hides immediately when the tab is
+   * unmounted or obscured.
+   */
+  const reconcileAfterNativeReady = useCallback(async () => {
     nativeReady.current = true;
-    recordRuntime(await host.command(workspaceId, browserId, {
-      type: "set_visible",
-      visible: mountedRef.current && visibleRef.current,
-    }));
     const bounds = readBrowserBounds(viewportSurfaceRef.current);
     if (bounds && !sameBrowserBounds(lastNativeBounds.current, bounds)) {
       lastNativeBounds.current = bounds;
@@ -167,6 +172,24 @@ function CodeBrowserTabSession({
         await host.command(workspaceId, browserId, { type: "set_bounds", bounds }),
       );
     }
+    if (!mountedRef.current || !visibleRef.current) {
+      recordRuntime(await host.command(workspaceId, browserId, {
+        type: "set_visible",
+        visible: false,
+      }));
+      return;
+    }
+    // Reveal through the same cancellable one-frame path used by the
+    // visibility effect so a click that hands off between two app overlays
+    // cannot briefly repaint the native WKWebView above the new one.
+    nativeRevealFrame.current = window.requestAnimationFrame(() => {
+      nativeRevealFrame.current = null;
+      if (!nativeReady.current || !visibleRef.current || !host.available()) {
+        return;
+      }
+      void host.command(workspaceId, browserId, { type: "set_visible", visible: true })
+        .catch(() => undefined);
+    });
   }, [browserId, host, recordRuntime, workspaceId]);
 
   useEffect(() => {
@@ -292,23 +315,16 @@ function CodeBrowserTabSession({
             });
             setAddress(browserDisplayAddress(snapshot.url));
           }
-          recordRuntime(
-            await host.command(workspaceId, browserId, { type: "set_bounds", bounds }),
-          );
-          lastNativeBounds.current = bounds;
-          recordRuntime(await host.command(workspaceId, browserId, {
-            type: "set_visible",
-            visible: visibleRef.current,
-          }));
+          await reconcileAfterNativeReady();
         } else {
           recordRuntime(await host.command(workspaceId, browserId, {
             type: "create",
             url: current.url,
             bounds,
-            visible: visibleRef.current,
+            visible: false,
           }));
           lastNativeBounds.current = bounds;
-          await settleCreatedNativeView();
+          await reconcileAfterNativeReady();
           nativeHistoryAvailable.current = current.history.length <= 1;
         }
       } catch (error) {
@@ -401,7 +417,7 @@ function CodeBrowserTabSession({
           .catch(() => undefined);
       }
     };
-  }, [browserId, host, recordRuntime, settleCreatedNativeView, updateSession, workspaceId]);
+  }, [browserId, host, recordRuntime, reconcileAfterNativeReady, updateSession, workspaceId]);
 
   useEffect(() => {
     const surface = viewportSurfaceRef.current;
@@ -507,10 +523,10 @@ function CodeBrowserTabSession({
         type: "create",
         url: target.url,
         bounds,
-        visible,
+        visible: false,
       }));
       lastNativeBounds.current = bounds;
-      await settleCreatedNativeView();
+      await reconcileAfterNativeReady();
       nativeHistoryAvailable.current = sessionRef.current.history.length <= 1;
     } catch (error) {
       if (mountedRef.current) {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -105,6 +105,7 @@ function CodeBrowserTabSession({
   const [address, setAddress] = useState(session.address);
   const [addressError, setAddressError] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [viewportOpen, setViewportOpen] = useState(false);
   const [slow, setSlow] = useState(false);
   const [runtime, setRuntime] = useState<BrowserHostSnapshot | null>(null);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
@@ -112,6 +113,7 @@ function CodeBrowserTabSession({
   const nativeReady = useRef(false);
   const nativeHistoryAvailable = useRef(false);
   const lastNativeBounds = useRef<BrowserBounds | null>(null);
+  const nativeRevealFrame = useRef<number | null>(null);
   const persistTimer = useRef<number | null>(null);
   const sessionRef = useRef(session);
   const [viewport, setViewport] = useState(() => restoreOrDefaultViewport());
@@ -119,7 +121,11 @@ function CodeBrowserTabSession({
   const [renderedViewportWidth, setRenderedViewportWidth] = useState<number | null>(
     null,
   );
-  const visible = !obscured && !historyOpen && session.loadState !== "failed";
+  const visible =
+    !obscured &&
+    !historyOpen &&
+    !viewportOpen &&
+    session.loadState !== "failed";
   const visibleRef = useRef(visible);
 
   sessionRef.current = session;
@@ -438,9 +444,32 @@ function CodeBrowserTabSession({
 
   useEffect(() => {
     if (!nativeReady.current || !host.available()) return;
-    void host
-      .command(workspaceId, browserId, { type: "set_visible", visible })
-      .catch(() => undefined);
+    if (nativeRevealFrame.current !== null) {
+      window.cancelAnimationFrame(nativeRevealFrame.current);
+      nativeRevealFrame.current = null;
+    }
+    if (!visible) {
+      void host
+        .command(workspaceId, browserId, { type: "set_visible", visible: false })
+        .catch(() => undefined);
+      return;
+    }
+
+    // Delay reveals by one frame so a click that hands off between two app
+    // overlays cannot briefly repaint the native WKWebView above the new one.
+    nativeRevealFrame.current = window.requestAnimationFrame(() => {
+      nativeRevealFrame.current = null;
+      if (!nativeReady.current || !visibleRef.current || !host.available()) return;
+      void host
+        .command(workspaceId, browserId, { type: "set_visible", visible: true })
+        .catch(() => undefined);
+    });
+    return () => {
+      if (nativeRevealFrame.current !== null) {
+        window.cancelAnimationFrame(nativeRevealFrame.current);
+        nativeRevealFrame.current = null;
+      }
+    };
   }, [browserId, host, visible, workspaceId]);
 
   async function navigate(input = address) {
@@ -639,6 +668,7 @@ function CodeBrowserTabSession({
             viewport={viewport}
             renderedWidth={renderedViewportWidth}
             onViewportChange={setViewport}
+            onOverlayOpenChange={setViewportOpen}
             disabled={!session.url}
           />
         }

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -154,6 +154,42 @@ function CodeBrowserTabSession({
     [browserId, workspaceId],
   );
 
+  const cancelNativeReveal = useCallback(() => {
+    if (nativeRevealFrame.current === null) return;
+    const frame = nativeRevealFrame.current;
+    nativeRevealFrame.current = null;
+    window.cancelAnimationFrame(frame);
+  }, []);
+
+  const scheduleNativeReveal = useCallback(() => {
+    cancelNativeReveal();
+    if (
+      !mountedRef.current ||
+      !nativeReady.current ||
+      !visibleRef.current ||
+      !host.available()
+    ) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      if (nativeRevealFrame.current !== frame) return;
+      nativeRevealFrame.current = null;
+      if (
+        !mountedRef.current ||
+        !nativeReady.current ||
+        !visibleRef.current ||
+        !host.available()
+      ) {
+        return;
+      }
+      void host
+        .command(workspaceId, browserId, { type: "set_visible", visible: true })
+        .catch(() => undefined);
+    });
+    nativeRevealFrame.current = frame;
+  }, [browserId, cancelNativeReveal, host, workspaceId]);
+
   /**
    * Shared post-ready reconciliation for create and existing-view paths.
    *
@@ -164,6 +200,15 @@ function CodeBrowserTabSession({
    * unmounted or obscured.
    */
   const reconcileAfterNativeReady = useCallback(async () => {
+    if (!mountedRef.current) {
+      nativeReady.current = false;
+      cancelNativeReveal();
+      await host.command(workspaceId, browserId, {
+        type: "set_visible",
+        visible: false,
+      });
+      return;
+    }
     nativeReady.current = true;
     const bounds = readBrowserBounds(viewportSurfaceRef.current);
     if (bounds && !sameBrowserBounds(lastNativeBounds.current, bounds)) {
@@ -173,31 +218,37 @@ function CodeBrowserTabSession({
       );
     }
     if (!mountedRef.current || !visibleRef.current) {
+      if (!mountedRef.current) nativeReady.current = false;
+      cancelNativeReveal();
       recordRuntime(await host.command(workspaceId, browserId, {
         type: "set_visible",
         visible: false,
       }));
       return;
     }
-    // Reveal through the same cancellable one-frame path used by the
-    // visibility effect so a click that hands off between two app overlays
-    // cannot briefly repaint the native WKWebView above the new one.
-    nativeRevealFrame.current = window.requestAnimationFrame(() => {
-      nativeRevealFrame.current = null;
-      if (!nativeReady.current || !visibleRef.current || !host.available()) {
-        return;
-      }
-      void host.command(workspaceId, browserId, { type: "set_visible", visible: true })
-        .catch(() => undefined);
-    });
-  }, [browserId, host, recordRuntime, workspaceId]);
+    scheduleNativeReveal();
+  }, [
+    browserId,
+    cancelNativeReveal,
+    host,
+    recordRuntime,
+    scheduleNativeReveal,
+    workspaceId,
+  ]);
 
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      cancelNativeReveal();
+      nativeReady.current = false;
+      if (host.available()) {
+        void host
+          .command(workspaceId, browserId, { type: "set_visible", visible: false })
+          .catch(() => undefined);
+      }
     };
-  }, []);
+  }, [browserId, cancelNativeReveal, host, workspaceId]);
 
   useEffect(() => {
     onTitleChange?.(session.title);
@@ -411,11 +462,6 @@ function CodeBrowserTabSession({
     return () => {
       cancelled = true;
       unsubscribe?.();
-      if (nativeReady.current && host.available()) {
-        void host
-          .command(workspaceId, browserId, { type: "set_visible", visible: false })
-          .catch(() => undefined);
-      }
     };
   }, [browserId, host, recordRuntime, reconcileAfterNativeReady, updateSession, workspaceId]);
 
@@ -460,33 +506,17 @@ function CodeBrowserTabSession({
 
   useEffect(() => {
     if (!nativeReady.current || !host.available()) return;
-    if (nativeRevealFrame.current !== null) {
-      window.cancelAnimationFrame(nativeRevealFrame.current);
-      nativeRevealFrame.current = null;
-    }
     if (!visible) {
+      cancelNativeReveal();
       void host
         .command(workspaceId, browserId, { type: "set_visible", visible: false })
         .catch(() => undefined);
       return;
     }
 
-    // Delay reveals by one frame so a click that hands off between two app
-    // overlays cannot briefly repaint the native WKWebView above the new one.
-    nativeRevealFrame.current = window.requestAnimationFrame(() => {
-      nativeRevealFrame.current = null;
-      if (!nativeReady.current || !visibleRef.current || !host.available()) return;
-      void host
-        .command(workspaceId, browserId, { type: "set_visible", visible: true })
-        .catch(() => undefined);
-    });
-    return () => {
-      if (nativeRevealFrame.current !== null) {
-        window.cancelAnimationFrame(nativeRevealFrame.current);
-        nativeRevealFrame.current = null;
-      }
-    };
-  }, [browserId, host, visible, workspaceId]);
+    scheduleNativeReveal();
+    return cancelNativeReveal;
+  }, [cancelNativeReveal, host, scheduleNativeReveal, visible]);
 
   async function navigate(input = address) {
     const target = browserTarget(input);

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -1,4 +1,7 @@
 import {
+  type CSSProperties,
+  type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -17,6 +20,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { BrowserNoticeRow, BrowserToolbar } from "./BrowserToolbar";
+import { BrowserViewportControl } from "./BrowserViewportControl";
 import {
   type BrowserBounds,
   type BrowserHostAction,
@@ -35,6 +39,12 @@ import {
   restoreOrCreateBrowserSession,
   writeStoredBrowserSession,
 } from "./browserPersistence";
+import {
+  type BrowserViewport,
+  restoreOrDefaultViewport,
+  viewportTargetWidth,
+  writeStoredViewport,
+} from "./browserViewport";
 import {
   beginBrowserNavigation,
   canBrowserGoBack,
@@ -104,11 +114,17 @@ function CodeBrowserTabSession({
   const lastNativeBounds = useRef<BrowserBounds | null>(null);
   const persistTimer = useRef<number | null>(null);
   const sessionRef = useRef(session);
+  const [viewport, setViewport] = useState(() => restoreOrDefaultViewport());
+  const viewportRef = useRef(viewport);
+  const viewportSurfaceRef = useRef<HTMLDivElement | null>(null);
+  const [renderedViewportWidth, setRenderedViewportWidth] = useState<number | null>(
+    null,
+  );
   const visible = !obscured && !historyOpen && session.loadState !== "failed";
   const visibleRef = useRef(visible);
 
   sessionRef.current = session;
-  visibleRef.current = visible;
+  viewportRef.current = viewport;
 
   const updateSession = useCallback(
     (update: (current: BrowserSession) => BrowserSession) => {
@@ -139,7 +155,7 @@ function CodeBrowserTabSession({
       type: "set_visible",
       visible: mountedRef.current && visibleRef.current,
     }));
-    const bounds = readBrowserBounds(surfaceRef.current);
+    const bounds = readBrowserBounds(viewportSurfaceRef.current);
     if (bounds && !sameBrowserBounds(lastNativeBounds.current, bounds)) {
       lastNativeBounds.current = bounds;
       recordRuntime(
@@ -186,6 +202,10 @@ function CodeBrowserTabSession({
     },
     [browserId],
   );
+
+  useEffect(() => {
+    writeStoredViewport(viewport);
+  }, [viewport]);
 
   useEffect(() => {
     if (session.loadState !== "loading") {
@@ -241,7 +261,7 @@ function CodeBrowserTabSession({
       }
 
       if (!current.url) return;
-      const bounds = readBrowserBounds(surfaceRef.current);
+      const bounds = readBrowserBounds(viewportSurfaceRef.current);
       if (!bounds) return;
 
       try {
@@ -379,7 +399,7 @@ function CodeBrowserTabSession({
   }, [browserId, host, recordRuntime, settleCreatedNativeView, updateSession, workspaceId]);
 
   useEffect(() => {
-    const surface = surfaceRef.current;
+    const surface = viewportSurfaceRef.current;
     if (!surface || !host.available()) return;
     let frame: number | null = null;
 
@@ -453,7 +473,7 @@ function CodeBrowserTabSession({
         );
         return;
       }
-      const bounds = readBrowserBounds(surfaceRef.current);
+      const bounds = readBrowserBounds(viewportSurfaceRef.current);
       if (!bounds) throw new Error("The browser surface is not ready");
       recordRuntime(await host.command(workspaceId, browserId, {
         type: "create",
@@ -615,6 +635,14 @@ function CodeBrowserTabSession({
         onSelectHistory={(index) => void selectHistory(index)}
         onOpenExternal={() => void openExternal()}
         onOverlayOpenChange={setHistoryOpen}
+        viewportControl={
+          <BrowserViewportControl
+            viewport={viewport}
+            renderedWidth={renderedViewportWidth}
+            onViewportChange={setViewport}
+            disabled={!session.url}
+          />
+        }
       />
       {notice && (
         <BrowserNoticeRow
@@ -637,14 +665,21 @@ function CodeBrowserTabSession({
         />
       )}
       <div ref={surfaceRef} className="relative min-h-0 flex-1 overflow-hidden">
-        {!showNative && (
-          <BrowserFallback
-            error={session.error}
-            hasUrl={Boolean(session.url)}
-            onRetry={session.url ? () => void navigate() : undefined}
-            onOpenExternal={session.url ? () => void openExternal() : undefined}
-          />
-        )}
+        <ViewportSurface
+          viewport={viewport}
+          showNative={showNative}
+          surfaceRef={viewportSurfaceRef}
+          onViewportBoundsChange={setRenderedViewportWidth}
+        >
+          {!showNative && (
+            <BrowserFallback
+              error={session.error}
+              hasUrl={Boolean(session.url)}
+              onRetry={session.url ? () => void navigate() : undefined}
+              onOpenExternal={session.url ? () => void openExternal() : undefined}
+            />
+          )}
+        </ViewportSurface>
       </div>
     </section>
   );
@@ -721,6 +756,80 @@ export function BrowserFallback({
             )}
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Centers and clips the native webview column inside the browser surface.
+ *
+ * For Fit, the column fills the surface. For fixed presets and custom widths,
+ * the column is constrained to the target width (clamped to the surface),
+ * centered horizontally, and reports its actual rendered width so the toolbar
+ * can display it without a second control. The native webview is positioned
+ * at the column's bounds so it visually matches the simulated viewport.
+ *
+ * A muted backdrop fills the gutter on either side of a fixed/custom column so
+ * the simulated device frame reads as a deliberate inset, not a broken layout.
+ */
+function ViewportSurface({
+  viewport,
+  showNative,
+  surfaceRef,
+  onViewportBoundsChange,
+  children,
+}: {
+  viewport: BrowserViewport;
+  showNative: boolean;
+  surfaceRef: RefObject<HTMLDivElement | null>;
+  onViewportBoundsChange: (width: number | null) => void;
+  children: ReactNode;
+}) {
+  useEffect(() => {
+    const el = surfaceRef.current;
+    if (!el) return;
+    let frame: number | null = null;
+    const sync = () => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        const rect = surfaceRef.current?.getBoundingClientRect();
+        onViewportBoundsChange(rect && rect.width > 0 ? rect.width : null);
+      });
+    };
+    const observer = new ResizeObserver(sync);
+    observer.observe(el);
+    sync();
+    return () => {
+      observer.disconnect();
+      if (frame !== null) window.cancelAnimationFrame(frame);
+    };
+  }, [surfaceRef, onViewportBoundsChange]);
+
+  const isFit = viewport.preset === "fit";
+  const targetWidth = isFit ? null : viewportTargetWidth(viewport);
+  const style: CSSProperties = isFit
+    ? {}
+    : { width: targetWidth ? `${targetWidth}px` : undefined, maxWidth: "100%" };
+
+  return (
+    <div className="absolute inset-0 flex justify-center overflow-hidden">
+      {!isFit && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 bg-muted/30"
+        />
+      )}
+      <div
+        ref={surfaceRef}
+        className={cn(
+          "relative min-h-0",
+          isFit ? "flex-1 w-full" : "h-full shrink-0",
+        )}
+        style={style}
+      >
+        {showNative ? null : children}
       </div>
     </div>
   );

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -105,6 +105,7 @@ function CodeBrowserTabSession({
   const [address, setAddress] = useState(session.address);
   const [addressError, setAddressError] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [agentAccessOpen, setAgentAccessOpen] = useState(false);
   const [viewportOpen, setViewportOpen] = useState(false);
   const [slow, setSlow] = useState(false);
   const [runtime, setRuntime] = useState<BrowserHostSnapshot | null>(null);
@@ -124,6 +125,7 @@ function CodeBrowserTabSession({
   const visible =
     !obscured &&
     !historyOpen &&
+    !agentAccessOpen &&
     !viewportOpen &&
     session.loadState !== "failed";
   const visibleRef = useRef(visible);
@@ -709,6 +711,8 @@ function CodeBrowserTabSession({
         onSelectHistory={(index) => void selectHistory(index)}
         onOpenExternal={() => void openExternal()}
         onOverlayOpenChange={setHistoryOpen}
+        onAgentAccessOpenChange={setAgentAccessOpen}
+        agentAccessOpen={agentAccessOpen}
         viewportControl={
           <BrowserViewportControl
             viewport={viewport}

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -130,8 +130,19 @@ function CodeBrowserTabSession({
     session.loadState !== "failed";
   const visibleRef = useRef(visible);
 
-  sessionRef.current = session;
-  visibleRef.current = visible;
+ sessionRef.current = session;
+ visibleRef.current = visible;
+
+  // Reset agentAccessOpen when agent access is revoked or becomes unavailable
+  // while its compact menu is open. Radix does not call onOpenChange(false)
+  // when BrowserAgentAccessControl returns null due to the early exit, so
+  // without this agentAccessOpen would stay latched true and the native
+  // WKWebView would stay hidden permanently.
+  useEffect(() => {
+    if (agentAccessOpen && !runtime?.agentAccess?.origin) {
+      setAgentAccessOpen(false);
+    }
+  }, [agentAccessOpen, runtime?.agentAccess?.origin]);
 
   const updateSession = useCallback(
     (update: (current: BrowserSession) => BrowserSession) => {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -115,7 +115,6 @@ function CodeBrowserTabSession({
   const persistTimer = useRef<number | null>(null);
   const sessionRef = useRef(session);
   const [viewport, setViewport] = useState(() => restoreOrDefaultViewport());
-  const viewportRef = useRef(viewport);
   const viewportSurfaceRef = useRef<HTMLDivElement | null>(null);
   const [renderedViewportWidth, setRenderedViewportWidth] = useState<number | null>(
     null,
@@ -124,7 +123,7 @@ function CodeBrowserTabSession({
   const visibleRef = useRef(visible);
 
   sessionRef.current = session;
-  viewportRef.current = viewport;
+  visibleRef.current = visible;
 
   const updateSession = useCallback(
     (update: (current: BrowserSession) => BrowserSession) => {

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserViewport.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserViewport.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  browserViewportBounds,
+  clampCustomWidth,
+  DEFAULT_CUSTOM_WIDTH,
+  DEFAULT_VIEWPORT,
+  MAX_CUSTOM_WIDTH,
+  MIN_CUSTOM_WIDTH,
+  parseViewport,
+  readStoredViewport,
+  restoreOrDefaultViewport,
+  viewportLabel,
+  viewportOverflows,
+  viewportTargetWidth,
+  VIEWPORT_PRESET_WIDTHS,
+  writeStoredViewport,
+  type BrowserViewport,
+} from "./browserViewport";
+
+describe("browserViewport", () => {
+  describe("clampCustomWidth", () => {
+    it("rounds and clamps into the valid range", () => {
+      expect(clampCustomWidth(500)).toBe(500);
+      expect(clampCustomWidth(100)).toBe(MIN_CUSTOM_WIDTH);
+      expect(clampCustomWidth(99999)).toBe(MAX_CUSTOM_WIDTH);
+      expect(clampCustomWidth(320.7)).toBe(321);
+      expect(clampCustomWidth(NaN)).toBe(DEFAULT_CUSTOM_WIDTH);
+      expect(clampCustomWidth(Infinity)).toBe(DEFAULT_CUSTOM_WIDTH);
+    });
+  });
+
+  describe("viewportTargetWidth", () => {
+    it("returns null for Fit and pixel widths for fixed presets", () => {
+      expect(viewportTargetWidth({ preset: "fit", customWidth: 800 })).toBeNull();
+      expect(viewportTargetWidth({ preset: "desktop", customWidth: 800 })).toBe(
+        VIEWPORT_PRESET_WIDTHS.desktop,
+      );
+      expect(viewportTargetWidth({ preset: "tablet", customWidth: 800 })).toBe(
+        VIEWPORT_PRESET_WIDTHS.tablet,
+      );
+      expect(viewportTargetWidth({ preset: "mobile", customWidth: 800 })).toBe(
+        VIEWPORT_PRESET_WIDTHS.mobile,
+      );
+      expect(viewportTargetWidth({ preset: "custom", customWidth: 500 })).toBe(500);
+      expect(viewportTargetWidth({ preset: "custom", customWidth: 10 })).toBe(
+        MIN_CUSTOM_WIDTH,
+      );
+    });
+  });
+
+  describe("viewportLabel", () => {
+    it("produces compact toolbar labels", () => {
+      expect(viewportLabel({ preset: "fit", customWidth: 800 })).toBe("Fit");
+      expect(viewportLabel({ preset: "desktop", customWidth: 800 })).toBe(
+        "Desktop 1440",
+      );
+      expect(viewportLabel({ preset: "custom", customWidth: 500 })).toBe(
+        "Custom 500",
+      );
+    });
+  });
+
+  describe("browserViewportBounds", () => {
+    it("fills the surface for Fit", () => {
+      expect(
+        browserViewportBounds({ width: 900, height: 600 }, {
+          preset: "fit",
+          customWidth: 800,
+        }),
+      ).toEqual({ x: 0, width: 900 });
+    });
+
+    it("centers a desktop preset that fits", () => {
+      const bounds = browserViewportBounds(
+        { width: 1600, height: 800 },
+        { preset: "desktop", customWidth: 800 },
+      );
+      expect(bounds.width).toBe(VIEWPORT_PRESET_WIDTHS.desktop);
+      expect(bounds.x).toBe(Math.round((1600 - 1440) / 2));
+    });
+
+    it("clamps a preset wider than the surface and centers at zero", () => {
+      const bounds = browserViewportBounds(
+        { width: 600, height: 400 },
+        { preset: "desktop", customWidth: 800 },
+      );
+      expect(bounds.width).toBe(600);
+      expect(bounds.x).toBe(0);
+    });
+
+    it("centers a custom width inside the surface", () => {
+      const bounds = browserViewportBounds(
+        { width: 1000, height: 600 },
+        { preset: "custom", customWidth: 500 },
+      );
+      expect(bounds.width).toBe(500);
+      expect(bounds.x).toBe(250);
+    });
+
+    it("handles a zero-width surface gracefully", () => {
+      expect(
+        browserViewportBounds({ width: 0, height: 400 }, {
+          preset: "desktop",
+          customWidth: 800,
+        }),
+      ).toEqual({ x: 0, width: 0 });
+    });
+  });
+
+  describe("viewportOverflows", () => {
+    it("is false for Fit and true when the target exceeds the surface", () => {
+      expect(
+        viewportOverflows({ width: 600 }, { preset: "fit", customWidth: 800 }),
+      ).toBe(false);
+      expect(
+        viewportOverflows({ width: 600 }, { preset: "desktop", customWidth: 800 }),
+      ).toBe(true);
+      expect(
+        viewportOverflows({ width: 1600 }, { preset: "desktop", customWidth: 800 }),
+      ).toBe(false);
+    });
+  });
+
+  describe("persistence", () => {
+    beforeEach(() => window.localStorage.clear());
+
+    it("round-trips a viewport preference", () => {
+      const viewport: BrowserViewport = {
+        preset: "custom",
+        customWidth: 480,
+      };
+      writeStoredViewport(viewport);
+      expect(readStoredViewport()).toEqual(viewport);
+    });
+
+    it("clamps custom width on write", () => {
+      writeStoredViewport({ preset: "custom", customWidth: 1 });
+      expect(readStoredViewport()?.customWidth).toBe(MIN_CUSTOM_WIDTH);
+    });
+
+    it("returns the default when nothing is stored", () => {
+      expect(restoreOrDefaultViewport()).toEqual(DEFAULT_VIEWPORT);
+    });
+
+    it("restores a stored preference", () => {
+      writeStoredViewport({ preset: "tablet", customWidth: 800 });
+      expect(restoreOrDefaultViewport()).toEqual({
+        preset: "tablet",
+        customWidth: 800,
+      });
+    });
+
+    it("ignores malformed stored values", () => {
+      window.localStorage.setItem(
+        "tidebreak.code-browser-viewport.v1",
+        JSON.stringify({ preset: "unknown", customWidth: 800 }),
+      );
+      expect(readStoredViewport()).toBeNull();
+      expect(restoreOrDefaultViewport()).toEqual(DEFAULT_VIEWPORT);
+    });
+
+    it("never throws when storage is unavailable", () => {
+      const broken = {
+        getItem: vi.fn(() => {
+          throw new Error("denied");
+        }),
+        setItem: vi.fn(() => {
+          throw new Error("denied");
+        }),
+      };
+      expect(readStoredViewport(broken)).toBeNull();
+      expect(() => writeStoredViewport(DEFAULT_VIEWPORT, broken)).not.toThrow();
+    });
+  });
+
+  describe("parseViewport", () => {
+    it("accepts valid presets and clamps custom width", () => {
+      expect(parseViewport({ preset: "fit", customWidth: 800 })).toEqual({
+        preset: "fit",
+        customWidth: 800,
+      });
+      expect(parseViewport({ preset: "mobile", customWidth: 50 })).toEqual({
+        preset: "mobile",
+        customWidth: MIN_CUSTOM_WIDTH,
+      });
+      expect(parseViewport({ preset: "custom" })).toEqual({
+        preset: "custom",
+        customWidth: DEFAULT_CUSTOM_WIDTH,
+      });
+    });
+
+    it("rejects invalid preset values", () => {
+      expect(parseViewport(null)).toBeNull();
+      expect(parseViewport({ preset: "ultrawide" })).toBeNull();
+      expect(parseViewport("fit")).toBeNull();
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserViewport.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserViewport.ts
@@ -1,0 +1,177 @@
+/**
+ * Responsive viewport simulation for the embedded browser.
+ *
+ * The native child webview is sized to match the selected viewport, not the
+ * full editor pane. Fit uses the available surface. Presets constrain the
+ * webview to a centered, clipped column at common device widths. A bounded
+ * custom width lets developers reproduce exact breakpoints.
+ *
+ * Viewport preference is harmless presentation state: it is persisted to
+ * localStorage and never sent to the native host as authority. The host only
+ * receives the resulting pixel bounds.
+ */
+
+export type BrowserViewportPreset =
+  | "fit"
+  | "desktop"
+  | "tablet"
+  | "mobile"
+  | "custom";
+
+export type BrowserViewport = {
+  preset: BrowserViewportPreset;
+  /** Custom width in CSS pixels. Ignored unless preset is "custom". */
+  customWidth: number;
+};
+
+/** Width in CSS pixels for each fixed preset. Fit has no intrinsic width. */
+export const VIEWPORT_PRESET_WIDTHS: Record<
+  Exclude<BrowserViewportPreset, "fit" | "custom">,
+  number
+> = {
+  desktop: 1440,
+  tablet: 768,
+  mobile: 390,
+};
+
+export const VIEWPORT_PRESET_LABELS: Record<BrowserViewportPreset, string> = {
+  fit: "Fit",
+  desktop: "Desktop",
+  tablet: "Tablet",
+  mobile: "Mobile",
+  custom: "Custom",
+};
+
+/** Short label for toolbar display, e.g. "Desktop 1440". */
+export function viewportLabel(viewport: BrowserViewport): string {
+  if (viewport.preset === "fit") return VIEWPORT_PRESET_LABELS.fit;
+  if (viewport.preset === "custom") {
+    return `${VIEWPORT_PRESET_LABELS.custom} ${viewport.customWidth}`;
+  }
+  return `${VIEWPORT_PRESET_LABELS[viewport.preset]} ${
+    VIEWPORT_PRESET_WIDTHS[viewport.preset]
+  }`;
+}
+
+export const MIN_CUSTOM_WIDTH = 240;
+export const MAX_CUSTOM_WIDTH = 3840;
+export const DEFAULT_CUSTOM_WIDTH = 1024;
+
+export const DEFAULT_VIEWPORT: BrowserViewport = {
+  preset: "fit",
+  customWidth: DEFAULT_CUSTOM_WIDTH,
+};
+
+/** Clamp a raw custom-width input into the valid range. */
+export function clampCustomWidth(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_CUSTOM_WIDTH;
+  return Math.min(
+    Math.max(Math.round(value), MIN_CUSTOM_WIDTH),
+    MAX_CUSTOM_WIDTH,
+  );
+}
+
+/**
+ * Resolve a viewport into a target width in CSS pixels.
+ *
+ * Returns `null` for Fit, meaning "use the available surface width".
+ */
+export function viewportTargetWidth(
+  viewport: BrowserViewport,
+): number | null {
+  if (viewport.preset === "fit") return null;
+  if (viewport.preset === "custom") return clampCustomWidth(viewport.customWidth);
+  return VIEWPORT_PRESET_WIDTHS[viewport.preset];
+}
+
+/**
+ * Compute the pixel bounds for the native webview given the surface
+ * dimensions and the active viewport.
+ *
+ * Fit fills the surface. Fixed presets and custom widths center a clipped
+ * column inside the surface, never exceeding it. The native webview is
+ * positioned at the column's left/top so it visually matches the simulated
+ * viewport.
+ */
+export function browserViewportBounds(
+  surface: { width: number; height: number },
+  viewport: BrowserViewport,
+): { x: number; width: number } {
+  const target = viewportTargetWidth(viewport);
+  if (target === null || surface.width <= 0) {
+    return { x: 0, width: surface.width };
+  }
+  const width = Math.min(target, surface.width);
+  const x = Math.round((surface.width - width) / 2);
+  return { x, width };
+}
+
+/** True when the fixed/custom viewport is wider than the surface (overflow). */
+export function viewportOverflows(
+  surface: { width: number },
+  viewport: BrowserViewport,
+): boolean {
+  const target = viewportTargetWidth(viewport);
+  if (target === null) return false;
+  return target > surface.width;
+}
+
+// --- Persistence (presentation preference only) ---
+
+const PREFERENCE_KEY = "tidebreak.code-browser-viewport.v1";
+
+export function readStoredViewport(
+  storage: Pick<Storage, "getItem"> = window.localStorage,
+): BrowserViewport | null {
+  try {
+    const raw = storage.getItem(PREFERENCE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return parseViewport(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredViewport(
+  viewport: BrowserViewport,
+  storage: Pick<Storage, "getItem" | "setItem"> = window.localStorage,
+): void {
+  try {
+    storage.setItem(
+      PREFERENCE_KEY,
+      JSON.stringify({
+        preset: viewport.preset,
+        customWidth: clampCustomWidth(viewport.customWidth),
+      }),
+    );
+  } catch {
+    // Presentation preference; never block the browser on storage.
+  }
+}
+
+export function restoreOrDefaultViewport(
+  storage: Pick<Storage, "getItem"> = window.localStorage,
+): BrowserViewport {
+  return readStoredViewport(storage) ?? DEFAULT_VIEWPORT;
+}
+
+export function parseViewport(value: unknown): BrowserViewport | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const preset = record.preset;
+  if (
+    preset !== "fit" &&
+    preset !== "desktop" &&
+    preset !== "tablet" &&
+    preset !== "mobile" &&
+    preset !== "custom"
+  ) {
+    return null;
+  }
+  const rawWidth =
+    typeof record.customWidth === "number" && Number.isFinite(record.customWidth)
+      ? record.customWidth
+      : DEFAULT_CUSTOM_WIDTH;
+  return { preset, customWidth: clampCustomWidth(rawWidth) };
+}

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -7,7 +7,9 @@ import {
   BrowserNoticeRow,
   BrowserToolbar,
 } from "@/code/browser/BrowserToolbar";
+import { BrowserViewportControl } from "@/code/browser/BrowserViewportControl";
 import { BrowserFallback } from "@/code/browser/CodeBrowserTab";
+import type { BrowserViewport } from "@/code/browser/browserViewport";
 import type {
   BrowserAgentAccess,
   BrowserController,
@@ -27,7 +29,12 @@ type BrowserScenario =
   | "slow"
   | "failure"
   | "popup"
-  | "download";
+  | "download"
+  | "viewport-fit"
+  | "viewport-desktop"
+  | "viewport-tablet"
+  | "viewport-mobile"
+  | "viewport-custom";
 
 const inspectEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
   name: "wk_webview",
@@ -120,9 +127,11 @@ function browserSession(
 function BrowserStory({
   scenario,
   compact = false,
+  viewport,
 }: {
   scenario: BrowserScenario;
   compact?: boolean;
+  viewport?: BrowserViewport;
 }) {
   const loadState = scenario === "empty"
     ? "idle"
@@ -133,6 +142,9 @@ function BrowserStory({
         : "ready";
   const session = browserSession(loadState);
   const [address, setAddress] = useState(session.address);
+  const [viewportState, setViewportState] = useState<BrowserViewport>(
+    viewport ?? { preset: "fit", customWidth: 1024 },
+  );
   const controller = scenario === "agent"
     ? activeAgent
     : scenario === "takeover"
@@ -176,6 +188,24 @@ function BrowserStory({
           onSelectHistory={fn()}
           onOpenExternal={fn()}
           onOverlayOpenChange={fn()}
+          viewportControl={
+            <BrowserViewportControl
+              viewport={viewportState}
+              renderedWidth={
+                viewportState.preset === "fit"
+                  ? null
+                  : viewportState.preset === "custom"
+                    ? viewportState.customWidth
+                    : viewportState.preset === "desktop"
+                      ? 1440
+                      : viewportState.preset === "tablet"
+                        ? 768
+                        : 390
+              }
+              onViewportChange={setViewportState}
+              disabled={!session.url}
+            />
+          }
         />
 
         {scenario === "slow" && (
@@ -204,21 +234,46 @@ function BrowserStory({
           />
         )}
 
-        <div className="min-h-0 flex-1">
-          {scenario === "empty" ? (
-            <BrowserFallback error={null} hasUrl={false} />
-          ) : scenario === "failure" ? (
-            <BrowserFallback
-              error="The local preview stopped responding. Restart the dev server, then try again."
-              hasUrl
-              onRetry={fn()}
-              onOpenExternal={fn()}
-            />
-          ) : scenario === "loading" || scenario === "slow" ? (
-            <LoadingPage />
-          ) : (
-            <DeveloperPage compact={compact} />
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          {viewportState.preset !== "fit" && scenario !== "empty" && scenario !== "failure" && (
+            <div aria-hidden className="absolute inset-0 bg-muted/30" />
           )}
+          <div
+            className={cn(
+              "relative h-full",
+              viewportState.preset === "fit" ? "w-full" : "mx-auto",
+            )}
+            style={
+              viewportState.preset === "fit"
+                ? undefined
+                : {
+                    width:
+                      viewportState.preset === "custom"
+                        ? `${Math.min(viewportState.customWidth, 1120)}px`
+                        : viewportState.preset === "desktop"
+                          ? "1120px"
+                          : viewportState.preset === "tablet"
+                            ? "768px"
+                            : "390px",
+                    maxWidth: "100%",
+                  }
+            }
+          >
+            {scenario === "empty" ? (
+              <BrowserFallback error={null} hasUrl={false} />
+            ) : scenario === "failure" ? (
+              <BrowserFallback
+                error="The local preview stopped responding. Restart the dev server, then try again."
+                hasUrl
+                onRetry={fn()}
+                onOpenExternal={fn()}
+              />
+            ) : scenario === "loading" || scenario === "slow" ? (
+              <LoadingPage />
+            ) : (
+              <DeveloperPage compact={compact} />
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -386,6 +441,59 @@ export const PopupBlocked: Story = { args: { scenario: "popup" } };
 export const DownloadBlocked: Story = { args: { scenario: "download" } };
 
 export const Compact: Story = { args: { scenario: "agent", compact: true } };
+
+export const ViewportFit: Story = {
+  args: { scenario: "viewport-fit", viewport: { preset: "fit", customWidth: 1024 } },
+};
+
+export const ViewportDesktop: Story = {
+  args: {
+    scenario: "viewport-desktop",
+    viewport: { preset: "desktop", customWidth: 1024 },
+  },
+};
+
+export const ViewportTablet: Story = {
+  args: {
+    scenario: "viewport-tablet",
+    viewport: { preset: "tablet", customWidth: 1024 },
+  },
+};
+
+export const ViewportMobile: Story = {
+  args: {
+    scenario: "viewport-mobile",
+    viewport: { preset: "mobile", customWidth: 1024 },
+  },
+};
+
+export const ViewportCustom: Story = {
+  args: {
+    scenario: "viewport-custom",
+    viewport: { preset: "custom", customWidth: 480 },
+  },
+};
+
+export const ViewportCompact: Story = {
+  args: {
+    scenario: "viewport-tablet",
+    compact: true,
+    viewport: { preset: "tablet", customWidth: 1024 },
+  },
+};
+
+export const ViewportAgentControlled: Story = {
+  args: {
+    scenario: "viewport-desktop",
+    viewport: { preset: "desktop", customWidth: 1024 },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", { name: /Viewport: Desktop 1440/i }),
+    ).toBeVisible();
+  },
+};
 
 export const ControllerStates: StoryObj<typeof ControlRows> = {
   render: () => <ControlRows />,

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -280,6 +280,70 @@ function BrowserStory({
   );
 }
 
+function NarrowToolbarStory({
+  width,
+  access,
+}: {
+  width: 320 | 390;
+  access: BrowserAgentAccess;
+}) {
+  const session = browserSession("ready");
+  const [address, setAddress] = useState(session.address);
+  const [viewport, setViewport] = useState<BrowserViewport>({
+    preset: "mobile",
+    customWidth: 1024,
+  });
+
+  return (
+    <div className="grid min-h-dvh place-items-center bg-muted/45 p-4">
+      <div
+        className="flex h-[min(760px,calc(100dvh-4rem))] w-full flex-col overflow-hidden rounded-xl border border-border-subtle bg-background shadow-lg"
+        style={{ maxWidth: width }}
+      >
+        <BrowserToolbar
+          session={session}
+          address={address}
+          addressError={null}
+          canGoBack={session.historyIndex > 0}
+          canGoForward={false}
+          controller={undefined}
+          agentAccess={access}
+          engine={inspectEngine}
+          onAddressChange={setAddress}
+          onNavigate={fn()}
+          onBack={fn()}
+          onForward={fn()}
+          onReload={fn()}
+          onStop={fn()}
+          onStopAgent={fn()}
+          onTakeOver={fn()}
+          onShareAgent={fn()}
+          onRevokeAgent={fn()}
+          onSelectHistory={fn()}
+          onOpenExternal={fn()}
+          onOverlayOpenChange={fn()}
+          viewportControl={
+            <BrowserViewportControl
+              viewport={viewport}
+              renderedWidth={390}
+              onViewportChange={setViewport}
+            />
+          }
+        />
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          <div className="absolute inset-0 bg-muted/30" aria-hidden />
+          <div
+            className="relative mx-auto h-full"
+            style={{ width: 390, maxWidth: "100%" }}
+          >
+            <DeveloperPage compact />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function DeveloperPage({ compact }: { compact: boolean }) {
   return (
     <div className="h-full overflow-auto bg-[#f1eee7] text-[#20211f]">
@@ -483,119 +547,43 @@ export const ViewportCompact: Story = {
 };
 
 export const ToolbarNarrow320: Story = {
-  args: {
-    scenario: "unshared",
-    compact: true,
-    viewport: { preset: "mobile", customWidth: 1024 },
-  },
-  render: (args) => {
-    const [address, setAddress] = useState("localhost:4173/review/browser");
-    const [viewportState, setViewportState] = useState<BrowserViewport>(
-      args.viewport ?? { preset: "mobile", customWidth: 1024 },
-    );
-    const session = browserSession("ready");
-    return (
-      <div className="grid min-h-dvh place-items-center bg-muted/45 p-4">
-        <div className="flex h-[min(760px,calc(100dvh-4rem))] w-full max-w-[320px] flex-col overflow-hidden rounded-xl border border-border-subtle bg-background shadow-lg">
-          <BrowserToolbar
-            session={session}
-            address={address}
-            addressError={null}
-            canGoBack={session.historyIndex > 0}
-            canGoForward={false}
-            controller={undefined}
-            agentAccess={unsharedAccess}
-            engine={inspectEngine}
-            onAddressChange={setAddress}
-            onNavigate={fn()}
-            onBack={fn()}
-            onForward={fn()}
-            onReload={fn()}
-            onStop={fn()}
-            onStopAgent={fn()}
-            onTakeOver={fn()}
-            onShareAgent={fn()}
-            onRevokeAgent={fn()}
-            onSelectHistory={fn()}
-            onOpenExternal={fn()}
-            onOverlayOpenChange={fn()}
-            viewportControl={
-              <BrowserViewportControl
-                viewport={viewportState}
-                renderedWidth={390}
-                onViewportChange={setViewportState}
-                disabled={false}
-              />
-            }
-          />
-          <div className="relative min-h-0 flex-1 overflow-hidden">
-            <div className="absolute inset-0 bg-muted/30" aria-hidden />
-            <div className="relative mx-auto h-full" style={{ width: 390, maxWidth: "100%" }}>
-              <DeveloperPage compact />
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  },
+  args: { scenario: "unshared" },
+  render: () => <NarrowToolbarStory width={320} access={unsharedAccess} />,
 };
 
 export const ToolbarNarrow390: Story = {
-  args: {
-    scenario: "unshared",
-    compact: true,
-    viewport: { preset: "mobile", customWidth: 1024 },
-  },
-  render: (args) => {
-    const [address, setAddress] = useState("localhost:4173/review/browser");
-    const [viewportState, setViewportState] = useState<BrowserViewport>(
-      args.viewport ?? { preset: "mobile", customWidth: 1024 },
-    );
-    const session = browserSession("ready");
-    return (
-      <div className="grid min-h-dvh place-items-center bg-muted/45 p-4">
-        <div className="flex h-[min(760px,calc(100dvh-4rem))] w-full max-w-[390px] flex-col overflow-hidden rounded-xl border border-border-subtle bg-background shadow-lg">
-          <BrowserToolbar
-            session={session}
-            address={address}
-            addressError={null}
-            canGoBack={session.historyIndex > 0}
-            canGoForward={false}
-            controller={undefined}
-            agentAccess={unsharedAccess}
-            engine={inspectEngine}
-            onAddressChange={setAddress}
-            onNavigate={fn()}
-            onBack={fn()}
-            onForward={fn()}
-            onReload={fn()}
-            onStop={fn()}
-            onStopAgent={fn()}
-            onTakeOver={fn()}
-            onShareAgent={fn()}
-            onRevokeAgent={fn()}
-            onSelectHistory={fn()}
-            onOpenExternal={fn()}
-            onOverlayOpenChange={fn()}
-            viewportControl={
-              <BrowserViewportControl
-                viewport={viewportState}
-                renderedWidth={390}
-                onViewportChange={setViewportState}
-                disabled={false}
-              />
-            }
-          />
-          <div className="relative min-h-0 flex-1 overflow-hidden">
-            <div className="absolute inset-0 bg-muted/30" aria-hidden />
-            <div className="relative mx-auto h-full" style={{ width: 390, maxWidth: "100%" }}>
-              <DeveloperPage compact />
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  },
+  args: { scenario: "unshared" },
+  render: () => <NarrowToolbarStory width={390} access={unsharedAccess} />,
+};
+
+export const ToolbarNarrow320Shared: Story = {
+  args: { scenario: "shared" },
+  render: () => <NarrowToolbarStory width={320} access={localSharedAccess} />,
+};
+
+export const ToolbarNarrow390Shared: Story = {
+  args: { scenario: "shared" },
+  render: () => <NarrowToolbarStory width={390} access={localSharedAccess} />,
+};
+
+export const ToolbarNarrow320Paused: Story = {
+  args: { scenario: "paused" },
+  render: () => (
+    <NarrowToolbarStory
+      width={320}
+      access={{ ...pausedAccess, shared: true, scope: "origin" }}
+    />
+  ),
+};
+
+export const ToolbarNarrow390Paused: Story = {
+  args: { scenario: "paused" },
+  render: () => (
+    <NarrowToolbarStory
+      width={390}
+      access={{ ...pausedAccess, shared: true, scope: "origin" }}
+    />
+  ),
 };
 
 export const ViewportAgentControlled: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -188,6 +188,7 @@ function BrowserStory({
           onSelectHistory={fn()}
           onOpenExternal={fn()}
           onOverlayOpenChange={fn()}
+          onAgentAccessOpenChange={fn()}
           viewportControl={
             <BrowserViewportControl
               viewport={viewportState}
@@ -322,6 +323,7 @@ function NarrowToolbarStory({
           onSelectHistory={fn()}
           onOpenExternal={fn()}
           onOverlayOpenChange={fn()}
+          onAgentAccessOpenChange={fn()}
           viewportControl={
             <BrowserViewportControl
               viewport={viewport}

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -482,6 +482,122 @@ export const ViewportCompact: Story = {
   },
 };
 
+export const ToolbarNarrow320: Story = {
+  args: {
+    scenario: "unshared",
+    compact: true,
+    viewport: { preset: "mobile", customWidth: 1024 },
+  },
+  render: (args) => {
+    const [address, setAddress] = useState("localhost:4173/review/browser");
+    const [viewportState, setViewportState] = useState<BrowserViewport>(
+      args.viewport ?? { preset: "mobile", customWidth: 1024 },
+    );
+    const session = browserSession("ready");
+    return (
+      <div className="grid min-h-dvh place-items-center bg-muted/45 p-4">
+        <div className="flex h-[min(760px,calc(100dvh-4rem))] w-full max-w-[320px] flex-col overflow-hidden rounded-xl border border-border-subtle bg-background shadow-lg">
+          <BrowserToolbar
+            session={session}
+            address={address}
+            addressError={null}
+            canGoBack={session.historyIndex > 0}
+            canGoForward={false}
+            controller={undefined}
+            agentAccess={unsharedAccess}
+            engine={inspectEngine}
+            onAddressChange={setAddress}
+            onNavigate={fn()}
+            onBack={fn()}
+            onForward={fn()}
+            onReload={fn()}
+            onStop={fn()}
+            onStopAgent={fn()}
+            onTakeOver={fn()}
+            onShareAgent={fn()}
+            onRevokeAgent={fn()}
+            onSelectHistory={fn()}
+            onOpenExternal={fn()}
+            onOverlayOpenChange={fn()}
+            viewportControl={
+              <BrowserViewportControl
+                viewport={viewportState}
+                renderedWidth={390}
+                onViewportChange={setViewportState}
+                disabled={false}
+              />
+            }
+          />
+          <div className="relative min-h-0 flex-1 overflow-hidden">
+            <div className="absolute inset-0 bg-muted/30" aria-hidden />
+            <div className="relative mx-auto h-full" style={{ width: 390, maxWidth: "100%" }}>
+              <DeveloperPage compact />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const ToolbarNarrow390: Story = {
+  args: {
+    scenario: "unshared",
+    compact: true,
+    viewport: { preset: "mobile", customWidth: 1024 },
+  },
+  render: (args) => {
+    const [address, setAddress] = useState("localhost:4173/review/browser");
+    const [viewportState, setViewportState] = useState<BrowserViewport>(
+      args.viewport ?? { preset: "mobile", customWidth: 1024 },
+    );
+    const session = browserSession("ready");
+    return (
+      <div className="grid min-h-dvh place-items-center bg-muted/45 p-4">
+        <div className="flex h-[min(760px,calc(100dvh-4rem))] w-full max-w-[390px] flex-col overflow-hidden rounded-xl border border-border-subtle bg-background shadow-lg">
+          <BrowserToolbar
+            session={session}
+            address={address}
+            addressError={null}
+            canGoBack={session.historyIndex > 0}
+            canGoForward={false}
+            controller={undefined}
+            agentAccess={unsharedAccess}
+            engine={inspectEngine}
+            onAddressChange={setAddress}
+            onNavigate={fn()}
+            onBack={fn()}
+            onForward={fn()}
+            onReload={fn()}
+            onStop={fn()}
+            onStopAgent={fn()}
+            onTakeOver={fn()}
+            onShareAgent={fn()}
+            onRevokeAgent={fn()}
+            onSelectHistory={fn()}
+            onOpenExternal={fn()}
+            onOverlayOpenChange={fn()}
+            viewportControl={
+              <BrowserViewportControl
+                viewport={viewportState}
+                renderedWidth={390}
+                onViewportChange={setViewportState}
+                disabled={false}
+              />
+            }
+          />
+          <div className="relative min-h-0 flex-1 overflow-hidden">
+            <div className="absolute inset-0 bg-muted/30" aria-hidden />
+            <div className="relative mx-auto h-full" style={{ width: 390, maxWidth: "100%" }}>
+              <DeveloperPage compact />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
 export const ViewportAgentControlled: Story = {
   args: {
     scenario: "viewport-desktop",


### PR DESCRIPTION
## Summary

- add Fit, desktop, tablet, mobile, and bounded custom viewport controls to the shared in-app browser
- improve keyboard/radiogroup behavior, active-state focus, validation, and persisted viewport preferences
- hide the native WKWebView while app-owned history or viewport overlays are open, including overlapping obscuration states and create-time races
- extend browser stories and DOM coverage for the reusable states

## Validation

- focused browser UI tests: 35/35 passed
- Storybook production build passed
- `git diff --check`
- live native visual QA remains pending because no connected in-app browser session was available

## Review status

Draft pending the final incremental accessibility/responsive review. The known native-overlay P1 is fixed.

## Tracking

Supersedes #2358, which GitHub automatically closed when the stacked foundation branch was squash-merged and deleted. Advances #2346 under epic #2335 and the Agent browser milestone.