### PR TITLE
feat(harness): add scoped browser channel contract

### DIFF
--- a/crates/tidebreak-harness/src/browser_channel.rs
+++ b/crates/tidebreak-harness/src/browser_channel.rs
@@ -1,0 +1,75 @@
+//! Browser channel contracts exercised without a live runtime.
+//!
+//! The trusted browser runtime (issue #2344) mints a session-private
+//! capability file whose path is injected through a harness-owned
+//! environment key. This module declares the contract adapters rely on
+//! and provides static-validation tests that do not require a browser
+//! process.
+
+use crate::BrowserChannelSpec;
+
+/// Adapter must inject this exact key; engines must consume it.
+///
+/// Changing this constant affects every adapter and engine tool bridge,
+/// so it lives here as the single source of truth.
+pub const BROWSER_CAPFILE_ENV_KEY: &str = BrowserChannelSpec::ENV_KEY;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn capfile_key_is_tidebreak_prefixed() {
+        assert!(
+            BROWSER_CAPFILE_ENV_KEY.starts_with("TIDEBREAK_"),
+            "the key must use the TIDEBREAK_ prefix so filter_child_env strips it"
+        );
+    }
+
+    #[test]
+    fn capfile_key_is_not_empty() {
+        assert!(!BROWSER_CAPFILE_ENV_KEY.is_empty());
+    }
+
+    #[test]
+    fn spec_new_roundtrips() {
+        let path = PathBuf::from("/tmp/browser-cap.json");
+        let spec = BrowserChannelSpec::new(path.clone());
+        assert_eq!(spec.capability_file, path);
+    }
+
+    #[test]
+    fn inject_env_sets_the_key() {
+        let path = PathBuf::from("/tmp/browser-cap.json");
+        let spec = BrowserChannelSpec::new(path.clone());
+        let mut cmd = std::process::Command::new("true");
+        spec.inject_env(&mut cmd);
+        assert_eq!(spec.capability_file, path);
+    }
+
+    #[test]
+    fn inject_env_tokio_sets_the_key() {
+        let path = PathBuf::from("/tmp/browser-cap.json");
+        let spec = BrowserChannelSpec::new(path.clone());
+        let mut cmd = tokio::process::Command::new("true");
+        spec.inject_env_tokio(&mut cmd);
+        assert_eq!(spec.capability_file, path);
+    }
+
+    #[test]
+    fn override_resistance_env_key_is_compile_time_constant() {
+        assert_eq!(
+            std::any::type_name_of_val(&BrowserChannelSpec::ENV_KEY),
+            "&str"
+        );
+    }
+
+    #[test]
+    fn absence_preserves_existing_behavior() {
+        assert!(BROWSER_CAPFILE_ENV_KEY.len() > 8);
+        assert!(BROWSER_CAPFILE_ENV_KEY
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c == '_'));
+    }
+}

--- a/crates/tidebreak-harness/src/browser_channel.rs
+++ b/crates/tidebreak-harness/src/browser_channel.rs
@@ -3,12 +3,14 @@
 //! The trusted browser runtime (issue #2342) mints a session-private
 //! capability file whose path is injected through a harness-owned
 //! environment key. This module declares the contract adapters rely on
-//! and provides static-validation tests that do not require a browser
-//! process.
+//! and owns the single shared helper that composes an engine child's
+//! environment. The tests exercise that production helper directly
+//! against a Tokio command, so the Some/None/final-override contract is
+//! verified on the real adapter path rather than a test-only seam.
 
-use std::ffi::OsStr;
+use std::ffi::OsString;
 
-use crate::BrowserChannelSpec;
+use crate::{filter_child_env, BrowserChannelSpec};
 
 /// Adapter must inject this exact key; engines must consume it.
 ///
@@ -16,18 +18,67 @@ use crate::BrowserChannelSpec;
 /// so it lives here as the single source of truth.
 pub const BROWSER_CAPFILE_ENV_KEY: &str = BrowserChannelSpec::ENV_KEY;
 
-/// Resolve an optional browser channel to the one environment pair an
-/// adapter may inject. `None` deliberately produces no child environment.
-#[must_use]
-pub fn browser_env_pair(browser: Option<&BrowserChannelSpec>) -> Option<(&'static str, &OsStr)> {
-    browser.map(BrowserChannelSpec::env_pair)
+/// Apply the complete child environment to a Tokio engine command in the
+/// single ordering every adapter must use:
+///
+/// 1. Clear the inherited process environment.
+/// 2. Restore the probe snapshot through [`filter_child_env`], which strips
+///    the reserved `TIDEBREAK_` namespace (case-insensitively).
+/// 3. Apply the sanitized launch-plan environment. Settings already rejected
+///    reserved keys via [`BrowserChannelSpec::is_reserved_env_key`], so this
+///    step can carry no adapter-owned override.
+/// 4. Inject the optional [`BrowserChannelSpec`] as the final value, making
+///    the trusted capability-file path win over any earlier environment entry.
+///
+/// `browser` is read directly here so all four adapters share one
+/// Some/None/final-override path. `None` adds no environment entry.
+pub fn apply_child_env_tokio<I>(
+    cmd: &mut tokio::process::Command,
+    snapshot: I,
+    plan_env: &[(String, String)],
+    browser: Option<&BrowserChannelSpec>,
+) where
+    I: IntoIterator<Item = (OsString, OsString)>,
+{
+    cmd.env_clear();
+    for (key, value) in filter_child_env(snapshot) {
+        cmd.env(key, value);
+    }
+    for (key, value) in plan_env {
+        cmd.env(key, value);
+    }
+    if let Some(browser) = browser {
+        browser.inject_env_tokio(cmd);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
     use std::path::PathBuf;
+
+    /// Collect the final environment of a Tokio command into a sorted,
+    /// deterministic map keyed by the uppercased name. The repo already
+    /// uses `as_std().get_envs()` (see `tidebreak-server`'s mcp_config
+    /// tests); this helper keeps the assertions below compact.
+    fn final_env(
+        snapshot: impl IntoIterator<Item = (OsString, OsString)>,
+        plan_env: &[(String, String)],
+        browser: Option<&BrowserChannelSpec>,
+    ) -> std::collections::BTreeMap<String, String> {
+        let mut cmd = tokio::process::Command::new("/bin/true");
+        apply_child_env_tokio(&mut cmd, snapshot, plan_env, browser);
+        cmd.as_std()
+            .get_envs()
+            .filter_map(|(name, value)| {
+                let value = value?;
+                Some((
+                    name.to_string_lossy().to_ascii_uppercase(),
+                    value.to_string_lossy().to_string(),
+                ))
+            })
+            .collect()
+    }
 
     #[test]
     fn capfile_key_is_tidebreak_prefixed() {
@@ -45,46 +96,82 @@ mod tests {
     }
 
     #[test]
-    fn browser_some_exposes_the_trusted_env_pair() {
-        let path = PathBuf::from("/tmp/browser-cap.json");
-        let browser = BrowserChannelSpec::new(path.clone());
-        let (key, value) = browser_env_pair(Some(&browser)).expect("browser env pair");
+    fn apply_with_browser_injects_the_trusted_pair_last() {
+        let trusted = PathBuf::from("/tmp/trusted-cap.json");
+        let browser = BrowserChannelSpec::new(trusted.clone());
 
+        let env = final_env(Vec::new(), &[], Some(&browser));
+        let (key, value) = env
+            .iter()
+            .find(|(name, _)| name.as_str() == BROWSER_CAPFILE_ENV_KEY)
+            .expect("trusted pair was injected");
         assert_eq!(key, BROWSER_CAPFILE_ENV_KEY);
-        assert_eq!(value, path.as_os_str());
+        assert_eq!(value, trusted.to_string_lossy());
+        assert_eq!(env.len(), 1, "no other entries when nothing else is supplied");
     }
 
     #[test]
-    fn reserved_value_cannot_shadow_the_trusted_pair() {
-        let attacker_path = "/tmp/attacker-cap.json";
-        let mut settings_env = vec![(
-            BROWSER_CAPFILE_ENV_KEY.to_ascii_lowercase(),
-            attacker_path.to_owned(),
+    fn apply_without_browser_injects_no_browser_entry() {
+        let env = final_env(Vec::new(), &[], None);
+        assert!(
+            !env.contains_key(BROWSER_CAPFILE_ENV_KEY),
+            "None must not add a browser capability entry"
+        );
+        assert!(env.is_empty(), "empty inputs yield an empty environment");
+    }
+
+    #[test]
+    fn reserved_snapshot_keys_are_stripped_case_insensitively() {
+        // A lowercase reserved key in the probe snapshot must not survive,
+        // mirroring the case-insensitive `filter_child_env` contract.
+        let snapshot = vec![(
+            OsString::from("tidebreak_browser_capfile"),
+            OsString::from("/tmp/snapshot-cap.json"),
         )];
-        settings_env.retain(|(key, _)| !BrowserChannelSpec::is_reserved_env_key(key));
+        let env = final_env(snapshot, &[], None);
         assert!(
-            settings_env.is_empty(),
-            "settings override must be rejected"
+            !env.contains_key(BROWSER_CAPFILE_ENV_KEY),
+            "a reserved snapshot key must be stripped before the browser step"
         );
-
-        let snapshot_env = crate::filter_child_env([(
-            OsString::from(BROWSER_CAPFILE_ENV_KEY),
-            OsString::from(attacker_path),
-        )]);
-        assert!(
-            snapshot_env.is_empty(),
-            "snapshot override must be stripped"
-        );
-
-        let trusted_path = PathBuf::from("/tmp/trusted-cap.json");
-        let browser = BrowserChannelSpec::new(trusted_path.clone());
-        let (key, value) = browser_env_pair(Some(&browser)).expect("trusted browser env pair");
-        assert_eq!(key, BROWSER_CAPFILE_ENV_KEY);
-        assert_eq!(value, trusted_path.as_os_str());
+        assert!(env.is_empty(), "only the reserved key was supplied");
     }
 
     #[test]
-    fn browser_none_exposes_no_env_pair() {
-        assert!(browser_env_pair(None).is_none());
+    fn reserved_plan_keys_are_rejected_case_insensitively() {
+        // Settings (plan.env) filtering is the adapter's responsibility, and
+        // the `is_reserved_env_key` guard is what makes plan.env trusted by
+        // the time it reaches the helper. A mixed-case reserved key must be
+        // rejected just like the canonical uppercase form, so no settings
+        // value can shadow the trusted browser injection.
+        let lower = BROWSER_CAPFILE_ENV_KEY.to_ascii_lowercase();
+        let mixed = String::from("Tidebreak_Browser_Capfile");
+        for key in [BROWSER_CAPFILE_ENV_KEY, lower.as_str(), mixed.as_str()] {
+            assert!(
+                BrowserChannelSpec::is_reserved_env_key(key),
+                "adapter must reject reserved settings key {key:?} before apply"
+            );
+        }
+    }
+
+    #[test]
+    fn trusted_browser_overrides_a_conflicting_plan_value() {
+        // The adapter sanitizes plan.env upstream via is_reserved_env_key,
+        // so a reserved key never legitimately reaches this helper through
+        // plan.env. The helper nonetheless defends ordering in depth by
+        // applying the browser injection after plan.env: if a conflicting
+        // value for the reserved key is present, the trusted path wins last.
+        let trusted = PathBuf::from("/tmp/trusted-cap.json");
+        let browser = BrowserChannelSpec::new(trusted.clone());
+        let plan_env = vec![(
+            BROWSER_CAPFILE_ENV_KEY.to_owned(),
+            "/tmp/plan-conflict-cap.json".to_owned(),
+        )];
+        let env = final_env(Vec::new(), &plan_env, Some(&browser));
+        assert_eq!(
+            env.get(BROWSER_CAPFILE_ENV_KEY).map(String::as_str),
+            Some(trusted.to_string_lossy().as_ref()),
+            "the trusted capability-file path is the final child value, even when plan.env carried the reserved key"
+        );
+        assert_eq!(env.len(), 1, "only the trusted pair survives the override");
     }
 }

--- a/crates/tidebreak-harness/src/browser_channel.rs
+++ b/crates/tidebreak-harness/src/browser_channel.rs
@@ -106,8 +106,12 @@ mod tests {
             .find(|(name, _)| name.as_str() == BROWSER_CAPFILE_ENV_KEY)
             .expect("trusted pair was injected");
         assert_eq!(key, BROWSER_CAPFILE_ENV_KEY);
-        assert_eq!(value, trusted.to_string_lossy());
-        assert_eq!(env.len(), 1, "no other entries when nothing else is supplied");
+        assert_eq!(value.as_str(), trusted.to_string_lossy().as_ref());
+        assert_eq!(
+            env.len(),
+            1,
+            "no other entries when nothing else is supplied"
+        );
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/browser_channel.rs
+++ b/crates/tidebreak-harness/src/browser_channel.rs
@@ -125,6 +125,23 @@ mod tests {
     }
 
     #[test]
+    fn apply_clears_preconfigured_command_environment() {
+        const AMBIENT_SENTINEL: &str = "TIDEBREAK_TEST_AMBIENT";
+
+        let mut cmd = tokio::process::Command::new("/bin/true");
+        cmd.env(AMBIENT_SENTINEL, "must-be-cleared");
+
+        apply_child_env_tokio(&mut cmd, Vec::new(), &[], None);
+
+        assert!(
+            cmd.as_std()
+                .get_envs()
+                .all(|(name, _)| name != std::ffi::OsStr::new(AMBIENT_SENTINEL)),
+            "the helper must clear command entries configured before its trusted environment is applied"
+        );
+    }
+
+    #[test]
     fn reserved_snapshot_keys_are_stripped_case_insensitively() {
         // A lowercase reserved key in the probe snapshot must not survive,
         // mirroring the case-insensitive `filter_child_env` contract.

--- a/crates/tidebreak-harness/src/browser_channel.rs
+++ b/crates/tidebreak-harness/src/browser_channel.rs
@@ -62,13 +62,19 @@ mod tests {
             attacker_path.to_owned(),
         )];
         settings_env.retain(|(key, _)| !BrowserChannelSpec::is_reserved_env_key(key));
-        assert!(settings_env.is_empty(), "settings override must be rejected");
+        assert!(
+            settings_env.is_empty(),
+            "settings override must be rejected"
+        );
 
         let snapshot_env = crate::filter_child_env([(
             OsString::from(BROWSER_CAPFILE_ENV_KEY),
             OsString::from(attacker_path),
         )]);
-        assert!(snapshot_env.is_empty(), "snapshot override must be stripped");
+        assert!(
+            snapshot_env.is_empty(),
+            "snapshot override must be stripped"
+        );
 
         let trusted_path = PathBuf::from("/tmp/trusted-cap.json");
         let browser = BrowserChannelSpec::new(trusted_path.clone());

--- a/crates/tidebreak-harness/src/browser_channel.rs
+++ b/crates/tidebreak-harness/src/browser_channel.rs
@@ -1,10 +1,12 @@
 //! Browser channel contracts exercised without a live runtime.
 //!
-//! The trusted browser runtime (issue #2344) mints a session-private
+//! The trusted browser runtime (issue #2342) mints a session-private
 //! capability file whose path is injected through a harness-owned
 //! environment key. This module declares the contract adapters rely on
 //! and provides static-validation tests that do not require a browser
 //! process.
+
+use std::ffi::OsStr;
 
 use crate::BrowserChannelSpec;
 
@@ -14,9 +16,17 @@ use crate::BrowserChannelSpec;
 /// so it lives here as the single source of truth.
 pub const BROWSER_CAPFILE_ENV_KEY: &str = BrowserChannelSpec::ENV_KEY;
 
+/// Resolve an optional browser channel to the one environment pair an
+/// adapter may inject. `None` deliberately produces no child environment.
+#[must_use]
+pub fn browser_env_pair(browser: Option<&BrowserChannelSpec>) -> Option<(&'static str, &OsStr)> {
+    browser.map(BrowserChannelSpec::env_pair)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::path::PathBuf;
 
     #[test]
@@ -28,11 +38,6 @@ mod tests {
     }
 
     #[test]
-    fn capfile_key_is_not_empty() {
-        assert!(!BROWSER_CAPFILE_ENV_KEY.is_empty());
-    }
-
-    #[test]
     fn spec_new_roundtrips() {
         let path = PathBuf::from("/tmp/browser-cap.json");
         let spec = BrowserChannelSpec::new(path.clone());
@@ -40,36 +45,40 @@ mod tests {
     }
 
     #[test]
-    fn inject_env_sets_the_key() {
+    fn browser_some_exposes_the_trusted_env_pair() {
         let path = PathBuf::from("/tmp/browser-cap.json");
-        let spec = BrowserChannelSpec::new(path.clone());
-        let mut cmd = std::process::Command::new("true");
-        spec.inject_env(&mut cmd);
-        assert_eq!(spec.capability_file, path);
+        let browser = BrowserChannelSpec::new(path.clone());
+        let (key, value) = browser_env_pair(Some(&browser)).expect("browser env pair");
+
+        assert_eq!(key, BROWSER_CAPFILE_ENV_KEY);
+        assert_eq!(value, path.as_os_str());
     }
 
     #[test]
-    fn inject_env_tokio_sets_the_key() {
-        let path = PathBuf::from("/tmp/browser-cap.json");
-        let spec = BrowserChannelSpec::new(path.clone());
-        let mut cmd = tokio::process::Command::new("true");
-        spec.inject_env_tokio(&mut cmd);
-        assert_eq!(spec.capability_file, path);
+    fn reserved_value_cannot_shadow_the_trusted_pair() {
+        let attacker_path = "/tmp/attacker-cap.json";
+        let mut settings_env = vec![(
+            BROWSER_CAPFILE_ENV_KEY.to_ascii_lowercase(),
+            attacker_path.to_owned(),
+        )];
+        settings_env.retain(|(key, _)| !BrowserChannelSpec::is_reserved_env_key(key));
+        assert!(settings_env.is_empty(), "settings override must be rejected");
+
+        let snapshot_env = crate::filter_child_env([(
+            OsString::from(BROWSER_CAPFILE_ENV_KEY),
+            OsString::from(attacker_path),
+        )]);
+        assert!(snapshot_env.is_empty(), "snapshot override must be stripped");
+
+        let trusted_path = PathBuf::from("/tmp/trusted-cap.json");
+        let browser = BrowserChannelSpec::new(trusted_path.clone());
+        let (key, value) = browser_env_pair(Some(&browser)).expect("trusted browser env pair");
+        assert_eq!(key, BROWSER_CAPFILE_ENV_KEY);
+        assert_eq!(value, trusted_path.as_os_str());
     }
 
     #[test]
-    fn override_resistance_env_key_is_compile_time_constant() {
-        assert_eq!(
-            std::any::type_name_of_val(&BrowserChannelSpec::ENV_KEY),
-            "&str"
-        );
-    }
-
-    #[test]
-    fn absence_preserves_existing_behavior() {
-        assert!(BROWSER_CAPFILE_ENV_KEY.len() > 8);
-        assert!(BROWSER_CAPFILE_ENV_KEY
-            .chars()
-            .all(|c| c.is_ascii_uppercase() || c == '_'));
+    fn browser_none_exposes_no_env_pair() {
+        assert!(browser_env_pair(None).is_none());
     }
 }

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -16,9 +16,9 @@ use crate::child::{turn_outcome, ChildPid};
 use crate::claude::parse::ClaudeStreamParser;
 use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
-    filter_child_env, spawn_process_tree, ApprovalDecision, HarnessApprovalRef, HarnessError,
-    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
-    TurnInput, TurnOutcome,
+    filter_child_env, spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
+    HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
+    StreamLineBuffer, TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -119,7 +119,7 @@ impl ClaudeSession {
         }
         argv.extend(self.spec.extra_argv.iter().cloned());
         let mut env = self.spec.extra_env.clone();
-        env.retain(|(key, _)| !key.to_ascii_uppercase().starts_with("TIDEBREAK_") && key != "PWD");
+        env.retain(|(key, _)| !BrowserChannelSpec::is_reserved_env_key(key) && key != "PWD");
         let plan = LaunchPlan {
             argv,
             cwd: self.spec.worktree.clone(),
@@ -161,7 +161,7 @@ impl HarnessSession for ClaudeSession {
             command.env(key, value);
         }
         if let Some(ref browser) = self.spec.browser {
-            browser.inject_env(&mut command);
+            browser.inject_env_tokio(&mut command);
         }
         let mut child = spawn_process_tree(&mut command)?;
         let mut stdin = child

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -12,15 +12,15 @@ use tokio::sync::watch;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::warn;
 
+use crate::browser_channel::apply_child_env_tokio;
 use crate::child::{turn_outcome, ChildPid};
 use crate::claude::parse::ClaudeStreamParser;
 use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
-    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
-    HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
-    StreamLineBuffer, TurnInput, TurnOutcome,
+    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef, HarnessError,
+    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
+    TurnInput, TurnOutcome,
 };
-use crate::browser_channel::apply_child_env_tokio;
 use tidebreak_core::CodePermissionMode;
 
 const INTERRUPT_GRACE: Duration = Duration::from_secs(2);

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -160,6 +160,9 @@ impl HarnessSession for ClaudeSession {
         for (key, value) in &plan.env {
             command.env(key, value);
         }
+        if let Some(ref browser) = self.spec.browser {
+            browser.inject_env(&mut command);
+        }
         let mut child = spawn_process_tree(&mut command)?;
         let mut stdin = child
             .take_stdin()
@@ -455,6 +458,7 @@ mod tests {
             approval: None,
             binary,
             sink: Arc::new(Discard),
+            browser: None,
         });
         assert!(
             session.child_pid_changes().is_some(),

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -16,10 +16,11 @@ use crate::child::{turn_outcome, ChildPid};
 use crate::claude::parse::ClaudeStreamParser;
 use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
-    filter_child_env, spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
+    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
     HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
     StreamLineBuffer, TurnInput, TurnOutcome,
 };
+use crate::browser_channel::apply_child_env_tokio;
 use tidebreak_core::CodePermissionMode;
 
 const INTERRUPT_GRACE: Duration = Duration::from_secs(2);
@@ -152,17 +153,13 @@ impl HarnessSession for ClaudeSession {
             .current_dir(&plan.cwd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .env_clear();
-        for (key, value) in filter_child_env(self.spec.env.iter().cloned()) {
-            command.env(key, value);
-        }
-        for (key, value) in &plan.env {
-            command.env(key, value);
-        }
-        if let Some(ref browser) = self.spec.browser {
-            browser.inject_env_tokio(&mut command);
-        }
+            .stderr(Stdio::piped());
+        apply_child_env_tokio(
+            &mut command,
+            self.spec.env.iter().cloned(),
+            &plan.env,
+            self.spec.browser.as_ref(),
+        );
         let mut child = spawn_process_tree(&mut command)?;
         let mut stdin = child
             .take_stdin()

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -17,10 +17,11 @@ use tracing::warn;
 use crate::codex::parse::CodexStreamParser;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::{
-    filter_child_env, spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
+    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
     HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
     StreamLineBuffer, TurnInput, TurnOutcome,
 };
+use crate::browser_channel::apply_child_env_tokio;
 use tidebreak_core::{CodePermissionMode, MAX_NOTICE_CHARS};
 
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
@@ -485,17 +486,13 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<CodexSession, HarnessErr
         .current_dir(&plan.cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .env_clear();
-    for (key, value) in filter_child_env(session.spec.env.iter().cloned()) {
-        command.env(key, value);
-    }
-    for (key, value) in &plan.env {
-        command.env(key, value);
-    }
-    if let Some(ref browser) = session.spec.browser {
-        browser.inject_env_tokio(&mut command);
-    }
+        .stderr(Stdio::piped());
+    apply_child_env_tokio(
+        &mut command,
+        session.spec.env.iter().cloned(),
+        &plan.env,
+        session.spec.browser.as_ref(),
+    );
     let mut child = spawn_process_tree(&mut command)?;
     let stdin = child
         .take_stdin()

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -17,9 +17,9 @@ use tracing::warn;
 use crate::codex::parse::CodexStreamParser;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::{
-    filter_child_env, spawn_process_tree, ApprovalDecision, HarnessApprovalRef, HarnessError,
-    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
-    TurnInput, TurnOutcome,
+    filter_child_env, spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
+    HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
+    StreamLineBuffer, TurnInput, TurnOutcome,
 };
 use tidebreak_core::{CodePermissionMode, MAX_NOTICE_CHARS};
 
@@ -449,7 +449,7 @@ pub(crate) fn compose_app_server_plan(
     ];
     argv.extend(extra_argv.iter().cloned());
     let mut env = extra_env.to_vec();
-    env.retain(|(key, _)| !key.to_ascii_uppercase().starts_with("TIDEBREAK_") && key != "PWD");
+    env.retain(|(key, _)| !BrowserChannelSpec::is_reserved_env_key(key) && key != "PWD");
     let plan = LaunchPlan {
         argv,
         cwd: cwd.to_path_buf(),
@@ -494,7 +494,7 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<CodexSession, HarnessErr
         command.env(key, value);
     }
     if let Some(ref browser) = session.spec.browser {
-        browser.inject_env(&mut command);
+        browser.inject_env_tokio(&mut command);
     }
     let mut child = spawn_process_tree(&mut command)?;
     let stdin = child

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -493,6 +493,9 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<CodexSession, HarnessErr
     for (key, value) in &plan.env {
         command.env(key, value);
     }
+    if let Some(ref browser) = session.spec.browser {
+        browser.inject_env(&mut command);
+    }
     let mut child = spawn_process_tree(&mut command)?;
     let stdin = child
         .take_stdin()
@@ -1299,6 +1302,7 @@ done
             approval: None,
             binary: PathBuf::from("codex"),
             sink,
+            browser: None,
         })
     }
 
@@ -1350,6 +1354,7 @@ done
             approval: None,
             binary: binary.to_path_buf(),
             sink: Arc::new(SilentSink),
+            browser: None,
         }
     }
 

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -14,14 +14,14 @@ use tokio::sync::{oneshot, Mutex as AsyncMutex, Notify};
 use tokio::time::{timeout, Instant};
 use tracing::warn;
 
+use crate::browser_channel::apply_child_env_tokio;
 use crate::codex::parse::CodexStreamParser;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::{
-    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
-    HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
-    StreamLineBuffer, TurnInput, TurnOutcome,
+    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef, HarnessError,
+    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
+    TurnInput, TurnOutcome,
 };
-use crate::browser_channel::apply_child_env_tokio;
 use tidebreak_core::{CodePermissionMode, MAX_NOTICE_CHARS};
 
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -17,10 +17,11 @@ use crate::child::{turn_outcome, ChildPid};
 use crate::grok::parse::GrokStreamParser;
 use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
-    filter_child_env, spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
+    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
     HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
     StreamLineBuffer, TurnInput, TurnOutcome,
 };
+use crate::browser_channel::apply_child_env_tokio;
 use tidebreak_core::CodePermissionMode;
 
 const INTERRUPT_GRACE: Duration = Duration::from_secs(2);
@@ -229,17 +230,13 @@ impl GrokSession {
             .current_dir(&plan.cwd)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .env_clear();
-        for (key, value) in filter_child_env(self.spec.env.iter().cloned()) {
-            command.env(key, value);
-        }
-        for (key, value) in &plan.env {
-            command.env(key, value);
-        }
-        if let Some(ref browser) = self.spec.browser {
-            browser.inject_env_tokio(&mut command);
-        }
+            .stderr(Stdio::piped());
+        apply_child_env_tokio(
+            &mut command,
+            self.spec.env.iter().cloned(),
+            &plan.env,
+            self.spec.browser.as_ref(),
+        );
         let mut child = spawn_process_tree(&mut command)?;
         let stdout = child
             .take_stdout()

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -237,6 +237,9 @@ impl GrokSession {
         for (key, value) in &plan.env {
             command.env(key, value);
         }
+        if let Some(ref browser) = self.spec.browser {
+            browser.inject_env(&mut command);
+        }
         let mut child = spawn_process_tree(&mut command)?;
         let stdout = child
             .take_stdout()

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -17,9 +17,9 @@ use crate::child::{turn_outcome, ChildPid};
 use crate::grok::parse::GrokStreamParser;
 use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
-    filter_child_env, spawn_process_tree, ApprovalDecision, HarnessApprovalRef, HarnessError,
-    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
-    TurnInput, TurnOutcome,
+    filter_child_env, spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
+    HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
+    StreamLineBuffer, TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -132,7 +132,7 @@ pub(crate) fn compose_print_plan(launch: PrintLaunch<'_>) -> Result<LaunchPlan, 
     }
     argv.extend(launch.extra_argv.iter().cloned());
     let mut env = launch.extra_env.to_vec();
-    env.retain(|(key, _)| !key.to_ascii_uppercase().starts_with("TIDEBREAK_") && key != "PWD");
+    env.retain(|(key, _)| !BrowserChannelSpec::is_reserved_env_key(key) && key != "PWD");
     let policy = match launch.mode {
         CodePermissionMode::Allow => BypassPolicy::Permitted,
         CodePermissionMode::Plan | CodePermissionMode::Ask | CodePermissionMode::Auto => {
@@ -238,7 +238,7 @@ impl GrokSession {
             command.env(key, value);
         }
         if let Some(ref browser) = self.spec.browser {
-            browser.inject_env(&mut command);
+            browser.inject_env_tokio(&mut command);
         }
         let mut child = spawn_process_tree(&mut command)?;
         let stdout = child

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -13,15 +13,15 @@ use tokio::sync::watch;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::warn;
 
+use crate::browser_channel::apply_child_env_tokio;
 use crate::child::{turn_outcome, ChildPid};
 use crate::grok::parse::GrokStreamParser;
 use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
 use crate::{
-    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
-    HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
-    StreamLineBuffer, TurnInput, TurnOutcome,
+    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef, HarnessError,
+    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
+    TurnInput, TurnOutcome,
 };
-use crate::browser_channel::apply_child_env_tokio;
 use tidebreak_core::CodePermissionMode;
 
 const INTERRUPT_GRACE: Duration = Duration::from_secs(2);

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -20,9 +20,9 @@ use tidebreak_core::{
     HarnessCommand, HarnessKind, HarnessNoticeLevel, ToolDetail, ToolOutcome,
 };
 
+pub mod browser_channel;
 pub mod budget;
 pub mod child;
-pub mod browser_channel;
 pub mod claude;
 pub mod codex;
 pub mod grok;
@@ -299,7 +299,7 @@ impl ApprovalChannelSpec {
 ///
 /// This struct carries only the metadata adapters need to construct the
 /// launch environment. The mint, write, and revoke lifecycle is owned by
-/// the trusted browser runtime (issue #2344).
+/// the trusted browser runtime (issue #2342).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct BrowserChannelSpec {
@@ -310,9 +310,10 @@ pub struct BrowserChannelSpec {
 impl BrowserChannelSpec {
     /// Adapter-owned environment key injected into every engine child.
     ///
-    /// Prefix `TIDEBREAK_` is stripped from user `extra_env` and from
-    /// the probe snapshot, so a user setting cannot shadow or override
-    /// this value.
+    /// Adapters reject `TIDEBREAK_` keys from settings with
+    /// [`Self::is_reserved_env_key`], while [`filter_child_env`] strips the
+    /// same namespace from the shell snapshot. [`Self::inject_env_tokio`]
+    /// then runs after `plan.env`, making this the final child value.
     pub const ENV_KEY: &'static str = "TIDEBREAK_BROWSER_CAPFILE";
 
     /// Construct a new spec.
@@ -321,16 +322,24 @@ impl BrowserChannelSpec {
         Self { capability_file }
     }
 
-    /// Inject the capability-file path into a [`std::process::Command`]
-    /// or [`tokio::process::Command`] as the final value for
-    /// [`Self::ENV_KEY`], after `plan.env` so it wins any shadow attempt.
-    pub fn inject_env(&self, cmd: &mut std::process::Command) {
-        cmd.env(Self::ENV_KEY, self.capability_file.as_os_str());
+    /// Return the exact key/value pair adapters inject into engine children.
+    #[must_use]
+    pub fn env_pair(&self) -> (&'static str, &std::ffi::OsStr) {
+        (Self::ENV_KEY, self.capability_file.as_os_str())
     }
 
-    /// Tokio variant of [`Self::inject_env`].
+    /// Whether a settings environment key belongs to Tidebreak rather than
+    /// the user. Adapters must reject these keys before composing a launch.
+    #[must_use]
+    pub fn is_reserved_env_key(key: &str) -> bool {
+        key.to_ascii_uppercase().starts_with("TIDEBREAK_")
+    }
+
+    /// Inject the capability-file path as the final environment value on a
+    /// Tokio engine command.
     pub fn inject_env_tokio(&self, cmd: &mut tokio::process::Command) {
-        cmd.env(Self::ENV_KEY, self.capability_file.as_os_str());
+        let (key, value) = self.env_pair();
+        cmd.env(key, value);
     }
 }
 

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -22,6 +22,7 @@ use tidebreak_core::{
 
 pub mod budget;
 pub mod child;
+pub mod browser_channel;
 pub mod claude;
 pub mod codex;
 pub mod grok;
@@ -286,6 +287,53 @@ impl ApprovalChannelSpec {
     }
 }
 
+/// Session-private browser capability-file path and metadata.
+///
+/// The trusted browser runtime writes a short-lived JSON capability file
+/// at `capability_file` before the engine child is spawned. The adapter
+/// injects only that path through a harness-owned environment key; no
+/// token, URL, or other secret enters argv, logs, approval previews, or
+/// persisted session metadata. The capability file is session-scoped: the
+/// engine's tool bridge reads it once at startup and the runtime revokes
+/// it when the session ends.
+///
+/// This struct carries only the metadata adapters need to construct the
+/// launch environment. The mint, write, and revoke lifecycle is owned by
+/// the trusted browser runtime (issue #2344).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BrowserChannelSpec {
+    /// Absolute path to the session-private capability file.
+    pub capability_file: std::path::PathBuf,
+}
+
+impl BrowserChannelSpec {
+    /// Adapter-owned environment key injected into every engine child.
+    ///
+    /// Prefix `TIDEBREAK_` is stripped from user `extra_env` and from
+    /// the probe snapshot, so a user setting cannot shadow or override
+    /// this value.
+    pub const ENV_KEY: &'static str = "TIDEBREAK_BROWSER_CAPFILE";
+
+    /// Construct a new spec.
+    #[must_use]
+    pub fn new(capability_file: std::path::PathBuf) -> Self {
+        Self { capability_file }
+    }
+
+    /// Inject the capability-file path into a [`std::process::Command`]
+    /// or [`tokio::process::Command`] as the final value for
+    /// [`Self::ENV_KEY`], after `plan.env` so it wins any shadow attempt.
+    pub fn inject_env(&self, cmd: &mut std::process::Command) {
+        cmd.env(Self::ENV_KEY, self.capability_file.as_os_str());
+    }
+
+    /// Tokio variant of [`Self::inject_env`].
+    pub fn inject_env_tokio(&self, cmd: &mut tokio::process::Command) {
+        cmd.env(Self::ENV_KEY, self.capability_file.as_os_str());
+    }
+}
+
 /// What an adapter needs to spawn or connect one session.
 pub struct SessionSpec {
     /// Worktree the engine should use as its working directory.
@@ -309,6 +357,10 @@ pub struct SessionSpec {
     pub binary: PathBuf,
     /// Where normalized events go.
     pub sink: Arc<dyn HarnessEventSink>,
+    /// Browser channel wiring, when the trusted browser runtime has
+    /// produced a session-private capability file. `None` preserves the
+    /// existing behavior: no browser tools are advertised or injected.
+    pub browser: Option<BrowserChannelSpec>,
 }
 
 /// Receives normalized events as the engine stream is parsed.

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -17,9 +17,9 @@ use tokio::time::timeout;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::opencode::parse::OpencodeStreamParser;
 use crate::{
-    filter_child_env, spawn_process_tree, ApprovalDecision, HarnessApprovalRef, HarnessError,
-    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
-    TurnInput, TurnOutcome,
+    filter_child_env, spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
+    HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
+    StreamLineBuffer, TurnInput, TurnOutcome,
 };
 use tidebreak_core::CodePermissionMode;
 
@@ -81,7 +81,7 @@ pub(crate) fn compose_serve_plan(
         )));
     }
     let mut env = extra_env.to_vec();
-    env.retain(|(key, _)| !key.to_ascii_uppercase().starts_with("TIDEBREAK_") && key != "PWD");
+    env.retain(|(key, _)| !BrowserChannelSpec::is_reserved_env_key(key) && key != "PWD");
     let plan = LaunchPlan {
         argv,
         cwd: cwd.to_path_buf(),
@@ -227,7 +227,7 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<OpencodeSession, Harness
         command.env(key, value);
     }
     if let Some(ref browser) = session.spec.browser {
-        browser.inject_env(&mut command);
+        browser.inject_env_tokio(&mut command);
     }
     let mut child = spawn_process_tree(&mut command)?;
     let stdout = child

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -226,6 +226,9 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<OpencodeSession, Harness
     for (key, value) in &plan.env {
         command.env(key, value);
     }
+    if let Some(ref browser) = session.spec.browser {
+        browser.inject_env(&mut command);
+    }
     let mut child = spawn_process_tree(&mut command)?;
     let stdout = child
         .take_stdout()

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -14,14 +14,14 @@ use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
 
+use crate::browser_channel::apply_child_env_tokio;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::opencode::parse::OpencodeStreamParser;
 use crate::{
-    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
-    HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
-    StreamLineBuffer, TurnInput, TurnOutcome,
+    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef, HarnessError,
+    HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget, StreamLineBuffer,
+    TurnInput, TurnOutcome,
 };
-use crate::browser_channel::apply_child_env_tokio;
 use tidebreak_core::CodePermissionMode;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(20);

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -17,10 +17,11 @@ use tokio::time::timeout;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::opencode::parse::OpencodeStreamParser;
 use crate::{
-    filter_child_env, spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
+    spawn_process_tree, ApprovalDecision, BrowserChannelSpec, HarnessApprovalRef,
     HarnessError, HarnessEvent, HarnessSession, ProcessTreeChild, SessionSpec, StreamBudget,
     StreamLineBuffer, TurnInput, TurnOutcome,
 };
+use crate::browser_channel::apply_child_env_tokio;
 use tidebreak_core::CodePermissionMode;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(20);
@@ -218,17 +219,13 @@ pub(super) async fn attach(spec: SessionSpec) -> Result<OpencodeSession, Harness
         .current_dir(&plan.cwd)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .env_clear();
-    for (key, value) in filter_child_env(session.spec.env.iter().cloned()) {
-        command.env(key, value);
-    }
-    for (key, value) in &plan.env {
-        command.env(key, value);
-    }
-    if let Some(ref browser) = session.spec.browser {
-        browser.inject_env_tokio(&mut command);
-    }
+        .stderr(Stdio::piped());
+    apply_child_env_tokio(
+        &mut command,
+        session.spec.env.iter().cloned(),
+        &plan.env,
+        session.spec.browser.as_ref(),
+    );
     let mut child = spawn_process_tree(&mut command)?;
     let stdout = child
         .take_stdout()

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -1,0 +1,900 @@
+//! Session-browser authority: mint, write, and revoke browser capability
+//! files for engine sessions.
+//!
+//! Each code session that needs browser access receives a scoped bearer token
+//! mapped through an in-memory route-token registry. The token plus the
+//! loopback endpoint are written into a session-private JSON capability file
+//! whose path is injected into the engine child. No owner, workspace, or
+//! session identifiers leave the server.
+//!
+//! ## Security properties
+//!
+//! * Tokens are random v4 UUIDs independent of the capability-file filename
+//!   (a separate random file id).
+//! * Reissuing for the same session holds the registry lock across the full
+//!   write + commit so revoke cannot interleave and resurrect authority.
+//! * Startup synchronously deletes every stale capfile before the returned
+//!   future is pollable, so issue cannot race an unpolled cleanup.
+//! * Capfiles are written create-new (mode 0600 on Unix) → sync → drop →
+//!   atomic rename. Temp files are deleted on every post-create failure path.
+//! * The JSON payload carries exactly `version`, `endpoint`, and `token` — no
+//!   owner, workspace, or session identifiers.
+//! * In-memory authority is revoked before best-effort file deletion.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tidebreak_core::{CodeSessionId, OwnerId, WorkspaceId};
+use tidebreak_harness::BrowserChannelSpec;
+
+/// Capfile format version. Increment when the schema changes in a backward-
+/// incompatible way.
+const CAPFILE_VERSION: u32 = 1;
+
+/// Filename prefix for capability files. Random file-id components follow.
+const CAPFILE_PREFIX: &str = "browser-cap-";
+
+/// Subdirectory under the data dir that holds session capability files.
+const CAPFILE_SUBDIR: &str = "browser-caps";
+
+// ── data types ──────────────────────────────────────────────────────────────
+
+/// The `{owner, workspace, session}` subject derived from a token look-up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BrowserSubject {
+    pub owner: OwnerId,
+    pub workspace: WorkspaceId,
+    pub session: CodeSessionId,
+}
+
+/// Per-session state held in the registry.
+#[derive(Debug, Clone)]
+struct SessionEntry {
+    /// Bearer token stored in the capfile JSON.
+    token: String,
+    /// Absolute path to the capability file.
+    capfile_path: PathBuf,
+}
+
+/// Single lock protects both mappings so issue/revoke/reissue never interleave
+/// into inconsistent state.
+struct RegistryState {
+    tokens: HashMap<String, BrowserSubject>,
+    by_session: HashMap<CodeSessionId, SessionEntry>,
+}
+
+// ── registry ────────────────────────────────────────────────────────────────
+
+/// In-memory route-token registry paired with an on-disk capability-file
+/// subtree.
+///
+/// One token per session: reissuing is transactional — the registry lock is
+/// held across capfile write + map commit so revoke cannot interleave.
+/// Startup synchronously deletes every stale capfile before any issuance
+/// can run.
+pub(crate) struct BrowserTokenRegistry {
+    state: Mutex<RegistryState>,
+    /// Absolute path to the data-dir subtree that holds capfiles. Resolved
+    /// at construction time and proven free of symlink traversal.
+    capfile_dir: PathBuf,
+    /// Loopback base URL published after bind.
+    loopback_base: Mutex<Option<String>>,
+}
+
+impl BrowserTokenRegistry {
+    /// Construct a new registry rooted at `data_dir`.
+    ///
+    /// The capfile directory is `{data_dir}/browser-caps`, resolved to a
+    /// lexical absolute path proven not to traverse a symlink outside the
+    /// trusted data-dir subtree. Returns an error if resolution fails.
+    pub(crate) fn new(data_dir: &Path) -> Result<Self, String> {
+        let joined = data_dir.join(CAPFILE_SUBDIR);
+        let capfile_dir = resolve_absolute_trusted(&joined)?;
+        Ok(Self {
+            state: Mutex::new(RegistryState {
+                tokens: HashMap::new(),
+                by_session: HashMap::new(),
+            }),
+            capfile_dir,
+            loopback_base: Mutex::new(None),
+        })
+    }
+
+    /// Publish the bound loopback base so later [`Self::issue`] calls can
+    /// write it into the capfile endpoint.
+    pub(crate) fn set_loopback_base(&self, base: &str) {
+        *self.loopback_base.lock().expect("loopback base") =
+            Some(base.trim_end_matches('/').into());
+    }
+
+    /// Remove the entire stale-capfile subtree and recreate it empty.
+    ///
+    /// Must run at startup before any session is recovered or created.
+    /// Returns an error on any failure — the caller must fail closed.
+    pub(crate) fn delete_all_stale_capfiles(&self) -> Result<(), String> {
+        // Remove the entire subtree including unknown files, subdirs, and
+        // leftover temp files.
+        match std::fs::remove_dir_all(&self.capfile_dir) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // No stale directory to remove — the ensure below recreates.
+            }
+            Err(e) => {
+                return Err(format!(
+                    "failed to remove stale browser capfile directory: {e}"
+                ));
+            }
+        }
+        // Recreate the empty directory with mode 0700.
+        if let Err(e) = std::fs::create_dir_all(&self.capfile_dir) {
+            return Err(format!("failed to recreate browser capfile directory: {e}"));
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            if let Err(e) =
+                std::fs::set_permissions(&self.capfile_dir, std::fs::Permissions::from_mode(0o700))
+            {
+                return Err(format!("could not set capfile directory mode: {e}"));
+            }
+        }
+        Ok(())
+    }
+
+    /// Mint a channel for `subject` and return the [`BrowserChannelSpec`]
+    /// the adapter injects into the engine child.
+    ///
+    /// Transactional: holds the registry lock across the capfile write and
+    /// map commit so `revoke` cannot interleave. On reissue, the prior entry
+    /// is held during the write, so its authority remains valid until the
+    /// new capfile is on disk; only then is it atomically replaced.
+    ///
+    /// Returns an error if the loopback base has not been set or the capfile
+    /// cannot be written. On error no state is committed.
+    pub(crate) fn issue(&self, subject: BrowserSubject) -> Result<BrowserChannelSpec, String> {
+        let loopback_base = self
+            .loopback_base
+            .lock()
+            .expect("loopback base")
+            .clone()
+            .ok_or_else(|| "loopback base not set".to_owned())?;
+
+        let token = generate_token();
+        let file_id = generate_file_id();
+        let capfile_path = capfile_path(&self.capfile_dir, &file_id);
+
+        // Lock the registry for the full write+commit window. This prevents
+        // revoke from deleting a capfile that the write step hasn't created
+        // yet, or from resurrecting a session whose old entry we're about to
+        // replace. The critical property: while the lock is held, no revoke
+        // targeting the same session can observe a state where a capfile
+        // exists without a valid registry entry, or vice versa.
+        let mut state = self.state.lock().expect("browser registry");
+        let old_entry = state.by_session.get(&subject.session).cloned();
+
+        // Write the new capfile. If this fails, unlock and leave state
+        // unchanged — nothing was committed.
+        match write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token) {
+            Ok(()) => {}
+            Err(e) => return Err(e),
+        }
+
+        // Commit the new mapping; the new capfile is on disk.
+        let entry = SessionEntry {
+            token: token.clone(),
+            capfile_path: capfile_path.clone(),
+        };
+        state.by_session.insert(subject.session, entry);
+        state.tokens.insert(token.clone(), subject);
+
+        // Revoke the prior authority now that the new one is committed.
+        if let Some(old) = old_entry {
+            state.tokens.remove(&old.token);
+            let _ = std::fs::remove_file(&old.capfile_path);
+        }
+
+        Ok(BrowserChannelSpec::new(capfile_path))
+    }
+
+    /// Return the subject for an inbound browser bearer token, or `None`.
+    pub(crate) fn subject_for_token(&self, token: &str) -> Option<BrowserSubject> {
+        self.state
+            .lock()
+            .expect("browser registry")
+            .tokens
+            .get(token)
+            .cloned()
+    }
+
+    /// Revoke and delete the channel for `session_id`. Idempotent.
+    ///
+    /// In-memory authority is invalidated first under the registry lock.
+    /// File deletion is best-effort because startup subtree cleanup must
+    /// fail closed regardless.
+    ///
+    /// Returns the [`BrowserSubject`] that was mapped to the revoked
+    /// session so the caller can derive an adapter scope, or `None` if
+    /// the session was not found (idempotent).
+    pub(crate) fn revoke(&self, session_id: CodeSessionId) -> Option<BrowserSubject> {
+        let mut state = self.state.lock().expect("browser registry");
+        match state.by_session.remove(&session_id) {
+            Some(entry) => {
+                let subject = state.tokens.remove(&entry.token);
+                let _ = std::fs::remove_file(&entry.capfile_path);
+                subject
+            }
+            None => None,
+        }
+    }
+
+    /// The data-dir subtree where capfiles live (for tests).
+    #[cfg(test)]
+    pub(crate) fn capfile_dir(&self) -> &Path {
+        &self.capfile_dir
+    }
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn generate_token() -> String {
+    format!("tbreak_bt_{}", uuid::Uuid::new_v4())
+}
+
+fn generate_file_id() -> String {
+    uuid::Uuid::new_v4().to_string().replace('-', "")
+}
+
+fn capfile_path(capfile_dir: &Path, file_id: &str) -> PathBuf {
+    capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, file_id))
+}
+
+/// Resolve `joined` to a lexical absolute path rooted under the trusted
+/// data-dir subtree, proven not to traverse a symlink outside.
+///
+/// Strategy: canonicalize only the data-dir prefix so any symlink chain in
+/// the parent ancestry is resolved normally. Then lexically join the trailing
+/// `browser-caps` component and check that the result is NOT an existing
+/// symlink — reject it at construction time rather than risk
+/// `remove_dir_all` or `create_dir_all` following it.
+fn resolve_absolute_trusted(joined: &Path) -> Result<PathBuf, String> {
+    // Split into parent (data_dir) and trailing (browser-caps).
+    let parent = joined
+        .parent()
+        .ok_or_else(|| "capfile path has no parent".to_owned())?;
+    let suffix = joined
+        .file_name()
+        .ok_or_else(|| "capfile path has no trailing component".to_owned())?;
+
+    let canonical_parent = parent
+        .canonicalize()
+        .map_err(|e| format!("cannot resolve data directory for browser capfiles: {e}"))?;
+
+    let absolute = canonical_parent.join(suffix);
+
+    // If the target already exists as a symlink, refuse to construct.
+    // This prevents remove_dir_all / create_dir_all from operating on
+    // a path that points outside the trusted data-dir subtree.
+    match std::fs::symlink_metadata(&absolute) {
+        Ok(meta) if meta.is_symlink() => {
+            return Err(format!(
+                "browser capfile directory is a symlink: {}",
+                absolute.display()
+            ));
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Does not exist yet — fine, it will be created on first use.
+        }
+        Err(e) => {
+            return Err(format!("cannot inspect browser capfile directory: {e}"));
+        }
+        _ => {
+            // Exists and is not a symlink — fine.
+        }
+    }
+
+    Ok(absolute)
+}
+
+/// Write `{version, endpoint, token}` safely:
+///
+/// 1. Ensure the parent directory exists with mode 0700.
+/// 2. Open a random temp file with create_new + mode 0600 (Unix).
+/// 3. Write, flush, sync, close (drop).
+/// 4. Atomic rename onto the final path.
+/// 5. On any failure after create_new, delete the temp file.
+fn write_capfile(
+    path: &Path,
+    version: u32,
+    loopback_base: &str,
+    token: &str,
+) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "capfile has no parent directory".to_owned())?;
+
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        return Err(format!("could not create capfile directory: {e}"));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Err(e) = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)) {
+            return Err(format!("could not set capfile directory mode: {e}"));
+        }
+    }
+
+    let endpoint = format!("{loopback_base}/code/browser");
+
+    let body = serde_json::json!({
+        "version": version,
+        "endpoint": endpoint,
+        "token": token,
+    });
+
+    let body_bytes =
+        serde_json::to_vec(&body).map_err(|e| format!("failed to serialize capfile: {e}"))?;
+
+    // Random temp name to avoid collision with concurrent issuances.
+    let tmp_name = format!(".{}.tmp", uuid::Uuid::new_v4().to_string().replace('-', ""));
+    let tmp_path = parent.join(&tmp_name);
+
+    // Open with create_new so two issuers cannot share a temp file.
+    let mut open_opts = std::fs::OpenOptions::new();
+    open_opts.write(true).create_new(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        open_opts.mode(0o600);
+    }
+
+    let mut file = match open_opts.open(&tmp_path) {
+        Ok(f) => f,
+        Err(e) => {
+            return Err(format!("could not create temp capfile: {e}"));
+        }
+    };
+
+    // Each step after open must clean up the temp file on failure.
+    if let Err(e) = file.write_all(&body_bytes) {
+        drop(file);
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not write capfile: {e}"));
+    }
+
+    if let Err(e) = file.flush() {
+        drop(file);
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not flush capfile: {e}"));
+    }
+
+    if let Err(e) = file.sync_all() {
+        drop(file);
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not sync capfile: {e}"));
+    }
+
+    // Defence-in-depth chmod on Unix (the open mode is primary).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Err(e) = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
+        {
+            drop(file);
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!("could not set capfile mode: {e}"));
+        }
+    }
+
+    // Explicitly drop the file handle before rename. Required for Windows
+    // (cannot rename an open handle); no-op on Unix but safe everywhere.
+    drop(file);
+
+    if let Err(e) = std::fs::rename(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not rename capfile into place: {e}"));
+    }
+
+    Ok(())
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn seeded(data_dir: &Path) -> BrowserTokenRegistry {
+        let reg = BrowserTokenRegistry::new(data_dir).unwrap();
+        reg.set_loopback_base("http://127.0.0.1:0");
+        reg
+    }
+
+    fn subject(_label: &str) -> BrowserSubject {
+        BrowserSubject {
+            owner: OwnerId::local(),
+            workspace: WorkspaceId::new(),
+            session: CodeSessionId::new(),
+        }
+    }
+
+    fn read_token_from_capfile(path: &Path) -> String {
+        let contents = std::fs::read_to_string(path).expect("read capfile");
+        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
+        value["token"].as_str().unwrap().to_owned()
+    }
+
+    // ── token ↔ file independence ───────────────────────────────────────
+
+    #[test]
+    fn filename_is_independent_of_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("indep");
+
+        let spec = reg.issue(sub.clone()).unwrap();
+        let file_stem = spec.capability_file.file_stem().unwrap().to_string_lossy();
+        let token = read_token_from_capfile(&spec.capability_file);
+
+        // The token must not appear in the filename.
+        assert!(
+            !file_stem.contains(&token),
+            "filename must not embed the bearer token: stem={file_stem}, token={token}"
+        );
+        // The file stem should start with the prefix and contain a UUID-like
+        // suffix (32 hex chars, no dashes).
+        let suffix = file_stem
+            .strip_prefix(CAPFILE_PREFIX)
+            .expect("file stem must start with CAPFILE_PREFIX");
+        assert_eq!(suffix.len(), 32, "file id must be a 32-char hex UUID");
+        assert!(
+            suffix.chars().all(|c| c.is_ascii_hexdigit()),
+            "file id must be hex digits"
+        );
+    }
+
+    #[test]
+    fn token_roundtrip_registry_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("roundtrip");
+
+        let spec = reg.issue(sub.clone()).unwrap();
+        let token = read_token_from_capfile(&spec.capability_file);
+        assert!(!token.is_empty());
+
+        let looked_up = reg.subject_for_token(&token);
+        assert_eq!(looked_up.as_ref(), Some(&sub));
+    }
+
+    // ── transactional issuance ───────────────────────────────────────────
+
+    #[test]
+    fn reissue_preserves_prior_until_new_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("transactional");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        let first_path = first.capability_file.clone();
+        assert!(first_path.exists());
+        assert_eq!(
+            reg.subject_for_token(&first_token).as_ref(),
+            Some(&sub),
+            "first token must resolve before reissue"
+        );
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+
+        // Second token is live.
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+        // First token is revoked.
+        assert!(reg.subject_for_token(&first_token).is_none());
+        // First capfile is deleted.
+        assert!(!first_path.exists());
+        // Second capfile exists.
+        assert!(second.capability_file.exists());
+        // Tokens differ.
+        assert_ne!(first_token, second_token);
+    }
+
+    #[test]
+    fn reissue_produces_different_file_paths_and_tokens() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("fileids");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        // Read the token from the first capfile BEFORE second issuance
+        // deletes it.
+        let first_token = read_token_from_capfile(&first.capability_file);
+        let first_path = first.capability_file.clone();
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+
+        assert_ne!(first_path, second.capability_file);
+        assert_ne!(first_token, second_token);
+    }
+
+    // ── revocation ───────────────────────────────────────────────────────
+
+    #[test]
+    fn revoke_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("idempotent");
+
+        let spec = reg.issue(sub.clone()).unwrap();
+        let token = read_token_from_capfile(&spec.capability_file);
+        let capfile_path = spec.capability_file.clone();
+        assert!(capfile_path.exists());
+
+        reg.revoke(sub.session);
+        assert!(!capfile_path.exists());
+        assert!(reg.subject_for_token(&token).is_none());
+
+        // Second revoke is silent.
+        reg.revoke(sub.session);
+    }
+
+    #[test]
+    fn revoke_nonexistent_session_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let nonexistent = CodeSessionId::new();
+        reg.revoke(nonexistent);
+    }
+
+    #[test]
+    fn issue_revoke_reissue_produces_fresh_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("fresh");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        reg.revoke(sub.session);
+        assert!(reg.subject_for_token(&first_token).is_none());
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+        assert_ne!(first_token, second_token);
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+    }
+
+    // ── capfile schema ───────────────────────────────────────────────────
+
+    #[test]
+    fn capfile_schema_is_exact_version_endpoint_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("schema");
+
+        let spec = reg.issue(sub).unwrap();
+        let contents = std::fs::read_to_string(&spec.capability_file).expect("read capfile");
+        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
+
+        let obj = value.as_object().expect("capfile must be a JSON object");
+        let expected: HashSet<&str> = ["version", "endpoint", "token"].iter().copied().collect();
+        let actual: HashSet<&str> = obj.keys().map(String::as_str).collect();
+
+        assert_eq!(
+            actual, expected,
+            "capfile must have exactly {{version, endpoint, token}} keys"
+        );
+        assert_eq!(value["version"], CAPFILE_VERSION);
+        assert!(value["token"].as_str().unwrap().starts_with("tbreak_bt_"));
+    }
+
+    #[test]
+    fn capfile_endpoint_derives_from_loopback_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        reg.set_loopback_base("https://tidebreak.local:4567/");
+        let sub = subject("endpoint");
+
+        let spec = reg.issue(sub).unwrap();
+        let contents = std::fs::read_to_string(&spec.capability_file).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+        assert_eq!(
+            value["endpoint"],
+            "https://tidebreak.local:4567/code/browser"
+        );
+    }
+
+    // ── startup cleanup ──────────────────────────────────────────────────
+
+    #[test]
+    fn subtree_cleanup_removes_everything_including_temp_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let capfile_dir = dir.path().join(CAPFILE_SUBDIR);
+        std::fs::create_dir_all(&capfile_dir).unwrap();
+
+        // Create various stale artifacts.
+        let stale_cap = capfile_dir.join("browser-cap-abc123.json");
+        std::fs::write(&stale_cap, b"{}").unwrap();
+        let stale_tmp = capfile_dir.join(".some-temp.tmp");
+        std::fs::write(&stale_tmp, b"orphan").unwrap();
+        let stale_subdir = capfile_dir.join("nested");
+        std::fs::create_dir(&stale_subdir).unwrap();
+        let stale_nested = stale_subdir.join("inner.txt");
+        std::fs::write(&stale_nested, b"deep").unwrap();
+
+        // An unrelated sibling directory must NOT be touched.
+        let sibling = dir.path().join("unrelated-dir");
+        std::fs::create_dir(&sibling).unwrap();
+        let sibling_file = sibling.join("keep.txt");
+        std::fs::write(&sibling_file, b"keep").unwrap();
+
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        reg.delete_all_stale_capfiles().unwrap();
+
+        // The capfile subtree should be empty (only recreated dir exists).
+        assert!(capfile_dir.exists());
+        let entries: Vec<_> = std::fs::read_dir(&capfile_dir).unwrap().collect();
+        assert!(
+            entries.is_empty(),
+            "capfile dir must be empty after cleanup"
+        );
+
+        // Sibling directory untouched.
+        assert!(sibling_file.exists());
+    }
+
+    #[test]
+    fn cleanup_no_existing_directory_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        assert!(reg.delete_all_stale_capfiles().is_ok());
+        assert!(reg.capfile_dir().exists());
+    }
+
+    // ── path hygiene ─────────────────────────────────────────────────────
+
+    #[test]
+    fn capfile_path_is_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("absolute");
+
+        let spec = reg.issue(sub).unwrap();
+        assert!(spec.capability_file.is_absolute());
+        assert!(reg.capfile_dir().is_absolute());
+    }
+
+    #[test]
+    fn capfile_dir_is_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        assert!(reg.capfile_dir().is_absolute());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_browser_caps_entry_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        // Create a target directory OUTSIDE the data dir.
+        let target = dir.path().join("evil-target");
+        std::fs::create_dir_all(&target).unwrap();
+
+        // Symlink data/browser-caps → evil-target (outside).
+        let link = data_dir.join(CAPFILE_SUBDIR);
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        // Construction must FAIL because the browser-caps component is an
+        // existing symlink.
+        let reg = BrowserTokenRegistry::new(&data_dir);
+        assert!(
+            reg.is_err(),
+            "must reject browser-caps symlink at construction"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_parent_ok_when_trailing_is_not_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Parent ancestry can have symlinks — canonicalize follows them.
+        let real_data = dir.path().join("real-data");
+        std::fs::create_dir_all(&real_data).unwrap();
+        let link_parent = dir.path().join("data");
+        std::os::unix::fs::symlink(&real_data, &link_parent).unwrap();
+
+        // Construction succeeds: the trailing browser-caps is NOT a symlink,
+        // and canonicalize(parent) resolves the ancestry normally.
+        let reg = BrowserTokenRegistry::new(&link_parent);
+        assert!(reg.is_ok());
+    }
+
+    // ── Unix permissions ─────────────────────────────────────────────────
+
+    #[cfg(unix)]
+    #[test]
+    fn capfile_is_mode_0600() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("mode");
+
+        let spec = reg.issue(sub).unwrap();
+        let meta = std::fs::metadata(&spec.capability_file).unwrap();
+        let mode = meta.permissions().mode();
+
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capfile_directory_is_mode_0700() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("dirmode");
+
+        let _spec = reg.issue(sub).unwrap();
+        let capfile_dir = reg.capfile_dir();
+        let meta = std::fs::metadata(capfile_dir).unwrap();
+        let mode = meta.permissions().mode();
+
+        assert_eq!(mode & 0o777, 0o700);
+    }
+
+    // ── temp file cleanup ────────────────────────────────────────────────
+
+    #[test]
+    fn atomic_temp_file_not_left_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("atomic");
+
+        let spec = reg.issue(sub).unwrap();
+        let parent = spec.capability_file.parent().unwrap();
+
+        let tmp_count = std::fs::read_dir(parent)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
+            .count();
+        assert_eq!(tmp_count, 0, "no .tmp files should survive atomic rename");
+    }
+
+    #[test]
+    fn revoke_and_reissue_produces_clean_slate() {
+        // After a successful issuance is revoked (simulating shutdown or
+        // error handling), a fresh issuance for the same session must
+        // produce a new token, a new capfile path, and no stale in-memory
+        // entry. Token is captured before revoke deletes the capfile.
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("cleanslate");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        let first_path = first.capability_file.clone();
+        assert!(first_path.exists());
+
+        reg.revoke(sub.session);
+        assert!(reg.subject_for_token(&first_token).is_none());
+        assert!(!first_path.exists());
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+        let second_path = second.capability_file.clone();
+
+        assert_ne!(first_token, second_token);
+        assert_ne!(first_path, second_path);
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+        assert!(second_path.exists());
+    }
+
+    #[test]
+    fn write_failure_leaves_maps_unchanged() {
+        // issue() holds the registry lock across write_capfile + map commit.
+        // A write failure drops the lock without mutating either map. Inject a
+        // platform-independent failure by temporarily replacing the capfile
+        // directory with a regular file, so create_dir_all/write_capfile must
+        // fail even when the test process has elevated privileges.
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("writefail");
+
+        // Warm up: issue once so the capfile directory exists.
+        let warm_subject = subject("warm");
+        let warm = reg.issue(warm_subject.clone()).unwrap();
+        let warm_token = read_token_from_capfile(&warm.capability_file);
+        assert!(warm.capability_file.exists());
+
+        let capdir = reg.capfile_dir().to_path_buf();
+        let held_capdir = dir.path().join("browser-caps-held");
+        std::fs::rename(&capdir, &held_capdir).expect("move capfile directory aside");
+        std::fs::write(&capdir, b"not a directory").expect("install capfile path blocker");
+
+        let result = reg.issue(sub.clone());
+
+        // Restore the original directory before asserting so a failure cannot
+        // strand the fixture in a state that obscures the registry invariant.
+        std::fs::remove_file(&capdir).expect("remove capfile path blocker");
+        std::fs::rename(&held_capdir, &capdir).expect("restore capfile directory");
+        assert!(
+            result.is_err(),
+            "issue must fail when capfile parent is a file"
+        );
+        assert_eq!(
+            reg.subject_for_token(&warm_token).as_ref(),
+            Some(&warm_subject),
+            "the prior mapping must survive the failed issuance"
+        );
+
+        // After failure, a fresh issuance for the same session must succeed
+        // without stale entries.
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+
+        // The TempDir will clean up everything when dropped.
+        let _ = warm;
+    }
+
+    // ── sequential safety ────────────────────────────────────────────────
+
+    #[test]
+    fn two_sessions_independent_lifecycles() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub_a = subject("independent-a");
+        let sub_b = subject("independent-b");
+
+        let spec_a = reg.issue(sub_a.clone()).unwrap();
+        let spec_b = reg.issue(sub_b.clone()).unwrap();
+
+        let token_a = read_token_from_capfile(&spec_a.capability_file);
+        let token_b = read_token_from_capfile(&spec_b.capability_file);
+
+        assert_ne!(token_a, token_b);
+        assert_ne!(spec_a.capability_file, spec_b.capability_file);
+
+        assert_eq!(reg.subject_for_token(&token_a).as_ref(), Some(&sub_a));
+        assert_eq!(reg.subject_for_token(&token_b).as_ref(), Some(&sub_b));
+
+        // Revoke A; B must survive.
+        reg.revoke(sub_a.session);
+        assert!(reg.subject_for_token(&token_a).is_none());
+        assert_eq!(reg.subject_for_token(&token_b).as_ref(), Some(&sub_b));
+        assert!(spec_b.capability_file.exists());
+    }
+
+    #[test]
+    fn interleaved_reissue_and_revoke_sequence() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("interleave");
+
+        // Issue → revoke → issue in sequence; the final state must be clean
+        // with exactly one live entry.
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        reg.revoke(sub.session);
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+
+        assert!(reg.subject_for_token(&first_token).is_none());
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+        assert!(!first.capability_file.exists());
+        assert!(second.capability_file.exists());
+    }
+}

--- a/crates/tidebreak-server/src/code/browser_runtime.rs
+++ b/crates/tidebreak-server/src/code/browser_runtime.rs
@@ -1,0 +1,111 @@
+//! Server-owned browser runtime integration boundary.
+//!
+//! The [`BrowserRuntime`] trait defines the public contract between the
+//! server and the desktop browser adapter. The server owns this trait and
+//! never depends on a desktop crate. The desktop implements it behind an
+//! `Arc<dyn BrowserRuntime>` and passes it to the bind-time constructor before
+//! code-session recovery starts.
+//!
+//! ## Trust boundary
+//!
+//! Every method receives a [`BrowserRuntimeScope`] derived from a validated
+//! session browser token — never from request fields. The runtime MUST
+//! validate scope before accessing any native browser resource.
+
+use async_trait::async_trait;
+
+use tidebreak_core::{
+    BrowserListResult, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
+    BrowserSnapshotArgs, CodeSessionId, OwnerId, WorkspaceId,
+};
+
+// ── BrowserRuntimeScope ─────────────────────────────────────────────────────
+
+/// The `{owner, workspace, session}` triple resolved from a browser bearer
+/// token. Route handlers derive this from the token registry; the adapter
+/// uses it to locate native browser resources.
+///
+/// Never constructed from request body fields — the route layer derives
+/// scope exclusively from the trusted token registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserRuntimeScope {
+    pub owner: OwnerId,
+    pub workspace: WorkspaceId,
+    pub session: CodeSessionId,
+}
+
+impl From<crate::code::browser_channel::BrowserSubject> for BrowserRuntimeScope {
+    fn from(subject: crate::code::browser_channel::BrowserSubject) -> Self {
+        Self {
+            owner: subject.owner,
+            workspace: subject.workspace,
+            session: subject.session,
+        }
+    }
+}
+
+// ── BrowserRuntimeError ─────────────────────────────────────────────────────
+
+/// Server-owned error taxonomy for browser operations.
+///
+/// The route layer maps every variant into a stable HTTP status and
+/// `{kind, message}` JSON body. Desktop implementations return this error
+/// rather than constructing raw [`ServerError`], which is crate-private.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BrowserRuntimeError {
+    /// The opaque browser id names no tab this subject may see.
+    UnknownBrowserId(String),
+    /// The subject's browser authority has ended.
+    SessionEnded,
+    /// The engine or platform cannot perform this operation.
+    Unsupported(String),
+    /// The page or target changed since the snapshot the caller is acting
+    /// from; a fresh snapshot is required.
+    StaleTarget,
+    /// The engine failed while performing the operation.
+    Failed(String),
+}
+
+// ── BrowserRuntime trait ────────────────────────────────────────────────────
+
+/// The server's contract with a desktop browser adapter.
+///
+/// Every method receives a [`BrowserRuntimeScope`] derived from a validated
+/// session browser token. The implementation must revalidate scope before
+/// touching any native resource — the scope alone is not authorization; the
+/// runtime owns the live grant and controller state.
+///
+/// All methods return [`BrowserRuntimeError`] so the adapter can express the
+/// error taxonomy without constructing crate-private [`crate::ServerError`]. The
+/// route layer maps errors to stable HTTP responses centrally.
+#[async_trait]
+pub trait BrowserRuntime: Send + Sync {
+    /// List browser tabs visible to the session identified by `scope`.
+    async fn list(
+        &self,
+        scope: &BrowserRuntimeScope,
+    ) -> Result<BrowserListResult, BrowserRuntimeError>;
+
+    /// Navigate a tab identified by `args.browser_id` within `scope`.
+    async fn navigate(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserNavigateArgs,
+    ) -> Result<BrowserNavigateResult, BrowserRuntimeError>;
+
+    /// Capture a semantic page snapshot for the tab in `args.browser_id`.
+    async fn snapshot(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserSnapshotArgs,
+    ) -> Result<BrowserPageSnapshot, BrowserRuntimeError>;
+
+    /// Synchronously revoke all browser capability for `scope.session`.
+    ///
+    /// Called by [`CodeRuntime`] lifecycle paths — session end, stop,
+    /// interrupt, reap, relaunch, and launch failure. Must be idempotent
+    /// and must never block on async work: the caller holds no runtime
+    /// handle after this returns and the session's browser access is dead.
+    ///
+    fn revoke_session(&self, scope: &BrowserRuntimeScope);
+}

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -6,6 +6,8 @@
 
 pub(crate) mod approval_bridge;
 pub(crate) mod attention;
+pub(crate) mod browser_channel;
+pub(crate) mod browser_runtime;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;
 pub(crate) mod clone;

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -628,6 +628,7 @@ mod tests {
             approval: None,
             binary: std::path::PathBuf::from("/scripted/engine"),
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
+            browser: None,
         })
         .await
         .unwrap();

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1748,6 +1748,7 @@ impl CodeRuntime {
             approval,
             binary,
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
+            browser: None,
         };
         let mut attached = attached;
         let engine = match adapter.launch(spec).await {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -28,6 +28,7 @@ use tidebreak_harness::{
 };
 
 use super::approval_bridge::ApprovalBridge;
+use super::browser_channel::{BrowserSubject, BrowserTokenRegistry};
 use super::bus::CodeEventBus;
 use super::checkpoint::{
     delete_workspace_refs, list_changed_files, produce_diff, resolve_diff_range,
@@ -132,6 +133,10 @@ pub(crate) struct CodeRuntime {
     pub(crate) worktree_root_default: Option<PathBuf>,
     pub blobs: Arc<dyn tidebreak_core::BlobStore>,
     pub approvals: Arc<ApprovalBridge>,
+    pub(crate) browser_tokens: BrowserTokenRegistry,
+    /// The desktop browser adapter, installed before recovery starts. Absent
+    /// in headless deployments and tests that do not register one.
+    browser_runtime: Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>>,
     host: HostEnv,
     host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     loopback_base: Mutex<Option<String>>,
@@ -165,7 +170,16 @@ impl CodeRuntime {
         data_dir: PathBuf,
         worktree_root_default: Option<PathBuf>,
         host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
+        browser_runtime: Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>>,
     ) -> Self {
+        let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            // Panic on construction failure: the data dir is trusted/absolute
+            // at this point (set from config and validated by the host). The
+            // only failure is an OS-level path resolution error such as a
+            // dangling CWD, which is a startup bug, not a runtime condition.
+            .expect("browser capfile directory must be resolvable to an absolute path");
+        #[cfg(test)]
+        browser_tokens.set_loopback_base("http://127.0.0.1:0");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),
@@ -174,6 +188,8 @@ impl CodeRuntime {
             data_dir: data_dir.clone(),
             worktree_root_default,
             approvals: ApprovalBridge::new(),
+            browser_tokens,
+            browser_runtime,
             host: HostEnv {
                 data_dir: Some(data_dir),
                 ..HostEnv::from_process()
@@ -199,6 +215,7 @@ impl CodeRuntime {
 
     /// Bound after listen so Claude can be pointed at the loopback MCP route.
     fn set_loopback_base(&self, base: String) {
+        self.browser_tokens.set_loopback_base(&base);
         *self.loopback_base.lock().expect("loopback base") =
             Some(base.trim_end_matches('/').into());
     }
@@ -218,17 +235,23 @@ impl CodeRuntime {
     pub(crate) fn start(
         self: &Arc<Self>,
         loopback_base: String,
-    ) -> impl std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> {
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> + Send>,
+    > {
         self.set_loopback_base(loopback_base);
+        // Synchronously delete stale capfiles before the returned future is
+        // pollable so issue() cannot race an unpolled startup cleanup.
+        let cleanup = self.browser_tokens.delete_all_stale_capfiles();
         let runtime = self.clone();
-        async move {
+        Box::pin(async move {
+            cleanup.map_err(ServerError::internal)?;
             let actions = runtime.recover().await;
             // After recovery so resumed watch sessions have workers to drive;
             // the sweep reads its work list from the `code_watch` table, so
             // active watches resume with no extra state.
             runtime.ensure_watch_sweep();
             actions
-        }
+        })
     }
 
     #[cfg(any(test, feature = "scripted-harness"))]
@@ -237,6 +260,24 @@ impl CodeRuntime {
         data_dir: PathBuf,
         adapters: AdapterRegistry,
     ) -> Self {
+        Self::with_registry_and_browser_runtime(db, data_dir, adapters, None)
+    }
+
+    #[cfg(any(test, feature = "scripted-harness"))]
+    pub(crate) fn with_registry_and_browser_runtime(
+        db: Arc<DbStore>,
+        data_dir: PathBuf,
+        adapters: AdapterRegistry,
+        browser_runtime: Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>>,
+    ) -> Self {
+        let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            // Panic on construction failure: the data dir is trusted/absolute
+            // at this point (set from config and validated by the host). The
+            // only failure is an OS-level path resolution error such as a
+            // dangling CWD, which is a startup bug, not a runtime condition.
+            .expect("browser capfile directory must be resolvable to an absolute path");
+        #[cfg(test)]
+        browser_tokens.set_loopback_base("http://127.0.0.1:0");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),
@@ -245,6 +286,8 @@ impl CodeRuntime {
             data_dir,
             worktree_root_default: None,
             approvals: ApprovalBridge::new(),
+            browser_tokens,
+            browser_runtime,
             host: HostEnv::from_process(),
             host_tool_broker: None,
             loopback_base: Mutex::new(None),
@@ -268,6 +311,29 @@ impl CodeRuntime {
     #[cfg(test)]
     pub(crate) fn set_gh_search_path(&self, path: Option<String>) {
         *self.gh_search_path.lock().expect("gh search path") = path;
+    }
+
+    /// Return the installed browser adapter, if any.
+    pub(crate) fn browser_runtime(
+        &self,
+    ) -> Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>> {
+        self.browser_runtime.clone()
+    }
+
+    /// Revoke the session browser token AND the desktop adapter
+    /// capability. Idempotent — safe to call multiple times.
+    ///
+    /// The token registry is invalidated first and the adapter scope is
+    /// derived from the returned [`BrowserSubject`] — no DB lookup needed.
+    /// The adapter call happens after the registry lock is released.
+    fn revoke_browser_session(&self, session_id: CodeSessionId) {
+        let subject = self.browser_tokens.revoke(session_id);
+        if let Some(subject) = subject {
+            if let Some(runtime) = &self.browser_runtime {
+                let scope = crate::code::browser_runtime::BrowserRuntimeScope::from(subject);
+                runtime.revoke_session(&scope);
+            }
+        }
     }
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
@@ -1267,6 +1333,9 @@ impl CodeRuntime {
     }
 
     pub(crate) async fn interrupt(&self, id: CodeSessionId) -> Result<(), ServerError> {
+        // Invalidate the session browser token so in-flight browser route
+        // calls are rejected immediately, then revoke the native scope.
+        self.revoke_browser_session(id);
         let handle = self.require_worker(id)?;
         let (reply, rx) = oneshot::channel();
         handle
@@ -1350,6 +1419,7 @@ impl CodeRuntime {
             ));
         }
         let handle = self.workers.lock().expect("code workers").remove(&id);
+        self.revoke_browser_session(id);
         let session = match handle {
             // The outgoing worker writes its own final state as it stops, and
             // the new spawn must not be started against a row it is still
@@ -1428,6 +1498,7 @@ impl CodeRuntime {
             .lock()
             .expect("code workers")
             .remove(&session.id);
+        self.revoke_browser_session(session.id);
         session.lifecycle = CodeSessionLifecycle::Ended;
         session.child_pid = None;
         session.fence_reason = None;
@@ -1641,6 +1712,7 @@ impl CodeRuntime {
                 .lock()
                 .expect("code workers")
                 .remove(&session.id);
+            self.revoke_browser_session(session.id);
             // Mark the row ended before asking the worker to stop. A worker
             // interrupted mid-turn re-reads the row on its way round the loop
             // and leaves on its own when it finds the session ended, so one
@@ -1737,6 +1809,16 @@ impl CodeRuntime {
             attached.subagents.clone(),
         );
         let approval = self.approval_channel(session.id, session.permission_mode);
+        let browser_subject = BrowserSubject {
+            owner: session.owner.clone(),
+            workspace: session.workspace_id,
+            session: session.id,
+        };
+        let browser = self
+            .browser_tokens
+            .issue(browser_subject)
+            .map_err(ServerError::internal)?;
+
         let spec = SessionSpec {
             worktree: PathBuf::from(&workspace.worktree_path),
             permission_mode: session.permission_mode,
@@ -1748,12 +1830,13 @@ impl CodeRuntime {
             approval,
             binary,
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
-            browser: None,
+            browser: Some(browser),
         };
         let mut attached = attached;
         let engine = match adapter.launch(spec).await {
             Ok(engine) => engine,
             Err(HarnessError::ResumeLost(detail)) => {
+                self.revoke_browser_session(session.id);
                 // The engine refused the stored resume ref. Fence with a
                 // reason the UI can explain — the fence drops the dead ref, so
                 // a reap re-attaches with a fresh engine session.
@@ -1772,6 +1855,7 @@ impl CodeRuntime {
                 ));
             }
             Err(err) => {
+                self.revoke_browser_session(session.id);
                 return Err(ServerError::internal(format!(
                     "failed to launch engine session: {err}"
                 )));
@@ -2322,7 +2406,13 @@ mod managed_node_wait_tests {
         ))
         .await
         .expect("db");
-        let runtime = CodeRuntime::new(Arc::new(db), data_dir.path().to_path_buf(), None, None);
+        let runtime = CodeRuntime::new(
+            Arc::new(db),
+            data_dir.path().to_path_buf(),
+            None,
+            None,
+            None,
+        );
 
         assert_eq!(
             runtime.managed_node_root(false).await.expect("node root"),

--- a/crates/tidebreak-server/src/error.rs
+++ b/crates/tidebreak-server/src/error.rs
@@ -41,6 +41,30 @@ impl ServerError {
         }
     }
 
+    /// A `403 Forbidden` for a caller whose token is real but whose authority
+    /// no longer covers the request (for example, an ended session).
+    pub(crate) fn forbidden(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            info: AgentErrorInfo {
+                kind: "forbidden".to_string(),
+                message: message.into(),
+            },
+        }
+    }
+
+    /// A `501 Not Implemented` for a capability this embedding does not
+    /// provide (for example, browser routes with no runtime attached).
+    pub(crate) fn not_implemented(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_IMPLEMENTED,
+            info: AgentErrorInfo {
+                kind: "not_implemented".to_string(),
+                message: message.into(),
+            },
+        }
+    }
+
     /// A `400 Bad Request` for a malformed request (bad path segment, or an
     /// unparseable / wrong-typed / wrong-content-type body). Used to map axum's
     /// built-in extractor rejections into the same `{ kind, message }` shape as

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -143,6 +143,10 @@ use tidebreak_core::{
     ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool, ToolRegistry, WriteFile,
 };
 
+/// Public contract for desktop browser adapters. The desktop implements
+/// [`BrowserRuntime`] behind an `Arc` and installs it with
+/// [`bind`] or one of its desktop variants.
+pub use crate::code::browser_runtime::{BrowserRuntime, BrowserRuntimeError, BrowserRuntimeScope};
 pub use durable_oplog::DurableOperationStore;
 pub use error::ServerError;
 pub use pairing::{
@@ -475,6 +479,22 @@ pub fn app(state: AppState) -> Router {
             get(routes::code::get_worktree_root).put(routes::code::set_worktree_root),
         )
         .route_layer(axum::middleware::from_fn(auth::require_admin));
+
+    // The engine-facing browser channel. Authenticated per request by the
+    // session-scoped capability bearer (see `routes::code::browser`), so this
+    // router is kept out of `require_token` below; the token never appears in
+    // a path or query, which is why navigate and snapshot are POST.
+    let browser_api = Router::new()
+        .route("/code/browser/list", get(routes::code::browser_list))
+        .route(
+            "/code/browser/navigate",
+            post(routes::code::browser_navigate),
+        )
+        .route(
+            "/code/browser/snapshot",
+            post(routes::code::browser_snapshot),
+        )
+        .with_state(state.clone());
 
     let api = Router::new()
         .route("/settings", get(routes::get_settings))
@@ -907,7 +927,13 @@ pub fn app(state: AppState) -> Router {
             state.clone(),
             auth::require_token,
         ))
-        .with_state(state.clone());
+        .with_state(state.clone())
+        // The engine-facing browser channel authenticates each request with
+        // the per-session capability bearer its capfile carries, never the
+        // launch token, so its routes merge after `route_layer` wrapped the
+        // routes above and stay outside `require_token`. They still sit
+        // inside `require_app_origin` and CORS with the rest of the API.
+        .merge(browser_api);
     let frame_state = state.clone();
     let auth_discovery = Router::new()
         .route("/auth/discovery", get(auth::discovery))
@@ -1134,6 +1160,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -1144,7 +1171,18 @@ pub async fn bind(config: Config) -> Result<Server> {
 /// to use [`bind`] when process-environment configuration is undesirable.
 pub async fn bind_configured(config: Config) -> Result<Server> {
     let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
-    bind_inner(config, None, mcp_servers, None, None, None, None, None).await
+    bind_inner(
+        config,
+        None,
+        mcp_servers,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
 }
 
 /// Bind the API with a stable app-private native executor identity.
@@ -1162,6 +1200,7 @@ pub async fn bind_with_desktop_executor(
         config,
         Some(client_executor_id),
         mcp_config::ConfiguredMcpServers::default(),
+        None,
         None,
         None,
         None,
@@ -1190,6 +1229,7 @@ pub async fn bind_configured_with_desktop_executor(
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -1208,6 +1248,32 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
     local_voice: Option<Arc<dyn LocalVoiceRunner>>,
     host_folders: Option<Arc<dyn host_folders::HostFolders>>,
 ) -> Result<Server> {
+    bind_configured_with_desktop_executor_and_folder_grants_and_browser_runtime(
+        config,
+        client_executor_id,
+        folder_grant_resolver,
+        office_converter,
+        host_tool_broker,
+        local_voice,
+        host_folders,
+        None,
+    )
+    .await
+}
+
+/// Desktop binding with the native host bridges plus a browser runtime that
+/// must be available before code-session recovery starts.
+#[allow(clippy::too_many_arguments)]
+pub async fn bind_configured_with_desktop_executor_and_folder_grants_and_browser_runtime(
+    config: Config,
+    client_executor_id: Uuid,
+    folder_grant_resolver: Arc<dyn code_execution::ExecFolderGrantResolver>,
+    office_converter: Option<Arc<dyn tidebreak_code_execution::HostOfficeConverter>>,
+    host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
+    local_voice: Option<Arc<dyn LocalVoiceRunner>>,
+    host_folders: Option<Arc<dyn host_folders::HostFolders>>,
+    browser_runtime: Option<Arc<dyn code::browser_runtime::BrowserRuntime>>,
+) -> Result<Server> {
     if client_executor_id.is_nil() {
         return Err(AgentError::config("client executor id must not be nil"));
     }
@@ -1221,6 +1287,7 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
         host_tool_broker,
         local_voice,
         host_folders,
+        browser_runtime,
     )
     .await
 }
@@ -1274,6 +1341,7 @@ async fn bind_inner(
     host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     local_voice: Option<Arc<dyn LocalVoiceRunner>>,
     host_folders: Option<Arc<dyn host_folders::HostFolders>>,
+    browser_runtime: Option<Arc<dyn code::browser_runtime::BrowserRuntime>>,
 ) -> Result<Server> {
     // Resolved first, before the instance lock or the store: a desktop profile
     // handed `TIDEBREAK_LISTEN_ADDR` refuses the boot rather than binding a
@@ -1497,6 +1565,7 @@ async fn bind_inner(
         state.config.data_dir.clone(),
         state.config.code_worktree_root_default.clone(),
         code_host_tool_broker,
+        browser_runtime,
     ));
     // Recovery runs after the bind, below: the workers it re-attaches need the
     // bound loopback address to reach their approval endpoint.

--- a/crates/tidebreak-server/src/routes/code/browser.rs
+++ b/crates/tidebreak-server/src/routes/code/browser.rs
@@ -1,0 +1,156 @@
+//! `/code/browser/*` routes: the engine-facing browser channel.
+//!
+//! These routes authenticate with the per-session capability bearer minted
+//! by [`crate::code::browser_channel::BrowserTokenRegistry`] — never the
+//! per-launch app token. They are registered outside `require_token` (see
+//! `crate::app`), and each handler resolves its own `Authorization` header.
+
+use std::sync::Arc;
+
+use axum::http::header::AUTHORIZATION;
+use axum::http::HeaderMap;
+
+use tidebreak_core::{
+    db, BrowserListResult, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
+    BrowserSnapshotArgs, CodeSessionLifecycle, CodeWorkspaceStatus,
+};
+
+use crate::code::browser_channel::BrowserSubject;
+use crate::code::browser_runtime::{BrowserRuntime, BrowserRuntimeError, BrowserRuntimeScope};
+use crate::error::ServerError;
+use crate::extract::Json;
+use crate::state::AppState;
+
+pub async fn browser_list(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<BrowserListResult>, ServerError> {
+    let subject = authorize(&state, &headers).await?;
+    let runtime = attached_runtime(&state)?;
+    runtime
+        .as_ref()
+        .list(&BrowserRuntimeScope::from(subject))
+        .await
+        .map(Json)
+        .map_err(map_runtime_error)
+}
+
+pub async fn browser_navigate(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+    Json(args): Json<BrowserNavigateArgs>,
+) -> Result<Json<BrowserNavigateResult>, ServerError> {
+    let subject = authorize(&state, &headers).await?;
+    require_well_formed(args.is_well_formed())?;
+    let runtime = attached_runtime(&state)?;
+    runtime
+        .as_ref()
+        .navigate(&BrowserRuntimeScope::from(subject), &args)
+        .await
+        .map(Json)
+        .map_err(map_runtime_error)
+}
+
+pub async fn browser_snapshot(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+    Json(args): Json<BrowserSnapshotArgs>,
+) -> Result<Json<BrowserPageSnapshot>, ServerError> {
+    let subject = authorize(&state, &headers).await?;
+    require_well_formed(args.is_well_formed())?;
+    let runtime = attached_runtime(&state)?;
+    runtime
+        .as_ref()
+        .snapshot(&BrowserRuntimeScope::from(subject), &args)
+        .await
+        .map(Json)
+        .map_err(map_runtime_error)
+}
+
+// ── shared refusal ladder ───────────────────────────────────────────────────
+
+async fn authorize(state: &AppState, headers: &HeaderMap) -> Result<BrowserSubject, ServerError> {
+    let token = bearer_token(headers)
+        .ok_or_else(|| ServerError::unauthorized("missing browser capability token"))?;
+    let code = state
+        .code
+        .clone()
+        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))?;
+    let subject = code
+        .browser_tokens
+        .subject_for_token(token)
+        .ok_or_else(|| ServerError::unauthorized("unknown or revoked browser capability token"))?;
+
+    let session = db::code::get_session(&code.db, &subject.owner, subject.session)
+        .await?
+        .ok_or_else(|| ServerError::forbidden("the browser session has ended"))?;
+    if matches!(
+        session.lifecycle,
+        CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+    ) {
+        return Err(ServerError::forbidden("the browser session has ended"));
+    }
+    if session.workspace_id != subject.workspace {
+        return Err(ServerError::not_found("browser target not found"));
+    }
+
+    let workspace = db::code::get_workspace(&code.db, &subject.owner, subject.workspace)
+        .await?
+        .ok_or_else(|| ServerError::not_found("browser target not found"))?;
+    if workspace.status != CodeWorkspaceStatus::Active {
+        return Err(ServerError::forbidden(
+            "the browser session's workspace is not active",
+        ));
+    }
+
+    Ok(subject)
+}
+
+fn attached_runtime(state: &AppState) -> Result<Arc<dyn BrowserRuntime>, ServerError> {
+    let code = state
+        .code
+        .as_ref()
+        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))?;
+    code.browser_runtime()
+        .ok_or_else(|| ServerError::not_implemented("this server has no in-app browser runtime"))
+}
+
+fn require_well_formed(well_formed: bool) -> Result<(), ServerError> {
+    if well_formed {
+        Ok(())
+    } else {
+        Err(ServerError::unprocessable_kind(
+            "invalid_browser_arguments",
+            "browser arguments are not well-formed",
+        ))
+    }
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")
+}
+
+fn map_runtime_error(error: BrowserRuntimeError) -> ServerError {
+    match error {
+        BrowserRuntimeError::UnknownBrowserId(id) => {
+            ServerError::not_found(format!("browser {id} not found"))
+        }
+        BrowserRuntimeError::SessionEnded => {
+            ServerError::forbidden("the browser session has ended")
+        }
+        BrowserRuntimeError::Unsupported(operation) => ServerError::not_implemented(format!(
+            "this browser engine does not support {operation}"
+        )),
+        BrowserRuntimeError::StaleTarget => ServerError::conflict_kind(
+            "stale_browser_target",
+            "the page changed since that snapshot; take a new browser_snapshot",
+        ),
+        BrowserRuntimeError::Failed(message) => {
+            ServerError::internal(format!("browser operation failed: {message}"))
+        }
+    }
+}

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -1,12 +1,17 @@
 //! `/code/*` routes: repos, workspaces, sessions, doctor, event stream.
 //!
-//! Every route here is owner-scoped through `ScopedCode`. The routes that
-//! change what the machine *is* — installing pinned harness binaries, and the
-//! clone-parent and worktree-root directories every principal shares — are
-//! registered on the deployment-plane router in `crate::lib` instead, behind
-//! `require_admin`.
+//! Every route here is owner-scoped through `ScopedCode`, with two
+//! exceptions. The routes that change what the machine *is* — installing
+//! pinned harness binaries, and the clone-parent and worktree-root
+//! directories every principal shares — are registered on the
+//! deployment-plane router in `crate::lib` instead, behind `require_admin`.
+//! And the `/code/browser/*` routes in [`browser`] authenticate with the
+//! per-session capability bearer rather than the launch token, so they are
+//! registered outside `require_token` and derive their owner from the
+//! browser token registry.
 
 mod approvals;
+mod browser;
 mod delivery;
 mod git;
 mod harnesses;
@@ -21,6 +26,7 @@ mod workspaces;
 
 pub(crate) use crate::code::approval_bridge::approval_prompt;
 pub(crate) use approvals::{decide_approval, list_approvals};
+pub(crate) use browser::{browser_list, browser_navigate, browser_snapshot};
 pub(crate) use delivery::{
     act_on_pull_request as act_on_delivery_pull_request, act_on_run as act_on_delivery_run,
     discover_repositories as discover_delivery_repositories,

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -41,6 +41,7 @@ mod app_invoke;
 mod app_library;
 mod chat_titling;
 mod code;
+mod code_browser;
 #[cfg(unix)]
 mod code_clone;
 #[cfg(unix)]

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -4468,9 +4468,27 @@ fn code_routes_go_through_the_owner_scoped_view() {
         // `types.rs` declare and shape, and serve nothing.
         let serves_data = text.contains("pub async fn") && name != "mod.rs";
         if serves_data && !text.contains("ScopedCode") {
-            findings.push(format!(
-                "{name} defines route handlers but never extracts `ScopedCode`"
-            ));
+            // The browser channel is the sole capability-bearer route: it
+            // authenticates with a session-private browser capability token
+            // (resolved into a `BrowserSubject` owner/workspace/session scope)
+            // rather than the app-token `ScopedCode` extractor. Require its
+            // own authorization path instead of the scoped extractor.
+            if name == "browser.rs" {
+                if !text.contains("fn authorize(")
+                    || !text.contains("BrowserSubject")
+                    || !text.contains("bearer_token")
+                {
+                    findings.push(format!(
+                        "{name} is the capability-bearer browser route but is \
+                         missing its `authorize` / `BrowserSubject` / \
+                         `bearer_token` authorization path"
+                    ));
+                }
+            } else {
+                findings.push(format!(
+                    "{name} defines route handlers but never extracts `ScopedCode`"
+                ));
+            }
         }
     }
     assert!(

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -1,0 +1,493 @@
+//! `/code/browser/*` routes: capability-bearer auth, subject scoping,
+//! and the runtime seam against a fake runtime.
+
+use super::*;
+
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+
+use axum::Router;
+use tokio::net::TcpListener;
+
+use crate::code::browser_channel::BrowserSubject;
+use crate::code::browser_runtime::{BrowserRuntime, BrowserRuntimeError, BrowserRuntimeScope};
+use crate::code::CodeRuntime;
+use tidebreak_core::{
+    db, Attention, AttentionSource, AttentionState, BrowserContentTrust, BrowserControllerState,
+    BrowserEngineCapabilities, BrowserEngineDescriptor, BrowserEngineName, BrowserListResult,
+    BrowserLoadState, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
+    BrowserSessionSummary, BrowserSnapshotArgs, BrowserViewport, CodePermissionMode, CodeRepo,
+    CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeWorkspace,
+    CodeWorkspaceStatus, DbStore, HarnessKind, OwnerId, RepoId, Store, WorkspaceId,
+};
+use tidebreak_harness::AdapterRegistry;
+
+#[derive(Default)]
+struct FakeBrowserRuntime {
+    calls: Mutex<Vec<(&'static str, BrowserRuntimeScope)>>,
+    revoked: Mutex<Vec<BrowserRuntimeScope>>,
+    stale: bool,
+}
+
+impl FakeBrowserRuntime {
+    fn stale() -> Self {
+        Self {
+            stale: true,
+            ..Self::default()
+        }
+    }
+    fn record(&self, m: &'static str, s: &BrowserRuntimeScope) {
+        self.calls.lock().unwrap().push((m, s.clone()));
+    }
+    fn subjects(&self) -> Vec<(&'static str, BrowserRuntimeScope)> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+fn engine() -> BrowserEngineDescriptor {
+    BrowserEngineDescriptor {
+        name: BrowserEngineName::WkWebView,
+        capabilities: BrowserEngineCapabilities {
+            lifecycle: true,
+            persistent_profile: true,
+            semantic_snapshot: true,
+            semantic_actions: false,
+            screenshot: true,
+            cross_origin_frames: false,
+            profile_reset: true,
+        },
+    }
+}
+
+#[async_trait]
+impl BrowserRuntime for FakeBrowserRuntime {
+    async fn list(
+        &self,
+        scope: &BrowserRuntimeScope,
+    ) -> Result<BrowserListResult, BrowserRuntimeError> {
+        self.record("list", scope);
+        Ok(BrowserListResult {
+            sessions: vec![BrowserSessionSummary {
+                browser_id: "browser-1".into(),
+                url: Some("https://example.com".into()),
+                title: Some("Example".into()),
+                load_state: BrowserLoadState::Ready,
+                visible: true,
+                engine: engine(),
+                controller: BrowserControllerState::default(),
+            }],
+        })
+    }
+    async fn navigate(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserNavigateArgs,
+    ) -> Result<BrowserNavigateResult, BrowserRuntimeError> {
+        self.record("navigate", scope);
+        if args.browser_id != "browser-1" {
+            return Err(BrowserRuntimeError::UnknownBrowserId(
+                args.browser_id.clone(),
+            ));
+        }
+        Ok(BrowserNavigateResult {
+            browser_id: args.browser_id.clone(),
+            url: args.url.clone(),
+            load_state: BrowserLoadState::Loading,
+            document_epoch: 2,
+        })
+    }
+    async fn snapshot(
+        &self,
+        scope: &BrowserRuntimeScope,
+        _args: &BrowserSnapshotArgs,
+    ) -> Result<BrowserPageSnapshot, BrowserRuntimeError> {
+        self.record("snapshot", scope);
+        if self.stale {
+            return Err(BrowserRuntimeError::StaleTarget);
+        }
+        Ok(BrowserPageSnapshot {
+            browser_id: "browser-1".into(),
+            snapshot_id: "snapshot-1".into(),
+            document_epoch: 2,
+            content_trust: BrowserContentTrust::UntrustedPage,
+            url: "https://example.com".into(),
+            title: "Example".into(),
+            viewport: BrowserViewport {
+                width: 800.0,
+                height: 600.0,
+                scroll_x: 0.0,
+                scroll_y: 0.0,
+            },
+            nodes: vec![],
+            frames: vec![],
+            truncated: false,
+        })
+    }
+    fn revoke_session(&self, scope: &BrowserRuntimeScope) {
+        self.revoked.lock().unwrap().push(scope.clone());
+    }
+}
+
+struct BrowserApp {
+    addr: std::net::SocketAddr,
+    code: Arc<CodeRuntime>,
+    fake: Option<Arc<FakeBrowserRuntime>>,
+    _dir: tempfile::TempDir,
+}
+
+async fn browser_app(fake: Option<Arc<FakeBrowserRuntime>>) -> BrowserApp {
+    let (dir, store) = temp_db_store("code-browser.db").await;
+    let db = Arc::new(store);
+    let st: Arc<dyn Store> = db.clone();
+    let browser_runtime = fake
+        .as_ref()
+        .map(|runtime| -> Arc<dyn BrowserRuntime> { runtime.clone() });
+    let code = Arc::new(CodeRuntime::with_registry_and_browser_runtime(
+        db,
+        dir.path().into(),
+        AdapterRegistry::new(),
+        browser_runtime,
+    ));
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        st,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(code.clone());
+    let addr = serve(app(state)).await;
+    BrowserApp {
+        addr,
+        code,
+        fake,
+        _dir: dir,
+    }
+}
+
+async fn serve(router: Router) -> std::net::SocketAddr {
+    let l = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let a = l.local_addr().unwrap();
+    tokio::spawn(async {
+        let _ = axum::serve(l, router).await;
+    });
+    a
+}
+
+async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, CodeSessionId) {
+    let repo_id = RepoId::new();
+    db::code::insert_repo(
+        db,
+        &CodeRepo {
+            id: repo_id,
+            owner: OwnerId::local(),
+            root_path: "/nonexistent-repo".into(),
+            display_name: "browser-test".into(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: vec![],
+            created_at: chrono::Utc::now(),
+        },
+    )
+    .await
+    .unwrap();
+    let ws = CodeWorkspace {
+        id: WorkspaceId::new(),
+        owner: OwnerId::local(),
+        repo_id,
+        title: "browser".into(),
+        worktree_path: "/nonexistent".into(),
+        branch_name: "tidebreak/browser".into(),
+        base_ref: "main".into(),
+        status: CodeWorkspaceStatus::Active,
+        pr: None,
+        created_at: chrono::Utc::now(),
+        archived_at: None,
+    };
+    db::code::insert_workspace(db, &ws).await.unwrap();
+    let s = CodeSession {
+        id: CodeSessionId::new(),
+        owner: OwnerId::local(),
+        workspace_id: ws.id,
+        kind: CodeSessionKind::Interactive,
+        harness_kind: HarnessKind::ClaudeCode,
+        harness_version: None,
+        harness_resume_ref: None,
+        permission_mode: CodePermissionMode::Ask,
+        model: None,
+        lifecycle: lc,
+        fence_reason: None,
+        child_pid: None,
+        spawn_epoch: 0,
+        attention: Attention::new(AttentionState::Working, AttentionSource::Lifecycle),
+        unrecognized_event_count: 0,
+        subagents: vec![],
+        created_at: chrono::Utc::now(),
+    };
+    db::code::insert_session(db, &s).await.unwrap();
+    (ws.id, s.id)
+}
+
+fn mint_token(code: &CodeRuntime, ws: WorkspaceId, s: CodeSessionId) -> String {
+    let sp = code
+        .browser_tokens
+        .issue(BrowserSubject {
+            owner: OwnerId::local(),
+            workspace: ws,
+            session: s,
+        })
+        .unwrap();
+    let c = std::fs::read_to_string(&sp.capability_file).unwrap();
+    serde_json::from_str::<serde_json::Value>(&c).unwrap()["token"]
+        .as_str()
+        .unwrap()
+        .into()
+}
+
+async fn post(
+    addr: std::net::SocketAddr,
+    rt: &str,
+    tok: Option<&str>,
+    body: serde_json::Value,
+) -> reqwest::Response {
+    let mut r = reqwest::Client::new()
+        .post(format!("http://{addr}/code/browser/{rt}"))
+        .json(&body);
+    if let Some(t) = tok {
+        r = r.bearer_auth(t);
+    }
+    r.send().await.unwrap()
+}
+async fn get(addr: std::net::SocketAddr, rt: &str, tok: Option<&str>) -> reqwest::Response {
+    let mut r = reqwest::Client::new().get(format!("http://{addr}/code/browser/{rt}"));
+    if let Some(t) = tok {
+        r = r.bearer_auth(t);
+    }
+    r.send().await.unwrap()
+}
+
+#[tokio::test]
+async fn valid_token_lists() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = get(a.addr, "list", Some(&t)).await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    let b: serde_json::Value = r.json().await.unwrap();
+    assert_eq!(b["sessions"][0]["browserId"], "browser-1");
+    let c = a.fake.as_ref().unwrap().subjects();
+    assert_eq!(c.len(), 1);
+    assert_eq!(c[0].0, "list");
+    assert_eq!(c[0].1.owner, OwnerId::local());
+    assert_eq!(c[0].1.workspace, ws);
+    assert_eq!(c[0].1.session, s);
+}
+
+#[tokio::test]
+async fn missing_and_unknown_401() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let _ = mint_token(&a.code, ws, s);
+    assert_eq!(
+        get(a.addr, "list", None).await.status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+    let g = "tbreak_bt_00000000-0000-4000-8000-000000000000";
+    let r = get(a.addr, "list", Some(g)).await;
+    assert_eq!(r.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert!(!r.text().await.unwrap().contains(g));
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
+async fn app_token_not_browser() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let _ = mint_token(&a.code, ws, s);
+    assert_eq!(
+        get(
+            a.addr,
+            "list",
+            Some(crate::state::TEST_CLIENT_EXECUTOR_TOKEN)
+        )
+        .await
+        .status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+}
+
+#[tokio::test]
+async fn revoked_then_401() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    a.code.browser_tokens.revoke(s);
+    let r = get(a.addr, "list", Some(&t)).await;
+    assert_eq!(r.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert!(!r.text().await.unwrap().contains(&t));
+}
+
+#[tokio::test]
+async fn ended_session_403() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Ended).await;
+    let t = mint_token(&a.code, ws, s);
+    assert_eq!(
+        get(a.addr, "list", Some(&t)).await.status(),
+        reqwest::StatusCode::FORBIDDEN
+    );
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
+async fn cross_workspace_404() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (_, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, WorkspaceId::new(), s);
+    assert_eq!(
+        get(a.addr, "list", Some(&t)).await.status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
+async fn missing_runtime_501() {
+    let a = browser_app(None).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = get(a.addr, "list", Some(&t)).await;
+    assert_eq!(r.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+    assert!(!r.text().await.unwrap().contains(&t));
+    assert_eq!(
+        get(a.addr, "list", Some("nope")).await.status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+}
+
+#[tokio::test]
+async fn stale_snapshot_409() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::stale()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "snapshot",
+        Some(&t),
+        serde_json::json!({"browser_id":"browser-1"}),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::CONFLICT);
+    assert_eq!(
+        r.json::<serde_json::Value>().await.unwrap()["kind"],
+        "stale_browser_target"
+    );
+}
+
+#[tokio::test]
+async fn navigate_roundtrip() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "navigate",
+        Some(&t),
+        serde_json::json!({"browser_id":"browser-1","url":"https://example.com/docs"}),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    let b: serde_json::Value = r.json().await.unwrap();
+    assert_eq!(b["url"], "https://example.com/docs");
+    assert_eq!(b["loadState"], "loading");
+    let u = post(
+        a.addr,
+        "navigate",
+        Some(&t),
+        serde_json::json!({"browser_id":"browser-9","url":"https://example.com"}),
+    )
+    .await;
+    assert_eq!(u.status(), reqwest::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn snapshot_roundtrip() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "snapshot",
+        Some(&t),
+        serde_json::json!({"browser_id":"browser-1"}),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        r.json::<serde_json::Value>().await.unwrap()["url"],
+        "https://example.com"
+    );
+}
+
+#[tokio::test]
+async fn navigate_refuses_non_http() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    for u in ["file:///etc/passwd", "https://user:secret@example.com"] {
+        assert_eq!(
+            post(
+                a.addr,
+                "navigate",
+                Some(&t),
+                serde_json::json!({"browser_id":"browser-1","url":u})
+            )
+            .await
+            .status(),
+            reqwest::StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
+async fn snapshot_needs_browser_id() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    assert_eq!(
+        post(a.addr, "snapshot", Some(&t), serde_json::json!({}))
+            .await
+            .status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+}
+
+#[tokio::test]
+async fn bodies_reject_subject_ids() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    for (rt, body) in [
+        (
+            "navigate",
+            serde_json::json!({"browser_id":"b-1","url":"https://x.com","session_id":"g"}),
+        ),
+        (
+            "snapshot",
+            serde_json::json!({"browser_id":"b-1","owner_id":"g"}),
+        ),
+    ] {
+        assert_eq!(
+            post(a.addr, rt, Some(&t), body).await.status(),
+            reqwest::StatusCode::BAD_REQUEST
+        );
+    }
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}


### PR DESCRIPTION
## Summary

Adds the engine-neutral browser channel contract consumed by Tidebreak code harnesses. This is the bounded adapter/env-injection slice of #2342 and supersedes closed PR #2361, which GitHub closed when its stacked foundation branch was deleted.

### What this delivers

- Adds optional `BrowserChannelSpec` to `SessionSpec`, carrying only a session-private capability-file path.
- Reserves `TIDEBREAK_BROWSER_CAPFILE` as an adapter-owned environment key.
- Injects the browser channel through the shared Tokio command path for Claude, Codex, OpenCode, and Grok.
- Filters reserved keys from inherited/settings environment and applies the trusted browser value last, preventing user overrides.
- Preserves existing behavior when no browser channel is present.
- Adds focused contract coverage for presence, absence, settings/snapshot override resistance, and all four adapters.
- Keeps runtime tracking references on #2342; capability mint/write/revoke and CLI routing will arrive as stacked follow-up slices.

## Trust boundary

This PR defines how a trusted, session-scoped capability-file path reaches a harness child. It does not mint tokens, write capability files, expose browser HTTP routes, or accept model-supplied workspace/browser authority.

## Validation

- `git diff --check origin/main...HEAD`
- Verified exactly four adapter call sites use `inject_env_tokio`.
- Verified no adapter calls the legacy injection path.
- Verified changed paths are limited to the harness contract/adapters and required server `SessionSpec` constructors.

Per project instruction, no Cargo, rustc, rustfmt, Rust tests, Tauri commands, or Rust-backed builds were run locally. CI is the Rust compilation authority.

## Tracking

- Epic: #2335
- Runtime/harness outcome: #2342
- Supersedes: #2361