### PR TITLE
fix(code): surface turn cache cost and dropped engine events

### DIFF
--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -1302,7 +1302,23 @@ fn print_turn_line(turn: &CodeTurnSnapshot) {
     let usage = turn
         .usage
         .as_ref()
-        .map(|usage| format!("  in={} out={}", usage.input_tokens, usage.output_tokens))
+        .map(|usage| {
+            // Cache reads and writes are most of the prompt on every
+            // Anthropic-routed harness, and a cache write bills above base
+            // input. Printing only `in=` made the most expensive turn in a
+            // session read as the cheapest.
+            let mut line = format!("  in={} out={}", usage.input_tokens, usage.output_tokens);
+            if usage.cache_read_input_tokens > 0 {
+                line.push_str(&format!("  cache-read={}", usage.cache_read_input_tokens));
+            }
+            if usage.cache_creation_input_tokens > 0 {
+                line.push_str(&format!(
+                    "  cache-write={}",
+                    usage.cache_creation_input_tokens
+                ));
+            }
+            line
+        })
         .unwrap_or_default();
     println!(
         "{}\t{}\t{}{stat}{usage}",

--- a/crates/tidebreak-harness/src/claude/parse.rs
+++ b/crates/tidebreak-harness/src/claude/parse.rs
@@ -380,12 +380,20 @@ impl ClaudeStreamParser {
         self.unrecognized += 1;
         let mut rendered = payload.to_string();
         crate::text::truncate_on_char_boundary(&mut rendered, MAX_UNRECOGNIZED_LOG);
-        tracing::debug!(
+        // The kind alone is what makes a dropped event findable later, and
+        // it carries no engine payload, so it rides at info. The truncated
+        // body stays at debug for whoever is actually chasing one.
+        tracing::info!(
             target: "tidebreak_harness::claude",
             unrecognized = self.unrecognized,
             kind = label,
-            payload = %rendered,
             "unrecognized engine event"
+        );
+        tracing::debug!(
+            target: "tidebreak_harness::claude",
+            kind = label,
+            payload = %rendered,
+            "unrecognized engine event payload"
         );
     }
 }

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -482,12 +482,20 @@ impl CodexStreamParser {
         self.unrecognized += 1;
         let mut rendered = payload.to_string();
         crate::text::truncate_on_char_boundary(&mut rendered, MAX_UNRECOGNIZED_LOG);
-        tracing::debug!(
+        // The kind alone is what makes a dropped event findable later, and
+        // it carries no engine payload, so it rides at info. The truncated
+        // body stays at debug for whoever is actually chasing one.
+        tracing::info!(
             target: "tidebreak_harness::codex",
             unrecognized = self.unrecognized,
             kind = label,
-            payload = %rendered,
             "unrecognized engine event"
+        );
+        tracing::debug!(
+            target: "tidebreak_harness::codex",
+            kind = label,
+            payload = %rendered,
+            "unrecognized engine event payload"
         );
     }
 }

--- a/crates/tidebreak-harness/src/grok/parse.rs
+++ b/crates/tidebreak-harness/src/grok/parse.rs
@@ -473,12 +473,20 @@ impl GrokStreamParser {
         self.unrecognized += 1;
         let mut rendered = payload.to_string();
         crate::text::truncate_on_char_boundary(&mut rendered, MAX_UNRECOGNIZED_LOG);
-        tracing::debug!(
+        // The kind alone is what makes a dropped event findable later, and
+        // it carries no engine payload, so it rides at info. The truncated
+        // body stays at debug for whoever is actually chasing one.
+        tracing::info!(
             target: "tidebreak_harness::grok",
             unrecognized = self.unrecognized,
             kind = label,
-            payload = %rendered,
             "unrecognized engine event"
+        );
+        tracing::debug!(
+            target: "tidebreak_harness::grok",
+            kind = label,
+            payload = %rendered,
+            "unrecognized engine event payload"
         );
     }
 }

--- a/crates/tidebreak-harness/src/opencode/parse.rs
+++ b/crates/tidebreak-harness/src/opencode/parse.rs
@@ -564,12 +564,20 @@ impl OpencodeStreamParser {
         self.unrecognized += 1;
         let mut rendered = payload.to_string();
         crate::text::truncate_on_char_boundary(&mut rendered, MAX_UNRECOGNIZED_LOG);
-        tracing::debug!(
+        // The kind alone is what makes a dropped event findable later, and
+        // it carries no engine payload, so it rides at info. The truncated
+        // body stays at debug for whoever is actually chasing one.
+        tracing::info!(
             target: "tidebreak_harness::opencode",
             unrecognized = self.unrecognized,
             kind = label,
-            payload = %rendered,
             "unrecognized engine event"
+        );
+        tracing::debug!(
+            target: "tidebreak_harness::opencode",
+            kind = label,
+            payload = %rendered,
+            "unrecognized engine event payload"
         );
     }
 }

--- a/crates/tidebreak-server/src/logging.rs
+++ b/crates/tidebreak-server/src/logging.rs
@@ -46,9 +46,9 @@ const LOG_ENV_VAR: &str = "TIDEBREAK_LOG";
 /// `info` for the workspace's own crates, `warn` for dependencies.
 const DEFAULT_DIRECTIVES: &str = "warn,tidebreak_cli=info,tidebreak_code_execution=info,\
     tidebreak_core=info,tidebreak_desktop=info,tidebreak_egress=info,\
-    tidebreak_host_broker=info,tidebreak_mcp=info,tidebreak_router=info,\
-    tidebreak_sandbox_agent=info,tidebreak_sandbox_protocol=info,tidebreak_server=info,\
-    tidebreak_shell_policy=info";
+    tidebreak_harness=info,tidebreak_host_broker=info,tidebreak_mcp=info,\
+    tidebreak_router=info,tidebreak_sandbox_agent=info,tidebreak_sandbox_protocol=info,\
+    tidebreak_server=info,tidebreak_shell_policy=info";
 
 /// Install the process-global subscriber, writing to `logs/tidebreak.log`
 /// under `data_dir`.
@@ -301,6 +301,39 @@ mod tests {
         assert!(
             contents.contains("gateway endpoint unreachable"),
             "message missing: {contents:?}"
+        );
+    }
+
+    /// Every workspace crate needs a directive, or it sits at the global
+    /// `warn` floor and anything it logs below that is invisible. That is how
+    /// `tidebreak_harness` came to swallow unrecognized engine events: the
+    /// crate was absent, so its diagnostics never reached the log.
+    #[test]
+    fn every_workspace_crate_has_a_log_directive() {
+        let listed: std::collections::HashSet<&str> = DEFAULT_DIRECTIVES
+            .split(',')
+            .filter_map(|directive| directive.split('=').next())
+            .map(str::trim)
+            .collect();
+
+        let crates_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("crates/ is the manifest's parent");
+        let mut missing = Vec::new();
+        for entry in std::fs::read_dir(crates_dir).expect("read crates/") {
+            let entry = entry.expect("crate dir entry");
+            if !entry.path().join("Cargo.toml").is_file() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().replace('-', "_");
+            if !listed.contains(name.as_str()) {
+                missing.push(name);
+            }
+        }
+        missing.sort();
+        assert!(
+            missing.is_empty(),
+            "workspace crates with no log directive, so they sit at warn: {missing:?}"
         );
     }
 }


### PR DESCRIPTION
Two things Tidebreak already measures and then hides.

## `code turns` hid the fields that carry the cost

The line printed `in=` and `out=` only. On every Anthropic-routed harness the engine puts almost the whole prompt into the cache fields, so a real turn list looked like this:

```
3  completed  Give me a two-sentence summary of what you chan…  +0 -0 (0 files)  in=2 out=153
```

That turn reads as the cheapest in its session. It wrote ~12k cache tokens, and a cache write bills *above* base input — it was the most expensive per token. `cache-read=` and `cache-write=` now print when non-zero.

## Dropped engine events left no trace

`unrecognized_event_count` rises on the session, but the only record of *which* events were dropped went to `debug!` — and `tidebreak_harness` was the single workspace crate missing from `DEFAULT_DIRECTIVES`, so the crate sat at the global `warn` floor and the debug line was unreachable in a normal run.

Both had to be wrong for the count to be unexplainable, and both were. A run that dropped 34 events across two harnesses left nothing to identify them by.

The event *kind* now logs at `info`: it is what makes a gap findable and it carries no engine payload. The truncated body stays at `debug` for whoever is actually chasing one. Applied to all four adapters.

## The guard

`every_workspace_crate_has_a_log_directive` walks `crates/` and asserts each one appears in `DEFAULT_DIRECTIVES`. `tidebreak_harness` was the only crate missing; with it added, all 13 are covered. This is the omission that made the debug line unreachable, so it is worth a test rather than a second look next time.

## Tests

`cargo test -p tidebreak-server --lib logging` — 5 passed. `cargo test -p tidebreak-harness` — 183 passed. `cargo test -p tidebreak-cli` — 91 + 2 passed. Clippy clean on all three.

`child::unix_process_tree_tests::*` is flaky on this machine and fails the same way on a clean `main` — unrelated.