### PR TITLE
feat(code): let a session change permission mode

### DIFF
--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -430,6 +430,18 @@ impl Client {
         .await
     }
 
+    pub async fn set_session_permission_mode(
+        &self,
+        session: CodeSessionId,
+        mode: CodePermissionMode,
+    ) -> Result<CodeSessionSnapshot> {
+        self.post_json(
+            format!("{}/code/sessions/{session}/mode", self.base_url()),
+            &serde_json::json!({ "permission_mode": mode }),
+        )
+        .await
+    }
+
     pub async fn list_approvals(
         &self,
         session: Option<CodeSessionId>,

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -50,6 +50,7 @@ usage: tidebreak code doctor [--refresh]
        tidebreak code ws archive <id> [--force]
        tidebreak code session start --ws <id> --harness <kind> [--mode plan|ask|auto|allow]
        tidebreak code session show <id>
+       tidebreak code session mode <id> plan|ask|auto|allow
        tidebreak code session reap <id>
        tidebreak code run (--session <id> | --ws <id>) [<message>]
                   [--on-approval wait|fail] [--timeout <secs>]
@@ -142,6 +143,11 @@ pub enum Command {
     },
     SessionShow {
         id: CodeSessionId,
+        format: OutputFormat,
+    },
+    SessionMode {
+        id: CodeSessionId,
+        mode: CodePermissionMode,
         format: OutputFormat,
     },
     SessionReap {
@@ -462,6 +468,17 @@ async fn execute(client: &Client, command: Command) -> Result<i32> {
                     print_turn_line(&turn);
                 }
             }
+            Ok(0)
+        }
+        Command::SessionMode { id, mode, format } => {
+            let session = client.set_session_permission_mode(id, mode).await?;
+            if format == OutputFormat::Json {
+                return emit_ok(&session);
+            }
+            println!(
+                "tidebreak: session {} is now in {} mode",
+                session.id, session.permission_mode
+            );
             Ok(0)
         }
         Command::SessionReap { id, format } => {
@@ -1835,6 +1852,32 @@ fn parse_session(cursor: &mut Cursor) -> std::result::Result<Command, String> {
         "reap" => {
             let (id, format) = take_id_and_format(cursor, "a session id", parse_session_id)?;
             Ok(Command::SessionReap { id, format })
+        }
+        "mode" => {
+            let id = cursor
+                .next()
+                .ok_or_else(|| "expected a session id".to_owned())
+                .and_then(|raw| parse_session_id(&raw))?;
+            let raw = cursor
+                .next()
+                .ok_or_else(|| "expected plan|ask|auto|allow".to_owned())?;
+            let mode = CodePermissionMode::from_str(&raw)
+                .ok_or_else(|| format!("unknown permission mode {raw:?}"))?;
+            let mut flags = SharedFlags {
+                format: OutputFormat::Text,
+            };
+            while let Some(arg) = cursor.next() {
+                if arg.starts_with("--") {
+                    take_format(&mut flags, cursor, &arg)?;
+                } else {
+                    return Err(format!("unexpected code session mode argument {arg:?}"));
+                }
+            }
+            Ok(Command::SessionMode {
+                id,
+                mode,
+                format: flags.format,
+            })
         }
         other => Err(format!("unknown session subcommand {other:?}")),
     }

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1542,6 +1542,80 @@ impl CodeRuntime {
         self.attach_and_spawn_worker(session).await
     }
 
+    /// Change a live session's permission mode.
+    ///
+    /// The mode reaches the engine through `SessionSpec`, which is built once
+    /// when the worker attaches, so a running worker keeps the posture it
+    /// started with no matter what the row says. Restarting it is what makes
+    /// the change take effect — the same stop-then-attach `reap` performs,
+    /// without the fence requirement.
+    ///
+    /// Order matters: the outgoing worker writes its own final state as it
+    /// stops, so the mode is persisted *after* the shutdown or it would be
+    /// clobbered.
+    ///
+    /// Refused while a turn is running. A turn that began under one posture
+    /// must not have it changed underneath it — that is the whole point of
+    /// the posture.
+    pub(crate) async fn set_permission_mode(
+        &self,
+        owner: &OwnerId,
+        id: CodeSessionId,
+        mode: CodePermissionMode,
+    ) -> Result<CodeSession, ServerError> {
+        let session = self.get_session(owner, id).await?;
+        if session.permission_mode == mode {
+            return Ok(session);
+        }
+        match session.lifecycle {
+            CodeSessionLifecycle::Running => {
+                return Err(ServerError::conflict_kind(
+                    "turn_running",
+                    "finish or interrupt the running turn before changing the permission mode",
+                ));
+            }
+            CodeSessionLifecycle::Ended => {
+                return Err(ServerError::conflict_kind(
+                    "session_ended",
+                    "this session has ended; start a new one to pick a different mode",
+                ));
+            }
+            _ => {}
+        }
+
+        // Refuse a mode this engine cannot honor here, not at the next turn,
+        // and with the same rule session creation applies (decision 0038).
+        let adapter = self.adapter(session.harness_kind)?;
+        let probe = self.probe(adapter.as_ref()).await;
+        let caps = adapter.capabilities(&probe);
+        refuse_unhonored_mode(session.harness_kind, mode, &caps)?;
+
+        let handle = self.workers.lock().expect("code workers").remove(&id);
+        if let Some(handle) = handle {
+            Self::shut_down_worker(id, handle).await;
+        }
+        self.revoke_browser_channel(id);
+
+        let mut session = self.get_session(owner, id).await?;
+        let previous = session.permission_mode;
+        session.permission_mode = mode;
+        save_session(&self.db, &session).await?;
+        let _ = super::session_worker::journal_event(
+            &self.db,
+            &self.bus,
+            owner,
+            id,
+            session.spawn_epoch,
+            CodeEvent::HarnessNotice {
+                level: tidebreak_core::HarnessNoticeLevel::Info,
+                message: format!("permission mode changed from {previous} to {mode}"),
+            },
+        )
+        .await;
+
+        self.attach_and_spawn_worker(session).await
+    }
+
     pub(crate) async fn set_attention(
         &self,
         owner: &OwnerId,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -482,6 +482,16 @@ impl ScopedCode {
         self.runtime.reap(&self.owner, id).await
     }
 
+    pub(crate) async fn set_permission_mode(
+        &self,
+        id: CodeSessionId,
+        mode: CodePermissionMode,
+    ) -> Result<CodeSession, ServerError> {
+        self.runtime
+            .set_permission_mode(&self.owner, id, mode)
+            .await
+    }
+
     pub(crate) async fn set_attention(
         &self,
         id: CodeSessionId,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -924,6 +924,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::interrupt_session),
         )
         .route("/code/sessions/{id}/reap", post(routes::code::reap_session))
+        .route(
+            "/code/sessions/{id}/mode",
+            post(routes::code::set_session_permission_mode),
+        )
         .route("/code/sessions/{id}/fork", post(routes::code::fork_session))
         .route(
             "/code/sessions/{id}/debug",

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -50,7 +50,7 @@ pub(crate) use session_events::session_events;
 pub(crate) use sessions::{
     create_session, fork_session, get_session_debug, get_session_image, interrupt_session,
     list_session_turns, list_workspace_sessions, publish_session_image, reap_session,
-    set_attention, steer_session, submit_turn,
+    set_attention, set_session_permission_mode, steer_session, submit_turn,
 };
 pub(crate) use terminals::{
     close_terminal, close_workspace_terminals, create_terminal, list_terminals, read_terminal,

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -13,7 +13,7 @@ use axum::response::{IntoResponse, Response};
 
 use super::types::{
     CodeForkTranscript, CodeSessionSnapshot, CodeTurnSnapshot, CreateSessionBody, QueuedCodeTurn,
-    SequencedCodeEventFrame, SetAttentionBody, SteerBody, SubmitTurnBody,
+    SequencedCodeEventFrame, SetAttentionBody, SetPermissionModeBody, SteerBody, SubmitTurnBody,
 };
 use crate::code::runtime::SubmitTurnOutcome;
 use tidebreak_core::{CodeSessionId, TurnSteer, WorkspaceId};
@@ -174,6 +174,20 @@ pub async fn reap_session(
     Path(id): Path<CodeSessionId>,
 ) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
     let session = code.reap(id).await?;
+    Ok((StatusCode::OK, Json(CodeSessionSnapshot::from(session))))
+}
+
+/// `POST /code/sessions/{id}/mode` — change a session's permission mode.
+///
+/// The engine is relaunched against the new posture, so this is refused
+/// while a turn is running and while the session has ended. A mode the
+/// engine cannot honor is refused here rather than approximated.
+pub async fn set_session_permission_mode(
+    code: ScopedCode,
+    Path(id): Path<CodeSessionId>,
+    Json(body): Json<SetPermissionModeBody>,
+) -> Result<(StatusCode, Json<CodeSessionSnapshot>), ServerError> {
+    let session = code.set_permission_mode(id, body.permission_mode).await?;
     Ok((StatusCode::OK, Json(CodeSessionSnapshot::from(session))))
 }
 

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -951,6 +951,13 @@ pub struct CreateSessionBody {
     pub model: Option<String>,
 }
 
+/// Body of `POST /code/sessions/{id}/mode`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SetPermissionModeBody {
+    pub permission_mode: CodePermissionMode,
+}
+
 /// Body of `POST /code/sessions/{id}/turns`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1351,6 +1351,93 @@ async fn a_workspace_runs_several_agents_that_take_turns_on_one_worktree() {
 }
 
 /// Create `count` interactive sessions in one workspace, returning their ids.
+/// Plan mode had no exit. The mode was settable only at creation, so once a
+/// user approved a plan the engine kept refusing the edits and the only way
+/// forward was a new session with a new conversation.
+#[tokio::test]
+async fn a_session_can_leave_plan_mode_and_the_engine_relaunches_under_the_new_one() {
+    let (router, token, _runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script()).with_auto_mode(CapLevel::Supported),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = create_sibling_sessions(&client, addr, &token, &workspace, 1)
+        .await
+        .remove(0);
+
+    let set_mode = |mode: &'static str| {
+        let client = client.clone();
+        let token = token.clone();
+        let session = session.clone();
+        async move {
+            let response = client
+                .post(format!("http://{addr}/code/sessions/{session}/mode"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "permission_mode": mode }))
+                .send()
+                .await
+                .unwrap();
+            let status = response.status();
+            let body: serde_json::Value = response.json().await.unwrap();
+            (status, body)
+        }
+    };
+
+    let (status, body) = set_mode("auto").await;
+    assert_eq!(status, reqwest::StatusCode::OK, "{body}");
+    assert_eq!(
+        body["permission_mode"], "auto",
+        "the change is reported on the session it returns: {body}"
+    );
+
+    // It stuck, and the engine came back up under it rather than being left
+    // stopped by the relaunch.
+    let reread: serde_json::Value = client
+        .get(format!("http://{addr}/code/sessions/{session}/debug"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(reread["session"]["permission_mode"], "auto", "{reread}");
+    assert_ne!(
+        reread["session"]["lifecycle"], "ended",
+        "the relaunch must leave a usable session: {reread}"
+    );
+
+    // Setting the mode it already has is a no-op, not a needless relaunch.
+    let (status, body) = set_mode("auto").await;
+    assert_eq!(status, reqwest::StatusCode::OK, "{body}");
+    assert_eq!(body["permission_mode"], "auto");
+
+    // A mode this engine cannot honor is refused here, not approximated at
+    // the next turn: the scripted adapter declares allow unsupported.
+    let (status, body) = set_mode("allow").await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+        "an unhonored mode must be refused: {body}"
+    );
+    let still: serde_json::Value = client
+        .get(format!("http://{addr}/code/sessions/{session}/debug"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        still["session"]["permission_mode"], "auto",
+        "a refused change must not move the row: {still}"
+    );
+}
+
 async fn create_sibling_sessions(
     client: &reqwest::Client,
     addr: std::net::SocketAddr,


### PR DESCRIPTION
## Plan mode had no exit

`permission_mode` was settable only at session creation. There was no route, no CLI verb, and no desktop control to change it — so the plan→act handoff dead-ended: a user approves the plan, the engine goes on refusing every edit, and the only way forward is a new session that loses the conversation.

Worse, the guidance the user gets is wrong for this surface. The harness answers with its own affordance:

> Switch the session out of plan mode (shift+tab to cycle the permission mode, or re-run without `--permission-mode plan`)

There is no TUI to press shift+tab in, and the user never typed that flag — Tidebreak composes it. In one measured run that turn spent 91,122 tokens producing a refusal, on top of 246,463 tokens of planning that a new session would strand.

## What this adds

`POST /code/sessions/{id}/mode` taking `{"permission_mode": "plan"|"ask"|"auto"|"allow"}`, and `tidebreak code session mode <id> <mode>` in front of it.

## Why it restarts the engine

The mode reaches the engine through `SessionSpec`, which is built once when the worker attaches. A running worker keeps the posture it started with no matter what the row says, so persisting alone would be a lie until something happened to relaunch it. The change stops the worker and reattaches — the same sequence `reap` already performs, minus the fence requirement.

Order matters: the outgoing worker writes its own final state as it stops, so the new mode is persisted *after* the shutdown. Writing first would let the worker clobber it.

## What it refuses

- **While a turn is running** (`409 turn_running`). A turn that began under one posture must not have it changed underneath it — that is the point of the posture.
- **A mode the engine cannot honor** (`422`), by `refuse_unhonored_mode`, the same capability rule session creation applies per decision 0038. Never approximated.
- An ended session (`409 session_ended`).

Setting the mode a session already has returns 200 without relaunching.

## Tests

`a_session_can_leave_plan_mode_and_the_engine_relaunches_under_the_new_one` drives the real route: plan → auto returns 200 with the new mode on the returned session, the change survives a re-read, the session is not left ended by the relaunch, re-setting the same mode is a no-op, and `allow` — which the scripted adapter declares unsupported — is refused 422 without moving the row.

`cargo test -p tidebreak-server --lib code::` — 185 passed. `cargo test -p tidebreak-cli` — 91 + 2 passed. Wire types current. Clippy clean.

## Not in this change

No desktop control yet — this is the API and the CLI. The UI affordance and a structured plan-accepted event (code mode has no plan event at all, where chat has `exit_plan_mode`) are follow-ups.