### PR TITLE
fix(code): report codex token usage as a disjoint turn total

### DIFF
--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -126,13 +126,30 @@ pub struct Diffstat {
     pub truncated: bool,
 }
 
-/// Token accounting as reported by the engine. Missing fields stay zero.
+/// Token accounting for one turn.
+///
+/// The four counts are **disjoint** and they are **turn totals**, summed over
+/// every model call the engine made while servicing the turn. This is the same
+/// contract the chat side states on `RendererTurnUsage`, and the reason to
+/// state it here is that every adapter reports something different natively:
+/// one engine sends a running total beside the last call's slice, another
+/// folds the cached portion back into the prompt count, another overwrites a
+/// snapshot per message. Normalizing belongs in the adapter, so that anything
+/// reading this struct — cost accounting, the CLI's turn list, the desktop's
+/// context indicator — can compare two harnesses without knowing which engine
+/// produced the row.
+///
+/// Concretely: `input_tokens` is the *fresh*, uncached prompt only. It never
+/// includes `cache_read_input_tokens` or `cache_creation_input_tokens`, so
+/// the prompt an engine actually sent is the sum of all three. Missing fields
+/// stay zero, which is not the same as "the engine sent zero" — an engine that
+/// does not surface cache counts reports nothing rather than a real zero.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, TS)]
 pub struct CodeUsage {
-    /// Input tokens.
+    /// Fresh, uncached input tokens. Excludes both cache fields.
     #[serde(default)]
     pub input_tokens: u64,
-    /// Output tokens.
+    /// Output tokens, summed over the turn's model calls.
     #[serde(default)]
     pub output_tokens: u64,
     /// Cache-read input tokens, when the engine reports them.

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1480,15 +1480,32 @@ watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number,
 subagents?: Array<CodeSubagentSummary>, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, } | { "type": "harness_install", kind: HarnessKind, version?: string, phase: string, done: boolean, error?: string, };
 
 /**
- * Token accounting as reported by the engine. Missing fields stay zero.
+ * Token accounting for one turn.
+ *
+ * The four counts are **disjoint** and they are **turn totals**, summed over
+ * every model call the engine made while servicing the turn. This is the same
+ * contract the chat side states on `RendererTurnUsage`, and the reason to
+ * state it here is that every adapter reports something different natively:
+ * one engine sends a running total beside the last call's slice, another
+ * folds the cached portion back into the prompt count, another overwrites a
+ * snapshot per message. Normalizing belongs in the adapter, so that anything
+ * reading this struct — cost accounting, the CLI's turn list, the desktop's
+ * context indicator — can compare two harnesses without knowing which engine
+ * produced the row.
+ *
+ * Concretely: `input_tokens` is the *fresh*, uncached prompt only. It never
+ * includes `cache_read_input_tokens` or `cache_creation_input_tokens`, so
+ * the prompt an engine actually sent is the sum of all three. Missing fields
+ * stay zero, which is not the same as "the engine sent zero" — an engine that
+ * does not surface cache counts reports nothing rather than a real zero.
  */
 export type CodeUsage = { 
 /**
- * Input tokens.
+ * Fresh, uncached input tokens. Excludes both cache fields.
  */
 input_tokens: number, 
 /**
- * Output tokens.
+ * Output tokens, summed over the turn's model calls.
  */
 output_tokens: number, 
 /**

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
@@ -116,9 +116,9 @@
   {
     "type": "turn_completed",
     "usage": {
-      "input_tokens": 14466,
-      "output_tokens": 5,
-      "cache_read_input_tokens": 14080,
+      "input_tokens": 5754,
+      "output_tokens": 118,
+      "cache_read_input_tokens": 23040,
       "cache_creation_input_tokens": 0
     }
   }

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
@@ -112,9 +112,9 @@
   {
     "type": "turn_completed",
     "usage": {
-      "input_tokens": 14499,
-      "output_tokens": 22,
-      "cache_read_input_tokens": 14080,
+      "input_tokens": 5785,
+      "output_tokens": 132,
+      "cache_read_input_tokens": 23040,
       "cache_creation_input_tokens": 0
     }
   }

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/plain-text.expected.json
@@ -27,7 +27,7 @@
   {
     "type": "turn_completed",
     "usage": {
-      "input_tokens": 13959,
+      "input_tokens": 4999,
       "output_tokens": 7,
       "cache_read_input_tokens": 8960,
       "cache_creation_input_tokens": 0

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
@@ -23,9 +23,9 @@
   {
     "type": "turn_completed",
     "usage": {
-      "input_tokens": 15352,
-      "output_tokens": 6,
-      "cache_read_input_tokens": 14080,
+      "input_tokens": 5819,
+      "output_tokens": 12,
+      "cache_read_input_tokens": 24064,
       "cache_creation_input_tokens": 0
     }
   }

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
@@ -40,9 +40,9 @@
   {
     "type": "turn_completed",
     "usage": {
-      "input_tokens": 14109,
-      "output_tokens": 5,
-      "cache_read_input_tokens": 13056,
+      "input_tokens": 6068,
+      "output_tokens": 114,
+      "cache_read_input_tokens": 22016,
       "cache_creation_input_tokens": 0
     }
   }

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -508,25 +508,38 @@ fn command_detail(item: &Value) -> ToolDetail {
     }
 }
 
+/// Normalize `thread/tokenUsage` into the disjoint per-turn split
+/// [`CodeUsage`] documents.
+///
+/// Two corrections over reading the payload verbatim.
+///
+/// The engine reports `total` (the turn so far) beside `last` (the most
+/// recent model call). A turn that makes several calls has genuinely
+/// different values in the two — `total.totalTokens 28912` against
+/// `last.totalTokens 14471` in `approval-approve.ndjson` — and the turn's
+/// usage is the total.
+///
+/// `inputTokens` is the whole prompt: `totalTokens == inputTokens +
+/// outputTokens` holds in every captured payload, and `cachedInputTokens` is
+/// a subset of it. Filing that subset into `cache_read_input_tokens` while
+/// leaving it inside `input_tokens` double-counts it. Subtract the cached and
+/// written portions so the four fields stay disjoint and still sum to the
+/// prompt.
 fn usage_from(value: Option<&Value>) -> CodeUsage {
     let Some(value) = value else {
         return CodeUsage::default();
     };
-    let last = value.get("last").unwrap_or(value);
+    let total = value.get("total").unwrap_or(value);
+    let field = |name: &str| total.get(name).and_then(Value::as_u64).unwrap_or(0);
+    let cache_read_input_tokens = field("cachedInputTokens");
+    let cache_creation_input_tokens = field("cacheWriteInputTokens");
     CodeUsage {
-        input_tokens: last.get("inputTokens").and_then(Value::as_u64).unwrap_or(0),
-        output_tokens: last
-            .get("outputTokens")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        cache_read_input_tokens: last
-            .get("cachedInputTokens")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        cache_creation_input_tokens: last
-            .get("cacheWriteInputTokens")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
+        input_tokens: field("inputTokens")
+            .saturating_sub(cache_read_input_tokens)
+            .saturating_sub(cache_creation_input_tokens),
+        output_tokens: field("outputTokens"),
+        cache_read_input_tokens,
+        cache_creation_input_tokens,
     }
 }
 
@@ -548,6 +561,53 @@ fn bound(text: &str, max: usize) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// `thread/tokenUsage` reports the turn's running `total` beside the last
+    /// model call's `last`, and folds the cached portion into `inputTokens`.
+    /// Reading it verbatim took one call's slice and double-counted the cache.
+    #[test]
+    fn token_usage_is_a_disjoint_turn_total() {
+        let payload = serde_json::json!({
+            "total": {
+                "totalTokens": 28912, "inputTokens": 28794,
+                "cachedInputTokens": 23040, "cacheWriteInputTokens": 0,
+                "outputTokens": 118, "reasoningOutputTokens": 9
+            },
+            "last": {
+                "totalTokens": 14471, "inputTokens": 14466,
+                "cachedInputTokens": 14080, "cacheWriteInputTokens": 0,
+                "outputTokens": 5, "reasoningOutputTokens": 0
+            }
+        });
+        let usage = usage_from(Some(&payload));
+
+        // The turn total, not the last call: `last` would report 5.
+        assert_eq!(usage.output_tokens, 118);
+        // Disjoint: the three prompt-side counts sum to the prompt the engine
+        // actually sent, and the cached portion is not also in `input_tokens`.
+        assert_eq!(usage.cache_read_input_tokens, 23040);
+        assert_eq!(usage.input_tokens, 5754);
+        assert_eq!(
+            usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens,
+            28794,
+            "the split must reconstruct inputTokens"
+        );
+    }
+
+    /// A payload with no `total` (an older shape, or one already narrowed)
+    /// still normalizes rather than reporting zeros.
+    #[test]
+    fn token_usage_without_a_total_falls_back_to_the_object_itself() {
+        let payload = serde_json::json!({
+            "inputTokens": 100, "cachedInputTokens": 30,
+            "cacheWriteInputTokens": 10, "outputTokens": 7
+        });
+        let usage = usage_from(Some(&payload));
+        assert_eq!(usage.input_tokens, 60);
+        assert_eq!(usage.cache_read_input_tokens, 30);
+        assert_eq!(usage.cache_creation_input_tokens, 10);
+        assert_eq!(usage.output_tokens, 7);
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
## The contract was implicit, and codex broke it twice

`CodeUsage` reuses the four field names the chat side documents on `RendererTurnUsage` as **disjoint per-turn totals**, but carried only a one-line comment. The codex adapter filled them in two ways that both disagree with it.

**It read the last model call, not the turn.** `thread/tokenUsage` reports a running `total` beside the most recent call's `last`, and `usage_from` took `last`. The captured fixtures show the two genuinely diverge on a multi-call turn:

```
"total":{"totalTokens":28912,"inputTokens":28794,"cachedInputTokens":23040,"outputTokens":118}
"last": {"totalTokens":14471,"inputTokens":14466,"cachedInputTokens":14080,"outputTokens":5}
```

So a turn that produced 118 output tokens recorded 5. That is the under-reporting shape you see when a codex turn streams a long answer and the stored row says a couple of hundred tokens.

**It double-counted the cache.** `totalTokens == inputTokens + outputTokens` holds in every captured payload, so `inputTokens` is the whole prompt and `cachedInputTokens` is a subset of it. Filing that subset into `cache_read_input_tokens` while leaving it inside `input_tokens` counts it twice.

Reading `total` and subtracting the cached and written portions leaves the three prompt-side counts disjoint and summing back to `inputTokens`.

## What this changes for readers

Anything comparing harnesses from `code_turn.usage` was reading a codex row that was simultaneously one call's slice and inflated by its cached prefix. Two lanes running identical work on the same fixture reported 256,833 against 47,232 prompt-side tokens; most of that gap was this, not efficiency.

## Scope: codex only, deliberately

While checking the other adapters against the same contract:

- **grok is already correct.** Its final usage event is the cumulative turn total, not a per-call snapshot. From `tool-use.ndjson`: calls of 9050 and 139 input, 384 and 9344 cache-read, 56 and 28 output; the closing event reports 9189 / 9728 / 84, and those sum to its `total_tokens` of 19001. `permission-denied.ndjson` checks out the same way across three calls. Its fields are disjoint already. No change.
- **opencode is unverified.** Every opencode fixture has zero usage lines, so there is nothing captured to establish whether its `tokens` object is per-message or cumulative, or whether `input` excludes `cache.read`. Changing it on a guess would be worse than leaving it. It wants a capture first; I did not touch it.

## Tests

- `token_usage_is_a_disjoint_turn_total` — the real two-call payload: asserts the turn's output (118, not 5), the cache read, and that the three prompt-side counts reconstruct `inputTokens`.
- `token_usage_without_a_total_falls_back_to_the_object_itself` — an object with no `total` still normalizes rather than reporting zeros.
- Five codex replay fixtures regenerated with `UPDATE_HARNESS_FIXTURES=1`. Only `usage` values moved; every event sequence is unchanged.

`cargo test -p tidebreak-harness codex` — 45 passed.

Note: `child::unix_process_tree_tests::{terminating,dropping}_a_process_tree_*` fail on this machine, and they fail identically on a clean checkout of `main` — pre-existing and unrelated to this change.