### PR TITLE
fix(ui): render the foreground browser panel instead of its tab title

### DIFF
--- a/crates/tidebreak-desktop/src/main.rs
+++ b/crates/tidebreak-desktop/src/main.rs
@@ -3,6 +3,12 @@
 //! Boots the in-process HTTP/WebSocket surface and hosts the chat UI webview.
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+// A debug build of this binary emits ~18MB of `__eh_frame`, past the 16MB the
+// Mach-O compact unwind table can address, so `ld` warns on every dev link.
+// Only unwinding a panic pays for that, and nothing here is on a hot path, so
+// the warning is noise. Scoped tight: release builds and every other platform
+// still surface whatever the linker has to say.
+#![cfg_attr(all(target_os = "macos", debug_assertions), allow(linker_messages))]
 
 fn main() {
     tidebreak_desktop_lib::run();

--- a/crates/tidebreak-desktop/ui/biome.jsonc
+++ b/crates/tidebreak-desktop/ui/biome.jsonc
@@ -39,6 +39,7 @@
       },
       "suspicious": {
         "noDebugger": "error",
+        "noDuplicateCase": "error",
         "noDuplicateClassMembers": "error",
         "noDuplicateJsxProps": "error",
         "noDuplicateObjectKeys": "error",

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -937,8 +937,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onOpenRun={(runId) => openPanel({ type: "agent", runId })}
           />
         );
-      case "browser":
-        return browserTitles[panel.browserId];
       case "agent":
         return <BackgroundAgentPanel chatId={chatId} runId={panel.runId} />;
       case "browser":


### PR DESCRIPTION
## What changed

`renderPanel` matched `case "browser"` twice, so the foreground browser panel rendered its tab title string instead of mounting `CodeBrowserTab` — both cases landed together in #2419, so the panel has never worked. Biome's `noDuplicateCase` is now on to catch the next one, since the UI lint sets `recommended: false` and TypeScript accepts a string as a valid `ReactNode`. The desktop binary also allows `linker_messages` on macOS debug builds, where ~18MB of `__eh_frame` overflows the 16MB a Mach-O compact unwind table can address and makes `ld` warn on every dev link.

## Validation

`npx tsc --noEmit` and `pnpm --dir crates/tidebreak-desktop/ui lint` both pass, and a probe file confirmed `noDuplicateCase` fires on a duplicate. I did not relink the desktop binary locally because this workspace's target directory is cold, so I checked the lint name with `rustc -W help` and confirmed the attribute compiles clean standalone; CI covers the real link.

## Compatibility and risk

Nothing persisted or on the wire changes, and the `allow` is scoped to macOS debug builds so release builds and every other platform keep their linker warnings.