### PR TITLE
feat(core): a chat carries attention, derived from its own rows

### DIFF
--- a/crates/tidebreak-core/src/db/mod.rs
+++ b/crates/tidebreak-core/src/db/mod.rs
@@ -2591,6 +2591,14 @@ impl Store for DbStore {
         ops::inbox::list_inbox_items(self, owner).await
     }
 
+    async fn chat_attention_scoped(
+        &self,
+        owner: &OwnerId,
+        items: &[crate::InboxItem],
+    ) -> Result<std::collections::HashMap<crate::ChatId, crate::Attention>> {
+        ops::chat_attention::chat_attention(self, owner, items).await
+    }
+
     async fn answer_user_questions(
         &self,
         request: &crate::AnswerUserQuestionsRequest,

--- a/crates/tidebreak-core/src/db/ops/active_work.rs
+++ b/crates/tidebreak-core/src/db/ops/active_work.rs
@@ -15,16 +15,10 @@ use super::super::{entities, store_err, DbStore};
 
 pub(in crate::db) async fn count_active_work(store: &DbStore) -> Result<ActiveWorkSnapshot> {
     let active_turns = entities::turn_run::Entity::find()
-        .filter(entities::turn_run::Column::Status.is_in([
-            TurnRunStatus::Queued.as_str(),
-            TurnRunStatus::Running.as_str(),
-            TurnRunStatus::Cancelling.as_str(),
-            TurnRunStatus::WaitingForClient.as_str(),
-            TurnRunStatus::WaitingForAgentRun.as_str(),
-            TurnRunStatus::CancellingClient.as_str(),
-            TurnRunStatus::Resuming.as_str(),
-            TurnRunStatus::RetryWait.as_str(),
-        ]))
+        .filter(
+            entities::turn_run::Column::Status
+                .is_in(TurnRunStatus::LIVE.iter().map(|status| status.as_str())),
+        )
         .count(&store.conn)
         .await
         .map_err(store_err)?;

--- a/crates/tidebreak-core/src/db/ops/chat_attention.rs
+++ b/crates/tidebreak-core/src/db/ops/chat_attention.rs
@@ -1,0 +1,109 @@
+//! A chat's attention, derived from the rows that already describe it.
+//!
+//! Decision 48 step 3 gives every conversation the attention vocabulary code
+//! mode introduced, so one supervising client watches one queue. Code stores
+//! its attention on `code_session`, because a session is the unit and its
+//! lifecycle lives on the same row. Chat has no such row: a conversation's
+//! liveness is spread across `turn_run`, and its waiting work is the same set
+//! the inbox already projects.
+//!
+//! So chat derives rather than stores. Adding attention columns to `chat`
+//! would duplicate state `turn_run` owns and need a write at every turn
+//! transition to stay true — the shape issue #1462 spent a wave removing. The
+//! inbox next door already states the principle: a projection of rows that
+//! carry the state, "deliberately not a store of its own, so resolving an item
+//! through its existing route is what removes it from here."
+//!
+//! Chat never produces [`AttentionState::DoneUnreviewed`] or
+//! [`AttentionState::Fenced`]. Reviewed-ness is a code-mode notion carried by
+//! an attached events socket, and there is no foreign process to fence. A
+//! shared vocabulary does not oblige every engine to use all of it.
+
+use std::collections::HashMap;
+
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+
+use crate::attention::{Attention, AttentionSource, AttentionState};
+use crate::error::Result;
+use crate::model::{OwnerId, TurnRunStatus};
+use crate::storage::{InboxItem, InboxItemKind};
+use crate::ChatId;
+
+use super::super::{entities, store_err, DbStore};
+
+/// What the reader is being asked, for a badge that must stay opaque.
+///
+/// Kind only — never question text, plan prose, or tool arguments. The inbox
+/// holds that line deliberately, and an attention prompt is shown in more
+/// places than the inbox is.
+fn needs_you_prompt(kind: InboxItemKind) -> &'static str {
+    match kind {
+        InboxItemKind::ToolApproval => "a tool call is waiting for approval",
+        InboxItemKind::Question => "a question is waiting for an answer",
+        InboxItemKind::PlanReview => "a plan is waiting for review",
+        InboxItemKind::FolderAccess => "a folder request is waiting",
+        InboxItemKind::OutputWriteback => "a file write is waiting for confirmation",
+    }
+}
+
+/// Derive one attention value per chat that has anything to say.
+///
+/// Chats absent from the map are [`AttentionState::Idle`]; materializing a
+/// row per idle conversation would make the cost scale with history rather
+/// than with what is happening now.
+pub(in crate::db) async fn chat_attention(
+    store: &DbStore,
+    owner: &OwnerId,
+    items: &[InboxItem],
+) -> Result<HashMap<ChatId, Attention>> {
+    let mut attention = HashMap::<ChatId, Attention>::new();
+
+    // A live turn is the weaker claim, so it goes first and a waiting item
+    // overwrites it below. A conversation that is both running and holding an
+    // approval is, to the reader, waiting on them.
+    let live = entities::turn_run::Entity::find()
+        .filter(
+            entities::turn_run::Column::Status
+                .is_in(TurnRunStatus::LIVE.iter().map(|status| status.as_str())),
+        )
+        .order_by_asc(entities::turn_run::Column::Id)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    let owned = entities::chat::Entity::find()
+        .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(|chat| chat.id)
+        .collect::<std::collections::HashSet<_>>();
+    for run in live {
+        if !owned.contains(&run.chat_id) {
+            continue;
+        }
+        attention.insert(
+            ChatId(run.chat_id),
+            Attention::working(AttentionSource::Lifecycle),
+        );
+    }
+
+    // `items` is already owner-scoped and oldest-first, so the first item for
+    // a chat is the one that has been waiting longest — which is the one the
+    // badge should name.
+    for item in items {
+        match attention.get(&item.chat_id) {
+            // Already naming an older wait: the badge keeps the longest-waiting
+            // one, which is what `items` ordering already decided.
+            Some(existing) if matches!(existing.state, AttentionState::NeedsYou { .. }) => continue,
+            _ => {
+                attention.insert(
+                    item.chat_id,
+                    Attention::needs_you(needs_you_prompt(item.kind), AttentionSource::Structured),
+                );
+            }
+        }
+    }
+
+    Ok(attention)
+}

--- a/crates/tidebreak-core/src/db/ops/mod.rs
+++ b/crates/tidebreak-core/src/db/ops/mod.rs
@@ -10,6 +10,7 @@ pub(in crate::db) mod agent_run;
 pub(in crate::db) mod app;
 pub(in crate::db) mod approval;
 pub(in crate::db) mod blob;
+pub(in crate::db) mod chat_attention;
 pub(in crate::db) mod chat_image_publication;
 pub(in crate::db) mod chat_prompt;
 pub(in crate::db) mod citation;

--- a/crates/tidebreak-core/src/model/turns.rs
+++ b/crates/tidebreak-core/src/model/turns.rs
@@ -148,6 +148,29 @@ pub enum TurnRunStatus {
 }
 
 impl TurnRunStatus {
+    /// Every status that means the conversation is still working.
+    ///
+    /// One definition, because "busy" must mean the same thing to the host's
+    /// quiescence check and to the reader's attention badge. A new
+    /// non-terminal status added without landing here would make a live
+    /// conversation look settled in one of them.
+    pub const LIVE: &'static [Self] = &[
+        Self::Queued,
+        Self::Running,
+        Self::Cancelling,
+        Self::WaitingForClient,
+        Self::WaitingForAgentRun,
+        Self::CancellingClient,
+        Self::Resuming,
+        Self::RetryWait,
+    ];
+
+    /// Whether this status means the conversation is still working.
+    #[must_use]
+    pub fn is_live(self) -> bool {
+        Self::LIVE.contains(&self)
+    }
+
     /// Stable database and wire representation.
     #[must_use]
     pub const fn as_str(self) -> &'static str {

--- a/crates/tidebreak-core/src/storage/store.rs
+++ b/crates/tidebreak-core/src/storage/store.rs
@@ -2935,6 +2935,21 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
+    /// One attention value per conversation that has something to say,
+    /// derived from the same rows the inbox projects (decision 48 step 3).
+    ///
+    /// Absent means [`crate::AttentionState::Idle`]. Chat derives rather than
+    /// stores: its liveness lives on `turn_run` and its waiting work is the
+    /// inbox, so a stored copy would be a duplicate needing a write at every
+    /// transition to stay true.
+    async fn chat_attention_scoped(
+        &self,
+        _owner: &OwnerId,
+        _items: &[InboxItem],
+    ) -> Result<std::collections::HashMap<crate::ChatId, crate::Attention>> {
+        turn_storage_unavailable()
+    }
+
     /// Atomically commit exact answers, complete the same tool call, and move
     /// its blocked turn to the shared resumable state.
     async fn answer_user_questions(

--- a/crates/tidebreak-server/src/tests/lifecycle.rs
+++ b/crates/tidebreak-server/src/tests/lifecycle.rs
@@ -2003,6 +2003,61 @@ async fn the_inbox_lists_parked_work_until_its_own_route_resolves_it() {
     );
 }
 
+/// Decision 48 step 3: a chat carries the attention vocabulary code mode
+/// introduced, so one supervising client watches one queue.
+///
+/// Derived, not stored — the assertions below are all about rows the inbox
+/// already projects, and resolving an item through its own route is what
+/// changes the answer. A stored copy would need a write at every one of those
+/// points to say the same thing.
+#[tokio::test]
+async fn a_chat_carries_attention_derived_from_its_parked_work() {
+    let (router, token, store, _dir) = test_app_without_turn_worker().await;
+    let bearer = format!("Bearer {token}");
+    let owner = tidebreak_core::OwnerId::local();
+
+    let waiting = make_chat(&router, &bearer).await;
+    let approval_call = park_tool_approval_for_route_test(&*store, waiting.id).await;
+    let quiet = make_chat(&router, &bearer).await;
+
+    let items = store.list_inbox_items_scoped(&owner).await.unwrap();
+    let attention = store.chat_attention_scoped(&owner, &items).await.unwrap();
+
+    let state = &attention.get(&waiting.id).expect("the waiting chat").state;
+    assert!(
+        matches!(state, tidebreak_core::AttentionState::NeedsYou { .. }),
+        "a parked approval must read as needs-you, got {state:?}"
+    );
+    // The prompt names the kind and nothing else: an attention badge appears
+    // in more places than the inbox does, and the inbox deliberately never
+    // carries tool arguments or question text.
+    if let tidebreak_core::AttentionState::NeedsYou { prompt, .. } = state {
+        assert_eq!(prompt, "a tool call is waiting for approval");
+    }
+
+    // Absent means idle. Materializing a row for every settled conversation
+    // would scale the read with history instead of with what is happening.
+    assert!(
+        !attention.contains_key(&quiet.id),
+        "a chat with nothing parked must not appear"
+    );
+
+    assert_eq!(
+        decide_approval(&router, &bearer, waiting.id, approval_call, "approve").await,
+        StatusCode::NO_CONTENT
+    );
+    let items = store.list_inbox_items_scoped(&owner).await.unwrap();
+    let attention = store.chat_attention_scoped(&owner, &items).await.unwrap();
+    // Approving resumes the turn, so the chat stops waiting on the reader and
+    // starts working. Asserting it goes quiet here would be asserting that
+    // approving a call does nothing.
+    assert_eq!(
+        attention.get(&waiting.id).map(|value| &value.state),
+        Some(&tidebreak_core::AttentionState::Working),
+        "approving must hand the conversation back to the engine"
+    );
+}
+
 async fn list_inbox(router: &Router, bearer: &str) -> Vec<serde_json::Value> {
     let response = router
         .clone()


### PR DESCRIPTION
Third of the stack for #2314, after #2460 and #2463.

## What

Every conversation now has an attention value in the vocabulary code mode introduced, so one supervising client can watch one queue. `Store::chat_attention_scoped` returns one value per chat that has something to say; absent means `Idle`.

## Derived, not stored

Code keeps attention on `code_session` because a session *is* the unit — its lifecycle lives on the same row. Chat has no equivalent row. A conversation's liveness is spread across `turn_run`, and its waiting work is exactly the set the inbox already projects.

So attention columns on `chat` would duplicate both, and would need a write at every turn transition to stay true. That is the shape #1462 spent a wave removing, and the inbox next door already states the principle in its own doc comment: a projection of the rows that carry the state, "deliberately not a store of its own, so resolving an item through its existing route is what removes it from here."

The test asserts exactly that property — an approval parked, then resolved through its normal route, with no attention-specific write anywhere in between.

## One definition of "busy"

Live turn statuses become `TurnRunStatus::LIVE`, shared with `count_active_work`, which had the list inline. Busy has to mean the same thing to the host's quiescence check and to the reader's badge; a new non-terminal status added to one and not the other would make a live conversation look settled.

## What chat does not produce

Neither `DoneUnreviewed` nor `Fenced`. Reviewed-ness rides an attached events socket chat does not have, and there is no foreign process to fence. This is the principle #2460 wrote into the module: adopting a shared vocabulary is not a promise to use all of it.

## Not a schema change

No baseline edit, no epoch bump.

## Tests

`a_chat_carries_attention_derived_from_its_parked_work` covers needs-you with a kind-only prompt, absent-means-idle, and the hand-back to `Working` when an approval is granted — the turn resumes, so asserting the chat goes quiet there would be asserting that approving a call does nothing.

`tidebreak-core` 720 pass, `tidebreak-server --lib` 1199 pass. One unrelated failure under parallel load, `code_terminals::create_write_read_and_two_cursors`, which passes in isolation; filed as #2467.
