### PR TITLE
fix(code): read the context ring from the resident prompt, not turn spend

### DIFF
--- a/crates/tidebreak-core/fixtures/code-journal-events.json
+++ b/crates/tidebreak-core/fixtures/code-journal-events.json
@@ -73,7 +73,8 @@
       "input_tokens": 11,
       "output_tokens": 22,
       "cache_read_input_tokens": 33,
-      "cache_creation_input_tokens": 44
+      "cache_creation_input_tokens": 44,
+      "context_tokens": 88
     },
     "checkpoint": {
       "checkpoint_ref": "refs/tidebreak/checkpoints/ws/1",

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -144,6 +144,11 @@ pub struct Diffstat {
 /// the prompt an engine actually sent is the sum of all three. Missing fields
 /// stay zero, which is not the same as "the engine sent zero" — an engine that
 /// does not surface cache counts reports nothing rather than a real zero.
+///
+/// None of the four answers "how full is the window". Summing turn totals
+/// counts the same transcript once per model call, so a long turn reads as a
+/// multiple of the prompt that was actually resident. That reading has its own
+/// field: [`CodeUsage::context_tokens`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, TS)]
 pub struct CodeUsage {
     /// Fresh, uncached input tokens. Excludes both cache fields.
@@ -158,6 +163,18 @@ pub struct CodeUsage {
     /// Cache-write input tokens, when the engine reports them.
     #[serde(default)]
     pub cache_creation_input_tokens: u64,
+    /// Prompt tokens resident on the turn's final model call — what actually
+    /// occupied the context window at the end of the turn.
+    ///
+    /// Distinct from the four counts above, which are the turn's *spend*
+    /// summed across every model call. On a six-call turn those sum to
+    /// roughly six prompts; this is the one prompt that was live when the
+    /// turn ended, and it is the only honest numerator for "how full is the
+    /// window".
+    ///
+    /// Zero when the engine does not publish enough to compute it.
+    #[serde(default)]
+    pub context_tokens: u64,
 }
 
 /// Hint that a turn recorded a checkpoint. The diff body is loaded separately.
@@ -469,6 +486,7 @@ mod tests {
                     output_tokens: 22,
                     cache_read_input_tokens: 33,
                     cache_creation_input_tokens: 44,
+                    context_tokens: 88,
                 },
                 checkpoint: Some(CheckpointHint {
                     checkpoint_ref: Some("refs/tidebreak/checkpoints/ws/1".into()),

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -12,6 +12,7 @@ import type {
 import { useApp } from "./AppContext";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
 import { ChatHeaderTitle } from "./ChatHeaderTitle";
+import { summedTurnTokens } from "./ContextUsage";
 import { ChatStatusChip } from "./ChatStatusChip";
 import {
   loadChatApprovalHydration,
@@ -765,11 +766,28 @@ export function ChatRoute({ chatId }: { chatId: string }) {
               onChange={onModelChange}
             />
           }
-          contextUsage={{
-            usage: lastTurnUsage,
-            contextWindow: activeModel?.context_window,
-            modelName: activeModel?.display_name,
-          }}
+          contextUsage={
+            lastTurnUsage
+              ? {
+                  // Chat has no per-call figure to read, so the ring keeps
+                  // the summed turn totals it always used. That carries the
+                  // same over-read code mode just fixed: a multi-call turn
+                  // re-sends its transcript, so this runs to several prompts
+                  // where the window only ever held one. Fixing it needs the
+                  // provider paths to publish the last call's prompt on
+                  // `RendererTurnUsage`, which is not in this change.
+                  contextTokens: summedTurnTokens(lastTurnUsage),
+                  spend: {
+                    input: lastTurnUsage.input_tokens,
+                    output: lastTurnUsage.output_tokens,
+                    cacheRead: lastTurnUsage.cache_read_input_tokens,
+                    cacheWrite: lastTurnUsage.cache_creation_input_tokens,
+                  },
+                  contextWindow: activeModel?.context_window,
+                  modelName: activeModel?.display_name,
+                }
+              : null
+          }
           composerPermissionMenu={
             <PermissionModeMenu
               scopeKey={chatId}

--- a/crates/tidebreak-desktop/ui/src/ChatUsageDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatUsageDialog.tsx
@@ -6,10 +6,10 @@ import { useApp } from "./AppContext";
 import { chatUsageTotals } from "./ChatUsage";
 import { useChatSessionStore } from "./ChatSessionStore";
 import {
-  contextTokens,
   contextUsageLevel,
   contextUsagePercent,
   formatTokenCount,
+  summedTurnTokens,
 } from "./ContextUsage";
 import type { ChatTerminalTurnSnapshot, RendererTurnUsage } from "./generated/wire";
 import { modelForChat } from "./ModelSelection";
@@ -51,8 +51,11 @@ export function ChatUsageDialog({
   const [turns, setTurns] = useState<ChatTerminalTurnSnapshot[] | null>(null);
   const model = modelForChat(models, chat.model, defaultModelKey);
   const contextWindow = model?.context_window ?? undefined;
+  // Chat has no per-call reading, so this dialog keeps the summed turn
+  // totals. Same over-read the code-mode ring just shed: it needs the
+  // provider paths to publish the last call's prompt before it can improve.
   const percent = lastTurnUsage
-    ? contextUsagePercent(lastTurnUsage, contextWindow)
+    ? contextUsagePercent(summedTurnTokens(lastTurnUsage), contextWindow)
     : null;
   const totals = chatUsageTotals(turns ?? undefined);
 
@@ -121,7 +124,7 @@ function ContextWindowPanel({
     );
   }
 
-  const used = contextTokens(lastTurnUsage);
+  const used = summedTurnTokens(lastTurnUsage);
   const metered = percent !== null && contextWindow !== undefined;
   const level = metered ? contextUsageLevel(percent) : "normal";
 

--- a/crates/tidebreak-desktop/ui/src/ChatView.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.tsx
@@ -8,7 +8,7 @@ import {
   type RefObject,
 } from "react";
 import type { ApiClient, Chat } from "./api";
-import type { RendererTurnUsage } from "./generated/wire";
+import type { ContextUsageReading } from "./ContextUsageIndicator";
 import { followScrollBehavior } from "./ChatScroll";
 import { useTranscriptFollow } from "./useTranscriptFollow";
 import { useChatSessionStore } from "./ChatSessionStore";
@@ -68,11 +68,7 @@ export type ChatViewProps = {
   composerModelMenu: ReactNode;
   composerPermissionMenu: ReactNode;
   /** Context-window reading the composer shows beside its own controls. */
-  contextUsage?: {
-    usage: RendererTurnUsage | null;
-    contextWindow: number | undefined;
-    modelName: string | undefined;
-  };
+  contextUsage?: ContextUsageReading | null;
   composerNetwork?: ComposerNetwork;
   composerReasoning?: ComposerReasoning;
   composerImages: ComposerImages;

--- a/crates/tidebreak-desktop/ui/src/Composer.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.test.tsx
@@ -525,12 +525,6 @@ describe("Composer", () => {
   });
 
   it("shows last-turn usage left of Send even when the window is unknown", () => {
-    const usage = {
-      input_tokens: 12_000,
-      output_tokens: 800,
-      cache_read_input_tokens: 4_000,
-      cache_creation_input_tokens: 0,
-    };
     const markup = renderToStaticMarkup(
       <Composer
         activeTurnId="turn-2"
@@ -540,7 +534,13 @@ describe("Composer", () => {
         disabled={false}
         draft=""
         contextUsage={{
-          usage,
+          contextTokens: 16_800,
+          spend: {
+            input: 12_000,
+            output: 800,
+            cacheRead: 4_000,
+            cacheWrite: 0,
+          },
           contextWindow: undefined,
           modelName: "GPT-5.6 Sol",
         }}
@@ -571,11 +571,7 @@ describe("Composer", () => {
         cancelPending={false}
         disabled={false}
         draft=""
-        contextUsage={{
-          usage: null,
-          contextWindow: 1_050_000,
-          modelName: "GPT-5.6 Sol",
-        }}
+        contextUsage={null}
         onDraftChange={vi.fn()}
         onSend={noop}
         onSteer={noop}

--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -20,8 +20,10 @@ import {
   X,
 } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
-import { ContextUsageIndicator } from "./ContextUsageIndicator";
-import type { RendererTurnUsage } from "./generated/wire";
+import {
+  ContextUsageIndicator,
+  type ContextUsageReading,
+} from "./ContextUsageIndicator";
 import {
   activeSlashQuery,
   availableSlashOptions,
@@ -314,12 +316,11 @@ export type ComposerProps = {
   /** Sits immediately to the right of `modelMenu` when the surface offers one. */
   effortMenu?: ReactNode;
   permissionMenu?: ReactNode;
-  /** Context-window reading, shown with the composer's own controls. */
-  contextUsage?: {
-    usage: RendererTurnUsage | null;
-    contextWindow: number | undefined;
-    modelName: string | undefined;
-  };
+  /**
+   * Context-window reading, shown with the composer's own controls. Null
+   * until a turn has finished; the surface maps its own usage shape in.
+   */
+  contextUsage?: ContextUsageReading | null;
   network?: ComposerNetwork;
   reasoning?: ComposerReasoning;
   plugins?: ComposerPlugins;
@@ -1133,13 +1134,7 @@ export function Composer({
           {/* The ring reads as status, so it sits ahead of the two controls
               that act on the draft: it answers how much room is left for the
               next turn before you reach for the mic or send. */}
-          {contextUsage && (
-            <ContextUsageIndicator
-              usage={contextUsage.usage}
-              contextWindow={contextUsage.contextWindow}
-              modelName={contextUsage.modelName}
-            />
-          )}
+          {contextUsage && <ContextUsageIndicator {...contextUsage} />}
           {/* The mic sits immediately before send: both act on the draft, so
               they belong in the same cluster, apart from the tools and
               model controls that only set the turn up. */}

--- a/crates/tidebreak-desktop/ui/src/ContextUsage.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ContextUsage.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  contextTokens,
   contextTruncationNotice,
   contextUsageLevel,
   contextUsagePercent,
   formatTokenCount,
+  summedTurnTokens,
 } from "./ContextUsage";
 
 const USAGE = {
@@ -14,25 +14,29 @@ const USAGE = {
   cache_creation_input_tokens: 2_500,
 };
 
-describe("context occupancy", () => {
-  it("counts cached prompt tokens as occupying the window", () => {
-    // The four counts are disjoint — a cache hit still fills the window, and
-    // a meter that read only `input_tokens` would report 1k against 200k for
-    // a conversation actually holding 64k.
-    expect(contextTokens(USAGE)).toBe(64_000);
-    expect(contextUsagePercent(USAGE, 200_000)).toBe(32);
+describe("turn spend", () => {
+  it("counts every disjoint field once", () => {
+    // The four counts are disjoint — a cache hit still costs the turn, and a
+    // total that read only `input_tokens` would report 1k for a turn that
+    // actually moved 64k.
+    expect(summedTurnTokens(USAGE)).toBe(64_000);
+  });
+});
+
+describe("context percent", () => {
+  it("divides the resident prompt by the window", () => {
+    expect(contextUsagePercent(64_000, 200_000)).toBe(32);
   });
 
   it("has no percent when the model's window is unknown", () => {
-    expect(contextUsagePercent(USAGE, undefined)).toBeNull();
-    expect(contextUsagePercent(USAGE, 0)).toBeNull();
+    expect(contextUsagePercent(64_000, undefined)).toBeNull();
+    expect(contextUsagePercent(64_000, 0)).toBeNull();
   });
 
-  it("clamps a turn whose totals exceed the window", () => {
-    // A long multi-step turn re-sends its transcript on every model call, so
-    // the summed totals legitimately run past the window. "Full" is the most
-    // a reader can act on.
-    expect(contextUsagePercent(USAGE, 8_000)).toBe(100);
+  it("clamps a reading that exceeds the window", () => {
+    // Trimming, a model switch, or a stale denominator can all put the
+    // numerator over the window. "Full" is the most a reader can act on.
+    expect(contextUsagePercent(64_000, 8_000)).toBe(100);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/ContextUsage.ts
+++ b/crates/tidebreak-desktop/ui/src/ContextUsage.ts
@@ -1,16 +1,20 @@
 import type { RendererTurnUsage } from "./generated/wire";
 
 /**
- * How much of a model's context window the last turn accounted for.
+ * A turn's token spend, summed across every model call it made.
  *
- * The four counts on [`RendererTurnUsage`] are disjoint — `input_tokens` is the
- * fresh prompt only, and the two cache figures are the portions read from and
- * written to the provider's prompt cache — so the tokens that occupied the
- * window are their plain sum. See the generated type's own doc comment for why
- * that holds on every provider, and for the caveat that these are turn totals
- * summed across model calls rather than a snapshot of the final prompt.
+ * The four counts on [`RendererTurnUsage`] are disjoint — `input_tokens` is
+ * the fresh prompt only, and the two cache figures are the portions read from
+ * and written to the provider's prompt cache — so the turn's whole token spend
+ * is their plain sum. See the generated type's own doc comment for why that
+ * holds on every provider.
+ *
+ * This is spend, not occupancy. A turn that ran six model calls re-sent its
+ * transcript six times, so this runs to roughly six prompts while the window
+ * only ever held one. Use it for "what did this turn cost", never for "how
+ * full is the window" — that reading is `CodeUsage.context_tokens`.
  */
-export function contextTokens(usage: RendererTurnUsage): number {
+export function summedTurnTokens(usage: RendererTurnUsage): number {
   return (
     usage.input_tokens +
     usage.output_tokens +
@@ -22,20 +26,22 @@ export function contextTokens(usage: RendererTurnUsage): number {
 /**
  * Share of the window used, as a whole percent clamped to 0–100.
  *
+ * Takes the resident prompt, not a turn total: the caller decides which number
+ * is an honest numerator, because only some surfaces have a per-call reading.
+ *
  * Clamped rather than allowed to run over: a bar reading 130% tells a reader
- * nothing they can act on beyond what "full" already tells them, and the turn
- * totals can legitimately exceed the window on a long multi-step turn.
+ * nothing they can act on beyond what "full" already tells them.
  *
  * Returns null when the denominator is unusable. That is a missing percent,
  * not a missing reading — used tokens are still honest without a window.
+ * Whether the numerator is a reading at all is the caller's call.
  */
 export function contextUsagePercent(
-  usage: RendererTurnUsage,
+  tokens: number,
   contextWindow: number | undefined,
 ): number | null {
   if (!contextWindow || contextWindow <= 0) return null;
-  const used = contextTokens(usage);
-  return Math.min(100, Math.max(0, Math.round((used / contextWindow) * 100)));
+  return Math.min(100, Math.max(0, Math.round((tokens / contextWindow) * 100)));
 }
 
 /** How loudly the meter should read at a given fill. */

--- a/crates/tidebreak-desktop/ui/src/ContextUsageIndicator.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ContextUsageIndicator.dom.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  ContextUsageIndicator,
+  type ContextUsageReading,
+} from "./ContextUsageIndicator";
+
+/**
+ * A real code-mode turn: six model calls, so the four spend counts total far
+ * more than the window while the prompt still resident is a quarter of it.
+ */
+const SIX_CALL_TURN: ContextUsageReading = {
+  contextTokens: 44_172,
+  spend: {
+    input: 1_244,
+    output: 12_902,
+    cacheRead: 236_180,
+    cacheWrite: 8_412,
+  },
+  contextWindow: 200_000,
+  modelName: "Sonnet 5",
+};
+
+describe("the ring reads context, not spend", () => {
+  it("fills from the resident prompt when the spend runs past the window", () => {
+    // Measured on a real lane: 258,738 summed against a 44,172 prompt. The
+    // sum clamps to 100% and colours the ring destructive; the prompt is 22%.
+    const markup = renderToStaticMarkup(
+      <ContextUsageIndicator {...SIX_CALL_TURN} />,
+    );
+
+    expect(markup).toContain('aria-label="Context: 22% of 200k tokens used"');
+    expect(markup).not.toContain("100%");
+    expect(markup).not.toContain("text-destructive");
+  });
+
+  it("escalates on the resident prompt alone", () => {
+    const markup = renderToStaticMarkup(
+      <ContextUsageIndicator {...SIX_CALL_TURN} contextTokens={185_000} />,
+    );
+
+    expect(markup).toContain('aria-label="Context: 93% of 200k tokens used"');
+    expect(markup).toContain("text-destructive");
+  });
+});
+
+describe("readings the engine did not publish", () => {
+  it("shows no percent when there is no context figure", () => {
+    const markup = renderToStaticMarkup(
+      <ContextUsageIndicator {...SIX_CALL_TURN} contextTokens={null} />,
+    );
+
+    expect(markup).toContain('aria-label="Context: no reading from this engine"');
+    expect(markup).not.toContain("% of");
+    expect(markup).not.toContain("text-destructive");
+  });
+
+  it("treats a zero from the engine as no reading, not an empty window", () => {
+    const markup = renderToStaticMarkup(
+      <ContextUsageIndicator {...SIX_CALL_TURN} contextTokens={0} />,
+    );
+
+    expect(markup).toContain('aria-label="Context: no reading from this engine"');
+    expect(markup).not.toContain("0%");
+  });
+
+  it("keeps the token count when only the window is missing", () => {
+    const markup = renderToStaticMarkup(
+      <ContextUsageIndicator {...SIX_CALL_TURN} contextWindow={undefined} />,
+    );
+
+    expect(markup).toContain('aria-label="Context: 44,172 tokens used"');
+    expect(markup).not.toContain("% of");
+  });
+});
+
+describe("the hover", () => {
+  it("names the four counts as spend and states the context separately", async () => {
+    const user = userEvent.setup();
+    render(<ContextUsageIndicator {...SIX_CALL_TURN} />);
+
+    await user.hover(screen.getByRole("button"));
+
+    const tooltip = await screen.findByRole("tooltip");
+    // The four counts are labelled as spend, so nobody reads 236,180 cached
+    // tokens as a window that overflowed.
+    expect(tooltip).toHaveTextContent("Turn spend");
+    expect(tooltip).toHaveTextContent("236,180");
+    // And the occupancy reading is stated in full beside them.
+    expect(tooltip).toHaveTextContent("44,172 / 200,000");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/ContextUsageIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/ContextUsageIndicator.tsx
@@ -1,6 +1,4 @@
-import type { RendererTurnUsage } from "./generated/wire";
 import {
-  contextTokens,
   contextUsageLevel,
   contextUsagePercent,
   formatTokenCount,
@@ -9,10 +7,43 @@ import { WithTooltip } from "./components/ui/tooltip";
 import { cn } from "./lib/utils";
 
 /**
- * How much of the active model's context window the last turn accounted for.
+ * The two readings a finished turn produces, mapped by whoever has them.
  *
- * Renders nothing only when no turn has finished. An unknown window still
- * shows the used tokens — a missing denominator is not a missing reading.
+ * Deliberately not a wire type. Code mode reads occupancy from the engine's
+ * last model call; chat has only turn totals. Naming both here forces each
+ * surface to say which number it is handing over, instead of passing a usage
+ * struct whose four counts get quietly reinterpreted as occupancy.
+ */
+export type ContextUsageReading = {
+  /**
+   * Prompt tokens resident on the last model call — the ring's numerator.
+   *
+   * Null when the engine published nothing that answers "how full is the
+   * window". The ring then shows no fill rather than a made-up one.
+   */
+  contextTokens: number | null;
+  /** The turn's token spend, summed across every model call it made. */
+  spend: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  contextWindow: number | undefined;
+  modelName: string | undefined;
+};
+
+/**
+ * How much of the active model's context window the last turn left resident.
+ *
+ * The ring shows context; the hover shows spend. They are different numbers:
+ * a turn that ran six model calls spent roughly six prompts' worth of tokens
+ * while the window still only held one, so summing the spend to fill the ring
+ * reads several times too high and pins a healthy session at "full".
+ *
+ * An unknown window still shows the resident tokens — a missing denominator is
+ * not a missing reading. An engine that publishes no per-call figure gets no
+ * fill at all, which is the honest presentation of "not measured".
  *
  * The denominator is the *currently selected* model, not the one that ran the
  * turn. Switching models mid-chat is a question about what will fit next, so
@@ -22,25 +53,25 @@ import { cn } from "./lib/utils";
  * magnitude is a glance, and the numbers wait on hover.
  */
 export function ContextUsageIndicator({
-  usage,
+  contextTokens,
+  spend,
   contextWindow,
   modelName,
-}: {
-  usage: RendererTurnUsage | null;
-  contextWindow: number | undefined;
-  modelName: string | undefined;
-}) {
-  if (!usage) return null;
-
-  const used = contextTokens(usage);
-  const percent = contextUsagePercent(usage, contextWindow);
-  const metered = percent !== null && contextWindow !== undefined;
+}: ContextUsageReading) {
+  // Zero is not a reading. An engine that publishes nothing usable reports
+  // zero, and filling a ring from it would read as an empty window rather
+  // than an unmeasured one.
+  const resident = contextTokens && contextTokens > 0 ? contextTokens : null;
+  const percent =
+    resident === null ? null : contextUsagePercent(resident, contextWindow);
+  const metered =
+    resident !== null && percent !== null && contextWindow !== undefined;
   const level = metered ? contextUsageLevel(percent) : "normal";
   const parts = [
-    { label: "In", tokens: usage.input_tokens },
-    { label: "Out", tokens: usage.output_tokens },
-    { label: "Cache read", tokens: usage.cache_read_input_tokens },
-    { label: "Cache write", tokens: usage.cache_creation_input_tokens },
+    { label: "In", tokens: spend.input },
+    { label: "Out", tokens: spend.output },
+    { label: "Cache read", tokens: spend.cacheRead },
+    { label: "Cache write", tokens: spend.cacheWrite },
   ].filter((part) => part.tokens > 0);
 
   return (
@@ -60,13 +91,13 @@ export function ContextUsageIndicator({
                 <>
                   {percent}%
                   <span className="mx-1 opacity-50">·</span>
-                  {formatTokenCount(used)}
+                  {formatTokenCount(resident)}
                   <span className="mx-0.5 opacity-50">/</span>
                   {formatTokenCount(contextWindow)}
                 </>
-              ) : (
-                <>{used.toLocaleString()} tokens</>
-              )}
+              ) : resident !== null ? (
+                <>{resident.toLocaleString()} tokens</>
+              ) : null}
             </div>
           </div>
           {metered ? (
@@ -86,20 +117,42 @@ export function ContextUsageIndicator({
             </div>
           ) : (
             <p className="text-[11px] leading-snug opacity-70">
-              No published context window
+              {resident === null
+                ? "This engine reports no context reading"
+                : "No published context window"}
             </p>
           )}
+          <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-0.5 border-t border-primary-foreground/15 pt-2 text-[11px] leading-relaxed">
+            <div className="col-span-2 grid grid-cols-subgrid">
+              <dt className="opacity-70">Context</dt>
+              <dd className="font-mono tabular-nums">
+                {resident === null
+                  ? "—"
+                  : contextWindow
+                    ? `${resident.toLocaleString()} / ${contextWindow.toLocaleString()}`
+                    : resident.toLocaleString()}
+              </dd>
+            </div>
+          </dl>
           {parts.length > 0 && (
-            <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-0.5 border-t border-primary-foreground/15 pt-2 text-[11px] leading-relaxed">
-              {parts.map((part) => (
-                <div key={part.label} className="col-span-2 grid grid-cols-subgrid">
-                  <dt className="opacity-70">{part.label}</dt>
-                  <dd className="font-mono tabular-nums">
-                    {part.tokens.toLocaleString()}
-                  </dd>
-                </div>
-              ))}
-            </dl>
+            <div className="space-y-1 border-t border-primary-foreground/15 pt-2">
+              {/* Labeled, because these are not the ring's numbers: they sum
+                  every model call the turn made, and on a long turn they run
+                  well past what the window ever held. */}
+              <p className="text-[10px] uppercase tracking-wide opacity-60">
+                Turn spend
+              </p>
+              <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-0.5 text-[11px] leading-relaxed">
+                {parts.map((part) => (
+                  <div key={part.label} className="col-span-2 grid grid-cols-subgrid">
+                    <dt className="opacity-70">{part.label}</dt>
+                    <dd className="font-mono tabular-nums">
+                      {part.tokens.toLocaleString()}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
           )}
         </div>
       }
@@ -117,7 +170,9 @@ export function ContextUsageIndicator({
         aria-label={
           metered
             ? `Context: ${percent}% of ${formatTokenCount(contextWindow)} tokens used`
-            : `Context: ${used.toLocaleString()} tokens used`
+            : resident !== null
+              ? `Context: ${resident.toLocaleString()} tokens used`
+              : "Context: no reading from this engine"
         }
       >
         <ContextUsageRing percent={metered ? percent : null} />

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -220,11 +220,12 @@ describe("CodeComposer", () => {
         running={false}
         permissionMode="ask"
         contextUsage={{
-          usage: {
-            input_tokens: 11_000,
-            output_tokens: 12,
-            cache_read_input_tokens: 0,
-            cache_creation_input_tokens: 0,
+          contextTokens: 11_000,
+          spend: {
+            input: 11_000,
+            output: 12,
+            cacheRead: 0,
+            cacheWrite: 0,
           },
           contextWindow: 200_000,
           modelName: "Sonnet",

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import type { RendererTurnUsage } from "../generated/wire";
+import type { ContextUsageReading } from "../ContextUsageIndicator";
 import type { CodeTurnSubmission } from "./parsers";
 import { useCodeUiStore } from "./CodeUiStore";
 import {
@@ -490,12 +490,8 @@ export function CodeComposer({
   lastTurnBeganId?: string | null;
   onModelChange?: (model: string) => void;
   onModeChange?: (mode: CodePermissionMode) => void;
-  /** Same meter as chat: last turn's usage in the send cluster. */
-  contextUsage?: {
-    usage: RendererTurnUsage | null;
-    contextWindow: number | undefined;
-    modelName: string | undefined;
-  };
+  /** Same meter as chat: the last turn's reading in the send cluster. */
+  contextUsage?: ContextUsageReading | null;
   /**
    * Engine-discovered slash commands. Empty or absent hides the `/` popup;
    * free-typed `/` text still submits verbatim.

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -21,6 +21,7 @@ const NO_USAGE = {
   output_tokens: 4,
   cache_read_input_tokens: 0,
   cache_creation_input_tokens: 0,
+  context_tokens: 0,
 };
 
 function deps(): CodeSessionDeps {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
@@ -90,6 +90,7 @@ describe("accepted turn after the socket already painted", () => {
             output_tokens: 1,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            context_tokens: 0,
           },
         },
       },

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -16,6 +16,7 @@ const USAGE = {
   output_tokens: 3_100,
   cache_read_input_tokens: 900,
   cache_creation_input_tokens: 40,
+  context_tokens: 13_340,
 };
 
 const items: CodeTranscriptItem[] = [

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -171,6 +171,9 @@ const TURN = {
     output_tokens: 12,
     cache_read_input_tokens: 0,
     cache_creation_input_tokens: 0,
+    // Deliberately not the sum of the four: the ring reads the prompt the
+    // engine reported resident, not what the turn spent getting there.
+    context_tokens: 9_500,
   },
 };
 
@@ -521,7 +524,7 @@ describe("CodeWorkspacePage", () => {
     expect(seam).toHaveTextContent("2 files +42 −7");
     expect(seam).not.toHaveTextContent("in /");
     expect(
-      screen.getByRole("button", { name: /Context: 11,012 tokens used/ }),
+      screen.getByRole("button", { name: /Context: 9,500 tokens used/ }),
     ).toBeInTheDocument();
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1847,16 +1847,30 @@ function CodeSessionPane({
           onModelChange={
             harnessHonorsTurnModel(session.harness_kind) ? setModel : undefined
           }
-          contextUsage={{
-            usage: lastUsage,
-            contextWindow: catalogModels.find(
-              (entry) => entry.id === model || entry.key === model,
-            )?.context_window,
-            modelName:
-              modelOptions.find((option) => option.id === model)?.label ??
-              model ??
-              undefined,
-          }}
+          contextUsage={
+            lastUsage
+              ? {
+                  // The engine's own reading of the prompt still resident
+                  // after its last model call. The four counts below are the
+                  // turn's spend across every call, which on a long turn runs
+                  // to several times this.
+                  contextTokens: lastUsage.context_tokens,
+                  spend: {
+                    input: lastUsage.input_tokens,
+                    output: lastUsage.output_tokens,
+                    cacheRead: lastUsage.cache_read_input_tokens,
+                    cacheWrite: lastUsage.cache_creation_input_tokens,
+                  },
+                  contextWindow: catalogModels.find(
+                    (entry) => entry.id === model || entry.key === model,
+                  )?.context_window,
+                  modelName:
+                    modelOptions.find((option) => option.id === model)?.label ??
+                    model ??
+                    undefined,
+                }
+              : null
+          }
           onSend={send}
           onSteer={steeringSupported ? steer : undefined}
           onInterrupt={interrupt}

--- a/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
@@ -245,6 +245,7 @@ describe("PrCard", () => {
             output_tokens: 1,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            context_tokens: 0,
           },
         },
       });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -251,6 +251,7 @@ const USAGE = {
   output_tokens: 3,
   cache_read_input_tokens: 0,
   cache_creation_input_tokens: 0,
+  context_tokens: 12,
 };
 
 describe("parseCodeTurnList", () => {
@@ -263,6 +264,15 @@ describe("parseCodeTurnList", () => {
     const withUsage = { ...TURN, usage: USAGE };
     expect(parseCodeTurn(withUsage)).toEqual(withUsage);
     expect(parseCodeTurnList([withUsage])).toEqual([withUsage]);
+  });
+
+  it("reads a turn journaled before context_tokens existed as no reading", () => {
+    // The field is serde-defaulted, so old rows arrive without it. Dropping
+    // the whole usage object over a missing occupancy figure would lose the
+    // spend counts beside it.
+    const { context_tokens: _omitted, ...older } = USAGE;
+    const parsed = parseCodeTurn({ ...TURN, usage: older });
+    expect(parsed?.usage).toEqual({ ...older, context_tokens: 0 });
   });
 
   it("rejects a non-array or a row the turn parser would drop", () => {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2699,11 +2699,20 @@ function parseUsage(value: unknown): CodeUsage | null {
   ) {
     return null;
   }
+  // `context_tokens` is serde-defaulted, so a turn journaled before the field
+  // existed omits it. Rejecting the whole object over a missing occupancy
+  // reading would throw away the spend counts beside it; absent reads as no
+  // reading, which is what zero already means here.
+  const contextTokens = value.context_tokens;
+  if (contextTokens !== undefined && !isFiniteNumber(contextTokens)) {
+    return null;
+  }
   return {
     input_tokens: value.input_tokens,
     output_tokens: value.output_tokens,
     cache_read_input_tokens: value.cache_read_input_tokens,
     cache_creation_input_tokens: value.cache_creation_input_tokens,
+    context_tokens: contextTokens ?? 0,
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1532,6 +1532,11 @@ subagents?: Array<CodeSubagentSummary>, } | { "type": "terminal_activity", works
  * the prompt an engine actually sent is the sum of all three. Missing fields
  * stay zero, which is not the same as "the engine sent zero" — an engine that
  * does not surface cache counts reports nothing rather than a real zero.
+ *
+ * None of the four answers "how full is the window". Summing turn totals
+ * counts the same transcript once per model call, so a long turn reads as a
+ * multiple of the prompt that was actually resident. That reading has its own
+ * field: [`CodeUsage::context_tokens`].
  */
 export type CodeUsage = { 
 /**
@@ -1549,7 +1554,20 @@ cache_read_input_tokens: number,
 /**
  * Cache-write input tokens, when the engine reports them.
  */
-cache_creation_input_tokens: number, };
+cache_creation_input_tokens: number, 
+/**
+ * Prompt tokens resident on the turn's final model call — what actually
+ * occupied the context window at the end of the turn.
+ *
+ * Distinct from the four counts above, which are the turn's *spend*
+ * summed across every model call. On a six-call turn those sum to
+ * roughly six prompts; this is the one prompt that was live when the
+ * turn ended, and it is the only honest numerator for "how full is the
+ * window".
+ *
+ * Zero when the engine does not publish enough to compute it.
+ */
+context_tokens: number, };
 
 /**
  * Identifies one durable watch task on a workspace's pull request.

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -197,6 +197,7 @@ const usage = {
   output_tokens: 1_842,
   cache_read_input_tokens: 11_730,
   cache_creation_input_tokens: 0,
+  context_tokens: 24_180,
 };
 
 const turns: CodeTurnSnapshot[] = [

--- a/crates/tidebreak-desktop/ui/src/stories/ContextUsageIndicator.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ContextUsageIndicator.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ContextUsageIndicator } from "@/ContextUsageIndicator";
+import {
+  contextUsageCritical,
+  contextUsageNoReading,
+  contextUsageNormal,
+  contextUsageUnmetered,
+  contextUsageWarning,
+} from "./fixtures";
+
+/**
+ * The composer's context ring.
+ *
+ * Every story shares one turn's spend — 258,738 prompt-side tokens across six
+ * model calls — and varies only the prompt left resident at the end. That is
+ * the point: the ring must move with the resident prompt and ignore the sum,
+ * which would clamp all five of these to a red 100%.
+ *
+ * Hover any of them for the split: the context line, then the turn's spend.
+ */
+const meta = {
+  title: "Composer/Context ring",
+  component: ContextUsageIndicator,
+  decorators: [
+    (Story) => (
+      <div className="flex items-center gap-3 p-10">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ContextUsageIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 22% of a 200k window, from a turn that spent nearly six times that. */
+export const Normal: Story = {
+  args: contextUsageNormal,
+};
+
+/** 79%: the ring takes the warning colour from the trigger, not the arc. */
+export const Warning: Story = {
+  args: contextUsageWarning,
+};
+
+/** 96%: the only state that should ever read destructive. */
+export const Critical: Story = {
+  args: contextUsageCritical,
+};
+
+/** No published window. Tokens are still honest without a denominator. */
+export const Unmetered: Story = {
+  args: contextUsageUnmetered,
+};
+
+/** The engine published nothing usable: an empty track, and no percent. */
+export const NoReading: Story = {
+  args: contextUsageNoReading,
+};

--- a/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
@@ -17,6 +17,7 @@ function boundary(
       output_tokens: 2_931,
       cache_read_input_tokens: 31_002,
       cache_creation_input_tokens: 0,
+      context_tokens: 52_640,
     },
     error: null,
     diffstat: { files: 3, insertions: 96, deletions: 14, truncated: false },

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -24,6 +24,7 @@ import type {
   WebSearchCredentialReadiness,
 } from "@/api";
 import type { CodeDeliveryNotification } from "@/code/CodeDeliveryStore";
+import type { ContextUsageReading } from "@/ContextUsageIndicator";
 
 export const taskPlan: TaskPlan = {
   turn_id: "turn-storybook",
@@ -1210,3 +1211,45 @@ export const webSearchCredentials: WebSearchCredentialReadiness[] = [
   { provider: "tavily", has_credential: false },
   { provider: "brave", has_credential: true },
 ];
+
+/**
+ * A finished six-call code turn, as the composer's ring receives it.
+ *
+ * The spend is the shape that made the ring lie: 258,738 prompt-side tokens
+ * summed across every call against a 200k window, while the prompt actually
+ * resident at the end was 44,172. The ring reads the latter.
+ */
+export const contextUsageNormal: ContextUsageReading = {
+  contextTokens: 44_172,
+  spend: {
+    input: 1_244,
+    output: 12_902,
+    cacheRead: 236_180,
+    cacheWrite: 8_412,
+  },
+  contextWindow: 200_000,
+  modelName: "Sonnet 5",
+};
+
+export const contextUsageWarning: ContextUsageReading = {
+  ...contextUsageNormal,
+  contextTokens: 158_400,
+};
+
+export const contextUsageCritical: ContextUsageReading = {
+  ...contextUsageNormal,
+  contextTokens: 191_600,
+};
+
+/** A model whose window the catalog does not publish: tokens, no percent. */
+export const contextUsageUnmetered: ContextUsageReading = {
+  ...contextUsageNormal,
+  contextWindow: undefined,
+  modelName: "Local model",
+};
+
+/** An engine that publishes no per-call figure: no fill, no invented percent. */
+export const contextUsageNoReading: ContextUsageReading = {
+  ...contextUsageNormal,
+  contextTokens: null,
+};

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
@@ -50,7 +50,8 @@
       "input_tokens": 4,
       "output_tokens": 107,
       "cache_read_input_tokens": 103012,
-      "cache_creation_input_tokens": 186
+      "cache_creation_input_tokens": 186,
+      "context_tokens": 51694
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
@@ -38,7 +38,8 @@
       "input_tokens": 4,
       "output_tokens": 140,
       "cache_read_input_tokens": 99470,
-      "cache_creation_input_tokens": 3728
+      "cache_creation_input_tokens": 3728,
+      "context_tokens": 51679
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
@@ -47,7 +47,8 @@
       "input_tokens": 4,
       "output_tokens": 123,
       "cache_read_input_tokens": 91858,
-      "cache_creation_input_tokens": 3759
+      "cache_creation_input_tokens": 3759,
+      "context_tokens": 47883
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/plain-text.expected.json
@@ -19,7 +19,8 @@
       "input_tokens": 2,
       "output_tokens": 574,
       "cache_read_input_tokens": 44122,
-      "cache_creation_input_tokens": 5211
+      "cache_creation_input_tokens": 5211,
+      "context_tokens": 49335
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/resume.expected.json
@@ -23,7 +23,8 @@
       "input_tokens": 2,
       "output_tokens": 14,
       "cache_read_input_tokens": 49333,
-      "cache_creation_input_tokens": 596
+      "cache_creation_input_tokens": 596,
+      "context_tokens": 49931
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/subagent-task.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/subagent-task.expected.json
@@ -56,7 +56,8 @@
       "input_tokens": 8,
       "output_tokens": 76,
       "cache_read_input_tokens": 0,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 8
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
@@ -85,7 +85,8 @@
       "input_tokens": 6,
       "output_tokens": 196,
       "cache_read_input_tokens": 142916,
-      "cache_creation_input_tokens": 5479
+      "cache_creation_input_tokens": 5479,
+      "context_tokens": 49603
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
@@ -119,7 +119,8 @@
       "input_tokens": 5754,
       "output_tokens": 118,
       "cache_read_input_tokens": 23040,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 14466
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
@@ -115,7 +115,8 @@
       "input_tokens": 5785,
       "output_tokens": 132,
       "cache_read_input_tokens": 23040,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 14499
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/plain-text.expected.json
@@ -30,7 +30,8 @@
       "input_tokens": 4999,
       "output_tokens": 7,
       "cache_read_input_tokens": 8960,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 13959
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
@@ -26,7 +26,8 @@
       "input_tokens": 5819,
       "output_tokens": 12,
       "cache_read_input_tokens": 24064,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 15352
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
@@ -43,7 +43,8 @@
       "input_tokens": 6068,
       "output_tokens": 114,
       "cache_read_input_tokens": 22016,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 14109
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/permission-denied.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/permission-denied.expected.json
@@ -378,7 +378,8 @@
       "input_tokens": 18140,
       "output_tokens": 161,
       "cache_read_input_tokens": 36608,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 18311
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/plain-text.expected.json
@@ -355,7 +355,8 @@
       "input_tokens": 102,
       "output_tokens": 17,
       "cache_read_input_tokens": 18048,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 18150
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/resume.expected.json
@@ -83,7 +83,8 @@
       "input_tokens": 18290,
       "output_tokens": 17,
       "cache_read_input_tokens": 384,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 18674
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/tool-use.expected.json
@@ -290,7 +290,8 @@
       "input_tokens": 9189,
       "output_tokens": 84,
       "cache_read_input_tokens": 9728,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 9483
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.5/subagent-task.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.5/subagent-task.expected.json
@@ -73,7 +73,8 @@
       "input_tokens": 40,
       "output_tokens": 18,
       "cache_read_input_tokens": 0,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 40
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
@@ -144,7 +144,8 @@
       "input_tokens": 123,
       "output_tokens": 3,
       "cache_read_input_tokens": 7552,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 7675
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/plain-text.expected.json
@@ -86,7 +86,8 @@
       "input_tokens": 8281,
       "output_tokens": 4,
       "cache_read_input_tokens": 0,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 8281
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/resume.expected.json
@@ -30,7 +30,8 @@
       "input_tokens": 116,
       "output_tokens": 4,
       "cache_read_input_tokens": 8192,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 8308
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/tool-use.expected.json
@@ -125,7 +125,8 @@
       "input_tokens": 125,
       "output_tokens": 2,
       "cache_read_input_tokens": 6272,
-      "cache_creation_input_tokens": 0
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 6397
     }
   }
 ]

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -219,6 +219,45 @@ mod tests {
         )));
     }
 
+    /// The ring's numerator is one prompt, not the turn's summed spend.
+    ///
+    /// `tool-use` ran three model calls: the four spend counts total 148,401
+    /// prompt-side tokens while the last call's own prompt was 49,603. On a
+    /// 200k window that is the difference between reading 74% and 25%.
+    #[test]
+    fn context_tokens_are_the_last_call_not_the_turn_total() {
+        let (events, _) = replay("tool-use");
+        let usage = completed_usage(&events);
+        assert_eq!(usage.context_tokens, 49_603);
+        let spend =
+            usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
+        assert_eq!(spend, 148_401);
+        assert!(
+            usage.context_tokens < spend,
+            "summed spend must not be mistaken for occupancy"
+        );
+    }
+
+    /// A single-call turn publishes no `iterations`, and the top-level object
+    /// is that one call — so occupancy and prompt-side spend agree.
+    #[test]
+    fn a_result_without_iterations_reads_its_own_prompt() {
+        let (events, _) = replay("subagent-task");
+        let usage = completed_usage(&events);
+        assert_eq!(usage.context_tokens, 8);
+        assert_eq!(usage.input_tokens, 8);
+    }
+
+    fn completed_usage(events: &[HarnessEvent]) -> tidebreak_core::CodeUsage {
+        events
+            .iter()
+            .find_map(|event| match event {
+                HarnessEvent::TurnCompleted { usage } => Some(usage.clone()),
+                _ => None,
+            })
+            .expect("the fixture completes its turn")
+    }
+
     #[test]
     fn fixture_replay_permission_denied() {
         let (events, _) = replay("permission-denied");

--- a/crates/tidebreak-harness/src/claude/parse.rs
+++ b/crates/tidebreak-harness/src/claude/parse.rs
@@ -500,7 +500,29 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
             .get("cache_creation_input_tokens")
             .and_then(Value::as_u64)
             .unwrap_or(0),
+        context_tokens: context_tokens_from(value),
     }
+}
+
+/// The prompt resident on the turn's last model call.
+///
+/// `result.usage` carries `iterations`, one entry per API call, beside the
+/// turn totals it already sums into the four spend counts. The last entry is
+/// the call that closed the turn, so its three prompt-side counts are what the
+/// window actually held. Without this, a ten-call turn reports ten prompts.
+///
+/// A `result` with no `iterations` came from a single call, so the top-level
+/// object is that call and the same three-way sum is correct for it.
+fn context_tokens_from(usage: &Value) -> u64 {
+    let call = usage
+        .get("iterations")
+        .and_then(Value::as_array)
+        .and_then(|iterations| iterations.last())
+        .unwrap_or(usage);
+    let field = |name: &str| call.get(name).and_then(Value::as_u64).unwrap_or(0);
+    field("input_tokens")
+        .saturating_add(field("cache_read_input_tokens"))
+        .saturating_add(field("cache_creation_input_tokens"))
 }
 
 fn bound(text: &str, max: usize) -> String {
@@ -514,6 +536,50 @@ fn bound(text: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `usage.iterations` is one entry per API call. Summing the turn totals
+    /// counts the transcript once per call, so a three-call turn reads as
+    /// three prompts; the window only ever held the last one.
+    #[test]
+    fn context_tokens_come_from_the_last_iteration() {
+        let usage = serde_json::json!({
+            "input_tokens": 6,
+            "output_tokens": 196,
+            "cache_read_input_tokens": 142_916,
+            "cache_creation_input_tokens": 5_479,
+            "iterations": [
+                {"input_tokens": 2, "output_tokens": 80,
+                 "cache_read_input_tokens": 44_122, "cache_creation_input_tokens": 5_211},
+                {"input_tokens": 2, "output_tokens": 91,
+                 "cache_read_input_tokens": 49_334, "cache_creation_input_tokens": 127},
+                {"input_tokens": 2, "output_tokens": 25,
+                 "cache_read_input_tokens": 49_460, "cache_creation_input_tokens": 141}
+            ]
+        });
+        let parsed = usage_from(Some(&usage));
+
+        assert_eq!(parsed.context_tokens, 49_603);
+        // The four spend counts keep the turn totals they already carried.
+        assert_eq!(parsed.cache_read_input_tokens, 142_916);
+        assert_eq!(parsed.output_tokens, 196);
+    }
+
+    /// A single-call turn reports no `iterations`, and the object itself is
+    /// that call.
+    #[test]
+    fn context_tokens_fall_back_to_the_result_itself() {
+        let usage = serde_json::json!({
+            "input_tokens": 12,
+            "output_tokens": 4,
+            "cache_read_input_tokens": 8_192,
+            "cache_creation_input_tokens": 100
+        });
+        assert_eq!(usage_from(Some(&usage)).context_tokens, 8_304);
+
+        // An empty array is the same situation as a missing one.
+        let empty = serde_json::json!({"input_tokens": 12, "iterations": []});
+        assert_eq!(usage_from(Some(&empty)).context_tokens, 12);
+    }
 
     #[test]
     fn unknown_event_types_are_counted_and_do_not_drop_known_events() {

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -377,6 +377,30 @@ mod tests {
             .any(|event| matches!(event, HarnessEvent::TurnCompleted { .. })));
     }
 
+    /// `tokenUsage` reports `total` (the turn) beside `last` (the call that
+    /// just finished). The spend counts read `total`; occupancy reads `last`,
+    /// whose raw `inputTokens` is the whole prompt that call sent.
+    #[test]
+    fn context_tokens_come_from_the_last_call() {
+        let (events, _) = replay("approval-approve");
+        let usage = completed_usage(&events);
+        assert_eq!(usage.context_tokens, 14_466);
+        let spend =
+            usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
+        assert_eq!(spend, 28_794);
+        assert!(usage.context_tokens < spend);
+    }
+
+    fn completed_usage(events: &[HarnessEvent]) -> tidebreak_core::CodeUsage {
+        events
+            .iter()
+            .find_map(|event| match event {
+                HarnessEvent::TurnCompleted { usage } => Some(usage.clone()),
+                _ => None,
+            })
+            .expect("the fixture completes its turn")
+    }
+
     #[test]
     fn fixture_replay_hook_lifecycle() {
         let (events, unrecognized) = replay("hook-lifecycle");

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -548,7 +548,25 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
         output_tokens: field("outputTokens"),
         cache_read_input_tokens,
         cache_creation_input_tokens,
+        context_tokens: context_tokens_from(value),
     }
+}
+
+/// The prompt resident on the turn's last model call.
+///
+/// `last` is that call. Its `inputTokens` is the whole prompt the call sent —
+/// `cachedInputTokens` is a subset already inside it — so the cached prefix
+/// needs no adding back. The written portion sits outside it and does.
+///
+/// Read from the raw payload on purpose. [`usage_from`] subtracts both cache
+/// figures back out of `input_tokens` so the four spend counts stay disjoint,
+/// which leaves that field a remainder rather than a prompt.
+///
+/// A payload with no `last` is itself one call.
+fn context_tokens_from(usage: &Value) -> u64 {
+    let last = usage.get("last").unwrap_or(usage);
+    let field = |name: &str| last.get(name).and_then(Value::as_u64).unwrap_or(0);
+    field("inputTokens").saturating_add(field("cacheWriteInputTokens"))
 }
 
 fn id_key(id: &Value) -> String {

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -554,19 +554,26 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
 
 /// The prompt resident on the turn's last model call.
 ///
-/// `last` is that call. Its `inputTokens` is the whole prompt the call sent —
-/// `cachedInputTokens` is a subset already inside it — so the cached prefix
-/// needs no adding back. The written portion sits outside it and does.
+/// `last` is that call, and its `inputTokens` is the whole prompt it sent.
+/// Both cache figures are subsets already inside that number, so neither is
+/// added back.
 ///
-/// Read from the raw payload on purpose. [`usage_from`] subtracts both cache
-/// figures back out of `input_tokens` so the four spend counts stay disjoint,
-/// which leaves that field a remainder rather than a prompt.
+/// That `cacheWriteInputTokens` sits inside rather than beside `inputTokens`
+/// is what the payload's own arithmetic says: `totalTokens` equals
+/// `inputTokens + outputTokens` in every captured object, so `inputTokens`
+/// has to carry the whole prompt or the total would not balance once a write
+/// is non-zero. [`usage_from`] reads it the same way — it subtracts both cache
+/// figures back out to keep the four spend counts disjoint, which is also why
+/// this reads the raw payload instead of that remainder.
+///
+/// Every captured fixture has `cacheWriteInputTokens: 0`, so no test
+/// distinguishes the two readings. Adding the write on top would double-count
+/// it exactly on a cache miss — the case the context ring exists to show.
 ///
 /// A payload with no `last` is itself one call.
 fn context_tokens_from(usage: &Value) -> u64 {
     let last = usage.get("last").unwrap_or(usage);
-    let field = |name: &str| last.get(name).and_then(Value::as_u64).unwrap_or(0);
-    field("inputTokens").saturating_add(field("cacheWriteInputTokens"))
+    last.get("inputTokens").and_then(Value::as_u64).unwrap_or(0)
 }
 
 fn id_key(id: &Value) -> String {
@@ -632,6 +639,49 @@ mod tests {
         assert_eq!(usage.cache_read_input_tokens, 30);
         assert_eq!(usage.cache_creation_input_tokens, 10);
         assert_eq!(usage.output_tokens, 7);
+    }
+
+    /// A written cache block is inside `inputTokens`, not beside it.
+    ///
+    /// No captured fixture proves this — every one reports
+    /// `cacheWriteInputTokens: 0`. The payload's arithmetic does:
+    /// `totalTokens` is `inputTokens + outputTokens`, so `inputTokens` carries
+    /// the whole prompt. [`usage_from`] agrees, subtracting the written block
+    /// back out to keep the spend counts disjoint.
+    ///
+    /// Adding it on top instead would inflate the context reading by exactly
+    /// the written block on a cache miss — the moment the ring matters most.
+    #[test]
+    fn a_written_cache_block_is_not_added_on_top_of_the_prompt() {
+        let payload = serde_json::json!({
+            "total": {
+                "totalTokens": 60_020, "inputTokens": 60_000,
+                "cachedInputTokens": 12_000, "cacheWriteInputTokens": 8_000,
+                "outputTokens": 20, "reasoningOutputTokens": 0
+            },
+            "last": {
+                "totalTokens": 40_007, "inputTokens": 40_000,
+                "cachedInputTokens": 12_000, "cacheWriteInputTokens": 8_000,
+                "outputTokens": 7, "reasoningOutputTokens": 0
+            }
+        });
+
+        assert_eq!(
+            context_tokens_from(&payload),
+            40_000,
+            "the resident prompt is the last call's inputTokens, not that plus the write"
+        );
+
+        // The same reading `usage_from` takes: the three prompt-side spend
+        // counts reconstruct the turn's `inputTokens` exactly.
+        let usage = usage_from(Some(&payload));
+        assert_eq!(
+            usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens,
+            60_000
+        );
+        // And the resident prompt is below the turn's prompt-side spend,
+        // which is the whole reason the two numbers are separate fields.
+        assert!(usage.context_tokens < 60_000);
     }
 
     use super::*;

--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -232,6 +232,46 @@ mod tests {
             .any(|event| matches!(event, HarnessEvent::ToolCompleted { .. })));
     }
 
+    /// Grok publishes both shapes: a per-call `usage` event and a cumulative
+    /// `end` payload. The spend counts take the cumulative one; occupancy
+    /// takes the last per-call event.
+    ///
+    /// `permission-denied` ran three calls. Its `end` payload sums to 54,748
+    /// prompt-side tokens while the prompt still resident was 18,311 — a 3x
+    /// over-read, and enough to clamp a ring that should read a third full.
+    #[test]
+    fn context_tokens_are_the_last_call_not_the_cumulative_end() {
+        let (events, _) = replay("permission-denied");
+        let usage = completed_usage(&events);
+        assert_eq!(usage.context_tokens, 18_311);
+        let spend =
+            usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
+        assert_eq!(spend, 54_748);
+    }
+
+    /// A single-call turn has nothing to disagree about: the one `usage`
+    /// event and the `end` payload report the same prompt.
+    #[test]
+    fn a_single_call_turn_reads_the_same_prompt_either_way() {
+        let (events, _) = replay("plain-text");
+        let usage = completed_usage(&events);
+        assert_eq!(usage.context_tokens, 18_150);
+        assert_eq!(
+            usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens,
+            18_150
+        );
+    }
+
+    fn completed_usage(events: &[HarnessEvent]) -> tidebreak_core::CodeUsage {
+        events
+            .iter()
+            .find_map(|event| match event {
+                HarnessEvent::TurnCompleted { usage } => Some(usage.clone()),
+                _ => None,
+            })
+            .expect("the fixture completes its turn")
+    }
+
     #[test]
     fn fixture_replay_permission_denied() {
         let (events, _) = replay("permission-denied");

--- a/crates/tidebreak-harness/src/grok/parse.rs
+++ b/crates/tidebreak-harness/src/grok/parse.rs
@@ -31,6 +31,10 @@ pub struct GrokStreamParser {
     settled_subagents: HashSet<String>,
     emitted_session: bool,
     last_usage: CodeUsage,
+    /// Prompt tokens on the most recent `usage` event, which is one model
+    /// call. Kept apart from `last_usage` because the closing `end` event
+    /// overwrites that with the turn's cumulative total.
+    last_call_context_tokens: Option<u64>,
     pending_text: String,
 }
 
@@ -47,6 +51,7 @@ impl Default for GrokStreamParser {
             settled_subagents: HashSet::new(),
             emitted_session: false,
             last_usage: CodeUsage::default(),
+            last_call_context_tokens: None,
             pending_text: String::new(),
         }
     }
@@ -384,7 +389,13 @@ impl GrokStreamParser {
     }
 
     fn parse_usage(&mut self, value: &Value) -> Vec<HarnessEvent> {
-        self.last_usage = usage_from(value.get("usage"));
+        let usage = usage_from(value.get("usage"));
+        // A `usage` event is one model call: `tool-use.ndjson` reports 9050
+        // then 139 fresh input across two calls, and the closing `end` event
+        // reports their 9189 sum. So this call's prompt-side sum is an
+        // occupancy reading; the `end` event's is spend.
+        self.last_call_context_tokens = Some(usage.context_tokens);
+        self.last_usage = usage;
         self.flush_assistant()
     }
 
@@ -394,6 +405,14 @@ impl GrokStreamParser {
         }
         if let Some(usage) = value.get("usage") {
             self.last_usage = usage_from(Some(usage));
+        }
+        // The `end` usage sums every model call, so its own prompt-side sum
+        // is roughly one prompt per call. The last per-call `usage` event is
+        // the prompt that was still resident when the turn ended. A turn that
+        // published no per-call event keeps the fallback, which is correct
+        // for the single-call case the two shapes agree on.
+        if let Some(context_tokens) = self.last_call_context_tokens {
+            self.last_usage.context_tokens = context_tokens;
         }
         let mut events = self.emit_session();
         events.extend(self.flush_assistant());
@@ -699,6 +718,7 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
     let Some(value) = value else {
         return CodeUsage::default();
     };
+    let field = |name: &str| value.get(name).and_then(Value::as_u64).unwrap_or(0);
     CodeUsage {
         input_tokens: value
             .get("input_tokens")
@@ -716,6 +736,12 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
             .get("cache_creation_input_tokens")
             .and_then(Value::as_u64)
             .unwrap_or(0),
+        // Correct for a per-call `usage` event, which is the only place this
+        // reading survives; `parse_end` replaces it when the cumulative
+        // `end` payload lands here.
+        context_tokens: field("input_tokens")
+            .saturating_add(field("cache_read_input_tokens"))
+            .saturating_add(field("cache_creation_input_tokens")),
     }
 }
 

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -202,6 +202,28 @@ mod tests {
             .any(|event| matches!(event, HarnessEvent::TurnCompleted { .. })));
     }
 
+    /// `step-finish` reports one model call, and the parser keeps the most
+    /// recent one. `approval-approve` ran two calls — 5267 then 123 fresh
+    /// input — so the prompt still resident at the end is the second.
+    #[test]
+    fn context_tokens_are_the_last_step_prompt() {
+        let (events, _) = replay("approval-approve");
+        let usage = completed_usage(&events);
+        assert_eq!(usage.context_tokens, 7_675);
+        assert_eq!(usage.input_tokens, 123);
+        assert_eq!(usage.cache_read_input_tokens, 7_552);
+    }
+
+    fn completed_usage(events: &[HarnessEvent]) -> tidebreak_core::CodeUsage {
+        events
+            .iter()
+            .find_map(|event| match event {
+                HarnessEvent::TurnCompleted { usage } => Some(usage.clone()),
+                _ => None,
+            })
+            .expect("the fixture completes its turn")
+    }
+
     #[test]
     fn fixture_replay_tool_use() {
         let (events, _) = replay("tool-use");

--- a/crates/tidebreak-harness/src/opencode/parse.rs
+++ b/crates/tidebreak-harness/src/opencode/parse.rs
@@ -546,17 +546,28 @@ impl OpencodeStreamParser {
         if tokens.get("input").is_none() && tokens.get("output").is_none() {
             return;
         }
+        let input_tokens = tokens.get("input").and_then(Value::as_u64).unwrap_or(0);
+        let cache_read_input_tokens = tokens
+            .pointer("/cache/read")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let cache_creation_input_tokens = tokens
+            .pointer("/cache/write")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
         self.last_usage = CodeUsage {
-            input_tokens: tokens.get("input").and_then(Value::as_u64).unwrap_or(0),
+            input_tokens,
             output_tokens: tokens.get("output").and_then(Value::as_u64).unwrap_or(0),
-            cache_read_input_tokens: tokens
-                .pointer("/cache/read")
-                .and_then(Value::as_u64)
-                .unwrap_or(0),
-            cache_creation_input_tokens: tokens
-                .pointer("/cache/write")
-                .and_then(Value::as_u64)
-                .unwrap_or(0),
+            cache_read_input_tokens,
+            cache_creation_input_tokens,
+            // `step-finish` and `message.updated` both report one model call
+            // — `approval-approve.ndjson` shows 5267 then 123 fresh input,
+            // and the session-level `session.updated` row carries their 5390
+            // sum, which this parser does not read. So the snapshot standing
+            // when the turn ends is the last call's prompt.
+            context_tokens: input_tokens
+                .saturating_add(cache_read_input_tokens)
+                .saturating_add(cache_creation_input_tokens),
         };
     }
 

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -438,6 +438,7 @@ pub(crate) fn plain_text_script() -> Vec<HarnessEvent> {
                 output_tokens: 6,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                context_tokens: 4,
             },
         },
     ]


### PR DESCRIPTION
## The ring was reading spend

`ContextUsageIndicator` divided the sum of `CodeUsage`'s four counts by the model's context window. Those four are the turn's **spend**, summed across every model call the engine made. A turn that ran six calls re-sent its transcript six times, so the sum is roughly six prompts while the window only ever held one.

Measured on a real lane: the turn summed to **258,738** prompt-side tokens while the widest prompt in it was **44,172** — a 5.9x over-read. The ring clamped to a red `critical` 100% while the window sat at 22% of 200k.

The fixtures show the same shape on every engine. Claude's `tool-use` turn spends 148,401 against a resident 49,603; grok's `permission-denied` spends 54,748 against a resident 18,311.

## The ring shows context, the hover shows spend

`CodeUsage` gains a fifth field, `context_tokens`: the prompt resident on the turn's final model call. It is the only honest numerator for "how full is the window", and every engine already publishes what it takes to compute it.

| Engine | Source of the resident prompt |
| --- | --- |
| claude | Last entry of `result.usage.iterations[]`, summing its three prompt-side counts. A single-call turn omits the array, so the top-level object is that call. |
| codex | `tokenUsage.last.inputTokens + last.cacheWriteInputTokens`, read from the **raw** payload — `usage_from` subtracts the cache figures back out of `input_tokens` to keep the spend counts disjoint, which leaves that field a remainder rather than a prompt. |
| opencode | The `step-finish` / `message.updated` snapshot, which is already one call. The cumulative figure lives on `session.updated`, which this parser does not read. |
| grok | The last per-call `usage` event, tracked separately. Its closing `end` payload overwrites the snapshot with the turn's cumulative total, so reading the snapshot at turn end would have reproduced the same over-read. |

On the UI side, `ContextUsageIndicator` takes an explicit prop shape instead of a `RendererTurnUsage`, so both surfaces map into it deliberately:

```ts
{ contextTokens: number | null; spend: {...}; contextWindow?: number; modelName?: string }
```

- The ring fills from `contextTokens / contextWindow`, with the same clamping and the same `normal` / `warning` / `critical` bands.
- `contextTokens` null or zero renders the unmetered presentation — an empty track, no percent, no false `critical`.
- The hover keeps the In / Out / Cache read / Cache write breakdown but labels it **Turn spend**, and states the context reading on its own line against the window.

## Chat mode is unchanged

Chat passes its existing four-field sum as `contextTokens`, so its behaviour is identical to before this PR. `RendererTurnUsage` has no per-call data, so chat carries the same latent over-read. Fixing it needs the provider paths to publish the last call's prompt; a comment at that call site and in `ChatUsageDialog` says so. Deliberately out of scope here.

## Notes

- **No schema epoch bump.** `context_tokens` is `#[serde(default)]`, so journal rows written before the field existed still deserialize. The pinned journal fixture was regenerated as a change record only; `DESKTOP_SCHEMA_EPOCH` stays at 35. The TypeScript validator accepts a row without the field and reads it as zero, with a test covering that.
- **No fixture has more than one `iterations` entry**, so the claude multi-call case is covered by a unit test over a synthetic three-call `result` alongside the fixture-backed assertions.
- **One inconsistency worth a second opinion:** `usage_from` for codex subtracts `cacheWriteInputTokens` out of `input_tokens` (treating it as inside `inputTokens`), while `context_tokens` adds it back (treating it as outside). Both cannot be right. Every captured codex payload reports `cacheWriteInputTokens: 0`, so nothing observable distinguishes them today, and this PR follows the reading that matches Anthropic's own split. Worth settling when a capture with a non-zero cache write exists.

## Checks

- `cargo test -p tidebreak-harness --lib` — 194 pass, including six new `context_tokens` tests
- `cargo test -p tidebreak-core --lib` — 710 pass
- `cargo test -p tidebreak-server --lib code` — pass
- `cargo fmt --all --check`, `cargo clippy -p tidebreak-core -p tidebreak-harness -p tidebreak-server --all-targets` — clean
- `tsc --noEmit` and the full UI suite — 1585 pass
- `pnpm storybook:build` — succeeds; new `Composer/Context ring` story covers normal, warning, critical, unmetered, and no-reading
