### PR TITLE
fix(ui): parse the idle attention state

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -213,6 +213,46 @@ describe("parseCodeSubscriptionUsage", () => {
   });
 });
 
+/**
+ * Every state the server can send must parse.
+ *
+ * The parser is a runtime string switch, so a new variant on the Rust side is
+ * invisible to `tsc` — and `parseCodeSessionList` returns null when any single
+ * row fails, so one unparsed state blanks the whole session list rather than
+ * degrading. `idle` shipped without landing here and did exactly that.
+ *
+ * Keep this list in step with `AttentionState` in `generated/wire.ts`.
+ */
+describe("parseCodeSession attention states", () => {
+  const STATES = [
+    { type: "working" },
+    { type: "idle" },
+    { type: "done_unreviewed" },
+    { type: "needs_you", prompt: "approve this", source: "structured" },
+    { type: "stalled", idle_secs: 42 },
+    { type: "fenced", reason: { type: "orphan_alive" } },
+    { type: "manual", note: "later" },
+  ];
+
+  it.each(STATES)("accepts %o", (state) => {
+    const parsed = parseCodeSession({
+      ...SESSION,
+      attention: { state, source: "lifecycle" },
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed?.attention.state.type).toBe(state.type);
+  });
+
+  it("still rejects a state the server cannot send", () => {
+    expect(
+      parseCodeSession({
+        ...SESSION,
+        attention: { state: { type: "napping" }, source: "lifecycle" },
+      }),
+    ).toBeNull();
+  });
+});
+
 describe("parseCodeSessionList", () => {
   it("accepts GET /code/workspaces/{id}/sessions", () => {
     const ended = {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2767,6 +2767,7 @@ function parseAttentionState(value: unknown): AttentionState | null {
   switch (value.type) {
     case "working":
     case "done_unreviewed":
+    case "idle":
       return { type: value.type };
     case "needs_you":
       if (


### PR DESCRIPTION
Regression from #2463, which I shipped earlier today.

## What broke

#2463 added `AttentionState::Idle`. The Rust side and both exhaustive TypeScript switches were compile breaks, so they got updated. `parseAttentionState` is a **runtime string switch** over the same union — `tsc` cannot see it, and it was missed.

The failure mode is the bad one:

```
parseAttentionState({ type: "idle" })  -> null
parseCodeSession(...)                  -> null   (any unparsed attention)
parseCodeSessionList([...])            -> null   (any single row failing)
```

So one session resting in the new state blanks the entire code session list rather than degrading to a missing badge. Every session created after #2463 reaches `Idle` as soon as it settles, so this is not a rare path.

## The fix

Accept `idle`, plus a test that walks every variant of the wire union and asserts the parser accepts each — with a note to keep it in step with `generated/wire.ts`.

Verified the test actually catches it: removing the one-line fix turns the suite red on `accepts { type: 'idle' }`, and nothing else.

## Why the tripwires missed it

The schema fixture covers table DDL and the journal fixtures cover event payloads. Neither covers a hand-written parser mirroring a generated union, and `tsc` cannot type a `switch` on `value.type` where `value` is `unknown`. The parity test is the smallest thing that closes that gap for this union.

`tsc`, `biome check`, and all 58 parser tests pass.