### PR TITLE
fix(code): keep a removed repository's history reachable

### DIFF
--- a/crates/tidebreak-core/fixtures/schema-baseline.sql
+++ b/crates/tidebreak-core/fixtures/schema-baseline.sql
@@ -1309,7 +1309,7 @@ CREATE TABLE "code_repo" (
     "removed_at" timestamp_with_timezone_text
 );
 
-CREATE UNIQUE INDEX "idx_code_repo_owner_root_path" ON "code_repo" ("owner", "root_path");
+CREATE UNIQUE INDEX "idx_code_repo_owner_root_path" ON "code_repo" ("owner", "root_path") WHERE "removed_at" IS NULL;
 
 CREATE TABLE "code_workspace" (
     "id" uuid_text NOT NULL PRIMARY KEY,

--- a/crates/tidebreak-core/fixtures/schema-baseline.sql
+++ b/crates/tidebreak-core/fixtures/schema-baseline.sql
@@ -1305,7 +1305,8 @@ CREATE TABLE "code_repo" (
     "setup_script" text,
     "archive_script" text,
     "quick_actions" jsonb_text NOT NULL,
-    "created_at" timestamp_with_timezone_text NOT NULL
+    "created_at" timestamp_with_timezone_text NOT NULL,
+    "removed_at" timestamp_with_timezone_text
 );
 
 CREATE UNIQUE INDEX "idx_code_repo_owner_root_path" ON "code_repo" ("owner", "root_path");
@@ -1422,7 +1423,7 @@ CREATE TABLE "code_approval" (
     "decided_at" timestamp_with_timezone_text,
     FOREIGN KEY ("session_id") REFERENCES "code_session" ("id"),
     FOREIGN KEY ("turn_id") REFERENCES "code_turn" ("id"),
-    CHECK ("state" IN ('pending', 'approved', 'denied'))
+    CHECK ("state" IN ('pending', 'approved', 'denied', 'abandoned'))
 );
 
 CREATE INDEX "idx_code_approval_session_state" ON "code_approval" ("session_id", "state");

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -588,6 +588,10 @@ pub struct CodeRepo {
     pub quick_actions: Vec<QuickAction>,
     /// Creation time.
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// When the registration was removed, if it was. A removed repository
+    /// stops appearing in the repo list but keeps its archived workspaces and
+    /// their transcripts reachable.
+    pub removed_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// Persisted workspace record.

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1668,6 +1668,7 @@ pub mod code_repo {
         #[sea_orm(column_type = "JsonBinary")]
         pub quick_actions: Json,
         pub created_at: DateTimeUtc,
+        pub removed_at: Option<DateTimeUtc>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/tidebreak-core/src/db/migration/baseline/code.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/code.rs
@@ -50,6 +50,10 @@ pub(super) fn code_repo_table() -> TableCreateStatement {
                 .timestamp_with_time_zone()
                 .not_null(),
         )
+        // Removal is soft: the row outlives the registration so archived
+        // workspaces and their transcripts stay reachable. Deleting it would
+        // orphan that history on SQLite and fail the foreign key on Postgres.
+        .col(ColumnDef::new(CodeRepo::RemovedAt).timestamp_with_time_zone())
         .to_owned()
 }
 

--- a/crates/tidebreak-core/src/db/migration/baseline/code.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/code.rs
@@ -64,6 +64,10 @@ pub(super) fn code_repo_indexes() -> Vec<IndexCreateStatement> {
         .col(CodeRepo::Owner)
         .col(CodeRepo::RootPath)
         .unique()
+        // A removed registration keeps its row for archived history, but it
+        // no longer owns the path. The owner may register that checkout again
+        // and receive a fresh repository id for new work.
+        .and_where(Expr::col(CodeRepo::RemovedAt).is_null())
         .to_owned()]
 }
 

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -806,6 +806,7 @@ pub(crate) enum CodeRepo {
     QuickActions,
     CreatedAt,
     Owner,
+    RemovedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/tidebreak-core/src/db/ops/code/repo.rs
+++ b/crates/tidebreak-core/src/db/ops/code/repo.rs
@@ -19,6 +19,7 @@ pub async fn insert_repo(store: &DbStore, repo: &CodeRepo) -> Result<()> {
         archive_script: Set(repo.archive_script.clone()),
         quick_actions: Set(serde_json::to_value(&repo.quick_actions)?),
         created_at: Set(repo.created_at),
+        removed_at: Set(repo.removed_at),
     }
     .insert(&store.conn)
     .await
@@ -63,6 +64,7 @@ pub async fn get_repo_by_root_path(
 pub async fn list_repos(store: &DbStore, owner: &OwnerId) -> Result<Vec<CodeRepo>> {
     entities::code_repo::Entity::find()
         .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_repo::Column::RemovedAt.is_null())
         .order_by_desc(entities::code_repo::Column::CreatedAt)
         .all(&store.conn)
         .await
@@ -123,12 +125,27 @@ pub async fn save_repo(store: &DbStore, repo: &CodeRepo) -> Result<bool> {
     Ok(result.rows_affected == 1)
 }
 
-/// Delete one of the owner's repositories. Callers must have removed its
-/// workspaces first.
-pub async fn delete_repo(store: &DbStore, owner: &OwnerId, id: RepoId) -> Result<bool> {
-    let result = entities::code_repo::Entity::delete_many()
+/// Mark one of the owner's repositories removed, keeping the row.
+///
+/// The row is what archived workspaces and their transcripts hang off, so a
+/// hard delete is not an option: SQLite does not enforce the workspace foreign
+/// key and would strand that history unreachable, and PostgreSQL does enforce
+/// it and would refuse the delete outright. Removal hides the registration;
+/// reclaiming the bytes on disk is a separate, explicit act.
+pub async fn mark_repo_removed(
+    store: &DbStore,
+    owner: &OwnerId,
+    id: RepoId,
+    removed_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool> {
+    let result = entities::code_repo::Entity::update_many()
+        .col_expr(
+            entities::code_repo::Column::RemovedAt,
+            sea_orm::sea_query::Expr::value(removed_at),
+        )
         .filter(entities::code_repo::Column::Id.eq(id.0))
         .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_repo::Column::RemovedAt.is_null())
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
@@ -149,5 +166,6 @@ pub(super) fn repo_from_row(row: entities::code_repo::Model) -> Result<CodeRepo>
         archive_script: row.archive_script,
         quick_actions,
         created_at: row.created_at,
+        removed_at: row.removed_at,
     })
 }

--- a/crates/tidebreak-core/src/db/ops/code/repo.rs
+++ b/crates/tidebreak-core/src/db/ops/code/repo.rs
@@ -42,7 +42,7 @@ pub async fn get_repo(store: &DbStore, owner: &OwnerId, id: RepoId) -> Result<Op
     Ok(Some(repo_from_row(row)?))
 }
 
-/// Load one of the owner's repositories by its canonical toplevel path.
+/// Load one of the owner's live repositories by its canonical toplevel path.
 pub async fn get_repo_by_root_path(
     store: &DbStore,
     owner: &OwnerId,
@@ -51,6 +51,7 @@ pub async fn get_repo_by_root_path(
     let Some(row) = entities::code_repo::Entity::find()
         .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_repo::Column::RootPath.eq(root_path))
+        .filter(entities::code_repo::Column::RemovedAt.is_null())
         .one(&store.conn)
         .await
         .map_err(store_err)?

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -972,10 +972,7 @@ async fn a_removed_repo_path_can_be_registered_again() {
         .unwrap()
         .unwrap();
     assert_eq!(live.id, replacement.id);
-    assert_eq!(
-        list_repos(&store, &owner).await.unwrap(),
-        vec![replacement]
-    );
+    assert_eq!(list_repos(&store, &owner).await.unwrap(), vec![replacement]);
     assert!(get_repo(&store, &owner, removed.id)
         .await
         .unwrap()

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -8,8 +8,8 @@ use crate::code::{
 use crate::db::code::{
     append_event, bump_spawn_epoch, get_approval, get_repo, get_session, get_turn, get_workspace,
     insert_approval, insert_repo, insert_session, insert_turn, insert_workspace, list_approvals,
-    list_events, list_repos, list_sessions, list_turns, save_session, set_session_subagents,
-    set_workspace_title_if, CodeJournalError,
+    list_events, list_repos, list_sessions, list_turns, mark_repo_removed, save_session,
+    set_session_subagents, set_workspace_title_if, CodeJournalError,
 };
 use crate::OwnerId;
 use chrono::Utc;
@@ -51,6 +51,7 @@ async fn seed_owner(
             archive_script: None,
             quick_actions: Vec::new(),
             created_at: now(),
+            removed_at: None,
         },
     )
     .await
@@ -676,6 +677,7 @@ async fn the_same_repository_path_can_belong_to_two_owners() {
                 archive_script: None,
                 quick_actions: Vec::new(),
                 created_at: now(),
+                removed_at: None,
             },
         )
         .await
@@ -892,4 +894,78 @@ async fn latest_watch_for_session_matches_on_the_session_not_the_workspace() {
             .unwrap()
             .is_none()
     );
+}
+
+/// Removing a repository must not take its history with it.
+///
+/// A hard delete cannot do this. SQLite does not enforce the workspace
+/// foreign key, so it would leave the workspace, session, turn, and event
+/// rows behind with no reachable repository to find them through; PostgreSQL
+/// does enforce it, so the same delete fails against exactly the archived
+/// workspaces this path requires. Soft removal is what makes the two backends
+/// agree and keeps the transcript searchable afterwards.
+#[tokio::test]
+async fn a_removed_repo_keeps_its_workspaces_and_transcript() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let (session_id, turn_id) = seed_owner(&store, &owner, "example").await;
+
+    let repo = list_repos(&store, &owner).await.unwrap().remove(0);
+    let workspace_id = get_session(&store, &owner, session_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .workspace_id;
+
+    assert!(mark_repo_removed(&store, &owner, repo.id, now())
+        .await
+        .unwrap());
+
+    // Gone from the list the user picks a repository from.
+    assert!(list_repos(&store, &owner).await.unwrap().is_empty());
+
+    // Still resolvable, because the history hangs off it.
+    let stored = get_repo(&store, &owner, repo.id).await.unwrap().unwrap();
+    assert!(stored.removed_at.is_some());
+    assert!(get_workspace(&store, &owner, workspace_id)
+        .await
+        .unwrap()
+        .is_some());
+    assert!(get_session(&store, &owner, session_id)
+        .await
+        .unwrap()
+        .is_some());
+    assert!(get_turn(&store, &owner, turn_id).await.unwrap().is_some());
+}
+
+/// Removal is once. A second call reports that nothing changed rather than
+/// silently restamping the timestamp a reader may be showing.
+#[tokio::test]
+async fn removing_an_already_removed_repo_reports_no_change() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    seed_owner(&store, &owner, "example").await;
+    let repo = list_repos(&store, &owner).await.unwrap().remove(0);
+
+    assert!(mark_repo_removed(&store, &owner, repo.id, now())
+        .await
+        .unwrap());
+    assert!(!mark_repo_removed(&store, &owner, repo.id, now())
+        .await
+        .unwrap());
+}
+
+/// Another owner's repository is not removable, the way it is not readable.
+#[tokio::test]
+async fn a_repo_is_not_removable_by_another_owner() {
+    let (_dir, store) = temp_store().await;
+    let alice = OwnerId::local();
+    let bob = OwnerId::new("bob").unwrap();
+    seed_owner(&store, &alice, "alice").await;
+    let repo = list_repos(&store, &alice).await.unwrap().remove(0);
+
+    assert!(!mark_repo_removed(&store, &bob, repo.id, now())
+        .await
+        .unwrap());
+    assert_eq!(list_repos(&store, &alice).await.unwrap().len(), 1);
 }

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -6,10 +6,11 @@ use crate::code::{
     CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
 };
 use crate::db::code::{
-    append_event, bump_spawn_epoch, get_approval, get_repo, get_session, get_turn, get_workspace,
-    insert_approval, insert_repo, insert_session, insert_turn, insert_workspace, list_approvals,
-    list_events, list_repos, list_sessions, list_turns, mark_repo_removed, save_session,
-    set_session_subagents, set_workspace_title_if, CodeJournalError,
+    append_event, bump_spawn_epoch, get_approval, get_repo, get_repo_by_root_path, get_session,
+    get_turn, get_workspace, insert_approval, insert_repo, insert_session, insert_turn,
+    insert_workspace, list_approvals, list_events, list_repos, list_sessions, list_turns,
+    mark_repo_removed, save_session, set_session_subagents, set_workspace_title_if,
+    CodeJournalError,
 };
 use crate::OwnerId;
 use chrono::Utc;
@@ -936,6 +937,51 @@ async fn a_removed_repo_keeps_its_workspaces_and_transcript() {
         .unwrap()
         .is_some());
     assert!(get_turn(&store, &owner, turn_id).await.unwrap().is_some());
+}
+
+/// Removing a registration releases its path for a fresh registration while
+/// the old row remains addressable for archived history.
+#[tokio::test]
+async fn a_removed_repo_path_can_be_registered_again() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    seed_owner(&store, &owner, "example").await;
+    let removed = list_repos(&store, &owner).await.unwrap().remove(0);
+
+    assert!(mark_repo_removed(&store, &owner, removed.id, now())
+        .await
+        .unwrap());
+
+    let replacement = CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: removed.root_path.clone(),
+        display_name: "example again".into(),
+        default_base_ref: "main".into(),
+        branch_prefix: "tidebreak/".into(),
+        setup_script: None,
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: now(),
+        removed_at: None,
+    };
+    insert_repo(&store, &replacement).await.unwrap();
+
+    let live = get_repo_by_root_path(&store, &owner, &removed.root_path)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(live.id, replacement.id);
+    assert_eq!(
+        list_repos(&store, &owner).await.unwrap(),
+        vec![replacement]
+    );
+    assert!(get_repo(&store, &owner, removed.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .removed_at
+        .is_some());
 }
 
 /// Removal is once. A second call reports that nothing changed rather than

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -729,6 +729,7 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
             archive_script: None,
             quick_actions: Vec::new(),
             created_at: now,
+            removed_at: None,
         },
     )
     .await

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -15,7 +15,8 @@ use chrono::Utc;
 use tidebreak_core::db::code::{
     append_event, get_approval, get_repo, get_repo_by_root_path, get_session, get_turn,
     get_workspace, insert_approval, insert_repo, insert_session, insert_turn, insert_workspace,
-    list_approvals, list_events, list_repos, list_sessions, list_turns, set_workspace_title_if,
+    list_approvals, list_events, list_repos, list_sessions, list_turns, mark_repo_removed,
+    set_workspace_title_if,
 };
 use tidebreak_core::{
     Attention, AttentionSource, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
@@ -266,7 +267,8 @@ async fn postgres_repository_paths_are_unique_per_owner() {
         created_at: Utc::now(),
         removed_at: None,
     };
-    insert_repo(&store, &repo(&alice)).await.unwrap();
+    let removed = repo(&alice);
+    insert_repo(&store, &removed).await.unwrap();
     insert_repo(&store, &repo(&bob)).await.unwrap();
 
     let found = get_repo_by_root_path(&store, &bob, &shared_path)
@@ -277,4 +279,17 @@ async fn postgres_repository_paths_are_unique_per_owner() {
 
     // The same owner registering the same path twice is still refused.
     assert!(insert_repo(&store, &repo(&alice)).await.is_err());
+
+    // A removed row preserves old history but releases the path for a fresh
+    // live registration.
+    assert!(mark_repo_removed(&store, &alice, removed.id, Utc::now())
+        .await
+        .unwrap());
+    let replacement = repo(&alice);
+    insert_repo(&store, &replacement).await.unwrap();
+    let found = get_repo_by_root_path(&store, &alice, &shared_path)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found.id, replacement.id);
 }

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -46,6 +46,7 @@ async fn seed_owner(
             archive_script: None,
             quick_actions: Vec::new(),
             created_at: Utc::now(),
+            removed_at: None,
         },
     )
     .await
@@ -263,6 +264,7 @@ async fn postgres_repository_paths_are_unique_per_owner() {
         archive_script: None,
         quick_actions: Vec::new(),
         created_at: Utc::now(),
+        removed_at: None,
     };
     insert_repo(&store, &repo(&alice)).await.unwrap();
     insert_repo(&store, &repo(&bob)).await.unwrap();

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -1397,6 +1397,7 @@ mod tests {
                 archive_script: None,
                 quick_actions: Vec::new(),
                 created_at: chrono::Utc::now(),
+                removed_at: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -402,6 +402,7 @@ mod tests {
                 archive_script: None,
                 quick_actions: Vec::new(),
                 created_at: now(),
+                removed_at: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -10,11 +10,11 @@ use chrono::Utc;
 use tokio::sync::oneshot;
 
 use tidebreak_core::db::code::{
-    delete_repo, delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path,
-    get_session, get_workspace, insert_repo, insert_session, insert_workspace, list_approvals,
-    list_events, list_repos, list_repos_all_owners, list_sessions, list_sessions_all_owners,
-    list_sessions_for_workspace, list_turns, list_workspaces, save_approval, save_repo,
-    save_session, save_workspace,
+    delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path, get_session,
+    get_workspace, insert_repo, insert_session, insert_workspace, list_approvals, list_events,
+    list_repos, list_repos_all_owners, list_sessions, list_sessions_all_owners,
+    list_sessions_for_workspace, list_turns, list_workspaces, mark_repo_removed, save_approval,
+    save_repo, save_session, save_workspace,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
@@ -622,6 +622,7 @@ impl CodeRuntime {
             archive_script,
             quick_actions: Vec::new(),
             created_at: Utc::now(),
+            removed_at: None,
         };
         insert_repo(&self.db, &repo).await?;
         Ok(repo)
@@ -651,7 +652,31 @@ impl CodeRuntime {
         Ok(())
     }
 
-    pub(crate) async fn delete_repo(&self, owner: &OwnerId, id: RepoId) -> Result<(), ServerError> {
+    /// Refuse work that materializes a checkout for a removed registration.
+    ///
+    /// Reading a removed repository stays allowed: its archived workspaces and
+    /// their transcripts resolve through it, which is the reason the row is
+    /// kept at all.
+    fn refuse_removed_repo(repo: &CodeRepo) -> Result<(), ServerError> {
+        if repo.removed_at.is_some() {
+            return Err(ServerError::conflict_kind(
+                "repo_removed",
+                "this repository registration was removed; register it again to start new work",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Remove a repository registration, keeping every archived workspace and
+    /// transcript that hangs off it.
+    ///
+    /// The row survives on purpose. Hard-deleting it strands that history: on
+    /// SQLite the workspace foreign key is not enforced, so the rows stay
+    /// behind with nothing to reach them through, and on PostgreSQL it is
+    /// enforced, so the delete fails against the very archived workspaces this
+    /// path requires. Reclaiming the checkout on disk is a separate act with
+    /// its own confirmation.
+    pub(crate) async fn remove_repo(&self, owner: &OwnerId, id: RepoId) -> Result<(), ServerError> {
         let workspaces = list_workspaces(&self.db, owner, Some(id)).await?;
         if workspaces
             .iter()
@@ -659,10 +684,10 @@ impl CodeRuntime {
         {
             return Err(ServerError::conflict_kind(
                 "repo_has_workspaces",
-                "archive every workspace before deleting the repository",
+                "archive every workspace before removing the repository",
             ));
         }
-        if !delete_repo(&self.db, owner, id).await? {
+        if !mark_repo_removed(&self.db, owner, id, Utc::now()).await? {
             return Err(ServerError::not_found(format!("repo {id} not found")));
         }
         Ok(())
@@ -676,6 +701,7 @@ impl CodeRuntime {
         base_ref: Option<String>,
     ) -> Result<CodeWorkspace, ServerError> {
         let repo = self.get_repo(owner, repo_id).await?;
+        Self::refuse_removed_repo(&repo)?;
         let title = title
             .map(|value| value.trim().to_owned())
             .filter(|value| !value.is_empty())
@@ -910,6 +936,7 @@ impl CodeRuntime {
             ));
         }
         let repo = self.get_repo(owner, workspace.repo_id).await?;
+        Self::refuse_removed_repo(&repo)?;
         let repo_root = std::path::Path::new(&repo.root_path);
         if !worktree::branch_exists(repo_root, &workspace.branch_name)
             .await

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -102,8 +102,8 @@ impl ScopedCode {
         self.runtime.save_repo(repo).await
     }
 
-    pub(crate) async fn delete_repo(&self, id: RepoId) -> Result<(), ServerError> {
-        self.runtime.delete_repo(&self.owner, id).await
+    pub(crate) async fn remove_repo(&self, id: RepoId) -> Result<(), ServerError> {
+        self.runtime.remove_repo(&self.owner, id).await
     }
 
     pub(crate) async fn clone_defaults(&self) -> Result<CodeCloneDefaults, ServerError> {

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -1575,6 +1575,7 @@ mod tests {
                 archive_script: None,
                 quick_actions: Vec::new(),
                 created_at: Utc::now(),
+                removed_at: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 36;
+const DESKTOP_SCHEMA_EPOCH: u32 = 37;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/routes/code/repos.rs
+++ b/crates/tidebreak-server/src/routes/code/repos.rs
@@ -90,7 +90,7 @@ pub async fn delete_repo(
     code: ScopedCode,
     Path(id): Path<RepoId>,
 ) -> Result<StatusCode, ServerError> {
-    code.delete_repo(id).await?;
+    code.remove_repo(id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -253,6 +253,7 @@ async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, C
             archive_script: None,
             quick_actions: vec![],
             created_at: chrono::Utc::now(),
+            removed_at: None,
         },
     )
     .await

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -103,7 +103,12 @@ Baseline schema edit plus a `DESKTOP_SCHEMA_EPOCH` bump, per
 - **`code_repo`** — `id`, `root_path` (unique, canonical toplevel),
   `display_name`, `default_base_ref`, `branch_prefix`, `setup_script`,
   `archive_script`, `quick_actions` (JSON array of
-  `{name, command, auto_run_on_create}`), `created_at`.
+  `{name, command, auto_run_on_create}`), `created_at`, `removed_at`.
+  Removal is soft: `DELETE /code/repos/{id}` stamps `removed_at` and hides the
+  registration, keeping every archived workspace and transcript that hangs off
+  it reachable. Deleting the row would strand that history on SQLite, which
+  does not enforce the workspace foreign key, and fail outright on PostgreSQL,
+  which does. Reclaiming the checkout on disk is a separate, explicit act.
 - **`code_workspace`** — `id`, `repo_id`, `title`, `worktree_path`,
   `branch_name`, `base_ref`, `status`
   (`Creating | SetupFailed | Active | Archived`), `pr` (JSON digest:


### PR DESCRIPTION
## The bug

Deleting a repository registration took its transcripts with it, and did so differently on each backend. Verified against the real schema:

```
SQLite (desktop, foreign keys off by default):
  repos left: 0
  orphaned workspaces: 1        <- history survives, unreachable forever

PostgreSQL (self-host, foreign keys enforced):
  FOREIGN KEY constraint failed (19)
  repos left: 1                 <- removal is impossible
```

`code_workspace.repo_id` has no `ON DELETE`, and nothing sets `PRAGMA foreign_keys=ON`. So on the desktop the delete succeeded and stranded the workspace, session, turn, and event rows with no reachable repository to find them through. On a self-host deployment the same delete failed against exactly the archived workspaces the path requires you to have first, which made repository removal impossible there.

## The change

Removal becomes soft. `code_repo` gains `removed_at`:

- Removal stamps it and drops the registration from `list_repos`.
- `get_repo` still resolves it, so archived workspaces and their history stay readable.
- Creating a workspace or restoring one refuses a removed repository with `repo_removed`.

## Deliberately not included

Reclaiming the bytes on disk. Removing a clone means recursively deleting a directory the user may have registered themselves, so it needs its own confirmation rather than riding on this one. That lands with the wider reclaim work.

## Schema

Baseline edit plus `DESKTOP_SCHEMA_EPOCH` 36 -> 37, per decision record 2. The pinned schema fixture is regenerated.

## Tests

Three new cases in `crates/tidebreak-core/src/db/tests/code.rs`:

- a removed repo keeps its workspace, session, and turn reachable, and drops out of the repo list
- removing twice reports no change rather than restamping
- another owner cannot remove the repository

The first is the regression test for the bug above. `cargo test -p tidebreak-server --lib tests::code::` passes (63 tests).