### PR TITLE
feat(desktop): drive code mode from the keyboard

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -43,11 +43,14 @@ import {
 } from "./code/codeChrome";
 import { CodeDeliveryMonitor } from "./code/CodeDeliveryMonitor";
 import { useCodeUiStore } from "./code/CodeUiStore";
+import { stepRailWorkspace } from "./code/railNavigation";
 import {
   codeRepoIdFromPath,
   codeWorkspaceIdFromPath,
+  isCodeRoute,
   shellShortcutMode,
 } from "./code/routes";
+import type { WorkflowShortcut } from "./code/workspaceWorkflow";
 import { layoutFromSearch, searchFromLayout, type PanelSearch } from "./panel/panelUrl";
 import type { LayoutState } from "./panel/panelTypes";
 import { connectOutputs } from "./deliverables";
@@ -237,6 +240,38 @@ export function AppShell() {
     });
   }
 
+  /**
+   * Raise a Ship chord for the workspace header to carry out.
+   *
+   * The shell knows the chord and nothing else: what "open a pull request"
+   * means depends on the branch and pull-request state, which lives a route
+   * down. Off a workspace there is nothing to ship, so the key goes back to
+   * whatever is focused.
+   */
+  function askWorkspace(shortcut: WorkflowShortcut): boolean | void {
+    const workspaceId = codeWorkspaceIdFromPath(router.state.location.pathname);
+    if (!workspaceId) return false;
+    useCodeUiStore.getState().requestWorkflowShortcut(workspaceId, shortcut);
+  }
+
+  /**
+   * Move to the workspace the rail draws next, wherever in code mode we are.
+   *
+   * Works off a workspace too — from a repo page or the code home, a step
+   * enters the rail rather than doing nothing, which is what a reader arriving
+   * by keyboard wants.
+   */
+  function stepWorkspace(delta: -1 | 1): boolean | void {
+    const { pathname } = router.state.location;
+    if (!isCodeRoute(pathname)) return false;
+    const next = stepRailWorkspace(codeWorkspaceIdFromPath(pathname), delta);
+    if (!next) return false;
+    void navigate({
+      to: "/code/w/$workspaceId",
+      params: { workspaceId: next },
+    });
+  }
+
   // Shell shortcuts are defined here because these actions outlive any one
   // route: toggling the frame, starting a chat, reaching the composer, and
   // scaling the window all work wherever the reader is. Mode-scoped ones act
@@ -274,6 +309,19 @@ export function AppShell() {
       const { pathname } = router.state.location;
       if (!codeWorkspaceIdFromPath(pathname)) return false;
       useCodeUiStore.getState().requestFilesSearch();
+    },
+    "code-prev-workspace": () => stepWorkspace(-1),
+    "code-next-workspace": () => stepWorkspace(1),
+    "code-workflow-next": () => askWorkspace("next"),
+    "code-create-pr": () => askWorkspace("pull_request"),
+    "code-update-branch": () => askWorkspace("update_branch"),
+    "code-watch-pr": () => askWorkspace("watch"),
+    "code-merge-pr": () => askWorkspace("merge"),
+    "code-view-pr": () => askWorkspace("view_pr"),
+    "code-source-control": () => askWorkspace("source_control"),
+    "code-archive-workspace": () => {
+      if (!codeWorkspaceIdFromPath(router.state.location.pathname)) return false;
+      useCodeUiStore.getState().requestArchiveWorkspace();
     },
     "code-prev-tab": () => applyCodeLayout((l) => stepCenterTab(l, -1)),
     "code-next-tab": () => applyCodeLayout((l) => stepCenterTab(l, 1)),

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
@@ -121,6 +121,81 @@ describe("shell shortcut resolution", () => {
     ).toBe("toggle-sidebar");
   });
 
+  it("separates the shifted Ship chords from their unshifted neighbours", () => {
+    // Cmd+P opens a file and Cmd+Shift+P opens a pull request; Cmd+W closes a
+    // tab and Cmd+Shift+W starts a watch; Cmd+R reloads and Cmd+Shift+R
+    // rebases. Shift is the only thing between each pair, so a shift the
+    // matcher ignored would make three chords do the wrong, sometimes
+    // destructive, thing.
+    const pairs: Array<[string, ShellShortcutAction, ShellShortcutAction]> = [
+      ["KeyP", "code-quick-open", "code-create-pr"],
+      ["KeyW", "close-tab", "code-watch-pr"],
+      ["KeyR", "reload-app", "code-update-branch"],
+    ];
+    for (const [code, plain, shifted] of pairs) {
+      const context_ = context({ mode: "code" });
+      expect(
+        resolveShellShortcut(keyEvent({ code, shiftKey: false }), context_)?.id,
+      ).toBe(plain);
+      expect(
+        resolveShellShortcut(keyEvent({ code, shiftKey: true }), context_)?.id,
+      ).toBe(shifted);
+    }
+  });
+
+  it("keeps the Ship chords out of chat, where there is nothing to ship", () => {
+    const ship: Array<[Partial<KeyboardEvent>, ShellShortcutAction]> = [
+      [{ code: "Enter" }, "code-workflow-next"],
+      [{ code: "KeyM" }, "code-merge-pr"],
+      [{ code: "KeyO" }, "code-view-pr"],
+      [{ code: "KeyG" }, "code-source-control"],
+      [{ code: "KeyA" }, "code-archive-workspace"],
+    ];
+    for (const [event, id] of ship) {
+      const pressed = keyEvent({ ...event, shiftKey: true });
+      expect(resolveShellShortcut(pressed, context({ mode: "code" }))?.id).toBe(
+        id,
+      );
+      expect(
+        resolveShellShortcut(pressed, context({ mode: "chat" })),
+      ).toBeNull();
+    }
+    // Cmd+Shift+A in chat is still free for the text field's own use.
+    expect(
+      resolveShellShortcut(
+        keyEvent({ code: "KeyA", shiftKey: true }),
+        context({ mode: "chat" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("walks the rail on Cmd+Alt+Arrow, even from the composer", () => {
+    // Cmd+Shift+Arrow selects to the end of a text field, so rail walking takes
+    // Alt instead and stays usable while the reader is writing a prompt.
+    const up = keyEvent({
+      key: "ArrowUp",
+      code: "ArrowUp",
+      altKey: true,
+    });
+    expect(resolveShellShortcut(up, context({ mode: "code" }))?.id).toBe(
+      "code-prev-workspace",
+    );
+    expect(
+      resolveShellShortcut(
+        keyEvent({ key: "ArrowDown", code: "ArrowDown", altKey: true }),
+        context({ mode: "code" }),
+      )?.id,
+    ).toBe("code-next-workspace");
+    // Without the command modifier it is Option+Arrow, which belongs to the
+    // text field and to nothing here.
+    expect(
+      resolveShellShortcut(
+        keyEvent({ key: "ArrowUp", code: "ArrowUp", altKey: true, metaKey: false }),
+        context({ mode: "code" }),
+      ),
+    ).toBeNull();
+  });
+
   it("leaves Alt+Arrow to the field the reader is typing in", () => {
     // Option+Arrow jumps a word in every macOS text field. History navigation
     // takes it only when focus is somewhere the keys mean nothing else.
@@ -224,6 +299,13 @@ describe("shortcut help", () => {
     const zoomIn = SHELL_SHORTCUTS.find((def) => def.id === "zoom-in")!;
     expect(shortcutKeycaps(zoomIn, true)).toEqual(["⌘", "="]);
     expect(shortcutKeycaps(zoomIn, false)).toEqual(["Ctrl", "="]);
+    // Named keys draw as the glyph on the keycap, not as their DOM name.
+    const next = SHELL_SHORTCUTS.find((def) => def.id === "code-workflow-next")!;
+    expect(shortcutKeycaps(next, true)).toEqual(["⌘", "⇧", "↩"]);
+    const nextWorkspace = SHELL_SHORTCUTS.find(
+      (def) => def.id === "code-next-workspace",
+    )!;
+    expect(shortcutKeycaps(nextWorkspace, true)).toEqual(["⌘", "⌥", "↓"]);
     expect(usesCommandModifier("Mozilla/5.0 (Macintosh; Intel Mac OS X)")).toBe(
       true,
     );

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -345,11 +345,14 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     allowInEditable: true,
   },
   {
+    // Green merges now; anything else GitHub can still land arms auto-merge.
+    // One chord for one intent — "get this in" — with the confirmation naming
+    // which of the two is about to happen.
     id: "code-merge-pr",
     codes: ["KeyM"],
     mod: true,
     shift: true,
-    description: "Merge the pull request",
+    description: "Merge, or auto-merge once the checks pass",
     group: "Ship",
     scope: "code",
     allowInEditable: true,

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -22,6 +22,16 @@ export type ShellShortcutAction =
   | "code-next-tab"
   | "code-select-tab"
   | "code-split-editor"
+  | "code-prev-workspace"
+  | "code-next-workspace"
+  | "code-workflow-next"
+  | "code-create-pr"
+  | "code-update-branch"
+  | "code-watch-pr"
+  | "code-merge-pr"
+  | "code-view-pr"
+  | "code-source-control"
+  | "code-archive-workspace"
   | "close-tab"
   | "focus-composer"
   | "zoom-in"
@@ -44,6 +54,7 @@ export type ShellShortcutMode = "chat" | "code";
 export type ShellShortcutGroup =
   | "Navigation"
   | "Work"
+  | "Ship"
   | "Code"
   | "View"
   | "Help";
@@ -52,6 +63,7 @@ export type ShellShortcutGroup =
 export const SHELL_SHORTCUT_GROUPS: readonly ShellShortcutGroup[] = [
   "Navigation",
   "Work",
+  "Ship",
   "Code",
   "View",
   "Help",
@@ -137,6 +149,30 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     description: "Go forward (outside text fields)",
     group: "Navigation",
     allowInEditable: false,
+  },
+  {
+    // Cmd+Alt+Arrow walks the rail in the order the rail draws, so what the
+    // chord lands on is always the next card down. Alt rather than Shift
+    // because Cmd+Shift+Arrow is "select to the end" in every text field, and
+    // this one has to work while the reader is writing the next prompt.
+    id: "code-prev-workspace",
+    keys: ["arrowup"],
+    mod: true,
+    alt: true,
+    description: "Previous workspace",
+    group: "Navigation",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "code-next-workspace",
+    keys: ["arrowdown"],
+    mod: true,
+    alt: true,
+    description: "Next workspace",
+    group: "Navigation",
+    scope: "code",
+    allowInEditable: true,
   },
   {
     id: "new-chat",
@@ -258,6 +294,101 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     allowInEditable: true,
   },
   {
+    // The whole spine behind one chord. What it runs is whatever the header's
+    // primary control says next — push, open a pull request, mark ready, fix
+    // CI, resolve conflicts, merge — so a reader who learns no other Ship
+    // shortcut can still carry a branch to merged from the keyboard. Every
+    // other chord in this group names one of those steps directly, for when
+    // the next step and the wanted step are not the same.
+    id: "code-workflow-next",
+    codes: ["Enter", "NumpadEnter"],
+    mod: true,
+    shift: true,
+    description: "Run the next step for this workspace",
+    group: "Ship",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    // Shift is what separates this from Cmd+P's file picker. Both are "P for
+    // the thing this app is about"; on a shipping surface the shifted one is
+    // the pull request.
+    id: "code-create-pr",
+    codes: ["KeyP"],
+    mod: true,
+    shift: true,
+    description: "Push and open a pull request",
+    group: "Ship",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "code-update-branch",
+    codes: ["KeyR"],
+    mod: true,
+    shift: true,
+    description: "Rebase on the base branch, resolving conflicts",
+    group: "Ship",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    // Pressing it again stops the watch, because a watch is a thing that is
+    // either on or off and the reader has one key for it either way.
+    id: "code-watch-pr",
+    codes: ["KeyW"],
+    mod: true,
+    shift: true,
+    description: "Watch the pull request and fix failures",
+    group: "Ship",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "code-merge-pr",
+    codes: ["KeyM"],
+    mod: true,
+    shift: true,
+    description: "Merge the pull request",
+    group: "Ship",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    id: "code-view-pr",
+    codes: ["KeyO"],
+    mod: true,
+    shift: true,
+    description: "Open the pull request on GitHub",
+    group: "Ship",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    // The chord VS Code gives its source-control view. Cmd+I toggles the whole
+    // review rail; this one always opens it and lands on the changes.
+    id: "code-source-control",
+    codes: ["KeyG"],
+    mod: true,
+    shift: true,
+    description: "Review and commit changes",
+    group: "Ship",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
+    // The end of the workflow, and the only chord here that removes a
+    // worktree, so it goes through the same confirmation the menu item does.
+    id: "code-archive-workspace",
+    codes: ["KeyA"],
+    mod: true,
+    shift: true,
+    description: "Archive this workspace",
+    group: "Ship",
+    scope: "code",
+    allowInEditable: true,
+  },
+  {
     id: "close-tab",
     codes: ["KeyW"],
     mod: true,
@@ -367,18 +498,29 @@ export function shortcutKeycaps(
   return caps;
 }
 
-/** The single keycap a definition's key is drawn as. */
+/**
+ * The single keycap a definition's key is drawn as.
+ *
+ * Named keys get the glyph their keycap carries rather than their DOM name, so
+ * a row reads the way the keyboard looks.
+ */
 function shortcutKeyLabel(def: ShellShortcutDef): string {
   if (def.codes) {
     const code = def.codes[0] ?? "";
     const label = code.replace(/^(Key|Digit|Numpad)/, "");
+    if (label === "Enter") return "↩";
     return label.length === 1 ? label.toUpperCase() : code;
   }
   const key = def.keys[0] ?? "";
-  if (key === "arrowleft") return "←";
-  if (key === "arrowright") return "→";
-  return key.length === 1 ? key.toUpperCase() : key;
+  return ARROW_KEYCAPS[key] ?? (key.length === 1 ? key.toUpperCase() : key);
 }
+
+const ARROW_KEYCAPS: Record<string, string> = {
+  arrowleft: "←",
+  arrowright: "→",
+  arrowup: "↑",
+  arrowdown: "↓",
+};
 
 /**
  * The shortcuts under their headings, in the order the help dialog lists them.

--- a/crates/tidebreak-desktop/ui/src/ShortcutsDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/ShortcutsDialog.tsx
@@ -15,6 +15,7 @@ import {
   shortcutKeycaps,
   usesCommandModifier,
   type ShellShortcutDef,
+  type ShellShortcutMode,
 } from "./ShellShortcuts";
 
 function Keycap({ children }: { children: string }) {
@@ -53,9 +54,46 @@ function ShortcutRow({
  * Rendering from the table the listener matches on is the point: a hand-written
  * second copy would drift the first time a binding changed, and a help dialog
  * that misstates the keys is worse than no dialog at all. Listed for the mode
- * the route is in, for the same reason: Cmd+N is one row, and which one is true
+ * asked for, for the same reason: Cmd+N is one row, and which one is true
  * depends on where the reader pressed it.
+ *
+ * Split from the dialog so a story can draw both modes without standing up a
+ * router to answer which one the reader is in.
  */
+export function ShortcutsList({
+  mode,
+  command = usesCommandModifier(navigator.userAgent),
+}: {
+  mode: ShellShortcutMode;
+  command?: boolean;
+}) {
+  const groups = useMemo(() => groupedShellShortcuts(mode), [mode]);
+  return (
+    <div className="grid max-h-[65vh] grid-cols-[1fr_auto] items-center gap-x-6 gap-y-2 overflow-y-auto pr-1">
+      {groups.map(({ group, items }, index) => (
+        <Fragment key={group}>
+          <h3
+            className={cn(
+              "col-span-2 text-2xs font-semibold tracking-[0.08em] text-muted-foreground uppercase",
+              index > 0 && "mt-4",
+            )}
+          >
+            {group}
+          </h3>
+          {items.map((shortcut) => (
+            <ShortcutRow
+              key={`${shortcut.id}:${shortcutKeycaps(shortcut, command).join("")}`}
+              shortcut={shortcut}
+              command={command}
+            />
+          ))}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+/** The help dialog, listing whichever mode the route puts the reader in. */
 export function ShortcutsDialog({
   open,
   onOpenChange,
@@ -63,11 +101,9 @@ export function ShortcutsDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const command = useMemo(() => usesCommandModifier(navigator.userAgent), []);
   const mode = useRouterState({
     select: (state) => shellShortcutMode(state.location.pathname),
   });
-  const groups = useMemo(() => groupedShellShortcuts(mode), [mode]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -78,27 +114,7 @@ export function ShortcutsDialog({
             These act on the app frame, so they work from every screen.
           </DialogDescription>
         </DialogHeader>
-        <div className="grid max-h-[65vh] grid-cols-[1fr_auto] items-center gap-x-6 gap-y-2 overflow-y-auto pr-1">
-          {groups.map(({ group, items }, index) => (
-            <Fragment key={group}>
-              <h3
-                className={cn(
-                  "col-span-2 text-2xs font-semibold tracking-[0.08em] text-muted-foreground uppercase",
-                  index > 0 && "mt-4",
-                )}
-              >
-                {group}
-              </h3>
-              {items.map((shortcut) => (
-                <ShortcutRow
-                  key={shortcut.id}
-                  shortcut={shortcut}
-                  command={command}
-                />
-              ))}
-            </Fragment>
-          ))}
-        </div>
+        <ShortcutsList mode={mode} />
       </DialogContent>
     </Dialog>
   );

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -2408,6 +2408,23 @@ export class ApiClient {
   }
 
   /**
+   * User-initiated draft-to-ready. Decision 42 keeps pull-request state
+   * changes off the agent path, so this is a dedicated endpoint rather than a
+   * prompt. Returns the post-change snapshot.
+   */
+  async markCodePrReady(workspaceId: string): Promise<CodeWorkspacePrSnapshot> {
+    return requireParsed(
+      parseCodeWorkspacePr(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/ready`,
+          { method: "POST", headers: this.headers(true) },
+        ),
+      ),
+      "code pull request",
+    );
+  }
+
+  /**
    * User-initiated merge. auto=true arms host auto-merge instead of merging
    * immediately. Returns the post-merge snapshot.
    */

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -55,7 +55,7 @@ import { FilesPanel } from "./FilesPanel";
 import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { MiddleTruncate } from "./MiddleTruncate";
 import { PrCommentCard } from "./PrCommentCard";
-import { prWorkflowStatus, type PrWorkflowState } from "./prActions";
+import { prMergeControls, prWorkflowStatus } from "./prActions";
 import { useWorkspaceDigest } from "./CodeUpdatesStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
@@ -677,89 +677,6 @@ function mergeMethodLabel(method: CodePrMergeMethod): string {
       return "Rebase and merge";
   }
 }
-
-function prMergeControls(state: PrWorkflowState): {
-  canMerge: boolean;
-  canEnableAutoMerge: boolean;
-  explanation: string | null;
-} {
-  switch (state) {
-    case "ready":
-      return { canMerge: true, canEnableAutoMerge: true, explanation: null };
-    case "checking":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: true,
-        explanation:
-          "GitHub is still determining mergeability. Merge stays unavailable until the pull request is explicitly ready.",
-      };
-    case "pending":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: true,
-        explanation: "Wait for the pending checks before merging directly.",
-      };
-    case "failing":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: true,
-        explanation: "Fix the failing checks before merging directly.",
-      };
-    case "conflict":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: false,
-        explanation: "Resolve the merge conflicts before merging directly.",
-      };
-    case "behind":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: true,
-        explanation: "Update the branch from its base before merging directly.",
-      };
-    case "blocked":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: true,
-        explanation:
-          "A review or repository requirement is still blocking a direct merge.",
-      };
-    case "changes_requested":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: true,
-        explanation: "Address the requested changes before merging directly.",
-      };
-    case "draft":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: false,
-        explanation:
-          "Mark the pull request ready for review on GitHub before merging it.",
-      };
-    case "queued":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: false,
-        explanation: "This pull request is already waiting in the merge queue.",
-      };
-    case "auto_merge":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: false,
-        explanation:
-          "Auto-merge is already enabled and will merge after the remaining requirements pass.",
-      };
-    case "merged":
-    case "closed":
-      return {
-        canMerge: false,
-        canEnableAutoMerge: false,
-        explanation: null,
-      };
-  }
-}
-
 function ReviewDecisionBadge({ decision }: { decision?: string }) {
   if (!decision) return null;
   if (decision === "approved") {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -251,14 +251,16 @@ export function CodeSidebar() {
                       action === "open_source" ||
                       action === "push" ||
                       action === "create_pr" ||
-                      action === "merge"
+                      action === "merge" ||
+                      action === "mark_ready"
                     ) {
                       // Local-git stages never arise from the digest-only
                       // model; the workspace page is where they resolve.
-                      // Merging goes there too: decision 42 makes it the
-                      // reader's call, and a card in a rail is the wrong place
-                      // to land a shared branch from — the header puts the
-                      // pull request in front of them first.
+                      // Merging and readying go there too: decision 42 makes
+                      // both the reader's call, and a card in a rail is the
+                      // wrong place to land a shared branch or open work for
+                      // review from — the header puts the pull request in
+                      // front of them first.
                       void navigate({
                         to: "/code/w/$workspaceId",
                         params: { workspaceId: workspace.id },

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -250,10 +250,15 @@ export function CodeSidebar() {
                     if (
                       action === "open_source" ||
                       action === "push" ||
-                      action === "create_pr"
+                      action === "create_pr" ||
+                      action === "merge"
                     ) {
                       // Local-git stages never arise from the digest-only
                       // model; the workspace page is where they resolve.
+                      // Merging goes there too: decision 42 makes it the
+                      // reader's call, and a card in a rail is the wrong place
+                      // to land a shared branch from — the header puts the
+                      // pull request in front of them first.
                       void navigate({
                         to: "/code/w/$workspaceId",
                         params: { workspaceId: workspace.id },

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import type { HarnessKind } from "../api/types";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import type { WorkflowShortcut } from "./workspaceWorkflow";
 import {
   isCardDensity,
   isWorkspaceSortMode,
@@ -260,6 +261,33 @@ export type CodeUiStore = {
   /** Opens the review sidebar too: search is dead while that rail is hidden. */
   requestFilesSearch: () => void;
   takeFilesSearch: () => boolean;
+  /**
+   * The Ship chord waiting for the workspace header, which is the one surface
+   * that knows the branch and pull-request state a chord resolves against.
+   *
+   * Held rather than run here because the shell has none of that state, and
+   * because the same chord means different actions at different stages —
+   * deciding which in the store would put the decision two layers from the
+   * data it depends on.
+   *
+   * Scoped to the workspace it was pressed on, the way a queued composer
+   * prompt is. An archived workspace draws no header control, so a chord
+   * pressed there is never taken; without the scope it would sit in the store
+   * and fire on the next workspace the reader opened.
+   */
+  workflowShortcutPending: {
+    workspaceId: string;
+    shortcut: WorkflowShortcut;
+  } | null;
+  requestWorkflowShortcut: (
+    workspaceId: string,
+    shortcut: WorkflowShortcut,
+  ) => void;
+  takeWorkflowShortcut: (workspaceId: string) => WorkflowShortcut | null;
+  /** The archive chord, taken by the workspace page that owns the command. */
+  archivePending: boolean;
+  requestArchiveWorkspace: () => void;
+  takeArchiveWorkspace: () => boolean;
 };
 
 export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
@@ -288,6 +316,24 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   takeFilesSearch: () => {
     if (!get().filesSearchPending) return false;
     set({ filesSearchPending: false });
+    return true;
+  },
+  workflowShortcutPending: null,
+  // Last chord wins rather than queueing. Two Ship chords in a row is a reader
+  // correcting themselves, not asking for both.
+  requestWorkflowShortcut: (workspaceId, shortcut) =>
+    set({ workflowShortcutPending: { workspaceId, shortcut } }),
+  takeWorkflowShortcut: (workspaceId) => {
+    const pending = get().workflowShortcutPending;
+    if (pending === null || pending.workspaceId !== workspaceId) return null;
+    set({ workflowShortcutPending: null });
+    return pending.shortcut;
+  },
+  archivePending: false,
+  requestArchiveWorkspace: () => set({ archivePending: true }),
+  takeArchiveWorkspace: () => {
+    if (!get().archivePending) return false;
+    set({ archivePending: false });
     return true;
   },
   offerComposerPrompt: (scope, prompt) =>

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -192,22 +192,33 @@ function digestUrgency(digest: CodeSessionDigest): number {
   return 3;
 }
 
+/**
+ * One digest per workspace, from a snapshot of the store.
+ *
+ * Split from the hook so callers outside React — the rail-walking shortcuts —
+ * order workspaces by the same digests the rail draws with, rather than by a
+ * second, subtly different arrangement.
+ */
+export function workspaceDigests(
+  state: Pick<CodeUpdatesState, "conversationsByWorkspace">,
+): Record<string, CodeSessionDigest> {
+  const digests: Record<string, CodeSessionDigest> = {};
+  for (const workspaceId of Object.keys(state.conversationsByWorkspace)) {
+    const digest = workspaceDigest(state, workspaceId);
+    if (digest) digests[workspaceId] = digest;
+  }
+  return digests;
+}
+
 /** One digest per workspace, for the rail and the card lists. */
 export function useWorkspaceDigests(): Record<string, CodeSessionDigest> {
   const conversations = useCodeUpdatesStore(
     (state) => state.conversationsByWorkspace,
   );
-  return useMemo(() => {
-    const digests: Record<string, CodeSessionDigest> = {};
-    for (const workspaceId of Object.keys(conversations)) {
-      const digest = workspaceDigest(
-        { conversationsByWorkspace: conversations },
-        workspaceId,
-      );
-      if (digest) digests[workspaceId] = digest;
-    }
-    return digests;
-  }, [conversations]);
+  return useMemo(
+    () => workspaceDigests({ conversationsByWorkspace: conversations }),
+    [conversations],
+  );
 }
 
 /** The digest that speaks for one workspace, for a header or an inspector. */

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import type { ReactNode } from "react";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -253,6 +254,19 @@ function makeClient() {
         remediation: "",
       }),
     ),
+    mergeCodePr: vi.fn(
+      async (): Promise<CodeWorkspacePrSnapshot> => ({
+        dirty: false,
+        unpushed: false,
+        ahead: 0,
+        has_upstream: true,
+        suggested_commit_message: "",
+        pr: { ...PR, draft: false, state: "merged", merged: true },
+        gh_found: true,
+        gh_authenticated: true,
+        remediation: "",
+      }),
+    ),
     startCodeWatch: vi.fn(async () => ({
       id: "watch-1",
       workspace_id: "ws-1",
@@ -487,6 +501,8 @@ afterEach(() => {
   useCodeUiStore.setState({
     pendingComposerPrompt: null,
     composerActionScope: null,
+    workflowShortcutPending: null,
+    archivePending: false,
   });
   browserMocks.close.mockClear();
   window.localStorage.clear();
@@ -742,6 +758,153 @@ describe("CodeWorkspacePage", () => {
     const menu = await screen.findByRole("menu");
     expect(menu).toHaveTextContent("app");
     expect(menu).toHaveTextContent(WORKSPACE.worktree_path);
+  });
+
+  it("runs Ship chords through the same actions the header buttons do", async () => {
+    // The shell's keymap sits above the route, so a chord arrives as a request
+    // on the store and the header resolves it against the branch and pull
+    // request state only it holds. This is that seam: raise the chord, and the
+    // right server call has to follow with no button in between.
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: PR });
+    client.getCodeWorkspacePr.mockResolvedValue({
+      dirty: false,
+      unpushed: false,
+      ahead: 1,
+      has_upstream: true,
+      suggested_commit_message: "",
+      pr: PR,
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+    });
+    await mountWorkspace(client);
+    await screen.findByTestId("workspace-workflow-control");
+
+    act(() => useCodeUiStore.getState().requestWorkflowShortcut("ws-1", "watch"));
+    await waitFor(() =>
+      expect(client.startCodeWatch).toHaveBeenCalledWith("ws-1"),
+    );
+
+    // This one is a draft, so it is not green. The chord says so rather than
+    // asking an agent to merge it — decision 42 keeps merging off the agent
+    // path, so "not mergeable" has to be a refusal, not a prompt.
+    act(() => useCodeUiStore.getState().requestWorkflowShortcut("ws-1", "merge"));
+    await waitFor(() =>
+      expect(toast.message).toHaveBeenCalledWith(
+        "Mark the pull request ready for review on GitHub before merging it.",
+      ),
+    );
+    expect(client.mergeCodePr).not.toHaveBeenCalled();
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+  });
+
+  it("merges a green pull request through the user endpoint, not the agent", async () => {
+    // Decision 42: the general `gh` runner refuses merge argv, and only
+    // POST /pr/merge reaches the runner that allows it. A chord that prompted
+    // an agent to merge would route around that boundary using the agent's own
+    // shell, so this pins that the chord calls the endpoint instead.
+    const green: PullRequestDigest = {
+      ...PR,
+      draft: false,
+      mergeable: "mergeable",
+      merge_state_status: "clean",
+      checks: [{ name: "ci / rust", bucket: "pass" as const }],
+    };
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: green });
+    client.getCodeWorkspacePr.mockResolvedValue({
+      dirty: false,
+      unpushed: false,
+      ahead: 0,
+      has_upstream: true,
+      suggested_commit_message: "",
+      pr: green,
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+    });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+    const control = await screen.findByTestId("workspace-workflow-control");
+    await waitFor(() => expect(control).toHaveTextContent("Ready"));
+
+    act(() => useCodeUiStore.getState().requestWorkflowShortcut("ws-1", "merge"));
+
+    // Merging publishes to a shared branch, so the chord still stops at the
+    // same confirmation the review sidebar's Merge button shows.
+    const confirmation = await screen.findByRole("alertdialog");
+    expect(confirmation).toHaveTextContent("Merge #41?");
+    expect(confirmation).toHaveTextContent("squash-merged into main");
+    await user.click(
+      within(confirmation).getByRole("button", { name: "Merge" }),
+    );
+
+    await waitFor(() =>
+      expect(client.mergeCodePr).toHaveBeenCalledWith("ws-1", {
+        method: "squash",
+        auto: false,
+      }),
+    );
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+  });
+
+  it("says why a Ship chord did nothing instead of swallowing it", async () => {
+    // A chord that silently no-ops is indistinguishable from one that never
+    // fired, which is the fastest way to stop trusting the keyboard.
+    const client = makeClient();
+    client.getCodeWorkspace.mockResolvedValue(WORKSPACE);
+    client.getCodeWorkspacePr.mockResolvedValue({
+      dirty: false,
+      unpushed: false,
+      ahead: 0,
+      has_upstream: true,
+      suggested_commit_message: "",
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+    });
+    await mountWorkspace(client);
+    const control = await screen.findByTestId("workspace-workflow-control");
+    await waitFor(() => expect(control).toHaveTextContent("No changes"));
+
+    act(() => useCodeUiStore.getState().requestWorkflowShortcut("ws-1", "merge"));
+    await waitFor(() =>
+      expect(toast.message).toHaveBeenCalledWith("No pull request yet"),
+    );
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+
+    // A chord raised on another workspace — an archived one, which draws no
+    // header control to take it — must not fire on whatever is open here.
+    act(() =>
+      useCodeUiStore.getState().requestWorkflowShortcut("ws-other", "merge"),
+    );
+    await waitFor(() =>
+      expect(useCodeUiStore.getState().workflowShortcutPending).not.toBeNull(),
+    );
+    expect(toast.message).toHaveBeenCalledTimes(1);
+  });
+
+  it("archives from a chord through the same confirmation the menu uses", async () => {
+    // Archiving removes a worktree. The keyboard path must not be the one that
+    // skips the dialog.
+    const client = makeClient();
+    const { router } = await mountWorkspace(client);
+    const user = userEvent.setup();
+    await screen.findByRole("heading", { name: /Fix login/ });
+
+    act(() => useCodeUiStore.getState().requestArchiveWorkspace());
+    const confirmation = await screen.findByRole("alertdialog");
+    await user.click(
+      within(confirmation).getByRole("button", { name: "Archive" }),
+    );
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/r/repo-1"),
+    );
+    expect(client.archiveCodeWorkspace).toHaveBeenCalledWith("ws-1", false);
   });
 
   it("opens Source control for local changes without crowding the composer", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -254,6 +254,19 @@ function makeClient() {
         remediation: "",
       }),
     ),
+    markCodePrReady: vi.fn(
+      async (): Promise<CodeWorkspacePrSnapshot> => ({
+        dirty: false,
+        unpushed: false,
+        ahead: 0,
+        has_upstream: true,
+        suggested_commit_message: "",
+        pr: { ...PR, draft: false },
+        gh_found: true,
+        gh_authenticated: true,
+        remediation: "",
+      }),
+    ),
     mergeCodePr: vi.fn(
       async (): Promise<CodeWorkspacePrSnapshot> => ({
         dirty: false,
@@ -725,24 +738,6 @@ describe("CodeWorkspacePage", () => {
     expect(popover).toHaveTextContent("1 passing · 1 pending");
 
     await user.click(
-      within(control).getByRole("button", { name: "Mark ready" }),
-    );
-    await waitFor(() =>
-      expect(client.submitCodeTurn).toHaveBeenCalledWith(
-        "sess-1",
-        expect.stringMatching(/Mark pull request #41 ready for review/),
-        undefined,
-        undefined,
-      ),
-    );
-    expect(client.submitCodeTurn.mock.calls[0]?.[1]).toMatch(
-      /Pull request: #41 - Fix login flow/,
-    );
-    expect(client.submitCodeTurn.mock.calls[0]?.[1]).toMatch(
-      /Branch: tidebreak\/fix-login -> main/,
-    );
-
-    await user.click(
       within(control).getByRole("button", { name: "More workspace actions" }),
     );
     await user.click(
@@ -752,7 +747,19 @@ describe("CodeWorkspacePage", () => {
     await waitFor(() =>
       expect(client.startCodeWatch).toHaveBeenCalledWith("ws-1"),
     );
-    expect(client.submitCodeTurn).toHaveBeenCalledTimes(1);
+
+    // Readying a draft is a pull-request state change, so the button calls the
+    // endpoint rather than composing a prompt, and the adopted snapshot moves
+    // the control off draft. It goes last for that reason. `prActions` covers
+    // what the remaining prompt-backed actions put in front of the agent.
+    await user.click(
+      within(control).getByRole("button", { name: "Mark ready" }),
+    );
+    await waitFor(() =>
+      expect(client.markCodePrReady).toHaveBeenCalledWith("ws-1"),
+    );
+    await waitFor(() => expect(control).not.toHaveTextContent("Draft"));
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Workspace actions" }));
     const menu = await screen.findByRole("menu");
@@ -885,6 +892,85 @@ describe("CodeWorkspacePage", () => {
       expect(useCodeUiStore.getState().workflowShortcutPending).not.toBeNull(),
     );
     expect(toast.message).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a draft ready through the endpoint rather than by prompt", async () => {
+    // Readying a draft puts work in front of reviewers, which decision 42
+    // keeps off the agent path for the same reason merging is. The chord for
+    // "run the next step" is what reaches it at this stage.
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: PR });
+    client.getCodeWorkspacePr.mockResolvedValue({
+      dirty: false,
+      unpushed: false,
+      ahead: 0,
+      has_upstream: true,
+      suggested_commit_message: "",
+      pr: PR,
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+    });
+    await mountWorkspace(client);
+    const control = await screen.findByTestId("workspace-workflow-control");
+    await waitFor(() => expect(control).toHaveTextContent("Draft"));
+
+    act(() => useCodeUiStore.getState().requestWorkflowShortcut("ws-1", "next"));
+
+    await waitFor(() =>
+      expect(client.markCodePrReady).toHaveBeenCalledWith("ws-1"),
+    );
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+  });
+
+  it("arms auto-merge when the pull request is landable but not yet green", async () => {
+    // One chord, one intent: the reader means "get this in" whether or not the
+    // checks have finished. The confirmation is what names which of the two is
+    // about to happen.
+    const pending: PullRequestDigest = {
+      ...PR,
+      draft: false,
+      mergeable: "mergeable",
+      merge_state_status: "blocked",
+      checks: [{ name: "ci / rust", bucket: "pending" as const }],
+    };
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: pending });
+    client.getCodeWorkspacePr.mockResolvedValue({
+      dirty: false,
+      unpushed: false,
+      ahead: 0,
+      has_upstream: true,
+      suggested_commit_message: "",
+      pr: pending,
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+    });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+    await screen.findByTestId("workspace-workflow-control");
+
+    act(() => useCodeUiStore.getState().requestWorkflowShortcut("ws-1", "merge"));
+
+    const confirmation = await screen.findByRole("alertdialog");
+    expect(confirmation).toHaveTextContent("Auto-merge #41?");
+    expect(confirmation).toHaveTextContent(
+      "once the remaining requirements pass",
+    );
+    await user.click(
+      within(confirmation).getByRole("button", { name: "Enable auto-merge" }),
+    );
+
+    await waitFor(() =>
+      expect(client.mergeCodePr).toHaveBeenCalledWith("ws-1", {
+        method: "squash",
+        auto: true,
+      }),
+    );
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
   });
 
   it("archives from a chord through the same confirmation the menu uses", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -217,6 +217,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     (state) => state.setReviewSidebarOpen,
   );
   const quickOpenPending = useCodeUiStore((state) => state.quickOpenPending);
+  const archivePending = useCodeUiStore((state) => state.archivePending);
   const shortcutHints = useCodeShortcutHints();
   const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(
     null,
@@ -559,6 +560,29 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     if (!useCodeUiStore.getState().takeQuickOpen()) return;
     requestNewTab(splitFocused ? "secondary" : "primary");
   }, [quickOpenPending, splitFocused]);
+
+  /**
+   * Archive from the keyboard, through the same confirmation the menu uses.
+   *
+   * The page takes this one rather than the header control, because archiving
+   * is a workspace command and not a step in the pull-request workflow.
+   */
+  useEffect(() => {
+    if (!archivePending) return;
+    if (!useCodeUiStore.getState().takeArchiveWorkspace()) return;
+    if (!workspace) return;
+    if (workspace.status === "archived") {
+      toast.message("This workspace is already archived");
+      return;
+    }
+    run("archive", {
+      workspace,
+      title: title ?? workspace.title,
+      session: session ?? undefined,
+    });
+    // The chord is the trigger; the rest is state read when it arrives.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [archivePending]);
 
   /**
    * Attach a child task's transcript (or the conversation when undefined).

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import {
   ChevronDown,
   CircleDotDashed,
@@ -11,11 +11,13 @@ import { toast } from "sonner";
 
 import { HttpError, type ApiClient } from "../api/client";
 import type {
+  CodePrMergeMethod,
   CodeWatchSnapshot,
   CodeWatchState,
   PullRequestDigest,
 } from "../api/types";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ConfirmDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,6 +37,7 @@ import { useCodeUiStore } from "./CodeUiStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import {
   checkSummary,
+  resolveWorkflowShortcut,
   workspaceWorkflowActionLabel,
   workspaceWorkflowModel,
   type WorkspaceWorkflowAction,
@@ -62,6 +65,7 @@ export function WorkspaceWorkflowControl({
     ApiClient,
     | "pushCodeWorkspace"
     | "createCodePullRequest"
+    | "mergeCodePr"
     | "startCodeWatch"
     | "stopCodeWatch"
   >;
@@ -76,8 +80,12 @@ export function WorkspaceWorkflowControl({
 }) {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const popoverTitleId = useId();
+  const { confirm, dialog: confirmDialog } = useConfirm();
   const runComposerPrompt = useCodeUiStore(
     (state) => state.runComposerPrompt,
+  );
+  const workflowShortcutPending = useCodeUiStore(
+    (state) => state.workflowShortcutPending,
   );
   const agentActionRunning = useCodeUiStore(
     (state) => state.composerActionScope !== null,
@@ -116,6 +124,39 @@ export function WorkspaceWorkflowControl({
       )
     : model.secondary;
 
+  /**
+   * Carry out a Ship chord raised by the shell.
+   *
+   * Taken here rather than run there because the chord's meaning depends on the
+   * branch and pull-request state this control already holds. Effects run after
+   * the render that saw the request, so the model this resolves against is the
+   * current one. Taking the request is what keeps a remount from repeating it.
+   */
+  useEffect(() => {
+    if (workflowShortcutPending?.workspaceId !== workspaceId) return;
+    const shortcut = useCodeUiStore
+      .getState()
+      .takeWorkflowShortcut(workspaceId);
+    if (shortcut === null) return;
+    const resolution = resolveWorkflowShortcut(shortcut, model, watchActive);
+    if ("blocked" in resolution) {
+      toast.message(resolution.blocked);
+      return;
+    }
+    if ("stopWatch" in resolution) {
+      void stopWatch();
+      return;
+    }
+    if (busy !== null || agentActionRunning) {
+      toast.message("Another workspace action is already running");
+      return;
+    }
+    void run(resolution.run);
+    // Only the request re-runs this. The rest is state the effect reads at the
+    // moment the chord arrives; listing it would re-fire on every status poll.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workflowShortcutPending, workspaceId]);
+
   function runAgentAction(action: Exclude<PrWorkflowAction, "watch_and_fix">) {
     const pr = model.pr;
     if (!pr) return;
@@ -133,6 +174,54 @@ export function WorkspaceWorkflowControl({
       toast.success("Watching the pull request");
     } catch (err) {
       const message = friendlyErrorMessage(err, "Could not start the watch");
+      resource.setMutationError(message);
+      toast.error(message);
+    }
+  }
+
+  /**
+   * Merge through the user-initiated endpoint, not through the agent.
+   *
+   * Decision 42 reserves merging for the user: the general `gh` runner refuses
+   * merge argv, and only `POST /code/workspaces/{id}/pr/merge` reaches the
+   * runner that allows it. Asking an agent to merge would route around that,
+   * so this button and its chord call the endpoint the review sidebar's Merge
+   * button calls.
+   *
+   * Squash is the default the review sidebar opens on, and the confirmation
+   * names the method, so the reader sees which one before it lands. Pick a
+   * different one from the review sidebar.
+   */
+  async function mergePr(method: CodePrMergeMethod = "squash") {
+    const pr = model.pr;
+    if (!pr) return;
+    setDetailsOpen(false);
+    const ok = await confirm({
+      title: `Merge #${pr.number}?`,
+      description: `The pull request is ${
+        method === "squash"
+          ? "squash-merged"
+          : method === "rebase"
+            ? "rebased and merged"
+            : "merged"
+      } into ${pr.base_branch ?? "its base branch"} on GitHub.`,
+      confirmLabel: "Merge",
+    });
+    if (!ok) return;
+    try {
+      const next = await resource.runMutation("merge", () =>
+        client.mergeCodePr(workspaceId, { method, auto: false }),
+      );
+      if (!next) return;
+      resource.adopt(next);
+      toast.success("Merged");
+    } catch (err) {
+      // The host's own refusal is the useful sentence here, so it goes to the
+      // status line rather than being flattened into a generic failure.
+      const message =
+        err instanceof HttpError && err.kind === "pr_not_mergeable"
+          ? err.message
+          : friendlyErrorMessage(err, "Could not merge");
       resource.setMutationError(message);
       toast.error(message);
     }
@@ -208,12 +297,17 @@ export function WorkspaceWorkflowControl({
       case "watch_and_fix":
         await startWatch();
         return;
+      case "merge":
+        await mergePr();
+        return;
       default:
         runAgentAction(action);
     }
   }
 
   return (
+    <>
+      {confirmDialog}
     <div
       className="border-border-subtle bg-page-background/70 flex min-w-0 max-w-[min(40vw,26rem)] shrink items-center overflow-hidden rounded-lg border shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_6%,transparent)]"
       data-testid="workspace-workflow-control"
@@ -562,6 +656,7 @@ export function WorkspaceWorkflowControl({
         </DropdownMenu>
       ) : null}
     </div>
+    </>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -32,7 +32,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { openExternal } from "@/host";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
-import { prWorkflowPrompt, type PrWorkflowAction } from "./prActions";
+import { prWorkflowPrompt, type PrPromptAction } from "./prActions";
 import { useCodeUiStore } from "./CodeUiStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import {
@@ -65,6 +65,7 @@ export function WorkspaceWorkflowControl({
     ApiClient,
     | "pushCodeWorkspace"
     | "createCodePullRequest"
+    | "markCodePrReady"
     | "mergeCodePr"
     | "startCodeWatch"
     | "stopCodeWatch"
@@ -147,6 +148,14 @@ export function WorkspaceWorkflowControl({
       void stopWatch();
       return;
     }
+    if ("autoMerge" in resolution) {
+      if (busy !== null) {
+        toast.message("Another workspace action is already running");
+        return;
+      }
+      void mergePr(true);
+      return;
+    }
     if (busy !== null || agentActionRunning) {
       toast.message("Another workspace action is already running");
       return;
@@ -157,7 +166,7 @@ export function WorkspaceWorkflowControl({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workflowShortcutPending, workspaceId]);
 
-  function runAgentAction(action: Exclude<PrWorkflowAction, "watch_and_fix">) {
+  function runAgentAction(action: PrPromptAction) {
     const pr = model.pr;
     if (!pr) return;
     setDetailsOpen(false);
@@ -192,29 +201,34 @@ export function WorkspaceWorkflowControl({
    * names the method, so the reader sees which one before it lands. Pick a
    * different one from the review sidebar.
    */
-  async function mergePr(method: CodePrMergeMethod = "squash") {
+  async function mergePr(auto = false, method: CodePrMergeMethod = "squash") {
     const pr = model.pr;
     if (!pr) return;
     setDetailsOpen(false);
+    const base = pr.base_branch ?? "its base branch";
+    // Two forms of the same verb: the immediate merge reads as something done
+    // to the pull request, the armed one as something GitHub will do.
+    const [landed, lands] =
+      method === "squash"
+        ? ["squash-merged", "squash-merges"]
+        : method === "rebase"
+          ? ["rebased and merged", "rebases and merges"]
+          : ["merged", "merges"];
     const ok = await confirm({
-      title: `Merge #${pr.number}?`,
-      description: `The pull request is ${
-        method === "squash"
-          ? "squash-merged"
-          : method === "rebase"
-            ? "rebased and merged"
-            : "merged"
-      } into ${pr.base_branch ?? "its base branch"} on GitHub.`,
-      confirmLabel: "Merge",
+      title: auto ? `Auto-merge #${pr.number}?` : `Merge #${pr.number}?`,
+      description: auto
+        ? `GitHub ${lands} the pull request into ${base} once the remaining requirements pass.`
+        : `The pull request is ${landed} into ${base} on GitHub.`,
+      confirmLabel: auto ? "Enable auto-merge" : "Merge",
     });
     if (!ok) return;
     try {
-      const next = await resource.runMutation("merge", () =>
-        client.mergeCodePr(workspaceId, { method, auto: false }),
+      const next = await resource.runMutation(auto ? "auto_merge" : "merge", () =>
+        client.mergeCodePr(workspaceId, { method, auto }),
       );
       if (!next) return;
       resource.adopt(next);
-      toast.success("Merged");
+      toast.success(auto ? "Auto-merge enabled" : "Merged");
     } catch (err) {
       // The host's own refusal is the useful sentence here, so it goes to the
       // status line rather than being flattened into a generic failure.
@@ -222,6 +236,31 @@ export function WorkspaceWorkflowControl({
         err instanceof HttpError && err.kind === "pr_not_mergeable"
           ? err.message
           : friendlyErrorMessage(err, "Could not merge");
+      resource.setMutationError(message);
+      toast.error(message);
+    }
+  }
+
+  /**
+   * Take the pull request out of draft through the user-initiated endpoint.
+   *
+   * Readying a draft is a pull-request state change, which decision 42 keeps
+   * off the agent path for the same reason merging is: it puts work in front
+   * of reviewers, and an agent should not decide when that happens.
+   */
+  async function markReady() {
+    const pr = model.pr;
+    if (!pr) return;
+    setDetailsOpen(false);
+    try {
+      const next = await resource.runMutation("mark_ready", () =>
+        client.markCodePrReady(workspaceId),
+      );
+      if (!next) return;
+      resource.adopt(next);
+      toast.success("Marked ready for review");
+    } catch (err) {
+      const message = friendlyErrorMessage(err, "Could not mark it ready");
       resource.setMutationError(message);
       toast.error(message);
     }
@@ -299,6 +338,9 @@ export function WorkspaceWorkflowControl({
         return;
       case "merge":
         await mergePr();
+        return;
+      case "mark_ready":
+        await markReady();
         return;
       default:
         runAgentAction(action);

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -158,10 +158,10 @@ describe("prWorkflowPrompt", () => {
         },
       ],
     });
-    expect(prWorkflowPrompt("merge", digest)).toMatch(/#41/);
-    expect(prWorkflowPrompt("merge", digest)).toMatch(/main/);
-    expect(prWorkflowPrompt("merge", digest)).toMatch(/Fix login/);
-    expect(prWorkflowPrompt("merge", digest)).toMatch(/fix-login -> main/);
+    expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/#41/);
+    expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/main/);
+    expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/Fix login/);
+    expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/fix-login -> main/);
     expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/ci \/ ui/);
     expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/Tests failed/);
     expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/actions\/runs\/7/);
@@ -171,6 +171,17 @@ describe("prWorkflowPrompt", () => {
     expect(prWorkflowPrompt("address_feedback", digest)).toMatch(
       /requested changes/,
     );
-    expect(prWorkflowPrompt("mark_ready", digest)).toMatch(/ready for review/);
+  });
+
+  it("has no prompt for the pull-request state changes", () => {
+    // Decision 42 keeps merging and readying a draft on user-initiated
+    // endpoints. Excluding them from the prompt type is what stops either from
+    // being wired back onto the agent path, where an agent's own shell would
+    // route around the `gh` runner that refuses merge argv. These lines must
+    // not compile.
+    // @ts-expect-error merging is not an agent action
+    expect(() => prWorkflowPrompt("merge", pr({}))).toBeDefined();
+    // @ts-expect-error readying a draft is not an agent action
+    expect(() => prWorkflowPrompt("mark_ready", pr({}))).toBeDefined();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -192,13 +192,24 @@ export function prMergeControls(state: PrWorkflowState): {
   }
 }
 
+/** The workflow actions an agent carries out, as opposed to an endpoint. */
+export type PrPromptAction = Exclude<
+  PrWorkflowAction,
+  "watch_and_fix" | "mark_ready" | "merge"
+>;
+
 /**
- * Prompt actions run in the workspace's interactive session. "Watch and fix"
- * is not one of them: it starts a durable server-side watch task instead
- * (`POST /code/workspaces/{id}/watch`).
+ * Prompt actions run in the workspace's interactive session.
+ *
+ * Three of the workflow actions are deliberately absent. "Watch and fix"
+ * starts a durable server-side watch task (`POST
+ * /code/workspaces/{id}/watch`). Merging and readying a draft are
+ * pull-request state changes, which decision 42 reserves for the user: they
+ * run through their own endpoints, and excluding them from this type is what
+ * stops a merge prompt from being wired back up by accident.
  */
 export function prWorkflowPrompt(
-  action: Exclude<PrWorkflowAction, "watch_and_fix">,
+  action: PrPromptAction,
   pr: PullRequestDigest,
 ): string {
   const number = `#${pr.number}`;
@@ -206,12 +217,6 @@ export function prWorkflowPrompt(
   const context = prWorkflowPromptContext(pr);
   let instruction: string;
   switch (action) {
-    case "mark_ready":
-      instruction = `Mark pull request ${number} ready for review. First confirm the current head is pushed and the pull request is still a draft. Do not merge it. Report the result.`;
-      break;
-    case "merge":
-      instruction = `Merge pull request ${number} into ${base}. Re-check the current head SHA, required checks, reviews, conflicts, and queue requirements immediately before merging. Use the repository's preferred merge or merge-queue path. Do not change the branch unless the merge requires it. Report the result.`;
-      break;
     case "fix_errors":
       instruction = `Pull request ${number} has failing checks. Inspect the latest failing CI logs for the current head SHA, reproduce the cause when practical, make the smallest safe fix in this workspace, run focused validation, commit, and push. Do not merge.`;
       break;

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -98,6 +98,101 @@ export function prWorkflowStatus(pr: PullRequestDigest): PrWorkflowStatus {
 }
 
 /**
+ * Whether a pull request in this state may be merged, or auto-merge armed.
+ *
+ * One table for every surface that offers merging. Decision 42 makes merging a
+ * user action rather than an agent capability, so the answer to "may this
+ * merge" has to be the same whether the reader clicks the review sidebar's
+ * button, the workspace header's, or presses the chord — a second copy would
+ * eventually let one of them offer a merge the others refuse.
+ *
+ * `explanation` is the sentence to show when the answer is no. `null` means
+ * the pull request is either mergeable or already resolved, and there is
+ * nothing to explain.
+ */
+export function prMergeControls(state: PrWorkflowState): {
+  canMerge: boolean;
+  canEnableAutoMerge: boolean;
+  explanation: string | null;
+} {
+  switch (state) {
+    case "ready":
+      return { canMerge: true, canEnableAutoMerge: true, explanation: null };
+    case "checking":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: true,
+        explanation:
+          "GitHub is still determining mergeability. Merge stays unavailable until the pull request is explicitly ready.",
+      };
+    case "pending":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: true,
+        explanation: "Wait for the pending checks before merging directly.",
+      };
+    case "failing":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: true,
+        explanation: "Fix the failing checks before merging directly.",
+      };
+    case "conflict":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: false,
+        explanation: "Resolve the merge conflicts before merging directly.",
+      };
+    case "behind":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: true,
+        explanation: "Update the branch from its base before merging directly.",
+      };
+    case "blocked":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: true,
+        explanation:
+          "A review or repository requirement is still blocking a direct merge.",
+      };
+    case "changes_requested":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: true,
+        explanation: "Address the requested changes before merging directly.",
+      };
+    case "draft":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: false,
+        explanation:
+          "Mark the pull request ready for review on GitHub before merging it.",
+      };
+    case "queued":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: false,
+        explanation: "This pull request is already waiting in the merge queue.",
+      };
+    case "auto_merge":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: false,
+        explanation:
+          "Auto-merge is already enabled and will merge after the remaining requirements pass.",
+      };
+    case "merged":
+    case "closed":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: false,
+        explanation: null,
+      };
+  }
+}
+
+/**
  * Prompt actions run in the workspace's interactive session. "Watch and fix"
  * is not one of them: it starts a durable server-side watch task instead
  * (`POST /code/workspaces/{id}/watch`).

--- a/crates/tidebreak-desktop/ui/src/code/railNavigation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/railNavigation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { stepWorkspaceId } from "./railNavigation";
+
+describe("stepWorkspaceId", () => {
+  const rail = ["a", "b", "c"];
+
+  it("cycles the rail in both directions", () => {
+    // A rail is a ring: stopping at the last card would make the chord feel
+    // broken exactly when the reader is furthest from the top.
+    expect(stepWorkspaceId(rail, "a", 1)).toBe("b");
+    expect(stepWorkspaceId(rail, "c", 1)).toBe("a");
+    expect(stepWorkspaceId(rail, "a", -1)).toBe("c");
+    expect(stepWorkspaceId(rail, "b", -1)).toBe("a");
+  });
+
+  it("enters the rail at the end it is walking towards", () => {
+    // From a repo page or the code home there is no current workspace, and
+    // doing nothing would leave the reader with no keyboard way onto the rail.
+    expect(stepWorkspaceId(rail, undefined, 1)).toBe("a");
+    expect(stepWorkspaceId(rail, undefined, -1)).toBe("c");
+    // A workspace the rail no longer draws — archived while it was open — is
+    // the same situation: there is no position to step from.
+    expect(stepWorkspaceId(rail, "gone", 1)).toBe("a");
+  });
+
+  it("has nowhere to go on an empty rail", () => {
+    expect(stepWorkspaceId([], undefined, 1)).toBeNull();
+    expect(stepWorkspaceId([], "a", -1)).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
+++ b/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
@@ -1,0 +1,51 @@
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
+import { useCodeUpdatesStore, workspaceDigests } from "./CodeUpdatesStore";
+import { arrangeWorkspaces } from "./workspaceCards";
+
+/**
+ * Walking the workspace rail from the keyboard.
+ *
+ * The order is the rail's own — the same `arrangeWorkspaces` call the rail
+ * renders, read from the same stores. Recomputing it here rather than caching
+ * a list is what keeps the chord landing on the card the reader can see: sort
+ * order, repo grouping, and archiving all move rows, and a remembered order
+ * would send Cmd+Alt+Down somewhere the rail no longer draws.
+ */
+
+/**
+ * The id a step lands on, or `null` when the rail has nothing to step to.
+ *
+ * Wraps at both ends, the way the tab chords do: a rail is a ring the reader
+ * cycles, and stopping at the last card would make the chord feel broken
+ * exactly when they are furthest from the top. From off the rail — a repo page
+ * or the code home — a step enters at the end it is walking towards.
+ */
+export function stepWorkspaceId(
+  ids: readonly string[],
+  current: string | undefined,
+  delta: -1 | 1,
+): string | null {
+  if (ids.length === 0) return null;
+  const position = current === undefined ? -1 : ids.indexOf(current);
+  if (position < 0) return (delta === 1 ? ids[0] : ids[ids.length - 1]) ?? null;
+  return ids[(position + delta + ids.length) % ids.length] ?? null;
+}
+
+/** The rail's workspaces in the order it draws them, groups flattened. */
+export function railWorkspaceIds(): string[] {
+  const { repos, workspaces } = useCodeCatalogStore.getState();
+  const { sortMode } = useCodeUiStore.getState().railPrefs;
+  const digests = workspaceDigests(useCodeUpdatesStore.getState());
+  return arrangeWorkspaces(sortMode, repos, workspaces, digests).flatMap(
+    (group) => group.workspaces.map((workspace) => workspace.id),
+  );
+}
+
+/** The workspace a rail step lands on, or `null` when there is nowhere to go. */
+export function stepRailWorkspace(
+  current: string | undefined,
+  delta: -1 | 1,
+): string | null {
+  return stepWorkspaceId(railWorkspaceIds(), current, delta);
+}

--- a/crates/tidebreak-desktop/ui/src/code/useCodeWorkspacePr.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useCodeWorkspacePr.ts
@@ -9,6 +9,7 @@ export type CodeWorkspacePrMutation =
   | "commit"
   | "push"
   | "create_pr"
+  | "mark_ready"
   | "merge"
   | "auto_merge"
   | "watch"

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
@@ -201,6 +201,7 @@ describe("resolveWorkflowShortcut", () => {
     );
     if ("run" in resolution) return resolution.run;
     if ("stopWatch" in resolution) return "stop_watch";
+    if ("autoMerge" in resolution) return "auto_merge";
     return `blocked: ${resolution.blocked}`;
   }
 
@@ -288,11 +289,24 @@ describe("resolveWorkflowShortcut", () => {
     };
     expect(chord("merge", green)).toBe("merge");
 
+    // Not green but still landable: the reader means "get this in" either way,
+    // so the chord arms auto-merge and GitHub finishes the job. Which one is
+    // about to happen is named in the confirmation, not guessed at here.
+    for (const snapshot of [
+      pr({ checks: [{ name: "ci", bucket: "fail" }] }),
+      pr({ checks: [{ name: "ci", bucket: "pending" }] }),
+      pr({ merge_state_status: "behind" }),
+      pr({ review_decision: "changes_requested" }),
+    ]) {
+      expect(chord("merge", { ...CLEAN, pr: snapshot })).toBe("auto_merge");
+    }
+
+    // Neither path is open in these states, so the chord says why. Conflicts
+    // and drafts cannot even be queued, and the last two are already landing.
     for (const [snapshot, reason] of [
       [pr({ draft: true }), "Mark the pull request ready for review on GitHub before merging it."],
       [pr({ mergeable: "conflicting" }), "Resolve the merge conflicts before merging directly."],
-      [pr({ checks: [{ name: "ci", bucket: "fail" }] }), "Fix the failing checks before merging directly."],
-      [pr({ merge_state_status: "behind" }), "Update the branch from its base before merging directly."],
+      [pr({ in_merge_queue: true }), "This pull request is already waiting in the merge queue."],
       [pr({ auto_merge_enabled: true }), "Auto-merge is already enabled and will merge after the remaining requirements pass."],
     ] as const) {
       expect(chord("merge", { ...CLEAN, pr: snapshot })).toBe(

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { CodeWorkspacePrSnapshot, PullRequestDigest } from "../api/types";
 import {
+  resolveWorkflowShortcut,
   workspaceWorkflowActionLabel,
   workspaceWorkflowModel,
+  type WorkflowShortcut,
 } from "./workspaceWorkflow";
 
 const CLEAN: CodeWorkspacePrSnapshot = {
@@ -182,5 +184,149 @@ describe("workspaceWorkflowModel", () => {
     );
     expect(model.stage).toBe("clean");
     expect(model.pr).toBeUndefined();
+  });
+});
+
+describe("resolveWorkflowShortcut", () => {
+  /** What a chord does against a snapshot, as a string the assertions read. */
+  function chord(
+    shortcut: WorkflowShortcut,
+    snapshot: CodeWorkspacePrSnapshot | null,
+    watching = false,
+  ): string {
+    const resolution = resolveWorkflowShortcut(
+      shortcut,
+      workspaceWorkflowModel(snapshot),
+      watching,
+    );
+    if ("run" in resolution) return resolution.run;
+    if ("stopWatch" in resolution) return "stop_watch";
+    return `blocked: ${resolution.blocked}`;
+  }
+
+  it("carries one chord through commit, push, create, and view", () => {
+    // Cmd+Shift+P names an intent, not an action: the reader means "get this in
+    // front of reviewers" at every stage, and the action that serves it changes
+    // under them. Uncommitted work goes to the commit box rather than being
+    // refused, because that is the actual next step towards a pull request.
+    expect(chord("pull_request", { ...CLEAN, dirty: true })).toBe("open_source");
+    expect(chord("pull_request", { ...CLEAN, unpushed: true, ahead: 1 })).toBe(
+      "push",
+    );
+    expect(chord("pull_request", { ...CLEAN, ahead: 2 })).toBe("create_pr");
+    expect(
+      chord("pull_request", { ...CLEAN, pr: pr({ url: "https://x/41" }) }),
+    ).toBe("open_pr");
+    expect(chord("pull_request", CLEAN)).toBe(
+      "blocked: No commits to open a pull request for",
+    );
+  });
+
+  it("runs whatever the header's primary control says next", () => {
+    // The point of Cmd+Shift+Enter: one chord the reader can hold down the
+    // whole workflow, wired to the same decision the button draws.
+    expect(chord("next", { ...CLEAN, unpushed: true, ahead: 1 })).toBe("push");
+    expect(chord("next", { ...CLEAN, pr: pr({ draft: true }) })).toBe(
+      "mark_ready",
+    );
+    expect(
+      chord("next", {
+        ...CLEAN,
+        pr: pr({ mergeable: "mergeable", merge_state_status: "clean" }),
+      }),
+    ).toBe("merge");
+    // A clean workspace has no next step, and says which state it is in rather
+    // than swallowing the key.
+    expect(chord("next", CLEAN)).toBe("blocked: Workspace is clean");
+  });
+
+  it("picks conflict resolution over a plain rebase, and refuses over dirt", () => {
+    expect(
+      chord("update_branch", { ...CLEAN, pr: pr({ mergeable: "conflicting" }) }),
+    ).toBe("resolve_conflicts");
+    expect(
+      chord("update_branch", {
+        ...CLEAN,
+        pr: pr({ merge_state_status: "behind" }),
+      }),
+    ).toBe("update_branch");
+    // Rebasing over uncommitted work is how it gets lost, and the snapshot
+    // already knows the worktree is dirty.
+    expect(chord("update_branch", { ...CLEAN, dirty: true, pr: pr({}) })).toBe(
+      "blocked: Commit or discard your changes before rebasing",
+    );
+    expect(chord("update_branch", CLEAN)).toBe("blocked: No pull request yet");
+  });
+
+  it("stops a running watch with the key that started it", () => {
+    const withPr = { ...CLEAN, pr: pr({}) };
+    expect(chord("watch", withPr)).toBe("watch_and_fix");
+    expect(chord("watch", withPr, true)).toBe("stop_watch");
+  });
+
+  it("refuses the chords that would start a second agent in a watched worktree", () => {
+    // The header disables the same actions for the same reason: two agents in
+    // one worktree is a corrupt checkout, not a race worth running.
+    const withPr = { ...CLEAN, pr: pr({ url: "https://x/41" }) };
+    const busy = "blocked: A watch task is already working on this pull request";
+    expect(chord("next", withPr, true)).toBe(busy);
+    expect(chord("merge", withPr, true)).toBe(busy);
+    expect(chord("update_branch", withPr, true)).toBe(busy);
+    // Reading and pushing do not contend, so they stay live.
+    expect(chord("view_pr", withPr, true)).toBe("open_pr");
+    expect(chord("source_control", withPr, true)).toBe("open_source");
+  });
+
+  it("merges only when the pull request is green", () => {
+    // Merging publishes to a shared branch, so the chord runs the real merge
+    // rather than asking an agent to. That makes "green" a question it has to
+    // answer honestly, from the same table the review sidebar's Merge button
+    // reads — otherwise the chord offers merges the button refuses.
+    const green = {
+      ...CLEAN,
+      pr: pr({ mergeable: "mergeable", merge_state_status: "clean" }),
+    };
+    expect(chord("merge", green)).toBe("merge");
+
+    for (const [snapshot, reason] of [
+      [pr({ draft: true }), "Mark the pull request ready for review on GitHub before merging it."],
+      [pr({ mergeable: "conflicting" }), "Resolve the merge conflicts before merging directly."],
+      [pr({ checks: [{ name: "ci", bucket: "fail" }] }), "Fix the failing checks before merging directly."],
+      [pr({ merge_state_status: "behind" }), "Update the branch from its base before merging directly."],
+      [pr({ auto_merge_enabled: true }), "Auto-merge is already enabled and will merge after the remaining requirements pass."],
+    ] as const) {
+      expect(chord("merge", { ...CLEAN, pr: snapshot })).toBe(
+        `blocked: ${reason}`,
+      );
+    }
+
+    // Local state blocks too: work that is not in the pull request would be
+    // left behind by a merge the reader thought was landing all of it.
+    expect(chord("merge", { ...green, dirty: true })).toBe(
+      "blocked: Commit or discard your changes before merging",
+    );
+    expect(chord("merge", { ...green, unpushed: true })).toBe(
+      "blocked: Push your local commits before merging",
+    );
+  });
+
+  it("says why a merged or closed pull request has nothing to do", () => {
+    const merged = { ...CLEAN, pr: pr({ state: "merged" }) };
+    expect(chord("merge", merged)).toBe(
+      "blocked: Pull request #41 is already merged",
+    );
+    expect(chord("watch", { ...CLEAN, pr: pr({ state: "closed" }) })).toBe(
+      "blocked: Pull request #41 is closed",
+    );
+    expect(chord("view_pr", CLEAN)).toBe("blocked: No pull request to open yet");
+  });
+
+  it("opens source control before the status has loaded", () => {
+    // The review rail is chrome, not a Git operation. Everything else waits for
+    // a snapshot rather than acting on a guess.
+    expect(chord("source_control", null)).toBe("open_source");
+    expect(chord("merge", null)).toBe(
+      "blocked: Still reading this workspace's status",
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -1,5 +1,6 @@
 import type { CodeWorkspacePrSnapshot, PullRequestDigest } from "../api/types";
 import {
+  prMergeControls,
   prWorkflowStatus,
   type PrCheckCounts,
   type PrWorkflowAction,
@@ -282,6 +283,145 @@ function pullRequestWorkflow(pr: PullRequestDigest): WorkspaceWorkflowModel {
         secondary: [],
       };
   }
+}
+
+/**
+ * A keyboard ask against the workflow.
+ *
+ * A chord names an intent, not an action: `pull_request` means "get this
+ * branch in front of reviewers", which is a push on an unpushed branch, a
+ * create on a pushed one, and a trip to GitHub once the pull request exists.
+ * Binding chords to intents rather than to actions is what lets the reader
+ * press the same key at every stage and always get the useful thing.
+ */
+export type WorkflowShortcut =
+  | "next"
+  | "pull_request"
+  | "update_branch"
+  | "watch"
+  | "merge"
+  | "view_pr"
+  | "source_control";
+
+/**
+ * What a chord does in the state the workspace is actually in.
+ *
+ * `blocked` carries the sentence to show the reader. A chord that quietly did
+ * nothing would be indistinguishable from one that did not fire, which is the
+ * fastest way to lose trust in a keyboard-driven surface.
+ */
+export type WorkflowShortcutResolution =
+  | { run: WorkspaceWorkflowAction }
+  | { stopWatch: true }
+  | { blocked: string };
+
+/**
+ * Resolve a chord against the current workflow model.
+ *
+ * `watching` mirrors the header's own rule: while a watch task holds the
+ * worktree, the chords that would start a second agent in it are refused, and
+ * the ones that only read or push are not.
+ */
+export function resolveWorkflowShortcut(
+  shortcut: WorkflowShortcut,
+  model: WorkspaceWorkflowModel,
+  watching: boolean,
+): WorkflowShortcutResolution {
+  // The review rail is chrome, not a Git operation: it opens whatever else is
+  // going on, including while the status is still loading.
+  if (shortcut === "source_control") return { run: "open_source" };
+  if (shortcut === "view_pr") {
+    return model.pr?.url
+      ? { run: "open_pr" }
+      : { blocked: "No pull request to open yet" };
+  }
+  if (model.stage === "loading") {
+    return { blocked: "Still reading this workspace's status" };
+  }
+  if (shortcut === "watch") {
+    if (watching) return { stopWatch: true };
+    return prBlocker(model) ?? { run: "watch_and_fix" };
+  }
+  if (watching) {
+    return { blocked: "A watch task is already working on this pull request" };
+  }
+  switch (shortcut) {
+    case "next":
+      // `title` rather than `detail`: the title is the one-line statement of
+      // what this workspace is, which is exactly the answer to "why did
+      // nothing happen".
+      return model.primary ? { run: model.primary } : { blocked: model.title };
+    case "pull_request":
+      // Commit and push come first whether or not a pull request exists, so
+      // these stages lead — reaching a pull request from uncommitted work
+      // means going through the commit box.
+      if (model.stage === "dirty" || model.stage === "github_setup") {
+        return { run: "open_source" };
+      }
+      if (model.stage === "unpushed") return { run: "push" };
+      if (model.stage === "ready_for_pr") return { run: "create_pr" };
+      if (model.pr) {
+        return model.pr.url
+          ? { run: "open_pr" }
+          : { blocked: `Pull request #${model.pr.number} has no URL yet` };
+      }
+      return { blocked: "No commits to open a pull request for" };
+    case "update_branch":
+      // A rebase over uncommitted work is the classic way to lose it, and the
+      // snapshot already knows. Send the reader to the commit box instead.
+      if (model.stage === "dirty") {
+        return { blocked: "Commit or discard your changes before rebasing" };
+      }
+      return (
+        prBlocker(model) ?? {
+          run: model.stage === "conflict" ? "resolve_conflicts" : "update_branch",
+        }
+      );
+    case "merge":
+      return prBlocker(model) ?? mergeIfGreen(model);
+  }
+}
+
+/**
+ * Merge only when the pull request is actually mergeable.
+ *
+ * Merging publishes to a shared branch and is the one step decision 42 keeps
+ * for the user, so the chord runs the real merge rather than asking an agent
+ * to. That makes "is it green" a question this has to answer honestly: the
+ * same `prMergeControls` table the review sidebar's Merge button reads, so the
+ * chord can never offer a merge the button refuses.
+ *
+ * Local state blocks too. Uncommitted or unpushed work is not in the pull
+ * request, and merging without it lands a branch the reader thought was
+ * finished.
+ */
+function mergeIfGreen(model: WorkspaceWorkflowModel): WorkflowShortcutResolution {
+  if (model.stage === "dirty") {
+    return { blocked: "Commit or discard your changes before merging" };
+  }
+  if (model.stage === "unpushed") {
+    return { blocked: "Push your local commits before merging" };
+  }
+  const pr = model.pr;
+  if (!pr) return { blocked: "No pull request yet" };
+  const controls = prMergeControls(prWorkflowStatus(pr).state);
+  if (controls.canMerge) return { run: "merge" };
+  return {
+    blocked:
+      controls.explanation ?? `Pull request #${pr.number} cannot merge yet`,
+  };
+}
+
+/** Why a pull request cannot be acted on, or `null` when it can. */
+function prBlocker(model: WorkspaceWorkflowModel): { blocked: string } | null {
+  if (!model.pr) return { blocked: "No pull request yet" };
+  if (model.stage === "merged") {
+    return { blocked: `Pull request #${model.pr.number} is already merged` };
+  }
+  if (model.stage === "closed") {
+    return { blocked: `Pull request #${model.pr.number} is closed` };
+  }
+  return null;
 }
 
 function withOpenPr(

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -313,6 +313,8 @@ export type WorkflowShortcut =
 export type WorkflowShortcutResolution =
   | { run: WorkspaceWorkflowAction }
   | { stopWatch: true }
+  /** Arm host auto-merge rather than merging now. */
+  | { autoMerge: true }
   | { blocked: string };
 
 /**
@@ -383,17 +385,23 @@ export function resolveWorkflowShortcut(
 }
 
 /**
- * Merge only when the pull request is actually mergeable.
+ * Land the pull request: merge it now when it is green, otherwise ask GitHub
+ * to merge it once the remaining requirements pass.
  *
- * Merging publishes to a shared branch and is the one step decision 42 keeps
- * for the user, so the chord runs the real merge rather than asking an agent
- * to. That makes "is it green" a question this has to answer honestly: the
- * same `prMergeControls` table the review sidebar's Merge button reads, so the
+ * One chord for one intent. The reader pressing it means "this is done, get it
+ * in" whether the checks have finished or not, and the two ways to say that
+ * differ only in when GitHub acts. The confirmation names which one is about
+ * to happen, so the difference is visible before anything lands.
+ *
+ * Merging publishes to a shared branch and is the step decision 42 keeps for
+ * the user, so the chord runs the real merge rather than asking an agent to.
+ * That makes "is it green" a question this has to answer honestly: the same
+ * `prMergeControls` table the review sidebar's Merge button reads, so the
  * chord can never offer a merge the button refuses.
  *
- * Local state blocks too. Uncommitted or unpushed work is not in the pull
- * request, and merging without it lands a branch the reader thought was
- * finished.
+ * Local state blocks both paths. Uncommitted or unpushed work is not in the
+ * pull request, and landing without it leaves behind work the reader thought
+ * was going in.
  */
 function mergeIfGreen(model: WorkspaceWorkflowModel): WorkflowShortcutResolution {
   if (model.stage === "dirty") {
@@ -406,6 +414,7 @@ function mergeIfGreen(model: WorkspaceWorkflowModel): WorkflowShortcutResolution
   if (!pr) return { blocked: "No pull request yet" };
   const controls = prMergeControls(prWorkflowStatus(pr).state);
   if (controls.canMerge) return { run: "merge" };
+  if (controls.canEnableAutoMerge) return { autoMerge: true };
   return {
     blocked:
       controls.explanation ?? `Pull request #${pr.number} cannot merge yet`,

--- a/crates/tidebreak-desktop/ui/src/stories/Shortcuts.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Shortcuts.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ShortcutsList } from "@/ShortcutsDialog";
+
+/**
+ * The keyboard-shortcut help, drawn from the same table the listener matches
+ * on.
+ *
+ * The list is per mode because one chord can mean two things: Cmd+N is a
+ * conversation in chat and a workspace in code. `command` is fixed per story
+ * rather than read from the browser, so the keycaps look the same wherever the
+ * story is opened.
+ */
+const meta = {
+  title: "Foundations/Keyboard shortcuts",
+  component: ShortcutsList,
+  args: { command: true },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-md rounded-xl border border-border-subtle bg-background p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ShortcutsList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Code mode: the Ship group carries a branch from commit to merged without the
+ * mouse, and the frame chords sit under it.
+ */
+export const CodeMode: Story = {
+  args: { mode: "code" },
+};
+
+/** Chat mode, where the Ship and Code groups have nothing to list. */
+export const ChatMode: Story = {
+  args: { mode: "chat" },
+};
+
+/** The same table on a keyboard whose modifier is Ctrl rather than Cmd. */
+export const WindowsKeycaps: Story = {
+  args: { mode: "code", command: false },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -59,6 +59,7 @@ function HeaderState({
             client={{
               pushCodeWorkspace: fn(),
               createCodePullRequest: fn(),
+              markCodePrReady: fn(),
               mergeCodePr: fn(),
               startCodeWatch: fn(),
               stopCodeWatch: fn(),

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -59,6 +59,7 @@ function HeaderState({
             client={{
               pushCodeWorkspace: fn(),
               createCodePullRequest: fn(),
+              mergeCodePr: fn(),
               startCodeWatch: fn(),
               stopCodeWatch: fn(),
             }}

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -49,6 +49,7 @@ function WorkflowState({
       client={{
         pushCodeWorkspace: fn(),
         createCodePullRequest: fn(),
+        markCodePrReady: fn(),
         mergeCodePr: fn(),
         startCodeWatch: fn(),
         stopCodeWatch: fn(),

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -49,6 +49,7 @@ function WorkflowState({
       client={{
         pushCodeWorkspace: fn(),
         createCodePullRequest: fn(),
+        mergeCodePr: fn(),
         startCodeWatch: fn(),
         stopCodeWatch: fn(),
       }}

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -400,6 +400,31 @@ pub(crate) async fn merge_pull_request(
     Ok(())
 }
 
+/// Mark the workspace's own draft pull request ready for review.
+///
+/// The worktree's branch is what `gh` resolves the pull request from, the same
+/// way the merge operation does, so this needs no repository coordinates —
+/// that is the difference from [`mark_pull_request_ready`], which serves the
+/// repository-qualified delivery surface.
+///
+/// It stays on the general runner. Readying a draft is a user state change but
+/// not a merge, and widening the merge-only runner to carry it would undo the
+/// point of having two runners (decision 42).
+pub(crate) async fn mark_workspace_pull_request_ready(
+    worktree: &Path,
+    workspace_id: WorkspaceId,
+    cache: &PrDigestCache,
+    gh_search_path: Option<&str>,
+) -> Result<(), GhError> {
+    let observation = observe_gh(gh_search_path).await;
+    let binary = require_gh_binary(&observation)?;
+    run_gh(worktree, &binary, &["pr", "ready"], GH_TIMEOUT)
+        .await
+        .map_err(|error| classify_observed_gh(error, &observation))?;
+    cache.invalidate(workspace_id);
+    Ok(())
+}
+
 /// Turn a `gh pr merge` failure into something the PR card can show.
 pub(crate) fn classify_merge_error(err: String) -> GhError {
     let bounded = bound_text(&err);
@@ -2096,6 +2121,54 @@ exit 3
         }
         let after = std::fs::read_to_string(&log).unwrap();
         assert_eq!(logged, after, "a refused command must never reach gh");
+    }
+
+    #[tokio::test]
+    async fn readying_a_draft_runs_pr_ready_and_cannot_reach_the_merge_runner() {
+        // Readying a draft is a user state change but not a merge, so it rides
+        // the general runner (decision 42). Two things have to hold: it really
+        // runs `gh pr ready` in the worktree, and the runner it uses still
+        // refuses merge argv — otherwise widening the app to ready a draft
+        // would have quietly widened it to merge.
+        let shim_dir = TempDir::new().unwrap();
+        let log = shim_dir.path().join("log");
+        write_executable(
+            &shim_dir.path().join("gh"),
+            &format!(
+                r#"#!/bin/sh
+echo "$@" >> {log}
+if [ "$1" = auth ]; then exit 0; fi
+if [ "$1" = pr ] && [ "$2" = ready ]; then exit 0; fi
+echo unexpected "$@" >&2
+exit 3
+"#,
+                log = log.display()
+            ),
+        );
+        let work = TempDir::new().unwrap();
+        let cache = PrDigestCache::default();
+        let workspace = WorkspaceId::new();
+        mark_workspace_pull_request_ready(
+            work.path(),
+            workspace,
+            &cache,
+            Some(shim_dir.path().to_str().unwrap()),
+        )
+        .await
+        .expect("gh pr ready should run");
+        let logged = std::fs::read_to_string(&log).unwrap();
+        assert!(logged.contains("pr ready"), "{logged}");
+        assert!(!logged.contains("merge"), "{logged}");
+
+        let refused = run_gh(
+            work.path(),
+            &shim_dir.path().join("gh"),
+            &["pr", "merge", "--squash"],
+            GH_TIMEOUT,
+        )
+        .await
+        .unwrap_err();
+        assert!(refused.contains("refusing"), "{refused}");
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1064,6 +1064,28 @@ impl CodeRuntime {
         self.workspace_pr(owner, id).await
     }
 
+    /// Take the workspace's pull request out of draft and return a fresh
+    /// status. Decision 42 keeps pull-request state changes on a user-initiated
+    /// endpoint rather than on any agent or automation path, so this is the
+    /// only route to `gh pr ready` for a workspace.
+    pub(crate) async fn mark_workspace_pr_ready(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        let workspace = self.require_live_workspace(owner, id).await?;
+        let gh_path = self.gh_search_path_owned();
+        gh::mark_workspace_pull_request_ready(
+            std::path::Path::new(&workspace.worktree_path),
+            workspace.id,
+            &self.pr_cache,
+            gh_path.as_deref(),
+        )
+        .await
+        .map_err(map_gh)?;
+        self.workspace_pr(owner, id).await
+    }
+
     pub(crate) async fn create_workspace_pr(
         &self,
         owner: &OwnerId,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -370,6 +370,13 @@ impl ScopedCode {
             .await
     }
 
+    pub(crate) async fn mark_workspace_pr_ready(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        self.runtime.mark_workspace_pr_ready(&self.owner, id).await
+    }
+
     pub(crate) async fn create_workspace_pr(
         &self,
         id: WorkspaceId,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -902,6 +902,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::merge_workspace_pr),
         )
         .route(
+            "/code/workspaces/{id}/pr/ready",
+            post(routes::code::mark_workspace_pr_ready),
+        )
+        .route(
             "/code/workspaces/{id}/watch",
             post(routes::code::start_workspace_watch).delete(routes::code::stop_workspace_watch),
         )

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -101,6 +101,15 @@ pub async fn merge_workspace_pr(
     Ok(Json(pr_snapshot(status, watch)))
 }
 
+pub async fn mark_workspace_pr_ready(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
+    let status = code.mark_workspace_pr_ready(id).await?;
+    let watch = code.latest_watch(id).await?;
+    Ok(Json(pr_snapshot(status, watch)))
+}
+
 pub async fn run_workspace_action(
     code: ScopedCode,
     Path((id, name)): Path<(WorkspaceId, String)>,

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -38,8 +38,8 @@ pub(crate) use delivery::{
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,
-    merge_workspace_pr, push_workspace, refresh_workspace_pr, run_workspace_action,
-    start_workspace_watch, stop_workspace_watch,
+    mark_workspace_pr_ready, merge_workspace_pr, push_workspace, refresh_workspace_pr,
+    run_workspace_action, start_workspace_watch, stop_workspace_watch,
 };
 pub(crate) use harnesses::{
     install_harness, list_harness_models, list_harnesses, refresh_harnesses,


### PR DESCRIPTION
## What changed

Code mode gains a **Ship** group in its keymap so a branch reaches merged without the mouse: `⌘⇧↩` runs whatever the workspace header's primary control says next, and `⌘⇧P/R/W/M/O/G/A` name the individual steps (push and open, rebase, watch, merge, view on GitHub, source control, archive), with `⌘⌥↑/↓` walking the workspace rail. A chord names an intent rather than an action — `⌘⇧P` is a commit on a dirty tree, a push on an unpushed branch, and a create on a pushed one — and a chord with nothing to do says why, because a silent no-op reads the same as a key that never fired.

The second commit takes pull-request state changes off the agent path. Marking a draft ready and merging both publish work to other people, and [decision 42](docs/decisions/0042-user-initiated-pr-merge.md) reserves them for the user — but the header asked an agent to do both, and an agent has its own shell, so the general `gh` runner's refusal of merge argv never applied. Merging now calls `POST /code/workspaces/{id}/pr/merge`, readying calls a new `POST /code/workspaces/{id}/pr/ready`, both behind the confirmation the review sidebar shows and gated by the same `prMergeControls` table it reads; `⌘⇧M` merges a green pull request and arms auto-merge on anything GitHub can still land, naming which in the dialog. `prWorkflowPrompt` loses those two prompt bodies and takes a narrowed `PrPromptAction`, so the type system now refuses to let either be wired back onto the agent path.

## Validation

`tsc --noEmit` clean, 565 UI tests pass, and `pnpm storybook:build` succeeds. `cargo test -p tidebreak-server` passes 1152 tests; the one failure was `tests::code_terminals::create_write_read_and_two_cursors`, a PTY timing test that passes in isolation and shares no code with this change. New coverage pins the shift-disambiguated pairs (`⌘P`/`⌘⇧P`, `⌘W`/`⌘⇧W`, `⌘R`/`⌘⇧R`), the intent-to-action resolution at each workflow stage, that green merges and pending arms auto-merge through the endpoint rather than `submitCodeTurn`, that the ready path runs `gh pr ready` while its runner still refuses merge argv, and — via `@ts-expect-error` — that neither state change can be prompted. Each new assertion was checked to fail when its wiring is removed rather than passing vacuously.

## Compatibility and risk

One new endpoint; no persisted or wire-format changes and no new generated types. Both merge repoints narrow what the agent path can do rather than widening it, and the merge-only runner is untouched. Auto-merge is armed only by an explicit user chord behind a confirmation, never by the watch or any other automation, which decision 42 excludes on purpose.

## Tracking

None. #2431 was the second commit, merged into this branch rather than opened against `main` separately.