### PR TITLE
test(core): give the Postgres claim test a queue it owns

### DIFF
--- a/crates/tidebreak-core/tests/postgres_turn_state.rs
+++ b/crates/tidebreak-core/tests/postgres_turn_state.rs
@@ -118,6 +118,40 @@ async fn expire_postgres_turn_admission(url: &str, turn_id: TurnId) {
     assert_eq!(updated.rows_affected(), 1);
 }
 
+/// Delete every row the product owns, leaving the migrated schema in place.
+///
+/// The tests in this file share one database and serialize on
+/// [`POSTGRES_TEST_LOCK`], which keeps them from running at once but not from
+/// reading each other's leftovers. A test that asserts on a scan across the
+/// whole store has to start from an empty one, or it passes only against a
+/// database no run has touched — which is exactly what CI hands it, and why
+/// running the suite twice locally used to fail.
+///
+/// The table list comes from the catalog rather than a constant, so a new table
+/// is covered without anyone remembering to add it. Two tables are held back:
+/// SeaORM's bookkeeping, because dropping it re-runs every migration, and
+/// `advisory_lock`, whose seeded rows are what serializes the claim paths — the
+/// baseline inserts them once, and every claim fails without them.
+async fn empty_postgres_tables(url: &str) {
+    let connection = Database::connect(url).await.unwrap();
+    connection
+        .execute_unprepared(
+            "DO $$ \
+             DECLARE tables text; \
+             BEGIN \
+               SELECT string_agg(format('%I.%I', schemaname, tablename), ', ') INTO tables \
+                 FROM pg_tables \
+                WHERE schemaname = 'public' \
+                  AND tablename NOT IN ('seaql_migrations', 'advisory_lock'); \
+               IF tables IS NOT NULL THEN \
+                 EXECUTE 'TRUNCATE TABLE ' || tables || ' CASCADE'; \
+               END IF; \
+             END $$;",
+        )
+        .await
+        .unwrap();
+}
+
 async fn set_postgres_turn_max_attempts(url: &str, turn_id: TurnId, max_attempts: i32) {
     assert!(max_attempts > 0);
     let connection = Database::connect(url).await.unwrap();
@@ -2642,6 +2676,12 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         Err(_) => return,
     };
     let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    // The claims below race over the whole queue, not over one chat, and this
+    // test asserts the winner is its own turn. Every other test in this file
+    // leaves queued turns behind, and so does every earlier run of this one
+    // against the same database. Start from an empty queue so a global claim
+    // really is global over one turn.
+    empty_postgres_tables(&url).await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
     let turn_id = TurnId::new();


### PR DESCRIPTION
## What

`postgres_turn_acceptance_claims_and_receipts_are_atomic` passes against a fresh database and fails on every run after that against the same one, two different ways depending on how far it gets:

```
assertion `left == right` failed
  left: ChatId(acdb555b-…)     right: ChatId(c9cacadc-…)

assertion `left == right` failed
  left: Some(TurnRun { id: TurnId(40b0e920-…), … })     right: None
```

`claim_turn_run` is a work-queue poll across the whole store, not a per-chat lookup — it takes the globally oldest due or expired turn. The test spawns eight racing claims and asserts the single winner is its own turn, which holds only when the queue contains nothing else. Every other test in this file leaves queued turns behind, and so does every earlier run of this one, so the claim picks up a stale turn with an older `available_at` and the identity assertions compare against the wrong row.

Nothing is wrong with `claim_turn_run` — it behaves exactly as a global queue claim should. CI hid this by starting a fresh Postgres service container every run, which is also why it is invisible to anyone who does not run the suite twice.

## How

Option 2 from #2457: empty the store before the racing claims, so a global claim really is global over one turn. That keeps the identity coverage, which option 3 would have thrown away, and does not pay a fresh migration per test the way option 1 would.

The table list comes from `pg_tables` rather than a constant, so a new table is covered without anyone remembering to add it. Two are held back:

- `seaql_migrations`, because dropping it re-runs every migration.
- `advisory_lock`, whose seeded rows are what serializes the claim paths. The baseline inserts them once (`SEED_STATEMENTS`), and every claim fails with `durable advisory lock turn_claim is missing` without them — which is what the first version of this change did.

Only this test resets, because only this test asserts on a scan across the whole store. The helper's doc says when to reach for it.

## Tests

Run against `postgres:17-alpine`, the CI image, five times in a row against a single database that is never recreated: 29 passed every time. On `main` the same loop fails from the second run on. The sibling `postgres_code_owner` suite still passes against the same reused database.