### PR TITLE
refactor(exec): name code-execution types Exec, not CodeExecution

### DIFF
--- a/crates/tidebreak-code-execution/src/credential.rs
+++ b/crates/tidebreak-code-execution/src/credential.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use sha2::{Digest, Sha256};
 use tidebreak_core::SecretProvider;
 
-use crate::CodeExecutionError;
+use crate::ExecError;
 
 /// Shared storage and redaction primitive for managed-provider credentials.
 #[derive(Clone)]
@@ -19,14 +19,11 @@ impl std::fmt::Debug for SecretCredential {
 }
 
 impl SecretCredential {
-    pub(crate) fn parse(
-        provider: &str,
-        value: impl Into<String>,
-    ) -> Result<Self, CodeExecutionError> {
+    pub(crate) fn parse(provider: &str, value: impl Into<String>) -> Result<Self, ExecError> {
         let value = value.into();
         let trimmed = value.trim();
         if trimmed.is_empty() {
-            return Err(CodeExecutionError::InvalidRequest(format!(
+            return Err(ExecError::InvalidRequest(format!(
                 "{provider} API key must not be empty"
             )));
         }
@@ -37,9 +34,9 @@ impl SecretCredential {
         secrets: &dyn SecretProvider,
         key: &str,
         provider: &str,
-    ) -> Result<Option<Self>, CodeExecutionError> {
+    ) -> Result<Option<Self>, ExecError> {
         let value = secrets.get_secret(key).await.map_err(|_| {
-            CodeExecutionError::Unavailable(format!("{provider} credential storage is unavailable"))
+            ExecError::Unavailable(format!("{provider} credential storage is unavailable"))
         })?;
         value
             .filter(|value| !value.trim().is_empty())

--- a/crates/tidebreak-code-execution/src/daytona.rs
+++ b/crates/tidebreak-code-execution/src/daytona.rs
@@ -26,10 +26,10 @@ use crate::sandbox_image::{
     DOCUMENTS_IMAGE, DOCUMENTS_MEMORY_GB as DOCUMENTS_SNAPSHOT_MEMORY_GB,
 };
 use crate::{
-    CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, ExecutionWorkspaceId, SandboxPreparation, SandboxPreparationSink,
-    StagedUpload, WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing,
-    MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
+    ExecError, ExecProvider, ExecProviderKind, ExecRequest, ExecResponse, ExecutionWorkspaceId,
+    SandboxPreparation, SandboxPreparationSink, StagedUpload, WorkspaceFileEntry,
+    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_WORKSPACE_FILE_BYTES,
+    MAX_WORKSPACE_LIST_ENTRIES,
 };
 
 const DAYTONA_API_BASE: &str = "https://app.daytona.io/api";
@@ -96,12 +96,12 @@ impl std::fmt::Debug for DaytonaCredential {
 }
 
 impl DaytonaCredential {
-    pub fn parse(value: impl Into<String>) -> Result<Self, CodeExecutionError> {
+    pub fn parse(value: impl Into<String>) -> Result<Self, ExecError> {
         SecretCredential::parse("Daytona", value).map(Self)
     }
 
     /// Resolve the credential without exposing it through serializable config.
-    pub async fn load(secrets: &dyn SecretProvider) -> Result<Option<Self>, CodeExecutionError> {
+    pub async fn load(secrets: &dyn SecretProvider) -> Result<Option<Self>, ExecError> {
         SecretCredential::load(secrets, DAYTONA_CREDENTIAL_KEY, "Daytona")
             .await
             .map(|credential| credential.map(Self))
@@ -168,7 +168,7 @@ impl Default for DaytonaEndpoints {
 }
 
 /// Why the documents snapshot could not be made ready. Separated from
-/// [`CodeExecutionError`] because the two outcomes differ: a rejected
+/// [`ExecError`] because the two outcomes differ: a rejected
 /// credential (401) is the user's problem and surfaces, while everything
 /// else — including a key that can create sandboxes but not register
 /// snapshots (403) — degrades to Daytona's default snapshot, which still
@@ -217,10 +217,7 @@ impl Drop for PreparationReport<'_> {
 }
 
 impl DaytonaExecutionProvider {
-    pub fn new(
-        credential: DaytonaCredential,
-        timeout: Duration,
-    ) -> Result<Self, CodeExecutionError> {
+    pub fn new(credential: DaytonaCredential, timeout: Duration) -> Result<Self, ExecError> {
         Self::with_session_pool(credential, timeout, RemoteSessionPool::default())
     }
 
@@ -228,7 +225,7 @@ impl DaytonaExecutionProvider {
         credential: DaytonaCredential,
         timeout: Duration,
         pool: RemoteSessionPool,
-    ) -> Result<Self, CodeExecutionError> {
+    ) -> Result<Self, ExecError> {
         Self::with_endpoints(credential, timeout, pool, DaytonaEndpoints::default())
     }
 
@@ -237,9 +234,9 @@ impl DaytonaExecutionProvider {
         timeout: Duration,
         pool: RemoteSessionPool,
         endpoints: DaytonaEndpoints,
-    ) -> Result<Self, CodeExecutionError> {
+    ) -> Result<Self, ExecError> {
         if timeout.is_zero() {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "execution timeout must be positive".into(),
             ));
         }
@@ -247,9 +244,7 @@ impl DaytonaExecutionProvider {
             .connect_timeout(Duration::from_secs(10))
             .timeout(timeout.saturating_add(DAYTONA_TRANSPORT_GRACE))
             .build()
-            .map_err(|_| {
-                CodeExecutionError::Unavailable("could not configure Daytona transport".into())
-            })?;
+            .map_err(|_| ExecError::Unavailable("could not configure Daytona transport".into()))?;
         Ok(Self {
             credential,
             timeout,
@@ -298,15 +293,15 @@ impl DaytonaExecutionProvider {
     /// list declared by [`Self::egress_enforcement`], and to Daytona's plan
     /// gating on per-sandbox network overrides. Fails when the allowlist
     /// exceeds Daytona's entry limits, before any sandbox is created.
-    pub fn with_egress_policy(mut self, policy: EgressPolicy) -> Result<Self, CodeExecutionError> {
+    pub fn with_egress_policy(mut self, policy: EgressPolicy) -> Result<Self, ExecError> {
         if let EgressPolicy::Allowlist(allowlist) = &policy {
             if allowlist.cidrs().len() > DAYTONA_MAX_NETWORK_ALLOW_ENTRIES {
-                return Err(CodeExecutionError::InvalidRequest(format!(
+                return Err(ExecError::InvalidRequest(format!(
                     "Daytona accepts at most {DAYTONA_MAX_NETWORK_ALLOW_ENTRIES} egress address blocks"
                 )));
             }
             if allowlist.domains().len() > DAYTONA_MAX_DOMAIN_ALLOW_ENTRIES {
-                return Err(CodeExecutionError::InvalidRequest(format!(
+                return Err(ExecError::InvalidRequest(format!(
                     "Daytona accepts at most {DAYTONA_MAX_DOMAIN_ALLOW_ENTRIES} egress domain patterns"
                 )));
             }
@@ -352,10 +347,7 @@ impl DaytonaExecutionProvider {
         EgressEnforcement::external(Vec::new())
     }
 
-    async fn create_sandbox(
-        &self,
-        workspace_id: &str,
-    ) -> Result<RemoteSession, CodeExecutionError> {
+    async fn create_sandbox(&self, workspace_id: &str) -> Result<RemoteSession, ExecError> {
         let snapshot = self.resolve_snapshot(workspace_id).await?;
         let response = self
             .client
@@ -375,14 +367,12 @@ impl DaytonaExecutionProvider {
             })
             .send()
             .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+            .map_err(|_| ExecError::Unavailable("could not reach Daytona".into()))?;
         let sandbox = self.decode_sandbox(response).await?;
         self.wait_until_started(sandbox, true)
             .await?
             .ok_or_else(|| {
-                CodeExecutionError::Unavailable(
-                    "Daytona sandbox disappeared while it was starting".into(),
-                )
+                ExecError::Unavailable("Daytona sandbox disappeared while it was starting".into())
             })
     }
 
@@ -404,10 +394,7 @@ impl DaytonaExecutionProvider {
     /// made ready once per provider instance — registered from the pinned
     /// digest if missing, reactivated if Daytona let it lapse — and `None`
     /// (Daytona's default snapshot) is the degraded answer when that fails.
-    async fn resolve_snapshot(
-        &self,
-        workspace_id: &str,
-    ) -> Result<Option<&str>, CodeExecutionError> {
+    async fn resolve_snapshot(&self, workspace_id: &str) -> Result<Option<&str>, ExecError> {
         if let Some(configured) = self.snapshot.as_deref() {
             return Ok(Some(configured));
         }
@@ -564,7 +551,7 @@ impl DaytonaExecutionProvider {
     async fn reconnect_sandbox(
         &self,
         sandbox_id: &str,
-    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+    ) -> Result<Option<RemoteSession>, ExecError> {
         validate_sandbox_id(sandbox_id)?;
         let response = self
             .client
@@ -572,7 +559,7 @@ impl DaytonaExecutionProvider {
             .bearer_auth(self.credential.as_str())
             .send()
             .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+            .map_err(|_| ExecError::Unavailable("could not reach Daytona".into()))?;
         if response.status() == StatusCode::NOT_FOUND {
             return Ok(None);
         }
@@ -584,7 +571,7 @@ impl DaytonaExecutionProvider {
         &self,
         mut sandbox: DaytonaSandbox,
         start_if_stopped: bool,
-    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+    ) -> Result<Option<RemoteSession>, ExecError> {
         let deadline = Instant::now() + DAYTONA_START_TIMEOUT;
         let mut requested_start = false;
         loop {
@@ -596,7 +583,7 @@ impl DaytonaExecutionProvider {
                 }
                 Some("destroyed" | "destroying") => return Ok(None),
                 Some("error" | "build_failed") => {
-                    return Err(CodeExecutionError::Unavailable(
+                    return Err(ExecError::Unavailable(
                         "Daytona sandbox failed to start".into(),
                     ));
                 }
@@ -607,9 +594,7 @@ impl DaytonaExecutionProvider {
                         .bearer_auth(self.credential.as_str())
                         .send()
                         .await
-                        .map_err(|_| {
-                            CodeExecutionError::Unavailable("could not reach Daytona".into())
-                        })?;
+                        .map_err(|_| ExecError::Unavailable("could not reach Daytona".into()))?;
                     if response.status() == StatusCode::NOT_FOUND {
                         return Ok(None);
                     }
@@ -622,18 +607,18 @@ impl DaytonaExecutionProvider {
                     | "pulling_snapshot" | "resuming",
                 ) => {}
                 Some("stopped" | "paused" | "archived") => {
-                    return Err(CodeExecutionError::Unavailable(
+                    return Err(ExecError::Unavailable(
                         "Daytona sandbox did not start".into(),
                     ));
                 }
                 _ => {
-                    return Err(CodeExecutionError::Unavailable(
+                    return Err(ExecError::Unavailable(
                         "Daytona returned an unknown sandbox state".into(),
                     ));
                 }
             }
             if Instant::now() >= deadline {
-                return Err(CodeExecutionError::Unavailable(
+                return Err(ExecError::Unavailable(
                     "Daytona sandbox did not start before its deadline".into(),
                 ));
             }
@@ -644,7 +629,7 @@ impl DaytonaExecutionProvider {
                 .bearer_auth(self.credential.as_str())
                 .send()
                 .await
-                .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+                .map_err(|_| ExecError::Unavailable("could not reach Daytona".into()))?;
             if response.status() == StatusCode::NOT_FOUND {
                 return Ok(None);
             }
@@ -655,11 +640,11 @@ impl DaytonaExecutionProvider {
     async fn run_daytona_command(
         &self,
         session: &RemoteSession,
-        request: &CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+        request: &ExecRequest,
+    ) -> Result<ExecResponse, RemoteSessionError> {
         validate_sandbox_id(&session.sandbox_id)?;
         let endpoint = session.endpoint.as_deref().ok_or_else(|| {
-            CodeExecutionError::Unavailable("Daytona toolbox endpoint is unavailable".into())
+            ExecError::Unavailable("Daytona toolbox endpoint is unavailable".into())
         })?;
         let url = toolbox_url(
             endpoint,
@@ -679,7 +664,7 @@ impl DaytonaExecutionProvider {
             })
             .send()
             .await
-            .map_err(|_| CodeExecutionError::AmbiguousExecution)?;
+            .map_err(|_| ExecError::AmbiguousExecution)?;
         if matches!(
             response.status(),
             StatusCode::NOT_FOUND | StatusCode::GONE | StatusCode::BAD_GATEWAY
@@ -687,12 +672,7 @@ impl DaytonaExecutionProvider {
             return Err(RemoteSessionError::Missing);
         }
         if response.status() == StatusCode::REQUEST_TIMEOUT {
-            return Ok(Capture::default().response(
-                CodeExecutionProviderKind::Daytona,
-                started,
-                None,
-                true,
-            ));
+            return Ok(Capture::default().response(ExecProviderKind::Daytona, started, None, true));
         }
         if !response.status().is_success() {
             let status = response.status();
@@ -708,7 +688,7 @@ impl DaytonaExecutionProvider {
                 .is_some_and(|code| code == "PROCESS_EXECUTION_TIMEOUT")
             {
                 return Ok(Capture::default().response(
-                    CodeExecutionProviderKind::Daytona,
+                    ExecProviderKind::Daytona,
                     started,
                     None,
                     true,
@@ -721,21 +701,12 @@ impl DaytonaExecutionProvider {
                 .await?;
         let mut capture = Capture::default();
         capture.append(body.result.as_bytes(), StreamKind::Stdout);
-        Ok(capture.response(
-            CodeExecutionProviderKind::Daytona,
-            started,
-            body.exit_code,
-            false,
-        ))
+        Ok(capture.response(ExecProviderKind::Daytona, started, body.exit_code, false))
     }
 
-    fn toolbox_file_url(
-        &self,
-        session: &RemoteSession,
-        suffix: &str,
-    ) -> Result<Url, CodeExecutionError> {
+    fn toolbox_file_url(&self, session: &RemoteSession, suffix: &str) -> Result<Url, ExecError> {
         let endpoint = session.endpoint.as_deref().ok_or_else(|| {
-            CodeExecutionError::Unavailable("Daytona toolbox endpoint is unavailable".into())
+            ExecError::Unavailable("Daytona toolbox endpoint is unavailable".into())
         })?;
         toolbox_url(
             endpoint,
@@ -745,10 +716,7 @@ impl DaytonaExecutionProvider {
         )
     }
 
-    async fn decode_sandbox(
-        &self,
-        response: Response,
-    ) -> Result<DaytonaSandbox, CodeExecutionError> {
+    async fn decode_sandbox(&self, response: Response) -> Result<DaytonaSandbox, ExecError> {
         if !response.status().is_success() {
             return Err(provider_status_error(response.status()));
         }
@@ -765,8 +733,8 @@ impl DaytonaExecutionProvider {
 
 #[async_trait]
 impl RemoteSandboxAdapter for DaytonaExecutionProvider {
-    fn kind(&self) -> CodeExecutionProviderKind {
-        CodeExecutionProviderKind::Daytona
+    fn kind(&self) -> ExecProviderKind {
+        ExecProviderKind::Daytona
     }
 
     fn credential_fingerprint(&self) -> [u8; 32] {
@@ -777,14 +745,11 @@ impl RemoteSandboxAdapter for DaytonaExecutionProvider {
         crate::remote::egress_policy_fingerprint(self.egress.as_ref())
     }
 
-    async fn create_session(
-        &self,
-        workspace_id: &str,
-    ) -> Result<RemoteSession, CodeExecutionError> {
+    async fn create_session(&self, workspace_id: &str) -> Result<RemoteSession, ExecError> {
         self.create_sandbox(workspace_id).await
     }
 
-    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError> {
+    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), ExecError> {
         validate_sandbox_id(&session.sandbox_id)?;
         let response = self
             .client
@@ -792,7 +757,7 @@ impl RemoteSandboxAdapter for DaytonaExecutionProvider {
             .bearer_auth(self.credential.as_str())
             .send()
             .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+            .map_err(|_| ExecError::Unavailable("could not reach Daytona".into()))?;
         if response.status() == StatusCode::NOT_FOUND || response.status().is_success() {
             return Ok(());
         }
@@ -802,15 +767,15 @@ impl RemoteSandboxAdapter for DaytonaExecutionProvider {
     async fn reconnect_session(
         &self,
         session: &RemoteSession,
-    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+    ) -> Result<Option<RemoteSession>, ExecError> {
         self.reconnect_sandbox(&session.sandbox_id).await
     }
 
     async fn run_command(
         &self,
         session: &RemoteSession,
-        request: &CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+        request: &ExecRequest,
+    ) -> Result<ExecResponse, RemoteSessionError> {
         self.run_daytona_command(session, request).await
     }
 }
@@ -834,7 +799,7 @@ impl RemoteWorkspaceAdapter for DaytonaExecutionProvider {
             .body(multipart.body)
             .send()
             .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+            .map_err(|_| ExecError::Unavailable("could not reach Daytona".into()))?;
         if matches!(
             response.status(),
             StatusCode::NOT_FOUND | StatusCode::GONE | StatusCode::BAD_GATEWAY
@@ -860,11 +825,11 @@ impl RemoteWorkspaceAdapter for DaytonaExecutionProvider {
             .query(&[("path", path.as_str())])
             .send()
             .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+            .map_err(|_| ExecError::Unavailable("could not reach Daytona".into()))?;
         // The session was reconciled immediately before this call, so a 404
         // here is the file rather than the sandbox.
         if response.status() == StatusCode::NOT_FOUND {
-            return Err(CodeExecutionError::WorkspaceFileNotFound.into());
+            return Err(ExecError::WorkspaceFileNotFound.into());
         }
         if matches!(
             response.status(),
@@ -894,9 +859,9 @@ impl RemoteWorkspaceAdapter for DaytonaExecutionProvider {
             .query(&[("path", listed)])
             .send()
             .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+            .map_err(|_| ExecError::Unavailable("could not reach Daytona".into()))?;
         if response.status() == StatusCode::NOT_FOUND {
-            return Err(CodeExecutionError::WorkspaceFileNotFound.into());
+            return Err(ExecError::WorkspaceFileNotFound.into());
         }
         if matches!(
             response.status(),
@@ -938,24 +903,15 @@ impl RemoteWorkspaceAdapter for DaytonaExecutionProvider {
 
 #[async_trait]
 impl WorkspaceLifecycle for DaytonaExecutionProvider {
-    async fn create_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError> {
+    async fn create_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError> {
         create_remote_workspace(self, &self.pool, workspace.as_str()).await
     }
 
-    async fn connect_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<bool, CodeExecutionError> {
+    async fn connect_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<bool, ExecError> {
         connect_remote_workspace(self, &self.pool, workspace.as_str()).await
     }
 
-    async fn destroy_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError> {
+    async fn destroy_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError> {
         destroy_remote_workspace(self, &self.pool, workspace.as_str()).await
     }
 
@@ -964,9 +920,9 @@ impl WorkspaceLifecycle for DaytonaExecutionProvider {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> Result<(), CodeExecutionError> {
+    ) -> Result<(), ExecError> {
         if content.len() > MAX_WORKSPACE_FILE_BYTES {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         with_remote_session(
             self,
@@ -982,9 +938,9 @@ impl WorkspaceLifecycle for DaytonaExecutionProvider {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> Result<StagedUpload, CodeExecutionError> {
+    ) -> Result<StagedUpload, ExecError> {
         if content.len() > MAX_WORKSPACE_FILE_BYTES {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         stage_remote_file(self, &self.pool, workspace.as_str(), path, content).await
     }
@@ -993,7 +949,7 @@ impl WorkspaceLifecycle for DaytonaExecutionProvider {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
-    ) -> Result<Vec<u8>, CodeExecutionError> {
+    ) -> Result<Vec<u8>, ExecError> {
         with_remote_session(
             self,
             &self.pool,
@@ -1007,7 +963,7 @@ impl WorkspaceLifecycle for DaytonaExecutionProvider {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: Option<&WorkspaceFilePath>,
-    ) -> Result<WorkspaceListing, CodeExecutionError> {
+    ) -> Result<WorkspaceListing, ExecError> {
         with_remote_session(
             self,
             &self.pool,
@@ -1019,11 +975,8 @@ impl WorkspaceLifecycle for DaytonaExecutionProvider {
 }
 
 #[async_trait]
-impl CodeExecutionProvider for DaytonaExecutionProvider {
-    async fn execute(
-        &self,
-        request: CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, CodeExecutionError> {
+impl ExecProvider for DaytonaExecutionProvider {
+    async fn execute(&self, request: ExecRequest) -> Result<ExecResponse, ExecError> {
         let mut response = execute_remote(self, &self.pool, request).await?;
         if self.degradation_pending.swap(false, Ordering::Relaxed) {
             response.degraded = Some(ExecDegradation::SandboxImageUnavailable);
@@ -1189,7 +1142,7 @@ struct DaytonaSandbox {
 }
 
 impl DaytonaSandbox {
-    fn into_session(self, allow_insecure: bool) -> Result<RemoteSession, CodeExecutionError> {
+    fn into_session(self, allow_insecure: bool) -> Result<RemoteSession, ExecError> {
         validate_toolbox_base(&self.toolbox_proxy_url, allow_insecure)?;
         Ok(RemoteSession {
             sandbox_id: self.id,
@@ -1240,7 +1193,7 @@ struct DaytonaFileInfo {
 /// Preserve the provider-neutral direct argv contract over Daytona's shell-text
 /// transport. Quoting every element keeps metacharacters as argument data; the
 /// shell is only the protocol bridge and is replaced by the requested process.
-fn direct_command(request: &CodeExecutionRequest) -> String {
+fn direct_command(request: &ExecRequest) -> String {
     std::iter::once(request.command.as_str())
         .chain(request.arguments.iter().map(String::as_str))
         .map(shell_quote)
@@ -1275,7 +1228,7 @@ fn toolbox_url(
     sandbox_id: &str,
     allow_insecure: bool,
     suffix: &str,
-) -> Result<Url, CodeExecutionError> {
+) -> Result<Url, ExecError> {
     validate_sandbox_id(sandbox_id)?;
     let mut url = validate_toolbox_base(endpoint, allow_insecure)?;
     let path = format!("{}/{sandbox_id}/{suffix}", url.path().trim_end_matches('/'));
@@ -1283,9 +1236,9 @@ fn toolbox_url(
     Ok(url)
 }
 
-fn validate_toolbox_base(endpoint: &str, allow_insecure: bool) -> Result<Url, CodeExecutionError> {
+fn validate_toolbox_base(endpoint: &str, allow_insecure: bool) -> Result<Url, ExecError> {
     let url = Url::parse(endpoint).map_err(|_| {
-        CodeExecutionError::Unavailable("Daytona returned an invalid toolbox endpoint".into())
+        ExecError::Unavailable("Daytona returned an invalid toolbox endpoint".into())
     })?;
     let host = url.host_str().unwrap_or_default();
     let cloud_endpoint =
@@ -1299,36 +1252,36 @@ fn validate_toolbox_base(endpoint: &str, allow_insecure: bool) -> Result<Url, Co
         || url.query().is_some()
         || url.fragment().is_some()
     {
-        return Err(CodeExecutionError::Unavailable(
+        return Err(ExecError::Unavailable(
             "Daytona returned an invalid toolbox endpoint".into(),
         ));
     }
     Ok(url)
 }
 
-fn validate_sandbox_id(value: &str) -> Result<(), CodeExecutionError> {
+fn validate_sandbox_id(value: &str) -> Result<(), ExecError> {
     if value.is_empty()
         || value.len() > 128
         || !value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
     {
-        return Err(CodeExecutionError::Unavailable(
+        return Err(ExecError::Unavailable(
             "Daytona returned an invalid sandbox identity".into(),
         ));
     }
     Ok(())
 }
 
-fn provider_status_error(status: StatusCode) -> CodeExecutionError {
+fn provider_status_error(status: StatusCode) -> ExecError {
     match status {
         StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-            CodeExecutionError::Unavailable("Daytona credential was rejected".into())
+            ExecError::Unavailable("Daytona credential was rejected".into())
         }
         StatusCode::TOO_MANY_REQUESTS => {
-            CodeExecutionError::Unavailable("Daytona rate limit exceeded".into())
+            ExecError::Unavailable("Daytona rate limit exceeded".into())
         }
-        _ => CodeExecutionError::Unavailable(format!(
+        _ => ExecError::Unavailable(format!(
             "Daytona request failed with status {}",
             status.as_u16()
         )),
@@ -1608,8 +1561,8 @@ mod tests {
         body[start..body.len() - tail.len()].to_vec()
     }
 
-    fn request(execution_id: &str) -> CodeExecutionRequest {
-        CodeExecutionRequest::new(
+    fn request(execution_id: &str) -> ExecRequest {
+        ExecRequest::new(
             ExecutionId::parse(execution_id).unwrap(),
             ExecutionWorkspaceId::parse("chat-123").unwrap(),
             "printf",
@@ -1623,8 +1576,8 @@ mod tests {
         .unwrap()
     }
 
-    fn request_in(workspace_id: &str, execution_id: &str) -> CodeExecutionRequest {
-        CodeExecutionRequest::new(
+    fn request_in(workspace_id: &str, execution_id: &str) -> ExecRequest {
+        ExecRequest::new(
             ExecutionId::parse(execution_id).unwrap(),
             ExecutionWorkspaceId::parse(workspace_id).unwrap(),
             "printf",
@@ -1649,8 +1602,8 @@ mod tests {
         }
     }
 
-    fn timeout_request() -> CodeExecutionRequest {
-        CodeExecutionRequest::new(
+    fn timeout_request() -> ExecRequest {
+        ExecRequest::new(
             ExecutionId::parse("call-timeout").unwrap(),
             ExecutionWorkspaceId::parse("chat-timeout").unwrap(),
             "slow",
@@ -1676,7 +1629,7 @@ mod tests {
         let first = provider.execute(request("call-123")).await.unwrap();
         let second = provider.execute(request("call-456")).await.unwrap();
         let replay = provider.execute(request("call-456")).await.unwrap();
-        assert_eq!(first.provider, CodeExecutionProviderKind::Daytona);
+        assert_eq!(first.provider, ExecProviderKind::Daytona);
         assert_eq!(first.stdout, "ok\n");
         assert_eq!(second, replay);
 
@@ -1793,7 +1746,7 @@ mod tests {
         let cidr_refs: Vec<&str> = cidrs.iter().map(String::as_str).collect();
         assert!(matches!(
             provider().with_egress_policy(allowlist(&[], &cidr_refs)),
-            Err(CodeExecutionError::InvalidRequest(_))
+            Err(ExecError::InvalidRequest(_))
         ));
         let domains: Vec<String> = (0..21)
             .map(|index| format!("host{index}.example.com"))
@@ -1801,7 +1754,7 @@ mod tests {
         let domain_refs: Vec<&str> = domains.iter().map(String::as_str).collect();
         assert!(matches!(
             provider().with_egress_policy(allowlist(&domain_refs, &[])),
-            Err(CodeExecutionError::InvalidRequest(_))
+            Err(ExecError::InvalidRequest(_))
         ));
     }
 
@@ -1832,7 +1785,7 @@ mod tests {
             provider
                 .get_workspace_file(&workspace, &WorkspaceFilePath::parse("missing").unwrap())
                 .await,
-            Err(CodeExecutionError::WorkspaceFileNotFound)
+            Err(ExecError::WorkspaceFileNotFound)
         ));
 
         let listing = provider
@@ -2107,7 +2060,7 @@ mod tests {
         assert!(
             matches!(
                 error,
-                CodeExecutionError::Unavailable(ref message) if message.contains("credential")
+                ExecError::Unavailable(ref message) if message.contains("credential")
             ),
             "expected a credential rejection, got {error:?}"
         );

--- a/crates/tidebreak-code-execution/src/docker.rs
+++ b/crates/tidebreak-code-execution/src/docker.rs
@@ -1,4 +1,4 @@
-//! A [`CodeExecutionProvider`] over a host-local Docker-compatible runtime.
+//! A [`ExecProvider`] over a host-local Docker-compatible runtime.
 //!
 //! # Why this exists
 //!
@@ -102,10 +102,9 @@ use crate::sandbox_image::{
     image_digest_pinned, DOCUMENTS_CPU, DOCUMENTS_IMAGE, DOCUMENTS_MEMORY_GB,
 };
 use crate::{
-    CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, CodeExecutionUnavailableReason, ExecutionWorkspaceId, StagedUpload,
-    WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing,
-    MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
+    ExecError, ExecProvider, ExecProviderKind, ExecRequest, ExecResponse, ExecUnavailableReason,
+    ExecutionWorkspaceId, StagedUpload, WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle,
+    WorkspaceListing, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
 };
 
 /// The runtime binary, preferred on `PATH`. Any Docker-CLI-compatible runtime
@@ -312,16 +311,16 @@ fn container_network(policy: Option<&EgressPolicy>) -> ContainerNetwork {
 }
 
 impl DockerExecutionProvider {
-    pub fn new(timeout: Duration) -> Result<Self, CodeExecutionError> {
+    pub fn new(timeout: Duration) -> Result<Self, ExecError> {
         Self::with_session_pool(timeout, RemoteSessionPool::default())
     }
 
     pub fn with_session_pool(
         timeout: Duration,
         pool: RemoteSessionPool,
-    ) -> Result<Self, CodeExecutionError> {
+    ) -> Result<Self, ExecError> {
         if timeout.is_zero() {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "execution timeout must be positive".into(),
             ));
         }
@@ -411,12 +410,12 @@ impl DockerExecutionProvider {
     /// socket not permitted to this user). The answer is cached for
     /// [`AVAILABILITY_TTL`] in both directions, so a settings render costs at
     /// most one probe and starting the daemon is picked up without a restart.
-    pub async fn availability() -> Result<(), CodeExecutionUnavailableReason> {
+    pub async fn availability() -> Result<(), ExecUnavailableReason> {
         Self::availability_of(&resolve_container_runtime_binary()).await
     }
 
     /// [`Self::availability`] for a named runtime binary.
-    pub async fn availability_of(binary: &str) -> Result<(), CodeExecutionUnavailableReason> {
+    pub async fn availability_of(binary: &str) -> Result<(), ExecUnavailableReason> {
         static CACHE: LazyLock<Mutex<HashMap<String, (Instant, AvailabilityAnswer)>>> =
             LazyLock::new(|| Mutex::new(HashMap::new()));
         if let Ok(cache) = CACHE.lock() {
@@ -466,7 +465,7 @@ impl DockerExecutionProvider {
     ///
     /// Adopts an existing container rather than duplicating it, so a host that
     /// restarted reuses the files a previous session left in the workspace.
-    async fn ensure_container(&self, workspace_id: &str) -> Result<String, CodeExecutionError> {
+    async fn ensure_container(&self, workspace_id: &str) -> Result<String, ExecError> {
         let name = container_name(workspace_id);
         let configuration = self.configuration_identity();
         if let Some(existing) = self.inspect_container(&name).await? {
@@ -497,7 +496,7 @@ impl DockerExecutionProvider {
                     self.remove_container(&existing.id).await?;
                 }
                 ExistingContainerDisposition::Conflict => {
-                    return Err(CodeExecutionError::Unavailable(
+                    return Err(ExecError::Unavailable(
                         "the workspace container name is already in use".into(),
                     ));
                 }
@@ -505,9 +504,7 @@ impl DockerExecutionProvider {
         }
         match self.control(&self.run_args(workspace_id)).await {
             Ok(stdout) => parse_container_id(&stdout).ok_or_else(|| {
-                CodeExecutionError::Unavailable(
-                    "the container runtime returned no container id".into(),
-                )
+                ExecError::Unavailable("the container runtime returned no container id".into())
             }),
             // Another process (or another Tidebreak window) won the race to
             // create this workspace's container; adopt what is there.
@@ -522,7 +519,7 @@ impl DockerExecutionProvider {
                     {
                         Ok(existing.id)
                     }
-                    _ => Err(CodeExecutionError::Unavailable(
+                    _ => Err(ExecError::Unavailable(
                         "the workspace container could not be started".into(),
                     )),
                 }
@@ -535,7 +532,7 @@ impl DockerExecutionProvider {
     async fn inspect_container(
         &self,
         reference: &str,
-    ) -> Result<Option<ContainerState>, CodeExecutionError> {
+    ) -> Result<Option<ContainerState>, ExecError> {
         let args = inspect_args(reference);
         match self.control(&args).await {
             Ok(stdout) => Ok(parse_inspect(&stdout)),
@@ -547,7 +544,7 @@ impl DockerExecutionProvider {
     /// `docker rm -f -v`, treating a missing container as success. `-v`
     /// removes the anonymous workspace volume; without it every torn-down
     /// workspace would leave its volume dangling on the host's disk.
-    async fn remove_container(&self, reference: &str) -> Result<(), CodeExecutionError> {
+    async fn remove_container(&self, reference: &str) -> Result<(), ExecError> {
         match self.control(&remove_args(reference)).await {
             Ok(_) => Ok(()),
             Err(ControlFailure::Refused(stderr)) if is_no_such_container(&stderr) => Ok(()),
@@ -665,8 +662,8 @@ impl DockerExecutionProvider {
     async fn run_docker_command(
         &self,
         session: &RemoteSession,
-        request: &CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+        request: &ExecRequest,
+    ) -> Result<ExecResponse, RemoteSessionError> {
         validate_container_id(&session.sandbox_id)?;
         let started = Instant::now();
         let mut command = self.command();
@@ -677,7 +674,7 @@ impl DockerExecutionProvider {
         )?);
         let child = command
             .spawn()
-            .map_err(|_| CodeExecutionError::Unavailable(RUNTIME_SPAWN_FAILED.into()))?;
+            .map_err(|_| ExecError::Unavailable(RUNTIME_SPAWN_FAILED.into()))?;
         let Some(output) = bounded_output(
             child,
             self.timeout.saturating_add(CLI_GRACE),
@@ -687,10 +684,10 @@ impl DockerExecutionProvider {
         else {
             // The CLI itself was abandoned, so whether the command ran to
             // completion inside the container is genuinely unknown.
-            return Err(CodeExecutionError::AmbiguousExecution.into());
+            return Err(ExecError::AmbiguousExecution.into());
         };
         if output.status.is_none() {
-            return Err(CodeExecutionError::AmbiguousExecution.into());
+            return Err(ExecError::AmbiguousExecution.into());
         }
         if is_missing_container(output.status, &output.stderr) {
             return Err(RemoteSessionError::Missing);
@@ -704,7 +701,7 @@ impl DockerExecutionProvider {
         // every backend's timeout reporting carries.
         let timed_out = output.status == Some(TIMEOUT_EXIT);
         Ok(capture.response(
-            CodeExecutionProviderKind::Docker,
+            ExecProviderKind::Docker,
             started,
             if timed_out { None } else { output.status },
             timed_out,
@@ -729,12 +726,12 @@ impl DockerExecutionProvider {
         command.args(helper_args(&session.sandbox_id, script, argument));
         let mut child = command
             .spawn()
-            .map_err(|_| CodeExecutionError::Unavailable(RUNTIME_SPAWN_FAILED.into()))?;
+            .map_err(|_| ExecError::Unavailable(RUNTIME_SPAWN_FAILED.into()))?;
         if let Some(bytes) = stdin {
             let mut pipe = child
                 .stdin
                 .take()
-                .ok_or_else(|| CodeExecutionError::Unavailable(RUNTIME_SPAWN_FAILED.into()))?;
+                .ok_or_else(|| ExecError::Unavailable(RUNTIME_SPAWN_FAILED.into()))?;
             let bytes = bytes.to_vec();
             tokio::spawn(async move {
                 let _ = pipe.write_all(&bytes).await;
@@ -743,7 +740,7 @@ impl DockerExecutionProvider {
         }
         let output = bounded_output(child, CONTROL_TIMEOUT, capture_bytes)
             .await
-            .ok_or_else(|| CodeExecutionError::Unavailable(RUNTIME_SPAWN_FAILED.into()))?;
+            .ok_or_else(|| ExecError::Unavailable(RUNTIME_SPAWN_FAILED.into()))?;
         if is_missing_container(output.status, &output.stderr) {
             return Err(RemoteSessionError::Missing);
         }
@@ -753,8 +750,8 @@ impl DockerExecutionProvider {
 
 #[async_trait]
 impl RemoteSandboxAdapter for DockerExecutionProvider {
-    fn kind(&self) -> CodeExecutionProviderKind {
-        CodeExecutionProviderKind::Docker
+    fn kind(&self) -> ExecProviderKind {
+        ExecProviderKind::Docker
     }
 
     /// There is no credential; what distinguishes one configuration's
@@ -776,10 +773,7 @@ impl RemoteSandboxAdapter for DockerExecutionProvider {
         egress_policy_fingerprint(self.egress.as_ref())
     }
 
-    async fn create_session(
-        &self,
-        workspace_id: &str,
-    ) -> Result<RemoteSession, CodeExecutionError> {
+    async fn create_session(&self, workspace_id: &str) -> Result<RemoteSession, ExecError> {
         let id = self.ensure_container(workspace_id).await?;
         Ok(RemoteSession {
             sandbox_id: id,
@@ -788,7 +782,7 @@ impl RemoteSandboxAdapter for DockerExecutionProvider {
         })
     }
 
-    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError> {
+    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), ExecError> {
         validate_container_id(&session.sandbox_id)?;
         self.remove_container(&session.sandbox_id).await
     }
@@ -796,7 +790,7 @@ impl RemoteSandboxAdapter for DockerExecutionProvider {
     async fn reconnect_session(
         &self,
         session: &RemoteSession,
-    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+    ) -> Result<Option<RemoteSession>, ExecError> {
         validate_container_id(&session.sandbox_id)?;
         let Some(state) = self.inspect_container(&session.sandbox_id).await? else {
             return Ok(None);
@@ -812,8 +806,8 @@ impl RemoteSandboxAdapter for DockerExecutionProvider {
     async fn run_command(
         &self,
         session: &RemoteSession,
-        request: &CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+        request: &ExecRequest,
+    ) -> Result<ExecResponse, RemoteSessionError> {
         self.run_docker_command(session, request).await
     }
 }
@@ -838,7 +832,7 @@ impl RemoteWorkspaceAdapter for DockerExecutionProvider {
         if output.status == Some(0) {
             return Ok(());
         }
-        Err(CodeExecutionError::Unavailable("could not write the workspace file".into()).into())
+        Err(ExecError::Unavailable("could not write the workspace file".into()).into())
     }
 
     async fn download_file(
@@ -857,11 +851,9 @@ impl RemoteWorkspaceAdapter for DockerExecutionProvider {
             .await?;
         match output.status {
             Some(0) => Ok(output.stdout),
-            Some(FILE_MISSING_EXIT) => Err(CodeExecutionError::WorkspaceFileNotFound.into()),
-            Some(FILE_TOO_LARGE_EXIT) => Err(CodeExecutionError::WorkspaceFileTooLarge.into()),
-            _ => Err(
-                CodeExecutionError::Unavailable("could not read the workspace file".into()).into(),
-            ),
+            Some(FILE_MISSING_EXIT) => Err(ExecError::WorkspaceFileNotFound.into()),
+            Some(FILE_TOO_LARGE_EXIT) => Err(ExecError::WorkspaceFileTooLarge.into()),
+            _ => Err(ExecError::Unavailable("could not read the workspace file".into()).into()),
         }
     }
 
@@ -882,12 +874,11 @@ impl RemoteWorkspaceAdapter for DockerExecutionProvider {
             .await?;
         match output.status {
             Some(0) => {}
-            Some(DIR_MISSING_EXIT) => return Err(CodeExecutionError::WorkspaceFileNotFound.into()),
+            Some(DIR_MISSING_EXIT) => return Err(ExecError::WorkspaceFileNotFound.into()),
             _ => {
-                return Err(CodeExecutionError::Unavailable(
-                    "could not list the workspace directory".into(),
+                return Err(
+                    ExecError::Unavailable("could not list the workspace directory".into()).into(),
                 )
-                .into())
             }
         }
         Ok(parse_listing(&output.stdout, path))
@@ -896,24 +887,15 @@ impl RemoteWorkspaceAdapter for DockerExecutionProvider {
 
 #[async_trait]
 impl WorkspaceLifecycle for DockerExecutionProvider {
-    async fn create_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError> {
+    async fn create_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError> {
         create_remote_workspace(self, &self.pool, workspace.as_str()).await
     }
 
-    async fn connect_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<bool, CodeExecutionError> {
+    async fn connect_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<bool, ExecError> {
         connect_remote_workspace(self, &self.pool, workspace.as_str()).await
     }
 
-    async fn destroy_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError> {
+    async fn destroy_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError> {
         destroy_remote_workspace(self, &self.pool, workspace.as_str()).await
     }
 
@@ -922,9 +904,9 @@ impl WorkspaceLifecycle for DockerExecutionProvider {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> Result<(), CodeExecutionError> {
+    ) -> Result<(), ExecError> {
         if content.len() > MAX_WORKSPACE_FILE_BYTES {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         with_remote_session(
             self,
@@ -940,9 +922,9 @@ impl WorkspaceLifecycle for DockerExecutionProvider {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> Result<StagedUpload, CodeExecutionError> {
+    ) -> Result<StagedUpload, ExecError> {
         if content.len() > MAX_WORKSPACE_FILE_BYTES {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         stage_remote_file(self, &self.pool, workspace.as_str(), path, content).await
     }
@@ -951,7 +933,7 @@ impl WorkspaceLifecycle for DockerExecutionProvider {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
-    ) -> Result<Vec<u8>, CodeExecutionError> {
+    ) -> Result<Vec<u8>, ExecError> {
         with_remote_session(
             self,
             &self.pool,
@@ -965,7 +947,7 @@ impl WorkspaceLifecycle for DockerExecutionProvider {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: Option<&WorkspaceFilePath>,
-    ) -> Result<WorkspaceListing, CodeExecutionError> {
+    ) -> Result<WorkspaceListing, ExecError> {
         with_remote_session(
             self,
             &self.pool,
@@ -977,11 +959,8 @@ impl WorkspaceLifecycle for DockerExecutionProvider {
 }
 
 #[async_trait]
-impl CodeExecutionProvider for DockerExecutionProvider {
-    async fn execute(
-        &self,
-        request: CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, CodeExecutionError> {
+impl ExecProvider for DockerExecutionProvider {
+    async fn execute(&self, request: ExecRequest) -> Result<ExecResponse, ExecError> {
         execute_remote(self, &self.pool, request).await
     }
 
@@ -1024,11 +1003,11 @@ enum AvailabilityAnswer {
 }
 
 impl AvailabilityAnswer {
-    fn into_result(self) -> Result<(), CodeExecutionUnavailableReason> {
+    fn into_result(self) -> Result<(), ExecUnavailableReason> {
         match self {
             Self::Ready => Ok(()),
-            Self::MissingRuntime => Err(CodeExecutionUnavailableReason::MissingContainerRuntime),
-            Self::Unreachable => Err(CodeExecutionUnavailableReason::ContainerRuntimeUnreachable),
+            Self::MissingRuntime => Err(ExecUnavailableReason::MissingContainerRuntime),
+            Self::Unreachable => Err(ExecUnavailableReason::ContainerRuntimeUnreachable),
         }
     }
 }
@@ -1063,20 +1042,20 @@ enum ControlFailure {
 }
 
 impl ControlFailure {
-    fn into_error(self) -> CodeExecutionError {
+    fn into_error(self) -> ExecError {
         match self {
-            Self::Runtime => CodeExecutionError::Unavailable(RUNTIME_SPAWN_FAILED.into()),
+            Self::Runtime => ExecError::Unavailable(RUNTIME_SPAWN_FAILED.into()),
             // The runtime's own message is not surfaced: it is operator
             // diagnostics, and the model-facing error stays a stable sentence.
             Self::Refused(stderr) => {
                 tracing::debug!(stderr = %stderr, "container runtime refused an invocation");
-                CodeExecutionError::Unavailable("the container runtime refused the request".into())
+                ExecError::Unavailable("the container runtime refused the request".into())
             }
         }
     }
 }
 
-impl From<ControlFailure> for CodeExecutionError {
+impl From<ControlFailure> for ExecError {
     fn from(failure: ControlFailure) -> Self {
         failure.into_error()
     }
@@ -1206,9 +1185,9 @@ fn inspect_args(reference: &str) -> Vec<String> {
 /// would leave the command running inside the container.
 fn exec_command_args(
     container: &str,
-    request: &CodeExecutionRequest,
+    request: &ExecRequest,
     timeout: Duration,
-) -> Result<Vec<String>, CodeExecutionError> {
+) -> Result<Vec<String>, ExecError> {
     let mut args = vec![
         "exec".to_owned(),
         "--workdir".to_owned(),
@@ -1242,20 +1221,20 @@ fn helper_args(container: &str, script: &str, argument: &str) -> Vec<String> {
 }
 
 /// Resolve a workspace-relative working directory to its container path.
-fn container_cwd(cwd: &str) -> Result<String, CodeExecutionError> {
+fn container_cwd(cwd: &str) -> Result<String, ExecError> {
     let mut resolved = WORKSPACE_ROOT.to_owned();
     for component in Path::new(cwd).components() {
         match component {
             Component::CurDir => {}
             Component::Normal(part) => {
-                let part = part.to_str().ok_or_else(|| {
-                    CodeExecutionError::InvalidRequest("invalid working directory".into())
-                })?;
+                let part = part
+                    .to_str()
+                    .ok_or_else(|| ExecError::InvalidRequest("invalid working directory".into()))?;
                 resolved.push('/');
                 resolved.push_str(part);
             }
             _ => {
-                return Err(CodeExecutionError::InvalidRequest(
+                return Err(ExecError::InvalidRequest(
                     "invalid working directory".into(),
                 ))
             }
@@ -1335,7 +1314,7 @@ fn parse_listing(stdout: &[u8], parent: Option<&WorkspaceFilePath>) -> Workspace
 /// argument vectors, so each one is re-proved to be an identifier before use.
 /// The leading character must be alphanumeric: an id that could start with
 /// `-` would read as a flag to the next invocation it is passed to.
-fn validate_container_id(value: &str) -> Result<(), CodeExecutionError> {
+fn validate_container_id(value: &str) -> Result<(), ExecError> {
     if value.is_empty()
         || value.len() > 128
         || !value.starts_with(|first: char| first.is_ascii_alphanumeric())
@@ -1343,7 +1322,7 @@ fn validate_container_id(value: &str) -> Result<(), CodeExecutionError> {
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
     {
-        return Err(CodeExecutionError::Unavailable(
+        return Err(ExecError::Unavailable(
             "the container runtime returned an invalid container identity".into(),
         ));
     }
@@ -1376,8 +1355,8 @@ mod tests {
         DockerExecutionProvider::new(Duration::from_secs(30)).unwrap()
     }
 
-    fn request(cwd: &str) -> CodeExecutionRequest {
-        CodeExecutionRequest::new(
+    fn request(cwd: &str) -> ExecRequest {
+        ExecRequest::new(
             ExecutionId::parse("call-123").unwrap(),
             ExecutionWorkspaceId::parse("chat-123").unwrap(),
             "python3",
@@ -1731,7 +1710,7 @@ mod tests {
 
         let response = provider
             .execute(
-                CodeExecutionRequest::new(
+                ExecRequest::new(
                     ExecutionId::parse("call-e2e-1").unwrap(),
                     workspace.clone(),
                     "python3",
@@ -1744,7 +1723,7 @@ mod tests {
             .unwrap();
         assert_eq!(response.exit_code, Some(0), "stderr: {}", response.stderr);
         assert_eq!(response.stdout.trim(), "ok");
-        assert_eq!(response.provider, CodeExecutionProviderKind::Docker);
+        assert_eq!(response.provider, ExecProviderKind::Docker);
 
         let path = WorkspaceFilePath::parse("output/report.bin").unwrap();
         let content = b"\x00docker\xff".to_vec();
@@ -1771,7 +1750,7 @@ mod tests {
             provider
                 .get_workspace_file(&workspace, &WorkspaceFilePath::parse("nope").unwrap())
                 .await,
-            Err(CodeExecutionError::WorkspaceFileNotFound)
+            Err(ExecError::WorkspaceFileNotFound)
         ));
 
         // The command is stopped inside the container, not by abandoning the
@@ -1782,7 +1761,7 @@ mod tests {
         )
         .unwrap()
         .execute(
-            CodeExecutionRequest::new(
+            ExecRequest::new(
                 ExecutionId::parse("call-e2e-2").unwrap(),
                 workspace.clone(),
                 "sleep",

--- a/crates/tidebreak-code-execution/src/e2b.rs
+++ b/crates/tidebreak-code-execution/src/e2b.rs
@@ -22,10 +22,9 @@ use crate::remote::{
     RemoteSessionError, RemoteSessionPool, RemoteWorkspaceAdapter,
 };
 use crate::{
-    CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, ExecutionWorkspaceId, StagedUpload, WorkspaceFileEntry,
-    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_WORKSPACE_FILE_BYTES,
-    MAX_WORKSPACE_LIST_ENTRIES,
+    ExecError, ExecProvider, ExecProviderKind, ExecRequest, ExecResponse, ExecutionWorkspaceId,
+    StagedUpload, WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing,
+    MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
 };
 
 const E2B_API_BASE: &str = "https://api.e2b.app";
@@ -84,12 +83,12 @@ impl std::fmt::Debug for E2BCredential {
 }
 
 impl E2BCredential {
-    pub fn parse(value: impl Into<String>) -> Result<Self, CodeExecutionError> {
+    pub fn parse(value: impl Into<String>) -> Result<Self, ExecError> {
         SecretCredential::parse("E2B", value).map(Self)
     }
 
     /// Resolve the credential without exposing it through serializable config.
-    pub async fn load(secrets: &dyn SecretProvider) -> Result<Option<Self>, CodeExecutionError> {
+    pub async fn load(secrets: &dyn SecretProvider) -> Result<Option<Self>, ExecError> {
         SecretCredential::load(secrets, E2B_CREDENTIAL_KEY, "E2B")
             .await
             .map(|credential| credential.map(Self))
@@ -142,7 +141,7 @@ impl Default for E2BEndpoints {
 }
 
 impl E2BExecutionProvider {
-    pub fn new(credential: E2BCredential, timeout: Duration) -> Result<Self, CodeExecutionError> {
+    pub fn new(credential: E2BCredential, timeout: Duration) -> Result<Self, ExecError> {
         Self::with_session_pool(credential, timeout, RemoteSessionPool::default())
     }
 
@@ -150,7 +149,7 @@ impl E2BExecutionProvider {
         credential: E2BCredential,
         timeout: Duration,
         pool: RemoteSessionPool,
-    ) -> Result<Self, CodeExecutionError> {
+    ) -> Result<Self, ExecError> {
         Self::with_endpoints(credential, timeout, pool, E2BEndpoints::default())
     }
 
@@ -159,9 +158,9 @@ impl E2BExecutionProvider {
         timeout: Duration,
         pool: RemoteSessionPool,
         endpoints: E2BEndpoints,
-    ) -> Result<Self, CodeExecutionError> {
+    ) -> Result<Self, ExecError> {
         if timeout.is_zero() {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "execution timeout must be positive".into(),
             ));
         }
@@ -172,9 +171,7 @@ impl E2BExecutionProvider {
             // preventing a stalled HTTP response from holding the tool forever.
             .timeout(timeout.saturating_add(E2B_TRANSPORT_GRACE))
             .build()
-            .map_err(|_| {
-                CodeExecutionError::Unavailable("could not configure E2B transport".into())
-            })?;
+            .map_err(|_| ExecError::Unavailable("could not configure E2B transport".into()))?;
         Ok(Self {
             credential,
             timeout,
@@ -249,10 +246,7 @@ impl E2BExecutionProvider {
         ])
     }
 
-    async fn create_sandbox(
-        &self,
-        workspace_id: &str,
-    ) -> Result<RemoteSession, CodeExecutionError> {
+    async fn create_sandbox(&self, workspace_id: &str) -> Result<RemoteSession, ExecError> {
         if !self.default_template || self.template_unavailable.load(Ordering::Relaxed) {
             let template = if self.default_template {
                 E2B_FALLBACK_TEMPLATE
@@ -315,7 +309,7 @@ impl E2BExecutionProvider {
             .send()
             .await
             .map_err(|_| {
-                CreateSandboxFailure::Other(CodeExecutionError::Unavailable(
+                CreateSandboxFailure::Other(ExecError::Unavailable(
                     "could not reach the E2B API".into(),
                 ))
             })?;
@@ -332,10 +326,7 @@ impl E2BExecutionProvider {
             .map_err(CreateSandboxFailure::Other)
     }
 
-    async fn connect_sandbox(
-        &self,
-        sandbox_id: &str,
-    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+    async fn connect_sandbox(&self, sandbox_id: &str) -> Result<Option<RemoteSession>, ExecError> {
         validate_sandbox_id(sandbox_id)?;
         let url = format!(
             "{}/sandboxes/{sandbox_id}/connect",
@@ -350,7 +341,7 @@ impl E2BExecutionProvider {
             })
             .send()
             .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach the E2B API".into()))?;
+            .map_err(|_| ExecError::Unavailable("could not reach the E2B API".into()))?;
         if response.status() == StatusCode::NOT_FOUND {
             return Ok(None);
         }
@@ -360,12 +351,13 @@ impl E2BExecutionProvider {
     async fn run_e2b_command(
         &self,
         session: &RemoteSession,
-        request: &CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+        request: &ExecRequest,
+    ) -> Result<ExecResponse, RemoteSessionError> {
         validate_sandbox_id(&session.sandbox_id)?;
-        let access_token = session.access_token.as_deref().ok_or_else(|| {
-            CodeExecutionError::Unavailable("E2B sandbox token is unavailable".into())
-        })?;
+        let access_token = session
+            .access_token
+            .as_deref()
+            .ok_or_else(|| ExecError::Unavailable("E2B sandbox token is unavailable".into()))?;
         let started = Instant::now();
         let request_json = serde_json::to_vec(&StartRequest {
             process: ProcessConfig {
@@ -376,9 +368,7 @@ impl E2BExecutionProvider {
             },
             stdin: false,
         })
-        .map_err(|_| {
-            CodeExecutionError::InvalidRequest("E2B request is not serializable".into())
-        })?;
+        .map_err(|_| ExecError::InvalidRequest("E2B request is not serializable".into()))?;
         let body = connect_envelope(0, &request_json)?;
         let timeout_ms = u64::try_from(self.timeout.as_millis()).unwrap_or(u64::MAX);
         let url = format!(
@@ -397,7 +387,7 @@ impl E2BExecutionProvider {
             .body(body)
             .send()
             .await
-            .map_err(|_| CodeExecutionError::AmbiguousExecution)?;
+            .map_err(|_| ExecError::AmbiguousExecution)?;
         if response.status() == StatusCode::NOT_FOUND
             || response.status() == StatusCode::BAD_GATEWAY
         {
@@ -416,10 +406,11 @@ impl E2BExecutionProvider {
         &self,
         builder: reqwest::RequestBuilder,
         session: &RemoteSession,
-    ) -> Result<reqwest::RequestBuilder, CodeExecutionError> {
-        let access_token = session.access_token.as_deref().ok_or_else(|| {
-            CodeExecutionError::Unavailable("E2B sandbox token is unavailable".into())
-        })?;
+    ) -> Result<reqwest::RequestBuilder, ExecError> {
+        let access_token = session
+            .access_token
+            .as_deref()
+            .ok_or_else(|| ExecError::Unavailable("E2B sandbox token is unavailable".into()))?;
         Ok(builder
             .header("E2b-Sandbox-Id", &session.sandbox_id)
             .header("E2b-Sandbox-Port", E2B_ENVD_PORT)
@@ -436,8 +427,8 @@ impl E2BExecutionProvider {
 
 #[async_trait]
 impl RemoteSandboxAdapter for E2BExecutionProvider {
-    fn kind(&self) -> CodeExecutionProviderKind {
-        CodeExecutionProviderKind::E2b
+    fn kind(&self) -> ExecProviderKind {
+        ExecProviderKind::E2b
     }
 
     fn credential_fingerprint(&self) -> [u8; 32] {
@@ -448,14 +439,11 @@ impl RemoteSandboxAdapter for E2BExecutionProvider {
         crate::remote::egress_policy_fingerprint(self.egress.as_ref())
     }
 
-    async fn create_session(
-        &self,
-        workspace_id: &str,
-    ) -> Result<RemoteSession, CodeExecutionError> {
+    async fn create_session(&self, workspace_id: &str) -> Result<RemoteSession, ExecError> {
         self.create_sandbox(workspace_id).await
     }
 
-    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError> {
+    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), ExecError> {
         validate_sandbox_id(&session.sandbox_id)?;
         let url = format!(
             "{}/sandboxes/{}",
@@ -468,7 +456,7 @@ impl RemoteSandboxAdapter for E2BExecutionProvider {
             .header("X-API-Key", self.credential.as_str())
             .send()
             .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach the E2B API".into()))?;
+            .map_err(|_| ExecError::Unavailable("could not reach the E2B API".into()))?;
         if response.status() == StatusCode::NOT_FOUND || response.status().is_success() {
             return Ok(());
         }
@@ -478,15 +466,15 @@ impl RemoteSandboxAdapter for E2BExecutionProvider {
     async fn reconnect_session(
         &self,
         session: &RemoteSession,
-    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+    ) -> Result<Option<RemoteSession>, ExecError> {
         self.connect_sandbox(&session.sandbox_id).await
     }
 
     async fn run_command(
         &self,
         session: &RemoteSession,
-        request: &CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+        request: &ExecRequest,
+    ) -> Result<ExecResponse, RemoteSessionError> {
         self.run_e2b_command(session, request).await
     }
 }
@@ -511,9 +499,7 @@ impl RemoteWorkspaceAdapter for E2BExecutionProvider {
             .body(multipart.body)
             .send()
             .await
-            .map_err(|_| {
-                CodeExecutionError::Unavailable("could not reach the E2B sandbox".into())
-            })?;
+            .map_err(|_| ExecError::Unavailable("could not reach the E2B sandbox".into()))?;
         if response.status() == StatusCode::NOT_FOUND
             || response.status() == StatusCode::BAD_GATEWAY
         {
@@ -539,13 +525,11 @@ impl RemoteWorkspaceAdapter for E2BExecutionProvider {
             ])
             .send()
             .await
-            .map_err(|_| {
-                CodeExecutionError::Unavailable("could not reach the E2B sandbox".into())
-            })?;
+            .map_err(|_| ExecError::Unavailable("could not reach the E2B sandbox".into()))?;
         // The session was reconciled immediately before this call, so a 404
         // here is the file, while a routing failure surfaces as 502.
         if response.status() == StatusCode::NOT_FOUND {
-            return Err(CodeExecutionError::WorkspaceFileNotFound.into());
+            return Err(ExecError::WorkspaceFileNotFound.into());
         }
         if response.status() == StatusCode::BAD_GATEWAY {
             return Err(RemoteSessionError::Missing);
@@ -577,11 +561,9 @@ impl RemoteWorkspaceAdapter for E2BExecutionProvider {
             })
             .send()
             .await
-            .map_err(|_| {
-                CodeExecutionError::Unavailable("could not reach the E2B sandbox".into())
-            })?;
+            .map_err(|_| ExecError::Unavailable("could not reach the E2B sandbox".into()))?;
         if response.status() == StatusCode::NOT_FOUND {
-            return Err(CodeExecutionError::WorkspaceFileNotFound.into());
+            return Err(ExecError::WorkspaceFileNotFound.into());
         }
         if response.status() == StatusCode::BAD_GATEWAY {
             return Err(RemoteSessionError::Missing);
@@ -626,24 +608,15 @@ impl RemoteWorkspaceAdapter for E2BExecutionProvider {
 
 #[async_trait]
 impl WorkspaceLifecycle for E2BExecutionProvider {
-    async fn create_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError> {
+    async fn create_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError> {
         create_remote_workspace(self, &self.pool, workspace.as_str()).await
     }
 
-    async fn connect_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<bool, CodeExecutionError> {
+    async fn connect_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<bool, ExecError> {
         connect_remote_workspace(self, &self.pool, workspace.as_str()).await
     }
 
-    async fn destroy_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError> {
+    async fn destroy_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError> {
         destroy_remote_workspace(self, &self.pool, workspace.as_str()).await
     }
 
@@ -652,9 +625,9 @@ impl WorkspaceLifecycle for E2BExecutionProvider {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> Result<(), CodeExecutionError> {
+    ) -> Result<(), ExecError> {
         if content.len() > MAX_WORKSPACE_FILE_BYTES {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         with_remote_session(
             self,
@@ -670,9 +643,9 @@ impl WorkspaceLifecycle for E2BExecutionProvider {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> Result<StagedUpload, CodeExecutionError> {
+    ) -> Result<StagedUpload, ExecError> {
         if content.len() > MAX_WORKSPACE_FILE_BYTES {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         stage_remote_file(self, &self.pool, workspace.as_str(), path, content).await
     }
@@ -681,7 +654,7 @@ impl WorkspaceLifecycle for E2BExecutionProvider {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
-    ) -> Result<Vec<u8>, CodeExecutionError> {
+    ) -> Result<Vec<u8>, ExecError> {
         with_remote_session(
             self,
             &self.pool,
@@ -695,7 +668,7 @@ impl WorkspaceLifecycle for E2BExecutionProvider {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: Option<&WorkspaceFilePath>,
-    ) -> Result<WorkspaceListing, CodeExecutionError> {
+    ) -> Result<WorkspaceListing, ExecError> {
         with_remote_session(
             self,
             &self.pool,
@@ -707,11 +680,8 @@ impl WorkspaceLifecycle for E2BExecutionProvider {
 }
 
 #[async_trait]
-impl CodeExecutionProvider for E2BExecutionProvider {
-    async fn execute(
-        &self,
-        request: CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, CodeExecutionError> {
+impl ExecProvider for E2BExecutionProvider {
+    async fn execute(&self, request: ExecRequest) -> Result<ExecResponse, ExecError> {
         let mut response = execute_remote(self, &self.pool, request).await?;
         if self.degradation_pending.swap(false, Ordering::Relaxed) {
             response.degraded = Some(ExecDegradation::SandboxImageUnavailable);
@@ -725,17 +695,17 @@ impl CodeExecutionProvider for E2BExecutionProvider {
 }
 
 /// Why a single sandbox-creation attempt failed. Split out from
-/// [`CodeExecutionError`] because only one shape — E2B failing to resolve the
+/// [`ExecError`] because only one shape — E2B failing to resolve the
 /// template — may be retried against a different template.
 enum CreateSandboxFailure {
     TemplateMissing,
-    Other(CodeExecutionError),
+    Other(ExecError),
 }
 
 impl CreateSandboxFailure {
-    fn into_error(self, template: &str) -> CodeExecutionError {
+    fn into_error(self, template: &str) -> ExecError {
         match self {
-            Self::TemplateMissing => CodeExecutionError::Unavailable(format!(
+            Self::TemplateMissing => ExecError::Unavailable(format!(
                 "E2B could not find the sandbox template '{template}'"
             )),
             Self::Other(error) => error,
@@ -808,7 +778,7 @@ struct SandboxResponse {
     access_token: Option<String>,
 }
 
-async fn decode_session(response: Response) -> Result<RemoteSession, CodeExecutionError> {
+async fn decode_session(response: Response) -> Result<RemoteSession, ExecError> {
     if !response.status().is_success() {
         return Err(provider_status_error(response.status()));
     }
@@ -820,7 +790,7 @@ async fn decode_session(response: Response) -> Result<RemoteSession, CodeExecuti
         .access_token
         .filter(|token| !token.is_empty())
         .ok_or_else(|| {
-            CodeExecutionError::Unavailable("E2B did not return a secure sandbox token".into())
+            ExecError::Unavailable("E2B did not return a secure sandbox token".into())
         })?;
     Ok(RemoteSession {
         sandbox_id: body.sandbox_id,
@@ -829,29 +799,27 @@ async fn decode_session(response: Response) -> Result<RemoteSession, CodeExecuti
     })
 }
 
-fn provider_status_error(status: StatusCode) -> CodeExecutionError {
+fn provider_status_error(status: StatusCode) -> ExecError {
     match status {
         StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-            CodeExecutionError::Unavailable("E2B credential was rejected".into())
+            ExecError::Unavailable("E2B credential was rejected".into())
         }
-        StatusCode::TOO_MANY_REQUESTS => {
-            CodeExecutionError::Unavailable("E2B rate limit exceeded".into())
-        }
-        _ => CodeExecutionError::Unavailable(format!(
+        StatusCode::TOO_MANY_REQUESTS => ExecError::Unavailable("E2B rate limit exceeded".into()),
+        _ => ExecError::Unavailable(format!(
             "E2B request failed with status {}",
             status.as_u16()
         )),
     }
 }
 
-fn validate_sandbox_id(value: &str) -> Result<(), CodeExecutionError> {
+fn validate_sandbox_id(value: &str) -> Result<(), ExecError> {
     if value.is_empty()
         || value.len() > 128
         || !value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
     {
-        return Err(CodeExecutionError::Unavailable(
+        return Err(ExecError::Unavailable(
             "E2B returned an invalid sandbox identity".into(),
         ));
     }
@@ -899,20 +867,20 @@ struct ListDirEntry {
     size: Option<serde_json::Value>,
 }
 
-fn remote_cwd(cwd: &str) -> Result<String, CodeExecutionError> {
+fn remote_cwd(cwd: &str) -> Result<String, ExecError> {
     let mut remote = E2B_WORKSPACE_ROOT.to_owned();
     for component in Path::new(cwd).components() {
         match component {
             Component::CurDir => {}
             Component::Normal(part) => {
-                let part = part.to_str().ok_or_else(|| {
-                    CodeExecutionError::InvalidRequest("invalid working directory".into())
-                })?;
+                let part = part
+                    .to_str()
+                    .ok_or_else(|| ExecError::InvalidRequest("invalid working directory".into()))?;
                 remote.push('/');
                 remote.push_str(part);
             }
             _ => {
-                return Err(CodeExecutionError::InvalidRequest(
+                return Err(ExecError::InvalidRequest(
                     "invalid working directory".into(),
                 ));
             }
@@ -935,10 +903,9 @@ struct ProcessConfig<'a> {
     cwd: String,
 }
 
-fn connect_envelope(flags: u8, payload: &[u8]) -> Result<Vec<u8>, CodeExecutionError> {
-    let length = u32::try_from(payload.len()).map_err(|_| {
-        CodeExecutionError::InvalidRequest("E2B request exceeds the protocol bound".into())
-    })?;
+fn connect_envelope(flags: u8, payload: &[u8]) -> Result<Vec<u8>, ExecError> {
+    let length = u32::try_from(payload.len())
+        .map_err(|_| ExecError::InvalidRequest("E2B request exceeds the protocol bound".into()))?;
     let mut encoded = Vec::with_capacity(payload.len() + 5);
     encoded.push(flags);
     encoded.extend_from_slice(&length.to_be_bytes());
@@ -949,7 +916,7 @@ fn connect_envelope(flags: u8, payload: &[u8]) -> Result<Vec<u8>, CodeExecutionE
 async fn decode_command_response(
     response: Response,
     started: Instant,
-) -> Result<CodeExecutionResponse, CodeExecutionError> {
+) -> Result<ExecResponse, ExecError> {
     let mut decoder = EnvelopeDecoder::default();
     let mut stream = response.bytes_stream();
     let mut capture = Capture::default();
@@ -957,31 +924,29 @@ async fn decode_command_response(
     let mut end_stream = false;
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|_| CodeExecutionError::AmbiguousExecution)?;
+        let chunk = chunk.map_err(|_| ExecError::AmbiguousExecution)?;
         for envelope in decoder.decode(&chunk)? {
             if envelope.flags & CONNECT_COMPRESSED_FLAG != 0 {
-                return Err(CodeExecutionError::Unavailable(
+                return Err(ExecError::Unavailable(
                     "E2B returned unsupported compressed output".into(),
                 ));
             }
             if envelope.flags & CONNECT_END_STREAM_FLAG != 0 {
                 if end_stream {
-                    return Err(CodeExecutionError::Unavailable(
+                    return Err(ExecError::Unavailable(
                         "E2B returned duplicate stream trailers".into(),
                     ));
                 }
                 end_stream = true;
                 let end: ConnectEndStream =
                     serde_json::from_slice(&envelope.payload).map_err(|_| {
-                        CodeExecutionError::Unavailable(
-                            "E2B returned invalid stream trailers".into(),
-                        )
+                        ExecError::Unavailable("E2B returned invalid stream trailers".into())
                     })?;
                 if let Some(error) = end.error {
                     if error.code == "deadline_exceeded" {
                         return Ok(command_response(started, capture, None, true));
                     }
-                    return Err(CodeExecutionError::Unavailable(format!(
+                    return Err(ExecError::Unavailable(format!(
                         "E2B command stream failed: {}",
                         error.code
                     )));
@@ -989,12 +954,12 @@ async fn decode_command_response(
                 continue;
             }
             if end_stream {
-                return Err(CodeExecutionError::Unavailable(
+                return Err(ExecError::Unavailable(
                     "E2B returned output after stream trailers".into(),
                 ));
             }
             let event: StartResponse = serde_json::from_slice(&envelope.payload).map_err(|_| {
-                CodeExecutionError::Unavailable("E2B returned an invalid command event".into())
+                ExecError::Unavailable("E2B returned an invalid command event".into())
             })?;
             let Some(event) = event.event else {
                 continue;
@@ -1009,7 +974,7 @@ async fn decode_command_response(
             }
             if let Some(end) = event.end {
                 if process_end.is_some() {
-                    return Err(CodeExecutionError::Unavailable(
+                    return Err(ExecError::Unavailable(
                         "E2B returned duplicate process completion".into(),
                     ));
                 }
@@ -1022,9 +987,9 @@ async fn decode_command_response(
     }
 
     if decoder.has_incomplete_frame() || !end_stream {
-        return Err(CodeExecutionError::AmbiguousExecution);
+        return Err(ExecError::AmbiguousExecution);
     }
-    let end = process_end.ok_or(CodeExecutionError::AmbiguousExecution)?;
+    let end = process_end.ok_or(ExecError::AmbiguousExecution)?;
     let exit_code = end.exited.then_some(end.exit_code.unwrap_or_default());
     Ok(command_response(started, capture, exit_code, false))
 }
@@ -1034,13 +999,8 @@ fn command_response(
     capture: Capture,
     exit_code: Option<i32>,
     timed_out: bool,
-) -> CodeExecutionResponse {
-    capture.response(
-        CodeExecutionProviderKind::E2b,
-        started,
-        exit_code,
-        timed_out,
-    )
+) -> ExecResponse {
+    capture.response(ExecProviderKind::E2b, started, exit_code, timed_out)
 }
 
 #[derive(Default)]
@@ -1054,9 +1014,9 @@ struct Envelope {
 }
 
 impl EnvelopeDecoder {
-    fn decode(&mut self, chunk: &[u8]) -> Result<Vec<Envelope>, CodeExecutionError> {
+    fn decode(&mut self, chunk: &[u8]) -> Result<Vec<Envelope>, ExecError> {
         if chunk.len() > MAX_CONNECT_FRAME_BYTES.saturating_mul(2) {
-            return Err(CodeExecutionError::Unavailable(
+            return Err(ExecError::Unavailable(
                 "E2B returned an oversized stream chunk".into(),
             ));
         }
@@ -1075,7 +1035,7 @@ impl EnvelopeDecoder {
                 self.buffer[offset + 4],
             ]) as usize;
             if length > MAX_CONNECT_FRAME_BYTES {
-                return Err(CodeExecutionError::Unavailable(
+                return Err(ExecError::Unavailable(
                     "E2B returned an oversized stream frame".into(),
                 ));
             }
@@ -1083,7 +1043,7 @@ impl EnvelopeDecoder {
                 .checked_add(5)
                 .and_then(|start| start.checked_add(length))
                 .ok_or_else(|| {
-                    CodeExecutionError::Unavailable("E2B returned an invalid stream frame".into())
+                    ExecError::Unavailable("E2B returned an invalid stream frame".into())
                 })?;
             if self.buffer.len() < end {
                 break;
@@ -1098,7 +1058,7 @@ impl EnvelopeDecoder {
             self.buffer.drain(..offset);
         }
         if self.buffer.len() > MAX_CONNECT_FRAME_BYTES + 5 {
-            return Err(CodeExecutionError::Unavailable(
+            return Err(ExecError::Unavailable(
                 "E2B returned an oversized incomplete frame".into(),
             ));
         }
@@ -1481,8 +1441,8 @@ mod tests {
         connect_envelope(flags, &serde_json::to_vec(value).unwrap()).unwrap()
     }
 
-    fn request(execution: &str, workspace: &str, argument: &str) -> CodeExecutionRequest {
-        CodeExecutionRequest::new(
+    fn request(execution: &str, workspace: &str, argument: &str) -> ExecRequest {
+        ExecRequest::new(
             ExecutionId::parse(execution).unwrap(),
             ExecutionWorkspaceId::parse(workspace).unwrap(),
             "/bin/echo",
@@ -1504,7 +1464,7 @@ mod tests {
         let (provider, state, server) = mock_provider(ProcessMode::Complete, None).await;
         let first_request = request("execution-1", "workspace-1", "first");
         let first = provider.execute(first_request.clone()).await.unwrap();
-        assert_eq!(first.provider, CodeExecutionProviderKind::E2b);
+        assert_eq!(first.provider, ExecProviderKind::E2b);
         assert_eq!(first.exit_code, Some(0));
         assert_eq!(first.stdout, "ok\n");
 
@@ -1512,7 +1472,7 @@ mod tests {
         assert_eq!(replay, first);
         assert_eq!(state.starts.load(Ordering::SeqCst), 1);
 
-        let conflict = CodeExecutionRequest::new(
+        let conflict = ExecRequest::new(
             first_request.execution_id.clone(),
             first_request.workspace_id.clone(),
             "/bin/echo",
@@ -1522,7 +1482,7 @@ mod tests {
         .unwrap();
         assert!(matches!(
             provider.execute(conflict).await,
-            Err(CodeExecutionError::IdentityConflict)
+            Err(ExecError::IdentityConflict)
         ));
 
         provider
@@ -1597,7 +1557,7 @@ mod tests {
             provider
                 .get_workspace_file(&workspace, &WorkspaceFilePath::parse("missing").unwrap())
                 .await,
-            Err(CodeExecutionError::WorkspaceFileNotFound)
+            Err(ExecError::WorkspaceFileNotFound)
         ));
 
         let listing = provider
@@ -1774,7 +1734,7 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            matches!(&error, CodeExecutionError::Unavailable(message) if message.contains("acme-custom")),
+            matches!(&error, ExecError::Unavailable(message) if message.contains("acme-custom")),
             "unexpected error: {error:?}"
         );
         assert_eq!(

--- a/crates/tidebreak-code-execution/src/http.rs
+++ b/crates/tidebreak-code-execution/src/http.rs
@@ -3,30 +3,29 @@ use reqwest::Response;
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 
-use crate::CodeExecutionError;
+use crate::ExecError;
 
 /// Bound JSON returned by managed-provider control and command APIs.
 pub(crate) async fn decode_bounded_json<T: DeserializeOwned>(
     response: Response,
     provider: &str,
     max_bytes: usize,
-) -> Result<T, CodeExecutionError> {
+) -> Result<T, ExecError> {
     let mut bytes = Vec::new();
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|_| {
-            CodeExecutionError::Unavailable(format!("{provider} returned an incomplete response"))
+            ExecError::Unavailable(format!("{provider} returned an incomplete response"))
         })?;
         if bytes.len().saturating_add(chunk.len()) > max_bytes {
-            return Err(CodeExecutionError::Unavailable(format!(
+            return Err(ExecError::Unavailable(format!(
                 "{provider} returned an oversized response"
             )));
         }
         bytes.extend_from_slice(&chunk);
     }
-    serde_json::from_slice(&bytes).map_err(|_| {
-        CodeExecutionError::Unavailable(format!("{provider} returned an invalid response"))
-    })
+    serde_json::from_slice(&bytes)
+        .map_err(|_| ExecError::Unavailable(format!("{provider} returned an invalid response")))
 }
 
 /// Download one workspace file, refusing anything beyond the transfer bound.
@@ -34,15 +33,15 @@ pub(crate) async fn download_bounded_file(
     response: Response,
     provider: &str,
     max_bytes: usize,
-) -> Result<Vec<u8>, CodeExecutionError> {
+) -> Result<Vec<u8>, ExecError> {
     let mut bytes = Vec::new();
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|_| {
-            CodeExecutionError::Unavailable(format!("{provider} returned an incomplete file"))
+            ExecError::Unavailable(format!("{provider} returned an incomplete file"))
         })?;
         if bytes.len().saturating_add(chunk.len()) > max_bytes {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         bytes.extend_from_slice(&chunk);
     }

--- a/crates/tidebreak-code-execution/src/lib.rs
+++ b/crates/tidebreak-code-execution/src/lib.rs
@@ -1,7 +1,7 @@
 //! Provider-neutral, bounded command execution for Tidebreak.
 //!
-//! The model-facing [`ExecTool`] sends a normalized [`CodeExecutionRequest`] to
-//! a host-selected [`CodeExecutionProvider`]. Requests carry a stable execution
+//! The model-facing [`ExecTool`] sends a normalized [`ExecRequest`] to
+//! a host-selected [`ExecProvider`]. Requests carry a stable execution
 //! identity and an opaque workspace identity, so a future managed adapter can
 //! reconcile retries and map a chat to its own remote session without exposing
 //! provider credentials or accepting model-authored host paths.
@@ -91,12 +91,11 @@ pub use skills::{
 };
 pub use tool::{ExecTool, EXEC_TOOL_NAME};
 pub use types::{
-    CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, CodeExecutionUnavailableReason, ExecFolderAccess, ExecFolderGrant,
-    ExecutionId, ExecutionWorkspaceId, OutputArtifactEntry, OutputArtifactScan,
-    OutputArtifactStatus, SandboxPreparation, SandboxPreparationSink, StagedUpload,
-    WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_ARGUMENTS,
-    MAX_ARGUMENT_BYTES, MAX_CAPTURE_BYTES, MAX_COMMAND_BYTES, MAX_CWD_BYTES,
+    ExecError, ExecFolderAccess, ExecFolderGrant, ExecProvider, ExecProviderKind, ExecRequest,
+    ExecResponse, ExecUnavailableReason, ExecutionId, ExecutionWorkspaceId, OutputArtifactEntry,
+    OutputArtifactScan, OutputArtifactStatus, SandboxPreparation, SandboxPreparationSink,
+    StagedUpload, WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing,
+    MAX_ARGUMENTS, MAX_ARGUMENT_BYTES, MAX_CAPTURE_BYTES, MAX_COMMAND_BYTES, MAX_CWD_BYTES,
     MAX_EXEC_FOLDER_GRANTS, MAX_STAGED_PATHS, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
     MAX_WORKSPACE_PATH_BYTES,
 };

--- a/crates/tidebreak-code-execution/src/local.rs
+++ b/crates/tidebreak-code-execution/src/local.rs
@@ -28,11 +28,11 @@ use crate::output::{Capture, StreamKind};
 use crate::receipt::{request_fingerprint, BeginExecution, ExecutionReceipt};
 use crate::sbpl::SANDBOX_EXEC;
 #[cfg(target_os = "macos")]
-use crate::CodeExecutionProviderKind;
+use crate::ExecProviderKind;
 use crate::{
-    CodeExecutionError, CodeExecutionProvider, CodeExecutionRequest, CodeExecutionResponse,
-    CodeExecutionUnavailableReason, ExecutionWorkspaceId, WorkspaceFileEntry, WorkspaceFilePath,
-    WorkspaceLifecycle, WorkspaceListing, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
+    ExecError, ExecProvider, ExecRequest, ExecResponse, ExecUnavailableReason,
+    ExecutionWorkspaceId, WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle,
+    WorkspaceListing, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
 };
 #[cfg(target_os = "macos")]
 use crate::{ExecFolderAccess, ExecFolderGrant};
@@ -137,12 +137,9 @@ struct CanonicalExecFolderGrant {
 }
 
 impl LocalExecutionProvider {
-    pub fn new(
-        scratch_root: impl Into<PathBuf>,
-        timeout: Duration,
-    ) -> Result<Self, CodeExecutionError> {
+    pub fn new(scratch_root: impl Into<PathBuf>, timeout: Duration) -> Result<Self, ExecError> {
         if timeout.is_zero() {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "execution timeout must be positive".into(),
             ));
         }
@@ -200,12 +197,12 @@ impl LocalExecutionProvider {
     /// `Ok(())` means the mandatory confinement primitive exists. The error is
     /// a stable reason code, so a caller can report *why* local execution is
     /// impossible without re-deriving the platform rules itself.
-    pub fn availability() -> Result<(), CodeExecutionUnavailableReason> {
+    pub fn availability() -> Result<(), ExecUnavailableReason> {
         if !cfg!(target_os = "macos") {
-            return Err(CodeExecutionUnavailableReason::UnsupportedPlatform);
+            return Err(ExecUnavailableReason::UnsupportedPlatform);
         }
         if !Path::new(SANDBOX_EXEC).is_file() {
-            return Err(CodeExecutionUnavailableReason::MissingSandboxBinary);
+            return Err(ExecUnavailableReason::MissingSandboxBinary);
         }
         Ok(())
     }
@@ -218,32 +215,28 @@ impl LocalExecutionProvider {
         tidebreak_egress::EgressEnforcement::external(Vec::new())
     }
 
-    fn resolve_paths(
-        &self,
-        request: &CodeExecutionRequest,
-    ) -> Result<ResolvedExecutionPaths, CodeExecutionError> {
-        let root = fs::canonicalize(&self.scratch_root).map_err(|_| {
-            CodeExecutionError::Sandbox("private scratch root is unavailable".into())
-        })?;
+    fn resolve_paths(&self, request: &ExecRequest) -> Result<ResolvedExecutionPaths, ExecError> {
+        let root = fs::canonicalize(&self.scratch_root)
+            .map_err(|_| ExecError::Sandbox("private scratch root is unavailable".into()))?;
         let workspace_candidate = root.join(request.workspace_id.as_str());
         let metadata = fs::symlink_metadata(&workspace_candidate)
-            .map_err(|_| CodeExecutionError::Sandbox("private workspace is unavailable".into()))?;
+            .map_err(|_| ExecError::Sandbox("private workspace is unavailable".into()))?;
         if !metadata.is_dir() || metadata.file_type().is_symlink() {
-            return Err(CodeExecutionError::Sandbox(
+            return Err(ExecError::Sandbox(
                 "private workspace is not a regular directory".into(),
             ));
         }
         let workspace = fs::canonicalize(workspace_candidate)
-            .map_err(|_| CodeExecutionError::Sandbox("private workspace is unavailable".into()))?;
+            .map_err(|_| ExecError::Sandbox("private workspace is unavailable".into()))?;
         if !workspace.starts_with(&root) {
-            return Err(CodeExecutionError::Sandbox(
+            return Err(ExecError::Sandbox(
                 "private workspace escaped its root".into(),
             ));
         }
         let cwd = fs::canonicalize(workspace.join(&request.cwd))
-            .map_err(|_| CodeExecutionError::Sandbox("working directory is unavailable".into()))?;
+            .map_err(|_| ExecError::Sandbox("working directory is unavailable".into()))?;
         if !cwd.starts_with(&workspace) || !cwd.is_dir() {
-            return Err(CodeExecutionError::Sandbox(
+            return Err(ExecError::Sandbox(
                 "working directory escaped the private workspace".into(),
             ));
         }
@@ -266,19 +259,18 @@ impl LocalExecutionProvider {
         })
     }
 
-    fn ensured_root(&self) -> Result<PathBuf, CodeExecutionError> {
-        fs::create_dir_all(&self.scratch_root).map_err(|_| {
-            CodeExecutionError::Sandbox("private scratch root is unavailable".into())
-        })?;
+    fn ensured_root(&self) -> Result<PathBuf, ExecError> {
+        fs::create_dir_all(&self.scratch_root)
+            .map_err(|_| ExecError::Sandbox("private scratch root is unavailable".into()))?;
         fs::canonicalize(&self.scratch_root)
-            .map_err(|_| CodeExecutionError::Sandbox("private scratch root is unavailable".into()))
+            .map_err(|_| ExecError::Sandbox("private scratch root is unavailable".into()))
     }
 
-    fn existing_root(&self) -> Result<Option<PathBuf>, CodeExecutionError> {
+    fn existing_root(&self) -> Result<Option<PathBuf>, ExecError> {
         match fs::canonicalize(&self.scratch_root) {
             Ok(root) => Ok(Some(root)),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(_) => Err(CodeExecutionError::Sandbox(
+            Err(_) => Err(ExecError::Sandbox(
                 "private scratch root is unavailable".into(),
             )),
         }
@@ -287,12 +279,10 @@ impl LocalExecutionProvider {
     /// Open the host-owned scratch `root` as a pinned descriptor. The root is
     /// canonicalized by the caller and is not sandbox-writable, so ambient
     /// resolution of it carries no containment question.
-    async fn root_dir(root: &Path) -> Result<ScratchDir, CodeExecutionError> {
+    async fn root_dir(root: &Path) -> Result<ScratchDir, ExecError> {
         resolve_scratch_directory(root, "", false)
             .await
-            .ok_or_else(|| {
-                CodeExecutionError::Sandbox("private scratch root is unavailable".into())
-            })
+            .ok_or_else(|| ExecError::Sandbox("private scratch root is unavailable".into()))
     }
 
     /// Open the workspace directory one level under `root` as a pinned
@@ -303,7 +293,7 @@ impl LocalExecutionProvider {
         root: &ScratchDir,
         workspace: &ExecutionWorkspaceId,
         create: bool,
-    ) -> Result<Option<ScratchDir>, CodeExecutionError> {
+    ) -> Result<Option<ScratchDir>, ExecError> {
         let name = workspace.as_str();
         let opened = if create {
             root.create_dir(name).await
@@ -317,11 +307,11 @@ impl LocalExecutionProvider {
                 // The no-follow open is what refused; the stats only label the
                 // refusal and are not what enforced it.
                 if root.is_symlink(name).await || root.file_stamp(name).await.is_some() {
-                    return Err(CodeExecutionError::Sandbox(
+                    return Err(ExecError::Sandbox(
                         "private workspace is not a regular directory".into(),
                     ));
                 }
-                Err(CodeExecutionError::Sandbox(
+                Err(ExecError::Sandbox(
                     "private workspace is unavailable".into(),
                 ))
             }
@@ -332,7 +322,7 @@ impl LocalExecutionProvider {
         root: &Path,
         workspace: &ExecutionWorkspaceId,
         create: bool,
-    ) -> Result<Option<ScratchDir>, CodeExecutionError> {
+    ) -> Result<Option<ScratchDir>, ExecError> {
         let root = Self::root_dir(root).await?;
         Self::workspace_under(&root, workspace, create).await
     }
@@ -340,11 +330,11 @@ impl LocalExecutionProvider {
     async fn ensured_workspace(
         &self,
         workspace: &ExecutionWorkspaceId,
-    ) -> Result<ScratchDir, CodeExecutionError> {
+    ) -> Result<ScratchDir, ExecError> {
         let root = self.ensured_root()?;
         Self::workspace_in(&root, workspace, true)
             .await?
-            .ok_or_else(|| CodeExecutionError::Sandbox("private workspace is unavailable".into()))
+            .ok_or_else(|| ExecError::Sandbox("private workspace is unavailable".into()))
     }
 
     /// Open `path`'s parent directory inside `workspace` as a pinned
@@ -382,14 +372,11 @@ impl LocalExecutionProvider {
 }
 
 #[async_trait]
-impl CodeExecutionProvider for LocalExecutionProvider {
-    async fn execute(
-        &self,
-        request: CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, CodeExecutionError> {
+impl ExecProvider for LocalExecutionProvider {
+    async fn execute(&self, request: ExecRequest) -> Result<ExecResponse, ExecError> {
         request.validate()?;
         if let Err(reason) = Self::availability() {
-            return Err(CodeExecutionError::Unavailable(format!(
+            return Err(ExecError::Unavailable(format!(
                 "native local sandboxing is not available on this host: {}",
                 reason.message()
             )));
@@ -427,8 +414,8 @@ impl CodeExecutionProvider for LocalExecutionProvider {
         }
         #[cfg(target_os = "macos")]
         if denied_host_path.is_some() {
-            let response = CodeExecutionResponse {
-                provider: CodeExecutionProviderKind::Local,
+            let response = ExecResponse {
+                provider: ExecProviderKind::Local,
                 exit_code: Some(126),
                 stdout: String::new(),
                 stderr: sandbox_path_denied_message(!folder_grants.is_empty()),
@@ -452,9 +439,7 @@ impl CodeExecutionProvider for LocalExecutionProvider {
             .as_ref()
             .map(|path| {
                 fs::canonicalize(path).map_err(|_| {
-                    CodeExecutionError::Sandbox(
-                        "bundled document helper directory is unavailable".into(),
-                    )
+                    ExecError::Sandbox("bundled document helper directory is unavailable".into())
                 })
             })
             .transpose()?;
@@ -462,9 +447,8 @@ impl CodeExecutionProvider for LocalExecutionProvider {
             .shared_package_cache
             .as_ref()
             .map(|path| {
-                fs::canonicalize(path).map_err(|_| {
-                    CodeExecutionError::Sandbox("shared package cache is unavailable".into())
-                })
+                fs::canonicalize(path)
+                    .map_err(|_| ExecError::Sandbox("shared package cache is unavailable".into()))
             })
             .transpose()?;
         // A runtime that has been uninstalled between turns simply drops out:
@@ -532,27 +516,18 @@ impl CodeExecutionProvider for LocalExecutionProvider {
 
 #[async_trait]
 impl WorkspaceLifecycle for LocalExecutionProvider {
-    async fn create_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError> {
+    async fn create_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError> {
         self.ensured_workspace(workspace).await.map(|_| ())
     }
 
-    async fn connect_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<bool, CodeExecutionError> {
+    async fn connect_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<bool, ExecError> {
         let Some(root) = self.existing_root()? else {
             return Ok(false);
         };
         Ok(Self::workspace_in(&root, workspace, false).await?.is_some())
     }
 
-    async fn destroy_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError> {
+    async fn destroy_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError> {
         let Some(root) = self.existing_root()? else {
             return Ok(());
         };
@@ -565,14 +540,14 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
                 Ok(()) => {}
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                 Err(_) => {
-                    return Err(CodeExecutionError::Sandbox(
+                    return Err(ExecError::Sandbox(
                         "could not remove private execution storage".into(),
                     ))
                 }
             },
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(_) => {
-                return Err(CodeExecutionError::Sandbox(
+                return Err(ExecError::Sandbox(
                     "could not remove private execution storage".into(),
                 ))
             }
@@ -585,7 +560,7 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
         }
         root.remove_dir_all(workspace.as_str())
             .await
-            .map_err(|_| CodeExecutionError::Sandbox("could not remove private workspace".into()))
+            .map_err(|_| ExecError::Sandbox("could not remove private workspace".into()))
     }
 
     async fn put_workspace_file(
@@ -593,16 +568,14 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> Result<(), CodeExecutionError> {
+    ) -> Result<(), ExecError> {
         if content.len() > MAX_WORKSPACE_FILE_BYTES {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         let workspace = self.ensured_workspace(workspace).await?;
         let parent = Self::resolve_parent(&workspace, path, true)
             .await
-            .ok_or_else(|| {
-                CodeExecutionError::Sandbox("workspace directories are unavailable".into())
-            })?;
+            .ok_or_else(|| ExecError::Sandbox("workspace directories are unavailable".into()))?;
         // The write goes to an unpredictable temp name created exclusively and
         // without following, then renamed into place — both relative to the
         // pinned parent. A process with write access to chat scratch (an
@@ -612,22 +585,22 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
         parent
             .write_file(path.file_name(), content)
             .await
-            .map_err(|_| CodeExecutionError::Sandbox("could not write the workspace file".into()))
+            .map_err(|_| ExecError::Sandbox("could not write the workspace file".into()))
     }
 
     async fn get_workspace_file(
         &self,
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
-    ) -> Result<Vec<u8>, CodeExecutionError> {
+    ) -> Result<Vec<u8>, ExecError> {
         let Some(root) = self.existing_root()? else {
-            return Err(CodeExecutionError::WorkspaceFileNotFound);
+            return Err(ExecError::WorkspaceFileNotFound);
         };
         let Some(workspace) = Self::workspace_in(&root, workspace, false).await? else {
-            return Err(CodeExecutionError::WorkspaceFileNotFound);
+            return Err(ExecError::WorkspaceFileNotFound);
         };
         let Some(parent) = Self::resolve_parent(&workspace, path, false).await else {
-            return Err(CodeExecutionError::WorkspaceFileNotFound);
+            return Err(ExecError::WorkspaceFileNotFound);
         };
         // Open relative to the pinned parent without following the final
         // component, then judge the opened descriptor — never a path stat'd
@@ -643,35 +616,35 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
                 // indistinguishable from absence; the stat explains the refusal
                 // and is not what enforced it.
                 if parent.is_symlink(path.file_name()).await {
-                    return Err(CodeExecutionError::InvalidRequest(
+                    return Err(ExecError::InvalidRequest(
                         "workspace path is not a regular file".into(),
                     ));
                 }
                 if error.kind() == std::io::ErrorKind::NotFound {
-                    return Err(CodeExecutionError::WorkspaceFileNotFound);
+                    return Err(ExecError::WorkspaceFileNotFound);
                 }
-                return Err(CodeExecutionError::Sandbox(
+                return Err(ExecError::Sandbox(
                     "could not read the workspace file".into(),
                 ));
             }
         };
         let metadata = file
             .metadata()
-            .map_err(|_| CodeExecutionError::Sandbox("could not read the workspace file".into()))?;
+            .map_err(|_| ExecError::Sandbox("could not read the workspace file".into()))?;
         if !metadata.is_file() {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "workspace path is not a regular file".into(),
             ));
         }
         if metadata.len() > MAX_WORKSPACE_FILE_BYTES as u64 {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         let mut content = Vec::new();
         file.take(MAX_WORKSPACE_FILE_BYTES as u64 + 1)
             .read_to_end(&mut content)
-            .map_err(|_| CodeExecutionError::Sandbox("could not read the workspace file".into()))?;
+            .map_err(|_| ExecError::Sandbox("could not read the workspace file".into()))?;
         if content.len() > MAX_WORKSPACE_FILE_BYTES {
-            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+            return Err(ExecError::WorkspaceFileTooLarge);
         }
         Ok(content)
     }
@@ -680,7 +653,7 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: Option<&WorkspaceFilePath>,
-    ) -> Result<WorkspaceListing, CodeExecutionError> {
+    ) -> Result<WorkspaceListing, ExecError> {
         let workspace = self.ensured_workspace(workspace).await?;
         let base = match path {
             None => workspace,
@@ -701,23 +674,21 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
                             // The stats below only label the refusal; they are
                             // not what enforced it.
                             if error.kind() == std::io::ErrorKind::NotFound {
-                                return Err(CodeExecutionError::WorkspaceFileNotFound);
+                                return Err(ExecError::WorkspaceFileNotFound);
                             }
                             if base.is_symlink(component).await {
-                                return Err(CodeExecutionError::Sandbox(
+                                return Err(ExecError::Sandbox(
                                     "workspace path escaped the private workspace".into(),
                                 ));
                             }
                             if index + 1 == components.len()
                                 && base.file_stamp(component).await.is_some()
                             {
-                                return Err(CodeExecutionError::InvalidRequest(
+                                return Err(ExecError::InvalidRequest(
                                     "workspace path is not a directory".into(),
                                 ));
                             }
-                            return Err(CodeExecutionError::Sandbox(
-                                "could not list the workspace".into(),
-                            ));
+                            return Err(ExecError::Sandbox("could not list the workspace".into()));
                         }
                     };
                 }
@@ -728,7 +699,7 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
         for entry in base
             .entries()
             .await
-            .map_err(|_| CodeExecutionError::Sandbox("could not list the workspace".into()))?
+            .map_err(|_| ExecError::Sandbox("could not list the workspace".into()))?
         {
             let (directory, size_bytes) = match entry.kind {
                 ScratchEntryKind::Directory => (true, None),
@@ -759,10 +730,10 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
     }
 }
 
-fn begin_execution(path: &Path, fingerprint: &str) -> Result<BeginExecution, CodeExecutionError> {
+fn begin_execution(path: &Path, fingerprint: &str) -> Result<BeginExecution, ExecError> {
     let receipt = ExecutionReceipt::running(fingerprint);
     let bytes = serde_json::to_vec(&receipt)
-        .map_err(|_| CodeExecutionError::Sandbox("could not encode receipt".into()))?;
+        .map_err(|_| ExecError::Sandbox("could not encode receipt".into()))?;
     begin_execution_with_persistence(path, fingerprint, |file| {
         file.write_all(&bytes).and_then(|()| file.sync_all())
     })
@@ -772,10 +743,10 @@ fn begin_execution_with_persistence(
     path: &Path,
     fingerprint: &str,
     persist: impl FnOnce(&mut fs::File) -> std::io::Result<()>,
-) -> Result<BeginExecution, CodeExecutionError> {
+) -> Result<BeginExecution, ExecError> {
     let parent = path
         .parent()
-        .ok_or_else(|| CodeExecutionError::Sandbox("execution receipt has no parent".into()))?;
+        .ok_or_else(|| ExecError::Sandbox("execution receipt has no parent".into()))?;
     let mut options = OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
@@ -785,71 +756,68 @@ fn begin_execution_with_persistence(
             if persist(&mut file).and_then(|()| sync_dir(parent)).is_err() {
                 drop(file);
                 discard_unstarted_receipt(path, parent)?;
-                return Err(CodeExecutionError::Sandbox(
-                    "could not persist receipt".into(),
-                ));
+                return Err(ExecError::Sandbox("could not persist receipt".into()));
             }
             Ok(BeginExecution::Started)
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let receipt = read_receipt(path)?;
-            receipt.replay(fingerprint, CodeExecutionError::Sandbox)
+            receipt.replay(fingerprint, ExecError::Sandbox)
         }
-        Err(_) => Err(CodeExecutionError::Sandbox(
+        Err(_) => Err(ExecError::Sandbox(
             "could not create execution receipt".into(),
         )),
     }
 }
 
-fn discard_unstarted_receipt(path: &Path, parent: &Path) -> Result<(), CodeExecutionError> {
+fn discard_unstarted_receipt(path: &Path, parent: &Path) -> Result<(), ExecError> {
     match fs::remove_file(path) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(_) => {
-            return Err(CodeExecutionError::Sandbox(
+            return Err(ExecError::Sandbox(
                 "could not clean up incomplete execution receipt".into(),
             ));
         }
     }
-    sync_dir(parent).map_err(|_| {
-        CodeExecutionError::Sandbox("could not clean up incomplete execution receipt".into())
-    })
+    sync_dir(parent)
+        .map_err(|_| ExecError::Sandbox("could not clean up incomplete execution receipt".into()))
 }
 
-fn read_receipt(path: &Path) -> Result<ExecutionReceipt, CodeExecutionError> {
+fn read_receipt(path: &Path) -> Result<ExecutionReceipt, ExecError> {
     let file = fs::File::open(path)
-        .map_err(|_| CodeExecutionError::Sandbox("could not read execution receipt".into()))?;
+        .map_err(|_| ExecError::Sandbox("could not read execution receipt".into()))?;
     if file
         .metadata()
-        .map_err(|_| CodeExecutionError::Sandbox("could not inspect execution receipt".into()))?
+        .map_err(|_| ExecError::Sandbox("could not inspect execution receipt".into()))?
         .len()
         > MAX_RECEIPT_BYTES
     {
-        return Err(CodeExecutionError::Sandbox(
+        return Err(ExecError::Sandbox(
             "execution receipt exceeds its bound".into(),
         ));
     }
     let mut bytes = Vec::new();
     file.take(MAX_RECEIPT_BYTES + 1)
         .read_to_end(&mut bytes)
-        .map_err(|_| CodeExecutionError::Sandbox("could not read execution receipt".into()))?;
+        .map_err(|_| ExecError::Sandbox("could not read execution receipt".into()))?;
     serde_json::from_slice(&bytes)
-        .map_err(|_| CodeExecutionError::Sandbox("execution receipt is invalid".into()))
+        .map_err(|_| ExecError::Sandbox("execution receipt is invalid".into()))
 }
 
-fn finish_execution(path: &Path, receipt: &ExecutionReceipt) -> Result<(), CodeExecutionError> {
+fn finish_execution(path: &Path, receipt: &ExecutionReceipt) -> Result<(), ExecError> {
     let parent = path
         .parent()
-        .ok_or_else(|| CodeExecutionError::Sandbox("execution receipt has no parent".into()))?;
+        .ok_or_else(|| ExecError::Sandbox("execution receipt has no parent".into()))?;
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
-        .ok_or_else(|| CodeExecutionError::Sandbox("execution receipt name is invalid".into()))?;
+        .ok_or_else(|| ExecError::Sandbox("execution receipt name is invalid".into()))?;
     let temporary = parent.join(format!(".{file_name}.terminal"));
     let bytes = serde_json::to_vec(receipt)
-        .map_err(|_| CodeExecutionError::Sandbox("could not encode receipt".into()))?;
+        .map_err(|_| ExecError::Sandbox("could not encode receipt".into()))?;
     if bytes.len() as u64 > MAX_RECEIPT_BYTES {
-        return Err(CodeExecutionError::Sandbox(
+        return Err(ExecError::Sandbox(
             "execution receipt exceeds its bound".into(),
         ));
     }
@@ -859,12 +827,12 @@ fn finish_execution(path: &Path, receipt: &ExecutionReceipt) -> Result<(), CodeE
     options.mode(0o600);
     let mut file = options
         .open(&temporary)
-        .map_err(|_| CodeExecutionError::AmbiguousExecution)?;
+        .map_err(|_| ExecError::AmbiguousExecution)?;
     file.write_all(&bytes)
         .and_then(|()| file.sync_all())
-        .map_err(|_| CodeExecutionError::AmbiguousExecution)?;
-    fs::rename(&temporary, path).map_err(|_| CodeExecutionError::AmbiguousExecution)?;
-    sync_dir(parent).map_err(|_| CodeExecutionError::AmbiguousExecution)
+        .map_err(|_| ExecError::AmbiguousExecution)?;
+    fs::rename(&temporary, path).map_err(|_| ExecError::AmbiguousExecution)?;
+    sync_dir(parent).map_err(|_| ExecError::AmbiguousExecution)
 }
 
 #[cfg(unix)]
@@ -877,29 +845,26 @@ fn sync_dir(_path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn secure_dir(path: &Path) -> Result<(), CodeExecutionError> {
-    fs::create_dir_all(path).map_err(|_| {
-        CodeExecutionError::Sandbox("could not create private execution storage".into())
-    })?;
-    let metadata = fs::symlink_metadata(path).map_err(|_| {
-        CodeExecutionError::Sandbox("could not inspect private execution storage".into())
-    })?;
+fn secure_dir(path: &Path) -> Result<(), ExecError> {
+    fs::create_dir_all(path)
+        .map_err(|_| ExecError::Sandbox("could not create private execution storage".into()))?;
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|_| ExecError::Sandbox("could not inspect private execution storage".into()))?;
     if !metadata.is_dir() || metadata.file_type().is_symlink() {
-        return Err(CodeExecutionError::Sandbox(
+        return Err(ExecError::Sandbox(
             "private execution storage is not a regular directory".into(),
         ));
     }
     #[cfg(unix)]
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700)).map_err(|_| {
-        CodeExecutionError::Sandbox("could not secure private execution storage".into())
-    })?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|_| ExecError::Sandbox("could not secure private execution storage".into()))?;
     Ok(())
 }
 
 #[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 async fn run_native(
-    request: &CodeExecutionRequest,
+    request: &ExecRequest,
     workspace: &Path,
     cwd: &Path,
     env_home: &Path,
@@ -909,7 +874,7 @@ async fn run_native(
     managed_node_dir: Option<&Path>,
     folder_grants: &[CanonicalExecFolderGrant],
     network_policy: &NetworkPolicy,
-) -> Result<CodeExecutionResponse, CodeExecutionError> {
+) -> Result<ExecResponse, ExecError> {
     let broker = if matches!(network_policy, NetworkPolicy::Off) {
         None
     } else {
@@ -972,23 +937,23 @@ async fn run_native(
     configure_unix_limits(&mut command, timeout);
 
     let started = Instant::now();
-    let mut child = command.spawn().map_err(|_| CodeExecutionError::Spawn)?;
+    let mut child = command.spawn().map_err(|_| ExecError::Spawn)?;
     let process_group = child.id().map(|id| id as i32);
     let stdout = child
         .stdout
         .take()
-        .ok_or_else(|| CodeExecutionError::Sandbox("stdout capture is unavailable".into()))?;
+        .ok_or_else(|| ExecError::Sandbox("stdout capture is unavailable".into()))?;
     let stderr = child
         .stderr
         .take()
-        .ok_or_else(|| CodeExecutionError::Sandbox("stderr capture is unavailable".into()))?;
+        .ok_or_else(|| ExecError::Sandbox("stderr capture is unavailable".into()))?;
     let capture = Arc::new(Mutex::new(Capture::default()));
     let stdout_reader = tokio::spawn(drain_output(stdout, capture.clone(), StreamKind::Stdout));
     let stderr_reader = tokio::spawn(drain_output(stderr, capture.clone(), StreamKind::Stderr));
 
     let (status, timed_out) = match tokio::time::timeout(timeout, child.wait()).await {
         Ok(waited) => (
-            waited.map_err(|_| CodeExecutionError::Sandbox("could not wait for command".into()))?,
+            waited.map_err(|_| ExecError::Sandbox("could not wait for command".into()))?,
             false,
         ),
         Err(_) => {
@@ -1000,13 +965,13 @@ async fn run_native(
                 child
                     .kill()
                     .await
-                    .map_err(|_| CodeExecutionError::Sandbox("could not stop command".into()))?;
+                    .map_err(|_| ExecError::Sandbox("could not stop command".into()))?;
             }
             (
                 child
                     .wait()
                     .await
-                    .map_err(|_| CodeExecutionError::Sandbox("could not reap command".into()))?,
+                    .map_err(|_| ExecError::Sandbox("could not reap command".into()))?,
                 true,
             )
         }
@@ -1020,18 +985,13 @@ async fn run_native(
     finish_reader(stderr_reader).await;
 
     let capture = std::mem::take(&mut *capture.lock().unwrap());
-    Ok(capture.response(
-        CodeExecutionProviderKind::Local,
-        started,
-        status.code(),
-        timed_out,
-    ))
+    Ok(capture.response(ExecProviderKind::Local, started, status.code(), timed_out))
 }
 
 #[cfg(not(target_os = "macos"))]
 #[allow(clippy::too_many_arguments)]
 async fn run_native(
-    _request: &CodeExecutionRequest,
+    _request: &ExecRequest,
     _workspace: &Path,
     _cwd: &Path,
     _env_home: &Path,
@@ -1041,8 +1001,8 @@ async fn run_native(
     _managed_node_dir: Option<&Path>,
     _folder_grants: &[()],
     _network_policy: &NetworkPolicy,
-) -> Result<CodeExecutionResponse, CodeExecutionError> {
-    Err(CodeExecutionError::Unavailable(
+) -> Result<ExecResponse, ExecError> {
+    Err(ExecError::Unavailable(
         "native local sandboxing is not supported on this host".into(),
     ))
 }
@@ -1136,7 +1096,7 @@ fn sandbox_path(developer_dir: Option<&Path>, managed_node_dir: Option<&Path>) -
 
 #[cfg(target_os = "macos")]
 fn direct_denied_host_path(
-    request: &CodeExecutionRequest,
+    request: &ExecRequest,
     workspace: &Path,
     env_home: &Path,
     document_scripts_dir: Option<&Path>,
@@ -1170,7 +1130,7 @@ fn annotate_seatbelt_access_denial(
     shared_package_cache: Option<&Path>,
     managed_node_dir: Option<&Path>,
     folder_grants: &[CanonicalExecFolderGrant],
-    response: &mut CodeExecutionResponse,
+    response: &mut ExecResponse,
 ) {
     if response.stdout.contains(SANDBOX_PATH_DENIED_CODE)
         || response.stderr.contains(SANDBOX_PATH_DENIED_CODE)
@@ -1525,7 +1485,7 @@ fn macos_profile(
     managed_node_dir: Option<&Path>,
     folder_grants: &[CanonicalExecFolderGrant],
     broker_port: Option<u16>,
-) -> Result<String, CodeExecutionError> {
+) -> Result<String, ExecError> {
     const RUNTIME_ANCESTORS: &[&str] = &[
         "/Applications",
         "/Applications/Xcode.app",
@@ -1650,7 +1610,7 @@ fn macos_profile(
 #[cfg(target_os = "macos")]
 fn sandbox_metadata_ancestors<'a>(
     paths: impl IntoIterator<Item = &'a Path>,
-) -> Result<String, CodeExecutionError> {
+) -> Result<String, ExecError> {
     let mut ancestors = paths
         .into_iter()
         .flat_map(|path| path.ancestors().skip(1))
@@ -1667,7 +1627,7 @@ fn sandbox_metadata_ancestors<'a>(
 #[cfg(target_os = "macos")]
 fn canonicalize_folder_grants(
     grants: &[ExecFolderGrant],
-) -> Result<Vec<CanonicalExecFolderGrant>, CodeExecutionError> {
+) -> Result<Vec<CanonicalExecFolderGrant>, ExecError> {
     let mut canonical = Vec::<CanonicalExecFolderGrant>::new();
     for grant in grants {
         let path = canonicalize_grant_directory(&grant.path)?;
@@ -1701,21 +1661,20 @@ fn canonicalize_folder_grants(
 }
 
 #[cfg(target_os = "macos")]
-fn canonicalize_grant_directory(path: &Path) -> Result<PathBuf, CodeExecutionError> {
+fn canonicalize_grant_directory(path: &Path) -> Result<PathBuf, ExecError> {
     let metadata = fs::symlink_metadata(path)
-        .map_err(|_| CodeExecutionError::Sandbox("granted folder is unavailable".into()))?;
+        .map_err(|_| ExecError::Sandbox("granted folder is unavailable".into()))?;
     if metadata.file_type().is_symlink() {
-        return Err(CodeExecutionError::Sandbox(
+        return Err(ExecError::Sandbox(
             "granted folder must not be a symbolic link".into(),
         ));
     }
     if !metadata.is_dir() {
-        return Err(CodeExecutionError::Sandbox(
+        return Err(ExecError::Sandbox(
             "granted folder is not a directory".into(),
         ));
     }
-    fs::canonicalize(path)
-        .map_err(|_| CodeExecutionError::Sandbox("granted folder is unavailable".into()))
+    fs::canonicalize(path).map_err(|_| ExecError::Sandbox("granted folder is unavailable".into()))
 }
 
 #[cfg(target_os = "macos")]
@@ -1742,13 +1701,13 @@ fn sbpl_subpath(path: &str) -> String {
 }
 
 #[cfg(target_os = "macos")]
-fn sandbox_subpath(path: &Path) -> Result<String, CodeExecutionError> {
-    crate::sbpl::subpath(path).map_err(|error| CodeExecutionError::Sandbox(error.to_string()))
+fn sandbox_subpath(path: &Path) -> Result<String, ExecError> {
+    crate::sbpl::subpath(path).map_err(|error| ExecError::Sandbox(error.to_string()))
 }
 
 #[cfg(target_os = "macos")]
-fn sandbox_literal(path: &Path) -> Result<String, CodeExecutionError> {
-    crate::sbpl::literal(path).map_err(|error| CodeExecutionError::Sandbox(error.to_string()))
+fn sandbox_literal(path: &Path) -> Result<String, ExecError> {
+    crate::sbpl::literal(path).map_err(|error| ExecError::Sandbox(error.to_string()))
 }
 
 #[cfg(test)]
@@ -1810,8 +1769,8 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
-    fn request(workspace: &str, execution: &str, script: &str) -> CodeExecutionRequest {
-        CodeExecutionRequest::new(
+    fn request(workspace: &str, execution: &str, script: &str) -> ExecRequest {
+        ExecRequest::new(
             ExecutionId::parse(execution).unwrap(),
             ExecutionWorkspaceId::parse(workspace).unwrap(),
             "/bin/sh",
@@ -1841,7 +1800,7 @@ mod tests {
             vec![ExecFolderGrant::new(&connected_path, ExecFolderAccess::ReadOnly).unwrap()];
 
         let denied_path = "/tmp/sentinel-denied-path-do-not-leak.md";
-        let denied = CodeExecutionRequest::new(
+        let denied = ExecRequest::new(
             ExecutionId::parse("call-denied-path").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/bin/cat",
@@ -1855,7 +1814,7 @@ mod tests {
         let first = provider.execute(denied.clone()).await.unwrap();
         let replay = provider.execute(denied).await.unwrap();
         assert_eq!(first, replay);
-        assert_eq!(first.provider, CodeExecutionProviderKind::Local);
+        assert_eq!(first.provider, ExecProviderKind::Local);
         assert_eq!(first.exit_code, Some(126));
         assert!(first.stderr.contains(SANDBOX_PATH_DENIED_CODE));
         assert!(first.stderr.contains("available capabilities"));
@@ -1868,7 +1827,7 @@ mod tests {
             .contains("sentinel-connected-folder-do-not-leak"));
         assert!(!first.stderr.contains(&connected_path.display().to_string()));
 
-        let changed = CodeExecutionRequest::new(
+        let changed = ExecRequest::new(
             ExecutionId::parse("call-denied-path").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/bin/cat",
@@ -1878,10 +1837,10 @@ mod tests {
         .unwrap();
         assert!(matches!(
             provider.execute(changed).await.unwrap_err(),
-            CodeExecutionError::IdentityConflict
+            ExecError::IdentityConflict
         ));
 
-        let missing = CodeExecutionRequest::new(
+        let missing = ExecRequest::new(
             ExecutionId::parse("call-missing-workspace-file").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/bin/cat",
@@ -1931,7 +1890,7 @@ mod tests {
             .join("sentinel-dynamic-connected-folder-do-not-leak");
         fs::create_dir(&connected).unwrap();
         let connected = fs::canonicalize(connected).unwrap();
-        let request = CodeExecutionRequest::new(
+        let request = ExecRequest::new(
             ExecutionId::parse("call-dynamic-python-denied-path").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/usr/bin/python3",
@@ -1999,7 +1958,7 @@ mod tests {
         let (_root, provider, workspace) = fixture(Duration::from_secs(3));
         let denied_path = "/tmp/sentinel-caught-python-denied-path-do-not-leak";
         let script = "try:\n    open('/' + 'tmp' + '/sentinel-caught-python-denied-path-do-not-leak').read()\nexcept PermissionError as error:\n    print(error)\n    raise SystemExit(19)";
-        let request = CodeExecutionRequest::new(
+        let request = ExecRequest::new(
             ExecutionId::parse("call-caught-python-denied-path").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/usr/bin/python3",
@@ -2024,7 +1983,7 @@ mod tests {
         let (_root, provider, workspace) = fixture(Duration::from_secs(3));
         let denied_path = "/tmp/sentinel-caught-success-denied-path-do-not-leak";
         let script = "path = '/' + 'tmp' + '/sentinel-caught-success-denied-path-do-not-leak'\ntry:\n    open(path).read()\nexcept PermissionError:\n    print(f'Operation not permitted: x{path}')";
-        let request = CodeExecutionRequest::new(
+        let request = ExecRequest::new(
             ExecutionId::parse("call-caught-success-python-denied-path").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/usr/bin/python3",
@@ -2053,7 +2012,7 @@ try:
     open(path).read()
 except PermissionError as error:
     print("Operation not permitted: https://" + error.filename)"#;
-        let request = CodeExecutionRequest::new(
+        let request = ExecRequest::new(
             ExecutionId::parse("call-malformed-url-denied-path").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/usr/bin/python3",
@@ -2100,7 +2059,7 @@ except PermissionError as error:
         ];
 
         for (execution_id, script, sentinel) in cases {
-            let request = CodeExecutionRequest::new(
+            let request = ExecRequest::new(
                 ExecutionId::parse(execution_id).unwrap(),
                 ExecutionWorkspaceId::parse(&workspace).unwrap(),
                 "/usr/bin/python3",
@@ -2137,7 +2096,7 @@ try:
     open(path).read()
 except PermissionError as error:
     print("Operation not permitted: file://" + error.filename, file=sys.stderr)"#;
-        let request = CodeExecutionRequest::new(
+        let request = ExecRequest::new(
             ExecutionId::parse("call-file-url-denied-path").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/usr/bin/python3",
@@ -2162,7 +2121,7 @@ except PermissionError as error:
         let (_root, provider, workspace) = fixture(Duration::from_secs(3));
         let denied_path = "/tmp/sentinel-cross-channel-denied-path-do-not-leak";
         let script = "import sys\npath = '/' + 'tmp' + '/sentinel-cross-channel-denied-path-do-not-leak'\ntry:\n    open(path).read()\nexcept PermissionError:\n    print('Operation not permitted')\n    print(f'x{path}', file=sys.stderr)\n    raise SystemExit(29)";
-        let request = CodeExecutionRequest::new(
+        let request = ExecRequest::new(
             ExecutionId::parse("call-cross-channel-python-denied-path").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/usr/bin/python3",
@@ -2284,7 +2243,7 @@ path = os.path.join(os.getcwd(), "allowed.txt")
 print('Operation not permitted: "' + path.replace("/", "\\/") + '"')
 print("Operation not permitted: https://example.com/tmp/sentinel-url-path")
 print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sys.stderr)"#;
-        let request = CodeExecutionRequest::new(
+        let request = ExecRequest::new(
             ExecutionId::parse("call-successful-allowed-path-diagnostic").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/usr/bin/python3",
@@ -2318,7 +2277,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
         let connected = tempfile::tempdir().unwrap();
         let connected_path = fs::canonicalize(connected.path()).unwrap();
         let missing = connected_path.join("incident-notes.md");
-        let request = CodeExecutionRequest::new(
+        let request = ExecRequest::new(
             ExecutionId::parse("call-connected-missing").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/bin/cat",
@@ -2348,7 +2307,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
         let workspace_path = fs::canonicalize(root.path().join(&workspace)).unwrap();
         fs::create_dir(workspace_path.join("nested")).unwrap();
         let in_workspace = workspace_path.join("nested/../incident-notes.md");
-        let missing = CodeExecutionRequest::new(
+        let missing = ExecRequest::new(
             ExecutionId::parse("call-absolute-workspace-missing").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/bin/cat",
@@ -2363,7 +2322,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
 
         let outside = tempfile::tempdir().unwrap();
         symlink(outside.path(), workspace_path.join("escaped")).unwrap();
-        let escaped = CodeExecutionRequest::new(
+        let escaped = ExecRequest::new(
             ExecutionId::parse("call-workspace-symlink-escape").unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
             "/bin/cat",
@@ -2434,7 +2393,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
                 eprintln!("skipping {command}: host interpreter unusable in this environment");
                 continue;
             }
-            let python = CodeExecutionRequest::new(
+            let python = ExecRequest::new(
                 ExecutionId::parse(execution).unwrap(),
                 ExecutionWorkspaceId::parse("chat-1").unwrap(),
                 command,
@@ -2561,7 +2520,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
             .execute(request(&workspace, "call-conflict", "printf two"))
             .await
             .unwrap_err();
-        assert!(matches!(conflict, CodeExecutionError::IdentityConflict));
+        assert!(matches!(conflict, ExecError::IdentityConflict));
     }
 
     #[tokio::test]
@@ -2610,7 +2569,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
             provider
                 .get_workspace_file(&workspace, &WorkspaceFilePath::parse("missing").unwrap())
                 .await,
-            Err(CodeExecutionError::WorkspaceFileNotFound)
+            Err(ExecError::WorkspaceFileNotFound)
         ));
         assert!(matches!(
             provider
@@ -2620,7 +2579,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
                     &vec![0_u8; crate::MAX_WORKSPACE_FILE_BYTES + 1],
                 )
                 .await,
-            Err(CodeExecutionError::WorkspaceFileTooLarge)
+            Err(ExecError::WorkspaceFileTooLarge)
         ));
 
         // A symlink planted in the workspace must never let a read escape it,
@@ -2695,7 +2654,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
             .get_workspace_file(&workspace, &WorkspaceFilePath::parse("leak.txt").unwrap())
             .await;
         assert!(
-            matches!(leak, Err(CodeExecutionError::InvalidRequest(_))),
+            matches!(leak, Err(ExecError::InvalidRequest(_))),
             "no-follow read must refuse a symlink, got {leak:?}"
         );
 
@@ -2758,7 +2717,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
             Ok(_) => panic!("injected persistence failure unexpectedly succeeded"),
         };
 
-        assert!(matches!(error, CodeExecutionError::Sandbox(_)));
+        assert!(matches!(error, ExecError::Sandbox(_)));
         assert!(
             !path.exists(),
             "an unstarted partial claim must not block retries"

--- a/crates/tidebreak-code-execution/src/network.rs
+++ b/crates/tidebreak-code-execution/src/network.rs
@@ -18,7 +18,7 @@ use tokio::sync::Semaphore;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::Instant;
 
-use crate::{CodeExecutionError, PACKAGE_MANAGER_DOMAINS};
+use crate::{ExecError, PACKAGE_MANAGER_DOMAINS};
 
 const MAX_CONNECT_HEADERS: usize = 16 * 1024;
 const MAX_CONCURRENT_CONNECTIONS: usize = 32;
@@ -34,15 +34,13 @@ pub(crate) struct LocalEgressBroker {
 }
 
 impl LocalEgressBroker {
-    pub(crate) async fn start(policy: NetworkPolicy) -> Result<Self, CodeExecutionError> {
+    pub(crate) async fn start(policy: NetworkPolicy) -> Result<Self, ExecError> {
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
             .await
-            .map_err(|_| {
-                CodeExecutionError::Sandbox("could not bind the local egress broker".into())
-            })?;
-        let address = listener.local_addr().map_err(|_| {
-            CodeExecutionError::Sandbox("could not inspect the local egress broker".into())
-        })?;
+            .map_err(|_| ExecError::Sandbox("could not bind the local egress broker".into()))?;
+        let address = listener
+            .local_addr()
+            .map_err(|_| ExecError::Sandbox("could not inspect the local egress broker".into()))?;
         let task = tokio::spawn(serve(listener, policy));
         Ok(Self { address, task })
     }

--- a/crates/tidebreak-code-execution/src/output.rs
+++ b/crates/tidebreak-code-execution/src/output.rs
@@ -2,9 +2,7 @@ use std::time::Instant;
 
 use base64::Engine as _;
 
-use crate::{
-    CodeExecutionError, CodeExecutionProviderKind, CodeExecutionResponse, MAX_CAPTURE_BYTES,
-};
+use crate::{ExecError, ExecProviderKind, ExecResponse, MAX_CAPTURE_BYTES};
 
 #[derive(Clone, Copy)]
 pub(crate) enum StreamKind {
@@ -38,13 +36,11 @@ impl Capture {
         value: &str,
         kind: StreamKind,
         provider: &str,
-    ) -> Result<(), CodeExecutionError> {
+    ) -> Result<(), ExecError> {
         let decoded = base64::engine::general_purpose::STANDARD
             .decode(value)
             .map_err(|_| {
-                CodeExecutionError::Unavailable(format!(
-                    "{provider} returned invalid encoded output"
-                ))
+                ExecError::Unavailable(format!("{provider} returned invalid encoded output"))
             })?;
         self.append(&decoded, kind);
         Ok(())
@@ -52,12 +48,12 @@ impl Capture {
 
     pub(crate) fn response(
         self,
-        provider: CodeExecutionProviderKind,
+        provider: ExecProviderKind,
         started: Instant,
         exit_code: Option<i32>,
         timed_out: bool,
-    ) -> CodeExecutionResponse {
-        CodeExecutionResponse {
+    ) -> ExecResponse {
+        ExecResponse {
             provider,
             exit_code,
             stdout: String::from_utf8_lossy(&self.stdout).into_owned(),

--- a/crates/tidebreak-code-execution/src/package_cache.rs
+++ b/crates/tidebreak-code-execution/src/package_cache.rs
@@ -39,7 +39,7 @@ use std::time::{Duration, SystemTime};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::CodeExecutionError;
+use crate::ExecError;
 
 /// Dotted sibling of the per-chat workspaces at the scratch root, like the
 /// receipt and env-home directories: file tools and provider sync never see it.
@@ -93,8 +93,8 @@ struct ManifestEntry {
     promoted_at: u64,
 }
 
-fn cache_error(message: impl Into<String>) -> CodeExecutionError {
-    CodeExecutionError::Sandbox(message.into())
+fn cache_error(message: impl Into<String>) -> ExecError {
+    ExecError::Sandbox(message.into())
 }
 
 /// Whether `key` is a well-formed runtime key: bounded, lowercase
@@ -127,7 +127,7 @@ fn is_valid_artifact_name(name: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b'+'))
 }
 
-fn secure_dir(path: &Path) -> Result<(), CodeExecutionError> {
+fn secure_dir(path: &Path) -> Result<(), ExecError> {
     fs::create_dir_all(path)
         .map_err(|_| cache_error("could not create the shared package cache"))?;
     let metadata = fs::symlink_metadata(path)
@@ -174,7 +174,7 @@ fn unix_now() -> u64 {
 impl SharedPackageCache {
     /// Open (creating if needed) the cache keyspace for one runtime key under
     /// `cache_root`. The root and keyspace are host-owned `0o700` directories.
-    pub fn open(cache_root: &Path, runtime_key: &str) -> Result<Self, CodeExecutionError> {
+    pub fn open(cache_root: &Path, runtime_key: &str) -> Result<Self, ExecError> {
         if !is_valid_runtime_key(runtime_key) {
             return Err(cache_error("shared package cache runtime key is invalid"));
         }
@@ -274,7 +274,7 @@ impl SharedPackageCache {
             .collect()
     }
 
-    fn store_populated_pins(&self, sets: &[Vec<String>]) -> Result<(), CodeExecutionError> {
+    fn store_populated_pins(&self, sets: &[Vec<String>]) -> Result<(), ExecError> {
         let bytes = serde_json::to_vec_pretty(sets)
             .map_err(|_| cache_error("could not encode populated package cache pins"))?;
         let temporary = self.runtime_dir.join(format!(".{POPULATED_PINS_FILE}.tmp"));
@@ -283,7 +283,7 @@ impl SharedPackageCache {
             .map_err(|_| cache_error("could not persist populated package cache pins"))
     }
 
-    fn store_manifest(&self, manifest: &Manifest) -> Result<(), CodeExecutionError> {
+    fn store_manifest(&self, manifest: &Manifest) -> Result<(), ExecError> {
         let bytes = serde_json::to_vec_pretty(manifest)
             .map_err(|_| cache_error("could not encode the package cache manifest"))?;
         let temporary = self.runtime_dir.join(format!(".{MANIFEST_FILE}.tmp"));
@@ -294,15 +294,12 @@ impl SharedPackageCache {
 
     /// Verify the cached artifacts against the manifest and promote staged
     /// ones, then evict down to the size bound. See [`promote_with_limits`].
-    pub fn verify_and_promote(
-        &self,
-        staging: &Path,
-    ) -> Result<PromotionReport, CodeExecutionError> {
+    pub fn verify_and_promote(&self, staging: &Path) -> Result<PromotionReport, ExecError> {
         self.promote_with_limits(Some(staging), MAX_ARTIFACT_BYTES, MAX_TOTAL_BYTES)
     }
 
     /// Re-verify every cached artifact without promoting anything.
-    pub fn verify(&self) -> Result<PromotionReport, CodeExecutionError> {
+    pub fn verify(&self) -> Result<PromotionReport, ExecError> {
         self.promote_with_limits(None, MAX_ARTIFACT_BYTES, MAX_TOTAL_BYTES)
     }
 
@@ -311,7 +308,7 @@ impl SharedPackageCache {
         staging: Option<&Path>,
         max_artifact_bytes: u64,
         max_total_bytes: u64,
-    ) -> Result<PromotionReport, CodeExecutionError> {
+    ) -> Result<PromotionReport, ExecError> {
         let wheels = self.wheels_dir();
         let mut report = PromotionReport::default();
         // Integrity-unknown manifests rebuild from empty: every unrecorded
@@ -473,7 +470,7 @@ impl SharedPackageCache {
         &self,
         python: &Path,
         pins: &[String],
-    ) -> Result<PromotionReport, CodeExecutionError> {
+    ) -> Result<PromotionReport, ExecError> {
         if pins.is_empty() || self.has_populated_pins(pins) {
             return Ok(PromotionReport::default());
         }
@@ -510,7 +507,7 @@ impl SharedPackageCache {
         pins: &[String],
         staging: &Path,
         offline: bool,
-    ) -> Result<(), CodeExecutionError> {
+    ) -> Result<(), ExecError> {
         let mut download = tokio::process::Command::new(python);
         download.args([
             "-m",

--- a/crates/tidebreak-code-execution/src/receipt.rs
+++ b/crates/tidebreak-code-execution/src/receipt.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{CodeExecutionError, CodeExecutionRequest, CodeExecutionResponse};
+use crate::{ExecError, ExecRequest, ExecResponse};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
@@ -11,7 +11,7 @@ pub(crate) enum ExecutionReceipt {
     },
     Completed {
         fingerprint: String,
-        response: CodeExecutionResponse,
+        response: ExecResponse,
     },
     Failed {
         fingerprint: String,
@@ -21,7 +21,7 @@ pub(crate) enum ExecutionReceipt {
 
 pub(crate) enum BeginExecution {
     Started,
-    Cached(CodeExecutionResponse),
+    Cached(ExecResponse),
 }
 
 impl ExecutionReceipt {
@@ -33,7 +33,7 @@ impl ExecutionReceipt {
 
     pub(crate) fn from_outcome(
         fingerprint: String,
-        outcome: &Result<CodeExecutionResponse, CodeExecutionError>,
+        outcome: &Result<ExecResponse, ExecError>,
     ) -> Self {
         match outcome {
             Ok(response) => Self::Completed {
@@ -50,14 +50,14 @@ impl ExecutionReceipt {
     pub(crate) fn replay(
         &self,
         fingerprint: &str,
-        failed_error: fn(String) -> CodeExecutionError,
-    ) -> Result<BeginExecution, CodeExecutionError> {
+        failed_error: fn(String) -> ExecError,
+    ) -> Result<BeginExecution, ExecError> {
         match self {
             Self::Running {
                 fingerprint: existing,
             } => {
                 ensure_same_fingerprint(existing, fingerprint)?;
-                Err(CodeExecutionError::AmbiguousExecution)
+                Err(ExecError::AmbiguousExecution)
             }
             Self::Completed {
                 fingerprint: existing,
@@ -77,19 +77,17 @@ impl ExecutionReceipt {
     }
 }
 
-pub(crate) fn request_fingerprint(
-    request: &CodeExecutionRequest,
-) -> Result<String, CodeExecutionError> {
+pub(crate) fn request_fingerprint(request: &ExecRequest) -> Result<String, ExecError> {
     let bytes = serde_json::to_vec(request)
-        .map_err(|_| CodeExecutionError::InvalidRequest("request is not serializable".into()))?;
+        .map_err(|_| ExecError::InvalidRequest("request is not serializable".into()))?;
     let digest = Sha256::digest(bytes);
     Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
 }
 
-fn ensure_same_fingerprint(existing: &str, expected: &str) -> Result<(), CodeExecutionError> {
+fn ensure_same_fingerprint(existing: &str, expected: &str) -> Result<(), ExecError> {
     if existing == expected {
         Ok(())
     } else {
-        Err(CodeExecutionError::IdentityConflict)
+        Err(ExecError::IdentityConflict)
     }
 }

--- a/crates/tidebreak-code-execution/src/remote.rs
+++ b/crates/tidebreak-code-execution/src/remote.rs
@@ -9,8 +9,8 @@ use tokio::sync::Mutex;
 
 use crate::receipt::{request_fingerprint, BeginExecution, ExecutionReceipt};
 use crate::{
-    CodeExecutionError, CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse,
-    StagedUpload, WorkspaceFilePath, WorkspaceListing,
+    ExecError, ExecProviderKind, ExecRequest, ExecResponse, StagedUpload, WorkspaceFilePath,
+    WorkspaceListing,
 };
 
 /// How long a receipt left in `Running` keeps reporting the execution as
@@ -155,14 +155,14 @@ struct StagedDigests {
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct SessionKey {
-    provider: CodeExecutionProviderKind,
+    provider: ExecProviderKind,
     credential: [u8; 32],
     workspace_id: String,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct ReceiptKey {
-    provider: CodeExecutionProviderKind,
+    provider: ExecProviderKind,
     execution_id: String,
 }
 
@@ -208,18 +208,18 @@ pub(crate) fn egress_policy_fingerprint(policy: Option<&EgressPolicy>) -> [u8; 3
 
 pub(crate) enum RemoteSessionError {
     Missing,
-    Provider(CodeExecutionError),
+    Provider(ExecError),
 }
 
-impl From<CodeExecutionError> for RemoteSessionError {
-    fn from(error: CodeExecutionError) -> Self {
+impl From<ExecError> for RemoteSessionError {
+    fn from(error: ExecError) -> Self {
         Self::Provider(error)
     }
 }
 
 #[async_trait]
 pub(crate) trait RemoteSandboxAdapter: Send + Sync {
-    fn kind(&self) -> CodeExecutionProviderKind;
+    fn kind(&self) -> ExecProviderKind;
     fn credential_fingerprint(&self) -> [u8; 32];
 
     /// Fingerprint of the egress policy this adapter compiles into sandbox
@@ -228,22 +228,21 @@ pub(crate) trait RemoteSandboxAdapter: Send + Sync {
     /// and must be replaced rather than reused.
     fn egress_fingerprint(&self) -> [u8; 32];
 
-    async fn create_session(&self, workspace_id: &str)
-        -> Result<RemoteSession, CodeExecutionError>;
+    async fn create_session(&self, workspace_id: &str) -> Result<RemoteSession, ExecError>;
 
     /// Destroy the remote sandbox. A sandbox that is already gone is success.
-    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError>;
+    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), ExecError>;
 
     async fn reconnect_session(
         &self,
         session: &RemoteSession,
-    ) -> Result<Option<RemoteSession>, CodeExecutionError>;
+    ) -> Result<Option<RemoteSession>, ExecError>;
 
     async fn run_command(
         &self,
         session: &RemoteSession,
-        request: &CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, RemoteSessionError>;
+        request: &ExecRequest,
+    ) -> Result<ExecResponse, RemoteSessionError>;
 }
 
 /// Vendor file and teardown transports behind the shared workspace lifecycle.
@@ -272,9 +271,9 @@ pub(crate) trait RemoteWorkspaceAdapter: RemoteSandboxAdapter {
 impl RemoteSessionPool {
     async fn begin_execution(
         &self,
-        provider: CodeExecutionProviderKind,
-        request: &CodeExecutionRequest,
-    ) -> Result<BeginExecution, CodeExecutionError> {
+        provider: ExecProviderKind,
+        request: &ExecRequest,
+    ) -> Result<BeginExecution, ExecError> {
         let fingerprint = request_fingerprint(request)?;
         let key = ReceiptKey {
             provider,
@@ -290,18 +289,16 @@ impl RemoteSessionPool {
                 );
                 Ok(BeginExecution::Started)
             }
-            Some(entry) => entry
-                .receipt
-                .replay(&fingerprint, CodeExecutionError::Unavailable),
+            Some(entry) => entry.receipt.replay(&fingerprint, ExecError::Unavailable),
         }
     }
 
     async fn finish_execution(
         &self,
-        provider: CodeExecutionProviderKind,
-        request: &CodeExecutionRequest,
-        outcome: &Result<CodeExecutionResponse, CodeExecutionError>,
-    ) -> Result<(), CodeExecutionError> {
+        provider: ExecProviderKind,
+        request: &ExecRequest,
+        outcome: &Result<ExecResponse, ExecError>,
+    ) -> Result<(), ExecError> {
         let key = ReceiptKey {
             provider,
             execution_id: request.execution_id.as_str().to_owned(),
@@ -317,7 +314,7 @@ impl RemoteSessionPool {
 
     async fn session(
         &self,
-        provider: CodeExecutionProviderKind,
+        provider: ExecProviderKind,
         credential: [u8; 32],
         workspace_id: &str,
     ) -> Arc<Mutex<Option<PooledSession>>> {
@@ -428,8 +425,8 @@ impl RemoteSessionPool {
 pub(crate) async fn execute_remote(
     adapter: &dyn RemoteSandboxAdapter,
     pool: &RemoteSessionPool,
-    request: CodeExecutionRequest,
-) -> Result<CodeExecutionResponse, CodeExecutionError> {
+    request: ExecRequest,
+) -> Result<ExecResponse, ExecError> {
     request.validate()?;
     let provider = adapter.kind();
     match pool.begin_execution(provider, &request).await? {
@@ -444,8 +441,8 @@ pub(crate) async fn execute_remote(
 async fn execute_uncached(
     adapter: &dyn RemoteSandboxAdapter,
     pool: &RemoteSessionPool,
-    request: &CodeExecutionRequest,
-) -> Result<CodeExecutionResponse, CodeExecutionError> {
+    request: &ExecRequest,
+) -> Result<ExecResponse, ExecError> {
     with_remote_session(
         adapter,
         pool,
@@ -464,7 +461,7 @@ pub(crate) async fn with_remote_session<'a, A, T, F, Fut>(
     pool: &RemoteSessionPool,
     workspace_id: &str,
     operation: F,
-) -> Result<T, CodeExecutionError>
+) -> Result<T, ExecError>
 where
     A: RemoteSandboxAdapter + ?Sized,
     F: FnOnce(&'a A, RemoteSession) -> Fut,
@@ -483,7 +480,7 @@ where
         Ok(value) => Ok(value),
         Err(RemoteSessionError::Missing) => {
             *slot = None;
-            Err(CodeExecutionError::Unavailable(format!(
+            Err(ExecError::Unavailable(format!(
                 "{} sandbox is no longer available",
                 adapter.kind()
             )))
@@ -504,7 +501,7 @@ pub(crate) async fn stage_remote_file<A>(
     workspace_id: &str,
     path: &WorkspaceFilePath,
     content: &[u8],
-) -> Result<StagedUpload, CodeExecutionError>
+) -> Result<StagedUpload, ExecError>
 where
     A: RemoteWorkspaceAdapter + ?Sized,
 {
@@ -533,7 +530,7 @@ async fn connected_session<A>(
     adapter: &A,
     slot: &mut Option<PooledSession>,
     workspace_id: &str,
-) -> Result<RemoteSession, CodeExecutionError>
+) -> Result<RemoteSession, ExecError>
 where
     A: RemoteSandboxAdapter + ?Sized,
 {
@@ -568,7 +565,7 @@ pub(crate) async fn create_remote_workspace<A>(
     adapter: &A,
     pool: &RemoteSessionPool,
     workspace_id: &str,
-) -> Result<(), CodeExecutionError>
+) -> Result<(), ExecError>
 where
     A: RemoteSandboxAdapter + ?Sized,
 {
@@ -592,7 +589,7 @@ pub(crate) async fn connect_remote_workspace<A>(
     adapter: &A,
     pool: &RemoteSessionPool,
     workspace_id: &str,
-) -> Result<bool, CodeExecutionError>
+) -> Result<bool, ExecError>
 where
     A: RemoteSandboxAdapter + ?Sized,
 {
@@ -638,7 +635,7 @@ pub(crate) async fn destroy_remote_workspace<A>(
     adapter: &A,
     pool: &RemoteSessionPool,
     workspace_id: &str,
-) -> Result<(), CodeExecutionError>
+) -> Result<(), ExecError>
 where
     A: RemoteWorkspaceAdapter + ?Sized,
 {
@@ -700,8 +697,8 @@ mod tests {
 
     #[async_trait]
     impl RemoteSandboxAdapter for FakeAdapter {
-        fn kind(&self) -> CodeExecutionProviderKind {
-            CodeExecutionProviderKind::E2b
+        fn kind(&self) -> ExecProviderKind {
+            ExecProviderKind::E2b
         }
 
         fn credential_fingerprint(&self) -> [u8; 32] {
@@ -712,10 +709,7 @@ mod tests {
             [9; 32]
         }
 
-        async fn create_session(
-            &self,
-            _workspace_id: &str,
-        ) -> Result<RemoteSession, CodeExecutionError> {
+        async fn create_session(&self, _workspace_id: &str) -> Result<RemoteSession, ExecError> {
             Ok(RemoteSession {
                 sandbox_id: "sandbox-1".to_owned(),
                 endpoint: None,
@@ -723,10 +717,7 @@ mod tests {
             })
         }
 
-        async fn destroy_sandbox(
-            &self,
-            _session: &RemoteSession,
-        ) -> Result<(), CodeExecutionError> {
+        async fn destroy_sandbox(&self, _session: &RemoteSession) -> Result<(), ExecError> {
             self.destroys.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
@@ -734,21 +725,21 @@ mod tests {
         async fn reconnect_session(
             &self,
             session: &RemoteSession,
-        ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+        ) -> Result<Option<RemoteSession>, ExecError> {
             Ok(Some(session.clone()))
         }
 
         async fn run_command(
             &self,
             _session: &RemoteSession,
-            _request: &CodeExecutionRequest,
-        ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+            _request: &ExecRequest,
+        ) -> Result<ExecResponse, RemoteSessionError> {
             self.runs.fetch_add(1, Ordering::SeqCst);
             if self.hang.load(Ordering::SeqCst) {
                 std::future::pending::<()>().await;
             }
-            Ok(CodeExecutionResponse {
-                provider: CodeExecutionProviderKind::E2b,
+            Ok(ExecResponse {
+                provider: ExecProviderKind::E2b,
                 exit_code: Some(0),
                 stdout: "done".to_owned(),
                 stderr: String::new(),
@@ -792,8 +783,8 @@ mod tests {
         }
     }
 
-    fn request(execution: &str, workspace: &str) -> CodeExecutionRequest {
-        CodeExecutionRequest::new(
+    fn request(execution: &str, workspace: &str) -> ExecRequest {
+        ExecRequest::new(
             ExecutionId::parse(execution).unwrap(),
             ExecutionWorkspaceId::parse(workspace).unwrap(),
             "/bin/echo",
@@ -826,7 +817,7 @@ mod tests {
         adapter.hang.store(false, Ordering::SeqCst);
         let replayed = execute_remote(&adapter, &pool, request("execution-1", "workspace-1")).await;
         assert!(
-            matches!(replayed, Err(CodeExecutionError::AmbiguousExecution)),
+            matches!(replayed, Err(ExecError::AmbiguousExecution)),
             "an execution that may still be running stays ambiguous"
         );
 

--- a/crates/tidebreak-code-execution/src/sync.rs
+++ b/crates/tidebreak-code-execution/src/sync.rs
@@ -22,7 +22,7 @@ use crate::host_paths::{
     try_resolve_scratch_directory, ScratchDir, ScratchEntryKind, ScratchRefusal,
 };
 use crate::{
-    CodeExecutionError, ExecutionWorkspaceId, StagedUpload, WorkspaceFilePath, WorkspaceLifecycle,
+    ExecError, ExecutionWorkspaceId, StagedUpload, WorkspaceFilePath, WorkspaceLifecycle,
     MAX_WORKSPACE_FILE_BYTES,
 };
 
@@ -103,7 +103,7 @@ struct StagedFile {
 pub async fn validate_staged_paths(
     host_dir: &Path,
     listed: &[WorkspaceFilePath],
-) -> Result<(), CodeExecutionError> {
+) -> Result<(), ExecError> {
     resolve_staged_files(host_dir, listed).await.map(|_| ())
 }
 
@@ -117,7 +117,7 @@ pub async fn stage_listed_paths(
     workspace: &ExecutionWorkspaceId,
     host_dir: &Path,
     listed: &[WorkspaceFilePath],
-) -> Result<SyncReport, CodeExecutionError> {
+) -> Result<SyncReport, ExecError> {
     let (files, mut report) = resolve_staged_files(host_dir, listed).await?;
     for staged in files {
         let content = match staged.dir.read_file(&staged.name).await {
@@ -169,7 +169,7 @@ pub async fn stage_listed_paths(
 async fn resolve_staged_files(
     host_dir: &Path,
     listed: &[WorkspaceFilePath],
-) -> Result<(Vec<StagedFile>, SyncReport), CodeExecutionError> {
+) -> Result<(Vec<StagedFile>, SyncReport), ExecError> {
     let mut report = SyncReport::default();
     let mut files: Vec<StagedFile> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
@@ -182,7 +182,7 @@ async fn resolve_staged_files(
             .await
             .map_err(|refusal| listed_path_error(path, refusal))?;
         if parent.is_symlink(name).await {
-            return Err(CodeExecutionError::InvalidRequest(format!(
+            return Err(ExecError::InvalidRequest(format!(
                 "staged path '{}' is a symlink; symlinks are never staged",
                 path.as_str()
             )));
@@ -191,13 +191,13 @@ async fn resolve_staged_files(
             expand_directory(dir, path, &mut files, &mut seen, &mut report).await?;
         } else {
             let Some(stamp) = parent.file_stamp(name).await else {
-                return Err(CodeExecutionError::InvalidRequest(format!(
+                return Err(ExecError::InvalidRequest(format!(
                     "staged path '{}' does not exist in the chat's files",
                     path.as_str()
                 )));
             };
             if stamp.len > MAX_WORKSPACE_FILE_BYTES as u64 {
-                return Err(CodeExecutionError::InvalidRequest(format!(
+                return Err(ExecError::InvalidRequest(format!(
                     "staged path '{}' exceeds the {MAX_WORKSPACE_FILE_BYTES}-byte file limit",
                     path.as_str()
                 )));
@@ -227,7 +227,7 @@ async fn expand_directory(
     files: &mut Vec<StagedFile>,
     seen: &mut HashSet<String>,
     report: &mut SyncReport,
-) -> Result<(), CodeExecutionError> {
+) -> Result<(), ExecError> {
     let mut stack: Vec<(ScratchDir, String)> = vec![(root, listed.as_str().to_owned())];
     while let Some((dir, prefix)) = stack.pop() {
         let entries = match dir.entries().await {
@@ -320,15 +320,15 @@ async fn expand_directory(
     Ok(())
 }
 
-fn staging_bound_error(listed: &WorkspaceFilePath, count: usize) -> CodeExecutionError {
-    CodeExecutionError::InvalidRequest(format!(
+fn staging_bound_error(listed: &WorkspaceFilePath, count: usize) -> ExecError {
+    ExecError::InvalidRequest(format!(
         "staging '{}' expands the staged set past the {MAX_STAGED_FILES}-file bound \
          ({count}+ files); list fewer or more specific paths",
         listed.as_str()
     ))
 }
 
-fn listed_path_error(path: &WorkspaceFilePath, refusal: ScratchRefusal) -> CodeExecutionError {
+fn listed_path_error(path: &WorkspaceFilePath, refusal: ScratchRefusal) -> ExecError {
     let reason = match refusal {
         ScratchRefusal::Escape => "escapes the chat's files",
         ScratchRefusal::SymlinkedComponent => "crosses a symlink",
@@ -336,7 +336,7 @@ fn listed_path_error(path: &WorkspaceFilePath, refusal: ScratchRefusal) -> CodeE
             "does not exist in the chat's files"
         }
     };
-    CodeExecutionError::InvalidRequest(format!("staged path '{}' {reason}", path.as_str()))
+    ExecError::InvalidRequest(format!("staged path '{}' {reason}", path.as_str()))
 }
 
 /// Pull the `output/` and `preview/` subtrees back into `host_dir`, writing
@@ -347,7 +347,7 @@ pub async fn pull_result_dirs(
     lifecycle: &dyn WorkspaceLifecycle,
     workspace: &ExecutionWorkspaceId,
     host_dir: &Path,
-) -> Result<SyncReport, CodeExecutionError> {
+) -> Result<SyncReport, ExecError> {
     let mut report = SyncReport::default();
     let mut stack: Vec<WorkspaceFilePath> = PULLED_DIRS
         .iter()
@@ -359,7 +359,7 @@ pub async fn pull_result_dirs(
             Ok(listing) => listing,
             // A workspace with no output/ or preview/ yet has nothing to pull;
             // a directory that vanished mid-walk means the same.
-            Err(CodeExecutionError::WorkspaceFileNotFound) => continue,
+            Err(ExecError::WorkspaceFileNotFound) => continue,
             Err(error) => return Err(error),
         };
         if listing.truncated {
@@ -556,26 +556,26 @@ fn refuse(report: &mut SyncReport, path: &WorkspaceFilePath, refusal: ScratchRef
 /// host-side — an unreadable file, a directory that vanished mid-walk — and
 /// those are per-entry by nature: the next entry has every chance of
 /// succeeding, so none of them are ever fatal.
-fn aborts_the_sync(error: &CodeExecutionError) -> bool {
+fn aborts_the_sync(error: &ExecError) -> bool {
     match error {
-        CodeExecutionError::WorkspaceFileNotFound
-        | CodeExecutionError::WorkspaceFileTooLarge
-        | CodeExecutionError::InvalidRequest(_)
-        | CodeExecutionError::Sandbox(_) => false,
-        CodeExecutionError::NotConfigured
-        | CodeExecutionError::Unavailable(_)
-        | CodeExecutionError::Spawn
-        | CodeExecutionError::IdentityConflict
-        | CodeExecutionError::AmbiguousExecution => true,
+        ExecError::WorkspaceFileNotFound
+        | ExecError::WorkspaceFileTooLarge
+        | ExecError::InvalidRequest(_)
+        | ExecError::Sandbox(_) => false,
+        ExecError::NotConfigured
+        | ExecError::Unavailable(_)
+        | ExecError::Spawn
+        | ExecError::IdentityConflict
+        | ExecError::AmbiguousExecution => true,
     }
 }
 
-fn unwritable(path: &str) -> CodeExecutionError {
-    CodeExecutionError::Sandbox(format!("private scratch entry '{path}' is unwritable"))
+fn unwritable(path: &str) -> ExecError {
+    ExecError::Sandbox(format!("private scratch entry '{path}' is unwritable"))
 }
 
-fn unwritable_dir() -> CodeExecutionError {
-    CodeExecutionError::Sandbox("the private scratch directory is unwritable".into())
+fn unwritable_dir() -> ExecError {
+    ExecError::Sandbox("the private scratch directory is unwritable".into())
 }
 
 #[cfg(test)]
@@ -614,21 +614,21 @@ mod tests {
         async fn create_workspace(
             &self,
             _workspace: &ExecutionWorkspaceId,
-        ) -> Result<(), CodeExecutionError> {
+        ) -> Result<(), ExecError> {
             Ok(())
         }
 
         async fn connect_workspace(
             &self,
             _workspace: &ExecutionWorkspaceId,
-        ) -> Result<bool, CodeExecutionError> {
+        ) -> Result<bool, ExecError> {
             Ok(true)
         }
 
         async fn destroy_workspace(
             &self,
             _workspace: &ExecutionWorkspaceId,
-        ) -> Result<(), CodeExecutionError> {
+        ) -> Result<(), ExecError> {
             Ok(())
         }
 
@@ -637,7 +637,7 @@ mod tests {
             _workspace: &ExecutionWorkspaceId,
             path: &WorkspaceFilePath,
             content: &[u8],
-        ) -> Result<(), CodeExecutionError> {
+        ) -> Result<(), ExecError> {
             self.insert(path.as_str(), content);
             Ok(())
         }
@@ -646,16 +646,16 @@ mod tests {
             &self,
             _workspace: &ExecutionWorkspaceId,
             path: &WorkspaceFilePath,
-        ) -> Result<Vec<u8>, CodeExecutionError> {
+        ) -> Result<Vec<u8>, ExecError> {
             self.get(path.as_str())
-                .ok_or_else(|| CodeExecutionError::Sandbox("missing file".into()))
+                .ok_or_else(|| ExecError::Sandbox("missing file".into()))
         }
 
         async fn list_workspace_files(
             &self,
             _workspace: &ExecutionWorkspaceId,
             path: Option<&WorkspaceFilePath>,
-        ) -> Result<WorkspaceListing, CodeExecutionError> {
+        ) -> Result<WorkspaceListing, ExecError> {
             let prefix = path.map_or(String::new(), |dir| format!("{}/", dir.as_str()));
             let mut entries: Vec<WorkspaceFileEntry> = Vec::new();
             let mut seen_dirs: Vec<String> = Vec::new();

--- a/crates/tidebreak-code-execution/src/tool.rs
+++ b/crates/tidebreak-code-execution/src/tool.rs
@@ -10,20 +10,20 @@ use tidebreak_core::{
 };
 
 use crate::{
-    CodeExecutionProvider, CodeExecutionRequest, ExecutionId, ExecutionWorkspaceId, MAX_ARGUMENTS,
-    MAX_COMMAND_BYTES, MAX_CWD_BYTES, MAX_STAGED_PATHS,
+    ExecProvider, ExecRequest, ExecutionId, ExecutionWorkspaceId, MAX_ARGUMENTS, MAX_COMMAND_BYTES,
+    MAX_CWD_BYTES, MAX_STAGED_PATHS,
 };
 
 pub const EXEC_TOOL_NAME: &str = "exec";
 
 /// Model-facing command execution backed by a host-selected provider.
 pub struct ExecTool {
-    provider: Arc<dyn CodeExecutionProvider>,
+    provider: Arc<dyn ExecProvider>,
 }
 
 impl ExecTool {
     #[must_use]
-    pub fn new(provider: Arc<dyn CodeExecutionProvider>) -> Self {
+    pub fn new(provider: Arc<dyn ExecProvider>) -> Self {
         Self { provider }
     }
 }
@@ -171,7 +171,7 @@ impl Tool for ExecTool {
             Ok(id) => id,
             Err(error) => return Ok(ToolOutput::error(error.to_string())),
         };
-        let request = match CodeExecutionRequest::new(
+        let request = match ExecRequest::new(
             execution_id.clone(),
             workspace_id.clone(),
             arguments.command,
@@ -333,7 +333,7 @@ impl Tool for ExecTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CodeExecutionError, CodeExecutionProviderKind, CodeExecutionResponse};
+    use crate::{ExecError, ExecProviderKind, ExecResponse};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
@@ -341,18 +341,18 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingProvider {
-        request: Mutex<Option<CodeExecutionRequest>>,
+        request: Mutex<Option<ExecRequest>>,
     }
 
     #[async_trait]
-    impl CodeExecutionProvider for RecordingProvider {
+    impl ExecProvider for RecordingProvider {
         async fn execute(
             &self,
-            request: CodeExecutionRequest,
-        ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
+            request: ExecRequest,
+        ) -> std::result::Result<ExecResponse, ExecError> {
             *self.request.lock().unwrap() = Some(request);
-            Ok(CodeExecutionResponse {
-                provider: CodeExecutionProviderKind::Local,
+            Ok(ExecResponse {
+                provider: ExecProviderKind::Local,
                 exit_code: Some(0),
                 stdout: "ok\n".into(),
                 stderr: String::new(),
@@ -432,13 +432,13 @@ mod tests {
     struct TimedOutProvider;
 
     #[async_trait]
-    impl CodeExecutionProvider for TimedOutProvider {
+    impl ExecProvider for TimedOutProvider {
         async fn execute(
             &self,
-            _request: CodeExecutionRequest,
-        ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
-            Ok(CodeExecutionResponse {
-                provider: CodeExecutionProviderKind::Local,
+            _request: ExecRequest,
+        ) -> std::result::Result<ExecResponse, ExecError> {
+            Ok(ExecResponse {
+                provider: ExecProviderKind::Local,
                 exit_code: None,
                 stdout: String::new(),
                 stderr: String::new(),
@@ -484,13 +484,13 @@ mod tests {
     }
 
     #[async_trait]
-    impl CodeExecutionProvider for PreviewProvider {
+    impl ExecProvider for PreviewProvider {
         async fn execute(
             &self,
-            _request: CodeExecutionRequest,
-        ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
-            Ok(CodeExecutionResponse {
-                provider: CodeExecutionProviderKind::Local,
+            _request: ExecRequest,
+        ) -> std::result::Result<ExecResponse, ExecError> {
+            Ok(ExecResponse {
+                provider: ExecProviderKind::Local,
                 exit_code: Some(self.exit_code),
                 stdout: String::new(),
                 stderr: String::new(),
@@ -505,7 +505,7 @@ mod tests {
         async fn collect_preview_images(
             &self,
             _workspace: &ExecutionWorkspaceId,
-        ) -> std::result::Result<crate::PreviewScan, CodeExecutionError> {
+        ) -> std::result::Result<crate::PreviewScan, ExecError> {
             self.scans.fetch_add(1, Ordering::SeqCst);
             let bytes = vec![1, 2, 3];
             let image = tidebreak_core::ImageRef {
@@ -531,13 +531,13 @@ mod tests {
     }
 
     #[async_trait]
-    impl CodeExecutionProvider for ArtifactProvider {
+    impl ExecProvider for ArtifactProvider {
         async fn execute(
             &self,
-            _request: CodeExecutionRequest,
-        ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
-            Ok(CodeExecutionResponse {
-                provider: CodeExecutionProviderKind::Local,
+            _request: ExecRequest,
+        ) -> std::result::Result<ExecResponse, ExecError> {
+            Ok(ExecResponse {
+                provider: ExecProviderKind::Local,
                 exit_code: Some(self.exit_code),
                 stdout: String::new(),
                 stderr: String::new(),
@@ -553,7 +553,7 @@ mod tests {
             &self,
             _workspace: &ExecutionWorkspaceId,
             _execution: &ExecutionId,
-        ) -> std::result::Result<crate::OutputArtifactScan, CodeExecutionError> {
+        ) -> std::result::Result<crate::OutputArtifactScan, ExecError> {
             self.scans.fetch_add(1, Ordering::SeqCst);
             Ok(crate::OutputArtifactScan {
                 entries: vec![

--- a/crates/tidebreak-code-execution/src/types.rs
+++ b/crates/tidebreak-code-execution/src/types.rs
@@ -32,7 +32,7 @@ const MAX_ID_BYTES: usize = 128;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
-pub enum CodeExecutionProviderKind {
+pub enum ExecProviderKind {
     /// The host's native process sandbox.
     Local,
     /// A managed E2B cloud sandbox.
@@ -43,7 +43,7 @@ pub enum CodeExecutionProviderKind {
     Docker,
 }
 
-impl CodeExecutionProviderKind {
+impl ExecProviderKind {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -55,7 +55,7 @@ impl CodeExecutionProviderKind {
     }
 }
 
-impl std::fmt::Display for CodeExecutionProviderKind {
+impl std::fmt::Display for ExecProviderKind {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str(self.as_str())
     }
@@ -70,7 +70,7 @@ impl std::fmt::Display for CodeExecutionProviderKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
-pub enum CodeExecutionUnavailableReason {
+pub enum ExecUnavailableReason {
     /// The provider's confinement primitive does not exist for this operating
     /// system at all. Nothing the user installs or pastes changes this.
     UnsupportedPlatform,
@@ -88,7 +88,7 @@ pub enum CodeExecutionUnavailableReason {
     ContainerRuntimeUnreachable,
 }
 
-impl CodeExecutionUnavailableReason {
+impl ExecUnavailableReason {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -118,7 +118,7 @@ impl CodeExecutionUnavailableReason {
     }
 }
 
-impl std::fmt::Display for CodeExecutionUnavailableReason {
+impl std::fmt::Display for ExecUnavailableReason {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str(self.as_str())
     }
@@ -130,7 +130,7 @@ impl std::fmt::Display for CodeExecutionUnavailableReason {
 pub struct ExecutionId(String);
 
 impl ExecutionId {
-    pub fn parse(value: impl Into<String>) -> Result<Self, CodeExecutionError> {
+    pub fn parse(value: impl Into<String>) -> Result<Self, ExecError> {
         let value = value.into();
         validate_id(&value, "execution id")?;
         Ok(Self(value))
@@ -148,7 +148,7 @@ impl ExecutionId {
 pub struct ExecutionWorkspaceId(String);
 
 impl ExecutionWorkspaceId {
-    pub fn parse(value: impl Into<String>) -> Result<Self, CodeExecutionError> {
+    pub fn parse(value: impl Into<String>) -> Result<Self, ExecError> {
         let value = value.into();
         validate_id(&value, "workspace id")?;
         Ok(Self(value))
@@ -170,9 +170,9 @@ impl ExecutionWorkspaceId {
 pub struct WorkspaceFilePath(String);
 
 impl WorkspaceFilePath {
-    pub fn parse(value: impl Into<String>) -> Result<Self, CodeExecutionError> {
+    pub fn parse(value: impl Into<String>) -> Result<Self, ExecError> {
         let value = value.into();
-        let invalid = || CodeExecutionError::InvalidRequest("invalid workspace path".into());
+        let invalid = || ExecError::InvalidRequest("invalid workspace path".into());
         if value.is_empty()
             || value.len() > MAX_WORKSPACE_PATH_BYTES
             || value.chars().any(char::is_control)
@@ -237,7 +237,7 @@ pub enum StagedUpload {
     AlreadyCurrent,
 }
 
-/// Optional durable-workspace capability beside [`CodeExecutionProvider::execute`].
+/// Optional durable-workspace capability beside [`ExecProvider::execute`].
 ///
 /// This is a host-internal surface: nothing here is model-facing, and no
 /// credential or absolute host path crosses it. File transfers are bounded by
@@ -245,23 +245,14 @@ pub enum StagedUpload {
 #[async_trait]
 pub trait WorkspaceLifecycle: Send + Sync {
     /// Ensure the durable workspace exists, connecting when it already does.
-    async fn create_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError>;
+    async fn create_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError>;
 
     /// Connect to an existing workspace without creating one. `Ok(false)`
     /// means no durable workspace is currently reachable.
-    async fn connect_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<bool, CodeExecutionError>;
+    async fn connect_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<bool, ExecError>;
 
     /// Destroy the workspace. Destroying one that no longer exists succeeds.
-    async fn destroy_workspace(
-        &self,
-        workspace: &ExecutionWorkspaceId,
-    ) -> Result<(), CodeExecutionError>;
+    async fn destroy_workspace(&self, workspace: &ExecutionWorkspaceId) -> Result<(), ExecError>;
 
     /// Write one bounded file, creating parent directories inside the
     /// workspace and the workspace itself when needed.
@@ -270,7 +261,7 @@ pub trait WorkspaceLifecycle: Send + Sync {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> Result<(), CodeExecutionError>;
+    ) -> Result<(), ExecError>;
 
     /// Stage one bounded file for the next command.
     ///
@@ -283,7 +274,7 @@ pub trait WorkspaceLifecycle: Send + Sync {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> Result<StagedUpload, CodeExecutionError> {
+    ) -> Result<StagedUpload, ExecError> {
         self.put_workspace_file(workspace, path, content).await?;
         Ok(StagedUpload::Uploaded)
     }
@@ -293,26 +284,24 @@ pub trait WorkspaceLifecycle: Send + Sync {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
-    ) -> Result<Vec<u8>, CodeExecutionError>;
+    ) -> Result<Vec<u8>, ExecError>;
 
     /// List one directory (the workspace root when `path` is `None`).
     async fn list_workspace_files(
         &self,
         workspace: &ExecutionWorkspaceId,
         path: Option<&WorkspaceFilePath>,
-    ) -> Result<WorkspaceListing, CodeExecutionError>;
+    ) -> Result<WorkspaceListing, ExecError>;
 }
 
-fn validate_id(value: &str, label: &str) -> Result<(), CodeExecutionError> {
+fn validate_id(value: &str, label: &str) -> Result<(), ExecError> {
     if value.is_empty()
         || value.len() > MAX_ID_BYTES
         || !value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
     {
-        return Err(CodeExecutionError::InvalidRequest(format!(
-            "invalid {label}"
-        )));
+        return Err(ExecError::InvalidRequest(format!("invalid {label}")));
     }
     Ok(())
 }
@@ -323,7 +312,7 @@ fn validate_id(value: &str, label: &str) -> Result<(), CodeExecutionError> {
 /// that deliberately needs a shell must name it explicitly (for example,
 /// `command: "/bin/sh", arguments: ["-c", "…"]`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeExecutionRequest {
+pub struct ExecRequest {
     pub execution_id: ExecutionId,
     pub workspace_id: ExecutionWorkspaceId,
     pub command: String,
@@ -373,10 +362,7 @@ pub struct ExecFolderGrant {
 }
 
 impl ExecFolderGrant {
-    pub fn new(
-        path: impl Into<PathBuf>,
-        access: ExecFolderAccess,
-    ) -> Result<Self, CodeExecutionError> {
+    pub fn new(path: impl Into<PathBuf>, access: ExecFolderAccess) -> Result<Self, ExecError> {
         let grant = Self {
             path: path.into(),
             access,
@@ -387,7 +373,7 @@ impl ExecFolderGrant {
     }
 
     /// Stage this grant's writes at `overlay`. Host-set, like the grant itself.
-    pub fn staged_at(mut self, overlay: impl Into<PathBuf>) -> Result<Self, CodeExecutionError> {
+    pub fn staged_at(mut self, overlay: impl Into<PathBuf>) -> Result<Self, ExecError> {
         self.overlay = Some(overlay.into());
         validate_folder_grant(&self)?;
         Ok(self)
@@ -403,14 +389,14 @@ impl ExecFolderGrant {
     }
 }
 
-impl CodeExecutionRequest {
+impl ExecRequest {
     pub fn new(
         execution_id: ExecutionId,
         workspace_id: ExecutionWorkspaceId,
         command: impl Into<String>,
         arguments: Vec<String>,
         cwd: impl Into<String>,
-    ) -> Result<Self, CodeExecutionError> {
+    ) -> Result<Self, ExecError> {
         let request = Self {
             execution_id,
             workspace_id,
@@ -426,12 +412,12 @@ impl CodeExecutionRequest {
 
     /// Install the model-listed staged paths, validating each and naming the
     /// first offender rather than reporting a bare "invalid".
-    pub fn with_staged_files(mut self, files: Vec<String>) -> Result<Self, CodeExecutionError> {
+    pub fn with_staged_files(mut self, files: Vec<String>) -> Result<Self, ExecError> {
         self.files = files
             .into_iter()
             .map(|path| {
                 WorkspaceFilePath::parse(&path).map_err(|_| {
-                    CodeExecutionError::InvalidRequest(format!(
+                    ExecError::InvalidRequest(format!(
                         "invalid staged path '{path}': paths must be scratch-relative with no traversal"
                     ))
                 })
@@ -442,16 +428,14 @@ impl CodeExecutionRequest {
     }
 
     /// Revalidate public/deserialized fields at the provider boundary.
-    pub fn validate(&self) -> Result<(), CodeExecutionError> {
+    pub fn validate(&self) -> Result<(), ExecError> {
         validate_id(self.execution_id.as_str(), "execution id")?;
         validate_id(self.workspace_id.as_str(), "workspace id")?;
         if self.command.is_empty()
             || self.command.len() > MAX_COMMAND_BYTES
             || self.command.as_bytes().contains(&0)
         {
-            return Err(CodeExecutionError::InvalidRequest(
-                "invalid executable".into(),
-            ));
+            return Err(ExecError::InvalidRequest("invalid executable".into()));
         }
         if self.arguments.len() > MAX_ARGUMENTS
             || self
@@ -464,7 +448,7 @@ impl CodeExecutionRequest {
                 .try_fold(0_usize, |total, argument| total.checked_add(argument.len()))
                 .is_none_or(|total| total > MAX_ARGUMENT_BYTES)
         {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "invalid command arguments".into(),
             ));
         }
@@ -473,12 +457,12 @@ impl CodeExecutionRequest {
             || self.cwd.as_bytes().contains(&0)
             || !is_safe_relative_path(Path::new(&self.cwd))
         {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "invalid working directory".into(),
             ));
         }
         if self.files.len() > MAX_STAGED_PATHS {
-            return Err(CodeExecutionError::InvalidRequest(format!(
+            return Err(ExecError::InvalidRequest(format!(
                 "too many staged paths: {} listed, at most {MAX_STAGED_PATHS} allowed",
                 self.files.len()
             )));
@@ -487,14 +471,14 @@ impl CodeExecutionRequest {
             // Transparent deserialization bypasses the parse-time checks, so
             // the boundary re-proves each path is its own normalized form.
             if !WorkspaceFilePath::parse(file.as_str()).is_ok_and(|parsed| &parsed == file) {
-                return Err(CodeExecutionError::InvalidRequest(format!(
+                return Err(ExecError::InvalidRequest(format!(
                     "invalid staged path '{}'",
                     file.as_str()
                 )));
             }
         }
         if self.folder_grants.len() > MAX_EXEC_FOLDER_GRANTS {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "too many execution folder grants".into(),
             ));
         }
@@ -502,7 +486,7 @@ impl CodeExecutionRequest {
         for grant in &self.folder_grants {
             validate_folder_grant(grant)?;
             if !unique_paths.insert(&grant.path) {
-                return Err(CodeExecutionError::InvalidRequest(
+                return Err(ExecError::InvalidRequest(
                     "duplicate execution folder grant".into(),
                 ));
             }
@@ -515,7 +499,7 @@ impl CodeExecutionRequest {
     pub fn with_folder_grants(
         mut self,
         folder_grants: Vec<ExecFolderGrant>,
-    ) -> Result<Self, CodeExecutionError> {
+    ) -> Result<Self, ExecError> {
         self.folder_grants = folder_grants;
         self.validate()?;
         Ok(self)
@@ -526,24 +510,22 @@ fn default_cwd() -> String {
     ".".into()
 }
 
-fn validate_folder_grant(grant: &ExecFolderGrant) -> Result<(), CodeExecutionError> {
+fn validate_folder_grant(grant: &ExecFolderGrant) -> Result<(), ExecError> {
     validate_folder_path(&grant.path)?;
     match &grant.overlay {
         None => Ok(()),
         // A read-only folder with a write overlay would be a contradiction the
         // profile builder would have to resolve, so it is rejected here.
-        Some(_) if grant.access != ExecFolderAccess::ReadWrite => {
-            Err(CodeExecutionError::InvalidRequest(
-                "a read-only execution folder cannot stage writes".into(),
-            ))
-        }
+        Some(_) if grant.access != ExecFolderAccess::ReadWrite => Err(ExecError::InvalidRequest(
+            "a read-only execution folder cannot stage writes".into(),
+        )),
         Some(overlay) => validate_folder_path(overlay),
     }
 }
 
-fn validate_folder_path(path: &Path) -> Result<(), CodeExecutionError> {
+fn validate_folder_path(path: &Path) -> Result<(), ExecError> {
     let Some(rendered) = path.to_str() else {
-        return Err(CodeExecutionError::InvalidRequest(
+        return Err(ExecError::InvalidRequest(
             "execution folder path must be valid UTF-8".into(),
         ));
     };
@@ -551,7 +533,7 @@ fn validate_folder_path(path: &Path) -> Result<(), CodeExecutionError> {
         || rendered.len() > MAX_EXEC_FOLDER_PATH_BYTES
         || rendered.chars().any(char::is_control)
     {
-        return Err(CodeExecutionError::InvalidRequest(
+        return Err(ExecError::InvalidRequest(
             "invalid execution folder path".into(),
         ));
     }
@@ -567,8 +549,8 @@ fn is_safe_relative_path(path: &Path) -> bool {
 
 /// Normalized, bounded result returned by every provider.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeExecutionResponse {
-    pub provider: CodeExecutionProviderKind,
+pub struct ExecResponse {
+    pub provider: ExecProviderKind,
     pub exit_code: Option<i32>,
     pub stdout: String,
     pub stderr: String,
@@ -654,11 +636,8 @@ pub struct OutputArtifactScan {
 /// `request.execution_id` as an idempotency key and reject an identity reused
 /// with different canonical arguments.
 #[async_trait]
-pub trait CodeExecutionProvider: Send + Sync {
-    async fn execute(
-        &self,
-        request: CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, CodeExecutionError>;
+pub trait ExecProvider: Send + Sync {
+    async fn execute(&self, request: ExecRequest) -> Result<ExecResponse, ExecError>;
 
     /// Collect bounded visual previews after a successful execution.
     ///
@@ -668,7 +647,7 @@ pub trait CodeExecutionProvider: Send + Sync {
     async fn collect_preview_images(
         &self,
         _workspace: &ExecutionWorkspaceId,
-    ) -> Result<crate::PreviewScan, CodeExecutionError> {
+    ) -> Result<crate::PreviewScan, ExecError> {
         Ok(crate::PreviewScan::default())
     }
 
@@ -684,7 +663,7 @@ pub trait CodeExecutionProvider: Send + Sync {
         &self,
         _workspace: &ExecutionWorkspaceId,
         _execution: &ExecutionId,
-    ) -> Result<OutputArtifactScan, CodeExecutionError> {
+    ) -> Result<OutputArtifactScan, ExecError> {
         Ok(OutputArtifactScan::default())
     }
 
@@ -697,7 +676,7 @@ pub trait CodeExecutionProvider: Send + Sync {
 }
 
 #[derive(Debug, Error)]
-pub enum CodeExecutionError {
+pub enum ExecError {
     #[error("invalid code execution request: {0}")]
     InvalidRequest(String),
     #[error(
@@ -735,7 +714,7 @@ mod tests {
     #[test]
     fn validates_bounded_direct_command_requests() {
         let (execution, workspace) = ids();
-        assert!(CodeExecutionRequest::new(
+        assert!(ExecRequest::new(
             execution.clone(),
             workspace.clone(),
             "/usr/bin/python3",
@@ -743,7 +722,7 @@ mod tests {
             ".",
         )
         .is_ok());
-        assert!(CodeExecutionRequest::new(
+        assert!(ExecRequest::new(
             execution.clone(),
             workspace.clone(),
             "/bin/sh",
@@ -751,7 +730,7 @@ mod tests {
             "../outside",
         )
         .is_err());
-        assert!(CodeExecutionRequest::new(
+        assert!(ExecRequest::new(
             execution,
             workspace,
             "x".repeat(MAX_COMMAND_BYTES + 1),

--- a/crates/tidebreak-desktop/ui/src/ExecDisclosure.ts
+++ b/crates/tidebreak-desktop/ui/src/ExecDisclosure.ts
@@ -1,4 +1,4 @@
-import type { CodeExecutionConfigInfo } from "./api";
+import type { ExecConfigInfo } from "./api";
 
 export const MANAGED_EXECUTION_DISCLOSURE =
   "Code execution runs in an E2B or Daytona cloud sandbox on this device. Files staged for a run leave this machine and are uploaded to that provider.";
@@ -9,7 +9,7 @@ export const MANAGED_EXECUTION_DISCLOSURE =
  * interprets its structured Local-provider capability row.
  */
 export function requiresManagedExecutionDisclosure(
-  providers: CodeExecutionConfigInfo["providers"] | null | undefined,
+  providers: ExecConfigInfo["providers"] | null | undefined,
 ): boolean {
   const local = providers?.find((row) => row.provider === "local");
   return (

--- a/crates/tidebreak-desktop/ui/src/MessageList.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.tsx
@@ -271,7 +271,7 @@ type MessageListProps = {
   onRetryTurn?: (turn: RetryableTurn) => void;
   hydrated?: boolean;
   imageClient?: Pick<ApiClient, "getChatImageAttachment">;
-  executionConfigClient?: Pick<ApiClient, "getCodeExecutionConfig">;
+  executionConfigClient?: Pick<ApiClient, "getExecConfig">;
   changeClient?: Pick<
     ApiClient,
     "getFileChangePreview" | "undoFileChange" | "undoTurnFileChanges"

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.test.tsx
@@ -10,19 +10,19 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   ApiClient,
-  CodeExecutionConfigInfo,
+  ExecConfigInfo,
 } from "./api";
 import { WelcomeState } from "./WelcomeState";
 
 afterEach(cleanup);
 
 function executionClient(
-  providers: CodeExecutionConfigInfo["providers"],
-): Pick<ApiClient, "getCodeExecutionConfig"> {
+  providers: ExecConfigInfo["providers"],
+): Pick<ApiClient, "getExecConfig"> {
   return {
-    getCodeExecutionConfig: vi.fn().mockResolvedValue({
+    getExecConfig: vi.fn().mockResolvedValue({
       providers,
-    } as CodeExecutionConfigInfo),
+    } as ExecConfigInfo),
   };
 }
 
@@ -119,7 +119,7 @@ describe("WelcomeState", () => {
     render(<WelcomeState executionConfigClient={client} />);
 
     await waitFor(() =>
-      expect(client.getCodeExecutionConfig).toHaveBeenCalled(),
+      expect(client.getExecConfig).toHaveBeenCalled(),
     );
     expect(
       screen.queryByText(/Files staged for a run leave this machine/i),

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
@@ -9,13 +9,13 @@ import {
 } from "lucide-react";
 import type {
   ApiClient,
-  CodeExecutionConfigInfo,
+  ExecConfigInfo,
   PluginPromptInfo,
 } from "./api";
 import {
   MANAGED_EXECUTION_DISCLOSURE,
   requiresManagedExecutionDisclosure,
-} from "./CodeExecutionDisclosure";
+} from "./ExecDisclosure";
 import { Logomark } from "./Logomark";
 import type { PluginsApis } from "./plugins/pluginsApis";
 import { Button } from "@/components/ui/button";
@@ -148,7 +148,7 @@ export function WelcomeState({
   onStartWalkthrough,
 }: {
   onSelectPrompt?: (prompt: string, options?: StarterPromptOptions) => void;
-  executionConfigClient?: Pick<ApiClient, "getCodeExecutionConfig">;
+  executionConfigClient?: Pick<ApiClient, "getExecConfig">;
   heading?: string;
   description?: string;
   onStartWalkthrough?: () => void;
@@ -160,21 +160,21 @@ export function WelcomeState({
   promptLibrary?: PromptLibraryApis;
 }) {
   const [executionProviders, setExecutionProviders] = useState<
-    CodeExecutionConfigInfo["providers"] | null
+    ExecConfigInfo["providers"] | null
   >(null);
   const [libraryPrompts, setLibraryPrompts] = useState<PluginPromptInfo[]>([]);
 
   useEffect(() => {
     if (
       !executionConfigClient ||
-      typeof executionConfigClient.getCodeExecutionConfig !== "function"
+      typeof executionConfigClient.getExecConfig !== "function"
     ) {
       return;
     }
     let cancelled = false;
     setExecutionProviders(null);
     void executionConfigClient
-      .getCodeExecutionConfig()
+      .getExecConfig()
       .then((config) => {
         if (!cancelled) setExecutionProviders(config.providers);
       })

--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -1049,7 +1049,7 @@ describe("code-execution configuration API", () => {
     vi.stubGlobal("fetch", fetchMock);
     const client = new ApiClient("http://127.0.0.1", "token");
 
-    await client.putCodeExecutionConfig({
+    await client.putExecConfig({
       provider: "local",
       timeout_ms: 30_000,
     });

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -15,9 +15,9 @@ import {
   type Chat,
   type ChatFrame,
   type ChatTranscript,
-  type CodeExecutionConfigInfo,
-  type CodeExecutionCredentialReadiness,
-  type CodeExecutionProviderKind,
+  type ExecConfigInfo,
+  type ExecCredentialReadiness,
+  type ExecProviderKind,
   type CompactionRun,
   type ConnectedAppsInfo,
   type ConsentStatementSnapshot,
@@ -485,15 +485,15 @@ export class ApiClient {
     });
   }
 
-  getCodeExecutionConfig(): Promise<CodeExecutionConfigInfo> {
+  getExecConfig(): Promise<ExecConfigInfo> {
     return this.json("/code-execution", { headers: this.headers() });
   }
 
-  putCodeExecutionConfig(body: {
-    provider?: CodeExecutionProviderKind | null;
+  putExecConfig(body: {
+    provider?: ExecProviderKind | null;
     timeout_ms?: number;
     egress?: EgressConfig;
-  }): Promise<CodeExecutionConfigInfo> {
+  }): Promise<ExecConfigInfo> {
     return this.json("/code-execution", {
       method: "PUT",
       headers: this.headers(true),
@@ -501,18 +501,18 @@ export class ApiClient {
     });
   }
 
-  listCodeExecutionCredentials(): Promise<{
-    credentials: CodeExecutionCredentialReadiness[];
+  listExecCredentials(): Promise<{
+    credentials: ExecCredentialReadiness[];
   }> {
     return this.json("/code-execution/credentials", {
       headers: this.headers(),
     });
   }
 
-  putCodeExecutionCredential(
-    provider: CodeExecutionProviderKind,
+  putExecCredential(
+    provider: ExecProviderKind,
     apiKey: string,
-  ): Promise<CodeExecutionCredentialReadiness> {
+  ): Promise<ExecCredentialReadiness> {
     return this.json(`/code-execution/credentials/${provider}`, {
       method: "PUT",
       headers: this.headers(true),
@@ -520,9 +520,9 @@ export class ApiClient {
     });
   }
 
-  deleteCodeExecutionCredential(
-    provider: CodeExecutionProviderKind,
-  ): Promise<CodeExecutionCredentialReadiness> {
+  deleteExecCredential(
+    provider: ExecProviderKind,
+  ): Promise<ExecCredentialReadiness> {
     return this.json(`/code-execution/credentials/${provider}`, {
       method: "DELETE",
       headers: this.headers(),

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -20,15 +20,15 @@ import {
   type AgentRunTaskPlan as WireAgentRunTaskPlan,
   type Chat as WireChat,
   type ChatTranscript as WireChatTranscript,
-  type CodeExecutionConfigInfo as WireCodeExecutionConfigInfo,
+  type ExecConfigInfo as WireExecConfigInfo,
   type ConnectedAppInfo as WireConnectedAppInfo,
   type ConnectedAppsInfo as WireConnectedAppsInfo,
   type CredentialPlacement as WireCredentialPlacement,
   type RestCredentialStatus as WireRestCredentialStatus,
   type SpecPreviewInfo as WireSpecPreviewInfo,
   type SpecPreviewOperation as WireSpecPreviewOperation,
-  type CodeExecutionCredentialReadiness as WireCodeExecutionCredentialReadiness,
-  type CodeExecutionProviderKind as WireCodeExecutionProviderKind,
+  type ExecCredentialReadiness as WireExecCredentialReadiness,
+  type ExecProviderKind as WireExecProviderKind,
   type CodeDeliveryActionResult as WireCodeDeliveryActionResult,
   type CodeDeliveryCheck as WireCodeDeliveryCheck,
   type CodeDeliveryDeploymentStatus as WireCodeDeliveryDeploymentStatus,
@@ -439,14 +439,14 @@ export type WebSearchConfigInfo = WireWebSearchConfigInfo;
 export type WebSearchCredentialReadiness = WireWebSearchCredentialReadiness;
 
 /** The fixed, host-owned code-execution providers supported by this build. */
-export type CodeExecutionProviderKind = WireCodeExecutionProviderKind;
+export type ExecProviderKind = WireExecProviderKind;
 
 /** Non-secret code-execution selection, timeout policy, and host readiness. */
-export type CodeExecutionConfigInfo = WireCodeExecutionConfigInfo;
+export type ExecConfigInfo = WireExecConfigInfo;
 
 /** Readiness only: the API never returns a saved managed-provider key. */
-export type CodeExecutionCredentialReadiness =
-  WireCodeExecutionCredentialReadiness;
+export type ExecCredentialReadiness =
+  WireExecCredentialReadiness;
 
 /**
  * Host-owned egress policy for the managed sandboxes. Never a secret: only

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -147,10 +147,10 @@ export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, t
 /**
  * Active host code-execution backend for `exec`, not the run-loop seat.
  *
- * See [`CodeExecutionProviderSnapshot`]. Read from the current host
+ * See [`ExecProviderSnapshot`]. Read from the current host
  * setting at list time — the same selection the next `exec` would use.
  */
-code_execution_provider: CodeExecutionProviderSnapshot, status: AgentRunStatus, 
+code_execution_provider: ExecProviderSnapshot, status: AgentRunStatus, 
 /**
  * Completed provider calls accumulated across every attempt.
  */
@@ -1154,114 +1154,6 @@ state: AttentionState,
 source: AttentionSource, };
 
 /**
- * Renderer-safe configuration and readiness.
- */
-export type CodeExecutionConfigInfo = { provider?: CodeExecutionProviderKind, timeout_ms: number, available: boolean, 
-/**
- * Why the *selected* provider cannot run, when it cannot. Absent while
- * execution is available or no provider is selected at all.
- */
-unavailable_reason?: CodeExecutionUnavailableReason, has_credential: boolean, 
-/**
- * One row per shipped provider: whether it could run here at all, and the
- * reason it could not. This is what makes an unusable host legible —
- * "paste an E2B key" is visible instead of being inferred from a generic
- * execution failure.
- */
-providers: Array<CodeExecutionProviderAvailability>, 
-/**
- * The configured egress policy and each managed provider's enforcement
- * status, so the renderer can present the policy and disclose which
- * providers actually restrict egress today.
- */
-egress: CodeExecutionEgressInfo, 
-/**
- * Per-provider detached-admission evaluation: for each execution
- * provider, whether the fail-closed gate (issue #824) would admit a
- * detached run it hosted, and every named precondition it fails. Derived
- * by running the real admission evaluator over each provider's declared
- * capabilities — the settings surface and the gate cannot disagree.
- */
-detached_admission: Array<DetachedAdmissionProviderInfo>, };
-
-/**
- * Renderer-safe readiness for one managed provider's fixed credential slot.
- */
-export type CodeExecutionCredentialReadiness = { provider: CodeExecutionProviderKind, has_credential: boolean, };
-
-/**
- * A managed provider's egress-enforcement status, as host knowledge rather
- * than a claim the backend makes about itself.
- */
-export type CodeExecutionEgressEnforcement = { provider: CodeExecutionProviderKind, status: EgressEnforcementStatus, 
-/**
- * Destinations the vendor's mechanism keeps reachable regardless of the
- * configured policy — each a short purpose string straight from the
- * enforcement model, so the settings surface can show the caveat inline
- * instead of burying it in prose the user skims past.
- */
-gaps: Array<string>, 
-/**
- * A precondition the boundary is gated on that the host cannot verify
- * statically ("Daytona org tier 3+"). Present only for a
- * [`EgressEnforcementStatus::ConditionalBoundary`], so the surface can
- * state the condition inline rather than implying an unconditional
- * boundary.
- */
-requirement?: string, };
-
-/**
- * Renderer-safe egress policy plus per-provider enforcement disclosure.
- */
-export type CodeExecutionEgressInfo = { 
-/**
- * The configured host policy. `Open` is the default: managed sandboxes are
- * created with open internet access. An allowlist restricts every managed
- * sandbox created afterwards.
- */
-policy: EgressConfig, 
-/**
- * One row per managed provider, stating whether its egress restriction is
- * confirmed against the live vendor API or still pending confirmation.
- */
-enforcement: Array<CodeExecutionEgressEnforcement>, };
-
-/**
- * Structured capability report for one execution provider on this host.
- *
- * `available` and `unavailable_reason` are two views of one decision, made in
- * [`provider_availability`], so no surface has to re-derive whether a platform
- * supports a provider or whether a key is saved.
- */
-export type CodeExecutionProviderAvailability = { provider: CodeExecutionProviderKind, available: boolean, unavailable_reason?: CodeExecutionUnavailableReason, };
-
-/**
- * A configured code-execution backend.
- */
-export type CodeExecutionProviderKind = "local" | "e2b" | "daytona" | "docker";
-
-/**
- * Host-selected backend that runs `exec` tool calls.
- *
- * Distinct from [`AgentRunExecutionLocation`], which names where the agent
- * *run loop* itself executes (`in_process` vs `container`). A background run
- * can be in-process while its shell work still lands on e2b, docker, or
- * daytona — this field is that backend, or `off` when code execution is
- * disabled.
- */
-export type CodeExecutionProviderSnapshot = "local" | "e2b" | "daytona" | "docker" | "off";
-
-/**
- * Why a provider cannot execute anything on this host right now.
- *
- * A stable machine-readable code, not a sentence: the reason is decided where
- * the fact is known (the platform probe, the credential slot) and every
- * surface renders its own copy from the code. Reasons are what the user can
- * act on — install a key, switch provider — never an internal failure detail.
- */
-export type CodeExecutionUnavailableReason = "unsupported_platform" | "missing_sandbox_binary" | "missing_credential" | "missing_container_runtime" | "container_runtime_unreachable";
-
-/**
  * One changed path in a workspace or turn file list.
  */
 export type CodeFileChange = { path: string, kind: FileChangeKind, insertions: number, deletions: number, previous_path?: string, };
@@ -1888,7 +1780,7 @@ export type DetachedAdmissionDenialReason = "no_scoped_model_token" | "no_extern
  * providers that cannot host background runs at all — every precondition is
  * simply unestablished for them, and the fail-closed evaluation names each.
  */
-export type DetachedAdmissionProviderInfo = { provider: CodeExecutionProviderKind, 
+export type DetachedAdmissionProviderInfo = { provider: ExecProviderKind, 
 /**
  * Whether the gate would admit a detached run hosted by this provider.
  */
@@ -1966,6 +1858,42 @@ export type EgressEnforcementStatus = "boundary" | "conditional_boundary" | "app
 export type ExecBackend = "local" | "e2b" | "daytona" | "docker";
 
 /**
+ * Renderer-safe configuration and readiness.
+ */
+export type ExecConfigInfo = { provider?: ExecProviderKind, timeout_ms: number, available: boolean, 
+/**
+ * Why the *selected* provider cannot run, when it cannot. Absent while
+ * execution is available or no provider is selected at all.
+ */
+unavailable_reason?: ExecUnavailableReason, has_credential: boolean, 
+/**
+ * One row per shipped provider: whether it could run here at all, and the
+ * reason it could not. This is what makes an unusable host legible —
+ * "paste an E2B key" is visible instead of being inferred from a generic
+ * execution failure.
+ */
+providers: Array<ExecProviderAvailability>, 
+/**
+ * The configured egress policy and each managed provider's enforcement
+ * status, so the renderer can present the policy and disclose which
+ * providers actually restrict egress today.
+ */
+egress: ExecEgressInfo, 
+/**
+ * Per-provider detached-admission evaluation: for each execution
+ * provider, whether the fail-closed gate (issue #824) would admit a
+ * detached run it hosted, and every named precondition it fails. Derived
+ * by running the real admission evaluator over each provider's declared
+ * capabilities — the settings surface and the gate cannot disagree.
+ */
+detached_admission: Array<DetachedAdmissionProviderInfo>, };
+
+/**
+ * Renderer-safe readiness for one managed provider's fixed credential slot.
+ */
+export type ExecCredentialReadiness = { provider: ExecProviderKind, has_credential: boolean, };
+
+/**
  * A way the execution backend ran with less than its intended setup.
  *
  * Closed, and deliberately coarse: what a reader needs is what happened and
@@ -1974,6 +1902,43 @@ export type ExecBackend = "local" | "e2b" | "daytona" | "docker";
  * string, because the sentence the card shows is written on this side.
  */
 export type ExecDegradation = "sandbox_image_unavailable";
+
+/**
+ * A managed provider's egress-enforcement status, as host knowledge rather
+ * than a claim the backend makes about itself.
+ */
+export type ExecEgressEnforcement = { provider: ExecProviderKind, status: EgressEnforcementStatus, 
+/**
+ * Destinations the vendor's mechanism keeps reachable regardless of the
+ * configured policy — each a short purpose string straight from the
+ * enforcement model, so the settings surface can show the caveat inline
+ * instead of burying it in prose the user skims past.
+ */
+gaps: Array<string>, 
+/**
+ * A precondition the boundary is gated on that the host cannot verify
+ * statically ("Daytona org tier 3+"). Present only for a
+ * [`EgressEnforcementStatus::ConditionalBoundary`], so the surface can
+ * state the condition inline rather than implying an unconditional
+ * boundary.
+ */
+requirement?: string, };
+
+/**
+ * Renderer-safe egress policy plus per-provider enforcement disclosure.
+ */
+export type ExecEgressInfo = { 
+/**
+ * The configured host policy. `Open` is the default: managed sandboxes are
+ * created with open internet access. An allowlist restricts every managed
+ * sandbox created afterwards.
+ */
+policy: EgressConfig, 
+/**
+ * One row per managed provider, stating whether its egress restriction is
+ * confirmed against the live vendor API or still pending confirmation.
+ */
+enforcement: Array<ExecEgressEnforcement>, };
 
 /**
  * Renderer-safe selection metadata; bytes remain behind the scoped endpoint.
@@ -2016,6 +1981,41 @@ export type ExecFileRejectionReason = "stale" | "snapshot_unavailable" | "staged
  * Whether an applied file can still be safely reverted now.
  */
 export type ExecFileUndoAvailability = "available" | "already_undone" | "stale" | "not_available";
+
+/**
+ * Structured capability report for one execution provider on this host.
+ *
+ * `available` and `unavailable_reason` are two views of one decision, made in
+ * [`provider_availability`], so no surface has to re-derive whether a platform
+ * supports a provider or whether a key is saved.
+ */
+export type ExecProviderAvailability = { provider: ExecProviderKind, available: boolean, unavailable_reason?: ExecUnavailableReason, };
+
+/**
+ * A configured code-execution backend.
+ */
+export type ExecProviderKind = "local" | "e2b" | "daytona" | "docker";
+
+/**
+ * Host-selected backend that runs `exec` tool calls.
+ *
+ * Distinct from [`AgentRunExecutionLocation`], which names where the agent
+ * *run loop* itself executes (`in_process` vs `container`). A background run
+ * can be in-process while its shell work still lands on e2b, docker, or
+ * daytona — this field is that backend, or `off` when code execution is
+ * disabled.
+ */
+export type ExecProviderSnapshot = "local" | "e2b" | "daytona" | "docker" | "off";
+
+/**
+ * Why a provider cannot execute anything on this host right now.
+ *
+ * A stable machine-readable code, not a sentence: the reason is decided where
+ * the fact is known (the platform probe, the credential slot) and every
+ * surface renders its own copy from the code. Reasons are what the user can
+ * act on — install a key, switch provider — never an internal failure detail.
+ */
+export type ExecUnavailableReason = "unsupported_platform" | "missing_sandbox_binary" | "missing_credential" | "missing_container_runtime" | "container_runtime_unreachable";
 
 /**
  * Why a session is fenced: observed but not controlled, until an explicit

--- a/crates/tidebreak-desktop/ui/src/settings/ExecPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ExecPanel.dom.test.tsx
@@ -10,16 +10,16 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   ApiClient,
-  CodeExecutionConfigInfo,
-  CodeExecutionCredentialReadiness,
+  ExecConfigInfo,
+  ExecCredentialReadiness,
 } from "../api";
-import { CodeExecutionPanel } from "./CodeExecutionPanel";
+import { ExecPanel } from "./ExecPanel";
 
 /**
  * The default egress projection: open policy, E2B applied-with-gaps, Daytona a
  * strict per-sandbox boundary conditional on org tier 3+ (no phantom gaps).
  */
-const OPEN_EGRESS: CodeExecutionConfigInfo["egress"] = {
+const OPEN_EGRESS: ExecConfigInfo["egress"] = {
   policy: { mode: "open" },
   enforcement: [
     {
@@ -40,7 +40,7 @@ const OPEN_EGRESS: CodeExecutionConfigInfo["egress"] = {
  * Today's server position: no provider is admitted for detached runs, and the
  * local row names the three structural gaps.
  */
-const NO_DETACHED: CodeExecutionConfigInfo["detached_admission"] = [
+const NO_DETACHED: ExecConfigInfo["detached_admission"] = [
   {
     provider: "local",
     admitted: false,
@@ -71,54 +71,54 @@ const NO_DETACHED: CodeExecutionConfigInfo["detached_admission"] = [
 ];
 
 /** Every provider usable: the macOS shape, where nothing is dark. */
-const ALL_PROVIDERS_AVAILABLE: CodeExecutionConfigInfo["providers"] = [
+const ALL_PROVIDERS_AVAILABLE: ExecConfigInfo["providers"] = [
   { provider: "local", available: true },
   { provider: "e2b", available: true },
   { provider: "daytona", available: true },
 ];
 
 function clientFor(
-  config: Omit<CodeExecutionConfigInfo, "providers"> &
-    Partial<Pick<CodeExecutionConfigInfo, "providers">>,
-  credentials: CodeExecutionCredentialReadiness[] = [
+  config: Omit<ExecConfigInfo, "providers"> &
+    Partial<Pick<ExecConfigInfo, "providers">>,
+  credentials: ExecCredentialReadiness[] = [
     { provider: "e2b", has_credential: false },
     { provider: "daytona", has_credential: false },
   ],
 ) {
-  const resolved: CodeExecutionConfigInfo = {
+  const resolved: ExecConfigInfo = {
     providers: ALL_PROVIDERS_AVAILABLE,
     ...config,
   };
-  const putCodeExecutionConfig = vi.fn().mockResolvedValue(resolved);
-  const putCodeExecutionCredential = vi
+  const putExecConfig = vi.fn().mockResolvedValue(resolved);
+  const putExecCredential = vi
     .fn()
     .mockImplementation((provider: string) =>
       Promise.resolve({ provider, has_credential: true }),
     );
-  const deleteCodeExecutionCredential = vi
+  const deleteExecCredential = vi
     .fn()
     .mockImplementation((provider: string) =>
       Promise.resolve({ provider, has_credential: false }),
     );
   return {
     client: {
-      getCodeExecutionConfig: vi.fn().mockResolvedValue(resolved),
-      listCodeExecutionCredentials: vi.fn().mockResolvedValue({ credentials }),
-      putCodeExecutionConfig,
-      putCodeExecutionCredential,
-      deleteCodeExecutionCredential,
+      getExecConfig: vi.fn().mockResolvedValue(resolved),
+      listExecCredentials: vi.fn().mockResolvedValue({ credentials }),
+      putExecConfig,
+      putExecCredential,
+      deleteExecCredential,
     } as unknown as ApiClient,
-    putCodeExecutionConfig,
-    putCodeExecutionCredential,
-    deleteCodeExecutionCredential,
+    putExecConfig,
+    putExecCredential,
+    deleteExecCredential,
   };
 }
 
 afterEach(cleanup);
 
-describe("CodeExecutionPanel", () => {
+describe("ExecPanel", () => {
   it("saves a key per managed provider before the active selection", async () => {
-    const { client, putCodeExecutionConfig, putCodeExecutionCredential } =
+    const { client, putExecConfig, putExecCredential } =
       clientFor({
         provider: "e2b",
         timeout_ms: 20_000,
@@ -128,7 +128,7 @@ describe("CodeExecutionPanel", () => {
       detached_admission: NO_DETACHED,
       });
 
-    render(<CodeExecutionPanel client={client} />);
+    render(<ExecPanel client={client} />);
 
     fireEvent.change(await screen.findByLabelText(/E2B API key/), {
       target: { value: "  e2b-secret  " },
@@ -142,30 +142,30 @@ describe("CodeExecutionPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
 
     await waitFor(() =>
-      expect(putCodeExecutionCredential).toHaveBeenCalledWith(
+      expect(putExecCredential).toHaveBeenCalledWith(
         "e2b",
         "e2b-secret",
       ),
     );
-    expect(putCodeExecutionCredential).toHaveBeenCalledWith(
+    expect(putExecCredential).toHaveBeenCalledWith(
       "daytona",
       "daytona-secret",
     );
-    expect(putCodeExecutionConfig).toHaveBeenCalledWith({
+    expect(putExecConfig).toHaveBeenCalledWith({
       provider: "e2b",
       timeout_ms: 30_000,
     });
     // A provider must not go active in a pass that failed to store its key.
     expect(
-      putCodeExecutionCredential.mock.invocationCallOrder[0],
-    ).toBeLessThan(putCodeExecutionConfig.mock.invocationCallOrder[0]);
+      putExecCredential.mock.invocationCallOrder[0],
+    ).toBeLessThan(putExecConfig.mock.invocationCallOrder[0]);
     expect(
       screen.queryByText(/Files staged for a run leave this machine/i),
     ).toBeNull();
   });
 
   it("removes one provider's saved key without touching the other", async () => {
-    const { client, deleteCodeExecutionCredential } = clientFor(
+    const { client, deleteExecCredential } = clientFor(
       {
         provider: "e2b",
         timeout_ms: 20_000,
@@ -180,16 +180,16 @@ describe("CodeExecutionPanel", () => {
       ],
     );
 
-    render(<CodeExecutionPanel client={client} />);
+    render(<ExecPanel client={client} />);
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Remove saved Daytona key" }),
     );
 
     await waitFor(() =>
-      expect(deleteCodeExecutionCredential).toHaveBeenCalledWith("daytona"),
+      expect(deleteExecCredential).toHaveBeenCalledWith("daytona"),
     );
-    expect(deleteCodeExecutionCredential).toHaveBeenCalledTimes(1);
+    expect(deleteExecCredential).toHaveBeenCalledTimes(1);
   });
 
   it("does not present E2B as a full boundary and surfaces its gaps inline", async () => {
@@ -202,7 +202,7 @@ describe("CodeExecutionPanel", () => {
       detached_admission: NO_DETACHED,
     });
 
-    render(<CodeExecutionPanel client={client} />);
+    render(<ExecPanel client={client} />);
 
     // The E2B badge must read "not a full boundary", never a plain green
     // "Enforced"/boundary, and the reachable holes are shown next to it.
@@ -223,7 +223,7 @@ describe("CodeExecutionPanel", () => {
       detached_admission: NO_DETACHED,
     });
 
-    render(<CodeExecutionPanel client={client} />);
+    render(<ExecPanel client={client} />);
 
     // The tier-3+ requirement is surfaced inline, and the badge reads
     // conditional — never a plain green "Boundary".
@@ -235,7 +235,7 @@ describe("CodeExecutionPanel", () => {
   });
 
   it("rejects a timeout outside the bounds before touching the server", async () => {
-    const { client, putCodeExecutionConfig } = clientFor({
+    const { client, putExecConfig } = clientFor({
       provider: "local",
       timeout_ms: 20_000,
       available: true,
@@ -244,7 +244,7 @@ describe("CodeExecutionPanel", () => {
       detached_admission: NO_DETACHED,
     });
 
-    render(<CodeExecutionPanel client={client} />);
+    render(<ExecPanel client={client} />);
 
     fireEvent.change(await screen.findByLabelText(/Execution timeout/), {
       target: { value: "500" },
@@ -252,7 +252,7 @@ describe("CodeExecutionPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
 
     await screen.findByRole("alert");
-    expect(putCodeExecutionConfig).not.toHaveBeenCalled();
+    expect(putExecConfig).not.toHaveBeenCalled();
   });
 
   it("names why each provider is unusable on a host with no execution at all", async () => {
@@ -282,7 +282,7 @@ describe("CodeExecutionPanel", () => {
       detached_admission: NO_DETACHED,
     });
 
-    render(<CodeExecutionPanel client={client} />);
+    render(<ExecPanel client={client} />);
 
     // The headline states the host has nothing, and each row says what would
     // change it — a missing key must be readable here, not archaeological.

--- a/crates/tidebreak-desktop/ui/src/settings/ExecPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ExecPanel.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import type {
   ApiClient,
-  CodeExecutionConfigInfo,
-  CodeExecutionCredentialReadiness,
-  CodeExecutionProviderKind,
+  ExecConfigInfo,
+  ExecCredentialReadiness,
+  ExecProviderKind,
 } from "../api";
 import {
   MANAGED_EXECUTION_DISCLOSURE,
   requiresManagedExecutionDisclosure,
-} from "../CodeExecutionDisclosure";
+} from "../ExecDisclosure";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,23 +29,23 @@ const MIN_CODE_EXECUTION_TIMEOUT_SECONDS = 1;
 const MAX_CODE_EXECUTION_TIMEOUT_SECONDS = 120;
 
 /** The local sandbox needs no credential, so it never appears in the key list. */
-const LOCAL_PROVIDER: CodeExecutionProviderKind = "local";
+const LOCAL_PROVIDER: ExecProviderKind = "local";
 
-export function CodeExecutionPanel({ client }: { client: ApiClient }) {
-  const [config, setConfig] = useState<CodeExecutionConfigInfo | null>(null);
+export function ExecPanel({ client }: { client: ApiClient }) {
+  const [config, setConfig] = useState<ExecConfigInfo | null>(null);
   const [credentials, setCredentials] = useState<
-    CodeExecutionCredentialReadiness[]
+    ExecCredentialReadiness[]
   >([]);
-  const [provider, setProvider] = useState<CodeExecutionProviderKind | "">("");
+  const [provider, setProvider] = useState<ExecProviderKind | "">("");
   const [timeoutSeconds, setTimeoutSeconds] = useState("");
   // One draft key per managed provider, so E2B and Daytona can be configured
   // together and switching the active provider discards neither.
   const [apiKeys, setApiKeys] = useState<
-    Partial<Record<CodeExecutionProviderKind, string>>
+    Partial<Record<ExecProviderKind, string>>
   >({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [removing, setRemoving] = useState<CodeExecutionProviderKind | null>(
+  const [removing, setRemoving] = useState<ExecProviderKind | null>(
     null,
   );
   const [error, setError] = useState<string | null>(null);
@@ -57,8 +57,8 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
     void (async () => {
       try {
         const [nextConfig, nextCredentials] = await Promise.all([
-          client.getCodeExecutionConfig(),
-          client.listCodeExecutionCredentials(),
+          client.getExecConfig(),
+          client.listExecCredentials(),
         ]);
         if (cancelled) return;
         setConfig(nextConfig);
@@ -98,14 +98,14 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
       for (const credential of credentials) {
         const key = apiKeys[credential.provider]?.trim();
         if (!key) continue;
-        await client.putCodeExecutionCredential(credential.provider, key);
+        await client.putExecCredential(credential.provider, key);
         setApiKeys((current) => ({ ...current, [credential.provider]: "" }));
       }
-      const nextConfig = await client.putCodeExecutionConfig({
+      const nextConfig = await client.putExecConfig({
         provider: provider || null,
         timeout_ms: timeout.timeoutMs,
       });
-      const nextCredentials = await client.listCodeExecutionCredentials();
+      const nextCredentials = await client.listExecCredentials();
       setConfig(nextConfig);
       setCredentials(nextCredentials.credentials);
       setProvider(nextConfig.provider ?? "");
@@ -118,14 +118,14 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
     }
   }
 
-  async function removeCredential(target: CodeExecutionProviderKind) {
+  async function removeCredential(target: ExecProviderKind) {
     setRemoving(target);
     setError(null);
     try {
-      await client.deleteCodeExecutionCredential(target);
+      await client.deleteExecCredential(target);
       const [nextConfig, nextCredentials] = await Promise.all([
-        client.getCodeExecutionConfig(),
-        client.listCodeExecutionCredentials(),
+        client.getExecConfig(),
+        client.listExecCredentials(),
       ]);
       setConfig(nextConfig);
       setCredentials(nextCredentials.credentials);
@@ -257,10 +257,10 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
 }
 
 type EgressEnforcementRow =
-  CodeExecutionConfigInfo["egress"]["enforcement"][number];
+  ExecConfigInfo["egress"]["enforcement"][number];
 
 type DetachedAdmissionRow =
-  CodeExecutionConfigInfo["detached_admission"][number];
+  ExecConfigInfo["detached_admission"][number];
 
 const PROVIDER_SANDBOX_LABEL: Record<
   DetachedAdmissionRow["provider"],
@@ -272,7 +272,7 @@ const PROVIDER_SANDBOX_LABEL: Record<
   docker: "Docker container",
 };
 
-type ProviderAvailabilityRow = CodeExecutionConfigInfo["providers"][number];
+type ProviderAvailabilityRow = ExecConfigInfo["providers"][number];
 type ProviderUnavailableReason = NonNullable<
   ProviderAvailabilityRow["unavailable_reason"]
 >;
@@ -304,7 +304,7 @@ const PROVIDER_UNAVAILABLE_SENTENCES: Record<ProviderUnavailableReason, string> 
 function ProviderAvailabilityDisclosure({
   rows,
 }: {
-  rows: CodeExecutionConfigInfo["providers"];
+  rows: ExecConfigInfo["providers"];
 }) {
   return (
     <div className="flex flex-col gap-2">
@@ -378,7 +378,7 @@ const EGRESS_STATUS_PRESENTATION: Record<
 function EgressEnforcementDisclosure({
   enforcement,
 }: {
-  enforcement: CodeExecutionConfigInfo["egress"]["enforcement"];
+  enforcement: ExecConfigInfo["egress"]["enforcement"];
 }) {
   return (
     <div className="flex flex-col gap-2">
@@ -410,7 +410,7 @@ function EgressEnforcementDisclosure({
   );
 }
 
-function codeExecutionState(config: CodeExecutionConfigInfo | null): {
+function codeExecutionState(config: ExecConfigInfo | null): {
   kind: "disabled" | "ready" | "not-configured";
   label: string;
   description: string;
@@ -450,7 +450,7 @@ function codeExecutionState(config: CodeExecutionConfigInfo | null): {
 }
 
 function codeExecutionProviderLabel(
-  provider: CodeExecutionProviderKind,
+  provider: ExecProviderKind,
 ): string {
   switch (provider) {
     case "local":

--- a/crates/tidebreak-desktop/ui/src/settings/sections.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.tsx
@@ -23,7 +23,7 @@ import { useManagedPolicy } from "@/managedPolicy";
 import { useTheme } from "@/theme";
 import { AppearancePanel } from "./AppearancePanel";
 import { AgentsPanel } from "./AgentsPanel";
-import { CodeExecutionPanel } from "./CodeExecutionPanel";
+import { ExecPanel } from "./ExecPanel";
 import { CompactionPanel } from "./CompactionPanel";
 import { ConnectedAppsPanel } from "./ConnectedAppsPanel";
 import { GatewayPanel } from "./GatewayPanel";
@@ -124,9 +124,9 @@ function VoiceTranscriptionSection() {
   return <VoiceTranscriptionPanel client={client} />;
 }
 
-function CodeExecutionSection() {
+function ExecSection() {
   const { client } = useApp();
-  return <CodeExecutionPanel client={client} />;
+  return <ExecPanel client={client} />;
 }
 
 function CompactionSection() {
@@ -270,7 +270,7 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     label: "Code execution",
     icon: SquareTerminal,
     iconClass: "text-icon-green",
-    Component: CodeExecutionSection,
+    Component: ExecSection,
   },
   {
     path: "coding-harnesses",

--- a/crates/tidebreak-server/src/agent_run_scratch_reaper.rs
+++ b/crates/tidebreak-server/src/agent_run_scratch_reaper.rs
@@ -34,7 +34,7 @@
 //!
 //! A run's *published outputs* live under `scratch_root/<chat_id>/outputs/…`,
 //! never under the run's own workspace — that split (and the bug it fixed) is
-//! in `ConfiguredCodeExecutionProvider::publish_output_directory`. Destroying
+//! in `ConfiguredExecProvider::publish_output_directory`. Destroying
 //! `scratch_root/agent-run-<id>` therefore never touches a published output;
 //! the two live under different directory names by construction.
 
@@ -49,7 +49,7 @@ use tidebreak_code_execution::{ExecutionWorkspaceId, WorkspaceLifecycle};
 use tidebreak_core::{AgentError, AgentRunId, Result, Store};
 use tokio::sync::Mutex;
 
-use crate::code_execution::ConfiguredCodeExecutionProvider;
+use crate::code_execution::ConfiguredExecProvider;
 
 /// Directory-name prefix for a background run's workspace; must match
 /// `sandbox_exec_worker::agent_run_workspace`.
@@ -102,7 +102,7 @@ pub(crate) struct AgentRunScratchReapFailure {
 #[derive(Clone)]
 pub(crate) struct AgentRunScratchReaper {
     store: Arc<dyn Store>,
-    code_execution: Arc<ConfiguredCodeExecutionProvider>,
+    code_execution: Arc<ConfiguredExecProvider>,
     scratch_root: Arc<PathBuf>,
     sweep: Arc<Mutex<()>>,
     inventory: Arc<Mutex<VecDeque<AgentRunId>>>,
@@ -118,7 +118,7 @@ struct ScanResult {
 impl AgentRunScratchReaper {
     pub(crate) fn new(
         store: Arc<dyn Store>,
-        code_execution: Arc<ConfiguredCodeExecutionProvider>,
+        code_execution: Arc<ConfiguredExecProvider>,
         scratch_root: impl Into<PathBuf>,
         config: AgentRunScratchReaperConfig,
     ) -> Self {
@@ -281,7 +281,7 @@ impl AgentRunScratchReaper {
 /// deleted conversation's former runs immediately rather than waiting for the
 /// next sweep. Safe to call when the workspace is already gone.
 pub(crate) async fn destroy_agent_run_workspace(
-    code_execution: &ConfiguredCodeExecutionProvider,
+    code_execution: &ConfiguredExecProvider,
     scratch_root: &Path,
     run_id: AgentRunId,
 ) -> Result<()> {
@@ -453,8 +453,8 @@ mod tests {
         )
     }
 
-    fn provider(store: Arc<DbStore>, scratch_root: &Path) -> Arc<ConfiguredCodeExecutionProvider> {
-        Arc::new(ConfiguredCodeExecutionProvider::new(
+    fn provider(store: Arc<DbStore>, scratch_root: &Path) -> Arc<ConfiguredExecProvider> {
+        Arc::new(ConfiguredExecProvider::new(
             store,
             Arc::new(NoSecrets),
             scratch_root,
@@ -642,7 +642,7 @@ mod tests {
     }
 
     /// The bytes a run published are the parent conversation's, not the run's
-    /// own — see `ConfiguredCodeExecutionProvider::publish_output_directory`.
+    /// own — see `ConfiguredExecProvider::publish_output_directory`.
     /// A reap of the run's workspace must never reach into the conversation's
     /// own scratch directory, even when both are old.
     #[tokio::test]

--- a/crates/tidebreak-server/src/code_execution/config.rs
+++ b/crates/tidebreak-server/src/code_execution/config.rs
@@ -8,10 +8,10 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tidebreak_code_execution::{
-    CodeExecutionError, CodeExecutionProviderKind, CodeExecutionUnavailableReason,
     DaytonaCredential, DaytonaExecutionProvider, DockerExecutionProvider, E2BCredential,
-    E2BExecutionProvider, LocalExecutionProvider, RemoteSessionPool, DAYTONA_CREDENTIAL_KEY,
-    E2B_CREDENTIAL_KEY, PACKAGE_MANAGER_DOMAINS,
+    E2BExecutionProvider, ExecError, ExecProviderKind, ExecUnavailableReason,
+    LocalExecutionProvider, RemoteSessionPool, DAYTONA_CREDENTIAL_KEY, E2B_CREDENTIAL_KEY,
+    PACKAGE_MANAGER_DOMAINS,
 };
 use tidebreak_core::{ChatId, HostRootId, NetworkPolicy, ProjectId, Result, SecretProvider, Store};
 use tidebreak_egress::{
@@ -160,20 +160,18 @@ pub trait ExecFolderGrantResolver: Send + Sync {
 /// The fixed managed providers this host can hold a credential for. Local needs
 /// none. Keeping the allow-list here means a local API route can never turn an
 /// arbitrary path segment into a keychain key.
-pub(super) const CREDENTIAL_PROVIDERS: [CodeExecutionProviderKind; 2] = [
-    CodeExecutionProviderKind::E2b,
-    CodeExecutionProviderKind::Daytona,
-];
+pub(super) const CREDENTIAL_PROVIDERS: [ExecProviderKind; 2] =
+    [ExecProviderKind::E2b, ExecProviderKind::Daytona];
 
 /// Every execution provider this build ships, in the order the settings
 /// surface reports them. Availability is computed per row, so a host with no
 /// usable provider says so with a reason for each rather than presenting a
 /// selection that cannot run.
-pub(super) const EXECUTION_PROVIDERS: [CodeExecutionProviderKind; 4] = [
-    CodeExecutionProviderKind::Local,
-    CodeExecutionProviderKind::E2b,
-    CodeExecutionProviderKind::Daytona,
-    CodeExecutionProviderKind::Docker,
+pub(super) const EXECUTION_PROVIDERS: [ExecProviderKind; 4] = [
+    ExecProviderKind::Local,
+    ExecProviderKind::E2b,
+    ExecProviderKind::Daytona,
+    ExecProviderKind::Docker,
 ];
 
 /// Host-owned, non-secret egress policy for the managed exec sandboxes.
@@ -237,9 +235,9 @@ impl EgressConfig {
 /// chat's network policy outside the workload. `None` explicitly removes
 /// execution from service without changing the stable tool contract.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CodeExecutionConfig {
+pub struct ExecConfig {
     #[serde(default)]
-    pub provider: Option<CodeExecutionProviderKind>,
+    pub provider: Option<ExecProviderKind>,
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
     /// Egress policy for the managed adapters. Absent in configs written
@@ -265,7 +263,7 @@ pub struct CodeExecutionConfig {
     pub daytona_snapshot: Option<String>,
 }
 
-impl Default for CodeExecutionConfig {
+impl Default for ExecConfig {
     fn default() -> Self {
         Self {
             // Local is the default only on hosts where it can actually run.
@@ -276,7 +274,7 @@ impl Default for CodeExecutionConfig {
             // why.
             provider: LocalExecutionProvider::availability()
                 .is_ok()
-                .then_some(CodeExecutionProviderKind::Local),
+                .then_some(ExecProviderKind::Local),
             timeout_ms: DEFAULT_TIMEOUT_MS,
             egress: EgressConfig::Open,
             e2b_template: None,
@@ -285,7 +283,7 @@ impl Default for CodeExecutionConfig {
     }
 }
 
-impl CodeExecutionConfig {
+impl ExecConfig {
     pub(super) fn disabled() -> Self {
         Self {
             provider: None,
@@ -319,10 +317,10 @@ pub(super) const fn default_timeout_ms() -> u64 {
 /// refusing execution rather than degrading to open egress.
 pub(super) fn resolve_egress_policy(
     egress: &EgressConfig,
-) -> std::result::Result<Option<EgressPolicy>, CodeExecutionError> {
-    egress.to_policy().map_err(|error| {
-        CodeExecutionError::InvalidRequest(format!("invalid egress policy: {error}"))
-    })
+) -> std::result::Result<Option<EgressPolicy>, ExecError> {
+    egress
+        .to_policy()
+        .map_err(|error| ExecError::InvalidRequest(format!("invalid egress policy: {error}")))
 }
 
 /// Build the E2B adapter with the configured egress policy applied.
@@ -337,7 +335,7 @@ pub(super) fn configured_e2b(
     pool: RemoteSessionPool,
     egress: &EgressConfig,
     template: Option<&str>,
-) -> std::result::Result<E2BExecutionProvider, CodeExecutionError> {
+) -> std::result::Result<E2BExecutionProvider, ExecError> {
     let mut provider = E2BExecutionProvider::with_session_pool(credential, timeout, pool)?;
     if let Some(template) = template {
         provider = provider.with_template(template);
@@ -358,7 +356,7 @@ pub(super) fn configured_daytona(
     egress: &EgressConfig,
     snapshot: Option<&str>,
     preparation: Option<Arc<dyn tidebreak_code_execution::SandboxPreparationSink>>,
-) -> std::result::Result<DaytonaExecutionProvider, CodeExecutionError> {
+) -> std::result::Result<DaytonaExecutionProvider, ExecError> {
     let mut provider = DaytonaExecutionProvider::with_session_pool(credential, timeout, pool)?;
     if let Some(snapshot) = snapshot {
         provider = provider.with_snapshot(snapshot);
@@ -384,7 +382,7 @@ pub(super) fn configured_docker(
     timeout: Duration,
     pool: RemoteSessionPool,
     egress: &EgressConfig,
-) -> std::result::Result<DockerExecutionProvider, CodeExecutionError> {
+) -> std::result::Result<DockerExecutionProvider, ExecError> {
     let provider = DockerExecutionProvider::with_session_pool(timeout, pool)?;
     Ok(match resolve_egress_policy(egress)? {
         Some(policy) => provider.with_egress_policy(policy),
@@ -394,27 +392,27 @@ pub(super) fn configured_docker(
 
 /// Renderer-safe configuration and readiness.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
-pub struct CodeExecutionConfigInfo {
+pub struct ExecConfigInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
-    pub provider: Option<CodeExecutionProviderKind>,
+    pub provider: Option<ExecProviderKind>,
     pub timeout_ms: u64,
     pub available: bool,
     /// Why the *selected* provider cannot run, when it cannot. Absent while
     /// execution is available or no provider is selected at all.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
-    pub unavailable_reason: Option<CodeExecutionUnavailableReason>,
+    pub unavailable_reason: Option<ExecUnavailableReason>,
     pub has_credential: bool,
     /// One row per shipped provider: whether it could run here at all, and the
     /// reason it could not. This is what makes an unusable host legible —
     /// "paste an E2B key" is visible instead of being inferred from a generic
     /// execution failure.
-    pub providers: Vec<CodeExecutionProviderAvailability>,
+    pub providers: Vec<ExecProviderAvailability>,
     /// The configured egress policy and each managed provider's enforcement
     /// status, so the renderer can present the policy and disclose which
     /// providers actually restrict egress today.
-    pub egress: CodeExecutionEgressInfo,
+    pub egress: ExecEgressInfo,
     /// Per-provider detached-admission evaluation: for each execution
     /// provider, whether the fail-closed gate (issue #824) would admit a
     /// detached run it hosted, and every named precondition it fails. Derived
@@ -425,14 +423,14 @@ pub struct CodeExecutionConfigInfo {
 
 /// Renderer-safe egress policy plus per-provider enforcement disclosure.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
-pub struct CodeExecutionEgressInfo {
+pub struct ExecEgressInfo {
     /// The configured host policy. `Open` is the default: managed sandboxes are
     /// created with open internet access. An allowlist restricts every managed
     /// sandbox created afterwards.
     pub policy: EgressConfig,
     /// One row per managed provider, stating whether its egress restriction is
     /// confirmed against the live vendor API or still pending confirmation.
-    pub enforcement: Vec<CodeExecutionEgressEnforcement>,
+    pub enforcement: Vec<ExecEgressEnforcement>,
 }
 
 /// The honest state of a managed provider's egress enforcement.
@@ -473,8 +471,8 @@ pub enum EgressEnforcementStatus {
 /// A managed provider's egress-enforcement status, as host knowledge rather
 /// than a claim the backend makes about itself.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
-pub struct CodeExecutionEgressEnforcement {
-    pub provider: CodeExecutionProviderKind,
+pub struct ExecEgressEnforcement {
+    pub provider: ExecProviderKind,
     pub status: EgressEnforcementStatus,
     /// Destinations the vendor's mechanism keeps reachable regardless of the
     /// configured policy — each a short purpose string straight from the
@@ -499,7 +497,7 @@ pub struct CodeExecutionEgressEnforcement {
 /// simply unestablished for them, and the fail-closed evaluation names each.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct DetachedAdmissionProviderInfo {
-    pub provider: CodeExecutionProviderKind,
+    pub provider: ExecProviderKind,
     /// Whether the gate would admit a detached run hosted by this provider.
     pub admitted: bool,
     /// Every unmet precondition, named — not just the first.
@@ -584,18 +582,16 @@ pub(super) const DAYTONA_TIER_REQUIREMENT: &str = "Daytona org tier 3+";
 /// policy rather than only on the backend, so the policy the row describes is
 /// an argument: a policy that permits nothing is a real boundary there
 /// (`--network none`), and every other class is enforced by nothing at all.
-pub(super) fn egress_enforcement_status(
-    policy: &EgressConfig,
-) -> Vec<CodeExecutionEgressEnforcement> {
+pub(super) fn egress_enforcement_status(policy: &EgressConfig) -> Vec<ExecEgressEnforcement> {
     vec![
         enforcement_row(
-            CodeExecutionProviderKind::E2b,
+            ExecProviderKind::E2b,
             &E2BExecutionProvider::egress_enforcement(),
             true,
             None,
         ),
         enforcement_row(
-            CodeExecutionProviderKind::Daytona,
+            ExecProviderKind::Daytona,
             &DaytonaExecutionProvider::egress_enforcement(),
             true,
             Some(DAYTONA_TIER_REQUIREMENT),
@@ -616,14 +612,12 @@ pub(super) fn egress_enforcement_status(
 /// A policy that does not parse is treated as unenforced. It cannot create a
 /// sandbox at all ([`resolve_egress_policy`] fails closed), so the honest
 /// disclosure is the one that claims nothing.
-fn docker_enforcement_row(policy: &EgressConfig) -> CodeExecutionEgressEnforcement {
+fn docker_enforcement_row(policy: &EgressConfig) -> ExecEgressEnforcement {
     let compiled = policy.to_policy().ok().flatten();
     match DockerExecutionProvider::egress_enforcement(compiled.as_ref()) {
-        Some(enforcement) => {
-            enforcement_row(CodeExecutionProviderKind::Docker, &enforcement, true, None)
-        }
-        None => CodeExecutionEgressEnforcement {
-            provider: CodeExecutionProviderKind::Docker,
+        Some(enforcement) => enforcement_row(ExecProviderKind::Docker, &enforcement, true, None),
+        None => ExecEgressEnforcement {
+            provider: ExecProviderKind::Docker,
             status: EgressEnforcementStatus::NotEnforced,
             gaps: vec![DOCKER_OPEN_EGRESS_GAP.to_owned()],
             requirement: None,
@@ -650,11 +644,11 @@ pub(super) const DOCKER_OPEN_EGRESS_GAP: &str =
 /// present it as an unconditional boundary. Every declared exception is
 /// surfaced as a gap so nothing the vendor leaves open is hidden from the user.
 pub(super) fn enforcement_row(
-    provider: CodeExecutionProviderKind,
+    provider: ExecProviderKind,
     enforcement: &EgressEnforcement,
     confirmed: bool,
     requirement: Option<&'static str>,
-) -> CodeExecutionEgressEnforcement {
+) -> ExecEgressEnforcement {
     let status = if !confirmed {
         EgressEnforcementStatus::Unconfirmed
     } else if enforcement.is_credential_boundary() {
@@ -671,7 +665,7 @@ pub(super) fn enforcement_row(
         .iter()
         .map(|exception| exception.purpose.to_owned())
         .collect();
-    CodeExecutionEgressEnforcement {
+    ExecEgressEnforcement {
         provider,
         status,
         gaps,
@@ -679,7 +673,7 @@ pub(super) fn enforcement_row(
     }
 }
 
-impl CodeExecutionEgressInfo {
+impl ExecEgressInfo {
     fn from_config(policy: EgressConfig) -> Self {
         Self {
             enforcement: egress_enforcement_status(&policy),
@@ -690,8 +684,8 @@ impl CodeExecutionEgressInfo {
 
 /// Renderer-safe readiness for one managed provider's fixed credential slot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
-pub struct CodeExecutionCredentialReadiness {
-    pub provider: CodeExecutionProviderKind,
+pub struct ExecCredentialReadiness {
+    pub provider: ExecProviderKind,
     pub has_credential: bool,
 }
 
@@ -701,19 +695,16 @@ pub struct CodeExecutionCredentialReadiness {
 /// [`provider_availability`], so no surface has to re-derive whether a platform
 /// supports a provider or whether a key is saved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
-pub struct CodeExecutionProviderAvailability {
-    pub provider: CodeExecutionProviderKind,
+pub struct ExecProviderAvailability {
+    pub provider: ExecProviderKind,
     pub available: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
-    pub unavailable_reason: Option<CodeExecutionUnavailableReason>,
+    pub unavailable_reason: Option<ExecUnavailableReason>,
 }
 
-impl CodeExecutionProviderAvailability {
-    fn new(
-        provider: CodeExecutionProviderKind,
-        unavailable_reason: Option<CodeExecutionUnavailableReason>,
-    ) -> Self {
+impl ExecProviderAvailability {
+    fn new(provider: ExecProviderKind, unavailable_reason: Option<ExecUnavailableReason>) -> Self {
         Self {
             provider,
             available: unavailable_reason.is_none(),
@@ -730,35 +721,35 @@ impl CodeExecutionProviderAvailability {
 /// reads this, so they cannot disagree.
 pub(super) async fn provider_availability(
     secrets: &dyn SecretProvider,
-    provider: CodeExecutionProviderKind,
-) -> CodeExecutionProviderAvailability {
+    provider: ExecProviderKind,
+) -> ExecProviderAvailability {
     let reason = match provider {
-        CodeExecutionProviderKind::Local => LocalExecutionProvider::availability().err(),
+        ExecProviderKind::Local => LocalExecutionProvider::availability().err(),
         // The container backend needs no credential; what it needs is a
         // runtime that answers. The probe distinguishes an absent runtime
         // from an installed one whose daemon is down, and caches its answer,
         // so rendering this surface costs at most one probe.
-        CodeExecutionProviderKind::Docker => DockerExecutionProvider::availability().await.err(),
+        ExecProviderKind::Docker => DockerExecutionProvider::availability().await.err(),
         _ => (!has_credential(secrets, provider).await)
-            .then_some(CodeExecutionUnavailableReason::MissingCredential),
+            .then_some(ExecUnavailableReason::MissingCredential),
     };
-    CodeExecutionProviderAvailability::new(provider, reason)
+    ExecProviderAvailability::new(provider, reason)
 }
 
 /// Credential readiness for every managed provider this host supports, so the
 /// renderer can offer a key field per provider without selecting one first.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct CodeExecutionCredentialsInfo {
-    pub credentials: Vec<CodeExecutionCredentialReadiness>,
+pub struct ExecCredentialsInfo {
+    pub credentials: Vec<ExecCredentialReadiness>,
 }
 
 /// Partial update accepted by `PUT /code-execution`. An explicit null disables
 /// all providers; an absent field leaves the current value unchanged.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct CodeExecutionConfigUpdate {
+pub struct ExecConfigUpdate {
     #[serde(default, deserialize_with = "double_option")]
-    pub provider: Option<Option<CodeExecutionProviderKind>>,
+    pub provider: Option<Option<ExecProviderKind>>,
     #[serde(default)]
     pub timeout_ms: Option<u64>,
     /// Replace the egress policy. Absent leaves the current policy unchanged;
@@ -787,20 +778,20 @@ where
 }
 
 /// Read configured host policy. Invalid hand-edited state fails closed.
-pub async fn read_config(store: &dyn Store) -> Result<CodeExecutionConfig> {
+pub async fn read_config(store: &dyn Store) -> Result<ExecConfig> {
     let Some(value) = store.get_setting(CODE_EXECUTION_SETTING).await? else {
-        return Ok(CodeExecutionConfig::default());
+        return Ok(ExecConfig::default());
     };
-    let Ok(config) = serde_json::from_value::<CodeExecutionConfig>(value) else {
-        return Ok(CodeExecutionConfig::disabled());
+    let Ok(config) = serde_json::from_value::<ExecConfig>(value) else {
+        return Ok(ExecConfig::disabled());
     };
     if config.validate().is_err() {
-        return Ok(CodeExecutionConfig::disabled());
+        return Ok(ExecConfig::disabled());
     }
     Ok(config)
 }
 
-pub(super) async fn write_config(store: &dyn Store, config: &CodeExecutionConfig) -> Result<()> {
+pub(super) async fn write_config(store: &dyn Store, config: &ExecConfig) -> Result<()> {
     store
         .set_setting(CODE_EXECUTION_SETTING, &serde_json::to_value(config)?)
         .await
@@ -810,7 +801,7 @@ pub async fn config_info(
     host_config: &tidebreak_core::Config,
     store: &dyn Store,
     secrets: &dyn SecretProvider,
-) -> Result<CodeExecutionConfigInfo> {
+) -> Result<ExecConfigInfo> {
     let config = read_config(store).await?;
     let has_credential = match config.provider {
         Some(provider) => has_credential(secrets, provider).await,
@@ -828,37 +819,37 @@ pub async fn config_info(
             .find(|candidate| candidate.provider == provider)
             .copied()
     });
-    Ok(CodeExecutionConfigInfo {
+    Ok(ExecConfigInfo {
         provider: config.provider,
         timeout_ms: config.timeout_ms,
         available: selected.is_some_and(|row| row.available),
         unavailable_reason: selected.and_then(|row| row.unavailable_reason),
         has_credential,
         providers,
-        egress: CodeExecutionEgressInfo::from_config(config.egress),
+        egress: ExecEgressInfo::from_config(config.egress),
         detached_admission: detached_admission_info(host_config),
     })
 }
 
 /// Report readiness for every managed provider without reading or returning any
 /// key material.
-pub async fn credentials_info(secrets: &dyn SecretProvider) -> CodeExecutionCredentialsInfo {
+pub async fn credentials_info(secrets: &dyn SecretProvider) -> ExecCredentialsInfo {
     let mut credentials = Vec::with_capacity(CREDENTIAL_PROVIDERS.len());
     for provider in CREDENTIAL_PROVIDERS {
-        credentials.push(CodeExecutionCredentialReadiness {
+        credentials.push(ExecCredentialReadiness {
             provider,
             has_credential: has_credential(secrets, provider).await,
         });
     }
-    CodeExecutionCredentialsInfo { credentials }
+    ExecCredentialsInfo { credentials }
 }
 
 pub async fn update_config(
     host_config: &tidebreak_core::Config,
     store: &dyn Store,
     secrets: &dyn SecretProvider,
-    update: CodeExecutionConfigUpdate,
-) -> std::result::Result<CodeExecutionConfigInfo, ServerError> {
+    update: ExecConfigUpdate,
+) -> std::result::Result<ExecConfigInfo, ServerError> {
     let mut config = read_config(store).await?;
     if let Some(provider) = update.provider {
         config.provider = provider;
@@ -884,15 +875,15 @@ pub async fn update_config(
 
 pub async fn write_credential(
     secrets: &dyn SecretProvider,
-    provider: CodeExecutionProviderKind,
+    provider: ExecProviderKind,
     api_key: &str,
-) -> std::result::Result<CodeExecutionCredentialReadiness, ServerError> {
+) -> std::result::Result<ExecCredentialReadiness, ServerError> {
     let (key, label) = credential_spec(provider)?;
     secrets
         .set_secret(key, api_key)
         .await
         .map_err(|_| ServerError::internal(format!("{label} credential storage is unavailable")))?;
-    Ok(CodeExecutionCredentialReadiness {
+    Ok(ExecCredentialReadiness {
         provider,
         has_credential: true,
     })
@@ -900,22 +891,20 @@ pub async fn write_credential(
 
 pub async fn delete_credential(
     secrets: &dyn SecretProvider,
-    provider: CodeExecutionProviderKind,
-) -> std::result::Result<CodeExecutionCredentialReadiness, ServerError> {
+    provider: ExecProviderKind,
+) -> std::result::Result<ExecCredentialReadiness, ServerError> {
     let (key, label) = credential_spec(provider)?;
     secrets
         .delete_secret(key)
         .await
         .map_err(|_| ServerError::internal(format!("{label} credential storage is unavailable")))?;
-    Ok(CodeExecutionCredentialReadiness {
+    Ok(ExecCredentialReadiness {
         provider,
         has_credential: false,
     })
 }
 
-pub fn credential_provider(
-    value: &str,
-) -> std::result::Result<CodeExecutionProviderKind, ServerError> {
+pub fn credential_provider(value: &str) -> std::result::Result<ExecProviderKind, ServerError> {
     CREDENTIAL_PROVIDERS
         .into_iter()
         .find(|provider| provider.as_str() == value)
@@ -928,28 +917,26 @@ pub fn credential_provider(
 
 pub(super) async fn has_credential(
     secrets: &dyn SecretProvider,
-    provider: CodeExecutionProviderKind,
+    provider: ExecProviderKind,
 ) -> bool {
     match provider {
-        CodeExecutionProviderKind::E2b => {
-            E2BCredential::load(secrets).await.ok().flatten().is_some()
-        }
-        CodeExecutionProviderKind::Daytona => DaytonaCredential::load(secrets)
+        ExecProviderKind::E2b => E2BCredential::load(secrets).await.ok().flatten().is_some(),
+        ExecProviderKind::Daytona => DaytonaCredential::load(secrets)
             .await
             .ok()
             .flatten()
             .is_some(),
-        CodeExecutionProviderKind::Local | CodeExecutionProviderKind::Docker => false,
+        ExecProviderKind::Local | ExecProviderKind::Docker => false,
         _ => false,
     }
 }
 
 pub(super) fn credential_spec(
-    provider: CodeExecutionProviderKind,
+    provider: ExecProviderKind,
 ) -> std::result::Result<(&'static str, &'static str), ServerError> {
     match provider {
-        CodeExecutionProviderKind::E2b => Ok((E2B_CREDENTIAL_KEY, "E2B")),
-        CodeExecutionProviderKind::Daytona => Ok((DAYTONA_CREDENTIAL_KEY, "Daytona")),
+        ExecProviderKind::E2b => Ok((E2B_CREDENTIAL_KEY, "E2B")),
+        ExecProviderKind::Daytona => Ok((DAYTONA_CREDENTIAL_KEY, "Daytona")),
         _ => Err(ServerError::not_found(format!(
             "unknown credentialed code execution provider kind: {provider}"
         ))),

--- a/crates/tidebreak-server/src/code_execution/mod.rs
+++ b/crates/tidebreak-server/src/code_execution/mod.rs
@@ -1,7 +1,7 @@
 //! Host-owned code-execution provider selection and policy.
 //!
 //! The model cannot select a provider or timeout. The foreground `exec` tool
-//! calls [`ConfiguredCodeExecutionProvider`], which reads the current host
+//! calls [`ConfiguredExecProvider`], which reads the current host
 //! setting at the last possible boundary and delegates to the selected adapter.
 //! Local and managed adapters implement the same provider contract without
 //! changing the tool schema or persisted tool-call arguments.

--- a/crates/tidebreak-server/src/code_execution/provider.rs
+++ b/crates/tidebreak-server/src/code_execution/provider.rs
@@ -8,13 +8,12 @@ use std::time::Duration;
 use async_trait::async_trait;
 use chrono::Utc;
 use tidebreak_code_execution::{
-    sync, CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind,
-    CodeExecutionRequest, CodeExecutionResponse, DaytonaCredential, E2BCredential,
-    ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
-    MaterializationPrecondition, MaterializedChangeKind, OutputArtifactEntry, OutputArtifactScan,
-    OutputArtifactStatus, PreviewScan, RejectedChangeReason, RemoteSessionPool, SharedPackageCache,
-    StagedUpload, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, WriteOverlay,
-    WriteSnapshotSink, PACKAGE_CACHE_DIR,
+    sync, DaytonaCredential, E2BCredential, ExecError, ExecFolderAccess, ExecFolderGrant,
+    ExecProvider, ExecProviderKind, ExecRequest, ExecResponse, ExecutionId, ExecutionWorkspaceId,
+    LocalExecutionProvider, MaterializationPrecondition, MaterializedChangeKind,
+    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, PreviewScan,
+    RejectedChangeReason, RemoteSessionPool, SharedPackageCache, StagedUpload, WorkspaceFilePath,
+    WorkspaceLifecycle, WorkspaceListing, WriteOverlay, WriteSnapshotSink, PACKAGE_CACHE_DIR,
 };
 use tidebreak_core::{
     BlobStore, CallId, Chat, ChatId, ExecFileRejectionReason, ExecFileRejectionRecord, HostRootId,
@@ -30,7 +29,7 @@ use super::staging::{
     required_host_deps, staged_set_note, StagedFolders, StagedTurn,
 };
 
-pub struct ConfiguredCodeExecutionProvider {
+pub struct ConfiguredExecProvider {
     pub(super) store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
     blobs: Option<Arc<dyn BlobStore>>,
@@ -136,7 +135,7 @@ impl tidebreak_code_execution::SandboxPreparationSink for SandboxPreparationNoti
 }
 
 #[async_trait]
-impl StagedFolders for ConfiguredCodeExecutionProvider {
+impl StagedFolders for ConfiguredExecProvider {
     fn staged_root(&self, chat: ChatId, root_id: HostRootId) -> Option<PathBuf> {
         self.write_overlays
             .lock()
@@ -205,7 +204,7 @@ impl StagedFolders for ConfiguredCodeExecutionProvider {
     }
 }
 
-impl ConfiguredCodeExecutionProvider {
+impl ConfiguredExecProvider {
     #[must_use]
     pub fn new(
         store: Arc<dyn Store>,
@@ -728,7 +727,7 @@ impl ConfiguredCodeExecutionProvider {
             .await
             .ok()
             .and_then(|c| c.provider);
-        if !matches!(provider, None | Some(CodeExecutionProviderKind::Local)) {
+        if !matches!(provider, None | Some(ExecProviderKind::Local)) {
             return Some(tidebreak_code_execution::HostToolStatus::Available);
         }
         let Some(broker) = self.host_tool_broker.as_deref() else {
@@ -775,7 +774,7 @@ impl ConfiguredCodeExecutionProvider {
         let Ok(config) = read_config(&*self.store).await else {
             return false;
         };
-        if config.provider != Some(CodeExecutionProviderKind::Local) {
+        if config.provider != Some(ExecProviderKind::Local) {
             return false;
         }
         match self.shared_package_cache().await {
@@ -853,7 +852,7 @@ impl ConfiguredCodeExecutionProvider {
         let Ok(config) = read_config(&*self.store).await else {
             return;
         };
-        if config.provider != Some(CodeExecutionProviderKind::Local) {
+        if config.provider != Some(ExecProviderKind::Local) {
             return;
         }
         let Some(cache) = self.shared_package_cache().await else {
@@ -946,11 +945,11 @@ impl ConfiguredCodeExecutionProvider {
         &self,
         chat: &Chat,
         turn: TurnId,
-    ) -> std::result::Result<Vec<ResolvedExecFolderGrant>, CodeExecutionError> {
-        let config = read_config(&*self.store).await.map_err(|_| {
-            CodeExecutionError::Unavailable("configuration storage is unavailable".into())
-        })?;
-        if config.provider != Some(CodeExecutionProviderKind::Local) || !cfg!(target_os = "macos") {
+    ) -> std::result::Result<Vec<ResolvedExecFolderGrant>, ExecError> {
+        let config = read_config(&*self.store)
+            .await
+            .map_err(|_| ExecError::Unavailable("configuration storage is unavailable".into()))?;
+        if config.provider != Some(ExecProviderKind::Local) || !cfg!(target_os = "macos") {
             return Ok(Vec::new());
         }
         let mut grants = self.resolve_chat_folder_grants(chat).await?;
@@ -1147,7 +1146,7 @@ impl ConfiguredCodeExecutionProvider {
     pub(super) async fn resolve_chat_folder_grants(
         &self,
         chat: &Chat,
-    ) -> std::result::Result<Vec<ResolvedExecFolderGrant>, CodeExecutionError> {
+    ) -> std::result::Result<Vec<ResolvedExecFolderGrant>, ExecError> {
         let Some(resolver) = self.folder_grant_resolver.as_ref() else {
             return Ok(Vec::new());
         };
@@ -1167,16 +1166,16 @@ impl ConfiguredCodeExecutionProvider {
                 root_ids: root_ids.clone(),
             })
             .await
-            .map_err(CodeExecutionError::Sandbox)?;
+            .map_err(ExecError::Sandbox)?;
         if resolved.len() > root_ids.len() {
-            return Err(CodeExecutionError::Sandbox(
+            return Err(ExecError::Sandbox(
                 "host returned too many execution folder grants".into(),
             ));
         }
         let mut by_id = HashMap::new();
         for grant in resolved {
             if !allowed.contains(&grant.root_id) || by_id.insert(grant.root_id, grant).is_some() {
-                return Err(CodeExecutionError::Sandbox(
+                return Err(ExecError::Sandbox(
                     "host returned an invalid execution folder grant".into(),
                 ));
             }
@@ -1222,18 +1221,15 @@ impl ConfiguredCodeExecutionProvider {
     async fn resolve(
         &self,
         network_policy: Option<&NetworkPolicy>,
-    ) -> std::result::Result<
-        (CodeExecutionProviderKind, Box<dyn CodeExecutionProvider>),
-        CodeExecutionError,
-    > {
-        let config = read_config(&*self.store).await.map_err(|_| {
-            CodeExecutionError::Unavailable("configuration storage is unavailable".into())
-        })?;
+    ) -> std::result::Result<(ExecProviderKind, Box<dyn ExecProvider>), ExecError> {
+        let config = read_config(&*self.store)
+            .await
+            .map_err(|_| ExecError::Unavailable("configuration storage is unavailable".into()))?;
         let Some(provider) = config.provider else {
-            return Err(CodeExecutionError::NotConfigured);
+            return Err(ExecError::NotConfigured);
         };
-        let resolved: Box<dyn CodeExecutionProvider> = match provider {
-            CodeExecutionProviderKind::Local => {
+        let resolved: Box<dyn ExecProvider> = match provider {
+            ExecProviderKind::Local => {
                 // Mounted only once verified artifacts exist; an empty or
                 // unusable cache leaves execution exactly as it was.
                 let package_cache = match self.shared_package_cache().await {
@@ -1251,10 +1247,10 @@ impl ConfiguredCodeExecutionProvider {
                     .with_managed_node(self.managed_node_dir().await),
                 )
             }
-            CodeExecutionProviderKind::E2b => {
+            ExecProviderKind::E2b => {
                 let credential = E2BCredential::load(&*self.secrets)
                     .await?
-                    .ok_or(CodeExecutionError::NotConfigured)?;
+                    .ok_or(ExecError::NotConfigured)?;
                 let egress = network_policy
                     .map(network_egress_config)
                     .unwrap_or_else(|| config.egress.clone());
@@ -1266,10 +1262,10 @@ impl ConfiguredCodeExecutionProvider {
                     config.e2b_template.as_deref(),
                 )?)
             }
-            CodeExecutionProviderKind::Daytona => {
+            ExecProviderKind::Daytona => {
                 let credential = DaytonaCredential::load(&*self.secrets)
                     .await?
-                    .ok_or(CodeExecutionError::NotConfigured)?;
+                    .ok_or(ExecError::NotConfigured)?;
                 let egress = network_policy
                     .map(network_egress_config)
                     .unwrap_or_else(|| config.egress.clone());
@@ -1282,7 +1278,7 @@ impl ConfiguredCodeExecutionProvider {
                     self.preparation_sink(),
                 )?)
             }
-            CodeExecutionProviderKind::Docker => {
+            ExecProviderKind::Docker => {
                 // The chat's policy reaches container creation, but only its
                 // strictest class is enforced there: "no network" creates the
                 // container with no network at all, and an allowlist runs on
@@ -1298,7 +1294,7 @@ impl ConfiguredCodeExecutionProvider {
                 )?)
             }
             _ => {
-                return Err(CodeExecutionError::Unavailable(
+                return Err(ExecError::Unavailable(
                     "selected provider is not supported by this build".into(),
                 ))
             }
@@ -1312,12 +1308,10 @@ impl ConfiguredCodeExecutionProvider {
     /// configured, or the selected backend has no workspace lifecycle, so host
     /// callers degrade instead of failing. This is a host-internal API; no
     /// model-facing tool is registered over it.
-    pub async fn workspace(
-        &self,
-    ) -> std::result::Result<Option<ConfiguredWorkspace>, CodeExecutionError> {
+    pub async fn workspace(&self) -> std::result::Result<Option<ConfiguredWorkspace>, ExecError> {
         let provider = match self.resolve(None).await {
             Ok((_, provider)) => provider,
-            Err(CodeExecutionError::NotConfigured) => return Ok(None),
+            Err(ExecError::NotConfigured) => return Ok(None),
             Err(error) => return Err(error),
         };
         if provider.workspace_lifecycle().is_none() {
@@ -1338,10 +1332,10 @@ impl ConfiguredCodeExecutionProvider {
     pub async fn execute_for_agent_run(
         &self,
         chat_id: ChatId,
-        request: CodeExecutionRequest,
-    ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
+        request: ExecRequest,
+    ) -> std::result::Result<ExecResponse, ExecError> {
         if !request.folder_grants.is_empty() {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "a background run's execution carries no folder authority".into(),
             ));
         }
@@ -1349,11 +1343,9 @@ impl ConfiguredCodeExecutionProvider {
             .store
             .get_chat(chat_id)
             .await
-            .map_err(|_| {
-                CodeExecutionError::Unavailable("conversation storage is unavailable".into())
-            })?
+            .map_err(|_| ExecError::Unavailable("conversation storage is unavailable".into()))?
             .ok_or_else(|| {
-                CodeExecutionError::InvalidRequest("execution conversation does not exist".into())
+                ExecError::InvalidRequest("execution conversation does not exist".into())
             })?;
         let (kind, provider) = self.resolve(Some(&chat.network_policy)).await?;
         self.execute_prepared(kind, provider, request, None, chat_id)
@@ -1372,17 +1364,17 @@ impl ConfiguredCodeExecutionProvider {
     /// against.
     async fn execute_prepared(
         &self,
-        kind: CodeExecutionProviderKind,
-        provider: Box<dyn CodeExecutionProvider>,
-        request: CodeExecutionRequest,
+        kind: ExecProviderKind,
+        provider: Box<dyn ExecProvider>,
+        request: ExecRequest,
         chat: Option<ChatId>,
         degradation_chat: ChatId,
-    ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
+    ) -> std::result::Result<ExecResponse, ExecError> {
         let host_dir = self.scratch_root.join(request.workspace_id.as_str());
         let skills = self.current_skills().await;
         prepare_execution_directories(
             &host_dir,
-            kind != CodeExecutionProviderKind::Local,
+            kind != ExecProviderKind::Local,
             self.document_scripts_source.as_deref(),
             &skills,
         )
@@ -1399,7 +1391,7 @@ impl ConfiguredCodeExecutionProvider {
         // there, but the listed paths are validated identically so a bad path
         // fails the same way on every provider.
         let lifecycle = match kind {
-            CodeExecutionProviderKind::Local => None,
+            ExecProviderKind::Local => None,
             _ => provider.workspace_lifecycle(),
         };
         let Some(lifecycle) = lifecycle else {
@@ -1490,7 +1482,7 @@ impl ConfiguredCodeExecutionProvider {
         chat_id: ChatId,
         call_id: CallId,
         run_id: tidebreak_core::AgentRunId,
-    ) -> std::result::Result<OutputArtifactScan, CodeExecutionError> {
+    ) -> std::result::Result<OutputArtifactScan, ExecError> {
         self.publish_output_directory(workspace, chat_id, call_id, RevisionProducer::Run(run_id))
             .await
     }
@@ -1501,15 +1493,15 @@ impl ConfiguredCodeExecutionProvider {
     async fn open_scratch_directory(
         &self,
         name: &str,
-    ) -> std::result::Result<cap_std::fs::Dir, CodeExecutionError> {
+    ) -> std::result::Result<cap_std::fs::Dir, ExecError> {
         let path = self.scratch_root.join(name);
         tokio::task::spawn_blocking(move || {
             std::fs::create_dir_all(&path)?;
             cap_std::fs::Dir::open_ambient_dir(&path, cap_std::ambient_authority())
         })
         .await
-        .map_err(|_| CodeExecutionError::Sandbox("output scan task failed".into()))?
-        .map_err(|_| CodeExecutionError::Sandbox("the private workspace is unavailable".into()))
+        .map_err(|_| ExecError::Sandbox("output scan task failed".into()))?
+        .map_err(|_| ExecError::Sandbox("the private workspace is unavailable".into()))
     }
 
     /// Scan one workspace's `output/` and record what changed as revisions.
@@ -1525,12 +1517,12 @@ impl ConfiguredCodeExecutionProvider {
         chat_id: ChatId,
         call_id: CallId,
         producer: RevisionProducer,
-    ) -> std::result::Result<OutputArtifactScan, CodeExecutionError> {
+    ) -> std::result::Result<OutputArtifactScan, ExecError> {
         let workspace_dir = self.open_scratch_directory(workspace.as_str()).await?;
         let publication_dir = if workspace.as_str() == chat_id.to_string() {
-            workspace_dir.try_clone().map_err(|_| {
-                CodeExecutionError::Sandbox("the private workspace is unavailable".into())
-            })?
+            workspace_dir
+                .try_clone()
+                .map_err(|_| ExecError::Sandbox("the private workspace is unavailable".into()))?
         } else {
             self.open_scratch_directory(&chat_id.to_string()).await?
         };
@@ -1546,7 +1538,7 @@ impl ConfiguredCodeExecutionProvider {
         )
         .await
         .map_err(|error| {
-            CodeExecutionError::Unavailable(format!("outputs could not be recorded: {error}"))
+            ExecError::Unavailable(format!("outputs could not be recorded: {error}"))
         })?;
         Ok(OutputArtifactScan {
             entries: sync
@@ -1672,7 +1664,7 @@ pub(super) fn finish_package_cache_population(
     }
 }
 
-pub(super) fn deterministic_package_cache_failure(error: &CodeExecutionError) -> bool {
+pub(super) fn deterministic_package_cache_failure(error: &ExecError) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("could not find a version that satisfies the requirement")
         || message.contains("no matching distribution found")
@@ -1780,7 +1772,7 @@ async fn populate_one_pin_set(
 pub(super) fn exec_folder_grant_for_turn(
     grant: ResolvedExecFolderGrant,
     staged: &HashMap<PathBuf, PathBuf>,
-) -> std::result::Result<ExecFolderGrant, CodeExecutionError> {
+) -> std::result::Result<ExecFolderGrant, ExecError> {
     let overlay = grant
         .writable
         .then(|| staged.get(&grant.path))
@@ -1805,13 +1797,13 @@ pub(super) fn exec_folder_grant_for_turn(
 }
 
 #[async_trait]
-impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
+impl ExecProvider for ConfiguredExecProvider {
     async fn execute(
         &self,
-        mut request: CodeExecutionRequest,
-    ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
+        mut request: ExecRequest,
+    ) -> std::result::Result<ExecResponse, ExecError> {
         if !request.folder_grants.is_empty() {
-            return Err(CodeExecutionError::InvalidRequest(
+            return Err(ExecError::InvalidRequest(
                 "execution folder grants are host-resolved state".into(),
             ));
         }
@@ -1820,7 +1812,7 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
             .as_str()
             .parse::<ChatId>()
             .map_err(|_| {
-                CodeExecutionError::InvalidRequest(
+                ExecError::InvalidRequest(
                     "execution workspace does not identify a conversation".into(),
                 )
             })?;
@@ -1828,16 +1820,12 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
             .store
             .get_chat(chat_id)
             .await
-            .map_err(|_| {
-                CodeExecutionError::Unavailable("conversation storage is unavailable".into())
-            })?
+            .map_err(|_| ExecError::Unavailable("conversation storage is unavailable".into()))?
             .ok_or_else(|| {
-                CodeExecutionError::InvalidRequest("execution conversation does not exist".into())
+                ExecError::InvalidRequest("execution conversation does not exist".into())
             })?;
         let (kind, provider) = self.resolve(Some(&chat.network_policy)).await?;
-        if kind == CodeExecutionProviderKind::Local
-            && permits_package_installs(&chat.network_policy)
-        {
+        if kind == ExecProviderKind::Local && permits_package_installs(&chat.network_policy) {
             // A networked local exec is the signal that installs are wanted:
             // the same pins a conversation installs under its per-chat HOME
             // are acquired host-side into the shared cache, so a later
@@ -1846,7 +1834,7 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
                 self.spawn_package_cache_population(cache);
             }
         }
-        if kind == CodeExecutionProviderKind::Local && cfg!(target_os = "macos") {
+        if kind == ExecProviderKind::Local && cfg!(target_os = "macos") {
             // Authority is resolved again here rather than reused from the
             // turn's prompt snapshot, so a revocation mid-turn fails closed.
             // Staging is looked up rather than re-established: the overlay
@@ -1868,41 +1856,41 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
     async fn collect_preview_images(
         &self,
         workspace: &ExecutionWorkspaceId,
-    ) -> std::result::Result<PreviewScan, CodeExecutionError> {
+    ) -> std::result::Result<PreviewScan, ExecError> {
         let preview_dir = self.scratch_root.join(workspace.as_str()).join("preview");
         tokio::task::spawn_blocking(move || {
             tidebreak_code_execution::scan_preview_directory(&preview_dir)
         })
         .await
-        .map_err(|_| CodeExecutionError::Sandbox("preview scan task failed".into()))
+        .map_err(|_| ExecError::Sandbox("preview scan task failed".into()))
     }
 
     async fn collect_output_artifacts(
         &self,
         workspace: &ExecutionWorkspaceId,
         execution: &ExecutionId,
-    ) -> std::result::Result<OutputArtifactScan, CodeExecutionError> {
+    ) -> std::result::Result<OutputArtifactScan, ExecError> {
         let chat_id = workspace.as_str().parse::<ChatId>().map_err(|_| {
-            CodeExecutionError::InvalidRequest(
-                "execution workspace does not identify a conversation".into(),
-            )
+            ExecError::InvalidRequest("execution workspace does not identify a conversation".into())
         })?;
         let call_id = execution.as_str().parse::<CallId>().map_err(|_| {
-            CodeExecutionError::InvalidRequest(
+            ExecError::InvalidRequest(
                 "execution does not carry a canonical tool-call identity".into(),
             )
         })?;
         // The revision's producer is the turn that owns this exec call, read
         // from the durable call record rather than anything the model asserts.
-        let calls = self.store.list_tool_calls(chat_id).await.map_err(|_| {
-            CodeExecutionError::Unavailable("tool-call storage is unavailable".into())
-        })?;
+        let calls = self
+            .store
+            .list_tool_calls(chat_id)
+            .await
+            .map_err(|_| ExecError::Unavailable("tool-call storage is unavailable".into()))?;
         let turn_id = calls
             .into_iter()
             .find(|call| call.id == call_id)
             .map(|call| call.turn_id)
             .ok_or_else(|| {
-                CodeExecutionError::InvalidRequest(
+                ExecError::InvalidRequest(
                     "execution identity is not owned by this conversation".into(),
                 )
             })?;
@@ -1913,20 +1901,20 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
     // `workspace_lifecycle` stays `None` here on purpose: the capability of
     // this late-binding wrapper depends on the configuration read at call
     // time, which the synchronous trait flag cannot express. Host callers use
-    // [`ConfiguredCodeExecutionProvider::workspace`] instead.
+    // [`ConfiguredExecProvider::workspace`] instead.
 }
 
 /// A resolved workspace-lifecycle handle over the currently selected provider.
 pub struct ConfiguredWorkspace {
-    provider: Box<dyn CodeExecutionProvider>,
+    provider: Box<dyn ExecProvider>,
 }
 
 impl ConfiguredWorkspace {
-    fn lifecycle(&self) -> std::result::Result<&dyn WorkspaceLifecycle, CodeExecutionError> {
+    fn lifecycle(&self) -> std::result::Result<&dyn WorkspaceLifecycle, ExecError> {
         // Checked when this handle was constructed; re-checked instead of
         // unwrapped so a defect degrades into an error, not a panic.
         self.provider.workspace_lifecycle().ok_or_else(|| {
-            CodeExecutionError::Unavailable("selected provider lost its workspace surface".into())
+            ExecError::Unavailable("selected provider lost its workspace surface".into())
         })
     }
 }
@@ -1936,21 +1924,21 @@ impl WorkspaceLifecycle for ConfiguredWorkspace {
     async fn create_workspace(
         &self,
         workspace: &ExecutionWorkspaceId,
-    ) -> std::result::Result<(), CodeExecutionError> {
+    ) -> std::result::Result<(), ExecError> {
         self.lifecycle()?.create_workspace(workspace).await
     }
 
     async fn connect_workspace(
         &self,
         workspace: &ExecutionWorkspaceId,
-    ) -> std::result::Result<bool, CodeExecutionError> {
+    ) -> std::result::Result<bool, ExecError> {
         self.lifecycle()?.connect_workspace(workspace).await
     }
 
     async fn destroy_workspace(
         &self,
         workspace: &ExecutionWorkspaceId,
-    ) -> std::result::Result<(), CodeExecutionError> {
+    ) -> std::result::Result<(), ExecError> {
         self.lifecycle()?.destroy_workspace(workspace).await
     }
 
@@ -1959,7 +1947,7 @@ impl WorkspaceLifecycle for ConfiguredWorkspace {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> std::result::Result<(), CodeExecutionError> {
+    ) -> std::result::Result<(), ExecError> {
         self.lifecycle()?
             .put_workspace_file(workspace, path, content)
             .await
@@ -1970,7 +1958,7 @@ impl WorkspaceLifecycle for ConfiguredWorkspace {
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
         content: &[u8],
-    ) -> std::result::Result<StagedUpload, CodeExecutionError> {
+    ) -> std::result::Result<StagedUpload, ExecError> {
         // Delegated rather than left to the trait default so the selected
         // backend's session memory is not bypassed by the wrapper.
         self.lifecycle()?
@@ -1982,7 +1970,7 @@ impl WorkspaceLifecycle for ConfiguredWorkspace {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: &WorkspaceFilePath,
-    ) -> std::result::Result<Vec<u8>, CodeExecutionError> {
+    ) -> std::result::Result<Vec<u8>, ExecError> {
         self.lifecycle()?.get_workspace_file(workspace, path).await
     }
 
@@ -1990,7 +1978,7 @@ impl WorkspaceLifecycle for ConfiguredWorkspace {
         &self,
         workspace: &ExecutionWorkspaceId,
         path: Option<&WorkspaceFilePath>,
-    ) -> std::result::Result<WorkspaceListing, CodeExecutionError> {
+    ) -> std::result::Result<WorkspaceListing, ExecError> {
         self.lifecycle()?
             .list_workspace_files(workspace, path)
             .await

--- a/crates/tidebreak-server/src/code_execution/staging.rs
+++ b/crates/tidebreak-server/src/code_execution/staging.rs
@@ -5,9 +5,9 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use tidebreak_code_execution::{
-    resolve_scratch_directory, CodeExecutionError, MaterializationPrecondition,
-    MaterializedChangeKind, RejectedChangeReason, WorkspaceFilePath, WriteOverlay,
-    DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES,
+    resolve_scratch_directory, ExecError, MaterializationPrecondition, MaterializedChangeKind,
+    RejectedChangeReason, WorkspaceFilePath, WriteOverlay, DOCUMENT_SCRIPTS_DIR,
+    DOCUMENT_SCRIPT_FILES,
 };
 use tidebreak_core::{
     exec_attachment_file_name, BlobStore, ChatId, HostRootId, MessageDocumentAttachment, Store,
@@ -124,11 +124,11 @@ pub(super) async fn materialize_chat_attachments(
     blobs: &dyn BlobStore,
     chat_id: ChatId,
     host_dir: &std::path::Path,
-) -> std::result::Result<(), CodeExecutionError> {
+) -> std::result::Result<(), ExecError> {
     let attachments = store
         .list_message_document_attachments(chat_id)
         .await
-        .map_err(|_| CodeExecutionError::Unavailable("attachment storage is unavailable".into()))?;
+        .map_err(|_| ExecError::Unavailable("attachment storage is unavailable".into()))?;
     materialize_attachments(&attachments, blobs, host_dir).await
 }
 
@@ -136,13 +136,13 @@ pub(super) async fn materialize_attachments(
     attachments: &[MessageDocumentAttachment],
     blobs: &dyn BlobStore,
     host_dir: &std::path::Path,
-) -> std::result::Result<(), CodeExecutionError> {
+) -> std::result::Result<(), ExecError> {
     let documents_dir = host_dir.join("documents");
     let metadata = tokio::fs::symlink_metadata(&documents_dir)
         .await
-        .map_err(|_| CodeExecutionError::Sandbox("documents/ is unavailable".into()))?;
+        .map_err(|_| ExecError::Sandbox("documents/ is unavailable".into()))?;
     if metadata.file_type().is_symlink() || !metadata.is_dir() {
-        return Err(CodeExecutionError::Sandbox(
+        return Err(ExecError::Sandbox(
             "documents/ is not a private workspace directory".into(),
         ));
     }
@@ -161,24 +161,24 @@ pub(super) async fn materialize_attachments(
             continue;
         }
         let bytes = blobs.get(source_blob.id).await.map_err(|_| {
-            CodeExecutionError::Unavailable("attached document bytes are unavailable".into())
+            ExecError::Unavailable("attached document bytes are unavailable".into())
         })?;
         let Some(bytes) = bytes else {
-            return Err(CodeExecutionError::Unavailable(
+            return Err(ExecError::Unavailable(
                 "attached document bytes are unavailable".into(),
             ));
         };
         if bytes.len() > MAX_EXEC_WORKSPACE_FILE_BYTES
             || tidebreak_core::DocumentBlob::from_bytes(&bytes) != *source_blob
         {
-            return Err(CodeExecutionError::Unavailable(
+            return Err(ExecError::Unavailable(
                 "attached document bytes do not match their stored descriptor".into(),
             ));
         }
         let destination = documents_dir.join(&file_name);
         match tokio::fs::symlink_metadata(&destination).await {
             Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
-                return Err(CodeExecutionError::Sandbox(format!(
+                return Err(ExecError::Sandbox(format!(
                     "documents/{file_name} is not a regular workspace file"
                 )));
             }
@@ -192,13 +192,13 @@ pub(super) async fn materialize_attachments(
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(_) => {
-                return Err(CodeExecutionError::Sandbox(format!(
+                return Err(ExecError::Sandbox(format!(
                     "documents/{file_name} is unavailable"
                 )));
             }
         }
         tokio::fs::write(&destination, bytes).await.map_err(|_| {
-            CodeExecutionError::Sandbox(format!(
+            ExecError::Sandbox(format!(
                 "attached document documents/{file_name} could not be materialized"
             ))
         })?;
@@ -235,7 +235,7 @@ pub(super) async fn prepare_execution_directories(
     mirrored: bool,
     document_scripts_source: Option<&std::path::Path>,
     skills: &[tidebreak_code_execution::LoadedSkill],
-) -> std::result::Result<(), CodeExecutionError> {
+) -> std::result::Result<(), ExecError> {
     // The scratch directory itself is host-owned and named after the chat, but
     // everything inside it is writable by local exec, which can plant
     // `<scratch>/output -> /any/dir` between two runs. `create_dir_all` and a
@@ -243,12 +243,12 @@ pub(super) async fn prepare_execution_directories(
     // directory is resolved a component at a time into an open descriptor and
     // the marker is written relative to that descriptor, without following a
     // link at the final component either.
-    tokio::fs::create_dir_all(host_dir).await.map_err(|_| {
-        CodeExecutionError::Sandbox("the private workspace directory is unavailable".into())
-    })?;
+    tokio::fs::create_dir_all(host_dir)
+        .await
+        .map_err(|_| ExecError::Sandbox("the private workspace directory is unavailable".into()))?;
     for name in ["output", "preview", "documents"] {
         let unavailable = || {
-            CodeExecutionError::Sandbox(format!(
+            ExecError::Sandbox(format!(
                 "private workspace directory '{name}/' is unavailable"
             ))
         };
@@ -284,12 +284,10 @@ pub(super) async fn prepare_execution_directories(
 pub(super) async fn install_skills(
     skills: &[tidebreak_code_execution::LoadedSkill],
     host_dir: &std::path::Path,
-) -> std::result::Result<(), CodeExecutionError> {
+) -> std::result::Result<(), ExecError> {
     let root = resolve_scratch_directory(host_dir, tidebreak_code_execution::SKILLS_DIR, true)
         .await
-        .ok_or_else(|| {
-            CodeExecutionError::Sandbox("the staged skills directory is unavailable".into())
-        })?;
+        .ok_or_else(|| ExecError::Sandbox("the staged skills directory is unavailable".into()))?;
     // Staging is the whole set, not an accumulation. A skill the install has
     // switched off — or one the user deleted — must leave a workspace that
     // staged it on an earlier turn, or the model could still `read_file`
@@ -320,18 +318,14 @@ pub(super) async fn install_skills(
             true,
         )
         .await
-        .ok_or_else(|| {
-            CodeExecutionError::Sandbox(format!("skill directory '{name}' is unavailable"))
-        })?;
+        .ok_or_else(|| ExecError::Sandbox(format!("skill directory '{name}' is unavailable")))?;
         destination
             .write_file(
                 tidebreak_code_execution::SKILL_MANIFEST_FILE,
                 skill.manifest.as_bytes(),
             )
             .await
-            .map_err(|_| {
-                CodeExecutionError::Sandbox(format!("skill '{name}' could not be installed"))
-            })?;
+            .map_err(|_| ExecError::Sandbox(format!("skill '{name}' could not be installed")))?;
         if skill.scripts.is_empty() {
             continue;
         }
@@ -346,14 +340,14 @@ pub(super) async fn install_skills(
         )
         .await
         .ok_or_else(|| {
-            CodeExecutionError::Sandbox(format!("skill '{name}' scripts directory is unavailable"))
+            ExecError::Sandbox(format!("skill '{name}' scripts directory is unavailable"))
         })?;
         for script in &skill.scripts {
             scripts
                 .write_file(&script.name, &script.content)
                 .await
                 .map_err(|_| {
-                    CodeExecutionError::Sandbox(format!(
+                    ExecError::Sandbox(format!(
                         "skill '{name}' script '{}' could not be installed",
                         script.name
                     ))
@@ -366,7 +360,7 @@ pub(super) async fn install_skills(
 pub(super) async fn install_document_scripts(
     source: &std::path::Path,
     host_dir: &std::path::Path,
-) -> std::result::Result<(), CodeExecutionError> {
+) -> std::result::Result<(), ExecError> {
     // `.tidebreak/` sits inside the scratch directory local exec writes to, so
     // a planted `.tidebreak -> /elsewhere` would relocate the helper install
     // and truncate known filenames there. Resolve it a component at a time and
@@ -374,35 +368,31 @@ pub(super) async fn install_document_scripts(
     // rather than whatever the name points at by the time we write.
     let destination = resolve_scratch_directory(host_dir, DOCUMENT_SCRIPTS_DIR, true)
         .await
-        .ok_or_else(|| {
-            CodeExecutionError::Sandbox("document helper directory is unavailable".into())
-        })?;
+        .ok_or_else(|| ExecError::Sandbox("document helper directory is unavailable".into()))?;
     for name in DOCUMENT_SCRIPT_FILES {
         let source_file = source.join(name);
         let metadata = tokio::fs::symlink_metadata(&source_file)
             .await
             .map_err(|_| {
-                CodeExecutionError::Sandbox(format!(
-                    "bundled document helper '{name}' is unavailable"
-                ))
+                ExecError::Sandbox(format!("bundled document helper '{name}' is unavailable"))
             })?;
         if !metadata.is_file() || metadata.file_type().is_symlink() {
-            return Err(CodeExecutionError::Sandbox(format!(
+            return Err(ExecError::Sandbox(format!(
                 "bundled document helper '{name}' is not a regular file"
             )));
         }
         let content = tokio::fs::read(&source_file).await.map_err(|_| {
-            CodeExecutionError::Sandbox(format!(
+            ExecError::Sandbox(format!(
                 "bundled document helper '{name}' could not be read"
             ))
         })?;
         if content.len() > tidebreak_code_execution::MAX_WORKSPACE_FILE_BYTES {
-            return Err(CodeExecutionError::Sandbox(format!(
+            return Err(ExecError::Sandbox(format!(
                 "bundled document helper '{name}' exceeds the workspace file limit"
             )));
         }
         destination.write_file(name, &content).await.map_err(|_| {
-            CodeExecutionError::Sandbox(format!(
+            ExecError::Sandbox(format!(
                 "bundled document helper '{name}' could not be installed"
             ))
         })?;

--- a/crates/tidebreak-server/src/code_execution/tests.rs
+++ b/crates/tidebreak-server/src/code_execution/tests.rs
@@ -5,11 +5,11 @@ use std::time::Duration;
 use async_trait::async_trait;
 use chrono::Utc;
 use tidebreak_code_execution::{
-    CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind,
-    CodeExecutionUnavailableReason, DaytonaCredential, DaytonaExecutionProvider,
-    DockerExecutionProvider, E2BCredential, E2BExecutionProvider, ExecFolderAccess, ExecutionId,
-    ExecutionWorkspaceId, LocalExecutionProvider, OutputArtifactStatus, RemoteSessionPool,
-    DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, PACKAGE_MANAGER_DOMAINS,
+    DaytonaCredential, DaytonaExecutionProvider, DockerExecutionProvider, E2BCredential,
+    E2BExecutionProvider, ExecError, ExecFolderAccess, ExecProvider, ExecProviderKind,
+    ExecUnavailableReason, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
+    OutputArtifactStatus, RemoteSessionPool, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES,
+    PACKAGE_MANAGER_DOMAINS,
 };
 use tidebreak_core::{
     exec_attachment_file_name, BlobStore, Chat, ChatId, HostRootId, NetworkPolicy, Result,
@@ -151,13 +151,12 @@ fn coalesced_population_pins_are_one_sorted_union() {
 
 #[test]
 fn only_unresolvable_pip_failures_are_deterministic() {
-    let unavailable = CodeExecutionError::Sandbox(
+    let unavailable = ExecError::Sandbox(
         "package cache acquisition failed: No matching distribution found for pillow==12.3.0"
             .into(),
     );
-    let network = CodeExecutionError::Sandbox(
-        "package cache acquisition failed: connection reset by peer".into(),
-    );
+    let network =
+        ExecError::Sandbox("package cache acquisition failed: connection reset by peer".into());
     assert!(deterministic_package_cache_failure(&unavailable));
     assert!(!deterministic_package_cache_failure(&network));
 }
@@ -178,7 +177,7 @@ async fn folder_resolution_is_fenced_to_the_chat_projection() {
             staging_unavailable: false,
         }],
     });
-    let provider = ConfiguredCodeExecutionProvider::new(
+    let provider = ConfiguredExecProvider::new(
         Arc::new(store),
         Arc::new(NoSecrets),
         tempfile::tempdir().unwrap().path(),
@@ -215,7 +214,7 @@ async fn folder_resolution_is_fenced_to_the_chat_projection() {
         }],
     });
     let (store, _database) = test_store().await;
-    let bad_provider = ConfiguredCodeExecutionProvider::new(
+    let bad_provider = ConfiguredExecProvider::new(
         Arc::new(store),
         Arc::new(NoSecrets),
         tempfile::tempdir().unwrap().path(),
@@ -241,7 +240,7 @@ async fn a_folder_that_cannot_be_staged_fails_closed_and_stays_visible() {
     }
     let root_id = HostRootId::from_uuid(Uuid::new_v4()).unwrap();
     let provider =
-        ConfiguredCodeExecutionProvider::new(Arc::new(store), Arc::new(NoSecrets), scratch.path());
+        ConfiguredExecProvider::new(Arc::new(store), Arc::new(NoSecrets), scratch.path());
     let mut grants = vec![ResolvedExecFolderGrant {
         root_id,
         path: folder.path().to_path_buf(),
@@ -321,11 +320,8 @@ async fn output_files_publish_as_turn_attributed_outputs() {
     std::fs::create_dir_all(&output_dir).unwrap();
     std::fs::write(output_dir.join("report.md"), b"# Draft").unwrap();
 
-    let provider = ConfiguredCodeExecutionProvider::new(
-        store.clone(),
-        Arc::new(NoSecrets),
-        scratch_root.path(),
-    );
+    let provider =
+        ConfiguredExecProvider::new(store.clone(), Arc::new(NoSecrets), scratch_root.path());
     let workspace = ExecutionWorkspaceId::parse(chat.id.to_string()).unwrap();
     let execution = ExecutionId::parse(call_id.to_string()).unwrap();
 
@@ -581,13 +577,10 @@ async fn turn_start_staging_makes_skills_readable_before_any_exec() {
     std::fs::create_dir(&scripts_dir).unwrap();
     std::fs::write(scripts_dir.join("build_deck.py"), "print('deck')\n").unwrap();
 
-    let provider = ConfiguredCodeExecutionProvider::new(
-        store.clone(),
-        Arc::new(NoSecrets),
-        scratch_root.path(),
-    )
-    .with_skills(Some(source.path().to_owned()))
-    .with_user_skills(Some(scratch_root.path().join("user-skills")));
+    let provider =
+        ConfiguredExecProvider::new(store.clone(), Arc::new(NoSecrets), scratch_root.path())
+            .with_skills(Some(source.path().to_owned()))
+            .with_user_skills(Some(scratch_root.path().join("user-skills")));
     let chat_id = ChatId::new();
 
     provider.stage_turn_workspace(chat_id).await;
@@ -656,8 +649,7 @@ async fn turn_start_staging_makes_skills_readable_before_any_exec() {
     );
 
     // A skill-less configuration (headless embeddings) stages nothing.
-    let bare =
-        ConfiguredCodeExecutionProvider::new(store, Arc::new(NoSecrets), scratch_root.path());
+    let bare = ConfiguredExecProvider::new(store, Arc::new(NoSecrets), scratch_root.path());
     let bare_chat = ChatId::new();
     bare.stage_turn_workspace(bare_chat).await;
     assert!(!scratch_root.path().join(bare_chat.to_string()).exists());
@@ -692,13 +684,10 @@ async fn disabling_drops_a_component_from_staging_and_the_catalog() {
     )
     .unwrap();
 
-    let provider = ConfiguredCodeExecutionProvider::new(
-        store.clone(),
-        Arc::new(NoSecrets),
-        scratch_root.path(),
-    )
-    .with_skills(Some(skills_dir.path().to_owned()))
-    .with_plugins(Some(plugins_dir.path().to_owned()));
+    let provider =
+        ConfiguredExecProvider::new(store.clone(), Arc::new(NoSecrets), scratch_root.path())
+            .with_skills(Some(skills_dir.path().to_owned()))
+            .with_plugins(Some(plugins_dir.path().to_owned()));
     let chat_id = ChatId::new();
     let staged = |name: &str| {
         scratch_root
@@ -803,13 +792,10 @@ async fn staged_skills_warm_their_host_tools_and_gate_the_capability_lines() {
         ensured: Mutex::new(Vec::new()),
         available: true,
     });
-    let provider = ConfiguredCodeExecutionProvider::new(
-        store.clone(),
-        Arc::new(NoSecrets),
-        scratch_root.path(),
-    )
-    .with_skills(Some(source.path().to_owned()))
-    .with_host_tool_broker(Some(broker.clone()));
+    let provider =
+        ConfiguredExecProvider::new(store.clone(), Arc::new(NoSecrets), scratch_root.path())
+            .with_skills(Some(source.path().to_owned()))
+            .with_host_tool_broker(Some(broker.clone()));
 
     provider.stage_turn_workspace(ChatId::new()).await;
     assert_eq!(
@@ -832,13 +818,10 @@ async fn staged_skills_warm_their_host_tools_and_gate_the_capability_lines() {
         ensured: Mutex::new(Vec::new()),
         available: false,
     });
-    let provider = ConfiguredCodeExecutionProvider::new(
-        store.clone(),
-        Arc::new(NoSecrets),
-        scratch_root.path(),
-    )
-    .with_skills(Some(source.path().to_owned()))
-    .with_host_tool_broker(Some(unavailable));
+    let provider =
+        ConfiguredExecProvider::new(store.clone(), Arc::new(NoSecrets), scratch_root.path())
+            .with_skills(Some(source.path().to_owned()))
+            .with_host_tool_broker(Some(unavailable));
     assert_eq!(provider.office_rendering_available().await, Some(false));
     assert!(matches!(
         provider.node_runtime_status().await,
@@ -854,18 +837,14 @@ async fn staged_skills_warm_their_host_tools_and_gate_the_capability_lines() {
         "---\nname: charts\ndescription: Plots.\n---\nBody.\n",
     )
     .unwrap();
-    let provider = ConfiguredCodeExecutionProvider::new(
-        store.clone(),
-        Arc::new(NoSecrets),
-        scratch_root.path(),
-    )
-    .with_skills(Some(no_deps.path().to_owned()));
+    let provider =
+        ConfiguredExecProvider::new(store.clone(), Arc::new(NoSecrets), scratch_root.path())
+            .with_skills(Some(no_deps.path().to_owned()));
     assert_eq!(provider.office_rendering_available().await, None);
     assert_eq!(provider.node_runtime_status().await, None);
 
-    let brokerless =
-        ConfiguredCodeExecutionProvider::new(store, Arc::new(NoSecrets), scratch_root.path())
-            .with_skills(Some(source.path().to_owned()));
+    let brokerless = ConfiguredExecProvider::new(store, Arc::new(NoSecrets), scratch_root.path())
+        .with_skills(Some(source.path().to_owned()));
     assert_eq!(brokerless.office_rendering_available().await, Some(false));
     assert!(matches!(
         brokerless.node_runtime_status().await,
@@ -921,7 +900,7 @@ async fn preparation_does_not_write_through_a_planted_symlink() {
 
 #[test]
 fn the_default_selection_is_never_a_provider_that_cannot_run() {
-    let config = CodeExecutionConfig::default();
+    let config = ExecConfig::default();
     // Local is the only unattended default, and only where its sandbox
     // exists: on any other host the honest default is no provider, so the
     // surface reports "not configured" instead of a selection that fails
@@ -930,12 +909,12 @@ fn the_default_selection_is_never_a_provider_that_cannot_run() {
         config.provider,
         LocalExecutionProvider::availability()
             .is_ok()
-            .then_some(CodeExecutionProviderKind::Local)
+            .then_some(ExecProviderKind::Local)
     );
     assert_eq!(config.timeout_ms, DEFAULT_TIMEOUT_MS);
     assert!(config.validate().is_ok());
-    assert!(CodeExecutionConfig {
-        provider: Some(CodeExecutionProviderKind::Local),
+    assert!(ExecConfig {
+        provider: Some(ExecProviderKind::Local),
         timeout_ms: MIN_TIMEOUT_MS - 1,
         egress: EgressConfig::Open,
         e2b_template: None,
@@ -947,9 +926,9 @@ fn the_default_selection_is_never_a_provider_that_cannot_run() {
 
 #[test]
 fn selection_contains_no_endpoint_or_credential_reference() {
-    let json = serde_json::to_value(CodeExecutionConfig {
-        provider: Some(CodeExecutionProviderKind::Local),
-        ..CodeExecutionConfig::default()
+    let json = serde_json::to_value(ExecConfig {
+        provider: Some(ExecProviderKind::Local),
+        ..ExecConfig::default()
     })
     .unwrap();
     assert_eq!(json["provider"], "local");
@@ -959,7 +938,7 @@ fn selection_contains_no_endpoint_or_credential_reference() {
 
 #[test]
 fn egress_defaults_to_open_and_compiles_no_policy() {
-    let config = CodeExecutionConfig::default();
+    let config = ExecConfig::default();
     assert_eq!(config.egress, EgressConfig::Open);
     // Open must leave the managed adapters on today's open-internet
     // creation: no policy is threaded into the create path.
@@ -998,8 +977,8 @@ fn egress_allowlist_compiles_to_a_deny_by_default_decision_policy() {
         cidrs: vec![],
     };
     assert!(bad.to_policy().is_err());
-    assert!(CodeExecutionConfig {
-        provider: Some(CodeExecutionProviderKind::E2b),
+    assert!(ExecConfig {
+        provider: Some(ExecProviderKind::E2b),
         timeout_ms: DEFAULT_TIMEOUT_MS,
         egress: bad,
         e2b_template: None,
@@ -1051,8 +1030,8 @@ fn egress_enforcement_never_oversells_a_provider_past_its_model() {
             .find(|row| row.provider == provider)
             .unwrap_or_else(|| panic!("{provider} enforcement is disclosed"))
     };
-    let e2b = row(CodeExecutionProviderKind::E2b);
-    let daytona = row(CodeExecutionProviderKind::Daytona);
+    let e2b = row(ExecProviderKind::E2b);
+    let daytona = row(ExecProviderKind::Daytona);
 
     // E2B is confirmed, but its own enforcement model says it is not a full
     // boundary — domain rules cover only HTTP/HTTPS and DNS stays open — so
@@ -1102,7 +1081,7 @@ fn egress_enforcement_never_oversells_a_provider_past_its_model() {
     // borrow a status for the rest. Under an allowlist it compiles nothing
     // into container networking, so the row stays at the absence of a
     // boundary rather than the `unconfirmed` of a policy that was sent.
-    let docker = row(CodeExecutionProviderKind::Docker);
+    let docker = row(ExecProviderKind::Docker);
     assert_eq!(docker.status, EgressEnforcementStatus::NotEnforced);
     assert_eq!(docker.gaps, [DOCKER_OPEN_EGRESS_GAP]);
     assert!(docker.requirement.is_none());
@@ -1118,7 +1097,7 @@ fn container_egress_disclosure_splits_by_policy_class() {
     let row = |policy: &EgressConfig| {
         egress_enforcement_status(policy)
             .into_iter()
-            .find(|row| row.provider == CodeExecutionProviderKind::Docker)
+            .find(|row| row.provider == ExecProviderKind::Docker)
             .expect("the container backend's enforcement is disclosed")
     };
 
@@ -1257,7 +1236,7 @@ async fn configuration_can_disable_and_reenable_local_execution() {
         &host_config,
         &store,
         &secrets,
-        CodeExecutionConfigUpdate {
+        ExecConfigUpdate {
             provider: Some(None),
             timeout_ms: Some(MIN_TIMEOUT_MS),
             egress: None,
@@ -1277,8 +1256,8 @@ async fn configuration_can_disable_and_reenable_local_execution() {
         &host_config,
         &store,
         &secrets,
-        CodeExecutionConfigUpdate {
-            provider: Some(Some(CodeExecutionProviderKind::Local)),
+        ExecConfigUpdate {
+            provider: Some(Some(ExecProviderKind::Local)),
             timeout_ms: Some(MAX_TIMEOUT_MS),
             egress: None,
             e2b_template: None,
@@ -1290,7 +1269,7 @@ async fn configuration_can_disable_and_reenable_local_execution() {
         Ok(info) => info,
         Err(_) => panic!("valid local code-execution configuration was rejected"),
     };
-    assert_eq!(local.provider, Some(CodeExecutionProviderKind::Local));
+    assert_eq!(local.provider, Some(ExecProviderKind::Local));
     assert_eq!(local.timeout_ms, MAX_TIMEOUT_MS);
 }
 
@@ -1313,10 +1292,10 @@ async fn unavailable_providers_report_an_actionable_reason() {
         assert!(!row.available);
         assert_eq!(
             row.unavailable_reason,
-            Some(CodeExecutionUnavailableReason::MissingCredential)
+            Some(ExecUnavailableReason::MissingCredential)
         );
     }
-    let local = rows[&CodeExecutionProviderKind::Local];
+    let local = rows[&ExecProviderKind::Local];
     assert_eq!(
         local.unavailable_reason,
         LocalExecutionProvider::availability().err()
@@ -1332,7 +1311,7 @@ async fn unavailable_providers_report_an_actionable_reason() {
 #[tokio::test]
 async fn workspace_capability_degrades_to_none_instead_of_failing() {
     let (store, dir) = test_store().await;
-    let provider = ConfiguredCodeExecutionProvider::new(
+    let provider = ConfiguredExecProvider::new(
         Arc::new(store),
         Arc::new(NoSecrets),
         dir.path().join("scratch"),
@@ -1386,8 +1365,5 @@ async fn invalid_persisted_policy_fails_closed() {
         )
         .await
         .unwrap();
-    assert_eq!(
-        read_config(&store).await.unwrap(),
-        CodeExecutionConfig::disabled()
-    );
+    assert_eq!(read_config(&store).await.unwrap(), ExecConfig::disabled());
 }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1070,7 +1070,7 @@ pub struct Server {
     store: Arc<dyn Store>,
     /// The live exec staging registry, handed to native embedders so the host
     /// folder tools answer from the same per-turn copy exec writes into.
-    code_execution: Arc<code_execution::ConfiguredCodeExecutionProvider>,
+    code_execution: Arc<code_execution::ConfiguredExecProvider>,
     /// The live MCP runtime, handed to pairing so a profile that becomes
     /// managed mid-session takes its manual servers down immediately.
     mcp: Arc<mcp_config::McpRuntime>,
@@ -1615,7 +1615,7 @@ async fn bind_inner(
     ));
     let code_host_tool_broker = host_tool_broker.clone();
     let code_execution = Arc::new(
-        code_execution::ConfiguredCodeExecutionProvider::new(
+        code_execution::ConfiguredExecProvider::new(
             store.clone(),
             secrets.clone(),
             config.data_dir.join("scratch"),
@@ -1971,7 +1971,7 @@ async fn bind_inner(
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 fn agent_deps(
-    code_execution: Arc<dyn tidebreak_code_execution::CodeExecutionProvider>,
+    code_execution: Arc<dyn tidebreak_code_execution::ExecProvider>,
     web_search: Box<dyn Tool>,
     web_extract: Box<dyn Tool>,
     source_store: Arc<dyn Store>,
@@ -2004,7 +2004,7 @@ fn agent_deps(
 
 #[allow(clippy::too_many_arguments)]
 fn agent_deps_with_cancellation_acceleration(
-    code_execution: Arc<dyn tidebreak_code_execution::CodeExecutionProvider>,
+    code_execution: Arc<dyn tidebreak_code_execution::ExecProvider>,
     web_search: Box<dyn Tool>,
     web_extract: Box<dyn Tool>,
     source_store: Arc<dyn Store>,

--- a/crates/tidebreak-server/src/plugin_mcp.rs
+++ b/crates/tidebreak-server/src/plugin_mcp.rs
@@ -83,14 +83,14 @@ pub(crate) trait PluginMcpCatalog: Send + Sync {
 /// The production catalog: the installed plugin tree, the stored enable flags,
 /// and the app data directory the `PLUGIN_DATA` directories live under.
 pub(crate) struct InstalledPluginMcpCatalog {
-    exec: Arc<crate::code_execution::ConfiguredCodeExecutionProvider>,
+    exec: Arc<crate::code_execution::ConfiguredExecProvider>,
     store: Arc<dyn Store>,
     data_root: PathBuf,
 }
 
 impl InstalledPluginMcpCatalog {
     pub(crate) fn new(
-        exec: Arc<crate::code_execution::ConfiguredCodeExecutionProvider>,
+        exec: Arc<crate::code_execution::ConfiguredExecProvider>,
         store: Arc<dyn Store>,
         data_root: PathBuf,
     ) -> Self {

--- a/crates/tidebreak-server/src/routes/agent_runs.rs
+++ b/crates/tidebreak-server/src/routes/agent_runs.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use tidebreak_code_execution::CodeExecutionProviderKind;
+use tidebreak_code_execution::ExecProviderKind;
 use tidebreak_core::{
     AgentRun, AgentRunExecutionLocation, AgentRunStatus, AgentRunTier, CallId, ChatId,
     RequestAgentRunCancellationOutcome, SandboxToolCall, SandboxToolCallStatus, TurnId,
@@ -27,7 +27,7 @@ use crate::state::{AppState, SandboxSteerRefusal};
 /// disabled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
-pub enum CodeExecutionProviderSnapshot {
+pub enum ExecProviderSnapshot {
     Local,
     E2b,
     Daytona,
@@ -35,14 +35,14 @@ pub enum CodeExecutionProviderSnapshot {
     Off,
 }
 
-impl CodeExecutionProviderSnapshot {
-    fn from_config(provider: Option<CodeExecutionProviderKind>) -> Self {
+impl ExecProviderSnapshot {
+    fn from_config(provider: Option<ExecProviderKind>) -> Self {
         match provider {
-            Some(CodeExecutionProviderKind::Local) => Self::Local,
-            Some(CodeExecutionProviderKind::E2b) => Self::E2b,
-            Some(CodeExecutionProviderKind::Daytona) => Self::Daytona,
-            Some(CodeExecutionProviderKind::Docker) => Self::Docker,
-            // `CodeExecutionProviderKind` is non-exhaustive; an unknown future
+            Some(ExecProviderKind::Local) => Self::Local,
+            Some(ExecProviderKind::E2b) => Self::E2b,
+            Some(ExecProviderKind::Daytona) => Self::Daytona,
+            Some(ExecProviderKind::Docker) => Self::Docker,
+            // `ExecProviderKind` is non-exhaustive; an unknown future
             // variant is not something a renderer can name yet.
             Some(_) | None => Self::Off,
         }
@@ -61,9 +61,9 @@ pub struct AgentRunSnapshot {
     pub execution_location: AgentRunExecutionLocation,
     /// Active host code-execution backend for `exec`, not the run-loop seat.
     ///
-    /// See [`CodeExecutionProviderSnapshot`]. Read from the current host
+    /// See [`ExecProviderSnapshot`]. Read from the current host
     /// setting at list time — the same selection the next `exec` would use.
-    pub code_execution_provider: CodeExecutionProviderSnapshot,
+    pub code_execution_provider: ExecProviderSnapshot,
     pub status: AgentRunStatus,
     /// Completed provider calls accumulated across every attempt.
     pub model_steps: i32,
@@ -116,7 +116,7 @@ impl AgentRunSnapshot {
         terminal_text: Option<String>,
         submitted_outputs: Vec<SubmittedOutputSnapshot>,
         task_plan: Option<AgentRunTaskPlanProgress>,
-        code_execution_provider: CodeExecutionProviderSnapshot,
+        code_execution_provider: ExecProviderSnapshot,
     ) -> Self {
         Self {
             id: run.id,
@@ -413,7 +413,7 @@ pub async fn list_agent_runs(
     // Host code-exec selection is independent of where the run loop sits.
     // One read covers every snapshot in the response: the next `exec` uses
     // the same setting, whether the child is foreground or background.
-    let code_execution_provider = CodeExecutionProviderSnapshot::from_config(
+    let code_execution_provider = ExecProviderSnapshot::from_config(
         code_execution::read_config(&*state.store).await?.provider,
     );
     let mut snapshots = Vec::with_capacity(runs.len());

--- a/crates/tidebreak-server/src/routes/settings.rs
+++ b/crates/tidebreak-server/src/routes/settings.rs
@@ -14,8 +14,7 @@ use tidebreak_core::{
 };
 
 use crate::code_execution::{
-    self, CodeExecutionConfigInfo, CodeExecutionConfigUpdate, CodeExecutionCredentialReadiness,
-    CodeExecutionCredentialsInfo,
+    self, ExecConfigInfo, ExecConfigUpdate, ExecCredentialReadiness, ExecCredentialsInfo,
 };
 use crate::error::ServerError;
 use crate::exec_write_snapshot::{
@@ -596,7 +595,7 @@ pub async fn put_web_search_config(
 /// and readiness. No executable or provider endpoint is accepted here.
 pub async fn get_code_execution_config(
     State(state): State<AppState>,
-) -> Result<Json<CodeExecutionConfigInfo>, ServerError> {
+) -> Result<Json<ExecConfigInfo>, ServerError> {
     Ok(Json(
         code_execution::config_info(&state.config, &*state.store, &*state.secrets).await?,
     ))
@@ -605,8 +604,8 @@ pub async fn get_code_execution_config(
 /// `PUT /code-execution` — select a fixed provider and bounded host timeout.
 pub async fn put_code_execution_config(
     State(state): State<AppState>,
-    Json(body): Json<CodeExecutionConfigUpdate>,
-) -> Result<Json<CodeExecutionConfigInfo>, ServerError> {
+    Json(body): Json<ExecConfigUpdate>,
+) -> Result<Json<ExecConfigInfo>, ServerError> {
     Ok(Json(
         code_execution::update_config(&state.config, &*state.store, &*state.secrets, body).await?,
     ))
@@ -616,7 +615,7 @@ pub async fn put_code_execution_config(
 /// credential slots. Local execution needs no credential and is absent here.
 pub async fn get_code_execution_credentials(
     State(state): State<AppState>,
-) -> Json<CodeExecutionCredentialsInfo> {
+) -> Json<ExecCredentialsInfo> {
     Json(code_execution::credentials_info(&*state.secrets).await)
 }
 
@@ -626,14 +625,14 @@ const MAX_CODE_EXECUTION_CREDENTIAL_BYTES: usize = 8 * 1024;
 /// redacts the credential.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct CodeExecutionCredentialUpdate {
+pub struct ExecCredentialUpdate {
     pub api_key: String,
 }
 
-impl std::fmt::Debug for CodeExecutionCredentialUpdate {
+impl std::fmt::Debug for ExecCredentialUpdate {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
-            .debug_struct("CodeExecutionCredentialUpdate")
+            .debug_struct("ExecCredentialUpdate")
             .field("api_key", &"***")
             .finish()
     }
@@ -643,8 +642,8 @@ impl std::fmt::Debug for CodeExecutionCredentialUpdate {
 pub async fn put_code_execution_credential(
     State(state): State<AppState>,
     Path(provider): Path<String>,
-    Json(body): Json<CodeExecutionCredentialUpdate>,
-) -> Result<Json<CodeExecutionCredentialReadiness>, ServerError> {
+    Json(body): Json<ExecCredentialUpdate>,
+) -> Result<Json<ExecCredentialReadiness>, ServerError> {
     let provider = code_execution::credential_provider(&provider)?;
     if body.api_key.len() > MAX_CODE_EXECUTION_CREDENTIAL_BYTES {
         return Err(ServerError::bad_request(format!(
@@ -666,7 +665,7 @@ pub async fn put_code_execution_credential(
 pub async fn delete_code_execution_credential(
     State(state): State<AppState>,
     Path(provider): Path<String>,
-) -> Result<Json<CodeExecutionCredentialReadiness>, ServerError> {
+) -> Result<Json<ExecCredentialReadiness>, ServerError> {
     let provider = code_execution::credential_provider(&provider)?;
     Ok(Json(
         code_execution::delete_credential(&*state.secrets, provider).await?,

--- a/crates/tidebreak-server/src/sandbox_admission.rs
+++ b/crates/tidebreak-server/src/sandbox_admission.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use tidebreak_code_execution::CodeExecutionProviderKind;
+use tidebreak_code_execution::ExecProviderKind;
 use tidebreak_core::{AgentRunExecutionLocation, Config, SandboxAdmissionMode};
 use tidebreak_sandbox_protocol::provisioning::SandboxBackend;
 
@@ -232,7 +232,7 @@ pub(crate) fn structural_preconditions(
 /// a detached run needs.
 pub(crate) fn settings_detached_admissions(
     config: &Config,
-) -> Vec<(CodeExecutionProviderKind, DetachedAdmission)> {
+) -> Vec<(ExecProviderKind, DetachedAdmission)> {
     let scoped_token = GatewayScopedTokenIssuer.available();
     let local = DockerSandboxBackend::new(docker_config(config));
     let local_facts = (
@@ -240,10 +240,10 @@ pub(crate) fn settings_detached_admissions(
         local.verifies_image_integrity(),
     );
     [
-        (CodeExecutionProviderKind::Local, local_facts),
-        (CodeExecutionProviderKind::E2b, (false, false)),
-        (CodeExecutionProviderKind::Daytona, (false, false)),
-        (CodeExecutionProviderKind::Docker, (false, false)),
+        (ExecProviderKind::Local, local_facts),
+        (ExecProviderKind::E2b, (false, false)),
+        (ExecProviderKind::Daytona, (false, false)),
+        (ExecProviderKind::Docker, (false, false)),
     ]
     .into_iter()
     .map(|(provider, (lifetime_cap, image_verified))| {

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/config.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/config.rs
@@ -11,7 +11,7 @@ use tidebreak_core::{AgentConfig, SecretProvider, Store, TurnWebSearch};
 use tokio::sync::Notify;
 
 use crate::bus::EventBus;
-use crate::code_execution::ConfiguredCodeExecutionProvider;
+use crate::code_execution::ConfiguredExecProvider;
 use crate::foreground_prompt::skill_summary_catalog_lines;
 use crate::resolver::ProviderResolver;
 use crate::retry::RetrySchedule;
@@ -51,7 +51,7 @@ pub(super) const SANDBOX_PROMPT_SKILLS_INTRO: &str = "Document skills available 
 /// at all loses the clause, exactly as a foreground turn's prompt does.
 ///
 /// `skills` / `plugins` are the same host-derived catalogs a foreground turn
-/// composes from (`ConfiguredCodeExecutionProvider::skill_catalog` /
+/// composes from (`ConfiguredExecProvider::skill_catalog` /
 /// `plugin_catalog`). An empty catalog omits the skills section rather than
 /// inventing entries or claiming none exist when the host has no surface.
 pub(super) fn sandbox_system_prompt(
@@ -232,6 +232,6 @@ pub(crate) struct SandboxAgentRunWorker {
     /// Same host code-execution surface the foreground turn uses for its skill
     /// catalog. Absent on a headless embedding with no exec provider — the
     /// sandbox prompt then carries no skills section.
-    pub(crate) code_execution: Option<Arc<ConfiguredCodeExecutionProvider>>,
+    pub(crate) code_execution: Option<Arc<ConfiguredExecProvider>>,
     pub(crate) config: SandboxAgentRunWorkerConfig,
 }

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
@@ -92,7 +92,7 @@ impl SandboxAgentRunWorker {
         attempts: Arc<SandboxAttemptGuard>,
         agent_config: AgentConfig,
         private_scratch_root: Option<PathBuf>,
-        code_execution: Option<Arc<crate::code_execution::ConfiguredCodeExecutionProvider>>,
+        code_execution: Option<Arc<crate::code_execution::ConfiguredExecProvider>>,
         config: SandboxAgentRunWorkerConfig,
     ) -> Self {
         assert!(!config.lease.is_zero());

--- a/crates/tidebreak-server/src/sandbox_exec_worker.rs
+++ b/crates/tidebreak-server/src/sandbox_exec_worker.rs
@@ -13,8 +13,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use tidebreak_code_execution::{
-    CodeExecutionError, CodeExecutionRequest, CodeExecutionResponse, ExecutionId,
-    ExecutionWorkspaceId, OutputArtifactScan, OutputArtifactStatus,
+    ExecError, ExecRequest, ExecResponse, ExecutionId, ExecutionWorkspaceId, OutputArtifactScan,
+    OutputArtifactStatus,
 };
 use tidebreak_core::{
     AgentError, AgentRunId, CallId, ChatId, ClaimSandboxToolCallOutcome, Result, SandboxExecArgs,
@@ -22,7 +22,7 @@ use tidebreak_core::{
 };
 use tokio::sync::Notify;
 
-use crate::code_execution::ConfiguredCodeExecutionProvider;
+use crate::code_execution::ConfiguredExecProvider;
 use crate::retry::LaneBackoff;
 use crate::state::SandboxAttemptGuard;
 
@@ -65,12 +65,12 @@ pub(crate) trait SandboxExecRunner: Send + Sync {
     async fn run(
         &self,
         job: SandboxExecJob,
-    ) -> std::result::Result<(CodeExecutionResponse, OutputArtifactScan), SandboxExecFailure>;
+    ) -> std::result::Result<(ExecResponse, OutputArtifactScan), SandboxExecFailure>;
 }
 
 /// The configured host provider, confined to one background run's workspace.
 struct HostSandboxExec {
-    provider: Arc<ConfiguredCodeExecutionProvider>,
+    provider: Arc<ConfiguredExecProvider>,
 }
 
 #[async_trait]
@@ -78,12 +78,12 @@ impl SandboxExecRunner for HostSandboxExec {
     async fn run(
         &self,
         job: SandboxExecJob,
-    ) -> std::result::Result<(CodeExecutionResponse, OutputArtifactScan), SandboxExecFailure> {
+    ) -> std::result::Result<(ExecResponse, OutputArtifactScan), SandboxExecFailure> {
         let workspace = agent_run_workspace(job.run_id).map_err(classify)?;
         let execution = ExecutionId::parse(job.call_id.to_string()).map_err(classify)?;
         // `files` and `folder_grants` stay empty: the run's workspace is the
         // only filesystem it has, and nothing outside it may be staged in.
-        let request = CodeExecutionRequest::new(
+        let request = ExecRequest::new(
             execution,
             workspace.clone(),
             job.arguments.command,
@@ -128,19 +128,17 @@ impl SandboxExecRunner for HostSandboxExec {
 /// message execute concurrently and must not share a filesystem. They do share
 /// the conversation's outputs catalog, so two runs that write `report.md`
 /// produce two versions of one output.
-fn agent_run_workspace(
-    run_id: AgentRunId,
-) -> std::result::Result<ExecutionWorkspaceId, CodeExecutionError> {
+fn agent_run_workspace(run_id: AgentRunId) -> std::result::Result<ExecutionWorkspaceId, ExecError> {
     ExecutionWorkspaceId::parse(format!("agent-run-{run_id}"))
 }
 
-fn classify(error: CodeExecutionError) -> SandboxExecFailure {
+fn classify(error: ExecError) -> SandboxExecFailure {
     match error {
-        CodeExecutionError::NotConfigured => SandboxExecFailure::Rejected {
+        ExecError::NotConfigured => SandboxExecFailure::Rejected {
             code: "exec_not_configured",
             message: "Code execution is not configured for this host.".into(),
         },
-        CodeExecutionError::InvalidRequest(_) => SandboxExecFailure::Rejected {
+        ExecError::InvalidRequest(_) => SandboxExecFailure::Rejected {
             code: "invalid_exec_arguments",
             message: "The command could not be run as requested.".into(),
         },
@@ -200,7 +198,7 @@ pub(crate) struct SandboxExecWorker {
 impl SandboxExecWorker {
     pub(crate) fn with_attempts(
         store: Arc<dyn Store>,
-        provider: Arc<ConfiguredCodeExecutionProvider>,
+        provider: Arc<ConfiguredExecProvider>,
         wake: Arc<Notify>,
         attempts: Arc<SandboxAttemptGuard>,
         config: SandboxExecWorkerConfig,
@@ -472,10 +470,7 @@ fn parse_exec_job(
 /// finishes by naming them. A nonzero exit is not a lane failure — the model
 /// asked for a command and is owed its exit code — but it is marked as an error
 /// receipt so the model does not read a failed build as a success.
-fn exec_resolution(
-    response: &CodeExecutionResponse,
-    outputs: &OutputArtifactScan,
-) -> ToolCallResolution {
+fn exec_resolution(response: &ExecResponse, outputs: &OutputArtifactScan) -> ToolCallResolution {
     let exit = response
         .exit_code
         .map_or_else(|| "signal".into(), |code| code.to_string());
@@ -572,9 +567,7 @@ mod tests {
     use std::sync::Mutex;
 
     use chrono::Utc;
-    use tidebreak_code_execution::{
-        CodeExecutionProviderKind, OutputArtifactEntry, OutputArtifactStatus,
-    };
+    use tidebreak_code_execution::{ExecProviderKind, OutputArtifactEntry, OutputArtifactStatus};
     use tidebreak_core::{
         Chat, DbStore, ParkSandboxToolCallOutcome, SandboxToolCallRequest, SandboxToolCallStatus,
     };
@@ -585,14 +578,8 @@ mod tests {
     /// rather than inferred.
     struct ScriptedExec {
         attempts: AtomicUsize,
-        results: Mutex<
-            Vec<
-                std::result::Result<
-                    (CodeExecutionResponse, OutputArtifactScan),
-                    SandboxExecFailure,
-                >,
-            >,
-        >,
+        results:
+            Mutex<Vec<std::result::Result<(ExecResponse, OutputArtifactScan), SandboxExecFailure>>>,
     }
 
     #[async_trait]
@@ -600,17 +587,14 @@ mod tests {
         async fn run(
             &self,
             _job: SandboxExecJob,
-        ) -> std::result::Result<(CodeExecutionResponse, OutputArtifactScan), SandboxExecFailure>
-        {
+        ) -> std::result::Result<(ExecResponse, OutputArtifactScan), SandboxExecFailure> {
             self.attempts.fetch_add(1, Ordering::SeqCst);
             self.results.lock().unwrap().remove(0)
         }
     }
 
     fn scripted(
-        results: Vec<
-            std::result::Result<(CodeExecutionResponse, OutputArtifactScan), SandboxExecFailure>,
-        >,
+        results: Vec<std::result::Result<(ExecResponse, OutputArtifactScan), SandboxExecFailure>>,
     ) -> Arc<ScriptedExec> {
         Arc::new(ScriptedExec {
             attempts: AtomicUsize::new(0),
@@ -618,9 +602,9 @@ mod tests {
         })
     }
 
-    fn response(stdout: &str) -> CodeExecutionResponse {
-        CodeExecutionResponse {
-            provider: CodeExecutionProviderKind::Local,
+    fn response(stdout: &str) -> ExecResponse {
+        ExecResponse {
+            provider: ExecProviderKind::Local,
             exit_code: Some(0),
             stdout: stdout.into(),
             stderr: String::new(),

--- a/crates/tidebreak-server/src/secret_rehome.rs
+++ b/crates/tidebreak-server/src/secret_rehome.rs
@@ -473,7 +473,7 @@ mod tests {
             };
             assert!(keys.iter().any(|key| key == expected), "{kind:?}");
         }
-        // `CodeExecutionProviderKind` is `#[non_exhaustive]`, so a match here
+        // `ExecProviderKind` is `#[non_exhaustive]`, so a match here
         // cannot stand in for coverage; assert the credentialed kinds' keys
         // directly (`Local` runs in the host sandbox and stores nothing).
         for expected in [E2B_CREDENTIAL_KEY, DAYTONA_CREDENTIAL_KEY] {

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -241,7 +241,7 @@ pub struct AppState {
     /// management routes read it — they list what is installed, which is the
     /// provider's own load — so an embedding without one (tests, headless)
     /// simply has nothing to manage.
-    pub(crate) code_execution: Option<Arc<crate::code_execution::ConfiguredCodeExecutionProvider>>,
+    pub(crate) code_execution: Option<Arc<crate::code_execution::ConfiguredExecProvider>>,
     /// The host-folder surface for local-app folder bindings, when this
     /// embedding has one (docs/folder-bindings.md).
     ///

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -3907,7 +3907,7 @@ fn plugin_app_with_broker(
     );
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     state.code_execution = Some(Arc::new(
-        crate::code_execution::ConfiguredCodeExecutionProvider::new(
+        crate::code_execution::ConfiguredExecProvider::new(
             store,
             secrets,
             data_dir.join("scratch"),
@@ -4005,7 +4005,7 @@ fn plugin_install_app(
     );
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     state.code_execution = Some(Arc::new(
-        crate::code_execution::ConfiguredCodeExecutionProvider::new(
+        crate::code_execution::ConfiguredExecProvider::new(
             store,
             secrets,
             data_dir.join("scratch"),
@@ -4587,7 +4587,7 @@ async fn imported_plugin_mcp_does_not_start_until_enabled() {
         },
     );
     let exec = Arc::new(
-        crate::code_execution::ConfiguredCodeExecutionProvider::new(
+        crate::code_execution::ConfiguredExecProvider::new(
             store.clone(),
             secrets,
             dir.path().join("scratch"),
@@ -4994,7 +4994,7 @@ async fn user_plugins_load_from_the_data_directory_and_keep_their_flags() {
             },
         );
         state.code_execution = Some(Arc::new(
-            crate::code_execution::ConfiguredCodeExecutionProvider::new(
+            crate::code_execution::ConfiguredExecProvider::new(
                 store.clone(),
                 secrets,
                 dir.path().join("scratch"),
@@ -5134,7 +5134,7 @@ async fn the_catalog_lists_prompts_and_serves_their_bodies() {
         },
     );
     state.code_execution = Some(Arc::new(
-        crate::code_execution::ConfiguredCodeExecutionProvider::new(
+        crate::code_execution::ConfiguredExecProvider::new(
             store,
             secrets,
             dir.path().join("scratch"),
@@ -5516,7 +5516,7 @@ async fn a_plugins_bundled_mcp_server_mounts_only_while_the_plugin_is_enabled() 
             },
         );
         let exec = Arc::new(
-            crate::code_execution::ConfiguredCodeExecutionProvider::new(
+            crate::code_execution::ConfiguredExecProvider::new(
                 store.clone(),
                 secrets,
                 dir.path().join("scratch"),

--- a/crates/tidebreak-server/src/tests/documents.rs
+++ b/crates/tidebreak-server/src/tests/documents.rs
@@ -1555,18 +1555,18 @@ async fn ingest_accepts_any_media_type_via_the_fallback_parser() {
 
 /// A code-execution provider that is never configured, for `agent_deps`
 /// assembly tests that never execute a command.
-struct UnavailableCodeExecution;
+struct UnavailableExec;
 
 #[async_trait::async_trait]
-impl tidebreak_code_execution::CodeExecutionProvider for UnavailableCodeExecution {
+impl tidebreak_code_execution::ExecProvider for UnavailableExec {
     async fn execute(
         &self,
-        _request: tidebreak_code_execution::CodeExecutionRequest,
+        _request: tidebreak_code_execution::ExecRequest,
     ) -> std::result::Result<
-        tidebreak_code_execution::CodeExecutionResponse,
-        tidebreak_code_execution::CodeExecutionError,
+        tidebreak_code_execution::ExecResponse,
+        tidebreak_code_execution::ExecError,
     > {
-        Err(tidebreak_code_execution::CodeExecutionError::NotConfigured)
+        Err(tidebreak_code_execution::ExecError::NotConfigured)
     }
 }
 
@@ -1585,7 +1585,7 @@ async fn agent_deps_for_test(
     let extract_store = store.clone();
     let store_for_gateway = store.clone();
     agent_deps(
-        Arc::new(UnavailableCodeExecution),
+        Arc::new(UnavailableExec),
         web_search::foreground_tool(
             store.clone(),
             Arc::new(MemSecrets::default()),

--- a/crates/tidebreak-server/src/tests/outputs.rs
+++ b/crates/tidebreak-server/src/tests/outputs.rs
@@ -57,7 +57,7 @@ async fn a_published_output_is_listed_read_revised_restored_and_exported_over_ht
     std::fs::create_dir_all(&output_dir).unwrap();
     let published = b"def revenue():\n    return 'up'\n";
     std::fs::write(output_dir.join("analysis.py"), published).unwrap();
-    let provider = crate::code_execution::ConfiguredCodeExecutionProvider::new(
+    let provider = crate::code_execution::ConfiguredExecProvider::new(
         store.clone(),
         Arc::new(MemSecrets::default()),
         &scratch_root,

--- a/crates/tidebreak-server/src/tests/workers.rs
+++ b/crates/tidebreak-server/src/tests/workers.rs
@@ -62,7 +62,7 @@ async fn test_app_with_skills(
     );
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     state.code_execution = Some(Arc::new(
-        crate::code_execution::ConfiguredCodeExecutionProvider::new(
+        crate::code_execution::ConfiguredExecProvider::new(
             store.clone(),
             secrets,
             dir.path().join("scratch"),
@@ -93,7 +93,7 @@ fn test_router_with_skills_from_store(
     );
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     state.code_execution = Some(Arc::new(
-        crate::code_execution::ConfiguredCodeExecutionProvider::new(store, secrets, scratch_dir)
+        crate::code_execution::ConfiguredExecProvider::new(store, secrets, scratch_dir)
             .with_skills(Some(root.join("skills"))),
     ));
     let token = state.token.clone();

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -110,7 +110,7 @@ pub(crate) struct TurnWorker {
     wake: Arc<Notify>,
     sandbox_agent_wake: Arc<Notify>,
     agent_config: AgentConfig,
-    exec_folder_context: Option<Arc<crate::code_execution::ConfiguredCodeExecutionProvider>>,
+    exec_folder_context: Option<Arc<crate::code_execution::ConfiguredExecProvider>>,
     private_scratch_root: Option<PathBuf>,
     config: TurnWorkerConfig,
     #[cfg(test)]
@@ -477,7 +477,7 @@ impl TurnWorker {
     /// authority.
     pub(crate) fn with_exec_folder_context(
         mut self,
-        provider: Arc<crate::code_execution::ConfiguredCodeExecutionProvider>,
+        provider: Arc<crate::code_execution::ConfiguredExecProvider>,
     ) -> Self {
         self.exec_folder_context = Some(provider);
         self

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -362,10 +362,8 @@ mod tests {
         generate::collect_from::<crate::chatgpt_runtime::ChatGptSignInStatus>(&cfg, &mut out);
         generate::collect_from::<crate::web_search::WebSearchConfigInfo>(&cfg, &mut out);
         generate::collect_from::<crate::web_search::WebSearchCredentialReadiness>(&cfg, &mut out);
-        generate::collect_from::<crate::code_execution::CodeExecutionConfigInfo>(&cfg, &mut out);
-        generate::collect_from::<crate::code_execution::CodeExecutionCredentialReadiness>(
-            &cfg, &mut out,
-        );
+        generate::collect_from::<crate::code_execution::ExecConfigInfo>(&cfg, &mut out);
+        generate::collect_from::<crate::code_execution::ExecCredentialReadiness>(&cfg, &mut out);
         generate::collect_from::<crate::mcp_config::McpServersInfo>(&cfg, &mut out);
         // The installed plugin/skill catalog, its host-derived capability
         // badges, and the toggle body the management surface sends back.

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -172,7 +172,7 @@ not silently change a chat's authority.
 ExecTool
     |
     v
-CodeExecutionProvider::execute
+ExecProvider::execute
     |
     +-- LocalExecutionProvider
     |


### PR DESCRIPTION
## Why

`Code` names two unrelated subsystems in this repo:

- `CodeSession`, `CodeTurn`, `CodeEvent` — a harness driving a repo (code mode).
- `CodeExecutionRequest`, `CodeExecutionProvider`, `CodeExecutionError` — one bounded command in a sandbox (the `exec` tool, E2B/Daytona/Docker).

`docs/code-execution.md` already opens by disambiguating the second from a third thing. A reader has to know which meaning applies before the rest of a file parses.

The `Exec` prefix already names that second subsystem — `ExecTool`, `ExecFileChange`, `ExecFolderGrant`, `ExecUndoState`, `ExecFileSnapshot`, and the `exec_file_change` table. This renames the 19 stragglers to match.

Decision 30 named code mode's nouns as **repo**, **workspace**, **session**, **turn**. Keeping `Code` on an unrelated subsystem makes finishing that rename harder later.

## What changed

`CodeExecution*` → `Exec*` across 19 types, plus three UI file renames:

- `CodeExecutionDisclosure.ts` → `ExecDisclosure.ts`
- `settings/CodeExecutionPanel.tsx` → `settings/ExecPanel.tsx`
- `settings/CodeExecutionPanel.dom.test.tsx` → `settings/ExecPanel.dom.test.tsx`

## What deliberately did not change

Every persisted and wire-bearing string keeps its value:

| Value | Where |
|---|---|
| `code_execution` | setting row key |
| `code_execution.e2b.api_key` | keychain key |
| `code_execution.daytona.api_key` | keychain key |
| `code_execution_provider` | wire field, CLI snapshot field |

Renaming those would orphan stored credentials in the OS keychain, which no schema epoch reset touches. No epoch bump is needed for this change.

The `tidebreak-code-execution` crate and the `tidebreak-server` `code_execution` module keep their names. Renaming those reaches Cargo metadata and the logging directive default; it belongs in its own change.

## Diff shape

1,189 insertions / 1,462 deletions across 49 files. The asymmetry is `cargo fmt`: the type name is nine characters shorter, so multi-line signatures and import lists collapse. `git diff -w` filtered against the rename shows no semantic lines.

## Checks

- `cargo check -p tidebreak-code-execution -p tidebreak-server -p tidebreak-desktop`
- `cargo clippy -p tidebreak-code-execution -p tidebreak-server --all-targets` — clean
- `cargo fmt --all`
- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server` — regenerated; diff moves type names only, `code_execution_provider` field preserved
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/settings/ExecPanel.dom.test.tsx` — 6 passed