### PR TITLE
fix(code): fence a session whose turns keep failing

### DIFF
--- a/crates/tidebreak-core/src/code/attention.rs
+++ b/crates/tidebreak-core/src/code/attention.rs
@@ -76,6 +76,18 @@ pub enum FenceReason {
         /// Bounded human-readable detail, as the engine reported it.
         detail: String,
     },
+    /// Consecutive turns failed without one succeeding between them.
+    ///
+    /// Whatever broke is not specific to a prompt — an expired credential,
+    /// a revoked key, an engine that cannot reach its provider — so the next
+    /// turn would fail the same way. Fencing offers a reap instead of a
+    /// session that reads idle and is not.
+    RepeatedTurnFailures {
+        /// How many turns failed in a row.
+        count: u32,
+        /// Bounded detail from the last failure, as the engine reported it.
+        detail: String,
+    },
 }
 
 /// Server-computed attention for one unit of supervised work.

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -7,32 +7,33 @@ import {
   parseCodeCloneDefaults,
   parseCodeCloneJob,
   parseCodeCommit,
-  parseCodeEvent,
-  parseCodePush,
-  parseCodeSession,
-  parseCodeSessionList,
-  parseCodeSubscriptionUsage,
   parseCodeDeliveryActionResult,
   parseCodeDeliveryPullRequestDetail,
   parseCodeDeliveryPullRequestsPage,
   parseCodeDeliveryRepositories,
   parseCodeDeliveryRunDetail,
   parseCodeDeliveryRunsPage,
-  parseCodeUpdateNotice,
-  parseCodeWorktreeRoot,
+  parseCodeEvent,
+  parseCodePrComments,
+  parseCodePush,
+  parseCodeSession,
+  parseCodeSessionList,
+  parseCodeSubscriptionUsage,
   parseCodeTerminal,
   parseCodeTerminalList,
   parseCodeTerminalRead,
   parseCodeTurn,
   parseCodeTurnList,
   parseCodeTurnSubmission,
+  parseCodeUpdateNotice,
   parseCodeWorkspaceBlob,
   parseCodeWorkspaceDiff,
   parseCodeWorkspaceFiles,
+  parseCodeWorkspacePr,
   parseCodeWorkspaceSearch,
   parseCodeWorkspaceTree,
-  parseCodeWorkspacePr,
-  parseCodePrComments,
+  parseCodeWorktreeRoot,
+  parseFenceReason,
 } from "./parsers";
 
 const DELIVERY_CAPABILITY = {
@@ -968,5 +969,34 @@ describe("code delivery wire parsers", () => {
     expect(
       parseCodeDeliveryActionResult({ success: "yes", message: "done" }),
     ).toBeNull();
+  });
+});
+
+describe("parseFenceReason", () => {
+  it("accepts every reason the server can send", () => {
+    expect(parseFenceReason({ type: "orphan_alive" })).toEqual({
+      type: "orphan_alive",
+    });
+    expect(
+      parseFenceReason({ type: "resume_lost", detail: "gone" }),
+    ).toEqual({ type: "resume_lost", detail: "gone" });
+    // A session fenced for repeated failures used to fail this parse, and
+    // a null here drops the whole session from the list rather than just
+    // its badge.
+    expect(
+      parseFenceReason({
+        type: "repeated_turn_failures",
+        count: 3,
+        detail: "401",
+      }),
+    ).toEqual({ type: "repeated_turn_failures", count: 3, detail: "401" });
+  });
+
+  it("rejects a malformed reason", () => {
+    expect(parseFenceReason({ type: "repeated_turn_failures" })).toBeNull();
+    expect(
+      parseFenceReason({ type: "repeated_turn_failures", count: "3", detail: "x" }),
+    ).toBeNull();
+    expect(parseFenceReason({ type: "who_knows" })).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2675,6 +2675,17 @@ export function parseFenceReason(value: unknown): FenceReason | null {
   if (value.type === "resume_lost" && typeof value.detail === "string") {
     return { type: "resume_lost", detail: value.detail };
   }
+  if (
+    value.type === "repeated_turn_failures" &&
+    typeof value.count === "number" &&
+    typeof value.detail === "string"
+  ) {
+    return {
+      type: "repeated_turn_failures",
+      count: value.count,
+      detail: value.detail,
+    };
+  }
   return null;
 }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1978,6 +1978,14 @@ detail: string, } | { "type": "resume_lost",
 /**
  * Bounded human-readable detail, as the engine reported it.
  */
+detail: string, } | { "type": "repeated_turn_failures", 
+/**
+ * How many turns failed in a row.
+ */
+count: number, 
+/**
+ * Bounded detail from the last failure, as the engine reported it.
+ */
 detail: string, };
 
 /**

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -979,6 +979,15 @@ async fn drive_turn(
             false,
         );
     } else if turn.status == CodeTurnStatus::Failed {
+        // Whatever broke may not be about this prompt. An expired credential
+        // or an unreachable provider fails every turn identically, and a
+        // session that keeps saying "idle" invites the user to retry into it
+        // forever. Once enough turns fail back to back, fence and offer a
+        // reap.
+        if let Some(reason) = repeated_failure_fence(db, session, &turn).await {
+            let _ = super::recovery::fence_session(db, bus, session, reason).await;
+            return Ok(turn);
+        }
         super::attention::replace_attention(
             session,
             Attention::needs_you("the engine turn failed", AttentionSource::Lifecycle),
@@ -1026,6 +1035,57 @@ async fn hydrate_turn_images(
         });
     }
     Ok(images)
+}
+
+/// How many turns must fail back to back before the session is fenced.
+///
+/// Three, not one: a single failure is ordinary — a bad prompt, a transient
+/// provider hiccup, a tool that blew up — and fencing on it would be worse
+/// than the problem. Three in a row with no success between them is a
+/// property of the session, not of any one turn.
+const REPEATED_FAILURE_FENCE: u32 = 3;
+
+/// A fence reason when this failure is the latest in an unbroken run of them.
+///
+/// Counts backwards over the session's turns and stops at the first one that
+/// did not fail, so a session that recovers starts the count over.
+async fn repeated_failure_fence(
+    db: &DbStore,
+    session: &CodeSession,
+    turn: &CodeTurn,
+) -> Option<FenceReason> {
+    let turns = tidebreak_core::db::code::list_turns(db, &session.owner, session.id)
+        .await
+        .ok()?;
+    let mut count = 0u32;
+    for candidate in turns.iter().rev() {
+        match candidate.status {
+            CodeTurnStatus::Failed => count += 1,
+            // A turn still running is the one we are closing out; anything
+            // else ends the streak.
+            CodeTurnStatus::Running if candidate.id == turn.id => count += 1,
+            _ => break,
+        }
+    }
+    if count < REPEATED_FAILURE_FENCE {
+        return None;
+    }
+    let detail = last_failure_detail(db, session).await.unwrap_or_default();
+    Some(FenceReason::RepeatedTurnFailures { count, detail })
+}
+
+/// The message from the most recent `TurnFailed` in the journal.
+///
+/// The turn row keeps no error column, so the journal is the only place the
+/// reason survives. Without it the fence would say only that turns failed.
+async fn last_failure_detail(db: &DbStore, session: &CodeSession) -> Option<String> {
+    let events = tidebreak_core::db::code::list_recent_events(db, &session.owner, session.id, 64)
+        .await
+        .ok()?;
+    events.into_iter().find_map(|item| match item.event {
+        CodeEvent::TurnFailed { error } => Some(error.message),
+        _ => None,
+    })
 }
 
 async fn session_was_ended(db: &DbStore, session: &mut CodeSession) -> bool {

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1351,6 +1351,99 @@ async fn a_workspace_runs_several_agents_that_take_turns_on_one_worktree() {
 }
 
 /// Create `count` interactive sessions in one workspace, returning their ids.
+/// A turn script that always fails, the way an expired credential does.
+fn always_failing_script() -> Vec<HarnessEvent> {
+    vec![
+        HarnessEvent::SessionStarted {
+            harness_kind: tidebreak_core::HarnessKind::ClaudeCode,
+            harness_version: "scripted".into(),
+            resume_ref: Some("scripted-session".into()),
+        },
+        HarnessEvent::TurnStarted,
+        HarnessEvent::TurnFailed {
+            error: tidebreak_core::BoundedError {
+                message: "Auth recovery succeeded but 4 authenticated inference requests \
+                          were still rejected (401); giving up after 3 retries."
+                    .into(),
+            },
+        },
+    ]
+}
+
+/// A credential that stops working fails every turn identically, and the
+/// session went on reporting `idle` — so the next turn, and the one after
+/// that, were invited to fail the same way with no remedy offered.
+#[tokio::test]
+async fn a_session_whose_turns_keep_failing_is_fenced_rather_than_left_idle() {
+    let (router, token, _runtime, dir) =
+        code_app_with(ScriptedAdapter::new(always_failing_script())).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = create_sibling_sessions(&client, addr, &token, &workspace, 1)
+        .await
+        .remove(0);
+
+    let lifecycle = |session: String| {
+        let client = client.clone();
+        let token = token.clone();
+        async move {
+            let body: serde_json::Value = client
+                .get(format!("http://{addr}/code/sessions/{session}/debug"))
+                .bearer_auth(&token)
+                .send()
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap();
+            body["session"].clone()
+        }
+    };
+
+    for attempt in 1..=3 {
+        let response = client
+            .post(format!("http://{addr}/code/sessions/{session}/turns"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({ "message": format!("attempt {attempt}") }))
+            .send()
+            .await
+            .unwrap();
+        assert!(
+            response.status().is_success(),
+            "the turn is accepted even though the engine fails it"
+        );
+
+        let row = lifecycle(session.clone()).await;
+        if attempt < 3 {
+            assert_eq!(
+                row["lifecycle"], "idle",
+                "one or two failures are ordinary; do not fence early: {row}"
+            );
+            assert!(row["fence_reason"].is_null(), "{row}");
+        }
+    }
+
+    let row = lifecycle(session.clone()).await;
+    assert_eq!(
+        row["lifecycle"], "fenced",
+        "three failures in a row is a property of the session: {row}"
+    );
+    assert_eq!(
+        row["fence_reason"]["type"], "repeated_turn_failures",
+        "{row}"
+    );
+    assert_eq!(row["fence_reason"]["count"], 3, "{row}");
+    assert!(
+        row["fence_reason"]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("401"),
+        "the fence carries why, which the turn row never stored: {row}"
+    );
+}
+
 async fn create_sibling_sessions(
     client: &reqwest::Client,
     addr: std::net::SocketAddr,


### PR DESCRIPTION
## What happened

A grok session ran two turns fine, then failed the third:

```
Auth recovery succeeded but 4 authenticated inference requests were still
rejected (401); giving up after 3 retries.
```

Turns four and five failed identically — the fifth was a bare `Reply with the single word: ok`. Throughout, the session reported `lifecycle: "idle"` with `fence_reason: null`: indistinguishable from one waiting for work.

`session_worker.rs` already states the invariant this breaks, for the resume-lost case:

> The engine has lost this session: every later turn would fail the same way. Fence it so the user is offered a reap instead of a session that is idle and broken.

Only `HarnessError::ResumeLost` reaches that arm, and only the codex and opencode adapters raise it. `FenceReason` had no variant for a credential that died.

## The approach

Not string-matching provider errors — that is brittle and only ever covers the failures someone already saw. Count consecutive failures instead: three in a row with no success between them is a property of the *session* rather than of any one turn, whatever the cause. An expired key, a revoked token, a provider that cannot be reached, an engine that is simply broken — all read the same from outside, and all deserve the same remedy.

One failure stays ordinary: a bad prompt, a transient hiccup, a tool that blew up. Fencing on that would be worse than the problem.

`FenceReason::RepeatedTurnFailures { count, detail }` carries the last failure's message. The turn row has no error column, so the journal is the only place that message survives — the fence is what makes it reachable without replaying events.

## Desktop

`parseFenceReason` returns `null` for a reason type it does not know, and its caller drops the **whole session** on a null rather than just the badge. So the new variant is parsed there too, with a test — this would otherwise have made fenced sessions vanish from the list.

## Tests

`a_session_whose_turns_keep_failing_is_fenced_rather_than_left_idle` drives a scripted always-failing engine through three turns: after one and two the session must still be `idle` with no fence reason, and after the third it must be `fenced` with `repeated_turn_failures`, `count: 3`, and a detail carrying the `401`.

Verified the test has teeth — raising the threshold to 99 fails it with exactly the production symptom:

```
assertion `left == right` failed: three failures in a row is a property of the session
  left: String("idle")
```

`parseFenceReason` gets its own vitest case, including the malformed shapes it must still reject.

`cargo test -p tidebreak-server --lib code::` — 186 passed. Wire types regenerated for the new variant. Clippy and fmt clean.