### PR TITLE
test(browser): cover wait and screenshot bridge contract

### DIFF
--- a/crates/tidebreak-desktop/tests/browser-bridge-e2e/README.md
+++ b/crates/tidebreak-desktop/tests/browser-bridge-e2e/README.md
@@ -1,7 +1,8 @@
 # Browser bridge E2E tests
 
 Deterministic pure-Node shipped-path contract tests for the agent
-browser channel (`/code/browser/list`, `/navigate`, `/snapshot`).
+browser channel (`/code/browser/list`, `/navigate`, `/snapshot`,
+`/wait`, `/screenshot`).
 
 ## What this covers
 
@@ -14,18 +15,31 @@ kinds, and capability-file protocol the real CLI and MCP bridge speak.
 Coverage includes:
 
 - Exact tool registry (only `browser_list`, `browser_navigate`,
-  `browser_snapshot`; `act`/`wait`/`screenshot` absent).
+  `browser_snapshot`, `browser_wait`, `browser_screenshot`; `act` and
+  semantic action tools absent).
 - Capfile v1 schema validation and token secrecy.
-- Positive contract: list → navigate → snapshot with camelCase shape
-  assertions.
+- Positive contract: list → navigate → snapshot → wait → screenshot with
+  camelCase shape assertions.
+- Wait conditions: `load_state`, `url_changed`, `text_present`,
+  `text_absent`; deterministic `resolved`, `timed_out`, and `stopped`
+  outcomes.
+- Screenshot: deterministic valid PNG base64 payload with camelCase
+  `browserId`, `snapshotId`, `documentEpoch`, `imageBase64`, `mimeType`.
 - Absolute bridge command with `PATH` unavailable; token never appears in
   argv, stdout, stderr, or capfile path.
 - Negative matrix: missing/unknown/revoked token (401), ended session
   (403), cross-workspace browser id (404), stopped control, hidden
-  browser, stale document epoch (409), invalid/credentialed URLs (422),
-  unknown fields in body (400), missing required fields (400),
-  out-of-range max_nodes (422), redirect refusal, missing runtime (501).
-- Provider-neutral `camelCase` response shapes.
+  browser, stale document epoch (409), stale instance/session-replaced
+  (409), invalid/credentialed URLs (422), unknown fields in body (400),
+  missing required fields (400), out-of-range max_nodes (422), invalid
+  wait conditions/timeouts/text-length (422), invalid screenshot
+  dimensions (422), invalid browser_id format (422), redirect refusal,
+  missing runtime (501).
+- Auth and argument-validation ordering before runtime disclosure: a
+  request with no token gets 401 even when the runtime is missing; a
+  request with a valid token but invalid arguments gets 422 before the
+  501 missing-runtime response.
+- Provider-neutral `camelCase` response shapes for all five tools.
 
 ## What this does NOT cover
 
@@ -36,12 +50,16 @@ These tests do **not** prove any of the following (CI-only Rust assertions):
 - Real `browser-mcp` MCP protocol bytes or `tools/list` against a
   running `tidebreak` binary.
 - Desktop `BrowserRuntime` adapter driving a native browser engine.
+- Native screenshot image capture or PNG encoding from a real webview.
 - Provider adapter argv/env emission (Claude `--mcp-config`, Codex
   `-c`, OpenCode config merge, Grok prompt append).
 - Real CLI capfile validation or bounded response body decoding.
 
 The mock server is intentionally separate from the native
-`BrowserRegistry`. It implements the HTTP contract only.
+`BrowserRegistry`. It implements the HTTP contract only. It does not
+claim to prove native registry internals — the wait/screenshot
+determinism is a mock-side contract, not a proof of native polling or
+image capture behavior.
 
 ## Running
 
@@ -66,9 +84,10 @@ contract explicitly.
 ## Files
 
 - `bridge-server.mjs` — loopback-only mock `/code/browser` HTTP server
-  with deterministic browser state.
+  with deterministic browser state, wait/screenshot route mocks, and
+  bounded validation.
 - `scripted-harness.mjs` — capfile protocol, bounded HTTP client,
-  tool registry assertions, camelCase contract assertions, and
-  simulated absolute-command launch.
+  tool registry assertions, camelCase contract assertions for all five
+  tools, and simulated absolute-command launch.
 - `bridge-e2e.test.mjs` — the test suite.
 - `README.md` — this file.

--- a/crates/tidebreak-desktop/tests/browser-bridge-e2e/bridge-e2e.test.mjs
+++ b/crates/tidebreak-desktop/tests/browser-bridge-e2e/bridge-e2e.test.mjs
@@ -2,10 +2,10 @@
 //
 // These tests exercise the real v1 capfile JSON shape {version, endpoint,
 // token} and the real HTTP route shapes at /code/browser/list, /navigate,
-// /snapshot through a loopback-only mock bridge server. The mock is honest:
-// it does NOT claim to prove native BrowserRegistry internals. Rust-backed
-// authority, token registry transactionality, and desktop runtime
-// integration are CI-only.
+// /snapshot, /wait, /screenshot through a loopback-only mock bridge server.
+// The mock is honest: it does NOT claim to prove native BrowserRegistry
+// internals. Rust-backed authority, token registry transactionality, and
+// desktop runtime integration are CI-only.
 //
 // Page content is treated as untrusted throughout. No assertion treats
 // page content as instruction.
@@ -27,6 +27,8 @@ import {
   assertListShape,
   assertNavigateShape,
   assertSnapshotShape,
+  assertWaitShape,
+  assertScreenshotShape,
   drivePositiveContract,
   simulateAbsoluteLaunch,
   writeCapfile,
@@ -80,15 +82,17 @@ after(async () => {
 
 // ── tool registry contract ──────────────────────────────────────────────────
 
-test("exact tool registry is only browser_list, browser_navigate, browser_snapshot", () => {
-  // Assert BROWSER_TOOLS is exactly three elements
+test("exact tool registry is five browser tools, no act/semantic", () => {
+  // Assert BROWSER_TOOLS is exactly five elements
   assert.deepEqual(BROWSER_TOOLS, [
     "browser_list",
     "browser_navigate",
     "browser_snapshot",
+    "browser_wait",
+    "browser_screenshot",
   ]);
 
-  // Assert the three are recognized
+  // Assert the five are recognized
   const registry = BROWSER_TOOLS.map((name) => ({ name }));
   assertToolRegistry(registry);
 
@@ -139,27 +143,28 @@ test("capfile rejects missing or extra keys", async () => {
   await assert.rejects(() => readCapfile(bad2), /unexpected keys/);
 });
 
-// ── positive contract: list → navigate → snapshot ───────────────────────────
+// ── positive contract: list → navigate → snapshot → wait → screenshot ───────
 
-test("drive list → navigate → snapshot against deterministic fixture", async () => {
+test("drive list → navigate → snapshot → wait → screenshot against deterministic fixture", async () => {
   const token = bridge.tokenRegistry.issue();
 
-  const snapshot = await drivePositiveContract(
+  const screenshot = await drivePositiveContract(
     bridgeEndpoint,
     token,
     fixture.origin
   );
 
-  // Verify snapshot content is present and matches the fixture
-  assert.equal(snapshot.url, fixture.origin);
-  assert.equal(snapshot.title, "Agent browser fixture");
-  assert.equal(snapshot.contentTrust, "untrusted_page");
-  assert.equal(snapshot.truncated, false);
+  // Verify screenshot wire shape
+  assert.equal(screenshot.mimeType, "image/png");
+  assert.ok(screenshot.imageBase64.length > 0, "screenshot must have image data");
 
-  // Verify node shapes
-  assert.ok(snapshot.nodes.length > 0, "snapshot must have at least one node");
-  const interactive = snapshot.nodes.filter((n) => n.kind === "interactive");
-  assert.ok(interactive.length > 0, "must have interactive nodes");
+  // Verify the base64 decodes to a valid PNG
+  const decoded = Buffer.from(screenshot.imageBase64, "base64");
+  assert.ok(decoded.length >= 8, "PNG must be at least 8 bytes");
+  assert.equal(decoded[0], 0x89, "PNG signature byte 0");
+  assert.equal(decoded[1], 0x50, "PNG signature byte 1 (P)");
+  assert.equal(decoded[2], 0x4e, "PNG signature byte 2 (N)");
+  assert.equal(decoded[3], 0x47, "PNG signature byte 3 (G)");
 });
 
 test("navigate and snapshot return camelCase shapes", async () => {
@@ -174,9 +179,20 @@ test("navigate and snapshot return camelCase shapes", async () => {
   );
   assert.equal(nav.status, 200);
   assertNavigateShape(nav.body);
-  assert.equal(nav.body.documentEpoch, 3);
+  assert.ok(nav.body.documentEpoch >= 3, "navigate must increment epoch");
+});
 
-  // Snapshot with max_nodes
+test("snapshot with max_nodes returns camelCase shape", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  // Navigate first to get a fresh epoch
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+
   const snap = await callBrowserRoute(
     bridgeEndpoint,
     "snapshot",
@@ -185,6 +201,342 @@ test("navigate and snapshot return camelCase shapes", async () => {
   );
   assert.equal(snap.status, 200);
   assertSnapshotShape(snap.body);
+});
+
+// ── positive: wait contract ─────────────────────────────────────────────────
+
+test("wait with load_state condition returns resolved status", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  // Navigate + snapshot to get a valid epoch
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const wait = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+      condition: { kind: "load_state", state: "ready" },
+    },
+    token
+  );
+  assert.equal(wait.status, 200);
+  assertWaitShape(wait.body);
+  assert.equal(wait.body.status, "resolved");
+  assert.equal(wait.body.browserId, "browser-1");
+});
+
+test("wait with url_changed condition returns resolved status", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const wait = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+      condition: { kind: "url_changed" },
+    },
+    token
+  );
+  assert.equal(wait.status, 200);
+  assertWaitShape(wait.body);
+  assert.equal(wait.body.status, "resolved");
+});
+
+test("wait with text_present condition returns resolved status", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const wait = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+      condition: { kind: "text_present", text: "Agent browser fixture" },
+    },
+    token
+  );
+  assert.equal(wait.status, 200);
+  assertWaitShape(wait.body);
+  assert.equal(wait.body.status, "resolved");
+});
+
+test("wait with text_absent condition returns resolved status", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const wait = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+      condition: { kind: "text_absent", text: "This text does not exist" },
+    },
+    token
+  );
+  assert.equal(wait.status, 200);
+  assertWaitShape(wait.body);
+  assert.equal(wait.body.status, "resolved");
+});
+
+test("wait with explicit timeout_ms returns resolved status", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const wait = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+      condition: { kind: "load_state", state: "ready" },
+      timeout_ms: 5000,
+    },
+    token
+  );
+  assert.equal(wait.status, 200);
+  assertWaitShape(wait.body);
+  assert.equal(wait.body.status, "resolved");
+});
+
+test("wait returns timed_out when configured with waitOutcome", async () => {
+  const timedOutBridge = await startBridgeServer({
+    port: 0,
+    fixtureOrigin: fixture.origin,
+    waitOutcome: "timed_out",
+  });
+
+  try {
+    const token = timedOutBridge.tokenRegistry.issue();
+    const snap = await callBrowserRoute(
+      timedOutBridge.endpoint,
+      "snapshot",
+      { browser_id: "browser-1" },
+      token
+    );
+
+    const wait = await callBrowserRoute(
+      timedOutBridge.endpoint,
+      "wait",
+      {
+        browser_id: "browser-1",
+        snapshot_id: snap.body.snapshotId,
+        document_epoch: snap.body.documentEpoch,
+        condition: { kind: "text_present", text: "never appears" },
+        timeout_ms: 1000,
+      },
+      token
+    );
+    assert.equal(wait.status, 200);
+    assertWaitShape(wait.body);
+    assert.equal(wait.body.status, "timed_out");
+    assert.match(wait.body.message, /timed out/i);
+  } finally {
+    await close(timedOutBridge.server);
+  }
+});
+
+test("wait returns stopped when control is halted", async () => {
+  const stoppedBridge = await startBridgeServer({
+    port: 0,
+    fixtureOrigin: fixture.origin,
+    stoppedControl: true,
+  });
+
+  try {
+    const token = stoppedBridge.tokenRegistry.issue();
+    const snap = await callBrowserRoute(
+      stoppedBridge.endpoint,
+      "snapshot",
+      { browser_id: "browser-1" },
+      token
+    );
+
+    const wait = await callBrowserRoute(
+      stoppedBridge.endpoint,
+      "wait",
+      {
+        browser_id: "browser-1",
+        snapshot_id: snap.body.snapshotId,
+        document_epoch: snap.body.documentEpoch,
+        condition: { kind: "load_state", state: "ready" },
+      },
+      token
+    );
+    assert.equal(wait.status, 200);
+    assertWaitShape(wait.body);
+    assert.equal(wait.body.status, "stopped");
+    assert.match(wait.body.message, /stopped/i);
+  } finally {
+    await close(stoppedBridge.server);
+  }
+});
+
+// ── positive: screenshot contract ───────────────────────────────────────────
+
+test("screenshot returns deterministic valid PNG base64", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const screenshot = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+    },
+    token
+  );
+  assert.equal(screenshot.status, 200);
+  assertScreenshotShape(screenshot.body);
+  assert.equal(screenshot.body.browserId, "browser-1");
+  assert.equal(screenshot.body.snapshotId, snap.body.snapshotId);
+  assert.equal(screenshot.body.documentEpoch, snap.body.documentEpoch);
+});
+
+test("screenshot with max_width and max_height returns valid PNG", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const screenshot = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+      max_width: 1920,
+      max_height: 1080,
+    },
+    token
+  );
+  assert.equal(screenshot.status, 200);
+  assertScreenshotShape(screenshot.body);
+});
+
+test("screenshot with max_height=0 (viewport height) returns valid PNG", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const screenshot = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+      max_height: 0,
+    },
+    token
+  );
+  assert.equal(screenshot.status, 200);
+  assertScreenshotShape(screenshot.body);
 });
 
 // ── absolute command, no PATH ───────────────────────────────────────────────
@@ -222,7 +574,9 @@ test("absolute launch rejects capfile-path output leakage", async () => {
       tools: [
         { name: "browser_list" },
         { name: "browser_navigate" },
-        { name: "browser_snapshot" }
+        { name: "browser_snapshot" },
+        { name: "browser_wait" },
+        { name: "browser_screenshot" }
       ]
     }));
   `;
@@ -250,7 +604,9 @@ test("absolute launch rejects JSON-escaped backslash path leakage", async () => 
       tools: [
         { name: "browser_list" },
         { name: "browser_navigate" },
-        { name: "browser_snapshot" }
+        { name: "browser_snapshot" },
+        { name: "browser_wait" },
+        { name: "browser_screenshot" }
       ]
     }));
   `;
@@ -277,7 +633,9 @@ test("absolute launch rejects JSON-escaped backslash path in argv", async () => 
       tools: [
         { name: "browser_list" },
         { name: "browser_navigate" },
-        { name: "browser_snapshot" }
+        { name: "browser_snapshot" },
+        { name: "browser_wait" },
+        { name: "browser_screenshot" }
       ]
     }));
   `;
@@ -424,6 +782,32 @@ test("argument validation runs before missing-runtime disclosure", async () => {
     );
     assert.equal(invalidSnapshot.status, 422);
 
+    const invalidWait = await callBrowserRoute(
+      noRuntime.endpoint,
+      "wait",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snap-1",
+        document_epoch: 0,
+        condition: { kind: "text_present", text: "x".repeat(600) },
+      },
+      token
+    );
+    assert.equal(invalidWait.status, 422);
+
+    const invalidScreenshot = await callBrowserRoute(
+      noRuntime.endpoint,
+      "screenshot",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snap-1",
+        document_epoch: 0,
+        max_width: 5000,
+      },
+      token
+    );
+    assert.equal(invalidScreenshot.status, 422);
+
     const validNavigation = await callBrowserRoute(
       noRuntime.endpoint,
       "navigate",
@@ -458,6 +842,33 @@ test("cross-workspace / unknown browser id returns 404", async () => {
     token
   );
   assert.equal(snap.status, 404);
+
+  // Wait with unknown browser id
+  const wait = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-9",
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+      condition: { kind: "load_state", state: "ready" },
+    },
+    token
+  );
+  assert.equal(wait.status, 404);
+
+  // Screenshot with unknown browser id
+  const screenshot = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      browser_id: "browser-9",
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+    },
+    token
+  );
+  assert.equal(screenshot.status, 404);
 });
 
 // ── negative: stopped control ───────────────────────────────────────────────
@@ -528,6 +939,128 @@ test("stale snapshot returns 409 conflict", async () => {
     assert.equal(result.body.kind, "stale_browser_target");
   } finally {
     await close(staleBridge.server);
+  }
+});
+
+test("stale document epoch on wait returns 409 conflict", async () => {
+  const staleBridge = await startBridgeServer({
+    port: 0,
+    fixtureOrigin: fixture.origin,
+    staleSnapshot: true,
+  });
+
+  try {
+    const token = staleBridge.tokenRegistry.issue();
+    const result = await callBrowserRoute(
+      staleBridge.endpoint,
+      "wait",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snap-old",
+        document_epoch: 999,
+        condition: { kind: "load_state", state: "ready" },
+      },
+      token
+    );
+    assert.equal(result.status, 409);
+    assert.equal(result.body.kind, "stale_browser_target");
+  } finally {
+    await close(staleBridge.server);
+  }
+});
+
+test("stale document epoch on screenshot returns 409 conflict", async () => {
+  const staleBridge = await startBridgeServer({
+    port: 0,
+    fixtureOrigin: fixture.origin,
+    staleSnapshot: true,
+  });
+
+  try {
+    const token = staleBridge.tokenRegistry.issue();
+    const result = await callBrowserRoute(
+      staleBridge.endpoint,
+      "screenshot",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snap-old",
+        document_epoch: 999,
+      },
+      token
+    );
+    assert.equal(result.status, 409);
+    assert.equal(result.body.kind, "stale_browser_target");
+  } finally {
+    await close(staleBridge.server);
+  }
+});
+
+test("stale instance (session replaced) on wait returns 409", async () => {
+  const staleInstanceBridge = await startBridgeServer({
+    port: 0,
+    fixtureOrigin: fixture.origin,
+    staleInstance: true,
+  });
+
+  try {
+    const token = staleInstanceBridge.tokenRegistry.issue();
+    const snap = await callBrowserRoute(
+      staleInstanceBridge.endpoint,
+      "snapshot",
+      { browser_id: "browser-1" },
+      token
+    );
+    assert.equal(snap.status, 200);
+
+    const wait = await callBrowserRoute(
+      staleInstanceBridge.endpoint,
+      "wait",
+      {
+        browser_id: "browser-1",
+        snapshot_id: snap.body.snapshotId,
+        document_epoch: snap.body.documentEpoch,
+        condition: { kind: "load_state", state: "ready" },
+      },
+      token
+    );
+    assert.equal(wait.status, 409);
+    assert.equal(wait.body.kind, "stale_browser_target");
+  } finally {
+    await close(staleInstanceBridge.server);
+  }
+});
+
+test("stale instance (session replaced) on screenshot returns 409", async () => {
+  const staleInstanceBridge = await startBridgeServer({
+    port: 0,
+    fixtureOrigin: fixture.origin,
+    staleInstance: true,
+  });
+
+  try {
+    const token = staleInstanceBridge.tokenRegistry.issue();
+    const snap = await callBrowserRoute(
+      staleInstanceBridge.endpoint,
+      "snapshot",
+      { browser_id: "browser-1" },
+      token
+    );
+    assert.equal(snap.status, 200);
+
+    const screenshot = await callBrowserRoute(
+      staleInstanceBridge.endpoint,
+      "screenshot",
+      {
+        browser_id: "browser-1",
+        snapshot_id: snap.body.snapshotId,
+        document_epoch: snap.body.documentEpoch,
+      },
+      token
+    );
+    assert.equal(screenshot.status, 409);
+    assert.equal(screenshot.body.kind, "stale_browser_target");
+  } finally {
+    await close(staleInstanceBridge.server);
   }
 });
 
@@ -602,6 +1135,35 @@ test("bodies with unknown fields return 400", async () => {
     token
   );
   assert.equal(snap.status, 400);
+
+  // Wait with extra field
+  const wait = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+      condition: { kind: "load_state", state: "ready" },
+      workspace_id: "leak",
+    },
+    token
+  );
+  assert.equal(wait.status, 400);
+
+  // Screenshot with extra field
+  const screenshot = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+      owner_id: "leak",
+    },
+    token
+  );
+  assert.equal(screenshot.status, 400);
 });
 
 test("snapshot requires browser_id", async () => {
@@ -614,6 +1176,102 @@ test("snapshot requires browser_id", async () => {
     token
   );
   assert.equal(result.status, 400);
+});
+
+test("wait requires browser_id, snapshot_id, document_epoch, condition", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  // Missing browser_id
+  const noBid = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+      condition: { kind: "load_state", state: "ready" },
+    },
+    token
+  );
+  assert.equal(noBid.status, 400);
+
+  // Missing snapshot_id
+  const noSid = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      document_epoch: 0,
+      condition: { kind: "load_state", state: "ready" },
+    },
+    token
+  );
+  assert.equal(noSid.status, 400);
+
+  // Missing document_epoch
+  const noEpoch = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snap-1",
+      condition: { kind: "load_state", state: "ready" },
+    },
+    token
+  );
+  assert.equal(noEpoch.status, 400);
+
+  // Missing condition
+  const noCond = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+    },
+    token
+  );
+  assert.equal(noCond.status, 400);
+});
+
+test("screenshot requires browser_id, snapshot_id, document_epoch", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  // Missing browser_id
+  const noBid = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+    },
+    token
+  );
+  assert.equal(noBid.status, 400);
+
+  // Missing snapshot_id
+  const noSid = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      browser_id: "browser-1",
+      document_epoch: 0,
+    },
+    token
+  );
+  assert.equal(noSid.status, 400);
+
+  // Missing document_epoch
+  const noEpoch = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snap-1",
+    },
+    token
+  );
+  assert.equal(noEpoch.status, 400);
 });
 
 test("snapshot rejects out-of-range max_nodes", async () => {
@@ -630,6 +1288,211 @@ test("snapshot rejects out-of-range max_nodes", async () => {
       result.status,
       422,
       `snapshot with max_nodes=${badMax} must return 422, got ${result.status}`
+    );
+  }
+});
+
+// ── negative: wait validation ───────────────────────────────────────────────
+
+test("wait rejects non-deserializable conditions with 400", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  // These conditions would fail serde deserialization of BrowserWaitCondition
+  // (missing kind, unknown kind, wrong type, missing variant fields) → 400
+  for (const badCondition of [
+    { kind: "unknown_condition" },
+    { kind: "click" },
+    {},
+    "not an object",
+    { kind: "load_state" }, // missing state
+    { kind: "text_present" }, // missing text
+    { kind: "text_absent" }, // missing text
+  ]) {
+    const result = await callBrowserRoute(
+      bridgeEndpoint,
+      "wait",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snap-1",
+        document_epoch: 0,
+        condition: badCondition,
+      },
+      token
+    );
+    assert.equal(
+      result.status,
+      400,
+      `wait with condition ${JSON.stringify(badCondition)} must return 400, got ${result.status}`
+    );
+  }
+});
+
+test("wait rejects load_state with invalid state value (400)", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  // "not_a_state" is not a valid BrowserLoadState variant — serde rejects → 400
+  const result = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+      condition: { kind: "load_state", state: "not_a_state" },
+    },
+    token
+  );
+  assert.equal(result.status, 400);
+});
+
+test("wait rejects text_present with missing text (400)", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  // Missing text field is a serde deserialization failure → 400
+  const result = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+      condition: { kind: "text_present" },
+    },
+    token
+  );
+  assert.equal(result.status, 400);
+});
+
+test("wait rejects text_present with oversized text (>512 chars)", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  const result = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snap-1",
+      document_epoch: 0,
+      condition: { kind: "text_present", text: "x".repeat(513) },
+    },
+    token
+  );
+  assert.equal(result.status, 422);
+});
+
+test("wait rejects out-of-range timeout_ms", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  for (const badTimeout of [50, 50000, 0, -1]) {
+    const result = await callBrowserRoute(
+      bridgeEndpoint,
+      "wait",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snap-1",
+        document_epoch: 0,
+        condition: { kind: "load_state", state: "ready" },
+        timeout_ms: badTimeout,
+      },
+      token
+    );
+    assert.equal(
+      result.status,
+      422,
+      `wait with timeout_ms=${badTimeout} must return 422, got ${result.status}`
+    );
+  }
+});
+
+test("wait rejects invalid browser_id format", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  for (const badId of ["", "x".repeat(81), "has spaces", "has/slashes"]) {
+    const result = await callBrowserRoute(
+      bridgeEndpoint,
+      "wait",
+      {
+        browser_id: badId,
+        snapshot_id: "snap-1",
+        document_epoch: 0,
+        condition: { kind: "load_state", state: "ready" },
+      },
+      token
+    );
+    assert.equal(
+      result.status,
+      422,
+      `wait with browser_id="${badId}" must return 422, got ${result.status}`
+    );
+  }
+});
+
+// ── negative: screenshot validation ─────────────────────────────────────────
+
+test("screenshot rejects out-of-range max_width", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  for (const badWidth of [0, 5000, 10000, -1]) {
+    const result = await callBrowserRoute(
+      bridgeEndpoint,
+      "screenshot",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snap-1",
+        document_epoch: 0,
+        max_width: badWidth,
+      },
+      token
+    );
+    assert.equal(
+      result.status,
+      422,
+      `screenshot with max_width=${badWidth} must return 422, got ${result.status}`
+    );
+  }
+});
+
+test("screenshot rejects out-of-range max_height", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  for (const badHeight of [5000, 10000, -1]) {
+    const result = await callBrowserRoute(
+      bridgeEndpoint,
+      "screenshot",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snap-1",
+        document_epoch: 0,
+        max_height: badHeight,
+      },
+      token
+    );
+    assert.equal(
+      result.status,
+      422,
+      `screenshot with max_height=${badHeight} must return 422, got ${result.status}`
+    );
+  }
+});
+
+test("screenshot rejects invalid browser_id format", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  for (const badId of ["", "x".repeat(81), "has spaces", "has/slashes"]) {
+    const result = await callBrowserRoute(
+      bridgeEndpoint,
+      "screenshot",
+      {
+        browser_id: badId,
+        snapshot_id: "snap-1",
+        document_epoch: 0,
+      },
+      token
+    );
+    assert.equal(
+      result.status,
+      422,
+      `screenshot with browser_id="${badId}" must return 422, got ${result.status}`
     );
   }
 });
@@ -698,4 +1561,74 @@ test("snapshot response uses provider-neutral camelCase", async () => {
   assert.equal(result.body.contentTrust, "untrusted_page");
   assert.ok("scrollX" in result.body.viewport, "viewport must be camelCase");
   assert.ok("scrollY" in result.body.viewport, "viewport must be camelCase");
+});
+
+test("wait response uses provider-neutral camelCase", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const result = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+      condition: { kind: "load_state", state: "ready" },
+    },
+    token
+  );
+  assert.equal(result.status, 200);
+  assert.ok("browserId" in result.body, "must have browserId, not browser_id");
+  assert.ok("documentEpoch" in result.body, "must have documentEpoch, not document_epoch");
+  // status is snake_case on the wire (resolved/timed_out/stopped)
+  assert.ok("status" in result.body);
+  assert.ok("message" in result.body);
+});
+
+test("screenshot response uses provider-neutral camelCase", async () => {
+  const token = bridge.tokenRegistry.issue();
+
+  await callBrowserRoute(
+    bridgeEndpoint,
+    "navigate",
+    { browser_id: "browser-1", url: fixture.origin },
+    token
+  );
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+
+  const result = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snap.body.snapshotId,
+      document_epoch: snap.body.documentEpoch,
+    },
+    token
+  );
+  assert.equal(result.status, 200);
+  assert.ok("browserId" in result.body, "must have browserId, not browser_id");
+  assert.ok("snapshotId" in result.body, "must have snapshotId, not snapshot_id");
+  assert.ok("documentEpoch" in result.body, "must have documentEpoch, not document_epoch");
+  assert.ok("imageBase64" in result.body, "must have imageBase64, not image_base64");
+  assert.ok("mimeType" in result.body, "must have mimeType, not mime_type");
+  assert.equal(result.body.mimeType, "image/png");
 });

--- a/crates/tidebreak-desktop/tests/browser-bridge-e2e/bridge-e2e.test.mjs
+++ b/crates/tidebreak-desktop/tests/browser-bridge-e2e/bridge-e2e.test.mjs
@@ -405,11 +405,11 @@ test("wait returns timed_out when configured with waitOutcome", async () => {
   }
 });
 
-test("wait returns stopped when control is halted", async () => {
+test("wait returns stopped when Stop races an in-flight wait", async () => {
   const stoppedBridge = await startBridgeServer({
     port: 0,
     fixtureOrigin: fixture.origin,
-    stoppedControl: true,
+    waitOutcome: "stopped",
   });
 
   try {
@@ -892,6 +892,41 @@ test("stopped control does not prevent list but signals halted state", async () 
       true,
       "stopped control must set halted=true"
     );
+
+    const snap = await callBrowserRoute(
+      stoppedBridge.endpoint,
+      "snapshot",
+      { browser_id: "browser-1" },
+      token
+    );
+    assert.equal(snap.status, 200);
+
+    const wait = await callBrowserRoute(
+      stoppedBridge.endpoint,
+      "wait",
+      {
+        browser_id: "browser-1",
+        snapshot_id: snap.body.snapshotId,
+        document_epoch: snap.body.documentEpoch,
+        condition: { kind: "load_state", state: "ready" },
+      },
+      token
+    );
+    assert.equal(wait.status, 403);
+    assert.match(wait.body.message, /stopped/i);
+
+    const screenshot = await callBrowserRoute(
+      stoppedBridge.endpoint,
+      "screenshot",
+      {
+        browser_id: "browser-1",
+        snapshot_id: snap.body.snapshotId,
+        document_epoch: snap.body.documentEpoch,
+      },
+      token
+    );
+    assert.equal(screenshot.status, 403);
+    assert.match(screenshot.body.message, /stopped/i);
   } finally {
     await close(stoppedBridge.server);
   }
@@ -899,7 +934,7 @@ test("stopped control does not prevent list but signals halted state", async () 
 
 // ── negative: hidden browser ────────────────────────────────────────────────
 
-test("hidden browser is listed but visible=false", async () => {
+test("hidden browser is omitted from list and cannot be observed", async () => {
   const hiddenBridge = await startBridgeServer({
     port: 0,
     fixtureOrigin: fixture.origin,
@@ -910,9 +945,32 @@ test("hidden browser is listed but visible=false", async () => {
     const token = hiddenBridge.tokenRegistry.issue();
     const list = await callBrowserRoute(hiddenBridge.endpoint, "list", null, token);
     assert.equal(list.status, 200);
-    const session = list.body.sessions?.[0];
-    assert.ok(session, "list must return a session");
-    assert.equal(session.visible, false, "hidden browser must have visible=false");
+    assert.deepEqual(list.body.sessions, []);
+
+    const wait = await callBrowserRoute(
+      hiddenBridge.endpoint,
+      "wait",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snapshot-hidden",
+        document_epoch: 2,
+        condition: { kind: "load_state", state: "ready" },
+      },
+      token
+    );
+    assert.equal(wait.status, 404);
+
+    const screenshot = await callBrowserRoute(
+      hiddenBridge.endpoint,
+      "screenshot",
+      {
+        browser_id: "browser-1",
+        snapshot_id: "snapshot-hidden",
+        document_epoch: 2,
+      },
+      token
+    );
+    assert.equal(screenshot.status, 404);
   } finally {
     await close(hiddenBridge.server);
   }
@@ -993,6 +1051,44 @@ test("stale document epoch on screenshot returns 409 conflict", async () => {
   } finally {
     await close(staleBridge.server);
   }
+});
+
+test("forged snapshot id on wait and screenshot returns 409", async () => {
+  const token = bridge.tokenRegistry.issue();
+  const snap = await callBrowserRoute(
+    bridgeEndpoint,
+    "snapshot",
+    { browser_id: "browser-1" },
+    token
+  );
+  assert.equal(snap.status, 200);
+
+  const wait = await callBrowserRoute(
+    bridgeEndpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snapshot-forged",
+      document_epoch: snap.body.documentEpoch,
+      condition: { kind: "load_state", state: "ready" },
+    },
+    token
+  );
+  assert.equal(wait.status, 409);
+  assert.equal(wait.body.kind, "stale_browser_target");
+
+  const screenshot = await callBrowserRoute(
+    bridgeEndpoint,
+    "screenshot",
+    {
+      browser_id: "browser-1",
+      snapshot_id: "snapshot-forged",
+      document_epoch: snap.body.documentEpoch,
+    },
+    token
+  );
+  assert.equal(screenshot.status, 409);
+  assert.equal(screenshot.body.kind, "stale_browser_target");
 });
 
 test("stale instance (session replaced) on wait returns 409", async () => {

--- a/crates/tidebreak-desktop/tests/browser-bridge-e2e/bridge-server.mjs
+++ b/crates/tidebreak-desktop/tests/browser-bridge-e2e/bridge-server.mjs
@@ -269,17 +269,19 @@ export async function startBridgeServer({
         if (stoppedControl) controller.halted = true;
 
         json(response, {
-          sessions: [
-            {
-              browserId: "browser-1",
-              url: fixtureOrigin,
-              title: "Agent browser fixture",
-              loadState: "ready",
-              visible: !hiddenBrowser,
-              engine: defaultEngine(),
-              controller,
-            },
-          ],
+          sessions: hiddenBrowser
+            ? []
+            : [
+                {
+                  browserId: "browser-1",
+                  url: fixtureOrigin,
+                  title: "Agent browser fixture",
+                  loadState: "ready",
+                  visible: true,
+                  engine: defaultEngine(),
+                  controller,
+                },
+              ],
         });
         return;
       }
@@ -657,8 +659,28 @@ export async function startBridgeServer({
           return;
         }
 
-        // Stale document epoch → 409
-        if (staleSnapshot && document_epoch !== currentDocumentEpoch) {
+        // Hidden targets are not addressable through an observation
+        // capability, matching BrowserRegistry::list_for_capability and the
+        // desktop adapter's fail-closed mapping.
+        if (hiddenBrowser) {
+          errJson(response, 404, "not_found", `browser ${browser_id} not found`);
+          return;
+        }
+
+        // A Stop that already happened refuses a new operation. The separate
+        // waitOutcome="stopped" fixture models Stop racing an in-flight wait.
+        if (stoppedControl) {
+          errJson(response, 403, "forbidden", "browser control was stopped by the user");
+          return;
+        }
+
+        // Snapshot identity and epoch are authoritative even without an
+        // explicitly forced stale fixture.
+        if (
+          staleSnapshot ||
+          document_epoch !== currentDocumentEpoch ||
+          snapshot_id !== currentSnapshotId
+        ) {
           errJson(
             response,
             409,
@@ -682,10 +704,7 @@ export async function startBridgeServer({
         // Deterministic wait outcome
         let status;
         let message;
-        if (stoppedControl) {
-          status = "stopped";
-          message = "Browser control was stopped by the user.";
-        } else if (waitOutcome === "timed_out") {
+        if (waitOutcome === "timed_out") {
           status = "timed_out";
           const effectiveTimeout = timeout_ms ?? DEFAULT_BROWSER_WAIT_TIMEOUT_MS;
           message = `Wait timed out after ${effectiveTimeout} ms.`;
@@ -801,8 +820,23 @@ export async function startBridgeServer({
           return;
         }
 
-        // Stale document epoch → 409
-        if (staleSnapshot && document_epoch !== currentDocumentEpoch) {
+        if (hiddenBrowser) {
+          errJson(response, 404, "not_found", `browser ${browser_id} not found`);
+          return;
+        }
+
+        if (stoppedControl) {
+          errJson(response, 403, "forbidden", "browser control was stopped by the user");
+          return;
+        }
+
+        // Screenshot publication must echo a host-issued snapshot for the
+        // exact live document generation.
+        if (
+          staleSnapshot ||
+          document_epoch !== currentDocumentEpoch ||
+          snapshot_id !== currentSnapshotId
+        ) {
           errJson(
             response,
             409,
@@ -818,7 +852,7 @@ export async function startBridgeServer({
             response,
             409,
             "stale_browser_target",
-            "browser session was replaced while waiting"
+            "browser session was replaced while capturing the screenshot"
           );
           return;
         }

--- a/crates/tidebreak-desktop/tests/browser-bridge-e2e/bridge-server.mjs
+++ b/crates/tidebreak-desktop/tests/browser-bridge-e2e/bridge-server.mjs
@@ -93,18 +93,89 @@ function defaultController() {
   };
 }
 
+// ── validation constants (match crates/tidebreak-core/src/browser.rs) ───────
+
+const MAX_BROWSER_ID_CHARS = 80;
+const MAX_BROWSER_URL_CHARS = 8_192;
+const DEFAULT_BROWSER_WAIT_TIMEOUT_MS = 5_000;
+const MAX_BROWSER_WAIT_TIMEOUT_MS = 30_000;
+const MAX_BROWSER_SCREENSHOT_DIMENSION = 4_096;
+const MAX_WAIT_TEXT_CHARS = 512;
+
+const BROWSER_ID_RE = /^[A-Za-z0-9_-]{1,80}$/;
+
+function validBrowserId(id) {
+  return typeof id === "string" && BROWSER_ID_RE.test(id);
+}
+
+function validWaitCondition(condition) {
+  if (!condition || typeof condition !== "object") return false;
+  const kind = condition.kind;
+  switch (kind) {
+    case "url_changed":
+      return true;
+    case "load_state":
+      // is_well_formed always returns true for LoadState; the state value
+      // validity is a deserialization concern (handled as 400 above).
+      return true;
+    case "text_present":
+    case "text_absent":
+      return (
+        typeof condition.text === "string" &&
+        [...condition.text].length <= MAX_WAIT_TEXT_CHARS
+      );
+    default:
+      return false;
+  }
+}
+
+function validTimeoutMs(timeoutMs) {
+  if (timeoutMs === undefined || timeoutMs === null) return true;
+  return (
+    typeof timeoutMs === "number" &&
+    Number.isInteger(timeoutMs) &&
+    timeoutMs >= 100 &&
+    timeoutMs <= MAX_BROWSER_WAIT_TIMEOUT_MS
+  );
+}
+
+function validScreenshotDimension(value, allowZero) {
+  if (value === undefined || value === null) return true;
+  if (typeof value !== "number" || !Number.isInteger(value)) return false;
+  if (allowZero && value === 0) return true;
+  return value >= 1 && value <= MAX_BROWSER_SCREENSHOT_DIMENSION;
+}
+
+// ── deterministic small valid PNG ───────────────────────────────────────────
+
+/**
+ * A deterministic 1×1 transparent PNG, base64-encoded. This is the smallest
+ * valid PNG (67 bytes raw). The screenshot route returns this so the test can
+ * verify the wire shape without depending on a native image capture.
+ */
+const DETERMINISTIC_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
 // ── server ──────────────────────────────────────────────────────────────────
 
 /**
  * Start the mock bridge server.
  *
  * The returned `endpoint` is the full `/code/browser` base URL —
- * callers append just `list`, `navigate`, or `snapshot`. This matches
- * the real capfile `endpoint` field exactly.
+ * callers append just `list`, `navigate`, `snapshot`, `wait`, or `screenshot`.
+ * This matches the real capfile `endpoint` field exactly.
  *
  * Tokens are strings returned by `tokenRegistry.issue()`. The server
  * validates token presence and liveness but does not derive
  * workspace/session identity from the token.
+ *
+ * Options:
+ * - staleSnapshot: if true, snapshot/wait/screenshot return 409 stale_browser_target
+ * - hiddenBrowser: if true, list returns visible=false
+ * - stoppedControl: if true, list returns controller.halted=true, wait returns stopped
+ * - missingRuntime: if true, all routes return 501 after auth+validation
+ * - waitOutcome: "resolved" | "timed_out" | "stopped" — controls wait result status
+ * - staleInstance: if true, wait/screenshot return a 409 with instance-replaced semantics
  */
 export async function startBridgeServer({
   host = "127.0.0.1",
@@ -114,6 +185,8 @@ export async function startBridgeServer({
   hiddenBrowser = false,
   stoppedControl = false,
   missingRuntime = false,
+  waitOutcome = "resolved",
+  staleInstance = false,
 } = {}) {
   if (!fixtureOrigin) {
     throw new Error("fixtureOrigin is required");
@@ -144,6 +217,10 @@ export async function startBridgeServer({
       return entry ? entry.ended : false;
     },
   };
+
+  // The current snapshot/document epoch. Navigate increments it.
+  let currentDocumentEpoch = 2;
+  let currentSnapshotId = `snapshot-${randomUUID().slice(0, 8)}`;
 
   const server = createServer(async (request, response) => {
     try {
@@ -298,11 +375,15 @@ export async function startBridgeServer({
           return;
         }
 
+        // Navigate increments the document epoch and generates a new snapshot id
+        currentDocumentEpoch += 1;
+        currentSnapshotId = `snapshot-${randomUUID().slice(0, 8)}`;
+
         json(response, {
           browserId: "browser-1",
           url: navUrl,
           loadState: "loading",
-          documentEpoch: 3,
+          documentEpoch: currentDocumentEpoch,
         });
         return;
       }
@@ -391,10 +472,13 @@ export async function startBridgeServer({
           return;
         }
 
+        // Refresh the snapshot id on each successful snapshot
+        currentSnapshotId = `snapshot-${randomUUID().slice(0, 8)}`;
+
         json(response, {
           browserId: "browser-1",
-          snapshotId: `snapshot-${randomUUID().slice(0, 8)}`,
-          documentEpoch: 2,
+          snapshotId: currentSnapshotId,
+          documentEpoch: currentDocumentEpoch,
           contentTrust: "untrusted_page",
           url: fixtureOrigin,
           title: "Agent browser fixture",
@@ -442,6 +526,309 @@ export async function startBridgeServer({
           ],
           frames: [],
           truncated: false,
+        });
+        return;
+      }
+
+      // ── POST /wait ──────────────────────────────────────────────────────
+
+      if (route === "wait" && request.method === "POST") {
+        const body = await readBody(request);
+
+        if (!body || typeof body !== "object") {
+          errJson(response, 400, "bad_request", "invalid JSON body");
+          return;
+        }
+
+        // Deny unknown fields (matches #[serde(deny_unknown_fields)])
+        const allowed = new Set([
+          "browser_id",
+          "snapshot_id",
+          "document_epoch",
+          "condition",
+          "timeout_ms",
+        ]);
+        for (const key of Object.keys(body)) {
+          if (!allowed.has(key)) {
+            errJson(
+              response,
+              400,
+              "invalid_browser_arguments",
+              `unknown field \`${key}\``
+            );
+            return;
+          }
+        }
+
+        const { browser_id, snapshot_id, document_epoch, condition, timeout_ms } = body;
+
+        // Missing required fields → 400
+        if (typeof browser_id !== "string") {
+          errJson(response, 400, "bad_request", "missing browser_id");
+          return;
+        }
+        if (typeof snapshot_id !== "string") {
+          errJson(response, 400, "bad_request", "missing snapshot_id");
+          return;
+        }
+        if (typeof document_epoch !== "number" || !Number.isInteger(document_epoch) || document_epoch < 0) {
+          errJson(response, 400, "bad_request", "missing or invalid document_epoch");
+          return;
+        }
+        if (!condition || typeof condition !== "object") {
+          errJson(response, 400, "bad_request", "missing or invalid condition");
+          return;
+        }
+
+        // Validate browser_id format → 422
+        if (!validBrowserId(browser_id)) {
+          errJson(
+            response,
+            422,
+            "invalid_browser_arguments",
+            "browser arguments are not well-formed"
+          );
+          return;
+        }
+
+        // Condition deserialization: missing kind or unknown kind → 400
+        // (matches serde rejection of the tagged enum)
+        const condKind = condition.kind;
+        if (typeof condKind !== "string") {
+          errJson(response, 400, "bad_request", "condition missing kind tag");
+          return;
+        }
+        if (!["url_changed", "load_state", "text_present", "text_absent"].includes(condKind)) {
+          errJson(response, 400, "bad_request", `unknown condition kind: ${condKind}`);
+          return;
+        }
+        // Variant field deserialization: missing required variant fields → 400
+        if (condKind === "load_state") {
+          if (typeof condition.state !== "string") {
+            errJson(response, 400, "bad_request", "load_state condition missing state");
+            return;
+          }
+          // BrowserLoadState is a snake_case enum: idle, loading, ready, failed
+          if (!["idle", "loading", "ready", "failed"].includes(condition.state)) {
+            errJson(response, 400, "bad_request", `unknown load_state: ${condition.state}`);
+            return;
+          }
+        }
+        if ((condKind === "text_present" || condKind === "text_absent") && typeof condition.text !== "string") {
+          errJson(response, 400, "bad_request", `${condKind} condition missing text`);
+          return;
+        }
+
+        // Condition is_well_formed check (post-deserialization) → 422
+        if (!validWaitCondition(condition)) {
+          errJson(
+            response,
+            422,
+            "invalid_browser_arguments",
+            "browser arguments are not well-formed"
+          );
+          return;
+        }
+
+        // Validate timeout_ms bounds → 422
+        if (!validTimeoutMs(timeout_ms)) {
+          errJson(
+            response,
+            422,
+            "invalid_browser_arguments",
+            "browser arguments are not well-formed"
+          );
+          return;
+        }
+
+        if (missingRuntime) {
+          errJson(
+            response,
+            501,
+            "not_implemented",
+            "this server has no in-app browser runtime"
+          );
+          return;
+        }
+
+        // Cross-workspace / unknown browser id → 404
+        if (browser_id !== "browser-1") {
+          errJson(response, 404, "not_found", `browser ${browser_id} not found`);
+          return;
+        }
+
+        // Stale document epoch → 409
+        if (staleSnapshot && document_epoch !== currentDocumentEpoch) {
+          errJson(
+            response,
+            409,
+            "stale_browser_target",
+            "the page changed since that snapshot; take a new browser_snapshot"
+          );
+          return;
+        }
+
+        // Stale instance (session replaced) → 409
+        if (staleInstance) {
+          errJson(
+            response,
+            409,
+            "stale_browser_target",
+            "browser session was replaced while waiting"
+          );
+          return;
+        }
+
+        // Deterministic wait outcome
+        let status;
+        let message;
+        if (stoppedControl) {
+          status = "stopped";
+          message = "Browser control was stopped by the user.";
+        } else if (waitOutcome === "timed_out") {
+          status = "timed_out";
+          const effectiveTimeout = timeout_ms ?? DEFAULT_BROWSER_WAIT_TIMEOUT_MS;
+          message = `Wait timed out after ${effectiveTimeout} ms.`;
+        } else if (waitOutcome === "stopped") {
+          status = "stopped";
+          message = "Browser control was stopped by the user.";
+        } else {
+          status = "resolved";
+          message = "Wait condition satisfied.";
+        }
+
+        json(response, {
+          browserId: "browser-1",
+          status,
+          message,
+          documentEpoch: currentDocumentEpoch,
+          url: fixtureOrigin,
+          title: "Agent browser fixture",
+        });
+        return;
+      }
+
+      // ── POST /screenshot ────────────────────────────────────────────────
+
+      if (route === "screenshot" && request.method === "POST") {
+        const body = await readBody(request);
+
+        if (!body || typeof body !== "object") {
+          errJson(response, 400, "bad_request", "invalid JSON body");
+          return;
+        }
+
+        // Deny unknown fields (matches #[serde(deny_unknown_fields)])
+        const allowed = new Set([
+          "browser_id",
+          "snapshot_id",
+          "document_epoch",
+          "max_width",
+          "max_height",
+        ]);
+        for (const key of Object.keys(body)) {
+          if (!allowed.has(key)) {
+            errJson(
+              response,
+              400,
+              "invalid_browser_arguments",
+              `unknown field \`${key}\``
+            );
+            return;
+          }
+        }
+
+        const { browser_id, snapshot_id, document_epoch, max_width, max_height } = body;
+
+        // Missing required fields → 400
+        if (typeof browser_id !== "string") {
+          errJson(response, 400, "bad_request", "missing browser_id");
+          return;
+        }
+        if (typeof snapshot_id !== "string") {
+          errJson(response, 400, "bad_request", "missing snapshot_id");
+          return;
+        }
+        if (typeof document_epoch !== "number" || !Number.isInteger(document_epoch) || document_epoch < 0) {
+          errJson(response, 400, "bad_request", "missing or invalid document_epoch");
+          return;
+        }
+
+        // Validate browser_id format → 422
+        if (!validBrowserId(browser_id)) {
+          errJson(
+            response,
+            422,
+            "invalid_browser_arguments",
+            "browser arguments are not well-formed"
+          );
+          return;
+        }
+
+        // Validate dimension bounds → 422
+        if (!validScreenshotDimension(max_width, false)) {
+          errJson(
+            response,
+            422,
+            "invalid_browser_arguments",
+            "browser arguments are not well-formed"
+          );
+          return;
+        }
+        if (!validScreenshotDimension(max_height, true)) {
+          errJson(
+            response,
+            422,
+            "invalid_browser_arguments",
+            "browser arguments are not well-formed"
+          );
+          return;
+        }
+
+        if (missingRuntime) {
+          errJson(
+            response,
+            501,
+            "not_implemented",
+            "this server has no in-app browser runtime"
+          );
+          return;
+        }
+
+        // Cross-workspace / unknown browser id → 404
+        if (browser_id !== "browser-1") {
+          errJson(response, 404, "not_found", `browser ${browser_id} not found`);
+          return;
+        }
+
+        // Stale document epoch → 409
+        if (staleSnapshot && document_epoch !== currentDocumentEpoch) {
+          errJson(
+            response,
+            409,
+            "stale_browser_target",
+            "the page changed since that snapshot; take a new browser_snapshot"
+          );
+          return;
+        }
+
+        // Stale instance (session replaced) → 409
+        if (staleInstance) {
+          errJson(
+            response,
+            409,
+            "stale_browser_target",
+            "browser session was replaced while waiting"
+          );
+          return;
+        }
+
+        json(response, {
+          browserId: "browser-1",
+          snapshotId: snapshot_id,
+          documentEpoch: currentDocumentEpoch,
+          imageBase64: DETERMINISTIC_PNG_BASE64,
+          mimeType: "image/png",
         });
         return;
       }

--- a/crates/tidebreak-desktop/tests/browser-bridge-e2e/scripted-harness.mjs
+++ b/crates/tidebreak-desktop/tests/browser-bridge-e2e/scripted-harness.mjs
@@ -1,7 +1,7 @@
 // Deterministic scripted harness that drives the mock /code/browser bridge
 // using the real v1 capfile protocol. This simulates what a provider
 // adapter (Claude, Codex, OpenCode) does: read the capfile, extract
-// endpoint + token, then call the three browser tools in sequence.
+// endpoint + token, then call the five browser tools in sequence.
 //
 // It also simulates a "browser-mcp" style process that accepts a capfile
 // path from TIDEBREAK_BROWSER_CAPFILE and validates the tool registry.
@@ -115,18 +115,26 @@ export async function callBrowserRoute(endpoint, route, body, token) {
 // ── tool registry contract ──────────────────────────────────────────────────
 
 /**
- * The exact three browser tools this slice advertises. These names MUST
+ * The exact five browser tools this slice advertises. These names MUST
  * match the constants in crates/tidebreak-core/src/browser.rs.
  */
-export const BROWSER_TOOLS = ["browser_list", "browser_navigate", "browser_snapshot"];
+export const BROWSER_TOOLS = [
+  "browser_list",
+  "browser_navigate",
+  "browser_snapshot",
+  "browser_wait",
+  "browser_screenshot",
+];
 
 /**
- * Tools that MUST NOT be advertised in this slice.
+ * Tools that MUST NOT be advertised in this slice. browser_act and all
+ * semantic action tools remain intentionally absent while
+ * semantic_actions is false.
  */
-export const FORBIDDEN_TOOLS = ["act", "wait", "screenshot"];
+export const FORBIDDEN_TOOLS = ["act"];
 
 /**
- * Assert the tool registry contains exactly the three browser tools and
+ * Assert the tool registry contains exactly the five browser tools and
  * nothing from the forbidden set.
  */
 export function assertToolRegistry(tools) {
@@ -148,7 +156,7 @@ export function assertToolRegistry(tools) {
     }
   }
 
-  // Only the three tools, nothing more
+  // Only the five tools, nothing more
   const extra = [...names].filter((n) => !BROWSER_TOOLS.includes(n));
   if (extra.length > 0) {
     throw new Error(
@@ -229,13 +237,67 @@ export function assertSnapshotShape(body) {
   }
 }
 
-// ── harness: list → navigate → snapshot ─────────────────────────────────────
+/**
+ * Assert the browser_wait response has the expected camelCase shape.
+ */
+export function assertWaitShape(body) {
+  if (typeof body.browserId !== "string") {
+    throw new Error("wait result missing browserId");
+  }
+  if (typeof body.status !== "string") {
+    throw new Error("wait result missing status");
+  }
+  if (!["resolved", "timed_out", "stopped"].includes(body.status)) {
+    throw new Error(
+      `wait status is ${body.status}, expected resolved/timed_out/stopped`
+    );
+  }
+  if (typeof body.message !== "string") {
+    throw new Error("wait result missing message");
+  }
+  if (typeof body.documentEpoch !== "number") {
+    throw new Error("wait result missing documentEpoch");
+  }
+  // url and title are Option<String> — present in this mock but optional on the wire
+}
+
+/**
+ * Assert the browser_screenshot response has the expected camelCase shape.
+ */
+export function assertScreenshotShape(body) {
+  if (typeof body.browserId !== "string") {
+    throw new Error("screenshot result missing browserId");
+  }
+  if (typeof body.snapshotId !== "string") {
+    throw new Error("screenshot result missing snapshotId");
+  }
+  if (typeof body.documentEpoch !== "number") {
+    throw new Error("screenshot result missing documentEpoch");
+  }
+  if (typeof body.imageBase64 !== "string") {
+    throw new Error("screenshot result missing imageBase64");
+  }
+  if (body.mimeType !== "image/png") {
+    throw new Error(
+      `screenshot mimeType is ${body.mimeType}, expected image/png`
+    );
+  }
+  // Verify the base64 string is a valid PNG (starts with the PNG signature)
+  const decoded = Buffer.from(body.imageBase64, "base64");
+  // PNG signature: 0x89504E470D0A1A0A
+  if (decoded.length < 8 || decoded[0] !== 0x89 || decoded[1] !== 0x50 || decoded[2] !== 0x4e || decoded[3] !== 0x47) {
+    throw new Error("screenshot imageBase64 is not a valid PNG");
+  }
+}
+
+// ── harness: list → navigate → snapshot → wait → screenshot ────────────────
 
 /**
  * Drive the deterministic positive contract: list → navigate → snapshot
- * against a bridge server using the real capfile protocol.
+ * → wait → screenshot against a bridge server using the real capfile
+ * protocol.
  *
- * Returns the final snapshot body for further assertion.
+ * Returns the final screenshot body for further assertion.
  */
 export async function drivePositiveContract(endpoint, token, fixtureOrigin) {
   // 1. List
@@ -269,7 +331,43 @@ export async function drivePositiveContract(endpoint, token, fixtureOrigin) {
   }
   assertSnapshotShape(snapshot.body);
 
-  return snapshot.body;
+  const snapshotId = snapshot.body.snapshotId;
+  const documentEpoch = snapshot.body.documentEpoch;
+
+  // 4. Wait (load_state ready — deterministic resolve)
+  const wait = await callBrowserRoute(
+    endpoint,
+    "wait",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snapshotId,
+      document_epoch: documentEpoch,
+      condition: { kind: "load_state", state: "ready" },
+    },
+    token
+  );
+  if (wait.status !== 200) {
+    throw new Error(`wait failed with ${wait.status}: ${JSON.stringify(wait.body)}`);
+  }
+  assertWaitShape(wait.body);
+
+  // 5. Screenshot
+  const screenshot = await callBrowserRoute(
+    endpoint,
+    "screenshot",
+    {
+      browser_id: "browser-1",
+      snapshot_id: snapshotId,
+      document_epoch: documentEpoch,
+    },
+    token
+  );
+  if (screenshot.status !== 200) {
+    throw new Error(`screenshot failed with ${screenshot.status}: ${JSON.stringify(screenshot.body)}`);
+  }
+  assertScreenshotShape(screenshot.body);
+
+  return screenshot.body;
 }
 
 // ── negative contract helpers ───────────────────────────────────────────────


### PR DESCRIPTION
Part of #2400.

## What changed

- expands the dependency-free browser bridge fixture from exactly three tools to exactly five: list, navigate, snapshot, wait, and screenshot;
- adds deterministic wait and PNG screenshot route shapes with the core snake_case request / camelCase response contract;
- enforces auth, hidden/Stop, snapshot id, document epoch, stale-instance, validation-order, and secrecy failures in the mock;
- keeps `browser_act` and every semantic action surface absent while `semantic_actions` is false;
- documents precisely what this HTTP mock proves and what remains CI/native-only.

## Validation

- `node --test crates/tidebreak-desktop/tests/browser-bridge-e2e/bridge-e2e.test.mjs` — 60/60 passing
- `git diff --check`

No Cargo, rustc, rustfmt, Clippy, Rust tests, Tauri, or Rust-backed builds were run locally.