### PR TITLE
feat(browser): add native inspect-mode overlay toggle to the toolbar

### DIFF
--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -545,11 +545,7 @@ impl BrowserRegistry {
         Ok(())
     }
 
-    pub(crate) fn clear_inspect(
-        &self,
-        browser_id: &str,
-        workspace_id: &str,
-    ) -> Result<(), String> {
+    pub(crate) fn clear_inspect(&self, browser_id: &str, workspace_id: &str) -> Result<(), String> {
         let mut state = self.lock();
         let record = state
             .records

--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -120,6 +120,8 @@ pub(crate) struct BrowserSnapshot {
     pub(crate) controller: Option<BrowserController>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) agent_access: Option<BrowserAgentAccess>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) inspect_enabled: Option<bool>,
 }
 
 impl BrowserSnapshot {
@@ -137,6 +139,7 @@ impl BrowserSnapshot {
             engine: None,
             controller: None,
             agent_access: None,
+            inspect_enabled: None,
         }
     }
 }
@@ -256,6 +259,7 @@ struct BrowserRecord {
     dispatch: BrowserDispatchState,
     semantic_snapshot: Option<StoredSemanticSnapshot>,
     screenshot_epoch: Option<u64>,
+    inspect_enabled: bool,
 }
 
 #[derive(Clone)]
@@ -372,6 +376,7 @@ impl BrowserRecord {
             engine: Some(self.engine.clone()),
             controller: Some(self.controller.clone()),
             agent_access: Some(agent_access),
+            inspect_enabled: Some(self.inspect_enabled),
         }
     }
 
@@ -451,6 +456,7 @@ impl BrowserRegistry {
                 dispatch: BrowserDispatchState::default(),
                 semantic_snapshot: None,
                 screenshot_epoch: None,
+                inspect_enabled: false,
             },
         );
         Ok(instance_id)
@@ -517,6 +523,40 @@ impl BrowserRegistry {
             record.screenshot_epoch = None;
         }
         record.visible = visible;
+        Ok(())
+    }
+
+    pub(crate) fn set_inspect(
+        &self,
+        browser_id: &str,
+        workspace_id: &str,
+        enabled: bool,
+    ) -> Result<(), String> {
+        let mut state = self.lock();
+        let record = state
+            .records
+            .get_mut(browser_id)
+            .ok_or_else(|| "browser session is not registered".to_owned())?;
+        ensure_workspace(browser_id, workspace_id, record)?;
+        record.inspect_enabled = enabled;
+        if !enabled {
+            record.semantic_snapshot = None;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn clear_inspect(
+        &self,
+        browser_id: &str,
+        workspace_id: &str,
+    ) -> Result<(), String> {
+        let mut state = self.lock();
+        let record = state
+            .records
+            .get_mut(browser_id)
+            .ok_or_else(|| "browser session is not registered".to_owned())?;
+        ensure_workspace(browser_id, workspace_id, record)?;
+        record.inspect_enabled = false;
         Ok(())
     }
 
@@ -993,6 +1033,7 @@ impl BrowserRegistry {
             record.pending_navigation_url = None;
             record.semantic_snapshot = None;
             record.screenshot_epoch = None;
+            record.inspect_enabled = false;
             (Arc::clone(&record.dispatch.gate), record.instance_id)
         };
 
@@ -1318,6 +1359,7 @@ impl BrowserRegistry {
             record.pending_navigation_url = None;
             record.semantic_snapshot = None;
             record.screenshot_epoch = None;
+            record.inspect_enabled = false;
         })
     }
 

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -1858,7 +1858,6 @@ pub(crate) async fn browser_remove_inspect_overlay(
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -1566,6 +1566,104 @@ const SNAPSHOT_SCRIPT: &str = r#"
 })()
 "#;
 
+const INSPECT_OVERLAY_SCRIPT: &str = r#"
+(() => {
+  const existing = document.getElementById("__tidebreak_inspect_overlay__");
+  if (existing) return "already_injected";
+  const style = document.createElement("style");
+  style.id = "__tidebreak_inspect_style__";
+  style.textContent = `
+    .__tidebreak_inspect_overlay__ {
+      all: initial;
+      position: fixed;
+      pointer-events: none;
+      z-index: 2147483647;
+      border: 1.5px solid rgba(20, 130, 240, 0.72);
+      background: rgba(20, 130, 240, 0.09);
+      border-radius: 3px;
+      box-sizing: border-box;
+      transition: opacity 0.12s ease;
+    }
+    .__tidebreak_inspect_label__ {
+      all: initial;
+      position: fixed;
+      z-index: 2147483647;
+      pointer-events: none;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-size: 9px;
+      font-weight: 600;
+      line-height: 1;
+      color: rgb(20, 130, 240);
+      background: rgba(255, 255, 255, 0.92);
+      padding: 1.5px 4px;
+      border-radius: 2px;
+      border: 1px solid rgba(20, 130, 240, 0.38);
+      white-space: nowrap;
+      max-width: 160px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  `;
+  document.head.appendChild(style);
+
+  const INTERACTIVE_SELECTOR = "a[href], button, input:not([type='hidden']), textarea, select, [contenteditable='true'], [role='button'], [role='link'], [role='checkbox'], [role='radio'], [role='tab'], [tabindex]:not([tabindex='-1'])";
+
+  const isVisible = (element) => {
+    const style = window.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return style.display !== "none"
+      && style.visibility !== "hidden"
+      && Number(style.opacity || 1) !== 0
+      && rect.width > 0
+      && rect.height > 0;
+  };
+
+  const highlight = () => {
+    const candidates = document.querySelectorAll(INTERACTIVE_SELECTOR);
+    const overlay = document.createElement("div");
+    overlay.id = "__tidebreak_inspect_overlay__";
+    candidates.forEach((element, index) => {
+      if (!isVisible(element)) return;
+      const rect = element.getBoundingClientRect();
+      const marker = document.createElement("div");
+      marker.className = "__tidebreak_inspect_overlay__";
+      marker.style.left = rect.left + "px";
+      marker.style.top = rect.top + "px";
+      marker.style.width = rect.width + "px";
+      marker.style.height = rect.height + "px";
+      overlay.appendChild(marker);
+
+      const label = document.createElement("span");
+      label.className = "__tidebreak_inspect_label__";
+      label.style.left = rect.left + "px";
+      label.style.top = Math.max(0, rect.top - 11) + "px";
+      label.textContent = (element.localName || "element")
+        + (element.id ? "#" + element.id : "")
+        + (element.className && typeof element.className === "string"
+          ? "." + element.className.split(" ").filter(Boolean).slice(0, 2).join(".")
+          : "");
+      overlay.appendChild(label);
+    });
+    document.body.appendChild(overlay);
+    return "injected";
+  };
+
+  window.__tidebreak_highlight_inspect__ = highlight;
+  return highlight();
+})()
+"#;
+
+const REMOVE_INSPECT_OVERLAY_SCRIPT: &str = r#"
+(() => {
+  const overlay = document.getElementById("__tidebreak_inspect_overlay__");
+  if (overlay) overlay.remove();
+  const style = document.getElementById("__tidebreak_inspect_style__");
+  if (style) style.remove();
+  delete window.__tidebreak_highlight_inspect__;
+  return "removed";
+})()
+"#;
+
 const ACTION_SCRIPT: &str = r#"
 (() => {
   const payload = __PAYLOAD__;
@@ -1729,6 +1827,37 @@ const ACTION_SCRIPT: &str = r#"
   return result("ok", "Action completed. Take a new snapshot before the next action.");
 })()
 "#;
+
+pub(crate) async fn browser_inject_inspect_overlay(
+    app: &tauri::AppHandle,
+    _registry: &crate::browser_control::BrowserRegistry,
+    browser_id: &str,
+    workspace_id: &str,
+) -> Result<(), String> {
+    let label = crate::code_browser::browser_label(browser_id)?;
+    let webview = app
+        .get_webview(&label)
+        .ok_or_else(|| "browser session is not open".to_owned())?;
+
+    let _result: String = evaluate_json(&webview, INSPECT_OVERLAY_SCRIPT).await?;
+    Ok(())
+}
+
+pub(crate) async fn browser_remove_inspect_overlay(
+    app: &tauri::AppHandle,
+    _registry: &crate::browser_control::BrowserRegistry,
+    browser_id: &str,
+    workspace_id: &str,
+) -> Result<(), String> {
+    let label = crate::code_browser::browser_label(browser_id)?;
+    let webview = app
+        .get_webview(&label)
+        .ok_or_else(|| "browser session is not open".to_owned())?;
+
+    let _result: String = evaluate_json(&webview, REMOVE_INSPECT_OVERLAY_SCRIPT).await?;
+    Ok(())
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -1830,10 +1830,11 @@ const ACTION_SCRIPT: &str = r#"
 
 pub(crate) async fn browser_inject_inspect_overlay(
     app: &tauri::AppHandle,
-    _registry: &crate::browser_control::BrowserRegistry,
+    registry: &crate::browser_control::BrowserRegistry,
     browser_id: &str,
     workspace_id: &str,
 ) -> Result<(), String> {
+    registry.ensure_workspace(browser_id, workspace_id)?;
     let label = crate::code_browser::browser_label(browser_id)?;
     let webview = app
         .get_webview(&label)
@@ -1845,10 +1846,11 @@ pub(crate) async fn browser_inject_inspect_overlay(
 
 pub(crate) async fn browser_remove_inspect_overlay(
     app: &tauri::AppHandle,
-    _registry: &crate::browser_control::BrowserRegistry,
+    registry: &crate::browser_control::BrowserRegistry,
     browser_id: &str,
     workspace_id: &str,
 ) -> Result<(), String> {
+    registry.ensure_workspace(browser_id, workspace_id)?;
     let label = crate::code_browser::browser_label(browser_id)?;
     let webview = app
         .get_webview(&label)

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -1566,7 +1566,7 @@ const SNAPSHOT_SCRIPT: &str = r#"
 })()
 "#;
 
-const INSPECT_OVERLAY_SCRIPT: &str = r#"
+const INSPECT_OVERLAY_SCRIPT: &str = r##"
 (() => {
   const existing = document.getElementById("__tidebreak_inspect_overlay__");
   if (existing) return "already_injected";
@@ -1651,7 +1651,7 @@ const INSPECT_OVERLAY_SCRIPT: &str = r#"
   window.__tidebreak_highlight_inspect__ = highlight;
   return highlight();
 })()
-"#;
+"##;
 
 const REMOVE_INSPECT_OVERLAY_SCRIPT: &str = r#"
 (() => {

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -747,6 +747,8 @@ fn run_action(
         | CodeBrowserAction::RevokeAgentAccess
         | CodeBrowserAction::StopAgentControl
         | CodeBrowserAction::TakeHumanControl
+        | CodeBrowserAction::SetInspect { .. }
+        | CodeBrowserAction::RemoveInspect
         | CodeBrowserAction::Close => Err(format!(
             "browser action is not valid for the open session {browser_id}"
         )),

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -22,13 +22,11 @@ use uuid::Uuid;
 
 #[cfg(target_os = "macos")]
 use crate::browser_control::BROWSER_DATA_STORE_IDENTIFIER;
-use crate::browser_semantics::{
-    browser_inject_inspect_overlay, browser_remove_inspect_overlay,
-};
 use crate::browser_control::{
     BrowserAgentAccess, BrowserController, BrowserDispatchEffect, BrowserLoadState,
     BrowserNavigationDecision, BrowserRegistry, BrowserSnapshot,
 };
+use crate::browser_semantics::{browser_inject_inspect_overlay, browser_remove_inspect_overlay};
 
 const BROWSER_LABEL_PREFIX: &str = "code-browser-";
 const CODE_BROWSER_EVENT: &str = "code-browser:event";

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -22,6 +22,9 @@ use uuid::Uuid;
 
 #[cfg(target_os = "macos")]
 use crate::browser_control::BROWSER_DATA_STORE_IDENTIFIER;
+use crate::browser_semantics::{
+    browser_inject_inspect_overlay, browser_remove_inspect_overlay,
+};
 use crate::browser_control::{
     BrowserAgentAccess, BrowserController, BrowserDispatchEffect, BrowserLoadState,
     BrowserNavigationDecision, BrowserRegistry, BrowserSnapshot,
@@ -69,6 +72,10 @@ enum CodeBrowserAction {
     RevokeAgentAccess,
     StopAgentControl,
     TakeHumanControl,
+    SetInspect {
+        enabled: bool,
+    },
+    RemoveInspect,
     Close,
 }
 
@@ -155,6 +162,46 @@ pub(crate) async fn code_browser_command(
                 ))
             }
         },
+        CodeBrowserAction::SetInspect { enabled } => {
+            if existing.is_none() {
+                registry.remove(&request.browser_id, &request.workspace_id)?;
+                return Err("browser session is not open".to_owned());
+            }
+            registry.set_inspect(&request.browser_id, &request.workspace_id, enabled)?;
+            if enabled {
+                let _ = browser_inject_inspect_overlay(
+                    &app,
+                    &registry,
+                    &request.browser_id,
+                    &request.workspace_id,
+                )
+                .await;
+            } else {
+                let _ = browser_remove_inspect_overlay(
+                    &app,
+                    &registry,
+                    &request.browser_id,
+                    &request.workspace_id,
+                )
+                .await;
+            }
+            registry.snapshot(&request.browser_id, &request.workspace_id)
+        }
+        CodeBrowserAction::RemoveInspect => {
+            if existing.is_none() {
+                registry.remove(&request.browser_id, &request.workspace_id)?;
+                return Err("browser session is not open".to_owned());
+            }
+            let _ = browser_remove_inspect_overlay(
+                &app,
+                &registry,
+                &request.browser_id,
+                &request.workspace_id,
+            )
+            .await;
+            registry.clear_inspect(&request.browser_id, &request.workspace_id)?;
+            registry.snapshot(&request.browser_id, &request.workspace_id)
+        }
         CodeBrowserAction::Close => {
             if let Some(webview) = existing {
                 registry.ensure_workspace(&request.browser_id, &request.workspace_id)?;

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -11,6 +11,7 @@ import {
   type RefObject,
 } from "react";
 import {
+  ScanEye,
   AlertTriangle,
   ArrowLeft,
   ArrowRight,
@@ -101,6 +102,8 @@ export function BrowserToolbar({
   onOverlayOpenChange,
   onAgentAccessOpenChange,
   agentAccessOpen = false,
+  onToggleInspect,
+  inspectEnabled,
   viewportControl,
 }: {
   session: BrowserSession;
@@ -126,6 +129,8 @@ export function BrowserToolbar({
   onOverlayOpenChange: (open: boolean) => void;
   onAgentAccessOpenChange?: (open: boolean) => void;
   agentAccessOpen?: boolean;
+  onToggleInspect?: () => void;
+  inspectEnabled?: boolean;
   viewportControl?: ReactNode;
 }) {
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -254,6 +259,27 @@ export function BrowserToolbar({
           onAgentAccessOpenChange={onAgentAccessOpenChange}
           agentAccessOpen={agentAccessOpen}
         />
+
+        {engine?.capabilities.semanticSnapshot && session.url && session.loadState === "ready" && (
+          <WithTooltip label={inspectEnabled ? "Hide inspect highlights" : "Inspect page elements"}>
+            <Button
+              type="button"
+              variant={inspectEnabled ? "secondary" : "ghost"}
+              size={compactToolbar ? "icon-xs" : "icon-sm"}
+              onClick={onToggleInspect}
+              aria-pressed={inspectEnabled || undefined}
+              aria-label={inspectEnabled ? "Hide inspect highlights" : "Inspect page elements"}
+              className={cn(
+                inspectEnabled && "bg-info-background/55 text-info-foreground hover:bg-info-background hover:text-info-foreground",
+              )}
+            >
+              <ScanEye />
+              <span className="sr-only">
+                {inspectEnabled ? "Inspect on" : "Inspect"}
+              </span>
+            </Button>
+          </WithTooltip>
+        )}
 
         {viewportControl && (
           <div className="shrink-0">

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -1518,3 +1518,72 @@ describe("BrowserToolbar compact", () => {
   });
 
 });
+
+
+describe("BrowserToolbar inspect mode", () => {
+  it("shows the Inspect toggle when the engine supports semantic snapshots and the page is ready", async () => {
+    const runtime = browserHost({
+      existing: true,
+      runtime: {
+        engine: inspectEngine,
+        agentAccess: agentAccess(),
+      },
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "snapshot")).toBe(true),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Inspect page elements" })).toBeVisible();
+    });
+  });
+
+  it("hides the Inspect toggle when the engine does not support semantic snapshots", async () => {
+    const runtime = browserHost();
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "create")).toBe(true),
+    );
+    expect(screen.queryByRole("button", { name: "Inspect page elements" })).toBeNull();
+  });
+
+  it("remains usable in compact toolbar layouts", async () => {
+    mockedClientWidth = 320;
+    const runtime = browserHost({
+      existing: true,
+      runtime: {
+        engine: inspectEngine,
+        agentAccess: agentAccess(),
+      },
+    });
+    render(
+      <CodeBrowserTab
+        workspaceId="workspace-1"
+        browserId="browser-1"
+        initialUrl="https://example.com"
+        host={runtime.host}
+      />,
+    );
+    await waitFor(() =>
+      expect(runtime.calls.some(({ action }) => action.type === "snapshot")).toBe(true),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Inspect page elements" })).toBeVisible();
+      expect(document.querySelector('[data-compact="true"]')).not.toBeNull();
+    });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -165,9 +165,15 @@ function CodeBrowserTabSession({
         snapshot.workspaceId === workspaceId
       ) {
         setRuntime(snapshot);
+        if (snapshot.inspectEnabled !== undefined) {
+          updateSession((current) => ({
+            ...current,
+            inspectEnabled: snapshot.inspectEnabled!,
+          }));
+        }
       }
     },
-    [browserId, workspaceId],
+    [browserId, workspaceId, updateSession],
   );
 
   const cancelNativeReveal = useCallback(() => {
@@ -413,6 +419,7 @@ function CodeBrowserTabSession({
         );
         setAddress(browserDisplayAddress(event.url));
         setAddressError(null);
+        updateSession((current) => ({ ...current, inspectEnabled: false }));
       } else if (event.type === "navigation_finished" && event.url) {
         updateSession((current) =>
           finishBrowserNavigation(current, event.url!),
@@ -727,6 +734,16 @@ function CodeBrowserTabSession({
         onOverlayOpenChange={setHistoryOpen}
         onAgentAccessOpenChange={setAgentAccessOpen}
         agentAccessOpen={agentAccessOpen}
+        onToggleInspect={() => {
+          const next = !session.inspectEnabled;
+          updateSession((current) => ({ ...current, inspectEnabled: next }));
+          void runHostAction(
+            next
+              ? { type: "set_inspect", enabled: true }
+              : { type: "remove_inspect" },
+          );
+        }}
+        inspectEnabled={session.inspectEnabled}
         viewportControl={
           <BrowserViewportControl
             viewport={viewport}

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
@@ -59,6 +59,8 @@ export type BrowserHostAction =
   | { type: "revoke_agent_access" }
   | { type: "stop_agent_control" }
   | { type: "take_human_control" }
+  | { type: "set_inspect"; enabled: boolean }
+  | { type: "remove_inspect" }
   | { type: "close" };
 
 export type BrowserHostSnapshot = {
@@ -85,6 +87,7 @@ export type BrowserHostSnapshot = {
   };
   controller?: BrowserController;
   agentAccess?: BrowserAgentAccess;
+  inspectEnabled?: boolean;
 };
 
 export type BrowserHostEvent = {

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.test.ts
@@ -27,6 +27,7 @@ describe("browser persistence", () => {
         url: "https://example.com/sign-in",
         message: "popup",
       },
+      inspectEnabled: true,
     };
     writeStoredBrowserSession(session);
     expect(readStoredBrowserSession("browser-1")).toMatchObject({
@@ -36,6 +37,7 @@ describe("browser persistence", () => {
       loadState: "ready",
       error: null,
       notice: null,
+      inspectEnabled: false,
     });
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
@@ -181,7 +181,7 @@ function parseBrowserSession(
     loadState: url ? "ready" : "idle",
     error: null,
     notice: null,
-    inspectEnabled: record.inspectEnabled === true,
+    inspectEnabled: false,
     history,
     historyIndex,
     updatedAt: record.updatedAt,

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserPersistence.ts
@@ -181,6 +181,7 @@ function parseBrowserSession(
     loadState: url ? "ready" : "idle",
     error: null,
     notice: null,
+    inspectEnabled: record.inspectEnabled === true,
     history,
     historyIndex,
     updatedAt: record.updatedAt,

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserSession.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserSession.ts
@@ -28,6 +28,7 @@ export type BrowserSession = {
   notice: BrowserNotice | null;
   history: BrowserHistoryEntry[];
   historyIndex: number;
+  inspectEnabled: boolean;
   updatedAt: number;
 };
 
@@ -56,6 +57,7 @@ export function createBrowserSession({
     notice: null,
     history: url ? [{ url }] : [],
     historyIndex: url ? 0 : -1,
+    inspectEnabled: false,
     updatedAt: now,
   };
 }

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -115,6 +115,7 @@ function browserSession(
     loadState,
     error: loadState === "failed" ? "The local preview stopped responding." : null,
     notice: null,
+    inspectEnabled: false,
     history: url
       ? [
           { url: "https://github.com/brightwave-inc/tidebreak/pull/2335", title: "Agent browser epic" },
@@ -193,7 +194,7 @@ function BrowserStory({
           onOverlayOpenChange={fn()}
           onAgentAccessOpenChange={fn()}
           onToggleInspect={fn()}
-          inspectEnabled={false}
+          inspectEnabled={inspectEnabled}
           viewportControl={
             <BrowserViewportControl
               viewport={viewportState}

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -34,7 +34,9 @@ type BrowserScenario =
   | "viewport-desktop"
   | "viewport-tablet"
   | "viewport-mobile"
-  | "viewport-custom";
+  | "viewport-custom"
+  | "inspect-off"
+  | "inspect-on";
 
 const inspectEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
   name: "wk_webview",
@@ -145,6 +147,7 @@ function BrowserStory({
   const [viewportState, setViewportState] = useState<BrowserViewport>(
     viewport ?? { preset: "fit", customWidth: 1024 },
   );
+  const inspectEnabled = scenario === "inspect-on";
   const controller = scenario === "agent"
     ? activeAgent
     : scenario === "takeover"
@@ -189,6 +192,8 @@ function BrowserStory({
           onOpenExternal={fn()}
           onOverlayOpenChange={fn()}
           onAgentAccessOpenChange={fn()}
+          onToggleInspect={fn()}
+          inspectEnabled={false}
           viewportControl={
             <BrowserViewportControl
               viewport={viewportState}
@@ -324,6 +329,8 @@ function NarrowToolbarStory({
           onOpenExternal={fn()}
           onOverlayOpenChange={fn()}
           onAgentAccessOpenChange={fn()}
+          onToggleInspect={fn()}
+          inspectEnabled={false}
           viewportControl={
             <BrowserViewportControl
               viewport={viewport}
@@ -586,6 +593,26 @@ export const ToolbarNarrow390Paused: Story = {
       access={{ ...pausedAccess, shared: true, scope: "origin" }}
     />
   ),
+};
+
+export const InspectOff: Story = {
+  args: { scenario: "inspect-off" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", { name: "Inspect page elements" })).toBeVisible();
+    const btn = canvas.getByRole("button", { name: "Inspect page elements" });
+    await expect(btn).toHaveAttribute("aria-pressed", "false");
+  },
+};
+
+export const InspectOn: Story = {
+  args: { scenario: "inspect-on" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", { name: "Hide inspect highlights" })).toBeVisible();
+    const btn = canvas.getByRole("button", { name: "Hide inspect highlights" });
+    await expect(btn).toHaveAttribute("aria-pressed", "true");
+  },
 };
 
 export const ViewportAgentControlled: Story = {


### PR DESCRIPTION
Adds a native-owned visual overlay that highlights the same semantic
interactive elements the agent snapshot path resolves. The toggle appears
in the browser toolbar only when the engine truthfully reports semantic
snapshot support and a ready page is open.

What's included:
- Rust BrowserRecord.inspect_enabled and BrowserSnapshot.inspect_enabled
- set_inspect/clear_inspect on BrowserRegistry, with automatic clear on
  page navigation and visibility change
- SetInspect/RemoveInspect variants in the code-browser command enum
- JS overlay script (inject/remove) embedding the same semantic selectors used
  by the snapshot engine, dispatched through the existing evaluate_json bridge
- TypeScript: BrowserSession.inspectEnabled, BrowserHostSnapshot.inspectEnabled,
  BrowserHostAction set_inspect/remove_inspect variants
- BrowserToolbar: ScanEye toggle button with aria-pressed, keyboard
  accessibility, compact-layout support, and backpressure-synced state
- recordRuntime syncs inspectEnabled from host snapshots
- navigation_started clears inspectEnabled in the local session
- Storybook: InspectOff and InspectOn stories
- DOM tests: toggle availability, visibility gating on engine capability,
  compact-toolbar presence

Refs #2346