### PR TITLE
fix(desktop): keep a profile's credentials in one keychain item

### DIFF
--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -945,26 +945,39 @@ async fn serve() -> Result<()> {
     server.serve().await
 }
 
-/// Rewrite each stored credential so the item belongs to this binary's code
-/// signature.
+/// Rewrite this profile's stored credentials so their item belongs to this
+/// binary's code signature.
 ///
 /// macOS keeps prompting for credentials an earlier, differently signed build
 /// created — see [`tidebreak_server::secret_rehome`] for why an approval given at
 /// that prompt does not survive the next rebuild. Run this through Cargo
 /// (`cargo run -p tidebreak-cli -- rehome-secrets`) so the dev signing runner
-/// applies; each credential asks for access once more, and then stops asking.
+/// applies; access is asked for once more, and then stops being asked.
+///
+/// Credentials live in one item, so this normally rewrites exactly that one.
+/// A profile last written by a build that predates the bundle also has its
+/// leftover per-key items swept in on the way past.
 async fn rehome_secrets() -> Result<()> {
+    use tidebreak_core::BUNDLE_KEY;
     use tidebreak_server::secret_rehome::RehomeOutcome;
 
     let config = profile_config()?;
     let mut touched = 0usize;
     let mut lost = 0usize;
     for (key, outcome) in tidebreak_server::rehome_configured_secrets(&config).await? {
+        // The bundle is the item itself; every other key is a credential that
+        // used to have one of its own. Saying "re-homed" about both would tell
+        // a reader nothing about which happened.
+        let bundle = key == BUNDLE_KEY;
         match outcome {
             RehomeOutcome::Absent => {}
+            RehomeOutcome::Rehomed if bundle => {
+                touched += 1;
+                println!("tidebreak: re-homed the credential bundle");
+            }
             RehomeOutcome::Rehomed => {
                 touched += 1;
-                println!("tidebreak: re-homed {key}");
+                println!("tidebreak: moved {key} into the credential bundle");
             }
             RehomeOutcome::Skipped(reason) => {
                 touched += 1;

--- a/crates/tidebreak-core/Cargo.toml
+++ b/crates/tidebreak-core/Cargo.toml
@@ -19,6 +19,7 @@ sqlite = [
     "dep:sea-orm-migration",
     "sea-orm/sqlx-sqlite",
     "sea-orm-migration/sqlx-sqlite",
+    "dep:tokio",
 ]
 # PostgreSQL-backed Store for self-hosted deployments and cross-backend tests.
 postgres = [
@@ -26,6 +27,7 @@ postgres = [
     "dep:sea-orm-migration",
     "sea-orm/sqlx-postgres",
     "sea-orm-migration/sqlx-postgres",
+    "dep:tokio",
 ]
 # The OS-keychain-backed SecretProvider.
 keychain = ["dep:keyring", "dep:tokio"]

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -80,6 +80,7 @@ pub mod plan_mode;
 pub mod preview;
 pub mod provider;
 mod renderer_tool;
+pub mod secret_bundle;
 pub mod secret_cache;
 pub mod semantic_checkpoint;
 pub mod steer;
@@ -273,6 +274,10 @@ pub use provider::{
     RefusalDetails, RefusalOutcome, ResponseFormat, StopReason, ToolChoice, Usage, VendorWebSearch,
 };
 pub use renderer_tool::RendererToolName;
+pub use secret_bundle::{
+    AbsorbOutcome, BundledSecretProvider, RehomeItemOutcome, BUNDLE_KEY,
+    DESKTOP_REMOTE_MACHINE_TOKEN_KEY,
+};
 pub use secret_cache::CachingSecretProvider;
 pub use semantic_checkpoint::{
     ContextCheckpoint, ContextCheckpointPayloadV1, ContextCheckpointPayloadV2,

--- a/crates/tidebreak-core/src/secret_bundle.rs
+++ b/crates/tidebreak-core/src/secret_bundle.rs
@@ -1,0 +1,664 @@
+//! A [`SecretProvider`] decorator that keeps every key in **one** stored item.
+//!
+//! macOS grants keychain access on the code signature of the binary that
+//! *created* an item, so an app update strands every credential the previous
+//! binary wrote. `secret_rehome` in `tidebreak-server` repairs that by
+//! rewriting each value from the new binary — but the repair is per item, and
+//! so is the prompt. A profile holding four credentials therefore cost roughly
+//! eight approvals on every update, one pair per item, forever.
+//!
+//! [`CachingSecretProvider`](crate::secret_cache::CachingSecretProvider)
+//! already removes *repeat* reads within a process. What it cannot remove is
+//! the first read of each distinct item — that is one prompt per item, by
+//! construction. The only way past it is to stop having many items.
+//!
+//! So the whole profile lives in one item ([`BUNDLE_KEY`]) holding a JSON
+//! object of key → value. One item is one approval, whatever the profile
+//! stores. Everything above this layer still names logical keys
+//! (`provider.anthropic.credential`) and never learns where they sit.
+//!
+//! **Reading a key the bundle does not hold falls through to the per-key item
+//! of the same name.** Migration is a boot-time pass
+//! ([`BundledSecretProvider::absorb_legacy_items`]), and the shell's remote
+//! attachment reads its token before that pass can have run — without the
+//! fallback, one launch after an update would read as "not attached" and
+//! silently drop the user back onto this computer. The fallback makes the
+//! order stop mattering; migration then becomes cleanup rather than a
+//! prerequisite.
+//!
+//! **Writes re-read before they merge.** The desktop builds two providers over
+//! the same item — the server's and the shell's remote attachment — and
+//! `tidebreak rehome-secrets` deliberately runs without the instance lock, so
+//! a blind read-modify-write could drop a credential another writer had just
+//! stored. Every write takes a process-wide lock, re-reads the item, applies
+//! its change, and confirms the result read back; a store that changed
+//! underneath is merged again rather than overwritten.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::error::{AgentError, Result};
+use crate::storage::SecretProvider;
+
+/// The single item every logical key is stored inside.
+///
+/// Namespaced so it cannot collide with a logical key. Those are
+/// `provider.{kind}.credential`, `gateway.credentials_v1`,
+/// `mcp.{uuid}.env_v1`, `connected_app.{uuid}.credential`, and friends — none
+/// of which start with `tidebreak.`.
+pub const BUNDLE_KEY: &str = "tidebreak.secret_bundle_v1";
+
+/// The desktop shell's stored bearer for a machine attached with a static
+/// token.
+///
+/// Declared here rather than beside its only writer (`tidebreak-desktop`'s
+/// `remote` module) so the server's credential enumeration can name it. The
+/// shell depends on the server, not the other way round, and a key the
+/// enumeration cannot name is a key that never gets re-homed — which is
+/// exactly what happened to this one.
+pub const DESKTOP_REMOTE_MACHINE_TOKEN_KEY: &str = "desktop.remote-machine.token";
+
+/// How many times a write re-merges before giving up.
+///
+/// Only a writer outside this process can force a retry, and only by landing
+/// between this one's read and its read-back. Three attempts is far past what
+/// that window can plausibly produce; exhausting them means something is
+/// rewriting the item continuously, and failing loudly beats overwriting it.
+const WRITE_ATTEMPTS: usize = 3;
+
+/// Serializes bundle writes across every provider in this process.
+///
+/// One item, several providers over it: the server's and the shell's remote
+/// attachment both wrap the same keychain service. Per-instance locking would
+/// let those two interleave a read-modify-write and lose a key.
+fn write_lock() -> &'static AsyncMutex<()> {
+    static LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
+    &LOCK
+}
+
+/// What happened to one per-key item during
+/// [`BundledSecretProvider::absorb_legacy_items`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AbsorbOutcome {
+    /// No per-key item under this name; nothing to move.
+    Absent,
+    /// The value is in the bundle, and the per-key item is gone.
+    Absorbed,
+    /// The value is in the bundle, but the per-key item could not be removed.
+    /// Harmless — the bundle wins on read — and retried next launch.
+    CopiedNotRemoved(String),
+    /// The value could not be read or could not be stored. It is still
+    /// wherever it was; nothing was removed.
+    Skipped(String),
+}
+
+/// What happened to the bundle item during
+/// [`BundledSecretProvider::rehome_bundle_item`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RehomeItemOutcome {
+    /// This profile stores nothing yet, so there is no item to re-home.
+    Absent,
+    /// The item was rewritten by this binary and read back unchanged.
+    Rehomed,
+    /// The item is still stored, and still owned by whatever created it. The
+    /// prompt will return, which is better than losing the credentials.
+    Skipped(String),
+    /// The item was removed but could not be written back. Every credential in
+    /// it has to be entered again.
+    Lost(String),
+}
+
+/// Wraps a [`SecretProvider`], keeping every key inside one stored item.
+pub struct BundledSecretProvider {
+    inner: Arc<dyn SecretProvider>,
+    /// The decoded item. `None` until first read.
+    cache: Mutex<Option<BTreeMap<String, String>>>,
+}
+
+impl BundledSecretProvider {
+    /// Store `inner`'s keys in a single item.
+    #[must_use]
+    pub fn new(inner: Arc<dyn SecretProvider>) -> Self {
+        Self {
+            inner,
+            cache: Mutex::new(None),
+        }
+    }
+
+    /// The decoded bundle, read through on first use.
+    async fn load(&self) -> Result<BTreeMap<String, String>> {
+        if let Some(hit) = self.cache.lock().unwrap().clone() {
+            return Ok(hit);
+        }
+        let fresh = self.read_through().await?;
+        *self.cache.lock().unwrap() = Some(fresh.clone());
+        Ok(fresh)
+    }
+
+    /// Read and decode the item, ignoring the cache.
+    async fn read_through(&self) -> Result<BTreeMap<String, String>> {
+        let Some(raw) = self.inner.get_secret(BUNDLE_KEY).await? else {
+            return Ok(BTreeMap::new());
+        };
+        serde_json::from_str(&raw).map_err(|error| {
+            // Refuse rather than start over: an unreadable bundle is every
+            // credential at once, and silently treating it as empty would
+            // hand the reader a profile that looks freshly installed and then
+            // overwrite the item they could have recovered from.
+            AgentError::Secret(format!(
+                "the stored credential bundle could not be read: {error}"
+            ))
+        })
+    }
+
+    /// Apply one change to the item, merging against whatever is stored now.
+    async fn write(&self, change: impl Fn(&mut BTreeMap<String, String>)) -> Result<()> {
+        let _guard = write_lock().lock().await;
+        let mut last_seen = None;
+        for _ in 0..WRITE_ATTEMPTS {
+            // Deliberately not `load`: a write merges against the store, not
+            // against whatever this process last happened to read.
+            let stored = self.read_through().await?;
+            let mut merged = stored.clone();
+            change(&mut merged);
+            if merged == stored {
+                // A delete of a key that is not there, or a set of the value
+                // already stored. Writing would only churn the item — and on
+                // an empty profile it would create one that need not exist.
+                *self.cache.lock().unwrap() = Some(merged);
+                return Ok(());
+            }
+            let encoded = serde_json::to_string(&merged)
+                .map_err(|error| AgentError::Secret(error.to_string()))?;
+            self.inner.set_secret(BUNDLE_KEY, &encoded).await?;
+            let confirmed = self.read_through().await?;
+            if confirmed == merged {
+                *self.cache.lock().unwrap() = Some(confirmed);
+                return Ok(());
+            }
+            // Something wrote between the read and the read-back. Merging
+            // again re-applies this change on top of theirs, which converges;
+            // overwriting would drop whatever they stored.
+            last_seen = Some(confirmed);
+        }
+        // Whatever the store holds now is the truth for the next reader, not
+        // the value this call was trying to reach.
+        *self.cache.lock().unwrap() = last_seen;
+        Err(AgentError::Secret(format!(
+            "another writer kept changing the credential bundle; \
+             after {WRITE_ATTEMPTS} attempts this change could not be confirmed \
+             as stored, and no other credential was overwritten"
+        )))
+    }
+
+    /// Move any per-key items named by `keys` into the bundle, then remove
+    /// them.
+    ///
+    /// The order is what makes this safe: a value is stored in the bundle and
+    /// read back before its old item is touched. Today's per-item re-home
+    /// deletes first and has a "deleted, then could not store it again" state
+    /// where the credential is simply gone; this cannot reach that state. If
+    /// the removal fails the value lives in both places, the bundle wins on
+    /// read, and the next launch tries the removal again.
+    pub async fn absorb_legacy_items(&self, keys: &[String]) -> Vec<(String, AbsorbOutcome)> {
+        let mut outcomes = Vec::with_capacity(keys.len());
+        for key in keys {
+            outcomes.push((key.clone(), self.absorb_one(key).await));
+        }
+        outcomes
+    }
+
+    async fn absorb_one(&self, key: &str) -> AbsorbOutcome {
+        if key == BUNDLE_KEY {
+            return AbsorbOutcome::Absent;
+        }
+        let value = match self.inner.get_secret(key).await {
+            Ok(Some(value)) => value,
+            Ok(None) => return AbsorbOutcome::Absent,
+            Err(error) => return AbsorbOutcome::Skipped(format!("could not read it: {error}")),
+        };
+        if let Err(error) = self
+            .write(|bundle| {
+                bundle.insert(key.to_string(), value.clone());
+            })
+            .await
+        {
+            return AbsorbOutcome::Skipped(format!("could not store it in the bundle: {error}"));
+        }
+        match self.read_through().await {
+            Ok(bundle) if bundle.get(key) == Some(&value) => {}
+            Ok(_) => {
+                return AbsorbOutcome::Skipped(
+                    "it did not read back from the bundle unchanged".to_string(),
+                )
+            }
+            Err(error) => {
+                return AbsorbOutcome::Skipped(format!(
+                    "the bundle could not be read back: {error}"
+                ))
+            }
+        }
+        match self.inner.delete_secret(key).await {
+            Ok(()) => AbsorbOutcome::Absorbed,
+            Err(error) => AbsorbOutcome::CopiedNotRemoved(error.to_string()),
+        }
+    }
+
+    /// Rewrite the bundle item so the running binary owns it.
+    ///
+    /// Delete-then-store is the whole point: an in-place update keeps the
+    /// original item, and with it the ownership that makes macOS prompt. The
+    /// value is held in memory across the gap, so a failed delete leaves the
+    /// credentials exactly where they were.
+    pub async fn rehome_bundle_item(&self) -> RehomeItemOutcome {
+        let _guard = write_lock().lock().await;
+        let stored = match self.inner.get_secret(BUNDLE_KEY).await {
+            Ok(Some(stored)) => stored,
+            Ok(None) => return RehomeItemOutcome::Absent,
+            Err(error) => return RehomeItemOutcome::Skipped(format!("could not read it: {error}")),
+        };
+        if let Err(error) = self.inner.delete_secret(BUNDLE_KEY).await {
+            return RehomeItemOutcome::Skipped(format!("could not remove the old item: {error}"));
+        }
+        if let Err(error) = self.inner.set_secret(BUNDLE_KEY, &stored).await {
+            return RehomeItemOutcome::Lost(format!("could not store it again: {error}"));
+        }
+        match self.inner.get_secret(BUNDLE_KEY).await {
+            Ok(Some(read_back)) if read_back == stored => RehomeItemOutcome::Rehomed,
+            Ok(_) => RehomeItemOutcome::Lost("it did not read back unchanged".to_string()),
+            Err(error) => RehomeItemOutcome::Lost(format!("it could not be read back: {error}")),
+        }
+    }
+
+    /// Forget the decoded item, so the next read asks the store.
+    #[cfg(test)]
+    fn forget(&self) {
+        *self.cache.lock().unwrap() = None;
+    }
+}
+
+#[async_trait]
+impl SecretProvider for BundledSecretProvider {
+    async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+        if key == BUNDLE_KEY {
+            return self.inner.get_secret(key).await;
+        }
+        if let Some(hit) = self.load().await?.get(key) {
+            return Ok(Some(hit.clone()));
+        }
+        // Absent from the decoded item. Re-read before believing it: a value
+        // can land in the item without this provider observing the write —
+        // the other provider in this process, another process, or a sign-in
+        // completing beside a boot-time read. Reading an item that is already
+        // approved for this process raises no prompt.
+        let fresh = self.read_through().await?;
+        *self.cache.lock().unwrap() = Some(fresh.clone());
+        if let Some(hit) = fresh.get(key) {
+            return Ok(Some(hit.clone()));
+        }
+        // Still nothing: fall through to the per-key item this key used to
+        // live in. See the module docs — this is what lets migration be
+        // cleanup rather than a prerequisite.
+        self.inner.get_secret(key).await
+    }
+
+    async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+        if key == BUNDLE_KEY {
+            return Err(reserved_key());
+        }
+        self.write(|bundle| {
+            bundle.insert(key.to_string(), value.to_string());
+        })
+        .await
+    }
+
+    async fn delete_secret(&self, key: &str) -> Result<()> {
+        if key == BUNDLE_KEY {
+            return Err(reserved_key());
+        }
+        self.write(|bundle| {
+            bundle.remove(key);
+        })
+        .await?;
+        // The per-key item may still exist on a profile this pass has not
+        // migrated yet. Leaving it would resurrect the credential through the
+        // read fallback, which is the opposite of what a delete means.
+        self.inner.delete_secret(key).await
+    }
+}
+
+fn reserved_key() -> AgentError {
+    AgentError::Secret(format!(
+        "{BUNDLE_KEY} is where credentials are stored; it is not itself a credential key"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    /// A stand-in for the OS credential store, counting the items it holds so
+    /// a test can assert the thing this module exists for: one item, not many.
+    #[derive(Default)]
+    struct FakeStore {
+        items: Mutex<HashMap<String, String>>,
+    }
+
+    impl FakeStore {
+        fn keys(&self) -> Vec<String> {
+            let mut keys: Vec<String> = self.items.lock().unwrap().keys().cloned().collect();
+            keys.sort();
+            keys
+        }
+    }
+
+    #[async_trait]
+    impl SecretProvider for FakeStore {
+        async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+            Ok(self.items.lock().unwrap().get(key).cloned())
+        }
+        async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+            self.items
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_string());
+            Ok(())
+        }
+        async fn delete_secret(&self, key: &str) -> Result<()> {
+            self.items.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    fn bundled() -> (Arc<FakeStore>, BundledSecretProvider) {
+        let store = Arc::new(FakeStore::default());
+        let provider = BundledSecretProvider::new(store.clone());
+        (store, provider)
+    }
+
+    /// The reason this module exists: whatever the profile stores, the OS
+    /// holds one item, so an update costs one approval rather than one per
+    /// credential.
+    #[tokio::test]
+    async fn every_credential_lands_in_a_single_item() {
+        let (store, secrets) = bundled();
+
+        secrets
+            .set_secret("provider.anthropic.credential", "key-a")
+            .await
+            .unwrap();
+        secrets
+            .set_secret("provider.openai.credential", "key-o")
+            .await
+            .unwrap();
+        secrets
+            .set_secret("gateway.credentials_v1", "session")
+            .await
+            .unwrap();
+
+        assert_eq!(store.keys(), vec![BUNDLE_KEY.to_string()]);
+        assert_eq!(
+            secrets
+                .get_secret("provider.openai.credential")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("key-o")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_key_round_trips_and_a_delete_leaves_the_others() {
+        let (_store, secrets) = bundled();
+        secrets.set_secret("a", "1").await.unwrap();
+        secrets.set_secret("b", "2").await.unwrap();
+
+        secrets.delete_secret("a").await.unwrap();
+
+        assert_eq!(secrets.get_secret("a").await.unwrap(), None);
+        assert_eq!(secrets.get_secret("b").await.unwrap().as_deref(), Some("2"));
+        // Deleting what is not there is a no-op, as on the real thing.
+        secrets.delete_secret("a").await.unwrap();
+    }
+
+    /// An empty profile must not gain an item just because something asked
+    /// about a key it does not have.
+    #[tokio::test]
+    async fn a_no_op_write_stores_nothing() {
+        let (store, secrets) = bundled();
+        secrets.delete_secret("never-stored").await.unwrap();
+        assert!(store.keys().is_empty());
+    }
+
+    /// The shell's remote attachment and the server both wrap the same item.
+    /// A write through one has to be visible to the other, or the second one
+    /// to write clobbers the first.
+    #[tokio::test]
+    async fn two_providers_over_one_item_do_not_lose_each_others_keys() {
+        let store = Arc::new(FakeStore::default());
+        let server = BundledSecretProvider::new(store.clone());
+        let shell = BundledSecretProvider::new(store.clone());
+
+        // Both decode the (empty) item first, so each holds a stale view.
+        assert_eq!(server.get_secret("a").await.unwrap(), None);
+        assert_eq!(shell.get_secret("b").await.unwrap(), None);
+
+        server.set_secret("a", "1").await.unwrap();
+        shell.set_secret("b", "2").await.unwrap();
+
+        // The write merged against the store rather than against the stale
+        // read, so the first key survived the second write.
+        assert_eq!(server.get_secret("a").await.unwrap().as_deref(), Some("1"));
+        assert_eq!(server.get_secret("b").await.unwrap().as_deref(), Some("2"));
+        assert_eq!(store.keys(), vec![BUNDLE_KEY.to_string()]);
+    }
+
+    /// A session written outside this provider — by another instance, or by a
+    /// sign-in racing a boot-time read — is seen without a restart.
+    #[tokio::test]
+    async fn a_miss_re_reads_so_a_later_write_is_seen() {
+        let (store, secrets) = bundled();
+        assert_eq!(
+            secrets.get_secret("gateway.credentials_v1").await.unwrap(),
+            None
+        );
+
+        store
+            .set_secret(BUNDLE_KEY, r#"{"gateway.credentials_v1":"session"}"#)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            secrets
+                .get_secret("gateway.credentials_v1")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("session")
+        );
+    }
+
+    /// Migration runs at server boot, and the shell reads its remote-machine
+    /// token before that. Without the fallback that launch reads as "not
+    /// attached" and drops the reader back onto this computer.
+    #[tokio::test]
+    async fn a_key_still_in_its_own_item_reads_before_migration_runs() {
+        let (store, secrets) = bundled();
+        store
+            .set_secret(DESKTOP_REMOTE_MACHINE_TOKEN_KEY, "legacy-token")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            secrets
+                .get_secret(DESKTOP_REMOTE_MACHINE_TOKEN_KEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("legacy-token")
+        );
+    }
+
+    /// The bundle is the newer truth: a migration that stored the value and
+    /// then failed to remove the old item must not serve the stale one.
+    #[tokio::test]
+    async fn the_bundle_wins_over_a_leftover_item() {
+        let (store, secrets) = bundled();
+        store.set_secret("k", "old").await.unwrap();
+        secrets.set_secret("k", "new").await.unwrap();
+
+        assert_eq!(
+            secrets.get_secret("k").await.unwrap().as_deref(),
+            Some("new")
+        );
+    }
+
+    /// A delete has to reach the per-key item too, or the read fallback
+    /// resurrects the credential the reader just removed.
+    #[tokio::test]
+    async fn a_delete_removes_the_leftover_item_as_well() {
+        let (store, secrets) = bundled();
+        store.set_secret("k", "old").await.unwrap();
+        secrets.set_secret("k", "new").await.unwrap();
+
+        secrets.delete_secret("k").await.unwrap();
+
+        assert_eq!(secrets.get_secret("k").await.unwrap(), None);
+        assert_eq!(store.keys(), vec![BUNDLE_KEY.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn absorbing_moves_each_item_into_the_bundle_and_removes_it() {
+        let (store, secrets) = bundled();
+        store
+            .set_secret("provider.anthropic.credential", "key-a")
+            .await
+            .unwrap();
+        store
+            .set_secret("gateway.credentials_v1", "session")
+            .await
+            .unwrap();
+
+        let outcomes = secrets
+            .absorb_legacy_items(&[
+                "provider.anthropic.credential".to_string(),
+                "gateway.credentials_v1".to_string(),
+                "provider.openai.credential".to_string(),
+            ])
+            .await;
+
+        assert_eq!(
+            outcomes,
+            vec![
+                (
+                    "provider.anthropic.credential".to_string(),
+                    AbsorbOutcome::Absorbed
+                ),
+                (
+                    "gateway.credentials_v1".to_string(),
+                    AbsorbOutcome::Absorbed
+                ),
+                (
+                    "provider.openai.credential".to_string(),
+                    AbsorbOutcome::Absent
+                ),
+            ]
+        );
+        assert_eq!(store.keys(), vec![BUNDLE_KEY.to_string()]);
+        assert_eq!(
+            secrets
+                .get_secret("provider.anthropic.credential")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("key-a")
+        );
+    }
+
+    /// Absorbing twice is what a retried launch does. It must not double-move
+    /// or report a second pass as work.
+    #[tokio::test]
+    async fn absorbing_again_finds_nothing_left_to_move() {
+        let (store, secrets) = bundled();
+        store.set_secret("k", "v").await.unwrap();
+        let keys = vec!["k".to_string()];
+
+        assert_eq!(
+            secrets.absorb_legacy_items(&keys).await,
+            vec![("k".to_string(), AbsorbOutcome::Absorbed)]
+        );
+        assert_eq!(
+            secrets.absorb_legacy_items(&keys).await,
+            vec![("k".to_string(), AbsorbOutcome::Absent)]
+        );
+        assert_eq!(secrets.get_secret("k").await.unwrap().as_deref(), Some("v"));
+    }
+
+    /// The store the item lands in is the one the caller wrapped, so a value
+    /// survives a process that forgot everything it had decoded.
+    #[tokio::test]
+    async fn the_item_outlives_the_decoded_copy() {
+        let (_store, secrets) = bundled();
+        secrets.set_secret("k", "v").await.unwrap();
+        secrets.forget();
+        assert_eq!(secrets.get_secret("k").await.unwrap().as_deref(), Some("v"));
+    }
+
+    /// Re-homing is delete-then-store: an in-place update keeps the original
+    /// item, and with it the ownership that makes macOS prompt.
+    #[tokio::test]
+    async fn re_homing_rewrites_the_item_without_changing_what_it_holds() {
+        let (store, secrets) = bundled();
+        secrets.set_secret("k", "v").await.unwrap();
+
+        assert_eq!(
+            secrets.rehome_bundle_item().await,
+            RehomeItemOutcome::Rehomed
+        );
+
+        assert_eq!(store.keys(), vec![BUNDLE_KEY.to_string()]);
+        assert_eq!(secrets.get_secret("k").await.unwrap().as_deref(), Some("v"));
+    }
+
+    #[tokio::test]
+    async fn re_homing_an_empty_profile_reports_nothing_to_do() {
+        let (_store, secrets) = bundled();
+        assert_eq!(
+            secrets.rehome_bundle_item().await,
+            RehomeItemOutcome::Absent
+        );
+    }
+
+    /// An unreadable item is every credential at once. Reporting it as an
+    /// empty profile would look like a fresh install and then overwrite the
+    /// one thing the reader could have recovered from.
+    #[tokio::test]
+    async fn an_undecodable_item_is_refused_rather_than_treated_as_empty() {
+        let (store, secrets) = bundled();
+        store.set_secret(BUNDLE_KEY, "not json").await.unwrap();
+
+        let error = secrets.get_secret("k").await.unwrap_err();
+        assert!(
+            error.to_string().contains("could not be read"),
+            "unexpected error: {error}"
+        );
+        assert!(secrets.set_secret("k", "v").await.is_err());
+        // And nothing was overwritten.
+        assert_eq!(
+            store.get_secret(BUNDLE_KEY).await.unwrap().as_deref(),
+            Some("not json")
+        );
+    }
+
+    #[tokio::test]
+    async fn the_bundle_key_is_not_a_credential_key() {
+        let (_store, secrets) = bundled();
+        assert!(secrets.set_secret(BUNDLE_KEY, "{}").await.is_err());
+        assert!(secrets.delete_secret(BUNDLE_KEY).await.is_err());
+    }
+}

--- a/crates/tidebreak-core/src/secret_bundle.rs
+++ b/crates/tidebreak-core/src/secret_bundle.rs
@@ -35,10 +35,10 @@
 //! underneath is merged again rather than overwritten.
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
-use tokio::sync::Mutex as AsyncMutex;
+use futures::lock::Mutex as AsyncMutex;
 
 use crate::error::{AgentError, Result};
 use crate::storage::SecretProvider;
@@ -75,8 +75,10 @@ const WRITE_ATTEMPTS: usize = 3;
 /// attachment both wrap the same keychain service. Per-instance locking would
 /// let those two interleave a read-modify-write and lose a key.
 fn write_lock() -> &'static AsyncMutex<()> {
-    static LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
-    &LOCK
+    // `futures`, not `tokio`: this module is available in every feature
+    // configuration of the crate, and `tokio` is optional here.
+    static LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| AsyncMutex::new(()))
 }
 
 /// What happened to one per-key item during

--- a/crates/tidebreak-desktop/src/remote.rs
+++ b/crates/tidebreak-desktop/src/remote.rs
@@ -31,10 +31,13 @@ use tokio::sync::RwLock;
 
 use tidebreak_core::config::tidebreak_machine_resource;
 use tidebreak_core::keychain::KeychainSecretProvider;
+use tidebreak_core::secret_bundle::BundledSecretProvider;
 use tidebreak_core::storage::SecretProvider;
-
-/// Keychain key holding the bearer token for a legacy static-token machine.
-const TOKEN_KEY: &str = "desktop.remote-machine.token";
+// The credential key holding the bearer for a legacy static-token machine.
+// Declared in `tidebreak-core` rather than here so the server's credential
+// enumeration can name it: the shell depends on the server, not the other way
+// round, and a key that enumeration cannot name never gets re-homed.
+use tidebreak_core::DESKTOP_REMOTE_MACHINE_TOKEN_KEY as TOKEN_KEY;
 
 /// File under the profile data dir holding the attached machine's address.
 /// The address is not a secret; the token that reaches it is, and lives in the
@@ -176,11 +179,15 @@ impl RemoteAttachment {
     /// The service is the channel-scoped one the embedded server uses, so a
     /// staging build never reads the release build's remote token.
     pub fn new(data_dir: &Path, keychain_service: Option<&str>) -> Self {
-        let secrets: Arc<dyn SecretProvider> = Arc::new(match keychain_service {
+        let keychain: Arc<dyn SecretProvider> = Arc::new(match keychain_service {
             Some(service) => KeychainSecretProvider::with_service(service),
             None => KeychainSecretProvider::new(),
         });
-        Self::with_secrets(data_dir, secrets)
+        // The same bundle the embedded server reads, so the token shares the
+        // one item — and the one access prompt — with every other credential
+        // in the profile. Its own instance rather than the server's: this is
+        // read before the server has booted, and often instead of it.
+        Self::with_secrets(data_dir, Arc::new(BundledSecretProvider::new(keychain)))
     }
 
     fn with_secrets(data_dir: &Path, secrets: Arc<dyn SecretProvider>) -> Self {

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -140,8 +140,9 @@ use tidebreak_core::{
     validate_list_folder_arguments, validate_read_connected_file_arguments,
     validate_request_folder_access_arguments, validate_write_output_to_connected_folder_arguments,
     write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, ApprovalClass, BlobStore,
-    CachingSecretProvider, Config, CreateAppTool, DbStore, FsBlobStore, KeychainSecretProvider,
-    ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool, ToolRegistry, WriteFile,
+    BundledSecretProvider, CachingSecretProvider, Config, CreateAppTool, DbStore, FsBlobStore,
+    KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool,
+    ToolRegistry, WriteFile,
 };
 
 /// Public contract for desktop browser adapters. The desktop implements
@@ -1428,10 +1429,13 @@ async fn bind_configured_with_desktop_executor_and_folder_grants_and_browser_par
 
 /// The secret store the configured profile keeps its credentials in.
 ///
-/// Wrapped in a [`CachingSecretProvider`] so a key costs one keychain read per
-/// process rather than one per turn: [`resolver::ConfiguredResolver`] rebuilds
-/// its route set on every turn, and each candidate route reads its provider's
-/// credential to decide whether it exists.
+/// Two decorators over the OS keychain, and the order matters.
+/// [`BundledSecretProvider`] puts every key in one stored item, so an app
+/// update costs one access prompt rather than one per credential.
+/// [`CachingSecretProvider`] sits above it so a key costs one read of that
+/// item per process rather than one per turn: [`resolver::ConfiguredResolver`]
+/// rebuilds its route set on every turn, and each candidate route reads its
+/// provider's credential to decide whether it exists.
 ///
 /// The gateway session key is the one exception to memoized misses: a session
 /// can land in the keychain without this cache observing the write — a
@@ -1440,15 +1444,27 @@ async fn bind_configured_with_desktop_executor_and_folder_grants_and_browser_par
 /// cached `None` would then hide the session from the sync loop until
 /// restart. Its misses re-ask the store instead; an absent item answers
 /// `NoEntry` without an ACL prompt, so the slow-path rereads are cheap.
-fn secret_provider(config: &Config) -> Arc<dyn SecretProvider> {
+fn secret_provider(config: &Config) -> ProfileSecrets {
     let keychain: Arc<dyn SecretProvider> = Arc::new(match &config.keychain_service {
         Some(service) => KeychainSecretProvider::with_service(service),
         None => KeychainSecretProvider::new(),
     });
-    Arc::new(
-        CachingSecretProvider::new(keychain)
+    let bundle = Arc::new(BundledSecretProvider::new(keychain));
+    let provider = Arc::new(
+        CachingSecretProvider::new(bundle.clone())
             .with_miss_passthrough([crate::connectors::GATEWAY_SECRET_KEY]),
-    )
+    );
+    ProfileSecrets { bundle, provider }
+}
+
+/// The profile's credential store, at the two layers callers need.
+struct ProfileSecrets {
+    /// The single stored item. Held apart from `provider` because re-homing
+    /// and migration act on the item itself, which is below what the
+    /// `SecretProvider` contract can express.
+    bundle: Arc<BundledSecretProvider>,
+    /// What every consumer uses: the bundle behind the per-process read cache.
+    provider: Arc<dyn SecretProvider>,
 }
 
 /// Re-home the configured profile's credentials — see [`secret_rehome`].
@@ -1460,7 +1476,7 @@ pub async fn rehome_configured_secrets(
     config: &Config,
 ) -> Result<Vec<(String, secret_rehome::RehomeOutcome)>> {
     let store = connect_store(config).await?;
-    secret_rehome::rehome_secrets(&*store, &*secret_provider(config)).await
+    secret_rehome::rehome_secrets(&*store, &secret_provider(config).bundle).await
 }
 
 // Every parameter is one optional native bridge an embedding may supply;
@@ -1491,16 +1507,19 @@ async fn bind_inner(
     let sandbox_spawn_execution_location = sandbox_container_admission.execution_location;
     let db = connect_db(&config).await?;
     let store: Arc<dyn Store> = db.clone();
-    let secrets = secret_provider(&config);
-    // An app update replaces this binary, and macOS pins each keychain
-    // item's access to the creating binary's signature — so the first boot
-    // of a new binary re-homes every stored credential before any consumer
-    // reads one. Inline, not spawned: a concurrent pass could interleave
-    // with token refresh and strand a session (see the function), and the
-    // pass is cheap — one read+rewrite per stored credential, once per
-    // binary, with later boots of the same binary skipping it entirely.
+    let ProfileSecrets {
+        bundle: secret_bundle,
+        provider: secrets,
+    } = secret_provider(&config);
+    // An app update replaces this binary, and macOS pins a keychain item's
+    // access to the creating binary's signature — so the first boot of a new
+    // binary re-homes the credential bundle before any consumer reads from
+    // it. Inline, not spawned: a concurrent pass could interleave with token
+    // refresh and strand a session (see the function), and the pass is cheap —
+    // one read+rewrite of one item, once per binary, with later boots of the
+    // same binary skipping it entirely.
     // Best-effort: a failure here must not take boot down with it.
-    if let Err(error) = secret_rehome::rehome_once_per_binary(&*store, &*secrets).await {
+    if let Err(error) = secret_rehome::rehome_once_per_binary(&*store, &secret_bundle).await {
         tracing::warn!("could not re-home stored credentials: {error}");
     }
     // The product boot path is where this platform's OS-managed (MDM) policy

--- a/crates/tidebreak-server/src/secret_rehome.rs
+++ b/crates/tidebreak-server/src/secret_rehome.rs
@@ -1,4 +1,10 @@
-//! Re-home stored credentials so the running binary owns their keychain items.
+//! Re-home stored credentials so the running binary owns their keychain item.
+//!
+//! Every credential this profile stores lives in one item — see
+//! [`BundledSecretProvider`] for why. This pass does two things to it: it
+//! rewrites that item so the running binary owns it, and it sweeps up any
+//! per-key items left behind by a build that predates the bundle, moving each
+//! value in and removing the old item.
 //!
 //! macOS grants keychain access on the code signature of the process that
 //! *created* an item. An item created by a binary carrying the dev designated
@@ -10,13 +16,16 @@
 //! rebuild invalidates it. Credentials stored before a machine had a stable dev
 //! identity therefore prompt once per credential on every launch, forever.
 //!
-//! Rewriting each value from a signed binary is the durable repair: delete the
+//! Rewriting the value from a signed binary is the durable repair: delete the
 //! item, then store the value again so the new item belongs to the current
 //! signature. Read the value first and hold it in memory, so a failure to
-//! delete leaves the credential in place.
+//! delete leaves the credentials in place.
 //!
-//! Two entry points run that rewrite. Server boot calls
-//! [`rehome_once_per_binary`], which re-homes once per binary (an app update
+//! Because there is one item, that repair now costs one approval rather than
+//! one per credential — which is the whole reason the bundle exists.
+//!
+//! Two entry points run the pass. Server boot calls
+//! [`rehome_once_per_binary`], which runs once per binary (an app update
 //! always replaces the binary, so that is once per update) before any
 //! credential consumer is constructed. And `tidebreak rehome-secrets` runs
 //! [`rehome_secrets`] on demand — the manual repair for a dev machine whose
@@ -25,7 +34,10 @@
 use crate::web_search::WebSearchProviderKind;
 use tidebreak_code_execution::{DAYTONA_CREDENTIAL_KEY, E2B_CREDENTIAL_KEY};
 use tidebreak_core::connected_app::ConnectedAppKind;
-use tidebreak_core::{Result, SecretProvider, Store};
+use tidebreak_core::{
+    AbsorbOutcome, BundledSecretProvider, RehomeItemOutcome, Result, Store, BUNDLE_KEY,
+    DESKTOP_REMOTE_MACHINE_TOKEN_KEY,
+};
 
 use crate::connectors::{CHATGPT_SECRET_KEY, GATEWAY_SECRET_KEY};
 use crate::mcp_config::env_secret_key;
@@ -121,6 +133,10 @@ fn static_secret_keys() -> Vec<String> {
     // the user re-pairs — so they must not be missed here.
     keys.push(GATEWAY_SECRET_KEY.to_string());
     keys.push(CHATGPT_SECRET_KEY.to_string());
+    // The desktop shell's bearer for a machine attached with a static token.
+    // Written by the shell, not the server, and missing from this list until
+    // the bundle landed — so it was the one credential the pass never swept.
+    keys.push(DESKTOP_REMOTE_MACHINE_TOKEN_KEY.to_string());
     keys.extend(
         WEB_SEARCH_CREDENTIAL_KEYS
             .iter()
@@ -130,13 +146,63 @@ fn static_secret_keys() -> Vec<String> {
     keys
 }
 
-/// Re-home every stored credential, reporting each key in the order of
+/// Re-home the credential bundle, then sweep any per-key items into it.
+///
+/// The bundle is re-homed first. On a profile that has already migrated that
+/// is the entire pass; on one that has not, the item does not exist yet and
+/// the sweep creates it — from this binary, so it is owned from birth and
+/// there is nothing to re-home afterwards.
+///
+/// Reports the bundle item first, then each key in the order of
 /// [`stored_secret_keys`].
 pub async fn rehome_secrets(
     store: &dyn Store,
-    secrets: &dyn SecretProvider,
+    secrets: &BundledSecretProvider,
 ) -> Result<Vec<(String, RehomeOutcome)>> {
     Ok(rehome_keys(secrets, stored_secret_keys(store).await?).await)
+}
+
+/// The pass itself, over an already-enumerated key list.
+async fn rehome_keys(
+    secrets: &BundledSecretProvider,
+    keys: Vec<String>,
+) -> Vec<(String, RehomeOutcome)> {
+    let mut outcomes = vec![(
+        BUNDLE_KEY.to_string(),
+        match secrets.rehome_bundle_item().await {
+            RehomeItemOutcome::Absent => RehomeOutcome::Absent,
+            RehomeItemOutcome::Rehomed => RehomeOutcome::Rehomed,
+            RehomeItemOutcome::Skipped(reason) => RehomeOutcome::Skipped(reason),
+            RehomeItemOutcome::Lost(reason) => RehomeOutcome::Lost(reason),
+        },
+    )];
+    outcomes.extend(
+        secrets
+            .absorb_legacy_items(&keys)
+            .await
+            .into_iter()
+            .map(|(key, outcome)| (key, absorbed(outcome))),
+    );
+    outcomes
+}
+
+/// What a swept per-key item means in this module's vocabulary.
+///
+/// [`RehomeOutcome::Lost`] is deliberately unreachable here. The sweep stores
+/// the value in the bundle and reads it back *before* touching the old item,
+/// so the "removed, then could not store it again" state the per-item repair
+/// could reach simply does not exist for it. A value that reached the bundle
+/// but whose old item survives is reported as skipped: harmless, because the
+/// bundle wins on read, and retried on the next launch.
+fn absorbed(outcome: AbsorbOutcome) -> RehomeOutcome {
+    match outcome {
+        AbsorbOutcome::Absent => RehomeOutcome::Absent,
+        AbsorbOutcome::Absorbed => RehomeOutcome::Rehomed,
+        AbsorbOutcome::CopiedNotRemoved(reason) => RehomeOutcome::Skipped(format!(
+            "it is stored in the credential bundle, but the old item remains — {reason}"
+        )),
+        AbsorbOutcome::Skipped(reason) => RehomeOutcome::Skipped(reason),
+    }
 }
 
 /// The settings key recording which binary last completed a re-home pass.
@@ -189,7 +255,7 @@ fn binary_stamp() -> String {
 /// stamped).
 pub(crate) async fn rehome_once_per_binary(
     store: &dyn Store,
-    secrets: &dyn SecretProvider,
+    secrets: &BundledSecretProvider,
 ) -> Result<bool> {
     let stamp = binary_stamp();
     if store
@@ -237,44 +303,15 @@ pub(crate) async fn rehome_once_per_binary(
     Ok(true)
 }
 
-async fn rehome_keys(
-    secrets: &dyn SecretProvider,
-    keys: Vec<String>,
-) -> Vec<(String, RehomeOutcome)> {
-    let mut outcomes = Vec::new();
-    for key in keys {
-        let outcome = rehome_one(secrets, &key).await;
-        outcomes.push((key, outcome));
-    }
-    outcomes
-}
-
-async fn rehome_one(secrets: &dyn SecretProvider, key: &str) -> RehomeOutcome {
-    let value = match secrets.get_secret(key).await {
-        Ok(Some(value)) => value,
-        Ok(None) => return RehomeOutcome::Absent,
-        Err(error) => return RehomeOutcome::Skipped(format!("could not read it: {error}")),
-    };
-    if let Err(error) = secrets.delete_secret(key).await {
-        return RehomeOutcome::Skipped(format!("could not remove the old item: {error}"));
-    }
-    if let Err(error) = secrets.set_secret(key, &value).await {
-        return RehomeOutcome::Lost(format!("could not store it again: {error}"));
-    }
-    match secrets.get_secret(key).await {
-        Ok(Some(stored)) if stored == value => RehomeOutcome::Rehomed,
-        Ok(_) => RehomeOutcome::Lost("it did not read back unchanged".to_string()),
-        Err(error) => RehomeOutcome::Lost(format!("it could not be read back: {error}")),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
     use std::sync::Mutex;
 
+    use std::sync::Arc;
+
     use async_trait::async_trait;
-    use tidebreak_core::Result;
+    use tidebreak_core::{Result, SecretProvider};
 
     use super::*;
 
@@ -283,6 +320,19 @@ mod tests {
         values: Mutex<BTreeMap<String, String>>,
         ops: Mutex<Vec<String>>,
         fail_delete: bool,
+    }
+
+    impl RecordingSecrets {
+        /// The keys the store actually holds — the count this change is about.
+        fn item_keys(&self) -> Vec<String> {
+            self.values.lock().unwrap().keys().cloned().collect()
+        }
+    }
+
+    /// The pass under test operates on the bundle, so a test store has to be
+    /// wrapped the way boot wraps the real keychain.
+    fn bundled(secrets: Arc<RecordingSecrets>) -> BundledSecretProvider {
+        BundledSecretProvider::new(secrets)
     }
 
     #[async_trait]
@@ -310,23 +360,19 @@ mod tests {
         }
     }
 
-    /// The repair only works if the item is removed before the value is stored
-    /// again — an in-place update keeps the original item, and with it the
-    /// ownership that makes macOS prompt.
+    /// The point of the pass: a credential left in its own item is moved into
+    /// the bundle and the old item is removed, so the profile is down to one
+    /// item — and one access prompt — afterwards.
     #[tokio::test]
-    async fn stored_values_are_deleted_then_written_back_intact() {
+    async fn a_per_key_item_is_swept_into_the_bundle_and_removed() {
         let key = ProviderKind::Anthropic.credential_key();
-        let secrets = RecordingSecrets::default();
-        secrets
-            .set_secret(&key, "test-anthropic-key")
-            .await
-            .unwrap();
-        secrets.ops.lock().unwrap().clear();
+        let store = Arc::new(RecordingSecrets::default());
+        store.set_secret(&key, "test-anthropic-key").await.unwrap();
+        let secrets = bundled(store.clone());
 
         let outcomes = rehome_keys(&secrets, static_secret_keys()).await;
 
-        let ops = secrets.ops.lock().unwrap().clone();
-        assert_eq!(ops, vec![format!("delete {key}"), format!("set {key}")]);
+        assert_eq!(store.item_keys(), vec![BUNDLE_KEY.to_string()]);
         assert_eq!(
             secrets.get_secret(&key).await.unwrap().as_deref(),
             Some("test-anthropic-key")
@@ -344,19 +390,54 @@ mod tests {
             .all(|(_, outcome)| *outcome == RehomeOutcome::Absent));
     }
 
-    /// A credential we cannot remove is left alone rather than reported as
-    /// repaired: the prompt will return, which is better than losing the value.
+    /// Once migrated, the pass rewrites one item however many credentials the
+    /// profile holds. This is the whole prompt reduction, asserted directly.
     #[tokio::test]
-    async fn an_undeletable_credential_is_kept_and_reported() {
+    async fn a_migrated_profile_re_homes_exactly_one_item() {
+        let store = Arc::new(RecordingSecrets::default());
+        for key in [
+            ProviderKind::Anthropic.credential_key(),
+            ProviderKind::Openai.credential_key(),
+            GATEWAY_SECRET_KEY.to_string(),
+            CHATGPT_SECRET_KEY.to_string(),
+        ] {
+            store.set_secret(&key, "value").await.unwrap();
+        }
+        let secrets = bundled(store.clone());
+        rehome_keys(&secrets, static_secret_keys()).await;
+        assert_eq!(store.item_keys(), vec![BUNDLE_KEY.to_string()]);
+        store.ops.lock().unwrap().clear();
+
+        // A second pass is what the next app update runs.
+        let outcomes = rehome_keys(&bundled(store.clone()), static_secret_keys()).await;
+
+        assert_eq!(
+            *store.ops.lock().unwrap(),
+            vec![format!("delete {BUNDLE_KEY}"), format!("set {BUNDLE_KEY}"),],
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|(_, outcome)| *outcome != RehomeOutcome::Absent)
+                .map(|(key, _)| key.as_str())
+                .collect::<Vec<_>>(),
+            vec![BUNDLE_KEY],
+        );
+    }
+
+    /// A per-key item we cannot remove never costs the credential: the value
+    /// is stored in the bundle and read back before the old item is touched,
+    /// so a failed removal leaves it in both places and the bundle wins.
+    /// Reported as skipped so the next launch tries the removal again.
+    #[tokio::test]
+    async fn an_undeletable_item_keeps_the_credential_and_is_reported() {
         let key = ProviderKind::Anthropic.credential_key();
-        let secrets = RecordingSecrets {
+        let store = Arc::new(RecordingSecrets {
             fail_delete: true,
             ..RecordingSecrets::default()
-        };
-        secrets
-            .set_secret(&key, "test-anthropic-key")
-            .await
-            .unwrap();
+        });
+        store.set_secret(&key, "test-anthropic-key").await.unwrap();
+        let secrets = bundled(store.clone());
 
         let outcomes = rehome_keys(&secrets, static_secret_keys()).await;
 
@@ -370,6 +451,8 @@ mod tests {
             .map(|(_, outcome)| outcome)
             .unwrap();
         assert!(matches!(outcome, RehomeOutcome::Skipped(_)), "{outcome:?}");
+        // Never `Lost`: the sweep stores before it removes, so the state where
+        // the value is gone from both places is unreachable.
     }
 
     /// A provider whose credential key is missing here would keep prompting
@@ -409,6 +492,16 @@ mod tests {
         assert!(keys.iter().any(|key| key == CHATGPT_SECRET_KEY));
     }
 
+    /// The desktop shell writes its remote-machine bearer, and this list is
+    /// what sweeps it. It was missing here for as long as the key existed, so
+    /// that credential kept its own item — and its own prompt — forever.
+    #[test]
+    fn the_desktop_remote_machine_token_is_covered() {
+        assert!(static_secret_keys()
+            .iter()
+            .any(|key| key == DESKTOP_REMOTE_MACHINE_TOKEN_KEY));
+    }
+
     /// MCP server environment values live under per-record `mcp.{id}.env_v1`
     /// keys; a re-home pass that skipped them would leave every MCP
     /// credential owned by the old signature.
@@ -440,32 +533,37 @@ mod tests {
         assert!(keys.contains(&expected), "{keys:?}");
     }
 
-    /// Re-homing is idempotent: a second pass over an already re-homed value
-    /// rewrites it again (the implementation cannot tell "already owned"
-    /// apart cheaply, so it rewrites unconditionally) and the value reads
-    /// back unchanged both times.
+    /// Re-homing is idempotent. The second pass finds nothing left to sweep
+    /// and rewrites the bundle item alone, and the value reads back unchanged
+    /// both times.
     #[tokio::test]
     async fn rehoming_twice_keeps_the_value_intact() {
         let key = ProviderKind::Anthropic.credential_key();
-        let secrets = RecordingSecrets::default();
-        secrets
-            .set_secret(&key, "test-anthropic-key")
-            .await
-            .unwrap();
+        let store = Arc::new(RecordingSecrets::default());
+        store.set_secret(&key, "test-anthropic-key").await.unwrap();
 
-        for _ in 0..2 {
+        for pass in 0..2 {
+            // A fresh provider each time: a second launch has no decoded copy
+            // of the item, and neither should the second pass here.
+            let secrets = bundled(store.clone());
             let outcomes = rehome_keys(&secrets, static_secret_keys()).await;
+            let swept = outcomes
+                .iter()
+                .find(|(candidate, _)| *candidate == key)
+                .map(|(_, outcome)| outcome);
             assert_eq!(
-                outcomes
-                    .iter()
-                    .find(|(candidate, _)| *candidate == key)
-                    .map(|(_, outcome)| outcome),
-                Some(&RehomeOutcome::Rehomed)
+                swept,
+                Some(&if pass == 0 {
+                    RehomeOutcome::Rehomed
+                } else {
+                    RehomeOutcome::Absent
+                }),
             );
             assert_eq!(
                 secrets.get_secret(&key).await.unwrap().as_deref(),
                 Some("test-anthropic-key")
             );
+            assert_eq!(store.item_keys(), vec![BUNDLE_KEY.to_string()]);
         }
     }
 
@@ -481,11 +579,9 @@ mod tests {
         .await
         .unwrap();
         let key = ProviderKind::Anthropic.credential_key();
-        let secrets = RecordingSecrets::default();
-        secrets
-            .set_secret(&key, "test-anthropic-key")
-            .await
-            .unwrap();
+        let items = Arc::new(RecordingSecrets::default());
+        items.set_secret(&key, "test-anthropic-key").await.unwrap();
+        let secrets = bundled(items.clone());
 
         assert!(rehome_once_per_binary(&store, &secrets).await.unwrap());
         assert_eq!(
@@ -493,9 +589,9 @@ mod tests {
             Some("test-anthropic-key")
         );
 
-        secrets.ops.lock().unwrap().clear();
+        items.ops.lock().unwrap().clear();
         assert!(!rehome_once_per_binary(&store, &secrets).await.unwrap());
-        assert!(secrets.ops.lock().unwrap().is_empty());
+        assert!(items.ops.lock().unwrap().is_empty());
     }
 
     /// A credential that could not be re-homed leaves the binary unstamped,
@@ -511,19 +607,17 @@ mod tests {
         .await
         .unwrap();
         let key = ProviderKind::Anthropic.credential_key();
-        let secrets = RecordingSecrets {
+        let items = Arc::new(RecordingSecrets {
             fail_delete: true,
             ..RecordingSecrets::default()
-        };
-        secrets
-            .set_secret(&key, "test-anthropic-key")
-            .await
-            .unwrap();
+        });
+        items.set_secret(&key, "test-anthropic-key").await.unwrap();
+        let secrets = bundled(items.clone());
 
         assert!(rehome_once_per_binary(&store, &secrets).await.unwrap());
         // Not stamped: the very next boot takes the pass again.
-        secrets.ops.lock().unwrap().clear();
+        items.ops.lock().unwrap().clear();
         assert!(rehome_once_per_binary(&store, &secrets).await.unwrap());
-        assert!(!secrets.ops.lock().unwrap().is_empty());
+        assert!(!items.ops.lock().unwrap().is_empty());
     }
 }

--- a/docs/decisions/0056-one-credential-item-per-profile.md
+++ b/docs/decisions/0056-one-credential-item-per-profile.md
@@ -1,0 +1,133 @@
+# 56. One credential item per profile
+
+- Status: Accepted
+- Date: 2026-08-21
+- Owners: desktop, server
+- Related: [`0016-desktop-staging-channel.md`](0016-desktop-staging-channel.md)
+  (per-channel keychain services),
+  `crates/tidebreak-core/src/secret_bundle.rs`,
+  `crates/tidebreak-server/src/secret_rehome.rs`
+
+## Context
+
+macOS grants keychain access on the code signature of the binary that *created*
+an item. An app update replaces the binary, so every credential the previous
+build wrote is stranded: reads prompt, and a gateway session that fails to read
+presents as "not connected".
+
+`secret_rehome` already repairs that by rewriting each value from the new
+binary. The repair works, but it is per item, and so is the prompt. A profile
+holding four credentials — two provider keys, the ChatGPT sign-in, the gateway
+session, which is what a real desktop profile looked like on 2026-08-21 —
+costs roughly eight approvals per update: `rehome_one` reads, deletes, stores,
+and reads back, and the first two of those hit an item the new binary does not
+own yet. The `tidebreak.log` on that machine records the pass running twice in
+two days, each time reporting four credentials.
+
+`CachingSecretProvider` removes *repeat* reads within a process. It cannot
+remove the first read of each distinct item, which is where the prompt is. The
+number of prompts is the number of items, by construction.
+
+`static_secret_keys` enumerates eighteen fixed keys before per-record MCP and
+connected-app keys, so the ceiling grows with the feature set rather than
+staying at four.
+
+## Decision
+
+Every logical key in a profile is stored inside **one** keychain item,
+`tidebreak.secret_bundle_v1`, holding a JSON object of key → value.
+`BundledSecretProvider` is a `SecretProvider` decorator, so nothing above it
+learns where a key sits; callers keep naming
+`provider.anthropic.credential`. The wrap order at boot is
+`Caching(Bundled(Keychain))`.
+
+Three rules make it safe:
+
+- **Reads fall back to a per-key item of the same name.** Migration is a
+  boot-time pass, and the shell's remote attachment reads its token before that
+  pass can have run. Without the fallback, the launch after an update would read
+  as "not attached". The fallback makes ordering stop mattering.
+- **Writes merge against the store.** A write takes a process-wide lock,
+  re-reads the item, applies its change, and confirms the read-back; a store
+  that changed underneath is merged again rather than overwritten. The desktop
+  builds two providers over one item — the server's and the shell's — and
+  `tidebreak rehome-secrets` deliberately runs without the instance lock.
+- **Migration stores before it removes.** The sweep writes a value into the
+  bundle and reads it back *before* touching the old item. The
+  "removed, then could not store it again" state that the per-item repair can
+  reach does not exist for it.
+
+`secret_rehome` becomes: re-home the one item, then sweep any leftover per-key
+items into it. `desktop.remote-machine.token` joins the swept set; it is a real
+stored credential that the enumeration never named, so it was never re-homed.
+
+Deliberately excluded: encrypting the JSON (the item is already protected), and
+deleting the item when it becomes empty (a churned item buys nothing).
+
+## Alternatives Considered
+
+**Do nothing.** The prompts are survivable and the repair already works. Rejected
+because the count scales with the feature set, not with anything the user did,
+and the most expensive prompt — the gateway session — is the one whose failure
+presents as a silent sign-out.
+
+**Keep per-key items, trim the re-home pass.** Skipping the read-back, or
+detecting "already owned" before rewriting, roughly halves the prompts. Rejected:
+it is the item count that sets the floor, and this leaves it untouched.
+
+**Put the credentials in SQLite, encrypted with one keychain-held key.** One item
+by another route, and a smaller item. Rejected: it moves secrets into the store
+that `SecretProvider` exists to keep them out of, and a pre-v1 schema-epoch reset
+deletes that database.
+
+**A macOS-specific ACL that trusts the application.** `SecAccessCreate` with the
+app in the trusted list would stop the prompts without changing the layout.
+Rejected: `keyring` does not expose it, it is one platform only, and it does not
+help the dev-signing case that motivated `secret_rehome` in the first place.
+
+## Consequences
+
+An update costs one approval rather than one per credential, and the cost stops
+growing as features add keys.
+
+What it costs:
+
+- **A lost-update window across processes.** Merge-on-write plus
+  read-back-and-retry narrows it to the write itself; it does not close it.
+  Writes are rare — credential edits and sign-in — and the daemon holds the
+  instance lock.
+- **A one-way migration.** A build older than this one sees no per-key items and
+  reads every credential as absent. Downgrading means re-entering credentials.
+  The pre-v1 data warning in the updater already covers the user-facing case.
+- **One item is one failure domain.** An undecodable bundle is every credential
+  at once, which is why the decoder refuses rather than treating the item as an
+  empty profile — reporting "no credentials" would look like a fresh install and
+  then overwrite the one thing a reader could recover from.
+- **Two extra cheap reads per absent key.** A miss re-reads the item and then
+  asks for a per-key item. Absent items answer without prompting, and the outer
+  cache absorbs the repeats.
+
+Revisit if a credential grows large enough to strain a generic password item, if
+concurrent writers stop being rare, or if a platform gains a way to grant an
+application durable access to an item across signatures — which would remove the
+prompt without needing the layout at all.
+
+## Validation
+
+`crates/tidebreak-core/src/secret_bundle.rs` asserts the property directly:
+storing three credentials leaves the store holding exactly one item. Alongside
+it: two providers over one item do not lose each other's keys; a key still in
+its own item reads before migration runs; a delete reaches the leftover item, so
+the fallback cannot resurrect it; and an undecodable item is refused rather than
+overwritten.
+
+`crates/tidebreak-server/src/secret_rehome.rs` asserts that a migrated profile
+re-homes exactly one item, by recording the operations the pass performs — a
+plausible wrong implementation that swept correctly but still rewrote each key
+would pass a value-level assertion and fail this one. It also pins that a
+per-key item which cannot be removed is reported as skipped and never as lost.
+
+What none of that covers is the real backend: the tests use an in-memory store,
+and the prompt behaviour lives in macOS. That was checked by hand against a
+scratch keychain service — two per-key items in, one bundle item out, values
+intact, and a second pass touching only the bundle.

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -96,7 +96,7 @@ The main local data is easy to recognize:
 | `tidebreak-schema.json` | pre-v1 local SQLite schema epoch |
 | `blobs/` | retained immutable document bytes |
 | `tidebreak.lock` | proof that one process owns this data directory |
-| OS keychain | provider credentials, kept outside the database |
+| OS keychain | provider credentials, kept outside the database — one item per profile |
 
 While the app remains at version `0.0.0`, baseline migrations may be rewritten
 instead of accumulated. The local SQLite schema epoch makes that explicit for


### PR DESCRIPTION
## Why

macOS pins a keychain item's access to the binary that created it, so an app
update strands every credential the previous build wrote. `secret_rehome`
already repairs that — but per item, and so is the prompt. `rehome_one` reads,
deletes, stores, and reads back, and the first two hit an item the new binary
does not own yet.

This laptop's profile holds four credentials (`provider.openai.credential`,
`provider.anthropic.credential`, `provider.openai.chatgpt_oauth_v1`,
`gateway.credentials_v1`), so an update costs roughly eight approvals. The log
shows the pass running twice in two days, four credentials each time:

```
00:05:15 INFO secret_rehome: re-homed 4 stored credential(s) …
12:49:29 INFO secret_rehome: re-homed 4 stored credential(s) …
```

`CachingSecretProvider` removes *repeat* reads. It cannot remove the first read
of each distinct item, which is where the prompt is — the prompt count is the
item count, by construction. And `static_secret_keys` names eighteen fixed keys
before per-record MCP and connected-app keys, so the ceiling grows with the
feature set.

## What

One item per profile — `tidebreak.secret_bundle_v1`, a JSON object of key →
value — behind a `SecretProvider` decorator, so nothing above it learns where a
key sits. Boot wraps `Caching(Bundled(Keychain))`.

Three rules make it safe:

- **Reads fall back to a per-key item.** Migration runs at server boot, and the
  shell's remote attachment reads its token before that. Without the fallback
  the launch after an update reads as "not attached" and drops you back onto
  this computer. The fallback makes ordering stop mattering.
- **Writes merge against the store.** The desktop builds two providers over the
  one item, and `tidebreak rehome-secrets` runs without the instance lock by
  design. A write takes a process-wide lock, re-reads, merges, and confirms the
  read-back.
- **Migration stores before it removes.** The value is in the bundle and read
  back before the old item is touched, so the "removed, then could not store it
  again" state the per-item repair can reach is now unreachable.

`desktop.remote-machine.token` joins the swept set — a real stored credential
the enumeration never named, so it had never been re-homed at all.

[ADR 0056](docs/decisions/0056-one-credential-item-per-profile.md) records the
alternatives, including the ACL approach `keyring` does not expose.

## Risks, stated plainly

- **Migration is one-way.** A build older than this one sees no per-key items
  and reads every credential as absent. Relevant to anyone downgrading.
- **A lost-update window across processes.** Narrowed to the write itself, not
  closed. Writes are rare; the daemon holds the instance lock.
- **One item is one failure domain.** An undecodable bundle is every credential
  at once, so the decoder refuses rather than reporting an empty profile — which
  would look like a fresh install and then overwrite the recoverable item.

## Tests

`secret_bundle.rs` (15) asserts the property directly: three credentials in, one
stored item. Plus two providers not clobbering each other, the pre-migration
read fallback, a delete reaching the leftover item, and the undecodable-item
refusal.

`secret_rehome.rs` asserts a migrated profile re-homes *exactly one item*, by
recording the operations — an implementation that swept correctly but still
rewrote each key passes a value assertion and fails this one.

Checked by hand against the real macOS keychain on a scratch service (live
credentials untouched, scratch items cleaned up):

```
before:  gateway.credentials_v1, provider.anthropic.credential
pass 1:  moved provider.anthropic.credential into the credential bundle
         moved gateway.credentials_v1 into the credential bundle
after:   tidebreak.secret_bundle_v1        ← one item, both values intact
pass 2:  re-homed the credential bundle    ← a later update touches only this
```

`cargo fmt` clean; clippy clean on both crates; `tidebreak-core` (694+17),
`tidebreak-server` lib (1130), and `tidebreak-desktop` lib (227) green.
`tests::code_terminals::create_write_read_and_two_cursors` failed once under
parallel load and passes on its own — a PTY timing flake, unrelated.