### PR TITLE
docs(code): point the last record-54 citations at 55

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -37,7 +37,7 @@ export type CodeUpdatesState = {
   /**
    * Conversation digests, keyed workspace → session. Never a watch.
    *
-   * A workspace runs several agents (record 54), so it names a set rather
+   * A workspace runs several agents (record 55), so it names a set rather
    * than one digest. List surfaces collapse the set through
    * `workspaceDigest`; the workspace page reads all of it to label its
    * conversation tabs.

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -223,7 +223,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   /**
    * Every session the server knows about here, conversations and watches alike.
    *
-   * A workspace runs several agents (record 54), so the page holds the list and
+   * A workspace runs several agents (record 55), so the page holds the list and
    * picks one to show rather than tracking a single session.
    */
   const [sessions, setSessions] = useState<CodeSessionSnapshot[]>(() => {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1632,7 +1632,7 @@ export function parseCodeSessionList(
 /**
  * The conversations a workspace page should offer, oldest first.
  *
- * A workspace runs several agents (record 54). The list arrives newest first,
+ * A workspace runs several agents (record 55). The list arrives newest first,
  * but the tab strip reads left to right in the order the agents were started,
  * so the first one keeps its place and a new one appends to the right.
  */


### PR DESCRIPTION
## What

Three comments in the desktop UI still say "record 54" when they mean the
sessions record, which is now 55.

## Why #2365 missed them

#2365 renumbered the record and rewrote its citations. #2356 added these three
while that PR was open. Each branched from a `main` that did not yet have the
other, so neither could see the other's lines — the same collision #2365
existed to fix, one layer down. A stale citation now names the agent-browser
record instead of the one it means.

## What changed

Three comment lines, in `CodeUpdatesStore.ts`, `parsers.ts`, and
`CodeWorkspacePage.tsx`. `git grep "record 54"` and `git grep
"0054-multiple"` are both empty after this.

## Worth noting

This is the second time in one day that two branches took the same view of
`main` and produced an inconsistency no lane caught. #2365 flagged a
duplicate-number check as out of scope; a citation check ("every `record N`
names a file that exists, and only one does") would have caught both this and
the original collision. Still a separate change, but the case for it is
stronger now.

## Verification

`pnpm exec tsc --noEmit` passes. Comments only — no behavior change.
