### PR TITLE
fix(desktop): make a failed boot recoverable

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -123,6 +123,10 @@ const unmanaged: import("./api").ManagedPolicy = {
 allow_local_mcp_servers: false,
 };
 const getPolicy = vi.fn(async () => unmanaged);
+/** The catalog fetch — the boot step a failing remote machine takes down. */
+const listModels = vi.hoisted(() =>
+  vi.fn(async () => ({ models: [] as unknown[], roles: [] as unknown[] })),
+);
 const getGatewayStatus = vi.fn(async () => ({
   base_url: "https://gateway.example",
   signed_in: false,
@@ -130,8 +134,35 @@ const getGatewayStatus = vi.fn(async () => ({
   sign_in: { state: "idle" },
 }));
 
-vi.mock("./boot", () => ({
-  resolveServerInfo: vi.fn(async () => ({ baseUrl: "http://127.0.0.1:1", token: "t" })),
+/** Boot's first step, held here so a test can make it fail and then recover. */
+const resolveServerInfo = vi.hoisted(() =>
+  vi.fn(async () => ({
+    baseUrl: "http://127.0.0.1:1",
+    token: "t",
+    attachment: "local" as "local" | "remote",
+    gatewayAuth: false,
+  })),
+);
+/** What the shell says this window is attached to, independent of the client. */
+const remoteMachineState = vi.hoisted(() =>
+  vi.fn(async () => ({
+    attachment: "local" as "local" | "remote",
+    baseUrl: null as string | null,
+  })),
+);
+const disconnectRemoteMachine = vi.hoisted(() =>
+  vi.fn(async () => ({ attachment: "local" as const, baseUrl: null })),
+);
+
+vi.mock("./boot", () => ({ resolveServerInfo }));
+
+// Partial: the shell reaches for three of this module's functions and the
+// settings panel for the rest, so replacing the whole module would break
+// routes these tests do not mean to touch.
+vi.mock("./remoteMachine", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./remoteMachine")>()),
+  remoteMachineState,
+  disconnectRemoteMachine,
 }));
 
 vi.mock("./api", () => ({
@@ -139,7 +170,7 @@ vi.mock("./api", () => ({
     getPolicy = getPolicy;
     getGatewayStatus = getGatewayStatus;
     gatewaySignIn = vi.fn(async () => ({ authorization_url: "http://gw/authorize" }));
-    listModels = vi.fn(async () => ({ models: [], roles: [] }));
+    listModels = listModels;
     listProviders = vi.fn(async () => ({ providers: [] }));
     getSettings = getSettings;
     listCodeRepos = listCodeRepos;
@@ -296,6 +327,19 @@ beforeEach(() => {
       y: 0,
       toJSON: () => ({}),
     } as DOMRect);
+  listModels.mockReset();
+  listModels.mockResolvedValue({ models: [], roles: [] });
+  resolveServerInfo.mockReset();
+  resolveServerInfo.mockResolvedValue({
+    baseUrl: "http://127.0.0.1:1",
+    token: "t",
+    attachment: "local",
+    gatewayAuth: false,
+  });
+  remoteMachineState.mockReset();
+  remoteMachineState.mockResolvedValue({ attachment: "local", baseUrl: null });
+  disconnectRemoteMachine.mockReset();
+  disconnectRemoteMachine.mockResolvedValue({ attachment: "local", baseUrl: null });
   listChats.mockClear();
   listChats.mockResolvedValue(chats);
   createChat.mockClear();
@@ -403,6 +447,72 @@ describe("app shell", () => {
     expect(
       await screen.findByLabelText("Work needs attention"),
     ).toBeInTheDocument();
+  });
+
+  /**
+   * A boot failure used to be a locked door: the raw string and nothing to do
+   * about it. On a remote attachment that cost the reader the whole app,
+   * because the only command that forgets the machine lives behind Settings,
+   * and Settings lives behind the client that just failed to reach it.
+   */
+  it("offers a way off an unreachable remote machine", async () => {
+    remoteMachineState.mockResolvedValue({
+      attachment: "remote",
+      baseUrl: "https://tidebreak.example.com",
+    });
+    resolveServerInfo.mockResolvedValue({
+      baseUrl: "https://tidebreak.example.com",
+      token: "t",
+      attachment: "remote",
+      gatewayAuth: true,
+    });
+    listModels.mockRejectedValue(new TypeError("Load failed"));
+    const user = userEvent.setup();
+    await mountApp();
+
+    const failure = await screen.findByRole("alert");
+    expect(failure).toHaveTextContent(
+      "Could not reach https://tidebreak.example.com.",
+    );
+    expect(failure).toHaveTextContent("TypeError: Load failed");
+
+    // Detaching forgets the machine and boots again, this time against the
+    // server inside the app — so the shell that comes up is a working one.
+    listModels.mockResolvedValue({ models: [], roles: [] });
+    resolveServerInfo.mockResolvedValue({
+      baseUrl: "http://127.0.0.1:1",
+      token: "t",
+      attachment: "local",
+      gatewayAuth: false,
+    });
+    await user.click(screen.getByRole("button", { name: /Work on this computer/ }));
+
+    await waitFor(() => expect(disconnectRemoteMachine).toHaveBeenCalledOnce());
+    expect(await screen.findByText("Welcome to Tidebreak")).toBeInTheDocument();
+  });
+
+  it("retries boot when the connection itself failed", async () => {
+    resolveServerInfo.mockRejectedValue(new Error("server failed to start"));
+    const user = userEvent.setup();
+    await mountApp();
+
+    const failure = await screen.findByRole("alert");
+    expect(failure).toHaveTextContent("Tidebreak could not start its server.");
+    // Nothing to detach from, so the screen does not offer it.
+    expect(
+      screen.queryByRole("button", { name: /Work on this computer/ }),
+    ).not.toBeInTheDocument();
+
+    resolveServerInfo.mockResolvedValue({
+      baseUrl: "http://127.0.0.1:1",
+      token: "t",
+      attachment: "local",
+      gatewayAuth: false,
+    });
+    await user.click(screen.getByRole("button", { name: /Try again/ }));
+
+    expect(await screen.findByText("Welcome to Tidebreak")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("keeps the shell up with a retryable list when loading chats fails", async () => {

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { Outlet, useNavigate, useRouter } from "@tanstack/react-router";
+import { getVersion } from "@tauri-apps/api/app";
 import { isTauri } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { toast } from "sonner";
@@ -15,7 +16,16 @@ import {
 import { AppContextProvider } from "./AppContext";
 
 import { resolveServerInfo } from "./boot";
-import { remoteMachineAccessToken } from "./remoteMachine";
+import {
+  BootFailure,
+  type BootAttachment,
+  type BootStage,
+} from "./BootFailure";
+import {
+  disconnectRemoteMachine,
+  remoteMachineAccessToken,
+  remoteMachineState,
+} from "./remoteMachine";
 import {
   deletionDescription,
   detachChatFolders,
@@ -132,7 +142,22 @@ function GatedShellHooks({
  */
 export function AppShell() {
   const navigate = useNavigate();
-  const [bootError, setBootError] = useState<string | null>(null);
+  const [bootFailure, setBootFailure] = useState<{
+    stage: BootStage;
+    error: unknown;
+  } | null>(null);
+  // Bumped by the boot screen's "Try again". Boot is otherwise a mount-once
+  // effect, so without this a reader who fixed the cause — reconnected the
+  // VPN, woke the other machine — had no way to act on it but to quit.
+  const [bootAttempt, setBootAttempt] = useState(0);
+  // What the shell says this window is attached to. Read separately from
+  // `info` because the connect stage can fail before `info` exists, and the
+  // boot screen's whole job in that case is to name the machine it could not
+  // reach.
+  const [bootAttachment, setBootAttachment] = useState<BootAttachment | null>(
+    null,
+  );
+  const [appVersion, setAppVersion] = useState<string | null>(null);
   const [info, setInfo] = useState<ServerInfo | null>(null);
   const [client, setClient] = useState<ApiClient | null>(null);
   const [models, setModels] = useState<ModelInfo[]>([]);
@@ -269,12 +294,49 @@ export function AppShell() {
     "show-shortcuts": () => setShortcutsOpen(true),
   };
 
+  // The app version, for the boot screen's debug report. Only the packaged
+  // host can report one; a browser dev build simply has none.
+  useEffect(() => {
+    if (!hasNativeHost()) return;
+    let cancelled = false;
+    void getVersion()
+      .then((value) => {
+        if (!cancelled) setAppVersion(value);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     void (async () => {
+      // Asked before the connection, and independently of it: this is the
+      // shell's own record of the address, so it still answers when the
+      // attachment it describes is exactly what failed to connect.
+      try {
+        const state = await remoteMachineState();
+        if (!cancelled) {
+          setBootAttachment({
+            attachment: state.attachment,
+            baseUrl: state.baseUrl,
+            gatewayAuth: null,
+          });
+        }
+      } catch {
+        // Not knowing the attachment costs the boot screen one sentence. It
+        // must never be the reason boot itself reports a failure.
+      }
       try {
         const server = await resolveServerInfo();
         if (cancelled) return;
+        setBootFailure(null);
+        setBootAttachment({
+          attachment: server.attachment,
+          baseUrl: server.attachment === "remote" ? server.baseUrl : null,
+          gatewayAuth: server.gatewayAuth,
+        });
         setInfo(server);
         setClient(new ApiClient(server.baseUrl, server.token));
         // Outputs are read over the same API; their module holds the
@@ -282,13 +344,13 @@ export function AppShell() {
         connectOutputs(server.baseUrl, server.token);
         setStatus(`connected ${server.baseUrl}`);
       } catch (err) {
-        if (!cancelled) setBootError(String(err));
+        if (!cancelled) setBootFailure({ stage: "connect", error: err });
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [bootAttempt]);
 
   useEffect(() => {
     if (!client || !info?.gatewayAuth) return;
@@ -323,8 +385,9 @@ export function AppShell() {
         setModels(catalog.models);
         setDefaultModelKey(resolvedRoleKey(catalog.roles, "chat"));
         setProviders(providerList.providers);
+        setBootFailure(null);
       } catch (err) {
-        if (!cancelled) setBootError(String(err));
+        if (!cancelled) setBootFailure({ stage: "catalog", error: err });
       }
     })();
     return () => {
@@ -706,16 +769,53 @@ export function AppShell() {
     if (confirmed) await desktopUpdates.restart();
   }
 
-  if (bootError) {
+  /**
+   * Run boot again from the top.
+   *
+   * Clearing the client as well as the failure matters: a catalog-stage
+   * failure leaves a client built against a machine that just proved
+   * unreachable, and re-running connect is the only thing that replaces it —
+   * after a detach it has to, because the address it holds is gone.
+   */
+  function retryBoot() {
+    setBootFailure(null);
+    setClient(null);
+    setInfo(null);
+    setStatus("starting…");
+    setBootAttempt((attempt) => attempt + 1);
+  }
+
+  /**
+   * Forget the attached machine and boot against the server inside this app.
+   *
+   * The same command the Machine settings panel runs, offered here because a
+   * reader whose remote machine is unreachable cannot get to that panel — the
+   * panel lives behind the client that failed to reach it.
+   */
+  async function workOnThisComputer() {
+    try {
+      await disconnectRemoteMachine();
+      setBootAttachment({
+        attachment: "local",
+        baseUrl: null,
+        gatewayAuth: null,
+      });
+      retryBoot();
+    } catch (err) {
+      setBootFailure({ stage: "connect", error: err });
+    }
+  }
+
+  if (bootFailure) {
     return (
-      <div className="boot">
-        <WindowDragStrip />
-        <div className="boot-brand">
-          <Logomark />
-          <h1>Tidebreak</h1>
-        </div>
-        <p>{bootError}</p>
-      </div>
+      <BootFailure
+        stage={bootFailure.stage}
+        error={bootFailure.error}
+        attachment={bootAttachment}
+        appVersion={appVersion}
+        onRetry={retryBoot}
+        onWorkLocally={workOnThisComputer}
+      />
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/BootFailure.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/BootFailure.dom.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BootFailure, bootDebugReport, type BootAttachment } from "./BootFailure";
+
+vi.mock("./host", () => ({
+  hasMacOverlayTitlebar: () => false,
+}));
+
+const remote: BootAttachment = {
+  attachment: "remote",
+  baseUrl: "https://tidebreak.example.com",
+  gatewayAuth: true,
+};
+
+const local: BootAttachment = {
+  attachment: "local",
+  baseUrl: null,
+  gatewayAuth: false,
+};
+
+function renderFailure(overrides: Partial<Parameters<typeof BootFailure>[0]> = {}) {
+  const props = {
+    stage: "catalog" as const,
+    error: new TypeError("Load failed"),
+    attachment: remote,
+    appVersion: "0.58.0",
+    onRetry: vi.fn(),
+    onWorkLocally: vi.fn(async () => {}),
+    writeClipboard: vi.fn(async () => {}),
+    ...overrides,
+  };
+  render(<BootFailure {...props} />);
+  return props;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("BootFailure", () => {
+  it("names the machine it could not reach and keeps the raw error", () => {
+    renderFailure();
+
+    const screenRoot = screen.getByRole("alert");
+    expect(screenRoot).toHaveTextContent(
+      "Could not reach https://tidebreak.example.com.",
+    );
+    // The raw string still matters — it is what a reader pastes into a bug
+    // report — it just no longer stands alone as the entire screen.
+    expect(screenRoot).toHaveTextContent("TypeError: Load failed");
+  });
+
+  it("offers a way back to this computer only when attached to another one", async () => {
+    const user = userEvent.setup();
+    const { onWorkLocally } = renderFailure();
+
+    await user.click(screen.getByRole("button", { name: /Work on this computer/ }));
+    await waitFor(() => expect(onWorkLocally).toHaveBeenCalledOnce());
+
+    cleanup();
+    renderFailure({ attachment: local });
+    expect(
+      screen.queryByRole("button", { name: /Work on this computer/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("always offers a retry", async () => {
+    const user = userEvent.setup();
+    const { onRetry } = renderFailure({ attachment: local, stage: "connect" });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Tidebreak could not start its server.",
+    );
+    await user.click(screen.getByRole("button", { name: /Try again/ }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("copies the debug report and says so", async () => {
+    const user = userEvent.setup();
+    const writeClipboard = vi.fn(async (_text: string) => {});
+    renderFailure({ writeClipboard });
+
+    await user.click(screen.getByRole("button", { name: "Copy debug info" }));
+
+    await waitFor(() => expect(writeClipboard).toHaveBeenCalledOnce());
+    const copied = JSON.parse(writeClipboard.mock.calls[0][0]);
+    expect(copied.remoteBaseUrl).toBe("https://tidebreak.example.com");
+    expect(copied.stage).toBe("catalog");
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+});
+
+describe("bootDebugReport", () => {
+  const report = (over: Record<string, unknown> = {}) =>
+    bootDebugReport({
+      stage: "catalog",
+      error: new TypeError("Load failed"),
+      attachment: remote,
+      appVersion: "0.58.0",
+      capturedAt: "2026-08-21T12:49:00.000Z",
+      userAgent: "Test/1.0",
+      ...over,
+    });
+
+  it("carries what a reader would be asked for", () => {
+    expect(JSON.parse(report())).toEqual({
+      capturedAt: "2026-08-21T12:49:00.000Z",
+      appVersion: "0.58.0",
+      stage: "catalog",
+      attachment: "remote",
+      remoteBaseUrl: "https://tidebreak.example.com",
+      gatewayAuth: true,
+      error: { name: "TypeError", message: "Load failed" },
+      userAgent: "Test/1.0",
+    });
+  });
+
+  /**
+   * The point of the control is that the payload is safe to paste in public.
+   * The bearer this window would have used is one careless spread away from
+   * the clipboard, so the shape is asserted rather than trusted.
+   */
+  it("carries no credential, whatever the failure was carrying", () => {
+    const error = new Error("refused") as Error & { token?: string };
+    error.token = "super-secret-bearer";
+    const serialized = report({ error });
+
+    expect(serialized).not.toContain("super-secret-bearer");
+    expect(serialized.toLowerCase()).not.toContain("authorization");
+    expect(JSON.parse(serialized).error).toEqual({
+      name: "Error",
+      message: "refused",
+    });
+  });
+
+  it("reports a thrown non-error without losing it", () => {
+    expect(JSON.parse(report({ error: "plain string failure" })).error).toEqual({
+      name: null,
+      message: "plain string failure",
+    });
+  });
+
+  it("says nothing about an attachment it could not read", () => {
+    const parsed = JSON.parse(report({ attachment: null }));
+    expect(parsed.attachment).toBeNull();
+    expect(parsed.remoteBaseUrl).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/BootFailure.tsx
+++ b/crates/tidebreak-desktop/ui/src/BootFailure.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from "react";
+import { Laptop, RotateCw } from "lucide-react";
+
+import type { Attachment } from "./api";
+import { copyPlainText } from "./ClipboardCopyButton";
+import { Logomark } from "./Logomark";
+import { WindowDragStrip } from "./WindowDragStrip";
+import { Button } from "@/components/ui/button";
+
+/**
+ * The screen a reader lands on when the shell cannot reach the API it is
+ * attached to.
+ *
+ * This used to be the logomark and the raw caught string, and nothing else. On
+ * a remote attachment that is a locked door: the address lives in the shell,
+ * the only command that forgets it is behind Settings, and Settings is behind
+ * the very client that failed to boot. A transient outage on the other machine
+ * therefore cost the reader the whole app until someone edited
+ * `remote-machine.json` by hand.
+ *
+ * So the screen carries the three things the reader needs: which machine could
+ * not be reached, a way to try again, and — when the answer is "that machine is
+ * not coming back right now" — a way to return this window to the server inside
+ * the app. The raw error stays, under the copy the reader can act on.
+ */
+
+/** Which step of boot failed. */
+export type BootStage = "connect" | "catalog";
+
+/** What the shell knew about its attachment when boot failed. */
+export type BootAttachment = {
+  attachment: Attachment;
+  baseUrl: string | null;
+  /**
+   * Whether the bearer is a Gateway-minted one. `null` before the connection
+   * resolves: the shell's address file records the machine, not how this
+   * window ends up authenticating to it, and a debug report that guessed
+   * `false` there would send a reader looking in the wrong place.
+   */
+  gatewayAuth: boolean | null;
+};
+
+export type BootFailureProps = {
+  stage: BootStage;
+  error: unknown;
+  attachment: BootAttachment | null;
+  appVersion: string | null;
+  onRetry: () => void;
+  onWorkLocally: () => Promise<void>;
+  /** Injectable for tests; defaults to the real clipboard. */
+  writeClipboard?: (text: string) => Promise<void>;
+};
+
+/**
+ * Stated next to the copy control. The payload names the machine this window
+ * is attached to and carries the failure verbatim; a reader pasting that into
+ * an issue should know what they are pasting before they paste it.
+ */
+export const BOOT_DEBUG_CONTENTS_NOTICE =
+  "Includes the machine address, the app version, and the error. No credentials.";
+
+/**
+ * The diagnostic payload, as a formatted JSON document.
+ *
+ * Deliberately built from named fields rather than from the objects they came
+ * out of: `ServerInfo` carries the bearer token this window would have used,
+ * and the whole value of a copy control on a boot screen is that a reader can
+ * paste it somewhere public. Widening this to spread an existing object would
+ * put the token one refactor away from the clipboard.
+ */
+export function bootDebugReport(input: {
+  stage: BootStage;
+  error: unknown;
+  attachment: BootAttachment | null;
+  appVersion: string | null;
+  capturedAt: string;
+  userAgent: string | null;
+}): string {
+  const error =
+    input.error instanceof Error
+      ? { name: input.error.name, message: input.error.message }
+      : { name: null, message: String(input.error) };
+  return JSON.stringify(
+    {
+      capturedAt: input.capturedAt,
+      appVersion: input.appVersion,
+      stage: input.stage,
+      attachment: input.attachment?.attachment ?? null,
+      remoteBaseUrl: input.attachment?.baseUrl ?? null,
+      gatewayAuth: input.attachment?.gatewayAuth ?? null,
+      error,
+      userAgent: input.userAgent,
+    },
+    null,
+    2,
+  );
+}
+
+/** The remote machine's address, or `null` when this is a local boot. */
+function attachedMachine(attachment: BootAttachment | null): string | null {
+  if (!attachment || attachment.attachment !== "remote") return null;
+  return attachment.baseUrl;
+}
+
+function headline(attachment: BootAttachment | null, stage: BootStage): string {
+  const machine = attachedMachine(attachment);
+  if (machine) return `Could not reach ${machine}.`;
+  return stage === "connect"
+    ? "Tidebreak could not start its server."
+    : "Tidebreak started, but could not load its models.";
+}
+
+export function BootFailure({
+  stage,
+  error,
+  attachment,
+  appVersion,
+  onRetry,
+  onWorkLocally,
+  writeClipboard = copyPlainText,
+}: BootFailureProps) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const [detaching, setDetaching] = useState(false);
+  const machine = attachedMachine(attachment);
+
+  useEffect(() => {
+    if (copyState === "idle") return;
+    const timer = window.setTimeout(() => setCopyState("idle"), 3_000);
+    return () => window.clearTimeout(timer);
+  }, [copyState]);
+
+  async function onCopy() {
+    try {
+      await writeClipboard(
+        bootDebugReport({
+          stage,
+          error,
+          attachment,
+          appVersion,
+          capturedAt: new Date().toISOString(),
+          userAgent: globalThis.navigator?.userAgent ?? null,
+        }),
+      );
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+  }
+
+  async function onDetach() {
+    setDetaching(true);
+    try {
+      await onWorkLocally();
+    } finally {
+      setDetaching(false);
+    }
+  }
+
+  return (
+    <div className="boot" role="alert">
+      <WindowDragStrip />
+      <div className="boot-brand">
+        <Logomark />
+        <h1>Tidebreak</h1>
+      </div>
+      <p>{headline(attachment, stage)}</p>
+      <p className="boot-error-detail">{String(error)}</p>
+      {machine && (
+        <p className="boot-error-hint">
+          Work on that machine keeps running. Returning to this computer changes
+          nothing there.
+        </p>
+      )}
+      <div className="boot-actions">
+        <Button size="sm" onClick={onRetry} disabled={detaching}>
+          <RotateCw size={16} aria-hidden />
+          Try again
+        </Button>
+        {machine && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => void onDetach()}
+            disabled={detaching}
+          >
+            <Laptop size={16} aria-hidden />
+            Work on this computer
+          </Button>
+        )}
+        <Button size="sm" variant="ghost" onClick={() => void onCopy()}>
+          {copyState === "copied"
+            ? "Copied"
+            : copyState === "failed"
+              ? "Copy failed"
+              : "Copy debug info"}
+        </Button>
+      </div>
+      <p className="boot-error-hint">{BOOT_DEBUG_CONTENTS_NOTICE}</p>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/BootFailure.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/BootFailure.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { BootFailure } from "@/BootFailure";
+
+/**
+ * The screen the shell falls back to when it cannot reach the API it is
+ * attached to.
+ *
+ * Worth a story because it is otherwise only reachable by breaking the
+ * network: the states below are the ones that decide whether a reader can get
+ * themselves out of it, and they differ mostly in which recovery is on offer.
+ */
+const meta = {
+  title: "Shell/Boot failure",
+  component: BootFailure,
+  parameters: { layout: "fullscreen" },
+  args: {
+    stage: "catalog",
+    error: new TypeError("Load failed"),
+    appVersion: "0.58.0",
+    onRetry: fn(),
+    onWorkLocally: fn(async () => {}),
+    writeClipboard: fn(async () => {}),
+    attachment: {
+      attachment: "remote",
+      baseUrl: "https://tidebreak.example.com",
+      gatewayAuth: true,
+    },
+  },
+} satisfies Meta<typeof BootFailure>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The state this screen exists for: the window is attached to another machine
+ * that stopped answering, so the reader is offered a way back to this one.
+ */
+export const UnreachableRemoteMachine: Story = {};
+
+/**
+ * The embedded server failed to start. Nothing to detach from, so retry is the
+ * only recovery — and the reader still gets the error and a way to report it.
+ */
+export const LocalServerFailed: Story = {
+  args: {
+    stage: "connect",
+    error: new Error("another instance already owns this data directory"),
+    attachment: { attachment: "local", baseUrl: null, gatewayAuth: false },
+  },
+};
+
+/**
+ * The connection resolved but the catalog did not. The machine is local, so
+ * the headline names the step rather than an address.
+ */
+export const LocalCatalogFailed: Story = {
+  args: {
+    error: new Error("500: could not read the model catalog"),
+    attachment: { attachment: "local", baseUrl: null, gatewayAuth: false },
+  },
+};
+
+/**
+ * The shell could not even read its own attachment — the boot screen degrades
+ * to the generic sentence rather than claiming a machine it cannot name.
+ */
+export const AttachmentUnknown: Story = {
+  args: { stage: "connect", attachment: null },
+};
+
+/**
+ * A long address and a long error, which is the realistic shape of a failure
+ * worth copying. Pins that neither one breaks the layout.
+ */
+export const LongDetail: Story = {
+  args: {
+    attachment: {
+      attachment: "remote",
+      baseUrl: "https://tidebreak.some-quite-long-internal-hostname.example.com",
+      gatewayAuth: true,
+    },
+    error: new Error(
+      "TypeError: Load failed — the machine did not answer within the " +
+        "request timeout, and no response headers were received",
+    ),
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -1555,6 +1555,19 @@ body {
   overflow-wrap: anywhere;
 }
 
+.boot .boot-error-hint {
+  max-width: 34rem;
+  font-size: 0.8rem;
+}
+
+.boot-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
 /* A transcript phase whose row threw while rendering. Deliberately quiet: the
    conversation around it is intact, and the step itself is recoverable from the
    durable record. */


### PR DESCRIPTION
## What

The boot screen rendered the caught error and nothing else. This is what a
reader saw this morning after the remote machine briefly stopped answering:

> **Tidebreak**
>
> TypeError: Load failed

Attached to a remote machine, that is a locked door. The address lives in the
shell, the only command that forgets it (`disconnect_remote_machine`) is behind
the Machine settings panel, and that panel is behind the very client that just
failed to reach the machine. Recovery meant quitting the app and editing
`remote-machine.json` by hand.

The screen now carries what the reader needs to act:

- **Which machine.** `Could not reach https://…` when attached remotely, and a
  sentence naming the step otherwise. The raw error stays underneath.
- **Try again.** Boot was a mount-once effect, so a reader who reconnected the
  VPN or woke the other machine had no way to say so.
- **Work on this computer.** The same command the Machine panel runs, offered
  where a reader who cannot open that panel can still reach it.
- **Copy debug info.** A JSON report — app version, stage, attachment, error.

## What is not here

The underlying network failure is not reproducible: the machine and the gateway
both answer fine from this laptop now (`/models` → 401, CORS echoes
`tauri://localhost`), so the outage looks transient. This PR is about the part
that was not transient — a transient outage should not cost you the app.

## Credentials

`ServerInfo` carries the bearer this window would have used, and the point of a
copy control is that the payload is safe to paste in public. `bootDebugReport`
is built from named fields rather than by spreading an existing object, and a
test asserts the serialized output carries neither the token nor an
`authorization` key.

## Tests

- `BootFailure.dom.test.tsx` — headline, the recoveries each state offers, the
  copy, and the report's shape including redaction.
- `AppShell.dom.test.tsx` — an unreachable remote machine detaches into a
  working local shell; a connect failure retries and clears.
- `stories/BootFailure.stories.tsx` — the five states, per `CLAUDE.md`.

Full UI suite green locally (210 files, 1551 tests); `tsc --noEmit` and
`storybook:build` clean.