### PR TITLE
fix(core): refresh schema baseline for abandoned approvals

### DIFF
--- a/crates/tidebreak-core/fixtures/schema-baseline.sql
+++ b/crates/tidebreak-core/fixtures/schema-baseline.sql
@@ -1422,7 +1422,7 @@ CREATE TABLE "code_approval" (
     "decided_at" timestamp_with_timezone_text,
     FOREIGN KEY ("session_id") REFERENCES "code_session" ("id"),
     FOREIGN KEY ("turn_id") REFERENCES "code_turn" ("id"),
-    CHECK ("state" IN ('pending', 'approved', 'denied'))
+    CHECK ("state" IN ('pending', 'approved', 'denied', 'abandoned'))
 );
 
 CREATE INDEX "idx_code_approval_session_state" ON "code_approval" ("session_id", "state");


### PR DESCRIPTION
## Why

#2425 deliberately added the `abandoned` approval state and bumped `DESKTOP_SCHEMA_EPOCH` from 35 to 36. #2427 landed its pinned schema fixture immediately before that merge, so `main` now fails `db::migration::tests::the_schema_baseline_is_pinned` with the old three-state constraint.

The same deterministic failure appears in the `main` CI run for `5055f5b56` and in #2426 after merging that exact `main` head.

## Change

Refresh the pinned `code_approval.state` constraint to include `abandoned`. No second epoch bump is needed because #2425 already supplied the required bump for this schema change.

## Checks

- `git diff --check`
- No Rust command ran locally; CI validates the generated fixture against the migration.
