### PR TITLE
perf(code): stop journaling assistant deltas and bound journal replay

### DIFF
--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -113,13 +113,24 @@ pub enum SubmitTurnResponse {
     Queued(QueuedCodeTurn),
 }
 
-/// One journaled event on the per-session WebSocket.
+/// One event on the per-session WebSocket.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SequencedCodeEventFrame {
+    /// Journal position, or — on a `transient` frame — the cursor the event
+    /// streamed behind. Resuming from it is correct either way.
     pub seq: i64,
     pub event: CodeEvent,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replayed: Option<bool>,
+    /// Set on a live-only event no journal row holds: assistant deltas, and
+    /// the catch-up delta a mid-turn reader gets on connect. Render it and
+    /// move on — it will not come back on reconnect.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transient: Option<bool>,
+    /// Set on the first replayed frame of a capped window: history older than
+    /// this frame was dropped and is not coming.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<bool>,
 }
 
 /// Doctor report for every registered engine adapter.
@@ -690,6 +701,25 @@ mod tests {
         assert_eq!(encoded["event"]["type"], "assistant_delta");
         assert_eq!(encoded["event"]["text"], "hello");
         assert_eq!(encoded["replayed"], true);
+    }
+
+    #[test]
+    fn a_transient_delta_frame_keeps_the_cursor_it_streamed_behind() {
+        // Deltas are live-only (record 57). `code run --json` prints them the
+        // same as any other frame, and the `seq` they carry is the journal
+        // position to resume from — a reconnect using it loses nothing,
+        // because no row holds the delta.
+        let frame = decode_event_frame(
+            r#"{"seq":12,"event":{"type":"assistant_delta","text":"half"},"transient":true}"#,
+        )
+        .unwrap();
+        assert_eq!(frame.seq, 12);
+        assert_eq!(frame.transient, Some(true));
+        assert_eq!(frame.replayed, None);
+        assert!(matches!(
+            frame.event,
+            CodeEvent::AssistantDelta { ref text } if text == "half"
+        ));
     }
 
     #[test]

--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -123,10 +123,15 @@ pub struct SequencedCodeEventFrame {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replayed: Option<bool>,
     /// Set on a live-only event no journal row holds: assistant deltas, and
-    /// the catch-up delta a mid-turn reader gets on connect. Render it and
-    /// move on — it will not come back on reconnect.
+    /// the catch-up delta a mid-turn reader gets on connect. Render it without
+    /// advancing the cursor. A reconnect may receive the complete current
+    /// tail with `replacement` set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transient: Option<bool>,
+    /// Set on a transient assistant delta that contains the complete live
+    /// tail. Replace buffered text instead of appending it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replacement: Option<bool>,
     /// Set on the first replayed frame of a capped window: history older than
     /// this frame was dropped and is not coming.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -707,14 +712,15 @@ mod tests {
     fn a_transient_delta_frame_keeps_the_cursor_it_streamed_behind() {
         // Deltas are live-only (record 57). `code run --json` prints them the
         // same as any other frame, and the `seq` they carry is the journal
-        // position to resume from — a reconnect using it loses nothing,
-        // because no row holds the delta.
+        // position to resume from. A reconnect receives the complete current
+        // tail as a replacement frame.
         let frame = decode_event_frame(
-            r#"{"seq":12,"event":{"type":"assistant_delta","text":"half"},"transient":true}"#,
+            r#"{"seq":12,"event":{"type":"assistant_delta","text":"half"},"transient":true,"replacement":true}"#,
         )
         .unwrap();
         assert_eq!(frame.seq, 12);
         assert_eq!(frame.transient, Some(true));
+        assert_eq!(frame.replacement, Some(true));
         assert_eq!(frame.replayed, None);
         assert!(matches!(
             frame.event,

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -989,7 +989,7 @@ async fn drain_checkpoint(
     turn_id: CodeTurnId,
     format: OutputFormat,
     mut dangling: bool,
-    streamed_text: &mut bool,
+    streamed_text: &mut String,
 ) -> bool {
     let deadline = tokio::time::Instant::now() + CHECKPOINT_TAIL_WAIT;
     loop {
@@ -1008,7 +1008,12 @@ async fn drain_checkpoint(
         if format == OutputFormat::Json {
             emit_line(&raw);
         } else {
-            dangling = render_event(&decoded.event, dangling, streamed_text);
+            dangling = render_event(
+                &decoded.event,
+                decoded.replacement == Some(true),
+                dangling,
+                streamed_text,
+            );
         }
         if done {
             return dangling;
@@ -1063,7 +1068,7 @@ async fn run_turn(
     let deadline =
         timeout.map(|secs| tokio::time::Instant::now() + std::time::Duration::from_secs(secs));
     let mut dangling = false;
-    let mut streamed_text = false;
+    let mut streamed_text = String::new();
 
     let outcome = loop {
         let frame = tokio::select! {
@@ -1117,7 +1122,12 @@ async fn run_turn(
                 if format == OutputFormat::Json {
                     emit_line(&raw);
                 } else {
-                    dangling = render_event(&decoded.event, dangling, &mut streamed_text);
+                    dangling = render_event(
+                        &decoded.event,
+                        decoded.replacement == Some(true),
+                        dangling,
+                        &mut streamed_text,
+                    );
                 }
                 // The checkpoint is journaled just after the turn's terminal
                 // event, so breaking here dropped it every time: the turn's
@@ -1144,7 +1154,12 @@ async fn run_turn(
         if format == OutputFormat::Json {
             emit_line(&raw);
         } else {
-            dangling = render_event(&decoded.event, dangling, &mut streamed_text);
+            dangling = render_event(
+                &decoded.event,
+                decoded.replacement == Some(true),
+                dangling,
+                &mut streamed_text,
+            );
         }
         if let CodeEvent::ApprovalRequested { approval_id } = &decoded.event {
             print_approval_prompt(*approval_id);
@@ -1202,19 +1217,32 @@ async fn sleep_until(deadline: Option<tokio::time::Instant>) {
     }
 }
 
-fn render_event(event: &CodeEvent, dangling: bool, streamed_text: &mut bool) -> bool {
+fn render_event(
+    event: &CodeEvent,
+    replacement: bool,
+    dangling: bool,
+    streamed_text: &mut String,
+) -> bool {
     match event {
         CodeEvent::AssistantDelta { text } => {
-            *streamed_text = true;
+            let text = if replacement {
+                reconcile_assistant_text(streamed_text, text)
+            } else {
+                streamed_text.push_str(text);
+                text.clone()
+            };
+            if text.is_empty() {
+                return dangling;
+            }
             let mut stdout = std::io::stdout().lock();
             let _ = write!(stdout, "{text}");
             let _ = stdout.flush();
             return !text.ends_with('\n');
         }
         CodeEvent::AssistantMessage { text, .. } => {
-            // Deltas already painted the same words; reprinting them as
-            // `pingping` is the usual stream+final pair.
-            if *streamed_text {
+            let text = reconcile_assistant_text(streamed_text, text);
+            streamed_text.clear();
+            if text.is_empty() {
                 return dangling;
             }
             let mut stdout = std::io::stdout().lock();
@@ -1227,7 +1255,15 @@ fn render_event(event: &CodeEvent, dangling: bool, streamed_text: &mut bool) -> 
                 eprint!("{text}");
             }
         }
-        CodeEvent::ToolStarted { name, detail, .. } => {
+        CodeEvent::ToolStarted {
+            name,
+            detail,
+            parent_call_id,
+            ..
+        } => {
+            if parent_call_id.is_none() {
+                streamed_text.clear();
+            }
             finish_line(dangling);
             eprintln!("tidebreak: tool {name}  {}", tool_detail(detail));
             return false;
@@ -1255,11 +1291,13 @@ fn render_event(event: &CodeEvent, dangling: bool, streamed_text: &mut bool) -> 
             return false;
         }
         CodeEvent::TurnFailed { error } => {
+            streamed_text.clear();
             finish_line(dangling);
             eprintln!("tidebreak: turn failed: {}", error.message);
             return false;
         }
         CodeEvent::TurnInterrupted => {
+            streamed_text.clear();
             finish_line(dangling);
             eprintln!("tidebreak: turn interrupted");
             return false;
@@ -1276,9 +1314,9 @@ fn render_event(event: &CodeEvent, dangling: bool, streamed_text: &mut bool) -> 
             );
             return false;
         }
-        CodeEvent::TurnCompleted { .. }
-        | CodeEvent::TurnStarted { .. }
-        | CodeEvent::SessionStarted { .. }
+        CodeEvent::TurnStarted { .. } => streamed_text.clear(),
+        CodeEvent::TurnCompleted { .. } => streamed_text.clear(),
+        CodeEvent::SessionStarted { .. }
         | CodeEvent::ApprovalRequested { .. }
         | CodeEvent::ApprovalResolved { .. }
         | CodeEvent::UserSteered { .. }
@@ -1287,6 +1325,22 @@ fn render_event(event: &CodeEvent, dangling: bool, streamed_text: &mut bool) -> 
         | _ => {}
     }
     dangling
+}
+
+/// Return the part of a complete assistant tail that has not been printed.
+fn reconcile_assistant_text(streamed: &mut String, complete: &str) -> String {
+    if let Some(suffix) = complete.strip_prefix(streamed.as_str()) {
+        let suffix = suffix.to_owned();
+        streamed.clear();
+        streamed.push_str(complete);
+        return suffix;
+    }
+    if streamed.starts_with(complete) {
+        return String::new();
+    }
+    streamed.clear();
+    streamed.push_str(complete);
+    complete.to_owned()
 }
 
 fn finish_line(dangling: bool) {
@@ -2758,6 +2812,27 @@ mod tests {
             FrameAction::Render
         );
         assert_eq!(gate.on_frame(false, &completed()), FrameAction::Terminal(0));
+    }
+
+    #[test]
+    fn a_replacement_tail_only_renders_text_not_already_printed() {
+        let mut streamed = "first second ".to_owned();
+        assert_eq!(
+            reconcile_assistant_text(&mut streamed, "first second third"),
+            "third"
+        );
+        assert_eq!(streamed, "first second third");
+        assert_eq!(
+            reconcile_assistant_text(&mut streamed, "first second third"),
+            ""
+        );
+    }
+
+    #[test]
+    fn a_bounded_replacement_does_not_repeat_a_longer_printed_prefix() {
+        let mut streamed = "first second third".to_owned();
+        assert_eq!(reconcile_assistant_text(&mut streamed, "first second "), "");
+        assert_eq!(streamed, "first second third");
     }
 
     #[test]

--- a/crates/tidebreak-core/src/db/ops/code/journal.rs
+++ b/crates/tidebreak-core/src/db/ops/code/journal.rs
@@ -87,21 +87,56 @@ pub async fn latest_event_created_at(
         .map(|model| model.created_at))
 }
 
+/// Default replay cap for [`list_events`].
+///
+/// A session journal grows for as long as the session lives, and a client
+/// that connects with `after = 0` asks for all of it. Two thousand events is
+/// more than any transcript a reader scrolls through, and it bounds what one
+/// reconnect can cost the server.
+pub const MAX_REPLAY_EVENTS: u64 = 2_000;
+
+/// One bounded window of a session journal.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct CodeEventPage {
+    /// Events in ascending sequence order.
+    pub events: Vec<SequencedCodeEvent>,
+    /// True when older events above the cursor were dropped to honor the cap.
+    ///
+    /// The window keeps the newest events, so a truncated page leaves a hole
+    /// between the caller's cursor and the first event it carries. Say so
+    /// rather than let a reader believe it holds the whole history.
+    pub truncated: bool,
+}
+
 /// Events for one of the owner's sessions with `seq > after`, in order.
+///
+/// At most `limit` events come back, and the window keeps the *newest* ones:
+/// a client that fell far behind resumes at the live tail instead of paying
+/// for history it would scroll past. Pass [`MAX_REPLAY_EVENTS`] unless you
+/// have a reason to want a different bound.
 pub async fn list_events(
     store: &DbStore,
     owner: &OwnerId,
     session_id: CodeSessionId,
     after: i64,
-) -> Result<Vec<SequencedCodeEvent>> {
-    entities::code_event::Entity::find()
+    limit: u64,
+) -> Result<CodeEventPage> {
+    // Read one past the cap so a full window is distinguishable from a window
+    // that happens to end exactly on it.
+    let probe = limit.saturating_add(1);
+    let mut rows = entities::code_event::Entity::find()
         .filter(entities::code_event::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_event::Column::SessionId.eq(session_id.0))
         .filter(entities::code_event::Column::Seq.gt(after))
-        .order_by_asc(entities::code_event::Column::Seq)
+        .order_by_desc(entities::code_event::Column::Seq)
+        .limit(probe)
         .all(&store.conn)
         .await
-        .map_err(store_err)?
+        .map_err(store_err)?;
+    let truncated = rows.len() as u64 > limit;
+    rows.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+    rows.reverse();
+    let events = rows
         .into_iter()
         .map(|model| {
             Ok(SequencedCodeEvent {
@@ -109,7 +144,8 @@ pub async fn list_events(
                 event: serde_json::from_value(model.event)?,
             })
         })
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    Ok(CodeEventPage { events, truncated })
 }
 
 /// Newest journal events for one session, newest first. Digests use this

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -10,7 +10,7 @@ use crate::db::code::{
     get_turn, get_workspace, insert_approval, insert_repo, insert_session, insert_turn,
     insert_workspace, list_approvals, list_events, list_repos, list_sessions, list_turns,
     mark_repo_removed, save_session, set_session_subagents, set_workspace_title_if,
-    CodeJournalError,
+    CodeJournalError, MAX_REPLAY_EVENTS,
 };
 use crate::OwnerId;
 use chrono::Utc;
@@ -385,12 +385,12 @@ async fn journal_rejects_stale_spawn_epoch() {
     append_event(&store, &OwnerId::local(), session_id, 1, &event)
         .await
         .unwrap();
-    let events = list_events(&store, &OwnerId::local(), session_id, 0)
+    let events = list_events(&store, &OwnerId::local(), session_id, 0, MAX_REPLAY_EVENTS)
         .await
         .unwrap();
-    assert_eq!(events.len(), 2);
-    assert_eq!(events[0].seq, 1);
-    assert_eq!(events[1].seq, 2);
+    assert_eq!(events.events.len(), 2);
+    assert_eq!(events.events[0].seq, 1);
+    assert_eq!(events.events[1].seq, 2);
 }
 
 #[tokio::test]
@@ -444,11 +444,67 @@ async fn journal_seq_is_monotonic_under_concurrent_appends() {
     }
     seqs.sort_unstable();
     assert_eq!(seqs, (1..=n).collect::<Vec<_>>());
-    let events = list_events(&store, &OwnerId::local(), session_id, 0)
+    let events = list_events(&store, &OwnerId::local(), session_id, 0, MAX_REPLAY_EVENTS)
         .await
         .unwrap();
-    assert_eq!(events.len(), n as usize);
-    assert!(events.windows(2).all(|pair| pair[0].seq + 1 == pair[1].seq));
+    assert_eq!(events.events.len(), n as usize);
+    assert!(events
+        .events
+        .windows(2)
+        .all(|pair| pair[0].seq + 1 == pair[1].seq));
+}
+
+/// A capped replay keeps the newest events and says the head is missing.
+///
+/// Dropping the tail instead would be worse than useless — a reader would
+/// resume before the live stream and never catch up — and dropping the head
+/// silently would let a session open on its middle and read as if that were
+/// the beginning.
+#[tokio::test]
+async fn a_capped_replay_keeps_the_newest_events_and_admits_the_head_is_gone() {
+    let (_dir, store, session_id, _turn) = seeded_session().await;
+    let owner = OwnerId::local();
+    for index in 0..6 {
+        append_event(
+            &store,
+            &owner,
+            session_id,
+            0,
+            &CodeEvent::HarnessNotice {
+                level: crate::code::HarnessNoticeLevel::Info,
+                message: format!("notice {index}"),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let capped = list_events(&store, &owner, session_id, 0, 4).await.unwrap();
+    assert!(capped.truncated);
+    assert_eq!(
+        capped
+            .events
+            .iter()
+            .map(|event| event.seq)
+            .collect::<Vec<_>>(),
+        vec![3, 4, 5, 6]
+    );
+
+    // A window that fits says nothing was dropped, including the exact fit.
+    let exact = list_events(&store, &owner, session_id, 0, 6).await.unwrap();
+    assert!(!exact.truncated);
+    assert_eq!(exact.events.len(), 6);
+
+    // The cursor still applies: the cap windows what is above it.
+    let tail = list_events(&store, &owner, session_id, 4, 4).await.unwrap();
+    assert!(!tail.truncated);
+    assert_eq!(
+        tail.events
+            .iter()
+            .map(|event| event.seq)
+            .collect::<Vec<_>>(),
+        vec![5, 6]
+    );
 }
 
 /// ADR 0030: no chat entity references a code-mode table or id type, and no
@@ -593,16 +649,20 @@ async fn owner_scoped_code_queries_partition_every_table() {
     .await
     .unwrap();
     assert_eq!(
-        list_events(&store, &alice, alice_session, 0)
+        list_events(&store, &alice, alice_session, 0, MAX_REPLAY_EVENTS)
             .await
             .unwrap()
+            .events
             .len(),
         1
     );
-    assert!(list_events(&store, &bob, alice_session, 0)
-        .await
-        .unwrap()
-        .is_empty());
+    assert!(
+        list_events(&store, &bob, alice_session, 0, MAX_REPLAY_EVENTS)
+            .await
+            .unwrap()
+            .events
+            .is_empty()
+    );
 
     // Approvals.
     let approval_id = CodeApprovalId::new();

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -16,7 +16,7 @@ use tidebreak_core::db::code::{
     append_event, get_approval, get_repo, get_repo_by_root_path, get_session, get_turn,
     get_workspace, insert_approval, insert_repo, insert_session, insert_turn, insert_workspace,
     list_approvals, list_events, list_repos, list_sessions, list_turns, mark_repo_removed,
-    set_workspace_title_if,
+    set_workspace_title_if, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
     Attention, AttentionSource, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
@@ -181,16 +181,20 @@ async fn postgres_code_queries_partition_by_owner() {
     .await
     .unwrap();
     assert_eq!(
-        list_events(&store, &alice, alice_session, 0)
+        list_events(&store, &alice, alice_session, 0, MAX_REPLAY_EVENTS)
             .await
             .unwrap()
+            .events
             .len(),
         1
     );
-    assert!(list_events(&store, &bob, alice_session, 0)
-        .await
-        .unwrap()
-        .is_empty());
+    assert!(
+        list_events(&store, &bob, alice_session, 0, MAX_REPLAY_EVENTS)
+            .await
+            .unwrap()
+            .events
+            .is_empty()
+    );
 
     // Approvals.
     let approval_id = CodeApprovalId::new();

--- a/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
@@ -108,8 +108,8 @@ function CodeArchiveBody() {
     }
   };
 
-  const totalArchived = workspaces.filter(
-    (workspace) => isPutAway(workspace),
+  const totalArchived = workspaces.filter((workspace) =>
+    isPutAway(workspace),
   ).length;
 
   return (

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -138,7 +138,9 @@ describe("seq cursor", () => {
       },
       clock,
     );
-    expect(again.state.items.filter((item) => item.kind === "notice")).toHaveLength(1);
+    expect(
+      again.state.items.filter((item) => item.kind === "notice"),
+    ).toHaveLength(1);
   });
 
   it("advances the cursor for unknown event kinds", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -111,6 +111,46 @@ describe("seq cursor", () => {
     expect(second.state.lastSeq).toBe(state.lastSeq);
   });
 
+  it("replaces streamed text with a catch-up tail after reconnect", () => {
+    const clock = deps();
+    const { state } = play(
+      [{ type: "turn_started", turn_id: "t1" }],
+      initialCodeSessionState(),
+      clock,
+    );
+    const streamed = reduceCodeSessionEvent(
+      state,
+      {
+        seq: state.lastSeq,
+        event: { type: "assistant_delta", text: "first second " },
+        transient: true,
+      },
+      clock,
+    );
+    const caughtUp = reduceCodeSessionEvent(
+      streamed.state,
+      {
+        seq: state.lastSeq,
+        event: { type: "assistant_delta", text: "first second third" },
+        transient: true,
+        replacement: true,
+      },
+      clock,
+    );
+    const continued = reduceCodeSessionEvent(
+      caughtUp.state,
+      {
+        seq: state.lastSeq,
+        event: { type: "assistant_delta", text: "." },
+        transient: true,
+      },
+      clock,
+    );
+
+    expect(continued.state.assistantBuffer).toBe("first second third.");
+    expect(continued.state.lastSeq).toBe(state.lastSeq);
+  });
+
   it("says so when the replay started partway through", () => {
     const clock = deps();
     const first = reduceCodeSessionEvent(

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -79,6 +79,68 @@ describe("seq cursor", () => {
     expect(replay.effects).toEqual([]);
   });
 
+  it("applies a transient frame without moving the cursor", () => {
+    // Assistant deltas are live-only (record 57): no row holds them, so the
+    // duplicate check does not apply and the resume cursor must stay where
+    // the journal left it. Gating them on `seq` would drop every one.
+    const clock = deps();
+    const { state } = play(
+      [{ type: "turn_started", turn_id: "t1" }],
+      initialCodeSessionState(),
+      clock,
+    );
+    const first = reduceCodeSessionEvent(
+      state,
+      {
+        seq: state.lastSeq,
+        event: { type: "assistant_delta", text: "half a " },
+        transient: true,
+      },
+      clock,
+    );
+    const second = reduceCodeSessionEvent(
+      first.state,
+      {
+        seq: state.lastSeq,
+        event: { type: "assistant_delta", text: "sentence" },
+        transient: true,
+      },
+      clock,
+    );
+    expect(second.state.assistantBuffer).toBe("half a sentence");
+    expect(second.state.lastSeq).toBe(state.lastSeq);
+  });
+
+  it("says so when the replay started partway through", () => {
+    const clock = deps();
+    const first = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      {
+        seq: 900,
+        event: { type: "turn_started", turn_id: "t9" },
+        replayed: true,
+        truncated: true,
+      },
+      clock,
+    );
+    expect(first.state.items[0]).toMatchObject({
+      kind: "notice",
+      level: "info",
+    });
+    // A reconnect that truncates again must not stack a second line.
+    const again = reduceCodeSessionEvent(
+      first.state,
+      {
+        seq: 901,
+        event: { type: "turn_started", turn_id: "t10" },
+        replayed: true,
+        truncated: true,
+      },
+      clock,
+    );
+    expect(again.state.items.filter((item) => item.kind === "notice")).toHaveLength(1);
+  });
+
   it("advances the cursor for unknown event kinds", () => {
     const { state, effects } = reduceCodeSessionEvent(
       initialCodeSessionState(),

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -321,11 +321,20 @@ export function reduceCodeSessionEvent(
   framed: SequencedCodeEventFrame,
   deps: CodeSessionDeps,
 ): CodeSessionTransition {
-  if (framed.seq <= state.lastSeq) return { state, effects: [] };
+  // A transient frame is live-only: no row holds it, so its `seq` is the
+  // cursor it streamed behind rather than a position of its own. Applying it
+  // must not move the cursor, and the duplicate check does not apply — the
+  // journal will never hand it back.
+  const transient = framed.transient === true;
+  if (!transient && framed.seq <= state.lastSeq) return { state, effects: [] };
   state = {
     ...state,
-    lastSeq: framed.seq,
+    lastSeq: transient ? state.lastSeq : framed.seq,
     animateStreaming: framed.replayed !== true,
+    items:
+      framed.truncated === true
+        ? withTruncationNotice(state.items)
+        : state.items,
   };
   const event = framed.event;
   const effects: CodeSessionEffect[] = [];
@@ -634,6 +643,31 @@ export function reduceCodeSessionEvent(
       return { state, effects };
   }
 }
+
+/**
+ * Say that the replay started partway through.
+ *
+ * The server caps how much journal one connect replays and flags the first
+ * frame of a capped window. Without a line saying so, a long session would
+ * quietly open on its middle and read as if that were the beginning.
+ */
+function withTruncationNotice(
+  items: CodeTranscriptItem[],
+): CodeTranscriptItem[] {
+  if (items.some((item) => item.id === TRUNCATED_NOTICE_ID)) return items;
+  return [
+    {
+      kind: "notice",
+      id: TRUNCATED_NOTICE_ID,
+      level: "info",
+      message: "Earlier history in this session is not shown.",
+    },
+    ...items,
+  ];
+}
+
+/** Fixed so a reconnect does not stack a second copy of the same line. */
+const TRUNCATED_NOTICE_ID = "notice:truncated-replay";
 
 function upsertStreaming(
   items: CodeTranscriptItem[],

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -324,7 +324,8 @@ export function reduceCodeSessionEvent(
   // A transient frame is live-only: no row holds it, so its `seq` is the
   // cursor it streamed behind rather than a position of its own. Applying it
   // must not move the cursor, and the duplicate check does not apply — the
-  // journal will never hand it back.
+  // journal will never hand it back. A replacement frame contains the whole
+  // current assistant tail, so it replaces the buffer instead of appending.
   const transient = framed.transient === true;
   if (!transient && framed.seq <= state.lastSeq) return { state, effects: [] };
   state = {
@@ -367,7 +368,10 @@ export function reduceCodeSessionEvent(
     }
 
     case "assistant_delta": {
-      const assistantBuffer = state.assistantBuffer + event.text;
+      const assistantBuffer =
+        framed.replacement === true
+          ? event.text
+          : state.assistantBuffer + event.text;
       return {
         state: {
           ...state,

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -3594,11 +3594,16 @@ export type SequencedCodeEventFrame = {
 seq: number, event: CodeEvent, replayed?: boolean, 
 /**
  * Set on a live-only event the journal does not hold: assistant deltas,
- * and the catch-up delta a mid-turn reader gets on connect. Apply it,
- * but do not advance the resume cursor past it and do not expect it
- * again on reconnect (record 57).
+ * and the catch-up delta a mid-turn reader gets on connect. Apply it but
+ * do not advance the resume cursor. A reconnect may receive the complete
+ * current tail with `replacement` set (record 57).
  */
 transient?: boolean, 
+/**
+ * Set on a transient assistant delta that contains the complete live
+ * tail. Replace the current assistant buffer instead of appending it.
+ */
+replacement?: boolean, 
 /**
  * Set on the first replayed frame of a capped window: older events above
  * the requested cursor were dropped, and the history in front of this

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -3583,9 +3583,28 @@ error: string, };
 export type RootAttachmentOrigin = "project_default" | "conversation";
 
 /**
- * One journaled event on the per-session WebSocket.
+ * One event on the per-session WebSocket.
  */
-export type SequencedCodeEventFrame = { seq: number, event: CodeEvent, replayed?: boolean, };
+export type SequencedCodeEventFrame = { 
+/**
+ * Journal position. On a `transient` frame this is the cursor the event
+ * streamed behind, not a position the frame occupies — resume from it
+ * and you lose nothing, because no row holds this event.
+ */
+seq: number, event: CodeEvent, replayed?: boolean, 
+/**
+ * Set on a live-only event the journal does not hold: assistant deltas,
+ * and the catch-up delta a mid-turn reader gets on connect. Apply it,
+ * but do not advance the resume cursor past it and do not expect it
+ * again on reconnect (record 57).
+ */
+transient?: boolean, 
+/**
+ * Set on the first replayed frame of a capped window: older events above
+ * the requested cursor were dropped, and the history in front of this
+ * frame is not coming.
+ */
+truncated?: boolean, };
 
 /**
  * Body of `PUT /code/worktree-root`. A null or blank root clears the setting.

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -59,6 +59,10 @@ pub(crate) async fn persist_session(
 ) -> Result<bool, tidebreak_core::AgentError> {
     let ok = save_session(db, session).await?;
     if ok {
+        bus.set_maybe_stalled(
+            session.id,
+            matches!(session.attention.state, AttentionState::Stalled { .. }),
+        );
         emit_digest(db, bus, session).await;
     }
     Ok(ok)
@@ -106,6 +110,7 @@ impl Default for ComputeOpts {
 /// clear, never to second-guess a live Manual pin.
 pub(crate) async fn compute_attention(
     db: &DbStore,
+    bus: &CodeEventBus,
     session: &CodeSession,
     opts: ComputeOpts,
 ) -> Result<Attention, tidebreak_core::AgentError> {
@@ -131,7 +136,7 @@ pub(crate) async fn compute_attention(
         ));
     }
     if session.lifecycle == CodeSessionLifecycle::Running {
-        let last = last_activity_at(db, session).await?;
+        let last = last_activity_at(db, bus, session).await?;
         let idle = opts.now.signed_duration_since(last).num_seconds().max(0) as u32;
         if idle >= opts.stall_idle_secs {
             return Ok(Attention::new(
@@ -201,6 +206,7 @@ pub(crate) async fn user_set_attention(
     let next = if clear {
         compute_attention(
             db,
+            bus,
             &session,
             ComputeOpts {
                 reviewed: true,
@@ -225,7 +231,7 @@ pub(crate) async fn sweep_stalled(
     let now = Utc::now();
     let running = list_sessions_by_lifecycle_all_owners(db, CodeSessionLifecycle::Running).await?;
     for session in running {
-        let last = last_activity_at(db, &session).await?;
+        let last = last_activity_at(db, bus, &session).await?;
         let idle = now.signed_duration_since(last).num_seconds().max(0) as u32;
         if idle < idle_secs {
             continue;
@@ -240,19 +246,30 @@ pub(crate) async fn sweep_stalled(
 }
 
 /// Activity on a running session clears a stall.
+///
+/// Called for every event a session produces, so the cheap answer comes
+/// first: the bus remembers whether this session might be stalled, and the
+/// common case — a session that is plainly working — returns without reading
+/// the row at all. The hint starts pessimistic and every read corrects it,
+/// so a wrong guess costs one query, never a missed clear.
 pub(crate) async fn note_activity(
     db: &DbStore,
     bus: &CodeEventBus,
     owner: &OwnerId,
     session_id: CodeSessionId,
 ) -> Result<(), tidebreak_core::AgentError> {
+    if !bus.maybe_stalled(session_id) {
+        return Ok(());
+    }
     let Some(session) = get_session(db, owner, session_id).await? else {
         return Ok(());
     };
+    let stalled = matches!(session.attention.state, AttentionState::Stalled { .. });
+    bus.set_maybe_stalled(session_id, stalled);
     if session.lifecycle != CodeSessionLifecycle::Running {
         return Ok(());
     }
-    if !matches!(session.attention.state, AttentionState::Stalled { .. }) {
+    if !stalled {
         return Ok(());
     }
     let _ = apply_attention(
@@ -425,17 +442,28 @@ fn classify_activity(name: &str, detail: &ToolDetail) -> CodeSessionActivity {
     }
 }
 
+/// When this session last showed a sign of life.
+///
+/// The journal answers for anything durable. It cannot answer for assistant
+/// deltas, which stream and are never written down, so the live bus is asked
+/// first: a session pouring out a long answer and touching nothing else is
+/// working, not silent, and the stall sweep must not call it stalled.
 async fn last_activity_at(
     db: &DbStore,
+    bus: &CodeEventBus,
     session: &CodeSession,
 ) -> Result<DateTime<Utc>, tidebreak_core::AgentError> {
-    if let Some(at) = latest_event_created_at(db, &session.owner, session.id).await? {
-        return Ok(at);
-    }
-    if let Some(turn) = latest_turn(db, &session.owner, session.id).await? {
-        return Ok(turn.started_at);
-    }
-    Ok(session.created_at)
+    let journaled = match latest_event_created_at(db, &session.owner, session.id).await? {
+        Some(at) => at,
+        None => match latest_turn(db, &session.owner, session.id).await? {
+            Some(turn) => turn.started_at,
+            None => session.created_at,
+        },
+    };
+    Ok(match bus.last_activity(session.id) {
+        Some(live) => journaled.max(live),
+        None => journaled,
+    })
 }
 
 /// Abort the stall sweep when the runtime is dropped.

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -5,6 +5,13 @@
 //! the live tail. The session worker appends each event to the journal and
 //! then publishes it here with its assigned `seq`.
 //!
+//! Assistant deltas are the exception, and the bus owns the whole of their
+//! life: they are published here and nowhere else, because the
+//! `assistant_message` that follows repeats them byte for byte and the
+//! journal would only store the same words twice (record 57). The bus keeps
+//! the text streamed so far so a reader who connects mid-answer is not shown
+//! a sentence that starts in the middle.
+//!
 //! `/code/updates` is unsequenced: a dropped notice costs nothing because the
 //! full digest is restated on every connect.
 //!
@@ -19,10 +26,11 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+use chrono::{DateTime, Utc};
 use tidebreak_core::{
-    Attention, CodeSessionActivity, CodeSessionId, CodeSessionKind, CodeSessionLifecycle,
-    CodeSubagentSummary, CodeWatchState, HarnessKind, OwnerId, PullRequestDigest, RepoId,
-    SequencedCodeEvent, WorkspaceId,
+    Attention, CodeEvent, CodeSessionActivity, CodeSessionId, CodeSessionKind,
+    CodeSessionLifecycle, CodeSubagentSummary, CodeWatchState, HarnessKind, OwnerId,
+    PullRequestDigest, RepoId, SequencedCodeEvent, WorkspaceId, MAX_EVENT_TEXT_CHARS,
 };
 use tokio::sync::broadcast;
 
@@ -90,8 +98,70 @@ pub(crate) enum CodeLiveUpdate {
 /// Per-session broadcast channels for live journal events, plus one digest
 /// channel per owner.
 pub(crate) struct CodeEventBus {
-    channels: Mutex<HashMap<CodeSessionId, broadcast::Sender<SequencedCodeEvent>>>,
+    channels: Mutex<HashMap<CodeSessionId, LiveSession>>,
     updates: Mutex<HashMap<OwnerId, broadcast::Sender<CodeLiveUpdate>>>,
+}
+
+/// One session's live state: the channel, plus the small facts that only the
+/// live stream knows.
+///
+/// The assistant tail is the reason this is a struct rather than a bare
+/// sender. Deltas are published and never journaled, so between the first
+/// delta and the `assistant_message` that states the whole answer, this is
+/// the only copy of the text a reader who connects mid-turn could be given.
+struct LiveSession {
+    sender: broadcast::Sender<CodeLiveEvent>,
+    /// Assistant text streamed since the last event that finished a message,
+    /// bounded the same way the event that will carry it is bounded.
+    assistant: String,
+    /// Sequence of the newest journaled event published here. Pairs with
+    /// `assistant`: the tail is only current for a reader that has not
+    /// already replayed past this point.
+    cursor: i64,
+    /// When this session last published anything, live or journaled.
+    last_activity: DateTime<Utc>,
+    /// Pessimistic hint for the stall check; see [`CodeEventBus::maybe_stalled`].
+    maybe_stalled: bool,
+}
+
+impl Default for LiveSession {
+    fn default() -> Self {
+        Self {
+            sender: broadcast::channel(LIVE_BUFFER).0,
+            assistant: String::new(),
+            cursor: 0,
+            last_activity: Utc::now(),
+            maybe_stalled: true,
+        }
+    }
+}
+
+/// One event on a session's live channel.
+///
+/// `seq` is the journal position, and `None` marks an event that no row
+/// holds: it is delivered live and never replayed, so it carries no cursor a
+/// client could resume from.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CodeLiveEvent {
+    pub seq: Option<i64>,
+    /// Journal position this event streamed behind — its own, for a journaled
+    /// event.
+    ///
+    /// A live-only event is only current while the journal has not moved past
+    /// it. Once it has, the event that moved it (the message, the tool call,
+    /// the turn's end) restates or discards this text, and a reader whose
+    /// replay already read that far must not be handed the fragment as well.
+    pub cursor: i64,
+    pub event: CodeEvent,
+}
+
+/// What a freshly attached reader needs to catch up on the live tail.
+pub(crate) struct LiveTail {
+    /// Assistant text streamed but not yet journaled. Empty most of the time.
+    pub assistant: String,
+    /// Journal position the tail is current as of. A reader whose replay went
+    /// past this cannot trust the text.
+    pub cursor: i64,
 }
 
 impl Default for CodeEventBus {
@@ -104,24 +174,114 @@ impl Default for CodeEventBus {
 }
 
 impl CodeEventBus {
-    pub(crate) fn sender(&self, session: CodeSessionId) -> broadcast::Sender<SequencedCodeEvent> {
+    fn with_session<T>(
+        &self,
+        session: CodeSessionId,
+        act: impl FnOnce(&mut LiveSession) -> T,
+    ) -> T {
+        let mut channels = self.channels.lock().expect("code event bus lock");
+        act(channels.entry(session).or_default())
+    }
+
+    /// Subscribe, and take the live tail in the same breath.
+    ///
+    /// The two have to be atomic. A caller that subscribed first and read the
+    /// tail afterwards would count any delta published in between twice: once
+    /// in the tail it read, once from its own receiver. Publication takes the
+    /// same lock, so nothing lands between these two lines.
+    pub(crate) fn attach(
+        &self,
+        session: CodeSessionId,
+    ) -> (broadcast::Receiver<CodeLiveEvent>, LiveTail) {
+        self.with_session(session, |live| {
+            (
+                live.sender.subscribe(),
+                LiveTail {
+                    assistant: live.assistant.clone(),
+                    cursor: live.cursor,
+                },
+            )
+        })
+    }
+
+    /// Publish a journaled event and advance this session's live cursor.
+    ///
+    /// Journaled events are what the tail is measured against: an event that
+    /// finishes the assistant's turn of speech retires the buffered text
+    /// rather than leaving a stale copy for the next reconnect to replay.
+    pub(crate) fn publish(&self, session: CodeSessionId, event: SequencedCodeEvent) {
+        self.with_session(session, |live| {
+            live.cursor = live.cursor.max(event.seq);
+            live.last_activity = Utc::now();
+            if ends_assistant_text(&event.event) {
+                live.assistant.clear();
+            }
+            let _ = live.sender.send(CodeLiveEvent {
+                seq: Some(event.seq),
+                cursor: event.seq,
+                event: event.event,
+            });
+        });
+    }
+
+    /// Publish a live-only event: no journal row, no cursor movement.
+    ///
+    /// Assistant deltas are the whole of this path today. They are how a
+    /// reader watches an answer arrive, and the `assistant_message` that
+    /// follows carries the same bytes, so the durable copy would say nothing
+    /// new (record 57).
+    pub(crate) fn publish_transient(&self, session: CodeSessionId, event: CodeEvent) {
+        self.with_session(session, |live| {
+            live.last_activity = Utc::now();
+            if let CodeEvent::AssistantDelta { text } = &event {
+                append_bounded(&mut live.assistant, text);
+            }
+            let _ = live.sender.send(CodeLiveEvent {
+                seq: None,
+                cursor: live.cursor,
+                event,
+            });
+        });
+    }
+
+    /// Assistant text streamed since the last event that finished a message.
+    ///
+    /// Empty once the message lands. Taking it clears it, which is what the
+    /// journal path wants: it is about to write the text down.
+    pub(crate) fn take_assistant_tail(&self, session: CodeSessionId) -> String {
+        self.with_session(session, |live| std::mem::take(&mut live.assistant))
+    }
+
+    /// Most recent moment this session published anything, live or journaled.
+    ///
+    /// The stall sweep reads it. Without it a session streaming a long answer
+    /// and nothing else would look silent, because the deltas carrying that
+    /// answer no longer touch a row's `created_at`.
+    pub(crate) fn last_activity(&self, session: CodeSessionId) -> Option<DateTime<Utc>> {
         self.channels
             .lock()
             .expect("code event bus lock")
-            .entry(session)
-            .or_insert_with(|| broadcast::channel(LIVE_BUFFER).0)
-            .clone()
+            .get(&session)
+            .map(|live| live.last_activity)
     }
 
-    pub(crate) fn subscribe(
-        &self,
-        session: CodeSessionId,
-    ) -> broadcast::Receiver<SequencedCodeEvent> {
-        self.sender(session).subscribe()
+    /// Whether this session might be carrying [`AttentionState::Stalled`].
+    ///
+    /// A hint, not an answer: it starts pessimistic and is corrected by the
+    /// first caller that reads the row. Its job is to spare the common path —
+    /// a running session that is not stalled — a `get_session` per event.
+    pub(crate) fn maybe_stalled(&self, session: CodeSessionId) -> bool {
+        self.channels
+            .lock()
+            .expect("code event bus lock")
+            .get(&session)
+            .is_none_or(|live| live.maybe_stalled)
     }
 
-    pub(crate) fn publish(&self, session: CodeSessionId, event: SequencedCodeEvent) {
-        let _ = self.sender(session).send(event);
+    /// Record what the session row actually says, so the next event can skip
+    /// the read.
+    pub(crate) fn set_maybe_stalled(&self, session: CodeSessionId, stalled: bool) {
+        self.with_session(session, |live| live.maybe_stalled = stalled);
     }
 
     fn updates_sender(&self, owner: &OwnerId) -> broadcast::Sender<CodeLiveUpdate> {
@@ -143,5 +303,38 @@ impl CodeEventBus {
     /// belongs to; there is no channel that reaches everyone.
     pub(crate) fn publish_update(&self, owner: &OwnerId, update: CodeLiveUpdate) {
         let _ = self.updates_sender(owner).send(update);
+    }
+}
+
+/// Does this journaled event end the assistant's current run of text?
+///
+/// `assistant_message` states the whole run, and a parent-level tool call or
+/// a turn boundary closes it the same way the renderer's reducer does. Child
+/// (subagent) messages and calls are excluded: they never owned the parent's
+/// buffer.
+fn ends_assistant_text(event: &CodeEvent) -> bool {
+    matches!(
+        event,
+        CodeEvent::AssistantMessage {
+            parent_call_id: None,
+            ..
+        } | CodeEvent::ToolStarted {
+            parent_call_id: None,
+            ..
+        } | CodeEvent::TurnStarted { .. }
+            | CodeEvent::TurnCompleted { .. }
+            | CodeEvent::TurnFailed { .. }
+            | CodeEvent::TurnInterrupted
+    )
+}
+
+fn append_bounded(buffer: &mut String, text: &str) {
+    let room = MAX_EVENT_TEXT_CHARS.saturating_sub(buffer.chars().count());
+    if room == 0 {
+        return;
+    }
+    match text.char_indices().nth(room) {
+        Some((cut, _)) => buffer.push_str(&text[..cut]),
+        None => buffer.push_str(text),
     }
 }

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -942,7 +942,7 @@ mod tests {
     use std::process::Command as StdCommand;
     use tempfile::TempDir;
     use tidebreak_core::db::code::{
-        insert_repo, insert_session, insert_turn, insert_workspace, list_events,
+        insert_repo, insert_session, insert_turn, insert_workspace, list_events, MAX_REPLAY_EVENTS,
     };
     use tidebreak_core::{
         Attention, AttentionSource, CodePermissionMode, CodeRepo, CodeSessionKind,
@@ -1543,9 +1543,10 @@ mod tests {
     }
 
     async fn recorded_events(db: &Arc<DbStore>, session: &CodeSession) -> Vec<CodeEvent> {
-        list_events(db, &session.owner, session.id, 0)
+        list_events(db, &session.owner, session.id, 0, MAX_REPLAY_EVENTS)
             .await
             .unwrap()
+            .events
             .into_iter()
             .map(|framed| framed.event)
             .collect()

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -14,7 +14,7 @@ use tidebreak_core::db::code::{
     get_workspace, insert_repo, insert_session, insert_workspace, list_approvals, list_events,
     list_repos, list_repos_all_owners, list_sessions, list_sessions_all_owners,
     list_sessions_for_workspace, list_turns, list_workspaces, mark_repo_removed, save_approval,
-    save_repo, save_session, save_workspace,
+    save_repo, save_session, save_workspace, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
@@ -1955,8 +1955,8 @@ impl CodeRuntime {
     > {
         let session = self.get_session(owner, session_id).await?;
         let turns = list_turns(&self.db, owner, session_id).await?;
-        let events = list_events(&self.db, owner, session_id, 0).await?;
-        Ok((session, turns, events))
+        let events = list_events(&self.db, owner, session_id, 0, MAX_REPLAY_EVENTS).await?;
+        Ok((session, turns, events.events))
     }
 
     /// Write this session's transcript into its worktree for a fork to read.
@@ -1975,12 +1975,12 @@ impl CodeRuntime {
             .require_live_workspace(owner, session.workspace_id)
             .await?;
         let turns = list_turns(&self.db, owner, session_id).await?;
-        let events = list_events(&self.db, owner, session_id, 0).await?;
+        let events = list_events(&self.db, owner, session_id, 0, MAX_REPLAY_EVENTS).await?;
         fork::write_transcript(
             std::path::Path::new(&workspace.worktree_path),
             &session,
             &turns,
-            &events,
+            &events.events,
         )
         .await
         .map_err(|err| ServerError::internal(format!("could not write the fork transcript: {err}")))

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -349,6 +349,16 @@ impl HarnessEventSink for LiveSink {
         let Some(code_event) = map_event(event, turn_id) else {
             return;
         };
+        // Assistant deltas stream and are gone. The `assistant_message` that
+        // closes the run repeats them exactly, so a row here would store the
+        // same words a second time (record 57).
+        if matches!(code_event, CodeEvent::AssistantDelta { .. }) {
+            self.bus.publish_transient(self.session_id, code_event);
+            let _ =
+                super::attention::note_activity(&self.db, &self.bus, &self.owner, self.session_id)
+                    .await;
+            return;
+        }
         self.note_subagent_boundary(&code_event).await;
         // An approval is parked on the call this completion names. Reconcile
         // it after the completion lands, so the journal reads in the order it
@@ -1288,6 +1298,7 @@ async fn persist_and_publish(
     spawn_epoch: i64,
     event: CodeEvent,
 ) -> Result<(), CodeJournalError> {
+    settle_streamed_text(db, bus, owner, session_id, spawn_epoch, &event).await;
     let activity_boundary = matches!(
         &event,
         CodeEvent::ToolStarted {
@@ -1329,11 +1340,64 @@ async fn persist_and_publish(
     Ok(())
 }
 
+/// Write down assistant text the engine streamed but never stated.
+///
+/// Deltas are live-only, so the `assistant_message` closing a run is what the
+/// journal keeps. A turn that ends mid-sentence — interrupted, or failed —
+/// never produces that message, and the words the reader watched arrive would
+/// otherwise be gone on reload. Synthesizing the message the engine did not
+/// send is safe where replaying the deltas would not be: the renderer and the
+/// CLI both treat a message as a *replacement* for the text they streamed, so
+/// a client that already has it shows it once.
+///
+/// Everything else that ends a run — the engine's own message, a parent-level
+/// tool call, the next turn — already carries the text or discards it, and
+/// [`CodeEventBus::publish`] retires the buffer when it goes by.
+///
+/// Best-effort on purpose: a recovery write that fails must not stop the
+/// terminal event that follows it from being journaled.
+async fn settle_streamed_text(
+    db: &DbStore,
+    bus: &CodeEventBus,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+    event: &CodeEvent,
+) {
+    if !matches!(
+        event,
+        CodeEvent::TurnCompleted { .. } | CodeEvent::TurnFailed { .. } | CodeEvent::TurnInterrupted
+    ) {
+        return;
+    }
+    let streamed = bus.take_assistant_tail(session_id);
+    if streamed.is_empty() {
+        return;
+    }
+    let recovered = CodeEvent::AssistantMessage {
+        text: streamed,
+        parent_call_id: None,
+    };
+    match append_event(db, owner, session_id, spawn_epoch, &recovered).await {
+        Ok(seq) => bus.publish(
+            session_id,
+            tidebreak_core::SequencedCodeEvent {
+                seq,
+                event: recovered,
+            },
+        ),
+        Err(err) => warn!(
+            session = %session_id,
+            error = %err,
+            "could not journal the text a turn streamed before it ended"
+        ),
+    }
+}
+
 fn is_activity(event: &CodeEvent) -> bool {
     matches!(
         event,
-        CodeEvent::AssistantDelta { .. }
-            | CodeEvent::AssistantMessage { .. }
+        CodeEvent::AssistantMessage { .. }
             | CodeEvent::ReasoningDelta { .. }
             | CodeEvent::ToolStarted { .. }
             | CodeEvent::ToolCompleted { .. }

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -70,7 +70,10 @@ async fn stream_events(
     {
         return;
     }
-    if send_live_tail(&mut socket, &tail, last_seq).await.is_err() {
+    if send_live_tail(&mut socket, &tail, after, last_seq)
+        .await
+        .is_err()
+    {
         return;
     }
     loop {
@@ -166,17 +169,18 @@ async fn stream_events(
 /// written down.
 ///
 /// Without this, a client that connects mid-answer sees the sentence from
-/// wherever it happened to arrive. The tail is only trustworthy while the
-/// replay stayed behind the position it was captured at: a replay that read
-/// further has already picked up the `assistant_message` (or the tool call,
-/// or the turn's end) that retired it, and sending the stale copy on top
-/// would show the same words twice.
+/// wherever it happened to arrive. A reconnect from the tail's cursor has
+/// already applied its transient text, so sending the tail again would append
+/// the same words twice. The tail is also only trustworthy while replay stays
+/// behind the position it was captured at: a replay that reads further has
+/// already picked up the event that retired it.
 async fn send_live_tail(
     socket: &mut WebSocket,
     tail: &LiveTail,
+    requested_after: i64,
     last_seq: i64,
 ) -> Result<(), axum::Error> {
-    if tail.assistant.is_empty() || last_seq > tail.cursor {
+    if tail.assistant.is_empty() || requested_after >= tail.cursor || last_seq > tail.cursor {
         return Ok(());
     }
     send_frame(

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -70,10 +70,7 @@ async fn stream_events(
     {
         return;
     }
-    if send_live_tail(&mut socket, &tail, after, last_seq)
-        .await
-        .is_err()
-    {
+    if send_live_tail(&mut socket, &tail, last_seq).await.is_err() {
         return;
     }
     loop {
@@ -112,6 +109,7 @@ async fn stream_events(
                                 event: event.event,
                                 replayed: None,
                                 transient: Some(true),
+                                replacement: None,
                                 truncated: None,
                             },
                         )
@@ -142,6 +140,7 @@ async fn stream_events(
                             event: event.event,
                             replayed: None,
                             transient: None,
+                            replacement: None,
                             truncated: None,
                         },
                     )
@@ -169,18 +168,17 @@ async fn stream_events(
 /// written down.
 ///
 /// Without this, a client that connects mid-answer sees the sentence from
-/// wherever it happened to arrive. A reconnect from the tail's cursor has
-/// already applied its transient text, so sending the tail again would append
-/// the same words twice. The tail is also only trustworthy while replay stays
+/// wherever it happened to arrive. The frame is a replacement because a
+/// reconnect may already hold a prefix while also missing text that streamed
+/// during the disconnect. The tail is only trustworthy while replay stays
 /// behind the position it was captured at: a replay that reads further has
 /// already picked up the event that retired it.
 async fn send_live_tail(
     socket: &mut WebSocket,
     tail: &LiveTail,
-    requested_after: i64,
     last_seq: i64,
 ) -> Result<(), axum::Error> {
-    if tail.assistant.is_empty() || requested_after >= tail.cursor || last_seq > tail.cursor {
+    if tail.assistant.is_empty() || last_seq > tail.cursor {
         return Ok(());
     }
     send_frame(
@@ -192,6 +190,7 @@ async fn send_live_tail(
             },
             replayed: None,
             transient: Some(true),
+            replacement: Some(true),
             truncated: None,
         },
     )
@@ -218,6 +217,7 @@ async fn replay_after(
                 event: event.event,
                 replayed: Some(true),
                 transient: None,
+                replacement: None,
                 // Only the first frame of a capped window carries the flag:
                 // it is the one the dropped history sits in front of.
                 truncated: truncated.then(|| {

--- a/crates/tidebreak-server/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server/src/routes/code/session_events.rs
@@ -1,4 +1,10 @@
 //! `WS /code/sessions/{id}/events?after=` — snapshot → replay → live.
+//!
+//! Replay is bounded (`MAX_REPLAY_EVENTS`) and says when it dropped history,
+//! so a very long session cannot make one connect read its whole life. The
+//! live stream also carries frames the journal does not hold: assistant
+//! deltas stream and are never written down (record 57), so they arrive
+//! marked `transient` with no cursor of their own.
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
@@ -6,10 +12,11 @@ use axum::response::Response;
 use axum::Extension;
 use tokio::sync::broadcast::error::RecvError;
 
-use tidebreak_core::db::code::list_events;
-use tidebreak_core::{CodeSessionId, OwnerId};
+use tidebreak_core::db::code::{list_events, MAX_REPLAY_EVENTS};
+use tidebreak_core::{CodeEvent, CodeSessionId, OwnerId};
 
 use crate::auth::{offered_handshake_subprotocol, GatewayAuthLease, WS_HANDSHAKE_SUBPROTOCOL};
+use crate::code::bus::LiveTail;
 use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Path, Query};
@@ -54,13 +61,16 @@ async fn stream_events(
     let Some(runtime) = state.code.clone() else {
         return;
     };
-    let mut live = runtime.bus.subscribe(session);
+    let (mut live, tail) = runtime.bus.attach(session);
     let _ = runtime.mark_session_viewed(&owner, session).await;
     let mut last_seq = after;
     if replay_after(&mut socket, &runtime.db, &owner, session, &mut last_seq)
         .await
         .is_err()
     {
+        return;
+    }
+    if send_live_tail(&mut socket, &tail, last_seq).await.is_err() {
         return;
     }
     loop {
@@ -81,10 +91,38 @@ async fn stream_events(
             },
             live_event = live.recv() => match live_event {
                 Ok(event) => {
-                    if event.seq <= last_seq {
+                    // A live-only event carries no journal position. Stamp it
+                    // with this socket's cursor so a client that resumes from
+                    // the last `seq` it saw asks for the right place. Drop it
+                    // when the journal has moved past the point it streamed
+                    // behind: the replay that read that far already carries
+                    // the message stating the same text, and applying the
+                    // fragment on top would say it twice.
+                    let Some(seq) = event.seq else {
+                        if !transient_is_current(event.cursor, last_seq) {
+                            continue;
+                        }
+                        if send_frame(
+                            &mut socket,
+                            &SequencedCodeEventFrame {
+                                seq: last_seq,
+                                event: event.event,
+                                replayed: None,
+                                transient: Some(true),
+                                truncated: None,
+                            },
+                        )
+                        .await
+                        .is_err()
+                        {
+                            break;
+                        }
+                        continue;
+                    };
+                    if seq <= last_seq {
                         continue;
                     }
-                    if event.seq > last_seq.saturating_add(1) {
+                    if seq > last_seq.saturating_add(1) {
                         if replay_after(&mut socket, &runtime.db, &owner, session, &mut last_seq)
                             .await
                             .is_err()
@@ -93,13 +131,15 @@ async fn stream_events(
                         }
                         continue;
                     }
-                    last_seq = event.seq;
+                    last_seq = seq;
                     if send_frame(
                         &mut socket,
                         &SequencedCodeEventFrame {
-                            seq: event.seq,
+                            seq,
                             event: event.event,
                             replayed: None,
+                            transient: None,
+                            truncated: None,
                         },
                     )
                     .await
@@ -122,6 +162,38 @@ async fn stream_events(
     }
 }
 
+/// Hand a fresh reader the assistant text that has streamed but is not yet
+/// written down.
+///
+/// Without this, a client that connects mid-answer sees the sentence from
+/// wherever it happened to arrive. The tail is only trustworthy while the
+/// replay stayed behind the position it was captured at: a replay that read
+/// further has already picked up the `assistant_message` (or the tool call,
+/// or the turn's end) that retired it, and sending the stale copy on top
+/// would show the same words twice.
+async fn send_live_tail(
+    socket: &mut WebSocket,
+    tail: &LiveTail,
+    last_seq: i64,
+) -> Result<(), axum::Error> {
+    if tail.assistant.is_empty() || last_seq > tail.cursor {
+        return Ok(());
+    }
+    send_frame(
+        socket,
+        &SequencedCodeEventFrame {
+            seq: last_seq,
+            event: CodeEvent::AssistantDelta {
+                text: tail.assistant.clone(),
+            },
+            replayed: None,
+            transient: Some(true),
+            truncated: None,
+        },
+    )
+    .await
+}
+
 async fn replay_after(
     socket: &mut WebSocket,
     store: &tidebreak_core::DbStore,
@@ -129,10 +201,11 @@ async fn replay_after(
     session: CodeSessionId,
     last_seq: &mut i64,
 ) -> Result<(), ()> {
-    let events = list_events(store, owner, session, *last_seq)
+    let page = list_events(store, owner, session, *last_seq, MAX_REPLAY_EVENTS)
         .await
         .map_err(|_| ())?;
-    for event in events {
+    let mut truncated = page.truncated;
+    for event in page.events {
         *last_seq = event.seq;
         send_frame(
             socket,
@@ -140,12 +213,34 @@ async fn replay_after(
                 seq: event.seq,
                 event: event.event,
                 replayed: Some(true),
+                transient: None,
+                // Only the first frame of a capped window carries the flag:
+                // it is the one the dropped history sits in front of.
+                truncated: truncated.then(|| {
+                    truncated = false;
+                    true
+                }),
             },
         )
         .await
         .map_err(|_| ())?;
     }
     Ok(())
+}
+
+/// Is a live-only event still worth delivering to a socket at `last_seq`?
+///
+/// `cursor` is where the journal stood when the event streamed. A socket
+/// whose replay has read past that point already holds the event that
+/// superseded it — the `assistant_message` restating the whole answer, the
+/// tool call that ended the run, the turn's own end — so delivering the
+/// fragment on top would repeat text the reader already has.
+///
+/// This is reachable on every connect: the receiver is subscribed before the
+/// replay query runs, so anything published during the replay is queued
+/// behind frames the replay itself may already have sent.
+fn transient_is_current(cursor: i64, last_seq: i64) -> bool {
+    cursor >= last_seq
 }
 
 async fn send_frame(
@@ -156,4 +251,22 @@ async fn send_frame(
         return Ok(());
     };
     socket.send(Message::Text(json.into())).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transient_is_current;
+
+    /// A delta published while the socket was still replaying, whose text the
+    /// replay then covered, must be dropped rather than applied twice.
+    #[test]
+    fn a_delta_the_replay_overtook_is_not_delivered_again() {
+        // Streamed at cursor 40; the reader replayed through 41, which is the
+        // message stating the same words.
+        assert!(!transient_is_current(40, 41));
+        // Streamed at the position the reader stopped at: still the live tail.
+        assert!(transient_is_current(41, 41));
+        // Streamed after the reader's cursor: plainly still ahead of it.
+        assert!(transient_is_current(42, 41));
+    }
 }

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -119,6 +119,8 @@ pub async fn get_session_debug(
                 seq: item.seq,
                 event: item.event,
                 replayed: None,
+                transient: None,
+                truncated: None,
             })
             .collect(),
     }))

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -120,6 +120,7 @@ pub async fn get_session_debug(
                 event: item.event,
                 replayed: None,
                 transient: None,
+                replacement: None,
                 truncated: None,
             })
             .collect(),

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -185,14 +185,30 @@ impl From<CodeTurn> for CodeTurnSnapshot {
     }
 }
 
-/// One journaled event on the per-session WebSocket.
+/// One event on the per-session WebSocket.
 #[derive(Debug, Clone, PartialEq, Serialize, TS)]
 pub struct SequencedCodeEventFrame {
+    /// Journal position. On a `transient` frame this is the cursor the event
+    /// streamed behind, not a position the frame occupies — resume from it
+    /// and you lose nothing, because no row holds this event.
     pub seq: i64,
     pub event: CodeEvent,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub replayed: Option<bool>,
+    /// Set on a live-only event the journal does not hold: assistant deltas,
+    /// and the catch-up delta a mid-turn reader gets on connect. Apply it,
+    /// but do not advance the resume cursor past it and do not expect it
+    /// again on reconnect (record 57).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub transient: Option<bool>,
+    /// Set on the first replayed frame of a capped window: older events above
+    /// the requested cursor were dropped, and the history in front of this
+    /// frame is not coming.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub truncated: Option<bool>,
 }
 
 /// `GET /code/sessions/{id}/debug` — journal plus turn rows for a bug report.

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -197,12 +197,17 @@ pub struct SequencedCodeEventFrame {
     #[ts(optional)]
     pub replayed: Option<bool>,
     /// Set on a live-only event the journal does not hold: assistant deltas,
-    /// and the catch-up delta a mid-turn reader gets on connect. Apply it,
-    /// but do not advance the resume cursor past it and do not expect it
-    /// again on reconnect (record 57).
+    /// and the catch-up delta a mid-turn reader gets on connect. Apply it but
+    /// do not advance the resume cursor. A reconnect may receive the complete
+    /// current tail with `replacement` set (record 57).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub transient: Option<bool>,
+    /// Set on a transient assistant delta that contains the complete live
+    /// tail. Replace the current assistant buffer instead of appending it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub replacement: Option<bool>,
     /// Set on the first replayed frame of a capped window: older events above
     /// the requested cursor were dropped, and the history in front of this
     /// frame is not coming.

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -3894,6 +3894,153 @@ async fn connecting_mid_answer_replays_the_text_that_already_streamed() {
     let _ = turn.await;
 }
 
+/// A reconnect keeps the transient text it already applied. The server must
+/// not send the full live tail again from the same journal cursor.
+#[tokio::test(flavor = "multi_thread")]
+async fn reconnecting_mid_answer_does_not_repeat_the_live_tail() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+
+    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut socket, _) = connect_async(request).await.unwrap();
+
+    let epoch = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .spawn_epoch;
+    let marker = CodeEvent::HarnessNotice {
+        level: tidebreak_core::HarnessNoticeLevel::Info,
+        message: "reconnect cursor".into(),
+    };
+    let cursor = tidebreak_core::db::code::append_event(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+        epoch,
+        &marker,
+    )
+    .await
+    .unwrap();
+    runtime.bus.publish(
+        parsed,
+        tidebreak_core::SequencedCodeEvent {
+            seq: cursor,
+            event: marker,
+        },
+    );
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(frame) = socket.next().await {
+            let WsMessage::Text(text) = frame.unwrap() else {
+                continue;
+            };
+            let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+            if value["seq"] == cursor {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("the socket did not reach the reconnect cursor");
+
+    runtime.bus.publish_transient(
+        parsed,
+        CodeEvent::AssistantDelta {
+            text: "first ".into(),
+        },
+    );
+    runtime.bus.publish_transient(
+        parsed,
+        CodeEvent::AssistantDelta {
+            text: "second ".into(),
+        },
+    );
+
+    let mut assembled = String::new();
+    for _ in 0..2 {
+        let frame = tokio::time::timeout(Duration::from_secs(5), socket.next())
+            .await
+            .expect("a live delta timed out")
+            .expect("the live socket closed")
+            .unwrap();
+        let WsMessage::Text(text) = frame else {
+            panic!("expected a text frame");
+        };
+        let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+        assert_eq!(value["seq"], cursor);
+        assert_eq!(value["transient"], true);
+        assembled.push_str(value["event"]["text"].as_str().unwrap());
+    }
+    assert_eq!(assembled, "first second ");
+    drop(socket);
+
+    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after={cursor}")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut resumed, _) = connect_async(request).await.unwrap();
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), resumed.next())
+            .await
+            .is_err(),
+        "the reconnect repeated text the client already applied"
+    );
+
+    runtime.bus.publish_transient(
+        parsed,
+        CodeEvent::AssistantDelta {
+            text: "third".into(),
+        },
+    );
+    let frame = tokio::time::timeout(Duration::from_secs(5), resumed.next())
+        .await
+        .expect("the resumed delta timed out")
+        .expect("the resumed socket closed")
+        .unwrap();
+    let WsMessage::Text(text) = frame else {
+        panic!("expected a text frame");
+    };
+    let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+    assert_eq!(value["event"]["type"], "assistant_delta");
+    assert_eq!(value["event"]["text"], "third");
+    assembled.push_str(value["event"]["text"].as_str().unwrap());
+    assert_eq!(assembled, "first second third");
+}
+
 #[tokio::test]
 async fn superseded_worker_cannot_append_to_the_journal() {
     let (router, token, runtime, dir) = code_app(plain_text_script()).await;

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -308,14 +308,30 @@ async fn approvals_for(
         .unwrap()
 }
 
+/// Every event a session journaled, in order.
+async fn journaled_events(
+    db: &DbStore,
+    session_id: CodeSessionId,
+) -> Vec<tidebreak_core::SequencedCodeEvent> {
+    tidebreak_core::db::code::list_events(
+        db,
+        &tidebreak_core::OwnerId::local(),
+        session_id,
+        0,
+        tidebreak_core::db::code::MAX_REPLAY_EVENTS,
+    )
+    .await
+    .unwrap()
+    .events
+}
+
 /// The outcome carried on every `ApprovalResolved` the session journaled.
 async fn journaled_resolutions(
     db: &DbStore,
     session_id: CodeSessionId,
 ) -> Vec<tidebreak_core::ApprovalDecisionKind> {
-    tidebreak_core::db::code::list_events(db, &tidebreak_core::OwnerId::local(), session_id, 0)
+    journaled_events(db, session_id)
         .await
-        .unwrap()
         .into_iter()
         .filter_map(|framed| match framed.event {
             CodeEvent::ApprovalResolved { decision, .. } => Some(decision),
@@ -965,7 +981,7 @@ async fn interrupt_stops_a_running_turn_without_ending_its_browser_channel() {
 
     let session_id: CodeSessionId = json_id(&session).parse().unwrap();
     let browser_token = browser_token_for_session(&runtime, session_id);
-    let mut events = runtime.bus.subscribe(session_id);
+    let (mut events, _) = runtime.bus.attach(session_id);
 
     let turn_req = client
         .post(format!(
@@ -1160,7 +1176,7 @@ async fn an_engine_that_dies_without_saying_so_journals_an_interrupted_turn() {
         .unwrap();
 
     let session_id: CodeSessionId = json_id(&session).parse().unwrap();
-    let mut events = runtime.bus.subscribe(session_id);
+    let (mut events, _) = runtime.bus.attach(session_id);
 
     let turn_req = client
         .post(format!(
@@ -2125,7 +2141,7 @@ async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_
         .unwrap();
     let session_id = json_id(&session).to_owned();
     let parsed: CodeSessionId = session_id.parse().unwrap();
-    let mut events = runtime.bus.subscribe(parsed);
+    let (mut events, _) = runtime.bus.attach(parsed);
 
     let turn = tokio::spawn({
         let client = client.clone();
@@ -2403,14 +2419,7 @@ async fn stale_turn_steering_is_rejected_before_reaching_the_adapter() {
     assert_eq!(body["kind"], "stale_turn");
     assert_eq!(turn.await.unwrap().status(), reqwest::StatusCode::ACCEPTED);
 
-    let events = tidebreak_core::db::code::list_events(
-        &runtime.db,
-        &tidebreak_core::OwnerId::local(),
-        parsed,
-        0,
-    )
-    .await
-    .unwrap();
+    let events = journaled_events(&runtime.db, parsed).await;
     assert!(
         events
             .iter()
@@ -2557,7 +2566,7 @@ async fn terminal_turn_event_closes_steering_before_a_late_command_is_admitted()
         .unwrap();
     let session_id = json_id(&session).to_owned();
     let parsed: CodeSessionId = session_id.parse().unwrap();
-    let mut events = runtime.bus.subscribe(parsed);
+    let (mut events, _) = runtime.bus.attach(parsed);
     let turn = tokio::spawn({
         let client = client.clone();
         let token = token.clone();
@@ -2631,7 +2640,7 @@ async fn a_native_steer_rejection_does_not_fail_or_redirect_the_turn() {
         .unwrap();
     let session_id = json_id(&session).to_owned();
     let parsed: CodeSessionId = session_id.parse().unwrap();
-    let mut events = runtime.bus.subscribe(parsed);
+    let (mut events, _) = runtime.bus.attach(parsed);
     let turn = tokio::spawn({
         let client = client.clone();
         let token = token.clone();
@@ -3293,12 +3302,20 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
         .unwrap();
 
     let mut seqs = Vec::new();
+    let mut streamed = String::new();
     let read = async {
         while let Some(frame) = socket.next().await {
             let WsMessage::Text(text) = frame.unwrap() else {
                 continue;
             };
             let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+            // Deltas ride the live stream without a row, so they repeat the
+            // cursor rather than advancing it. The ordering contract is about
+            // the journal.
+            if value["transient"] == true {
+                streamed.push_str(value["event"]["text"].as_str().unwrap());
+                continue;
+            }
             let seq = value["seq"].as_i64().unwrap();
             seqs.push(seq);
             if value["event"]["type"] == "turn_completed" {
@@ -3309,6 +3326,7 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
     tokio::time::timeout(Duration::from_secs(5), read)
         .await
         .expect("turn did not complete over the socket");
+    assert_eq!(streamed, "onetwo", "deltas must still stream live");
     assert!(seqs.windows(2).all(|pair| pair[0] < pair[1]), "{seqs:?}");
     assert_eq!(
         seqs.iter()
@@ -3373,6 +3391,9 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
     assert_eq!(recovered, vec![current + 1, current + 2]);
 }
 
+/// Delta rows are no longer written, but journals that already hold them
+/// must still read back. This appends them the way a pre-record-57 session
+/// did and replays the result.
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_replay_emits_every_durable_sequence_after_the_cursor_in_order() {
     let (router, token, runtime, dir) = code_app(plain_text_script()).await;
@@ -3398,16 +3419,10 @@ async fn ws_replay_emits_every_durable_sequence_after_the_cursor_in_order() {
         .unwrap();
     let session_id = json_id(&session).to_owned();
     let parsed: CodeSessionId = session_id.parse().unwrap();
-    let replay_after_seq = tidebreak_core::db::code::list_events(
-        &runtime.db,
-        &tidebreak_core::OwnerId::local(),
-        parsed,
-        0,
-    )
-    .await
-    .unwrap()
-    .last()
-    .map_or(0, |event| event.seq);
+    let replay_after_seq = journaled_events(&runtime.db, parsed)
+        .await
+        .last()
+        .map_or(0, |event| event.seq);
 
     let first_delta_seq = tidebreak_core::db::code::append_event(
         &runtime.db,
@@ -3460,6 +3475,423 @@ async fn ws_replay_emits_every_durable_sequence_after_the_cursor_in_order() {
     assert_eq!(replayed[1]["event"]["text"], "lo");
     assert_eq!(replayed[0]["replayed"], true);
     assert_eq!(replayed[1]["replayed"], true);
+}
+
+/// Record 57: the message states the whole answer, so the deltas that built
+/// it are streamed and dropped. A plausible wrong implementation stops
+/// publishing them too and passes every durable assertion here.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_turn_journals_its_message_and_none_of_the_deltas_that_built_it() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::AssistantDelta {
+                text: "half a ".into(),
+            },
+            HarnessEvent::AssistantDelta {
+                text: "sentence".into(),
+            },
+            HarnessEvent::AssistantMessage {
+                text: "half a sentence".into(),
+                parent_call_id: None,
+            },
+            HarnessEvent::TurnCompleted {
+                usage: Default::default(),
+            },
+        ])
+        .with_delay(Duration::from_millis(10)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+
+    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut socket, _) = connect_async(request).await.unwrap();
+
+    let turn = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "hi" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(turn.status(), reqwest::StatusCode::ACCEPTED);
+
+    let mut streamed = Vec::new();
+    let read = async {
+        while let Some(frame) = socket.next().await {
+            let WsMessage::Text(text) = frame.unwrap() else {
+                continue;
+            };
+            let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+            if value["event"]["type"] == "assistant_delta" {
+                assert_eq!(value["transient"], true, "a delta must not claim a row");
+                streamed.push(value["event"]["text"].as_str().unwrap().to_owned());
+            }
+            if value["event"]["type"] == "turn_completed" {
+                break;
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), read)
+        .await
+        .expect("turn did not complete over the socket");
+    assert_eq!(streamed, vec!["half a ", "sentence"]);
+
+    let journaled = journaled_events(&runtime.db, parsed).await;
+    assert!(
+        !journaled
+            .iter()
+            .any(|framed| matches!(framed.event, CodeEvent::AssistantDelta { .. })),
+        "a delta reached the journal: {journaled:?}"
+    );
+    let messages: Vec<&str> = journaled
+        .iter()
+        .filter_map(|framed| match &framed.event {
+            CodeEvent::AssistantMessage { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(messages, vec!["half a sentence"]);
+}
+
+/// Interrupt an answer mid-sentence and the words the reader watched arrive
+/// must survive a reload. The engine never sent a message for them, so the
+/// server writes the one it owed.
+#[tokio::test(flavor = "multi_thread")]
+async fn text_streamed_before_an_interrupt_is_written_down() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::AssistantDelta {
+                text: "thinking out ".into(),
+            },
+            HarnessEvent::AssistantDelta {
+                text: "loud".into(),
+            },
+            HarnessEvent::AssistantDelta {
+                text: " and on".into(),
+            },
+            HarnessEvent::TurnCompleted {
+                usage: Default::default(),
+            },
+        ])
+        .with_delay(Duration::from_millis(150)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let (mut events, _) = runtime.bus.attach(parsed);
+
+    let turn_req = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "go" }));
+    let interrupt = async {
+        // Wait for the first delta so there is streamed text to lose.
+        loop {
+            let event = events.recv().await.unwrap();
+            if matches!(event.event, CodeEvent::AssistantDelta { .. }) {
+                break;
+            }
+        }
+        client
+            .post(format!(
+                "http://{addr}/code/sessions/{session_id}/interrupt"
+            ))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap()
+    };
+    let (turn, interrupted) = tokio::join!(turn_req.send(), interrupt);
+    assert_eq!(interrupted.status(), reqwest::StatusCode::ACCEPTED);
+    assert_eq!(turn.unwrap().status(), reqwest::StatusCode::ACCEPTED);
+
+    let recovered = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let journaled = journaled_events(&runtime.db, parsed).await;
+            let text = journaled.iter().find_map(|framed| match &framed.event {
+                CodeEvent::AssistantMessage { text, .. } => Some(text.clone()),
+                _ => None,
+            });
+            if let Some(text) = text {
+                return text;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("streamed text must survive the interrupt");
+    assert!(
+        recovered.starts_with("thinking out"),
+        "expected the streamed text, got {recovered:?}"
+    );
+}
+
+/// Replay is capped, and the client is told when the cap bit. Silently
+/// dropping the head would let a long session open on its middle and read as
+/// if that were where it began.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_capped_replay_tells_the_socket_that_history_was_dropped() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+
+    let overflow = tidebreak_core::db::code::MAX_REPLAY_EVENTS + 2;
+    let epoch = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        parsed,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .spawn_epoch;
+    for index in 0..overflow {
+        tidebreak_core::db::code::append_event(
+            &runtime.db,
+            &tidebreak_core::OwnerId::local(),
+            parsed,
+            epoch,
+            &tidebreak_core::CodeEvent::HarnessNotice {
+                level: tidebreak_core::HarnessNoticeLevel::Info,
+                message: format!("notice {index}"),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut socket, _) = connect_async(request).await.unwrap();
+    let frame = tokio::time::timeout(Duration::from_secs(10), socket.next())
+        .await
+        .expect("replay timed out")
+        .expect("socket closed")
+        .unwrap();
+    let WsMessage::Text(text) = frame else {
+        panic!("expected a text frame");
+    };
+    let first: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+    assert_eq!(first["truncated"], true, "{first}");
+    // The window keeps the newest events, so it starts a cap's worth below
+    // the head of the journal rather than at the cursor the client asked
+    // from.
+    let newest = journaled_events(&runtime.db, parsed)
+        .await
+        .last()
+        .expect("the session journaled something")
+        .seq;
+    assert_eq!(
+        first["seq"].as_i64().unwrap(),
+        newest - tidebreak_core::db::code::MAX_REPLAY_EVENTS as i64 + 1
+    );
+
+    let second = tokio::time::timeout(Duration::from_secs(10), socket.next())
+        .await
+        .expect("second frame timed out")
+        .expect("socket closed")
+        .unwrap();
+    let WsMessage::Text(text) = second else {
+        panic!("expected a text frame");
+    };
+    let second: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+    assert!(
+        second.get("truncated").is_none(),
+        "only the first frame of the window carries the flag: {second}"
+    );
+}
+
+/// A reader who opens the pane mid-answer must see the sentence from its
+/// start, not from wherever they happened to arrive. Nothing durable holds
+/// that text yet, so the live tail is the only source.
+#[tokio::test(flavor = "multi_thread")]
+async fn connecting_mid_answer_replays_the_text_that_already_streamed() {
+    let (router, token, runtime, dir) = code_app_with(
+        ScriptedAdapter::new(vec![
+            HarnessEvent::TurnStarted,
+            HarnessEvent::AssistantDelta {
+                text: "first ".into(),
+            },
+            HarnessEvent::AssistantDelta {
+                text: "second ".into(),
+            },
+            HarnessEvent::AssistantDelta {
+                text: "third".into(),
+            },
+            HarnessEvent::AssistantMessage {
+                text: "first second third".into(),
+                parent_call_id: None,
+            },
+            HarnessEvent::TurnCompleted {
+                usage: Default::default(),
+            },
+        ])
+        .with_delay(Duration::from_millis(200)),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+    let (mut events, _) = runtime.bus.attach(parsed);
+
+    let turn = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .bearer_auth(&token)
+                .json(&serde_json::json!({ "message": "go" }))
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+
+    // Let two deltas go by, then connect as a second reader would.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let mut seen = 0;
+        while seen < 2 {
+            if matches!(
+                events.recv().await.unwrap().event,
+                CodeEvent::AssistantDelta { .. }
+            ) {
+                seen += 1;
+            }
+        }
+    })
+    .await
+    .expect("no deltas streamed");
+
+    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut socket, _) = connect_async(request).await.unwrap();
+
+    let mut assembled = String::new();
+    let mut finalized = None;
+    let read = async {
+        while let Some(frame) = socket.next().await {
+            let WsMessage::Text(text) = frame.unwrap() else {
+                continue;
+            };
+            let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+            match value["event"]["type"].as_str() {
+                Some("assistant_delta") => {
+                    assembled.push_str(value["event"]["text"].as_str().unwrap());
+                }
+                Some("assistant_message") => {
+                    finalized = Some(value["event"]["text"].as_str().unwrap().to_owned());
+                    break;
+                }
+                _ => {}
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(10), read)
+        .await
+        .expect("the late reader never saw the message");
+    assert_eq!(
+        assembled, "first second third",
+        "a mid-answer reader must be caught up before the message lands"
+    );
+    assert_eq!(finalized.as_deref(), Some("first second third"));
+    let _ = turn.await;
 }
 
 #[tokio::test]
@@ -3602,14 +4034,7 @@ async fn a_completed_turn_records_a_checkpoint_and_serves_bounded_review() {
     );
     assert_eq!(diff["truncated"], false);
 
-    let events = tidebreak_core::db::code::list_events(
-        &_runtime.db,
-        &tidebreak_core::OwnerId::local(),
-        json_id(&session).parse().unwrap(),
-        0,
-    )
-    .await
-    .unwrap();
+    let events = journaled_events(&_runtime.db, json_id(&session).parse().unwrap()).await;
     assert!(
         events.iter().any(|framed| {
             matches!(
@@ -3700,14 +4125,7 @@ async fn a_failed_checkpoint_does_not_fail_the_turn() {
     assert_eq!(turn["status"], "completed");
     assert!(turn["checkpoint_ref"].is_null());
 
-    let events = tidebreak_core::db::code::list_events(
-        &runtime.db,
-        &tidebreak_core::OwnerId::local(),
-        json_id(&session).parse().unwrap(),
-        0,
-    )
-    .await
-    .unwrap();
+    let events = journaled_events(&runtime.db, json_id(&session).parse().unwrap()).await;
     assert!(
         events.iter().any(|framed| {
             matches!(
@@ -3849,33 +4267,32 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
     assert_eq!(finished.status(), reqwest::StatusCode::ACCEPTED);
     let body: serde_json::Value = finished.json().await.unwrap();
     assert_eq!(body["status"], "completed");
-    let events = tidebreak_core::db::code::list_events(
-        &runtime.db,
-        &tidebreak_core::OwnerId::local(),
-        parsed,
-        0,
-    )
-    .await
-    .unwrap();
+    let events = journaled_events(&runtime.db, parsed).await;
     let kinds: Vec<&str> = events
         .iter()
         .map(|framed| match &framed.event {
             tidebreak_core::CodeEvent::ApprovalRequested { .. } => "requested",
             tidebreak_core::CodeEvent::ApprovalResolved { .. } => "resolved",
-            tidebreak_core::CodeEvent::AssistantDelta { .. } => "delta",
+            // Deltas stream and are never journaled; the message that states
+            // the same text is what the turn leaves behind (record 57).
+            tidebreak_core::CodeEvent::AssistantMessage { .. } => "message",
             tidebreak_core::CodeEvent::TurnCompleted { .. } => "completed",
             _ => "other",
         })
         .collect();
     assert!(kinds.contains(&"requested"));
     assert!(kinds.contains(&"resolved"));
-    assert!(kinds.contains(&"delta"));
+    assert!(kinds.contains(&"message"));
     assert!(kinds.contains(&"completed"));
+    assert!(events.iter().any(|framed| matches!(
+        &framed.event,
+        tidebreak_core::CodeEvent::AssistantMessage { text, .. } if text == "after the decision"
+    )));
     let requested = kinds.iter().position(|k| *k == "requested").unwrap();
-    let delta = kinds.iter().position(|k| *k == "delta").unwrap();
+    let message = kinds.iter().position(|k| *k == "message").unwrap();
     let completed = kinds.iter().position(|k| *k == "completed").unwrap();
-    assert!(requested < delta);
-    assert!(delta < completed);
+    assert!(requested < message);
+    assert!(message < completed);
 }
 
 #[tokio::test]

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -3894,10 +3894,10 @@ async fn connecting_mid_answer_replays_the_text_that_already_streamed() {
     let _ = turn.await;
 }
 
-/// A reconnect keeps the transient text it already applied. The server must
-/// not send the full live tail again from the same journal cursor.
+/// A reconnect may keep a prefix and miss later deltas while the socket is
+/// down. The server sends the complete tail as a replacement.
 #[tokio::test(flavor = "multi_thread")]
-async fn reconnecting_mid_answer_does_not_repeat_the_live_tail() {
+async fn reconnecting_mid_answer_replaces_with_the_complete_live_tail() {
     let (router, token, runtime, dir) = code_app(plain_text_script()).await;
     let addr = serve(router).await;
     let client = reqwest::Client::new();
@@ -4005,6 +4005,13 @@ async fn reconnecting_mid_answer_does_not_repeat_the_live_tail() {
     assert_eq!(assembled, "first second ");
     drop(socket);
 
+    runtime.bus.publish_transient(
+        parsed,
+        CodeEvent::AssistantDelta {
+            text: "third".into(),
+        },
+    );
+
     let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after={cursor}")
         .into_client_request()
         .unwrap();
@@ -4013,17 +4020,26 @@ async fn reconnecting_mid_answer_does_not_repeat_the_live_tail() {
         .insert("Authorization", format!("Bearer {token}").parse().unwrap());
     let (mut resumed, _) = connect_async(request).await.unwrap();
 
-    assert!(
-        tokio::time::timeout(Duration::from_millis(250), resumed.next())
-            .await
-            .is_err(),
-        "the reconnect repeated text the client already applied"
-    );
+    let frame = tokio::time::timeout(Duration::from_secs(5), resumed.next())
+        .await
+        .expect("the replacement tail timed out")
+        .expect("the resumed socket closed")
+        .unwrap();
+    let WsMessage::Text(text) = frame else {
+        panic!("expected a text frame");
+    };
+    let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+    assert_eq!(value["seq"], cursor);
+    assert_eq!(value["event"]["type"], "assistant_delta");
+    assert_eq!(value["event"]["text"], "first second third");
+    assert_eq!(value["transient"], true);
+    assert_eq!(value["replacement"], true);
+    assembled = value["event"]["text"].as_str().unwrap().to_owned();
 
     runtime.bus.publish_transient(
         parsed,
         CodeEvent::AssistantDelta {
-            text: "third".into(),
+            text: " fourth".into(),
         },
     );
     let frame = tokio::time::timeout(Duration::from_secs(5), resumed.next())
@@ -4036,9 +4052,10 @@ async fn reconnecting_mid_answer_does_not_repeat_the_live_tail() {
     };
     let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
     assert_eq!(value["event"]["type"], "assistant_delta");
-    assert_eq!(value["event"]["text"], "third");
+    assert_eq!(value["event"]["text"], " fourth");
+    assert!(value.get("replacement").is_none());
     assembled.push_str(value["event"]["text"].as_str().unwrap());
-    assert_eq!(assembled, "first second third");
+    assert_eq!(assembled, "first second third fourth");
 }
 
 #[tokio::test]

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -307,7 +307,7 @@ POST            /code/sessions/{id}/interrupt | /permission-mode | /attention | 
 WS              /code/sessions/{id}/events?after=    snapshot → replay → live
                                                      (replay is capped and flags truncation;
                                                      assistant deltas ride the same socket
-                                                     as live-only frames — record 0057)
+                                                     as live-only frames — record 0058)
 WS              /code/updates                        digests, restated on connect
 
 GET             /code/approvals?state=pending

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -305,6 +305,9 @@ POST            /code/sessions/{id}/turns            {message}  (queued while ru
                                                      mid_turn_steering capability carries it)
 POST            /code/sessions/{id}/interrupt | /permission-mode | /attention | /reap
 WS              /code/sessions/{id}/events?after=    snapshot → replay → live
+                                                     (replay is capped and flags truncation;
+                                                     assistant deltas ride the same socket
+                                                     as live-only frames — record 0057)
 WS              /code/updates                        digests, restated on connect
 
 GET             /code/approvals?state=pending

--- a/docs/decisions/0057-assistant-deltas-are-live-only.md
+++ b/docs/decisions/0057-assistant-deltas-are-live-only.md
@@ -1,0 +1,185 @@
+# 57. Assistant Deltas Are Live-Only, and Journal Replay Is Bounded
+
+- Status: Accepted
+- Date: 2026-08-21
+- Owners: code mode, wire contract
+- Related: [`0030-code-mode-separate-surface.md`](0030-code-mode-separate-surface.md),
+  [`0035-code-mode-wire-contract.md`](0035-code-mode-wire-contract.md),
+  [`docs/code-mode.md`](../code-mode.md)
+
+## Context
+
+`code_event` is append-only with no pruning, and most of what it holds says
+nothing. Across eight driven code-mode sessions, delta rows were 63% to 93%
+of the table by lane:
+
+| Lane | Rows | Delta rows | Share |
+|---|---|---|---|
+| codex | 354 | 329 | 92.9% |
+| grok | 536 | 487 | 90.9% |
+| opencode | 244 | 205 | 84.0% |
+| claude_code | 108 | 68 | 63.0% |
+
+The duplication is exact. Concatenating a turn's `assistant_delta` texts
+reproduces the `assistant_message` that follows it byte for byte — 38 of 38
+messages across all eight lanes, no mismatches. Deltas average 42–46 bytes, so
+each one pays roughly twice its own size in per-row overhead to store text the
+next event already carries in full.
+
+Three costs follow:
+
+- **Storage.** Around 200 KB of the 340 KB the table occupied in a light test
+  profile was delta rows.
+- **Replay.** `list_events` had no bound, so a fresh events-socket connect
+  deserialized every row the session had ever journaled.
+- **Write path.** Every event is one `INSERT` inside a transaction that takes
+  the session row lock and scans for the current maximum sequence, and every
+  activity event then issued a `get_session` to decide whether a stall needed
+  clearing — usually to return early.
+
+The renderer already treats deltas as transient. `CodeSessionReducer`
+accumulates them into a buffer and the message replaces the buffer wholesale,
+so replaying stored deltas rebuilds a string the next event overwrites.
+
+Two constraints shape the answer. [`0030`](0030-code-mode-separate-surface.md)
+requires the code journal to keep the chat journal's event-table shape,
+sequencing rule, journal-before-live-publication discipline, and
+snapshot→replay→live contract, and it calls a second streaming idiom out of
+bounds without a record saying why the shared shape cannot serve. And
+`reasoning_delta` looks like the same case but is not: no `reasoning_message`
+exists, so those deltas are the only record of reasoning there is.
+
+## Decision
+
+**Assistant deltas are live-only.** `assistant_delta` is published on the
+session bus and never journaled. Everything else keeps the existing
+discipline: journaled first, published second, under the spawn-epoch fence,
+with `(session_id, seq)` monotonic and gap-free.
+
+**The frame says which kind it is.** `SequencedCodeEventFrame` gains
+`transient: Option<bool>`. A transient frame carries the journal cursor it
+streamed behind rather than a position of its own; a client applies it, does
+not advance its resume cursor past it, and does not expect it back on
+reconnect. This is the chat socket's existing shape for out-of-band frames
+(`RendererChatFrame::Metadata`) rather than a new idiom — one socket, two
+frame classes, one cursor.
+
+**The bus holds the tail, so mid-turn reconnect is still correct.** Between
+the first delta and the message that states the whole answer, the only copy of
+that text is in memory. The bus keeps it per session, bounded by
+`MAX_EVENT_TEXT_CHARS` — the same bound the message carrying it will get — and
+retires it on any journaled event that ends the run: the message, a
+parent-level tool call, a turn boundary. A connecting socket takes the tail
+and subscribes under one lock, so no delta is counted twice, and it forwards
+the tail only when its replay did not read past the journal position the tail
+was captured at.
+
+**A turn that ends mid-sentence gets the message the engine owed it.** When a
+turn reaches a terminal event with text still buffered, the server journals it
+as an `assistant_message` before the terminal event. Synthesizing the message
+is safe where replaying the deltas would not be: both the renderer and the CLI
+treat a message as a *replacement* for text they already streamed, so a client
+that has it shows it once.
+
+**Replay is bounded and says when it truncated.** `list_events` takes a limit
+and returns a page. It keeps the *newest* events above the cursor —
+`MAX_REPLAY_EVENTS = 2000` — and the first frame of a capped window carries
+`truncated: true`. The renderer turns that into a transcript line saying
+earlier history is not shown.
+
+**`reasoning_delta` is unchanged.** The duplication that justifies dropping
+assistant deltas does not hold for reasoning: there is no durable event that
+restates it, so dropping those rows would lose the thinking accordion's
+contents on reload rather than deduplicate them.
+
+**Stall detection reads memory before it reads rows.** The bus tracks each
+session's last publication, live or journaled, so a session pouring out a long
+answer and touching nothing else is not mistaken for silent. It also carries a
+pessimistic "might be stalled" hint that every row read corrects, so the
+common activity event costs no query.
+
+Deliberately excluded: deleting delta rows already written (they stay
+readable), a durable `reasoning_message` event, and any pruning of the journal
+after the fact.
+
+## Alternatives Considered
+
+**Delete a turn's delta rows once its message lands.** Keeps the wire
+untouched, and keeps mid-turn reconnect exactly as it is. Rejected: it pays
+the insert *and* a second write, which is the opposite of the write-path cost
+this record is about; it needs either a JSON predicate the two backends
+express differently or a read-then-delete round trip; and it leaves holes in
+the sequence that every future reader of the journal has to be correct about.
+Never writing the row costs nothing and leaves the sequence dense.
+
+**Drop the deltas with no live tail.** Simplest possible change. Rejected on
+the reconnect story: a reader who opens the pane mid-answer would see the
+sentence from wherever they arrived until the message landed, and the CLI —
+which never reprints a message it believes it already streamed — would lose
+the head of that answer permanently.
+
+**Give transient frames no `seq` at all**, as a separate untagged frame kind.
+Rejected: existing clients set their resume cursor from `frame.seq`, and a
+frame without one would either reset that cursor to zero or need every client
+changed in lockstep. Carrying the cursor makes the change backward-compatible
+for readers that ignore the new field.
+
+**Coalesce deltas into one row per run instead of dropping them.** Would fix
+reasoning too. Rejected here: the coalesced row has to be journaled but *not*
+delivered to clients that already streamed its text, and the moment it is not
+published the sequence gains a gap that sends every connected socket back to
+the journal to fetch exactly the row it must not apply. Making that safe needs
+per-frame coverage bookkeeping on the wire, which is a larger contract change
+than this problem justifies.
+
+**Do nothing.** Rejected: the table grows without bound, and the unbounded
+replay is a latent problem on its own — a long-lived session makes every
+connect more expensive than the last.
+
+## Consequences
+
+The code journal now holds a strict subset of what the chat journal holds for
+the same conversation: chat still journals `TextDelta`. That is a real
+divergence from [`0030`](0030-code-mode-separate-surface.md)'s convergence
+constraint, and it is the reason this record exists. It is narrow on purpose —
+the table shape, the sequencing rule, the fence, and the reconnect contract
+are all unchanged, so a future unified journal is still a table merge. If chat
+adopts the same treatment, the transient frame class is already defined and
+the tail already lives in the bus.
+
+The bus stops being a pure fan-out. It now owns per-session live state — the
+streamed tail, the cursor, last-activity, the stall hint — which means it is
+the thing to look at when a live/replay disagreement shows up, and it is
+per-process: two servers fronting one database would each hold their own tail.
+Code mode is single-process today; this is a constraint on that changing.
+
+A synthesized `assistant_message` is a server-authored event. It says what the
+engine streamed, not what the engine declared, and the journal does not
+distinguish the two.
+
+Replay truncation is visible but lossy: a session past the cap opens on its
+newest 2000 events. Anything that needs the whole journal — the debug bundle,
+the fork transcript — now reads a bounded window too and will silently stop at
+the same cap.
+
+Revisit this when chat and code journals converge, when an engine appears
+whose messages do not restate their deltas (the byte-for-byte finding is the
+whole foundation here), or when reasoning gains a durable finalize event and
+the same treatment becomes available to it.
+
+## Validation
+
+- A turn's journal holds its `assistant_message` and no `assistant_delta`
+  rows, while the same turn's deltas arrive on the socket marked transient —
+  a wrong implementation that stopped publishing them too would pass every
+  durable assertion alone.
+- A socket that connects after some deltas have streamed and before the
+  message lands assembles the same text as one that was connected the whole
+  time.
+- A turn interrupted mid-sentence leaves the streamed text in the journal.
+- A journal written before this change — delta rows and all — still replays in
+  order.
+- A replay past the cap carries `truncated` on its first frame only, and keeps
+  the newest events rather than the oldest.
+- `list_events` with a window that fits exactly reports no truncation, which a
+  naive `limit(n)` implementation would get wrong.

--- a/docs/decisions/0058-assistant-deltas-are-live-only.md
+++ b/docs/decisions/0058-assistant-deltas-are-live-only.md
@@ -176,6 +176,8 @@ the same treatment becomes available to it.
 - A socket that connects after some deltas have streamed and before the
   message lands assembles the same text as one that was connected the whole
   time.
+- A socket that reconnects from the transient tail's journal cursor keeps its
+  existing text and receives only later deltas.
 - A turn interrupted mid-sentence leaves the streamed text in the journal.
 - A journal written before this change — delta rows and all — still replays in
   order.

--- a/docs/decisions/0058-assistant-deltas-are-live-only.md
+++ b/docs/decisions/0058-assistant-deltas-are-live-only.md
@@ -57,12 +57,14 @@ discipline: journaled first, published second, under the spawn-epoch fence,
 with `(session_id, seq)` monotonic and gap-free.
 
 **The frame says which kind it is.** `SequencedCodeEventFrame` gains
-`transient: Option<bool>`. A transient frame carries the journal cursor it
-streamed behind rather than a position of its own; a client applies it, does
-not advance its resume cursor past it, and does not expect it back on
-reconnect. This is the chat socket's existing shape for out-of-band frames
-(`RendererChatFrame::Metadata`) rather than a new idiom — one socket, two
-frame classes, one cursor.
+`transient: Option<bool>` and `replacement: Option<bool>`. A transient frame
+carries the journal cursor it streamed behind rather than a position of its
+own, so a client applies it without advancing its resume cursor. On connect,
+the server sends the complete current tail with `replacement: true`. The
+desktop replaces its assistant buffer, while the CLI prints only the suffix
+that it has not already emitted. This is the chat socket's existing shape for
+out-of-band frames (`RendererChatFrame::Metadata`) rather than a new idiom —
+one socket, two frame classes, one cursor.
 
 **The bus holds the tail, so mid-turn reconnect is still correct.** Between
 the first delta and the message that states the whole answer, the only copy of
@@ -70,9 +72,11 @@ that text is in memory. The bus keeps it per session, bounded by
 `MAX_EVENT_TEXT_CHARS` — the same bound the message carrying it will get — and
 retires it on any journaled event that ends the run: the message, a
 parent-level tool call, a turn boundary. A connecting socket takes the tail
-and subscribes under one lock, so no delta is counted twice, and it forwards
-the tail only when its replay did not read past the journal position the tail
-was captured at.
+and subscribes under one lock, so no delta lands between those operations. It
+forwards the tail only when replay did not read past the journal position
+where the tail was captured. Replacement semantics cover both a fresh reader
+with an empty buffer and a reconnect that holds a prefix but missed later
+deltas while its socket was down.
 
 **A turn that ends mid-sentence gets the message the engine owed it.** When a
 turn reaches a terminal event with text still buffered, the server journals it
@@ -176,8 +180,9 @@ the same treatment becomes available to it.
 - A socket that connects after some deltas have streamed and before the
   message lands assembles the same text as one that was connected the whole
   time.
-- A socket that reconnects from the transient tail's journal cursor keeps its
-  existing text and receives only later deltas.
+- A socket that reconnects after missing deltas receives the complete tail as
+  a replacement. The desktop shows the tail once, and the CLI prints only its
+  missing suffix.
 - A turn interrupted mid-sentence leaves the streamed text in the journal.
 - A journal written before this change — delta rows and all — still replays in
   order.

--- a/docs/decisions/0058-assistant-deltas-are-live-only.md
+++ b/docs/decisions/0058-assistant-deltas-are-live-only.md
@@ -1,4 +1,4 @@
-# 57. Assistant Deltas Are Live-Only, and Journal Replay Is Bounded
+# 58. Assistant Deltas Are Live-Only, and Journal Replay Is Bounded
 
 - Status: Accepted
 - Date: 2026-08-21


### PR DESCRIPTION
## What changed

`code_event` had no pruning and most of it said nothing. Assistant deltas
were 63–93% of the table by lane, and the text they carry is repeated byte
for byte by the `assistant_message` that follows — 38 of 38 messages across
the eight driven sessions, no mismatches.

- **Deltas are live-only.** `assistant_delta` is published on the session bus
  and never journaled. Everything else keeps the existing discipline:
  journaled first, published second, under the spawn-epoch fence, with
  `(session_id, seq)` monotonic and dense.
- **The frame says which kind it is.** `SequencedCodeEventFrame` gains
  `transient`. A transient frame carries the journal cursor it streamed
  behind, so a client that resumes from the last `seq` it saw loses nothing.
  This is the chat socket's existing shape for out-of-band frames, not a
  second streaming idiom.
- **Mid-turn reconnect stays correct.** The bus keeps the text streamed so
  far, bounded by `MAX_EVENT_TEXT_CHARS`, and retires it on any journaled
  event that ends the run. A connecting socket takes the tail and subscribes
  under one lock, and forwards it only when its replay did not read past the
  position the tail was captured at.
- **A turn that ends mid-sentence gets the message the engine owed it.**
  Synthesizing the message is safe where replaying deltas would not be: both
  the renderer and the CLI treat a message as a replacement for text they
  streamed, so a client that already has it shows it once.
- **Replay is bounded.** `list_events` takes a limit, keeps the newest events
  (`MAX_REPLAY_EVENTS = 2000`), and the first frame of a capped window carries
  `truncated`. The renderer turns that into a transcript line.
- **The per-delta `get_session` is gone.** `note_activity` reads a pessimistic
  in-memory hint that every row read corrects, so the common path costs a
  mutex rather than a query.

`reasoning_delta` is deliberately unchanged. There is no `reasoning_message`,
so those rows are the only record of reasoning there is — dropping them would
empty the thinking accordion on reload rather than deduplicate anything.

Measured on a scripted 40-delta turn: **45 journal rows before, 5 after.**

## Decision record

Dropping durable deltas diverges from record 0030's
journal-before-live-publication rule for one event kind, so this adds
`docs/decisions/0057-assistant-deltas-are-live-only.md`. The divergence is
narrow on purpose: the table shape, sequencing rule, fence, and reconnect
contract are unchanged, so a future unified journal is still a table merge.

## Validation

- `cargo test -p tidebreak-server --lib -- tests::code routes::code::session_events` (106 passed)
- `cargo test -p tidebreak-core --lib -- db::tests::code::` (19 passed)
- `cargo test -p tidebreak-cli --bins -- code` (23 passed)
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code` (533 passed)
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `cargo clippy -p tidebreak-core -p tidebreak-server -p tidebreak-cli --all-targets -- -D warnings`
- `cargo fmt --all --check`

New tests: a turn journals its message and none of its deltas while the
deltas still arrive on the socket; a socket connecting mid-answer assembles
the same text as one connected throughout; text streamed before an interrupt
survives in the journal; a capped replay flags truncation on its first frame
only and keeps the newest events; an exact-fit window reports no truncation;
a delta the replay overtook is not delivered twice. The existing durable
replay test — which appends delta rows directly — covers journals written
before this change.

## Compatibility and risk

No migration. Delta rows already stored stay readable and still replay. The
wire gains two optional fields; the CLI's decoder ignores unknown fields, so
an older client reading a newer server renders deltas exactly as before.

The bus stops being a pure fan-out — it now owns per-session live state, which
is per-process. Code mode is single-process today; this is a constraint on
that changing.
