### PR TITLE
docs(harness): record what Claude Code does with a mid-turn user line

### DIFF
--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/manifest.toml
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/manifest.toml
@@ -67,8 +67,26 @@ verified_2_1_238 = [
   "--resume <id> together with --input-format stream-json keeps the same session id",
   "new system subtype: session_state_changed, twice per turn",
 ]
+# Observed live on 2.1.239 while answering the mid-turn steering question
+# decision 57 left open. Recorded here rather than as a second fixture tree,
+# matching the 2.1.238 entry above: the stream shapes are unchanged, and what
+# was measured is when the engine reads a queued line, not a new wire format.
+# Captured twice, once on claude-haiku-4-5-20251001 and once on
+# claude-sonnet-5, with the same shape both times.
+verified_2_1_239 = [
+  "a stream-json user line written to open stdin during a running turn is queued, not merged into the request in flight",
+  "the queued line reaches the running turn at a tool-call boundary: the call in flight finished, one further tool call ran, then the model answered the injected message and abandoned the original task",
+  "a steered turn ends with one result, terminal_reason=completed and num_turns=3 — the engine counts the injected message into the turn it interrupted",
+  "a turn with no further tool call never sees the line: a 70-second text-only turn ran to completion after the write and ended num_turns=1",
+  "a line the running turn never reached runs as its own turn afterwards, preceded by a fresh system/init on the same session id — that reprinted init is the only wire signal that a steer missed",
+  "the injected line is not echoed on stdout and draws no control_response, so a successful stdin write is the only evidence the engine took it",
+]
 not_verified = [
-  "mid-turn steering input",
+  # No longer 'whether it works' — see verified_2_1_239. What is unverified is
+  # whether an adapter can bound the miss: a queued line the turn never reaches
+  # becomes an unannounced extra turn, and the session-long reader would hand
+  # its result to whatever turn is submitted next.
+  "recovering from a mid-turn steer the running turn never reached",
   "native file-change events",
   "reasoning-level control flags",
   "live Auto (acceptEdits) turn with the prompt tool — flag is documented; not recaptured",


### PR DESCRIPTION
[Decision 57](https://github.com/brightwave-inc/tidebreak/blob/main/docs/decisions/0057-one-claude-child-per-session.md)
holds Claude Code's stdin open and deliberately does not claim mid-turn
steering: `mid_turn_steering` stays `CapLevel::Unknown` until the behavior is
captured. The fixture manifest listed "mid-turn steering input" first under
`not_verified`. This records what the engine actually does.

## What was captured

Claude Code 2.1.239, the adapter's own argv
(`crates/tidebreak-harness/src/claude/session.rs`) and its stream-json user
line (`encode_turn_stdin`), stdin held open, a second user line written while
turn one ran. Captured twice, once on `claude-haiku-4-5-20251001` and once on
`claude-sonnet-5`, with the same shape both times.

**Steering works, at a tool-call boundary.** The tool call in flight finished,
one further tool call ran, and the model then answered the injected message and
abandoned its original task. The turn ended with a single `result`,
`terminal_reason=completed`, `num_turns=3` — the engine counts the injected
message into the turn it interrupted.

**A turn with no tool call never reaches it.** A text-only turn kept generating
for 70 seconds after the write and ended `num_turns=1`. The queued line then
ran as its own turn, preceded by a fresh `system/init` on the same session id.

**Nothing acknowledges the line.** It is not echoed on stdout and draws no
`control_response`, so a successful stdin write is the only evidence the engine
took it. Confirming from the other side: the 2.1.239 bundle's control-request
table has no steering subtype, and `interrupt` returns `still_queued` — the
queue the line lands in.

## Why this is not a capability flip

Declaring `Supported` needs more than this capture. A queued line the turn
never reaches becomes an unannounced extra turn, and `EngineChannel`'s reader
and parser live for the whole session — so that turn's `result` would be read
as the terminal event for whatever turn is submitted next. The reprinted
`system/init` is the signal an adapter would have to act on, and the parser
currently suppresses repeats behind `emitted_session`.

`not_verified` therefore keeps an entry, narrowed from "does it work" to
"recovering from a mid-turn steer the running turn never reached".

## Scope

Manifest only. No capability change, no adapter change, no fixture tree added:
per `fixtures/README.md` a version move wants the whole directory recaptured,
and these are facts about when the engine reads a queued line rather than a new
wire format — the same reason the 2.1.238 findings sit in this manifest.
