### PR TITLE
feat(code): reclaim only the checkouts Tidebreak cloned

### DIFF
--- a/crates/tidebreak-core/fixtures/schema-baseline.postgres.sql
+++ b/crates/tidebreak-core/fixtures/schema-baseline.postgres.sql
@@ -1225,7 +1225,8 @@ CREATE TABLE "code_repo" (
     "archive_script" text,
     "quick_actions" jsonb NOT NULL,
     "created_at" timestamp with time zone NOT NULL,
-    "removed_at" timestamp with time zone
+    "removed_at" timestamp with time zone,
+    "cloned_from" text
 );
 
 CREATE UNIQUE INDEX "idx_code_repo_owner_root_path" ON "code_repo" ("owner", "root_path") WHERE "removed_at" IS NULL;

--- a/crates/tidebreak-core/fixtures/schema-baseline.sql
+++ b/crates/tidebreak-core/fixtures/schema-baseline.sql
@@ -1306,7 +1306,8 @@ CREATE TABLE "code_repo" (
     "archive_script" text,
     "quick_actions" jsonb_text NOT NULL,
     "created_at" timestamp_with_timezone_text NOT NULL,
-    "removed_at" timestamp_with_timezone_text
+    "removed_at" timestamp_with_timezone_text,
+    "cloned_from" text
 );
 
 CREATE UNIQUE INDEX "idx_code_repo_owner_root_path" ON "code_repo" ("owner", "root_path") WHERE "removed_at" IS NULL;

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -601,6 +601,11 @@ pub struct CodeRepo {
     /// stops appearing in the repo list but keeps its archived workspaces and
     /// their transcripts reachable.
     pub removed_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The remote this checkout was cloned from, when Tidebreak cloned it.
+    ///
+    /// `None` means the user registered a directory that already existed.
+    /// Only a checkout Tidebreak created is Tidebreak's to delete.
+    pub cloned_from: Option<String>,
 }
 
 /// Persisted workspace record.

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1669,6 +1669,7 @@ pub mod code_repo {
         pub quick_actions: Json,
         pub created_at: DateTimeUtc,
         pub removed_at: Option<DateTimeUtc>,
+        pub cloned_from: Option<String>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/tidebreak-core/src/db/migration/baseline/code.rs
+++ b/crates/tidebreak-core/src/db/migration/baseline/code.rs
@@ -54,6 +54,13 @@ pub(super) fn code_repo_table() -> TableCreateStatement {
         // workspaces and their transcripts stay reachable. Deleting it would
         // orphan that history on SQLite and fail the foreign key on Postgres.
         .col(ColumnDef::new(CodeRepo::RemovedAt).timestamp_with_time_zone())
+        // The remote Tidebreak cloned this checkout from, when Tidebreak made
+        // it. Null means the user registered a directory that was already
+        // there. Reclaiming disk needs this distinction and cannot infer it:
+        // both paths register identically, and the clone parent is a setting
+        // that moves, so a path test would eventually delete someone's own
+        // repository.
+        .col(ColumnDef::new(CodeRepo::ClonedFrom).text())
         .to_owned()
 }
 

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -807,6 +807,7 @@ pub(crate) enum CodeRepo {
     CreatedAt,
     Owner,
     RemovedAt,
+    ClonedFrom,
 }
 
 #[derive(DeriveIden)]

--- a/crates/tidebreak-core/src/db/ops/code/repo.rs
+++ b/crates/tidebreak-core/src/db/ops/code/repo.rs
@@ -20,6 +20,7 @@ pub async fn insert_repo(store: &DbStore, repo: &CodeRepo) -> Result<()> {
         quick_actions: Set(serde_json::to_value(&repo.quick_actions)?),
         created_at: Set(repo.created_at),
         removed_at: Set(repo.removed_at),
+        cloned_from: Set(repo.cloned_from.clone()),
     }
     .insert(&store.conn)
     .await
@@ -168,5 +169,6 @@ pub(super) fn repo_from_row(row: entities::code_repo::Model) -> Result<CodeRepo>
         quick_actions,
         created_at: row.created_at,
         removed_at: row.removed_at,
+        cloned_from: row.cloned_from,
     })
 }

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -53,6 +53,7 @@ async fn seed_owner(
             quick_actions: Vec::new(),
             created_at: now(),
             removed_at: None,
+            cloned_from: None,
         },
     )
     .await
@@ -682,6 +683,7 @@ async fn the_same_repository_path_can_belong_to_two_owners() {
                 quick_actions: Vec::new(),
                 created_at: now(),
                 removed_at: None,
+                cloned_from: None,
             },
         )
         .await
@@ -967,6 +969,7 @@ async fn a_removed_repo_path_can_be_registered_again() {
         quick_actions: Vec::new(),
         created_at: now(),
         removed_at: None,
+        cloned_from: None,
     };
     insert_repo(&store, &replacement).await.unwrap();
 
@@ -1014,4 +1017,58 @@ async fn a_repo_is_not_removable_by_another_owner() {
         .await
         .unwrap());
     assert_eq!(list_repos(&store, &alice).await.unwrap().len(), 1);
+}
+
+/// Provenance is what makes a checkout reclaimable, so it must survive the
+/// round trip rather than being inferred later from a path.
+#[tokio::test]
+async fn a_cloned_repo_records_where_it_came_from() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let cloned = RepoId::new();
+    insert_repo(
+        &store,
+        &CodeRepo {
+            id: cloned,
+            owner: owner.clone(),
+            root_path: "/tmp/cloned-repo".into(),
+            display_name: "cloned".into(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: Vec::new(),
+            created_at: now(),
+            removed_at: None,
+            cloned_from: Some("https://example.invalid/team/repo.git".into()),
+        },
+    )
+    .await
+    .unwrap();
+
+    let stored = get_repo(&store, &owner, cloned).await.unwrap().unwrap();
+    assert_eq!(
+        stored.cloned_from.as_deref(),
+        Some("https://example.invalid/team/repo.git")
+    );
+
+    // A registered repository records nothing, which is what keeps reclaim
+    // from ever pointing at a directory the user brought.
+    let (session_id, _) = seed_owner(&store, &owner, "registered").await;
+    let workspace_id = get_session(&store, &owner, session_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .workspace_id;
+    let registered = get_workspace(&store, &owner, workspace_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .repo_id;
+    assert!(get_repo(&store, &owner, registered)
+        .await
+        .unwrap()
+        .unwrap()
+        .cloned_from
+        .is_none());
 }

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -730,6 +730,7 @@ async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
             quick_actions: Vec::new(),
             created_at: now,
             removed_at: None,
+            cloned_from: None,
         },
     )
     .await

--- a/crates/tidebreak-core/tests/postgres_code_owner.rs
+++ b/crates/tidebreak-core/tests/postgres_code_owner.rs
@@ -48,6 +48,7 @@ async fn seed_owner(
             quick_actions: Vec::new(),
             created_at: Utc::now(),
             removed_at: None,
+            cloned_from: None,
         },
     )
     .await
@@ -269,6 +270,7 @@ async fn postgres_repository_paths_are_unique_per_owner() {
         quick_actions: Vec::new(),
         created_at: Utc::now(),
         removed_at: None,
+        cloned_from: None,
     };
     let removed = repo(&alice);
     insert_repo(&store, &removed).await.unwrap();

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -1468,6 +1468,7 @@ mod tests {
                 quick_actions: Vec::new(),
                 created_at: chrono::Utc::now(),
                 removed_at: None,
+                cloned_from: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -212,7 +212,14 @@ impl CodeRuntime {
         .await
         {
             Ok(()) => match self
-                .register_repo(owner, target, super::runtime::RepoRegistration::default())
+                .register_repo(
+                    owner,
+                    target,
+                    super::runtime::RepoRegistration {
+                        cloned_from: Some(redact_clone_url(&url)),
+                        ..Default::default()
+                    },
+                )
                 .await
             {
                 Ok(repo) => {
@@ -339,6 +346,23 @@ async fn validate_parent_dir(parent: &Path) -> Result<(), ServerError> {
         ));
     }
     Ok(())
+}
+
+/// The clone URL with any embedded credentials removed.
+///
+/// A user may clone `https://token@host/org/repo.git`, and this string is
+/// persisted and shown back. Keep the origin, drop the secret: the userinfo
+/// segment is the credential, and nothing downstream needs it — the checkout's
+/// own remote holds whatever git needs to fetch again.
+pub(crate) fn redact_clone_url(url: &str) -> String {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        // scp-style `git@host:org/repo` carries a username, not a secret.
+        return url.to_owned();
+    };
+    match rest.split_once('@') {
+        Some((_userinfo, host)) => format!("{scheme}://{host}"),
+        None => url.to_owned(),
+    }
 }
 
 async fn clone_into(
@@ -554,5 +578,28 @@ mod tests {
         assert!(!valid_github_slug("acme"));
         assert!(!valid_github_slug("acme/demo/extra"));
         assert!(!valid_github_slug("acme/de mo"));
+    }
+
+    /// A clone URL is persisted and shown back, so a credential embedded in it
+    /// must not be what gets stored.
+    #[test]
+    fn a_clone_url_keeps_its_origin_and_loses_its_credential() {
+        assert_eq!(
+            redact_clone_url("https://ghp_secret@github.com/acme/demo.git"),
+            "https://github.com/acme/demo.git"
+        );
+        assert_eq!(
+            redact_clone_url("https://user:token@git.example.com/acme/demo.git"),
+            "https://git.example.com/acme/demo.git"
+        );
+        assert_eq!(
+            redact_clone_url("https://github.com/acme/demo.git"),
+            "https://github.com/acme/demo.git"
+        );
+        // scp-style carries a username, not a secret.
+        assert_eq!(
+            redact_clone_url("git@github.com:acme/demo.git"),
+            "git@github.com:acme/demo.git"
+        );
     }
 }

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -403,6 +403,7 @@ mod tests {
                 quick_actions: Vec::new(),
                 created_at: now(),
                 removed_at: None,
+                cloned_from: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -108,6 +108,9 @@ fn probe_describes(cached: Option<&HarnessProbe>, installed: &Path) -> bool {
 /// the value [`CodeRuntime::register_repo`] derives from the checkout.
 #[derive(Debug, Default)]
 pub(crate) struct RepoRegistration {
+    /// Set only by the clone path: the remote the checkout came from, which
+    /// is what makes the directory Tidebreak's to reclaim later.
+    pub cloned_from: Option<String>,
     pub display_name: Option<String>,
     pub default_base_ref: Option<String>,
     pub branch_prefix: Option<String>,
@@ -567,6 +570,7 @@ impl CodeRuntime {
         metadata: RepoRegistration,
     ) -> Result<CodeRepo, ServerError> {
         let RepoRegistration {
+            cloned_from,
             display_name,
             default_base_ref,
             branch_prefix,
@@ -623,6 +627,7 @@ impl CodeRuntime {
             quick_actions: Vec::new(),
             created_at: Utc::now(),
             removed_at: None,
+            cloned_from,
         };
         insert_repo(&self.db, &repo).await?;
         Ok(repo)
@@ -676,7 +681,13 @@ impl CodeRuntime {
     /// enforced, so the delete fails against the very archived workspaces this
     /// path requires. Reclaiming the checkout on disk is a separate act with
     /// its own confirmation.
-    pub(crate) async fn remove_repo(&self, owner: &OwnerId, id: RepoId) -> Result<(), ServerError> {
+    pub(crate) async fn remove_repo(
+        &self,
+        owner: &OwnerId,
+        id: RepoId,
+        reclaim_checkout: bool,
+    ) -> Result<(), ServerError> {
+        let repo = self.get_repo(owner, id).await?;
         let workspaces = list_workspaces(&self.db, owner, Some(id)).await?;
         if workspaces.iter().any(|workspace| {
             !matches!(
@@ -688,6 +699,49 @@ impl CodeRuntime {
                 "repo_has_workspaces",
                 "archive every workspace before removing the repository",
             ));
+        }
+        if reclaim_checkout {
+            // Only a checkout Tidebreak cloned is Tidebreak's to delete. A
+            // registration names a directory the user already had, and the
+            // clone parent is a setting that moves, so there is no path test
+            // that stays honest — the recorded origin is the only safe
+            // signal.
+            if repo.cloned_from.is_none() {
+                return Err(ServerError::conflict_kind(
+                    "checkout_not_reclaimable",
+                    "Tidebreak did not clone this repository, so it will not delete the directory; \
+                     remove the registration and delete the checkout yourself",
+                ));
+            }
+            let root = PathBuf::from(&repo.root_path);
+            // Re-validate rather than trusting the stored path: a row written
+            // long ago must not turn into a recursive delete of whatever
+            // occupies that path now.
+            match validate_repo_path(&root).await {
+                // `root_path` was stored as the canonical toplevel, so a
+                // repository still rooted there resolves back to the same
+                // path. Anything else — a nested checkout, a different repo
+                // moved in — compares unequal and is left alone.
+                Ok(validated) if validated.toplevel == root => {
+                    tokio::fs::remove_dir_all(&root).await.map_err(|error| {
+                        ServerError::internal(format!(
+                            "could not remove the cloned checkout {}: {error}",
+                            root.display()
+                        ))
+                    })?;
+                    tracing::info!(repo = %repo.id, "code-mode: reclaimed a cloned checkout");
+                }
+                _ => {
+                    return Err(ServerError::conflict_kind(
+                        "checkout_not_a_repository",
+                        format!(
+                            "{} is no longer the git repository Tidebreak cloned; \
+                             it was left alone",
+                            root.display()
+                        ),
+                    ));
+                }
+            }
         }
         if !mark_repo_removed(&self.db, owner, id, Utc::now()).await? {
             return Err(ServerError::not_found(format!("repo {id} not found")));

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -102,8 +102,14 @@ impl ScopedCode {
         self.runtime.save_repo(repo).await
     }
 
-    pub(crate) async fn remove_repo(&self, id: RepoId) -> Result<(), ServerError> {
-        self.runtime.remove_repo(&self.owner, id).await
+    pub(crate) async fn remove_repo(
+        &self,
+        id: RepoId,
+        reclaim_checkout: bool,
+    ) -> Result<(), ServerError> {
+        self.runtime
+            .remove_repo(&self.owner, id, reclaim_checkout)
+            .await
     }
 
     pub(crate) async fn clone_defaults(&self) -> Result<CodeCloneDefaults, ServerError> {

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -1652,6 +1652,7 @@ mod tests {
                 quick_actions: Vec::new(),
                 created_at: Utc::now(),
                 removed_at: None,
+                cloned_from: None,
             },
         )
         .await

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -33,7 +33,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 38;
+const DESKTOP_SCHEMA_EPOCH: u32 = 39;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/tidebreak-server/src/routes/code/repos.rs
+++ b/crates/tidebreak-server/src/routes/code/repos.rs
@@ -6,11 +6,11 @@ use uuid::Uuid;
 use crate::code::runtime::RepoRegistration;
 use crate::code::ScopedCode;
 use crate::error::ServerError;
-use crate::extract::{Json, Path};
+use crate::extract::{Json, Path, Query};
 
 use super::types::{
     CloneRepoBody, CodeCloneDefaults, CodeCloneJobSnapshot, CodeRepoSnapshot, CreateRepoBody,
-    PatchRepoBody,
+    PatchRepoBody, RemoveRepoQuery,
 };
 use tidebreak_core::RepoId;
 
@@ -22,6 +22,10 @@ pub async fn create_repo(
         .register_repo(
             PathBuf::from(body.path),
             RepoRegistration {
+                // A registration names a directory that already exists, so it
+                // is never Tidebreak's to delete. Only the clone path sets
+                // this, and a client cannot claim it.
+                cloned_from: None,
                 display_name: body.display_name,
                 default_base_ref: body.default_base_ref,
                 branch_prefix: body.branch_prefix,
@@ -86,11 +90,20 @@ pub async fn patch_repo(
     Ok(Json(CodeRepoSnapshot::from(repo)))
 }
 
+/// `DELETE /code/repos/{id}` — remove a registration, optionally reclaiming
+/// the checkout.
+///
+/// Removal is soft: archived workspaces and their transcripts stay reachable.
+/// `reclaim_checkout` additionally deletes the directory, and is honored only
+/// for a repository Tidebreak cloned — 409 `checkout_not_reclaimable`
+/// otherwise, and `checkout_not_a_repository` if the path stopped being the
+/// checkout that was cloned.
 pub async fn delete_repo(
     code: ScopedCode,
     Path(id): Path<RepoId>,
+    Query(query): Query<RemoveRepoQuery>,
 ) -> Result<StatusCode, ServerError> {
-    code.remove_repo(id).await?;
+    code.remove_repo(id, query.reclaim_checkout).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -402,6 +402,17 @@ pub struct PatchWorkspaceBody {
 /// Body of `POST /code/workspaces/{id}/archive`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct RemoveRepoQuery {
+    /// Delete the checkout on disk as well as the registration.
+    ///
+    /// Honored only when Tidebreak cloned it. A registered directory is the
+    /// user's, and removal leaves it alone whatever this says.
+    #[serde(default)]
+    pub reclaim_checkout: bool,
+}
+
+/// Body of `POST /code/workspaces/{id}/archive` and `/release`.
+#[derive(Debug, Deserialize)]
 pub struct ArchiveWorkspaceBody {
     #[serde(default)]
     pub force: bool,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -5901,3 +5901,67 @@ fn branch_exists_in(repo_root: &std::path::Path, branch: &str) -> bool {
         .map(|out| out.status.success())
         .unwrap_or(false)
 }
+
+/// Reclaim deletes only a checkout Tidebreak made.
+///
+/// A registered repository is a directory the user already had, and the clone
+/// parent is a setting that moves, so there is no path test that stays
+/// honest. The recorded origin is the whole guard: without it this route is a
+/// recursive delete pointed at someone's own work.
+#[tokio::test]
+async fn reclaim_refuses_a_checkout_tidebreak_did_not_clone() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let registered = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": repo }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), reqwest::StatusCode::CREATED);
+    let repo_body: serde_json::Value = registered.json().await.unwrap();
+    let repo_id = json_id(&repo_body);
+    let root = std::path::PathBuf::from(&repo);
+
+    let refused = client
+        .delete(format!(
+            "http://{addr}/code/repos/{repo_id}?reclaim_checkout=true"
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "checkout_not_reclaimable");
+    assert!(
+        root.join(".git").exists(),
+        "a registered checkout must survive a refused reclaim"
+    );
+
+    // The registration still goes away; only the directory is spared.
+    let removed = client
+        .delete(format!("http://{addr}/code/repos/{repo_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(removed.status(), reqwest::StatusCode::NO_CONTENT);
+    assert!(
+        root.join(".git").exists(),
+        "removal must not delete the user's checkout"
+    );
+    let listed = client
+        .get(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .unwrap();
+    assert!(listed.is_empty(), "a removed registration leaves the list");
+}

--- a/crates/tidebreak-server/src/tests/code_browser.rs
+++ b/crates/tidebreak-server/src/tests/code_browser.rs
@@ -254,6 +254,7 @@ async fn seed_session(db: &DbStore, lc: CodeSessionLifecycle) -> (WorkspaceId, C
             quick_actions: vec![],
             created_at: chrono::Utc::now(),
             removed_at: None,
+            cloned_from: None,
         },
     )
     .await

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -103,7 +103,14 @@ Baseline schema edit plus a `DESKTOP_SCHEMA_EPOCH` bump, per
 - **`code_repo`** — `id`, `root_path` (unique, canonical toplevel),
   `display_name`, `default_base_ref`, `branch_prefix`, `setup_script`,
   `archive_script`, `quick_actions` (JSON array of
-  `{name, command, auto_run_on_create}`), `created_at`, `removed_at`.
+  `{name, command, auto_run_on_create}`), `created_at`, `removed_at`,
+  `cloned_from`.
+  `cloned_from` records the remote Tidebreak cloned the checkout from, and is
+  null when the user registered a directory that already existed. It is what
+  makes `?reclaim_checkout=true` safe: both paths register identically, and
+  the clone parent is a setting that moves, so no path test stays honest.
+  Only a checkout Tidebreak made is Tidebreak's to delete.
+
   Removal is soft: `DELETE /code/repos/{id}` stamps `removed_at` and hides the
   registration, keeping every archived workspace and transcript that hangs off
   it reachable. Deleting the row would strand that history on SQLite, which


### PR DESCRIPTION
Part of #2441.

## The problem

Removing a repository left its checkout on disk, and there was no safe way to add reclaim — because nothing recorded who made the directory.

A Tidebreak-performed clone registers through the *same* path a manual registration uses (`clone.rs` passed `RepoRegistration::default()`), so `code_repo` could not distinguish "Tidebreak cloned this" from "the user pointed at their repo."

Any reclaim built on that would have to infer provenance from the path — testing against `code_clone_parent_dir`, a setting that moves, and that a user's own repo may sit under. Inferring wrong means `rm -rf` on work Tidebreak never created.

So this was never a policy question about how aggressive to be. It was a missing fact.

## The change

`code_repo` gains `cloned_from`, set only by the clone path. The manual registration route hardcodes `None`, so a client cannot claim it.

`DELETE /code/repos/{id}?reclaim_checkout=true` then needs no judgment:

- `cloned_from` set → delete the directory, after re-validating it is still the git repository that was cloned (a row written long ago must not become a recursive delete of whatever occupies that path now).
- `cloned_from` null → `checkout_not_reclaimable`. The registration is still removed; that was always the whole action for a directory the user brought.

Removal stays soft either way, so archived workspaces and transcripts remain reachable (#2439).

## Credential redaction

A clone URL can embed a credential — `https://ghp_token@github.com/org/repo.git`. That string is persisted and shown back, so it is redacted to its origin before storage, and the reclaim log line no longer includes it.

## Schema

Baseline edit plus `DESKTOP_SCHEMA_EPOCH` 38 → 39, per decision record 2. Both fixtures regenerated.

## Tests

- `reclaim_refuses_a_checkout_tidebreak_did_not_clone` — over HTTP: a registered repo refuses reclaim with `checkout_not_reclaimable`, its `.git` survives, and plain removal still drops the registration while leaving the directory. This is the guard; without it the route deletes user work.
- `a_cloned_repo_records_where_it_came_from` — provenance round-trips, and a registered repo records nothing.
- `a_clone_url_keeps_its_origin_and_loses_its_credential` — covers `token@host`, `user:token@host`, no-credential, and scp-style.

`tidebreak-core` 718 pass, `tidebreak-server --lib code::` 214 pass, clippy and rustfmt clean.