### PR TITLE
fix(core): regenerate the schema baseline for the abandoned approval state

### DIFF
--- a/crates/tidebreak-core/fixtures/schema-baseline.sql
+++ b/crates/tidebreak-core/fixtures/schema-baseline.sql
@@ -1422,7 +1422,7 @@ CREATE TABLE "code_approval" (
     "decided_at" timestamp_with_timezone_text,
     FOREIGN KEY ("session_id") REFERENCES "code_session" ("id"),
     FOREIGN KEY ("turn_id") REFERENCES "code_turn" ("id"),
-    CHECK ("state" IN ('pending', 'approved', 'denied'))
+    CHECK ("state" IN ('pending', 'approved', 'denied', 'abandoned'))
 );
 
 CREATE INDEX "idx_code_approval_session_state" ON "code_approval" ("session_id", "state");


### PR DESCRIPTION
`main` is red on `db::migration::tests::the_schema_baseline_is_pinned`.

#2425 added `abandoned` to the `code_approval.state` CHECK constraint and bumped `DESKTOP_SCHEMA_EPOCH` to 36, but did not regenerate `crates/tidebreak-core/fixtures/schema-baseline.sql`. The pinned-baseline test compares the live schema against that fixture, so it has failed on every commit since.

Every open pull request inherits the failure through its merge check, which is how this surfaced — a draft PR that touches only harness files was reported as failing `test`.

The epoch is already correct, so this is the regeneration on its own:

```diff
-CHECK ("state" IN ('pending', 'approved', 'denied'))
+CHECK ("state" IN ('pending', 'approved', 'denied', 'abandoned'))
```

Verified: `cargo test -p tidebreak-core --lib the_schema_baseline_is_pinned` fails on `main` at `5055f5b56` and passes here.