### PR TITLE
feat(browser): bridge wait and screenshot into code sessions

### DIFF
--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -858,6 +858,63 @@ impl BrowserRegistry {
         Ok(record.snapshot(browser_id, agent_access_for_record(&state, record)))
     }
 
+    /// Re-check live authorization for observation without clearing the
+    /// stored semantic snapshot.
+    ///
+    /// Unlike [`begin_agent_control`](Self::begin_agent_control), this
+    /// preserves `semantic_snapshot` and `screenshot_epoch` so a wait or
+    /// screenshot can chain on a prior snapshot. Used by observation-only
+    /// operations (wait, screenshot) that validate `snapshot_id` and
+    /// `document_epoch` against the stored snapshot.
+    ///
+    /// Requires exclusive agent control from a prior
+    /// [`begin_agent_control`](Self::begin_agent_control) — this method does
+    /// NOT acquire or mutate controller state. It returns
+    /// `"browser is not controlled by this agent"` when the controller is not
+    /// already this agent capability (human takeover, different agent, or
+    /// no prior control). Two concurrent observers for the same browser by
+    /// different capabilities are refused.
+    pub(crate) fn begin_agent_observation(
+        &self,
+        capability_id: Uuid,
+        browser_id: &str,
+    ) -> Result<BrowserSnapshot, String> {
+        let state = self.lock();
+        let capability = active_capability(&state, capability_id)?.clone();
+        let record = state
+            .records
+            .get(browser_id)
+            .ok_or_else(|| "browser session is not registered".to_owned())?;
+        ensure_workspace(browser_id, &capability.workspace_id, record)?;
+        let origin = current_origin(record)
+            .ok_or_else(|| "browser has no authorized HTTP origin".to_owned())?;
+        if !record.visible {
+            return Err("browser is hidden".to_owned());
+        }
+        if *record.dispatch.halt.borrow() {
+            return Err("browser control was stopped by the user".to_owned());
+        }
+        if !grants_cover(
+            &state,
+            &capability.workspace_id,
+            &origin,
+            BrowserGrantCapability::BrowserObserveOrigin,
+        ) {
+            return Err("browser origin is not shared with this agent".to_owned());
+        }
+        // Observation does NOT acquire or mutate controller state — it only
+        // succeeds when this capability already holds exclusive agent control
+        // (set by a prior begin_agent_control). A human takeover, a different
+        // agent, or no controller at all is refused. This preserves the stored
+        // semantic snapshot that issued the refs the observation chains from.
+        if record.controller.kind != BrowserControllerKind::Agent
+            || record.controller_capability_id != Some(capability_id)
+        {
+            return Err("browser is not controlled by this agent".to_owned());
+        }
+        Ok(record.snapshot(browser_id, agent_access_for_record(&state, record)))
+    }
+
     pub(crate) fn set_agent_action(
         &self,
         capability_id: Uuid,
@@ -2948,6 +3005,128 @@ mod tests {
             .is_err());
     }
 
+    // ── begin_agent_observation tests ─────────────────────────────
+
+    #[test]
+    fn begin_agent_observation_preserves_stored_snapshot_for_same_capability() {
+        let (registry, _, _origin, capability, _private) = controlled_registry();
+        // First acquire control via begin_agent_control (clears snapshot).
+        let _ = registry
+            .begin_agent_control(capability, "browser-1")
+            .unwrap();
+        // Then record a snapshot — this is what a real snapshot op does.
+        registry
+            .record_semantic_snapshot(
+                "browser-1",
+                "workspace-1",
+                0,
+                "snapshot-1".to_owned(),
+                HashMap::from([("@e1".to_owned(), target("Continue"))]),
+            )
+            .unwrap();
+
+        // begin_agent_observation must NOT clear the stored snapshot.
+        let _snap = registry
+            .begin_agent_observation(capability, "browser-1")
+            .unwrap();
+
+        registry
+            .validate_snapshot_id("browser-1", "workspace-1", "snapshot-1", 0)
+            .expect("snapshot must survive begin_agent_observation");
+    }
+
+    #[test]
+    fn begin_agent_observation_refuses_wrong_capability() {
+        let (registry, _, _origin, capability, _private) = controlled_registry();
+        let other = registry.issue_agent_capability("workspace-1", "Other");
+
+        let result = registry.begin_agent_observation(other, "browser-1");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not controlled by this agent"));
+        assert!(registry
+            .begin_agent_observation(capability, "browser-1")
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn begin_agent_observation_refuses_human_takeover() {
+        let (registry, _, _origin, capability, _private) = controlled_registry();
+        // Human takes over — clears the agent controller.
+        registry
+            .take_human_control("browser-1", "workspace-1")
+            .await
+            .unwrap();
+
+        // Observation must refuse: a human currently holds the browser.
+        let result = registry.begin_agent_observation(capability, "browser-1");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not controlled by this agent"));
+    }
+
+    #[test]
+    fn begin_agent_observation_refuses_no_prior_control() {
+        // ready_registry() registers a browser but issues no capability
+        // and calls no begin_agent_control — the controller is Human.
+        let (registry, _private) = ready_registry(true);
+        let origin = BrowserOrigin::from_url("https://example.com").unwrap();
+        registry
+            .grant_browser_access(
+                "browser-1",
+                "workspace-1",
+                &origin,
+                BrowserOriginScope::Origin { origin },
+                &[BrowserGrantCapability::BrowserControlOrigin],
+            )
+            .unwrap();
+        let capability = registry.issue_agent_capability("workspace-1", "Code agent");
+        let result = registry.begin_agent_observation(capability, "browser-1");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not controlled by this agent"));
+    }
+
+    #[tokio::test]
+    async fn begin_agent_observation_refuses_after_stop() {
+        let (registry, _, _origin, capability, _private) = controlled_registry();
+        let _ = registry
+            .begin_agent_control(capability, "browser-1")
+            .unwrap();
+        registry
+            .stop_agent_control("browser-1", "workspace-1")
+            .await
+            .unwrap();
+        let result = registry.begin_agent_observation(capability, "browser-1");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("stopped"));
+    }
+
+    #[test]
+    fn begin_agent_observation_same_capability_continuation_preserves_snapshot() {
+        let (registry, _, _origin, capability, _private) = controlled_registry();
+        let _ = registry
+            .begin_agent_control(capability, "browser-1")
+            .unwrap();
+        registry
+            .record_semantic_snapshot(
+                "browser-1",
+                "workspace-1",
+                0,
+                "snap-2".to_owned(),
+                HashMap::from([("@btn".to_owned(), target("Submit"))]),
+            )
+            .unwrap();
+
+        // Same capability, observation continues.
+        let snap = registry
+            .begin_agent_observation(capability, "browser-1")
+            .unwrap();
+        assert_eq!(snap.controller.unwrap().kind, BrowserControllerKind::Agent);
+
+        // Snapshot still validates.
+        registry
+            .validate_snapshot_id("browser-1", "workspace-1", "snap-2", 0)
+            .expect("snapshot must persist across observation continuation");
+    }
+
     #[tokio::test]
     async fn observation_fence_and_halt_watch_fail_closed_on_stop() {
         let (registry, instance, _origin, capability, _private) = controlled_registry();
@@ -3126,8 +3305,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn complete_screenshot_recording_rejects_wrong_instance() {
+    #[test]
+    fn complete_screenshot_recording_rejects_wrong_instance() {
         let (registry, instance, _origin, capability, _private) = controlled_registry();
         registry
             .record_semantic_snapshot(
@@ -3154,8 +3333,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn complete_screenshot_recording_rejects_forged_snapshot_id() {
+    #[test]
+    fn complete_screenshot_recording_rejects_forged_snapshot_id() {
         let (registry, instance, _origin, capability, _private) = controlled_registry();
         registry
             .record_semantic_snapshot(
@@ -3176,8 +3355,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn complete_screenshot_recording_rejects_missing_snapshot() {
+    #[test]
+    fn complete_screenshot_recording_rejects_missing_snapshot() {
         let (registry, instance, _origin, capability, _private) = controlled_registry();
         // No record_semantic_snapshot call — there is no stored snapshot.
 

--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -3074,7 +3074,9 @@ mod tests {
                 "browser-1",
                 "workspace-1",
                 &origin,
-                BrowserOriginScope::Origin { origin },
+                BrowserOriginScope::Origin {
+                    origin: origin.clone(),
+                },
                 &[BrowserGrantCapability::BrowserControlOrigin],
             )
             .unwrap();

--- a/crates/tidebreak-desktop/src/browser_runtime_adapter.rs
+++ b/crates/tidebreak-desktop/src/browser_runtime_adapter.rs
@@ -13,7 +13,8 @@ use async_trait::async_trait;
 use tauri::AppHandle;
 use tidebreak_core::{
     BrowserListResult, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
-    BrowserSnapshotArgs, CodeSessionId, OwnerId, WorkspaceId,
+    BrowserScreenshotArgs, BrowserScreenshotResult, BrowserSnapshotArgs, BrowserWaitArgs,
+    BrowserWaitResult, CodeSessionId, OwnerId, WorkspaceId,
 };
 use tidebreak_server::{BrowserRuntime, BrowserRuntimeError, BrowserRuntimeScope};
 use uuid::Uuid;
@@ -73,6 +74,38 @@ impl BrowserRuntime for DesktopBrowserRuntime {
     ) -> Result<BrowserPageSnapshot, BrowserRuntimeError> {
         let capability_id = self.sessions.capability_for(&self.registry, scope)?;
         crate::browser_semantics::browser_semantic_snapshot(
+            &self.app,
+            &self.registry,
+            capability_id,
+            args.clone(),
+        )
+        .await
+        .map_err(|error| map_native_error(Some(&args.browser_id), error))
+    }
+
+    async fn wait(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserWaitArgs,
+    ) -> Result<BrowserWaitResult, BrowserRuntimeError> {
+        let capability_id = self.sessions.capability_for(&self.registry, scope)?;
+        crate::browser_semantics::browser_wait(
+            &self.app,
+            &self.registry,
+            capability_id,
+            args.clone(),
+        )
+        .await
+        .map_err(|error| map_native_error(Some(&args.browser_id), error))
+    }
+
+    async fn screenshot(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserScreenshotArgs,
+    ) -> Result<BrowserScreenshotResult, BrowserRuntimeError> {
+        let capability_id = self.sessions.capability_for(&self.registry, scope)?;
+        crate::browser_semantics::browser_screenshot(
             &self.app,
             &self.registry,
             capability_id,
@@ -211,7 +244,22 @@ impl SessionCapabilities {
 }
 
 fn map_native_error(browser_id: Option<&str>, error: String) -> BrowserRuntimeError {
-    match error.as_str() {
+    // Strip known error-site prefixes so the inner authorization or stale
+    // reason is classified rather than collapsed to Failed.
+    fn strip_prefix(error: &str) -> &str {
+        for prefix in [
+            "screenshot authorization lapsed: ",
+            "screenshot recording failed: ",
+        ] {
+            if let Some(inner) = error.strip_prefix(prefix) {
+                return inner;
+            }
+        }
+        error
+    }
+
+    let inner = strip_prefix(error.as_str());
+    match inner {
         "browser capability is unavailable" => return BrowserRuntimeError::SessionEnded,
         "browser origin is not shared with this agent"
         | "browser origin is not shared for this operation"
@@ -239,14 +287,15 @@ fn map_native_error(browser_id: Option<&str>, error: String) -> BrowserRuntimeEr
     let Some(browser_id) = browser_id else {
         return BrowserRuntimeError::Failed(error);
     };
+    let inner = strip_prefix(error.as_str());
     if matches!(
-        error.as_str(),
+        inner,
         "browser session is not registered"
             | "browser session is not open"
             | "browser is hidden"
             | "browser is not controlled by this agent"
             | "browser is controlled by another agent"
-    ) || error == format!("browser session {browser_id} belongs to a different workspace")
+    ) || inner == format!("browser session {browser_id} belongs to a different workspace")
     {
         return BrowserRuntimeError::UnknownBrowserId(browser_id.to_owned());
     }
@@ -457,6 +506,41 @@ mod tests {
         assert_eq!(
             map_native_error(Some("browser-1"), message.clone()),
             BrowserRuntimeError::Failed(message)
+        );
+    }
+
+    #[test]
+    fn map_native_error_classifies_prefixed_screenshot_errors() {
+        // Prefixed authorization-lapse errors classify the inner cause.
+        assert_eq!(
+            map_native_error(
+                Some("browser-1"),
+                "screenshot authorization lapsed: browser capability is unavailable".to_owned(),
+            ),
+            BrowserRuntimeError::SessionEnded
+        );
+        assert_eq!(
+            map_native_error(
+                Some("browser-1"),
+                "screenshot authorization lapsed: browser is hidden".to_owned(),
+            ),
+            BrowserRuntimeError::UnknownBrowserId("browser-1".to_owned())
+        );
+        assert_eq!(
+            map_native_error(
+                Some("browser-1"),
+                "screenshot recording failed: browser document changed while screenshot was being captured".to_owned(),
+            ),
+            BrowserRuntimeError::StaleTarget
+        );
+    }
+
+    #[test]
+    fn map_native_error_preserves_original_error_on_unmatched_prefix() {
+        let original = "screenshot authorization lapsed: unknown browser reason".to_owned();
+        assert_eq!(
+            map_native_error(Some("browser-1"), original.clone()),
+            BrowserRuntimeError::Failed(original)
         );
     }
 }

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -558,7 +558,18 @@ pub(crate) async fn browser_wait(
     if !arguments.is_well_formed() {
         return Err("browser wait request is not valid".to_owned());
     }
-    let host_snapshot = registry.begin_agent_control(capability_id, &arguments.browser_id)?;
+    // Observation chained from a prior snapshot: re-check live authorization
+    // without clearing the stored snapshot (begin_agent_observation does not
+    // acquire or mutate controller state), then validate the caller's
+    // snapshot_id and document_epoch against the stored snapshot before
+    // dispatching the poll.
+    let host_snapshot = registry.begin_agent_observation(capability_id, &arguments.browser_id)?;
+    registry.validate_snapshot_id(
+        &arguments.browser_id,
+        &host_snapshot.workspace_id,
+        &arguments.snapshot_id,
+        arguments.document_epoch,
+    )?;
     let origin = host_snapshot
         .url
         .as_deref()
@@ -613,13 +624,32 @@ async fn poll_wait_condition(
     // The fence pins the controlled instance this wait started against; the
     // halt receiver lets Stop abort an in-flight probe or sleep immediately.
     let start_fence = registry.observation_fence(capability_id, &arguments.browser_id)?;
+    registry.validate_snapshot_id(
+        &arguments.browser_id,
+        &workspace_id,
+        &arguments.snapshot_id,
+        arguments.document_epoch,
+    )?;
     let mut halt = registry.subscribe_halt(&arguments.browser_id, &workspace_id)?;
 
-    // Capture the starting URL for UrlChanged condition
+    // Capture the starting URL only after the caller's exact snapshot and
+    // document epoch have been revalidated inside the serialized dispatch.
     let start_snapshot = registry.snapshot(&arguments.browser_id, &workspace_id)?;
+    if start_snapshot.document_epoch != Some(arguments.document_epoch) {
+        return Err("browser document changed since the snapshot was taken".to_owned());
+    }
     let start_url = start_snapshot.url.clone();
 
     loop {
+        let fence = registry.observation_fence(capability_id, &arguments.browser_id)?;
+        if fence.instance_id != start_fence.instance_id {
+            return Err("browser session was replaced while waiting".to_owned());
+        }
+        if fence.document_epoch != arguments.document_epoch
+            && !matches!(arguments.condition, BrowserWaitCondition::UrlChanged)
+        {
+            return Err("browser document changed since the snapshot was taken".to_owned());
+        }
         let snapshot = registry.snapshot(&arguments.browser_id, &workspace_id)?;
         let Some(document_epoch) = snapshot.document_epoch else {
             return Ok(wait_result(
@@ -629,6 +659,11 @@ async fn poll_wait_condition(
                 "browser document epoch is unavailable".to_owned(),
             ));
         };
+        if document_epoch != arguments.document_epoch
+            && !matches!(arguments.condition, BrowserWaitCondition::UrlChanged)
+        {
+            return Err("browser document changed since the snapshot was taken".to_owned());
+        }
 
         if *halt.borrow_and_update()
             || snapshot
@@ -695,11 +730,10 @@ async fn poll_wait_condition(
                 return Err("browser session was replaced while waiting".to_owned());
             }
             // UrlChanged resolves across documents by design. Every other
-            // condition was probed against `document_epoch`; if the document
-            // changed while the probe was in flight, discard the stale
-            // result and re-evaluate against the new document.
-            if fence.document_epoch == document_epoch
-                || matches!(arguments.condition, BrowserWaitCondition::UrlChanged)
+            // condition remains pinned to the caller's document epoch.
+            if matches!(arguments.condition, BrowserWaitCondition::UrlChanged)
+                || (document_epoch == arguments.document_epoch
+                    && fence.document_epoch == arguments.document_epoch)
             {
                 return Ok(wait_result(
                     &arguments.browser_id,
@@ -708,7 +742,7 @@ async fn poll_wait_condition(
                     "Wait condition satisfied.".to_owned(),
                 ));
             }
-            continue;
+            return Err("browser document changed since the snapshot was taken".to_owned());
         }
 
         let elapsed = start.elapsed().as_millis() as u64;
@@ -804,7 +838,9 @@ pub(crate) async fn browser_screenshot(
     if !arguments.is_well_formed() {
         return Err("browser screenshot request is not valid".to_owned());
     }
-    let host_snapshot = registry.begin_agent_control(capability_id, &arguments.browser_id)?;
+    // Observation chained from a prior snapshot: use begin_agent_observation
+    // so the stored snapshot survives for validate_snapshot_id below.
+    let host_snapshot = registry.begin_agent_observation(capability_id, &arguments.browser_id)?;
     let origin = host_snapshot
         .url
         .as_deref()

--- a/crates/tidebreak-server/src/code/browser_runtime.rs
+++ b/crates/tidebreak-server/src/code/browser_runtime.rs
@@ -16,7 +16,8 @@ use async_trait::async_trait;
 
 use tidebreak_core::{
     BrowserListResult, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
-    BrowserSnapshotArgs, CodeSessionId, OwnerId, WorkspaceId,
+    BrowserScreenshotArgs, BrowserScreenshotResult, BrowserSnapshotArgs, BrowserWaitArgs,
+    BrowserWaitResult, CodeSessionId, OwnerId, WorkspaceId,
 };
 
 // ── BrowserRuntimeScope ─────────────────────────────────────────────────────
@@ -101,6 +102,30 @@ pub trait BrowserRuntime: Send + Sync {
         scope: &BrowserRuntimeScope,
         args: &BrowserSnapshotArgs,
     ) -> Result<BrowserPageSnapshot, BrowserRuntimeError>;
+
+    /// Poll for a deterministic page condition on the tab in `args.browser_id`.
+    ///
+    /// `args.snapshot_id` and `args.document_epoch` are the caller's
+    /// last-known snapshot; the runtime must validate them before polling.
+    /// UrlChanged conditions resolve across document boundaries; every other
+    /// condition is bounded by `args.document_epoch`.
+    async fn wait(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserWaitArgs,
+    ) -> Result<BrowserWaitResult, BrowserRuntimeError>;
+
+    /// Capture a base-64 PNG screenshot bounded by `args.snapshot_id` and
+    /// `args.document_epoch`.
+    ///
+    /// The runtime must atomically fence, validate, capture, and record the
+    /// screenshot against the live controller/instance/document/snapshot
+    /// state. A changed document or replaced instance must refuse.
+    async fn screenshot(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserScreenshotArgs,
+    ) -> Result<BrowserScreenshotResult, BrowserRuntimeError>;
 
     /// Synchronously revoke all browser capability for `scope.session`.
     ///

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -541,6 +541,14 @@ pub fn app(state: AppState) -> Router {
             "/code/browser/snapshot",
             post(routes::code::browser_snapshot),
         )
+        .route(
+            "/code/browser/wait",
+            post(routes::code::browser_wait),
+        )
+        .route(
+            "/code/browser/screenshot",
+            post(routes::code::browser_screenshot),
+        )
         .with_state(state.clone());
 
     let api = Router::new()

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -541,10 +541,7 @@ pub fn app(state: AppState) -> Router {
             "/code/browser/snapshot",
             post(routes::code::browser_snapshot),
         )
-        .route(
-            "/code/browser/wait",
-            post(routes::code::browser_wait),
-        )
+        .route("/code/browser/wait", post(routes::code::browser_wait))
         .route(
             "/code/browser/screenshot",
             post(routes::code::browser_screenshot),

--- a/crates/tidebreak-server/src/routes/code/browser.rs
+++ b/crates/tidebreak-server/src/routes/code/browser.rs
@@ -12,7 +12,8 @@ use axum::http::HeaderMap;
 
 use tidebreak_core::{
     db, BrowserListResult, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
-    BrowserSnapshotArgs, CodeSessionLifecycle, CodeWorkspaceStatus,
+    BrowserScreenshotArgs, BrowserScreenshotResult, BrowserSnapshotArgs, BrowserWaitArgs,
+    BrowserWaitResult, CodeSessionLifecycle, CodeWorkspaceStatus,
 };
 
 use crate::code::browser_channel::BrowserSubject;
@@ -62,6 +63,38 @@ pub async fn browser_snapshot(
     runtime
         .as_ref()
         .snapshot(&BrowserRuntimeScope::from(subject), &args)
+        .await
+        .map(Json)
+        .map_err(map_runtime_error)
+}
+
+pub async fn browser_wait(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+    Json(args): Json<BrowserWaitArgs>,
+) -> Result<Json<BrowserWaitResult>, ServerError> {
+    let subject = authorize(&state, &headers).await?;
+    require_well_formed(args.is_well_formed())?;
+    let runtime = attached_runtime(&state)?;
+    runtime
+        .as_ref()
+        .wait(&BrowserRuntimeScope::from(subject), &args)
+        .await
+        .map(Json)
+        .map_err(map_runtime_error)
+}
+
+pub async fn browser_screenshot(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: HeaderMap,
+    Json(args): Json<BrowserScreenshotArgs>,
+) -> Result<Json<BrowserScreenshotResult>, ServerError> {
+    let subject = authorize(&state, &headers).await?;
+    require_well_formed(args.is_well_formed())?;
+    let runtime = attached_runtime(&state)?;
+    runtime
+        .as_ref()
+        .screenshot(&BrowserRuntimeScope::from(subject), &args)
         .await
         .map(Json)
         .map_err(map_runtime_error)

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -26,7 +26,9 @@ mod workspaces;
 
 pub(crate) use crate::code::approval_bridge::approval_prompt;
 pub(crate) use approvals::{decide_approval, list_approvals};
-pub(crate) use browser::{browser_list, browser_navigate, browser_snapshot};
+pub(crate) use browser::{
+    browser_list, browser_navigate, browser_screenshot, browser_snapshot, browser_wait,
+};
 pub(crate) use delivery::{
     act_on_pull_request as act_on_delivery_pull_request, act_on_run as act_on_delivery_run,
     discover_repositories as discover_delivery_repositories,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -19,7 +19,8 @@ use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, BrowserListResult, BrowserNavigateArgs,
-    BrowserNavigateResult, BrowserPageSnapshot, BrowserSnapshotArgs, CapLevel, CodeEvent,
+    BrowserNavigateResult, BrowserPageSnapshot, BrowserScreenshotArgs, BrowserScreenshotResult,
+    BrowserSnapshotArgs, BrowserWaitArgs, BrowserWaitResult, CapLevel, CodeEvent,
     CodePermissionMode, CodeSessionId, CodeSessionLifecycle, CodeTurnId, CodeTurnStatus,
     CodeWorkspaceStatus, DbStore, FenceReason, HarnessKind, WorkspaceId,
 };
@@ -55,6 +56,22 @@ impl BrowserRuntime for RecordingBrowserRuntime {
         _args: &BrowserSnapshotArgs,
     ) -> Result<BrowserPageSnapshot, BrowserRuntimeError> {
         Err(BrowserRuntimeError::Unsupported("test snapshot".into()))
+    }
+
+    async fn wait(
+        &self,
+        _scope: &BrowserRuntimeScope,
+        _args: &BrowserWaitArgs,
+    ) -> Result<BrowserWaitResult, BrowserRuntimeError> {
+        Err(BrowserRuntimeError::Unsupported("test wait".into()))
+    }
+
+    async fn screenshot(
+        &self,
+        _scope: &BrowserRuntimeScope,
+        _args: &BrowserScreenshotArgs,
+    ) -> Result<BrowserScreenshotResult, BrowserRuntimeError> {
+        Err(BrowserRuntimeError::Unsupported("test screenshot".into()))
     }
 
     fn revoke_session(&self, scope: &BrowserRuntimeScope) {

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -143,7 +143,9 @@ impl BrowserRuntime for FakeBrowserRuntime {
     ) -> Result<BrowserWaitResult, BrowserRuntimeError> {
         self.record("wait", scope);
         if args.browser_id != "browser-1" {
-            return Err(BrowserRuntimeError::UnknownBrowserId(args.browser_id.clone()));
+            return Err(BrowserRuntimeError::UnknownBrowserId(
+                args.browser_id.clone(),
+            ));
         }
         if self.stale {
             return Err(BrowserRuntimeError::StaleTarget);
@@ -164,7 +166,9 @@ impl BrowserRuntime for FakeBrowserRuntime {
     ) -> Result<BrowserScreenshotResult, BrowserRuntimeError> {
         self.record("screenshot", scope);
         if args.browser_id != "browser-1" {
-            return Err(BrowserRuntimeError::UnknownBrowserId(args.browser_id.clone()));
+            return Err(BrowserRuntimeError::UnknownBrowserId(
+                args.browser_id.clone(),
+            ));
         }
         if self.stale {
             return Err(BrowserRuntimeError::StaleTarget);
@@ -724,7 +728,14 @@ async fn new_routes_require_capability_token() {
     let _t = mint_token(&a.code, ws, s);
     for rt in ["wait", "screenshot"] {
         assert_eq!(
-            post(a.addr, rt, None, serde_json::json!({"browser_id":"browser-1"})).await.status(),
+            post(
+                a.addr,
+                rt,
+                None,
+                serde_json::json!({"browser_id":"browser-1"}),
+            )
+            .await
+            .status(),
             reqwest::StatusCode::UNAUTHORIZED
         );
     }

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -16,8 +16,9 @@ use tidebreak_core::{
     db, Attention, AttentionSource, AttentionState, BrowserContentTrust, BrowserControllerState,
     BrowserEngineCapabilities, BrowserEngineDescriptor, BrowserEngineName, BrowserListResult,
     BrowserLoadState, BrowserNavigateArgs, BrowserNavigateResult, BrowserPageSnapshot,
-    BrowserSessionSummary, BrowserSnapshotArgs, BrowserViewport, CodePermissionMode, CodeRepo,
-    CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeWorkspace,
+    BrowserScreenshotArgs, BrowserScreenshotResult, BrowserSessionSummary, BrowserSnapshotArgs,
+    BrowserViewport, BrowserWaitArgs, BrowserWaitResult, BrowserWaitStatus, CodePermissionMode,
+    CodeRepo, CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeWorkspace,
     CodeWorkspaceStatus, DbStore, HarnessKind, OwnerId, RepoId, Store, WorkspaceId,
 };
 use tidebreak_harness::AdapterRegistry;
@@ -133,6 +134,47 @@ impl BrowserRuntime for FakeBrowserRuntime {
             nodes: vec![],
             frames: vec![],
             truncated: false,
+        })
+    }
+    async fn wait(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserWaitArgs,
+    ) -> Result<BrowserWaitResult, BrowserRuntimeError> {
+        self.record("wait", scope);
+        if args.browser_id != "browser-1" {
+            return Err(BrowserRuntimeError::UnknownBrowserId(args.browser_id.clone()));
+        }
+        if self.stale {
+            return Err(BrowserRuntimeError::StaleTarget);
+        }
+        Ok(BrowserWaitResult {
+            browser_id: args.browser_id.clone(),
+            status: BrowserWaitStatus::Resolved,
+            message: "Wait condition satisfied.".into(),
+            document_epoch: 2,
+            url: Some("https://example.com".into()),
+            title: Some("Example".into()),
+        })
+    }
+    async fn screenshot(
+        &self,
+        scope: &BrowserRuntimeScope,
+        args: &BrowserScreenshotArgs,
+    ) -> Result<BrowserScreenshotResult, BrowserRuntimeError> {
+        self.record("screenshot", scope);
+        if args.browser_id != "browser-1" {
+            return Err(BrowserRuntimeError::UnknownBrowserId(args.browser_id.clone()));
+        }
+        if self.stale {
+            return Err(BrowserRuntimeError::StaleTarget);
+        }
+        Ok(BrowserScreenshotResult {
+            browser_id: args.browser_id.clone(),
+            snapshot_id: args.snapshot_id.clone(),
+            document_epoch: 2,
+            image_base64: "AAAA".into(),
+            mime_type: "image/png".into(),
         })
     }
     fn revoke_session(&self, scope: &BrowserRuntimeScope) {
@@ -493,6 +535,248 @@ async fn navigate_refuses_non_http() {
 }
 
 #[tokio::test]
+async fn wait_roundtrip() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "wait",
+        Some(&t),
+        serde_json::json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2,
+            "condition": {"kind": "load_state", "state": "ready"},
+            "timeout_ms": 5000
+        }),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    let b: serde_json::Value = r.json().await.unwrap();
+    assert_eq!(b["status"], "resolved");
+    assert_eq!(b["browserId"], "browser-1");
+}
+
+#[tokio::test]
+async fn wait_refuses_missing_browser_id() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    assert_eq!(
+        post(
+            a.addr,
+            "wait",
+            Some(&t),
+            serde_json::json!({
+                "browser_id": "browser-9",
+                "snapshot_id": "snapshot-1",
+                "document_epoch": 2,
+                "condition": {"kind": "load_state", "state": "ready"}
+            })
+        )
+        .await
+        .status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+}
+
+#[tokio::test]
+async fn wait_refuses_non_well_formed() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    assert_eq!(
+        post(
+            a.addr,
+            "wait",
+            Some(&t),
+            serde_json::json!({"browser_id":"b-1","snapshot_id":"s","document_epoch":0,"condition":{"kind":"text_present","text":""},"timeout_ms":99999})
+        )
+        .await
+        .status(),
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY
+    );
+}
+
+#[tokio::test]
+async fn wait_stale_409() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::stale()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "wait",
+        Some(&t),
+        serde_json::json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2,
+            "condition": {"kind": "load_state", "state": "ready"}
+        }),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn wait_missing_runtime_501() {
+    let a = browser_app(None).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "wait",
+        Some(&t),
+        serde_json::json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2,
+            "condition": {"kind": "load_state", "state": "ready"}
+        }),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+}
+
+#[tokio::test]
+async fn screenshot_roundtrip() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "screenshot",
+        Some(&t),
+        serde_json::json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2
+        }),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::OK);
+    let b: serde_json::Value = r.json().await.unwrap();
+    assert_eq!(b["mimeType"], "image/png");
+    assert_eq!(b["browserId"], "browser-1");
+}
+
+#[tokio::test]
+async fn screenshot_refuses_non_well_formed() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    assert_eq!(
+        post(
+            a.addr,
+            "screenshot",
+            Some(&t),
+            serde_json::json!({"browser_id":"b-1","snapshot_id":"s","document_epoch":0,"max_width":999999})
+        )
+        .await
+        .status(),
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY
+    );
+}
+
+#[tokio::test]
+async fn screenshot_stale_409() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::stale()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "screenshot",
+        Some(&t),
+        serde_json::json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2
+        }),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn screenshot_missing_runtime_501() {
+    let a = browser_app(None).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, ws, s);
+    let r = post(
+        a.addr,
+        "screenshot",
+        Some(&t),
+        serde_json::json!({
+            "browser_id": "browser-1",
+            "snapshot_id": "snapshot-1",
+            "document_epoch": 2
+        }),
+    )
+    .await;
+    assert_eq!(r.status(), reqwest::StatusCode::NOT_IMPLEMENTED);
+}
+
+#[tokio::test]
+async fn new_routes_require_capability_token() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let _t = mint_token(&a.code, ws, s);
+    for rt in ["wait", "screenshot"] {
+        assert_eq!(
+            post(a.addr, rt, None, serde_json::json!({"browser_id":"browser-1"})).await.status(),
+            reqwest::StatusCode::UNAUTHORIZED
+        );
+    }
+}
+
+#[tokio::test]
+async fn new_routes_refuse_wrong_workspace_scope() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (_, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
+    let t = mint_token(&a.code, WorkspaceId::new(), s);
+    for (rt, body) in [
+        (
+            "wait",
+            serde_json::json!({"browser_id":"browser-1","snapshot_id":"s","document_epoch":0,"condition":{"kind":"load_state","state":"ready"}}),
+        ),
+        (
+            "screenshot",
+            serde_json::json!({"browser_id":"browser-1","snapshot_id":"s","document_epoch":0}),
+        ),
+    ] {
+        assert_eq!(
+            post(a.addr, rt, Some(&t), body).await.status(),
+            reqwest::StatusCode::NOT_FOUND
+        );
+    }
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
+async fn new_routes_refuse_ended_session() {
+    let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
+    let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Ended).await;
+    let t = mint_token(&a.code, ws, s);
+    for (rt, body) in [
+        (
+            "wait",
+            serde_json::json!({"browser_id":"browser-1","snapshot_id":"s","document_epoch":0,"condition":{"kind":"load_state","state":"ready"}}),
+        ),
+        (
+            "screenshot",
+            serde_json::json!({"browser_id":"browser-1","snapshot_id":"s","document_epoch":0}),
+        ),
+    ] {
+        assert_eq!(
+            post(a.addr, rt, Some(&t), body).await.status(),
+            reqwest::StatusCode::FORBIDDEN
+        );
+    }
+    assert!(a.fake.as_ref().unwrap().subjects().is_empty());
+}
+
+#[tokio::test]
 async fn snapshot_needs_browser_id() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
     let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
@@ -518,6 +802,25 @@ async fn bodies_reject_subject_ids() {
         (
             "snapshot",
             serde_json::json!({"browser_id":"b-1","owner_id":"g"}),
+        ),
+        (
+            "wait",
+            serde_json::json!({
+                "browser_id":"b-1",
+                "snapshot_id":"snapshot-1",
+                "document_epoch":0,
+                "condition":{"kind":"url_changed"},
+                "session_id":"g"
+            }),
+        ),
+        (
+            "screenshot",
+            serde_json::json!({
+                "browser_id":"b-1",
+                "snapshot_id":"snapshot-1",
+                "document_epoch":0,
+                "owner_id":"g"
+            }),
         ),
     ] {
         assert_eq!(

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -726,16 +726,27 @@ async fn new_routes_require_capability_token() {
     let a = browser_app(Some(Arc::new(FakeBrowserRuntime::default()))).await;
     let (ws, s) = seed_session(&a.code.db, CodeSessionLifecycle::Idle).await;
     let _t = mint_token(&a.code, ws, s);
-    for rt in ["wait", "screenshot"] {
+    for (rt, body) in [
+        (
+            "wait",
+            serde_json::json!({
+                "browser_id": "browser-1",
+                "snapshot_id": "snapshot-1",
+                "document_epoch": 2,
+                "condition": {"kind": "load_state", "state": "ready"}
+            }),
+        ),
+        (
+            "screenshot",
+            serde_json::json!({
+                "browser_id": "browser-1",
+                "snapshot_id": "snapshot-1",
+                "document_epoch": 2
+            }),
+        ),
+    ] {
         assert_eq!(
-            post(
-                a.addr,
-                rt,
-                None,
-                serde_json::json!({"browser_id":"browser-1"}),
-            )
-            .await
-            .status(),
+            post(a.addr, rt, None, body).await.status(),
             reqwest::StatusCode::UNAUTHORIZED
         );
     }


### PR DESCRIPTION
## Summary

- add authenticated `wait` and `screenshot` operations to the server-owned browser runtime and `/code/browser/*` routes
- preserve the issuing snapshot across observation continuations while rechecking the same live capability, controller, origin grant, visibility, Stop state, instance, and document epoch
- retain typed authorization and stale-target failures for screenshot races instead of collapsing them to HTTP 500
- cover the route contract and native registry fences without exposing semantic action tools

Refs #2400

## Validation

- `git diff --check`
- Rust formatting, compilation, Clippy, and tests intentionally delegated to CI per the no-local-Rust-build instruction