### PR TITLE
refactor(core): move attention out of code mode

### DIFF
--- a/crates/tidebreak-core/src/attention.rs
+++ b/crates/tidebreak-core/src/attention.rs
@@ -1,7 +1,15 @@
 //! Attention for a unit of supervised work.
 //!
 //! The vocabulary is defined over "a unit of supervised work", not over a
-//! coding session specifically, so chat can adopt it later without renaming.
+//! coding session specifically. Decision 30 wrote it that way on purpose so
+//! chat could adopt it without renaming, and decision 48 step 3 is where that
+//! happens: this module moved out of `code` to a home neither surface owns,
+//! ahead of chat conversations carrying an [`Attention`] of their own.
+//!
+//! Not every engine produces every state. [`AttentionState::Fenced`] belongs
+//! to supervising a process the server does not control, and the internal
+//! engine has nothing to fence. A shared vocabulary does not oblige every
+//! engine to use all of it.
 
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -4,10 +4,11 @@
 //! `#[non_exhaustive]`, bounded payloads. Large bodies (diffs, raw engine
 //! payloads) never ride these events — they carry hints.
 
+use crate::attention::{AttentionSource, AttentionState};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-use super::{AttentionSource, AttentionState, CodeApprovalId, CodeTurnId, HarnessKind};
+use super::{CodeApprovalId, CodeTurnId, HarnessKind};
 
 /// Longest assistant / reasoning / steer text stored on one event.
 pub const MAX_EVENT_TEXT_CHARS: usize = 8_192;
@@ -391,7 +392,8 @@ pub struct SequencedCodeEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::code::{AttentionSource, AttentionState, FenceReason, HarnessKind};
+    use crate::attention::FenceReason;
+    use crate::code::HarnessKind;
     use uuid::Uuid;
 
     #[test]

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -7,14 +7,9 @@
 //! Id types are structurally identical to chat ids (UUID newtypes, transparent
 //! serde) but distinct so the two surfaces cannot be confused at compile time.
 
-mod attention;
 mod caps;
 mod event;
 
-pub use attention::{
-    should_replace, Attention, AttentionSource, AttentionState, FenceReason, MAX_ATTENTION_NOTE,
-    MAX_ATTENTION_PROMPT,
-};
 pub use caps::{CapLevel, HarnessCaps, HarnessCommand, HarnessTier};
 pub use event::{
     ApprovalDecisionKind, BoundedError, CheckpointHint, CodeEvent, CodeUsage, Diffstat,
@@ -22,6 +17,7 @@ pub use event::{
     MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS, MAX_TOOL_SUMMARY_CHARS,
 };
 
+use crate::attention::{Attention, FenceReason};
 use crate::PermissionMode;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;

--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -3,9 +3,10 @@ use sea_orm::{
     TransactionTrait,
 };
 
+use crate::attention::{Attention, AttentionSource, AttentionState, FenceReason};
 use crate::code::{
-    Attention, AttentionSource, AttentionState, CodeSession, CodeSessionId, CodeSessionKind,
-    CodeSessionLifecycle, CodeSubagentSummary, FenceReason, HarnessKind, WorkspaceId,
+    CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeSubagentSummary,
+    HarnessKind, WorkspaceId,
 };
 use crate::error::{AgentError, Result};
 use crate::OwnerId;

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -1,9 +1,10 @@
 use super::temp_store;
+use crate::attention::{Attention, AttentionSource};
 use crate::code::{
-    Attention, AttentionSource, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
-    CodeEvent, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle,
-    CodeSubagentStatus, CodeSubagentSummary, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace,
-    CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
+    CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent, CodeRepo,
+    CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeSubagentStatus,
+    CodeSubagentSummary, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus,
+    HarnessKind, RepoId, WorkspaceId,
 };
 use crate::db::code::{
     append_event, bump_spawn_epoch, get_approval, get_repo, get_repo_by_root_path, get_session,

--- a/crates/tidebreak-core/src/db/tests/message_attachment.rs
+++ b/crates/tidebreak-core/src/db/tests/message_attachment.rs
@@ -1,6 +1,7 @@
 //! Image attachment persistence and its effect on blob retention.
 
 use super::*;
+use crate::attention::{Attention, AttentionSource};
 use crate::image::{ImageMediaType, ImageRef};
 use crate::model::{DocumentBlob, MAX_MESSAGE_ATTACHMENTS};
 
@@ -708,9 +709,9 @@ impl ReferenceClass {
 
 async fn pin_code_turn_attachment(store: &DbStore, blob: &DocumentBlob) {
     use crate::code::{
-        Attention, AttentionSource, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind,
-        CodeSessionLifecycle, CodeTurn, CodeTurnAttachment, CodeTurnId, CodeTurnStatus,
-        CodeWorkspace, CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
+        CodeRepo, CodeSession, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeTurn,
+        CodeTurnAttachment, CodeTurnId, CodeTurnStatus, CodeWorkspace, CodeWorkspaceStatus,
+        HarnessKind, RepoId, WorkspaceId,
     };
     use crate::db::code::{insert_repo, insert_session, insert_turn, insert_workspace};
 

--- a/crates/tidebreak-core/src/lib.rs
+++ b/crates/tidebreak-core/src/lib.rs
@@ -67,6 +67,7 @@ pub mod deliverable;
 // Host-side acceptance writes bytes into private scratch, so it depends on the
 // capability filesystem and async runtime that only the `tools` feature pulls
 // in. The persisted contract and migration below stay available without it.
+pub mod attention;
 pub mod compaction;
 #[cfg(feature = "tools")]
 pub mod deliverable_acceptance;
@@ -125,6 +126,10 @@ pub use approval::{
     AutoJudgeStatus, GrantLevel, GrantScope, RefuseGate, StandingGrant, StandingGrantRecord,
     StandingGrants, ToolApproval, ToolApprovalKind, ToolApprovalStatus,
 };
+pub use attention::{
+    should_replace, Attention, AttentionSource, AttentionState, FenceReason, MAX_ATTENTION_NOTE,
+    MAX_ATTENTION_PROMPT,
+};
 #[cfg(feature = "blob-fs")]
 pub use blob::FsBlobStore;
 pub use browser::{
@@ -168,17 +173,16 @@ pub use client_tools::{
     READ_CONNECTED_FILE_TOOL, REQUEST_FOLDER_ACCESS_TOOL, WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
 pub use code::{
-    bound_subagents, should_replace, ApprovalDecisionKind, Attention, AttentionSource,
-    AttentionState, BoundedError, CapLevel, CheckpointHint, CodeApproval, CodeApprovalId,
-    CodeApprovalKind, CodeApprovalState, CodeEvent, CodeRepo, CodeSession, CodeSessionActivity,
-    CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeSubagentStatus, CodeSubagentSummary,
-    CodeTerminalId, CodeTurn, CodeTurnAttachment, CodeTurnId, CodeTurnStatus, CodeUsage, CodeWatch,
-    CodeWatchId, CodeWatchState, CodeWorkspace, CodeWorkspaceStatus, Diffstat, FenceReason,
-    FileChangeKind, HarnessCaps, HarnessCommand, HarnessKind, HarnessNoticeLevel, HarnessTier,
-    PullRequestCheck, PullRequestCheckBucket, PullRequestComment, PullRequestCommentKind,
-    PullRequestDigest, QuickAction, RepoId, SequencedCodeEvent, ToolDetail, ToolOutcome,
-    WorkspaceId, MAX_ATTENTION_NOTE, MAX_ATTENTION_PROMPT, MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS,
-    MAX_PREVIEW_CHARS, MAX_SESSION_SUBAGENTS, MAX_TOOL_SUMMARY_CHARS,
+    bound_subagents, ApprovalDecisionKind, BoundedError, CapLevel, CheckpointHint, CodeApproval,
+    CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent, CodeRepo, CodeSession,
+    CodeSessionActivity, CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeSubagentStatus,
+    CodeSubagentSummary, CodeTerminalId, CodeTurn, CodeTurnAttachment, CodeTurnId, CodeTurnStatus,
+    CodeUsage, CodeWatch, CodeWatchId, CodeWatchState, CodeWorkspace, CodeWorkspaceStatus,
+    Diffstat, FileChangeKind, HarnessCaps, HarnessCommand, HarnessKind, HarnessNoticeLevel,
+    HarnessTier, PullRequestCheck, PullRequestCheckBucket, PullRequestComment,
+    PullRequestCommentKind, PullRequestDigest, QuickAction, RepoId, SequencedCodeEvent, ToolDetail,
+    ToolOutcome, WorkspaceId, MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS,
+    MAX_SESSION_SUBAGENTS, MAX_TOOL_SUMMARY_CHARS,
 };
 pub use compaction::{
     CompactionPolicy, CompactionSelection, CompactionSourceBoundary, CompactionTokenBounds,


### PR DESCRIPTION
First of a stack for #2314 ([decision 48](https://github.com/brightwave-inc/tidebreak/blob/main/docs/decisions/0048-one-interaction-model.md) step 3).

## What

`attention` moves from `crates/tidebreak-core/src/code/` to `crates/tidebreak-core/src/attention.rs` — a home neither surface owns, the same move `PermissionMode` made in #2450.

Pure relocation. No type, variant, or wire name changes. The generated TypeScript is byte-identical, so no client can tell.

## Why now

[Decision 30](https://github.com/brightwave-inc/tidebreak/blob/main/docs/decisions/0030-code-mode-separate-surface.md) defined this vocabulary over "a unit of supervised work" rather than over a coding session, and said so in the module's own doc comment, explicitly so chat could adopt it later without renaming. This is that adoption starting.

Splitting the move from the behavior keeps the next PR — chat conversations deriving an `Attention` of their own — reviewable as behavior rather than as several hundred lines of import churn.

## One thing the module now states

A shared vocabulary does not oblige every engine to produce every state. `AttentionState::Fenced` exists for supervising a process the server does not control; the internal engine has nothing to fence. Worth writing down before chat adopts the type, since the alternative reading — that chat must now grow a fencing concept — is wrong.

## Tests

`tidebreak-core` 720 pass, `tidebreak-server --lib code::` 223 pass, clippy and rustfmt clean.