### PR TITLE
docs(decisions): renumber the sessions record to 55

### DIFF
--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -146,7 +146,7 @@ pub(crate) struct CodeRuntime {
     /// overlap: two harnesses editing the same files, and two checkpoints
     /// racing for `.git/index.lock`, is corruption rather than concurrency.
     /// A worker takes the workspace's lock for the length of a turn, so a
-    /// sibling's turn starts after this one ends. See record 54.
+    /// sibling's turn starts after this one ends. See record 55.
     worktree_turns: Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
     pr_cache: PrDigestCache,
     pub(crate) delivery_cache: DeliveryCache,
@@ -1068,7 +1068,7 @@ impl CodeRuntime {
     /// A workspace holds any number of interactive sessions and at most one
     /// watch session, so the guard below covers watch only. The worktree they
     /// share is protected by the per-workspace turn lock rather than by a cap
-    /// on conversations; see record 54.
+    /// on conversations; see record 55.
     pub(crate) async fn create_session_of_kind(
         &self,
         owner: &OwnerId,
@@ -1263,7 +1263,7 @@ impl CodeRuntime {
         // A fenced sibling means an engine from a previous boot may still be
         // alive in this checkout, outside every lock this process holds. The
         // turn lock cannot see it, so nothing in the workspace writes until it
-        // is reaped (record 54).
+        // is reaped (record 55).
         if let Some(reason) = self.workspace_fence_reason(owner, &session).await? {
             return Err(ServerError::conflict_kind("workspace_fenced", reason));
         }
@@ -1907,7 +1907,7 @@ impl CodeRuntime {
     ///
     /// Every session in the workspace hands the same `Arc` to its worker, so
     /// the lock outlives any one session and a worker recovered after a
-    /// restart rejoins the same queue. See record 54.
+    /// restart rejoins the same queue. See record 55.
     pub(super) fn worktree_turn_lock(
         &self,
         workspace_id: WorkspaceId,

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -98,7 +98,7 @@ pub(crate) struct WorkerHandle {
 /// `pending` and `wake` are this session's own single follow-up slot
 /// (record 9). `worktree` is shared with every other session in the
 /// workspace, and holding it is what keeps two agents from editing one
-/// checkout at the same time (record 54).
+/// checkout at the same time (record 55).
 #[derive(Clone)]
 pub(crate) struct TurnQueue {
     pending: Arc<std::sync::Mutex<Option<QueuedFollowUp>>>,
@@ -379,7 +379,7 @@ impl HarnessEventSink for LiveSink {
 /// `worktree_turn` is the workspace's turn lock, shared with every other
 /// session in the same checkout. The worker holds it for the length of a
 /// turn, which is what keeps two agents from editing one worktree at once;
-/// see record 54.
+/// see record 55.
 pub(crate) fn spawn_session_worker(
     session: CodeSession,
     engine: Box<dyn HarnessSession>,
@@ -695,7 +695,7 @@ async fn drive_turn(
     }
     let images = hydrate_turn_images(blobs, &attachments).await?;
 
-    // The workspace's checkout takes one turn at a time (record 54). Taking
+    // The workspace's checkout takes one turn at a time (record 55). Taking
     // the lock *is* the reservation: a pre-flight database read cannot be,
     // because two idle siblings both pass it before either marks itself
     // running. Blobs are hydrated first so a decode never holds the tree.

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -410,7 +410,7 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
         .await;
     }
     // Another session's turn owns the worktree right now; wait. The turn lock
-    // in the worker is what actually serializes the checkout (record 54);
+    // in the worker is what actually serializes the checkout (record 55);
     // skipping the cycle here avoids waking a harness that would only queue.
     let sessions = list_sessions_for_workspace(&runtime.db, &owner, watch.workspace_id).await?;
     if sessions

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -35,7 +35,7 @@ eventually including Tidebreak's own internal loop, sits behind
 |---|---|
 | repo | A registered local git repository: root path, default base ref, branch prefix, setup/archive scripts, quick actions. |
 | workspace | One isolated unit of work on a repo. Owns exactly one git worktree and one branch for life; carries PR state. |
-| session | One durable conversation with one harness inside a workspace. A workspace holds several, plus at most one watch session; their turns are serialized on the shared worktree ([`0054`](decisions/0054-multiple-sessions-per-workspace.md)). |
+| session | One durable conversation with one harness inside a workspace. A workspace holds several, plus at most one watch session; their turns are serialized on the shared worktree ([`0055`](decisions/0055-multiple-sessions-per-workspace.md)). |
 | turn | One user→agent cycle in a session, ending in a checkpoint. |
 | harness | The external coding-agent CLI being driven (never "provider"). |
 

--- a/docs/decisions/0055-multiple-sessions-per-workspace.md
+++ b/docs/decisions/0055-multiple-sessions-per-workspace.md
@@ -1,4 +1,4 @@
-# 54. Multiple Agent Sessions Share One Workspace
+# 55. Multiple Agent Sessions Share One Workspace
 
 - Status: Accepted
 - Date: 2026-08-20

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -222,7 +222,7 @@ purpose:
   and power turn-scoped diffs; the surface that restores a workspace to an
   earlier checkpoint waits until review flows have settled.
 - **Parallel turns in one worktree.** Several agents may share a workspace
-  ([record 54](decisions/0054-multiple-sessions-per-workspace.md)), but their
+  ([record 55](decisions/0055-multiple-sessions-per-workspace.md)), but their
   turns are serialized on the checkout: two harnesses editing one tree is
   corruption, not concurrency. Running turns side by side would mean a
   worktree per session, which splits the branch, the diff, and the pull


### PR DESCRIPTION
## What

Two decision records landed as `0054`. #2351 accepted the agent-browser
contract and #2355 accepted multiple sessions per workspace, each taking "the
next number" from a `main` that did not yet have the other. The browser record
merged first, so it keeps 54 and the sessions record becomes 55.

## Why it matters

The number is how the codebase cites a record. Eleven comments across
`runtime.rs`, `session_worker.rs`, and `watch.rs` say "record 54", and after the
collision each of them names two different decisions. `docs/code-mode.md` and
`docs/deferred.md` link the file, so their links still resolved — the prose did
not.

## What changed

The file is renamed, its title goes from `# 54.` to `# 55.`, and the citations
follow. The record's text is untouched. `docs/decisions/README.md` needs no
edit: it says the directory is the index and nothing lists the records
elsewhere.

## Not included

Nothing stops this recurring. Two agents branching from the same `main` will
both take the same next number again, and no lane checks for it. A duplicate-
number check would fit the existing `scripts/*.test.mjs` pattern, but it is a
separate change from fixing the collision that already exists.

## Verification

`cargo fmt --all --check` and `cargo check -p tidebreak-server` pass. No
behavior changes — comments, docs, and one filename.
