### PR TITLE
fix(cli): deliver a completed turn's checkpoint before code run exits

### DIFF
--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -892,6 +892,11 @@ impl TurnGate {
         self.ours
     }
 
+    /// The turn this submit owns, once bound.
+    fn bound_turn(&self) -> Option<CodeTurnId> {
+        self.ours.then_some(self.expected).flatten()
+    }
+
     fn on_ran(&mut self, id: CodeTurnId) {
         if self.ours && self.expected == Some(id) {
             return;
@@ -944,6 +949,53 @@ impl TurnGate {
             return FrameAction::Terminal(turn_exit_code(event).unwrap_or(1));
         }
         FrameAction::Render
+    }
+}
+
+/// How long to wait past a completed turn for its checkpoint.
+///
+/// The server records the checkpoint after publishing the turn's terminal
+/// event, so it lands tens of milliseconds later. This is a bound on that
+/// gap, not a poll interval — the wait ends the moment the frame arrives.
+const CHECKPOINT_TAIL_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Read the trailing `checkpoint_recorded` for a turn that just completed.
+///
+/// Returns the updated `dangling` state. A turn whose checkpoint failed
+/// journals a `harness_notice` instead, so that is accepted as an ending
+/// too; anything else is passed through untouched. Times out quietly — a
+/// missing checkpoint must never fail a turn that already succeeded.
+async fn drain_checkpoint(
+    client: &Client,
+    session: CodeSessionId,
+    stream: &mut CodeStream,
+    turn_id: CodeTurnId,
+    format: OutputFormat,
+    mut dangling: bool,
+    streamed_text: &mut bool,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + CHECKPOINT_TAIL_WAIT;
+    loop {
+        let frame = tokio::select! {
+            frame = stream.next_session(client, session) => frame,
+            () = tokio::time::sleep_until(deadline) => return dangling,
+        };
+        let Ok(Some((raw, decoded))) = frame else {
+            return dangling;
+        };
+        let done = match &decoded.event {
+            CodeEvent::CheckpointRecorded { turn_id: id, .. } => *id == turn_id,
+            CodeEvent::HarnessNotice { .. } => true,
+            _ => continue,
+        };
+        if format == OutputFormat::Json {
+            emit_line(&raw);
+        } else {
+            dangling = render_event(&decoded.event, dangling, streamed_text);
+        }
+        if done {
+            return dangling;
+        }
     }
 }
 
@@ -1049,6 +1101,25 @@ async fn run_turn(
                     emit_line(&raw);
                 } else {
                     dangling = render_event(&decoded.event, dangling, &mut streamed_text);
+                }
+                // The checkpoint is journaled just after the turn's terminal
+                // event, so breaking here dropped it every time: the turn's
+                // diffstat never reached a caller reading this stream, and a
+                // script that acted on our exit raced a checkpoint that was
+                // not durable yet.
+                if let CodeEvent::TurnCompleted { .. } = &decoded.event {
+                    if let Some(turn_id) = gate.bound_turn() {
+                        dangling = drain_checkpoint(
+                            client,
+                            session,
+                            &mut stream,
+                            turn_id,
+                            format,
+                            dangling,
+                            &mut streamed_text,
+                        )
+                        .await;
+                    }
                 }
                 break Ok(code);
             }
@@ -2567,6 +2638,39 @@ mod tests {
             FrameAction::Render
         );
         assert_eq!(gate.on_frame(false, &completed()), FrameAction::Terminal(0));
+    }
+
+    /// The tail drain needs the turn it just finished, and must not claim one
+    /// on a stream this submit does not own — otherwise it would wait out the
+    /// checkpoint window on somebody else's turn.
+    #[test]
+    fn bound_turn_is_only_reported_for_a_turn_we_own() {
+        let ours = turn(1);
+        let mut gate = TurnGate::submit();
+        assert_eq!(gate.bound_turn(), None, "nothing bound yet");
+
+        // `on_ran` names the turn, but ownership binds on its live start.
+        gate.on_ran(ours);
+        assert_eq!(
+            gate.bound_turn(),
+            None,
+            "named but not started: no tail to wait for yet"
+        );
+        assert_eq!(
+            gate.on_frame(false, &CodeEvent::TurnStarted { turn_id: ours }),
+            FrameAction::Render
+        );
+        assert_eq!(gate.bound_turn(), Some(ours));
+        assert_eq!(gate.on_frame(false, &completed()), FrameAction::Terminal(0));
+        assert_eq!(
+            gate.bound_turn(),
+            Some(ours),
+            "still ours after the terminal frame, so the checkpoint can be drained"
+        );
+
+        // An attach-owned turn is ours immediately.
+        let attached = turn(2);
+        assert_eq!(TurnGate::attach(attached).bound_turn(), Some(attached));
     }
 
     #[test]


### PR DESCRIPTION
## What

`code run`'s stream loop breaks on the turn's terminal frame. The server journals `checkpoint_recorded` just *after* publishing that frame, so the checkpoint was never delivered — across a full exercise run the journal held **20** and the CLI streamed **0**.

Two consequences:

- A `--json` consumer never received the turn's `diffstat`. That event is the only place it appears on the stream.
- A script acting the moment `code run` exited raced a checkpoint that was not durable yet — measured 0.25–1.6 s behind the process.

## How

After a turn completes, drain the stream until the matching `checkpoint_recorded` arrives, bounded by a five-second wait. It ends the instant the frame lands, so the normal cost is the tens of milliseconds the server actually takes.

A checkpoint that fails journals a `harness_notice` instead, so that ends the wait too. A timeout is quiet — a missing checkpoint must not fail a turn that already succeeded. Only a turn this submit owns is drained, so a stream that never bound one does not wait out the window on a sibling's turn.

## Verified against a live server

Same command that produced 0 of 20 before:

```
{"seq":114,"event":{"type":"turn_completed","usage":{...}}}
{"seq":115,"event":{"type":"checkpoint_recorded","turn_id":"227711e1-...","diffstat":{"files":0,...}}}
```

## Tests

`bound_turn_is_only_reported_for_a_turn_we_own` covers the gate accessor the drain depends on: nothing bound before a start, still nothing once the turn is merely named by `on_ran`, ours after its live `TurnStarted`, still ours after the terminal frame so the drain can run, and immediately ours for an attached turn.

`cargo test -p tidebreak-cli` — 92 + 2 + 7 + 16 passed. `cargo clippy -p tidebreak-cli --all-targets` clean.

## Not in this change

The stream frames still carry no timestamp, so measuring turn latency from `--json` output still needs a sidecar stamper. That is a server wire change (`SequencedCodeEventFrame` plus the generated TS types) and wants its own PR.