### PR TITLE
ci: run the Windows lane when a change reaches a Windows boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
       notices: ${{ steps.scope.outputs.notices }}
       rust: ${{ steps.scope.outputs.rust }}
       ui: ${{ steps.scope.outputs.ui }}
+      windows: ${{ steps.scope.outputs.windows }}
       workspace: ${{ steps.scope.outputs.workspace }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -148,6 +149,7 @@ jobs:
               echo "notices=true"
               echo "rust=true"
               echo "ui=true"
+              echo "windows=true"
               echo "workspace=true"
             } >> "$GITHUB_OUTPUT"
           }
@@ -197,6 +199,7 @@ jobs:
           notices=false
           rust=false
           ui=false
+          windows=false
           workspace=false
           git diff --no-renames --name-only -z "$diff_range" \
             > "$RUNNER_TEMP/changed-files"
@@ -239,6 +242,24 @@ jobs:
                 notices=true; rust=true; workspace=true ;;
               *) rust=true; workspace=true ;;
             esac
+            # A second, independent question about the same file: can it
+            # break on Windows in a way no Linux lane can see? These are the
+            # paths the Windows lane runs tests for. NTFS path shapes, the
+            # Windows process APIs, and the native credential store decide
+            # those results, and a cross-target `cargo check` proves none of
+            # them.
+            case "$file" in
+              # This file decides what every lane runs, including this one.
+              .github/workflows/ci.yml) windows=true ;;
+              crates/tidebreak-code-execution/*|crates/tidebreak-harness/*|crates/tidebreak-host-broker/*)
+                windows=true ;;
+              crates/tidebreak-server/src/code/*|crates/tidebreak-server/src/tests/code*)
+                windows=true ;;
+              crates/tidebreak-server/src/desktop_schema.rs|crates/tidebreak-core/src/keychain.rs)
+                windows=true ;;
+              crates/tidebreak-desktop/scripts/prepare-sidecar.mjs)
+                windows=true ;;
+            esac
           done < "$RUNNER_TEMP/changed-files"
 
           # Keep narrower scopes honest here, before conditional jobs consume
@@ -248,6 +269,10 @@ jobs:
             echo "workspace scope without Rust scope; the detector is wrong." >&2
             exit 1
           fi
+          if [[ "$windows" == true && "$rust" != true ]]; then
+            echo "Windows scope without Rust scope; the detector is wrong." >&2
+            exit 1
+          fi
 
           {
             echo "docs_site=$docs_site"
@@ -255,6 +280,7 @@ jobs:
             echo "notices=$notices"
             echo "rust=$rust"
             echo "ui=$ui"
+            echo "windows=$windows"
             echo "workspace=$workspace"
           } >> "$GITHUB_OUTPUT"
 
@@ -494,12 +520,15 @@ jobs:
     name: Windows cargo check
     needs: changes
     # A native runner keeps the Windows SDK and MSVC available for native
-    # dependencies such as ring and SQLite. Native Windows validation stays an
-    # explicit pre-merge choice even though every other lane runs by default:
-    # add `windows-ci` when the change reaches a Windows boundary; main and
-    # scheduled/manual runs retain the automatic backstop.
+    # dependencies such as ring and SQLite. This lane is expensive, so it
+    # stays off the default pull-request path. Asking authors to remember the
+    # label did not hold: two Windows-only breaks reached main from unlabeled
+    # pull requests (#2307, #2403). The `windows` scope now runs the lane for
+    # the paths it tests. The label stays as the manual override for a change
+    # the scope cannot see. Main, scheduled, and manual runs retain the
+    # automatic backstop.
     #
-    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'windows-ci')) }}
+    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'windows-ci') || needs.changes.outputs.windows == 'true') }}
     runs-on: windows-latest
     # Every Rust-scoped main push contains the prior main state, so the newest
     # Windows run proves everything an older in-progress one would have proven.

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -533,12 +533,49 @@ test("merge queue groups re-run required CI", () => {
   assert.match(prTitle, /github\.event_name == 'merge_group'/);
 });
 
-test("native Windows CI is an explicit PR opt-in with a main backstop", () => {
-  const windows = workflowJob(workflows["ci.yml"], "windows-check");
+test("native Windows CI is scope-triggered, label-overridable, with a main backstop", () => {
+  const ci = workflows["ci.yml"];
+  const windows = workflowJob(ci, "windows-check");
+  const changes = workflowJob(ci, "changes");
   const windowsCiGate =
     /github\.event_name != 'pull_request' \|\| contains\(github\.event\.pull_request\.labels\.\*\.name, 'windows-ci'\)/;
 
   assert.match(windows, windowsCiGate);
+  // The label was the only trigger until two Windows-only breaks reached
+  // main from unlabeled pull requests (#2307, #2403). A change to a path this
+  // lane tests must now run it without anyone remembering to ask.
+  assert.match(
+    windows,
+    /\|\| needs\.changes\.outputs\.windows == 'true'/,
+    "a Windows-boundary change must trigger the lane on its own",
+  );
+  assert.match(changes, /windows: \$\{\{ steps\.scope\.outputs\.windows \}\}/);
+  assert.match(changes, /echo "windows=\$windows"/);
+  assert.match(changes, /echo "windows=true"/);
+  // The scope must imply the Rust one, for the same reason `workspace` does:
+  // the lane is gated on both, so a scope the Rust gate never admits is dead.
+  assert.match(
+    changes,
+    /if \[\[ "\$windows" == true && "\$rust" != true \]\]; then/,
+  );
+  // Every crate or module the lane runs tests for. Dropping one silently
+  // returns that boundary to label-only coverage.
+  for (const boundary of [
+    "crates/tidebreak-code-execution/\\*",
+    "crates/tidebreak-harness/\\*",
+    "crates/tidebreak-host-broker/\\*",
+    "crates/tidebreak-server/src/code/\\*",
+    "crates/tidebreak-server/src/tests/code\\*",
+    "crates/tidebreak-server/src/desktop_schema\\.rs",
+    "crates/tidebreak-core/src/keychain\\.rs",
+    "crates/tidebreak-desktop/scripts/prepare-sidecar\\.mjs",
+  ]) {
+    assert.match(
+      changes,
+      new RegExp(`${boundary}[^\\n]*\\n?[^\\n]*windows=true`),
+      `${boundary} must set the Windows scope`,
+    );
+  }
   assert.match(
     windows,
     /group: \$\{\{ github\.event_name == 'push' && 'windows-check-main' \|\| format\('windows-check-run-\{0\}', github\.run_id\) \}\}/,


### PR DESCRIPTION
Follow-up to #2403.

## Problem

The Windows lane runs on a pull request only when someone applies the `windows-ci` label. Asking authors to remember that has now failed twice, and both times the break reached main:

- #2307 — CRLF mismatch and mid-turn steer races
- #2403 — a Unix-only bridge path fixture, which failed 17 tests on all three retry attempts

Both were changes to paths this lane runs tests for. Neither carried the label.

## Change

Add a `windows` scope to the change detector and let it trigger the lane on its own. The scope covers the crates and modules the lane actually runs tests for, not merely `cargo check`s:

| Path | Windows step it covers |
| --- | --- |
| `crates/tidebreak-code-execution/*`, `crates/tidebreak-harness/*` | Code mode Windows lifecycle tests |
| `crates/tidebreak-host-broker/*` | Host broker Windows tests |
| `crates/tidebreak-server/src/code/*`, `crates/tidebreak-server/src/tests/code*` | Code mode Windows lifecycle tests |
| `crates/tidebreak-server/src/desktop_schema.rs` | SQLite profile open and migrations |
| `crates/tidebreak-core/src/keychain.rs` | Credential Manager round trip |
| `crates/tidebreak-desktop/scripts/prepare-sidecar.mjs` | Prepare target-named sidecar binaries |
| `.github/workflows/ci.yml` | This file decides what every lane runs |

The label stays as the manual override for a change the scope cannot see. Main, scheduled, and manual runs keep the automatic backstop. The `windows` scope must imply the `rust` scope, asserted in the detector the same way `workspace` already is.

## Working within the trusted-policy ratchet

The `release policy` job runs the base branch's copy of `scripts/workflow-security.test.mjs` against this pull request's workflow, so a pull request cannot loosen a policy and rewrite its assertion in one commit.

The gate therefore keeps the label clause ahead of the new scope clause. Main's copy of the test asserts the label gate as a substring, and that substring survives intact:

```
github.event_name != 'pull_request' || contains(..., 'windows-ci') || needs.changes.outputs.windows == 'true'
```

This commit's own copy of the test then asserts the wider policy: the scope clause, the output plumbing, the implication guard, and every boundary path. Dropping a path from the ladder fails that test.

## Test plan

- [x] `node --test scripts/*.test.mjs` — 187 passed
- [x] Base branch's copy of `workflow-security.test.mjs` run against this workflow, as the `release policy` job does — 38 passed
- [x] Extracted the detector from the YAML and drove it against fixture file lists. Both historical breaks now trigger the lane; `sandbox_container_run/tests.rs`, `tests/lifecycle.rs`, `router/src/lib.rs`, `ui/src/App.tsx`, and `README.md` do not.
- [x] Broke the `rust` scope for a Windows path on purpose and confirmed the implication guard exits 1
- [x] This pull request edits `ci.yml`, so the Windows lane runs on it. That is the end-to-end check.

## Deliberately out of scope

`Cargo.lock` and `crates/*/Cargo.toml` do not set the scope. A native dependency bump is a genuine Windows risk, but including them would run an 18-minute lane on every Dependabot pull request. Apply the label for a risky bump instead.