### PR TITLE
fix(code): make the browser bridge test fixture absolute on Windows

### DIFF
--- a/crates/tidebreak-server/src/code/browser_channel.rs
+++ b/crates/tidebreak-server/src/code/browser_channel.rs
@@ -423,15 +423,30 @@ fn write_capfile(
     Ok(())
 }
 
+/// An absolute bridge-command path for tests, valid on the host platform.
+///
+/// [`BrowserTokenRegistry::issue`] refuses a bridge command that is not
+/// absolute, and `Path::is_absolute` is platform-defined: `/usr/local/bin`
+/// roots a path on Unix and is merely relative on Windows. Every test that
+/// mints a capability takes its bridge path from here so one definition
+/// stays correct on both hosts. The server never opens this path — the
+/// desktop sibling resolver owns existence and executability — so the
+/// target does not have to exist.
+#[cfg(test)]
+pub(crate) fn test_bridge_command() -> PathBuf {
+    if cfg!(windows) {
+        PathBuf::from(r"C:\Program Files\Tidebreak\tidebreak.exe")
+    } else {
+        PathBuf::from("/usr/local/bin/tidebreak")
+    }
+}
+
 // ── tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashSet;
-
-    /// Fixture bridge command path used by every test issuance.
-    const TEST_BRIDGE: &str = "/usr/local/bin/tidebreak";
 
     fn seeded(data_dir: &Path) -> BrowserTokenRegistry {
         let reg = BrowserTokenRegistry::new(data_dir).unwrap();
@@ -461,7 +476,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("indep");
 
-        let spec = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let spec = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let file_stem = spec.capability_file.file_stem().unwrap().to_string_lossy();
         let token = read_token_from_capfile(&spec.capability_file);
 
@@ -488,7 +503,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("roundtrip");
 
-        let spec = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let spec = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let token = read_token_from_capfile(&spec.capability_file);
         assert!(!token.is_empty());
 
@@ -504,7 +519,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("transactional");
 
-        let first = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let first = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let first_token = read_token_from_capfile(&first.capability_file);
         let first_path = first.capability_file.clone();
         assert!(first_path.exists());
@@ -514,7 +529,7 @@ mod tests {
             "first token must resolve before reissue"
         );
 
-        let second = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let second = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let second_token = read_token_from_capfile(&second.capability_file);
 
         // Second token is live.
@@ -535,13 +550,13 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("fileids");
 
-        let first = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let first = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         // Read the token from the first capfile BEFORE second issuance
         // deletes it.
         let first_token = read_token_from_capfile(&first.capability_file);
         let first_path = first.capability_file.clone();
 
-        let second = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let second = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let second_token = read_token_from_capfile(&second.capability_file);
 
         assert_ne!(first_path, second.capability_file);
@@ -556,7 +571,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("idempotent");
 
-        let spec = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let spec = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let token = read_token_from_capfile(&spec.capability_file);
         let capfile_path = spec.capability_file.clone();
         assert!(capfile_path.exists());
@@ -583,12 +598,12 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("fresh");
 
-        let first = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let first = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let first_token = read_token_from_capfile(&first.capability_file);
         reg.revoke(sub.session);
         assert!(reg.subject_for_token(&first_token).is_none());
 
-        let second = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let second = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let second_token = read_token_from_capfile(&second.capability_file);
         assert_ne!(first_token, second_token);
         assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
@@ -602,7 +617,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("schema");
 
-        let spec = reg.issue(sub, Path::new(TEST_BRIDGE)).unwrap();
+        let spec = reg.issue(sub, &test_bridge_command()).unwrap();
         let contents = std::fs::read_to_string(&spec.capability_file).expect("read capfile");
         let value: serde_json::Value = serde_json::from_str(&contents).expect("parse capfile");
 
@@ -625,7 +640,7 @@ mod tests {
         reg.set_loopback_base("https://tidebreak.local:4567/");
         let sub = subject("endpoint");
 
-        let spec = reg.issue(sub, Path::new(TEST_BRIDGE)).unwrap();
+        let spec = reg.issue(sub, &test_bridge_command()).unwrap();
         let contents = std::fs::read_to_string(&spec.capability_file).unwrap();
         let value: serde_json::Value = serde_json::from_str(&contents).unwrap();
 
@@ -690,7 +705,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("absolute");
 
-        let spec = reg.issue(sub, Path::new(TEST_BRIDGE)).unwrap();
+        let spec = reg.issue(sub, &test_bridge_command()).unwrap();
         assert!(spec.capability_file.is_absolute());
         assert!(reg.capfile_dir().is_absolute());
     }
@@ -711,7 +726,7 @@ mod tests {
             Err(error) => panic!("failed to inspect browser capfile directory: {error}"),
         }
 
-        let spec = reg.issue(sub, Path::new(TEST_BRIDGE)).unwrap();
+        let spec = reg.issue(sub, &test_bridge_command()).unwrap();
         assert!(spec.capability_file.exists());
     }
 
@@ -720,6 +735,19 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let reg = BrowserTokenRegistry::new(dir.path()).unwrap();
         assert!(reg.capfile_dir().is_absolute());
+    }
+
+    /// The fixture every issuing test depends on. Without this the whole
+    /// suite fails as a wall of identical `unwrap` panics on the one host
+    /// where the fixture is wrong; with it, one named test says why.
+    #[test]
+    fn the_test_bridge_fixture_is_absolute_on_this_host() {
+        let bridge = test_bridge_command();
+        assert!(
+            bridge.is_absolute(),
+            "the test bridge fixture must be absolute on this platform, got: {}",
+            bridge.display()
+        );
     }
 
     #[cfg(unix)]
@@ -774,7 +802,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("mode");
 
-        let spec = reg.issue(sub, Path::new(TEST_BRIDGE)).unwrap();
+        let spec = reg.issue(sub, &test_bridge_command()).unwrap();
         let meta = std::fs::metadata(&spec.capability_file).unwrap();
         let mode = meta.permissions().mode();
 
@@ -790,7 +818,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("dirmode");
 
-        let _spec = reg.issue(sub, Path::new(TEST_BRIDGE)).unwrap();
+        let _spec = reg.issue(sub, &test_bridge_command()).unwrap();
         let capfile_dir = reg.capfile_dir();
         let meta = std::fs::metadata(capfile_dir).unwrap();
         let mode = meta.permissions().mode();
@@ -806,7 +834,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("atomic");
 
-        let spec = reg.issue(sub, Path::new(TEST_BRIDGE)).unwrap();
+        let spec = reg.issue(sub, &test_bridge_command()).unwrap();
         let parent = spec.capability_file.parent().unwrap();
 
         let tmp_count = std::fs::read_dir(parent)
@@ -827,7 +855,7 @@ mod tests {
         let reg = seeded(dir.path());
         let sub = subject("cleanslate");
 
-        let first = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let first = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let first_token = read_token_from_capfile(&first.capability_file);
         let first_path = first.capability_file.clone();
         assert!(first_path.exists());
@@ -836,7 +864,7 @@ mod tests {
         assert!(reg.subject_for_token(&first_token).is_none());
         assert!(!first_path.exists());
 
-        let second = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let second = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let second_token = read_token_from_capfile(&second.capability_file);
         let second_path = second.capability_file.clone();
 
@@ -860,7 +888,7 @@ mod tests {
         // Warm up: issue once so the capfile directory exists.
         let warm_subject = subject("warm");
         let warm = reg
-            .issue(warm_subject.clone(), Path::new(TEST_BRIDGE))
+            .issue(warm_subject.clone(), &test_bridge_command())
             .unwrap();
         let warm_token = read_token_from_capfile(&warm.capability_file);
         assert!(warm.capability_file.exists());
@@ -870,7 +898,7 @@ mod tests {
         std::fs::rename(&capdir, &held_capdir).expect("move capfile directory aside");
         std::fs::write(&capdir, b"not a directory").expect("install capfile path blocker");
 
-        let result = reg.issue(sub.clone(), Path::new(TEST_BRIDGE));
+        let result = reg.issue(sub.clone(), &test_bridge_command());
 
         // Restore the original directory before asserting so a failure cannot
         // strand the fixture in a state that obscures the registry invariant.
@@ -888,7 +916,7 @@ mod tests {
 
         // After failure, a fresh issuance for the same session must succeed
         // without stale entries.
-        let second = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let second = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let second_token = read_token_from_capfile(&second.capability_file);
         assert_eq!(reg.subject_for_token(&second_token).as_ref(), Some(&sub));
 
@@ -905,8 +933,8 @@ mod tests {
         let sub_a = subject("independent-a");
         let sub_b = subject("independent-b");
 
-        let spec_a = reg.issue(sub_a.clone(), Path::new(TEST_BRIDGE)).unwrap();
-        let spec_b = reg.issue(sub_b.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let spec_a = reg.issue(sub_a.clone(), &test_bridge_command()).unwrap();
+        let spec_b = reg.issue(sub_b.clone(), &test_bridge_command()).unwrap();
 
         let token_a = read_token_from_capfile(&spec_a.capability_file);
         let token_b = read_token_from_capfile(&spec_b.capability_file);
@@ -932,11 +960,11 @@ mod tests {
 
         // Issue → revoke → issue in sequence; the final state must be clean
         // with exactly one live entry.
-        let first = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let first = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let first_token = read_token_from_capfile(&first.capability_file);
         reg.revoke(sub.session);
 
-        let second = reg.issue(sub.clone(), Path::new(TEST_BRIDGE)).unwrap();
+        let second = reg.issue(sub.clone(), &test_bridge_command()).unwrap();
         let second_token = read_token_from_capfile(&second.capability_file);
 
         assert!(reg.subject_for_token(&first_token).is_none());

--- a/crates/tidebreak-server/src/sandbox_container_run/tests.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run/tests.rs
@@ -3977,8 +3977,14 @@ async fn committed_cancellation_wakes_container_and_fences_reverse_egress_before
             "the attached container drive is registered under the durable lease"
         );
 
+        // A hang-guard, not a latency contract: the proof is which outcome
+        // the call settles on, and this bound only buys the provider-call
+        // count in the message instead of a bare outer-timeout expect. Five
+        // seconds was tight enough to fire on a loaded runner while the
+        // fence had in fact held, so keep it well clear of both the wake
+        // path and the 30s bound around the test.
         let late = tokio::time::timeout(
-            Duration::from_secs(5),
+            Duration::from_secs(20),
             sandbox.call(
                 OperationId::new(),
                 ReverseRequest::ModelInference(ModelInferenceParams {

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -94,7 +94,7 @@ async fn code_app_with_optional_browser(
         browser_runtime.map(|runtime| -> Arc<dyn BrowserRuntime> { runtime });
     let browser_bridge_command = installed_browser_runtime
         .as_ref()
-        .map(|_| std::path::PathBuf::from("/usr/local/bin/tidebreak"));
+        .map(|_| crate::code::browser_channel::test_bridge_command());
     let runtime = Arc::new(CodeRuntime::with_registry_and_browser_runtime(
         db,
         dir.path().to_path_buf(),

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -154,7 +154,7 @@ async fn browser_app(fake: Option<Arc<FakeBrowserRuntime>>) -> BrowserApp {
     let browser_runtime = fake
         .as_ref()
         .map(|runtime| -> Arc<dyn BrowserRuntime> { runtime.clone() });
-    let bridge = std::path::PathBuf::from("/usr/local/bin/tidebreak");
+    let bridge = crate::code::browser_channel::test_bridge_command();
     let code = Arc::new(CodeRuntime::with_registry_and_browser_runtime(
         db,
         dir.path().into(),
@@ -249,7 +249,7 @@ async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, C
 }
 
 fn mint_token(code: &CodeRuntime, ws: WorkspaceId, s: CodeSessionId) -> String {
-    let bridge = std::path::Path::new("/usr/local/bin/tidebreak");
+    let bridge = crate::code::browser_channel::test_bridge_command();
     let sp = code
         .browser_tokens
         .issue(
@@ -258,7 +258,7 @@ fn mint_token(code: &CodeRuntime, ws: WorkspaceId, s: CodeSessionId) -> String {
                 workspace: ws,
                 session: s,
             },
-            bridge,
+            &bridge,
         )
         .unwrap();
     let c = std::fs::read_to_string(&sp.capability_file).unwrap();


### PR DESCRIPTION
## Summary

Windows CI on `main` failed in `Code mode Windows lifecycle tests` ([run 32468324417](https://github.com/brightwave-inc/tidebreak/actions/runs/32468324417/job/96729661088)). Not a flake: 17 tests failed identically on all three attempts.

`BrowserTokenRegistry::issue` refuses a bridge command that is not absolute, and `Path::is_absolute` is platform-defined. The test fixture was the Unix literal `/usr/local/bin/tidebreak`, which Windows reads as relative, so every capability-minting test got `bridge command must be an absolute path`. The two `tests::code` failures are the same cause one layer up: session creation could not mint a channel, so the response carried no `id`.

- Give the server one `test_bridge_command()` helper that branches on the host, and point all three fixture sites at it (`code/browser_channel.rs`, `tests/code.rs`, `tests/code_browser.rs`). `tests/code_browser.rs` is not caught by the lane's `code::` filter but carried the same latent bug.
- Add `the_test_bridge_fixture_is_absolute_on_this_host`, so a wrong fixture names itself instead of surfacing as a wall of identical `unwrap` panics.

## Flake sweep

Audited the last 10–15 `main` runs of the Windows and Linux test lanes for retries the wrappers were absorbing.

- Windows lane: no real retries. The 3-attempt wrapper is currently masking nothing.
- Linux lane: one genuine flake, in `committed_cancellation_wakes_container_and_fences_reverse_egress_before_heartbeat` ([run 32425751130](https://github.com/brightwave-inc/tidebreak/actions/runs/32425751130)). It failed with `provider_calls=1`, meaning the fence had held and only the 5s bound blew. That bound is a hang-guard, not a latency contract, and the test already sits inside a 30s bound, so it moves to 20s.

## Test plan

- [x] `cargo test -p tidebreak-server --lib code:: --locked` (the lane's exact filter) — 184 passed
- [x] `cargo test -p tidebreak-server --lib code_browser --locked` — 14 passed
- [x] `cargo test -p tidebreak-server --lib committed_cancellation_wakes_container --locked`
- [x] Inverted the `cfg!(windows)` branch locally to force the Windows literal: reproduced the exact CI failure cluster, and the new guard test fired with `the test bridge fixture must be absolute on this platform, got: C:\Program Files\Tidebreak\tidebreak.exe`
- [x] `cargo fmt --all --check`, `cargo clippy -p tidebreak-server --all-targets --locked`
- [ ] Windows lane green on this PR (`windows-ci` label applied)

## Note

The Windows lane only runs pre-merge when a PR carries `windows-ci`; otherwise it is a post-merge backstop on `main`. That is the deliberate cost choice in the workflow, and it is why this landed. Worth considering whether changes under `crates/tidebreak-server/src/code/browser*` should auto-apply the label, but I have not changed the trigger here.