### PR TITLE
feat(ui): foreground-chat browser panel and scope

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
@@ -44,6 +44,11 @@ import { DocumentDetailRoot } from "./document-detail/DocumentDetailRoot";
 import { warmPresentationConverter } from "./document/officePdf";
 import { FoldersView } from "./FoldersView";
 import { hasNativeHost } from "./host";
+import { Skeleton } from "@/components/ui/skeleton";
+import { usePortalOverlayOpen } from "@/lib/usePortalOverlayOpen";
+import { foregroundBrowserScope } from "./code/browser/foregroundBrowserScope";
+import { seedBrowserSession } from "./code/browser/browserPersistence";
+
 import { friendlyErrorMessage } from "./lib/utils";
 import { attachChatFiles, type AttachedFiles } from "./attachments";
 import { type ImportedDocument, type LibraryImportSuccess } from "./documents";
@@ -79,6 +84,12 @@ import { useDeliverableCatalog } from "./useDeliverableCatalog";
 import { backgroundAgentSpawnKeys, useAgentRuns } from "./useAgentRuns";
 import { appendTranscript, useVoiceComposer } from "./useVoiceComposer";
 import { useVoiceInputStore, voiceSelectionReady } from "./VoiceInputStore";
+
+
+const CodeBrowserTab = lazy(async () => {
+  const module = await import("./code/browser/CodeBrowserTab");
+  return { default: module.CodeBrowserTab };
+});
 
 let msgSeq = 0;
 
@@ -169,6 +180,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     [agentRuns.runs, spawnKeys],
   );
   const deliverables = useDeliverableCatalog(chatId);
+  const overlayOpen = usePortalOverlayOpen();
+  const [browserTitles, setBrowserTitles] = useState<Record<string, string>>({});
+
 
   // A chat id that is not in the list — deleted in another window, or a stale
   // deep link — should land somewhere real rather than on an empty frame. The
@@ -581,6 +595,32 @@ export function ChatRoute({ chatId }: { chatId: string }) {
    * message only has to name it again. That is why no size comes with it — the
    * transcript records what a document is, not how many bytes it was.
    */
+  /**
+   * Open a chat-scoped browser tab.  If one is already in the strip,
+   * focus it rather than opening a duplicate.  One default browser tab
+   * per chat, seeded with a fresh browser id and a foreground workspace
+   * scope the native executor derives identically from the chat id.
+   */
+  function openBrowser() {
+    const existingIndex = layout.tabs.findIndex(
+      (tab) => tab.type === "browser",
+    );
+    if (existingIndex !== -1) {
+      openPanel(layout.tabs[existingIndex]);
+      return;
+    }
+    const browserId = crypto.randomUUID();
+    const session = seedBrowserSession({
+      browserId,
+      workspaceId: foregroundBrowserScope(chatId),
+    });
+    setBrowserTitles((current) => ({
+      ...current,
+      [browserId]: session.title || "Browser",
+    }));
+    openPanel({ type: "browser", browserId });
+  }
+
   function onReattachFile(file: TranscriptFileAttachment) {
     if (files.some((current) => current.documentId === file.documentId)) return;
     if (images.attachments.length + files.length >= MAX_IMAGE_ATTACHMENTS) {
@@ -857,8 +897,27 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onOpenRun={(runId) => openPanel({ type: "agent", runId })}
           />
         );
+      case "browser":
+        return browserTitles[panel.browserId];
       case "agent":
         return <BackgroundAgentPanel chatId={chatId} runId={panel.runId} />;
+      case "browser":
+        return (
+          <Suspense fallback={<Skeleton className="h-full w-full" />}>
+            <CodeBrowserTab
+              workspaceId={foregroundBrowserScope(chatId)}
+              browserId={panel.browserId}
+              obscured={overlayOpen}
+              onTitleChange={(title) =>
+                setBrowserTitles((current) =>
+                  current[panel.browserId] === title
+                    ? current
+                    : { ...current, [panel.browserId]: title },
+                )
+              }
+            />
+          </Suspense>
+        );
       case "terminal":
         return null;
     }
@@ -875,6 +934,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         return panel.outputId
           ? deliverables.find((d) => d.outputId === panel.outputId)?.filename
           : undefined;
+      case "browser":
+        return browserTitles[panel.browserId];
       case "agent":
         return (
           chatAgentRuns.find((run) => run.id === panel.runId)?.task ?? undefined
@@ -899,6 +960,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
               onOpenFolders={() => openPanel({ type: "folders" })}
               onOpenPermissions={() => openPanel({ type: "permissions" })}
               onOpenAgents={() => openPanel({ type: "agents" })}
+              onOpenBrowser={nativeHost ? () => openBrowser() : undefined}
+
             />
           </div>
         </header>

--- a/crates/tidebreak-desktop/ui/src/ChatStatusChip.browser.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatStatusChip.browser.dom.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ChatStatusChip } from "./ChatStatusChip";
+
+afterEach(cleanup);
+
+function baseProps() {
+  return {
+    outputCount: 0,
+    folders: [] as const,
+    runs: [] as const,
+    onOpenOutputs: vi.fn(),
+    onOpenFolders: vi.fn(),
+    onOpenPermissions: vi.fn(),
+    onOpenAgents: vi.fn(),
+  };
+}
+
+describe("ChatStatusChip browser row", () => {
+  it("hides the browser row when no onOpenBrowser is passed", () => {
+    render(<ChatStatusChip {...baseProps()} />);
+    expect(
+      screen.queryByRole("button", { name: /Browser/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the browser row when onOpenBrowser is passed", () => {
+    const onOpenBrowser = vi.fn();
+    render(
+      <ChatStatusChip {...baseProps()} onOpenBrowser={onOpenBrowser} />,
+    );
+
+    const browserButton = screen.getByRole("button", { name: /Browser/ });
+    expect(browserButton).toBeInTheDocument();
+  });
+
+  it("calls onOpenBrowser when the row is clicked", () => {
+    const onOpenBrowser = vi.fn();
+    render(
+      <ChatStatusChip {...baseProps()} onOpenBrowser={onOpenBrowser} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Browser/ }));
+    expect(onOpenBrowser).toHaveBeenCalledOnce();
+  });
+
+  it("displays 'Open shared tab' as the summary", () => {
+    render(
+      <ChatStatusChip {...baseProps()} onOpenBrowser={vi.fn()} />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Browser.*Open shared tab/ }),
+    ).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/ChatStatusChip.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatStatusChip.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   ChevronUp,
   FolderOpen,
+  Globe2,
   Shapes,
   Shield,
 } from "lucide-react";
@@ -51,6 +52,8 @@ export type ChatStatusChipProps = {
   onOpenPermissions: () => void;
   /** Bring the agents table forward. */
   onOpenAgents: () => void;
+  /** Open the chat-scoped browser tab.  Absent when no native host is available. */
+  onOpenBrowser?: () => void;
   /** How many standing approvals reach this chat, when known. */
   permissionCount?: number;
 };
@@ -74,6 +77,7 @@ export function ChatStatusChip({
   onOpenFolders,
   onOpenPermissions,
   onOpenAgents,
+  onOpenBrowser,
   permissionCount,
 }: ChatStatusChipProps) {
   const [open, setOpen] = useState(false);
@@ -135,6 +139,10 @@ export function ChatStatusChip({
       onOpenFolders={onOpenFolders}
       onOpenPermissions={onOpenPermissions}
       onOpenAgents={onOpenAgents}
+      onOpenBrowser={onOpenBrowser}
+      browserSummary={
+        onOpenBrowser ? "Open shared tab" : undefined
+      }
       onChoose={() => setOpen(false)}
     />
   );
@@ -217,16 +225,20 @@ function ActivityDetails({
   onOpenFolders,
   onOpenPermissions,
   onOpenAgents,
+  onOpenBrowser,
+  browserSummary,
   onChoose,
 }: {
   outputsSummary: string;
   folderSummary: string;
   permissionsSummary: string;
   agentsSummary: string;
+  browserSummary?: string;
   onOpenOutputs: () => void;
   onOpenFolders: () => void;
   onOpenPermissions: () => void;
   onOpenAgents: () => void;
+  onOpenBrowser?: () => void;
   onChoose: () => void;
 }) {
   const choose = (action: () => void) => {
@@ -260,6 +272,14 @@ function ActivityDetails({
         value={agentsSummary}
         onClick={() => choose(onOpenAgents)}
       />
+      {onOpenBrowser && (
+        <DetailRow
+          icon={<Globe2 className="size-4" aria-hidden="true" />}
+          label="Browser"
+          value={browserSummary ?? "Open shared tab"}
+          onClick={() => choose(onOpenBrowser)}
+        />
+      )}
     </>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -61,6 +61,7 @@ import { followScrollBehavior } from "@/ChatScroll";
 import { useStreamStalled } from "@/useStreamStalled";
 import { useTranscriptFollow } from "@/useTranscriptFollow";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
+import { usePortalOverlayOpen } from "@/lib/usePortalOverlayOpen";
 import {
   SHELL_SHORTCUTS,
   shortcutKeycaps,
@@ -201,7 +202,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const closedBrowserIdsRef = useRef(new Set<string>());
   const workspaceBrowserIdsRef = useRef(new Set<string>());
   const chrome = splitCodeChromeLayout(layout);
-  const workspaceOverlayOpen = useWorkspaceOverlayOpen();
+  const workspaceOverlayOpen = usePortalOverlayOpen();
   const navigate = useNavigate();
   const workspaceSearch = useSearch({ strict: false }) as {
     task?: string;
@@ -1316,45 +1317,6 @@ function storedBrowserTitles(layout: LayoutState): Record<string, string> {
 }
 
 /** Native child webviews must yield whenever a portaled app surface overlaps them. */
-function useWorkspaceOverlayOpen(): boolean {
-  const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    const selector = [
-      '[role="dialog"][data-state="open"]',
-      '[role="alertdialog"][data-state="open"]',
-      '[role="menu"][data-state="open"]',
-      '[role="listbox"][data-state="open"]',
-    ].join(",");
-    let frame: number | null = null;
-    const update = () => {
-      if (frame !== null) return;
-      frame = window.requestAnimationFrame(() => {
-        frame = null;
-        setOpen(document.querySelector(selector) !== null);
-      });
-    };
-    const stateObserver = new MutationObserver(update);
-    stateObserver.observe(document.body, {
-      attributes: true,
-      attributeFilter: ["data-state", "role"],
-      subtree: true,
-    });
-    // Radix portals are direct body children. Keep transcript and editor DOM
-    // churn out of this observer so streaming content does not trigger global
-    // overlay queries.
-    const portalObserver = new MutationObserver(update);
-    portalObserver.observe(document.body, { childList: true });
-    update();
-    return () => {
-      stateObserver.disconnect();
-      portalObserver.disconnect();
-      if (frame !== null) window.cancelAnimationFrame(frame);
-    };
-  }, []);
-
-  return open;
-}
 
 function shortcutHint(id: ShellShortcutAction, command: boolean): string {
   const def = SHELL_SHORTCUTS.find((item) => item.id === id);

--- a/crates/tidebreak-desktop/ui/src/code/browser/foregroundBrowserScope.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/foregroundBrowserScope.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { foregroundBrowserScope } from "./foregroundBrowserScope";
+
+describe("foregroundBrowserScope", () => {
+  it("returns the prefixed scope for a chat id", () => {
+    expect(foregroundBrowserScope("abc-123")).toBe("foreground-chat:abc-123");
+  });
+
+  it("is deterministic", () => {
+    expect(foregroundBrowserScope("chat-1")).toBe(foregroundBrowserScope("chat-1"));
+  });
+
+  it("creates disjoint scopes for different chat ids", () => {
+    expect(foregroundBrowserScope("chat-a")).not.toBe(foregroundBrowserScope("chat-b"));
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/foregroundBrowserScope.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/foregroundBrowserScope.ts
@@ -1,0 +1,13 @@
+/** Canonical prefix for foreground-chat browser workspace-scope strings. */
+const FOREGROUND_PREFIX = "foreground-chat:" as const;
+
+/**
+ * Derive the browser workspace-scope string for a foreground chat.
+ *
+ * The returned value is a deterministic opaque scope string.  The desktop
+ * native executor derives the same value from the persisted chat id, so
+ * the renderer must never invent or alter the mapping.
+ */
+export function foregroundBrowserScope(chatId: string): string {
+  return `${FOREGROUND_PREFIX}${chatId}`;
+}

--- a/crates/tidebreak-desktop/ui/src/lib/usePortalOverlayOpen.ts
+++ b/crates/tidebreak-desktop/ui/src/lib/usePortalOverlayOpen.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+
+/**
+ * True while any app-owned portaled dialog, menu, or listbox is open.
+ *
+ * Radix-based overlays are portaled as direct body children and use
+ * `data-state` attributes to signal visibility.  The hook observes both of
+ * those DOM signals (attribute changes + child-list mutations) so it
+ * reacts to opens and closes without missing fast transitions.
+ *
+ * Callers use this to hide a native child webview while DOM overlays
+ * are on screen, since the native surface always paints above web content.
+ */
+export function usePortalOverlayOpen(): boolean {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const selector = [
+      '[role="dialog"][data-state="open"]',
+      '[role="alertdialog"][data-state="open"]',
+      '[role="menu"][data-state="open"]',
+      '[role="listbox"][data-state="open"]',
+    ].join(",");
+    let frame: number | null = null;
+    const update = () => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        setOpen(document.querySelector(selector) !== null);
+      });
+    };
+    const stateObserver = new MutationObserver(update);
+    stateObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["data-state", "role"],
+      subtree: true,
+    });
+    // Radix portals are direct body children.  Keep transcript and editor DOM
+    // churn out of this observer so streaming content does not trigger global
+    // overlay queries.
+    const portalObserver = new MutationObserver(update);
+    portalObserver.observe(document.body, { childList: true });
+    update();
+    return () => {
+      stateObserver.disconnect();
+      portalObserver.disconnect();
+      if (frame !== null) window.cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  return open;
+}


### PR DESCRIPTION
Reuse CodeBrowserTab as the shared native browser surface for foreground chats.

### What is here

- Extracts usePortalOverlayOpen into a shared lib hook, used by both CodeWorkspacePage and ChatRoute to hide the native WKWebView while app-owned portaled overlays are open.
- Adds foregroundBrowserScope(chatId) helper — returns "foreground-chat:<chat_id>" — with unit tests.
- Teach ChatRoute renderPanel to render restored {type:"browser"} panels with CodeBrowserTab using the foreground scope, overlay obscuration, and title-change callback.
- One default browser tab per chat: the opener focuses an existing browser panel if present, otherwise creates a fresh browser id, seeds the session, and opens it.
- Add Browser row to ChatStatusChip (expanded card and compact popover), visible only when a native host is available. Copy: "Browser" / "Open shared tab".
- 7 focused tests pass (3 unit + 4 DOM). Storybook builds clean.

### What is not here

No semantic actions, foreground tool registration, or client-execution dispatch. Those are separate fail-closed PRs. No Inspect-mode files were modified.

### Changed files

| file | what |
|------|-------|
| lib/usePortalOverlayOpen.ts | new: shared overlay obscuration hook |
| code/browser/foregroundBrowserScope.ts | new: canonical scope helper |
| code/browser/foregroundBrowserScope.test.ts | new: 3 unit tests |
| ChatRoute.tsx | new: browser panel rendering + openBrowser handler + overlay wiring |
| ChatStatusChip.tsx | new: Browser row (expanded + compact, native-host-gated) |
| ChatStatusChip.browser.dom.test.tsx | new: 4 DOM tests for browser row |
| code/CodeWorkspacePage.tsx | refactor: use shared usePortalOverlayOpen, remove local copy |

Refs #2413