### PR TITLE
feat(server): session browser authority — token registry and capfile lifecycle

### DIFF
--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -9,18 +9,24 @@
 //!
 //! ## Security properties
 //!
-//! * Tokens are random v4 UUIDs; reissuing for the same session silently
-//!   revokes and deletes the prior token and its capability file.
-//! * Startup deletes every stale capability file so a restarted server cannot
-//!   accept a token it did not mint.
-//! * Capfiles are written create-new → sync → chmod 0600 → atomic rename.
-//! * The JSON payload carries only `version`, `endpoint`, and `token` — no
+//! * Tokens are random v4 UUIDs independent of the capability-file filename
+//!   (a separate random file id).
+//! * Reissuing for the same session writes the new capfile first, then
+//!   commits the new mapping and revokes the prior one. The prior authority
+//!   stays valid until the new capfile is on disk and the mapping is
+//!   installed.
+//! * Startup removes the entire dedicated stale-capfile subtree, then
+//!   recreates it. A restarted server cannot accept a token it did not mint.
+//! * Capfiles are written create-new (mode 0600 on Unix) → sync → atomic
+//!   rename. Temp files are deleted on every post-create failure path.
+//! * The JSON payload carries exactly `version`, `endpoint`, and `token` — no
 //!   owner, workspace, or session identifiers.
+//! * In-memory authority is revoked before best-effort file deletion.
 
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use tidebreak_core::{CodeSessionId, OwnerId, WorkspaceId};
 use tidebreak_harness::BrowserChannelSpec;
@@ -29,11 +35,13 @@ use tidebreak_harness::BrowserChannelSpec;
 /// incompatible way.
 const CAPFILE_VERSION: u32 = 1;
 
-/// Filename prefix for capability files. Random components follow.
+/// Filename prefix for capability files. Random file-id components follow.
 const CAPFILE_PREFIX: &str = "browser-cap-";
 
 /// Subdirectory under the data dir that holds session capability files.
 const CAPFILE_SUBDIR: &str = "browser-caps";
+
+// ── data types ──────────────────────────────────────────────────────────────
 
 /// The `{owner, workspace, session}` subject derived from a token look-up.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,29 +51,59 @@ pub(crate) struct BrowserSubject {
     pub session: CodeSessionId,
 }
 
-/// In-memory route-token registry paired with an on-disk capability-file tree.
+/// Per-session state held in the registry.
+#[derive(Debug, Clone)]
+struct SessionEntry {
+    /// Random file id independent of the bearer token.
+    file_id: String,
+    /// Bearer token stored in the capfile JSON.
+    token: String,
+    /// Absolute path to the capability file.
+    capfile_path: PathBuf,
+}
+
+/// Single lock protects both mappings so issue/revoke/reissue never interleave
+/// into inconsistent state.
+struct RegistryState {
+    tokens: HashMap<String, BrowserSubject>,
+    by_session: HashMap<CodeSessionId, SessionEntry>,
+}
+
+// ── registry ────────────────────────────────────────────────────────────────
+
+/// In-memory route-token registry paired with an on-disk capability-file
+/// subtree.
 ///
-/// One token per session: reissuing silently revokes and deletes the prior
-/// token and its capability file. Startup deletes every stale file so a
-/// restarted server cannot accept a token it did not mint.
+/// One token per session: reissuing is transactional — the new capfile is
+/// written before the prior entry is revoked. Startup removes and recreates
+/// the entire dedicated subtree so a restarted server cannot accept a token
+/// it did not mint.
 pub(crate) struct BrowserTokenRegistry {
-    tokens: Mutex<HashMap<String, BrowserSubject>>,
-    by_session: Mutex<HashMap<CodeSessionId, String>>,
-    /// Absolute path to the data-dir subtree that holds capfiles.
+    state: Mutex<RegistryState>,
+    /// Absolute path to the data-dir subtree that holds capfiles. Resolved
+    /// at construction time.
     capfile_dir: PathBuf,
     /// Loopback base URL published after bind.
     loopback_base: Mutex<Option<String>>,
 }
 
 impl BrowserTokenRegistry {
-    pub(crate) fn new(data_dir: &Path) -> Self {
-        let capfile_dir = data_dir.join(CAPFILE_SUBDIR);
-        Self {
-            tokens: Mutex::new(HashMap::new()),
-            by_session: Mutex::new(HashMap::new()),
+    /// Construct a new registry rooted at `data_dir`.
+    ///
+    /// The capfile directory is `{data_dir}/browser-caps`, resolved to an
+    /// absolute path. Returns an error if the absolute path cannot be
+    /// determined.
+    pub(crate) fn new(data_dir: &Path) -> Result<Self, String> {
+        let joined = data_dir.join(CAPFILE_SUBDIR);
+        let capfile_dir = resolve_absolute(&joined)?;
+        Ok(Self {
+            state: Mutex::new(RegistryState {
+                tokens: HashMap::new(),
+                by_session: HashMap::new(),
+            }),
             capfile_dir,
             loopback_base: Mutex::new(None),
-        }
+        })
     }
 
     /// Publish the bound loopback base so later [`Self::issue`] calls can
@@ -75,48 +113,57 @@ impl BrowserTokenRegistry {
             Some(base.trim_end_matches('/').into());
     }
 
-    /// Delete every stale capability file under the capfile directory.
+    /// Remove the entire stale-capfile subtree and recreate it empty.
     ///
-    /// Must run at startup before any session is recovered or created so a
-    /// restarted server cannot accept tokens it did not mint. The in-memory
-    /// registry is always fresh on restart.
-    pub(crate) fn delete_all_stale_capfiles(&self) {
-        match std::fs::read_dir(&self.capfile_dir) {
-            Ok(entries) => {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if path
-                        .file_name()
-                        .and_then(|f| f.to_str())
-                        .is_some_and(|f| f.starts_with(CAPFILE_PREFIX))
-                    {
-                        let _ = std::fs::remove_file(&path);
-                    }
-                }
-            }
+    /// Must run at startup before any session is recovered or created.
+    /// Returns an error on any failure — the caller must fail closed.
+    pub(crate) fn delete_all_stale_capfiles(&self) -> Result<(), String> {
+        // Remove the entire subtree including unknown files, subdirs, and
+        // leftover temp files.
+        match std::fs::remove_dir_all(&self.capfile_dir) {
+            Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // The directory does not exist yet — nothing to clean.
+                // No stale directory to remove — the ensure below recreates.
             }
             Err(e) => {
-                tracing::warn!(
-                    "code-mode: could not read browser capfile directory for cleanup: {e}"
-                );
+                return Err(format!(
+                    "failed to remove stale browser capfile directory: {e}"
+                ));
             }
         }
+        // Recreate the empty directory with mode 0700.
+        if let Err(e) = std::fs::create_dir_all(&self.capfile_dir) {
+            return Err(format!(
+                "failed to recreate browser capfile directory: {e}"
+            ));
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            if let Err(e) = std::fs::set_permissions(
+                &self.capfile_dir,
+                std::fs::Permissions::from_mode(0o700),
+            ) {
+                return Err(format!("could not set capfile directory mode: {e}"));
+            }
+        }
+        Ok(())
     }
 
     /// Mint a channel for `subject` and return the [`BrowserChannelSpec`]
     /// the adapter injects into the engine child.
     ///
-    /// The returned path is always absolute because it is resolved against the
-    /// absolute `data_dir` (closing PR #2364's accepted P3 about constructor-
-    /// level path validation — the server is the single trusted constructor
-    /// site and guarantees absoluteness at this boundary).
+    /// Transactional: writes the new capfile first, then commits the in-memory
+    /// mapping. On reissue, the prior authority (token + capfile) stays valid
+    /// until the new capfile is on disk and the new mapping is installed; only
+    /// then is the prior entry revoked and its file deleted.
     ///
-    /// Reissuing for the same session revokes and deletes the prior token
-    /// and its capability file.
-    pub(crate) fn issue(&self, subject: BrowserSubject) -> Result<BrowserChannelSpec, String> {
-        let token = generate_token();
+    /// Returns an error if the loopback base has not been set, the directory
+    /// cannot be created, or the capfile cannot be written.
+    pub(crate) fn issue(
+        &self,
+        subject: BrowserSubject,
+    ) -> Result<BrowserChannelSpec, String> {
         let loopback_base = self
             .loopback_base
             .lock()
@@ -124,45 +171,60 @@ impl BrowserTokenRegistry {
             .clone()
             .ok_or_else(|| "loopback base not set".to_owned())?;
 
-        // Revoke and delete any prior token for this session.
-        {
-            let mut by_session = self.by_session.lock().expect("browser session tokens");
-            if let Some(old) = by_session.insert(subject.session, token.clone()) {
-                let mut tokens = self.tokens.lock().expect("browser tokens");
-                tokens.remove(&old);
-                let old_path = capfile_path(&self.capfile_dir, &old);
-                let _ = std::fs::remove_file(&old_path);
-            }
-            let mut tokens = self.tokens.lock().expect("browser tokens");
-            tokens.insert(token.clone(), subject);
-        }
+        let token = generate_token();
+        let file_id = generate_file_id();
+        let capfile_path = capfile_path(&self.capfile_dir, &file_id);
 
-        let capfile_path = capfile_path(&self.capfile_dir, &token);
+        // 1. Write the new capfile. If this fails, nothing has been committed.
         write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)?;
+
+        // 2. Commit the in-memory mapping.
+        let entry = SessionEntry {
+            file_id: file_id.clone(),
+            token: token.clone(),
+            capfile_path: capfile_path.clone(),
+        };
+
+        let mut state = self.state.lock().expect("browser registry");
+        // If this session already has an entry, revoke the prior one now
+        // that the new capfile is safely on disk.
+        let old_entry = state.by_session.insert(subject.session, entry);
+        state.tokens.insert(token.clone(), subject);
+
+        // 3. Clean up the prior capfile (best-effort; authority is already
+        //    invalidated in memory).
+        if let Some(old) = old_entry {
+            state.tokens.remove(&old.token);
+            let _ = std::fs::remove_file(&old.capfile_path);
+        }
 
         Ok(BrowserChannelSpec::new(capfile_path))
     }
 
     /// Return the subject for an inbound browser bearer token, or `None`.
+    ///
+    /// This API is intentionally staged — it is the seam the follow-up
+    /// `/code/browser/*` route layer will call. Dead-code lint is suppressed
+    /// until that layer lands.
+    #[allow(dead_code)]
     pub(crate) fn subject_for_token(&self, token: &str) -> Option<BrowserSubject> {
-        self.tokens
+        self.state
             .lock()
-            .expect("browser tokens")
+            .expect("browser registry")
+            .tokens
             .get(token)
             .cloned()
     }
 
     /// Revoke and delete the channel for `session_id`. Idempotent.
+    ///
+    /// In-memory authority is invalidated first. File deletion is best-effort
+    /// because startup subtree cleanup must fail closed regardless.
     pub(crate) fn revoke(&self, session_id: CodeSessionId) {
-        let token = self
-            .by_session
-            .lock()
-            .expect("browser session tokens")
-            .remove(&session_id);
-        if let Some(token) = token {
-            self.tokens.lock().expect("browser tokens").remove(&token);
-            let path = capfile_path(&self.capfile_dir, &token);
-            let _ = std::fs::remove_file(&path);
+        let mut state = self.state.lock().expect("browser registry");
+        if let Some(entry) = state.by_session.remove(&session_id) {
+            state.tokens.remove(&entry.token);
+            let _ = std::fs::remove_file(&entry.capfile_path);
         }
     }
 
@@ -173,24 +235,46 @@ impl BrowserTokenRegistry {
     }
 }
 
-// ── helpers ────────────────────────────────────────────────────────────────
+// ── helpers ─────────────────────────────────────────────────────────────────
 
 fn generate_token() -> String {
     format!("tbreak_bt_{}", uuid::Uuid::new_v4())
 }
 
-fn capfile_path(capfile_dir: &Path, token: &str) -> PathBuf {
-    capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, token))
+fn generate_file_id() -> String {
+    uuid::Uuid::new_v4().to_string().replace('-', "")
+}
+
+fn capfile_path(capfile_dir: &Path, file_id: &str) -> PathBuf {
+    capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, file_id))
+}
+
+/// Resolve `joined` to an absolute path without requiring the directory to
+/// exist on disk. Uses [`std::path::absolute`] (or canonicalize on older
+/// Rust editions) to guarantee absoluteness at the trusted boundary.
+fn resolve_absolute(joined: &Path) -> Result<PathBuf, String> {
+    // If the directory already exists, canonicalize gives us the real path.
+    // Otherwise fall back to `std::path::absolute`.
+    match joined.canonicalize() {
+        Ok(abs) => return Ok(abs),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(format!(
+                "cannot resolve browser capfile directory: {e}"
+            ));
+        }
+    }
+    std::path::absolute(joined)
+        .map_err(|e| format!("cannot resolve absolute capfile directory: {e}"))
 }
 
 /// Write `{version, endpoint, token}` safely:
 ///
-/// 1. Ensure the directory exists with mode 0700.
-/// 2. Write to a random temp name under the capfile dir.
-/// 3. Write the JSON body.
-/// 4. fsync the file.
-/// 5. Set mode 0600.
-/// 6. Atomic rename onto the final path.
+/// 1. Ensure the parent directory exists with mode 0700.
+/// 2. Open a random temp file with create_new + mode 0600 (Unix).
+/// 3. Write the JSON body, flush, sync.
+/// 4. Atomic rename onto the final path.
+/// 5. On any failure after create_new, delete the temp file.
 fn write_capfile(
     path: &Path,
     version: u32,
@@ -231,38 +315,57 @@ fn write_capfile(
         ".{}.tmp",
         uuid::Uuid::new_v4().to_string().replace('-', "")
     );
-    let tmp_path = parent.join(tmp_name);
+    let tmp_path = parent.join(&tmp_name);
 
+    // Open with create_new so two issuers cannot share a temp file.
+    let mut open_opts = std::fs::OpenOptions::new();
+    open_opts.write(true).create_new(true);
+
+    #[cfg(unix)]
     {
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&tmp_path)
-            .map_err(|e| format!("could not create temp capfile: {e}"))?;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        open_opts.mode(0o600);
+    }
 
-        file.write_all(&body_bytes)
-            .map_err(|e| format!("could not write capfile: {e}"))?;
+    let mut file = match open_opts.open(&tmp_path) {
+        Ok(f) => f,
+        Err(e) => {
+            return Err(format!("could not create temp capfile: {e}"));
+        }
+    };
 
-        file.flush()
-            .map_err(|e| format!("could not flush capfile: {e}"))?;
+    // Each step after open must clean up the temp file on failure.
+    if let Err(e) = file.write_all(&body_bytes) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not write capfile: {e}"));
+    }
 
-        file.sync_all()
-            .map_err(|e| format!("could not sync capfile: {e}"))?;
+    if let Err(e) = file.flush() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not flush capfile: {e}"));
+    }
 
-        #[cfg(unix)]
+    if let Err(e) = file.sync_all() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not sync capfile: {e}"));
+    }
+
+    // Defence-in-depth chmod on Unix (the open mode is primary).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Err(e) =
+            std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
         {
-            use std::os::unix::fs::PermissionsExt as _;
-            if let Err(e) =
-                std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
-            {
-                let _ = std::fs::remove_file(&tmp_path);
-                return Err(format!("could not set capfile mode: {e}"));
-            }
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!("could not set capfile mode: {e}"));
         }
     }
 
-    std::fs::rename(&tmp_path, path)
-        .map_err(|e| format!("could not rename capfile into place: {e}"))?;
+    if let Err(e) = std::fs::rename(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not rename capfile into place: {e}"));
+    }
 
     Ok(())
 }
@@ -272,9 +375,10 @@ fn write_capfile(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     fn seeded(data_dir: &Path) -> BrowserTokenRegistry {
-        let reg = BrowserTokenRegistry::new(data_dir);
+        let reg = BrowserTokenRegistry::new(data_dir).unwrap();
         reg.set_loopback_base("http://127.0.0.1:0");
         reg
     }
@@ -287,6 +391,46 @@ mod tests {
         }
     }
 
+    fn read_token_from_capfile(path: &Path) -> String {
+        let contents = std::fs::read_to_string(path).expect("read capfile");
+        let value: serde_json::Value =
+            serde_json::from_str(&contents).expect("parse capfile");
+        value["token"].as_str().unwrap().to_owned()
+    }
+
+    // ── token ↔ file independence ───────────────────────────────────────
+
+    #[test]
+    fn filename_is_independent_of_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("indep");
+
+        let spec = reg.issue(sub.clone()).unwrap();
+        let file_stem = spec
+            .capability_file
+            .file_stem()
+            .unwrap()
+            .to_string_lossy();
+        let token = read_token_from_capfile(&spec.capability_file);
+
+        // The token must not appear in the filename.
+        assert!(
+            !file_stem.contains(&token),
+            "filename must not embed the bearer token: stem={file_stem}, token={token}"
+        );
+        // The file stem should start with the prefix and contain a UUID-like
+        // suffix (32 hex chars, no dashes).
+        let suffix = file_stem
+            .strip_prefix(CAPFILE_PREFIX)
+            .expect("file stem must start with CAPFILE_PREFIX");
+        assert_eq!(suffix.len(), 32, "file id must be a 32-char hex UUID");
+        assert!(
+            suffix.chars().all(|c| c.is_ascii_hexdigit()),
+            "file id must be hex digits"
+        );
+    }
+
     #[test]
     fn token_roundtrip_registry_mapping() {
         let dir = tempfile::tempdir().unwrap();
@@ -294,32 +438,67 @@ mod tests {
         let sub = subject("roundtrip");
 
         let spec = reg.issue(sub.clone()).unwrap();
-        let token = extract_token_from_path(&spec.capability_file);
+        let token = read_token_from_capfile(&spec.capability_file);
         assert!(!token.is_empty());
 
         let looked_up = reg.subject_for_token(&token);
         assert_eq!(looked_up.as_ref(), Some(&sub));
     }
 
+    // ── transactional issuance ───────────────────────────────────────────
+
     #[test]
-    fn reissue_revokes_and_replaces_prior_token() {
+    fn reissue_preserves_prior_until_new_succeeds() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
-        let sub = subject("reissue");
+        let sub = subject("transactional");
 
         let first = reg.issue(sub.clone()).unwrap();
-        let first_token = extract_token_from_path(&first.capability_file);
-        assert!(first.capability_file.exists());
+        let first_token = read_token_from_capfile(&first.capability_file);
+        let first_path = first.capability_file.clone();
+        assert!(first_path.exists());
+        assert_eq!(
+            reg.subject_for_token(&first_token).as_ref(),
+            Some(&sub),
+            "first token must resolve before reissue"
+        );
 
         let second = reg.issue(sub.clone()).unwrap();
-        let second_token = extract_token_from_path(&second.capability_file);
+        let second_token = read_token_from_capfile(&second.capability_file);
 
-        assert_ne!(first_token, second_token);
-        assert!(reg.subject_for_token(&first_token).is_none());
+        // Second token is live.
         assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
-        assert!(!first.capability_file.exists());
+        // First token is revoked.
+        assert!(reg.subject_for_token(&first_token).is_none());
+        // First capfile is deleted.
+        assert!(!first_path.exists());
+        // Second capfile exists.
         assert!(second.capability_file.exists());
+        // Tokens differ.
+        assert_ne!(first_token, second_token);
     }
+
+    #[test]
+    fn reissue_different_file_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("fileids");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let second = reg.issue(sub.clone()).unwrap();
+
+        assert_ne!(
+            first.capability_file, second.capability_file,
+            "each issuance must produce a unique file path"
+        );
+        assert_ne!(
+            read_token_from_capfile(&first.capability_file),
+            read_token_from_capfile(&second.capability_file),
+            "each issuance must produce a unique token"
+        );
+    }
+
+    // ── revocation ───────────────────────────────────────────────────────
 
     #[test]
     fn revoke_idempotent() {
@@ -328,11 +507,12 @@ mod tests {
         let sub = subject("idempotent");
 
         let spec = reg.issue(sub.clone()).unwrap();
-        let token = extract_token_from_path(&spec.capability_file);
-        assert!(spec.capability_file.exists());
+        let token = read_token_from_capfile(&spec.capability_file);
+        let capfile_path = spec.capability_file.clone();
+        assert!(capfile_path.exists());
 
         reg.revoke(sub.session);
-        assert!(!spec.capability_file.exists());
+        assert!(!capfile_path.exists());
         assert!(reg.subject_for_token(&token).is_none());
 
         // Second revoke is silent.
@@ -340,33 +520,67 @@ mod tests {
     }
 
     #[test]
-    fn capfile_schema_has_no_subject_ids() {
+    fn revoke_nonexistent_session_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let nonexistent = CodeSessionId::new();
+        reg.revoke(nonexistent);
+    }
+
+    #[test]
+    fn issue_then_revoke_then_reissue_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("fresh");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        reg.revoke(sub.session);
+        assert!(reg.subject_for_token(&first_token).is_none());
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+        assert_ne!(first_token, second_token);
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+    }
+
+    // ── capfile schema ───────────────────────────────────────────────────
+
+    #[test]
+    fn capfile_schema_is_exact_version_endpoint_token() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("schema");
 
         let spec = reg.issue(sub).unwrap();
-        let contents = std::fs::read_to_string(&spec.capability_file).expect("read capfile");
-        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
+        let contents =
+            std::fs::read_to_string(&spec.capability_file).expect("read capfile");
+        let value: serde_json::Value =
+            serde_json::from_str(&contents).expect("parse capfile");
 
-        assert!(value.get("version").is_some());
-        assert!(value.get("endpoint").is_some());
-        assert!(value.get("token").is_some());
-        assert!(value.get("owner").is_none());
-        assert!(value.get("workspace").is_none());
-        assert!(value.get("session").is_none());
-        assert!(value.get("browser_id").is_none());
+        let obj = value.as_object().expect("capfile must be a JSON object");
+        let expected: HashSet<&str> =
+            ["version", "endpoint", "token"].iter().copied().collect();
+        let actual: HashSet<&str> = obj.keys().map(String::as_str).collect();
+
+        assert_eq!(
+            actual, expected,
+            "capfile must have exactly {{version, endpoint, token}} keys"
+        );
+        assert_eq!(value["version"], CAPFILE_VERSION);
+        assert!(value["token"].as_str().unwrap().starts_with("tbreak_bt_"));
     }
 
     #[test]
     fn capfile_endpoint_derives_from_loopback_base() {
         let dir = tempfile::tempdir().unwrap();
-        let reg = BrowserTokenRegistry::new(dir.path());
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
         reg.set_loopback_base("https://tidebreak.local:4567/");
         let sub = subject("endpoint");
 
         let spec = reg.issue(sub).unwrap();
-        let contents = std::fs::read_to_string(&spec.capability_file).unwrap();
+        let contents =
+            std::fs::read_to_string(&spec.capability_file).unwrap();
         let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
 
         assert_eq!(
@@ -375,33 +589,56 @@ mod tests {
         );
     }
 
+    // ── startup cleanup ──────────────────────────────────────────────────
+
     #[test]
-    fn stale_directory_cleanup_removes_known_capfiles() {
+    fn subtree_cleanup_removes_everything_including_temp_files() {
         let dir = tempfile::tempdir().unwrap();
         let capfile_dir = dir.path().join(CAPFILE_SUBDIR);
         std::fs::create_dir_all(&capfile_dir).unwrap();
 
-        let stale_path = capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, uuid::Uuid::new_v4()));
-        std::fs::write(&stale_path, b"{}").unwrap();
-        assert!(stale_path.exists());
+        // Create various stale artifacts.
+        let stale_cap = capfile_dir.join("browser-cap-abc123.json");
+        std::fs::write(&stale_cap, b"{}").unwrap();
+        let stale_tmp = capfile_dir.join(".some-temp.tmp");
+        std::fs::write(&stale_tmp, b"orphan").unwrap();
+        let stale_subdir = capfile_dir.join("nested");
+        std::fs::create_dir(&stale_subdir).unwrap();
+        let stale_nested = stale_subdir.join("inner.txt");
+        std::fs::write(&stale_nested, b"deep").unwrap();
 
-        // A non-capfile in the same dir must survive.
-        let other = capfile_dir.join("not-a-browser-file.txt");
-        std::fs::write(&other, b"do not delete").unwrap();
+        // An unrelated sibling directory must NOT be touched.
+        let sibling = dir.path().join("unrelated-dir");
+        std::fs::create_dir(&sibling).unwrap();
+        let sibling_file = sibling.join("keep.txt");
+        std::fs::write(&sibling_file, b"keep").unwrap();
 
-        let reg = BrowserTokenRegistry::new(dir.path());
-        reg.delete_all_stale_capfiles();
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        reg.delete_all_stale_capfiles().unwrap();
 
-        assert!(!stale_path.exists());
-        assert!(other.exists());
+        // The capfile subtree should be empty (only recreated dir exists).
+        assert!(capfile_dir.exists());
+        let entries: Vec<_> = std::fs::read_dir(&capfile_dir)
+            .unwrap()
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "capfile dir must be empty after cleanup"
+        );
+
+        // Sibling directory untouched.
+        assert!(sibling_file.exists());
     }
 
     #[test]
-    fn cleanup_handles_missing_directory() {
+    fn cleanup_no_existing_directory_succeeds() {
         let dir = tempfile::tempdir().unwrap();
-        let reg = BrowserTokenRegistry::new(dir.path());
-        reg.delete_all_stale_capfiles();
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        assert!(reg.delete_all_stale_capfiles().is_ok());
+        assert!(reg.capfile_dir().exists());
     }
+
+    // ── path hygiene ─────────────────────────────────────────────────────
 
     #[test]
     fn capfile_path_is_absolute() {
@@ -411,7 +648,17 @@ mod tests {
 
         let spec = reg.issue(sub).unwrap();
         assert!(spec.capability_file.is_absolute());
+        assert!(reg.capfile_dir().is_absolute());
     }
+
+    #[test]
+    fn capfile_dir_is_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        assert!(reg.capfile_dir().is_absolute());
+    }
+
+    // ── Unix permissions ─────────────────────────────────────────────────
 
     #[cfg(unix)]
     #[test]
@@ -446,8 +693,10 @@ mod tests {
         assert_eq!(mode & 0o777, 0o700);
     }
 
+    // ── temp file cleanup ────────────────────────────────────────────────
+
     #[test]
-    fn atomic_temp_file_is_cleaned_up() {
+    fn atomic_temp_file_not_left_behind() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("atomic");
@@ -458,14 +707,64 @@ mod tests {
         let tmp_count = std::fs::read_dir(parent)
             .unwrap()
             .filter_map(|e| e.ok())
-            .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with('.')
+            })
             .count();
-        assert_eq!(tmp_count, 0, "no .tmp files should survive atomic rename");
+        assert_eq!(
+            tmp_count, 0,
+            "no .tmp files should survive atomic rename"
+        );
     }
 
-    fn extract_token_from_path(path: &Path) -> String {
-        let name = path.file_stem().unwrap().to_string_lossy();
-        let without_prefix = name.strip_prefix(CAPFILE_PREFIX).unwrap();
-        without_prefix.to_owned()
+    // ── concurrent safety ────────────────────────────────────────────────
+
+    #[test]
+    fn concurrent_issuance_two_sessions_no_state_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub_a = subject("concurrent-a");
+        let sub_b = subject("concurrent-b");
+
+        let spec_a = reg.issue(sub_a.clone()).unwrap();
+        let spec_b = reg.issue(sub_b.clone()).unwrap();
+
+        let token_a = read_token_from_capfile(&spec_a.capability_file);
+        let token_b = read_token_from_capfile(&spec_b.capability_file);
+
+        assert_ne!(token_a, token_b);
+        assert_ne!(spec_a.capability_file, spec_b.capability_file);
+
+        assert_eq!(reg.subject_for_token(&token_a).as_ref(), Some(&sub_a));
+        assert_eq!(reg.subject_for_token(&token_b).as_ref(), Some(&sub_b));
+
+        // Revoke A; B must survive.
+        reg.revoke(sub_a.session);
+        assert!(reg.subject_for_token(&token_a).is_none());
+        assert_eq!(reg.subject_for_token(&token_b).as_ref(), Some(&sub_b));
+        assert!(spec_b.capability_file.exists());
+    }
+
+    #[test]
+    fn concurrent_reissue_and_revoke_no_interleaving_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("interleave");
+
+        // Issue → revoke → issue in sequence; the final state must be clean
+        // with exactly one live entry.
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        reg.revoke(sub.session);
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+
+        assert!(reg.subject_for_token(&first_token).is_none());
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+        assert!(!first.capability_file.exists());
+        assert!(second.capability_file.exists());
     }
 }

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -801,44 +801,42 @@ mod tests {
     #[test]
     fn write_failure_leaves_maps_unchanged() {
         // issue() holds the registry lock across write_capfile + map commit.
-        // A write failure drops the lock without mutating either map. On
-        // Unix we prove this by removing write permission from the capfile
-        // directory so create_new fails; then a subsequent issuance succeeds
-        // with no stale state. On non-Unix the test is a structural-invariant
-        // check: a normal issue/revoke/reissue cycle leaves clean maps.
+        // A write failure drops the lock without mutating either map. Inject a
+        // platform-independent failure by temporarily replacing the capfile
+        // directory with a regular file, so create_dir_all/write_capfile must
+        // fail even when the test process has elevated privileges.
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("writefail");
 
         // Warm up: issue once so the capfile directory exists.
         let warm = reg.issue(subject("warm")).unwrap();
+        let warm_token = read_token_from_capfile(&warm.capability_file);
         assert!(warm.capability_file.exists());
 
-        #[cfg(unix)]
-        let did_fail = {
-            use std::os::unix::fs::PermissionsExt as _;
-            let capdir = reg.capfile_dir();
-            std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o500))
-                .expect("remove write permission for failure injection");
-            let result = reg.issue(sub.clone());
-            // Restore permissions immediately.
-            std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o700))
-                .expect("restore write permission");
-            assert!(
-                result.is_err(),
-                "issue must fail when directory is read-only"
-            );
-            true
-        };
+        let capdir = reg.capfile_dir().to_path_buf();
+        let held_capdir = dir.path().join("browser-caps-held");
+        std::fs::rename(&capdir, &held_capdir).expect("move capfile directory aside");
+        std::fs::write(&capdir, b"not a directory").expect("install capfile path blocker");
 
-        // After failure (or on non-Unix, after the structural warm), a fresh
-        // issuance for the same session must succeed without stale entries.
+        let result = reg.issue(sub.clone());
+
+        // Restore the original directory before asserting so a failure cannot
+        // strand the fixture in a state that obscures the registry invariant.
+        std::fs::remove_file(&capdir).expect("remove capfile path blocker");
+        std::fs::rename(&held_capdir, &capdir).expect("restore capfile directory");
+        assert!(result.is_err(), "issue must fail when capfile parent is a file");
+        assert_eq!(
+            reg.subject_for_token(&warm_token).as_ref(),
+            Some(&subject("warm")),
+            "the prior mapping must survive the failed issuance"
+        );
+
+        // After failure, a fresh issuance for the same session must succeed
+        // without stale entries.
         let second = reg.issue(sub.clone()).unwrap();
         let second_token = read_token_from_capfile(&second.capability_file);
         assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
-
-        #[cfg(unix)]
-        let _ = did_fail;
 
         // The TempDir will clean up everything when dropped.
         let _ = warm;

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -129,17 +129,14 @@ impl BrowserTokenRegistry {
         }
         // Recreate the empty directory with mode 0700.
         if let Err(e) = std::fs::create_dir_all(&self.capfile_dir) {
-            return Err(format!(
-                "failed to recreate browser capfile directory: {e}"
-            ));
+            return Err(format!("failed to recreate browser capfile directory: {e}"));
         }
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt as _;
-            if let Err(e) = std::fs::set_permissions(
-                &self.capfile_dir,
-                std::fs::Permissions::from_mode(0o700),
-            ) {
+            if let Err(e) =
+                std::fs::set_permissions(&self.capfile_dir, std::fs::Permissions::from_mode(0o700))
+            {
                 return Err(format!("could not set capfile directory mode: {e}"));
             }
         }
@@ -156,10 +153,7 @@ impl BrowserTokenRegistry {
     ///
     /// Returns an error if the loopback base has not been set or the capfile
     /// cannot be written. On error no state is committed.
-    pub(crate) fn issue(
-        &self,
-        subject: BrowserSubject,
-    ) -> Result<BrowserChannelSpec, String> {
+    pub(crate) fn issue(&self, subject: BrowserSubject) -> Result<BrowserChannelSpec, String> {
         let loopback_base = self
             .loopback_base
             .lock()
@@ -182,8 +176,7 @@ impl BrowserTokenRegistry {
 
         // Write the new capfile. If this fails, unlock and leave state
         // unchanged — nothing was committed.
-        match write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)
-        {
+        match write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token) {
             Ok(()) => {}
             Err(e) => return Err(e),
         }
@@ -271,9 +264,9 @@ fn resolve_absolute_trusted(joined: &Path) -> Result<PathBuf, String> {
         .file_name()
         .ok_or_else(|| "capfile path has no trailing component".to_owned())?;
 
-    let canonical_parent = parent.canonicalize().map_err(|e| {
-        format!("cannot resolve data directory for browser capfiles: {e}")
-    })?;
+    let canonical_parent = parent
+        .canonicalize()
+        .map_err(|e| format!("cannot resolve data directory for browser capfiles: {e}"))?;
 
     let absolute = canonical_parent.join(suffix);
 
@@ -291,9 +284,7 @@ fn resolve_absolute_trusted(joined: &Path) -> Result<PathBuf, String> {
             // Does not exist yet — fine, it will be created on first use.
         }
         Err(e) => {
-            return Err(format!(
-                "cannot inspect browser capfile directory: {e}"
-            ));
+            return Err(format!("cannot inspect browser capfile directory: {e}"));
         }
         _ => {
             // Exists and is not a symlink — fine.
@@ -327,9 +318,7 @@ fn write_capfile(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        if let Err(e) =
-            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
-        {
+        if let Err(e) = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)) {
             return Err(format!("could not set capfile directory mode: {e}"));
         }
     }
@@ -342,14 +331,11 @@ fn write_capfile(
         "token": token,
     });
 
-    let body_bytes = serde_json::to_vec(&body)
-        .map_err(|e| format!("failed to serialize capfile: {e}"))?;
+    let body_bytes =
+        serde_json::to_vec(&body).map_err(|e| format!("failed to serialize capfile: {e}"))?;
 
     // Random temp name to avoid collision with concurrent issuances.
-    let tmp_name = format!(
-        ".{}.tmp",
-        uuid::Uuid::new_v4().to_string().replace('-', "")
-    );
+    let tmp_name = format!(".{}.tmp", uuid::Uuid::new_v4().to_string().replace('-', ""));
     let tmp_path = parent.join(&tmp_name);
 
     // Open with create_new so two issuers cannot share a temp file.
@@ -392,8 +378,7 @@ fn write_capfile(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        if let Err(e) =
-            std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
+        if let Err(e) = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
         {
             drop(file);
             let _ = std::fs::remove_file(&tmp_path);
@@ -436,8 +421,7 @@ mod tests {
 
     fn read_token_from_capfile(path: &Path) -> String {
         let contents = std::fs::read_to_string(path).expect("read capfile");
-        let value: serde_json::Value =
-            serde_json::from_str(&contents).expect("parse capfile");
+        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
         value["token"].as_str().unwrap().to_owned()
     }
 
@@ -450,11 +434,7 @@ mod tests {
         let sub = subject("indep");
 
         let spec = reg.issue(sub.clone()).unwrap();
-        let file_stem = spec
-            .capability_file
-            .file_stem()
-            .unwrap()
-            .to_string_lossy();
+        let file_stem = spec.capability_file.file_stem().unwrap().to_string_lossy();
         let token = read_token_from_capfile(&spec.capability_file);
 
         // The token must not appear in the filename.
@@ -595,14 +575,11 @@ mod tests {
         let sub = subject("schema");
 
         let spec = reg.issue(sub).unwrap();
-        let contents =
-            std::fs::read_to_string(&spec.capability_file).expect("read capfile");
-        let value: serde_json::Value =
-            serde_json::from_str(&contents).expect("parse capfile");
+        let contents = std::fs::read_to_string(&spec.capability_file).expect("read capfile");
+        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
 
         let obj = value.as_object().expect("capfile must be a JSON object");
-        let expected: HashSet<&str> =
-            ["version", "endpoint", "token"].iter().copied().collect();
+        let expected: HashSet<&str> = ["version", "endpoint", "token"].iter().copied().collect();
         let actual: HashSet<&str> = obj.keys().map(String::as_str).collect();
 
         assert_eq!(
@@ -621,8 +598,7 @@ mod tests {
         let sub = subject("endpoint");
 
         let spec = reg.issue(sub).unwrap();
-        let contents =
-            std::fs::read_to_string(&spec.capability_file).unwrap();
+        let contents = std::fs::read_to_string(&spec.capability_file).unwrap();
         let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
 
         assert_eq!(
@@ -660,9 +636,7 @@ mod tests {
 
         // The capfile subtree should be empty (only recreated dir exists).
         assert!(capfile_dir.exists());
-        let entries: Vec<_> = std::fs::read_dir(&capfile_dir)
-            .unwrap()
-            .collect();
+        let entries: Vec<_> = std::fs::read_dir(&capfile_dir).unwrap().collect();
         assert!(
             entries.is_empty(),
             "capfile dir must be empty after cleanup"
@@ -790,16 +764,9 @@ mod tests {
         let tmp_count = std::fs::read_dir(parent)
             .unwrap()
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .starts_with('.')
-            })
+            .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
             .count();
-        assert_eq!(
-            tmp_count, 0,
-            "no .tmp files should survive atomic rename"
-        );
+        assert_eq!(tmp_count, 0, "no .tmp files should survive atomic rename");
     }
 
     #[test]
@@ -857,7 +824,10 @@ mod tests {
             // Restore permissions immediately.
             std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o700))
                 .expect("restore write permission");
-            assert!(result.is_err(), "issue must fail when directory is read-only");
+            assert!(
+                result.is_err(),
+                "issue must fail when directory is read-only"
+            );
             true
         };
 

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -825,7 +825,10 @@ mod tests {
         // strand the fixture in a state that obscures the registry invariant.
         std::fs::remove_file(&capdir).expect("remove capfile path blocker");
         std::fs::rename(&held_capdir, &capdir).expect("restore capfile directory");
-        assert!(result.is_err(), "issue must fail when capfile parent is a file");
+        assert!(
+            result.is_err(),
+            "issue must fail when capfile parent is a file"
+        );
         assert_eq!(
             reg.subject_for_token(&warm_token).as_ref(),
             Some(&subject("warm")),

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -11,14 +11,12 @@
 //!
 //! * Tokens are random v4 UUIDs independent of the capability-file filename
 //!   (a separate random file id).
-//! * Reissuing for the same session writes the new capfile first, then
-//!   commits the new mapping and revokes the prior one. The prior authority
-//!   stays valid until the new capfile is on disk and the mapping is
-//!   installed.
-//! * Startup removes the entire dedicated stale-capfile subtree, then
-//!   recreates it. A restarted server cannot accept a token it did not mint.
-//! * Capfiles are written create-new (mode 0600 on Unix) → sync → atomic
-//!   rename. Temp files are deleted on every post-create failure path.
+//! * Reissuing for the same session holds the registry lock across the full
+//!   write + commit so revoke cannot interleave and resurrect authority.
+//! * Startup synchronously deletes every stale capfile before the returned
+//!   future is pollable, so issue cannot race an unpolled cleanup.
+//! * Capfiles are written create-new (mode 0600 on Unix) → sync → drop →
+//!   atomic rename. Temp files are deleted on every post-create failure path.
 //! * The JSON payload carries exactly `version`, `endpoint`, and `token` — no
 //!   owner, workspace, or session identifiers.
 //! * In-memory authority is revoked before best-effort file deletion.
@@ -54,8 +52,6 @@ pub(crate) struct BrowserSubject {
 /// Per-session state held in the registry.
 #[derive(Debug, Clone)]
 struct SessionEntry {
-    /// Random file id independent of the bearer token.
-    file_id: String,
     /// Bearer token stored in the capfile JSON.
     token: String,
     /// Absolute path to the capability file.
@@ -74,14 +70,14 @@ struct RegistryState {
 /// In-memory route-token registry paired with an on-disk capability-file
 /// subtree.
 ///
-/// One token per session: reissuing is transactional — the new capfile is
-/// written before the prior entry is revoked. Startup removes and recreates
-/// the entire dedicated subtree so a restarted server cannot accept a token
-/// it did not mint.
+/// One token per session: reissuing is transactional — the registry lock is
+/// held across capfile write + map commit so revoke cannot interleave.
+/// Startup synchronously deletes every stale capfile before any issuance
+/// can run.
 pub(crate) struct BrowserTokenRegistry {
     state: Mutex<RegistryState>,
     /// Absolute path to the data-dir subtree that holds capfiles. Resolved
-    /// at construction time.
+    /// at construction time and proven free of symlink traversal.
     capfile_dir: PathBuf,
     /// Loopback base URL published after bind.
     loopback_base: Mutex<Option<String>>,
@@ -90,12 +86,12 @@ pub(crate) struct BrowserTokenRegistry {
 impl BrowserTokenRegistry {
     /// Construct a new registry rooted at `data_dir`.
     ///
-    /// The capfile directory is `{data_dir}/browser-caps`, resolved to an
-    /// absolute path. Returns an error if the absolute path cannot be
-    /// determined.
+    /// The capfile directory is `{data_dir}/browser-caps`, resolved to a
+    /// lexical absolute path proven not to traverse a symlink outside the
+    /// trusted data-dir subtree. Returns an error if resolution fails.
     pub(crate) fn new(data_dir: &Path) -> Result<Self, String> {
         let joined = data_dir.join(CAPFILE_SUBDIR);
-        let capfile_dir = resolve_absolute(&joined)?;
+        let capfile_dir = resolve_absolute_trusted(&joined)?;
         Ok(Self {
             state: Mutex::new(RegistryState {
                 tokens: HashMap::new(),
@@ -153,13 +149,13 @@ impl BrowserTokenRegistry {
     /// Mint a channel for `subject` and return the [`BrowserChannelSpec`]
     /// the adapter injects into the engine child.
     ///
-    /// Transactional: writes the new capfile first, then commits the in-memory
-    /// mapping. On reissue, the prior authority (token + capfile) stays valid
-    /// until the new capfile is on disk and the new mapping is installed; only
-    /// then is the prior entry revoked and its file deleted.
+    /// Transactional: holds the registry lock across the capfile write and
+    /// map commit so `revoke` cannot interleave. On reissue, the prior entry
+    /// is held during the write, so its authority remains valid until the
+    /// new capfile is on disk; only then is it atomically replaced.
     ///
-    /// Returns an error if the loopback base has not been set, the directory
-    /// cannot be created, or the capfile cannot be written.
+    /// Returns an error if the loopback base has not been set or the capfile
+    /// cannot be written. On error no state is committed.
     pub(crate) fn issue(
         &self,
         subject: BrowserSubject,
@@ -175,24 +171,32 @@ impl BrowserTokenRegistry {
         let file_id = generate_file_id();
         let capfile_path = capfile_path(&self.capfile_dir, &file_id);
 
-        // 1. Write the new capfile. If this fails, nothing has been committed.
-        write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)?;
+        // Lock the registry for the full write+commit window. This prevents
+        // revoke from deleting a capfile that the write step hasn't created
+        // yet, or from resurrecting a session whose old entry we're about to
+        // replace. The critical property: while the lock is held, no revoke
+        // targeting the same session can observe a state where a capfile
+        // exists without a valid registry entry, or vice versa.
+        let mut state = self.state.lock().expect("browser registry");
+        let old_entry = state.by_session.get(&subject.session).cloned();
 
-        // 2. Commit the in-memory mapping.
+        // Write the new capfile. If this fails, unlock and leave state
+        // unchanged — nothing was committed.
+        match write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)
+        {
+            Ok(()) => {}
+            Err(e) => return Err(e),
+        }
+
+        // Commit the new mapping; the new capfile is on disk.
         let entry = SessionEntry {
-            file_id: file_id.clone(),
             token: token.clone(),
             capfile_path: capfile_path.clone(),
         };
-
-        let mut state = self.state.lock().expect("browser registry");
-        // If this session already has an entry, revoke the prior one now
-        // that the new capfile is safely on disk.
-        let old_entry = state.by_session.insert(subject.session, entry);
+        state.by_session.insert(subject.session, entry);
         state.tokens.insert(token.clone(), subject);
 
-        // 3. Clean up the prior capfile (best-effort; authority is already
-        //    invalidated in memory).
+        // Revoke the prior authority now that the new one is committed.
         if let Some(old) = old_entry {
             state.tokens.remove(&old.token);
             let _ = std::fs::remove_file(&old.capfile_path);
@@ -218,8 +222,9 @@ impl BrowserTokenRegistry {
 
     /// Revoke and delete the channel for `session_id`. Idempotent.
     ///
-    /// In-memory authority is invalidated first. File deletion is best-effort
-    /// because startup subtree cleanup must fail closed regardless.
+    /// In-memory authority is invalidated first under the registry lock.
+    /// File deletion is best-effort because startup subtree cleanup must
+    /// fail closed regardless.
     pub(crate) fn revoke(&self, session_id: CodeSessionId) {
         let mut state = self.state.lock().expect("browser registry");
         if let Some(entry) = state.by_session.remove(&session_id) {
@@ -249,30 +254,60 @@ fn capfile_path(capfile_dir: &Path, file_id: &str) -> PathBuf {
     capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, file_id))
 }
 
-/// Resolve `joined` to an absolute path without requiring the directory to
-/// exist on disk. Uses [`std::path::absolute`] (or canonicalize on older
-/// Rust editions) to guarantee absoluteness at the trusted boundary.
-fn resolve_absolute(joined: &Path) -> Result<PathBuf, String> {
-    // If the directory already exists, canonicalize gives us the real path.
-    // Otherwise fall back to `std::path::absolute`.
-    match joined.canonicalize() {
-        Ok(abs) => return Ok(abs),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => {
+/// Resolve `joined` to a lexical absolute path rooted under the trusted
+/// data-dir subtree, proven not to traverse a symlink outside.
+///
+/// Strategy: canonicalize only the data-dir prefix so any symlink chain in
+/// the parent ancestry is resolved normally. Then lexically join the trailing
+/// `browser-caps` component and check that the result is NOT an existing
+/// symlink — reject it at construction time rather than risk
+/// `remove_dir_all` or `create_dir_all` following it.
+fn resolve_absolute_trusted(joined: &Path) -> Result<PathBuf, String> {
+    // Split into parent (data_dir) and trailing (browser-caps).
+    let parent = joined
+        .parent()
+        .ok_or_else(|| "capfile path has no parent".to_owned())?;
+    let suffix = joined
+        .file_name()
+        .ok_or_else(|| "capfile path has no trailing component".to_owned())?;
+
+    let canonical_parent = parent.canonicalize().map_err(|e| {
+        format!("cannot resolve data directory for browser capfiles: {e}")
+    })?;
+
+    let absolute = canonical_parent.join(suffix);
+
+    // If the target already exists as a symlink, refuse to construct.
+    // This prevents remove_dir_all / create_dir_all from operating on
+    // a path that points outside the trusted data-dir subtree.
+    match std::fs::symlink_metadata(&absolute) {
+        Ok(meta) if meta.is_symlink() => {
             return Err(format!(
-                "cannot resolve browser capfile directory: {e}"
+                "browser capfile directory is a symlink: {}",
+                absolute.display()
             ));
         }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Does not exist yet — fine, it will be created on first use.
+        }
+        Err(e) => {
+            return Err(format!(
+                "cannot inspect browser capfile directory: {e}"
+            ));
+        }
+        _ => {
+            // Exists and is not a symlink — fine.
+        }
     }
-    std::path::absolute(joined)
-        .map_err(|e| format!("cannot resolve absolute capfile directory: {e}"))
+
+    Ok(absolute)
 }
 
 /// Write `{version, endpoint, token}` safely:
 ///
 /// 1. Ensure the parent directory exists with mode 0700.
 /// 2. Open a random temp file with create_new + mode 0600 (Unix).
-/// 3. Write the JSON body, flush, sync.
+/// 3. Write, flush, sync, close (drop).
 /// 4. Atomic rename onto the final path.
 /// 5. On any failure after create_new, delete the temp file.
 fn write_capfile(
@@ -361,6 +396,10 @@ fn write_capfile(
             return Err(format!("could not set capfile mode: {e}"));
         }
     }
+
+    // Explicitly drop the file handle before rename. Required for Windows
+    // (cannot rename an open handle); no-op on Unix but safe everywhere.
+    drop(file);
 
     if let Err(e) = std::fs::rename(&tmp_path, path) {
         let _ = std::fs::remove_file(&tmp_path);
@@ -479,23 +518,22 @@ mod tests {
     }
 
     #[test]
-    fn reissue_different_file_ids() {
+    fn reissue_produces_different_file_paths_and_tokens() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("fileids");
 
         let first = reg.issue(sub.clone()).unwrap();
-        let second = reg.issue(sub.clone()).unwrap();
+        // Read the token from the first capfile BEFORE second issuance
+        // deletes it.
+        let first_token = read_token_from_capfile(&first.capability_file);
+        let first_path = first.capability_file.clone();
 
-        assert_ne!(
-            first.capability_file, second.capability_file,
-            "each issuance must produce a unique file path"
-        );
-        assert_ne!(
-            read_token_from_capfile(&first.capability_file),
-            read_token_from_capfile(&second.capability_file),
-            "each issuance must produce a unique token"
-        );
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+
+        assert_ne!(first_path, second.capability_file);
+        assert_ne!(first_token, second_token);
     }
 
     // ── revocation ───────────────────────────────────────────────────────
@@ -528,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    fn issue_then_revoke_then_reissue_fresh() {
+    fn issue_revoke_reissue_produces_fresh_authority() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("fresh");
@@ -658,6 +696,47 @@ mod tests {
         assert!(reg.capfile_dir().is_absolute());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_browser_caps_entry_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        // Create a target directory OUTSIDE the data dir.
+        let target = dir.path().join("evil-target");
+        std::fs::create_dir_all(&target).unwrap();
+
+        // Symlink data/browser-caps → evil-target (outside).
+        let link = data_dir.join(CAPFILE_SUBDIR);
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        // Construction must FAIL because the browser-caps component is an
+        // existing symlink.
+        let reg = BrowserTokenRegistry::new(&data_dir);
+        assert!(
+            reg.is_err(),
+            "must reject browser-caps symlink at construction"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_parent_ok_when_trailing_is_not_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Parent ancestry can have symlinks — canonicalize follows them.
+        let real_data = dir.path().join("real-data");
+        std::fs::create_dir_all(&real_data).unwrap();
+        let link_parent = dir.path().join("data");
+        std::os::unix::fs::symlink(&real_data, &link_parent).unwrap();
+
+        // Construction succeeds: the trailing browser-caps is NOT a symlink,
+        // and canonicalize(parent) resolves the ancestry normally.
+        let reg = BrowserTokenRegistry::new(&link_parent);
+        assert!(reg.is_ok());
+    }
+
     // ── Unix permissions ─────────────────────────────────────────────────
 
     #[cfg(unix)]
@@ -719,14 +798,44 @@ mod tests {
         );
     }
 
-    // ── concurrent safety ────────────────────────────────────────────────
-
     #[test]
-    fn concurrent_issuance_two_sessions_no_state_corruption() {
+    fn failed_write_does_not_leave_stale_in_memory_entry() {
+        // issue() holds the registry lock across write_capfile + map commit.
+        // On any write error the lock drops with the maps unchanged, so a
+        // subsequent issuance for the same session can proceed cleanly.
+        // This test proves the happy path after an error: issue → revoke →
+        // issue, simulating the normal lifecycle where a transient write
+        // failure was already handled by the caller.
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
-        let sub_a = subject("concurrent-a");
-        let sub_b = subject("concurrent-b");
+        let sub = subject("writefail");
+
+        // Issue, then revoke — simulates the caller cleaning up after a
+        // successful issuance that was no longer needed (or after a transient
+        // failure that was already retried and then revoked).
+        let first = reg.issue(sub.clone()).unwrap();
+        reg.revoke(sub.session);
+        assert!(reg.subject_for_token(
+            &read_token_from_capfile(&first.capability_file)
+        ).is_none());
+        assert!(!first.capability_file.exists());
+
+        // A fresh issuance must succeed with a clean state — no stale
+        // token or session entry survived the revoke.
+        let second = reg.issue(sub.clone()).unwrap();
+        let token = read_token_from_capfile(&second.capability_file);
+        assert_eq!(reg.subject_for_token(&token).as_ref(), Some(&sub));
+        assert!(second.capability_file.exists());
+    }
+
+    // ── sequential safety ────────────────────────────────────────────────
+
+    #[test]
+    fn two_sessions_independent_lifecycles() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub_a = subject("independent-a");
+        let sub_b = subject("independent-b");
 
         let spec_a = reg.issue(sub_a.clone()).unwrap();
         let spec_b = reg.issue(sub_b.clone()).unwrap();
@@ -748,7 +857,7 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_reissue_and_revoke_no_interleaving_corruption() {
+    fn interleaved_reissue_and_revoke_sequence() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("interleave");

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -810,7 +810,8 @@ mod tests {
         let sub = subject("writefail");
 
         // Warm up: issue once so the capfile directory exists.
-        let warm = reg.issue(subject("warm")).unwrap();
+        let warm_subject = subject("warm");
+        let warm = reg.issue(warm_subject.clone()).unwrap();
         let warm_token = read_token_from_capfile(&warm.capability_file);
         assert!(warm.capability_file.exists());
 
@@ -831,7 +832,7 @@ mod tests {
         );
         assert_eq!(
             reg.subject_for_token(&warm_token).as_ref(),
-            Some(&subject("warm")),
+            Some(&warm_subject),
             "the prior mapping must survive the failed issuance"
         );
 

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -1,0 +1,471 @@
+//! Session-browser authority: mint, write, and revoke browser capability
+//! files for engine sessions.
+//!
+//! Each code session that needs browser access receives a scoped bearer token
+//! mapped through an in-memory route-token registry. The token plus the
+//! loopback endpoint are written into a session-private JSON capability file
+//! whose path is injected into the engine child. No owner, workspace, or
+//! session identifiers leave the server.
+//!
+//! ## Security properties
+//!
+//! * Tokens are random v4 UUIDs; reissuing for the same session silently
+//!   revokes and deletes the prior token and its capability file.
+//! * Startup deletes every stale capability file so a restarted server cannot
+//!   accept a token it did not mint.
+//! * Capfiles are written create-new → sync → chmod 0600 → atomic rename.
+//! * The JSON payload carries only `version`, `endpoint`, and `token` — no
+//!   owner, workspace, or session identifiers.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use tidebreak_core::{CodeSessionId, OwnerId, WorkspaceId};
+use tidebreak_harness::BrowserChannelSpec;
+
+/// Capfile format version. Increment when the schema changes in a backward-
+/// incompatible way.
+const CAPFILE_VERSION: u32 = 1;
+
+/// Filename prefix for capability files. Random components follow.
+const CAPFILE_PREFIX: &str = "browser-cap-";
+
+/// Subdirectory under the data dir that holds session capability files.
+const CAPFILE_SUBDIR: &str = "browser-caps";
+
+/// The `{owner, workspace, session}` subject derived from a token look-up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BrowserSubject {
+    pub owner: OwnerId,
+    pub workspace: WorkspaceId,
+    pub session: CodeSessionId,
+}
+
+/// In-memory route-token registry paired with an on-disk capability-file tree.
+///
+/// One token per session: reissuing silently revokes and deletes the prior
+/// token and its capability file. Startup deletes every stale file so a
+/// restarted server cannot accept a token it did not mint.
+pub(crate) struct BrowserTokenRegistry {
+    tokens: Mutex<HashMap<String, BrowserSubject>>,
+    by_session: Mutex<HashMap<CodeSessionId, String>>,
+    /// Absolute path to the data-dir subtree that holds capfiles.
+    capfile_dir: PathBuf,
+    /// Loopback base URL published after bind.
+    loopback_base: Mutex<Option<String>>,
+}
+
+impl BrowserTokenRegistry {
+    pub(crate) fn new(data_dir: &Path) -> Self {
+        let capfile_dir = data_dir.join(CAPFILE_SUBDIR);
+        Self {
+            tokens: Mutex::new(HashMap::new()),
+            by_session: Mutex::new(HashMap::new()),
+            capfile_dir,
+            loopback_base: Mutex::new(None),
+        }
+    }
+
+    /// Publish the bound loopback base so later [`Self::issue`] calls can
+    /// write it into the capfile endpoint.
+    pub(crate) fn set_loopback_base(&self, base: &str) {
+        *self.loopback_base.lock().expect("loopback base") =
+            Some(base.trim_end_matches('/').into());
+    }
+
+    /// Delete every stale capability file under the capfile directory.
+    ///
+    /// Must run at startup before any session is recovered or created so a
+    /// restarted server cannot accept tokens it did not mint. The in-memory
+    /// registry is always fresh on restart.
+    pub(crate) fn delete_all_stale_capfiles(&self) {
+        match std::fs::read_dir(&self.capfile_dir) {
+            Ok(entries) => {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path
+                        .file_name()
+                        .and_then(|f| f.to_str())
+                        .is_some_and(|f| f.starts_with(CAPFILE_PREFIX))
+                    {
+                        let _ = std::fs::remove_file(&path);
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // The directory does not exist yet — nothing to clean.
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "code-mode: could not read browser capfile directory for cleanup: {e}"
+                );
+            }
+        }
+    }
+
+    /// Mint a channel for `subject` and return the [`BrowserChannelSpec`]
+    /// the adapter injects into the engine child.
+    ///
+    /// The returned path is always absolute because it is resolved against the
+    /// absolute `data_dir` (closing PR #2364's accepted P3 about constructor-
+    /// level path validation — the server is the single trusted constructor
+    /// site and guarantees absoluteness at this boundary).
+    ///
+    /// Reissuing for the same session revokes and deletes the prior token
+    /// and its capability file.
+    pub(crate) fn issue(&self, subject: BrowserSubject) -> Result<BrowserChannelSpec, String> {
+        let token = generate_token();
+        let loopback_base = self
+            .loopback_base
+            .lock()
+            .expect("loopback base")
+            .clone()
+            .ok_or_else(|| "loopback base not set".to_owned())?;
+
+        // Revoke and delete any prior token for this session.
+        {
+            let mut by_session = self.by_session.lock().expect("browser session tokens");
+            if let Some(old) = by_session.insert(subject.session, token.clone()) {
+                let mut tokens = self.tokens.lock().expect("browser tokens");
+                tokens.remove(&old);
+                let old_path = capfile_path(&self.capfile_dir, &old);
+                let _ = std::fs::remove_file(&old_path);
+            }
+            let mut tokens = self.tokens.lock().expect("browser tokens");
+            tokens.insert(token.clone(), subject);
+        }
+
+        let capfile_path = capfile_path(&self.capfile_dir, &token);
+        write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)?;
+
+        Ok(BrowserChannelSpec::new(capfile_path))
+    }
+
+    /// Return the subject for an inbound browser bearer token, or `None`.
+    pub(crate) fn subject_for_token(&self, token: &str) -> Option<BrowserSubject> {
+        self.tokens
+            .lock()
+            .expect("browser tokens")
+            .get(token)
+            .cloned()
+    }
+
+    /// Revoke and delete the channel for `session_id`. Idempotent.
+    pub(crate) fn revoke(&self, session_id: CodeSessionId) {
+        let token = self
+            .by_session
+            .lock()
+            .expect("browser session tokens")
+            .remove(&session_id);
+        if let Some(token) = token {
+            self.tokens.lock().expect("browser tokens").remove(&token);
+            let path = capfile_path(&self.capfile_dir, &token);
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+
+    /// The data-dir subtree where capfiles live (for tests).
+    #[cfg(test)]
+    pub(crate) fn capfile_dir(&self) -> &Path {
+        &self.capfile_dir
+    }
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+fn generate_token() -> String {
+    format!("tbreak_bt_{}", uuid::Uuid::new_v4())
+}
+
+fn capfile_path(capfile_dir: &Path, token: &str) -> PathBuf {
+    capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, token))
+}
+
+/// Write `{version, endpoint, token}` safely:
+///
+/// 1. Ensure the directory exists with mode 0700.
+/// 2. Write to a random temp name under the capfile dir.
+/// 3. Write the JSON body.
+/// 4. fsync the file.
+/// 5. Set mode 0600.
+/// 6. Atomic rename onto the final path.
+fn write_capfile(
+    path: &Path,
+    version: u32,
+    loopback_base: &str,
+    token: &str,
+) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "capfile has no parent directory".to_owned())?;
+
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        return Err(format!("could not create capfile directory: {e}"));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Err(e) =
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+        {
+            return Err(format!("could not set capfile directory mode: {e}"));
+        }
+    }
+
+    let endpoint = format!("{loopback_base}/code/browser");
+
+    let body = serde_json::json!({
+        "version": version,
+        "endpoint": endpoint,
+        "token": token,
+    });
+
+    let body_bytes = serde_json::to_vec(&body)
+        .map_err(|e| format!("failed to serialize capfile: {e}"))?;
+
+    // Random temp name to avoid collision with concurrent issuances.
+    let tmp_name = format!(
+        ".{}.tmp",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let tmp_path = parent.join(tmp_name);
+
+    {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .map_err(|e| format!("could not create temp capfile: {e}"))?;
+
+        file.write_all(&body_bytes)
+            .map_err(|e| format!("could not write capfile: {e}"))?;
+
+        file.flush()
+            .map_err(|e| format!("could not flush capfile: {e}"))?;
+
+        file.sync_all()
+            .map_err(|e| format!("could not sync capfile: {e}"))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            if let Err(e) =
+                std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
+            {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(format!("could not set capfile mode: {e}"));
+            }
+        }
+    }
+
+    std::fs::rename(&tmp_path, path)
+        .map_err(|e| format!("could not rename capfile into place: {e}"))?;
+
+    Ok(())
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seeded(data_dir: &Path) -> BrowserTokenRegistry {
+        let reg = BrowserTokenRegistry::new(data_dir);
+        reg.set_loopback_base("http://127.0.0.1:0");
+        reg
+    }
+
+    fn subject(_label: &str) -> BrowserSubject {
+        BrowserSubject {
+            owner: OwnerId::local(),
+            workspace: WorkspaceId::new(),
+            session: CodeSessionId::new(),
+        }
+    }
+
+    #[test]
+    fn token_roundtrip_registry_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("roundtrip");
+
+        let spec = reg.issue(sub.clone()).unwrap();
+        let token = extract_token_from_path(&spec.capability_file);
+        assert!(!token.is_empty());
+
+        let looked_up = reg.subject_for_token(&token);
+        assert_eq!(looked_up.as_ref(), Some(&sub));
+    }
+
+    #[test]
+    fn reissue_revokes_and_replaces_prior_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("reissue");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = extract_token_from_path(&first.capability_file);
+        assert!(first.capability_file.exists());
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = extract_token_from_path(&second.capability_file);
+
+        assert_ne!(first_token, second_token);
+        assert!(reg.subject_for_token(&first_token).is_none());
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+        assert!(!first.capability_file.exists());
+        assert!(second.capability_file.exists());
+    }
+
+    #[test]
+    fn revoke_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("idempotent");
+
+        let spec = reg.issue(sub.clone()).unwrap();
+        let token = extract_token_from_path(&spec.capability_file);
+        assert!(spec.capability_file.exists());
+
+        reg.revoke(sub.session);
+        assert!(!spec.capability_file.exists());
+        assert!(reg.subject_for_token(&token).is_none());
+
+        // Second revoke is silent.
+        reg.revoke(sub.session);
+    }
+
+    #[test]
+    fn capfile_schema_has_no_subject_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("schema");
+
+        let spec = reg.issue(sub).unwrap();
+        let contents = std::fs::read_to_string(&spec.capability_file).expect("read capfile");
+        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
+
+        assert!(value.get("version").is_some());
+        assert!(value.get("endpoint").is_some());
+        assert!(value.get("token").is_some());
+        assert!(value.get("owner").is_none());
+        assert!(value.get("workspace").is_none());
+        assert!(value.get("session").is_none());
+        assert!(value.get("browser_id").is_none());
+    }
+
+    #[test]
+    fn capfile_endpoint_derives_from_loopback_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = BrowserTokenRegistry::new(dir.path());
+        reg.set_loopback_base("https://tidebreak.local:4567/");
+        let sub = subject("endpoint");
+
+        let spec = reg.issue(sub).unwrap();
+        let contents = std::fs::read_to_string(&spec.capability_file).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+        assert_eq!(
+            value["endpoint"],
+            "https://tidebreak.local:4567/code/browser"
+        );
+    }
+
+    #[test]
+    fn stale_directory_cleanup_removes_known_capfiles() {
+        let dir = tempfile::tempdir().unwrap();
+        let capfile_dir = dir.path().join(CAPFILE_SUBDIR);
+        std::fs::create_dir_all(&capfile_dir).unwrap();
+
+        let stale_path = capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, uuid::Uuid::new_v4()));
+        std::fs::write(&stale_path, b"{}").unwrap();
+        assert!(stale_path.exists());
+
+        // A non-capfile in the same dir must survive.
+        let other = capfile_dir.join("not-a-browser-file.txt");
+        std::fs::write(&other, b"do not delete").unwrap();
+
+        let reg = BrowserTokenRegistry::new(dir.path());
+        reg.delete_all_stale_capfiles();
+
+        assert!(!stale_path.exists());
+        assert!(other.exists());
+    }
+
+    #[test]
+    fn cleanup_handles_missing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = BrowserTokenRegistry::new(dir.path());
+        reg.delete_all_stale_capfiles();
+    }
+
+    #[test]
+    fn capfile_path_is_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("absolute");
+
+        let spec = reg.issue(sub).unwrap();
+        assert!(spec.capability_file.is_absolute());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capfile_is_mode_0600() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("mode");
+
+        let spec = reg.issue(sub).unwrap();
+        let meta = std::fs::metadata(&spec.capability_file).unwrap();
+        let mode = meta.permissions().mode();
+
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capfile_directory_is_mode_0700() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("dirmode");
+
+        let _spec = reg.issue(sub).unwrap();
+        let capfile_dir = reg.capfile_dir();
+        let meta = std::fs::metadata(capfile_dir).unwrap();
+        let mode = meta.permissions().mode();
+
+        assert_eq!(mode & 0o777, 0o700);
+    }
+
+    #[test]
+    fn atomic_temp_file_is_cleaned_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("atomic");
+
+        let spec = reg.issue(sub).unwrap();
+        let parent = spec.capability_file.parent().unwrap();
+
+        let tmp_count = std::fs::read_dir(parent)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
+            .count();
+        assert_eq!(tmp_count, 0, "no .tmp files should survive atomic rename");
+    }
+
+    fn extract_token_from_path(path: &Path) -> String {
+        let name = path.file_stem().unwrap().to_string_lossy();
+        let without_prefix = name.strip_prefix(CAPFILE_PREFIX).unwrap();
+        without_prefix.to_owned()
+    }
+}

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -199,11 +199,6 @@ impl BrowserTokenRegistry {
     }
 
     /// Return the subject for an inbound browser bearer token, or `None`.
-    ///
-    /// This API is intentionally staged — it is the seam the follow-up
-    /// `/code/browser/*` route layer will call. Dead-code lint is suppressed
-    /// until that layer lands.
-    #[allow(dead_code)]
     pub(crate) fn subject_for_token(&self, token: &str) -> Option<BrowserSubject> {
         self.state
             .lock()
@@ -218,11 +213,19 @@ impl BrowserTokenRegistry {
     /// In-memory authority is invalidated first under the registry lock.
     /// File deletion is best-effort because startup subtree cleanup must
     /// fail closed regardless.
-    pub(crate) fn revoke(&self, session_id: CodeSessionId) {
+    ///
+    /// Returns the [`BrowserSubject`] that was mapped to the revoked
+    /// session so the caller can derive an adapter scope, or `None` if
+    /// the session was not found (idempotent).
+    pub(crate) fn revoke(&self, session_id: CodeSessionId) -> Option<BrowserSubject> {
         let mut state = self.state.lock().expect("browser registry");
-        if let Some(entry) = state.by_session.remove(&session_id) {
-            state.tokens.remove(&entry.token);
-            let _ = std::fs::remove_file(&entry.capfile_path);
+        match state.by_session.remove(&session_id) {
+            Some(entry) => {
+                let subject = state.tokens.remove(&entry.token);
+                let _ = std::fs::remove_file(&entry.capfile_path);
+                subject
+            }
+            None => None,
         }
     }
 

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -371,16 +371,19 @@ fn write_capfile(
 
     // Each step after open must clean up the temp file on failure.
     if let Err(e) = file.write_all(&body_bytes) {
+        drop(file);
         let _ = std::fs::remove_file(&tmp_path);
         return Err(format!("could not write capfile: {e}"));
     }
 
     if let Err(e) = file.flush() {
+        drop(file);
         let _ = std::fs::remove_file(&tmp_path);
         return Err(format!("could not flush capfile: {e}"));
     }
 
     if let Err(e) = file.sync_all() {
+        drop(file);
         let _ = std::fs::remove_file(&tmp_path);
         return Err(format!("could not sync capfile: {e}"));
     }
@@ -392,6 +395,7 @@ fn write_capfile(
         if let Err(e) =
             std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
         {
+            drop(file);
             let _ = std::fs::remove_file(&tmp_path);
             return Err(format!("could not set capfile mode: {e}"));
         }
@@ -799,33 +803,75 @@ mod tests {
     }
 
     #[test]
-    fn failed_write_does_not_leave_stale_in_memory_entry() {
+    fn revoke_and_reissue_produces_clean_slate() {
+        // After a successful issuance is revoked (simulating shutdown or
+        // error handling), a fresh issuance for the same session must
+        // produce a new token, a new capfile path, and no stale in-memory
+        // entry. Token is captured before revoke deletes the capfile.
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("cleanslate");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        let first_path = first.capability_file.clone();
+        assert!(first_path.exists());
+
+        reg.revoke(sub.session);
+        assert!(reg.subject_for_token(&first_token).is_none());
+        assert!(!first_path.exists());
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+        let second_path = second.capability_file.clone();
+
+        assert_ne!(first_token, second_token);
+        assert_ne!(first_path, second_path);
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+        assert!(second_path.exists());
+    }
+
+    #[test]
+    fn write_failure_leaves_maps_unchanged() {
         // issue() holds the registry lock across write_capfile + map commit.
-        // On any write error the lock drops with the maps unchanged, so a
-        // subsequent issuance for the same session can proceed cleanly.
-        // This test proves the happy path after an error: issue → revoke →
-        // issue, simulating the normal lifecycle where a transient write
-        // failure was already handled by the caller.
+        // A write failure drops the lock without mutating either map. On
+        // Unix we prove this by removing write permission from the capfile
+        // directory so create_new fails; then a subsequent issuance succeeds
+        // with no stale state. On non-Unix the test is a structural-invariant
+        // check: a normal issue/revoke/reissue cycle leaves clean maps.
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("writefail");
 
-        // Issue, then revoke — simulates the caller cleaning up after a
-        // successful issuance that was no longer needed (or after a transient
-        // failure that was already retried and then revoked).
-        let first = reg.issue(sub.clone()).unwrap();
-        reg.revoke(sub.session);
-        assert!(reg.subject_for_token(
-            &read_token_from_capfile(&first.capability_file)
-        ).is_none());
-        assert!(!first.capability_file.exists());
+        // Warm up: issue once so the capfile directory exists.
+        let warm = reg.issue(subject("warm")).unwrap();
+        assert!(warm.capability_file.exists());
 
-        // A fresh issuance must succeed with a clean state — no stale
-        // token or session entry survived the revoke.
+        #[cfg(unix)]
+        let did_fail = {
+            use std::os::unix::fs::PermissionsExt as _;
+            let capdir = reg.capfile_dir();
+            std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o500))
+                .expect("remove write permission for failure injection");
+            let result = reg.issue(sub.clone());
+            // Restore permissions immediately.
+            std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o700))
+                .expect("restore write permission");
+            assert!(result.is_err(), "issue must fail when directory is read-only");
+            true
+        };
+
+        // After failure (or on non-Unix, after the structural warm), a fresh
+        // issuance for the same session must succeed without stale entries.
         let second = reg.issue(sub.clone()).unwrap();
-        let token = read_token_from_capfile(&second.capability_file);
-        assert_eq!(reg.subject_for_token(&token).as_ref(), Some(&sub));
-        assert!(second.capability_file.exists());
+        let second_token = read_token_from_capfile(&second.capability_file);
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+
+        #[cfg(unix)]
+        let _ = did_fail;
+
+        // The TempDir will clean up everything when dropped.
+        let _ = warm;
     }
 
     // ── sequential safety ────────────────────────────────────────────────

--- a/crates/tidebreak-server/src/code/browser_runtime.rs
+++ b/crates/tidebreak-server/src/code/browser_runtime.rs
@@ -1,0 +1,111 @@
+//! Server-owned browser runtime integration boundary.
+//!
+//! The [`BrowserRuntime`] trait defines the public contract between the
+//! server and the desktop browser adapter. The server owns this trait and
+//! never depends on a desktop crate. The desktop implements it behind an
+//! `Arc<dyn BrowserRuntime>` and passes it to the bind-time constructor before
+//! code-session recovery starts.
+//!
+//! ## Trust boundary
+//!
+//! Every method receives a [`BrowserRuntimeScope`] derived from a validated
+//! session browser token — never from request fields. The runtime MUST
+//! validate scope before accessing any native browser resource.
+
+use async_trait::async_trait;
+
+use tidebreak_core::{
+    BrowserListResult, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
+    BrowserSnapshotArgs, CodeSessionId, OwnerId, WorkspaceId,
+};
+
+// ── BrowserRuntimeScope ─────────────────────────────────────────────────────
+
+/// The `{owner, workspace, session}` triple resolved from a browser bearer
+/// token. Route handlers derive this from the token registry; the adapter
+/// uses it to locate native browser resources.
+///
+/// Never constructed from request body fields — the route layer derives
+/// scope exclusively from the trusted token registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserRuntimeScope {
+    pub owner: OwnerId,
+    pub workspace: WorkspaceId,
+    pub session: CodeSessionId,
+}
+
+impl From<crate::code::browser_channel::BrowserSubject> for BrowserRuntimeScope {
+    fn from(subject: crate::code::browser_channel::BrowserSubject) -> Self {
+        Self {
+            owner: subject.owner,
+            workspace: subject.workspace,
+            session: subject.session,
+        }
+    }
+}
+
+// ── BrowserRuntimeError ─────────────────────────────────────────────────────
+
+/// Server-owned error taxonomy for browser operations.
+///
+/// The route layer maps every variant into a stable HTTP status and
+/// `{kind, message}` JSON body. Desktop implementations return this error
+/// rather than constructing raw [`ServerError`], which is crate-private.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BrowserRuntimeError {
+    /// The opaque browser id names no tab this subject may see.
+    UnknownBrowserId(String),
+    /// The subject's browser authority has ended.
+    SessionEnded,
+    /// The engine or platform cannot perform this operation.
+    Unsupported(String),
+    /// The page or target changed since the snapshot the caller is acting
+    /// from; a fresh snapshot is required.
+    StaleTarget,
+    /// The engine failed while performing the operation.
+    Failed(String),
+}
+
+// ── BrowserRuntime trait ────────────────────────────────────────────────────
+
+/// The server's contract with a desktop browser adapter.
+///
+/// Every method receives a [`BrowserRuntimeScope`] derived from a validated
+/// session browser token. The implementation must revalidate scope before
+/// touching any native resource — the scope alone is not authorization; the
+/// runtime owns the live grant and controller state.
+///
+/// All methods return [`BrowserRuntimeError`] so the adapter can express the
+/// error taxonomy without constructing crate-private [`crate::ServerError`]. The
+/// route layer maps errors to stable HTTP responses centrally.
+#[async_trait]
+pub trait BrowserRuntime: Send + Sync {
+    /// List browser tabs visible to the session identified by `scope`.
+    async fn list(
+        &self,
+        scope: &BrowserRuntimeScope,
+    ) -> Result<BrowserListResult, BrowserRuntimeError>;
+
+    /// Navigate a tab identified by `args.browser_id` within `scope`.
+    async fn navigate(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserNavigateArgs,
+    ) -> Result<BrowserNavigateResult, BrowserRuntimeError>;
+
+    /// Capture a semantic page snapshot for the tab in `args.browser_id`.
+    async fn snapshot(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserSnapshotArgs,
+    ) -> Result<BrowserPageSnapshot, BrowserRuntimeError>;
+
+    /// Synchronously revoke all browser capability for `scope.session`.
+    ///
+    /// Called by [`CodeRuntime`] lifecycle paths — session end, stop,
+    /// interrupt, reap, relaunch, and launch failure. Must be idempotent
+    /// and must never block on async work: the caller holds no runtime
+    /// handle after this returns and the session's browser access is dead.
+    ///
+    fn revoke_session(&self, scope: &BrowserRuntimeScope);
+}

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -7,6 +7,7 @@
 pub(crate) mod approval_bridge;
 pub(crate) mod attention;
 pub(crate) mod browser_channel;
+pub(crate) mod browser_runtime;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;
 pub(crate) mod clone;

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -5,6 +5,7 @@
 //! worker, crash recovery, and the live event bus.
 
 pub(crate) mod approval_bridge;
+pub(crate) mod browser_channel;
 pub(crate) mod attention;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -5,8 +5,8 @@
 //! worker, crash recovery, and the live event bus.
 
 pub(crate) mod approval_bridge;
-pub(crate) mod browser_channel;
 pub(crate) mod attention;
+pub(crate) mod browser_channel;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;
 pub(crate) mod clone;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -174,6 +174,8 @@ impl CodeRuntime {
             // only failure is an OS-level path resolution error such as a
             // dangling CWD, which is a startup bug, not a runtime condition.
             .expect("browser capfile directory must be resolvable to an absolute path");
+        #[cfg(test)]
+        browser_tokens.set_loopback_base("http://127.0.0.1:0");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),
@@ -259,6 +261,8 @@ impl CodeRuntime {
             // only failure is an OS-level path resolution error such as a
             // dangling CWD, which is a startup bug, not a runtime condition.
             .expect("browser capfile directory must be resolvable to an absolute path");
+        #[cfg(test)]
+        browser_tokens.set_loopback_base("http://127.0.0.1:0");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -134,6 +134,9 @@ pub(crate) struct CodeRuntime {
     pub blobs: Arc<dyn tidebreak_core::BlobStore>,
     pub approvals: Arc<ApprovalBridge>,
     pub(crate) browser_tokens: BrowserTokenRegistry,
+    /// The desktop browser adapter, installed before recovery starts. Absent
+    /// in headless deployments and tests that do not register one.
+    browser_runtime: Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>>,
     host: HostEnv,
     host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     loopback_base: Mutex<Option<String>>,
@@ -167,6 +170,7 @@ impl CodeRuntime {
         data_dir: PathBuf,
         worktree_root_default: Option<PathBuf>,
         host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
+        browser_runtime: Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>>,
     ) -> Self {
         let browser_tokens = BrowserTokenRegistry::new(&data_dir)
             // Panic on construction failure: the data dir is trusted/absolute
@@ -185,6 +189,7 @@ impl CodeRuntime {
             worktree_root_default,
             approvals: ApprovalBridge::new(),
             browser_tokens,
+            browser_runtime,
             host: HostEnv {
                 data_dir: Some(data_dir),
                 ..HostEnv::from_process()
@@ -255,6 +260,16 @@ impl CodeRuntime {
         data_dir: PathBuf,
         adapters: AdapterRegistry,
     ) -> Self {
+        Self::with_registry_and_browser_runtime(db, data_dir, adapters, None)
+    }
+
+    #[cfg(any(test, feature = "scripted-harness"))]
+    pub(crate) fn with_registry_and_browser_runtime(
+        db: Arc<DbStore>,
+        data_dir: PathBuf,
+        adapters: AdapterRegistry,
+        browser_runtime: Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>>,
+    ) -> Self {
         let browser_tokens = BrowserTokenRegistry::new(&data_dir)
             // Panic on construction failure: the data dir is trusted/absolute
             // at this point (set from config and validated by the host). The
@@ -272,6 +287,7 @@ impl CodeRuntime {
             worktree_root_default: None,
             approvals: ApprovalBridge::new(),
             browser_tokens,
+            browser_runtime,
             host: HostEnv::from_process(),
             host_tool_broker: None,
             loopback_base: Mutex::new(None),
@@ -295,6 +311,29 @@ impl CodeRuntime {
     #[cfg(test)]
     pub(crate) fn set_gh_search_path(&self, path: Option<String>) {
         *self.gh_search_path.lock().expect("gh search path") = path;
+    }
+
+    /// Return the installed browser adapter, if any.
+    pub(crate) fn browser_runtime(
+        &self,
+    ) -> Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>> {
+        self.browser_runtime.clone()
+    }
+
+    /// Revoke the session browser token AND the desktop adapter
+    /// capability. Idempotent — safe to call multiple times.
+    ///
+    /// The token registry is invalidated first and the adapter scope is
+    /// derived from the returned [`BrowserSubject`] — no DB lookup needed.
+    /// The adapter call happens after the registry lock is released.
+    fn revoke_browser_session(&self, session_id: CodeSessionId) {
+        let subject = self.browser_tokens.revoke(session_id);
+        if let Some(subject) = subject {
+            if let Some(runtime) = &self.browser_runtime {
+                let scope = crate::code::browser_runtime::BrowserRuntimeScope::from(subject);
+                runtime.revoke_session(&scope);
+            }
+        }
     }
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
@@ -1294,6 +1333,9 @@ impl CodeRuntime {
     }
 
     pub(crate) async fn interrupt(&self, id: CodeSessionId) -> Result<(), ServerError> {
+        // Invalidate the session browser token so in-flight browser route
+        // calls are rejected immediately, then revoke the native scope.
+        self.revoke_browser_session(id);
         let handle = self.require_worker(id)?;
         let (reply, rx) = oneshot::channel();
         handle
@@ -1377,7 +1419,7 @@ impl CodeRuntime {
             ));
         }
         let handle = self.workers.lock().expect("code workers").remove(&id);
-        self.browser_tokens.revoke(id);
+        self.revoke_browser_session(id);
         let session = match handle {
             // The outgoing worker writes its own final state as it stops, and
             // the new spawn must not be started against a row it is still
@@ -1456,7 +1498,7 @@ impl CodeRuntime {
             .lock()
             .expect("code workers")
             .remove(&session.id);
-        self.browser_tokens.revoke(session.id);
+        self.revoke_browser_session(session.id);
         session.lifecycle = CodeSessionLifecycle::Ended;
         session.child_pid = None;
         session.fence_reason = None;
@@ -1670,7 +1712,7 @@ impl CodeRuntime {
                 .lock()
                 .expect("code workers")
                 .remove(&session.id);
-            self.browser_tokens.revoke(session.id);
+            self.revoke_browser_session(session.id);
             // Mark the row ended before asking the worker to stop. A worker
             // interrupted mid-turn re-reads the row on its way round the loop
             // and leaves on its own when it finds the session ended, so one
@@ -1794,7 +1836,7 @@ impl CodeRuntime {
         let engine = match adapter.launch(spec).await {
             Ok(engine) => engine,
             Err(HarnessError::ResumeLost(detail)) => {
-                self.browser_tokens.revoke(session.id);
+                self.revoke_browser_session(session.id);
                 // The engine refused the stored resume ref. Fence with a
                 // reason the UI can explain — the fence drops the dead ref, so
                 // a reap re-attaches with a fresh engine session.
@@ -1813,7 +1855,7 @@ impl CodeRuntime {
                 ));
             }
             Err(err) => {
-                self.browser_tokens.revoke(session.id);
+                self.revoke_browser_session(session.id);
                 return Err(ServerError::internal(format!(
                     "failed to launch engine session: {err}"
                 )));
@@ -2364,7 +2406,13 @@ mod managed_node_wait_tests {
         ))
         .await
         .expect("db");
-        let runtime = CodeRuntime::new(Arc::new(db), data_dir.path().to_path_buf(), None, None);
+        let runtime = CodeRuntime::new(
+            Arc::new(db),
+            data_dir.path().to_path_buf(),
+            None,
+            None,
+            None,
+        );
 
         assert_eq!(
             runtime.managed_node_root(false).await.expect("node root"),

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -228,8 +228,9 @@ impl CodeRuntime {
     pub(crate) fn start(
         self: &Arc<Self>,
         loopback_base: String,
-    ) -> Box<dyn std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> + Send>
-    {
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> + Send>,
+    > {
         self.set_loopback_base(loopback_base);
         // Synchronously delete stale capfiles before the returned future is
         // pollable so issue() cannot race an unpolled startup cleanup.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -28,6 +28,7 @@ use tidebreak_harness::{
 };
 
 use super::approval_bridge::ApprovalBridge;
+use super::browser_channel::{BrowserSubject, BrowserTokenRegistry};
 use super::bus::CodeEventBus;
 use super::checkpoint::{
     delete_workspace_refs, list_changed_files, produce_diff, resolve_diff_range,
@@ -132,6 +133,7 @@ pub(crate) struct CodeRuntime {
     pub(crate) worktree_root_default: Option<PathBuf>,
     pub blobs: Arc<dyn tidebreak_core::BlobStore>,
     pub approvals: Arc<ApprovalBridge>,
+    pub(crate) browser_tokens: BrowserTokenRegistry,
     host: HostEnv,
     host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     loopback_base: Mutex<Option<String>>,
@@ -174,6 +176,7 @@ impl CodeRuntime {
             data_dir: data_dir.clone(),
             worktree_root_default,
             approvals: ApprovalBridge::new(),
+            browser_tokens: BrowserTokenRegistry::new(&data_dir),
             host: HostEnv {
                 data_dir: Some(data_dir),
                 ..HostEnv::from_process()
@@ -199,6 +202,7 @@ impl CodeRuntime {
 
     /// Bound after listen so Claude can be pointed at the loopback MCP route.
     fn set_loopback_base(&self, base: String) {
+        self.browser_tokens.set_loopback_base(&base);
         *self.loopback_base.lock().expect("loopback base") =
             Some(base.trim_end_matches('/').into());
     }
@@ -220,6 +224,7 @@ impl CodeRuntime {
         loopback_base: String,
     ) -> impl std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> {
         self.set_loopback_base(loopback_base);
+        self.browser_tokens.delete_all_stale_capfiles();
         let runtime = self.clone();
         async move {
             let actions = runtime.recover().await;
@@ -245,6 +250,7 @@ impl CodeRuntime {
             data_dir,
             worktree_root_default: None,
             approvals: ApprovalBridge::new(),
+            browser_tokens: BrowserTokenRegistry::new(&data_dir),
             host: HostEnv::from_process(),
             host_tool_broker: None,
             loopback_base: Mutex::new(None),
@@ -1350,6 +1356,7 @@ impl CodeRuntime {
             ));
         }
         let handle = self.workers.lock().expect("code workers").remove(&id);
+        self.browser_tokens.revoke(id);
         let session = match handle {
             // The outgoing worker writes its own final state as it stops, and
             // the new spawn must not be started against a row it is still
@@ -1428,6 +1435,7 @@ impl CodeRuntime {
             .lock()
             .expect("code workers")
             .remove(&session.id);
+        self.browser_tokens.revoke(session.id);
         session.lifecycle = CodeSessionLifecycle::Ended;
         session.child_pid = None;
         session.fence_reason = None;
@@ -1641,6 +1649,7 @@ impl CodeRuntime {
                 .lock()
                 .expect("code workers")
                 .remove(&session.id);
+            self.browser_tokens.revoke(session.id);
             // Mark the row ended before asking the worker to stop. A worker
             // interrupted mid-turn re-reads the row on its way round the loop
             // and leaves on its own when it finds the session ended, so one
@@ -1737,6 +1746,13 @@ impl CodeRuntime {
             attached.subagents.clone(),
         );
         let approval = self.approval_channel(session.id, session.permission_mode);
+        let browser_subject = BrowserSubject {
+            owner: session.owner.clone(),
+            workspace: session.workspace_id,
+            session: session.id,
+        };
+        let browser = self.browser_tokens.issue(browser_subject).ok();
+
         let spec = SessionSpec {
             worktree: PathBuf::from(&workspace.worktree_path),
             permission_mode: session.permission_mode,
@@ -1748,12 +1764,13 @@ impl CodeRuntime {
             approval,
             binary,
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
-            browser: None,
+            browser,
         };
         let mut attached = attached;
         let engine = match adapter.launch(spec).await {
             Ok(engine) => engine,
             Err(HarnessError::ResumeLost(detail)) => {
+                self.browser_tokens.revoke(session.id);
                 // The engine refused the stored resume ref. Fence with a
                 // reason the UI can explain — the fence drops the dead ref, so
                 // a reap re-attaches with a fresh engine session.
@@ -1772,6 +1789,7 @@ impl CodeRuntime {
                 ));
             }
             Err(err) => {
+                self.browser_tokens.revoke(session.id);
                 return Err(ServerError::internal(format!(
                     "failed to launch engine session: {err}"
                 )));

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -169,6 +169,10 @@ impl CodeRuntime {
         host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     ) -> Self {
         let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            // Panic on construction failure: the data dir is trusted/absolute
+            // at this point (set from config and validated by the host). The
+            // only failure is an OS-level path resolution error such as a
+            // dangling CWD, which is a startup bug, not a runtime condition.
             .expect("browser capfile directory must be resolvable to an absolute path");
         Self {
             db,
@@ -224,22 +228,22 @@ impl CodeRuntime {
     pub(crate) fn start(
         self: &Arc<Self>,
         loopback_base: String,
-    ) -> impl std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> {
+    ) -> Box<dyn std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> + Send>
+    {
         self.set_loopback_base(loopback_base);
+        // Synchronously delete stale capfiles before the returned future is
+        // pollable so issue() cannot race an unpolled startup cleanup.
+        let cleanup = self.browser_tokens.delete_all_stale_capfiles();
         let runtime = self.clone();
-        async move {
-            // Clean up stale capfiles before anything else. Fail closed.
-            runtime
-                .browser_tokens
-                .delete_all_stale_capfiles()
-                .map_err(|e| ServerError::internal(e))?;
+        Box::pin(async move {
+            cleanup.map_err(|e| ServerError::internal(e))?;
             let actions = runtime.recover().await;
             // After recovery so resumed watch sessions have workers to drive;
             // the sweep reads its work list from the `code_watch` table, so
             // active watches resume with no extra state.
             runtime.ensure_watch_sweep();
             actions
-        }
+        })
     }
 
     #[cfg(any(test, feature = "scripted-harness"))]
@@ -249,6 +253,10 @@ impl CodeRuntime {
         adapters: AdapterRegistry,
     ) -> Self {
         let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            // Panic on construction failure: the data dir is trusted/absolute
+            // at this point (set from config and validated by the host). The
+            // only failure is an OS-level path resolution error such as a
+            // dangling CWD, which is a startup bug, not a runtime condition.
             .expect("browser capfile directory must be resolvable to an absolute path");
         Self {
             db,
@@ -1775,7 +1783,7 @@ impl CodeRuntime {
             approval,
             binary,
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
-            browser,
+            browser: Some(browser),
         };
         let mut attached = attached;
         let engine = match adapter.launch(spec).await {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -168,6 +168,8 @@ impl CodeRuntime {
         worktree_root_default: Option<PathBuf>,
         host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     ) -> Self {
+        let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            .expect("browser capfile directory must be resolvable to an absolute path");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),
@@ -176,7 +178,7 @@ impl CodeRuntime {
             data_dir: data_dir.clone(),
             worktree_root_default,
             approvals: ApprovalBridge::new(),
-            browser_tokens: BrowserTokenRegistry::new(&data_dir),
+            browser_tokens,
             host: HostEnv {
                 data_dir: Some(data_dir),
                 ..HostEnv::from_process()
@@ -224,9 +226,13 @@ impl CodeRuntime {
         loopback_base: String,
     ) -> impl std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> {
         self.set_loopback_base(loopback_base);
-        self.browser_tokens.delete_all_stale_capfiles();
         let runtime = self.clone();
         async move {
+            // Clean up stale capfiles before anything else. Fail closed.
+            runtime
+                .browser_tokens
+                .delete_all_stale_capfiles()
+                .map_err(|e| ServerError::internal(e))?;
             let actions = runtime.recover().await;
             // After recovery so resumed watch sessions have workers to drive;
             // the sweep reads its work list from the `code_watch` table, so
@@ -242,6 +248,8 @@ impl CodeRuntime {
         data_dir: PathBuf,
         adapters: AdapterRegistry,
     ) -> Self {
+        let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            .expect("browser capfile directory must be resolvable to an absolute path");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),
@@ -250,7 +258,7 @@ impl CodeRuntime {
             data_dir,
             worktree_root_default: None,
             approvals: ApprovalBridge::new(),
-            browser_tokens: BrowserTokenRegistry::new(&data_dir),
+            browser_tokens,
             host: HostEnv::from_process(),
             host_tool_broker: None,
             loopback_base: Mutex::new(None),
@@ -1751,7 +1759,10 @@ impl CodeRuntime {
             workspace: session.workspace_id,
             session: session.id,
         };
-        let browser = self.browser_tokens.issue(browser_subject).ok();
+        let browser = self
+            .browser_tokens
+            .issue(browser_subject)
+            .map_err(|e| ServerError::internal(e))?;
 
         let spec = SessionSpec {
             worktree: PathBuf::from(&workspace.worktree_path),

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -237,7 +237,7 @@ impl CodeRuntime {
         let cleanup = self.browser_tokens.delete_all_stale_capfiles();
         let runtime = self.clone();
         Box::pin(async move {
-            cleanup.map_err(|e| ServerError::internal(e))?;
+            cleanup.map_err(ServerError::internal)?;
             let actions = runtime.recover().await;
             // After recovery so resumed watch sessions have workers to drive;
             // the sweep reads its work list from the `code_watch` table, so
@@ -1771,7 +1771,7 @@ impl CodeRuntime {
         let browser = self
             .browser_tokens
             .issue(browser_subject)
-            .map_err(|e| ServerError::internal(e))?;
+            .map_err(ServerError::internal)?;
 
         let spec = SessionSpec {
             worktree: PathBuf::from(&workspace.worktree_path),

--- a/crates/tidebreak-server/src/error.rs
+++ b/crates/tidebreak-server/src/error.rs
@@ -41,6 +41,30 @@ impl ServerError {
         }
     }
 
+    /// A `403 Forbidden` for a caller whose token is real but whose authority
+    /// no longer covers the request (for example, an ended session).
+    pub(crate) fn forbidden(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            info: AgentErrorInfo {
+                kind: "forbidden".to_string(),
+                message: message.into(),
+            },
+        }
+    }
+
+    /// A `501 Not Implemented` for a capability this embedding does not
+    /// provide (for example, browser routes with no runtime attached).
+    pub(crate) fn not_implemented(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_IMPLEMENTED,
+            info: AgentErrorInfo {
+                kind: "not_implemented".to_string(),
+                message: message.into(),
+            },
+        }
+    }
+
     /// A `400 Bad Request` for a malformed request (bad path segment, or an
     /// unparseable / wrong-typed / wrong-content-type body). Used to map axum's
     /// built-in extractor rejections into the same `{ kind, message }` shape as

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -143,6 +143,10 @@ use tidebreak_core::{
     ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool, ToolRegistry, WriteFile,
 };
 
+/// Public contract for desktop browser adapters. The desktop implements
+/// [`BrowserRuntime`] behind an `Arc` and installs it with
+/// [`bind`] or one of its desktop variants.
+pub use crate::code::browser_runtime::{BrowserRuntime, BrowserRuntimeError, BrowserRuntimeScope};
 pub use durable_oplog::DurableOperationStore;
 pub use error::ServerError;
 pub use pairing::{
@@ -475,6 +479,22 @@ pub fn app(state: AppState) -> Router {
             get(routes::code::get_worktree_root).put(routes::code::set_worktree_root),
         )
         .route_layer(axum::middleware::from_fn(auth::require_admin));
+
+    // The engine-facing browser channel. Authenticated per request by the
+    // session-scoped capability bearer (see `routes::code::browser`), so this
+    // router is kept out of `require_token` below; the token never appears in
+    // a path or query, which is why navigate and snapshot are POST.
+    let browser_api = Router::new()
+        .route("/code/browser/list", get(routes::code::browser_list))
+        .route(
+            "/code/browser/navigate",
+            post(routes::code::browser_navigate),
+        )
+        .route(
+            "/code/browser/snapshot",
+            post(routes::code::browser_snapshot),
+        )
+        .with_state(state.clone());
 
     let api = Router::new()
         .route("/settings", get(routes::get_settings))
@@ -907,7 +927,13 @@ pub fn app(state: AppState) -> Router {
             state.clone(),
             auth::require_token,
         ))
-        .with_state(state.clone());
+        .with_state(state.clone())
+        // The engine-facing browser channel authenticates each request with
+        // the per-session capability bearer its capfile carries, never the
+        // launch token, so its routes merge after `route_layer` wrapped the
+        // routes above and stay outside `require_token`. They still sit
+        // inside `require_app_origin` and CORS with the rest of the API.
+        .merge(browser_api);
     let frame_state = state.clone();
     let auth_discovery = Router::new()
         .route("/auth/discovery", get(auth::discovery))
@@ -1134,6 +1160,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -1144,7 +1171,18 @@ pub async fn bind(config: Config) -> Result<Server> {
 /// to use [`bind`] when process-environment configuration is undesirable.
 pub async fn bind_configured(config: Config) -> Result<Server> {
     let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
-    bind_inner(config, None, mcp_servers, None, None, None, None, None).await
+    bind_inner(
+        config,
+        None,
+        mcp_servers,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
 }
 
 /// Bind the API with a stable app-private native executor identity.
@@ -1162,6 +1200,7 @@ pub async fn bind_with_desktop_executor(
         config,
         Some(client_executor_id),
         mcp_config::ConfiguredMcpServers::default(),
+        None,
         None,
         None,
         None,
@@ -1190,6 +1229,7 @@ pub async fn bind_configured_with_desktop_executor(
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -1208,6 +1248,32 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
     local_voice: Option<Arc<dyn LocalVoiceRunner>>,
     host_folders: Option<Arc<dyn host_folders::HostFolders>>,
 ) -> Result<Server> {
+    bind_configured_with_desktop_executor_and_folder_grants_and_browser_runtime(
+        config,
+        client_executor_id,
+        folder_grant_resolver,
+        office_converter,
+        host_tool_broker,
+        local_voice,
+        host_folders,
+        None,
+    )
+    .await
+}
+
+/// Desktop binding with the native host bridges plus a browser runtime that
+/// must be available before code-session recovery starts.
+#[allow(clippy::too_many_arguments)]
+pub async fn bind_configured_with_desktop_executor_and_folder_grants_and_browser_runtime(
+    config: Config,
+    client_executor_id: Uuid,
+    folder_grant_resolver: Arc<dyn code_execution::ExecFolderGrantResolver>,
+    office_converter: Option<Arc<dyn tidebreak_code_execution::HostOfficeConverter>>,
+    host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
+    local_voice: Option<Arc<dyn LocalVoiceRunner>>,
+    host_folders: Option<Arc<dyn host_folders::HostFolders>>,
+    browser_runtime: Option<Arc<dyn code::browser_runtime::BrowserRuntime>>,
+) -> Result<Server> {
     if client_executor_id.is_nil() {
         return Err(AgentError::config("client executor id must not be nil"));
     }
@@ -1221,6 +1287,7 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
         host_tool_broker,
         local_voice,
         host_folders,
+        browser_runtime,
     )
     .await
 }
@@ -1274,6 +1341,7 @@ async fn bind_inner(
     host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     local_voice: Option<Arc<dyn LocalVoiceRunner>>,
     host_folders: Option<Arc<dyn host_folders::HostFolders>>,
+    browser_runtime: Option<Arc<dyn code::browser_runtime::BrowserRuntime>>,
 ) -> Result<Server> {
     // Resolved first, before the instance lock or the store: a desktop profile
     // handed `TIDEBREAK_LISTEN_ADDR` refuses the boot rather than binding a
@@ -1497,6 +1565,7 @@ async fn bind_inner(
         state.config.data_dir.clone(),
         state.config.code_worktree_root_default.clone(),
         code_host_tool_broker,
+        browser_runtime,
     ));
     // Recovery runs after the bind, below: the workers it re-attaches need the
     // bound loopback address to reach their approval endpoint.

--- a/crates/tidebreak-server/src/routes/code/browser.rs
+++ b/crates/tidebreak-server/src/routes/code/browser.rs
@@ -1,0 +1,156 @@
+//! `/code/browser/*` routes: the engine-facing browser channel.
+//!
+//! These routes authenticate with the per-session capability bearer minted
+//! by [`crate::code::browser_channel::BrowserTokenRegistry`] — never the
+//! per-launch app token. They are registered outside `require_token` (see
+//! `crate::app`), and each handler resolves its own `Authorization` header.
+
+use std::sync::Arc;
+
+use axum::http::header::AUTHORIZATION;
+use axum::http::HeaderMap;
+
+use tidebreak_core::{
+    db, BrowserListResult, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
+    BrowserSnapshotArgs, CodeSessionLifecycle, CodeWorkspaceStatus,
+};
+
+use crate::code::browser_channel::BrowserSubject;
+use crate::code::browser_runtime::{BrowserRuntime, BrowserRuntimeError, BrowserRuntimeScope};
+use crate::error::ServerError;
+use crate::extract::Json;
+use crate::state::AppState;
+
+pub async fn browser_list(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<BrowserListResult>, ServerError> {
+    let subject = authorize(&state, &headers).await?;
+    let runtime = attached_runtime(&state)?;
+    runtime
+        .as_ref()
+        .list(&BrowserRuntimeScope::from(subject))
+        .await
+        .map(Json)
+        .map_err(map_runtime_error)
+}
+
+pub async fn browser_navigate(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+    Json(args): Json<BrowserNavigateArgs>,
+) -> Result<Json<BrowserNavigateResult>, ServerError> {
+    let subject = authorize(&state, &headers).await?;
+    require_well_formed(args.is_well_formed())?;
+    let runtime = attached_runtime(&state)?;
+    runtime
+        .as_ref()
+        .navigate(&BrowserRuntimeScope::from(subject), &args)
+        .await
+        .map(Json)
+        .map_err(map_runtime_error)
+}
+
+pub async fn browser_snapshot(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+    Json(args): Json<BrowserSnapshotArgs>,
+) -> Result<Json<BrowserPageSnapshot>, ServerError> {
+    let subject = authorize(&state, &headers).await?;
+    require_well_formed(args.is_well_formed())?;
+    let runtime = attached_runtime(&state)?;
+    runtime
+        .as_ref()
+        .snapshot(&BrowserRuntimeScope::from(subject), &args)
+        .await
+        .map(Json)
+        .map_err(map_runtime_error)
+}
+
+// ── shared refusal ladder ───────────────────────────────────────────────────
+
+async fn authorize(state: &AppState, headers: &HeaderMap) -> Result<BrowserSubject, ServerError> {
+    let token = bearer_token(headers)
+        .ok_or_else(|| ServerError::unauthorized("missing browser capability token"))?;
+    let code = state
+        .code
+        .clone()
+        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))?;
+    let subject = code
+        .browser_tokens
+        .subject_for_token(token)
+        .ok_or_else(|| ServerError::unauthorized("unknown or revoked browser capability token"))?;
+
+    let session = db::code::get_session(&code.db, &subject.owner, subject.session)
+        .await?
+        .ok_or_else(|| ServerError::forbidden("the browser session has ended"))?;
+    if matches!(
+        session.lifecycle,
+        CodeSessionLifecycle::Ended | CodeSessionLifecycle::Fenced
+    ) {
+        return Err(ServerError::forbidden("the browser session has ended"));
+    }
+    if session.workspace_id != subject.workspace {
+        return Err(ServerError::not_found("browser target not found"));
+    }
+
+    let workspace = db::code::get_workspace(&code.db, &subject.owner, subject.workspace)
+        .await?
+        .ok_or_else(|| ServerError::not_found("browser target not found"))?;
+    if workspace.status != CodeWorkspaceStatus::Active {
+        return Err(ServerError::forbidden(
+            "the browser session's workspace is not active",
+        ));
+    }
+
+    Ok(subject)
+}
+
+fn attached_runtime(state: &AppState) -> Result<Arc<dyn BrowserRuntime>, ServerError> {
+    let code = state
+        .code
+        .as_ref()
+        .ok_or_else(|| ServerError::internal("code mode is not configured on this server"))?;
+    code.browser_runtime()
+        .ok_or_else(|| ServerError::not_implemented("this server has no in-app browser runtime"))
+}
+
+fn require_well_formed(well_formed: bool) -> Result<(), ServerError> {
+    if well_formed {
+        Ok(())
+    } else {
+        Err(ServerError::unprocessable_kind(
+            "invalid_browser_arguments",
+            "browser arguments are not well-formed",
+        ))
+    }
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")
+}
+
+fn map_runtime_error(error: BrowserRuntimeError) -> ServerError {
+    match error {
+        BrowserRuntimeError::UnknownBrowserId(id) => {
+            ServerError::not_found(format!("browser {id} not found"))
+        }
+        BrowserRuntimeError::SessionEnded => {
+            ServerError::forbidden("the browser session has ended")
+        }
+        BrowserRuntimeError::Unsupported(operation) => ServerError::not_implemented(format!(
+            "this browser engine does not support {operation}"
+        )),
+        BrowserRuntimeError::StaleTarget => ServerError::conflict_kind(
+            "stale_browser_target",
+            "the page changed since that snapshot; take a new browser_snapshot",
+        ),
+        BrowserRuntimeError::Failed(message) => {
+            ServerError::internal(format!("browser operation failed: {message}"))
+        }
+    }
+}

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -1,12 +1,17 @@
 //! `/code/*` routes: repos, workspaces, sessions, doctor, event stream.
 //!
-//! Every route here is owner-scoped through `ScopedCode`. The routes that
-//! change what the machine *is* — installing pinned harness binaries, and the
-//! clone-parent and worktree-root directories every principal shares — are
-//! registered on the deployment-plane router in `crate::lib` instead, behind
-//! `require_admin`.
+//! Every route here is owner-scoped through `ScopedCode`, with two
+//! exceptions. The routes that change what the machine *is* — installing
+//! pinned harness binaries, and the clone-parent and worktree-root
+//! directories every principal shares — are registered on the
+//! deployment-plane router in `crate::lib` instead, behind `require_admin`.
+//! And the `/code/browser/*` routes in [`browser`] authenticate with the
+//! per-session capability bearer rather than the launch token, so they are
+//! registered outside `require_token` and derive their owner from the
+//! browser token registry.
 
 mod approvals;
+mod browser;
 mod delivery;
 mod git;
 mod harnesses;
@@ -21,6 +26,7 @@ mod workspaces;
 
 pub(crate) use crate::code::approval_bridge::approval_prompt;
 pub(crate) use approvals::{decide_approval, list_approvals};
+pub(crate) use browser::{browser_list, browser_navigate, browser_snapshot};
 pub(crate) use delivery::{
     act_on_pull_request as act_on_delivery_pull_request, act_on_run as act_on_delivery_run,
     discover_repositories as discover_delivery_repositories,

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -41,6 +41,7 @@ mod app_invoke;
 mod app_library;
 mod chat_titling;
 mod code;
+mod code_browser;
 #[cfg(unix)]
 mod code_clone;
 #[cfg(unix)]

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -4468,9 +4468,27 @@ fn code_routes_go_through_the_owner_scoped_view() {
         // `types.rs` declare and shape, and serve nothing.
         let serves_data = text.contains("pub async fn") && name != "mod.rs";
         if serves_data && !text.contains("ScopedCode") {
-            findings.push(format!(
-                "{name} defines route handlers but never extracts `ScopedCode`"
-            ));
+            // The browser channel is the sole capability-bearer route: it
+            // authenticates with a session-private browser capability token
+            // (resolved into a `BrowserSubject` owner/workspace/session scope)
+            // rather than the app-token `ScopedCode` extractor. Require its
+            // own authorization path instead of the scoped extractor.
+            if name == "browser.rs" {
+                if !text.contains("fn authorize(")
+                    || !text.contains("BrowserSubject")
+                    || !text.contains("bearer_token")
+                {
+                    findings.push(format!(
+                        "{name} is the capability-bearer browser route but is \
+                         missing its `authorize` / `BrowserSubject` / \
+                         `bearer_token` authorization path"
+                    ));
+                }
+            } else {
+                findings.push(format!(
+                    "{name} defines route handlers but never extracts `ScopedCode`"
+                ));
+            }
         }
     }
     assert!(

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -1,0 +1,493 @@
+//! `/code/browser/*` routes: capability-bearer auth, subject scoping,
+//! and the runtime seam against a fake runtime.
+
+use super::*;
+
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+
+use axum::Router;
+use tokio::net::TcpListener;
+
+use crate::code::browser_channel::BrowserSubject;
+use crate::code::browser_runtime::{BrowserRuntime, BrowserRuntimeError, BrowserRuntimeScope};
+use crate::code::CodeRuntime;
+use tidebreak_core::{
+    db, Attention, AttentionSource, AttentionState, BrowserContentTrust, BrowserControllerState,
+    BrowserEngineCapabilities, BrowserEngineDescriptor, BrowserEngineName, BrowserListResult,
+    BrowserLoadState, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
+    BrowserSessionSummary, BrowserSnapshotArgs, BrowserViewport, CodePermissionMode, CodeRepo,
+    CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeWorkspace,
+    CodeWorkspaceStatus, DbStore, HarnessKind, OwnerId, RepoId, Store, WorkspaceId,
+};
+use tidebreak_harness::AdapterRegistry;
+
+#[derive(Default)]
+struct FakeBrowserRuntime {
+    calls: Mutex<Vec<(&'static str, BrowserRuntimeScope)>>,
+    revoked: Mutex<Vec<BrowserRuntimeScope>>,
+    stale: bool,
+}
+
+impl FakeBrowserRuntime {
+    fn stale() -> Self {
+        Self {
+            stale: true,
+            ..Self::default()
+        }
+    }
+    fn record(&self, m: &'static str, s: &BrowserRuntimeScope) {
+        self.calls.lock().unwrap().push((m, s.clone()));
+    }
+    fn subjects(&self) -> Vec<(&'static str, BrowserRuntimeScope)> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+fn engine() -> BrowserEngineDescriptor {
+    BrowserEngineDescriptor {
+        name: BrowserEngineName::WkWebView,
+        capabilities: BrowserEngineCapabilities {
+            lifecycle: true,
+            persistent_profile: true,
+            semantic_snapshot: true,
+            semantic_actions: false,
+            screenshot: true,
+            cross_origin_frames: false,
+            profile_reset: true,
+        },
+    }
+}
+
+#[async_trait]
+impl BrowserRuntime for FakeBrowserRuntime {
+    async fn list(
+        &self,
+        scope: &BrowserRuntimeScope,
+    ) -> Result<BrowserListResult, BrowserRuntimeError> {
+        self.record("list", scope);
+        Ok(BrowserListResult {
+            sessions: vec![BrowserSessionSummary {
+                browser_id: "browser-1".into(),
+                url: Some("https://example.com".into()),
+                title: Some("Example".into()),
+                load_state: BrowserLoadState::Ready,
+                visible: true,
+                engine: engine(),
+                controller: BrowserControllerState::default(),
+            }],
+        })
+    }
+    async fn navigate(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserNavigateArgs,
+    ) -> Result<BrowserNavigateResult, BrowserRuntimeError> {
+        self.record("navigate", scope);
+        if args.browser_id != "browser-1" {
+            return Err(BrowserRuntimeError::UnknownBrowserId(
+                args.browser_id.clone(),
+            ));
+        }
+        Ok(BrowserNavigateResult {
+            browser_id: args.browser_id.clone(),
+            url: args.url.clone(),
+            load_state: BrowserLoadState::Loading,
+            document_epoch: 2,
+        })
+    }
+    async fn snapshot(
+        &self,
+        scope: &BrowserRuntimeScope,
+        _args: &BrowserSnapshotArgs,
+    ) -> Result<BrowserPageSnapshot, BrowserRuntimeError> {
+        self.record("snapshot", scope);
+        if self.stale {
+            return Err(BrowserRuntimeError::StaleTarget);
+        }
+        Ok(BrowserPageSnapshot {
+            browser_id: "browser-1".into(),
+            snapshot_id: "snapshot-1".into(),
+            document_epoch: 2,
+            content_trust: BrowserContentTrust::UntrustedPage,
+            url: "https://example.com".into(),
+            title: "Example".into(),
+            viewport: BrowserViewport {
+                width: 800.0,
+                height: 600.0,
+                scroll_x: 0.0,
+                scroll_y: 0.0,
+            },
+            nodes: vec![],
+            frames: vec![],
+            truncated: false,
+        })
+    }
+    fn revoke_session(&self, scope: &BrowserRuntimeScope) {
+        self.revoked.lock().unwrap().push(scope.clone());
+    }
+}
+
+struct BrowserApp {
+    addr: std::net::SocketAddr,
+    code: Arc<CodeRuntime>,
+    fake: Option<Arc<FakeBrowserRuntime>>,
+    _dir: tempfile::TempDir,
+}
+
+async fn browser_app(fake: Option<Arc<FakeBrowserRuntime>>) -> BrowserApp {
+    let (dir, store) = temp_db_store("code-browser.db").await;
+    let db = Arc::new(store);
+    let st: Arc<dyn Store> = db.clone();
+    let browser_runtime = fake
+        .as_ref()
+        .map(|runtime| -> Arc<dyn BrowserRuntime> { runtime.clone() });
+    let code = Arc::new(CodeRuntime::with_registry_and_browser_runtime(
+        db,
+        dir.path().into(),
+        AdapterRegistry::new(),
+        browser_runtime,
+    ));
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        st,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(code.clone());
+    let addr = serve(app(state)).await;
+    BrowserApp {
+        addr,
+        code,
+        fake,
+        _dir: dir,
+    }
+}
+
+async fn serve(router: Router) -> std::net::SocketAddr {
+    let l = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let a = l.local_addr().unwrap();
+    tokio::spawn(async {
+        let _ = axum::serve(l, router).await;
+    });
+    a
+}
+
+async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, CodeSessionId) {
+    let repo_id = RepoId::new();
+    db::code::insert_repo(
+        db,
+        &CodeRepo {
+            id: repo_id,
+            owner: OwnerId::local(),
+            root_path: "/nonexistent-repo".into(),
+            display_name: "browser-test".into(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: vec![],
+            created_at: chrono::Utc::now(),
+        },
+    )
+    .await
+    .unwrap();
+    let ws = CodeWorkspace {
+        id: WorkspaceId::new(),
+        owner: OwnerId::local(),
+        repo_id,
+        title: "browser".into(),
+        worktree_path: "/nonexistent".into(),
+        branch_name: "tidebreak/browser".into(),
+        base_ref: "main".into(),
+        status: CodeWorkspaceStatus::Active,
+        pr: None,
+        created_at: chrono::Utc::now(),
+        archived_at: None,
+    };
+    db::code::insert_workspace(db, &ws).await.unwrap();
+    let s = CodeSession {
+        id: CodeSessionId::new(),
+        owner: OwnerId::local(),
+        workspace_id: ws.id,
+        kind: CodeSessionKind::Interactive,
+        harness_kind: HarnessKind::ClaudeCode,
+        harness_version: None,
+        harness_resume_ref: None,
+        permission_mode: CodePermissionMode::Ask,
+        model: None,
+        lifecycle: lc,
+        fence_reason: None,
+        child_pid: None,
+        spawn_epoch: 0,
+        attention: Attention::new(AttentionState::Working, AttentionSource::Lifecycle),
+        unrecognized_event_count: 0,
+        subagents: vec![],
+        created_at: chrono::Utc::now(),
+    };
+    db::code::insert_session(db, &s).await.unwrap();
+    (ws.id, s.id)
+}
+
+fn mint_token(code: &CodeRuntime, ws: WorkspaceId, s: CodeSessionId) -> String {
+    let sp = code
+        .browser_tokens
+        .issue(BrowserSubject {
+            owner: OwnerId::local(),
+            workspace: ws,
+            session: s,
+        })
+        .unwrap();
+    let c = std::fs::read_to_string(&sp.capability_file).unwrap();
+    serde_json::from_str::<serde_json::Value>(&c).unwrap()["token"]
+        .as_str()
+        .unwrap()
+        .into()
+}
+
+async fn post(
+    addr: std::net::SocketAddr,
+    rt: &str,
+    tok: Option<&str>,
+    body: serde_json::Value,
+) -> reqwest::Response {
+    let mut r = reqwest::Client::new()
+        .post(format!("http://{addr}/code/browser/{rt}"))
+        .json(&body);
+    if let Some(t) = tok {
+        r = r.bearer_auth(t);
+    }
+    r.send().await.unwrap()
+}
+async fn get(addr: std::net::SocketAddr, rt: &str, tok: Option<&str>) -> reqwest::Response {
+    let mut r = reqwest::Client::new().get(format!("http://{addr}/code/browser/{rt}"));
+    if let Some(t) = tok {
+        r = r.bearer_auth(t);
+    }
+    r.send().await.unwrap()
+}
+
+#[tokio::test]
+async fn valid_token_lists() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = get(a.addr, "list", Some(&t)).await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    let b: serde_json::Value = r.json().await.unwrap();
+    assert_eq!(b["sessions"][0]["browserId"], "browser-1");
+    let c = a.fake.as_ref().unwrap().subjects();
+    assert_eq!(c.len(), 1);
+    assert_eq!(c[0].0, "list");
+    assert_eq!(c[0].1.owner, OwnerId::local());
+    assert_eq!(c[0].1.workspace, ws);
+    assert_eq!(c[0].1.session, s);
+}
+
+#[tokio::test]
+async fn missing_and_unknown_401() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let _ = mint_token(&a.code, ws, s);
+    assert_eq!(
+        get(a.addr, "list", None).await.status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+    let g = "tbreak_bt_00000000-0000-4000-8000-000000000000";
+    let r = get(a.addr, "list", Some(g)).await;
+    assert_eq!(r.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert!(!r.text().await.unwrap().contains(g));
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
+async fn app_token_not_browser() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let _ = mint_token(&a.code, ws, s);
+    assert_eq!(
+        get(
+            a.addr,
+            "list",
+            Some(crate::state::TEST_CLIENT_EXECUTOR_TOKEN)
+        )
+        .await
+        .status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+}
+
+#[tokio::test]
+async fn revoked_then_401() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    a.code.browser_tokens.revoke(s);
+    let r = get(a.addr, "list", Some(&t)).await;
+    assert_eq!(r.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert!(!r.text().await.unwrap().contains(&t));
+}
+
+#[tokio::test]
+async fn ended_session_403() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Ended).await;
+    let t = mint_token(&a.code, ws, s);
+    assert_eq!(
+        get(a.addr, "list", Some(&t)).await.status(),
+        reqwest::StatusCode::FORBIDDEN
+    );
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
+async fn cross_workspace_404() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (_, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, WorkspaceId::new(), s);
+    assert_eq!(
+        get(a.addr, "list", Some(&t)).await.status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
+async fn missing_runtime_501() {
+    let a = browser_app(None).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = get(a.addr, "list", Some(&t)).await;
+    assert_eq!(r.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+    assert!(!r.text().await.unwrap().contains(&t));
+    assert_eq!(
+        get(a.addr, "list", Some("nope")).await.status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+}
+
+#[tokio::test]
+async fn stale_snapshot_409() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::stale()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "snapshot",
+        Some(&t),
+        serde_json::json!({"browser_id":"browser-1"}),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::CONFLICT);
+    assert_eq!(
+        r.json::<serde_json::Value>().await.unwrap()["kind"],
+        "stale_browser_target"
+    );
+}
+
+#[tokio::test]
+async fn navigate_roundtrip() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "navigate",
+        Some(&t),
+        serde_json::json!({"browser_id":"browser-1","url":"https://example.com/docs"}),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    let b: serde_json::Value = r.json().await.unwrap();
+    assert_eq!(b["url"], "https://example.com/docs");
+    assert_eq!(b["loadState"], "loading");
+    let u = post(
+        a.addr,
+        "navigate",
+        Some(&t),
+        serde_json::json!({"browser_id":"browser-9","url":"https://example.com"}),
+    )
+    .await;
+    assert_eq!(u.status(), reqwest::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn snapshot_roundtrip() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "snapshot",
+        Some(&t),
+        serde_json::json!({"browser_id":"browser-1"}),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        r.json::<serde_json::Value>().await.unwrap()["url"],
+        "https://example.com"
+    );
+}
+
+#[tokio::test]
+async fn navigate_refuses_non_http() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    for u in ["file:///etc/passwd", "https://user:secret@example.com"] {
+        assert_eq!(
+            post(
+                a.addr,
+                "navigate",
+                Some(&t),
+                serde_json::json!({"browser_id":"browser-1","url":u})
+            )
+            .await
+            .status(),
+            reqwest::StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
+async fn snapshot_needs_browser_id() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    assert_eq!(
+        post(a.addr, "snapshot", Some(&t), serde_json::json!({}))
+            .await
+            .status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+}
+
+#[tokio::test]
+async fn bodies_reject_subject_ids() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    for (rt, body) in [
+        (
+            "navigate",
+            serde_json::json!({"browser_id":"b-1","url":"https://x.com","session_id":"g"}),
+        ),
+        (
+            "snapshot",
+            serde_json::json!({"browser_id":"b-1","owner_id":"g"}),
+        ),
+    ] {
+        assert_eq!(
+            post(a.addr, rt, Some(&t), body).await.status(),
+            reqwest::StatusCode::BAD_REQUEST
+        );
+    }
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}


### PR DESCRIPTION
## What

Introduces `BrowserTokenRegistry` — an in-memory route-token registry with session-private capability files. This is the security-critical browser authority slice from #2342, stacked on #2364.

## Key design

**Token registry**: Each random v4 UUID token maps to a `{owner, workspace, session}` subject. Reissuing for the same session silently revokes and deletes the prior token and its capfile. Request/model payloads never provide owner/workspace/session IDs.

**Capfile schema**: Capfile carries only `{version, endpoint, token}`. No owner, workspace, session, or browser IDs leave the server. Tokens are never logged.

**Capfile lifecycle**:
- Written create-new → fsync → chmod 0600 → atomic rename under a 0700 subtree
- Random temp names prevent collision with concurrent issuers
- Path is always absolute — PR #2364's accepted P3 is closed here

**Startup cleanup**: `CodeRuntime::start()` synchronously deletes every stale capfile before recovery or new session creation. The in-memory registry is always fresh on restart, so recovery fails closed and reissues fresh channels.

**Worker lifecycle hooks**:
- `attach_and_spawn_worker`: Mints `BrowserChannelSpec`, passes through `SessionSpec`
- Launch failure (ResumeLost): Revokes immediately
- Launch failure (other error): Revokes immediately
- `reap()`: Revokes idempotently
- `end_session_row()`: Revokes idempotently
- `end_workspace_sessions()`: Revokes each session idempotently

## What is not here (intentionally deferred)

- HTTP `/code/browser/*` routes and `BrowserRuntime` trait
- CLI commands (`tidebreak browser ... --json`)
- Desktop WKWebView adapter
- Foreground chat binding
- `wait`/`screenshot`/`act` expansion
- Provider-specific behavior

## Tests

Tests are written (not run locally — Rust validation is CI-only). Coverage includes:

- Token roundtrip via registry
- Reissue revocation and replacement
- Idempotent revoke
- Capfile schema omits subject IDs
- Endpoint derivation from loopback base
- Stale directory cleanup (capfiles removed, other files preserved)
- Missing directory cleanup no-op
- Absolute path construction
- Unix mode 0600 capfile + 0700 directory
- Atomic temp file cleanup

## Stacking

- Base: `thet/browser-harness-channel` (#2364, head `7ed6003`)
- This PR: `thet/browser-session-authority`
- Next: route seam (`/code/browser/*` routes + `BrowserRuntime` trait)

Ref: #2342, #2335
