### PR TITLE
docs: fix the duplicate 56 record and the stale permission-mode entry

### DIFF
--- a/docs/decisions/0059-workspace-reclaim-tiers.md
+++ b/docs/decisions/0059-workspace-reclaim-tiers.md
@@ -1,4 +1,4 @@
-# 56. Workspace Reclaim Tiers
+# 59. Workspace Reclaim Tiers
 
 - Status: Accepted
 - Date: 2026-08-21

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -228,17 +228,20 @@ purpose:
   worktree per session, which splits the branch, the diff, and the pull
   request the workspace is keyed to. Reconsider only with a reason to give
   one workspace several trees.
-- **Changing a session's permission mode after it starts.** The mode is
-  chosen at session creation, refused per harness capability there
+- **Changing a session's permission mode underneath a running turn.**
+  Changing the mode on a live session shipped in #2411. The session asks its
+  engine on the engine's own channel first — Claude Code's
+  `set_permission_mode` control request, Codex's per-turn policy fields — and
+  only an engine that fixes its posture at launch pays for a stop and
+  re-attach. The mode is still refused per harness capability
   ([record 33](decisions/0033-code-mode-approvals.md),
   [record 38](decisions/0038-auto-is-a-declared-capability.md),
-  [record 39](decisions/0039-allow-is-a-first-class-code-permission-mode.md)), and composed
-  into the engine's launch; no adapter can renegotiate it on an attached
-  session. Changing it means tearing the engine down and relaunching it on a
-  resume ref — new semantics for spawn epochs, in-flight turns, and pending
-  approvals — so the composer states the session's mode rather than offering
-  it. Revisit when relaunch-on-resume is a proven path, or when a harness
-  protocol carries a mode change directly.
+  [record 39](decisions/0039-allow-is-a-first-class-code-permission-mode.md)),
+  now at the change as well as at creation, and each change is journaled.
+  What stays excluded is moving the posture while a turn runs: a turn that
+  began under one mode must not have it changed underneath it, so the change
+  is refused with `turn_running`. Reconsider only with a reason to let a
+  running turn's approvals change shape mid-flight.
 - **An in-app code editor.** V1 reviews server-produced diffs and hands
   editing to the user's editor via the worktree path. An embedded editor is
   a heavyweight dependency with its own product surface; it needs demand


### PR DESCRIPTION
Two documentation records went stale on the same day. Both corrections are
prerequisites for writing the next decision record, because the next free
number depends on the first one.

## Renumber the reclaim record to 59

`0056-one-credential-item-per-profile.md` (#2412, 11:11) and
`0056-workspace-reclaim-tiers.md` (#2443, 15:12) both landed as 56. The
reclaim record arrived second, so it takes the next free number, following
the precedent of #2365 and #2397. Nothing in the repository cites either
record, so the rename and its title line are the whole change. The next free
decision-record number is now 60.

## Say that a live session can change its permission mode

`docs/deferred.md` still said the mode is fixed at session creation and that
no adapter can renegotiate it on an attached session. #2411 shipped the
change: the session asks its engine on the engine's own channel — Claude
Code's `set_permission_mode` control request, Codex's per-turn policy fields
— and only an engine that fixes its posture at launch pays for a stop and
re-attach.

The entry is rewritten rather than removed, because `docs/deferred.md` is the
canonical record of parked scope and a silent deletion loses the reasoning.
What survives as parked is moving the posture underneath a running turn,
which `CodeRuntime::set_permission_mode` refuses with `turn_running`, so the
entry now names that instead.

## Checks

Documentation only. No code, schema, or interface change.