### PR TITLE
fix(code): name a tool call while it runs, not after it finishes

### DIFF
--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
@@ -11,18 +11,14 @@
     "name": "Write",
     "detail": {
       "kind": "file_edit",
-      "path": ""
+      "path": "/workspace/probe.txt"
     }
   },
   {
     "type": "tool_completed",
     "call_id": "toolu_01AccXU5wrjo1GDyiNaAGDXM",
     "outcome": "succeeded",
-    "preview": "File created successfully at: /workspace/probe.txt (file state is current in your context — no need to Read it back)",
-    "detail": {
-      "kind": "file_edit",
-      "path": "/workspace/probe.txt"
-    }
+    "preview": "File created successfully at: /workspace/probe.txt (file state is current in your context — no need to Read it back)"
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
@@ -11,18 +11,14 @@
     "name": "Write",
     "detail": {
       "kind": "file_edit",
-      "path": ""
+      "path": "/workspace/probe.txt"
     }
   },
   {
     "type": "tool_completed",
     "call_id": "toolu_01Pwo7nMXPQZWnBMyeTuL8ts",
     "outcome": "failed",
-    "preview": "no — use the fixtures directory instead",
-    "detail": {
-      "kind": "file_edit",
-      "path": "/workspace/probe.txt"
-    }
+    "preview": "no — use the fixtures directory instead"
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-request.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-request.expected.json
@@ -11,7 +11,7 @@
     "name": "Write",
     "detail": {
       "kind": "file_edit",
-      "path": ""
+      "path": "/workspace/probe.txt"
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
@@ -11,7 +11,7 @@
     "name": "Write",
     "detail": {
       "kind": "file_edit",
-      "path": ""
+      "path": "/workspace/probe.txt"
     }
   },
   {
@@ -23,11 +23,7 @@
     "type": "tool_completed",
     "call_id": "toolu_01NHAnSCW3oCoKt9Y5yijZtC",
     "outcome": "failed",
-    "preview": "Claude requested permissions to write to /workspace/probe.txt, but you haven't granted it yet.",
-    "detail": {
-      "kind": "file_edit",
-      "path": "/workspace/probe.txt"
-    }
+    "preview": "Claude requested permissions to write to /workspace/probe.txt, but you haven't granted it yet."
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
@@ -23,18 +23,14 @@
     "name": "Read",
     "detail": {
       "kind": "file_read",
-      "path": ""
+      "path": "/workspace/README.md"
     }
   },
   {
     "type": "tool_completed",
     "call_id": "toolu_019ykdV8Jr64h8Yd3HUjbsUF",
     "outcome": "succeeded",
-    "preview": "1\tdemo\n2\t\n3\tA tiny fixture repository.\n4\t",
-    "detail": {
-      "kind": "file_read",
-      "path": "/workspace/README.md"
-    }
+    "preview": "1\tdemo\n2\t\n3\tA tiny fixture repository.\n4\t"
   },
   {
     "type": "assistant_delta",

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
@@ -78,7 +78,7 @@
     "name": "bash",
     "detail": {
       "kind": "command",
-      "cmd": "",
+      "cmd": "echo hi",
       "cwd": ""
     }
   },

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-deny.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-deny.expected.json
@@ -77,16 +77,6 @@
     "text": "The user wants me to run exactly this shell command and then stop: echo hi"
   },
   {
-    "type": "tool_started",
-    "call_id": "call_00_UWLCr2nBoXdhyc2JM4ef2097",
-    "name": "bash",
-    "detail": {
-      "kind": "command",
-      "cmd": "",
-      "cwd": ""
-    }
-  },
-  {
     "type": "approval_requested",
     "harness_ref": {
       "call_id": "per_006f28b45001X8Mo5OoIrM4xyl"
@@ -118,6 +108,16 @@
     "decision": {
       "type": "deny",
       "feedback": "use the fixtures directory instead"
+    }
+  },
+  {
+    "type": "tool_started",
+    "call_id": "call_00_UWLCr2nBoXdhyc2JM4ef2097",
+    "name": "bash",
+    "detail": {
+      "kind": "command",
+      "cmd": "echo hi",
+      "cwd": ""
     }
   },
   {
@@ -249,7 +249,7 @@
     "name": "glob",
     "detail": {
       "kind": "search",
-      "query": "glob"
+      "query": "**/fixtures/**"
     }
   },
   {
@@ -319,16 +319,6 @@
     "text": "No fixtures directory found. Let me look at the directory structure."
   },
   {
-    "type": "tool_started",
-    "call_id": "call_00_pTqLHUb6Tp5CWsKjACRA5197",
-    "name": "bash",
-    "detail": {
-      "kind": "command",
-      "cmd": "",
-      "cwd": ""
-    }
-  },
-  {
     "type": "approval_requested",
     "harness_ref": {
       "call_id": "per_006f2966b001Edi4ogHcyFv2aT"
@@ -350,6 +340,16 @@
         "callID": "call_00_pTqLHUb6Tp5CWsKjACRA5197",
         "messageID": "msg_006f291c6001FWSz6DRzZDHn24"
       }
+    }
+  },
+  {
+    "type": "tool_started",
+    "call_id": "call_00_pTqLHUb6Tp5CWsKjACRA5197",
+    "name": "bash",
+    "detail": {
+      "kind": "command",
+      "cmd": "ls -la",
+      "cwd": ""
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/tool-use.expected.json
@@ -98,7 +98,7 @@
     "name": "read",
     "detail": {
       "kind": "file_read",
-      "path": ""
+      "path": "/workspace/README.md"
     }
   },
   {

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -201,22 +201,25 @@ mod tests {
     #[test]
     fn fixture_replay_tool_use() {
         let (events, _) = replay("tool-use");
-        // `content_block_start` opens the call with `input: {}`, so the
-        // started detail names nothing. The complete arguments arrive on the
-        // `assistant` message and ride the completion as a correction —
-        // without it the transcript line falls back to "Read".
+        // `content_block_start` opens the call with `input: {}` and the
+        // arguments stream in after it, so the call is held until they
+        // assemble. The start names the file it reads while the read is
+        // still running, and the completion needs no correction.
         assert!(events.iter().any(|event| matches!(
             event,
-            HarnessEvent::ToolStarted { name, detail, .. }
-                if name == "Read" && detail.specificity() == 0
-        )));
-        assert!(events.iter().any(|event| matches!(
-            event,
-            HarnessEvent::ToolCompleted {
-                detail: Some(tidebreak_core::ToolDetail::FileRead { path }),
+            HarnessEvent::ToolStarted {
+                name,
+                detail: tidebreak_core::ToolDetail::FileRead { path },
                 ..
-            } if path == "/workspace/README.md"
+            } if name == "Read" && path == "/workspace/README.md"
         )));
+        let read_start = events.iter().position(
+            |event| matches!(event, HarnessEvent::ToolStarted { name, .. } if name == "Read"),
+        );
+        let read_end = events
+            .iter()
+            .position(|event| matches!(event, HarnessEvent::ToolCompleted { detail: None, .. }));
+        assert!(read_start < read_end, "the call starts before it resolves");
     }
 
     /// The ring's numerator is one prompt, not the turn's summed spend.

--- a/crates/tidebreak-harness/src/claude/parse.rs
+++ b/crates/tidebreak-harness/src/claude/parse.rs
@@ -18,6 +18,12 @@ use crate::HarnessEvent;
 /// Longest unrecognized payload kept for the debug log.
 const MAX_UNRECOGNIZED_LOG: usize = 512;
 
+/// Longest assembled tool-argument JSON held while a call streams in.
+///
+/// A `Write` streams a whole file through this channel, and none of it is
+/// needed to name the call, so the buffer stops rather than grows.
+const MAX_TOOL_INPUT_JSON: usize = 16 * 1024;
+
 /// Incremental parser for one Claude Code print-mode stream.
 #[derive(Debug, Default)]
 pub struct ClaudeStreamParser {
@@ -28,7 +34,29 @@ pub struct ClaudeStreamParser {
     started_tools: HashMap<String, ToolDetail>,
     /// call id → detail to correct the started call with, once it resolves.
     late_details: HashMap<String, ToolDetail>,
+    /// open block → a call opened with no arguments yet, held until they
+    /// assemble.
+    open_blocks: HashMap<BlockKey, OpenToolCall>,
     emitted_session: bool,
+}
+
+/// Which content block a stream event belongs to.
+///
+/// Two subagents stream at once (decision 52) and each numbers its blocks
+/// from zero, so the index alone does not identify one. The `Task` call the
+/// lines run inside separates them.
+type BlockKey = (Option<String>, u64);
+
+/// A tool call the engine has opened but not yet described.
+#[derive(Debug)]
+struct OpenToolCall {
+    call_id: String,
+    name: String,
+    parent_call_id: Option<String>,
+    /// `input_json_delta` fragments, joined in arrival order.
+    input_json: String,
+    /// The fragments outgrew [`MAX_TOOL_INPUT_JSON`] and were dropped.
+    overflowed: bool,
 }
 
 /// Result of parsing a whole fixture or a finished stream.
@@ -189,7 +217,16 @@ impl ClaudeStreamParser {
                             }]
                         }
                     }
-                    Some("input_json_delta") | Some("signature_delta") => Vec::new(),
+                    Some("input_json_delta") => {
+                        if let (Some(key), Some(fragment)) = (
+                            block_key(value, event),
+                            delta.get("partial_json").and_then(Value::as_str),
+                        ) {
+                            self.accumulate_tool_input(&key, fragment);
+                        }
+                        Vec::new()
+                    }
+                    Some("signature_delta") => Vec::new(),
                     Some(other) => {
                         self.count_unrecognized(&format!("stream_event/delta/{other}"), &delta);
                         Vec::new()
@@ -201,11 +238,15 @@ impl ClaudeStreamParser {
                 let block = event.get("content_block").cloned().unwrap_or(Value::Null);
                 if block.get("type").and_then(Value::as_str) == Some("tool_use") {
                     let parent = parent_call_id(value);
-                    return self.emit_tool_started(&block, parent);
+                    return self.open_tool_call(&block, parent, block_key(value, event));
                 }
                 Vec::new()
             }
-            "message_start" | "message_delta" | "message_stop" | "content_block_stop" => Vec::new(),
+            "content_block_stop" => match block_key(value, event) {
+                Some(key) => self.close_tool_block(&key),
+                None => Vec::new(),
+            },
+            "message_start" | "message_delta" | "message_stop" => Vec::new(),
             other => {
                 self.count_unrecognized(&format!("stream_event/{other}"), event);
                 Vec::new()
@@ -272,6 +313,10 @@ impl ClaudeStreamParser {
                     let preview = tool_result_preview(&block);
                     if !call_id.is_empty() {
                         let detail = self.late_details.remove(&call_id);
+                        // A call whose arguments never assembled is still
+                        // held. Its start has to reach the transcript before
+                        // its completion does.
+                        events.extend(self.flush_open_call(&call_id));
                         events.push(HarnessEvent::ToolCompleted {
                             call_id,
                             outcome: if is_error {
@@ -333,29 +378,118 @@ impl ClaudeStreamParser {
         }]
     }
 
+    /// Take one view of a tool-use block from an `assistant` message.
     fn emit_tool_started(&mut self, block: &Value, parent: Option<String>) -> Vec<HarnessEvent> {
-        let call_id = block
-            .get("id")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_owned();
+        let call_id = tool_call_id(block);
         if call_id.is_empty() {
             return Vec::new();
         }
-        let name = block
-            .get("name")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown")
-            .to_owned();
+        let name = tool_name(block);
         let input = block.get("input").cloned().unwrap_or(Value::Null);
         let detail = tool_detail(&name, &input);
-        // `content_block_start` opens the call with `input: {}` and the
-        // arguments stream in after it, so the first view of a call names
-        // nothing. The `assistant` message repeats the same block with the
-        // assembled input; that later view is the correction, and it rides
-        // the call's `ToolCompleted`. A `Task` detail stays `Other` at both
-        // views (equal specificity), so it upgrades on any change: the
-        // assembled description is the subagent's display name (decision 52).
+        self.record_tool_view(call_id, &name, parent, detail)
+    }
+
+    /// Hold a call the engine just opened until its arguments assemble.
+    ///
+    /// `content_block_start` opens the call with `input: {}` and the
+    /// arguments stream in after it as `input_json_delta`, so the opening
+    /// view names nothing. Starting the call there leaves a supervising UI
+    /// showing a nameless card for as long as the tool runs — a `Bash` call
+    /// that times out after 60s spends all 60s unlabelled. The call waits
+    /// instead for the first view that carries its arguments: whichever of
+    /// `content_block_stop` and the `assistant` message repeating the block
+    /// arrives first. Both land before the engine runs the tool.
+    fn open_tool_call(
+        &mut self,
+        block: &Value,
+        parent: Option<String>,
+        key: Option<BlockKey>,
+    ) -> Vec<HarnessEvent> {
+        let call_id = tool_call_id(block);
+        if call_id.is_empty() {
+            return Vec::new();
+        }
+        let name = tool_name(block);
+        let input = block.get("input").cloned().unwrap_or(Value::Null);
+        let holdable =
+            key.filter(|_| arguments_pending(&input) && !self.started_tools.contains_key(&call_id));
+        let Some(key) = holdable else {
+            let detail = tool_detail(&name, &input);
+            return self.record_tool_view(call_id, &name, parent, detail);
+        };
+        self.open_blocks.insert(
+            key,
+            OpenToolCall {
+                call_id,
+                name,
+                parent_call_id: parent,
+                input_json: String::new(),
+                overflowed: false,
+            },
+        );
+        Vec::new()
+    }
+
+    /// Buffer one `input_json_delta` fragment for the call held at `key`.
+    fn accumulate_tool_input(&mut self, key: &BlockKey, fragment: &str) {
+        let Some(open) = self.open_blocks.get_mut(key) else {
+            return;
+        };
+        if open.overflowed {
+            return;
+        }
+        if open.input_json.len() + fragment.len() > MAX_TOOL_INPUT_JSON {
+            open.overflowed = true;
+            open.input_json = String::new();
+            return;
+        }
+        open.input_json.push_str(fragment);
+    }
+
+    /// Start the call held at `key`, named by the arguments it streamed.
+    fn close_tool_block(&mut self, key: &BlockKey) -> Vec<HarnessEvent> {
+        let Some(open) = self.open_blocks.remove(key) else {
+            return Vec::new();
+        };
+        // Arguments that overran the buffer, or that never parsed, leave the
+        // call as unnamed as it was when it opened. The correction on
+        // `ToolCompleted` still applies.
+        let input = if open.overflowed {
+            Value::Null
+        } else {
+            serde_json::from_str::<Value>(&open.input_json).unwrap_or(Value::Null)
+        };
+        let detail = tool_detail(&open.name, &input);
+        self.record_tool_view(open.call_id, &open.name, open.parent_call_id, detail)
+    }
+
+    /// Start a held call early, when something downstream needs it started.
+    fn flush_open_call(&mut self, call_id: &str) -> Vec<HarnessEvent> {
+        let held = self
+            .open_blocks
+            .iter()
+            .find_map(|(key, open)| (open.call_id == call_id).then(|| key.clone()));
+        match held {
+            Some(key) => self.close_tool_block(&key),
+            None => Vec::new(),
+        }
+    }
+
+    /// Fold one view of a call into the stream.
+    ///
+    /// The first view starts the call. A later, more specific one is a
+    /// correction and rides the call's `ToolCompleted`. A `Task` detail
+    /// stays `Other` at every view (equal specificity), so it upgrades on
+    /// any change: the assembled description is the subagent's display name
+    /// (decision 52).
+    fn record_tool_view(
+        &mut self,
+        call_id: String,
+        name: &str,
+        parent: Option<String>,
+        detail: ToolDetail,
+    ) -> Vec<HarnessEvent> {
         if let Some(started) = self.started_tools.get(&call_id) {
             let corrected = detail.specificity() > started.specificity()
                 || (name == "Task"
@@ -367,10 +501,11 @@ impl ClaudeStreamParser {
             }
             return Vec::new();
         }
+        self.open_blocks.retain(|_, open| open.call_id != call_id);
         self.started_tools.insert(call_id.clone(), detail.clone());
         vec![HarnessEvent::ToolStarted {
             call_id,
-            name,
+            name: name.to_owned(),
             detail,
             parent_call_id: parent,
         }]
@@ -396,6 +531,36 @@ impl ClaudeStreamParser {
             "unrecognized engine event payload"
         );
     }
+}
+
+/// The block a stream event belongs to: its index, under the `Task` call the
+/// line runs inside.
+fn block_key(value: &Value, event: &Value) -> Option<BlockKey> {
+    let index = event.get("index").and_then(Value::as_u64)?;
+    Some((parent_call_id(value), index))
+}
+
+/// Engine-native id of a `tool_use` block.
+fn tool_call_id(block: &Value) -> String {
+    block
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_owned()
+}
+
+/// Tool name of a `tool_use` block.
+fn tool_name(block: &Value) -> String {
+    block
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_owned()
+}
+
+/// Whether a view of a call still says nothing about its arguments.
+fn arguments_pending(input: &Value) -> bool {
+    input.as_object().is_none_or(serde_json::Map::is_empty)
 }
 
 /// The top-level `parent_tool_use_id` a subagent's lines carry. The parent's
@@ -599,5 +764,53 @@ mod tests {
             Some(HarnessEvent::TurnCompleted { .. })
         ));
         assert_eq!(out.resume_ref.as_deref(), Some("abc"));
+    }
+
+    /// The captured streams repeat a finished block on an `assistant` line
+    /// just before its `content_block_stop`, so that view is what names a
+    /// call in practice. The arguments are the engine's own guarantee
+    /// though: they stream in as `input_json_delta` and are complete at the
+    /// stop. Without the `assistant` line the call still starts named.
+    #[test]
+    fn a_call_starts_named_from_the_streamed_arguments_alone() {
+        let input = r#"
+{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"Bash","input":{}}}}
+{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"comm"}}}
+{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"and\": \"ls -R\"}"}}}
+{"type":"stream_event","event":{"type":"content_block_stop","index":1}}
+"#;
+        let out = ClaudeStreamParser::parse_ndjson(input);
+        assert_eq!(
+            out.events,
+            vec![HarnessEvent::ToolStarted {
+                call_id: "toolu_1".into(),
+                name: "Bash".into(),
+                detail: ToolDetail::Command {
+                    cmd: "ls -R".into(),
+                    cwd: String::new(),
+                },
+                parent_call_id: None,
+            }]
+        );
+    }
+
+    /// Holding a call until its arguments assemble must not lose it. A
+    /// result for a call still in flight starts it first, so no completion
+    /// ever lands on a call the transcript never opened.
+    #[test]
+    fn a_result_starts_a_call_whose_arguments_never_assembled() {
+        let input = r#"
+{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"Bash","input":{}}}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"done"}]}}
+"#;
+        let out = ClaudeStreamParser::parse_ndjson(input);
+        assert!(matches!(
+            out.events.first(),
+            Some(HarnessEvent::ToolStarted { call_id, .. }) if call_id == "toolu_1"
+        ));
+        assert!(matches!(
+            out.events.last(),
+            Some(HarnessEvent::ToolCompleted { call_id, .. }) if call_id == "toolu_1"
+        ));
     }
 }

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -742,4 +742,83 @@ mod tests {
             name.contains("image") && (name.ends_with(".ndjson") || name.ends_with(".json"))
         })
     }
+
+    /// A supervising user reads a tool call while it runs, so every adapter
+    /// has to name the call when it starts.
+    ///
+    /// Engines open a call before its arguments finish streaming. An adapter
+    /// that starts the call at that first view publishes an empty `cmd` or
+    /// `path` and names the tool only once the result lands, which leaves an
+    /// unlabelled card on screen for as long as the tool runs. Codex and
+    /// grok already named their calls at the start; this pins that, and the
+    /// claude-code and opencode captures that used to fail it.
+    #[test]
+    fn every_captured_tool_call_names_its_subject_when_it_starts() {
+        for (harness, path) in captured_streams() {
+            let input = std::fs::read_to_string(&path)
+                .unwrap_or_else(|err| panic!("unreadable fixture {}: {err}", path.display()));
+            let events = replay_captured_stream(&harness, &input);
+            let fixture = path.display();
+            let mut started: Vec<&str> = Vec::new();
+            for event in &events {
+                match event {
+                    HarnessEvent::ToolStarted {
+                        call_id,
+                        name,
+                        detail,
+                        ..
+                    } => {
+                        assert!(
+                            detail.specificity() > 0,
+                            "{fixture}: {name} starts with a detail that names nothing"
+                        );
+                        started.push(call_id);
+                    }
+                    HarnessEvent::ToolCompleted { call_id, .. } => assert!(
+                        started.contains(&call_id.as_str()),
+                        "{fixture}: {call_id} completes without having started"
+                    ),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Every captured stream, as `(harness, path)` pairs.
+    fn captured_streams() -> Vec<(String, PathBuf)> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures");
+        let mut streams = Vec::new();
+        for harness in read_dir_sorted(&root) {
+            let name = harness.file_name().to_string_lossy().into_owned();
+            for version in read_dir_sorted(&harness.path()) {
+                for capture in read_dir_sorted(&version.path()) {
+                    let path = capture.path();
+                    if path.extension().is_some_and(|ext| ext == "ndjson") {
+                        streams.push((name.clone(), path));
+                    }
+                }
+            }
+        }
+        assert!(!streams.is_empty(), "fixtures must ship captured streams");
+        streams
+    }
+
+    fn read_dir_sorted(dir: &Path) -> Vec<std::fs::DirEntry> {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return Vec::new();
+        };
+        let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        entries
+    }
+
+    fn replay_captured_stream(harness: &str, input: &str) -> Vec<HarnessEvent> {
+        match harness {
+            "claude-code" => claude::parse::ClaudeStreamParser::parse_ndjson(input).events,
+            "codex" => codex::parse::CodexStreamParser::parse_ndjson(input).events,
+            "grok" => grok::parse::GrokStreamParser::parse_ndjson(input).events,
+            "opencode" => opencode::parse::OpencodeStreamParser::parse_ndjson(input).events,
+            other => panic!("fixtures/{other} has no parser in this test"),
+        }
+    }
 }

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -227,13 +227,16 @@ mod tests {
     #[test]
     fn fixture_replay_tool_use() {
         let (events, _) = replay("tool-use");
-        // The `pending` part opens the call with `input: {}`, so the started
-        // detail names nothing. The terminal part repeats the complete input
-        // and rides the completion as a correction.
+        // The `pending` part opens the call with `input: {}` and no start
+        // time: the tool has not run yet. The `running` part carries the
+        // assembled arguments, so the call starts named.
         assert!(events.iter().any(|event| matches!(
             event,
-            HarnessEvent::ToolStarted { name, detail, .. }
-                if name == "read" && detail.specificity() == 0
+            HarnessEvent::ToolStarted {
+                name,
+                detail: tidebreak_core::ToolDetail::FileRead { path },
+                ..
+            } if name == "read" && path == "/workspace/README.md"
         )));
         assert!(events.iter().any(|event| matches!(
             event,

--- a/crates/tidebreak-harness/src/opencode/parse.rs
+++ b/crates/tidebreak-harness/src/opencode/parse.rs
@@ -378,9 +378,20 @@ impl OpencodeStreamParser {
         let input = state.get("input").cloned().unwrap_or(Value::Null);
         match status {
             "pending" | "running" => {
-                if !self.started_tools.insert(call_id.clone()) {
+                if self.started_tools.contains(&call_id) {
                     return Vec::new();
                 }
+                // The `pending` part opens the call with `input: {}` and no
+                // `time.start`: the model is still writing the arguments and
+                // the tool has not run yet. Starting the call there leaves a
+                // supervising UI showing a nameless card for as long as the
+                // tool runs. The `running` part carries the assembled
+                // arguments and the start time, so the call waits for it.
+                // A call that resolves without one still starts below.
+                if status == "pending" && arguments_pending(&input) {
+                    return Vec::new();
+                }
+                self.started_tools.insert(call_id.clone());
                 vec![HarnessEvent::ToolStarted {
                     call_id,
                     name: name.clone(),
@@ -418,9 +429,10 @@ impl OpencodeStreamParser {
                     .or(if error.is_empty() { None } else { Some(error) })
                     .unwrap_or("");
                 // The `pending` part that opens the call carries `input: {}`;
-                // the arguments land on the `running` and terminal parts. The
-                // terminal part is the correction for the call already
-                // started, and the detail above for one that was not.
+                // the arguments land on the `running` and terminal parts.
+                // The terminal part starts a call that never reported a
+                // `running` part, and corrects one whose start still names
+                // nothing.
                 let detail = tool_detail(&name, &input);
                 events.push(HarnessEvent::ToolCompleted {
                     call_id,
@@ -618,6 +630,11 @@ fn permission_id_from_path(path: &str) -> Option<String> {
         return None;
     }
     Some(id.to_owned())
+}
+
+/// Whether a view of a call still says nothing about its arguments.
+fn arguments_pending(input: &Value) -> bool {
+    input.as_object().is_none_or(serde_json::Map::is_empty)
 }
 
 fn tool_detail(name: &str, input: &Value) -> ToolDetail {

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -258,13 +258,16 @@ bounded):
 | `HarnessNotice` | level, message — the visible-degradation channel |
 | `AttentionChanged` | state, source |
 
-Engines open a tool call before its arguments finish streaming, so the
-`ToolDetail` on `ToolStarted` can name nothing and the transcript line falls
-back to the tool's name. `ToolCompleted` carries the detail rebuilt from the
-complete arguments as a correction, and the renderer takes it unless it says
-less than what the line already shows. An adapter whose completion payload
-carries no arguments leaves it unset — Grok's `tool_call` frame already
-carries the whole `rawInput`, so it has nothing to correct.
+Engines open a tool call before its arguments finish streaming. A supervisor
+reads the call while it runs, so an adapter waits for the first view that
+carries the arguments and starts the call there — still before the engine
+runs the tool. Claude Code assembles them at `content_block_stop`, and
+opencode publishes them on the tool part's `running` state.
+
+`ToolCompleted` carries the detail rebuilt from the complete arguments as a
+correction for a call that started with nothing to say, and the renderer
+takes it unless it says less than what the line already shows. An adapter
+whose completion payload carries no arguments leaves it unset.
 
 ## Server API surface
 


### PR DESCRIPTION
Supervision is the premise: a reader watches a tool while it runs. On the
reference-tier adapter they watched a card that named nothing. Measured
across a driven exercise, every `tool_started` on claude_code carried an
empty `cmd`/`path`/`cwd` (9/9, 8/8, 4/4, 2/2 across four sessions), and
opencode was nearly as bad (8/9, 8/8). In one session two `Bash` calls each
ran 60s before timing out, and the reader watched two unlabelled "command"
cards for the whole minute.

Before, from the journal — the call runs nameless and the arguments arrive
only with the result:

```
seq=6 tool_started   {"call_id":"toolu_01QgUb...","detail":{"cmd":"","cwd":"","kind":"command"},"name":"Bash"}
seq=7 tool_completed {"call_id":"toolu_01QgUb...","detail":{"cmd":"ls -R /Users/.../ex-a-claude && cat .../Makefile","cwd":"","kind":"command"},...}
```

After — the same pair, from the regenerated `tool-use` fixture:

```
tool_started   {"call_id":"toolu_019ykd...","name":"Read","detail":{"kind":"file_read","path":"/workspace/README.md"}}
tool_completed {"call_id":"toolu_019ykd...","outcome":"succeeded","preview":"1\tdemo\n2\t\n3\tA tiny fixture repository.\n4\t"}
```

A reader now sees `Read /workspace/README.md` or `Command run ls -R …` the
moment the card appears, for the whole time the tool runs — and the elapsed
timer ticks next to a line that says what is taking the time. The rail's
activity chip reads the same detail, and a `Task` row now names the subagent
it spawned instead of saying "Task" until the subagent finishes.
`tool_completed` no longer repeats a correction nobody needs.

## Approach

Both options in the brief were on the table: move the start to
`content_block_stop`, or keep the early start and publish a correction. The
captured streams settled it. Claude Code repeats each finished block on an
`assistant` line *just before* its `content_block_stop`, so the assembled
arguments are already on the wire one line earlier than the brief assumed —
and a second `ToolStarted` would need the UI reducer to upsert instead of
insert, because it inserts a card per `tool_started`.

So the adapter holds the call the engine opened and starts it at the first
view that carries its arguments, whichever of the two arrives first. That is
one `ToolStarted` per call with the detail already filled, no new
`CodeEvent` variant, and no reducer change. It costs the few hundred
milliseconds the arguments spend streaming — during which the tool has not
run yet.

- **claude_code**: `content_block_start` opens the call with `input: {}` and
  streams the arguments as `input_json_delta`. The parser buffers the
  fragments (capped, since a `Write` streams a whole file through that
  channel) and starts the call at `content_block_stop`, or at the `assistant`
  line if that lands first. A `tool_result` for a call still in flight starts
  it first, so no completion lands on a call the transcript never opened.
- **opencode**: different cause, same symptom. The `pending` tool part
  carries `input: {}` *and* `time: null` — the tool has not run. The parser
  used to start the call there and dedupe every later part, so the `running`
  part's assembled arguments were dropped. It now starts the call on
  `running`, which carries both the arguments and `time.start`. A call that
  resolves without a `running` part still starts on its terminal part.
  Visible in the fixture: with an approval parked, the call sits at `pending`
  until the reply, so its row now appears after the approval it was waiting
  on — the approval card already names the command.
- **codex** and **grok** are untouched. `item/started` and `tool_call`
  already carry the whole input.

## Tests

- One contract test in `lib.rs` replays every captured stream from all four
  adapters: no `tool_started` may carry a detail that names nothing, and no
  `tool_completed` may precede its start. It is the fix for claude_code and
  opencode and the pin for codex and grok.
- The `tool-use` replays for both adapters now assert the assembled subject
  on the start.
- Two claude parser unit tests: a call starts named from the streamed
  arguments alone (no `assistant` line), and a result starts a call whose
  arguments never assembled.
- Expected sequences regenerated with `UPDATE_HARNESS_FIXTURES=1 cargo test
  -p tidebreak-harness`. Codex and grok expectations are byte-identical.

`cargo test -p tidebreak-harness`, `cargo test -p tidebreak-server --lib
code::`, `cargo fmt --all --check`, and `cargo clippy -p tidebreak-harness
--all-targets` are clean. `child::unix_process_tree_tests` flakes on this
machine on `main` as well (1 in 3 runs); it does not touch the parsers.

No UI change: `CodeToolCard` already renders `toolSubject(detail, name)` on
a running row, so the filled detail shows up with no reducer or story work.
