### PR TITLE
fix(core): match the schema fixture to the abandoned approval state

### DIFF
--- a/crates/tidebreak-core/fixtures/schema-baseline.sql
+++ b/crates/tidebreak-core/fixtures/schema-baseline.sql
@@ -1422,7 +1422,7 @@ CREATE TABLE "code_approval" (
     "decided_at" timestamp_with_timezone_text,
     FOREIGN KEY ("session_id") REFERENCES "code_session" ("id"),
     FOREIGN KEY ("turn_id") REFERENCES "code_turn" ("id"),
-    CHECK ("state" IN ('pending', 'approved', 'denied'))
+    CHECK ("state" IN ('pending', 'approved', 'denied', 'abandoned'))
 );
 
 CREATE INDEX "idx_code_approval_session_state" ON "code_approval" ("session_id", "state");


### PR DESCRIPTION
## What

Regenerates `crates/tidebreak-core/fixtures/schema-baseline.sql` so it matches the baseline on `main`.

## Why

`main` is currently red on `the_schema_baseline_is_pinned`.

#2425 added `abandoned` to the `code_approval.state` check constraint and bumped `DESKTOP_SCHEMA_EPOCH` to 36. It merged within seconds of #2427, which introduced the fixture, so #2425 never ran against the tripwire and the fixture never learned about the new state.

This is the failure mode `CLAUDE.md` names: a conflicting PR ran nothing, so green was not evidence.

## Scope

One line. The epoch already moved in #2425, so nothing is owed here beyond the regeneration.

Verified: the test fails on `main` and passes with this change.