### PR TITLE
feat(cli): add session-scoped browser CLI and MCP bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7017,6 +7017,7 @@ dependencies = [
 name = "tidebreak-cli"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "base64 0.23.1",
  "chrono",
  "futures",
@@ -7032,6 +7033,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/tidebreak-cli/Cargo.toml
+++ b/crates/tidebreak-cli/Cargo.toml
@@ -30,6 +30,7 @@ tidebreak-code-execution = { path = "../tidebreak-code-execution" }
 tidebreak-host-broker = { path = "../tidebreak-host-broker" }
 tidebreak-mcp = { path = "../tidebreak-mcp" }
 tidebreak-server = { path = "../tidebreak-server" }
+async-trait = { workspace = true }
 # Decoding the broker's binary file reads, whose protocol shape is base64 —
 # `import_connected_file` publishes those bytes as a conversation source.
 base64 = { workspace = true }
@@ -44,6 +45,7 @@ tokio-tungstenite = { workspace = true }
 # The connected-folder executor's diagnostics belong in the profile's log file:
 # it polls, so stderr would flood a print run.
 tracing = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tidebreak-cli/src/browser.rs
+++ b/crates/tidebreak-cli/src/browser.rs
@@ -1,0 +1,2191 @@
+//! Tidebreak browser CLI commands and the `browser-mcp` stdio server.
+//!
+//! `tidebreak browser list|navigate|snapshot --json` drive a running Tidebreak
+//! browser server through the session-private capability file named by
+//! `TIDEBREAK_BROWSER_CAPFILE`. Every operation runs through a single
+//! [`BrowserClient`] that is shared between the direct CLI and the MCP tool
+//! implementations.
+//!
+//! `tidebreak browser-mcp` serves exactly three tools — browser_list,
+//! browser_navigate, browser_snapshot — over MCP stdio, using the canonical
+//! core tool specs and validating typed arguments before sending them to the
+//! browser server.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::Value;
+use tidebreak_core::{
+    browser_list_tool_spec, browser_navigate_tool_spec, browser_snapshot_tool_spec,
+    validate_browser_list_arguments, validate_browser_navigate_arguments,
+    validate_browser_snapshot_arguments, AgentError, ApprovalClass, AutoApproveGate,
+    BrowserListResult, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
+    BrowserSnapshotArgs, Result, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolRegistry,
+    ToolSpec,
+};
+
+// ---------------------------------------------------------------------------
+// Capability file
+// ---------------------------------------------------------------------------
+
+/// Maximum bytes the capfile is allowed to be (64 KiB).
+const CAPFILE_MAX_BYTES: u64 = 65_536;
+
+/// Hard ceiling on a successful snapshot response body. A reply larger than
+/// this is refused rather than decoded unbounded.
+const SNAPSHOT_BODY_MAX_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
+
+/// Ceiling on a list response body (small, bounded).
+const LIST_BODY_MAX_BYTES: usize = 256 * 1024; // 256 KiB
+
+/// Ceiling on a navigate response body (very small).
+const NAVIGATE_BODY_MAX_BYTES: usize = 64 * 1024; // 64 KiB
+
+/// Ceiling on an error body we attempt to parse for `{kind, message}`.
+const ERROR_BODY_MAX_BYTES: usize = 8 * 1024; // 8 KiB
+
+const BODY_TOO_LARGE_DETAIL: &str = "response body exceeded the size limit";
+
+const TOKEN_PREFIX: &str = "tbreak_bt_";
+const TOKEN_LENGTH: usize = TOKEN_PREFIX.len() + 36; // prefix + UUID
+
+/// The session-private capability file, read from the path named by
+/// `TIDEBREAK_BROWSER_CAPFILE`. It carries exactly the data needed to reach a
+/// running browser server: an endpoint and a bearer token.
+///
+/// This struct must never derive `Debug` — the token must not appear in debug
+/// output or error formatting.
+#[derive(Clone)]
+struct BrowserCapfile {
+    endpoint: String,
+    token: String,
+}
+
+/// Wire shape of the capfile. The only supported version is 1.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BrowserCapfileWire {
+    version: u32,
+    endpoint: String,
+    token: String,
+}
+
+impl BrowserCapfile {
+    /// Read and validate the capfile at `path`.
+    ///
+    /// Fails closed: the file must exist, fit in a hard byte cap, be regular
+    /// UTF-8 JSON, declare version 1, carry a loopback HTTP endpoint with an
+    /// explicit port and exact path `/code/browser`, no user/pass/query/fragment,
+    /// and a non-empty bearer token of the canonical `tbreak_bt_<UUID>` shape.
+    ///
+    /// The endpoint, token, and capfile path are never printed in error output.
+    fn load(path: &std::path::Path) -> Result<Self> {
+        // Stat once for the soft guard; the read uses a hard cap so a racing
+        // append cannot allocate unbounded.
+        let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+            AgentError::config(format!("browser capfile cannot be read ({error})"))
+        })?;
+        if !metadata.file_type().is_file() {
+            return Err(AgentError::config(
+                "browser capfile must be a regular file",
+            ));
+        }
+        if metadata.len() > CAPFILE_MAX_BYTES {
+            return Err(AgentError::config("browser capfile exceeds the size limit"));
+        }
+
+        // Read at most CAPFILE_MAX_BYTES + 1: the +1 lets us detect oversized
+        // files without allocating beyond the ceiling.
+        let raw = read_file_capped(path, CAPFILE_MAX_BYTES as usize).map_err(|error| {
+            AgentError::config(format!("browser capfile cannot be read ({error})"))
+        })?;
+        if raw.len() > CAPFILE_MAX_BYTES as usize {
+            return Err(AgentError::config("browser capfile exceeds the size limit"));
+        }
+
+        let wire: BrowserCapfileWire = serde_json::from_str(&raw).map_err(|error| {
+            AgentError::config(format!("browser capfile is not valid JSON ({error})"))
+        })?;
+        if wire.version != 1 {
+            return Err(AgentError::config(format!(
+                "browser capfile version {} is not supported (only version 1)",
+                wire.version
+            )));
+        }
+        Self::validate_endpoint(&wire.endpoint)?;
+        Self::validate_token(&wire.token)?;
+        Ok(Self {
+            endpoint: wire.endpoint,
+            token: wire.token,
+        })
+    }
+
+    /// Load from the path named by the `TIDEBREAK_BROWSER_CAPFILE` environment
+    /// variable, or fail with a clear message if the variable is not set.
+    fn from_env() -> Result<Self> {
+        let path = std::env::var_os("TIDEBREAK_BROWSER_CAPFILE")
+            .map(PathBuf::from)
+            .ok_or_else(|| AgentError::config("TIDEBREAK_BROWSER_CAPFILE is not set"))?;
+        Self::load(&path)
+    }
+
+    /// Validate the endpoint: HTTP only, loopback host, explicit port, path
+    /// exactly `/code/browser`, no user/pass/query/fragment.
+    fn validate_endpoint(endpoint: &str) -> Result<()> {
+        let url: url::Url = endpoint
+            .parse()
+            .map_err(|_| AgentError::config("browser capfile endpoint is not a valid URL"))?;
+        if url.scheme() != "http" {
+            return Err(AgentError::config("browser capfile endpoint must use http"));
+        }
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(AgentError::config(
+                "browser capfile endpoint must not contain credentials",
+            ));
+        }
+        if url.query().is_some() || url.fragment().is_some() {
+            return Err(AgentError::config(
+                "browser capfile endpoint must not contain a query or fragment",
+            ));
+        }
+        if url.path() != "/code/browser" {
+            return Err(AgentError::config(
+                "browser capfile endpoint path must be /code/browser",
+            ));
+        }
+        let Some(host) = url.host_str() else {
+            return Err(AgentError::config("browser capfile endpoint has no host"));
+        };
+        if url.port().is_none() {
+            return Err(AgentError::config(
+                "browser capfile endpoint must include an explicit port",
+            ));
+        }
+        let is_loopback = host.eq_ignore_ascii_case("localhost")
+            || host.to_ascii_lowercase().ends_with(".localhost")
+            || host
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|addr| addr.is_loopback());
+        if !is_loopback {
+            return Err(AgentError::config(
+                "browser capfile endpoint is not a loopback address",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Validate the v1 token shape: `tbreak_bt_` prefix followed by a UUID.
+    fn validate_token(token: &str) -> Result<()> {
+        if token.is_empty() {
+            return Err(AgentError::config("browser capfile token is empty"));
+        }
+        if token.len() != TOKEN_LENGTH {
+            return Err(AgentError::config(
+                "browser capfile token has an unexpected length",
+            ));
+        }
+        if !token.starts_with(TOKEN_PREFIX) {
+            return Err(AgentError::config(
+                "browser capfile token has an unexpected prefix",
+            ));
+        }
+        let uuid_part = &token[TOKEN_PREFIX.len()..];
+        uuid::Uuid::parse_str(uuid_part)
+            .map_err(|_| AgentError::config("browser capfile token suffix is not a UUID"))?;
+        Ok(())
+    }
+}
+
+/// Read `path` into a `String`, reading at most `cap + 1` bytes so a racing
+/// append cannot allocate unbounded. Returns the full bytes read; the caller
+/// checks against the cap.
+fn read_file_capped(path: &std::path::Path, cap: usize) -> std::io::Result<String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut buf = Vec::with_capacity(cap.saturating_add(1).min(cap + 4096));
+    let mut chunk = [0u8; 8192];
+    loop {
+        let n = file.read(&mut chunk)?;
+        if n == 0 {
+            break;
+        }
+        let room = cap.saturating_add(1).saturating_sub(buf.len());
+        let take = n.min(room);
+        buf.extend_from_slice(&chunk[..take]);
+        if buf.len() > cap {
+            // The open file closes when this function returns; there is no
+            // reason to drain a racing append after the hard cap is reached.
+            break;
+        }
+    }
+    String::from_utf8(buf)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+// ---------------------------------------------------------------------------
+// Browser client
+// ---------------------------------------------------------------------------
+
+/// Shared HTTP client for the browser server, constructed once from the
+/// capfile. Every request carries `Authorization: Bearer <token>`, has
+/// redirects disabled, and uses bounded connect and read timeouts.
+///
+/// This struct must never derive `Debug` — the token must not appear in debug
+/// output or error formatting.
+#[derive(Clone)]
+struct BrowserClient {
+    client: reqwest::Client,
+    endpoint: String,
+    token: String,
+}
+
+impl BrowserClient {
+    /// Build a client from the given capfile.
+    fn new(cap: &BrowserCapfile) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|error| {
+                AgentError::config(format!("could not build browser HTTP client ({error})"))
+            })?;
+        Ok(Self {
+            client,
+            endpoint: cap.endpoint.clone(),
+            token: cap.token.clone(),
+        })
+    }
+
+    /// Read a bounded response body, then deserialize to `T`.
+    async fn read_bounded_json<T: serde::de::DeserializeOwned>(
+        response: reqwest::Response,
+        max_bytes: usize,
+    ) -> std::result::Result<T, ClientFailure> {
+        let status = response.status();
+        let body_limit = if status.is_success() {
+            max_bytes
+        } else {
+            max_bytes.min(ERROR_BODY_MAX_BYTES)
+        };
+        let bytes = match read_response_body_bounded(response, body_limit).await {
+            Ok(bytes) => bytes,
+            Err(ClientFailure::ToolFailed { detail })
+                if !status.is_success() && detail == BODY_TOO_LARGE_DETAIL =>
+            {
+                return Err(ClientFailure::from_http_status(
+                    status.as_u16(),
+                    "error_body_too_large",
+                    "server error body exceeded the size limit",
+                ));
+            }
+            Err(failure) => return Err(failure),
+        };
+        if status.is_success() {
+            serde_json::from_slice(&bytes).map_err(|error| ClientFailure::TransportFailed {
+                detail: format!("unreadable success body ({error})"),
+            })
+        } else {
+            // Try to decode a stable server error {kind, message}.
+            let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+            let kind = body
+                .get("kind")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let message = body
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("no detail");
+            Err(ClientFailure::from_http_status(
+                status.as_u16(),
+                kind,
+                message,
+            ))
+        }
+    }
+}
+
+/// Read a response body up to `max_bytes`. Beyond that, the remainder is
+/// drained and the reader returns an error.
+async fn read_response_body_bounded(
+    response: reqwest::Response,
+    max_bytes: usize,
+) -> std::result::Result<Vec<u8>, ClientFailure> {
+    use futures::StreamExt;
+
+    let mut stream = response.bytes_stream();
+    let mut buf = Vec::with_capacity(max_bytes.min(4096));
+    while let Some(chunk_result) = stream.next().await {
+        let chunk = chunk_result.map_err(|error| ClientFailure::TransportFailed {
+            detail: format!("body chunk error ({error})"),
+        })?;
+        let room = max_bytes.saturating_sub(buf.len());
+        if chunk.len() > room {
+            // Dropping the response closes or retires this connection. Return
+            // immediately so an oversized stream cannot monopolize MCP stdio.
+            return Err(ClientFailure::ToolFailed {
+                detail: BODY_TOO_LARGE_DETAIL.to_string(),
+            });
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
+
+// -- client failure type ------------------------------------------------
+
+/// Typed failure from the browser client, mapped to [`ToolErrorCategory`] for
+/// the MCP tools and to [`AgentError`] for the direct CLI.
+///
+/// The bearer token and capfile path are never included in these errors.
+#[derive(Debug, Clone)]
+enum ClientFailure {
+    InvalidArguments { detail: String },
+    NotFound { detail: String },
+    ConfigurationRequired { detail: String },
+    TransportFailed { detail: String },
+    ToolFailed { detail: String },
+}
+
+impl ClientFailure {
+    /// Classify an HTTP error status plus the server's `{kind, message}` body
+    /// into the right [`ClientFailure`] variant.
+    fn from_http_status(status: u16, kind: &str, message: &str) -> ClientFailure {
+        // Scrub the message: if it contains the token prefix or any plausible
+        // bearer pattern, redact it.
+        let scrubbed = scrub_server_message(message);
+        let detail = format!("({kind}) {scrubbed}");
+        match status {
+            400 => ClientFailure::InvalidArguments { detail },
+            401 | 403 | 501 => ClientFailure::ConfigurationRequired { detail },
+            404 => ClientFailure::NotFound { detail },
+            _ => ClientFailure::ToolFailed { detail },
+        }
+    }
+
+    fn to_tool_error_category(&self) -> ToolErrorCategory {
+        match self {
+            ClientFailure::InvalidArguments { .. } => ToolErrorCategory::InvalidArguments,
+            ClientFailure::NotFound { .. } => ToolErrorCategory::NotFound,
+            ClientFailure::ConfigurationRequired { .. } => ToolErrorCategory::ConfigurationRequired,
+            ClientFailure::TransportFailed { .. } => ToolErrorCategory::TransportFailed,
+            ClientFailure::ToolFailed { .. } => ToolErrorCategory::ToolFailed,
+        }
+    }
+
+    fn redacted_text(&self) -> String {
+        match self {
+            ClientFailure::InvalidArguments { detail } => {
+                format!("browser: invalid arguments — {detail}")
+            }
+            ClientFailure::NotFound { detail } => {
+                format!("browser: not found — {detail}")
+            }
+            ClientFailure::ConfigurationRequired { detail } => {
+                format!("browser: configuration required — {detail}")
+            }
+            ClientFailure::TransportFailed { detail } => {
+                format!("browser: transport failed — {detail}")
+            }
+            ClientFailure::ToolFailed { detail } => {
+                format!("browser: tool failed — {detail}")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ClientFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.redacted_text())
+    }
+}
+
+impl std::error::Error for ClientFailure {}
+
+/// Remove any plausible token-bearing text from a server error message.
+fn scrub_server_message(message: &str) -> String {
+    // If the message literally contains the token prefix, redact the whole
+    // thing to a static label.
+    if message.contains("tbreak_") || message.contains("bearer") || message.contains("Bearer") {
+        return "[redacted]".to_string();
+    }
+    // Also scrub any substring that looks like a UUID.
+    let mut result = String::with_capacity(message.len());
+    let mut rest = message;
+    while let Some(start) = rest.char_indices().find_map(|(start, _)| {
+        let end = start.checked_add(36)?;
+        rest.get(start..end)
+            .filter(|candidate| uuid::Uuid::parse_str(candidate).is_ok())
+            .map(|_| start)
+    }) {
+        result.push_str(&rest[..start]);
+        result.push_str("[redacted]");
+        rest = &rest[start + 36..];
+    }
+    result.push_str(rest);
+    result
+}
+
+// -- typed operations ---------------------------------------------------
+
+async fn browser_list(
+    client: &BrowserClient,
+) -> std::result::Result<BrowserListResult, ClientFailure> {
+    let response = client
+        .client
+        .get(format!("{}/list", client.endpoint))
+        .bearer_auth(&client.token)
+        .send()
+        .await
+        .map_err(|error| ClientFailure::TransportFailed {
+            detail: format!("browser list request failed: {error}"),
+        })?;
+    BrowserClient::read_bounded_json(response, LIST_BODY_MAX_BYTES).await
+}
+
+async fn browser_navigate(
+    client: &BrowserClient,
+    args: &BrowserNavigateArgs,
+) -> std::result::Result<BrowserNavigateResult, ClientFailure> {
+    let response = client
+        .client
+        .post(format!("{}/navigate", client.endpoint))
+        .bearer_auth(&client.token)
+        .json(args)
+        .send()
+        .await
+        .map_err(|error| ClientFailure::TransportFailed {
+            detail: format!("browser navigate request failed: {error}"),
+        })?;
+    BrowserClient::read_bounded_json(response, NAVIGATE_BODY_MAX_BYTES).await
+}
+
+async fn browser_snapshot(
+    client: &BrowserClient,
+    args: &BrowserSnapshotArgs,
+) -> std::result::Result<BrowserPageSnapshot, ClientFailure> {
+    let response = client
+        .client
+        .post(format!("{}/snapshot", client.endpoint))
+        .bearer_auth(&client.token)
+        .json(args)
+        .send()
+        .await
+        .map_err(|error| ClientFailure::TransportFailed {
+            detail: format!("browser snapshot request failed: {error}"),
+        })?;
+    BrowserClient::read_bounded_json(response, SNAPSHOT_BODY_MAX_BYTES).await
+}
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+
+/// Parsed `tidebreak browser …` subcommand.
+#[derive(Debug, Clone)]
+pub(crate) enum BrowserCommand {
+    List,
+    Navigate {
+        browser_id: String,
+        url: String,
+    },
+    Snapshot {
+        browser_id: String,
+        max_nodes: Option<usize>,
+    },
+}
+
+/// Parse one `tidebreak browser <verb> …` invocation from positional strings.
+/// Returns a usage message on failure.
+pub(crate) fn parse_browser(args: Vec<String>) -> std::result::Result<BrowserCommand, String> {
+    let mut args = args.into_iter();
+    let Some(verb) = args.next() else {
+        return Err(BROWSER_USAGE.to_string());
+    };
+    match verb.as_str() {
+        "list" => {
+            if args.next().is_some() {
+                return Err("browser list takes no arguments".to_string());
+            }
+            Ok(BrowserCommand::List)
+        }
+        "navigate" => {
+            let mut browser_id = None;
+            let mut url = None;
+            while let Some(arg) = args.next() {
+                match arg.as_str() {
+                    "--browser-id" => {
+                        if browser_id.is_some() {
+                            return Err("duplicate --browser-id".to_string());
+                        }
+                        let Some(value) = args.next() else {
+                            return Err("--browser-id requires a value".to_string());
+                        };
+                        if value.starts_with("--") {
+                            return Err("--browser-id requires a value".to_string());
+                        }
+                        browser_id = Some(value);
+                    }
+                    "--url" => {
+                        if url.is_some() {
+                            return Err("duplicate --url".to_string());
+                        }
+                        let Some(value) = args.next() else {
+                            return Err("--url requires a value".to_string());
+                        };
+                        if value.starts_with("--") {
+                            return Err("--url requires a value".to_string());
+                        }
+                        url = Some(value);
+                    }
+                    other => {
+                        return Err(format!("unknown browser navigate argument {other:?}"));
+                    }
+                }
+            }
+            let Some(browser_id) = browser_id else {
+                return Err("browser navigate requires --browser-id".to_string());
+            };
+            let Some(url) = url else {
+                return Err("browser navigate requires --url".to_string());
+            };
+            Ok(BrowserCommand::Navigate { browser_id, url })
+        }
+        "snapshot" => {
+            let mut browser_id = None;
+            let mut max_nodes = None;
+            while let Some(arg) = args.next() {
+                match arg.as_str() {
+                    "--browser-id" => {
+                        if browser_id.is_some() {
+                            return Err("duplicate --browser-id".to_string());
+                        }
+                        let Some(value) = args.next() else {
+                            return Err("--browser-id requires a value".to_string());
+                        };
+                        if value.starts_with("--") {
+                            return Err("--browser-id requires a value".to_string());
+                        }
+                        browser_id = Some(value);
+                    }
+                    "--max-nodes" => {
+                        if max_nodes.is_some() {
+                            return Err("duplicate --max-nodes".to_string());
+                        }
+                        let Some(value) = args.next() else {
+                            return Err("--max-nodes requires a value".to_string());
+                        };
+                        if value.starts_with("--") {
+                            return Err("--max-nodes requires a value".to_string());
+                        }
+                        let n: usize = value.parse().map_err(|_| {
+                            format!("--max-nodes expects a positive integer, got {value:?}")
+                        })?;
+                        max_nodes = Some(n);
+                    }
+                    other => {
+                        return Err(format!("unknown browser snapshot argument {other:?}"));
+                    }
+                }
+            }
+            let Some(browser_id) = browser_id else {
+                return Err("browser snapshot requires --browser-id".to_string());
+            };
+            Ok(BrowserCommand::Snapshot {
+                browser_id,
+                max_nodes,
+            })
+        }
+        other => Err(format!("unknown browser command {other:?}")),
+    }
+}
+
+/// Usage text shown for `tidebreak browser` (and `browser-mcp`).
+pub(crate) const BROWSER_USAGE: &str = "\
+usage: tidebreak browser list --json
+       tidebreak browser navigate --browser-id <id> --url <url> --json
+       tidebreak browser snapshot --browser-id <id> [--max-nodes <n>] --json
+
+Browser commands use the session-private capfile named by
+TIDEBREAK_BROWSER_CAPFILE. They do not take --server/--attach.";
+
+// ---------------------------------------------------------------------------
+// CLI runner
+// ---------------------------------------------------------------------------
+
+/// Run a `tidebreak browser …` command.
+pub(crate) async fn run_browser(command: BrowserCommand) -> Result<()> {
+    let cap = BrowserCapfile::from_env()?;
+    let client = BrowserClient::new(&cap)?;
+    match command {
+        BrowserCommand::List => {
+            let result = browser_list(&client)
+                .await
+                .map_err(|failure| AgentError::msg(failure.redacted_text()))?;
+            println!(
+                "{}",
+                serde_json::to_string(&result)
+                    .map_err(|error| AgentError::msg(format!("JSON encode: {error}")))?
+            );
+            Ok(())
+        }
+        BrowserCommand::Navigate { browser_id, url } => {
+            let args = BrowserNavigateArgs { browser_id, url };
+            if !args.is_well_formed() {
+                return Err(AgentError::msg(
+                    "browser_id or url is not well-formed for navigate",
+                ));
+            }
+            let result = browser_navigate(&client, &args)
+                .await
+                .map_err(|failure| AgentError::msg(failure.redacted_text()))?;
+            println!(
+                "{}",
+                serde_json::to_string(&result)
+                    .map_err(|error| AgentError::msg(format!("JSON encode: {error}")))?
+            );
+            Ok(())
+        }
+        BrowserCommand::Snapshot {
+            browser_id,
+            max_nodes,
+        } => {
+            let args = BrowserSnapshotArgs {
+                browser_id,
+                max_nodes,
+            };
+            if !args.is_well_formed() {
+                return Err(AgentError::msg(
+                    "browser_id or max_nodes is not well-formed for snapshot",
+                ));
+            }
+            let result = browser_snapshot(&client, &args)
+                .await
+                .map_err(|failure| AgentError::msg(failure.redacted_text()))?;
+            println!(
+                "{}",
+                serde_json::to_string(&result)
+                    .map_err(|error| AgentError::msg(format!("JSON encode: {error}")))?
+            );
+            Ok(())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// browser-mcp: stdio MCP server with exactly three tools
+// ---------------------------------------------------------------------------
+
+/// Serve `tidebreak browser-mcp`: load the capfile, construct the client,
+/// build a registry of three tools backed by that client, and run MCP over
+/// stdio.
+///
+/// ## Tool classification
+///
+/// | Tool            | Class     | Rationale                                                   |
+/// |-----------------|-----------|-------------------------------------------------------------|
+/// | browser_list    | ReadOnly  | Observes session state; no mutation.                        |
+/// | browser_navigate| Sensitive | Mutates the shared visible browser; the user sees the change.|
+/// | browser_snapshot | ReadOnly | Reads untrusted page data; no side effects.                 |
+///
+/// ## Authorization
+///
+/// The registry contains only these three tools. We wire
+/// [`AutoApproveGate`] because possession of the session-private capfile
+/// *is* the actual scoped authorization boundary for this process: without
+/// the capfile the server cannot be reached, and with it every operation is
+/// exactly the one the capfile's issuer intended. The browser server
+/// authorizes each operation independently against its own origin-scoped
+/// grants.
+pub(crate) async fn run_browser_mcp() -> Result<()> {
+    let cap = BrowserCapfile::from_env()?;
+    let client = BrowserClient::new(&cap)?;
+
+    let tools = Arc::new(
+        ToolRegistry::new()
+            .with(Box::new(BrowserListTool {
+                client: client.clone(),
+            }))
+            .with(Box::new(BrowserNavigateTool {
+                client: client.clone(),
+            }))
+            .with(Box::new(BrowserSnapshotTool {
+                client: client.clone(),
+            })),
+    );
+
+    // No filesystem workspace: the tools reach the loopback server only.
+    let ctx = ToolCtx::without_private_scratch(tidebreak_core::ChatId::new(), None);
+
+    let server =
+        tidebreak_mcp::McpServer::new(tools, ctx).with_approval_gate(Arc::new(AutoApproveGate));
+
+    tidebreak_mcp::serve_stdio(server)
+        .await
+        .map_err(|error| AgentError::msg(format!("MCP stdio error: {error}")))
+}
+
+// ---------------------------------------------------------------------------
+// MCP tool implementations — one struct per tool, backed by BrowserClient
+// ---------------------------------------------------------------------------
+
+/// Map a [`ClientFailure`] to a [`ToolOutput`] carrying the right
+/// [`ToolErrorCategory`] and a concise redacted message.
+fn mcp_failure(output: ClientFailure) -> ToolOutput {
+    ToolOutput::failed(output.to_tool_error_category(), output.redacted_text())
+}
+
+/// [`BROWSER_LIST_TOOL`] as an MCP-registrable [`Tool`].
+struct BrowserListTool {
+    client: BrowserClient,
+}
+
+#[async_trait::async_trait]
+impl Tool for BrowserListTool {
+    fn spec(&self) -> ToolSpec {
+        browser_list_tool_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        if !validate_browser_list_arguments(&args) {
+            return Ok(mcp_failure(ClientFailure::InvalidArguments {
+                detail: "invalid browser_list arguments".to_string(),
+            }));
+        }
+        match browser_list(&self.client).await {
+            Ok(result) => {
+                let data = serde_json::to_value(&result).ok();
+                let text = format_browser_list_summary(&result);
+                Ok(ToolOutput::text(text).with_data(data.unwrap_or(Value::Null)))
+            }
+            Err(failure) => Ok(mcp_failure(failure)),
+        }
+    }
+}
+
+/// [`BROWSER_NAVIGATE_TOOL`] as an MCP-registrable [`Tool`].
+struct BrowserNavigateTool {
+    client: BrowserClient,
+}
+
+#[async_trait::async_trait]
+impl Tool for BrowserNavigateTool {
+    fn spec(&self) -> ToolSpec {
+        browser_navigate_tool_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        if !validate_browser_navigate_arguments(&args) {
+            return Ok(mcp_failure(ClientFailure::InvalidArguments {
+                detail: "invalid browser_navigate arguments".to_string(),
+            }));
+        }
+        let parsed: BrowserNavigateArgs = match serde_json::from_value(args) {
+            Ok(v) => v,
+            Err(_) => {
+                return Ok(mcp_failure(ClientFailure::InvalidArguments {
+                    detail: "browser_navigate arguments do not match the schema".to_string(),
+                }))
+            }
+        };
+        match browser_navigate(&self.client, &parsed).await {
+            Ok(result) => {
+                let data = serde_json::to_value(&result).ok();
+                let text = format!(
+                    "Navigated browser {} to {}. Load state: {:?}, epoch: {}.",
+                    result.browser_id, result.url, result.load_state, result.document_epoch
+                );
+                Ok(ToolOutput::text(text).with_data(data.unwrap_or(Value::Null)))
+            }
+            Err(failure) => Ok(mcp_failure(failure)),
+        }
+    }
+}
+
+/// [`BROWSER_SNAPSHOT_TOOL`] as an MCP-registrable [`Tool`].
+struct BrowserSnapshotTool {
+    client: BrowserClient,
+}
+
+#[async_trait::async_trait]
+impl Tool for BrowserSnapshotTool {
+    fn spec(&self) -> ToolSpec {
+        browser_snapshot_tool_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        if !validate_browser_snapshot_arguments(&args) {
+            return Ok(mcp_failure(ClientFailure::InvalidArguments {
+                detail: "invalid browser_snapshot arguments".to_string(),
+            }));
+        }
+        let parsed: BrowserSnapshotArgs = match serde_json::from_value(args) {
+            Ok(v) => v,
+            Err(_) => {
+                return Ok(mcp_failure(ClientFailure::InvalidArguments {
+                    detail: "browser_snapshot arguments do not match the schema".to_string(),
+                }))
+            }
+        };
+        match browser_snapshot(&self.client, &parsed).await {
+            Ok(snapshot) => {
+                let data = serde_json::to_value(&snapshot).ok();
+                let text = format_browser_snapshot_summary(&snapshot);
+                Ok(ToolOutput::text(text).with_data(data.unwrap_or(Value::Null)))
+            }
+            Err(failure) => Ok(mcp_failure(failure)),
+        }
+    }
+}
+
+// -- helper functions --
+
+/// Build a concise model-readable summary of a page snapshot.
+fn format_browser_snapshot_summary(snapshot: &BrowserPageSnapshot) -> String {
+    let truncated = if snapshot.truncated {
+        " (truncated)"
+    } else {
+        ""
+    };
+    format!(
+        "Snapshot of {} ({}). {} nodes, {} frames, epoch {}{}. Title: \"{}\".",
+        snapshot.url,
+        snapshot.browser_id,
+        snapshot.nodes.len(),
+        snapshot.frames.len(),
+        snapshot.document_epoch,
+        truncated,
+        snapshot.title
+    )
+}
+
+/// Build a concise model-readable summary of a browser list result.
+fn format_browser_list_summary(result: &BrowserListResult) -> String {
+    if result.sessions.is_empty() {
+        return "No browser sessions available.".to_string();
+    }
+    let lines: Vec<String> = result
+        .sessions
+        .iter()
+        .map(|session| {
+            let url = session.url.as_deref().unwrap_or("(no url)");
+            let title = session.title.as_deref().unwrap_or("(no title)");
+            format!(
+                "browser {}: {:?} at {} — \"{}\"",
+                session.browser_id, session.load_state, url, title
+            )
+        })
+        .collect();
+    format!("{} browser session(s):\n{}", lines.len(), lines.join("\n"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const VALID_TOKEN: &str = "tbreak_bt_00000000-0000-0000-0000-000000000000";
+
+    // -- Capfile parsing ---------------------------------------------------
+
+    #[test]
+    fn capfile_accepts_valid_v1() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://127.0.0.1:9876/code/browser",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let cap = BrowserCapfile::load(&path).unwrap();
+        assert_eq!(cap.endpoint, "http://127.0.0.1:9876/code/browser");
+        assert_eq!(cap.token, VALID_TOKEN);
+    }
+
+    #[test]
+    fn capfile_accepts_localhost() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://localhost:3000/code/browser",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(BrowserCapfile::load(&path).is_ok());
+    }
+
+    #[test]
+    fn capfile_accepts_ipv6_loopback() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://[::1]:8080/code/browser",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(BrowserCapfile::load(&path).is_ok());
+    }
+
+    #[test]
+    fn capfile_rejects_non_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = BrowserCapfile::load(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("regular file"));
+    }
+
+    // -- Capfile rejection: endpoint validation ----------------------------
+
+    #[test]
+    fn capfile_rejects_https() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "https://127.0.0.1:9876/code/browser",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(BrowserCapfile::load(&path).is_err());
+    }
+
+    #[test]
+    fn capfile_rejects_non_loopback() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://192.168.1.1:8080/code/browser",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("loopback"), "error: {msg}");
+    }
+
+    #[test]
+    fn capfile_rejects_missing_port() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://127.0.0.1/code/browser",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("port"), "error: {msg}");
+    }
+
+    #[test]
+    fn capfile_rejects_wrong_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://127.0.0.1:9876/some/other/path",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("/code/browser"), "error: {msg}");
+    }
+
+    #[test]
+    fn capfile_rejects_username_in_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://user@127.0.0.1:9876/code/browser",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(BrowserCapfile::load(&path).is_err());
+    }
+
+    #[test]
+    fn capfile_rejects_query_in_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://127.0.0.1:9876/code/browser?x=1",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(BrowserCapfile::load(&path).is_err());
+    }
+
+    // -- Capfile rejection: token validation -------------------------------
+
+    #[test]
+    fn capfile_rejects_wrong_token_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://127.0.0.1:9876/code/browser",
+                "token": "notbreak__00000000-0000-0000-0000-000000000000"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("prefix"), "error: {msg}");
+    }
+
+    #[test]
+    fn capfile_rejects_token_without_uuid_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://127.0.0.1:9876/code/browser",
+                "token": "tbreak_bt_not-a-uuid-at-all-no-really"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("UUID"), "error: {msg}");
+    }
+
+    #[test]
+    fn capfile_rejects_short_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://127.0.0.1:9876/code/browser",
+                "token": "tbreak_bt_short"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("length"), "error: {msg}");
+    }
+
+    // -- Capfile rejection: version, JSON, size, unknown fields ------------
+
+    #[test]
+    fn capfile_rejects_unsupported_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 2,
+                "endpoint": "http://127.0.0.1:9876/code/browser",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("version 2"), "error: {msg}");
+    }
+
+    #[test]
+    fn capfile_rejects_unknown_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://127.0.0.1:9876/code/browser",
+                "token": VALID_TOKEN,
+                "extra": "should be rejected"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(BrowserCapfile::load(&path).is_err());
+    }
+
+    #[test]
+    fn capfile_rejects_malformed_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(&path, "not json").unwrap();
+        assert!(BrowserCapfile::load(&path).is_err());
+    }
+
+    #[test]
+    fn capfile_rejects_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        let big = "x".repeat((CAPFILE_MAX_BYTES + 1) as usize);
+        std::fs::write(&path, big).unwrap();
+        assert!(BrowserCapfile::load(&path).is_err());
+    }
+
+    #[test]
+    fn capfile_rejects_non_utf8() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        std::fs::write(&path, vec![0xff, 0xfe, 0xfd]).unwrap();
+        assert!(BrowserCapfile::load(&path).is_err());
+    }
+
+    // -- Capfile: error redaction -----------------------------------------
+
+    #[test]
+    fn capfile_error_never_contains_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        let token = VALID_TOKEN;
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://192.168.1.1:8080/code/browser",
+                "token": token
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(!msg.contains(token), "token leaked into error: {msg}");
+    }
+
+    #[test]
+    fn capfile_error_never_contains_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        let path_str = path.to_string_lossy().to_string();
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": "http://192.168.1.1:8080/code/browser",
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains(&path_str),
+            "capfile path leaked into error: {msg}"
+        );
+    }
+
+    #[test]
+    fn capfile_error_never_contains_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cap.json");
+        let endpoint = "http://192.168.1.1:8080/code/browser";
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "version": 1,
+                "endpoint": endpoint,
+                "token": VALID_TOKEN
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let err = BrowserCapfile::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(!msg.contains(endpoint), "endpoint leaked into error: {msg}");
+    }
+
+    // -- Capfile: read_file_capped ----------------------------------------
+
+    #[test]
+    fn read_file_capped_returns_exact_contents_within_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.txt");
+        let content = "hello world";
+        std::fs::write(&path, content).unwrap();
+        let result = read_file_capped(&path, 1024).unwrap();
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn read_file_capped_truncates_at_cap_plus_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.txt");
+        let big: String = (0..200).map(|i| (b'a' + (i % 26) as u8) as char).collect();
+        std::fs::write(&path, &big).unwrap();
+        let result = read_file_capped(&path, 100).unwrap();
+        // Should have at most 101 bytes.
+        assert!(result.len() <= 101);
+    }
+
+    // -- Command parsing ---------------------------------------------------
+
+    #[test]
+    fn parse_browser_list() {
+        let cmd = parse_browser(vec!["list".to_string()]).unwrap();
+        assert!(matches!(cmd, BrowserCommand::List));
+    }
+
+    #[test]
+    fn parse_browser_list_rejects_extra_args() {
+        let err = parse_browser(vec!["list".to_string(), "extra".to_string()]).unwrap_err();
+        assert!(err.contains("no arguments"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_navigate() {
+        let cmd = parse_browser(vec![
+            "navigate".to_string(),
+            "--browser-id".to_string(),
+            "browser-123".to_string(),
+            "--url".to_string(),
+            "https://example.com".to_string(),
+        ])
+        .unwrap();
+        match cmd {
+            BrowserCommand::Navigate { browser_id, url } => {
+                assert_eq!(browser_id, "browser-123");
+                assert_eq!(url, "https://example.com");
+            }
+            _ => panic!("expected Navigate"),
+        }
+    }
+
+    #[test]
+    fn parse_browser_navigate_rejects_duplicate_browser_id() {
+        let err = parse_browser(vec![
+            "navigate".to_string(),
+            "--browser-id".to_string(),
+            "browser-1".to_string(),
+            "--browser-id".to_string(),
+            "browser-2".to_string(),
+            "--url".to_string(),
+            "https://example.com".to_string(),
+        ])
+        .unwrap_err();
+        assert!(err.contains("duplicate"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_navigate_rejects_duplicate_url() {
+        let err = parse_browser(vec![
+            "navigate".to_string(),
+            "--browser-id".to_string(),
+            "browser-1".to_string(),
+            "--url".to_string(),
+            "https://example.com".to_string(),
+            "--url".to_string(),
+            "https://other.com".to_string(),
+        ])
+        .unwrap_err();
+        assert!(err.contains("duplicate"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_navigate_requires_browser_id() {
+        let err = parse_browser(vec![
+            "navigate".to_string(),
+            "--url".to_string(),
+            "https://example.com".to_string(),
+        ])
+        .unwrap_err();
+        assert!(err.contains("--browser-id"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_navigate_requires_url() {
+        let err = parse_browser(vec![
+            "navigate".to_string(),
+            "--browser-id".to_string(),
+            "browser-123".to_string(),
+        ])
+        .unwrap_err();
+        assert!(err.contains("--url"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_snapshot_default() {
+        let cmd = parse_browser(vec![
+            "snapshot".to_string(),
+            "--browser-id".to_string(),
+            "browser-123".to_string(),
+        ])
+        .unwrap();
+        match cmd {
+            BrowserCommand::Snapshot {
+                browser_id,
+                max_nodes,
+            } => {
+                assert_eq!(browser_id, "browser-123");
+                assert_eq!(max_nodes, None);
+            }
+            _ => panic!("expected Snapshot"),
+        }
+    }
+
+    #[test]
+    fn parse_browser_snapshot_with_max_nodes() {
+        let cmd = parse_browser(vec![
+            "snapshot".to_string(),
+            "--browser-id".to_string(),
+            "browser-123".to_string(),
+            "--max-nodes".to_string(),
+            "100".to_string(),
+        ])
+        .unwrap();
+        match cmd {
+            BrowserCommand::Snapshot { max_nodes, .. } => {
+                assert_eq!(max_nodes, Some(100));
+            }
+            _ => panic!("expected Snapshot"),
+        }
+    }
+
+    #[test]
+    fn parse_browser_snapshot_rejects_duplicate_max_nodes() {
+        let err = parse_browser(vec![
+            "snapshot".to_string(),
+            "--browser-id".to_string(),
+            "browser-123".to_string(),
+            "--max-nodes".to_string(),
+            "100".to_string(),
+            "--max-nodes".to_string(),
+            "200".to_string(),
+        ])
+        .unwrap_err();
+        assert!(err.contains("duplicate"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_snapshot_requires_browser_id() {
+        let err = parse_browser(vec![
+            "snapshot".to_string(),
+            "--max-nodes".to_string(),
+            "100".to_string(),
+        ])
+        .unwrap_err();
+        assert!(err.contains("--browser-id"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_rejects_unknown_flag() {
+        let err = parse_browser(vec!["list".to_string(), "--unknown".to_string()]).unwrap_err();
+        assert!(err.contains("no arguments"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_navigate_rejects_unknown_flag() {
+        let err = parse_browser(vec![
+            "navigate".to_string(),
+            "--browser-id".to_string(),
+            "browser-1".to_string(),
+            "--url".to_string(),
+            "https://example.com".to_string(),
+            "--unknown".to_string(),
+        ])
+        .unwrap_err();
+        assert!(err.contains("unknown"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_rejects_unknown_verb() {
+        let err = parse_browser(vec!["unknown".to_string()]).unwrap_err();
+        assert!(err.contains("unknown browser command"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_browser_empty_is_usage() {
+        let err = parse_browser(vec![]).unwrap_err();
+        assert!(err.contains("usage"), "error: {err}");
+    }
+
+    // -- JSON round-trip contracts -----------------------------------------
+
+    #[test]
+    fn browser_list_result_round_trips() {
+        let result = BrowserListResult { sessions: vec![] };
+        let json = serde_json::to_string(&result).unwrap();
+        let back: BrowserListResult = serde_json::from_str(&json).unwrap();
+        assert!(back.sessions.is_empty());
+    }
+
+    #[test]
+    fn browser_navigate_result_round_trips() {
+        use tidebreak_core::BrowserLoadState;
+        let result = BrowserNavigateResult {
+            browser_id: "browser-1".to_string(),
+            url: "https://example.com".to_string(),
+            load_state: BrowserLoadState::Ready,
+            document_epoch: 5,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let back: BrowserNavigateResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.document_epoch, 5);
+    }
+
+    #[test]
+    fn browser_snapshot_args_well_formed_validates() {
+        let args = BrowserSnapshotArgs {
+            browser_id: "browser-123".to_string(),
+            max_nodes: None,
+        };
+        assert!(args.is_well_formed());
+    }
+
+    // -- Tool advertisement (three exact tools) ----------------------------
+
+    #[test]
+    fn registry_contains_exactly_three_browser_tools() {
+        let client = browser_client_stub();
+        let tools = ToolRegistry::new()
+            .with(Box::new(BrowserListTool {
+                client: client.clone(),
+            }))
+            .with(Box::new(BrowserNavigateTool {
+                client: client.clone(),
+            }))
+            .with(Box::new(BrowserSnapshotTool {
+                client: client.clone(),
+            }));
+        let specs = tools.specs();
+        let mut names: Vec<&str> = specs.iter().map(|s| s.name.as_str()).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            ["browser_list", "browser_navigate", "browser_snapshot"]
+        );
+    }
+
+    #[test]
+    fn tool_classes_match_spec() {
+        let client = browser_client_stub();
+        let list = BrowserListTool {
+            client: client.clone(),
+        };
+        let navigate = BrowserNavigateTool {
+            client: client.clone(),
+        };
+        let snapshot = BrowserSnapshotTool {
+            client: client.clone(),
+        };
+        assert_eq!(list.approval_class(), ApprovalClass::ReadOnly);
+        assert_eq!(navigate.approval_class(), ApprovalClass::Sensitive);
+        assert_eq!(snapshot.approval_class(), ApprovalClass::ReadOnly);
+    }
+
+    fn browser_client_stub() -> BrowserClient {
+        // Build a client that points nowhere — fine for registration tests
+        // since they never send a request.
+        BrowserClient {
+            client: reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .unwrap(),
+            endpoint: "http://127.0.0.1:1/code/browser".to_string(),
+            token: "tbreak_bt_00000000-0000-0000-0000-000000000000".to_string(),
+        }
+    }
+
+    // -- ClientFailure classification -------------------------------------
+
+    #[test]
+    fn client_failure_maps_http_statuses_to_correct_categories() {
+        let cases: &[(u16, ToolErrorCategory)] = &[
+            (400, ToolErrorCategory::InvalidArguments),
+            (401, ToolErrorCategory::ConfigurationRequired),
+            (403, ToolErrorCategory::ConfigurationRequired),
+            (404, ToolErrorCategory::NotFound),
+            (500, ToolErrorCategory::ToolFailed),
+            (501, ToolErrorCategory::ConfigurationRequired),
+            (502, ToolErrorCategory::ToolFailed),
+        ];
+        for (status, expected) in cases {
+            let failure = ClientFailure::from_http_status(*status, "test_kind", "test message");
+            assert_eq!(
+                failure.to_tool_error_category(),
+                *expected,
+                "status {status}"
+            );
+        }
+    }
+
+    #[test]
+    fn client_failure_scrubs_token_from_server_messages() {
+        let failure = ClientFailure::from_http_status(
+            500,
+            "internal",
+            &format!("server echoed token {VALID_TOKEN} in error"),
+        );
+        let text = failure.redacted_text();
+        assert!(!text.contains(VALID_TOKEN));
+        assert!(text.contains("[redacted]"));
+    }
+
+    #[test]
+    fn client_failure_scrubs_bearer_keyword() {
+        let failure =
+            ClientFailure::from_http_status(500, "internal", "Authorization: Bearer secret-token");
+        let text = failure.redacted_text();
+        assert!(text.contains("[redacted]"));
+        assert!(!text.contains("Bearer"));
+    }
+
+    #[test]
+    fn scrub_server_message_replaces_embedded_uuids() {
+        let msg = "resource 550e8400-e29b-41d4-a716-446655440000 is gone";
+        let scrubbed = scrub_server_message(msg);
+        assert!(!scrubbed.contains("550e8400"));
+        assert!(scrubbed.contains("[redacted]"));
+    }
+
+    #[test]
+    fn scrub_server_message_handles_unicode_before_uuid() {
+        let id = uuid::Uuid::nil().to_string();
+        let msg = format!("é resource {id} is gone");
+        let scrubbed = scrub_server_message(&msg);
+        assert!(!scrubbed.contains(&id));
+        assert!(scrubbed.starts_with("é resource [redacted]"));
+    }
+
+    // -- HTTP: redirects are not followed ---------------------------------
+
+    #[tokio::test]
+    async fn client_does_not_follow_redirects() {
+        // A server that returns 301 → the client must see the 301, not the
+        // redirect target.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let endpoint = format!("http://127.0.0.1:{}", addr.port());
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, writer) = stream.into_split();
+            let mut buf_reader = tokio::io::BufReader::new(reader);
+            // Drain the request headers.
+            loop {
+                let mut line = String::new();
+                if tokio::io::AsyncBufReadExt::read_line(&mut buf_reader, &mut line)
+                    .await
+                    .unwrap()
+                    == 0
+                {
+                    break;
+                }
+                if line == "\r\n" {
+                    break;
+                }
+            }
+            // Send a 301 redirect with a body containing a server error.
+            let body = serde_json::json!({
+                "kind": "redirect",
+                "message": "this resource has moved"
+            });
+            let body_bytes = serde_json::to_vec(&body).unwrap();
+            let response = format!(
+                "HTTP/1.1 301 Moved Permanently\r\n\
+                 Location: http://evil.example.com/\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n",
+                body_bytes.len()
+            );
+            let mut writer = writer;
+            tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes())
+                .await
+                .unwrap();
+            tokio::io::AsyncWriteExt::write_all(&mut writer, &body_bytes)
+                .await
+                .unwrap();
+        });
+
+        // Build a client pointed at *this* listener on an arbitrary port
+        // (not the /code/browser path, but that doesn't matter for the
+        // redirect test).
+        let cap = BrowserCapfile {
+            endpoint: format!("http://127.0.0.1:{}/code/browser", addr.port()),
+            token: VALID_TOKEN.to_string(),
+        };
+        let client = BrowserClient::new(&cap).unwrap();
+
+        // Override endpoint to point at the raw listener (no /code/browser).
+        let mut redirect_client = client.clone();
+        redirect_client.endpoint = endpoint;
+
+        let result = browser_list(&redirect_client).await;
+        // Must fail — reqwest with redirect::Policy::none() returns the 301
+        // without following it. Our client treats non-2xx as errors.
+        assert!(result.is_err(), "client must not follow redirects");
+        let failure = result.unwrap_err();
+        // The 301 body should be parsed, giving "redirect" kind.
+        let text = failure.redacted_text();
+        assert!(text.contains("redirect"), "error text: {text}");
+
+        handle.abort();
+    }
+
+    // -- HTTP: response body bounding -------------------------------------
+
+    #[tokio::test]
+    async fn overlimit_response_body_is_refused() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let endpoint = format!("http://127.0.0.1:{}", addr.port());
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, writer) = stream.into_split();
+            let mut buf_reader = tokio::io::BufReader::new(reader);
+            loop {
+                let mut line = String::new();
+                if tokio::io::AsyncBufReadExt::read_line(&mut buf_reader, &mut line)
+                    .await
+                    .unwrap()
+                    == 0
+                {
+                    break;
+                }
+                if line == "\r\n" {
+                    break;
+                }
+            }
+            // Send a response claiming a tiny body but actually streaming a
+            // huge one.
+            let padding = "x".repeat(128 * 1024); // 128 KiB > 64 KiB navigate cap
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Transfer-Encoding: chunked\r\n\
+                 Connection: close\r\n\r\n"
+            );
+            let mut writer = writer;
+            tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes())
+                .await
+                .unwrap();
+            // Write chunked body that exceeds the cap.
+            let chunk_header = format!("{:x}\r\n", padding.len());
+            tokio::io::AsyncWriteExt::write_all(&mut writer, chunk_header.as_bytes())
+                .await
+                .unwrap();
+            tokio::io::AsyncWriteExt::write_all(&mut writer, padding.as_bytes())
+                .await
+                .unwrap();
+            tokio::io::AsyncWriteExt::write_all(&mut writer, b"\r\n")
+                .await
+                .unwrap();
+            // Terminal chunk.
+            tokio::io::AsyncWriteExt::write_all(&mut writer, b"0\r\n\r\n")
+                .await
+                .unwrap();
+        });
+
+        let cap = BrowserCapfile {
+            endpoint: format!("http://127.0.0.1:{}/code/browser", addr.port()),
+            token: VALID_TOKEN.to_string(),
+        };
+        let client = BrowserClient::new(&cap).unwrap();
+        let mut big_client = client.clone();
+        big_client.endpoint = endpoint;
+
+        let result = browser_navigate(
+            &big_client,
+            &BrowserNavigateArgs {
+                browser_id: "browser-1".to_string(),
+                url: "https://example.com".to_string(),
+            },
+        )
+        .await;
+        assert!(result.is_err(), "oversized body must be refused");
+        let text = result.unwrap_err().redacted_text();
+        assert!(text.contains("size limit"), "error text: {text}");
+
+        handle.abort();
+    }
+
+    // -- HTTP: success path (actual JSON decode) ---------------------------
+
+    #[tokio::test]
+    async fn browser_list_decodes_successful_json_response() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let endpoint = format!("http://127.0.0.1:{}", addr.port());
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, writer) = stream.into_split();
+            let mut buf_reader = tokio::io::BufReader::new(reader);
+            let mut headers = Vec::new();
+            loop {
+                let mut line = String::new();
+                if tokio::io::AsyncBufReadExt::read_line(&mut buf_reader, &mut line)
+                    .await
+                    .unwrap()
+                    == 0
+                {
+                    break;
+                }
+                if line == "\r\n" || line == "\n" {
+                    break;
+                }
+                headers.push(line);
+            }
+            let has_auth = headers
+                .iter()
+                .any(|h| h.to_lowercase().starts_with("authorization"));
+            assert!(has_auth, "headers: {headers:?}");
+
+            let body = serde_json::json!({
+                "sessions": [{
+                    "browserId": "browser-1",
+                    "url": "https://example.com",
+                    "title": "Example",
+                    "loadState": "ready",
+                    "visible": true,
+                    "engine": {
+                        "name": "webkit_gtk",
+                        "capabilities": {
+                            "lifecycle": true,
+                            "persistentProfile": false,
+                            "semanticSnapshot": true,
+                            "semanticActions": false,
+                            "screenshot": false,
+                            "crossOriginFrames": false,
+                            "profileReset": false
+                        }
+                    },
+                    "controller": {
+                        "kind": "agent",
+                        "halted": false,
+                        "takeoverRequired": false
+                    }
+                }]
+            });
+            let body_bytes = serde_json::to_vec(&body).unwrap();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n",
+                body_bytes.len()
+            );
+            let mut writer = writer;
+            tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes())
+                .await
+                .unwrap();
+            tokio::io::AsyncWriteExt::write_all(&mut writer, &body_bytes)
+                .await
+                .unwrap();
+        });
+
+        let cap = BrowserCapfile {
+            endpoint: format!("http://127.0.0.1:{}/code/browser", addr.port()),
+            token: VALID_TOKEN.to_string(),
+        };
+        let client = BrowserClient::new(&cap).unwrap();
+        let mut test_client = client.clone();
+        test_client.endpoint = endpoint;
+
+        let result = browser_list(&test_client).await.unwrap();
+        assert_eq!(result.sessions.len(), 1);
+        assert_eq!(result.sessions[0].browser_id, "browser-1");
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn browser_list_decodes_server_error_body() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let endpoint = format!("http://127.0.0.1:{}", addr.port());
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, writer) = stream.into_split();
+            let mut buf_reader = tokio::io::BufReader::new(reader);
+            loop {
+                let mut line = String::new();
+                if tokio::io::AsyncBufReadExt::read_line(&mut buf_reader, &mut line)
+                    .await
+                    .unwrap()
+                    == 0
+                {
+                    break;
+                }
+                if line == "\r\n" {
+                    break;
+                }
+            }
+            let body = serde_json::json!({
+                "kind": "browser_not_found",
+                "message": "no browser session for this capability"
+            });
+            let body_bytes = serde_json::to_vec(&body).unwrap();
+            let response = format!(
+                "HTTP/1.1 404 Not Found\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n",
+                body_bytes.len()
+            );
+            let mut writer = writer;
+            tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes())
+                .await
+                .unwrap();
+            tokio::io::AsyncWriteExt::write_all(&mut writer, &body_bytes)
+                .await
+                .unwrap();
+        });
+
+        let cap = BrowserCapfile {
+            endpoint: format!("http://127.0.0.1:{}/code/browser", addr.port()),
+            token: VALID_TOKEN.to_string(),
+        };
+        let client = BrowserClient::new(&cap).unwrap();
+        let mut test_client = client.clone();
+        test_client.endpoint = endpoint;
+
+        let err = browser_list(&test_client).await.unwrap_err();
+        assert_eq!(err.to_tool_error_category(), ToolErrorCategory::NotFound);
+        let text = err.redacted_text();
+        assert!(text.contains("browser_not_found"), "error: {text}");
+        assert!(text.contains("no browser session"), "error: {text}");
+        handle.abort();
+    }
+
+    // -- Token scrubbing in server errors ---------------------------------
+
+    #[tokio::test]
+    async fn server_error_body_containing_token_is_scrubbed() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let endpoint = format!("http://127.0.0.1:{}", addr.port());
+        let token = VALID_TOKEN;
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, writer) = stream.into_split();
+            let mut buf_reader = tokio::io::BufReader::new(reader);
+            loop {
+                let mut line = String::new();
+                if tokio::io::AsyncBufReadExt::read_line(&mut buf_reader, &mut line)
+                    .await
+                    .unwrap()
+                    == 0
+                {
+                    break;
+                }
+                if line == "\r\n" {
+                    break;
+                }
+            }
+            let body = serde_json::json!({
+                "kind": "internal",
+                "message": format!("token is {token}")
+            });
+            let body_bytes = serde_json::to_vec(&body).unwrap();
+            let response = format!(
+                "HTTP/1.1 500 Internal Server Error\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n",
+                body_bytes.len()
+            );
+            let mut writer = writer;
+            tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes())
+                .await
+                .unwrap();
+            tokio::io::AsyncWriteExt::write_all(&mut writer, &body_bytes)
+                .await
+                .unwrap();
+        });
+
+        let cap = BrowserCapfile {
+            endpoint: format!("http://127.0.0.1:{}/code/browser", addr.port()),
+            token: token.to_string(),
+        };
+        let client = BrowserClient::new(&cap).unwrap();
+        let mut test_client = client.clone();
+        test_client.endpoint = endpoint;
+
+        let err = browser_list(&test_client).await.unwrap_err();
+        let text = err.redacted_text();
+        assert!(!text.contains(token), "token leaked: {text}");
+        assert!(text.contains("[redacted]"), "should be scrubbed: {text}");
+        assert_eq!(err.to_tool_error_category(), ToolErrorCategory::ToolFailed);
+        handle.abort();
+    }
+
+    // -- Navigate and snapshot success paths -------------------------------
+
+    #[tokio::test]
+    async fn browser_navigate_decodes_response() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let endpoint = format!("http://127.0.0.1:{}", addr.port());
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, writer) = stream.into_split();
+            let mut buf_reader = tokio::io::BufReader::new(reader);
+            let mut content_length: usize = 0;
+            loop {
+                let mut line = String::new();
+                if tokio::io::AsyncBufReadExt::read_line(&mut buf_reader, &mut line)
+                    .await
+                    .unwrap()
+                    == 0
+                {
+                    break;
+                }
+                if line == "\r\n" {
+                    break;
+                }
+                if line.to_lowercase().starts_with("content-length:") {
+                    content_length = line.split(':').nth(1).unwrap().trim().parse().unwrap_or(0);
+                }
+            }
+            let mut body_bytes = vec![0u8; content_length];
+            if content_length > 0 {
+                tokio::io::AsyncReadExt::read_exact(&mut buf_reader, &mut body_bytes)
+                    .await
+                    .unwrap();
+            }
+            let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(body["browserId"], "browser-1");
+            assert_eq!(body["url"], "https://example.com/");
+
+            let result = serde_json::json!({
+                "browserId": "browser-1",
+                "url": "https://example.com/",
+                "loadState": "loading",
+                "documentEpoch": 7
+            });
+            let result_bytes = serde_json::to_vec(&result).unwrap();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n",
+                result_bytes.len()
+            );
+            let mut writer = writer;
+            tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes())
+                .await
+                .unwrap();
+            tokio::io::AsyncWriteExt::write_all(&mut writer, &result_bytes)
+                .await
+                .unwrap();
+        });
+
+        let cap = BrowserCapfile {
+            endpoint: format!("http://127.0.0.1:{}/code/browser", addr.port()),
+            token: VALID_TOKEN.to_string(),
+        };
+        let client = BrowserClient::new(&cap).unwrap();
+        let mut test_client = client.clone();
+        test_client.endpoint = endpoint;
+
+        let args = BrowserNavigateArgs {
+            browser_id: "browser-1".to_string(),
+            url: "https://example.com/".to_string(),
+        };
+        let result = browser_navigate(&test_client, &args).await.unwrap();
+        assert_eq!(result.document_epoch, 7);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn browser_snapshot_decodes_response() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let endpoint = format!("http://127.0.0.1:{}", addr.port());
+
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, writer) = stream.into_split();
+            let mut buf_reader = tokio::io::BufReader::new(reader);
+            let mut content_length: usize = 0;
+            loop {
+                let mut line = String::new();
+                if tokio::io::AsyncBufReadExt::read_line(&mut buf_reader, &mut line)
+                    .await
+                    .unwrap()
+                    == 0
+                {
+                    break;
+                }
+                if line == "\r\n" {
+                    break;
+                }
+                if line.to_lowercase().starts_with("content-length:") {
+                    content_length = line.split(':').nth(1).unwrap().trim().parse().unwrap_or(0);
+                }
+            }
+            let mut body_bytes = vec![0u8; content_length];
+            if content_length > 0 {
+                tokio::io::AsyncReadExt::read_exact(&mut buf_reader, &mut body_bytes)
+                    .await
+                    .unwrap();
+            }
+            let result = serde_json::json!({
+                "browserId": "browser-1",
+                "snapshotId": "snap-1",
+                "documentEpoch": 3,
+                "contentTrust": "untrusted_page",
+                "url": "https://example.com/",
+                "title": "Test Page",
+                "viewport": {
+                    "width": 1024.0, "height": 768.0,
+                    "scrollX": 0.0, "scrollY": 0.0
+                },
+                "nodes": [],
+                "frames": [],
+                "truncated": false
+            });
+            let result_bytes = serde_json::to_vec(&result).unwrap();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n",
+                result_bytes.len()
+            );
+            let mut writer = writer;
+            tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes())
+                .await
+                .unwrap();
+            tokio::io::AsyncWriteExt::write_all(&mut writer, &result_bytes)
+                .await
+                .unwrap();
+        });
+
+        let cap = BrowserCapfile {
+            endpoint: format!("http://127.0.0.1:{}/code/browser", addr.port()),
+            token: VALID_TOKEN.to_string(),
+        };
+        let client = BrowserClient::new(&cap).unwrap();
+        let mut test_client = client.clone();
+        test_client.endpoint = endpoint;
+
+        let args = BrowserSnapshotArgs {
+            browser_id: "browser-1".to_string(),
+            max_nodes: Some(250),
+        };
+        let result = browser_snapshot(&test_client, &args).await.unwrap();
+        assert_eq!(result.title, "Test Page");
+        assert_eq!(result.document_epoch, 3);
+        handle.abort();
+    }
+
+    // -- MCP failure mapping ----------------------------------------------
+
+    #[test]
+    fn mcp_failure_uses_correct_tool_error_categories() {
+        let cases: &[(ClientFailure, ToolErrorCategory)] = &[
+            (
+                ClientFailure::InvalidArguments {
+                    detail: "bad".to_string(),
+                },
+                ToolErrorCategory::InvalidArguments,
+            ),
+            (
+                ClientFailure::NotFound {
+                    detail: "gone".to_string(),
+                },
+                ToolErrorCategory::NotFound,
+            ),
+            (
+                ClientFailure::ConfigurationRequired {
+                    detail: "setup".to_string(),
+                },
+                ToolErrorCategory::ConfigurationRequired,
+            ),
+            (
+                ClientFailure::TransportFailed {
+                    detail: "timeout".to_string(),
+                },
+                ToolErrorCategory::TransportFailed,
+            ),
+            (
+                ClientFailure::ToolFailed {
+                    detail: "crash".to_string(),
+                },
+                ToolErrorCategory::ToolFailed,
+            ),
+        ];
+        for (failure, expected) in cases {
+            let output = mcp_failure(failure.clone());
+            assert_eq!(output.error_category, Some(*expected));
+            assert!(output.is_error);
+        }
+    }
+}

--- a/crates/tidebreak-cli/src/browser.rs
+++ b/crates/tidebreak-cli/src/browser.rs
@@ -900,7 +900,6 @@ fn format_browser_list_summary(result: &BrowserListResult) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
 
     const VALID_TOKEN: &str = "tbreak_bt_00000000-0000-0000-0000-000000000000";
 
@@ -1117,7 +1116,7 @@ mod tests {
             serde_json::json!({
                 "version": 1,
                 "endpoint": "http://127.0.0.1:9876/code/browser",
-                "token": "tbreak_bt_not-a-uuid-at-all-no-really"
+                "token": "tbreak_bt_00000000-0000-0000-0000-00000000000Z"
             })
             .to_string(),
         )
@@ -1731,12 +1730,11 @@ mod tests {
             // Send a response claiming a tiny body but actually streaming a
             // huge one.
             let padding = "x".repeat(128 * 1024); // 128 KiB > 64 KiB navigate cap
-            let response = format!(
+            let response =
                 "HTTP/1.1 200 OK\r\n\
                  Content-Type: application/json\r\n\
                  Transfer-Encoding: chunked\r\n\
-                 Connection: close\r\n\r\n"
-            );
+                 Connection: close\r\n\r\n";
             let mut writer = writer;
             tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes())
                 .await
@@ -1821,7 +1819,7 @@ mod tests {
                     "loadState": "ready",
                     "visible": true,
                     "engine": {
-                        "name": "webkit_gtk",
+                        "name": "web_kit_gtk",
                         "capabilities": {
                             "lifecycle": true,
                             "persistentProfile": false,
@@ -2029,7 +2027,7 @@ mod tests {
                     .unwrap();
             }
             let body: Value = serde_json::from_slice(&body_bytes).unwrap();
-            assert_eq!(body["browserId"], "browser-1");
+            assert_eq!(body["browser_id"], "browser-1");
             assert_eq!(body["url"], "https://example.com/");
 
             let result = serde_json::json!({

--- a/crates/tidebreak-cli/src/browser.rs
+++ b/crates/tidebreak-cli/src/browser.rs
@@ -904,6 +904,19 @@ mod tests {
 
     const VALID_TOKEN: &str = "tbreak_bt_00000000-0000-0000-0000-000000000000";
 
+    /// Extract the error from `BrowserCapfile::load` without requiring
+    /// `Debug` on the `Ok` type. `BrowserCapfile` intentionally does not
+    /// implement `Debug` because it carries the bearer token, so
+    /// `Result::unwrap_err` (which requires `T: Debug`) cannot be used.
+    fn capfile_load_err(path: &std::path::Path) -> AgentError {
+        match BrowserCapfile::load(path) {
+            Ok(_) => panic!(
+                "expected BrowserCapfile::load to fail, but it succeeded"
+            ),
+            Err(error) => error,
+        }
+    }
+
     // -- Capfile parsing ---------------------------------------------------
 
     #[test]
@@ -962,7 +975,7 @@ mod tests {
     #[test]
     fn capfile_rejects_non_regular_file() {
         let dir = tempfile::tempdir().unwrap();
-        let err = BrowserCapfile::load(dir.path()).unwrap_err();
+        let err = capfile_load_err(dir.path());
         assert!(err.to_string().contains("regular file"));
     }
 
@@ -999,7 +1012,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(msg.contains("loopback"), "error: {msg}");
     }
@@ -1018,7 +1031,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(msg.contains("port"), "error: {msg}");
     }
@@ -1037,7 +1050,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(msg.contains("/code/browser"), "error: {msg}");
     }
@@ -1092,7 +1105,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(msg.contains("prefix"), "error: {msg}");
     }
@@ -1111,7 +1124,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(msg.contains("UUID"), "error: {msg}");
     }
@@ -1130,7 +1143,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(msg.contains("length"), "error: {msg}");
     }
@@ -1151,7 +1164,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(msg.contains("version 2"), "error: {msg}");
     }
@@ -1216,7 +1229,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(!msg.contains(token), "token leaked into error: {msg}");
     }
@@ -1236,7 +1249,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(
             !msg.contains(&path_str),
@@ -1259,7 +1272,7 @@ mod tests {
             .to_string(),
         )
         .unwrap();
-        let err = BrowserCapfile::load(&path).unwrap_err();
+        let err = capfile_load_err(&path);
         let msg = err.to_string();
         assert!(!msg.contains(endpoint), "endpoint leaked into error: {msg}");
     }

--- a/crates/tidebreak-cli/src/browser.rs
+++ b/crates/tidebreak-cli/src/browser.rs
@@ -910,9 +910,7 @@ mod tests {
     /// `Result::unwrap_err` (which requires `T: Debug`) cannot be used.
     fn capfile_load_err(path: &std::path::Path) -> AgentError {
         match BrowserCapfile::load(path) {
-            Ok(_) => panic!(
-                "expected BrowserCapfile::load to fail, but it succeeded"
-            ),
+            Ok(_) => panic!("expected BrowserCapfile::load to fail, but it succeeded"),
             Err(error) => error,
         }
     }

--- a/crates/tidebreak-cli/src/browser.rs
+++ b/crates/tidebreak-cli/src/browser.rs
@@ -88,9 +88,7 @@ impl BrowserCapfile {
             AgentError::config(format!("browser capfile cannot be read ({error})"))
         })?;
         if !metadata.file_type().is_file() {
-            return Err(AgentError::config(
-                "browser capfile must be a regular file",
-            ));
+            return Err(AgentError::config("browser capfile must be a regular file"));
         }
         if metadata.len() > CAPFILE_MAX_BYTES {
             return Err(AgentError::config("browser capfile exceeds the size limit"));

--- a/crates/tidebreak-cli/src/browser.rs
+++ b/crates/tidebreak-cli/src/browser.rs
@@ -1730,8 +1730,7 @@ mod tests {
             // Send a response claiming a tiny body but actually streaming a
             // huge one.
             let padding = "x".repeat(128 * 1024); // 128 KiB > 64 KiB navigate cap
-            let response =
-                "HTTP/1.1 200 OK\r\n\
+            let response = "HTTP/1.1 200 OK\r\n\
                  Content-Type: application/json\r\n\
                  Transfer-Encoding: chunked\r\n\
                  Connection: close\r\n\r\n";

--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -55,6 +55,16 @@
 //! process owns that broker state — `serve`, or the engine `-p` embeds. See
 //! [`folder_executor`].
 //!
+//! `tidebreak browser list|navigate|snapshot --json` drive a running Tidebreak
+//! browser server through the session-private capability file named by
+//! `TIDEBREAK_BROWSER_CAPFILE`. These commands write JSON to stdout and errors
+//! to stderr, and they refuse `--server`/`--attach` since the browser server
+//! is reached exclusively through the capfile.
+//!
+//! `tidebreak browser-mcp` serves the same three browser operations over MCP
+//! stdio so any MCP-speaking host can observe and navigate browser sessions.
+//! See [`browser`].
+//!
 //! Every client command above embeds its own server by default. `--server
 //! <url>` (or `TIDEBREAK_SERVER_URL`) makes it a pure client of one that is
 //! already running instead, with the bearer token coming from
@@ -74,6 +84,7 @@ use tidebreak_core::{
 };
 
 mod api;
+mod browser;
 mod code;
 mod connect;
 mod folder;
@@ -137,6 +148,11 @@ usage: tidebreak serve
        tidebreak agent-run list <chat>
        tidebreak agent-run show <chat> <run>
        tidebreak agent-run cancel <chat> <run>
+
+       tidebreak browser list --json
+       tidebreak browser navigate --browser-id <id> --url <url> --json
+       tidebreak browser snapshot --browser-id <id> [--max-nodes <n>] --json
+       tidebreak browser-mcp
 
        tidebreak folder connect <path> --chat <id> [--output-format text|json]
        tidebreak folder list [--chat <id>] [--output-format text|json]
@@ -358,6 +374,34 @@ async fn run() -> Result<i32> {
                 Ok(command) => folder::run(command).await.map(|()| 0),
                 Err(message) => usage_error(&message),
             }
+        }
+        Some(command) if command == OsStr::new("browser") => {
+            server_flags.refuse("browser");
+            let mut raw = text_args(args);
+            let json_count = raw.iter().filter(|a| a.as_str() == "--json").count();
+            if json_count == 0 {
+                usage_error("browser commands require --json");
+            }
+            if json_count > 1 {
+                usage_error("duplicate --json");
+            }
+            if let Some(pos) = raw.iter().position(|a| a == "--json") {
+                raw.remove(pos);
+            }
+            match crate::browser::parse_browser(raw) {
+                Ok(command) => crate::browser::run_browser(command).await.map(|()| 0),
+                Err(message) => {
+                    eprintln!("tidebreak: {message}\n\n{}", crate::browser::BROWSER_USAGE);
+                    std::process::exit(2);
+                }
+            }
+        }
+        Some(command) if command == OsStr::new("browser-mcp") => {
+            server_flags.refuse("browser-mcp");
+            if args.next().is_some() {
+                usage_error("browser-mcp accepts no arguments");
+            }
+            crate::browser::run_browser_mcp().await.map(|()| 0)
         }
         Some(command) if command == OsStr::new("code") => {
             match crate::code::parse(text_args(args)) {

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -9,18 +9,24 @@
 //!
 //! ## Security properties
 //!
-//! * Tokens are random v4 UUIDs; reissuing for the same session silently
-//!   revokes and deletes the prior token and its capability file.
-//! * Startup deletes every stale capability file so a restarted server cannot
-//!   accept a token it did not mint.
-//! * Capfiles are written create-new → sync → chmod 0600 → atomic rename.
-//! * The JSON payload carries only `version`, `endpoint`, and `token` — no
+//! * Tokens are random v4 UUIDs independent of the capability-file filename
+//!   (a separate random file id).
+//! * Reissuing for the same session writes the new capfile first, then
+//!   commits the new mapping and revokes the prior one. The prior authority
+//!   stays valid until the new capfile is on disk and the mapping is
+//!   installed.
+//! * Startup removes the entire dedicated stale-capfile subtree, then
+//!   recreates it. A restarted server cannot accept a token it did not mint.
+//! * Capfiles are written create-new (mode 0600 on Unix) → sync → atomic
+//!   rename. Temp files are deleted on every post-create failure path.
+//! * The JSON payload carries exactly `version`, `endpoint`, and `token` — no
 //!   owner, workspace, or session identifiers.
+//! * In-memory authority is revoked before best-effort file deletion.
 
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use tidebreak_core::{CodeSessionId, OwnerId, WorkspaceId};
 use tidebreak_harness::BrowserChannelSpec;
@@ -29,11 +35,13 @@ use tidebreak_harness::BrowserChannelSpec;
 /// incompatible way.
 const CAPFILE_VERSION: u32 = 1;
 
-/// Filename prefix for capability files. Random components follow.
+/// Filename prefix for capability files. Random file-id components follow.
 const CAPFILE_PREFIX: &str = "browser-cap-";
 
 /// Subdirectory under the data dir that holds session capability files.
 const CAPFILE_SUBDIR: &str = "browser-caps";
+
+// ── data types ──────────────────────────────────────────────────────────────
 
 /// The `{owner, workspace, session}` subject derived from a token look-up.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,29 +51,59 @@ pub(crate) struct BrowserSubject {
     pub session: CodeSessionId,
 }
 
-/// In-memory route-token registry paired with an on-disk capability-file tree.
+/// Per-session state held in the registry.
+#[derive(Debug, Clone)]
+struct SessionEntry {
+    /// Random file id independent of the bearer token.
+    file_id: String,
+    /// Bearer token stored in the capfile JSON.
+    token: String,
+    /// Absolute path to the capability file.
+    capfile_path: PathBuf,
+}
+
+/// Single lock protects both mappings so issue/revoke/reissue never interleave
+/// into inconsistent state.
+struct RegistryState {
+    tokens: HashMap<String, BrowserSubject>,
+    by_session: HashMap<CodeSessionId, SessionEntry>,
+}
+
+// ── registry ────────────────────────────────────────────────────────────────
+
+/// In-memory route-token registry paired with an on-disk capability-file
+/// subtree.
 ///
-/// One token per session: reissuing silently revokes and deletes the prior
-/// token and its capability file. Startup deletes every stale file so a
-/// restarted server cannot accept a token it did not mint.
+/// One token per session: reissuing is transactional — the new capfile is
+/// written before the prior entry is revoked. Startup removes and recreates
+/// the entire dedicated subtree so a restarted server cannot accept a token
+/// it did not mint.
 pub(crate) struct BrowserTokenRegistry {
-    tokens: Mutex<HashMap<String, BrowserSubject>>,
-    by_session: Mutex<HashMap<CodeSessionId, String>>,
-    /// Absolute path to the data-dir subtree that holds capfiles.
+    state: Mutex<RegistryState>,
+    /// Absolute path to the data-dir subtree that holds capfiles. Resolved
+    /// at construction time.
     capfile_dir: PathBuf,
     /// Loopback base URL published after bind.
     loopback_base: Mutex<Option<String>>,
 }
 
 impl BrowserTokenRegistry {
-    pub(crate) fn new(data_dir: &Path) -> Self {
-        let capfile_dir = data_dir.join(CAPFILE_SUBDIR);
-        Self {
-            tokens: Mutex::new(HashMap::new()),
-            by_session: Mutex::new(HashMap::new()),
+    /// Construct a new registry rooted at `data_dir`.
+    ///
+    /// The capfile directory is `{data_dir}/browser-caps`, resolved to an
+    /// absolute path. Returns an error if the absolute path cannot be
+    /// determined.
+    pub(crate) fn new(data_dir: &Path) -> Result<Self, String> {
+        let joined = data_dir.join(CAPFILE_SUBDIR);
+        let capfile_dir = resolve_absolute(&joined)?;
+        Ok(Self {
+            state: Mutex::new(RegistryState {
+                tokens: HashMap::new(),
+                by_session: HashMap::new(),
+            }),
             capfile_dir,
             loopback_base: Mutex::new(None),
-        }
+        })
     }
 
     /// Publish the bound loopback base so later [`Self::issue`] calls can
@@ -75,48 +113,57 @@ impl BrowserTokenRegistry {
             Some(base.trim_end_matches('/').into());
     }
 
-    /// Delete every stale capability file under the capfile directory.
+    /// Remove the entire stale-capfile subtree and recreate it empty.
     ///
-    /// Must run at startup before any session is recovered or created so a
-    /// restarted server cannot accept tokens it did not mint. The in-memory
-    /// registry is always fresh on restart.
-    pub(crate) fn delete_all_stale_capfiles(&self) {
-        match std::fs::read_dir(&self.capfile_dir) {
-            Ok(entries) => {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if path
-                        .file_name()
-                        .and_then(|f| f.to_str())
-                        .is_some_and(|f| f.starts_with(CAPFILE_PREFIX))
-                    {
-                        let _ = std::fs::remove_file(&path);
-                    }
-                }
-            }
+    /// Must run at startup before any session is recovered or created.
+    /// Returns an error on any failure — the caller must fail closed.
+    pub(crate) fn delete_all_stale_capfiles(&self) -> Result<(), String> {
+        // Remove the entire subtree including unknown files, subdirs, and
+        // leftover temp files.
+        match std::fs::remove_dir_all(&self.capfile_dir) {
+            Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // The directory does not exist yet — nothing to clean.
+                // No stale directory to remove — the ensure below recreates.
             }
             Err(e) => {
-                tracing::warn!(
-                    "code-mode: could not read browser capfile directory for cleanup: {e}"
-                );
+                return Err(format!(
+                    "failed to remove stale browser capfile directory: {e}"
+                ));
             }
         }
+        // Recreate the empty directory with mode 0700.
+        if let Err(e) = std::fs::create_dir_all(&self.capfile_dir) {
+            return Err(format!(
+                "failed to recreate browser capfile directory: {e}"
+            ));
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            if let Err(e) = std::fs::set_permissions(
+                &self.capfile_dir,
+                std::fs::Permissions::from_mode(0o700),
+            ) {
+                return Err(format!("could not set capfile directory mode: {e}"));
+            }
+        }
+        Ok(())
     }
 
     /// Mint a channel for `subject` and return the [`BrowserChannelSpec`]
     /// the adapter injects into the engine child.
     ///
-    /// The returned path is always absolute because it is resolved against the
-    /// absolute `data_dir` (closing PR #2364's accepted P3 about constructor-
-    /// level path validation — the server is the single trusted constructor
-    /// site and guarantees absoluteness at this boundary).
+    /// Transactional: writes the new capfile first, then commits the in-memory
+    /// mapping. On reissue, the prior authority (token + capfile) stays valid
+    /// until the new capfile is on disk and the new mapping is installed; only
+    /// then is the prior entry revoked and its file deleted.
     ///
-    /// Reissuing for the same session revokes and deletes the prior token
-    /// and its capability file.
-    pub(crate) fn issue(&self, subject: BrowserSubject) -> Result<BrowserChannelSpec, String> {
-        let token = generate_token();
+    /// Returns an error if the loopback base has not been set, the directory
+    /// cannot be created, or the capfile cannot be written.
+    pub(crate) fn issue(
+        &self,
+        subject: BrowserSubject,
+    ) -> Result<BrowserChannelSpec, String> {
         let loopback_base = self
             .loopback_base
             .lock()
@@ -124,45 +171,60 @@ impl BrowserTokenRegistry {
             .clone()
             .ok_or_else(|| "loopback base not set".to_owned())?;
 
-        // Revoke and delete any prior token for this session.
-        {
-            let mut by_session = self.by_session.lock().expect("browser session tokens");
-            if let Some(old) = by_session.insert(subject.session, token.clone()) {
-                let mut tokens = self.tokens.lock().expect("browser tokens");
-                tokens.remove(&old);
-                let old_path = capfile_path(&self.capfile_dir, &old);
-                let _ = std::fs::remove_file(&old_path);
-            }
-            let mut tokens = self.tokens.lock().expect("browser tokens");
-            tokens.insert(token.clone(), subject);
-        }
+        let token = generate_token();
+        let file_id = generate_file_id();
+        let capfile_path = capfile_path(&self.capfile_dir, &file_id);
 
-        let capfile_path = capfile_path(&self.capfile_dir, &token);
+        // 1. Write the new capfile. If this fails, nothing has been committed.
         write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)?;
+
+        // 2. Commit the in-memory mapping.
+        let entry = SessionEntry {
+            file_id: file_id.clone(),
+            token: token.clone(),
+            capfile_path: capfile_path.clone(),
+        };
+
+        let mut state = self.state.lock().expect("browser registry");
+        // If this session already has an entry, revoke the prior one now
+        // that the new capfile is safely on disk.
+        let old_entry = state.by_session.insert(subject.session, entry);
+        state.tokens.insert(token.clone(), subject);
+
+        // 3. Clean up the prior capfile (best-effort; authority is already
+        //    invalidated in memory).
+        if let Some(old) = old_entry {
+            state.tokens.remove(&old.token);
+            let _ = std::fs::remove_file(&old.capfile_path);
+        }
 
         Ok(BrowserChannelSpec::new(capfile_path))
     }
 
     /// Return the subject for an inbound browser bearer token, or `None`.
+    ///
+    /// This API is intentionally staged — it is the seam the follow-up
+    /// `/code/browser/*` route layer will call. Dead-code lint is suppressed
+    /// until that layer lands.
+    #[allow(dead_code)]
     pub(crate) fn subject_for_token(&self, token: &str) -> Option<BrowserSubject> {
-        self.tokens
+        self.state
             .lock()
-            .expect("browser tokens")
+            .expect("browser registry")
+            .tokens
             .get(token)
             .cloned()
     }
 
     /// Revoke and delete the channel for `session_id`. Idempotent.
+    ///
+    /// In-memory authority is invalidated first. File deletion is best-effort
+    /// because startup subtree cleanup must fail closed regardless.
     pub(crate) fn revoke(&self, session_id: CodeSessionId) {
-        let token = self
-            .by_session
-            .lock()
-            .expect("browser session tokens")
-            .remove(&session_id);
-        if let Some(token) = token {
-            self.tokens.lock().expect("browser tokens").remove(&token);
-            let path = capfile_path(&self.capfile_dir, &token);
-            let _ = std::fs::remove_file(&path);
+        let mut state = self.state.lock().expect("browser registry");
+        if let Some(entry) = state.by_session.remove(&session_id) {
+            state.tokens.remove(&entry.token);
+            let _ = std::fs::remove_file(&entry.capfile_path);
         }
     }
 
@@ -173,24 +235,46 @@ impl BrowserTokenRegistry {
     }
 }
 
-// ── helpers ────────────────────────────────────────────────────────────────
+// ── helpers ─────────────────────────────────────────────────────────────────
 
 fn generate_token() -> String {
     format!("tbreak_bt_{}", uuid::Uuid::new_v4())
 }
 
-fn capfile_path(capfile_dir: &Path, token: &str) -> PathBuf {
-    capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, token))
+fn generate_file_id() -> String {
+    uuid::Uuid::new_v4().to_string().replace('-', "")
+}
+
+fn capfile_path(capfile_dir: &Path, file_id: &str) -> PathBuf {
+    capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, file_id))
+}
+
+/// Resolve `joined` to an absolute path without requiring the directory to
+/// exist on disk. Uses [`std::path::absolute`] (or canonicalize on older
+/// Rust editions) to guarantee absoluteness at the trusted boundary.
+fn resolve_absolute(joined: &Path) -> Result<PathBuf, String> {
+    // If the directory already exists, canonicalize gives us the real path.
+    // Otherwise fall back to `std::path::absolute`.
+    match joined.canonicalize() {
+        Ok(abs) => return Ok(abs),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(format!(
+                "cannot resolve browser capfile directory: {e}"
+            ));
+        }
+    }
+    std::path::absolute(joined)
+        .map_err(|e| format!("cannot resolve absolute capfile directory: {e}"))
 }
 
 /// Write `{version, endpoint, token}` safely:
 ///
-/// 1. Ensure the directory exists with mode 0700.
-/// 2. Write to a random temp name under the capfile dir.
-/// 3. Write the JSON body.
-/// 4. fsync the file.
-/// 5. Set mode 0600.
-/// 6. Atomic rename onto the final path.
+/// 1. Ensure the parent directory exists with mode 0700.
+/// 2. Open a random temp file with create_new + mode 0600 (Unix).
+/// 3. Write the JSON body, flush, sync.
+/// 4. Atomic rename onto the final path.
+/// 5. On any failure after create_new, delete the temp file.
 fn write_capfile(
     path: &Path,
     version: u32,
@@ -231,38 +315,57 @@ fn write_capfile(
         ".{}.tmp",
         uuid::Uuid::new_v4().to_string().replace('-', "")
     );
-    let tmp_path = parent.join(tmp_name);
+    let tmp_path = parent.join(&tmp_name);
 
+    // Open with create_new so two issuers cannot share a temp file.
+    let mut open_opts = std::fs::OpenOptions::new();
+    open_opts.write(true).create_new(true);
+
+    #[cfg(unix)]
     {
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&tmp_path)
-            .map_err(|e| format!("could not create temp capfile: {e}"))?;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        open_opts.mode(0o600);
+    }
 
-        file.write_all(&body_bytes)
-            .map_err(|e| format!("could not write capfile: {e}"))?;
+    let mut file = match open_opts.open(&tmp_path) {
+        Ok(f) => f,
+        Err(e) => {
+            return Err(format!("could not create temp capfile: {e}"));
+        }
+    };
 
-        file.flush()
-            .map_err(|e| format!("could not flush capfile: {e}"))?;
+    // Each step after open must clean up the temp file on failure.
+    if let Err(e) = file.write_all(&body_bytes) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not write capfile: {e}"));
+    }
 
-        file.sync_all()
-            .map_err(|e| format!("could not sync capfile: {e}"))?;
+    if let Err(e) = file.flush() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not flush capfile: {e}"));
+    }
 
-        #[cfg(unix)]
+    if let Err(e) = file.sync_all() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not sync capfile: {e}"));
+    }
+
+    // Defence-in-depth chmod on Unix (the open mode is primary).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Err(e) =
+            std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
         {
-            use std::os::unix::fs::PermissionsExt as _;
-            if let Err(e) =
-                std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
-            {
-                let _ = std::fs::remove_file(&tmp_path);
-                return Err(format!("could not set capfile mode: {e}"));
-            }
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!("could not set capfile mode: {e}"));
         }
     }
 
-    std::fs::rename(&tmp_path, path)
-        .map_err(|e| format!("could not rename capfile into place: {e}"))?;
+    if let Err(e) = std::fs::rename(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("could not rename capfile into place: {e}"));
+    }
 
     Ok(())
 }
@@ -272,9 +375,10 @@ fn write_capfile(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     fn seeded(data_dir: &Path) -> BrowserTokenRegistry {
-        let reg = BrowserTokenRegistry::new(data_dir);
+        let reg = BrowserTokenRegistry::new(data_dir).unwrap();
         reg.set_loopback_base("http://127.0.0.1:0");
         reg
     }
@@ -287,6 +391,46 @@ mod tests {
         }
     }
 
+    fn read_token_from_capfile(path: &Path) -> String {
+        let contents = std::fs::read_to_string(path).expect("read capfile");
+        let value: serde_json::Value =
+            serde_json::from_str(&contents).expect("parse capfile");
+        value["token"].as_str().unwrap().to_owned()
+    }
+
+    // ── token ↔ file independence ───────────────────────────────────────
+
+    #[test]
+    fn filename_is_independent_of_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("indep");
+
+        let spec = reg.issue(sub.clone()).unwrap();
+        let file_stem = spec
+            .capability_file
+            .file_stem()
+            .unwrap()
+            .to_string_lossy();
+        let token = read_token_from_capfile(&spec.capability_file);
+
+        // The token must not appear in the filename.
+        assert!(
+            !file_stem.contains(&token),
+            "filename must not embed the bearer token: stem={file_stem}, token={token}"
+        );
+        // The file stem should start with the prefix and contain a UUID-like
+        // suffix (32 hex chars, no dashes).
+        let suffix = file_stem
+            .strip_prefix(CAPFILE_PREFIX)
+            .expect("file stem must start with CAPFILE_PREFIX");
+        assert_eq!(suffix.len(), 32, "file id must be a 32-char hex UUID");
+        assert!(
+            suffix.chars().all(|c| c.is_ascii_hexdigit()),
+            "file id must be hex digits"
+        );
+    }
+
     #[test]
     fn token_roundtrip_registry_mapping() {
         let dir = tempfile::tempdir().unwrap();
@@ -294,32 +438,67 @@ mod tests {
         let sub = subject("roundtrip");
 
         let spec = reg.issue(sub.clone()).unwrap();
-        let token = extract_token_from_path(&spec.capability_file);
+        let token = read_token_from_capfile(&spec.capability_file);
         assert!(!token.is_empty());
 
         let looked_up = reg.subject_for_token(&token);
         assert_eq!(looked_up.as_ref(), Some(&sub));
     }
 
+    // ── transactional issuance ───────────────────────────────────────────
+
     #[test]
-    fn reissue_revokes_and_replaces_prior_token() {
+    fn reissue_preserves_prior_until_new_succeeds() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
-        let sub = subject("reissue");
+        let sub = subject("transactional");
 
         let first = reg.issue(sub.clone()).unwrap();
-        let first_token = extract_token_from_path(&first.capability_file);
-        assert!(first.capability_file.exists());
+        let first_token = read_token_from_capfile(&first.capability_file);
+        let first_path = first.capability_file.clone();
+        assert!(first_path.exists());
+        assert_eq!(
+            reg.subject_for_token(&first_token).as_ref(),
+            Some(&sub),
+            "first token must resolve before reissue"
+        );
 
         let second = reg.issue(sub.clone()).unwrap();
-        let second_token = extract_token_from_path(&second.capability_file);
+        let second_token = read_token_from_capfile(&second.capability_file);
 
-        assert_ne!(first_token, second_token);
-        assert!(reg.subject_for_token(&first_token).is_none());
+        // Second token is live.
         assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
-        assert!(!first.capability_file.exists());
+        // First token is revoked.
+        assert!(reg.subject_for_token(&first_token).is_none());
+        // First capfile is deleted.
+        assert!(!first_path.exists());
+        // Second capfile exists.
         assert!(second.capability_file.exists());
+        // Tokens differ.
+        assert_ne!(first_token, second_token);
     }
+
+    #[test]
+    fn reissue_different_file_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("fileids");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let second = reg.issue(sub.clone()).unwrap();
+
+        assert_ne!(
+            first.capability_file, second.capability_file,
+            "each issuance must produce a unique file path"
+        );
+        assert_ne!(
+            read_token_from_capfile(&first.capability_file),
+            read_token_from_capfile(&second.capability_file),
+            "each issuance must produce a unique token"
+        );
+    }
+
+    // ── revocation ───────────────────────────────────────────────────────
 
     #[test]
     fn revoke_idempotent() {
@@ -328,11 +507,12 @@ mod tests {
         let sub = subject("idempotent");
 
         let spec = reg.issue(sub.clone()).unwrap();
-        let token = extract_token_from_path(&spec.capability_file);
-        assert!(spec.capability_file.exists());
+        let token = read_token_from_capfile(&spec.capability_file);
+        let capfile_path = spec.capability_file.clone();
+        assert!(capfile_path.exists());
 
         reg.revoke(sub.session);
-        assert!(!spec.capability_file.exists());
+        assert!(!capfile_path.exists());
         assert!(reg.subject_for_token(&token).is_none());
 
         // Second revoke is silent.
@@ -340,33 +520,67 @@ mod tests {
     }
 
     #[test]
-    fn capfile_schema_has_no_subject_ids() {
+    fn revoke_nonexistent_session_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let nonexistent = CodeSessionId::new();
+        reg.revoke(nonexistent);
+    }
+
+    #[test]
+    fn issue_then_revoke_then_reissue_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("fresh");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        reg.revoke(sub.session);
+        assert!(reg.subject_for_token(&first_token).is_none());
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+        assert_ne!(first_token, second_token);
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+    }
+
+    // ── capfile schema ───────────────────────────────────────────────────
+
+    #[test]
+    fn capfile_schema_is_exact_version_endpoint_token() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("schema");
 
         let spec = reg.issue(sub).unwrap();
-        let contents = std::fs::read_to_string(&spec.capability_file).expect("read capfile");
-        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
+        let contents =
+            std::fs::read_to_string(&spec.capability_file).expect("read capfile");
+        let value: serde_json::Value =
+            serde_json::from_str(&contents).expect("parse capfile");
 
-        assert!(value.get("version").is_some());
-        assert!(value.get("endpoint").is_some());
-        assert!(value.get("token").is_some());
-        assert!(value.get("owner").is_none());
-        assert!(value.get("workspace").is_none());
-        assert!(value.get("session").is_none());
-        assert!(value.get("browser_id").is_none());
+        let obj = value.as_object().expect("capfile must be a JSON object");
+        let expected: HashSet<&str> =
+            ["version", "endpoint", "token"].iter().copied().collect();
+        let actual: HashSet<&str> = obj.keys().map(String::as_str).collect();
+
+        assert_eq!(
+            actual, expected,
+            "capfile must have exactly {{version, endpoint, token}} keys"
+        );
+        assert_eq!(value["version"], CAPFILE_VERSION);
+        assert!(value["token"].as_str().unwrap().starts_with("tbreak_bt_"));
     }
 
     #[test]
     fn capfile_endpoint_derives_from_loopback_base() {
         let dir = tempfile::tempdir().unwrap();
-        let reg = BrowserTokenRegistry::new(dir.path());
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
         reg.set_loopback_base("https://tidebreak.local:4567/");
         let sub = subject("endpoint");
 
         let spec = reg.issue(sub).unwrap();
-        let contents = std::fs::read_to_string(&spec.capability_file).unwrap();
+        let contents =
+            std::fs::read_to_string(&spec.capability_file).unwrap();
         let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
 
         assert_eq!(
@@ -375,33 +589,56 @@ mod tests {
         );
     }
 
+    // ── startup cleanup ──────────────────────────────────────────────────
+
     #[test]
-    fn stale_directory_cleanup_removes_known_capfiles() {
+    fn subtree_cleanup_removes_everything_including_temp_files() {
         let dir = tempfile::tempdir().unwrap();
         let capfile_dir = dir.path().join(CAPFILE_SUBDIR);
         std::fs::create_dir_all(&capfile_dir).unwrap();
 
-        let stale_path = capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, uuid::Uuid::new_v4()));
-        std::fs::write(&stale_path, b"{}").unwrap();
-        assert!(stale_path.exists());
+        // Create various stale artifacts.
+        let stale_cap = capfile_dir.join("browser-cap-abc123.json");
+        std::fs::write(&stale_cap, b"{}").unwrap();
+        let stale_tmp = capfile_dir.join(".some-temp.tmp");
+        std::fs::write(&stale_tmp, b"orphan").unwrap();
+        let stale_subdir = capfile_dir.join("nested");
+        std::fs::create_dir(&stale_subdir).unwrap();
+        let stale_nested = stale_subdir.join("inner.txt");
+        std::fs::write(&stale_nested, b"deep").unwrap();
 
-        // A non-capfile in the same dir must survive.
-        let other = capfile_dir.join("not-a-browser-file.txt");
-        std::fs::write(&other, b"do not delete").unwrap();
+        // An unrelated sibling directory must NOT be touched.
+        let sibling = dir.path().join("unrelated-dir");
+        std::fs::create_dir(&sibling).unwrap();
+        let sibling_file = sibling.join("keep.txt");
+        std::fs::write(&sibling_file, b"keep").unwrap();
 
-        let reg = BrowserTokenRegistry::new(dir.path());
-        reg.delete_all_stale_capfiles();
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        reg.delete_all_stale_capfiles().unwrap();
 
-        assert!(!stale_path.exists());
-        assert!(other.exists());
+        // The capfile subtree should be empty (only recreated dir exists).
+        assert!(capfile_dir.exists());
+        let entries: Vec<_> = std::fs::read_dir(&capfile_dir)
+            .unwrap()
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "capfile dir must be empty after cleanup"
+        );
+
+        // Sibling directory untouched.
+        assert!(sibling_file.exists());
     }
 
     #[test]
-    fn cleanup_handles_missing_directory() {
+    fn cleanup_no_existing_directory_succeeds() {
         let dir = tempfile::tempdir().unwrap();
-        let reg = BrowserTokenRegistry::new(dir.path());
-        reg.delete_all_stale_capfiles();
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        assert!(reg.delete_all_stale_capfiles().is_ok());
+        assert!(reg.capfile_dir().exists());
     }
+
+    // ── path hygiene ─────────────────────────────────────────────────────
 
     #[test]
     fn capfile_path_is_absolute() {
@@ -411,7 +648,17 @@ mod tests {
 
         let spec = reg.issue(sub).unwrap();
         assert!(spec.capability_file.is_absolute());
+        assert!(reg.capfile_dir().is_absolute());
     }
+
+    #[test]
+    fn capfile_dir_is_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
+        assert!(reg.capfile_dir().is_absolute());
+    }
+
+    // ── Unix permissions ─────────────────────────────────────────────────
 
     #[cfg(unix)]
     #[test]
@@ -446,8 +693,10 @@ mod tests {
         assert_eq!(mode & 0o777, 0o700);
     }
 
+    // ── temp file cleanup ────────────────────────────────────────────────
+
     #[test]
-    fn atomic_temp_file_is_cleaned_up() {
+    fn atomic_temp_file_not_left_behind() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("atomic");
@@ -458,14 +707,64 @@ mod tests {
         let tmp_count = std::fs::read_dir(parent)
             .unwrap()
             .filter_map(|e| e.ok())
-            .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with('.')
+            })
             .count();
-        assert_eq!(tmp_count, 0, "no .tmp files should survive atomic rename");
+        assert_eq!(
+            tmp_count, 0,
+            "no .tmp files should survive atomic rename"
+        );
     }
 
-    fn extract_token_from_path(path: &Path) -> String {
-        let name = path.file_stem().unwrap().to_string_lossy();
-        let without_prefix = name.strip_prefix(CAPFILE_PREFIX).unwrap();
-        without_prefix.to_owned()
+    // ── concurrent safety ────────────────────────────────────────────────
+
+    #[test]
+    fn concurrent_issuance_two_sessions_no_state_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub_a = subject("concurrent-a");
+        let sub_b = subject("concurrent-b");
+
+        let spec_a = reg.issue(sub_a.clone()).unwrap();
+        let spec_b = reg.issue(sub_b.clone()).unwrap();
+
+        let token_a = read_token_from_capfile(&spec_a.capability_file);
+        let token_b = read_token_from_capfile(&spec_b.capability_file);
+
+        assert_ne!(token_a, token_b);
+        assert_ne!(spec_a.capability_file, spec_b.capability_file);
+
+        assert_eq!(reg.subject_for_token(&token_a).as_ref(), Some(&sub_a));
+        assert_eq!(reg.subject_for_token(&token_b).as_ref(), Some(&sub_b));
+
+        // Revoke A; B must survive.
+        reg.revoke(sub_a.session);
+        assert!(reg.subject_for_token(&token_a).is_none());
+        assert_eq!(reg.subject_for_token(&token_b).as_ref(), Some(&sub_b));
+        assert!(spec_b.capability_file.exists());
+    }
+
+    #[test]
+    fn concurrent_reissue_and_revoke_no_interleaving_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("interleave");
+
+        // Issue → revoke → issue in sequence; the final state must be clean
+        // with exactly one live entry.
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        reg.revoke(sub.session);
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+
+        assert!(reg.subject_for_token(&first_token).is_none());
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+        assert!(!first.capability_file.exists());
+        assert!(second.capability_file.exists());
     }
 }

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -801,44 +801,42 @@ mod tests {
     #[test]
     fn write_failure_leaves_maps_unchanged() {
         // issue() holds the registry lock across write_capfile + map commit.
-        // A write failure drops the lock without mutating either map. On
-        // Unix we prove this by removing write permission from the capfile
-        // directory so create_new fails; then a subsequent issuance succeeds
-        // with no stale state. On non-Unix the test is a structural-invariant
-        // check: a normal issue/revoke/reissue cycle leaves clean maps.
+        // A write failure drops the lock without mutating either map. Inject a
+        // platform-independent failure by temporarily replacing the capfile
+        // directory with a regular file, so create_dir_all/write_capfile must
+        // fail even when the test process has elevated privileges.
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("writefail");
 
         // Warm up: issue once so the capfile directory exists.
         let warm = reg.issue(subject("warm")).unwrap();
+        let warm_token = read_token_from_capfile(&warm.capability_file);
         assert!(warm.capability_file.exists());
 
-        #[cfg(unix)]
-        let did_fail = {
-            use std::os::unix::fs::PermissionsExt as _;
-            let capdir = reg.capfile_dir();
-            std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o500))
-                .expect("remove write permission for failure injection");
-            let result = reg.issue(sub.clone());
-            // Restore permissions immediately.
-            std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o700))
-                .expect("restore write permission");
-            assert!(
-                result.is_err(),
-                "issue must fail when directory is read-only"
-            );
-            true
-        };
+        let capdir = reg.capfile_dir().to_path_buf();
+        let held_capdir = dir.path().join("browser-caps-held");
+        std::fs::rename(&capdir, &held_capdir).expect("move capfile directory aside");
+        std::fs::write(&capdir, b"not a directory").expect("install capfile path blocker");
 
-        // After failure (or on non-Unix, after the structural warm), a fresh
-        // issuance for the same session must succeed without stale entries.
+        let result = reg.issue(sub.clone());
+
+        // Restore the original directory before asserting so a failure cannot
+        // strand the fixture in a state that obscures the registry invariant.
+        std::fs::remove_file(&capdir).expect("remove capfile path blocker");
+        std::fs::rename(&held_capdir, &capdir).expect("restore capfile directory");
+        assert!(result.is_err(), "issue must fail when capfile parent is a file");
+        assert_eq!(
+            reg.subject_for_token(&warm_token).as_ref(),
+            Some(&subject("warm")),
+            "the prior mapping must survive the failed issuance"
+        );
+
+        // After failure, a fresh issuance for the same session must succeed
+        // without stale entries.
         let second = reg.issue(sub.clone()).unwrap();
         let second_token = read_token_from_capfile(&second.capability_file);
         assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
-
-        #[cfg(unix)]
-        let _ = did_fail;
 
         // The TempDir will clean up everything when dropped.
         let _ = warm;

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -129,17 +129,14 @@ impl BrowserTokenRegistry {
         }
         // Recreate the empty directory with mode 0700.
         if let Err(e) = std::fs::create_dir_all(&self.capfile_dir) {
-            return Err(format!(
-                "failed to recreate browser capfile directory: {e}"
-            ));
+            return Err(format!("failed to recreate browser capfile directory: {e}"));
         }
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt as _;
-            if let Err(e) = std::fs::set_permissions(
-                &self.capfile_dir,
-                std::fs::Permissions::from_mode(0o700),
-            ) {
+            if let Err(e) =
+                std::fs::set_permissions(&self.capfile_dir, std::fs::Permissions::from_mode(0o700))
+            {
                 return Err(format!("could not set capfile directory mode: {e}"));
             }
         }
@@ -156,10 +153,7 @@ impl BrowserTokenRegistry {
     ///
     /// Returns an error if the loopback base has not been set or the capfile
     /// cannot be written. On error no state is committed.
-    pub(crate) fn issue(
-        &self,
-        subject: BrowserSubject,
-    ) -> Result<BrowserChannelSpec, String> {
+    pub(crate) fn issue(&self, subject: BrowserSubject) -> Result<BrowserChannelSpec, String> {
         let loopback_base = self
             .loopback_base
             .lock()
@@ -182,8 +176,7 @@ impl BrowserTokenRegistry {
 
         // Write the new capfile. If this fails, unlock and leave state
         // unchanged — nothing was committed.
-        match write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)
-        {
+        match write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token) {
             Ok(()) => {}
             Err(e) => return Err(e),
         }
@@ -271,9 +264,9 @@ fn resolve_absolute_trusted(joined: &Path) -> Result<PathBuf, String> {
         .file_name()
         .ok_or_else(|| "capfile path has no trailing component".to_owned())?;
 
-    let canonical_parent = parent.canonicalize().map_err(|e| {
-        format!("cannot resolve data directory for browser capfiles: {e}")
-    })?;
+    let canonical_parent = parent
+        .canonicalize()
+        .map_err(|e| format!("cannot resolve data directory for browser capfiles: {e}"))?;
 
     let absolute = canonical_parent.join(suffix);
 
@@ -291,9 +284,7 @@ fn resolve_absolute_trusted(joined: &Path) -> Result<PathBuf, String> {
             // Does not exist yet — fine, it will be created on first use.
         }
         Err(e) => {
-            return Err(format!(
-                "cannot inspect browser capfile directory: {e}"
-            ));
+            return Err(format!("cannot inspect browser capfile directory: {e}"));
         }
         _ => {
             // Exists and is not a symlink — fine.
@@ -327,9 +318,7 @@ fn write_capfile(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        if let Err(e) =
-            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
-        {
+        if let Err(e) = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)) {
             return Err(format!("could not set capfile directory mode: {e}"));
         }
     }
@@ -342,14 +331,11 @@ fn write_capfile(
         "token": token,
     });
 
-    let body_bytes = serde_json::to_vec(&body)
-        .map_err(|e| format!("failed to serialize capfile: {e}"))?;
+    let body_bytes =
+        serde_json::to_vec(&body).map_err(|e| format!("failed to serialize capfile: {e}"))?;
 
     // Random temp name to avoid collision with concurrent issuances.
-    let tmp_name = format!(
-        ".{}.tmp",
-        uuid::Uuid::new_v4().to_string().replace('-', "")
-    );
+    let tmp_name = format!(".{}.tmp", uuid::Uuid::new_v4().to_string().replace('-', ""));
     let tmp_path = parent.join(&tmp_name);
 
     // Open with create_new so two issuers cannot share a temp file.
@@ -392,8 +378,7 @@ fn write_capfile(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        if let Err(e) =
-            std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
+        if let Err(e) = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
         {
             drop(file);
             let _ = std::fs::remove_file(&tmp_path);
@@ -436,8 +421,7 @@ mod tests {
 
     fn read_token_from_capfile(path: &Path) -> String {
         let contents = std::fs::read_to_string(path).expect("read capfile");
-        let value: serde_json::Value =
-            serde_json::from_str(&contents).expect("parse capfile");
+        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
         value["token"].as_str().unwrap().to_owned()
     }
 
@@ -450,11 +434,7 @@ mod tests {
         let sub = subject("indep");
 
         let spec = reg.issue(sub.clone()).unwrap();
-        let file_stem = spec
-            .capability_file
-            .file_stem()
-            .unwrap()
-            .to_string_lossy();
+        let file_stem = spec.capability_file.file_stem().unwrap().to_string_lossy();
         let token = read_token_from_capfile(&spec.capability_file);
 
         // The token must not appear in the filename.
@@ -595,14 +575,11 @@ mod tests {
         let sub = subject("schema");
 
         let spec = reg.issue(sub).unwrap();
-        let contents =
-            std::fs::read_to_string(&spec.capability_file).expect("read capfile");
-        let value: serde_json::Value =
-            serde_json::from_str(&contents).expect("parse capfile");
+        let contents = std::fs::read_to_string(&spec.capability_file).expect("read capfile");
+        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
 
         let obj = value.as_object().expect("capfile must be a JSON object");
-        let expected: HashSet<&str> =
-            ["version", "endpoint", "token"].iter().copied().collect();
+        let expected: HashSet<&str> = ["version", "endpoint", "token"].iter().copied().collect();
         let actual: HashSet<&str> = obj.keys().map(String::as_str).collect();
 
         assert_eq!(
@@ -621,8 +598,7 @@ mod tests {
         let sub = subject("endpoint");
 
         let spec = reg.issue(sub).unwrap();
-        let contents =
-            std::fs::read_to_string(&spec.capability_file).unwrap();
+        let contents = std::fs::read_to_string(&spec.capability_file).unwrap();
         let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
 
         assert_eq!(
@@ -660,9 +636,7 @@ mod tests {
 
         // The capfile subtree should be empty (only recreated dir exists).
         assert!(capfile_dir.exists());
-        let entries: Vec<_> = std::fs::read_dir(&capfile_dir)
-            .unwrap()
-            .collect();
+        let entries: Vec<_> = std::fs::read_dir(&capfile_dir).unwrap().collect();
         assert!(
             entries.is_empty(),
             "capfile dir must be empty after cleanup"
@@ -790,16 +764,9 @@ mod tests {
         let tmp_count = std::fs::read_dir(parent)
             .unwrap()
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .starts_with('.')
-            })
+            .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
             .count();
-        assert_eq!(
-            tmp_count, 0,
-            "no .tmp files should survive atomic rename"
-        );
+        assert_eq!(tmp_count, 0, "no .tmp files should survive atomic rename");
     }
 
     #[test]
@@ -857,7 +824,10 @@ mod tests {
             // Restore permissions immediately.
             std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o700))
                 .expect("restore write permission");
-            assert!(result.is_err(), "issue must fail when directory is read-only");
+            assert!(
+                result.is_err(),
+                "issue must fail when directory is read-only"
+            );
             true
         };
 

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -825,7 +825,10 @@ mod tests {
         // strand the fixture in a state that obscures the registry invariant.
         std::fs::remove_file(&capdir).expect("remove capfile path blocker");
         std::fs::rename(&held_capdir, &capdir).expect("restore capfile directory");
-        assert!(result.is_err(), "issue must fail when capfile parent is a file");
+        assert!(
+            result.is_err(),
+            "issue must fail when capfile parent is a file"
+        );
         assert_eq!(
             reg.subject_for_token(&warm_token).as_ref(),
             Some(&subject("warm")),

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -11,14 +11,12 @@
 //!
 //! * Tokens are random v4 UUIDs independent of the capability-file filename
 //!   (a separate random file id).
-//! * Reissuing for the same session writes the new capfile first, then
-//!   commits the new mapping and revokes the prior one. The prior authority
-//!   stays valid until the new capfile is on disk and the mapping is
-//!   installed.
-//! * Startup removes the entire dedicated stale-capfile subtree, then
-//!   recreates it. A restarted server cannot accept a token it did not mint.
-//! * Capfiles are written create-new (mode 0600 on Unix) → sync → atomic
-//!   rename. Temp files are deleted on every post-create failure path.
+//! * Reissuing for the same session holds the registry lock across the full
+//!   write + commit so revoke cannot interleave and resurrect authority.
+//! * Startup synchronously deletes every stale capfile before the returned
+//!   future is pollable, so issue cannot race an unpolled cleanup.
+//! * Capfiles are written create-new (mode 0600 on Unix) → sync → drop →
+//!   atomic rename. Temp files are deleted on every post-create failure path.
 //! * The JSON payload carries exactly `version`, `endpoint`, and `token` — no
 //!   owner, workspace, or session identifiers.
 //! * In-memory authority is revoked before best-effort file deletion.
@@ -54,8 +52,6 @@ pub(crate) struct BrowserSubject {
 /// Per-session state held in the registry.
 #[derive(Debug, Clone)]
 struct SessionEntry {
-    /// Random file id independent of the bearer token.
-    file_id: String,
     /// Bearer token stored in the capfile JSON.
     token: String,
     /// Absolute path to the capability file.
@@ -74,14 +70,14 @@ struct RegistryState {
 /// In-memory route-token registry paired with an on-disk capability-file
 /// subtree.
 ///
-/// One token per session: reissuing is transactional — the new capfile is
-/// written before the prior entry is revoked. Startup removes and recreates
-/// the entire dedicated subtree so a restarted server cannot accept a token
-/// it did not mint.
+/// One token per session: reissuing is transactional — the registry lock is
+/// held across capfile write + map commit so revoke cannot interleave.
+/// Startup synchronously deletes every stale capfile before any issuance
+/// can run.
 pub(crate) struct BrowserTokenRegistry {
     state: Mutex<RegistryState>,
     /// Absolute path to the data-dir subtree that holds capfiles. Resolved
-    /// at construction time.
+    /// at construction time and proven free of symlink traversal.
     capfile_dir: PathBuf,
     /// Loopback base URL published after bind.
     loopback_base: Mutex<Option<String>>,
@@ -90,12 +86,12 @@ pub(crate) struct BrowserTokenRegistry {
 impl BrowserTokenRegistry {
     /// Construct a new registry rooted at `data_dir`.
     ///
-    /// The capfile directory is `{data_dir}/browser-caps`, resolved to an
-    /// absolute path. Returns an error if the absolute path cannot be
-    /// determined.
+    /// The capfile directory is `{data_dir}/browser-caps`, resolved to a
+    /// lexical absolute path proven not to traverse a symlink outside the
+    /// trusted data-dir subtree. Returns an error if resolution fails.
     pub(crate) fn new(data_dir: &Path) -> Result<Self, String> {
         let joined = data_dir.join(CAPFILE_SUBDIR);
-        let capfile_dir = resolve_absolute(&joined)?;
+        let capfile_dir = resolve_absolute_trusted(&joined)?;
         Ok(Self {
             state: Mutex::new(RegistryState {
                 tokens: HashMap::new(),
@@ -153,13 +149,13 @@ impl BrowserTokenRegistry {
     /// Mint a channel for `subject` and return the [`BrowserChannelSpec`]
     /// the adapter injects into the engine child.
     ///
-    /// Transactional: writes the new capfile first, then commits the in-memory
-    /// mapping. On reissue, the prior authority (token + capfile) stays valid
-    /// until the new capfile is on disk and the new mapping is installed; only
-    /// then is the prior entry revoked and its file deleted.
+    /// Transactional: holds the registry lock across the capfile write and
+    /// map commit so `revoke` cannot interleave. On reissue, the prior entry
+    /// is held during the write, so its authority remains valid until the
+    /// new capfile is on disk; only then is it atomically replaced.
     ///
-    /// Returns an error if the loopback base has not been set, the directory
-    /// cannot be created, or the capfile cannot be written.
+    /// Returns an error if the loopback base has not been set or the capfile
+    /// cannot be written. On error no state is committed.
     pub(crate) fn issue(
         &self,
         subject: BrowserSubject,
@@ -175,24 +171,32 @@ impl BrowserTokenRegistry {
         let file_id = generate_file_id();
         let capfile_path = capfile_path(&self.capfile_dir, &file_id);
 
-        // 1. Write the new capfile. If this fails, nothing has been committed.
-        write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)?;
+        // Lock the registry for the full write+commit window. This prevents
+        // revoke from deleting a capfile that the write step hasn't created
+        // yet, or from resurrecting a session whose old entry we're about to
+        // replace. The critical property: while the lock is held, no revoke
+        // targeting the same session can observe a state where a capfile
+        // exists without a valid registry entry, or vice versa.
+        let mut state = self.state.lock().expect("browser registry");
+        let old_entry = state.by_session.get(&subject.session).cloned();
 
-        // 2. Commit the in-memory mapping.
+        // Write the new capfile. If this fails, unlock and leave state
+        // unchanged — nothing was committed.
+        match write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)
+        {
+            Ok(()) => {}
+            Err(e) => return Err(e),
+        }
+
+        // Commit the new mapping; the new capfile is on disk.
         let entry = SessionEntry {
-            file_id: file_id.clone(),
             token: token.clone(),
             capfile_path: capfile_path.clone(),
         };
-
-        let mut state = self.state.lock().expect("browser registry");
-        // If this session already has an entry, revoke the prior one now
-        // that the new capfile is safely on disk.
-        let old_entry = state.by_session.insert(subject.session, entry);
+        state.by_session.insert(subject.session, entry);
         state.tokens.insert(token.clone(), subject);
 
-        // 3. Clean up the prior capfile (best-effort; authority is already
-        //    invalidated in memory).
+        // Revoke the prior authority now that the new one is committed.
         if let Some(old) = old_entry {
             state.tokens.remove(&old.token);
             let _ = std::fs::remove_file(&old.capfile_path);
@@ -218,8 +222,9 @@ impl BrowserTokenRegistry {
 
     /// Revoke and delete the channel for `session_id`. Idempotent.
     ///
-    /// In-memory authority is invalidated first. File deletion is best-effort
-    /// because startup subtree cleanup must fail closed regardless.
+    /// In-memory authority is invalidated first under the registry lock.
+    /// File deletion is best-effort because startup subtree cleanup must
+    /// fail closed regardless.
     pub(crate) fn revoke(&self, session_id: CodeSessionId) {
         let mut state = self.state.lock().expect("browser registry");
         if let Some(entry) = state.by_session.remove(&session_id) {
@@ -249,30 +254,60 @@ fn capfile_path(capfile_dir: &Path, file_id: &str) -> PathBuf {
     capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, file_id))
 }
 
-/// Resolve `joined` to an absolute path without requiring the directory to
-/// exist on disk. Uses [`std::path::absolute`] (or canonicalize on older
-/// Rust editions) to guarantee absoluteness at the trusted boundary.
-fn resolve_absolute(joined: &Path) -> Result<PathBuf, String> {
-    // If the directory already exists, canonicalize gives us the real path.
-    // Otherwise fall back to `std::path::absolute`.
-    match joined.canonicalize() {
-        Ok(abs) => return Ok(abs),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => {
+/// Resolve `joined` to a lexical absolute path rooted under the trusted
+/// data-dir subtree, proven not to traverse a symlink outside.
+///
+/// Strategy: canonicalize only the data-dir prefix so any symlink chain in
+/// the parent ancestry is resolved normally. Then lexically join the trailing
+/// `browser-caps` component and check that the result is NOT an existing
+/// symlink — reject it at construction time rather than risk
+/// `remove_dir_all` or `create_dir_all` following it.
+fn resolve_absolute_trusted(joined: &Path) -> Result<PathBuf, String> {
+    // Split into parent (data_dir) and trailing (browser-caps).
+    let parent = joined
+        .parent()
+        .ok_or_else(|| "capfile path has no parent".to_owned())?;
+    let suffix = joined
+        .file_name()
+        .ok_or_else(|| "capfile path has no trailing component".to_owned())?;
+
+    let canonical_parent = parent.canonicalize().map_err(|e| {
+        format!("cannot resolve data directory for browser capfiles: {e}")
+    })?;
+
+    let absolute = canonical_parent.join(suffix);
+
+    // If the target already exists as a symlink, refuse to construct.
+    // This prevents remove_dir_all / create_dir_all from operating on
+    // a path that points outside the trusted data-dir subtree.
+    match std::fs::symlink_metadata(&absolute) {
+        Ok(meta) if meta.is_symlink() => {
             return Err(format!(
-                "cannot resolve browser capfile directory: {e}"
+                "browser capfile directory is a symlink: {}",
+                absolute.display()
             ));
         }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Does not exist yet — fine, it will be created on first use.
+        }
+        Err(e) => {
+            return Err(format!(
+                "cannot inspect browser capfile directory: {e}"
+            ));
+        }
+        _ => {
+            // Exists and is not a symlink — fine.
+        }
     }
-    std::path::absolute(joined)
-        .map_err(|e| format!("cannot resolve absolute capfile directory: {e}"))
+
+    Ok(absolute)
 }
 
 /// Write `{version, endpoint, token}` safely:
 ///
 /// 1. Ensure the parent directory exists with mode 0700.
 /// 2. Open a random temp file with create_new + mode 0600 (Unix).
-/// 3. Write the JSON body, flush, sync.
+/// 3. Write, flush, sync, close (drop).
 /// 4. Atomic rename onto the final path.
 /// 5. On any failure after create_new, delete the temp file.
 fn write_capfile(
@@ -361,6 +396,10 @@ fn write_capfile(
             return Err(format!("could not set capfile mode: {e}"));
         }
     }
+
+    // Explicitly drop the file handle before rename. Required for Windows
+    // (cannot rename an open handle); no-op on Unix but safe everywhere.
+    drop(file);
 
     if let Err(e) = std::fs::rename(&tmp_path, path) {
         let _ = std::fs::remove_file(&tmp_path);
@@ -479,23 +518,22 @@ mod tests {
     }
 
     #[test]
-    fn reissue_different_file_ids() {
+    fn reissue_produces_different_file_paths_and_tokens() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("fileids");
 
         let first = reg.issue(sub.clone()).unwrap();
-        let second = reg.issue(sub.clone()).unwrap();
+        // Read the token from the first capfile BEFORE second issuance
+        // deletes it.
+        let first_token = read_token_from_capfile(&first.capability_file);
+        let first_path = first.capability_file.clone();
 
-        assert_ne!(
-            first.capability_file, second.capability_file,
-            "each issuance must produce a unique file path"
-        );
-        assert_ne!(
-            read_token_from_capfile(&first.capability_file),
-            read_token_from_capfile(&second.capability_file),
-            "each issuance must produce a unique token"
-        );
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+
+        assert_ne!(first_path, second.capability_file);
+        assert_ne!(first_token, second_token);
     }
 
     // ── revocation ───────────────────────────────────────────────────────
@@ -528,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    fn issue_then_revoke_then_reissue_fresh() {
+    fn issue_revoke_reissue_produces_fresh_authority() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("fresh");
@@ -658,6 +696,47 @@ mod tests {
         assert!(reg.capfile_dir().is_absolute());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_browser_caps_entry_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        // Create a target directory OUTSIDE the data dir.
+        let target = dir.path().join("evil-target");
+        std::fs::create_dir_all(&target).unwrap();
+
+        // Symlink data/browser-caps → evil-target (outside).
+        let link = data_dir.join(CAPFILE_SUBDIR);
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        // Construction must FAIL because the browser-caps component is an
+        // existing symlink.
+        let reg = BrowserTokenRegistry::new(&data_dir);
+        assert!(
+            reg.is_err(),
+            "must reject browser-caps symlink at construction"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_parent_ok_when_trailing_is_not_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Parent ancestry can have symlinks — canonicalize follows them.
+        let real_data = dir.path().join("real-data");
+        std::fs::create_dir_all(&real_data).unwrap();
+        let link_parent = dir.path().join("data");
+        std::os::unix::fs::symlink(&real_data, &link_parent).unwrap();
+
+        // Construction succeeds: the trailing browser-caps is NOT a symlink,
+        // and canonicalize(parent) resolves the ancestry normally.
+        let reg = BrowserTokenRegistry::new(&link_parent);
+        assert!(reg.is_ok());
+    }
+
     // ── Unix permissions ─────────────────────────────────────────────────
 
     #[cfg(unix)]
@@ -719,14 +798,44 @@ mod tests {
         );
     }
 
-    // ── concurrent safety ────────────────────────────────────────────────
-
     #[test]
-    fn concurrent_issuance_two_sessions_no_state_corruption() {
+    fn failed_write_does_not_leave_stale_in_memory_entry() {
+        // issue() holds the registry lock across write_capfile + map commit.
+        // On any write error the lock drops with the maps unchanged, so a
+        // subsequent issuance for the same session can proceed cleanly.
+        // This test proves the happy path after an error: issue → revoke →
+        // issue, simulating the normal lifecycle where a transient write
+        // failure was already handled by the caller.
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
-        let sub_a = subject("concurrent-a");
-        let sub_b = subject("concurrent-b");
+        let sub = subject("writefail");
+
+        // Issue, then revoke — simulates the caller cleaning up after a
+        // successful issuance that was no longer needed (or after a transient
+        // failure that was already retried and then revoked).
+        let first = reg.issue(sub.clone()).unwrap();
+        reg.revoke(sub.session);
+        assert!(reg.subject_for_token(
+            &read_token_from_capfile(&first.capability_file)
+        ).is_none());
+        assert!(!first.capability_file.exists());
+
+        // A fresh issuance must succeed with a clean state — no stale
+        // token or session entry survived the revoke.
+        let second = reg.issue(sub.clone()).unwrap();
+        let token = read_token_from_capfile(&second.capability_file);
+        assert_eq!(reg.subject_for_token(&token).as_ref(), Some(&sub));
+        assert!(second.capability_file.exists());
+    }
+
+    // ── sequential safety ────────────────────────────────────────────────
+
+    #[test]
+    fn two_sessions_independent_lifecycles() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub_a = subject("independent-a");
+        let sub_b = subject("independent-b");
 
         let spec_a = reg.issue(sub_a.clone()).unwrap();
         let spec_b = reg.issue(sub_b.clone()).unwrap();
@@ -748,7 +857,7 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_reissue_and_revoke_no_interleaving_corruption() {
+    fn interleaved_reissue_and_revoke_sequence() {
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("interleave");

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -810,7 +810,8 @@ mod tests {
         let sub = subject("writefail");
 
         // Warm up: issue once so the capfile directory exists.
-        let warm = reg.issue(subject("warm")).unwrap();
+        let warm_subject = subject("warm");
+        let warm = reg.issue(warm_subject.clone()).unwrap();
         let warm_token = read_token_from_capfile(&warm.capability_file);
         assert!(warm.capability_file.exists());
 
@@ -831,7 +832,7 @@ mod tests {
         );
         assert_eq!(
             reg.subject_for_token(&warm_token).as_ref(),
-            Some(&subject("warm")),
+            Some(&warm_subject),
             "the prior mapping must survive the failed issuance"
         );
 

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -1,0 +1,471 @@
+//! Session-browser authority: mint, write, and revoke browser capability
+//! files for engine sessions.
+//!
+//! Each code session that needs browser access receives a scoped bearer token
+//! mapped through an in-memory route-token registry. The token plus the
+//! loopback endpoint are written into a session-private JSON capability file
+//! whose path is injected into the engine child. No owner, workspace, or
+//! session identifiers leave the server.
+//!
+//! ## Security properties
+//!
+//! * Tokens are random v4 UUIDs; reissuing for the same session silently
+//!   revokes and deletes the prior token and its capability file.
+//! * Startup deletes every stale capability file so a restarted server cannot
+//!   accept a token it did not mint.
+//! * Capfiles are written create-new → sync → chmod 0600 → atomic rename.
+//! * The JSON payload carries only `version`, `endpoint`, and `token` — no
+//!   owner, workspace, or session identifiers.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use tidebreak_core::{CodeSessionId, OwnerId, WorkspaceId};
+use tidebreak_harness::BrowserChannelSpec;
+
+/// Capfile format version. Increment when the schema changes in a backward-
+/// incompatible way.
+const CAPFILE_VERSION: u32 = 1;
+
+/// Filename prefix for capability files. Random components follow.
+const CAPFILE_PREFIX: &str = "browser-cap-";
+
+/// Subdirectory under the data dir that holds session capability files.
+const CAPFILE_SUBDIR: &str = "browser-caps";
+
+/// The `{owner, workspace, session}` subject derived from a token look-up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BrowserSubject {
+    pub owner: OwnerId,
+    pub workspace: WorkspaceId,
+    pub session: CodeSessionId,
+}
+
+/// In-memory route-token registry paired with an on-disk capability-file tree.
+///
+/// One token per session: reissuing silently revokes and deletes the prior
+/// token and its capability file. Startup deletes every stale file so a
+/// restarted server cannot accept a token it did not mint.
+pub(crate) struct BrowserTokenRegistry {
+    tokens: Mutex<HashMap<String, BrowserSubject>>,
+    by_session: Mutex<HashMap<CodeSessionId, String>>,
+    /// Absolute path to the data-dir subtree that holds capfiles.
+    capfile_dir: PathBuf,
+    /// Loopback base URL published after bind.
+    loopback_base: Mutex<Option<String>>,
+}
+
+impl BrowserTokenRegistry {
+    pub(crate) fn new(data_dir: &Path) -> Self {
+        let capfile_dir = data_dir.join(CAPFILE_SUBDIR);
+        Self {
+            tokens: Mutex::new(HashMap::new()),
+            by_session: Mutex::new(HashMap::new()),
+            capfile_dir,
+            loopback_base: Mutex::new(None),
+        }
+    }
+
+    /// Publish the bound loopback base so later [`Self::issue`] calls can
+    /// write it into the capfile endpoint.
+    pub(crate) fn set_loopback_base(&self, base: &str) {
+        *self.loopback_base.lock().expect("loopback base") =
+            Some(base.trim_end_matches('/').into());
+    }
+
+    /// Delete every stale capability file under the capfile directory.
+    ///
+    /// Must run at startup before any session is recovered or created so a
+    /// restarted server cannot accept tokens it did not mint. The in-memory
+    /// registry is always fresh on restart.
+    pub(crate) fn delete_all_stale_capfiles(&self) {
+        match std::fs::read_dir(&self.capfile_dir) {
+            Ok(entries) => {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path
+                        .file_name()
+                        .and_then(|f| f.to_str())
+                        .is_some_and(|f| f.starts_with(CAPFILE_PREFIX))
+                    {
+                        let _ = std::fs::remove_file(&path);
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // The directory does not exist yet — nothing to clean.
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "code-mode: could not read browser capfile directory for cleanup: {e}"
+                );
+            }
+        }
+    }
+
+    /// Mint a channel for `subject` and return the [`BrowserChannelSpec`]
+    /// the adapter injects into the engine child.
+    ///
+    /// The returned path is always absolute because it is resolved against the
+    /// absolute `data_dir` (closing PR #2364's accepted P3 about constructor-
+    /// level path validation — the server is the single trusted constructor
+    /// site and guarantees absoluteness at this boundary).
+    ///
+    /// Reissuing for the same session revokes and deletes the prior token
+    /// and its capability file.
+    pub(crate) fn issue(&self, subject: BrowserSubject) -> Result<BrowserChannelSpec, String> {
+        let token = generate_token();
+        let loopback_base = self
+            .loopback_base
+            .lock()
+            .expect("loopback base")
+            .clone()
+            .ok_or_else(|| "loopback base not set".to_owned())?;
+
+        // Revoke and delete any prior token for this session.
+        {
+            let mut by_session = self.by_session.lock().expect("browser session tokens");
+            if let Some(old) = by_session.insert(subject.session, token.clone()) {
+                let mut tokens = self.tokens.lock().expect("browser tokens");
+                tokens.remove(&old);
+                let old_path = capfile_path(&self.capfile_dir, &old);
+                let _ = std::fs::remove_file(&old_path);
+            }
+            let mut tokens = self.tokens.lock().expect("browser tokens");
+            tokens.insert(token.clone(), subject);
+        }
+
+        let capfile_path = capfile_path(&self.capfile_dir, &token);
+        write_capfile(&capfile_path, CAPFILE_VERSION, &loopback_base, &token)?;
+
+        Ok(BrowserChannelSpec::new(capfile_path))
+    }
+
+    /// Return the subject for an inbound browser bearer token, or `None`.
+    pub(crate) fn subject_for_token(&self, token: &str) -> Option<BrowserSubject> {
+        self.tokens
+            .lock()
+            .expect("browser tokens")
+            .get(token)
+            .cloned()
+    }
+
+    /// Revoke and delete the channel for `session_id`. Idempotent.
+    pub(crate) fn revoke(&self, session_id: CodeSessionId) {
+        let token = self
+            .by_session
+            .lock()
+            .expect("browser session tokens")
+            .remove(&session_id);
+        if let Some(token) = token {
+            self.tokens.lock().expect("browser tokens").remove(&token);
+            let path = capfile_path(&self.capfile_dir, &token);
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+
+    /// The data-dir subtree where capfiles live (for tests).
+    #[cfg(test)]
+    pub(crate) fn capfile_dir(&self) -> &Path {
+        &self.capfile_dir
+    }
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+fn generate_token() -> String {
+    format!("tbreak_bt_{}", uuid::Uuid::new_v4())
+}
+
+fn capfile_path(capfile_dir: &Path, token: &str) -> PathBuf {
+    capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, token))
+}
+
+/// Write `{version, endpoint, token}` safely:
+///
+/// 1. Ensure the directory exists with mode 0700.
+/// 2. Write to a random temp name under the capfile dir.
+/// 3. Write the JSON body.
+/// 4. fsync the file.
+/// 5. Set mode 0600.
+/// 6. Atomic rename onto the final path.
+fn write_capfile(
+    path: &Path,
+    version: u32,
+    loopback_base: &str,
+    token: &str,
+) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "capfile has no parent directory".to_owned())?;
+
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        return Err(format!("could not create capfile directory: {e}"));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Err(e) =
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+        {
+            return Err(format!("could not set capfile directory mode: {e}"));
+        }
+    }
+
+    let endpoint = format!("{loopback_base}/code/browser");
+
+    let body = serde_json::json!({
+        "version": version,
+        "endpoint": endpoint,
+        "token": token,
+    });
+
+    let body_bytes = serde_json::to_vec(&body)
+        .map_err(|e| format!("failed to serialize capfile: {e}"))?;
+
+    // Random temp name to avoid collision with concurrent issuances.
+    let tmp_name = format!(
+        ".{}.tmp",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let tmp_path = parent.join(tmp_name);
+
+    {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .map_err(|e| format!("could not create temp capfile: {e}"))?;
+
+        file.write_all(&body_bytes)
+            .map_err(|e| format!("could not write capfile: {e}"))?;
+
+        file.flush()
+            .map_err(|e| format!("could not flush capfile: {e}"))?;
+
+        file.sync_all()
+            .map_err(|e| format!("could not sync capfile: {e}"))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            if let Err(e) =
+                std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
+            {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(format!("could not set capfile mode: {e}"));
+            }
+        }
+    }
+
+    std::fs::rename(&tmp_path, path)
+        .map_err(|e| format!("could not rename capfile into place: {e}"))?;
+
+    Ok(())
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seeded(data_dir: &Path) -> BrowserTokenRegistry {
+        let reg = BrowserTokenRegistry::new(data_dir);
+        reg.set_loopback_base("http://127.0.0.1:0");
+        reg
+    }
+
+    fn subject(_label: &str) -> BrowserSubject {
+        BrowserSubject {
+            owner: OwnerId::local(),
+            workspace: WorkspaceId::new(),
+            session: CodeSessionId::new(),
+        }
+    }
+
+    #[test]
+    fn token_roundtrip_registry_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("roundtrip");
+
+        let spec = reg.issue(sub.clone()).unwrap();
+        let token = extract_token_from_path(&spec.capability_file);
+        assert!(!token.is_empty());
+
+        let looked_up = reg.subject_for_token(&token);
+        assert_eq!(looked_up.as_ref(), Some(&sub));
+    }
+
+    #[test]
+    fn reissue_revokes_and_replaces_prior_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("reissue");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = extract_token_from_path(&first.capability_file);
+        assert!(first.capability_file.exists());
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = extract_token_from_path(&second.capability_file);
+
+        assert_ne!(first_token, second_token);
+        assert!(reg.subject_for_token(&first_token).is_none());
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+        assert!(!first.capability_file.exists());
+        assert!(second.capability_file.exists());
+    }
+
+    #[test]
+    fn revoke_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("idempotent");
+
+        let spec = reg.issue(sub.clone()).unwrap();
+        let token = extract_token_from_path(&spec.capability_file);
+        assert!(spec.capability_file.exists());
+
+        reg.revoke(sub.session);
+        assert!(!spec.capability_file.exists());
+        assert!(reg.subject_for_token(&token).is_none());
+
+        // Second revoke is silent.
+        reg.revoke(sub.session);
+    }
+
+    #[test]
+    fn capfile_schema_has_no_subject_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("schema");
+
+        let spec = reg.issue(sub).unwrap();
+        let contents = std::fs::read_to_string(&spec.capability_file).expect("read capfile");
+        let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
+
+        assert!(value.get("version").is_some());
+        assert!(value.get("endpoint").is_some());
+        assert!(value.get("token").is_some());
+        assert!(value.get("owner").is_none());
+        assert!(value.get("workspace").is_none());
+        assert!(value.get("session").is_none());
+        assert!(value.get("browser_id").is_none());
+    }
+
+    #[test]
+    fn capfile_endpoint_derives_from_loopback_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = BrowserTokenRegistry::new(dir.path());
+        reg.set_loopback_base("https://tidebreak.local:4567/");
+        let sub = subject("endpoint");
+
+        let spec = reg.issue(sub).unwrap();
+        let contents = std::fs::read_to_string(&spec.capability_file).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+        assert_eq!(
+            value["endpoint"],
+            "https://tidebreak.local:4567/code/browser"
+        );
+    }
+
+    #[test]
+    fn stale_directory_cleanup_removes_known_capfiles() {
+        let dir = tempfile::tempdir().unwrap();
+        let capfile_dir = dir.path().join(CAPFILE_SUBDIR);
+        std::fs::create_dir_all(&capfile_dir).unwrap();
+
+        let stale_path = capfile_dir.join(format!("{}{}.json", CAPFILE_PREFIX, uuid::Uuid::new_v4()));
+        std::fs::write(&stale_path, b"{}").unwrap();
+        assert!(stale_path.exists());
+
+        // A non-capfile in the same dir must survive.
+        let other = capfile_dir.join("not-a-browser-file.txt");
+        std::fs::write(&other, b"do not delete").unwrap();
+
+        let reg = BrowserTokenRegistry::new(dir.path());
+        reg.delete_all_stale_capfiles();
+
+        assert!(!stale_path.exists());
+        assert!(other.exists());
+    }
+
+    #[test]
+    fn cleanup_handles_missing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = BrowserTokenRegistry::new(dir.path());
+        reg.delete_all_stale_capfiles();
+    }
+
+    #[test]
+    fn capfile_path_is_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("absolute");
+
+        let spec = reg.issue(sub).unwrap();
+        assert!(spec.capability_file.is_absolute());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capfile_is_mode_0600() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("mode");
+
+        let spec = reg.issue(sub).unwrap();
+        let meta = std::fs::metadata(&spec.capability_file).unwrap();
+        let mode = meta.permissions().mode();
+
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capfile_directory_is_mode_0700() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("dirmode");
+
+        let _spec = reg.issue(sub).unwrap();
+        let capfile_dir = reg.capfile_dir();
+        let meta = std::fs::metadata(capfile_dir).unwrap();
+        let mode = meta.permissions().mode();
+
+        assert_eq!(mode & 0o777, 0o700);
+    }
+
+    #[test]
+    fn atomic_temp_file_is_cleaned_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("atomic");
+
+        let spec = reg.issue(sub).unwrap();
+        let parent = spec.capability_file.parent().unwrap();
+
+        let tmp_count = std::fs::read_dir(parent)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
+            .count();
+        assert_eq!(tmp_count, 0, "no .tmp files should survive atomic rename");
+    }
+
+    fn extract_token_from_path(path: &Path) -> String {
+        let name = path.file_stem().unwrap().to_string_lossy();
+        let without_prefix = name.strip_prefix(CAPFILE_PREFIX).unwrap();
+        without_prefix.to_owned()
+    }
+}

--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -371,16 +371,19 @@ fn write_capfile(
 
     // Each step after open must clean up the temp file on failure.
     if let Err(e) = file.write_all(&body_bytes) {
+        drop(file);
         let _ = std::fs::remove_file(&tmp_path);
         return Err(format!("could not write capfile: {e}"));
     }
 
     if let Err(e) = file.flush() {
+        drop(file);
         let _ = std::fs::remove_file(&tmp_path);
         return Err(format!("could not flush capfile: {e}"));
     }
 
     if let Err(e) = file.sync_all() {
+        drop(file);
         let _ = std::fs::remove_file(&tmp_path);
         return Err(format!("could not sync capfile: {e}"));
     }
@@ -392,6 +395,7 @@ fn write_capfile(
         if let Err(e) =
             std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
         {
+            drop(file);
             let _ = std::fs::remove_file(&tmp_path);
             return Err(format!("could not set capfile mode: {e}"));
         }
@@ -799,33 +803,75 @@ mod tests {
     }
 
     #[test]
-    fn failed_write_does_not_leave_stale_in_memory_entry() {
+    fn revoke_and_reissue_produces_clean_slate() {
+        // After a successful issuance is revoked (simulating shutdown or
+        // error handling), a fresh issuance for the same session must
+        // produce a new token, a new capfile path, and no stale in-memory
+        // entry. Token is captured before revoke deletes the capfile.
+        let dir = tempfile::tempdir().unwrap();
+        let reg = seeded(dir.path());
+        let sub = subject("cleanslate");
+
+        let first = reg.issue(sub.clone()).unwrap();
+        let first_token = read_token_from_capfile(&first.capability_file);
+        let first_path = first.capability_file.clone();
+        assert!(first_path.exists());
+
+        reg.revoke(sub.session);
+        assert!(reg.subject_for_token(&first_token).is_none());
+        assert!(!first_path.exists());
+
+        let second = reg.issue(sub.clone()).unwrap();
+        let second_token = read_token_from_capfile(&second.capability_file);
+        let second_path = second.capability_file.clone();
+
+        assert_ne!(first_token, second_token);
+        assert_ne!(first_path, second_path);
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+        assert!(second_path.exists());
+    }
+
+    #[test]
+    fn write_failure_leaves_maps_unchanged() {
         // issue() holds the registry lock across write_capfile + map commit.
-        // On any write error the lock drops with the maps unchanged, so a
-        // subsequent issuance for the same session can proceed cleanly.
-        // This test proves the happy path after an error: issue → revoke →
-        // issue, simulating the normal lifecycle where a transient write
-        // failure was already handled by the caller.
+        // A write failure drops the lock without mutating either map. On
+        // Unix we prove this by removing write permission from the capfile
+        // directory so create_new fails; then a subsequent issuance succeeds
+        // with no stale state. On non-Unix the test is a structural-invariant
+        // check: a normal issue/revoke/reissue cycle leaves clean maps.
         let dir = tempfile::tempdir().unwrap();
         let reg = seeded(dir.path());
         let sub = subject("writefail");
 
-        // Issue, then revoke — simulates the caller cleaning up after a
-        // successful issuance that was no longer needed (or after a transient
-        // failure that was already retried and then revoked).
-        let first = reg.issue(sub.clone()).unwrap();
-        reg.revoke(sub.session);
-        assert!(reg.subject_for_token(
-            &read_token_from_capfile(&first.capability_file)
-        ).is_none());
-        assert!(!first.capability_file.exists());
+        // Warm up: issue once so the capfile directory exists.
+        let warm = reg.issue(subject("warm")).unwrap();
+        assert!(warm.capability_file.exists());
 
-        // A fresh issuance must succeed with a clean state — no stale
-        // token or session entry survived the revoke.
+        #[cfg(unix)]
+        let did_fail = {
+            use std::os::unix::fs::PermissionsExt as _;
+            let capdir = reg.capfile_dir();
+            std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o500))
+                .expect("remove write permission for failure injection");
+            let result = reg.issue(sub.clone());
+            // Restore permissions immediately.
+            std::fs::set_permissions(capdir, std::fs::Permissions::from_mode(0o700))
+                .expect("restore write permission");
+            assert!(result.is_err(), "issue must fail when directory is read-only");
+            true
+        };
+
+        // After failure (or on non-Unix, after the structural warm), a fresh
+        // issuance for the same session must succeed without stale entries.
         let second = reg.issue(sub.clone()).unwrap();
-        let token = read_token_from_capfile(&second.capability_file);
-        assert_eq!(reg.subject_for_token(&token).as_ref(), Some(&sub));
-        assert!(second.capability_file.exists());
+        let second_token = read_token_from_capfile(&second.capability_file);
+        assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
+
+        #[cfg(unix)]
+        let _ = did_fail;
+
+        // The TempDir will clean up everything when dropped.
+        let _ = warm;
     }
 
     // ── sequential safety ────────────────────────────────────────────────

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -5,6 +5,7 @@
 //! worker, crash recovery, and the live event bus.
 
 pub(crate) mod approval_bridge;
+pub(crate) mod browser_channel;
 pub(crate) mod attention;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -5,8 +5,8 @@
 //! worker, crash recovery, and the live event bus.
 
 pub(crate) mod approval_bridge;
-pub(crate) mod browser_channel;
 pub(crate) mod attention;
+pub(crate) mod browser_channel;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;
 pub(crate) mod clone;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -174,6 +174,8 @@ impl CodeRuntime {
             // only failure is an OS-level path resolution error such as a
             // dangling CWD, which is a startup bug, not a runtime condition.
             .expect("browser capfile directory must be resolvable to an absolute path");
+        #[cfg(test)]
+        browser_tokens.set_loopback_base("http://127.0.0.1:0");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),
@@ -259,6 +261,8 @@ impl CodeRuntime {
             // only failure is an OS-level path resolution error such as a
             // dangling CWD, which is a startup bug, not a runtime condition.
             .expect("browser capfile directory must be resolvable to an absolute path");
+        #[cfg(test)]
+        browser_tokens.set_loopback_base("http://127.0.0.1:0");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -228,8 +228,9 @@ impl CodeRuntime {
     pub(crate) fn start(
         self: &Arc<Self>,
         loopback_base: String,
-    ) -> Box<dyn std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> + Send>
-    {
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> + Send>,
+    > {
         self.set_loopback_base(loopback_base);
         // Synchronously delete stale capfiles before the returned future is
         // pollable so issue() cannot race an unpolled startup cleanup.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -28,6 +28,7 @@ use tidebreak_harness::{
 };
 
 use super::approval_bridge::ApprovalBridge;
+use super::browser_channel::{BrowserSubject, BrowserTokenRegistry};
 use super::bus::CodeEventBus;
 use super::checkpoint::{
     delete_workspace_refs, list_changed_files, produce_diff, resolve_diff_range,
@@ -132,6 +133,7 @@ pub(crate) struct CodeRuntime {
     pub(crate) worktree_root_default: Option<PathBuf>,
     pub blobs: Arc<dyn tidebreak_core::BlobStore>,
     pub approvals: Arc<ApprovalBridge>,
+    pub(crate) browser_tokens: BrowserTokenRegistry,
     host: HostEnv,
     host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     loopback_base: Mutex<Option<String>>,
@@ -174,6 +176,7 @@ impl CodeRuntime {
             data_dir: data_dir.clone(),
             worktree_root_default,
             approvals: ApprovalBridge::new(),
+            browser_tokens: BrowserTokenRegistry::new(&data_dir),
             host: HostEnv {
                 data_dir: Some(data_dir),
                 ..HostEnv::from_process()
@@ -199,6 +202,7 @@ impl CodeRuntime {
 
     /// Bound after listen so Claude can be pointed at the loopback MCP route.
     fn set_loopback_base(&self, base: String) {
+        self.browser_tokens.set_loopback_base(&base);
         *self.loopback_base.lock().expect("loopback base") =
             Some(base.trim_end_matches('/').into());
     }
@@ -220,6 +224,7 @@ impl CodeRuntime {
         loopback_base: String,
     ) -> impl std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> {
         self.set_loopback_base(loopback_base);
+        self.browser_tokens.delete_all_stale_capfiles();
         let runtime = self.clone();
         async move {
             let actions = runtime.recover().await;
@@ -245,6 +250,7 @@ impl CodeRuntime {
             data_dir,
             worktree_root_default: None,
             approvals: ApprovalBridge::new(),
+            browser_tokens: BrowserTokenRegistry::new(&data_dir),
             host: HostEnv::from_process(),
             host_tool_broker: None,
             loopback_base: Mutex::new(None),
@@ -1350,6 +1356,7 @@ impl CodeRuntime {
             ));
         }
         let handle = self.workers.lock().expect("code workers").remove(&id);
+        self.browser_tokens.revoke(id);
         let session = match handle {
             // The outgoing worker writes its own final state as it stops, and
             // the new spawn must not be started against a row it is still
@@ -1428,6 +1435,7 @@ impl CodeRuntime {
             .lock()
             .expect("code workers")
             .remove(&session.id);
+        self.browser_tokens.revoke(session.id);
         session.lifecycle = CodeSessionLifecycle::Ended;
         session.child_pid = None;
         session.fence_reason = None;
@@ -1641,6 +1649,7 @@ impl CodeRuntime {
                 .lock()
                 .expect("code workers")
                 .remove(&session.id);
+            self.browser_tokens.revoke(session.id);
             // Mark the row ended before asking the worker to stop. A worker
             // interrupted mid-turn re-reads the row on its way round the loop
             // and leaves on its own when it finds the session ended, so one
@@ -1737,6 +1746,13 @@ impl CodeRuntime {
             attached.subagents.clone(),
         );
         let approval = self.approval_channel(session.id, session.permission_mode);
+        let browser_subject = BrowserSubject {
+            owner: session.owner.clone(),
+            workspace: session.workspace_id,
+            session: session.id,
+        };
+        let browser = self.browser_tokens.issue(browser_subject).ok();
+
         let spec = SessionSpec {
             worktree: PathBuf::from(&workspace.worktree_path),
             permission_mode: session.permission_mode,
@@ -1748,12 +1764,13 @@ impl CodeRuntime {
             approval,
             binary,
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
-            browser: None,
+            browser,
         };
         let mut attached = attached;
         let engine = match adapter.launch(spec).await {
             Ok(engine) => engine,
             Err(HarnessError::ResumeLost(detail)) => {
+                self.browser_tokens.revoke(session.id);
                 // The engine refused the stored resume ref. Fence with a
                 // reason the UI can explain — the fence drops the dead ref, so
                 // a reap re-attaches with a fresh engine session.
@@ -1772,6 +1789,7 @@ impl CodeRuntime {
                 ));
             }
             Err(err) => {
+                self.browser_tokens.revoke(session.id);
                 return Err(ServerError::internal(format!(
                     "failed to launch engine session: {err}"
                 )));

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -169,6 +169,10 @@ impl CodeRuntime {
         host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     ) -> Self {
         let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            // Panic on construction failure: the data dir is trusted/absolute
+            // at this point (set from config and validated by the host). The
+            // only failure is an OS-level path resolution error such as a
+            // dangling CWD, which is a startup bug, not a runtime condition.
             .expect("browser capfile directory must be resolvable to an absolute path");
         Self {
             db,
@@ -224,22 +228,22 @@ impl CodeRuntime {
     pub(crate) fn start(
         self: &Arc<Self>,
         loopback_base: String,
-    ) -> impl std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> {
+    ) -> Box<dyn std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> + Send>
+    {
         self.set_loopback_base(loopback_base);
+        // Synchronously delete stale capfiles before the returned future is
+        // pollable so issue() cannot race an unpolled startup cleanup.
+        let cleanup = self.browser_tokens.delete_all_stale_capfiles();
         let runtime = self.clone();
-        async move {
-            // Clean up stale capfiles before anything else. Fail closed.
-            runtime
-                .browser_tokens
-                .delete_all_stale_capfiles()
-                .map_err(|e| ServerError::internal(e))?;
+        Box::pin(async move {
+            cleanup.map_err(|e| ServerError::internal(e))?;
             let actions = runtime.recover().await;
             // After recovery so resumed watch sessions have workers to drive;
             // the sweep reads its work list from the `code_watch` table, so
             // active watches resume with no extra state.
             runtime.ensure_watch_sweep();
             actions
-        }
+        })
     }
 
     #[cfg(any(test, feature = "scripted-harness"))]
@@ -249,6 +253,10 @@ impl CodeRuntime {
         adapters: AdapterRegistry,
     ) -> Self {
         let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            // Panic on construction failure: the data dir is trusted/absolute
+            // at this point (set from config and validated by the host). The
+            // only failure is an OS-level path resolution error such as a
+            // dangling CWD, which is a startup bug, not a runtime condition.
             .expect("browser capfile directory must be resolvable to an absolute path");
         Self {
             db,
@@ -1775,7 +1783,7 @@ impl CodeRuntime {
             approval,
             binary,
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
-            browser,
+            browser: Some(browser),
         };
         let mut attached = attached;
         let engine = match adapter.launch(spec).await {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -168,6 +168,8 @@ impl CodeRuntime {
         worktree_root_default: Option<PathBuf>,
         host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
     ) -> Self {
+        let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            .expect("browser capfile directory must be resolvable to an absolute path");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),
@@ -176,7 +178,7 @@ impl CodeRuntime {
             data_dir: data_dir.clone(),
             worktree_root_default,
             approvals: ApprovalBridge::new(),
-            browser_tokens: BrowserTokenRegistry::new(&data_dir),
+            browser_tokens,
             host: HostEnv {
                 data_dir: Some(data_dir),
                 ..HostEnv::from_process()
@@ -224,9 +226,13 @@ impl CodeRuntime {
         loopback_base: String,
     ) -> impl std::future::Future<Output = Result<Vec<RecoveryAction>, ServerError>> {
         self.set_loopback_base(loopback_base);
-        self.browser_tokens.delete_all_stale_capfiles();
         let runtime = self.clone();
         async move {
+            // Clean up stale capfiles before anything else. Fail closed.
+            runtime
+                .browser_tokens
+                .delete_all_stale_capfiles()
+                .map_err(|e| ServerError::internal(e))?;
             let actions = runtime.recover().await;
             // After recovery so resumed watch sessions have workers to drive;
             // the sweep reads its work list from the `code_watch` table, so
@@ -242,6 +248,8 @@ impl CodeRuntime {
         data_dir: PathBuf,
         adapters: AdapterRegistry,
     ) -> Self {
+        let browser_tokens = BrowserTokenRegistry::new(&data_dir)
+            .expect("browser capfile directory must be resolvable to an absolute path");
         Self {
             db,
             bus: Arc::new(CodeEventBus::default()),
@@ -250,7 +258,7 @@ impl CodeRuntime {
             data_dir,
             worktree_root_default: None,
             approvals: ApprovalBridge::new(),
-            browser_tokens: BrowserTokenRegistry::new(&data_dir),
+            browser_tokens,
             host: HostEnv::from_process(),
             host_tool_broker: None,
             loopback_base: Mutex::new(None),
@@ -1751,7 +1759,10 @@ impl CodeRuntime {
             workspace: session.workspace_id,
             session: session.id,
         };
-        let browser = self.browser_tokens.issue(browser_subject).ok();
+        let browser = self
+            .browser_tokens
+            .issue(browser_subject)
+            .map_err(|e| ServerError::internal(e))?;
 
         let spec = SessionSpec {
             worktree: PathBuf::from(&workspace.worktree_path),

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -237,7 +237,7 @@ impl CodeRuntime {
         let cleanup = self.browser_tokens.delete_all_stale_capfiles();
         let runtime = self.clone();
         Box::pin(async move {
-            cleanup.map_err(|e| ServerError::internal(e))?;
+            cleanup.map_err(ServerError::internal)?;
             let actions = runtime.recover().await;
             // After recovery so resumed watch sessions have workers to drive;
             // the sweep reads its work list from the `code_watch` table, so
@@ -1771,7 +1771,7 @@ impl CodeRuntime {
         let browser = self
             .browser_tokens
             .issue(browser_subject)
-            .map_err(|e| ServerError::internal(e))?;
+            .map_err(ServerError::internal)?;
 
         let spec = SessionSpec {
             worktree: PathBuf::from(&workspace.worktree_path),


### PR DESCRIPTION
Part of #2335 and #2342.

Replaces #2375 with a clean one-commit implementation.

Adds `tidebreak browser list|navigate|snapshot --json` and `tidebreak browser-mcp`, exposing exactly `browser_list`, `browser_navigate`, and `browser_snapshot`. The client reads the session-private `TIDEBREAK_BROWSER_CAPFILE`, refuses redirects and malformed/non-loopback endpoints, bounds response bodies, preserves HTTP error categories, and redacts token-like material from failures.

Initial capability boundary: no act, wait, or screenshot advertisement.

Validation performed locally without Rust tooling:
- `git diff --check`
- gitleaks directory and branch-history scans
- static call-site and protocol review

Rust compile/format/test validation is delegated to CI per the requested workflow.