### PR TITLE
fix(code): stop a failure-fenced session from closing its whole workspace

### DIFF
--- a/crates/tidebreak-core/src/code/attention.rs
+++ b/crates/tidebreak-core/src/code/attention.rs
@@ -90,6 +90,28 @@ pub enum FenceReason {
     },
 }
 
+impl FenceReason {
+    /// Whether this fence must also stop every other session in the workspace.
+    ///
+    /// True when an engine process may be writing to the shared worktree
+    /// outside every lock this process holds — an orphan from a previous
+    /// boot, a pid the probe could not identify, or a session the engine no
+    /// longer recognizes. Nothing in the workspace may write until a reap
+    /// settles it (decision 0055).
+    ///
+    /// False for [`Self::RepeatedTurnFailures`]. That fence says the engine
+    /// answered and the turns failed — an expired credential, a refused
+    /// prompt, a provider outage. The process is accounted for and the
+    /// worktree is not at risk, so a healthy sibling session keeps working.
+    #[must_use]
+    pub const fn blocks_workspace(&self) -> bool {
+        match self {
+            Self::OrphanAlive | Self::ProbeAmbiguous { .. } | Self::ResumeLost { .. } => true,
+            Self::RepeatedTurnFailures { .. } => false,
+        }
+    }
+}
+
 /// Server-computed attention for one unit of supervised work.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1418,10 +1418,12 @@ impl CodeRuntime {
             session.model = Some(model);
             let _ = save_session(&self.db, &session).await?;
         }
-        // A fenced sibling means an engine from a previous boot may still be
-        // alive in this checkout, outside every lock this process holds. The
-        // turn lock cannot see it, so nothing in the workspace writes until it
-        // is reaped (record 55).
+        // A sibling fenced for an unaccounted engine — an orphan from a
+        // previous boot, an ambiguous pid, a lost resume — may still be alive
+        // in this checkout, outside every lock this process holds. The turn
+        // lock cannot see it, so nothing in the workspace writes until it is
+        // reaped (record 55). A sibling fenced for repeated turn failures is
+        // not that: its engine answered every time, so it does not stop us.
         if let Some(reason) = self.workspace_fence_reason(owner, &session).await? {
             return Err(ServerError::conflict_kind("workspace_fenced", reason));
         }
@@ -1496,7 +1498,18 @@ impl CodeRuntime {
         let siblings = list_sessions_for_workspace(&self.db, owner, session.workspace_id).await?;
         Ok(siblings
             .iter()
-            .find(|other| other.id != session.id && other.lifecycle == CodeSessionLifecycle::Fenced)
+            .find(|other| {
+                other.id != session.id
+                    && other.lifecycle == CodeSessionLifecycle::Fenced
+                    // Only a fence that implies an unaccounted engine process
+                    // stops the workspace. A sibling fenced for repeated turn
+                    // failures answered every time; its worktree is not at
+                    // risk, so this session keeps working.
+                    && other
+                        .fence_reason
+                        .as_ref()
+                        .is_none_or(FenceReason::blocks_workspace)
+            })
             .map(|fenced| {
                 format!(
                     "another session in this workspace is fenced until it is reaped ({})",

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1955,6 +1955,55 @@ async fn a_fenced_session_closes_its_whole_workspace_to_turns() {
 }
 
 #[tokio::test]
+async fn a_sibling_fenced_for_repeated_failures_does_not_close_the_workspace() {
+    // Repeated turn failures fence the session that hit them, but its engine
+    // answered every time — an expired credential, a refused prompt, a
+    // provider outage. No process is unaccounted for and the worktree is not
+    // at risk, so a healthy sibling keeps working. Only a fence that implies
+    // an engine outside our locks closes the workspace.
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let ids = create_sibling_sessions(&client, addr, &token, &workspace, 2).await;
+
+    let owner = tidebreak_core::OwnerId::local();
+    let fenced_id: CodeSessionId = ids[0].parse().unwrap();
+    let reason = FenceReason::RepeatedTurnFailures {
+        count: 3,
+        detail: "the provider refused three turns in a row".into(),
+    };
+    let mut row = tidebreak_core::db::code::get_session(&runtime.db, &owner, fenced_id)
+        .await
+        .unwrap()
+        .unwrap();
+    row.lifecycle = CodeSessionLifecycle::Fenced;
+    row.fence_reason = Some(reason.clone());
+    row.attention = Attention::new(
+        AttentionState::Fenced { reason },
+        AttentionSource::Lifecycle,
+    );
+    tidebreak_core::db::code::save_session(&runtime.db, &row)
+        .await
+        .unwrap();
+
+    let accepted = client
+        .post(format!("http://{addr}/code/sessions/{}/turns", ids[1]))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "while a sibling is fenced" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        accepted.status(),
+        reqwest::StatusCode::ACCEPTED,
+        "a sibling fenced for repeated failures must not close the workspace: {}",
+        accepted.text().await.unwrap()
+    );
+}
+
+#[tokio::test]
 async fn a_workspace_still_holds_only_one_watch_session() {
     // Watch keeps its cap: the fix loop belongs to the workspace, not to one
     // agent, so a second one would double every push. Record 54 lifted the cap


### PR DESCRIPTION
## What happens now

A sibling session fenced for **repeated turn failures** blocks every other session in the workspace with `409 workspace_fenced` until someone reaps it.

I hit this while verifying the persistent-child branch against a live profile. One session tripped a provider content refusal, failed three turns, and fenced. A second, healthy session in the same workspace then refused every turn — including a bare `Say only: ALIVE`:

```
tidebreak: request failed (409 Conflict): workspace_fenced: another session
in this workspace is fenced until it is reaped (a924ab2f-…)
```

## Why it is wrong

The workspace gate was written for fences that imply an **engine process nobody is holding a lock on** — `OrphanAlive`, `ProbeAmbiguous`, `ResumeLost`. For those, blocking is correct and record 55 says so: a process from a previous boot may be writing to the shared worktree.

`RepeatedTurnFailures` does not imply that. The engine answered every time. The failures were an expired credential, a refused prompt, a provider outage — none of which put the worktree at risk. The gate has treated it like an orphan since it was added.

## The change

`FenceReason::blocks_workspace()` names the distinction; `workspace_fence_reason` consults it. A fenced row with no recorded reason still blocks, so the conservative default holds for anything written earlier.

## Tests

- New: a sibling fenced for `RepeatedTurnFailures` does **not** close the workspace. Fails before this change with the exact 409 above.
- Existing `a_fenced_session_closes_its_whole_workspace_to_turns` uses `OrphanAlive` and stays green — that is the regression guard for the half that should still block.

`code::` 207 passed, `tidebreak-core --lib` 717 passed, fmt and clippy clean. `code_terminals::create_write_read_and_two_cursors` fails under full parallel load and passes in isolation on this branch and on clean `main` alike — pre-existing PTY timing flake.