### PR TITLE
test(core): stop racing the lease the admission test means to outlive

### DIFF
--- a/crates/tidebreak-core/tests/postgres_turn_state.rs
+++ b/crates/tidebreak-core/tests/postgres_turn_state.rs
@@ -56,7 +56,7 @@ async fn postgres_turn_admission_serializes_processes_and_recovers_expiry() {
     };
     let first_token = uuid::Uuid::new_v4();
     let first_lease = match first
-        .begin_turn_admission(&request, first_token, chrono::Duration::milliseconds(50))
+        .begin_turn_admission(&request, first_token, chrono::Duration::seconds(30))
         .await
         .unwrap()
     {
@@ -84,7 +84,9 @@ async fn postgres_turn_admission_serializes_processes_and_recovers_expiry() {
         BeginTurnAdmissionOutcome::IdentityConflict
     );
 
-    tokio::time::sleep(StdDuration::from_millis(75)).await;
+    // Expire the reservation explicitly instead of asking a loaded runner to
+    // finish every assertion above inside a lease short enough to sleep past.
+    expire_postgres_turn_admission(&url, request.id).await;
     let takeover_token = uuid::Uuid::new_v4();
     let takeover_lease = match second
         .begin_turn_admission(&request, takeover_token, chrono::Duration::seconds(1))
@@ -96,6 +98,24 @@ async fn postgres_turn_admission_serializes_processes_and_recovers_expiry() {
     };
     assert!(!first.release_turn_admission(first_lease).await.unwrap());
     assert!(second.release_turn_admission(takeover_lease).await.unwrap());
+}
+
+/// Move a reservation's lease into the past, so the next admission sees an
+/// expired lease without waiting for one.
+///
+/// PostgreSQL admission fences on `clock_timestamp()`, so the expiry has to be
+/// written against the same clock rather than the test process's.
+async fn expire_postgres_turn_admission(url: &str, turn_id: TurnId) {
+    let connection = Database::connect(url).await.unwrap();
+    let updated = connection
+        .execute_unprepared(&format!(
+            "UPDATE turn_admission SET lease_expires_at = clock_timestamp() - interval '1 second' \
+             WHERE id = '{}'",
+            turn_id.0
+        ))
+        .await
+        .unwrap();
+    assert_eq!(updated.rows_affected(), 1);
 }
 
 async fn set_postgres_turn_max_attempts(url: &str, turn_id: TurnId, max_attempts: i32) {


### PR DESCRIPTION
## What

`postgres_turn_admission_serializes_processes_and_recovers_expiry` took a 50 ms lease and then asserted that a second process observes `Pending`. That assertion races the expiry it is meant to precede: one round trip to a loaded Postgres can outlast 50 ms, and the second process then correctly reports `Acquired` — so the test fails on right behavior. It was seen on #2450, which touches nothing near turn admission.

## How

The 50 ms was doing two jobs at once: short enough to be racy for the `Pending` assertion before it, short enough for the `sleep(75ms)` takeover after it. Splitting them fixes it.

- Take a 30-second lease, so `Pending` is a fact rather than a race.
- Expire the reservation outright where the test wants the takeover, instead of sleeping past a deliberately tiny TTL.

This is what the SQLite twin (`turn_admission_reservation_is_global_exact_and_recoverable`) already does. The expiry is written against `clock_timestamp()`, the clock Postgres admission fences on, matching the raw-SQL lease helpers already in this file.

## Tests

Run against `postgres:17-alpine`, the CI image. The suite passes; the admission test no longer sleeps, so it also runs faster.

The expiry drives the outcome rather than merely happening to work: pushing the written expiry into the future instead of the past turns the takeover back into `Pending { .. }` and fails the test.

## Unrelated finding

`postgres_turn_acceptance_claims_and_receipts_are_atomic` fails on any run against a database an earlier run already used, on `main` and unchanged here. CI hides it by starting a fresh Postgres service every time. Filed separately.