### PR TITLE
docs: document code mode for users

### DIFF
--- a/docs-site/content/docs/code-mode.mdx
+++ b/docs-site/content/docs/code-mode.mdx
@@ -1,0 +1,113 @@
+---
+title: Code mode
+description: Point Tidebreak at a git repository and supervise coding agents — Claude Code, Codex CLI, opencode, and Grok CLI — each in its own worktree.
+---
+
+Chats are built around files. Code mode is built around a repository. You
+register a local git repo, open a **workspace** for a piece of work, and run a
+coding agent inside it — with the same permission modes, approval cards, and
+review step the rest of Tidebreak uses.
+
+Switch surfaces with the **Work / Code** control at the top of the sidebar.
+
+## Repos, workspaces, and sessions
+
+Three nouns, and they nest:
+
+- A **repo** is a local git repository you registered: its root path, the base
+  branch new work starts from, and a branch prefix.
+- A **workspace** is one unit of work on that repo. It owns exactly one git
+  worktree and one branch for its whole life, and it carries the pull-request
+  state for that branch.
+- A **session** is one conversation with one harness inside a workspace.
+
+The worktree is the important part. Each workspace is a separate checkout, so
+several agents can work on the same repository at once without writing over
+each other, and none of them touches the copy you have open in your editor.
+
+By default worktrees are created under `~/Tidebreak/workspaces`. You can change
+where the next one goes in settings; existing workspaces stay where they are,
+because git records absolute paths and moving a checkout is a repair operation
+rather than a rename.
+
+## Harnesses
+
+A **harness** is the coding-agent CLI Tidebreak drives. Four are supported:
+
+| Harness | Notes |
+| --- | --- |
+| Claude Code | The reference tier — the most complete integration |
+| Codex CLI | |
+| opencode | |
+| Grok CLI | Honors Auto and Allow only; see below |
+
+Tidebreak drives the harness you already have installed and signed in. It
+observes that authentication and never brokers it — your Claude or OpenAI
+subscription stays between you and the tool it belongs to. **Settings → Coding
+harnesses** runs a doctor that reports which harnesses it found and what is
+missing.
+
+Each harness runs on the model you configured for it, so the model choices from
+[Models and providers](/models-and-providers) apply here too.
+
+## A turn, and the review that follows
+
+A turn is one exchange with the agent. While it runs you see tool activity as
+it happens, and approval cards whenever the agent asks for something its
+permission mode does not cover. Denying opens a field so you can say why, and
+that reason goes back to the agent.
+
+When the turn ends you get a review card: what changed, how long it took, and
+the diffstat. Diffs open per file and are anchored per turn, so you can read
+one turn's work without untangling it from the rest.
+
+Nothing reaches your branch because a turn finished. The worktree holds the
+change until you commit it.
+
+## Permission modes
+
+Code mode uses the same four modes as chats — Plan, Ask, Auto, and Allow all —
+with the same meaning: how much the agent may do before it stops to ask. The
+selector sits in the composer, per session.
+
+<Callout type="warn">
+Grok CLI is the exception. It has no approval channel, and its plan and sandbox
+flags do not confine it, so only **Auto** and **Allow all** are offered. Auto is
+its unsupervised default. Tidebreak states this where you pick the mode rather
+than pretending the other two are available.
+</Callout>
+
+## Terminals
+
+Every workspace has a terminal, opened as a drawer at the bottom of the
+surface. It runs in that workspace's worktree, so you are always in the
+checkout the agent is working in. Use it for the things that are faster to type
+than to ask for — a test run, a git command, a quick look at a file.
+
+## Pull requests
+
+The review sidebar carries git state, the pull request, and its comments. From
+there you can push the branch, open a pull request, watch its checks, read
+review comments, and merge — without leaving the workspace that produced the
+change.
+
+Pull-request operations shell out to your own `gh` CLI. Tidebreak observes that
+authentication the same way it observes a harness login. If `gh` is missing or
+signed out, you get copyable instructions rather than a button that fails.
+
+## What it does not do yet
+
+Code mode is a full surface, not a preview, but some things are deliberately
+out of scope for now:
+
+- No in-app code editor. Tidebreak reviews changes; it does not replace the
+  editor you write in.
+- Checkpoints are recorded, but there is no restore-from-checkpoint surface
+  yet.
+- No remote execution — harnesses run on your machine, not in a managed
+  sandbox.
+- No mobile client for watching a run.
+
+The longer-term direction is to drop the mode switch entirely: one conversation
+concept, where binding it to a workspace is what makes it behave like code
+mode.

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -3,9 +3,11 @@ title: What Tidebreak is
 description: A local-first AI agent desktop app that runs on your machine with the models and tools you choose.
 ---
 
-Tidebreak is a desktop app for handing real work to an AI agent. You start a
-chat, attach the files the work depends on, and the agent reads them, runs
-code, searches the web, and writes the result out as a file you can save.
+Tidebreak is a desktop app for handing real work to an AI agent, and it has two
+surfaces. In a **chat**, you attach the files the work depends on and the agent
+reads them, runs code, searches the web, and writes the result out as a file you
+can save. In **code mode**, you point it at a git repository and supervise a
+coding agent working in an isolated worktree.
 
 It runs on your machine. Your conversations, your documents, and the files the
 agent produces live in a local database and a local folder. Your provider API
@@ -41,8 +43,12 @@ formats, and behavior change frequently. Expect rough edges.
   Fireworks, Together, OpenRouter, a local Ollama daemon, and any
   OpenAI-compatible endpoint. You can switch models mid-conversation without
   losing the thread.
-- **Decide how much rope to give it.** Every chat has a permission mode, from
-  read-only planning up to full autonomy.
+- **Drive coding agents over a repository.** [Code mode](/code-mode) runs
+  Claude Code, Codex CLI, opencode, or Grok CLI in its own git worktree per
+  workspace, with per-turn diffs, a review step, a terminal, and a pull-request
+  flow.
+- **Decide how much rope to give it.** Every chat and every coding session has a
+  permission mode, from read-only planning up to full autonomy.
 
 ## Who it's for
 

--- a/docs-site/content/docs/meta.json
+++ b/docs-site/content/docs/meta.json
@@ -7,6 +7,7 @@
     "quickstart",
     "---Using Tidebreak---",
     "chats",
+    "code-mode",
     "documents",
     "how-the-agent-works",
     "models-and-providers",

--- a/docs-site/content/docs/permission-modes.mdx
+++ b/docs-site/content/docs/permission-modes.mdx
@@ -4,7 +4,9 @@ description: Plan, Ask, Auto, and Allow all — what the agent can do without as
 ---
 
 Every chat runs in one of four permission modes. The selector sits in the
-composer, next to the send button, and applies to that chat only.
+composer, next to the send button, and applies to that chat only. Code-mode
+sessions use the same four modes with the same meanings — see
+[Code mode](/code-mode) for the one harness that narrows the choice.
 
 | Mode | What it means |
 | --- | --- |

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -11,10 +11,17 @@ change.
 
 ## Tidebreak in one minute
 
-Tidebreak is a local agent runtime. A user chooses a model and starts a chat,
-which is the current product's single workspace. Sources, connected folders,
-scratch, messages, and tool activity are all resolved through that
-exact conversation. The runtime can ask the model for an answer, call tools over
+Tidebreak is a local agent runtime with two product surfaces. In chat — the
+surface this document describes in detail — a user chooses a model and starts a
+conversation, and sources, connected folders, scratch, messages, and tool
+activity are all resolved through that exact conversation.
+
+The second surface is code mode: a registered git repository, one worktree and
+branch per workspace, and durable sessions driving an external coding-agent
+harness. It reuses this runtime's shape — the same job records, leases, event
+sequencing, and approval flow — behind an adapter contract rather than the
+in-process model loop. [`docs/code-mode.md`](code-mode.md) is the reference for
+it; this page stays with chat except where the two share machinery. The runtime can ask the model for an answer, call tools over
 folders connected to the chat, read sources attached to the chat, pause for
 approval before a sensitive action, and stream progress back to the client.
 


### PR DESCRIPTION
The published docs never mentioned code mode. Twenty pages, no page for it, two passing references in `installation.mdx` and `headless.mdx`, and **zero** occurrences of "worktree", "Claude Code", "Codex", or "opencode" anywhere in `content/docs`. Someone installing Tidebreak from the docs would not learn the second surface exists.

## New page

`content/docs/code-mode.mdx`, written from `docs/code-mode.md` and pitched at users rather than maintainers:

- **Repos, workspaces, sessions** — the three nouns and how they nest, and why the worktree per workspace is the part that matters.
- **Harnesses** — the four supported, Claude Code as reference tier, and that Tidebreak observes harness authentication rather than brokering it.
- **A turn and its review** — tool activity, approval cards with a reason on deny, the per-turn diff, and that nothing reaches the branch because a turn ended.
- **Permission modes** — the same four as chats, with a callout for Grok CLI offering only Auto and Allow, since it has no approval channel and its plan and sandbox flags do not confine it.
- **Terminals** and the **pull-request flow** through the user's own `gh`, including the degrade-to-instructions behaviour when `gh` is missing.
- **What it does not do yet** — no in-app editor, no checkpoint restore surface, no remote execution, no mobile client — plus the single-surface direction.

It sits next to Chats in the sidebar rather than in its own group, so the two surfaces read as a pair. I tried a dedicated `---Code mode---` section first; with one page under it the sidebar read "Code mode / Code mode".

## Existing pages

- `index.mdx` described one surface. It now opens on both and gains a code-mode bullet in "What you can do with it".
- `permission-modes.mdx` said "every chat runs in one of four permission modes" and now points across to the harness that narrows the choice.
- `meta.json` — sidebar entry.

## Internal docs

`docs/how-tidebreak-works.md` opened by calling chat "the current product's single workspace". It now names both surfaces and points at `docs/code-mode.md`, while remaining a chat document itself. The rest of `docs/` was already current — `README.md` lists code mode, and the only "experimental" in `code-mode.md` is the phrase "available without an experimental opt-in".

## Verification

`pnpm build` passes; `/code-mode` prerenders along with its `llms-mdx` and OG image variants. I served `out/` and read the rendered page. Internal links follow the existing `](/permission-modes)` convention — my first draft used `/docs/...`, which does not match this site.