### PR TITLE
perf(core): keep idle SQLite polls read-only

### DIFF
--- a/crates/tidebreak-core/src/db/ops/blob.rs
+++ b/crates/tidebreak-core/src/db/ops/blob.rs
@@ -229,20 +229,22 @@ pub(in crate::db) async fn claim(
             "blob retirement lease expiry must be after claim time".into(),
         ));
     }
+
+    // Idle fast path. The locked scan below is still authoritative, but a scan
+    // with no claimable retirement has nothing it can decide. Taking the no-op
+    // write lock first makes every idle worker poll join SQLite's single-writer
+    // queue and hold a pooled connection while it waits. A candidate that
+    // appears after this read is handled by the worker wake or the next bounded
+    // poll.
+    if !any_claimable_on(&store.conn, now).await? {
+        return Ok(None);
+    }
+
     loop {
         let transaction = store.conn.begin().await.map_err(store_err)?;
         acquire_write_lock(&transaction).await?;
         let due = entities::blob_retirement::Entity::find()
-            .filter(entities::blob_retirement::Column::Status.is_in([
-                BlobRetirementStatus::Queued.as_str(),
-                BlobRetirementStatus::RetryWait.as_str(),
-            ]))
-            .filter(entities::blob_retirement::Column::AvailableAt.lte(now))
-            .filter(
-                sea_orm::sea_query::Expr::col(entities::blob_retirement::Column::AttemptCount).lt(
-                    sea_orm::sea_query::Expr::col(entities::blob_retirement::Column::MaxAttempts),
-                ),
-            )
+            .filter(due_candidate_condition(now))
             .order_by_asc(entities::blob_retirement::Column::AvailableAt)
             .order_by_asc(entities::blob_retirement::Column::CreatedAt)
             .order_by_asc(entities::blob_retirement::Column::BlobId)
@@ -250,11 +252,7 @@ pub(in crate::db) async fn claim(
             .await
             .map_err(store_err)?;
         let expired = entities::blob_retirement::Entity::find()
-            .filter(
-                entities::blob_retirement::Column::Status
-                    .eq(BlobRetirementStatus::Running.as_str()),
-            )
-            .filter(entities::blob_retirement::Column::LeaseExpiresAt.lte(now))
+            .filter(expired_candidate_condition(now))
             .order_by_asc(entities::blob_retirement::Column::LeaseExpiresAt)
             .order_by_asc(entities::blob_retirement::Column::CreatedAt)
             .order_by_asc(entities::blob_retirement::Column::BlobId)
@@ -424,6 +422,42 @@ pub(in crate::db) async fn claim(
         transaction.commit().await.map_err(store_err)?;
         return Ok(Some(claimed));
     }
+}
+
+fn due_candidate_condition(now: chrono::DateTime<Utc>) -> sea_orm::Condition {
+    sea_orm::Condition::all()
+        .add(entities::blob_retirement::Column::Status.is_in([
+            BlobRetirementStatus::Queued.as_str(),
+            BlobRetirementStatus::RetryWait.as_str(),
+        ]))
+        .add(entities::blob_retirement::Column::AvailableAt.lte(now))
+        .add(
+            sea_orm::sea_query::Expr::col(entities::blob_retirement::Column::AttemptCount).lt(
+                sea_orm::sea_query::Expr::col(entities::blob_retirement::Column::MaxAttempts),
+            ),
+        )
+}
+
+fn expired_candidate_condition(now: chrono::DateTime<Utc>) -> sea_orm::Condition {
+    sea_orm::Condition::all()
+        .add(entities::blob_retirement::Column::Status.eq(BlobRetirementStatus::Running.as_str()))
+        .add(entities::blob_retirement::Column::LeaseExpiresAt.lte(now))
+}
+
+async fn any_claimable_on<C>(conn: &C, now: chrono::DateTime<Utc>) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    Ok(entities::blob_retirement::Entity::find()
+        .filter(
+            sea_orm::Condition::any()
+                .add(due_candidate_condition(now))
+                .add(expired_candidate_condition(now)),
+        )
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some())
 }
 
 pub(in crate::db) async fn heartbeat(

--- a/crates/tidebreak-core/src/db/ops/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/turn.rs
@@ -540,6 +540,18 @@ pub(in crate::db) async fn claim_turn_run(
         ));
     }
 
+    // Idle fast path. A turn worker draws a fresh token for each poll, and an
+    // empty scan has no receipt to persist. Check exact-retry evidence and
+    // claimable work without taking SQLite's single writer; the locked scan
+    // below remains authoritative when any of them exists. A turn admitted
+    // after this hint is picked up by the worker wake or the next bounded poll.
+    if !any_turn_claim_work_on(&store.conn, lease_token, now).await? {
+        return Ok(ClaimTurnRunOutcome {
+            turn: None,
+            terminal_event: None,
+        });
+    }
+
     loop {
         let transaction = store.conn.begin().await.map_err(store_err)?;
         acquire_turn_claim_write_lock(&transaction).await?;
@@ -583,27 +595,7 @@ pub(in crate::db) async fn claim_turn_run(
             });
         }
         let due = entities::turn_run::Entity::find()
-            .filter(
-                sea_orm::Condition::any()
-                    .add(entities::turn_run::Column::Status.eq(TurnRunStatus::Resuming.as_str()))
-                    .add(
-                        sea_orm::Condition::all()
-                            .add(entities::turn_run::Column::Status.is_in([
-                                TurnRunStatus::Queued.as_str(),
-                                TurnRunStatus::RetryWait.as_str(),
-                            ]))
-                            .add(
-                                sea_orm::sea_query::Expr::col(
-                                    entities::turn_run::Column::AttemptCount,
-                                )
-                                .lt(sea_orm::sea_query::Expr::col(
-                                    entities::turn_run::Column::MaxAttempts,
-                                )),
-                            ),
-                    ),
-            )
-            .filter(entities::turn_run::Column::AvailableAt.lte(now))
-            .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+            .filter(due_turn_candidate_condition(now))
             .order_by_asc(entities::turn_run::Column::AvailableAt)
             .order_by_asc(entities::turn_run::Column::CreatedAt)
             .order_by_asc(entities::turn_run::Column::Id)
@@ -611,12 +603,7 @@ pub(in crate::db) async fn claim_turn_run(
             .await
             .map_err(store_err)?;
         let expired = entities::turn_run::Entity::find()
-            .filter(entities::turn_run::Column::Status.is_in([
-                TurnRunStatus::Running.as_str(),
-                TurnRunStatus::Cancelling.as_str(),
-            ]))
-            .filter(entities::turn_run::Column::LeaseExpiresAt.lte(now))
-            .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+            .filter(expired_turn_candidate_condition(now))
             .order_by_asc(entities::turn_run::Column::LeaseExpiresAt)
             .order_by_asc(entities::turn_run::Column::CreatedAt)
             .order_by_asc(entities::turn_run::Column::Id)
@@ -990,6 +977,74 @@ pub(in crate::db) async fn claim_turn_run(
             terminal_event: None,
         });
     }
+}
+
+fn due_turn_candidate_condition(now: chrono::DateTime<Utc>) -> sea_orm::Condition {
+    sea_orm::Condition::all()
+        .add(
+            sea_orm::Condition::any()
+                .add(entities::turn_run::Column::Status.eq(TurnRunStatus::Resuming.as_str()))
+                .add(
+                    sea_orm::Condition::all()
+                        .add(entities::turn_run::Column::Status.is_in([
+                            TurnRunStatus::Queued.as_str(),
+                            TurnRunStatus::RetryWait.as_str(),
+                        ]))
+                        .add(
+                            sea_orm::sea_query::Expr::col(entities::turn_run::Column::AttemptCount)
+                                .lt(sea_orm::sea_query::Expr::col(
+                                    entities::turn_run::Column::MaxAttempts,
+                                )),
+                        ),
+                ),
+        )
+        .add(entities::turn_run::Column::AvailableAt.lte(now))
+        .add(entities::turn_run::Column::UpdatedAt.lte(now))
+}
+
+fn expired_turn_candidate_condition(now: chrono::DateTime<Utc>) -> sea_orm::Condition {
+    sea_orm::Condition::all()
+        .add(entities::turn_run::Column::Status.is_in([
+            TurnRunStatus::Running.as_str(),
+            TurnRunStatus::Cancelling.as_str(),
+        ]))
+        .add(entities::turn_run::Column::LeaseExpiresAt.lte(now))
+        .add(entities::turn_run::Column::UpdatedAt.lte(now))
+}
+
+async fn any_turn_claim_work_on<C>(
+    conn: &C,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    if entities::event::Entity::find()
+        .filter(entities::event::Column::ScanToken.eq(lease_token))
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some()
+        || entities::turn_claim::Entity::find_by_id(lease_token)
+            .one(conn)
+            .await
+            .map_err(store_err)?
+            .is_some()
+    {
+        return Ok(true);
+    }
+
+    Ok(entities::turn_run::Entity::find()
+        .filter(
+            sea_orm::Condition::any()
+                .add(due_turn_candidate_condition(now))
+                .add(expired_turn_candidate_condition(now)),
+        )
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some())
 }
 
 pub(in crate::db) async fn heartbeat_turn_run(

--- a/crates/tidebreak-core/src/db/tests.rs
+++ b/crates/tidebreak-core/src/db/tests.rs
@@ -73,6 +73,18 @@ async fn temp_store() -> (tempfile::TempDir, DbStore) {
     (dir, store)
 }
 
+async fn temp_store_with_max_connections(max_connections: u32) -> (tempfile::TempDir, DbStore) {
+    let template = migrated_sqlite_template().await;
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("test.db");
+    std::fs::copy(&template.database, &database).unwrap();
+    let url = format!("sqlite://{}?mode=rw", database.display());
+    let mut options = sea_orm::ConnectOptions::new(url);
+    options.max_connections(max_connections);
+    let store = DbStore::connect_with_options(options).await.unwrap();
+    (dir, store)
+}
+
 /// A checkpoint the host expects an executor lane to run.
 fn dispatchable(call: &crate::model::SandboxToolCallRequest) -> SandboxToolCallParkEntry {
     SandboxToolCallParkEntry {
@@ -3504,6 +3516,37 @@ async fn concurrent_cross_chat_reuse_of_a_turn_id_commits_once() {
             + store.list_messages(second_chat.id).await.unwrap().len(),
         1
     );
+}
+
+#[tokio::test]
+async fn empty_turn_claim_does_not_wait_for_sqlite_writer() {
+    let (_dir, store) = temp_store_with_max_connections(2).await;
+
+    // Hold SQLite's single writer with an unrelated transaction. A fresh scan
+    // with no turn to claim must remain read-only and leave the writer queue
+    // available for real work.
+    let writer = store.conn.begin().await.unwrap();
+    writer
+        .execute_unprepared("UPDATE advisory_lock SET name = name WHERE name = 'agent_run_claim'")
+        .await
+        .unwrap();
+
+    let now = Utc::now();
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        store.claim_turn_run(
+            uuid::Uuid::new_v4(),
+            now,
+            now + chrono::Duration::minutes(1),
+        ),
+    )
+    .await
+    .expect("an empty turn scan waited for SQLite's writer")
+    .unwrap();
+    assert!(outcome.turn.is_none());
+    assert!(outcome.terminal_event.is_none());
+
+    writer.rollback().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -824,6 +824,32 @@ async fn enqueue_retirement_despite_reference(store: &DbStore, blob_id: uuid::Uu
 }
 
 #[tokio::test]
+async fn empty_blob_retirement_poll_does_not_wait_for_sqlite_writer() {
+    let (_dir, store) = temp_store_with_max_connections(2).await;
+
+    // Hold SQLite's single writer with an unrelated transaction. An empty
+    // retirement scan is only a hint that no work exists, so it must remain a
+    // read and return without joining the writer queue.
+    let writer = store.conn.begin().await.unwrap();
+    writer
+        .execute_unprepared("UPDATE advisory_lock SET name = name WHERE name = 'turn_claim'")
+        .await
+        .unwrap();
+
+    let now = Utc::now();
+    let claimed = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        store.claim_blob_retirement(now, now + chrono::Duration::minutes(5)),
+    )
+    .await
+    .expect("an empty retirement scan waited for SQLite's writer")
+    .unwrap();
+    assert!(claimed.is_none());
+
+    writer.rollback().await.unwrap();
+}
+
+#[tokio::test]
 async fn every_reference_class_blocks_every_retirement_decision() {
     for class in ReferenceClass::ALL {
         let blob = DocumentBlob::from_bytes(b"bytes shared across reference classes");


### PR DESCRIPTION
## What changed

Idle turn and blob-retirement polls now check for claimable work before taking SQLite's single-writer lock, while the locked scans remain authoritative for claims and exact retries. Regression tests hold an unrelated write transaction and verify that empty polls return without waiting for it.

## Validation

- `cargo test -p tidebreak-core --lib blob_retirement_ -- --nocapture`
- `cargo test -p tidebreak-core --lib turn_claim -- --nocapture`
- `cargo clippy -p tidebreak-core --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

## Compatibility and risk

No persisted or wire-format changes; behavior changes only when a poll has no work.
