### PR TITLE
fix(code): a settled session is idle, not working

### DIFF
--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -1529,6 +1529,7 @@ fn attention_label(attention: &Attention) -> String {
         AttentionState::NeedsYou { prompt, .. } => format!("needs_you: {prompt}"),
         AttentionState::Stalled { idle_secs } => format!("stalled {idle_secs}s"),
         AttentionState::DoneUnreviewed => "done_unreviewed".to_owned(),
+        AttentionState::Idle => "idle".to_owned(),
         AttentionState::Fenced { .. } => "fenced".to_owned(),
         AttentionState::Manual { note } => format!("manual: {note}"),
     }

--- a/crates/tidebreak-core/src/attention.rs
+++ b/crates/tidebreak-core/src/attention.rs
@@ -140,6 +140,13 @@ pub enum AttentionState {
     },
     /// Finished work the user has not looked at.
     DoneUnreviewed,
+    /// Nothing is running and nothing is waiting.
+    ///
+    /// The resting state. Without it the derivation has to call an idle
+    /// conversation something it is not — the code path used to fall through
+    /// to `Working`, which is survivable for a session someone is watching and
+    /// plainly false for a chat sitting untouched for a week.
+    Idle,
     /// Crash recovery parked it.
     Fenced {
         /// Why it was fenced.

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -401,6 +401,8 @@ export function attentionLabel(attention: Attention): string {
       return "Stalled";
     case "done_unreviewed":
       return "Done";
+    case "idle":
+      return "Idle";
     case "fenced":
       return "Fenced";
     case "manual":

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.ts
@@ -115,6 +115,10 @@ export function attentionStatusTone(attention: Attention): StatusTone {
       return "pending";
     case "done_unreviewed":
       return "neutral";
+    // Resting, not finished: nothing for the reader to act on, and nothing
+    // that should read as a completed result they have yet to look at.
+    case "idle":
+      return "neutral";
   }
 }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -553,7 +553,7 @@ source: AttentionSource, } | { "type": "stalled",
 /**
  * Seconds of observed silence.
  */
-idle_secs: number, } | { "type": "done_unreviewed" } | { "type": "fenced", 
+idle_secs: number, } | { "type": "done_unreviewed" } | { "type": "idle" } | { "type": "fenced", 
 /**
  * Why it was fenced.
  */

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -158,7 +158,14 @@ pub(crate) async fn compute_attention(
         Some(turn) if turn.status == CodeTurnStatus::Completed && !opts.reviewed => Ok(
             Attention::new(AttentionState::DoneUnreviewed, AttentionSource::Lifecycle),
         ),
-        _ => Ok(Attention::working(AttentionSource::Lifecycle)),
+        // Nothing running, nothing waiting, nothing unreviewed. Reporting
+        // `Working` here — as this arm used to — claims an engine is busy
+        // when none is, and a session with no turns yet has never been busy
+        // at all.
+        _ => Ok(Attention::new(
+            AttentionState::Idle,
+            AttentionSource::Lifecycle,
+        )),
     }
 }
 
@@ -176,12 +183,16 @@ pub(crate) async fn mark_viewed(
     if !matches!(session.attention.state, AttentionState::DoneUnreviewed) {
         return Ok(());
     }
+    // The session is DoneUnreviewed, so no turn is running. Viewing it settles
+    // it; it does not start an engine. This wrote `Working` because `Idle` did
+    // not exist, which meant looking at a finished session made it claim to be
+    // busy for as long as it lived.
     let _ = apply_attention(
         db,
         bus,
         owner,
         session_id,
-        Attention::working(AttentionSource::Lifecycle),
+        Attention::new(AttentionState::Idle, AttentionSource::Lifecycle),
         false,
     )
     .await?;

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -122,9 +122,12 @@ pub(crate) async fn reap_session(
     session.lifecycle = CodeSessionLifecycle::Idle;
     session.fence_reason = None;
     session.child_pid = None;
+    // A reap resolves the fence and leaves the session idle. It does not start
+    // an engine, so the attention that follows is the resting state, not
+    // `Working` — which is what this said while `Idle` did not exist.
     replace_attention(
         &mut session,
-        Attention::working(AttentionSource::Lifecycle),
+        Attention::new(AttentionState::Idle, AttentionSource::Lifecycle),
         false,
     );
     persist_session(store, bus, &session).await?;

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -5330,14 +5330,18 @@ async fn attention_follows_approval_completion_and_view() {
             .await
             .unwrap()
             .unwrap();
-            if row.attention.state == AttentionState::Working {
+            // Idle, not Working. Viewing settles the session; it does not
+            // start an engine. This asserted `Working` while `Idle` did not
+            // exist, which is how the derivation came to claim a finished
+            // session was busy.
+            if row.attention.state == AttentionState::Idle {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
     })
     .await
-    .expect("viewing the session must clear DoneUnreviewed");
+    .expect("viewing the session must settle it to Idle, not report it Working");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Second of the stack for #2314. Follows #2460, which moved the attention vocabulary out of code mode.

## The bug

`AttentionState` had no resting state — `Working | NeedsYou | Stalled | DoneUnreviewed | Fenced | Manual`. So three paths reported a session as `Working` while no engine was running:

1. **`compute_attention`'s final arm.** Reached by a completed-and-reviewed session, and by one that has never taken a turn.
2. **`mark_viewed`.** Wrote `Attention::working(...)` outright — looking at a finished session made it claim to be busy.
3. **`reap_session`.** Sets `lifecycle = Idle`, resolves the fence, then set attention to `Working`.

## The evidence it was already known

`attention_follows_approval_completion_and_view` asserted that viewing a session makes it `Working`, with the message "viewing the session must clear DoneUnreviewed." That expectation was the bug written down: `Idle` was not available to assert instead, so the test pinned the wrong state. Correcting it is the regression test.

## Why now rather than as its own bug

Code mode survives this. A session is short-lived and usually being watched, so a wrong resting state is not on screen long enough to confuse anyone.

Decision 48 step 3 changes the stakes: chat conversations are about to carry the same vocabulary, and a chat idle for a week claiming an engine is busy is not a rounding error. Fixing the vocabulary before chat adopts it means chat inherits a state machine that can express rest.

## Not a schema change

`attention_state` is a `json_binary` column with no CHECK constraint, so a new variant needs no baseline edit and no epoch bump. Existing rows hold the old variants and still parse.

The stall-clearing path also writes `Working`, and that one is correct — it fires only when the session is `Running`. Left alone.

## Tests

`tidebreak-server --lib code::` 223 pass, `tidebreak-core` 720 pass, UI 539 pass, clippy, rustfmt, `tsc`, and `biome check` clean. The CLI and both UI switches over `AttentionState` are exhaustive, so the new variant was a compile break at each — all three now render "Idle".