### PR TITLE
feat(diagnostics): add local performance exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7679,6 +7679,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]
@@ -7690,10 +7701,13 @@ dependencies = [
  "matchers",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -8000,6 +8014,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ opening a substantial change. Decisions that future work must preserve live in
 - Read the [troubleshooting guide](https://www.tidebreak.io/docs/troubleshooting/)
   for installation, provider, execution, and local-state problems.
 - [Open a bug report](https://github.com/brightwave-inc/tidebreak/issues/new?template=bug-report.yml)
-  with a reproducible case and diagnostics scrubbed of sensitive data.
+  with a reproducible case and [diagnostics](docs/diagnostics.md) scrubbed of
+  sensitive data.
 - [Request a feature](https://github.com/brightwave-inc/tidebreak/issues/new?template=feature-request.yml)
   by describing the workflow and desired outcome.
 - Follow [`SECURITY.md`](SECURITY.md) to report a vulnerability privately.

--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -599,6 +599,43 @@ impl Client {
         }
     }
 
+    /// Read the server's bounded process and request measurements.
+    pub async fn diagnostics_snapshot(&self) -> Result<serde_json::Value> {
+        self.get_json(format!("{}/diagnostics/snapshot", self.base))
+            .await
+    }
+
+    /// Read the server's OpenMetrics snapshot.
+    pub async fn diagnostics_metrics(&self) -> Result<String> {
+        let response = self
+            .http
+            .get(format!("{}/diagnostics/metrics", self.base))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Self::expect_success(response)
+            .await?
+            .text()
+            .await
+            .map_err(request_error)
+    }
+
+    /// Read a ZIP containing the snapshot, OpenMetrics text, and log tails.
+    pub async fn diagnostics_export(&self) -> Result<Vec<u8>> {
+        let response = self
+            .http
+            .get(format!("{}/diagnostics/export", self.base))
+            .send()
+            .await
+            .map_err(request_error)?;
+        Ok(Self::expect_success(response)
+            .await?
+            .bytes()
+            .await
+            .map_err(request_error)?
+            .to_vec())
+    }
+
     // ------------------------------------------------------------------
     // Conversation outputs. The same routes the desktop reads outputs
     // through; writing the bytes to a path is the caller's job, because only

--- a/crates/tidebreak-cli/src/diagnostics.rs
+++ b/crates/tidebreak-cli/src/diagnostics.rs
@@ -1,0 +1,120 @@
+//! Read and export the diagnostics owned by a running Tidebreak server.
+
+use std::path::{Path, PathBuf};
+use std::{fs::OpenOptions, io::Write as _};
+
+use tidebreak_core::{AgentError, Result};
+
+use crate::api::client::Client;
+use crate::connect::{Server, Session};
+
+pub enum Command {
+    Snapshot,
+    Metrics,
+    Export { destination: PathBuf },
+}
+
+pub async fn run(command: Command, server: Server) -> Result<()> {
+    let session = Session::open(&server).await?;
+    execute(session.client(), command).await
+}
+
+async fn execute(client: &Client, command: Command) -> Result<()> {
+    match command {
+        Command::Snapshot => {
+            let snapshot = client.diagnostics_snapshot().await?;
+            let encoded = serde_json::to_string_pretty(&snapshot).map_err(|error| {
+                AgentError::msg(format!("could not encode the diagnostic snapshot: {error}"))
+            })?;
+            println!("{encoded}");
+            Ok(())
+        }
+        Command::Metrics => {
+            let metrics = client.diagnostics_metrics().await?;
+            print!("{metrics}");
+            Ok(())
+        }
+        Command::Export { destination } => {
+            let bytes = client.diagnostics_export().await?;
+            let written = bytes.len();
+            write_export(&destination, &bytes)?;
+            eprintln!(
+                "tidebreak: wrote {written} bytes to {}",
+                destination.display()
+            );
+            Ok(())
+        }
+    }
+}
+
+fn write_export(destination: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = destination
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    let temporary = match parent {
+        Some(parent) => parent.join(format!(
+            ".tidebreak-diagnostics-{}-{}.tmp",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        )),
+        None => PathBuf::from(format!(
+            ".tidebreak-diagnostics-{}-{}.tmp",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        )),
+    };
+    let mut created = false;
+    let write = (|| -> std::io::Result<()> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary)?;
+        created = true;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temporary, destination)
+    })();
+    if write.is_err() && created {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    write.map_err(|error| {
+        AgentError::msg(format!(
+            "could not write {}: {error}",
+            destination.display()
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_writes_the_complete_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("diagnostics.zip");
+
+        write_export(&path, b"new bundle").unwrap();
+
+        assert_eq!(std::fs::read(path).unwrap(), b"new bundle");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("diagnostics.zip");
+
+        write_export(&path, b"private bundle").unwrap();
+
+        let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}

--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -42,6 +42,11 @@
 //! `/code/*` routes the desktop uses. `--json` (or `--output-format json`)
 //! writes one object, or NDJSON for `code run` and `code watch`. See [`code`].
 //!
+//! `tidebreak diagnostics snapshot|metrics|export` reads bounded process
+//! measurements and local log tails from the same server. The export is a ZIP
+//! for performance investigations; the exporter does not read conversations,
+//! databases, blobs, attachments, or credential stores.
+//!
 //! `tidebreak folder connect|list|disconnect` is the headless equivalent of the
 //! desktop's folder picker: an operator records standing consent for a host
 //! folder, which the broker stamps as operator configuration. It is deliberate
@@ -87,6 +92,7 @@ mod api;
 mod browser;
 mod code;
 mod connect;
+mod diagnostics;
 mod folder;
 mod folder_executor;
 mod outputs;
@@ -149,6 +155,10 @@ usage: tidebreak serve
        tidebreak agent-run show <chat> <run>
        tidebreak agent-run cancel <chat> <run>
 
+       tidebreak diagnostics snapshot
+       tidebreak diagnostics metrics
+       tidebreak diagnostics export <path>
+
        tidebreak browser list --json
        tidebreak browser navigate --browser-id <id> --url <url> --json
        tidebreak browser snapshot --browser-id <id> [--max-nodes <n>] --json
@@ -197,7 +207,7 @@ A key is read from stdin, or from the environment variable named by
 --from-env — never from an argument, which every process on the machine
 can read.
 
--p, output, attach, the setup commands, and the code family also take
+-p, output, attach, diagnostics, the setup commands, and the code family also take
 --server <url> [--server-token-env <var>] or --attach, which talks to a
 server that is already running instead of embedding one. --attach reads
 {TIDEBREAK_DATA_DIR}/listen.json (written by serve and the desktop). With
@@ -380,6 +390,35 @@ async fn run() -> Result<i32> {
                 Ok(command) => folder::run(command).await.map(|()| 0),
                 Err(message) => usage_error(&message),
             }
+        }
+        Some(command) if command == OsStr::new("diagnostics") => {
+            let subcommand = args.next().unwrap_or_default();
+            let command = if subcommand == OsStr::new("snapshot") {
+                if args.next().is_some() {
+                    usage_error("diagnostics snapshot does not accept arguments");
+                }
+                diagnostics::Command::Snapshot
+            } else if subcommand == OsStr::new("metrics") {
+                if args.next().is_some() {
+                    usage_error("diagnostics metrics does not accept arguments");
+                }
+                diagnostics::Command::Metrics
+            } else if subcommand == OsStr::new("export") {
+                let Some(destination) = args.next() else {
+                    usage_error("diagnostics export requires a destination path");
+                };
+                if args.next().is_some() {
+                    usage_error("diagnostics export accepts one destination path");
+                }
+                diagnostics::Command::Export {
+                    destination: destination.into(),
+                }
+            } else {
+                usage_error("diagnostics accepts snapshot, metrics, or export");
+            };
+            diagnostics::run(command, server_flags.resolve()?)
+                .await
+                .map(|()| 0)
         }
         Some(command) if command == OsStr::new("browser") => {
             server_flags.refuse("browser");

--- a/crates/tidebreak-core/src/agent/registry.rs
+++ b/crates/tidebreak-core/src/agent/registry.rs
@@ -2,9 +2,11 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use serde_json::Value;
+use tracing::Instrument as _;
 
 use crate::agent_tools::{
     validate_spawn_sandbox_agent_arguments, validate_wait_for_agents_arguments,
@@ -215,17 +217,76 @@ impl Tool for SchemaValidatedTool {
     }
 
     async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
-        if let Some(mismatch) = self.registered.mismatch(&args) {
-            return Ok(ToolOutput::failed(
-                ToolErrorCategory::InvalidArguments,
-                format!(
-                    "arguments for {} do not satisfy its schema: {mismatch}; re-send the call \
-                     with arguments matching this schema: {}",
-                    self.registered.spec.name, self.registered.spec.input_schema
-                ),
-            ));
+        let tool_name = self.registered.spec.name.clone();
+        let span_name = format!("execute_tool {tool_name}");
+        let span = tracing::info_span!(
+            target: crate::DIAGNOSTICS_TRACING_TARGET,
+            "gen_ai.tool.execute",
+            otel.name = %span_name,
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            gen_ai.operation.name = "execute_tool",
+            gen_ai.tool.name = %tool_name,
+            tidebreak.tool.approval_class = self.inner.approval_class().as_str(),
+            tidebreak.outcome = tracing::field::Empty,
+            tidebreak.duration_ms = tracing::field::Empty,
+            tidebreak.response_bytes = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        );
+        let started = Instant::now();
+        let result = async {
+            if let Some(mismatch) = self.registered.mismatch(&args) {
+                return Ok(ToolOutput::failed(
+                    ToolErrorCategory::InvalidArguments,
+                    format!(
+                        "arguments for {} do not satisfy its schema: {mismatch}; re-send the call \
+                         with arguments matching this schema: {}",
+                        self.registered.spec.name, self.registered.spec.input_schema
+                    ),
+                ));
+            }
+            self.inner.execute(ctx, args).await
         }
-        self.inner.execute(ctx, args).await
+        .instrument(span.clone())
+        .await;
+        let duration_ms = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+        let (outcome, error_type, product_failure, response_bytes) = match &result {
+            Ok(output) if !output.is_error => ("completed", None, false, output.content.len()),
+            Ok(output) => {
+                let category = output
+                    .error_category
+                    .unwrap_or(ToolErrorCategory::ToolFailed);
+                (
+                    category.as_str(),
+                    category.is_product_failure().then_some(category.as_str()),
+                    category.is_product_failure(),
+                    output.content.len(),
+                )
+            }
+            Err(error) => (error.kind(), Some(error.kind()), true, 0),
+        };
+        span.record("tidebreak.outcome", outcome);
+        span.record("tidebreak.duration_ms", duration_ms);
+        span.record("tidebreak.response_bytes", response_bytes);
+        span.record(
+            "otel.status_code",
+            if product_failure { "ERROR" } else { "OK" },
+        );
+        if let Some(error_type) = error_type {
+            span.record("error.type", error_type);
+        }
+        span.in_scope(|| {
+            tracing::info!(
+                target: crate::DIAGNOSTICS_TRACING_TARGET,
+                event_name = "gen_ai.tool.execute.completed",
+                tool_name,
+                outcome,
+                duration_ms,
+                response_bytes,
+                "tool execution completed"
+            );
+        });
+        result
     }
 }
 

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -22,6 +22,10 @@ pub const VERSION: &str = match option_env!("TIDEBREAK_VERSION") {
     None => env!("CARGO_PKG_VERSION"),
 };
 
+/// Tracing target for structured performance events that stay out of the
+/// human log by default.
+pub const DIAGNOSTICS_TRACING_TARGET: &str = "tidebreak_diagnostics";
+
 /// Upper bound on the filename lookup when matching files to existing
 /// outputs. Far above the catalog's own display cap. Shared between the
 /// output scan, the agent's filename resolution for output write-backs, and a

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -81,7 +81,7 @@ tracing = { workspace = true }
 # install via [`logging::init_logging`]. Default features stay off: `ansi` and
 # `tracing-log` would pull crates the lockfile doesn't already resolve, and a
 # plain profile log file wants neither.
-tracing-subscriber = { version = "=0.3.23", default-features = false, features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "=0.3.23", default-features = false, features = ["fmt", "env-filter", "json"] }
 # Bounded unified diffs for the post-turn connected-folder change summary.
 similar = "=3.1.2"
 # Private, automatically removed inputs and outputs for ephemeral document previews.

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -13,14 +13,14 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use chrono::Utc;
 use futures::future::BoxFuture;
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::{mpsc, oneshot, watch, Notify};
-use tracing::warn;
+use tracing::{warn, Instrument as _};
 
 use tidebreak_core::db::code::{
     append_event, bump_spawn_epoch, get_open_turn, get_session, get_session_all_owners,
@@ -690,6 +690,59 @@ async fn drive_turn(
     blobs: Option<&dyn BlobStore>,
     commands: &mut mpsc::Receiver<WorkerCommand>,
     worktree: WorktreeTurn<'_>,
+    follow_up: QueuedFollowUp,
+) -> Result<CodeTurn, WorkerError> {
+    let session_id = session.id;
+    let wait = match worktree.wait {
+        TurnWait::Send => "send",
+        TurnWait::Queued => "queued",
+    };
+    let span = tracing::info_span!(
+        target: crate::diagnostics::EVENT_TARGET,
+        "tidebreak.code_turn",
+        otel.name = "tidebreak.code_turn",
+        otel.kind = "internal",
+        otel.status_code = tracing::field::Empty,
+        tidebreak.code.session_id = %session_id,
+        tidebreak.code.wait = wait,
+        tidebreak.outcome = tracing::field::Empty,
+        tidebreak.duration_ms = tracing::field::Empty,
+    );
+    let started = Instant::now();
+    let result = drive_turn_inner(session, engine, sink, blobs, commands, worktree, follow_up)
+        .instrument(span.clone())
+        .await;
+    let duration_ms = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    let outcome = code_turn_outcome(&result);
+    span.record("tidebreak.outcome", outcome);
+    span.record("tidebreak.duration_ms", duration_ms);
+    span.record(
+        "otel.status_code",
+        if code_turn_is_error(&result) {
+            "ERROR"
+        } else {
+            "OK"
+        },
+    );
+    span.in_scope(|| {
+        tracing::info!(
+            target: crate::diagnostics::EVENT_TARGET,
+            event_name = "tidebreak.code_turn.completed",
+            outcome,
+            duration_ms,
+            "code turn completed"
+        );
+    });
+    result
+}
+
+async fn drive_turn_inner(
+    session: &mut CodeSession,
+    engine: &dyn HarnessSession,
+    sink: &LiveSink,
+    blobs: Option<&dyn BlobStore>,
+    commands: &mut mpsc::Receiver<WorkerCommand>,
+    worktree: WorktreeTurn<'_>,
     QueuedFollowUp {
         message,
         model,
@@ -1028,6 +1081,29 @@ async fn drive_turn(
     session.lifecycle = CodeSessionLifecycle::Idle;
     let _ = super::attention::persist_session(db, bus, session).await;
     Ok(turn)
+}
+
+fn code_turn_outcome(result: &Result<CodeTurn, WorkerError>) -> &'static str {
+    match result {
+        Ok(turn) => turn.status.as_str(),
+        Err(WorkerError::Conflict(_)) => "conflict",
+        Err(WorkerError::NoActiveTurn(_)) => "no_active_turn",
+        Err(WorkerError::StaleTurn(_)) => "stale_turn",
+        Err(WorkerError::SteeringUnavailable(_)) => "steering_unavailable",
+        Err(WorkerError::SteeringRejected(_)) => "steering_rejected",
+        Err(WorkerError::Failed(_)) => "error",
+        Err(WorkerError::WorktreeBusy) => "worktree_busy",
+    }
+}
+
+fn code_turn_is_error(result: &Result<CodeTurn, WorkerError>) -> bool {
+    matches!(
+        result,
+        Ok(CodeTurn {
+            status: CodeTurnStatus::Failed,
+            ..
+        }) | Err(WorkerError::Failed(_))
+    )
 }
 
 async fn hydrate_turn_images(

--- a/crates/tidebreak-server/src/diagnostics.rs
+++ b/crates/tidebreak-server/src/diagnostics.rs
@@ -1,0 +1,1554 @@
+//! Bounded process diagnostics for operators and performance investigations.
+//!
+//! The live surface stays deliberately small: request and named-operation
+//! histograms, process uptime/resource counters, OpenMetrics text, and a ZIP
+//! bundle containing those snapshots plus the profile's allowlisted log files.
+//! It never reads the database, blobs, keychain, or arbitrary profile files.
+//!
+//! The event target is separate from the human log target. The logging module
+//! writes these high-volume timing events only to the structured JSONL file,
+//! where an agent can analyze them without flooding `tidebreak.log`.
+
+use std::collections::BTreeMap;
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::Poll;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::extract::{MatchedPath, State};
+use axum::http::{header, Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
+use chrono::{DateTime, Utc};
+use futures::stream::BoxStream;
+use futures::StreamExt as _;
+use serde::Serialize;
+use tidebreak_core::{
+    ChatRequest, ModelProvider, Profile, ProviderEvent, ProviderId, Result as AgentResult,
+    StopReason,
+};
+use tracing::Instrument as _;
+use zip::write::SimpleFileOptions;
+
+use crate::error::ServerError;
+use crate::resolver::ProviderResolver;
+use crate::state::AppState;
+
+/// Tracing target reserved for machine-oriented timing events.
+pub(crate) const EVENT_TARGET: &str = tidebreak_core::DIAGNOSTICS_TRACING_TARGET;
+
+const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+const BUNDLE_SCHEMA_VERSION: u32 = 1;
+const BUNDLE_LOG_TAIL_BYTES: u64 = 10 * 1024 * 1024;
+const MAX_MODEL_METRIC_SERIES: usize = 128;
+const MAX_METRIC_LABEL_BYTES: usize = 128;
+
+/// Millisecond boundaries shared by the JSON snapshot and OpenMetrics export.
+const DURATION_BUCKETS_MS: [u64; 16] = [
+    1, 2, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000, 60_000, 300_000,
+];
+
+const BUILD_VERSION: &str = match option_env!("TIDEBREAK_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
+/// Per-process measurements. One instance belongs to one assembled server.
+pub(crate) struct Diagnostics {
+    started_at: DateTime<Utc>,
+    started: Instant,
+    in_flight_http: Arc<AtomicU64>,
+    in_flight_model_requests: AtomicU64,
+    state: Mutex<DiagnosticState>,
+}
+
+#[derive(Default)]
+struct DiagnosticState {
+    http: BTreeMap<HttpMetricKey, Histogram>,
+    model_requests: BTreeMap<ModelMetricKey, ModelMeasurements>,
+    operations: BTreeMap<OperationMetricKey, Histogram>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct HttpMetricKey {
+    method: String,
+    route: String,
+    status_class: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OperationMetricKey {
+    operation: String,
+    outcome: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct ModelMetricKey {
+    provider: String,
+    model: String,
+    outcome: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ModelMeasurements {
+    duration: Histogram,
+    time_to_first_event: Histogram,
+    input_tokens: u64,
+    uncached_input_tokens: u64,
+    output_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct Histogram {
+    count: u64,
+    sum_ms: u128,
+    max_ms: u64,
+    buckets: [u64; DURATION_BUCKETS_MS.len()],
+}
+
+impl Histogram {
+    fn observe(&mut self, duration: Duration) {
+        let elapsed_ms = duration_ms(duration);
+        self.count = self.count.saturating_add(1);
+        self.sum_ms = self.sum_ms.saturating_add(u128::from(elapsed_ms));
+        self.max_ms = self.max_ms.max(elapsed_ms);
+        for (index, boundary) in DURATION_BUCKETS_MS.iter().enumerate() {
+            if elapsed_ms <= *boundary {
+                self.buckets[index] = self.buckets[index].saturating_add(1);
+            }
+        }
+    }
+
+    fn snapshot(&self) -> HistogramSnapshot {
+        HistogramSnapshot {
+            count: self.count,
+            sum_ms: self.sum_ms.min(u128::from(u64::MAX)) as u64,
+            max_ms: self.max_ms,
+            buckets: DURATION_BUCKETS_MS
+                .iter()
+                .zip(self.buckets)
+                .map(|(le_ms, count)| HistogramBucketSnapshot {
+                    le_ms: *le_ms,
+                    count,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl Default for Diagnostics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Diagnostics {
+    pub(crate) fn new() -> Self {
+        Self {
+            started_at: Utc::now(),
+            started: Instant::now(),
+            in_flight_http: Arc::new(AtomicU64::new(0)),
+            in_flight_model_requests: AtomicU64::new(0),
+            state: Mutex::new(DiagnosticState::default()),
+        }
+    }
+
+    fn begin_http(&self) -> HttpInFlightGuard {
+        self.in_flight_http.fetch_add(1, Ordering::Relaxed);
+        HttpInFlightGuard {
+            gauge: self.in_flight_http.clone(),
+        }
+    }
+
+    fn observe_http(&self, method: &str, route: &str, status: StatusCode, duration: Duration) {
+        let key = HttpMetricKey {
+            method: method.to_owned(),
+            route: route.to_owned(),
+            status_class: status_class(status).to_owned(),
+        };
+        self.lock_state()
+            .http
+            .entry(key)
+            .or_default()
+            .observe(duration);
+    }
+
+    /// Record one bounded, host-defined operation. Callers must use stable
+    /// names and outcomes rather than ids or provider-authored strings.
+    pub(crate) fn observe_operation(
+        &self,
+        operation: &'static str,
+        outcome: &'static str,
+        duration: Duration,
+    ) {
+        let key = OperationMetricKey {
+            operation: operation.to_owned(),
+            outcome: outcome.to_owned(),
+        };
+        self.lock_state()
+            .operations
+            .entry(key)
+            .or_default()
+            .observe(duration);
+    }
+
+    fn observe_model_request(
+        &self,
+        provider: &str,
+        model: &str,
+        outcome: &str,
+        duration: Duration,
+        first_event_ms: Option<u64>,
+        usage: ModelUsageSnapshot,
+    ) {
+        let mut state = self.lock_state();
+        let mut key = ModelMetricKey {
+            provider: bounded_metric_label(provider),
+            model: bounded_metric_label(model),
+            outcome: bounded_metric_label(outcome),
+        };
+        if !state.model_requests.contains_key(&key)
+            && state.model_requests.len() >= MAX_MODEL_METRIC_SERIES
+        {
+            key.provider = "other".to_owned();
+            key.model = "other".to_owned();
+        }
+        let measurements = state.model_requests.entry(key).or_default();
+        measurements.duration.observe(duration);
+        if let Some(first_event_ms) = first_event_ms {
+            measurements
+                .time_to_first_event
+                .observe(Duration::from_millis(first_event_ms));
+        }
+        measurements.input_tokens = measurements.input_tokens.saturating_add(usage.input_tokens);
+        measurements.uncached_input_tokens = measurements
+            .uncached_input_tokens
+            .saturating_add(usage.uncached_input_tokens);
+        measurements.output_tokens = measurements
+            .output_tokens
+            .saturating_add(usage.output_tokens);
+        measurements.cache_read_input_tokens = measurements
+            .cache_read_input_tokens
+            .saturating_add(usage.cache_read_input_tokens);
+        measurements.cache_creation_input_tokens = measurements
+            .cache_creation_input_tokens
+            .saturating_add(usage.cache_creation_input_tokens);
+    }
+
+    pub(crate) fn snapshot(&self, profile: Profile) -> DiagnosticSnapshot {
+        let state = self.lock_state();
+        DiagnosticSnapshot {
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            generated_at: Utc::now(),
+            build: BuildSnapshot {
+                version: BUILD_VERSION.to_owned(),
+                os: std::env::consts::OS.to_owned(),
+                arch: std::env::consts::ARCH.to_owned(),
+                profile: profile_name(profile).to_owned(),
+            },
+            process: process_snapshot(self.started_at, self.started.elapsed()),
+            runtime: runtime_snapshot(),
+            http: HttpDiagnosticsSnapshot {
+                in_flight: self.in_flight_http.load(Ordering::Relaxed),
+                requests: state
+                    .http
+                    .iter()
+                    .map(|(key, histogram)| HttpRequestSnapshot {
+                        method: key.method.clone(),
+                        route: key.route.clone(),
+                        status_class: key.status_class.clone(),
+                        duration: histogram.snapshot(),
+                    })
+                    .collect(),
+            },
+            model: ModelDiagnosticsSnapshot {
+                in_flight: self.in_flight_model_requests.load(Ordering::Relaxed),
+                requests: state
+                    .model_requests
+                    .iter()
+                    .map(|(key, measurements)| ModelRequestSnapshot {
+                        provider: key.provider.clone(),
+                        model: key.model.clone(),
+                        outcome: key.outcome.clone(),
+                        duration: measurements.duration.snapshot(),
+                        time_to_first_event: measurements.time_to_first_event.snapshot(),
+                        usage: ModelUsageSnapshot {
+                            input_tokens: measurements.input_tokens,
+                            uncached_input_tokens: measurements.uncached_input_tokens,
+                            output_tokens: measurements.output_tokens,
+                            cache_read_input_tokens: measurements.cache_read_input_tokens,
+                            cache_creation_input_tokens: measurements.cache_creation_input_tokens,
+                        },
+                    })
+                    .collect(),
+            },
+            operations: state
+                .operations
+                .iter()
+                .map(|(key, histogram)| OperationSnapshot {
+                    operation: key.operation.clone(),
+                    outcome: key.outcome.clone(),
+                    duration: histogram.snapshot(),
+                })
+                .collect(),
+        }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, DiagnosticState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+/// Add model-request spans and timings without changing provider behavior.
+pub(crate) struct DiagnosticProviderResolver {
+    inner: Arc<dyn ProviderResolver>,
+    diagnostics: Arc<Diagnostics>,
+}
+
+impl DiagnosticProviderResolver {
+    pub(crate) fn new(inner: Arc<dyn ProviderResolver>, diagnostics: Arc<Diagnostics>) -> Self {
+        Self { inner, diagnostics }
+    }
+
+    fn wrap(&self, provider: Arc<dyn ModelProvider>) -> Arc<dyn ModelProvider> {
+        Arc::new(DiagnosticModelProvider {
+            inner: provider,
+            diagnostics: self.diagnostics.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl ProviderResolver for DiagnosticProviderResolver {
+    async fn resolve(&self) -> Arc<dyn ModelProvider> {
+        self.wrap(self.inner.resolve().await)
+    }
+
+    async fn resolve_for(&self, owner: Option<&tidebreak_core::OwnerId>) -> Arc<dyn ModelProvider> {
+        self.wrap(self.inner.resolve_for(owner).await)
+    }
+
+    fn enforces_model_registry(&self) -> bool {
+        self.inner.enforces_model_registry()
+    }
+}
+
+struct DiagnosticModelProvider {
+    inner: Arc<dyn ModelProvider>,
+    diagnostics: Arc<Diagnostics>,
+}
+
+#[async_trait]
+impl ModelProvider for DiagnosticModelProvider {
+    fn id(&self) -> ProviderId {
+        self.inner.id()
+    }
+
+    async fn stream(&self, request: ChatRequest) -> AgentResult<BoxStream<'static, ProviderEvent>> {
+        let provider = request
+            .provider
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| self.inner.id().to_string());
+        let otel_provider = otel_provider_name(&provider);
+        let model = request.model.clone();
+        let conversation = request.conversation.map(|id| id.to_string());
+        let message_count = request.messages.len();
+        let tool_count = request.tools.len();
+        let image_count = request.images.len();
+        let image_bytes = request.images.total_bytes();
+        let max_tokens = request.max_tokens;
+        let span_name = format!("chat {model}");
+        let span = tracing::info_span!(
+            target: EVENT_TARGET,
+            "gen_ai.client.operation",
+            otel.name = %span_name,
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
+            gen_ai.operation.name = "chat",
+            gen_ai.provider.name = %otel_provider,
+            tidebreak.provider.id = %provider,
+            gen_ai.request.model = %model,
+            gen_ai.conversation.id = tracing::field::Empty,
+            gen_ai.usage.input_tokens = tracing::field::Empty,
+            gen_ai.usage.output_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+            gen_ai.request.max_tokens = tracing::field::Empty,
+            tidebreak.request.message_count = message_count,
+            tidebreak.request.tool_count = tool_count,
+            tidebreak.request.image_count = image_count,
+            tidebreak.request.image_bytes = image_bytes,
+            tidebreak.outcome = tracing::field::Empty,
+            tidebreak.finish_reason = tracing::field::Empty,
+            tidebreak.duration_ms = tracing::field::Empty,
+            tidebreak.time_to_first_event_ms = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        );
+        if let Some(conversation) = conversation.as_deref() {
+            span.record("gen_ai.conversation.id", conversation);
+        }
+        if let Some(max_tokens) = max_tokens {
+            span.record("gen_ai.request.max_tokens", max_tokens);
+        }
+        let mut guard =
+            ProviderRequestGuard::new(self.diagnostics.clone(), span.clone(), provider, model);
+        let mut stream = match self.inner.stream(request).instrument(span.clone()).await {
+            Ok(stream) => stream,
+            Err(error) => {
+                guard.finish(ProviderTerminal::error(error.kind()));
+                return Err(error);
+            }
+        };
+        Ok(futures::stream::poll_fn(move |cx| {
+            let poll = span.in_scope(|| stream.as_mut().poll_next(cx));
+            match poll {
+                Poll::Ready(Some(event)) => {
+                    guard.observe(&event);
+                    Poll::Ready(Some(event))
+                }
+                Poll::Ready(None) => {
+                    guard.finish_stream();
+                    Poll::Ready(None)
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        })
+        .boxed())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ProviderTerminal {
+    outcome: &'static str,
+    finish_reason: Option<&'static str>,
+    error_type: Option<&'static str>,
+    is_error: bool,
+}
+
+impl ProviderTerminal {
+    fn stop(reason: StopReason) -> Self {
+        let reason = stop_reason_name(reason);
+        Self {
+            outcome: reason,
+            finish_reason: Some(reason),
+            error_type: None,
+            is_error: false,
+        }
+    }
+
+    fn error(kind: &str) -> Self {
+        let kind = provider_error_kind(kind);
+        Self {
+            outcome: kind,
+            finish_reason: None,
+            error_type: Some(kind),
+            is_error: true,
+        }
+    }
+
+    const fn refusal() -> Self {
+        Self {
+            outcome: "refusal",
+            finish_reason: Some("refusal"),
+            error_type: None,
+            is_error: false,
+        }
+    }
+
+    const fn incomplete() -> Self {
+        Self {
+            outcome: "incomplete_stream",
+            finish_reason: None,
+            error_type: Some("incomplete_stream"),
+            is_error: true,
+        }
+    }
+
+    const fn cancelled() -> Self {
+        Self {
+            outcome: "cancelled",
+            finish_reason: Some("cancelled"),
+            error_type: None,
+            is_error: false,
+        }
+    }
+}
+
+struct ProviderRequestGuard {
+    diagnostics: Arc<Diagnostics>,
+    span: tracing::Span,
+    provider: String,
+    model: String,
+    started: Instant,
+    first_event_ms: Option<u64>,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+    terminal: Option<ProviderTerminal>,
+    finished: bool,
+}
+
+impl ProviderRequestGuard {
+    fn new(
+        diagnostics: Arc<Diagnostics>,
+        span: tracing::Span,
+        provider: String,
+        model: String,
+    ) -> Self {
+        diagnostics
+            .in_flight_model_requests
+            .fetch_add(1, Ordering::Relaxed);
+        Self {
+            diagnostics,
+            span,
+            provider,
+            model,
+            started: Instant::now(),
+            first_event_ms: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            terminal: None,
+            finished: false,
+        }
+    }
+
+    fn observe(&mut self, event: &ProviderEvent) {
+        self.first_event_ms
+            .get_or_insert_with(|| duration_ms(self.started.elapsed()));
+        match event {
+            ProviderEvent::Usage(usage) => {
+                self.input_tokens = self
+                    .input_tokens
+                    .saturating_add(u64::from(usage.input_tokens));
+                self.output_tokens = self
+                    .output_tokens
+                    .saturating_add(u64::from(usage.output_tokens));
+                self.cache_read_input_tokens = self
+                    .cache_read_input_tokens
+                    .saturating_add(u64::from(usage.cache_read_input_tokens));
+                self.cache_creation_input_tokens = self
+                    .cache_creation_input_tokens
+                    .saturating_add(u64::from(usage.cache_creation_input_tokens));
+            }
+            ProviderEvent::Stop { reason } => {
+                self.terminal.get_or_insert(ProviderTerminal::stop(*reason));
+            }
+            ProviderEvent::Refusal { .. } => {
+                self.terminal.get_or_insert(ProviderTerminal::refusal());
+            }
+            ProviderEvent::Failed { error } => {
+                self.terminal
+                    .get_or_insert_with(|| ProviderTerminal::error(&error.kind));
+            }
+            _ => {}
+        }
+    }
+
+    fn finish_stream(&mut self) {
+        self.finish(self.terminal.unwrap_or_else(ProviderTerminal::incomplete));
+    }
+
+    fn finish(&mut self, terminal: ProviderTerminal) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        self.diagnostics
+            .in_flight_model_requests
+            .fetch_sub(1, Ordering::Relaxed);
+        let duration = self.started.elapsed();
+        let duration_ms = duration_ms(duration);
+        let usage = ModelUsageSnapshot {
+            input_tokens: self
+                .input_tokens
+                .saturating_add(self.cache_read_input_tokens)
+                .saturating_add(self.cache_creation_input_tokens),
+            uncached_input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_read_input_tokens: self.cache_read_input_tokens,
+            cache_creation_input_tokens: self.cache_creation_input_tokens,
+        };
+        self.diagnostics.observe_model_request(
+            &self.provider,
+            &self.model,
+            terminal.outcome,
+            duration,
+            self.first_event_ms,
+            usage,
+        );
+        self.diagnostics
+            .observe_operation("model_request", terminal.outcome, duration);
+        self.span.record("tidebreak.outcome", terminal.outcome);
+        self.span.record("tidebreak.duration_ms", duration_ms);
+        self.span
+            .record("gen_ai.usage.input_tokens", usage.input_tokens);
+        self.span
+            .record("gen_ai.usage.output_tokens", self.output_tokens);
+        self.span.record(
+            "gen_ai.usage.cache_read.input_tokens",
+            self.cache_read_input_tokens,
+        );
+        self.span.record(
+            "gen_ai.usage.cache_creation.input_tokens",
+            self.cache_creation_input_tokens,
+        );
+        if let Some(first_event_ms) = self.first_event_ms {
+            self.span
+                .record("tidebreak.time_to_first_event_ms", first_event_ms);
+        }
+        if let Some(finish_reason) = terminal.finish_reason {
+            self.span.record("tidebreak.finish_reason", finish_reason);
+        }
+        if let Some(error_type) = terminal.error_type {
+            self.span.record("error.type", error_type);
+        }
+        self.span.record(
+            "otel.status_code",
+            if terminal.is_error { "ERROR" } else { "OK" },
+        );
+        self.span.in_scope(|| {
+            tracing::info!(
+                target: EVENT_TARGET,
+                event_name = "gen_ai.client.operation.completed",
+                provider = %self.provider,
+                model = %self.model,
+                outcome = terminal.outcome,
+                duration_ms,
+                time_to_first_event_ms = self.first_event_ms.unwrap_or_default(),
+                first_event_observed = self.first_event_ms.is_some(),
+                input_tokens = usage.input_tokens,
+                uncached_input_tokens = usage.uncached_input_tokens,
+                output_tokens = self.output_tokens,
+                cache_read_input_tokens = self.cache_read_input_tokens,
+                cache_creation_input_tokens = self.cache_creation_input_tokens,
+                "model request completed"
+            );
+        });
+    }
+}
+
+impl Drop for ProviderRequestGuard {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        self.finish(self.terminal.unwrap_or_else(ProviderTerminal::cancelled));
+    }
+}
+
+fn stop_reason_name(reason: StopReason) -> &'static str {
+    match reason {
+        StopReason::EndTurn => "end_turn",
+        StopReason::MaxTokens => "max_tokens",
+        StopReason::ToolUse => "tool_use",
+        StopReason::StopSequence => "stop_sequence",
+        StopReason::Refusal => "refusal",
+        StopReason::Cancelled => "cancelled",
+        _ => "other",
+    }
+}
+
+fn provider_error_kind(kind: &str) -> &'static str {
+    match kind {
+        "authentication" => "authentication",
+        "access_denied" => "access_denied",
+        "rate_limited" => "rate_limited",
+        "overloaded" => "overloaded",
+        "invalid_request" => "invalid_request",
+        "refusal" => "refusal",
+        "prompt_too_long" => "prompt_too_long",
+        "missing_credential" => "missing_credential",
+        "invalid_target" => "invalid_target",
+        _ => "provider",
+    }
+}
+
+fn otel_provider_name(provider: &str) -> &str {
+    match provider {
+        "gemini" => "gcp.gemini",
+        "xai" => "x_ai",
+        _ => provider,
+    }
+}
+
+struct HttpInFlightGuard {
+    gauge: Arc<AtomicU64>,
+}
+
+impl Drop for HttpInFlightGuard {
+    fn drop(&mut self) {
+        self.gauge.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct DiagnosticSnapshot {
+    schema_version: u32,
+    generated_at: DateTime<Utc>,
+    build: BuildSnapshot,
+    process: ProcessSnapshot,
+    runtime: Option<RuntimeSnapshot>,
+    http: HttpDiagnosticsSnapshot,
+    model: ModelDiagnosticsSnapshot,
+    operations: Vec<OperationSnapshot>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct BuildSnapshot {
+    version: String,
+    os: String,
+    arch: String,
+    profile: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ProcessSnapshot {
+    pid: u32,
+    started_at: DateTime<Utc>,
+    uptime_ms: u64,
+    cpu_user_ms: Option<u64>,
+    cpu_system_ms: Option<u64>,
+    max_resident_memory_bytes: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct RuntimeSnapshot {
+    worker_threads: u64,
+    alive_tasks: u64,
+    global_queue_depth: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct HttpDiagnosticsSnapshot {
+    in_flight: u64,
+    requests: Vec<HttpRequestSnapshot>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ModelDiagnosticsSnapshot {
+    in_flight: u64,
+    requests: Vec<ModelRequestSnapshot>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ModelRequestSnapshot {
+    provider: String,
+    model: String,
+    outcome: String,
+    duration: HistogramSnapshot,
+    time_to_first_event: HistogramSnapshot,
+    usage: ModelUsageSnapshot,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+struct ModelUsageSnapshot {
+    input_tokens: u64,
+    uncached_input_tokens: u64,
+    output_tokens: u64,
+    cache_read_input_tokens: u64,
+    cache_creation_input_tokens: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct HttpRequestSnapshot {
+    method: String,
+    route: String,
+    status_class: String,
+    duration: HistogramSnapshot,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct OperationSnapshot {
+    operation: String,
+    outcome: String,
+    duration: HistogramSnapshot,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct HistogramSnapshot {
+    count: u64,
+    sum_ms: u64,
+    max_ms: u64,
+    buckets: Vec<HistogramBucketSnapshot>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct HistogramBucketSnapshot {
+    le_ms: u64,
+    count: u64,
+}
+
+/// Measure one matched request without recording its raw URI or query string.
+pub(crate) async fn observe_http_request(
+    State(state): State<AppState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let method = request.method().as_str().to_owned();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(MatchedPath::as_str)
+        .unwrap_or("<unmatched>")
+        .to_owned();
+    let operation_name = format!("{method} {route}");
+    let span = tracing::info_span!(
+        target: EVENT_TARGET,
+        "http.server.request",
+        otel.name = %operation_name,
+        otel.kind = "server",
+        otel.status_code = tracing::field::Empty,
+        http.request.method = %method,
+        http.route = %route,
+        http.response.status_code = tracing::field::Empty,
+        tidebreak.duration_ms = tracing::field::Empty,
+        error.type = tracing::field::Empty,
+    );
+    let started = Instant::now();
+    let _in_flight = state.diagnostics.begin_http();
+    let response = next.run(request).instrument(span.clone()).await;
+    let duration = started.elapsed();
+    let status = response.status();
+    state
+        .diagnostics
+        .observe_http(&method, &route, status, duration);
+    span.record("http.response.status_code", status.as_u16());
+    span.record("tidebreak.duration_ms", duration_ms(duration));
+    if status.is_server_error() {
+        span.record("error.type", status.as_str());
+        span.record("otel.status_code", "ERROR");
+    }
+    span.in_scope(|| {
+        tracing::info!(
+            target: EVENT_TARGET,
+            event_name = "http.server.request.completed",
+            http_status_code = status.as_u16(),
+            duration_ms = duration_ms(duration),
+            "request completed"
+        );
+    });
+    response
+}
+
+/// `GET /diagnostics/snapshot` — one stable JSON view of live measurements.
+pub(crate) async fn get_snapshot(State(state): State<AppState>) -> Response {
+    (
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+        ],
+        Json(state.diagnostics.snapshot(state.config.profile)),
+    )
+        .into_response()
+}
+
+/// `GET /diagnostics/metrics` — OpenMetrics text for local scraping or export.
+pub(crate) async fn get_metrics(State(state): State<AppState>) -> Response {
+    let snapshot = state.diagnostics.snapshot(state.config.profile);
+    let body = render_openmetrics(&snapshot);
+    (
+        [
+            (
+                header::CONTENT_TYPE,
+                "application/openmetrics-text; version=1.0.0; charset=utf-8",
+            ),
+            (header::CACHE_CONTROL, "no-store"),
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+        ],
+        body,
+    )
+        .into_response()
+}
+
+/// `GET /diagnostics/export` — the snapshot, OpenMetrics, and allowlisted logs.
+pub(crate) async fn get_export(State(state): State<AppState>) -> Result<Response, ServerError> {
+    let snapshot = state.diagnostics.snapshot(state.config.profile);
+    let metrics = render_openmetrics(&snapshot);
+    let data_dir = state.config.data_dir.clone();
+    let bytes = tokio::task::spawn_blocking(move || build_bundle(&data_dir, &snapshot, &metrics))
+        .await
+        .map_err(|_| ServerError::internal("diagnostic export worker stopped"))?
+        .map_err(|error| {
+            tracing::warn!(%error, "could not build diagnostic export");
+            ServerError::internal("could not build diagnostic export")
+        })?;
+    let byte_len = bytes.len();
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/zip")
+        .header(
+            header::CONTENT_DISPOSITION,
+            "attachment; filename=\"tidebreak-diagnostics.zip\"",
+        )
+        .header(header::CONTENT_LENGTH, byte_len.to_string())
+        .header(header::CACHE_CONTROL, "no-store")
+        .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
+        .body(Body::from(bytes))
+        .map_err(|_| ServerError::internal("could not build diagnostic export response"))
+}
+
+fn render_openmetrics(snapshot: &DiagnosticSnapshot) -> String {
+    let mut out = String::new();
+    use std::fmt::Write as _;
+
+    out.push_str(
+        "# HELP tidebreak_process_uptime_seconds Time since this Tidebreak process started.\n",
+    );
+    out.push_str("# TYPE tidebreak_process_uptime_seconds gauge\n");
+    let _ = writeln!(
+        out,
+        "tidebreak_process_uptime_seconds {}",
+        seconds(snapshot.process.uptime_ms)
+    );
+    out.push_str("# HELP tidebreak_http_server_requests_in_flight Requests that have entered Tidebreak and not returned.\n");
+    out.push_str("# TYPE tidebreak_http_server_requests_in_flight gauge\n");
+    let _ = writeln!(
+        out,
+        "tidebreak_http_server_requests_in_flight {}",
+        snapshot.http.in_flight
+    );
+    out.push_str("# HELP tidebreak_gen_ai_client_requests_in_flight Model requests that have started and not reached a terminal stream outcome.\n");
+    out.push_str("# TYPE tidebreak_gen_ai_client_requests_in_flight gauge\n");
+    let _ = writeln!(
+        out,
+        "tidebreak_gen_ai_client_requests_in_flight {}",
+        snapshot.model.in_flight
+    );
+    if let Some(runtime) = &snapshot.runtime {
+        out.push_str("# HELP tidebreak_runtime_worker_threads Tokio runtime worker threads.\n");
+        out.push_str("# TYPE tidebreak_runtime_worker_threads gauge\n");
+        let _ = writeln!(
+            out,
+            "tidebreak_runtime_worker_threads {}",
+            runtime.worker_threads
+        );
+        out.push_str("# HELP tidebreak_runtime_tasks_alive Tasks that have started and not completed on this Tokio runtime.\n");
+        out.push_str("# TYPE tidebreak_runtime_tasks_alive gauge\n");
+        let _ = writeln!(out, "tidebreak_runtime_tasks_alive {}", runtime.alive_tasks);
+        out.push_str("# HELP tidebreak_runtime_global_queue_depth Tasks pending in the Tokio runtime global queue.\n");
+        out.push_str("# TYPE tidebreak_runtime_global_queue_depth gauge\n");
+        let _ = writeln!(
+            out,
+            "tidebreak_runtime_global_queue_depth {}",
+            runtime.global_queue_depth
+        );
+    }
+    out.push_str("# HELP tidebreak_http_server_request_duration_seconds End-to-end HTTP request duration by matched route.\n");
+    out.push_str("# TYPE tidebreak_http_server_request_duration_seconds histogram\n");
+    for request in &snapshot.http.requests {
+        let labels = format!(
+            "method=\"{}\",route=\"{}\",status_class=\"{}\"",
+            metric_label(&request.method),
+            metric_label(&request.route),
+            metric_label(&request.status_class),
+        );
+        render_histogram(
+            &mut out,
+            "tidebreak_http_server_request_duration_seconds",
+            &labels,
+            &request.duration,
+        );
+    }
+    out.push_str("# HELP tidebreak_gen_ai_client_operation_duration_seconds End-to-end model request duration.\n");
+    out.push_str("# TYPE tidebreak_gen_ai_client_operation_duration_seconds histogram\n");
+    for request in &snapshot.model.requests {
+        let labels = format!(
+            "operation=\"chat\",provider=\"{}\",model=\"{}\",outcome=\"{}\"",
+            metric_label(&request.provider),
+            metric_label(&request.model),
+            metric_label(&request.outcome),
+        );
+        render_histogram(
+            &mut out,
+            "tidebreak_gen_ai_client_operation_duration_seconds",
+            &labels,
+            &request.duration,
+        );
+    }
+    out.push_str("# HELP tidebreak_gen_ai_client_time_to_first_event_seconds Time from model request start to the first provider stream event.\n");
+    out.push_str("# TYPE tidebreak_gen_ai_client_time_to_first_event_seconds histogram\n");
+    for request in &snapshot.model.requests {
+        if request.time_to_first_event.count == 0 {
+            continue;
+        }
+        let labels = format!(
+            "operation=\"chat\",provider=\"{}\",model=\"{}\",outcome=\"{}\"",
+            metric_label(&request.provider),
+            metric_label(&request.model),
+            metric_label(&request.outcome),
+        );
+        render_histogram(
+            &mut out,
+            "tidebreak_gen_ai_client_time_to_first_event_seconds",
+            &labels,
+            &request.time_to_first_event,
+        );
+    }
+    out.push_str(
+        "# HELP tidebreak_gen_ai_client_tokens_total Model tokens reported by providers.\n",
+    );
+    out.push_str("# TYPE tidebreak_gen_ai_client_tokens_total counter\n");
+    for request in &snapshot.model.requests {
+        let labels = format!(
+            "operation=\"chat\",provider=\"{}\",model=\"{}\",outcome=\"{}\"",
+            metric_label(&request.provider),
+            metric_label(&request.model),
+            metric_label(&request.outcome),
+        );
+        for (token_type, count) in [
+            ("input", request.usage.input_tokens),
+            ("uncached_input", request.usage.uncached_input_tokens),
+            ("output", request.usage.output_tokens),
+            ("cache_read_input", request.usage.cache_read_input_tokens),
+            (
+                "cache_creation_input",
+                request.usage.cache_creation_input_tokens,
+            ),
+        ] {
+            let _ = writeln!(
+                out,
+                "tidebreak_gen_ai_client_tokens_total{{{labels},type=\"{token_type}\"}} {count}"
+            );
+        }
+    }
+    out.push_str(
+        "# HELP tidebreak_operation_duration_seconds Duration of host-defined operations.\n",
+    );
+    out.push_str("# TYPE tidebreak_operation_duration_seconds histogram\n");
+    for operation in &snapshot.operations {
+        let labels = format!(
+            "operation=\"{}\",outcome=\"{}\"",
+            metric_label(&operation.operation),
+            metric_label(&operation.outcome),
+        );
+        render_histogram(
+            &mut out,
+            "tidebreak_operation_duration_seconds",
+            &labels,
+            &operation.duration,
+        );
+    }
+    if let Some(bytes) = snapshot.process.max_resident_memory_bytes {
+        out.push_str("# HELP tidebreak_process_max_resident_memory_bytes Highest resident memory observed by the operating system.\n");
+        out.push_str("# TYPE tidebreak_process_max_resident_memory_bytes gauge\n");
+        let _ = writeln!(out, "tidebreak_process_max_resident_memory_bytes {bytes}");
+    }
+    for (mode, value) in [
+        ("user", snapshot.process.cpu_user_ms),
+        ("system", snapshot.process.cpu_system_ms),
+    ] {
+        if let Some(value) = value {
+            let _ = writeln!(
+                out,
+                "tidebreak_process_cpu_seconds_total{{mode=\"{mode}\"}} {}",
+                seconds(value)
+            );
+        }
+    }
+    if snapshot.process.cpu_user_ms.is_some() || snapshot.process.cpu_system_ms.is_some() {
+        out.insert_str(
+            out.find("tidebreak_process_cpu_seconds_total")
+                .unwrap_or(out.len()),
+            "# HELP tidebreak_process_cpu_seconds_total CPU time consumed by this process.\n# TYPE tidebreak_process_cpu_seconds_total counter\n",
+        );
+    }
+    out.push_str("# EOF\n");
+    out
+}
+
+fn render_histogram(out: &mut String, name: &str, labels: &str, histogram: &HistogramSnapshot) {
+    use std::fmt::Write as _;
+
+    for bucket in &histogram.buckets {
+        let _ = writeln!(
+            out,
+            "{name}_bucket{{{labels},le=\"{}\"}} {}",
+            seconds(bucket.le_ms),
+            bucket.count
+        );
+    }
+    let _ = writeln!(
+        out,
+        "{name}_bucket{{{labels},le=\"+Inf\"}} {}",
+        histogram.count
+    );
+    let _ = writeln!(out, "{name}_sum{{{labels}}} {}", seconds(histogram.sum_ms));
+    let _ = writeln!(out, "{name}_count{{{labels}}} {}", histogram.count);
+}
+
+fn seconds(milliseconds: u64) -> String {
+    format!("{}.{:03}", milliseconds / 1_000, milliseconds % 1_000)
+}
+
+fn metric_label(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('"', "\\\"")
+}
+
+fn bounded_metric_label(value: &str) -> String {
+    let mut bounded = String::new();
+    for character in value.chars() {
+        let character = if character.is_control() {
+            '\u{fffd}'
+        } else {
+            character
+        };
+        if bounded.len().saturating_add(character.len_utf8()) > MAX_METRIC_LABEL_BYTES {
+            break;
+        }
+        bounded.push(character);
+    }
+    if bounded.is_empty() {
+        "unknown".to_owned()
+    } else {
+        bounded
+    }
+}
+
+fn status_class(status: StatusCode) -> &'static str {
+    match status.as_u16() / 100 {
+        1 => "1xx",
+        2 => "2xx",
+        3 => "3xx",
+        4 => "4xx",
+        5 => "5xx",
+        _ => "other",
+    }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+fn profile_name(profile: Profile) -> &'static str {
+    match profile {
+        Profile::Desktop => "desktop",
+        Profile::SelfHost => "self_host",
+        _ => "unknown",
+    }
+}
+
+fn process_snapshot(started_at: DateTime<Utc>, uptime: Duration) -> ProcessSnapshot {
+    let (cpu_user_ms, cpu_system_ms, max_resident_memory_bytes) = process_usage();
+    ProcessSnapshot {
+        pid: std::process::id(),
+        started_at,
+        uptime_ms: duration_ms(uptime),
+        cpu_user_ms,
+        cpu_system_ms,
+        max_resident_memory_bytes,
+    }
+}
+
+fn runtime_snapshot() -> Option<RuntimeSnapshot> {
+    let metrics = tokio::runtime::Handle::try_current().ok()?.metrics();
+    Some(RuntimeSnapshot {
+        worker_threads: usize_u64(metrics.num_workers()),
+        alive_tasks: usize_u64(metrics.num_alive_tasks()),
+        global_queue_depth: usize_u64(metrics.global_queue_depth()),
+    })
+}
+
+fn usize_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+#[cfg(unix)]
+fn process_usage() -> (Option<u64>, Option<u64>, Option<u64>) {
+    // SAFETY: `getrusage` initializes the provided `rusage` value for the
+    // current process, and the pointer stays valid for the duration of the call.
+    let usage = unsafe {
+        let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+        if libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) != 0 {
+            return (None, None, None);
+        }
+        usage.assume_init()
+    };
+    let user = timeval_ms(usage.ru_utime.tv_sec, usage.ru_utime.tv_usec);
+    let system = timeval_ms(usage.ru_stime.tv_sec, usage.ru_stime.tv_usec);
+    #[cfg(target_os = "macos")]
+    let max_rss = u64::try_from(usage.ru_maxrss).ok();
+    #[cfg(not(target_os = "macos"))]
+    let max_rss = u64::try_from(usage.ru_maxrss)
+        .ok()
+        .map(|value| value.saturating_mul(1_024));
+    (user, system, max_rss)
+}
+
+#[cfg(unix)]
+fn timeval_ms(seconds: libc::time_t, micros: libc::suseconds_t) -> Option<u64> {
+    let seconds = u64::try_from(seconds).ok()?;
+    let micros = u64::try_from(micros).ok()?;
+    seconds.checked_mul(1_000)?.checked_add(micros / 1_000)
+}
+
+#[cfg(not(unix))]
+fn process_usage() -> (Option<u64>, Option<u64>, Option<u64>) {
+    (None, None, None)
+}
+
+#[derive(Serialize)]
+struct BundleManifest {
+    schema_version: u32,
+    generated_at: DateTime<Utc>,
+    build_version: String,
+    profile: String,
+    files: Vec<BundleFileManifest>,
+    excludes: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct BundleFileManifest {
+    path: String,
+    source_bytes: u64,
+    included_bytes: usize,
+    tail_truncated: bool,
+}
+
+struct BundleEntry {
+    path: &'static str,
+    bytes: Vec<u8>,
+    source_bytes: u64,
+    tail_truncated: bool,
+}
+
+fn build_bundle(
+    data_dir: &Path,
+    snapshot: &DiagnosticSnapshot,
+    metrics: &str,
+) -> Result<Vec<u8>, String> {
+    let mut entries = Vec::new();
+    let directory = Dir::open_ambient_dir(data_dir, ambient_authority()).ok();
+    if let Some(directory) = directory.as_ref() {
+        for (source, destination) in [
+            ("logs/tidebreak.log", "logs/tidebreak.log"),
+            ("logs/tidebreak.log.1", "logs/tidebreak.log.1"),
+            ("logs/tidebreak.events.jsonl", "logs/tidebreak.events.jsonl"),
+            (
+                "logs/tidebreak.events.jsonl.1",
+                "logs/tidebreak.events.jsonl.1",
+            ),
+            ("boot-failures.log", "logs/boot-failures.log"),
+        ] {
+            if let Some((bytes, source_bytes, tail_truncated)) =
+                read_regular_tail(directory, source, BUNDLE_LOG_TAIL_BYTES)?
+            {
+                entries.push(BundleEntry {
+                    path: destination,
+                    bytes,
+                    source_bytes,
+                    tail_truncated,
+                });
+            }
+        }
+    }
+
+    let file_manifest = entries
+        .iter()
+        .map(|entry| BundleFileManifest {
+            path: entry.path.to_owned(),
+            source_bytes: entry.source_bytes,
+            included_bytes: entry.bytes.len(),
+            tail_truncated: entry.tail_truncated,
+        })
+        .collect();
+    let manifest = BundleManifest {
+        schema_version: BUNDLE_SCHEMA_VERSION,
+        generated_at: snapshot.generated_at,
+        build_version: snapshot.build.version.clone(),
+        profile: snapshot.build.profile.clone(),
+        files: file_manifest,
+        excludes: vec![
+            "database contents",
+            "conversation transcripts",
+            "blobs and attachments",
+            "credentials and keychain values",
+            "arbitrary profile files",
+        ],
+    };
+    let manifest = serde_json::to_vec_pretty(&manifest)
+        .map_err(|error| format!("could not encode diagnostic manifest: {error}"))?;
+    let snapshot = serde_json::to_vec_pretty(snapshot)
+        .map_err(|error| format!("could not encode diagnostic snapshot: {error}"))?;
+
+    let cursor = Cursor::new(Vec::new());
+    let mut archive = zip::ZipWriter::new(cursor);
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .unix_permissions(0o600);
+    write_zip_file(
+        &mut archive,
+        "README.txt",
+        BUNDLE_README.as_bytes(),
+        options,
+    )?;
+    write_zip_file(&mut archive, "manifest.json", &manifest, options)?;
+    write_zip_file(&mut archive, "snapshot.json", &snapshot, options)?;
+    write_zip_file(&mut archive, "metrics.prom", metrics.as_bytes(), options)?;
+    for entry in entries {
+        write_zip_file(&mut archive, entry.path, &entry.bytes, options)?;
+    }
+    archive
+        .finish()
+        .map(Cursor::into_inner)
+        .map_err(|error| format!("could not finish diagnostic archive: {error}"))
+}
+
+fn write_zip_file(
+    archive: &mut zip::ZipWriter<Cursor<Vec<u8>>>,
+    path: &str,
+    bytes: &[u8],
+    options: SimpleFileOptions,
+) -> Result<(), String> {
+    archive
+        .start_file(path, options)
+        .map_err(|error| format!("could not add {path} to diagnostic archive: {error}"))?;
+    archive
+        .write_all(bytes)
+        .map_err(|error| format!("could not write {path} to diagnostic archive: {error}"))
+}
+
+fn read_regular_tail(
+    directory: &Dir,
+    relative_path: &str,
+    limit: u64,
+) -> Result<Option<(Vec<u8>, u64, bool)>, String> {
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let mut file = match directory.open_with(relative_path, &options) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "could not open diagnostic log {relative_path}: {error}"
+            ));
+        }
+    };
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("could not inspect diagnostic log {relative_path}: {error}"))?;
+    if !metadata.is_file() {
+        return Ok(None);
+    }
+    let source_bytes = metadata.len();
+    let start = source_bytes.saturating_sub(limit);
+    if start > 0 {
+        file.seek(SeekFrom::Start(start))
+            .map_err(|error| format!("could not seek diagnostic log {relative_path}: {error}"))?;
+    }
+    let read_len = source_bytes.saturating_sub(start).min(limit);
+    let mut bytes = Vec::with_capacity(usize::try_from(read_len).unwrap_or(usize::MAX));
+    file.take(read_len)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("could not read diagnostic log {relative_path}: {error}"))?;
+    Ok(Some((bytes, source_bytes, start > 0)))
+}
+
+const BUNDLE_README: &str = "Tidebreak diagnostic bundle\n\
+\n\
+This archive contains a process snapshot, OpenMetrics text, and bounded local log tails.\n\
+The exporter does not read the Tidebreak database, conversations, blobs, attachments, or credential stores.\n\
+Logs can contain local file paths, opaque record IDs, and provider diagnostics. Review them before sharing the archive.\n\
+\n\
+snapshot.json is the stable machine-readable snapshot.\n\
+metrics.prom uses OpenMetrics text.\n\
+logs/tidebreak.events.jsonl contains structured tracing events and span-close records.\n";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshots_and_openmetrics_keep_bounded_route_labels() {
+        let diagnostics = Diagnostics::new();
+        diagnostics.observe_http(
+            "GET",
+            "/chats/{id}",
+            StatusCode::OK,
+            Duration::from_millis(37),
+        );
+        diagnostics.observe_operation(
+            "foreground_turn_segment",
+            "completed",
+            Duration::from_millis(1_250),
+        );
+        diagnostics.observe_model_request(
+            "anthropic",
+            "claude-sonnet",
+            "end_turn",
+            Duration::from_millis(800),
+            Some(75),
+            ModelUsageSnapshot {
+                input_tokens: 120,
+                uncached_input_tokens: 40,
+                output_tokens: 45,
+                cache_read_input_tokens: 80,
+                cache_creation_input_tokens: 0,
+            },
+        );
+        let snapshot = diagnostics.snapshot(Profile::Desktop);
+        assert_eq!(snapshot.http.requests.len(), 1);
+        assert_eq!(snapshot.http.requests[0].route, "/chats/{id}");
+        assert_eq!(snapshot.http.requests[0].duration.count, 1);
+        assert_eq!(snapshot.operations[0].duration.max_ms, 1_250);
+        assert_eq!(snapshot.model.requests[0].provider, "anthropic");
+        assert_eq!(snapshot.model.requests[0].usage.input_tokens, 120);
+        assert_eq!(snapshot.model.requests[0].usage.uncached_input_tokens, 40);
+        assert_eq!(snapshot.model.requests[0].usage.output_tokens, 45);
+
+        let metrics = render_openmetrics(&snapshot);
+        assert!(metrics.contains("route=\"/chats/{id}\""));
+        assert!(metrics.contains("operation=\"foreground_turn_segment\""));
+        assert!(metrics.contains("provider=\"anthropic\",model=\"claude-sonnet\""));
+        assert!(metrics.contains("type=\"uncached_input\"} 40"));
+        assert!(metrics.contains("type=\"cache_read_input\"} 80"));
+        assert!(metrics.ends_with("# EOF\n"));
+    }
+
+    #[test]
+    fn otel_provider_names_use_semantic_convention_values() {
+        assert_eq!(otel_provider_name("anthropic"), "anthropic");
+        assert_eq!(otel_provider_name("gemini"), "gcp.gemini");
+        assert_eq!(otel_provider_name("xai"), "x_ai");
+        assert_eq!(otel_provider_name("model_gateway"), "model_gateway");
+    }
+
+    struct CompletedProvider;
+
+    #[async_trait]
+    impl ModelProvider for CompletedProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("anthropic")
+        }
+
+        async fn stream(
+            &self,
+            _request: ChatRequest,
+        ) -> AgentResult<BoxStream<'static, ProviderEvent>> {
+            Ok(futures::stream::iter([
+                ProviderEvent::Usage(tidebreak_core::Usage {
+                    input_tokens: 10,
+                    output_tokens: 3,
+                    cache_read_input_tokens: 7,
+                    cache_creation_input_tokens: 0,
+                }),
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    #[tokio::test]
+    async fn model_provider_wrapper_records_stream_usage_and_completion() {
+        let diagnostics = Arc::new(Diagnostics::new());
+        let provider = DiagnosticModelProvider {
+            inner: Arc::new(CompletedProvider),
+            diagnostics: diagnostics.clone(),
+        };
+        let stream = provider
+            .stream(ChatRequest {
+                provider: Some(ProviderId::new("anthropic")),
+                model: "claude-sonnet".to_owned(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(diagnostics.snapshot(Profile::Desktop).model.in_flight, 1);
+
+        let events = stream.collect::<Vec<_>>().await;
+
+        assert_eq!(events.len(), 2);
+        let snapshot = diagnostics.snapshot(Profile::Desktop);
+        assert_eq!(snapshot.model.in_flight, 0);
+        assert_eq!(snapshot.model.requests.len(), 1);
+        assert_eq!(snapshot.model.requests[0].outcome, "end_turn");
+        assert_eq!(snapshot.model.requests[0].usage.input_tokens, 17);
+        assert_eq!(snapshot.model.requests[0].usage.uncached_input_tokens, 10);
+        assert_eq!(snapshot.model.requests[0].usage.output_tokens, 3);
+    }
+
+    #[test]
+    fn bundle_includes_only_allowlisted_logs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("logs")).unwrap();
+        std::fs::write(dir.path().join("logs/tidebreak.log"), b"human log").unwrap();
+        std::fs::write(
+            dir.path().join("logs/tidebreak.events.jsonl"),
+            b"{\"event\":\"timing\"}\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("tidebreak.db"), b"private database").unwrap();
+        std::fs::write(dir.path().join("secret.txt"), b"private secret").unwrap();
+
+        let diagnostics = Diagnostics::new();
+        let snapshot = diagnostics.snapshot(Profile::Desktop);
+        let bytes = build_bundle(dir.path(), &snapshot, &render_openmetrics(&snapshot)).unwrap();
+        let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).unwrap();
+        let mut names = (0..archive.len())
+            .map(|index| archive.by_index(index).unwrap().name().to_owned())
+            .collect::<Vec<_>>();
+        names.sort();
+        assert!(names.contains(&"logs/tidebreak.log".to_owned()));
+        assert!(names.contains(&"logs/tidebreak.events.jsonl".to_owned()));
+        assert!(names.contains(&"manifest.json".to_owned()));
+        assert!(names.contains(&"metrics.prom".to_owned()));
+        assert!(names.contains(&"snapshot.json".to_owned()));
+        assert!(!names.iter().any(|name| name.contains("tidebreak.db")));
+        assert!(!names.iter().any(|name| name.contains("secret")));
+    }
+
+    #[test]
+    fn log_tail_reads_only_the_snapshotted_bound() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("logs")).unwrap();
+        std::fs::write(dir.path().join("logs/tidebreak.log"), b"0123456789").unwrap();
+        let directory = Dir::open_ambient_dir(dir.path(), ambient_authority()).unwrap();
+
+        let (bytes, source_bytes, truncated) =
+            read_regular_tail(&directory, "logs/tidebreak.log", 4)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(bytes, b"6789");
+        assert_eq!(source_bytes, 10);
+        assert!(truncated);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn log_tail_refuses_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("logs")).unwrap();
+        std::fs::write(dir.path().join("secret.txt"), b"private secret").unwrap();
+        std::os::unix::fs::symlink(
+            dir.path().join("secret.txt"),
+            dir.path().join("logs/tidebreak.log"),
+        )
+        .unwrap();
+        let directory = Dir::open_ambient_dir(dir.path(), ambient_authority()).unwrap();
+
+        let result = read_regular_tail(&directory, "logs/tidebreak.log", 1024);
+
+        assert!(result.is_err());
+    }
+}

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -36,6 +36,7 @@ pub mod connectors;
 /// capability grants as one renderer-facing statement shape.
 pub mod consent;
 mod desktop_schema;
+mod diagnostics;
 mod document_decode;
 mod durable_oplog;
 mod error;
@@ -531,6 +532,9 @@ pub fn app(state: AppState) -> Router {
             "/code/worktree-root",
             get(routes::code::get_worktree_root).put(routes::code::set_worktree_root),
         )
+        .route("/diagnostics/snapshot", get(diagnostics::get_snapshot))
+        .route("/diagnostics/metrics", get(diagnostics::get_metrics))
+        .route("/diagnostics/export", get(diagnostics::get_export))
         .route_layer(axum::middleware::from_fn(auth::require_admin));
 
     // The engine-facing browser channel. Authenticated per request by the
@@ -1055,10 +1059,14 @@ pub fn app(state: AppState) -> Router {
         // Inside CORS, so a foreign preflight is answered by the CORS layer's
         // own rejection rather than by a bare 403.
         .layer(axum::middleware::from_fn_with_state(
-            state,
+            state.clone(),
             auth::require_app_origin,
         ))
         .layer(cors)
+        .layer(axum::middleware::from_fn_with_state(
+            state,
+            diagnostics::observe_http_request,
+        ))
         // A liveness probe with no auth, added after both layers so it carries
         // neither: nothing reads it cross-origin, and answering preflights for
         // it only helps a page confirm the app is on a guessed port.
@@ -1861,7 +1869,8 @@ async fn bind_inner(
     .with_blobs(state.blobs.clone())
     .with_blob_write_locks(state.blob_writes.clone())
     .with_mcp_runtime(state.mcp.clone())
-    .with_exec_folder_context(code_execution.clone());
+    .with_exec_folder_context(code_execution.clone())
+    .with_diagnostics(state.diagnostics.clone());
     let sandbox_worker_config = sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default()
         .with_delegated_file_executor(client_executor_id.is_some());
     let sandbox_agent_run_worker = sandbox_agent_run_worker::SandboxAgentRunWorker::with_attempts(

--- a/crates/tidebreak-server/src/logging.rs
+++ b/crates/tidebreak-server/src/logging.rs
@@ -1,30 +1,29 @@
 //! Process-wide tracing subscriber for the desktop shell and `tidebreak serve`.
 //!
-//! Events land in a bounded log file under the profile data directory —
-//! `logs/tidebreak.log` next to `tidebreak.db` — so a warning like a gateway
-//! mount failure leaves a diagnosable trace on the user's machine. When the
-//! file passes [`LOG_ROTATE_BYTES`] it is renamed to `tidebreak.log.1`
-//! (replacing any previous rotation) and a fresh file is started, capping the
-//! profile's log footprint at roughly two files of that size. Debug builds
-//! also mirror events to stderr for `tidebreak serve` / `tauri dev` terminals.
+//! Events land in two bounded files under the profile data directory:
+//! `logs/tidebreak.log` for people and `logs/tidebreak.events.jsonl` for tools.
+//! Each file has one rotation slot. The structured file includes span-close
+//! records and timing events under the `tidebreak_diagnostics` target; those
+//! high-volume events stay out of the human log and debug stderr mirror.
 //!
 //! The default level policy is `info` for the workspace's own `tidebreak*`
 //! crates and `warn` for everything else. The `TIDEBREAK_LOG` environment
 //! variable overrides it with standard `tracing_subscriber::EnvFilter`
 //! directives (e.g. `TIDEBREAK_LOG=debug` or
 //! `TIDEBREAK_LOG=warn,tidebreak_server=trace`); an invalid spec falls back to
-//! the default rather than failing boot.
+//! the default rather than failing boot. `TIDEBREAK_DIAGNOSTICS_LOG` controls
+//! the structured file separately.
 //!
 //! # Redaction posture
 //!
 //! The workspace's emit sites are disciplined: reqwest errors are URL-stripped
 //! before logging, policy diagnostics name environment *variables* rather than
 //! values, and no secret or token ever appears in an error's `Display` text.
-//! This subscriber must not widen that surface: it uses the plain compact
-//! formatter (timestamp, level, target, message) and records no span-lifecycle
-//! events, so nothing beyond the literal event fields reaches disk. New log
-//! sites must uphold the same posture — log names and shapes, never values
-//! that could carry a credential, URL query, or file contents.
+//! The human layer uses the compact formatter and omits diagnostic timing
+//! spans. The structured layer records event fields, span context, and span
+//! close records, so diagnostic instrumentation must use names, counts, and
+//! durations rather than prompts, tool payloads, URL queries, credentials, or
+//! file contents. Every ordinary log site must keep the same boundary.
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
@@ -32,16 +31,29 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::filter::{filter_fn, FilterExt as _};
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::fmt::writer::MakeWriter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::Layer as _;
+
+type BoxedRegistryLayer =
+    Box<dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync>;
 
 /// Rotate `tidebreak.log` to `tidebreak.log.1` once it would pass this size.
 pub const LOG_ROTATE_BYTES: u64 = 5 * 1024 * 1024;
 
+/// Rotate the structured event file at a larger cap because JSON timing events
+/// and span context cost more bytes than compact text events.
+pub const EVENT_LOG_ROTATE_BYTES: u64 = 10 * 1024 * 1024;
+
 /// Environment variable holding `EnvFilter` directives that override
 /// [`DEFAULT_DIRECTIVES`].
 const LOG_ENV_VAR: &str = "TIDEBREAK_LOG";
+
+/// Optional `EnvFilter` directives for the structured event file.
+const DIAGNOSTIC_LOG_ENV_VAR: &str = "TIDEBREAK_DIAGNOSTICS_LOG";
 
 /// `info` for the workspace's own crates, `warn` for dependencies.
 const DEFAULT_DIRECTIVES: &str = "warn,tidebreak_cli=info,tidebreak_code_execution=info,\
@@ -50,71 +62,142 @@ const DEFAULT_DIRECTIVES: &str = "warn,tidebreak_cli=info,tidebreak_code_executi
     tidebreak_router=info,tidebreak_sandbox_agent=info,tidebreak_sandbox_protocol=info,\
     tidebreak_server=info,tidebreak_shell_policy=info";
 
-/// Install the process-global subscriber, writing to `logs/tidebreak.log`
-/// under `data_dir`.
+/// Keep the structured file focused on purpose-built, payload-free events.
+const DEFAULT_DIAGNOSTIC_DIRECTIVES: &str = "off,tidebreak_diagnostics=info";
+
+/// Install the process-global subscriber, writing the human and structured
+/// files under `data_dir/logs`.
 ///
 /// Infallible by design: if the log directory or file cannot be created the
 /// subscriber degrades to stderr-only, and if a subscriber is already
 /// installed (tests, a second call) the call is a no-op. Logging must never
 /// block boot.
 pub fn init_logging(data_dir: &Path) {
-    let filter = env_filter();
-    match open_log_writer(data_dir) {
+    let mut layers: Vec<BoxedRegistryLayer> = Vec::new();
+    let human = human_filter();
+    let _text_available = match open_log_writer(data_dir) {
         Ok(writer) => {
-            let subscriber = tracing_subscriber::registry().with(filter).with(
+            layers.push(
                 tracing_subscriber::fmt::layer()
                     .compact()
                     .with_ansi(false)
-                    .with_writer(writer),
+                    .with_writer(writer)
+                    .with_filter(human.clone())
+                    .boxed(),
             );
-            #[cfg(debug_assertions)]
-            let subscriber = subscriber.with(
-                tracing_subscriber::fmt::layer()
-                    .compact()
-                    .with_ansi(false)
-                    .with_writer(io::stderr),
-            );
-            let _ = subscriber.try_init();
+            true
         }
         Err(error) => {
-            eprintln!("tidebreak: profile log file unavailable ({error}); logging to stderr only");
-            let subscriber = tracing_subscriber::registry().with(filter).with(
-                tracing_subscriber::fmt::layer()
-                    .compact()
-                    .with_ansi(false)
-                    .with_writer(io::stderr),
+            eprintln!(
+                "tidebreak: profile log file unavailable ({error}); human logging falls back to stderr"
             );
-            let _ = subscriber.try_init();
+            false
+        }
+    };
+    match open_event_writer(data_dir) {
+        Ok(writer) => layers.push(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .flatten_event(true)
+                .with_current_span(true)
+                .with_span_list(true)
+                .with_span_events(FmtSpan::CLOSE)
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .with_file(true)
+                .with_line_number(true)
+                .with_ansi(false)
+                .with_writer(writer)
+                .with_filter(diagnostic_filter())
+                .boxed(),
+        ),
+        Err(error) => {
+            eprintln!("tidebreak: structured diagnostic log unavailable ({error})");
         }
     }
+    #[cfg(debug_assertions)]
+    layers.push(
+        tracing_subscriber::fmt::layer()
+            .compact()
+            .with_ansi(false)
+            .with_writer(io::stderr)
+            .with_filter(human)
+            .boxed(),
+    );
+    #[cfg(not(debug_assertions))]
+    if !_text_available {
+        layers.push(
+            tracing_subscriber::fmt::layer()
+                .compact()
+                .with_ansi(false)
+                .with_writer(io::stderr)
+                .with_filter(human)
+                .boxed(),
+        );
+    }
+    let subscriber = tracing_subscriber::registry().with(layers);
+    let _ = subscriber.try_init();
 }
 
 /// Install the file-only subscriber used by commands whose stdout is data.
 ///
-/// Unlike [`init_logging`] there is no stderr mirror — an unusable log file
-/// degrades to no subscriber at all rather than corrupting command output.
+/// Unlike [`init_logging`] there is no stderr mirror. If neither file opens,
+/// the function installs an empty subscriber rather than corrupting command
+/// output.
 pub fn init_logging_file_only(data_dir: &Path) {
+    let mut layers: Vec<BoxedRegistryLayer> = Vec::new();
     if let Ok(writer) = open_log_writer(data_dir) {
-        let subscriber = tracing_subscriber::registry().with(env_filter()).with(
+        layers.push(
             tracing_subscriber::fmt::layer()
                 .compact()
                 .with_ansi(false)
-                .with_writer(writer),
+                .with_writer(writer)
+                .with_filter(human_filter())
+                .boxed(),
         );
-        let _ = subscriber.try_init();
     }
+    if let Ok(writer) = open_event_writer(data_dir) {
+        layers.push(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .flatten_event(true)
+                .with_current_span(true)
+                .with_span_list(true)
+                .with_span_events(FmtSpan::CLOSE)
+                .with_thread_ids(true)
+                .with_thread_names(true)
+                .with_file(true)
+                .with_line_number(true)
+                .with_ansi(false)
+                .with_writer(writer)
+                .with_filter(diagnostic_filter())
+                .boxed(),
+        );
+    }
+    let subscriber = tracing_subscriber::registry().with(layers);
+    let _ = subscriber.try_init();
 }
 
 /// The active filter: `TIDEBREAK_LOG` when set and valid, the default policy
 /// otherwise.
-fn env_filter() -> EnvFilter {
-    match std::env::var(LOG_ENV_VAR) {
+fn env_filter(variable: &str, default: &str) -> EnvFilter {
+    match std::env::var(variable) {
         Ok(spec) if !spec.trim().is_empty() => EnvFilter::try_new(&spec).unwrap_or_else(|error| {
-            eprintln!("tidebreak: invalid {LOG_ENV_VAR} ({error}); using the default filter");
-            EnvFilter::new(DEFAULT_DIRECTIVES)
+            eprintln!("tidebreak: invalid {variable} ({error}); using the default filter");
+            EnvFilter::new(default)
         }),
-        _ => EnvFilter::new(DEFAULT_DIRECTIVES),
+        _ => EnvFilter::new(default),
     }
+}
+
+fn human_filter() -> impl tracing_subscriber::layer::Filter<tracing_subscriber::Registry> + Clone {
+    env_filter(LOG_ENV_VAR, DEFAULT_DIRECTIVES).and(filter_fn(|metadata| {
+        metadata.target() != crate::diagnostics::EVENT_TARGET
+    }))
+}
+
+fn diagnostic_filter() -> EnvFilter {
+    env_filter(DIAGNOSTIC_LOG_ENV_VAR, DEFAULT_DIAGNOSTIC_DIRECTIVES)
 }
 
 /// Create `logs/` under the data directory and open the bounded writer.
@@ -122,6 +205,12 @@ fn open_log_writer(data_dir: &Path) -> io::Result<RotatingFileWriter> {
     let logs = data_dir.join("logs");
     fs::create_dir_all(&logs)?;
     RotatingFileWriter::new(logs.join("tidebreak.log"), LOG_ROTATE_BYTES)
+}
+
+fn open_event_writer(data_dir: &Path) -> io::Result<RotatingFileWriter> {
+    let logs = data_dir.join("logs");
+    fs::create_dir_all(&logs)?;
+    RotatingFileWriter::new(logs.join("tidebreak.events.jsonl"), EVENT_LOG_ROTATE_BYTES)
 }
 
 /// A size-capped log file with a single rotation slot.
@@ -145,7 +234,7 @@ struct RotatingFile {
 
 impl RotatingFileWriter {
     fn new(path: PathBuf, cap: u64) -> io::Result<Self> {
-        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let file = open_private_log_file(&path, true)?;
         let written = file.metadata()?.len();
         Ok(Self {
             inner: Arc::new(Mutex::new(RotatingFile {
@@ -172,7 +261,7 @@ impl RotatingFile {
         let rotated = PathBuf::from(rotated);
         let _ = fs::remove_file(&rotated);
         let _ = fs::rename(&self.path, &rotated);
-        self.file = File::create(&self.path).ok();
+        self.file = open_private_log_file(&self.path, false).ok();
         self.written = 0;
     }
 
@@ -188,6 +277,28 @@ impl RotatingFile {
         // an error here would only make the fmt layer spam stderr forever.
         Ok(buf.len())
     }
+}
+
+fn open_private_log_file(path: &Path, append: bool) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.create(true).write(true);
+    if append {
+        options.append(true);
+    } else {
+        options.truncate(true);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(file)
 }
 
 impl Write for RotatingFileWriter {
@@ -264,6 +375,42 @@ mod tests {
         assert_eq!(fs::read(&path).unwrap(), b"third");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn log_files_are_owner_only_before_and_after_rotation() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tidebreak.log");
+        fs::write(&path, b"old").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        let mut writer = RotatingFileWriter::new(path.clone(), 8).unwrap();
+
+        writer.write_all(b"first").unwrap();
+        writer.write_all(b"second").unwrap();
+        writer.flush().unwrap();
+
+        for path in [path, dir.path().join("tidebreak.log.1")] {
+            let mode = fs::metadata(path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn log_writer_refuses_a_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("destination");
+        let path = dir.path().join("tidebreak.log");
+        fs::write(&destination, b"private").unwrap();
+        std::os::unix::fs::symlink(&destination, &path).unwrap();
+
+        let result = RotatingFileWriter::new(path, 64);
+
+        assert!(result.is_err());
+        assert_eq!(fs::read(destination).unwrap(), b"private");
+    }
+
     /// The degrade trigger: an unusable log location surfaces as an error from
     /// the writer constructor, which `init_logging` converts into stderr-only
     /// operation. Calling `init_logging` itself here would install a
@@ -285,14 +432,13 @@ mod tests {
     fn a_warn_event_lands_in_the_log_file() {
         let dir = tempfile::tempdir().unwrap();
         let writer = open_log_writer(dir.path()).unwrap();
-        let subscriber = tracing_subscriber::registry()
-            .with(EnvFilter::new(DEFAULT_DIRECTIVES))
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .compact()
-                    .with_ansi(false)
-                    .with_writer(writer),
-            );
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .compact()
+                .with_ansi(false)
+                .with_writer(writer)
+                .with_filter(EnvFilter::new(DEFAULT_DIRECTIVES)),
+        );
         tracing::subscriber::with_default(subscriber, || {
             tracing::warn!("gateway endpoint unreachable");
         });
@@ -335,5 +481,41 @@ mod tests {
             missing.is_empty(),
             "workspace crates with no log directive, so they sit at warn: {missing:?}"
         );
+    }
+
+    #[test]
+    fn structured_log_keeps_timing_events_and_span_close_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let writer = open_event_writer(dir.path()).unwrap();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .flatten_event(true)
+                .with_current_span(true)
+                .with_span_list(true)
+                .with_span_events(FmtSpan::CLOSE)
+                .with_ansi(false)
+                .with_writer(writer)
+                .with_filter(EnvFilter::new(DEFAULT_DIAGNOSTIC_DIRECTIVES)),
+        );
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!("ordinary warning");
+            let span = tracing::info_span!(
+                target: crate::diagnostics::EVENT_TARGET,
+                "http.server.request",
+                http.route = "/healthz"
+            );
+            span.in_scope(|| {
+                tracing::info!(
+                    target: crate::diagnostics::EVENT_TARGET,
+                    event_name = "http.server.request.completed",
+                    "request completed"
+                );
+            });
+        });
+        let contents = fs::read_to_string(dir.path().join("logs/tidebreak.events.jsonl")).unwrap();
+        assert!(contents.contains("http.server.request.completed"));
+        assert!(contents.contains("close"), "span close missing: {contents}");
+        assert!(!contents.contains("ordinary warning"));
     }
 }

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -114,6 +114,8 @@ impl LocalVoiceRunner for UnavailableLocalVoiceRunner {
 pub struct AppState {
     /// Boot configuration for this launch.
     pub config: Arc<Config>,
+    /// Bounded in-memory request and operation measurements for export.
+    pub(crate) diagnostics: Arc<crate::diagnostics::Diagnostics>,
     /// Durable metadata, conversation state, and the event journal.
     pub store: Arc<dyn Store>,
     /// Durable raw bytes and generated artifacts under the configured data directory.
@@ -397,8 +399,13 @@ impl AppState {
             gateway.clone(),
             gateway_drafts.clone(),
         );
+        let diagnostics = Arc::new(crate::diagnostics::Diagnostics::new());
+        let resolver: Arc<dyn ProviderResolver> = Arc::new(
+            crate::diagnostics::DiagnosticProviderResolver::new(resolver, diagnostics.clone()),
+        );
         Ok(Self {
             config: Arc::new(config),
+            diagnostics,
             store: store.clone(),
             blobs,
             resolver,

--- a/crates/tidebreak-server/src/tests/conformance.rs
+++ b/crates/tidebreak-server/src/tests/conformance.rs
@@ -567,6 +567,9 @@ fn deployment_plane_routes() -> Vec<(&'static str, &'static str)> {
         ("POST", "/providers/openai/chatgpt/sign-out"),
         ("PUT", "/voice-transcription"),
         ("POST", "/voice-transcription/install"),
+        ("GET", "/diagnostics/snapshot"),
+        ("GET", "/diagnostics/metrics"),
+        ("GET", "/diagnostics/export"),
     ]
 }
 

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::os::unix::fs::{DirBuilderExt as StdDirBuilderExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir, DirBuilder};
@@ -24,6 +24,7 @@ use tidebreak_core::{
     TurnId, TurnRun, TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL,
 };
 use tokio::sync::Notify;
+use tracing::Instrument as _;
 
 use crate::approvals::ApprovalBroker;
 use crate::bus::EventBus;
@@ -112,6 +113,7 @@ pub(crate) struct TurnWorker {
     agent_config: AgentConfig,
     exec_folder_context: Option<Arc<crate::code_execution::ConfiguredExecProvider>>,
     private_scratch_root: Option<PathBuf>,
+    diagnostics: Arc<crate::diagnostics::Diagnostics>,
     config: TurnWorkerConfig,
     #[cfg(test)]
     post_drive_pause: Option<(Arc<Notify>, Arc<Notify>)>,
@@ -418,6 +420,7 @@ impl TurnWorker {
             agent_config,
             exec_folder_context: None,
             private_scratch_root,
+            diagnostics: Arc::new(crate::diagnostics::Diagnostics::new()),
             config,
             #[cfg(test)]
             post_drive_pause: None,
@@ -480,6 +483,15 @@ impl TurnWorker {
         provider: Arc<crate::code_execution::ConfiguredExecProvider>,
     ) -> Self {
         self.exec_folder_context = Some(provider);
+        self
+    }
+
+    /// Record turn-segment timings in the server instance's diagnostics.
+    pub(crate) fn with_diagnostics(
+        mut self,
+        diagnostics: Arc<crate::diagnostics::Diagnostics>,
+    ) -> Self {
+        self.diagnostics = diagnostics;
         self
     }
 
@@ -589,15 +601,60 @@ impl TurnWorker {
     /// separate function rather than an early return in this one.
     async fn process(&self, turn: TurnRun, lease_token: uuid::Uuid) -> Result<TurnWorkerOutcome> {
         let chat_id = turn.chat_id;
-        let outcome = self.run_turn(turn, lease_token).await;
-        if let Some(provider) = self.exec_folder_context.as_ref() {
-            if let Some(turn_id) = provider.close_write_overlay(chat_id).await {
-                self.events.publish_metadata(
-                    chat_id,
-                    crate::bus::ChatMetadataNotice::FileChangesRecorded { turn_id },
-                );
+        let turn_id = turn.id;
+        let attempt_count = turn.attempt_count;
+        let span = tracing::info_span!(
+            target: crate::diagnostics::EVENT_TARGET,
+            "tidebreak.foreground_turn_segment",
+            otel.name = "tidebreak.foreground_turn_segment",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            tidebreak.turn.id = %turn_id,
+            tidebreak.turn.attempt = attempt_count,
+            tidebreak.outcome = tracing::field::Empty,
+            tidebreak.duration_ms = tracing::field::Empty,
+        );
+        let started = Instant::now();
+        let outcome = async {
+            let outcome = self.run_turn(turn, lease_token).await;
+            if let Some(provider) = self.exec_folder_context.as_ref() {
+                if let Some(turn_id) = provider.close_write_overlay(chat_id).await {
+                    self.events.publish_metadata(
+                        chat_id,
+                        crate::bus::ChatMetadataNotice::FileChangesRecorded { turn_id },
+                    );
+                }
             }
+            outcome
         }
+        .instrument(span.clone())
+        .await;
+        let duration = started.elapsed();
+        let label = turn_worker_outcome_label(&outcome);
+        self.diagnostics
+            .observe_operation("foreground_turn_segment", label, duration);
+        span.record("tidebreak.outcome", label);
+        span.record(
+            "tidebreak.duration_ms",
+            duration.as_millis().min(u128::from(u64::MAX)) as u64,
+        );
+        span.record(
+            "otel.status_code",
+            if turn_worker_outcome_is_error(&outcome) {
+                "ERROR"
+            } else {
+                "OK"
+            },
+        );
+        span.in_scope(|| {
+            tracing::info!(
+                target: crate::diagnostics::EVENT_TARGET,
+                event_name = "tidebreak.foreground_turn_segment.completed",
+                outcome = label,
+                duration_ms = duration.as_millis().min(u128::from(u64::MAX)) as u64,
+                "foreground turn segment completed"
+            );
+        });
         outcome
     }
 
@@ -2897,6 +2954,23 @@ fn log_turn_result(result: std::result::Result<Result<TurnWorkerOutcome>, tokio:
         Ok(Err(error)) => eprintln!("tidebreak: turn worker execution failed: {error}"),
         Err(error) => eprintln!("tidebreak: turn worker task stopped: {error}"),
     }
+}
+
+fn turn_worker_outcome_label(outcome: &Result<TurnWorkerOutcome>) -> &'static str {
+    match outcome {
+        Ok(TurnWorkerOutcome::Completed(_)) => "completed",
+        Ok(TurnWorkerOutcome::WaitingForClient(_)) => "waiting_for_client",
+        Ok(TurnWorkerOutcome::WaitingForAgentRun(_)) => "waiting_for_agent_run",
+        Ok(TurnWorkerOutcome::Resuming(_)) => "resuming",
+        Ok(TurnWorkerOutcome::Cancelled(_)) => "cancelled",
+        Ok(TurnWorkerOutcome::Failed(_)) => "failed",
+        Ok(TurnWorkerOutcome::LeaseLost(_)) => "lease_lost",
+        Err(_) => "error",
+    }
+}
+
+fn turn_worker_outcome_is_error(outcome: &Result<TurnWorkerOutcome>) -> bool {
+    matches!(outcome, Ok(TurnWorkerOutcome::Failed(_)) | Err(_))
 }
 
 #[cfg(test)]

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,8 @@ an accepted boundary.
 
 ## Interfaces, deployment, and operations
 
+- [Diagnostics](diagnostics.md) — local snapshots, OpenMetrics, structured
+  events, export bundles, and privacy limits.
 - [Wire types](wire-types.md) — generating the desktop TypeScript contract from
   Rust serde types and checking it in CI.
 - [Self-hosting](self-hosting.md) — deployment profile, token roles, Compose,

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,102 @@
+# Diagnostics
+
+Status: implemented as a local-first operator surface. Tidebreak writes no
+diagnostic telemetry to a remote service.
+
+Tidebreak keeps bounded measurements and structured events so you can inspect
+slow requests, model calls, tool execution, foreground turns, and code turns.
+The same administrator-only HTTP routes work in the desktop and self-host
+profiles.
+
+## Export diagnostics
+
+If the desktop or `tidebreak serve` owns the profile, attach to that process:
+
+```sh
+tidebreak diagnostics snapshot --attach
+tidebreak diagnostics metrics --attach
+tidebreak diagnostics export ./tidebreak-diagnostics.zip --attach
+```
+
+Without `--attach` or `--server`, the command starts an embedded server for the
+selected profile. A running desktop already holds that profile's lock, so use
+`--attach` for the desktop process.
+
+To inspect a self-host server, pass its URL and an administrator bearer token:
+
+```sh
+TIDEBREAK_SERVER_TOKEN=<token> \
+  tidebreak diagnostics export ./tidebreak-diagnostics.zip \
+  --server https://tidebreak.example.com
+```
+
+The routes are:
+
+- `GET /diagnostics/snapshot` returns JSON.
+- `GET /diagnostics/metrics` returns OpenMetrics text.
+- `GET /diagnostics/export` returns a ZIP archive.
+
+The desktop launch token resolves to the local owner. On self-host, members
+receive `403 Forbidden`; only administrators can read or export diagnostics.
+
+## Bundle contents
+
+The ZIP contains `snapshot.json`, `metrics.prom`, `manifest.json`, a short
+`README.txt`, and available tails from this allowlist:
+
+- `logs/tidebreak.log` and its one rotation.
+- `logs/tidebreak.events.jsonl` and its one rotation.
+- `boot-failures.log`.
+
+The snapshot contains build and process metadata, uptime, CPU time, maximum
+resident memory, Tokio worker and queue gauges, request histograms keyed by
+matched route, model duration and token measurements, and named operation
+histograms. The OpenMetrics file projects the same measurements for scraping or
+collector ingestion.
+
+In model usage records, `input_tokens` includes uncached, cache-read, and
+cache-creation input. `uncached_input_tokens` keeps the fresh-input component
+separate so you can measure cache effectiveness.
+
+The structured log records span-close events and timing summaries. It includes
+OpenTelemetry semantic-convention fields for HTTP and generative AI operations
+where the local data model has a safe equivalent. Tidebreak does not ship an
+OTLP exporter yet. A later exporter can send the same spans without changing
+the instrumented call sites.
+
+## Privacy and bounds
+
+The export code reads only the allowlist above. It does not read the database,
+conversation transcripts, blobs, attachments, credentials, keychain values, or
+arbitrary files from the profile directory.
+
+HTTP measurements use the matched route pattern, such as `/chats/{id}`. They
+never record the raw URL or query string. Model and tool spans record names,
+counts, durations, outcomes, and token usage. They do not record prompts, model
+output, tool arguments, or tool results.
+
+Logs can still contain local paths, opaque record IDs, and bounded provider
+diagnostics emitted elsewhere in Tidebreak. Review an archive before sharing
+it.
+
+The human log rotates at 5 MiB and keeps one prior file. The JSONL log rotates
+at 10 MiB and also keeps one prior file. Each exported log file is capped to
+the last 10 MiB of its source. On Unix, Tidebreak writes the log files and CLI
+exports with owner-only `0600` permissions.
+
+## Logging filters
+
+`TIDEBREAK_LOG` controls the human log and debug stderr mirror. Diagnostic
+timing events stay out of those outputs even if this filter enables their
+target.
+
+`TIDEBREAK_DIAGNOSTICS_LOG` controls the structured JSONL file. Its default
+records only the payload-free `tidebreak_diagnostics=info` target. To change
+its level, set:
+
+```sh
+TIDEBREAK_DIAGNOSTICS_LOG=off,tidebreak_diagnostics=trace
+```
+
+Both variables use `tracing-subscriber` filter directives. An invalid value
+falls back to the built-in default.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -186,6 +186,7 @@ aspirational.
 | `TIDEBREAK_AUTH_TOKENS_FILE` | one auth mode required | — | Standalone compatibility: path to the static token file above. Mutually exclusive with Gateway auth. |
 | `TIDEBREAK_DATA_DIR` | no | `./.tidebreak` | Instance lock, logs, per-turn scratch. Durable state lives in PostgreSQL, not here. |
 | `TIDEBREAK_LOG` | no | built-in policy | `tracing` filter directives, e.g. `debug` or `warn,tidebreak_server=trace`. An invalid spec falls back to the default. |
+| `TIDEBREAK_DIAGNOSTICS_LOG` | no | `off,tidebreak_diagnostics=info` | `tracing` filter directives for the bounded structured JSONL log. See [Diagnostics](diagnostics.md). |
 | `TIDEBREAK_MODEL` | no | built-in default | Default model name; also settable at runtime through settings or per chat. |
 | `TIDEBREAK_MCP_CONFIG` | no | unset | External stdio MCP server configuration file loaded at boot. |
 | `TIDEBREAK_CONTAINER_EXECUTION_ENABLED` | no | `false` | Enables the container code-execution backend. The compose stack does not configure one. |

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -25,7 +25,7 @@ a stale one.
 
 ## Summary
 
-- Rust crates: 827
+- Rust crates: 829
 - Desktop UI production packages: 525
 - Distinct license texts: 575
 - Packages with no declared license: 0
@@ -4023,6 +4023,12 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/tokio-rs/tracing
 - License text: `LICENSE` ([L-c1e08ee9a728](#l-c1e08ee9a728))
 
+### tracing-serde 0.2.0
+
+- License: `MIT`
+- Repository: https://github.com/tokio-rs/tracing
+- License text: `LICENSE` ([L-c1e08ee9a728](#l-c1e08ee9a728))
+
 ### tracing-subscriber 0.3.23
 
 - License: `MIT`
@@ -4225,6 +4231,12 @@ License identifiers named across all declared expressions:
 
 - License: `MIT`
 - Repository: https://github.com/Nugine/simd
+- License text: not distributed with this package
+
+### valuable 0.1.1
+
+- License: `MIT`
+- Repository: https://github.com/tokio-rs/valuable
 - License text: not distributed with this package
 
 ### vcpkg 0.2.15


### PR DESCRIPTION
## What changed

Adds administrator-only diagnostics snapshots, OpenMetrics, and ZIP exports for desktop and self-hosted Tidebreak, plus CLI commands and bounded JSONL span logging for HTTP, model, tool, foreground-turn, and code-turn performance. The exporter reads only allowlisted log files and uses owner-only local files on Unix; it does not read profile databases, conversations, blobs, attachments, or credential stores.

## Validation

Ran `cargo fmt --all --check`, `cargo check -p tidebreak-server -p tidebreak-cli`, focused server, CLI, and core tests, and `cargo clippy -p tidebreak-core -p tidebreak-server -p tidebreak-cli --lib --bins`.

## Compatibility and risk

No persisted or wire-format migration is required; remote telemetry remains disabled, and the new administrator routes expose only bounded aggregate measurements and allowlisted log tails.
