### PR TITLE
feat(code): take PR state changes off the agent path

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -345,11 +345,14 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     allowInEditable: true,
   },
   {
+    // Green merges now; anything else GitHub can still land arms auto-merge.
+    // One chord for one intent — "get this in" — with the confirmation naming
+    // which of the two is about to happen.
     id: "code-merge-pr",
     codes: ["KeyM"],
     mod: true,
     shift: true,
-    description: "Merge the pull request",
+    description: "Merge, or auto-merge once the checks pass",
     group: "Ship",
     scope: "code",
     allowInEditable: true,

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -2408,6 +2408,23 @@ export class ApiClient {
   }
 
   /**
+   * User-initiated draft-to-ready. Decision 42 keeps pull-request state
+   * changes off the agent path, so this is a dedicated endpoint rather than a
+   * prompt. Returns the post-change snapshot.
+   */
+  async markCodePrReady(workspaceId: string): Promise<CodeWorkspacePrSnapshot> {
+    return requireParsed(
+      parseCodeWorkspacePr(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/ready`,
+          { method: "POST", headers: this.headers(true) },
+        ),
+      ),
+      "code pull request",
+    );
+  }
+
+  /**
    * User-initiated merge. auto=true arms host auto-merge instead of merging
    * immediately. Returns the post-merge snapshot.
    */

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -251,14 +251,16 @@ export function CodeSidebar() {
                       action === "open_source" ||
                       action === "push" ||
                       action === "create_pr" ||
-                      action === "merge"
+                      action === "merge" ||
+                      action === "mark_ready"
                     ) {
                       // Local-git stages never arise from the digest-only
                       // model; the workspace page is where they resolve.
-                      // Merging goes there too: decision 42 makes it the
-                      // reader's call, and a card in a rail is the wrong place
-                      // to land a shared branch from — the header puts the
-                      // pull request in front of them first.
+                      // Merging and readying go there too: decision 42 makes
+                      // both the reader's call, and a card in a rail is the
+                      // wrong place to land a shared branch or open work for
+                      // review from — the header puts the pull request in
+                      // front of them first.
                       void navigate({
                         to: "/code/w/$workspaceId",
                         params: { workspaceId: workspace.id },

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -254,6 +254,19 @@ function makeClient() {
         remediation: "",
       }),
     ),
+    markCodePrReady: vi.fn(
+      async (): Promise<CodeWorkspacePrSnapshot> => ({
+        dirty: false,
+        unpushed: false,
+        ahead: 0,
+        has_upstream: true,
+        suggested_commit_message: "",
+        pr: { ...PR, draft: false },
+        gh_found: true,
+        gh_authenticated: true,
+        remediation: "",
+      }),
+    ),
     mergeCodePr: vi.fn(
       async (): Promise<CodeWorkspacePrSnapshot> => ({
         dirty: false,
@@ -725,24 +738,6 @@ describe("CodeWorkspacePage", () => {
     expect(popover).toHaveTextContent("1 passing · 1 pending");
 
     await user.click(
-      within(control).getByRole("button", { name: "Mark ready" }),
-    );
-    await waitFor(() =>
-      expect(client.submitCodeTurn).toHaveBeenCalledWith(
-        "sess-1",
-        expect.stringMatching(/Mark pull request #41 ready for review/),
-        undefined,
-        undefined,
-      ),
-    );
-    expect(client.submitCodeTurn.mock.calls[0]?.[1]).toMatch(
-      /Pull request: #41 - Fix login flow/,
-    );
-    expect(client.submitCodeTurn.mock.calls[0]?.[1]).toMatch(
-      /Branch: tidebreak\/fix-login -> main/,
-    );
-
-    await user.click(
       within(control).getByRole("button", { name: "More workspace actions" }),
     );
     await user.click(
@@ -752,7 +747,19 @@ describe("CodeWorkspacePage", () => {
     await waitFor(() =>
       expect(client.startCodeWatch).toHaveBeenCalledWith("ws-1"),
     );
-    expect(client.submitCodeTurn).toHaveBeenCalledTimes(1);
+
+    // Readying a draft is a pull-request state change, so the button calls the
+    // endpoint rather than composing a prompt, and the adopted snapshot moves
+    // the control off draft. It goes last for that reason. `prActions` covers
+    // what the remaining prompt-backed actions put in front of the agent.
+    await user.click(
+      within(control).getByRole("button", { name: "Mark ready" }),
+    );
+    await waitFor(() =>
+      expect(client.markCodePrReady).toHaveBeenCalledWith("ws-1"),
+    );
+    await waitFor(() => expect(control).not.toHaveTextContent("Draft"));
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Workspace actions" }));
     const menu = await screen.findByRole("menu");
@@ -885,6 +892,85 @@ describe("CodeWorkspacePage", () => {
       expect(useCodeUiStore.getState().workflowShortcutPending).not.toBeNull(),
     );
     expect(toast.message).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a draft ready through the endpoint rather than by prompt", async () => {
+    // Readying a draft puts work in front of reviewers, which decision 42
+    // keeps off the agent path for the same reason merging is. The chord for
+    // "run the next step" is what reaches it at this stage.
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: PR });
+    client.getCodeWorkspacePr.mockResolvedValue({
+      dirty: false,
+      unpushed: false,
+      ahead: 0,
+      has_upstream: true,
+      suggested_commit_message: "",
+      pr: PR,
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+    });
+    await mountWorkspace(client);
+    const control = await screen.findByTestId("workspace-workflow-control");
+    await waitFor(() => expect(control).toHaveTextContent("Draft"));
+
+    act(() => useCodeUiStore.getState().requestWorkflowShortcut("ws-1", "next"));
+
+    await waitFor(() =>
+      expect(client.markCodePrReady).toHaveBeenCalledWith("ws-1"),
+    );
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+  });
+
+  it("arms auto-merge when the pull request is landable but not yet green", async () => {
+    // One chord, one intent: the reader means "get this in" whether or not the
+    // checks have finished. The confirmation is what names which of the two is
+    // about to happen.
+    const pending: PullRequestDigest = {
+      ...PR,
+      draft: false,
+      mergeable: "mergeable",
+      merge_state_status: "blocked",
+      checks: [{ name: "ci / rust", bucket: "pending" as const }],
+    };
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([SESSION]);
+    client.getCodeWorkspace.mockResolvedValue({ ...WORKSPACE, pr: pending });
+    client.getCodeWorkspacePr.mockResolvedValue({
+      dirty: false,
+      unpushed: false,
+      ahead: 0,
+      has_upstream: true,
+      suggested_commit_message: "",
+      pr: pending,
+      gh_found: true,
+      gh_authenticated: true,
+      remediation: "",
+    });
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+    await screen.findByTestId("workspace-workflow-control");
+
+    act(() => useCodeUiStore.getState().requestWorkflowShortcut("ws-1", "merge"));
+
+    const confirmation = await screen.findByRole("alertdialog");
+    expect(confirmation).toHaveTextContent("Auto-merge #41?");
+    expect(confirmation).toHaveTextContent(
+      "once the remaining requirements pass",
+    );
+    await user.click(
+      within(confirmation).getByRole("button", { name: "Enable auto-merge" }),
+    );
+
+    await waitFor(() =>
+      expect(client.mergeCodePr).toHaveBeenCalledWith("ws-1", {
+        method: "squash",
+        auto: true,
+      }),
+    );
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
   });
 
   it("archives from a chord through the same confirmation the menu uses", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -32,7 +32,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { openExternal } from "@/host";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
-import { prWorkflowPrompt, type PrWorkflowAction } from "./prActions";
+import { prWorkflowPrompt, type PrPromptAction } from "./prActions";
 import { useCodeUiStore } from "./CodeUiStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import {
@@ -65,6 +65,7 @@ export function WorkspaceWorkflowControl({
     ApiClient,
     | "pushCodeWorkspace"
     | "createCodePullRequest"
+    | "markCodePrReady"
     | "mergeCodePr"
     | "startCodeWatch"
     | "stopCodeWatch"
@@ -147,6 +148,14 @@ export function WorkspaceWorkflowControl({
       void stopWatch();
       return;
     }
+    if ("autoMerge" in resolution) {
+      if (busy !== null) {
+        toast.message("Another workspace action is already running");
+        return;
+      }
+      void mergePr(true);
+      return;
+    }
     if (busy !== null || agentActionRunning) {
       toast.message("Another workspace action is already running");
       return;
@@ -157,7 +166,7 @@ export function WorkspaceWorkflowControl({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workflowShortcutPending, workspaceId]);
 
-  function runAgentAction(action: Exclude<PrWorkflowAction, "watch_and_fix">) {
+  function runAgentAction(action: PrPromptAction) {
     const pr = model.pr;
     if (!pr) return;
     setDetailsOpen(false);
@@ -192,29 +201,34 @@ export function WorkspaceWorkflowControl({
    * names the method, so the reader sees which one before it lands. Pick a
    * different one from the review sidebar.
    */
-  async function mergePr(method: CodePrMergeMethod = "squash") {
+  async function mergePr(auto = false, method: CodePrMergeMethod = "squash") {
     const pr = model.pr;
     if (!pr) return;
     setDetailsOpen(false);
+    const base = pr.base_branch ?? "its base branch";
+    // Two forms of the same verb: the immediate merge reads as something done
+    // to the pull request, the armed one as something GitHub will do.
+    const [landed, lands] =
+      method === "squash"
+        ? ["squash-merged", "squash-merges"]
+        : method === "rebase"
+          ? ["rebased and merged", "rebases and merges"]
+          : ["merged", "merges"];
     const ok = await confirm({
-      title: `Merge #${pr.number}?`,
-      description: `The pull request is ${
-        method === "squash"
-          ? "squash-merged"
-          : method === "rebase"
-            ? "rebased and merged"
-            : "merged"
-      } into ${pr.base_branch ?? "its base branch"} on GitHub.`,
-      confirmLabel: "Merge",
+      title: auto ? `Auto-merge #${pr.number}?` : `Merge #${pr.number}?`,
+      description: auto
+        ? `GitHub ${lands} the pull request into ${base} once the remaining requirements pass.`
+        : `The pull request is ${landed} into ${base} on GitHub.`,
+      confirmLabel: auto ? "Enable auto-merge" : "Merge",
     });
     if (!ok) return;
     try {
-      const next = await resource.runMutation("merge", () =>
-        client.mergeCodePr(workspaceId, { method, auto: false }),
+      const next = await resource.runMutation(auto ? "auto_merge" : "merge", () =>
+        client.mergeCodePr(workspaceId, { method, auto }),
       );
       if (!next) return;
       resource.adopt(next);
-      toast.success("Merged");
+      toast.success(auto ? "Auto-merge enabled" : "Merged");
     } catch (err) {
       // The host's own refusal is the useful sentence here, so it goes to the
       // status line rather than being flattened into a generic failure.
@@ -222,6 +236,31 @@ export function WorkspaceWorkflowControl({
         err instanceof HttpError && err.kind === "pr_not_mergeable"
           ? err.message
           : friendlyErrorMessage(err, "Could not merge");
+      resource.setMutationError(message);
+      toast.error(message);
+    }
+  }
+
+  /**
+   * Take the pull request out of draft through the user-initiated endpoint.
+   *
+   * Readying a draft is a pull-request state change, which decision 42 keeps
+   * off the agent path for the same reason merging is: it puts work in front
+   * of reviewers, and an agent should not decide when that happens.
+   */
+  async function markReady() {
+    const pr = model.pr;
+    if (!pr) return;
+    setDetailsOpen(false);
+    try {
+      const next = await resource.runMutation("mark_ready", () =>
+        client.markCodePrReady(workspaceId),
+      );
+      if (!next) return;
+      resource.adopt(next);
+      toast.success("Marked ready for review");
+    } catch (err) {
+      const message = friendlyErrorMessage(err, "Could not mark it ready");
       resource.setMutationError(message);
       toast.error(message);
     }
@@ -299,6 +338,9 @@ export function WorkspaceWorkflowControl({
         return;
       case "merge":
         await mergePr();
+        return;
+      case "mark_ready":
+        await markReady();
         return;
       default:
         runAgentAction(action);

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -158,10 +158,10 @@ describe("prWorkflowPrompt", () => {
         },
       ],
     });
-    expect(prWorkflowPrompt("merge", digest)).toMatch(/#41/);
-    expect(prWorkflowPrompt("merge", digest)).toMatch(/main/);
-    expect(prWorkflowPrompt("merge", digest)).toMatch(/Fix login/);
-    expect(prWorkflowPrompt("merge", digest)).toMatch(/fix-login -> main/);
+    expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/#41/);
+    expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/main/);
+    expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/Fix login/);
+    expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/fix-login -> main/);
     expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/ci \/ ui/);
     expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/Tests failed/);
     expect(prWorkflowPrompt("fix_errors", digest)).toMatch(/actions\/runs\/7/);
@@ -171,6 +171,17 @@ describe("prWorkflowPrompt", () => {
     expect(prWorkflowPrompt("address_feedback", digest)).toMatch(
       /requested changes/,
     );
-    expect(prWorkflowPrompt("mark_ready", digest)).toMatch(/ready for review/);
+  });
+
+  it("has no prompt for the pull-request state changes", () => {
+    // Decision 42 keeps merging and readying a draft on user-initiated
+    // endpoints. Excluding them from the prompt type is what stops either from
+    // being wired back onto the agent path, where an agent's own shell would
+    // route around the `gh` runner that refuses merge argv. These lines must
+    // not compile.
+    // @ts-expect-error merging is not an agent action
+    expect(() => prWorkflowPrompt("merge", pr({}))).toBeDefined();
+    // @ts-expect-error readying a draft is not an agent action
+    expect(() => prWorkflowPrompt("mark_ready", pr({}))).toBeDefined();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -192,13 +192,24 @@ export function prMergeControls(state: PrWorkflowState): {
   }
 }
 
+/** The workflow actions an agent carries out, as opposed to an endpoint. */
+export type PrPromptAction = Exclude<
+  PrWorkflowAction,
+  "watch_and_fix" | "mark_ready" | "merge"
+>;
+
 /**
- * Prompt actions run in the workspace's interactive session. "Watch and fix"
- * is not one of them: it starts a durable server-side watch task instead
- * (`POST /code/workspaces/{id}/watch`).
+ * Prompt actions run in the workspace's interactive session.
+ *
+ * Three of the workflow actions are deliberately absent. "Watch and fix"
+ * starts a durable server-side watch task (`POST
+ * /code/workspaces/{id}/watch`). Merging and readying a draft are
+ * pull-request state changes, which decision 42 reserves for the user: they
+ * run through their own endpoints, and excluding them from this type is what
+ * stops a merge prompt from being wired back up by accident.
  */
 export function prWorkflowPrompt(
-  action: Exclude<PrWorkflowAction, "watch_and_fix">,
+  action: PrPromptAction,
   pr: PullRequestDigest,
 ): string {
   const number = `#${pr.number}`;
@@ -206,12 +217,6 @@ export function prWorkflowPrompt(
   const context = prWorkflowPromptContext(pr);
   let instruction: string;
   switch (action) {
-    case "mark_ready":
-      instruction = `Mark pull request ${number} ready for review. First confirm the current head is pushed and the pull request is still a draft. Do not merge it. Report the result.`;
-      break;
-    case "merge":
-      instruction = `Merge pull request ${number} into ${base}. Re-check the current head SHA, required checks, reviews, conflicts, and queue requirements immediately before merging. Use the repository's preferred merge or merge-queue path. Do not change the branch unless the merge requires it. Report the result.`;
-      break;
     case "fix_errors":
       instruction = `Pull request ${number} has failing checks. Inspect the latest failing CI logs for the current head SHA, reproduce the cause when practical, make the smallest safe fix in this workspace, run focused validation, commit, and push. Do not merge.`;
       break;

--- a/crates/tidebreak-desktop/ui/src/code/useCodeWorkspacePr.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useCodeWorkspacePr.ts
@@ -9,6 +9,7 @@ export type CodeWorkspacePrMutation =
   | "commit"
   | "push"
   | "create_pr"
+  | "mark_ready"
   | "merge"
   | "auto_merge"
   | "watch"

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
@@ -201,6 +201,7 @@ describe("resolveWorkflowShortcut", () => {
     );
     if ("run" in resolution) return resolution.run;
     if ("stopWatch" in resolution) return "stop_watch";
+    if ("autoMerge" in resolution) return "auto_merge";
     return `blocked: ${resolution.blocked}`;
   }
 
@@ -288,11 +289,24 @@ describe("resolveWorkflowShortcut", () => {
     };
     expect(chord("merge", green)).toBe("merge");
 
+    // Not green but still landable: the reader means "get this in" either way,
+    // so the chord arms auto-merge and GitHub finishes the job. Which one is
+    // about to happen is named in the confirmation, not guessed at here.
+    for (const snapshot of [
+      pr({ checks: [{ name: "ci", bucket: "fail" }] }),
+      pr({ checks: [{ name: "ci", bucket: "pending" }] }),
+      pr({ merge_state_status: "behind" }),
+      pr({ review_decision: "changes_requested" }),
+    ]) {
+      expect(chord("merge", { ...CLEAN, pr: snapshot })).toBe("auto_merge");
+    }
+
+    // Neither path is open in these states, so the chord says why. Conflicts
+    // and drafts cannot even be queued, and the last two are already landing.
     for (const [snapshot, reason] of [
       [pr({ draft: true }), "Mark the pull request ready for review on GitHub before merging it."],
       [pr({ mergeable: "conflicting" }), "Resolve the merge conflicts before merging directly."],
-      [pr({ checks: [{ name: "ci", bucket: "fail" }] }), "Fix the failing checks before merging directly."],
-      [pr({ merge_state_status: "behind" }), "Update the branch from its base before merging directly."],
+      [pr({ in_merge_queue: true }), "This pull request is already waiting in the merge queue."],
       [pr({ auto_merge_enabled: true }), "Auto-merge is already enabled and will merge after the remaining requirements pass."],
     ] as const) {
       expect(chord("merge", { ...CLEAN, pr: snapshot })).toBe(

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -313,6 +313,8 @@ export type WorkflowShortcut =
 export type WorkflowShortcutResolution =
   | { run: WorkspaceWorkflowAction }
   | { stopWatch: true }
+  /** Arm host auto-merge rather than merging now. */
+  | { autoMerge: true }
   | { blocked: string };
 
 /**
@@ -383,17 +385,23 @@ export function resolveWorkflowShortcut(
 }
 
 /**
- * Merge only when the pull request is actually mergeable.
+ * Land the pull request: merge it now when it is green, otherwise ask GitHub
+ * to merge it once the remaining requirements pass.
  *
- * Merging publishes to a shared branch and is the one step decision 42 keeps
- * for the user, so the chord runs the real merge rather than asking an agent
- * to. That makes "is it green" a question this has to answer honestly: the
- * same `prMergeControls` table the review sidebar's Merge button reads, so the
+ * One chord for one intent. The reader pressing it means "this is done, get it
+ * in" whether the checks have finished or not, and the two ways to say that
+ * differ only in when GitHub acts. The confirmation names which one is about
+ * to happen, so the difference is visible before anything lands.
+ *
+ * Merging publishes to a shared branch and is the step decision 42 keeps for
+ * the user, so the chord runs the real merge rather than asking an agent to.
+ * That makes "is it green" a question this has to answer honestly: the same
+ * `prMergeControls` table the review sidebar's Merge button reads, so the
  * chord can never offer a merge the button refuses.
  *
- * Local state blocks too. Uncommitted or unpushed work is not in the pull
- * request, and merging without it lands a branch the reader thought was
- * finished.
+ * Local state blocks both paths. Uncommitted or unpushed work is not in the
+ * pull request, and landing without it leaves behind work the reader thought
+ * was going in.
  */
 function mergeIfGreen(model: WorkspaceWorkflowModel): WorkflowShortcutResolution {
   if (model.stage === "dirty") {
@@ -406,6 +414,7 @@ function mergeIfGreen(model: WorkspaceWorkflowModel): WorkflowShortcutResolution
   if (!pr) return { blocked: "No pull request yet" };
   const controls = prMergeControls(prWorkflowStatus(pr).state);
   if (controls.canMerge) return { run: "merge" };
+  if (controls.canEnableAutoMerge) return { autoMerge: true };
   return {
     blocked:
       controls.explanation ?? `Pull request #${pr.number} cannot merge yet`,

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -59,6 +59,7 @@ function HeaderState({
             client={{
               pushCodeWorkspace: fn(),
               createCodePullRequest: fn(),
+              markCodePrReady: fn(),
               mergeCodePr: fn(),
               startCodeWatch: fn(),
               stopCodeWatch: fn(),

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -49,6 +49,7 @@ function WorkflowState({
       client={{
         pushCodeWorkspace: fn(),
         createCodePullRequest: fn(),
+        markCodePrReady: fn(),
         mergeCodePr: fn(),
         startCodeWatch: fn(),
         stopCodeWatch: fn(),

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -400,6 +400,31 @@ pub(crate) async fn merge_pull_request(
     Ok(())
 }
 
+/// Mark the workspace's own draft pull request ready for review.
+///
+/// The worktree's branch is what `gh` resolves the pull request from, the same
+/// way the merge operation does, so this needs no repository coordinates —
+/// that is the difference from [`mark_pull_request_ready`], which serves the
+/// repository-qualified delivery surface.
+///
+/// It stays on the general runner. Readying a draft is a user state change but
+/// not a merge, and widening the merge-only runner to carry it would undo the
+/// point of having two runners (decision 42).
+pub(crate) async fn mark_workspace_pull_request_ready(
+    worktree: &Path,
+    workspace_id: WorkspaceId,
+    cache: &PrDigestCache,
+    gh_search_path: Option<&str>,
+) -> Result<(), GhError> {
+    let observation = observe_gh(gh_search_path).await;
+    let binary = require_gh_binary(&observation)?;
+    run_gh(worktree, &binary, &["pr", "ready"], GH_TIMEOUT)
+        .await
+        .map_err(|error| classify_observed_gh(error, &observation))?;
+    cache.invalidate(workspace_id);
+    Ok(())
+}
+
 /// Turn a `gh pr merge` failure into something the PR card can show.
 pub(crate) fn classify_merge_error(err: String) -> GhError {
     let bounded = bound_text(&err);
@@ -2096,6 +2121,54 @@ exit 3
         }
         let after = std::fs::read_to_string(&log).unwrap();
         assert_eq!(logged, after, "a refused command must never reach gh");
+    }
+
+    #[tokio::test]
+    async fn readying_a_draft_runs_pr_ready_and_cannot_reach_the_merge_runner() {
+        // Readying a draft is a user state change but not a merge, so it rides
+        // the general runner (decision 42). Two things have to hold: it really
+        // runs `gh pr ready` in the worktree, and the runner it uses still
+        // refuses merge argv — otherwise widening the app to ready a draft
+        // would have quietly widened it to merge.
+        let shim_dir = TempDir::new().unwrap();
+        let log = shim_dir.path().join("log");
+        write_executable(
+            &shim_dir.path().join("gh"),
+            &format!(
+                r#"#!/bin/sh
+echo "$@" >> {log}
+if [ "$1" = auth ]; then exit 0; fi
+if [ "$1" = pr ] && [ "$2" = ready ]; then exit 0; fi
+echo unexpected "$@" >&2
+exit 3
+"#,
+                log = log.display()
+            ),
+        );
+        let work = TempDir::new().unwrap();
+        let cache = PrDigestCache::default();
+        let workspace = WorkspaceId::new();
+        mark_workspace_pull_request_ready(
+            work.path(),
+            workspace,
+            &cache,
+            Some(shim_dir.path().to_str().unwrap()),
+        )
+        .await
+        .expect("gh pr ready should run");
+        let logged = std::fs::read_to_string(&log).unwrap();
+        assert!(logged.contains("pr ready"), "{logged}");
+        assert!(!logged.contains("merge"), "{logged}");
+
+        let refused = run_gh(
+            work.path(),
+            &shim_dir.path().join("gh"),
+            &["pr", "merge", "--squash"],
+            GH_TIMEOUT,
+        )
+        .await
+        .unwrap_err();
+        assert!(refused.contains("refusing"), "{refused}");
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1064,6 +1064,28 @@ impl CodeRuntime {
         self.workspace_pr(owner, id).await
     }
 
+    /// Take the workspace's pull request out of draft and return a fresh
+    /// status. Decision 42 keeps pull-request state changes on a user-initiated
+    /// endpoint rather than on any agent or automation path, so this is the
+    /// only route to `gh pr ready` for a workspace.
+    pub(crate) async fn mark_workspace_pr_ready(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        let workspace = self.require_live_workspace(owner, id).await?;
+        let gh_path = self.gh_search_path_owned();
+        gh::mark_workspace_pull_request_ready(
+            std::path::Path::new(&workspace.worktree_path),
+            workspace.id,
+            &self.pr_cache,
+            gh_path.as_deref(),
+        )
+        .await
+        .map_err(map_gh)?;
+        self.workspace_pr(owner, id).await
+    }
+
     pub(crate) async fn create_workspace_pr(
         &self,
         owner: &OwnerId,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -370,6 +370,13 @@ impl ScopedCode {
             .await
     }
 
+    pub(crate) async fn mark_workspace_pr_ready(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<WorkspaceGitStatus, ServerError> {
+        self.runtime.mark_workspace_pr_ready(&self.owner, id).await
+    }
+
     pub(crate) async fn create_workspace_pr(
         &self,
         id: WorkspaceId,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -902,6 +902,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::merge_workspace_pr),
         )
         .route(
+            "/code/workspaces/{id}/pr/ready",
+            post(routes::code::mark_workspace_pr_ready),
+        )
+        .route(
             "/code/workspaces/{id}/watch",
             post(routes::code::start_workspace_watch).delete(routes::code::stop_workspace_watch),
         )

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -101,6 +101,15 @@ pub async fn merge_workspace_pr(
     Ok(Json(pr_snapshot(status, watch)))
 }
 
+pub async fn mark_workspace_pr_ready(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodeWorkspacePrSnapshot>, ServerError> {
+    let status = code.mark_workspace_pr_ready(id).await?;
+    let watch = code.latest_watch(id).await?;
+    Ok(Json(pr_snapshot(status, watch)))
+}
+
 pub async fn run_workspace_action(
     code: ScopedCode,
     Path((id, name)): Path<(WorkspaceId, String)>,

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -38,8 +38,8 @@ pub(crate) use delivery::{
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,
-    merge_workspace_pr, push_workspace, refresh_workspace_pr, run_workspace_action,
-    start_workspace_watch, stop_workspace_watch,
+    mark_workspace_pr_ready, merge_workspace_pr, push_workspace, refresh_workspace_pr,
+    run_workspace_action, start_workspace_watch, stop_workspace_watch,
 };
 pub(crate) use harnesses::{
     install_harness, list_harness_models, list_harnesses, refresh_harnesses,


### PR DESCRIPTION
## What changed

Marking a draft ready and merging both publish work to other people, and [decision 42](docs/decisions/0042-user-initiated-pr-merge.md) reserves them for the user — but the workspace header asked an agent to do both, and an agent has its own shell, so the general `gh` runner's refusal of merge argv never applied. This adds `POST /code/workspaces/{id}/pr/ready` (a user-initiated endpoint running `gh pr ready` in the worktree, on the general runner since readying is a state change but not a merge) and points the header's Mark ready button and `⌘⇧↩` at it, with the rail card opening the workspace instead of prompting.

`⌘⇧M` now lands the pull request either way: green merges immediately, anything GitHub can still land arms auto-merge, and the confirmation names which of the two is about to happen — conflicts, drafts, and pull requests already queued or already armed say why instead, gated by the same `prMergeControls` table the review sidebar reads. `prWorkflowPrompt` loses its `merge` and `mark_ready` bodies and takes a narrowed `PrPromptAction`, so the type system now refuses to let either be wired back onto the agent path.

## Validation

`cargo check -p tidebreak-server` clean and `cargo test -p tidebreak-server` passes 1152 tests; the one failure was `tests::code_terminals::create_write_read_and_two_cursors`, a PTY timing test that passes in isolation and shares no code with this change. `tsc --noEmit` clean, 565 UI tests pass, and `pnpm storybook:build` succeeds. New coverage pins that the ready path really runs `gh pr ready` while its runner still refuses merge argv, that a draft readies through the endpoint rather than `submitCodeTurn`, that a pending pull request arms auto-merge with the auto-merge confirmation, and — via `@ts-expect-error` — that neither state change can be prompted.

## Compatibility and risk

One new endpoint; no persisted or wire-format changes, and no new generated types. The change narrows what the agent path can do rather than widening it, and the merge-only runner is untouched. Auto-merge is armed only by an explicit user chord behind a confirmation, never by the watch or any other automation, which decision 42 excludes on purpose.

## Tracking

Stacked on #2422; retarget to `main` once that lands.