### PR TITLE
feat(code): reclaim a workspace's branch without losing the work

### DIFF
--- a/crates/tidebreak-core/fixtures/schema-baseline.sql
+++ b/crates/tidebreak-core/fixtures/schema-baseline.sql
@@ -1323,8 +1323,11 @@ CREATE TABLE "code_workspace" (
     "pr" jsonb_text,
     "created_at" timestamp_with_timezone_text NOT NULL,
     "archived_at" timestamp_with_timezone_text,
+    "released_at" timestamp_with_timezone_text,
+    "released_tip" text,
+    "bundle_bytes" integer,
     FOREIGN KEY ("repo_id") REFERENCES "code_repo" ("id"),
-    CHECK ("status" IN ('creating', 'setup_failed', 'active', 'archived'))
+    CHECK ("status" IN ('creating', 'setup_failed', 'active', 'archived', 'released'))
 );
 
 CREATE UNIQUE INDEX "idx_code_workspace_repo_branch" ON "code_workspace" ("repo_id", "branch_name");

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -253,8 +253,15 @@ pub enum CodeWorkspaceStatus {
     SetupFailed,
     /// Ready for sessions.
     Active,
-    /// Archived; worktree removed.
+    /// Archived; worktree removed, branch kept.
     Archived,
+    /// Released; worktree and branch both gone, commits kept as a bundle.
+    ///
+    /// The deepest reclaim tier. A worktree is gigabytes of checkout and build
+    /// output; the branch's own commits are usually kilobytes, so bundling
+    /// them and dropping the branch frees nearly everything and still restores
+    /// exactly. The transcript is untouched at every tier.
+    Released,
 }
 
 impl CodeWorkspaceStatus {
@@ -266,6 +273,7 @@ impl CodeWorkspaceStatus {
             Self::SetupFailed => "setup_failed",
             Self::Active => "active",
             Self::Archived => "archived",
+            Self::Released => "released",
         }
     }
 
@@ -278,6 +286,7 @@ impl CodeWorkspaceStatus {
             "setup_failed" => Some(Self::SetupFailed),
             "active" => Some(Self::Active),
             "archived" => Some(Self::Archived),
+            "released" => Some(Self::Released),
             _ => None,
         }
     }
@@ -619,6 +628,14 @@ pub struct CodeWorkspace {
     pub created_at: chrono::DateTime<chrono::Utc>,
     /// Archive time, when archived.
     pub archived_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Release time, when released.
+    pub released_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Commit the released branch pointed at, so a restore can say what it
+    /// rebuilds and a reader can recognize the work without unbundling.
+    pub released_tip: Option<String>,
+    /// Size of the stored bundle. Kept for the reclaim surface, which has to
+    /// report what a release actually bought without stat-ing every file.
+    pub bundle_bytes: Option<i64>,
 }
 
 /// Most subagent rows kept on one session. Done entries fall off first.

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1696,6 +1696,9 @@ pub mod code_workspace {
         pub pr: Option<Json>,
         pub created_at: DateTimeUtc,
         pub archived_at: Option<DateTimeUtc>,
+        pub released_at: Option<DateTimeUtc>,
+        pub released_tip: Option<String>,
+        pub bundle_bytes: Option<i64>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/tidebreak-core/src/db/migration/baseline/code.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/code.rs
@@ -99,6 +99,14 @@ pub(super) fn code_workspace_table() -> TableCreateStatement {
                 .not_null(),
         )
         .col(ColumnDef::new(CodeWorkspace::ArchivedAt).timestamp_with_time_zone())
+        // Release is the deepest reclaim tier: worktree and branch both gone,
+        // the branch's own commits kept as a bundle beside the data directory.
+        // The tip and byte count are recorded so the reclaim surface can
+        // report what a release bought, and a restore can name what it
+        // rebuilds, without reading the bundle back.
+        .col(ColumnDef::new(CodeWorkspace::ReleasedAt).timestamp_with_time_zone())
+        .col(ColumnDef::new(CodeWorkspace::ReleasedTip).text())
+        .col(ColumnDef::new(CodeWorkspace::BundleBytes).big_integer())
         .foreign_key(
             ForeignKey::create()
                 .name("fk_code_workspace_repo")
@@ -110,6 +118,7 @@ pub(super) fn code_workspace_table() -> TableCreateStatement {
             "setup_failed",
             "active",
             "archived",
+            "released",
         ]))
         .to_owned()
 }

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -822,6 +822,9 @@ pub(crate) enum CodeWorkspace {
     Pr,
     CreatedAt,
     ArchivedAt,
+    ReleasedAt,
+    ReleasedTip,
+    BundleBytes,
     Owner,
 }
 

--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -24,6 +24,9 @@ pub async fn insert_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Res
         }),
         created_at: Set(workspace.created_at),
         archived_at: Set(workspace.archived_at),
+        released_at: Set(workspace.released_at),
+        released_tip: Set(workspace.released_tip.clone()),
+        bundle_bytes: Set(workspace.bundle_bytes),
     }
     .insert(&store.conn)
     .await
@@ -106,6 +109,18 @@ pub async fn save_workspace(store: &DbStore, workspace: &CodeWorkspace) -> Resul
             entities::code_workspace::Column::ArchivedAt,
             sea_orm::sea_query::Expr::value(workspace.archived_at),
         )
+        .col_expr(
+            entities::code_workspace::Column::ReleasedAt,
+            sea_orm::sea_query::Expr::value(workspace.released_at),
+        )
+        .col_expr(
+            entities::code_workspace::Column::ReleasedTip,
+            sea_orm::sea_query::Expr::value(workspace.released_tip.clone()),
+        )
+        .col_expr(
+            entities::code_workspace::Column::BundleBytes,
+            sea_orm::sea_query::Expr::value(workspace.bundle_bytes),
+        )
         .filter(entities::code_workspace::Column::Id.eq(workspace.id.0))
         .filter(entities::code_workspace::Column::Owner.eq(workspace.owner.as_str()))
         .exec(&store.conn)
@@ -177,5 +192,8 @@ pub(super) fn workspace_from_row(row: entities::code_workspace::Model) -> Result
         pr,
         created_at: row.created_at,
         archived_at: row.archived_at,
+        released_at: row.released_at,
+        released_tip: row.released_tip,
+        bundle_bytes: row.bundle_bytes,
     })
 }

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -72,6 +72,9 @@ async fn seed_owner(
             pr: None,
             created_at: now(),
             archived_at: None,
+            released_at: None,
+            released_tip: None,
+            bundle_bytes: None,
         },
     )
     .await

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -749,6 +749,9 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
             pr: None,
             created_at: now,
             archived_at: None,
+            released_at: None,
+            released_tip: None,
+            bundle_bytes: None,
         },
     )
     .await

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -67,6 +67,9 @@ async fn seed_owner(
             pr: None,
             created_at: Utc::now(),
             archived_at: None,
+            released_at: None,
+            released_tip: None,
+            bundle_bytes: None,
         },
     )
     .await

--- a/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
@@ -35,7 +35,7 @@ import { openInBrowser } from "@/openInBrowser";
 import { RouteFrame } from "@/RouteFrame";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { CodeSidebar } from "./CodeSidebar";
-import { listArchivedWorkspaces } from "./workspaceCards";
+import { listArchivedWorkspaces, isPutAway } from "./workspaceCards";
 
 type AgeFilter = "all" | "7d" | "30d" | "90d";
 
@@ -105,7 +105,7 @@ function CodeArchiveBody() {
   };
 
   const totalArchived = workspaces.filter(
-    (workspace) => workspace.status === "archived",
+    (workspace) => isPutAway(workspace),
   ).length;
 
   return (

--- a/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeRepoPage.tsx
@@ -19,7 +19,7 @@ import { useCodeUiStore } from "./CodeUiStore";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { WORKSPACE_STATUS_LABELS } from "./labels";
 import { useWorkspaceCardCommands } from "./workspaceActions";
-import { middleTruncate } from "./workspaceCards";
+import { middleTruncate, isPutAway } from "./workspaceCards";
 
 /**
  * One registered repo: its workspaces and the new-workspace flow.
@@ -107,7 +107,7 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
                 type="button"
                 className={cn(
                   "hover:bg-muted flex w-full cursor-pointer items-center justify-between gap-3 rounded-md px-3 py-2 text-left text-sm",
-                  workspace.status === "archived" && "opacity-70",
+                  isPutAway(workspace) && "opacity-70",
                   FOCUS_RING,
                   HOVER_TINT,
                 )}
@@ -143,7 +143,7 @@ function CodeRepoBody({ repoId }: { repoId: string }) {
                   {WORKSPACE_STATUS_LABELS[workspace.status]}
                 </span>
               </button>
-              {workspace.status === "archived" && (
+              {isPutAway(workspace) && (
                 // A sibling, not a child, of the row button: buttons cannot
                 // nest, and restoring should not also open the workspace.
                 <Button

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -32,7 +32,7 @@ import {
   workspaceCommands,
 } from "./workspaceActions";
 import { WorkspaceCard } from "./WorkspaceCard";
-import { arrangeWorkspaces } from "./workspaceCards";
+import { arrangeWorkspaces, isPutAway } from "./workspaceCards";
 import { prWorkflowPrompt } from "./prActions";
 import type { WorkspaceWorkflowAction } from "./workspaceWorkflow";
 
@@ -193,7 +193,7 @@ export function CodeSidebar() {
                   }}
                   commands={workspaceCommands({
                     hasPr: Boolean(pr),
-                    archived: workspace.status === "archived",
+                    archived: isPutAway(workspace),
                     hasSession: Boolean(sessions[workspace.id]),
                     attentionPinned:
                       (digest?.attention ?? sessions[workspace.id]?.attention)

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -161,7 +161,7 @@ import {
   useWorkspaceCardCommands,
   workspaceHeaderCommands,
 } from "./workspaceActions";
-import { sessionActivityLabel } from "./workspaceCards";
+import { sessionActivityLabel, isPutAway } from "./workspaceCards";
 import {
   createPermissionModes,
   fenceReasonText,
@@ -492,7 +492,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const pr = digest?.pr_state ?? workspace?.pr;
   const headerCommands = workspace
     ? workspaceHeaderCommands({
-        archived: workspace.status === "archived",
+        archived: isPutAway(workspace),
         hasSession: Boolean(session),
         attentionPinned:
           (digest?.attention ?? session?.attention)?.state.type === "manual",
@@ -572,7 +572,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     if (!archivePending) return;
     if (!useCodeUiStore.getState().takeArchiveWorkspace()) return;
     if (!workspace) return;
-    if (workspace.status === "archived") {
+    if (isPutAway(workspace)) {
       toast.message("This workspace is already archived");
       return;
     }
@@ -1125,7 +1125,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         worktreePath={workspace?.worktree_path}
         loading={!title && !error}
         workflow={
-          workspace && workspace.status !== "archived" ? (
+          workspace && !isPutAway(workspace) ? (
             <WorkspaceWorkflowControl
               client={client}
               workspaceId={workspaceId}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -56,6 +56,7 @@ import {
   watchRowLabel,
   workspaceCardLabel,
   type CardDensity,
+  isPutAway,
 } from "./workspaceCards";
 
 /**
@@ -101,7 +102,7 @@ export function WorkspaceCard({
 }) {
   const title = digest?.title ?? workspace.title;
   const pr = digest?.pr_state ?? workspace.pr;
-  const archived = workspace.status === "archived";
+  const archived = isPutAway(workspace);
   const watchActive = childSessions.some(
     (child) =>
       child.watch_state === "watching" ||

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -77,6 +77,7 @@ export const WORKSPACE_STATUS_LABELS: Record<CodeWorkspaceStatus, string> = {
   setup_failed: "Setup failed",
   active: "Active",
   archived: "Archived",
+  released: "Released",
 };
 
 export const PERMISSION_MODE_LABELS: Record<CodePermissionMode, string> = {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -199,6 +199,7 @@ const WORKSPACE_STATUSES = new Set<CodeWorkspaceStatus>([
   "setup_failed",
   "active",
   "archived",
+  "released",
 ]);
 const TURN_STATUSES = new Set<CodeTurnStatus>([
   "running",

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -13,6 +13,18 @@ import { STATUS_CHIP, STATUS_MARK, type StatusTone } from "./statusTone";
  * them.
  */
 
+/**
+ * Whether a workspace has been put away rather than being live work.
+ *
+ * Archived and released are both reclaim tiers — released has simply given up
+ * more (its branch, not only its checkout). Every surface that asks "is this
+ * still on the rail?" wants both, so ask it here rather than comparing to
+ * `"archived"` and silently letting released workspaces read as live.
+ */
+export function isPutAway(workspace: CodeWorkspaceSnapshot): boolean {
+  return workspace.status === "archived" || workspace.status === "released";
+}
+
 export type WorkspaceGroup = {
   /** Null collects workspaces whose repo is missing from the catalog. */
   repo: CodeRepoSnapshot | null;
@@ -31,7 +43,7 @@ export function groupWorkspacesByRepo(
 ): WorkspaceGroup[] {
   const byRepo = new Map<string, CodeWorkspaceSnapshot[]>();
   for (const workspace of workspaces) {
-    if (workspace.status === "archived") continue;
+    if (isPutAway(workspace)) continue;
     const listed = byRepo.get(workspace.repo_id);
     if (listed) {
       listed.push(workspace);
@@ -119,7 +131,7 @@ export function workspaceStatusRank(
   workspace: CodeWorkspaceSnapshot,
   digest: CodeSessionDigest | undefined,
 ): WorkspaceStatusRank {
-  if (workspace.status === "archived") return "archived";
+  if (isPutAway(workspace)) return "archived";
   if (digest?.attention.state.type === "needs_you") return "needs_you";
   if (digest?.lifecycle === "running") return "running";
   const pr = digest?.pr_state ?? workspace.pr;
@@ -167,7 +179,7 @@ export function listWorkspacesByCreated(
   workspaces: readonly CodeWorkspaceSnapshot[],
 ): CodeWorkspaceSnapshot[] {
   return sortByCreated(
-    workspaces.filter((workspace) => workspace.status !== "archived"),
+    workspaces.filter((workspace) => !isPutAway(workspace)),
     "desc",
   );
 }
@@ -238,7 +250,7 @@ export function listArchivedWorkspaces(
   workspaces: readonly CodeWorkspaceSnapshot[],
 ): CodeWorkspaceSnapshot[] {
   return workspaces
-    .filter((workspace) => workspace.status === "archived")
+    .filter((workspace) => isPutAway(workspace))
     .sort((left, right) => {
       const byTime = (right.archived_at ?? right.created_at).localeCompare(
         left.archived_at ?? left.created_at,

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1509,12 +1509,21 @@ export type CodeWorkspaceSearchMatch = { path: string, line_number: number, line
 /**
  * One isolated workspace (worktree + branch) on a repo.
  */
-export type CodeWorkspaceSnapshot = { id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, };
+export type CodeWorkspaceSnapshot = { id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, released_at?: string, 
+/**
+ * Commit the released branch pointed at, so a client can name the work
+ * without the branch existing.
+ */
+released_tip?: string, 
+/**
+ * Stored bundle size, for reporting what a release reclaimed.
+ */
+bundle_bytes?: number, };
 
 /**
  * Status of a persisted workspace.
  */
-export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archived";
+export type CodeWorkspaceStatus = "creating" | "setup_failed" | "active" | "archived" | "released";
 
 /**
  * Bounded path listing for `GET /code/workspaces/{id}/tree`.

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -5,6 +5,7 @@ import { workspaceCommands } from "@/code/workspaceActions";
 import { WorkspaceCard } from "@/code/WorkspaceCard";
 import {
   archivedWorkspace,
+  releasedWorkspace,
   closedPrDigest,
   codeSession,
   codeWorkspace,
@@ -242,6 +243,17 @@ export const TerminalOpen: Story = {
 export const Archived: Story = {
   args: {
     workspace: archivedWorkspace,
+    commands: workspaceCommands({ hasPr: false, archived: true }),
+  },
+};
+
+/**
+ * Released reads as put-away, like Archived: the rail must not show a
+ * workspace whose branch is gone as live work.
+ */
+export const Released: Story = {
+  args: {
+    workspace: releasedWorkspace,
     commands: workspaceCommands({ hasPr: false, archived: true }),
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -468,6 +468,21 @@ export const archivedWorkspace: CodeWorkspaceSnapshot = {
   archived_at: "2026-08-18T17:00:00.000Z",
 };
 
+/**
+ * The deepest reclaim tier: worktree and branch both gone, the branch's own
+ * commits kept as a bundle so a restore still rebuilds the work exactly.
+ */
+export const releasedWorkspace: CodeWorkspaceSnapshot = {
+  ...codeWorkspace,
+  id: "ws-released",
+  title: "Reclaimed after review",
+  status: "released",
+  archived_at: "2026-08-18T17:00:00.000Z",
+  released_at: "2026-08-20T09:30:00.000Z",
+  released_tip: "9f3c1ab2d4e5f60718293a4b5c6d7e8f90a1b2c3",
+  bundle_bytes: 12_288,
+};
+
 // ---------------------------------------------------------------------------
 // Delivery center: cross-repository pull requests, runs, archive, notifications.
 // ---------------------------------------------------------------------------

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -1487,6 +1487,9 @@ mod tests {
                 pr: None,
                 created_at: chrono::Utc::now(),
                 archived_at: None,
+                released_at: None,
+                released_tip: None,
+                bundle_bytes: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -422,6 +422,9 @@ mod tests {
                 pr: None,
                 created_at: now(),
                 archived_at: None,
+                released_at: None,
+                released_tip: None,
+                bundle_bytes: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -678,10 +678,12 @@ impl CodeRuntime {
     /// its own confirmation.
     pub(crate) async fn remove_repo(&self, owner: &OwnerId, id: RepoId) -> Result<(), ServerError> {
         let workspaces = list_workspaces(&self.db, owner, Some(id)).await?;
-        if workspaces
-            .iter()
-            .any(|workspace| workspace.status != CodeWorkspaceStatus::Archived)
-        {
+        if workspaces.iter().any(|workspace| {
+            !matches!(
+                workspace.status,
+                CodeWorkspaceStatus::Archived | CodeWorkspaceStatus::Released
+            )
+        }) {
             return Err(ServerError::conflict_kind(
                 "repo_has_workspaces",
                 "archive every workspace before removing the repository",
@@ -760,6 +762,9 @@ impl CodeRuntime {
             pr: None,
             created_at: Utc::now(),
             archived_at: None,
+            released_at: None,
+            released_tip: None,
+            bundle_bytes: None,
         };
         insert_workspace(&self.db, &workspace).await?;
         match create_worktree(std::path::Path::new(&repo.root_path), &path, &branch, &base).await {
@@ -920,6 +925,114 @@ impl CodeRuntime {
     /// `create_workspace`'s branch-collision check reads archived rows too,
     /// so this route is the sanctioned way to get an archived branch back
     /// into a workspace.
+    /// Release an archived workspace: drop its branch, keep its commits.
+    ///
+    /// The deepest reclaim tier. Archive already removed the checkout, which
+    /// is where the bytes are; what is left is the branch and the objects it
+    /// holds alive. Bundling `base..branch` captures the work this workspace
+    /// did — usually kilobytes against a checkout measured in gigabytes — so
+    /// dropping the ref frees nearly everything and a restore still rebuilds
+    /// exactly. The transcript is not touched at any tier.
+    /// Drop a restored workspace's release bookkeeping and its bundle.
+    ///
+    /// The branch is back in the repository, so the bundle is a second copy of
+    /// commits git already has. Removing it is best-effort: a bundle left
+    /// behind wastes space, while failing the restore over it would strand a
+    /// workspace whose checkout is already on disk.
+    fn clear_release(workspace: &mut CodeWorkspace, data_dir: &std::path::Path) {
+        if workspace.released_at.is_none() && workspace.bundle_bytes.is_none() {
+            return;
+        }
+        let bundle = worktree::bundle_path(data_dir, &workspace.id.0);
+        if let Err(error) = std::fs::remove_file(&bundle) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    workspace = %workspace.id,
+                    "code-mode: could not remove restored bundle {}: {error}",
+                    bundle.display()
+                );
+            }
+        }
+        workspace.released_at = None;
+        workspace.released_tip = None;
+        workspace.bundle_bytes = None;
+    }
+
+    pub(crate) async fn release_workspace(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+        force: bool,
+    ) -> Result<CodeWorkspace, ServerError> {
+        let mut workspace = self.get_workspace(owner, id).await?;
+        if workspace.status == CodeWorkspaceStatus::Released {
+            return Ok(workspace);
+        }
+        if workspace.status != CodeWorkspaceStatus::Archived {
+            return Err(ServerError::conflict_kind(
+                "workspace_not_archived",
+                format!(
+                    "archive the workspace before releasing it; it is {}",
+                    workspace.status.as_str()
+                ),
+            ));
+        }
+        let repo = self.get_repo(owner, workspace.repo_id).await?;
+        let repo_root = std::path::Path::new(&repo.root_path);
+
+        // A branch that archive already lost is nothing to bundle. Record the
+        // release anyway: the tier describes what is on disk, and refusing
+        // here would strand the row in a state no action can leave.
+        if !worktree::branch_exists(repo_root, &workspace.branch_name)
+            .await
+            .map_err(map_worktree)?
+        {
+            workspace.status = CodeWorkspaceStatus::Released;
+            workspace.released_at = Some(Utc::now());
+            save_workspace(&self.db, &workspace).await?;
+            return Ok(workspace);
+        }
+
+        if !force
+            && worktree::release_is_unmerged(repo_root, &workspace.base_ref, &workspace.branch_name)
+                .await
+                .map_err(map_worktree)?
+        {
+            return Err(ServerError::conflict_kind(
+                "branch_unmerged",
+                "this branch has commits the base does not; pass force to bundle and drop it",
+            ));
+        }
+
+        let tip = worktree::branch_tip(repo_root, &workspace.branch_name)
+            .await
+            .map_err(map_worktree)?;
+        let bundle = worktree::bundle_path(&self.data_dir, &workspace.id.0);
+        let bytes = worktree::create_bundle(
+            repo_root,
+            &workspace.base_ref,
+            &workspace.branch_name,
+            &bundle,
+        )
+        .await
+        .map_err(map_worktree)?;
+
+        // Drop the ref only once the bundle is on disk and measured. The
+        // ordering is the whole safety property: a failure above leaves an
+        // archived workspace with its branch, which is exactly where it was.
+        worktree::delete_branch(repo_root, &workspace.branch_name)
+            .await
+            .map_err(map_worktree)?;
+
+        workspace.status = CodeWorkspaceStatus::Released;
+        workspace.released_at = Some(Utc::now());
+        workspace.released_tip = Some(tip);
+        workspace.bundle_bytes = Some(i64::try_from(bytes).unwrap_or(i64::MAX));
+        save_workspace(&self.db, &workspace).await?;
+        super::attention::emit_workspace_digests(&self.db, &self.bus, owner, workspace.id).await;
+        Ok(workspace)
+    }
+
     pub(crate) async fn restore_workspace(
         &self,
         owner: &OwnerId,
@@ -929,7 +1042,8 @@ impl CodeRuntime {
         if workspace.status == CodeWorkspaceStatus::Active {
             return Ok(workspace);
         }
-        if workspace.status != CodeWorkspaceStatus::Archived {
+        let released = workspace.status == CodeWorkspaceStatus::Released;
+        if !released && workspace.status != CodeWorkspaceStatus::Archived {
             return Err(ServerError::conflict_kind(
                 "workspace_not_ready",
                 format!("workspace is {}", workspace.status.as_str()),
@@ -938,6 +1052,19 @@ impl CodeRuntime {
         let repo = self.get_repo(owner, workspace.repo_id).await?;
         Self::refuse_removed_repo(&repo)?;
         let repo_root = std::path::Path::new(&repo.root_path);
+        // A released workspace has no branch: release bundled its commits and
+        // dropped the ref. Put the branch back from the bundle first, and the
+        // rest of restore is the archived path unchanged.
+        if released
+            && !worktree::branch_exists(repo_root, &workspace.branch_name)
+                .await
+                .map_err(map_worktree)?
+        {
+            let bundle = worktree::bundle_path(&self.data_dir, &workspace.id.0);
+            worktree::unbundle_branch(repo_root, &bundle, &workspace.branch_name)
+                .await
+                .map_err(map_worktree)?;
+        }
         if !worktree::branch_exists(repo_root, &workspace.branch_name)
             .await
             .map_err(map_worktree)?
@@ -969,12 +1096,14 @@ impl CodeRuntime {
             Ok(()) => {
                 workspace.status = CodeWorkspaceStatus::Active;
                 workspace.archived_at = None;
+                Self::clear_release(&mut workspace, &self.data_dir);
                 save_workspace(&self.db, &workspace).await?;
                 Ok(workspace)
             }
             Err(err) => {
                 workspace.status = CodeWorkspaceStatus::SetupFailed;
                 workspace.archived_at = None;
+                Self::clear_release(&mut workspace, &self.data_dir);
                 save_workspace(&self.db, &workspace).await?;
                 Err(ServerError::unprocessable_kind(
                     "setup_failed",

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -241,6 +241,14 @@ impl ScopedCode {
         self.runtime.archive_workspace(&self.owner, id, force).await
     }
 
+    pub(crate) async fn release_workspace(
+        &self,
+        id: WorkspaceId,
+        force: bool,
+    ) -> Result<CodeWorkspace, ServerError> {
+        self.runtime.release_workspace(&self.owner, id, force).await
+    }
+
     pub(crate) async fn restore_workspace(
         &self,
         id: WorkspaceId,

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -1595,6 +1595,9 @@ mod tests {
                 pr: None,
                 created_at: Utc::now(),
                 archived_at: None,
+                released_at: None,
+                released_tip: None,
+                bundle_bytes: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -648,6 +648,149 @@ pub(crate) async fn remove_worktree(
     prune_worktrees(repo_root).await
 }
 
+/// Where a released workspace's bundle lives.
+///
+/// Bundles are derived data, not user work: unlike a worktree (decision 53)
+/// they belong in the disposable app-data directory, beside the database that
+/// records them.
+pub(crate) fn bundle_path(data_dir: &Path, workspace: &uuid::Uuid) -> PathBuf {
+    data_dir
+        .join("code")
+        .join("bundles")
+        .join(format!("{workspace}.bundle"))
+}
+
+/// The commit a branch points at.
+pub(crate) async fn branch_tip(repo_root: &Path, branch: &str) -> Result<String, WorktreeError> {
+    let sha = git_stdout(
+        Some(repo_root),
+        &["rev-parse", &format!("refs/heads/{branch}")],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|err| WorktreeError::internal(format!("could not resolve {branch}: {err}")))?;
+    Ok(sha.trim().to_owned())
+}
+
+/// Whether a released branch would strand commits nothing else can reach.
+///
+/// Release drops the branch, so the question archive asks about the checkout
+/// is asked here about the history: are these commits merged into the base, or
+/// would dropping the ref be the only copy going away? The bundle means the
+/// answer is recoverable either way — this is what the confirmation is for,
+/// not a correctness gate.
+pub(crate) async fn release_is_unmerged(
+    repo_root: &Path,
+    base_ref: &str,
+    branch: &str,
+) -> Result<bool, WorktreeError> {
+    let count = git_stdout(
+        Some(repo_root),
+        &[
+            "rev-list",
+            "--count",
+            &format!("{base_ref}..refs/heads/{branch}"),
+        ],
+        GIT_TIMEOUT,
+    )
+    .await
+    .map_err(|err| WorktreeError::internal(format!("git rev-list failed: {err}")))?;
+    Ok(count.trim().parse::<u64>().unwrap_or(1) > 0)
+}
+
+/// Bundle a branch's own commits and return the file's size.
+///
+/// The range is `base..branch`, not the whole history: the base is still in
+/// the repository, so carrying it would multiply the bundle by the size of the
+/// project for nothing. What is left is the work this workspace did, which is
+/// what a restore needs to put the branch back.
+pub(crate) async fn create_bundle(
+    repo_root: &Path,
+    base_ref: &str,
+    branch: &str,
+    out: &Path,
+) -> Result<u64, WorktreeError> {
+    if let Some(parent) = out.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|err| {
+            WorktreeError::internal(format!(
+                "could not create bundle directory {}: {err}",
+                parent.display()
+            ))
+        })?;
+    }
+    // `--` separates the revision range from the ref that names it, so the
+    // bundle carries `refs/heads/<branch>` and a restore can fetch it by name.
+    git(
+        Some(repo_root),
+        &[
+            "bundle",
+            "create",
+            &out.to_string_lossy(),
+            &format!("{base_ref}..refs/heads/{branch}"),
+            &format!("refs/heads/{branch}"),
+        ],
+        GIT_WORKTREE_TIMEOUT,
+    )
+    .await
+    .map_err(|err| WorktreeError::internal(format!("git bundle create failed: {err}")))?;
+    let size = tokio::fs::metadata(out)
+        .await
+        .map_err(|err| {
+            WorktreeError::internal(format!("could not stat bundle {}: {err}", out.display()))
+        })?
+        .len();
+    Ok(size)
+}
+
+/// Restore a branch from its bundle.
+///
+/// Verifies the bundle before fetching: a truncated or corrupt file must fail
+/// here, with the branch still absent, rather than half-populate the object
+/// store and leave a ref pointing at commits whose parents never arrived.
+pub(crate) async fn unbundle_branch(
+    repo_root: &Path,
+    bundle: &Path,
+    branch: &str,
+) -> Result<(), WorktreeError> {
+    if !bundle.exists() {
+        return Err(WorktreeError::user(format!(
+            "bundle {} is missing; this workspace cannot be restored",
+            bundle.display()
+        )));
+    }
+    let path = bundle.to_string_lossy();
+    git(
+        Some(repo_root),
+        &["bundle", "verify", path.as_ref()],
+        GIT_WORKTREE_TIMEOUT,
+    )
+    .await
+    .map_err(|err| WorktreeError::user(format!("bundle {path} is not usable: {err}")))?;
+    git(
+        Some(repo_root),
+        &[
+            "fetch",
+            path.as_ref(),
+            &format!("refs/heads/{branch}:refs/heads/{branch}"),
+        ],
+        GIT_WORKTREE_TIMEOUT,
+    )
+    .await
+    .map_err(|err| WorktreeError::internal(format!("git fetch from bundle failed: {err}")))?;
+    Ok(())
+}
+
+/// Delete a branch, discarding the ref whether or not it merged.
+///
+/// Release has already bundled the commits, so `-D` is the honest flag: `-d`
+/// would refuse exactly the unmerged branches release exists to reclaim.
+pub(crate) async fn delete_branch(repo_root: &Path, branch: &str) -> Result<(), WorktreeError> {
+    git(Some(repo_root), &["branch", "-D", branch], GIT_TIMEOUT)
+        .await
+        .map(|_| ())
+        .map_err(|err| WorktreeError::internal(format!("git branch -D {branch} failed: {err}")))
+}
+
 /// Drop stale worktree registrations from the repo.
 pub(crate) async fn prune_worktrees(repo_root: &Path) -> Result<(), WorktreeError> {
     git(Some(repo_root), &["worktree", "prune"], GIT_TIMEOUT)
@@ -1331,5 +1474,104 @@ mod tests {
             Path::new(r"\\Server\Share\Repo"),
             Path::new(r"\\Server\Other\Repo")
         ));
+    }
+
+    /// The whole premise of the release tier: a bundle of `base..branch`
+    /// carries the work, so dropping the branch is recoverable.
+    #[tokio::test]
+    async fn a_released_branch_round_trips_through_its_bundle() {
+        let (dir, repo) = init_repo();
+        run(&repo, &["git", "checkout", "-b", "tidebreak/work"]);
+        std::fs::write(repo.join("feature.txt"), "work\n").unwrap();
+        run(&repo, &["git", "add", "feature.txt"]);
+        run(&repo, &["git", "commit", "-m", "add the feature"]);
+        let tip = branch_tip(&repo, "tidebreak/work").await.unwrap();
+        run(&repo, &["git", "checkout", "main"]);
+
+        assert!(release_is_unmerged(&repo, "main", "tidebreak/work")
+            .await
+            .unwrap());
+
+        let bundle = dir.path().join("work.bundle");
+        let bytes = create_bundle(&repo, "main", "tidebreak/work", &bundle)
+            .await
+            .unwrap();
+        assert!(bytes > 0);
+
+        delete_branch(&repo, "tidebreak/work").await.unwrap();
+        assert!(!branch_exists(&repo, "tidebreak/work").await.unwrap());
+
+        unbundle_branch(&repo, &bundle, "tidebreak/work")
+            .await
+            .unwrap();
+        assert!(branch_exists(&repo, "tidebreak/work").await.unwrap());
+        // Same commit, not merely a branch of the same name.
+        assert_eq!(branch_tip(&repo, "tidebreak/work").await.unwrap(), tip);
+        run(&repo, &["git", "checkout", "tidebreak/work"]);
+        assert_eq!(
+            std::fs::read_to_string(repo.join("feature.txt")).unwrap(),
+            "work\n"
+        );
+    }
+
+    /// The bundle carries the branch's own commits, not the history behind
+    /// them. This is what makes the tier worth having: the base is still in
+    /// the repository, so shipping it again would scale the bundle with the
+    /// project instead of with the work.
+    #[tokio::test]
+    async fn a_bundle_carries_only_the_branch_commits() {
+        let (dir, repo) = init_repo();
+        // Bulk on the base, which the bundle must not copy.
+        std::fs::write(repo.join("big.bin"), "x".repeat(400_000)).unwrap();
+        run(&repo, &["git", "add", "big.bin"]);
+        run(&repo, &["git", "commit", "-m", "add bulk to the base"]);
+
+        run(&repo, &["git", "checkout", "-b", "tidebreak/small"]);
+        std::fs::write(repo.join("note.txt"), "one line\n").unwrap();
+        run(&repo, &["git", "add", "note.txt"]);
+        run(&repo, &["git", "commit", "-m", "add a note"]);
+        run(&repo, &["git", "checkout", "main"]);
+
+        let bundle = dir.path().join("small.bundle");
+        let bytes = create_bundle(&repo, "main", "tidebreak/small", &bundle)
+            .await
+            .unwrap();
+        assert!(
+            bytes < 100_000,
+            "bundle carried the base: {bytes} bytes for a one-line commit"
+        );
+    }
+
+    /// A merged branch is the case release does not have to warn about.
+    #[tokio::test]
+    async fn a_merged_branch_is_not_reported_unmerged() {
+        let (_dir, repo) = init_repo();
+        run(&repo, &["git", "checkout", "-b", "tidebreak/merged"]);
+        std::fs::write(repo.join("merged.txt"), "done\n").unwrap();
+        run(&repo, &["git", "add", "merged.txt"]);
+        run(&repo, &["git", "commit", "-m", "merged work"]);
+        run(&repo, &["git", "checkout", "main"]);
+        run(
+            &repo,
+            &["git", "merge", "--no-ff", "-m", "merge", "tidebreak/merged"],
+        );
+
+        assert!(!release_is_unmerged(&repo, "main", "tidebreak/merged")
+            .await
+            .unwrap());
+    }
+
+    /// A corrupt bundle must fail before it half-populates the object store.
+    #[tokio::test]
+    async fn a_corrupt_bundle_is_refused_and_leaves_no_branch() {
+        let (dir, repo) = init_repo();
+        let bundle = dir.path().join("broken.bundle");
+        std::fs::write(&bundle, b"not a bundle").unwrap();
+
+        let err = unbundle_branch(&repo, &bundle, "tidebreak/nope")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WorktreeError::User(_)), "{err:?}");
+        assert!(!branch_exists(&repo, "tidebreak/nope").await.unwrap());
     }
 }

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -1508,8 +1508,13 @@ mod tests {
         // Same commit, not merely a branch of the same name.
         assert_eq!(branch_tip(&repo, "tidebreak/work").await.unwrap(), tip);
         run(&repo, &["git", "checkout", "tidebreak/work"]);
+        // Normalize: git checks out with CRLF under Windows' default
+        // `core.autocrlf`, and the round trip is about the content, not the
+        // platform's line endings.
         assert_eq!(
-            std::fs::read_to_string(repo.join("feature.txt")).unwrap(),
+            std::fs::read_to_string(repo.join("feature.txt"))
+                .unwrap()
+                .replace("\r\n", "\n"),
             "work\n"
         );
     }

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 37;
+const DESKTOP_SCHEMA_EPOCH: u32 = 38;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -855,6 +855,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::archive_workspace),
         )
         .route(
+            "/code/workspaces/{id}/release",
+            post(routes::code::release_workspace),
+        )
+        .route(
             "/code/workspaces/{id}/restore",
             post(routes::code::restore_workspace),
         )

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -80,7 +80,7 @@ pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_workspace, get_workspace, get_workspace_blob, get_workspace_diff,
     get_worktree_root, list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace,
-    restore_workspace, search_workspace, set_worktree_root,
+    release_workspace, restore_workspace, search_workspace, set_worktree_root,
 };
 
 // Nothing here reaches `AppState.code` directly. Every handler in this module

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -63,6 +63,18 @@ pub struct CodeWorkspaceSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub archived_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub released_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Commit the released branch pointed at, so a client can name the work
+    /// without the branch existing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub released_tip: Option<String>,
+    /// Stored bundle size, for reporting what a release reclaimed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub bundle_bytes: Option<i64>,
 }
 
 impl From<CodeWorkspace> for CodeWorkspaceSnapshot {
@@ -78,6 +90,9 @@ impl From<CodeWorkspace> for CodeWorkspaceSnapshot {
             pr: workspace.pr,
             created_at: workspace.created_at,
             archived_at: workspace.archived_at,
+            released_at: workspace.released_at,
+            released_tip: workspace.released_tip,
+            bundle_bytes: workspace.bundle_bytes,
         }
     }
 }

--- a/crates/tidebreak-server/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server/src/routes/code/workspaces.rs
@@ -96,6 +96,23 @@ pub async fn archive_workspace(
     Ok(Json(CodeWorkspaceSnapshot::from(archived)))
 }
 
+/// `POST /code/workspaces/{id}/release` — reclaim an archived workspace's branch.
+///
+/// The deepest reclaim tier. The branch's own commits are bundled beside the
+/// database and the ref is dropped, which frees the objects the branch held
+/// alive. `restore_workspace` puts it back from that bundle, so the work stays
+/// rebuildable and the transcript is untouched. 409 kinds:
+/// `workspace_not_archived`, and `branch_unmerged` (the branch has commits the
+/// base does not — pass force).
+pub async fn release_workspace(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+    Json(body): Json<ArchiveWorkspaceBody>,
+) -> Result<Json<CodeWorkspaceSnapshot>, ServerError> {
+    let released = code.release_workspace(id, body.force).await?;
+    Ok(Json(CodeWorkspaceSnapshot::from(released)))
+}
+
 /// `POST /code/workspaces/{id}/restore` — reactivate an archived workspace.
 ///
 /// The worktree comes back at the same path on the kept branch; session rows

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -5827,8 +5827,12 @@ async fn release_frees_the_branch_and_restore_rebuilds_it_from_the_bundle() {
     let restored_body: serde_json::Value = restored.json().await.unwrap();
     assert_eq!(restored_body["status"], "active");
     assert!(restored_body["released_at"].is_null());
+    // Normalize: git checks out with CRLF under Windows' default
+    // `core.autocrlf`.
     assert_eq!(
-        std::fs::read_to_string(path.join("kept.txt")).unwrap(),
+        std::fs::read_to_string(path.join("kept.txt"))
+            .unwrap()
+            .replace("\r\n", "\n"),
         "survives release\n",
         "the released commit did not come back"
     );

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -5690,3 +5690,161 @@ async fn restore_refuses_a_missing_branch_and_an_occupied_path() {
     let missing_body: serde_json::Value = missing.json().await.unwrap();
     assert_eq!(missing_body["kind"], "branch_missing");
 }
+
+/// The reclaim ladder end to end over HTTP: archive frees the checkout,
+/// release frees the branch, restore rebuilds both from the bundle.
+///
+/// The assertion that matters is the last one — the file the workspace's
+/// commit added is back on disk after a round trip through a branch that no
+/// longer existed. Without that, release is deletion with extra steps.
+#[tokio::test]
+async fn release_frees_the_branch_and_restore_rebuilds_it_from_the_bundle() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let created = client
+        .post(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "repo_id": json_id(&repo_body),
+            "title": "released later",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let workspace: serde_json::Value = created.json().await.unwrap();
+    let workspace_id = json_id(&workspace);
+    let branch = workspace["branch_name"].as_str().unwrap().to_owned();
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    let repo_root = std::path::PathBuf::from(&repo);
+
+    // Commit real work, so the bundle has something to carry.
+    std::fs::write(path.join("kept.txt"), "survives release\n").unwrap();
+    for args in [
+        vec!["add", "kept.txt"],
+        vec!["commit", "-m", "work worth keeping"],
+    ] {
+        let ok = std::process::Command::new("git")
+            .args(&args)
+            .current_dir(&path)
+            .status()
+            .unwrap();
+        assert!(ok.success(), "git {args:?} failed");
+    }
+
+    // Release requires an archived workspace.
+    let too_early = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/release"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(too_early.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = too_early.json().await.unwrap();
+    assert_eq!(body["kind"], "workspace_not_archived");
+
+    let archived = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/archive"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), reqwest::StatusCode::OK);
+    assert!(!path.exists(), "archive removes the checkout");
+    assert!(
+        branch_exists_in(&repo_root, &branch),
+        "archive keeps the branch"
+    );
+
+    // Unmerged commits are the case release confirms rather than assumes.
+    let refused = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/release"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "branch_unmerged");
+    assert!(
+        branch_exists_in(&repo_root, &branch),
+        "a refused release must not drop the branch"
+    );
+
+    let released = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/release"
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(released.status(), reqwest::StatusCode::OK);
+    let released_body: serde_json::Value = released.json().await.unwrap();
+    assert_eq!(released_body["status"], "released");
+    assert!(released_body["bundle_bytes"].as_i64().unwrap() > 0);
+    assert!(released_body["released_tip"].as_str().is_some());
+    assert!(
+        !branch_exists_in(&repo_root, &branch),
+        "release drops the branch"
+    );
+
+    let restored = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{workspace_id}/restore"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        restored.status(),
+        reqwest::StatusCode::OK,
+        "restore from bundle failed: {}",
+        restored.text().await.unwrap()
+    );
+    let restored_body: serde_json::Value = restored.json().await.unwrap();
+    assert_eq!(restored_body["status"], "active");
+    assert!(restored_body["released_at"].is_null());
+    assert_eq!(
+        std::fs::read_to_string(path.join("kept.txt")).unwrap(),
+        "survives release\n",
+        "the released commit did not come back"
+    );
+}
+
+/// Whether a branch ref exists in a repository.
+fn branch_exists_in(repo_root: &std::path::Path, branch: &str) -> bool {
+    std::process::Command::new("git")
+        .args([
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ])
+        .current_dir(repo_root)
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -270,6 +270,9 @@ async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, C
         pr: None,
         created_at: chrono::Utc::now(),
         archived_at: None,
+        released_at: None,
+        released_tip: None,
+        bundle_bytes: None,
     };
     db::code::insert_workspace(db, &ws).await.unwrap();
     let s = CodeSession {

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -111,9 +111,17 @@ Baseline schema edit plus a `DESKTOP_SCHEMA_EPOCH` bump, per
   which does. Reclaiming the checkout on disk is a separate, explicit act.
 - **`code_workspace`** — `id`, `repo_id`, `title`, `worktree_path`,
   `branch_name`, `base_ref`, `status`
-  (`Creating | SetupFailed | Active | Archived`), `pr` (JSON digest:
+  (`Creating | SetupFailed | Active | Archived | Released`), `pr` (JSON digest:
   number, url, state, checks summary; nullable), `created_at`,
-  `archived_at`.
+  `archived_at`, `released_at`, `released_tip`, `bundle_bytes`.
+
+  Archived and Released are reclaim tiers. Archive removes the worktree and
+  keeps the branch, so restore is `git worktree add`. Release bundles
+  `base..branch` into `<data_dir>/code/bundles/<id>.bundle` and drops the
+  branch, so restore fetches from the bundle first. A checkout is gigabytes of
+  build output; a branch's own commits are usually kilobytes, which is what
+  makes the deeper tier worth the step. Transcripts are untouched at every
+  tier — the row and its journal outlive the bytes.
 - **`code_session`** — `id`, `workspace_id`, `kind`
   (`Interactive | Watch`, per
   [`0050`](decisions/0050-watch-and-fix-is-a-durable-task.md)), `harness_kind`,
@@ -288,6 +296,7 @@ GET/PUT         /code/worktree-root        {root}    where new worktrees land (a
 POST/GET        /code/workspaces           {repo_id, base_ref?, title?}
 GET/PATCH       /code/workspaces/{id}
 POST            /code/workspaces/{id}/archive        {force?}
+POST            /code/workspaces/{id}/release        {force?}
 POST            /code/workspaces/{id}/sessions       {harness, permission_mode}
 POST            /code/sessions/{id}/turns            {message}  (queued while running —
                                                      the chat product's queue-default rule;

--- a/docs/decisions/0056-workspace-reclaim-tiers.md
+++ b/docs/decisions/0056-workspace-reclaim-tiers.md
@@ -1,0 +1,117 @@
+# 56. Workspace Reclaim Tiers
+
+- Status: Accepted
+- Date: 2026-08-21
+- Owners: Code mode
+- Related: [`0032`](0032-code-workspaces-worktrees-checkpoints.md),
+  [`0002`](0002-pre-v1-schema-and-persisted-format-mutability.md),
+  [`0053`](0053-code-worktrees-live-in-a-user-visible-root.md)
+
+## Context
+
+Archive removed a workspace's worktree and kept its branch, so `restore` was
+`git worktree add` and the transcript was never touched. That freed the
+expensive part — a checkout carrying build output and dependencies — and left
+the branch, its objects, and any clone behind.
+
+For someone running many parallel agents that residue accumulates. The
+machine this record was written on holds around eighty worktrees. Archiving
+aggressively is the answer, but only if archiving is not a decision about
+whether the work is still reachable.
+
+The measurement that shapes the design: on a real branch in this repository,
+`git bundle create main..branch` is 12 KB against a 1.1 GB checkout. The bytes
+are in the checkout, not the commits. So the branch can be dropped and still
+restored, for storage that rounds to nothing.
+
+## Decision
+
+**A workspace has reclaim tiers, and the transcript is outside them.**
+
+| Tier | On disk | Rebuild |
+| --- | --- | --- |
+| Active | worktree | — |
+| Archived | branch only | `git worktree add` |
+| Released | nothing | unbundle, then `git worktree add` |
+
+**Release bundles `base..branch`, not the whole history.** The base is still
+in the repository; carrying it would scale the bundle with the project instead
+of with the work. Bundles live at `<data_dir>/code/bundles/<id>.bundle`.
+Unlike a worktree (record 53) a bundle is derived data, not user work, so it
+belongs in the app-data directory beside the database that records it.
+
+**The bundle is written and measured before the ref is dropped.** A failure
+anywhere earlier leaves an archived workspace with its branch — exactly where
+it was.
+
+**Each tier confirms what it makes unrecoverable, and confirmation is not a
+correctness gate.** Archive already refuses uncommitted or unpushed work
+without `force`. Release refuses a branch holding commits the base does not,
+with `branch_unmerged`. The bundle means the answer is recoverable either
+way; the prompt exists because dropping a ref should be deliberate.
+
+**Restore is one path.** A released workspace fetches its branch back from
+the bundle and then follows the archived path unchanged, including the setup
+script. Restoring clears the release bookkeeping and removes the bundle,
+which is by then a second copy of commits git already has.
+
+**Row and journal outlive the bytes at every tier.** Nothing in a reclaim tier
+deletes a session, turn, or event. This is what makes the tiers safe to use
+rather than a decision to lose work.
+
+Deliberately excluded: reclaiming a clone directory, which recursively deletes
+a directory the user may have registered themselves and needs its own
+confirmation; a size guard on unusually large bundles, which wants a threshold
+real use should set; and searching transcripts across put-away workspaces
+(#2440), which is what makes deep reclaim comfortable rather than possible.
+
+## Alternatives Considered
+
+**Delete the branch with no bundle.** What Orca does on cleanup. Simplest, and
+it reclaims the same bytes — but the work is then gone, so the confirmation
+has to carry weight the user may not be able to judge. The bundle costs
+kilobytes and removes the stake from the decision. Rejected.
+
+**Bundle the full history rather than `base..branch`.** Self-contained, and
+restorable into a repository that no longer has the base. Rejected: it scales
+with the project, which is the cost this tier exists to avoid, and the base
+being present is the premise of the workspace already.
+
+**Store bundles as blobs.** The blob subsystem has leases, reference counting,
+and a retirement queue built for chat attachments. Using it would couple code
+mode to the chat content model ahead of record 48 step 5, for a file whose
+lifetime is exactly one row's. Rejected.
+
+**One tier: make archive drop the branch.** Fewer states. Rejected: archive's
+cheap restore is what makes it a routine action, and folding an irreversible
+step into it would make people hesitate over the one they should reach for
+most.
+
+## Consequences
+
+- Deep reclaim is now a normal action rather than a cleanup project. The tier
+  a workspace sits in describes what is on disk, not how finished the work is.
+- Every surface asking "is this still live?" must ask about both put-away
+  tiers. The UI does this through one `isPutAway` helper rather than comparing
+  to `"archived"`, which is the mistake a new tier invites.
+- Baseline edit plus an epoch bump, per record 2.
+- A released workspace depends on a file outside the database. Losing the data
+  directory loses the bundle, and restore fails with the branch still absent
+  rather than half-populating the object store.
+
+## Validation
+
+The round trip is the claim: a released branch is deleted, restored from its
+bundle, and the file its commit added is back on disk with the same tip. A
+wrong implementation that bundles nothing, or fetches without verifying, fails
+there rather than in review.
+
+A separate test asserts the bundle stays under 100 KB for a one-line commit on
+a base carrying a 400 KB blob. That is the efficiency premise stated as a
+test: if a future change bundles full history, the tier stops being worth its
+step and this fails.
+
+The case a plausible wrong implementation still passes: dropping the branch
+inside the same step that writes the bundle looks correct until the write
+fails. The ordering is asserted by the refused-release test, which checks the
+branch still exists after `branch_unmerged`.


### PR DESCRIPTION
Closes #2441 (first slice).

## Why

Archive frees the checkout — the gigabytes of build output and dependencies — and keeps the branch, so `restore` is `git worktree add`. What it never frees is the branch and the objects it holds alive. Running many parallel agents, that residue accumulates; the machine this was built on holds ~80 worktrees.

The measurement that shapes the design, taken on a real branch in this repo:

```
bundle (base..branch):   12K
worktree on disk:       1.1G
```

The bytes are in the checkout, not the commits. So the branch can be dropped and still restored exactly, for storage that rounds to nothing.

## What

A third reclaim tier:

| Tier | On disk | Rebuild |
| --- | --- | --- |
| Active | worktree | — |
| Archived | branch only | `git worktree add` |
| **Released** | nothing | unbundle, then `git worktree add` |

- `POST /code/workspaces/{id}/release` bundles `base..branch` into `<data_dir>/code/bundles/<id>.bundle` and drops the ref.
- The bundle is written and measured **before** the ref is dropped, so any earlier failure leaves the workspace exactly where it was.
- Release refuses a branch with commits the base lacks (`branch_unmerged`) unless forced. The bundle makes it recoverable either way — the prompt is for deliberateness, not correctness.
- `restore` fetches the branch back from the bundle, then follows the archived path unchanged. It verifies the bundle first, so a corrupt file fails with the branch still absent rather than half-populating the object store.

**No tier deletes a session, turn, or event.** The row and its journal outlive the bytes. That is what makes reclaiming safe to do routinely.

## UI

A new status is exactly the kind of thing surfaces forget. Every "is this still live?" check now goes through one `isPutAway` helper instead of comparing to `"archived"`, so released workspaces do not read as live work on the rail. Added a `Released` story and fixture.

## Deliberately not included

Clone reclaim (recursively deletes a directory the user may own — needs its own confirmation), a large-bundle size guard (wants a threshold real use should set), and transcript search across put-away workspaces (#2440). All tracked on #2441.

## Schema

Baseline edit plus `DESKTOP_SCHEMA_EPOCH` 37 → 38, per decision record 2. Fixture regenerated. `code_workspace` gains `released_at`, `released_tip`, `bundle_bytes`, and the `released` status.

Decision record: `docs/decisions/0056-workspace-reclaim-tiers.md`.

## Tests

- **Round trip** (`release_frees_the_branch_and_restore_rebuilds_it_from_the_bundle`) — end to end over HTTP: commit work, archive, release, confirm the branch is gone, restore, confirm the file is back. This is the claim; a release that bundles nothing fails here.
- **Efficiency** (`a_bundle_carries_only_the_branch_commits`) — asserts the bundle stays under 100 KB for a one-line commit on a base carrying a 400 KB blob. If a future change bundles full history, the tier stops being worth its step and this fails.
- **Ordering** — a refused release leaves the branch in place.
- **Corrupt bundle** — refused, with no branch created.
- Plus merged/unmerged detection and the git-level round trip.

`cargo test -p tidebreak-server --lib code::` passes (211), `tidebreak-core` (717), UI (531). Clippy and rustfmt clean, `tsc --noEmit` clean.