### PR TITLE
fix: record the code worktrees an epoch reset orphans

### DIFF
--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod terminal;
 pub(crate) mod titling;
 pub(crate) mod watch;
 pub(crate) mod worktree;
+pub(crate) mod worktree_orphans;
 pub(crate) mod worktree_root;
 
 pub(crate) use runtime::CodeRuntime;

--- a/crates/tidebreak-server/src/code/worktree_orphans.rs
+++ b/crates/tidebreak-server/src/code/worktree_orphans.rs
@@ -1,0 +1,215 @@
+//! What a pre-v1 epoch reset is about to lose track of.
+//!
+//! Code worktrees do not live in the data directory. Decision 53 moved them to
+//! a user-visible root on purpose, because a worktree is user work —
+//! uncommitted code on a real branch. The reset in [`crate::desktop_schema`]
+//! deletes the database and nothing outside the data directory, so every
+//! epoch bump drops the `code_workspace` rows and leaves the trees behind:
+//! directories full of possibly-uncommitted work, entries in each source
+//! repository's `.git/worktrees`, and branches on the user's real repository.
+//!
+//! Deleting them is not the answer, and neither is silence. So the reset
+//! writes them down. Right before the database goes, read the rows that name
+//! the trees and record them in a sidecar file beside the schema marker, which
+//! survives a reset by design. The trees are still orphaned afterwards, but
+//! they are now recoverable by hand, and adoptable by a first-run surface
+//! later.
+//!
+//! Everything here is best effort. It runs against a database whose schema
+//! this binary no longer matches, on a path that has to end with the app
+//! booting, so a scan that fails is reported and never blocks the reset.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, Statement};
+use serde::{Deserialize, Serialize};
+
+/// Sidecar naming the trees a reset left on disk.
+pub(crate) const ORPHANED_WORKTREES_FILE: &str = "orphaned-code-worktrees.json";
+
+/// Where an unreadable sidecar is moved before a fresh one replaces it, so a
+/// record we cannot parse is still not a record we destroyed.
+const PREVIOUS_WORKTREES_FILE: &str = "orphaned-code-worktrees.previous.json";
+
+/// Every code worktree a reset is known to have left behind, oldest first.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct OrphanedWorktrees {
+    pub(crate) worktrees: Vec<OrphanedWorktree>,
+}
+
+/// One tree on disk that no `code_workspace` row points at any more.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct OrphanedWorktree {
+    /// Absolute path to the tree, which is still on disk.
+    pub(crate) worktree_path: String,
+    /// Branch the workspace created in the source repository.
+    pub(crate) branch_name: Option<String>,
+    /// Root of the repository whose `.git/worktrees` still lists the tree.
+    pub(crate) repo_root_path: Option<String>,
+    /// What the workspace was called, to make the record readable.
+    pub(crate) title: Option<String>,
+    /// When the reset that orphaned this tree ran.
+    pub(crate) recorded_at: DateTime<Utc>,
+}
+
+/// Record every code worktree still on disk that `database` is the last record
+/// of, merging into whatever earlier resets already recorded.
+///
+/// Reports rather than fails: the caller is a reset that has to end with a
+/// bootable app.
+pub(crate) async fn record_orphaned_worktrees(database: &Path, data_dir: &Path) {
+    let found = match scan(database).await {
+        Ok(found) => found,
+        Err(error) => {
+            tracing::warn!(
+                database = %database.display(),
+                %error,
+                "could not read code worktrees out of the database this epoch reset is about to \
+                 delete; any worktrees it recorded are orphaned without a record"
+            );
+            return;
+        }
+    };
+    if found.is_empty() {
+        return;
+    }
+    let sidecar = data_dir.join(ORPHANED_WORKTREES_FILE);
+    if let Err(error) = merge_into_sidecar(&sidecar, found.clone()) {
+        tracing::error!(
+            sidecar = %sidecar.display(),
+            %error,
+            count = found.len(),
+            "failed to record the code worktrees this epoch reset orphaned; they are still on \
+             disk and now have no record"
+        );
+        return;
+    }
+    tracing::warn!(
+        sidecar = %sidecar.display(),
+        count = found.len(),
+        "this epoch reset dropped the workspaces owning code worktrees that are still on disk; \
+         their paths, branches, and source repositories are recorded in the sidecar, and nothing \
+         removes the trees, their `.git/worktrees` entries, or their branches"
+    );
+}
+
+/// Read the doomed database's worktree rows, keeping only trees still on disk.
+async fn scan(database: &Path) -> Result<Vec<OrphanedWorktree>, String> {
+    if !database.exists() {
+        return Ok(Vec::new());
+    }
+    // Read-only, so a scan can never create or migrate the file it is about to
+    // delete.
+    let url = format!("sqlite://{}?mode=ro", database.display());
+    let connection = Database::connect(&url)
+        .await
+        .map_err(|error| error.to_string())?;
+
+    // `SELECT *` because this database predates the current schema by an
+    // unknown number of epochs: naming a column that no longer exists fails the
+    // whole scan, and the join fails outright before code repositories existed.
+    let joined = "SELECT w.*, r.root_path AS repo_root_path \
+                  FROM code_workspace w LEFT JOIN code_repo r ON r.id = w.repo_id";
+    let rows = match query(&connection, joined).await {
+        Ok(rows) => Ok(rows),
+        Err(_) => query(&connection, "SELECT * FROM code_workspace").await,
+    };
+    // Close before returning either way: Windows refuses to delete a file this
+    // process still has open, and the caller deletes this one next.
+    let _ = connection.close().await;
+
+    let recorded_at = Utc::now();
+    let mut found = Vec::new();
+    for row in rows.map_err(|error| error.to_string())? {
+        let Ok(worktree_path) = row.try_get::<String>("", "worktree_path") else {
+            continue;
+        };
+        // A workspace whose tree is already gone is not an orphan.
+        if !Path::new(&worktree_path).is_dir() {
+            continue;
+        }
+        found.push(OrphanedWorktree {
+            worktree_path,
+            branch_name: row.try_get("", "branch_name").ok(),
+            repo_root_path: row.try_get("", "repo_root_path").ok(),
+            title: row.try_get("", "title").ok(),
+            recorded_at,
+        });
+    }
+    Ok(found)
+}
+
+async fn query(
+    connection: &sea_orm::DatabaseConnection,
+    sql: &str,
+) -> Result<Vec<sea_orm::QueryResult>, sea_orm::DbErr> {
+    connection
+        .query_all_raw(Statement::from_string(DatabaseBackend::Sqlite, sql))
+        .await
+}
+
+/// Add `found` to the sidecar, keeping the first record of each tree.
+///
+/// Epoch bumps come in runs, and each one can orphan trees an earlier one
+/// already recorded. The earliest record is the honest one: it says when the
+/// tree stopped being a workspace.
+fn merge_into_sidecar(sidecar: &Path, found: Vec<OrphanedWorktree>) -> std::io::Result<()> {
+    let mut record = read_sidecar(sidecar)?;
+    let mut known: BTreeSet<String> = record
+        .worktrees
+        .iter()
+        .map(|worktree| worktree.worktree_path.clone())
+        .collect();
+    for worktree in found {
+        if known.insert(worktree.worktree_path.clone()) {
+            record.worktrees.push(worktree);
+        }
+    }
+    write_sidecar(sidecar, &record)
+}
+
+/// Read what earlier resets recorded.
+///
+/// A sidecar we cannot parse is moved aside rather than overwritten: it is
+/// still the only pointer to somebody's uncommitted work.
+fn read_sidecar(sidecar: &Path) -> std::io::Result<OrphanedWorktrees> {
+    let bytes = match std::fs::read(sidecar) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(OrphanedWorktrees::default())
+        }
+        Err(error) => return Err(error),
+    };
+    match serde_json::from_slice(&bytes) {
+        Ok(record) => Ok(record),
+        Err(error) => {
+            let previous = sidecar.with_file_name(PREVIOUS_WORKTREES_FILE);
+            tracing::warn!(
+                sidecar = %sidecar.display(),
+                previous = %previous.display(),
+                %error,
+                "could not parse the record of previously orphaned code worktrees; keeping it \
+                 beside the new one"
+            );
+            crate::desktop_schema::replace_file(sidecar, &previous)?;
+            Ok(OrphanedWorktrees::default())
+        }
+    }
+}
+
+fn write_sidecar(sidecar: &Path, record: &OrphanedWorktrees) -> std::io::Result<()> {
+    let mut bytes = serde_json::to_vec_pretty(record).map_err(std::io::Error::other)?;
+    bytes.push(b'\n');
+    let temporary: PathBuf = sidecar.with_file_name(format!(
+        ".{ORPHANED_WORKTREES_FILE}.{}.tmp",
+        uuid::Uuid::new_v4()
+    ));
+    let result = std::fs::write(&temporary, &bytes)
+        .and_then(|()| crate::desktop_schema::replace_file(&temporary, sidecar));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result
+}

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -14,6 +14,12 @@
 //! itself, and the provisioned gateway policy (`gateway-policy.json`, see
 //! [`crate::managed_policy`]), whose loss would resolve the profile
 //! unmanaged and orphan the gateway session it authorized.
+//!
+//! The data directory is not the whole story, though. Code worktrees live
+//! outside it on purpose (Decision 53), so dropping the database strands every
+//! tree on disk with nothing pointing at it. Those are user work and the reset
+//! does not touch them; it records them first, in a third sidecar written by
+//! [`crate::code::worktree_orphans`].
 
 use std::fs::{File, OpenOptions};
 use std::future::Future;
@@ -63,7 +69,7 @@ where
     C: FnOnce(String) -> F,
     F: Future<Output = Result<DbStore>>,
 {
-    let needs_marker = prepare(&config.data_dir)?;
+    let needs_marker = prepare(&config.data_dir).await?;
     let store = connector(config.database_url()?).await?;
     if needs_marker {
         write_current_marker(&config.data_dir)?;
@@ -73,14 +79,14 @@ where
 
 /// Prepare the SQLite files and return whether a current marker must be
 /// recorded after migrations succeed.
-fn prepare(data_dir: &Path) -> Result<bool> {
+async fn prepare(data_dir: &Path) -> Result<bool> {
     let product_major = tidebreak_core::VERSION
         .split_once('.')
         .map_or(tidebreak_core::VERSION, |(major, _)| major);
-    prepare_for_product_major(data_dir, product_major)
+    prepare_for_product_major(data_dir, product_major).await
 }
 
-fn prepare_for_product_major(data_dir: &Path, product_major: &str) -> Result<bool> {
+async fn prepare_for_product_major(data_dir: &Path, product_major: &str) -> Result<bool> {
     if product_major != "0" {
         return Err(AgentError::config(format!(
             "pre-v1 local SQLite schema lifecycle is disabled for product major {product_major}"
@@ -101,21 +107,21 @@ fn prepare_for_product_major(data_dir: &Path, product_major: &str) -> Result<boo
             if saved.lifecycle == PRE_V1_LIFECYCLE && saved.epoch < DESKTOP_SCHEMA_EPOCH =>
         {
             remove_retired_vectors(&data_dir.join(VECTOR_DIRECTORY))?;
-            reset_pre_v1_state(&database)?;
+            reset_pre_v1_state(&database).await?;
             Ok(true)
         }
         None if database.exists() => {
             // Databases predating this marker are from the disposable pre-v1
             // development line. The v1 lifecycle will always retain a marker.
             remove_retired_vectors(&data_dir.join(VECTOR_DIRECTORY))?;
-            reset_pre_v1_state(&database)?;
+            reset_pre_v1_state(&database).await?;
             Ok(true)
         }
         None => {
             // Clean up journals left after an interrupted reset even when the
             // main database file is already gone.
             remove_retired_vectors(&data_dir.join(VECTOR_DIRECTORY))?;
-            reset_pre_v1_state(&database)?;
+            reset_pre_v1_state(&database).await?;
             Ok(true)
         }
         Some(saved) => Err(AgentError::config(format!(
@@ -173,16 +179,22 @@ fn read_marker(marker: &Path) -> Result<Option<SchemaMarker>> {
         })
 }
 
-fn reset_pre_v1_state(database: &Path) -> Result<()> {
+async fn reset_pre_v1_state(database: &Path) -> Result<()> {
+    let data_dir = database
+        .parent()
+        .ok_or_else(|| AgentError::config("local SQLite database path has no parent directory"))?;
+    // Code worktrees are the one piece of durable state a reset can strand
+    // without touching: they live outside the data directory, and the rows
+    // naming them are inside the database about to be deleted. Read them out
+    // while the database still exists, so the trees are written down rather
+    // than silently orphaned.
+    crate::code::worktree_orphans::record_orphaned_worktrees(database, data_dir).await;
     remove_sqlite_files(database)?;
     // Host-broker authority is durable beside SQLite, not inside it. An epoch
     // wipe throws away every conversation id the product will ever know; grants
     // and attachments keyed to those ids would otherwise keep authorizing work
     // against subjects that can never come back. Clear the broker's durable
     // files with the database during disposable pre-v1 resets.
-    let data_dir = database
-        .parent()
-        .ok_or_else(|| AgentError::config("local SQLite database path has no parent directory"))?;
     remove_host_broker_durable_state(data_dir)
 }
 
@@ -317,13 +329,17 @@ fn write_current_marker_inner(data_dir: &Path, failure: MarkerWriteFailure) -> R
     })
 }
 
+/// Atomically move `temporary` over `destination`.
+///
+/// Shared with [`crate::code::worktree_orphans`], which writes its own sidecar
+/// into this directory with the same publish-or-leave-the-old-one guarantee.
 #[cfg(unix)]
-fn replace_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
+pub(crate) fn replace_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
     std::fs::rename(temporary, destination)
 }
 
 #[cfg(windows)]
-fn replace_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
+pub(crate) fn replace_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
     use std::os::windows::ffi::OsStrExt;
     use windows_sys::Win32::Storage::FileSystem::{
         MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
@@ -354,7 +370,7 @@ fn replace_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn replace_file(_temporary: &Path, _destination: &Path) -> std::io::Result<()> {
+pub(crate) fn replace_file(_temporary: &Path, _destination: &Path) -> std::io::Result<()> {
     Err(std::io::Error::new(
         ErrorKind::Unsupported,
         "atomic schema marker replacement is unsupported on this platform",
@@ -374,9 +390,13 @@ fn sync_directory(_path: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use tidebreak_core::{Chat, ChatId, Store};
+    use tidebreak_core::{
+        db, Chat, ChatId, CodeRepo, CodeWorkspace, CodeWorkspaceStatus, OwnerId, RepoId, Store,
+        WorkspaceId,
+    };
 
     use super::*;
+    use crate::code;
 
     fn chat() -> Chat {
         Chat {
@@ -458,6 +478,159 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn epoch_reset_records_the_code_worktrees_it_orphans_and_leaves_them_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Config::desktop(dir.path());
+        let first = connect(&config).await.unwrap();
+        // A worktree lives outside the data directory on purpose, so it is
+        // still there after the reset with nothing left pointing at it.
+        let worktree = dir.path().parent().unwrap().join("orphan-worktree");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(worktree.join("uncommitted.rs"), b"user work").unwrap();
+        // A workspace whose tree is already gone is not an orphan.
+        let vanished = dir.path().parent().unwrap().join("already-gone");
+        seed_workspace(&first, "orphan", &worktree).await;
+        seed_workspace(&first, "vanished", &vanished).await;
+        first.close().await.unwrap();
+        write_older_epoch_marker(dir.path());
+
+        let reset = connect(&config).await.unwrap();
+
+        assert!(reset.list_chats().await.unwrap().is_empty());
+        let recorded: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(
+                dir.path()
+                    .join(code::worktree_orphans::ORPHANED_WORKTREES_FILE),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let worktrees = recorded["worktrees"].as_array().unwrap();
+        assert_eq!(worktrees.len(), 1, "recorded: {recorded:#}");
+        assert_eq!(
+            worktrees[0]["worktree_path"],
+            worktree.display().to_string()
+        );
+        assert_eq!(worktrees[0]["branch_name"], "tidebreak/orphan");
+        assert_eq!(worktrees[0]["repo_root_path"], "/nonexistent-repo/orphan");
+        assert_eq!(worktrees[0]["title"], "orphan");
+        assert_eq!(
+            std::fs::read(worktree.join("uncommitted.rs")).unwrap(),
+            b"user work",
+            "the reset must not touch a tree it only recorded"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_second_epoch_reset_keeps_what_the_first_one_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Config::desktop(dir.path());
+        let sidecar = dir
+            .path()
+            .join(code::worktree_orphans::ORPHANED_WORKTREES_FILE);
+        let first_tree = dir.path().parent().unwrap().join("first-orphan");
+        let second_tree = dir.path().parent().unwrap().join("second-orphan");
+        std::fs::create_dir_all(&first_tree).unwrap();
+        std::fs::create_dir_all(&second_tree).unwrap();
+
+        for (title, worktree) in [("first", &first_tree), ("second", &second_tree)] {
+            let store = connect(&config).await.unwrap();
+            seed_workspace(&store, title, worktree).await;
+            store.close().await.unwrap();
+            write_older_epoch_marker(dir.path());
+            connect(&config).await.unwrap().close().await.unwrap();
+        }
+
+        let recorded: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&sidecar).unwrap()).unwrap();
+        let paths: Vec<&str> = recorded["worktrees"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|worktree| worktree["worktree_path"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            paths,
+            vec![
+                first_tree.display().to_string().as_str(),
+                second_tree.display().to_string().as_str()
+            ],
+            "a later reset must add to the record, not replace it"
+        );
+    }
+
+    #[tokio::test]
+    async fn epoch_reset_with_no_code_worktrees_writes_no_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Config::desktop(dir.path());
+        connect(&config).await.unwrap().close().await.unwrap();
+        write_older_epoch_marker(dir.path());
+
+        connect(&config).await.unwrap();
+
+        assert!(!dir
+            .path()
+            .join(code::worktree_orphans::ORPHANED_WORKTREES_FILE)
+            .exists());
+    }
+
+    async fn seed_workspace(store: &DbStore, title: &str, worktree_path: &Path) {
+        let repo_id = RepoId::new();
+        db::code::insert_repo(
+            store,
+            &CodeRepo {
+                id: repo_id,
+                owner: OwnerId::local(),
+                root_path: format!("/nonexistent-repo/{title}"),
+                display_name: "reset-test".into(),
+                default_base_ref: "main".into(),
+                branch_prefix: "tidebreak/".into(),
+                setup_script: None,
+                archive_script: None,
+                quick_actions: vec![],
+                created_at: Utc::now(),
+                removed_at: None,
+                cloned_from: None,
+            },
+        )
+        .await
+        .unwrap();
+        db::code::insert_workspace(
+            store,
+            &CodeWorkspace {
+                id: WorkspaceId::new(),
+                owner: OwnerId::local(),
+                repo_id,
+                title: title.to_owned(),
+                worktree_path: worktree_path.display().to_string(),
+                branch_name: format!("tidebreak/{title}"),
+                base_ref: "main".into(),
+                status: CodeWorkspaceStatus::Active,
+                pr: None,
+                created_at: Utc::now(),
+                archived_at: None,
+                released_at: None,
+                released_tip: None,
+                bundle_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    fn write_older_epoch_marker(data_dir: &Path) {
+        std::fs::write(
+            data_dir.join(MARKER_FILE),
+            serde_json::to_vec(&SchemaMarker {
+                lifecycle: PRE_V1_LIFECYCLE.to_owned(),
+                epoch: DESKTOP_SCHEMA_EPOCH - 1,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
     async fn current_schema_epoch_preserves_database_and_removes_retired_vectors() {
         let dir = tempfile::tempdir().unwrap();
         let config = Config::desktop(dir.path());
@@ -487,15 +660,7 @@ mod tests {
         // An explicit close, not a drop: the epoch reset below deletes the
         // SQLite files, which Windows refuses while a handle is open.
         first.close().await.unwrap();
-        std::fs::write(
-            dir.path().join(MARKER_FILE),
-            serde_json::to_vec(&SchemaMarker {
-                lifecycle: PRE_V1_LIFECYCLE.to_owned(),
-                epoch: DESKTOP_SCHEMA_EPOCH - 1,
-            })
-            .unwrap(),
-        )
-        .unwrap();
+        write_older_epoch_marker(dir.path());
 
         let reset = connect(&config).await.unwrap();
 
@@ -637,8 +802,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn released_package_guard_prevents_all_reset_deletions() {
+    #[tokio::test]
+    async fn released_package_guard_prevents_all_reset_deletions() {
         let dir = tempfile::tempdir().unwrap();
         let database = dir.path().join(DATABASE_FILE);
         let vector = dir.path().join(VECTOR_DIRECTORY).join("keep-me");
@@ -649,7 +814,9 @@ mod tests {
         std::fs::create_dir_all(vector.parent().unwrap()).unwrap();
         std::fs::write(&vector, b"vector").unwrap();
 
-        let error = prepare_for_product_major(dir.path(), "1").unwrap_err();
+        let error = prepare_for_product_major(dir.path(), "1")
+            .await
+            .unwrap_err();
 
         assert!(error.to_string().contains("disabled for product major 1"));
         assert_eq!(std::fs::read(database).unwrap(), b"database");
@@ -662,8 +829,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn unsupported_lifecycle_performs_no_deletions() {
+    #[tokio::test]
+    async fn unsupported_lifecycle_performs_no_deletions() {
         let dir = tempfile::tempdir().unwrap();
         let database = dir.path().join(DATABASE_FILE);
         let vector = dir.path().join(VECTOR_DIRECTORY).join("keep-me");
@@ -680,7 +847,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(prepare(dir.path()).is_err());
+        assert!(prepare(dir.path()).await.is_err());
 
         assert_eq!(std::fs::read(database).unwrap(), b"database");
         assert_eq!(std::fs::read(vector).unwrap(), b"vector");

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -94,6 +94,7 @@ The main local data is easy to recognize:
 | --- | --- |
 | `tidebreak.db` | SQLite operational source of truth |
 | `tidebreak-schema.json` | pre-v1 local SQLite schema epoch |
+| `orphaned-code-worktrees.json` | code worktrees an epoch reset left on disk |
 | `blobs/` | retained immutable document bytes |
 | `tidebreak.lock` | proof that one process owns this data directory |
 | OS keychain | provider credentials, kept outside the database — one item per profile |
@@ -104,7 +105,10 @@ both the desktop app and a headless `tidebreak serve` using the desktop profile.
 Opening an older pre-v1 database rebuilds `tidebreak.db` and its SQLite journals
 so stale state cannot survive the reset. A current epoch preserves both stores.
 Startup also removes the retired `vectors/` directory when it is safe to open
-the current schema. Unknown, newer, or post-v1 lifecycle markers fail closed so
+the current schema. Code worktrees are the exception to "rebuilt": they live
+outside the data directory because they hold uncommitted user work, so a reset
+records them in `orphaned-code-worktrees.json` and leaves the trees, their
+`.git/worktrees` entries, and their branches alone. Unknown, newer, or post-v1 lifecycle markers fail closed so
 a prerelease binary cannot silently erase a future stable database, and the
 destructive path is disabled at runtime for package major version 1 and later.
 


### PR DESCRIPTION
## What

`reset_pre_v1_state` deletes the SQLite files and the host-broker durable state, and its comment said "nothing else in the data directory". Code worktrees are not in the data directory. [Decision 53](https://github.com/brightwave-inc/tidebreak/blob/main/docs/decisions/0053-code-worktrees-live-in-a-user-visible-root.md) moved them to `~/Tidebreak/workspaces` deliberately, because a worktree is user work — uncommitted code on a real branch.

So every epoch bump drops the `code_workspace` rows and leaves behind the trees, the entries in each source repository's `.git/worktrees`, and the branches the workspaces created on the user's real repository. Eight bumps have gone by and nothing sweeps them.

## How

This is option 1 from #2429, the non-destructive floor.

Right before the database goes, `code::worktree_orphans` reads the rows that name the trees and records every tree still on disk in `orphaned-code-worktrees.json`, beside the schema marker — a sidecar because sidecars survive a reset by design, which is already how the marker and `gateway-policy.json` work. A warning names the file and says plainly that nothing removes the trees, their `.git/worktrees` entries, or their branches.

Deliberate choices:

- **Best effort, never blocking.** The scan reads a database whose schema this binary no longer matches, on a path that has to end with the app booting. It opens read-only so it can never create or migrate the file it is about to delete, `SELECT *`s rather than naming columns that may not exist, falls back to an unjoined query for databases from before code repositories, and closes before the caller deletes the file so Windows can. Every failure is logged and the reset continues.
- **Merges rather than replaces.** Epoch bumps come in runs. A later reset adds to the record and keeps the first sighting of each tree, which is the honest timestamp: it says when the tree stopped being a workspace.
- **A tree already gone is not an orphan.** Only paths still on disk are recorded.
- **An unparseable sidecar is moved to `orphaned-code-worktrees.previous.json`, not overwritten.** It is still the only pointer to somebody's uncommitted work.

Options 2 (a first-run surface) and 3 (re-adoption) stay open on top of this and need no rework — the record is the input either would read.

`prepare` and `reset_pre_v1_state` become `async` to do the read; two sync tests become `#[tokio::test]`. `replace_file` is now `pub(crate)` so the sidecar publishes with the same guarantee as the marker.

## Tests

Three, in `desktop_schema` where the reset contract already lives:

- A reset records the orphaned tree with its path, branch, source repository, and title, does not record a workspace whose tree is already gone, and leaves the tree's contents untouched.
- A second reset adds to the record instead of replacing it.
- A reset with no code worktrees writes no file at all.

## Note on timing

Worth landing before #2428 closes the epoch window. After that the resets stop, but the orphans from the previous eight are still on disk — this records new ones, and does not go back for those.