### PR TITLE
fix(code): settle an approval whose tool call already resolved

### DIFF
--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -13,9 +13,9 @@ use std::str::FromStr;
 
 use futures::StreamExt as _;
 use tidebreak_core::{
-    AgentError, Attention, AttentionState, CapLevel, CodeApprovalId, CodeApprovalKind, CodeEvent,
-    CodePermissionMode, CodeSessionId, CodeSessionLifecycle, CodeTurnId, HarnessCaps, HarnessKind,
-    RepoId, Result, WorkspaceId,
+    AgentError, ApprovalDecisionKind, Attention, AttentionState, CapLevel, CodeApprovalId,
+    CodeApprovalKind, CodeEvent, CodePermissionMode, CodeSessionId, CodeSessionLifecycle,
+    CodeTurnId, HarnessCaps, HarnessKind, RepoId, Result, WorkspaceId,
 };
 use tokio_tungstenite::tungstenite::Message;
 
@@ -1262,6 +1262,18 @@ fn render_event(event: &CodeEvent, dangling: bool, streamed_text: &mut bool) -> 
         CodeEvent::TurnInterrupted => {
             finish_line(dangling);
             eprintln!("tidebreak: turn interrupted");
+            return false;
+        }
+        // `code run` already told the user to decide this one. Say when the
+        // window closes, or the prompt is the last thing they ever hear.
+        CodeEvent::ApprovalResolved {
+            approval_id,
+            decision: ApprovalDecisionKind::Abandoned,
+        } => {
+            finish_line(dangling);
+            eprintln!(
+                "tidebreak: approval {approval_id} went undecided; the engine stopped waiting"
+            );
             return false;
         }
         CodeEvent::TurnCompleted { .. }

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -192,7 +192,7 @@ pub enum HarnessNoticeLevel {
     Error,
 }
 
-/// Decision recorded on [`CodeEvent::ApprovalResolved`].
+/// Outcome recorded on [`CodeEvent::ApprovalResolved`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ApprovalDecisionKind {
@@ -205,6 +205,13 @@ pub enum ApprovalDecisionKind {
         #[ts(optional)]
         feedback: Option<String>,
     },
+    /// Nobody decided: the tool call resolved first, so the request is dead.
+    ///
+    /// This rides `ApprovalResolved` rather than an event of its own so that
+    /// every consumer already listening for "this approval is settled" stops
+    /// showing the request. A separate event would let an un-updated reader
+    /// keep rendering a pending card that can never be acted on.
+    Abandoned,
 }
 
 /// One event in an external agent-engine session's journal.

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -333,6 +333,11 @@ pub enum CodeApprovalState {
     Approved,
     /// The user denied, optionally with steering feedback.
     Denied,
+    /// The tool call resolved before anyone decided, so the decision can no
+    /// longer reach the engine. An engine that times a parked call out — or a
+    /// turn that ends while the call is still open — leaves the approval here
+    /// rather than pending forever.
+    Abandoned,
 }
 
 impl CodeApprovalState {
@@ -343,6 +348,7 @@ impl CodeApprovalState {
             Self::Pending => "pending",
             Self::Approved => "approved",
             Self::Denied => "denied",
+            Self::Abandoned => "abandoned",
         }
     }
 
@@ -354,8 +360,15 @@ impl CodeApprovalState {
             "pending" => Some(Self::Pending),
             "approved" => Some(Self::Approved),
             "denied" => Some(Self::Denied),
+            "abandoned" => Some(Self::Abandoned),
             _ => None,
         }
+    }
+
+    /// Whether this state still accepts a decision.
+    #[must_use]
+    pub const fn is_pending(self) -> bool {
+        matches!(self, Self::Pending)
     }
 }
 

--- a/crates/tidebreak-core/src/db/migration/baseline/code.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/code.rs
@@ -378,7 +378,7 @@ pub(super) fn code_approval_table() -> TableCreateStatement {
                 .from(CodeApproval::Table, CodeApproval::TurnId)
                 .to(CodeTurn::Table, CodeTurn::Id),
         )
-        .check(Expr::col(CodeApproval::State).is_in(["pending", "approved", "denied"]))
+        .check(Expr::col(CodeApproval::State).is_in(["pending", "approved", "denied", "abandoned"]))
         .to_owned()
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.dom.test.tsx
@@ -116,6 +116,25 @@ describe("CodeApprovalCard", () => {
     ).not.toBeNull();
   });
 
+  it("drops the buttons on an approval nobody decided", () => {
+    render(
+      <CodeApprovalCard
+        approval={{
+          ...pendingCommand,
+          state: "abandoned",
+          decided_at: "2026-08-15T12:01:00.000Z",
+        }}
+        onDecide={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Not decided")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Deny" })).toBeNull();
+    expect(
+      screen.getByText(/a decision can no longer\s+reach it/),
+    ).toBeInTheDocument();
+  });
+
   it("does not render an unknown engine summary as the decision", () => {
     render(
       <CodeApprovalCard

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -61,6 +61,12 @@ export function CodeApprovalCard({
       {approval.state === "denied" && approval.feedback && (
         <p className="text-[13.5px] break-words">{approval.feedback}</p>
       )}
+      {approval.state === "abandoned" && (
+        <p className="text-muted-foreground text-[13.5px] break-words">
+          The engine stopped waiting for this one, so a decision can no longer
+          reach it. Whatever it asked for did not run on your say-so.
+        </p>
+      )}
       <div>
         <button
           type="button"
@@ -164,6 +170,11 @@ function ApprovalState({ approval }: { approval: CodeApprovalSnapshot }) {
   if (approval.state === "denied") {
     return (
       <p className="text-warning-foreground shrink-0 text-[11px]">Denied</p>
+    );
+  }
+  if (approval.state === "abandoned") {
+    return (
+      <p className="text-muted-foreground shrink-0 text-[11px]">Not decided</p>
     );
   }
   return null;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -114,6 +114,24 @@ describe("approvals", () => {
       state: "denied",
     });
   });
+
+  it("marks an undecided request abandoned rather than denied", () => {
+    const { state } = play([
+      { type: "turn_started", turn_id: "t1" },
+      { type: "approval_requested", approval_id: "appr-1" },
+      {
+        type: "approval_resolved",
+        approval_id: "appr-1",
+        decision: { type: "abandoned" },
+      },
+    ]);
+    const card = state.items.find((item) => item.kind === "approval");
+    expect(card).toMatchObject({
+      kind: "approval",
+      approvalId: "appr-1",
+      state: "abandoned",
+    });
+  });
 });
 
 describe("turn lifecycle", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -1,5 +1,7 @@
+import type { ApprovalDecisionKind } from "../generated/wire";
 import type {
   Attention,
+  CodeApprovalState,
   CodeSessionLifecycle,
   CodeTurnSnapshot,
   CodeTurnStatus,
@@ -23,6 +25,20 @@ import type {
  */
 
 export type CodeToolStatus = "running" | ToolOutcome;
+
+/**
+ * Terminal approval state each resolution carries. `abandoned` is not a
+ * decision: the tool call resolved before anyone made one, so the card stops
+ * offering buttons and says the request went undecided.
+ */
+const RESOLVED_APPROVAL_STATE: Record<
+  ApprovalDecisionKind["type"],
+  CodeApprovalState
+> = {
+  approve: "approved",
+  deny: "denied",
+  abandoned: "abandoned",
+};
 
 export type CodeTranscriptItem =
   | {
@@ -86,7 +102,7 @@ export type CodeTranscriptItem =
       kind: "approval";
       id: string;
       approvalId: string;
-      state: "pending" | "approved" | "denied";
+      state: CodeApprovalState;
     }
   | {
       kind: "steer";
@@ -485,8 +501,7 @@ export function reduceCodeSessionEvent(
 
     case "approval_resolved": {
       const approvalId = event.approval_id;
-      const nextState =
-        event.decision.type === "approve" ? "approved" : "denied";
+      const nextState = RESOLVED_APPROVAL_STATE[event.decision.type];
       return {
         state: {
           ...state,

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -217,6 +217,7 @@ const APPROVAL_STATES = new Set<CodeApprovalState>([
   "pending",
   "approved",
   "denied",
+  "abandoned",
 ]);
 const TOOL_OUTCOMES = new Set<ToolOutcome>(["succeeded", "failed", "denied"]);
 const ATTENTION_SOURCES = new Set<AttentionSource>([
@@ -2582,7 +2583,9 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
         !onlyKeys(value, ["type", "approval_id", "decision"]) ||
         !nonEmpty(value.approval_id) ||
         !isRecord(value.decision) ||
-        (value.decision.type !== "approve" && value.decision.type !== "deny")
+        (value.decision.type !== "approve" &&
+          value.decision.type !== "deny" &&
+          value.decision.type !== "abandoned")
       ) {
         return null;
       }

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -488,13 +488,13 @@ export type AppViewSession = { frame_path: string, };
 export type ApprovalClass = "read_only" | "workspace" | "sensitive";
 
 /**
- * Decision recorded on [`CodeEvent::ApprovalResolved`].
+ * Outcome recorded on [`CodeEvent::ApprovalResolved`].
  */
 export type ApprovalDecisionKind = { "type": "approve" } | { "type": "deny", 
 /**
  * Feedback returned to the engine, when any.
  */
-feedback?: string, };
+feedback?: string, } | { "type": "abandoned" };
 
 /**
  * How wide a standing grant the human chose, narrowest first.
@@ -860,7 +860,7 @@ harness_raw_json: string, state: CodeApprovalState, feedback?: string, requested
 /**
  * State of a persisted approval.
  */
-export type CodeApprovalState = "pending" | "approved" | "denied";
+export type CodeApprovalState = "pending" | "approved" | "denied" | "abandoned";
 
 /**
  * Remembered clone destination plus observed `gh` status.

--- a/crates/tidebreak-desktop/ui/src/stories/CodeApprovalCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeApprovalCard.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { CodeApprovalCard } from "@/code/CodeApprovalCard";
+import type { CodeApprovalSnapshot } from "@/api/types";
+
+const pending: CodeApprovalSnapshot = {
+  id: "3f1c0d4a-0000-4000-8000-000000000001",
+  session_id: "3f1c0d4a-0000-4000-8000-000000000002",
+  turn_id: "3f1c0d4a-0000-4000-8000-000000000003",
+  kind: {
+    type: "command",
+    cmd: "cargo test -p tidebreak-server",
+    cwd: "/workspace",
+  },
+  harness_raw_json: JSON.stringify(
+    {
+      tool_name: "Bash",
+      input: { command: "cargo test -p tidebreak-server" },
+      tool_use_id: "toolu_01ApprovalStory",
+    },
+    null,
+    2,
+  ),
+  state: "pending",
+  requested_at: "2026-08-15T12:00:00.000Z",
+};
+
+/**
+ * The code transcript's approval card. The states that matter are the two the
+ * user creates and the one the engine creates for them: an approval whose tool
+ * call resolved before anyone decided is `abandoned`, and it must read as a
+ * request that went undecided rather than as a denial.
+ */
+const meta = {
+  title: "Code/Approval card",
+  component: CodeApprovalCard,
+  args: {
+    approval: pending,
+    onDecide: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CodeApprovalCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Pending: Story = {};
+
+export const Deciding: Story = {
+  args: { deciding: true },
+};
+
+export const Approved: Story = {
+  args: {
+    approval: {
+      ...pending,
+      state: "approved",
+      decided_at: "2026-08-15T12:00:12.000Z",
+    },
+  },
+};
+
+export const Denied: Story = {
+  args: {
+    approval: {
+      ...pending,
+      state: "denied",
+      feedback:
+        "Run the focused test instead — the workspace suite is too slow.",
+      decided_at: "2026-08-15T12:00:20.000Z",
+    },
+  },
+};
+
+/**
+ * The engine timed the parked tool call out. Nobody decided, and nobody can:
+ * the card drops its buttons and says so, because the alternative is a row
+ * that sits pending forever and accepts an approval that reaches nothing.
+ */
+export const Abandoned: Story = {
+  args: {
+    approval: {
+      ...pending,
+      state: "abandoned",
+      decided_at: "2026-08-15T12:01:00.000Z",
+    },
+  },
+};
+
+export const DecisionFailed: Story = {
+  args: {
+    error: "The decision could not be saved. The command has not run.",
+  },
+};

--- a/crates/tidebreak-server/src/code/approval_sweep.rs
+++ b/crates/tidebreak-server/src/code/approval_sweep.rs
@@ -1,0 +1,163 @@
+//! Reconcile approvals whose tool call resolved before anyone decided.
+//!
+//! An approval is parked on the engine's `tool_use_id`, and the same id comes
+//! back on [`CodeEvent::ToolCompleted`]. When a completion arrives for a call
+//! that still has a pending approval, nobody's decision can reach the engine
+//! any more: the engine timed the call out, denied it itself, or ran it under
+//! a rule of its own. Leaving the row `Pending` would list a request that can
+//! never be acted on, and would let a later `code approve` report success for
+//! a command the engine already failed.
+//!
+//! So the row moves to [`CodeApprovalState::Abandoned`] and the session
+//! journals an `ApprovalResolved` carrying
+//! [`ApprovalDecisionKind::Abandoned`]. The turn and session boundaries sweep
+//! the same way, because a tool call that never reports completion must not
+//! leave a row pending forever.
+
+use tidebreak_core::db::code::{list_approvals, list_turns, save_approval};
+use tidebreak_core::{
+    ApprovalDecisionKind, Attention, AttentionSource, CodeApproval, CodeApprovalState, CodeEvent,
+    CodeSessionId, CodeTurnStatus, DbStore, OwnerId,
+};
+
+use super::bus::CodeEventBus;
+
+/// The engine-native call id an approval row was parked on.
+///
+/// Written as a sibling of the capped payload, so an oversized request still
+/// carries it — the same field [`super::runtime::CodeRuntime::decide_approval`]
+/// reads.
+fn call_id_of(approval: &CodeApproval) -> Option<&str> {
+    approval
+        .harness_raw
+        .get("call_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|call_id| !call_id.is_empty())
+}
+
+/// Abandon the pending approval parked on `call_id`, if there is one.
+pub(crate) async fn abandon_for_call(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+    call_id: &str,
+) {
+    if call_id.is_empty() {
+        return;
+    }
+    let doomed: Vec<CodeApproval> = pending(db, owner, session_id)
+        .await
+        .into_iter()
+        .filter(|approval| call_id_of(approval) == Some(call_id))
+        .collect();
+    abandon(db, bus, owner, session_id, spawn_epoch, doomed).await;
+}
+
+/// Abandon every pending approval whose turn has already reached a terminal
+/// status. The turn-end sweep: an engine that drops a tool call without
+/// reporting its completion still ends the turn.
+pub(crate) async fn abandon_for_settled_turns(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+) {
+    let waiting = pending(db, owner, session_id).await;
+    if waiting.is_empty() {
+        return;
+    }
+    let Ok(turns) = list_turns(db, owner, session_id).await else {
+        return;
+    };
+    let settled: Vec<_> = turns
+        .iter()
+        .filter(|turn| turn.status != CodeTurnStatus::Running)
+        .map(|turn| turn.id)
+        .collect();
+    let doomed: Vec<CodeApproval> = waiting
+        .into_iter()
+        .filter(|approval| settled.contains(&approval.turn_id))
+        .collect();
+    abandon(db, bus, owner, session_id, spawn_epoch, doomed).await;
+}
+
+/// Abandon every pending approval on the session, whatever its turn says.
+/// The session-end sweep: no later decision can reach a stopped engine.
+pub(crate) async fn abandon_for_ended_session(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+) {
+    let doomed = pending(db, owner, session_id).await;
+    abandon(db, bus, owner, session_id, spawn_epoch, doomed).await;
+}
+
+async fn pending(db: &DbStore, owner: &OwnerId, session_id: CodeSessionId) -> Vec<CodeApproval> {
+    list_approvals(
+        db,
+        owner,
+        Some(CodeApprovalState::Pending),
+        Some(session_id),
+    )
+    .await
+    .unwrap_or_default()
+}
+
+/// Mark each row abandoned and journal the resolution.
+///
+/// Best-effort throughout: this runs on event and lifecycle paths that must
+/// not fail because a reconciliation write did. A row that loses the race
+/// with a real decision simply fails the pending filter next time round.
+async fn abandon(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+    doomed: Vec<CodeApproval>,
+) {
+    if doomed.is_empty() {
+        return;
+    }
+    let now = chrono::Utc::now();
+    for mut approval in doomed {
+        approval.state = CodeApprovalState::Abandoned;
+        approval.decided_at = Some(now);
+        match save_approval(db, owner, &approval).await {
+            Ok(true) => {}
+            _ => continue,
+        }
+        // Boxed because the turn-end sweep is itself reached from the
+        // journal path: without it the two futures would size each other.
+        let _ = Box::pin(super::session_worker::journal_event(
+            db,
+            bus,
+            owner,
+            session_id,
+            spawn_epoch,
+            CodeEvent::ApprovalResolved {
+                approval_id: approval.id,
+                decision: ApprovalDecisionKind::Abandoned,
+            },
+        ))
+        .await;
+    }
+    // Nothing is waiting on the user any more. Mirrors the decision path:
+    // the turn boundary overwrites this with its own verdict a moment later.
+    if pending(db, owner, session_id).await.is_empty() {
+        let _ = super::attention::apply_attention(
+            db,
+            bus,
+            owner,
+            session_id,
+            Attention::working(AttentionSource::Lifecycle),
+            false,
+        )
+        .await;
+    }
+}

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -5,6 +5,7 @@
 //! worker, crash recovery, and the live event bus.
 
 pub(crate) mod approval_bridge;
+pub(crate) mod approval_sweep;
 pub(crate) mod attention;
 pub(crate) mod browser_channel;
 pub(crate) mod browser_runtime;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1696,6 +1696,14 @@ impl CodeRuntime {
                 "the session did not stay ended after the worker stopped",
             ));
         }
+        super::approval_sweep::abandon_for_ended_session(
+            &self.db,
+            &self.bus,
+            owner,
+            current.id,
+            current.spawn_epoch,
+        )
+        .await;
         Ok(())
     }
 
@@ -1949,6 +1957,14 @@ impl CodeRuntime {
                     "the session did not stay ended after the worker stopped",
                 ));
             }
+            super::approval_sweep::abandon_for_ended_session(
+                &self.db,
+                &self.bus,
+                owner,
+                current.id,
+                current.spawn_epoch,
+            )
+            .await;
         }
         Ok(all_stopped)
     }
@@ -2218,10 +2234,17 @@ impl CodeRuntime {
         decision: ApprovalDecision,
     ) -> Result<CodeApproval, ServerError> {
         let mut approval = self.get_approval(owner, id).await?;
-        if approval.state != CodeApprovalState::Pending {
+        // A terminal row is the only thing standing between the user and a
+        // decision that reaches nothing: the parked MCP call may be long gone
+        // — after a restart, for one — and the bridge accepts a decision with
+        // no waiter on purpose. So the row's state, not the park, decides.
+        if !approval.state.is_pending() {
             return Err(ServerError::conflict_kind(
-                "approval_already_decided",
-                format!("approval {id} is {}", approval.state.as_str()),
+                "approval_not_pending",
+                format!(
+                    "approval {id} is no longer awaiting a decision: it is {}",
+                    approval.state.as_str()
+                ),
             ));
         }
         let call_id = approval

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -350,6 +350,13 @@ impl HarnessEventSink for LiveSink {
             return;
         };
         self.note_subagent_boundary(&code_event).await;
+        // An approval is parked on the call this completion names. Reconcile
+        // it after the completion lands, so the journal reads in the order it
+        // happened. See `approval_sweep`.
+        let completed_call = match &code_event {
+            CodeEvent::ToolCompleted { call_id, .. } => Some(call_id.clone()),
+            _ => None,
+        };
         match persist_and_publish(
             &self.db,
             &self.bus,
@@ -370,6 +377,17 @@ impl HarnessEventSink for LiveSink {
             Err(err) => {
                 warn!(session = %self.session_id, error = %err, "failed to journal engine event");
             }
+        }
+        if let Some(call_id) = completed_call {
+            super::approval_sweep::abandon_for_call(
+                &self.db,
+                &self.bus,
+                &self.owner,
+                self.session_id,
+                self.spawn_epoch,
+                &call_id,
+            )
+            .await;
         }
     }
 }
@@ -1205,10 +1223,24 @@ async fn persist_and_publish(
     if is_activity(&event) {
         let _ = super::attention::note_activity(db, bus, owner, session_id).await;
     }
+    // A tool call the engine dropped without reporting a completion leaves
+    // its approval pending. The turn is over, so nothing can decide it now.
+    // Every route that closes a turn passes through here, and each does so
+    // before writing the turn's own attention verdict, which supersedes the
+    // sweep's. Swept after this event is published so the resolution it
+    // journals keeps its later sequence number on the live stream too.
+    let closes_turn = matches!(
+        &event,
+        CodeEvent::TurnCompleted { .. } | CodeEvent::TurnFailed { .. } | CodeEvent::TurnInterrupted
+    );
     bus.publish(
         session_id,
         tidebreak_core::SequencedCodeEvent { seq, event },
     );
+    if closes_turn {
+        super::approval_sweep::abandon_for_settled_turns(db, bus, owner, session_id, spawn_epoch)
+            .await;
+    }
     if activity_boundary {
         if let Ok(Some(session)) = get_session(db, owner, session_id).await {
             super::attention::emit_digest(db, bus, &session).await;

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 35;
+const DESKTOP_SCHEMA_EPOCH: u32 = 36;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -86,6 +86,7 @@ pub(crate) struct ScriptedAdapter {
     unrecognized_per_turn: u64,
     silent_interrupt: bool,
     lost_resume: Option<String>,
+    park_approvals: bool,
     approver: Arc<ScriptedApprover>,
     probes: Arc<AtomicU64>,
     /// Approval endpoint each launch was handed, `None` when it was handed no
@@ -110,6 +111,7 @@ impl ScriptedAdapter {
             unrecognized_per_turn: 0,
             silent_interrupt: false,
             lost_resume: None,
+            park_approvals: true,
             approver: Arc::new(ScriptedApprover::default()),
             probes: Arc::new(AtomicU64::new(0)),
             launched_approvals: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -201,6 +203,14 @@ impl ScriptedAdapter {
         self
     }
 
+    /// Model an engine that asks for an approval and then stops waiting for
+    /// one, the way Claude Code's own 60-second permission-prompt timeout
+    /// does: the script plays straight past the request.
+    pub(crate) fn with_unattended_approvals(mut self) -> Self {
+        self.park_approvals = false;
+        self
+    }
+
     /// Stands in for a parser that could not map part of the stream: the
     /// scripted session reports this many unrecognized events per turn.
     pub(crate) fn with_unrecognized_per_turn(mut self, count: u64) -> Self {
@@ -273,6 +283,7 @@ impl HarnessAdapter for ScriptedAdapter {
             silent_interrupt: self.silent_interrupt,
             pid: ChildPid::new(),
             lost_resume: self.lost_resume.clone(),
+            park_approvals: self.park_approvals,
             interrupt: Arc::new(AtomicBool::new(false)),
             unrecognized: AtomicU64::new(0),
             unrecognized_per_turn: self.unrecognized_per_turn,
@@ -292,6 +303,7 @@ struct ScriptedSession {
     silent_interrupt: bool,
     pid: ChildPid,
     lost_resume: Option<String>,
+    park_approvals: bool,
     interrupt: Arc<AtomicBool>,
     unrecognized: AtomicU64,
     unrecognized_per_turn: u64,
@@ -310,6 +322,9 @@ impl ScriptedSession {
             }
             if let HarnessEvent::ApprovalRequested { harness_ref, .. } = event {
                 self.sink.emit(event.clone()).await;
+                if !self.park_approvals {
+                    continue;
+                }
                 let rx = self.approver.park();
                 if let Ok(decision) = rx.await {
                     self.sink

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -190,6 +190,140 @@ fn write_approval_script(call_id: &str, content: &str) -> Vec<HarnessEvent> {
     ]
 }
 
+/// An engine that asks for an approval and then stops waiting for one. Claude
+/// Code times a parked permission prompt out after 60 seconds, resolves the
+/// tool call `failed`, and finishes the turn with nobody having decided.
+fn timed_out_approval_script() -> Vec<HarnessEvent> {
+    let mut events = undecided_approval_script("toolu_timeout");
+    events.insert(
+        3,
+        HarnessEvent::ToolCompleted {
+            call_id: "toolu_timeout".into(),
+            outcome: tidebreak_core::ToolOutcome::Failed,
+            preview: "Bash tool call timed out after 60s".into(),
+            detail: None,
+            parent_call_id: None,
+        },
+    );
+    events
+}
+
+/// The same request, but the engine never reports the call at all: only the
+/// turn boundary can settle the row.
+fn dropped_approval_script() -> Vec<HarnessEvent> {
+    undecided_approval_script("toolu_dropped")
+}
+
+fn undecided_approval_script(call_id: &str) -> Vec<HarnessEvent> {
+    vec![
+        HarnessEvent::SessionStarted {
+            harness_kind: HarnessKind::ClaudeCode,
+            harness_version: "scripted".into(),
+            resume_ref: Some("scripted-session".into()),
+        },
+        HarnessEvent::TurnStarted,
+        HarnessEvent::ApprovalRequested {
+            harness_ref: HarnessApprovalRef {
+                call_id: call_id.into(),
+            },
+            raw: serde_json::json!({
+                "tool_name": "Bash",
+                "input": { "command": "rm -rf /tmp/scratch" },
+                "tool_use_id": call_id
+            }),
+        },
+        HarnessEvent::TurnCompleted {
+            usage: Default::default(),
+        },
+    ]
+}
+
+/// Register a repo and workspace, open an Ask session, and run one turn to
+/// completion. Only useful for scripts that never park, which is every script
+/// modelling an approval nobody decides.
+async fn ran_one_ask_turn(
+    adapter: ScriptedAdapter,
+) -> (
+    reqwest::Client,
+    std::net::SocketAddr,
+    Arc<str>,
+    CodeSessionId,
+    Arc<CodeRuntime>,
+    tempfile::TempDir,
+) {
+    let (router, token, runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session: serde_json::Value = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "ask",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let session_id: CodeSessionId = json_id(&session).parse().unwrap();
+    let turn = tokio::time::timeout(
+        Duration::from_secs(10),
+        client
+            .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({ "message": "run it" }))
+            .send(),
+    )
+    .await
+    .expect("the turn must not park on an approval nobody answers")
+    .unwrap();
+    assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
+    (client, addr, token, session_id, runtime, dir)
+}
+
+/// Every approval on the session, whatever its state.
+async fn approvals_for(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+    session_id: CodeSessionId,
+) -> Vec<serde_json::Value> {
+    client
+        .get(format!(
+            "http://{addr}/code/approvals?session_id={session_id}"
+        ))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+/// The outcome carried on every `ApprovalResolved` the session journaled.
+async fn journaled_resolutions(
+    db: &DbStore,
+    session_id: CodeSessionId,
+) -> Vec<tidebreak_core::ApprovalDecisionKind> {
+    tidebreak_core::db::code::list_events(db, &tidebreak_core::OwnerId::local(), session_id, 0)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter_map(|framed| match framed.event {
+            CodeEvent::ApprovalResolved { decision, .. } => Some(decision),
+            _ => None,
+        })
+        .collect()
+}
+
 fn init_git_repo_named(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
     let repo = dir.join(name);
     std::fs::create_dir_all(&repo).unwrap();
@@ -3949,6 +4083,122 @@ async fn pending_approval_survives_restart_and_is_decidable() {
     let seen = observed.observed_decisions();
     assert_eq!(seen.len(), 1);
     assert_eq!(seen[0].1, ApprovalDecision::Approve);
+}
+
+/// The bug this fixes: an engine that times its own tool call out leaves the
+/// approval row `pending` forever, so `code approvals` lists a request nobody
+/// can act on and `code approve` reports success for a command that never ran.
+/// The completion carries the `tool_use_id` the approval is parked on, which
+/// is the join.
+#[tokio::test]
+async fn an_approval_is_abandoned_when_its_tool_call_resolves_undecided() {
+    let adapter = ScriptedAdapter::new(timed_out_approval_script())
+        .with_approvals(CapLevel::Supported)
+        .with_unattended_approvals();
+    let (client, addr, token, session_id, runtime, _dir) = ran_one_ask_turn(adapter).await;
+
+    let rows = approvals_for(&client, addr, &token, session_id).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["state"], "abandoned");
+    assert!(
+        rows[0]["decided_at"].is_string(),
+        "an abandoned approval is settled, so it carries a decided_at"
+    );
+
+    let pending: Vec<serde_json::Value> = client
+        .get(format!("http://{addr}/code/approvals?state=pending"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        pending.is_empty(),
+        "a settled approval must leave the pending list"
+    );
+
+    assert_eq!(
+        journaled_resolutions(&runtime.db, session_id).await,
+        vec![tidebreak_core::ApprovalDecisionKind::Abandoned],
+        "the journal is how the CLI and the UI learn the request went undecided"
+    );
+}
+
+/// Deciding a settled approval must fail out loud. The bridge accepts a
+/// decision with nothing parked on purpose — that is the restart path — so the
+/// row's state is the only thing that can tell the user their approval would
+/// reach nothing.
+#[tokio::test]
+async fn deciding_an_abandoned_approval_is_refused() {
+    let adapter = ScriptedAdapter::new(timed_out_approval_script())
+        .with_approvals(CapLevel::Supported)
+        .with_unattended_approvals();
+    let observed = adapter.clone();
+    let (client, addr, token, session_id, runtime, _dir) = ran_one_ask_turn(adapter).await;
+
+    let rows = approvals_for(&client, addr, &token, session_id).await;
+    let approval_id = rows[0]["id"].as_str().unwrap().to_owned();
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/approvals/{approval_id}/decision"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "decision": "approve" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert!(
+        body.to_string().contains("no longer awaiting a decision"),
+        "the refusal must say why, got {body}"
+    );
+
+    let rows = approvals_for(&client, addr, &token, session_id).await;
+    assert_eq!(rows[0]["state"], "abandoned");
+    assert_eq!(
+        journaled_resolutions(&runtime.db, session_id).await,
+        vec![tidebreak_core::ApprovalDecisionKind::Abandoned],
+        "a refused decision journals nothing"
+    );
+    assert!(
+        observed.observed_decisions().is_empty(),
+        "a refused decision never reaches the engine"
+    );
+}
+
+/// A tool call the engine drops without reporting must not leave a row pending
+/// forever either. The turn boundary is the backstop.
+#[tokio::test]
+async fn a_turn_that_ends_without_a_tool_result_abandons_its_approval() {
+    let adapter = ScriptedAdapter::new(dropped_approval_script())
+        .with_approvals(CapLevel::Supported)
+        .with_unattended_approvals();
+    let (client, addr, token, session_id, runtime, _dir) = ran_one_ask_turn(adapter).await;
+
+    let rows = approvals_for(&client, addr, &token, session_id).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["state"], "abandoned");
+    assert!(rows[0]["decided_at"].is_string());
+    assert_eq!(
+        journaled_resolutions(&runtime.db, session_id).await,
+        vec![tidebreak_core::ApprovalDecisionKind::Abandoned]
+    );
+
+    let session = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        session_id,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        !matches!(session.attention.state, AttentionState::NeedsYou { .. }),
+        "nothing is waiting on the user once the request is settled"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## The bug

An approval parked on a tool call stayed `pending` forever once the engine resolved that call on its own. Claude Code times a permission prompt out after 60 seconds — that timer is the engine's, not Tidebreak's — fails the tool call, and finishes the turn. Both `code_approval` rows from the driven session that surfaced this are still `state: pending`, `decided_at: NULL`, while their tool calls read `failed` and the turn reads `completed`.

Two harms:

1. **`code approvals --session <id>` lists requests nobody can act on.** The session's attention reads `done_unreviewed`, so nothing surfaces them either.
2. **`code approve <stale-id>` reports success for a command that never ran.** `approval_bridge.rs` accepts a decision when nothing is parked, deliberately, so a decision arriving after a server restart still lands. But the same path let a decision on a dead request flip the row to `approved` and journal an `ApprovalResolved` for a command the engine had already failed and would never run. The user was told they approved something that did not happen. The added test confirms this: without the fix, the decision route answers `200 OK`.

## The fix

Approvals are parked on the engine's `tool_use_id`, and `ToolCompleted` carries the same id — verified through `event_from_prompt_request` (which copies `PermissionPromptRequest.tool_use_id` into `HarnessApprovalRef::call_id`) and the Claude parser, which reads `tool_use_id` off the `tool_result` block. That is the join.

- `CodeApprovalState` gains `Abandoned`: the tool call resolved before anyone decided. Added to the enum, the DB check constraint, and the generated wire types. `DESKTOP_SCHEMA_EPOCH` bumps so disposable local databases rebuild, matching how every earlier code-mode baseline edit landed.
- New `code/approval_sweep.rs` marks a pending approval `Abandoned`, sets `decided_at`, and journals the resolution. It runs from three places: on `ToolCompleted` for the matching call, on every event that closes a turn, and at session end. The turn-end hook sits on the journal path rather than in `drive_turn`, so every route that closes a turn — the sink, the worker's own close, the failure arm — sweeps once.
- Deciding a settled approval now fails with `approval_not_pending` and the message "approval `<id>` is no longer awaiting a decision: it is abandoned", instead of succeeding.

**The restart path is unchanged.** An approval that is still `pending` with no parked waiter is still decidable — that is exactly what the bridge's no-waiter branch is for, and `pending_approval_survives_restart_and_is_decidable` still covers it. The distinction is the row's state, not whether a waiter is parked. Recovery settles an open turn through `append_event` rather than the journal path, so a restart deliberately does not sweep.

## Wire contract

`ApprovalDecisionKind` gains a third variant, `Abandoned`, rather than the journal gaining a new event.

`ApprovalResolved` is the one event that says "this approval reached a terminal state". Every consumer already listens to it to stop showing the request, so reusing it means an existing reader does the right thing with no change. A separate `ApprovalAbandoned` event would let any consumer that only handles `ApprovalResolved` keep rendering the stale pending card this PR exists to remove — it would reintroduce the bug in every un-updated reader. The variant is not a decision and its doc comment says so.

## Attention

`done_unreviewed` stays right. `compute_attention` filters on `pending`, so an abandoned row no longer pins the session to "an approval is waiting", and the turn's own verdict is the honest one.

The user still learns the request went undecided, through three surfaces:

- The journal carries `ApprovalResolved { decision: abandoned }`.
- `code run` prints `approval <id> went undecided; the engine stopped waiting` — previously it printed the "decide with:" prompt and then went silent forever.
- The desktop card drops its buttons, badges "Not decided", and says a decision can no longer reach it.

## Tests

Four new, three of which fail before the change:

| Test | Without the fix |
| --- | --- |
| `an_approval_is_abandoned_when_its_tool_call_resolves_undecided` | row reads `pending` |
| `deciding_an_abandoned_approval_is_refused` | decision returns `200 OK` |
| `a_turn_that_ends_without_a_tool_result_abandons_its_approval` | row reads `pending` |
| `marks an undecided request abandoned rather than denied` (reducer) | the card would read "denied" |

`ScriptedAdapter::with_unattended_approvals` models an engine that asks and then stops waiting, which is what the 60-second timeout does.

The restart case is already covered by `pending_approval_survives_restart_and_is_decidable`, which still passes; a duplicate would not change what we do.

## Checks

`cargo fmt --all --check`, clippy on `tidebreak-core`, `tidebreak-server`, and `tidebreak-cli` with `-D warnings`, the server code-mode suite, `tidebreak-core --lib` (710), the CLI suite, UI typecheck, focused UI tests, and `storybook:build`. Wire types regenerated through `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server`, not hand-edited.

`tests::code_terminals::create_write_read_and_two_cursors` fails under parallel load on this machine, and fails the same way on a clean `main` — pre-existing and unrelated.

## Known gap

An abandoned approval's MCP request stays parked in `ApprovalBridge`, because the sink has no handle on the bridge. That leak predates this change and costs one map entry per timed-out approval; unparking it needs the completer plumbed into `LiveSink`, which is more surgery than this fix warrants.
