### PR TITLE
feat(ui): fold code-mode thinking and group its tool calls

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ThinkingAccordion.tsx
+++ b/crates/tidebreak-desktop/ui/src/ThinkingAccordion.tsx
@@ -25,12 +25,23 @@ import { cn } from "@/lib/utils";
 export function ThinkingAccordion({
   text,
   streaming,
+  expandWhileStreaming = true,
 }: {
   text: string;
   /** Reasoning is still arriving and no answer has started. */
   streaming: boolean;
+  /**
+   * Whether live reasoning opens itself.
+   *
+   * A surface that pauses to think several times in one turn — code mode does,
+   * between every pair of tool calls — would otherwise stack open blocks until
+   * they are the whole viewport. It passes false: the line still says
+   * "Thinking" and still pulses, so the work is legible, but the text is one
+   * click away rather than in the way.
+   */
+  expandWhileStreaming?: boolean;
 }) {
-  const [expanded, setExpanded] = useState(streaming);
+  const [expanded, setExpanded] = useState(streaming && expandWhileStreaming);
   const toggledByReader = useRef(false);
 
   useEffect(() => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -803,3 +803,58 @@ describe("user item createdAt", () => {
     });
   });
 });
+
+describe("reasoning lifecycle", () => {
+  it("settles a reasoning block when the next call or the answer starts", () => {
+    // An engine thinks between every pair of calls. Left live until the turn
+    // ends, every block in the turn pulses and every one claims to be the one
+    // the engine is in right now.
+    const { state } = play([
+      { type: "turn_started", turn_id: "t1" },
+      { type: "reasoning_delta", text: "Check how fencing works." },
+      {
+        type: "tool_started",
+        call_id: "c1",
+        name: "Grep",
+        detail: { kind: "search", query: "Fenced" },
+      },
+      {
+        type: "tool_completed",
+        call_id: "c1",
+        outcome: "succeeded",
+        preview: "recovery.rs",
+      },
+      { type: "reasoning_delta", text: "Now the identity we store." },
+      { type: "assistant_delta", text: "Auto-reap is safe because" },
+    ]);
+
+    const reasoning = state.items.filter((item) => item.kind === "reasoning");
+    expect(reasoning).toHaveLength(2);
+    expect(reasoning.every((item) => item.streaming === false)).toBe(true);
+  });
+
+  it("leaves the parent's reasoning live while a subagent works", () => {
+    // A subagent's call says nothing about what its parent was thinking, so it
+    // must not settle a block the parent is still writing.
+    const { state } = play([
+      { type: "turn_started", turn_id: "t1" },
+      {
+        type: "tool_started",
+        call_id: "task-1",
+        name: "Task",
+        detail: { kind: "other", summary: "Audit the parser" },
+      },
+      { type: "reasoning_delta", text: "While that runs, consider fencing." },
+      {
+        type: "tool_started",
+        call_id: "child-read",
+        name: "Read",
+        detail: { kind: "file_read", path: "src/parser.rs" },
+        parent_call_id: "task-1",
+      },
+    ]);
+
+    const reasoning = state.items.find((item) => item.kind === "reasoning");
+    expect(reasoning).toMatchObject({ kind: "reasoning", streaming: true });
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -377,7 +377,10 @@ export function reduceCodeSessionEvent(
           ...state,
           assistantBuffer,
           items: upsertStreaming(
-            state.items,
+            // Prose starting means the thinking behind it ended. Left live, an
+            // earlier block keeps pulsing and keeps saying "Thinking" while the
+            // answer it produced is already being written underneath it.
+            finalizeStreaming(state.items, "reasoning"),
             "assistant",
             assistantBuffer,
             state.activeTurnId,
@@ -437,28 +440,32 @@ export function reduceCodeSessionEvent(
 
     case "tool_started": {
       const parentCallId = event.parent_call_id ?? null;
+      const settled = finalizeStreaming(state.items, "assistant", parentCallId);
+      // The reasoning that led to this call is done, the same way the prose
+      // before it is. A subagent's call settles nothing of the parent's: its
+      // own work is not what the parent was thinking about.
+      const opened =
+        parentCallId === null
+          ? finalizeStreaming(settled, "reasoning")
+          : settled;
       return {
         state: {
           ...state,
           assistantBuffer: parentCallId === null ? "" : state.assistantBuffer,
           reasoningBuffer: parentCallId === null ? "" : state.reasoningBuffer,
-          items: insertBeforeTurnBoundary(
-            finalizeStreaming(state.items, "assistant", parentCallId),
-            state.activeTurnId,
-            {
-              kind: "tool",
-              id: deps.nextId(),
-              turnId: state.activeTurnId,
-              callId: event.call_id,
-              parentCallId,
-              name: event.name,
-              detail: event.detail,
-              status: "running",
-              preview: "",
-              startedAt: framed.replayed ? null : deps.now(),
-              durationMs: null,
-            },
-          ),
+          items: insertBeforeTurnBoundary(opened, state.activeTurnId, {
+            kind: "tool",
+            id: deps.nextId(),
+            turnId: state.activeTurnId,
+            callId: event.call_id,
+            parentCallId,
+            name: event.name,
+            detail: event.detail,
+            status: "running",
+            preview: "",
+            startedAt: framed.replayed ? null : deps.now(),
+            durationMs: null,
+          }),
         },
         effects,
       };

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -66,6 +66,58 @@ const items: CodeTranscriptItem[] = [
   },
 ];
 
+type CodeToolItem = Extract<CodeTranscriptItem, { kind: "tool" }>;
+
+/**
+ * A burst of three calls, the way an engine actually works: search, read,
+ * read. The last one carries the run's status.
+ */
+function run(last: "running" | "succeeded"): CodeToolItem[] {
+  return [
+    {
+      kind: "tool",
+      id: "run-1",
+      turnId: "t1",
+      callId: "r1",
+      parentCallId: null,
+      name: "Grep",
+      detail: { kind: "search", query: "Fenced|reap" },
+      status: "succeeded",
+      preview: "3 matches",
+      startedAt: null,
+      durationMs: 400,
+    },
+    {
+      kind: "tool",
+      id: "run-2",
+      turnId: "t1",
+      callId: "r2",
+      parentCallId: null,
+      name: "Read",
+      detail: { kind: "file_read", path: "docs/code-mode.md" },
+      status: "succeeded",
+      preview: "",
+      startedAt: null,
+      durationMs: 600,
+    },
+    {
+      kind: "tool",
+      id: "run-3",
+      turnId: "t1",
+      callId: "r3",
+      parentCallId: null,
+      name: "Read",
+      detail: { kind: "file_read", path: "src/code/recovery.rs" },
+      status: last,
+      preview: "",
+      // Null so a running row draws no elapsed label: the transcript reads
+      // the real clock, and a fixed fixture timestamp would age into nonsense.
+      startedAt: null,
+      durationMs: last === "running" ? null : 1_200,
+    },
+  ];
+}
+
 describe("CodeTranscript", () => {
   it("renders assistant text, a tool card, and a harness notice", () => {
     render(<CodeTranscript items={items} />);
@@ -467,5 +519,142 @@ describe("CodeTranscript", () => {
     expect(
       document.querySelector('[data-code-approval-attached="true"]'),
     ).toBeNull();
+  });
+
+  it("folds a run of calls behind its newest line and opens to the rows", async () => {
+    // A burst of calls is not what the reader came for, and one row per call
+    // is the whole viewport. The line names the call still running, because
+    // that is the one worth watching.
+    render(<CodeTranscript items={[...run("running")]} />);
+
+    expect(screen.getByText("+2 more")).toBeInTheDocument();
+    const line = screen.getByRole("button", {
+      name: /File read.*recovery\.rs.*and 2 more.*running/,
+    });
+    expect(line).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Fenced|reap")).toBeNull();
+
+    await userEvent.click(line);
+    expect(line).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Fenced|reap")).toBeInTheDocument();
+    expect(screen.getByText("docs/code-mode.md")).toBeInTheDocument();
+  });
+
+  it("names the last call and totals the run once it settles", () => {
+    render(<CodeTranscript items={[...run("succeeded")]} />);
+
+    expect(
+      screen.getByRole("button", {
+        name: /File read.*recovery\.rs.*and 2 more.*succeeded/,
+      }),
+    ).toBeInTheDocument();
+    // 400ms + 600ms + 1200ms of sequential work, said once.
+    expect(screen.getByText("2.2s")).toBeInTheDocument();
+  });
+
+  it("opens a run that holds a failure", () => {
+    const middle = run("succeeded")[1]!;
+    const items: CodeToolItem[] = [
+      run("succeeded")[0]!,
+      { ...middle, status: "failed", preview: "no such file" },
+      run("succeeded")[2]!,
+    ];
+    render(<CodeTranscript items={items} />);
+
+    // A failure inside a closed group is a failure the reader has to go
+    // looking for.
+    expect(
+      screen.getByRole("button", { name: /and 2 more.*failed/ }),
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("no such file")).toBeInTheDocument();
+  });
+
+  it("holds a parked call out of the group it would end", () => {
+    const parked: CodeTranscriptItem[] = [
+      ...run("succeeded").slice(0, 2),
+      {
+        kind: "tool",
+        id: "tool-parked",
+        turnId: "t1",
+        callId: "c9",
+        parentCallId: null,
+        name: "Bash",
+        detail: { kind: "command", cmd: "rm -rf /tmp/scratch", cwd: "/tmp" },
+        status: "running",
+        preview: "",
+        startedAt: "2026-08-15T12:00:00.000Z",
+        durationMs: null,
+      },
+      {
+        kind: "approval",
+        id: "approval:a9",
+        approvalId: "a9",
+        state: "pending",
+      },
+    ];
+    render(
+      <CodeTranscript
+        items={parked}
+        approvals={{
+          a9: {
+            id: "a9",
+            session_id: "s1",
+            turn_id: "t1",
+            kind: { type: "command", cmd: "rm -rf /tmp/scratch", cwd: "/tmp" },
+            harness_raw_json: "{}",
+            state: "pending",
+            requested_at: "2026-08-15T12:00:00.000Z",
+          },
+        }}
+      />,
+    );
+
+    // The two settled calls still group; the parked one is held out of it,
+    // because the card below repeats the command that row shows.
+    expect(screen.getByText("+1 more")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /Command run.*rm -rf \/tmp\/scratch.*running/,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-code-approval-attached="true"]'),
+    ).not.toBeNull();
+  });
+
+  it("keeps a folded thought line between the groups it separates", async () => {
+    // Where the engine paused is part of the story, so reasoning breaks a run
+    // rather than disappearing into one. It arrives folded: this surface
+    // thinks between every pair of calls, and blocks that open themselves
+    // stack until they are the whole turn.
+    render(
+      <CodeTranscript
+        items={[
+          ...run("succeeded").slice(0, 2),
+          {
+            kind: "reasoning",
+            id: "think-1",
+            turnId: "t1",
+            text: "Now check what identity we store for the child.",
+            streaming: true,
+          },
+          ...run("succeeded")
+            .slice(0, 2)
+            .map((tool, index) => ({ ...tool, id: `late-${index}` })),
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("+1 more")).toHaveLength(2);
+    const thought = screen.getByRole("button", { name: /Thinking/i });
+    expect(thought).toHaveAttribute("data-state", "closed");
+    expect(
+      screen.queryByText("Now check what identity we store for the child."),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(thought);
+    expect(
+      screen.getByText("Now check what identity we store for the child."),
+    ).toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -150,33 +150,45 @@ export function CodeTranscript({
   return (
     <div className="messages" ref={scrollRef} onScroll={onScroll}>
       <div className="messages-column" ref={contentRef}>
-        {items.map((item, index) =>
-          isolatedCard(
-            item.id,
-            itemSignature(item, decidingId, approvalError),
-            <TranscriptItem
-              item={item}
-              animateStreaming={animateStreaming}
-              approval={
-                item.kind === "approval"
-                  ? approvals[item.approvalId]
-                  : undefined
-              }
-              attached={parksTheCallAbove(items, index)}
-              deciding={
-                item.kind === "approval" && decidingId === item.approvalId
-              }
-              approvalError={
-                item.kind === "approval" && decidingId === item.approvalId
-                  ? approvalError
-                  : undefined
-              }
-              onDecide={onDecide}
-              onOpenTurnDiff={onOpenTurnDiff}
-              sessionId={sessionId}
-              onReveal={onReveal}
-            />,
-          ),
+        {groupCodeTranscriptRows(items).map((row) =>
+          row.kind === "group"
+            ? isolatedCard(
+                row.id,
+                row.signature,
+                <CodeActivityGroup
+                  tools={row.tools}
+                  signature={row.signature}
+                  onReveal={onReveal}
+                />,
+              )
+            : isolatedCard(
+                row.item.id,
+                itemSignature(row.item, decidingId, approvalError),
+                <TranscriptItem
+                  item={row.item}
+                  animateStreaming={animateStreaming}
+                  approval={
+                    row.item.kind === "approval"
+                      ? approvals[row.item.approvalId]
+                      : undefined
+                  }
+                  attached={row.attached}
+                  deciding={
+                    row.item.kind === "approval" &&
+                    decidingId === row.item.approvalId
+                  }
+                  approvalError={
+                    row.item.kind === "approval" &&
+                    decidingId === row.item.approvalId
+                      ? approvalError
+                      : undefined
+                  }
+                  onDecide={onDecide}
+                  onOpenTurnDiff={onOpenTurnDiff}
+                  sessionId={sessionId}
+                  onReveal={onReveal}
+                />,
+              ),
         )}
         {shouldShowCodeWorking(items, busy, streamStalled) && (
           <AssistantWorkingIndicator />
@@ -283,6 +295,87 @@ function parksTheCallAbove(
   if (item?.kind !== "approval") return false;
   const previous = items[index - 1];
   return previous?.kind === "tool" && previous.status === "running";
+}
+
+type CodeToolItem = Extract<CodeTranscriptItem, { kind: "tool" }>;
+
+/** One thing the column draws: an item on its own, or a run behind one line. */
+export type CodeTranscriptRow =
+  | {
+      kind: "item";
+      item: CodeTranscriptItem;
+      /** This approval parks the tool line drawn directly above it. */
+      attached: boolean;
+    }
+  | {
+      kind: "group";
+      id: string;
+      tools: CodeToolItem[];
+      /** What the group draws on, for its key and its memo. */
+      signature: string;
+    };
+
+/**
+ * The transcript's items, with each run of tool calls folded behind one line.
+ *
+ * An engine works in bursts — search, read, read, search — and drawn one row
+ * per call those bursts are the whole viewport, with the prose the reader is
+ * waiting for pushed off the bottom. A run collapses to a single line naming
+ * its newest call, which is the one worth watching, and opens to the same rows
+ * it always drew.
+ *
+ * Only tool calls join a run. Reasoning breaks one, because a folded "Thought"
+ * line between two groups is where the engine actually paused, and hiding that
+ * inside a group would put the model's own account of the work two clicks away.
+ */
+export function groupCodeTranscriptRows(
+  items: readonly CodeTranscriptItem[],
+): CodeTranscriptRow[] {
+  const rows: CodeTranscriptRow[] = [];
+  let run: CodeToolItem[] = [];
+
+  // `detach` holds the run's last call out of the group: an approval hangs its
+  // card off the row directly above it, and a card hanging off a collapsed
+  // group would point at a line that no longer shows the command it repeats.
+  function flush(detach: boolean) {
+    const parked = detach ? run.pop() : undefined;
+    if (run.length > 1) {
+      rows.push({
+        kind: "group",
+        id: `group:${run[0]!.id}`,
+        tools: run,
+        signature: run.map(toolSignature).join("|"),
+      });
+    } else {
+      // A group of one is just a row.
+      for (const tool of run)
+        rows.push({ kind: "item", item: tool, attached: false });
+    }
+    if (parked) rows.push({ kind: "item", item: parked, attached: false });
+    run = [];
+  }
+
+  items.forEach((item, index) => {
+    if (item.kind === "tool") {
+      run.push(item);
+      return;
+    }
+    const attached = parksTheCallAbove(items, index);
+    flush(attached);
+    rows.push({ kind: "item", item, attached });
+  });
+  flush(false);
+  return rows;
+}
+
+/**
+ * What a grouped call draws on, so a streamed byte re-renders the group it
+ * changed rather than every group in the transcript. The subject is in it
+ * because a harness that starts a call before its arguments finish streaming
+ * fills the detail in on completion.
+ */
+function toolSignature(tool: CodeToolItem): string {
+  return `${tool.id}:${tool.status}:${tool.preview.length}:${toolSubject(tool.detail, tool.name)}`;
 }
 
 /**
@@ -397,7 +490,15 @@ const TranscriptItem = memo(function TranscriptItem({
         </article>
       );
     case "reasoning":
-      return <ThinkingAccordion text={item.text} streaming={item.streaming} />;
+      return (
+        <ThinkingAccordion
+          text={item.text}
+          streaming={item.streaming}
+          // An engine pauses to think between every pair of calls here. Left to
+          // open themselves, those blocks stack until they are the whole turn.
+          expandWhileStreaming={false}
+        />
+      );
     case "tool":
       return (
         <CodeToolCard
@@ -449,6 +550,141 @@ const TranscriptItem = memo(function TranscriptItem({
       return <TurnReviewCard turn={item} onOpenTurnDiff={onOpenTurnDiff} />;
   }
 });
+
+/**
+ * A run of tool calls behind one line.
+ *
+ * The line is the run's newest call drawn the way its own row would draw it,
+ * plus a count of what came before — so a live phase still says what the engine
+ * is doing right now, and a settled one says what it last did and how much work
+ * that took. Opening it gives back the rows, unchanged, on a rail dropped from
+ * the group's own icon column.
+ *
+ * Closed by default, because the reason to group at all is that a burst of
+ * calls is not what the reader came for. A run holding a failure is the
+ * exception: it opens itself, the same way a failed row does.
+ */
+export const CodeActivityGroup = memo(
+  function CodeActivityGroup({
+    tools,
+    onReveal,
+  }: {
+    tools: readonly CodeToolItem[];
+    /** What the group draws on. The memo compares this and nothing else. */
+    signature: string;
+    onReveal?: () => void;
+  }) {
+    const unresolved = tools.some(
+      (tool) => tool.status === "failed" || tool.status === "denied",
+    );
+    const [expanded, setExpanded] = useState(unresolved);
+    useEffect(() => {
+      // A failure inside a closed group is a failure the reader has to go
+      // looking for. Opening is one-way: once they close it, it stays closed.
+      if (unresolved) setExpanded(true);
+    }, [unresolved]);
+
+    const lead = leadingCall(tools);
+    const status = groupStatus(tools);
+    const verb = toolVerb(lead.detail, lead.status);
+    const subject = toolSubject(lead.detail, lead.name);
+    const rest = tools.length - 1;
+    const elapsed = useElapsedLabel(lead.startedAt, status === "running");
+    const duration =
+      status === "running"
+        ? elapsed
+        : formatTurnDuration(totalDurationMs(tools));
+
+    return (
+      <ToolCardShell
+        icon={toolIcon(lead.detail)}
+        title={
+          <>
+            <span className="shrink-0 font-semibold">{verb}</span>
+            <MiddleTruncate
+              text={subject}
+              className="text-muted-foreground min-w-[6ch] flex-1 font-mono"
+            />
+            {/* Hidden and said again below, because "plus 2 more" lands
+                mid-command when it is read out where it is drawn. */}
+            <span className="text-muted-foreground shrink-0" aria-hidden="true">
+              +{rest} more
+            </span>
+          </>
+        }
+        titleClassName="flex items-center gap-2"
+        trailing={
+          <>
+            <span className="sr-only">and {rest} more</span>
+            {duration}
+            <span className="sr-only">{status}</span>
+            <StatusGlyph status={status} />
+          </>
+        }
+        expanded={expanded}
+        onExpandedChange={(next) => {
+          onReveal?.();
+          setExpanded(next);
+        }}
+        label={`${verb} ${subject} and ${rest} more ${status}`}
+        announce={false}
+        bodyClassName="border-border ml-[7px] flex flex-col gap-1 border-l pl-4"
+      >
+        {tools.map((tool) => (
+          <CodeToolCard
+            key={tool.id}
+            name={tool.name}
+            detail={tool.detail}
+            status={tool.status}
+            preview={tool.preview}
+            startedAt={tool.startedAt}
+            durationMs={tool.durationMs}
+            onReveal={onReveal}
+          />
+        ))}
+      </ToolCardShell>
+    );
+  },
+  (previous, next) =>
+    previous.signature === next.signature &&
+    previous.onReveal === next.onReveal,
+);
+
+/**
+ * The call the group's one line speaks for: whatever is running now, or the
+ * last thing that ran. Harnesses batch calls, so "running" is not always the
+ * one at the end.
+ */
+function leadingCall(tools: readonly CodeToolItem[]): CodeToolItem {
+  for (let index = tools.length - 1; index >= 0; index -= 1) {
+    const tool = tools[index]!;
+    if (tool.status === "running") return tool;
+  }
+  return tools[tools.length - 1]!;
+}
+
+/** The run's outcome: still working, else the worst thing in it. */
+function groupStatus(
+  tools: readonly CodeToolItem[],
+): "running" | "succeeded" | "failed" | "denied" {
+  if (tools.some((tool) => tool.status === "running")) return "running";
+  if (tools.some((tool) => tool.status === "failed")) return "failed";
+  if (tools.some((tool) => tool.status === "denied")) return "denied";
+  return "succeeded";
+}
+
+/**
+ * How long the run took, or nothing. A replayed call carries no duration, and
+ * a total that silently skips those would undercount the phase.
+ */
+function totalDurationMs(tools: readonly CodeToolItem[]): number | null {
+  let total = 0;
+  for (const tool of tools) {
+    if (tool.durationMs === null) return null;
+    total += tool.durationMs;
+  }
+  return total;
+}
 
 /**
  * One engine action as a boxless line. The verb is a constant; the muted mono

--- a/crates/tidebreak-desktop/ui/src/code/MiddleTruncate.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/MiddleTruncate.tsx
@@ -35,7 +35,10 @@ export function MiddleTruncate({
   return (
     <span className={cn("flex min-w-0", className)} title={text}>
       <span className="truncate">{text.slice(0, -tail)}</span>
-      <span className="shrink-0">{text.slice(-tail)}</span>
+      {/* `whitespace-pre` because the split can land on a space, and a flex
+          item drops the whitespace it starts with — which reads as a command
+          with two of its words run together. */}
+      <span className="shrink-0 whitespace-pre">{text.slice(-tail)}</span>
     </span>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/stories/CodeActivityGroup.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeActivityGroup.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CodeActivityGroup } from "@/code/CodeTranscript";
+import type { CodeTranscriptItem } from "@/code/CodeSessionReducer";
+
+type CodeToolItem = Extract<CodeTranscriptItem, { kind: "tool" }>;
+
+function call(
+  id: string,
+  detail: CodeToolItem["detail"],
+  overrides: Partial<CodeToolItem> = {},
+): CodeToolItem {
+  return {
+    kind: "tool",
+    id,
+    turnId: "t1",
+    callId: id,
+    parentCallId: null,
+    name: "Bash",
+    detail,
+    status: "succeeded",
+    preview: "",
+    startedAt: null,
+    durationMs: 600,
+    ...overrides,
+  };
+}
+
+const SETTLED: CodeToolItem[] = [
+  call(
+    "g1",
+    { kind: "search", query: "Fenced|reap|pid.reuse|start_time" },
+    {
+      name: "Grep",
+      preview: "6 matches",
+      durationMs: 400,
+    },
+  ),
+  call(
+    "g2",
+    { kind: "file_read", path: "docs/code-mode.md" },
+    { name: "Read" },
+  ),
+  call(
+    "g3",
+    { kind: "search", query: "pid_reuse|OrphanAlive|probe_pid" },
+    { name: "Grep", preview: "2 matches", durationMs: 300 },
+  ),
+  call(
+    "g4",
+    { kind: "file_read", path: "crates/tidebreak-server/src/code/recovery.rs" },
+    { name: "Read", durationMs: 900 },
+  ),
+];
+
+/**
+ * A run of tool calls behind one line, and the reason the code transcript no
+ * longer reads as a log. The states worth looking at are the ones that decide
+ * whether the reader has to open it: a live run naming the call still going, a
+ * settled one totalling the phase, and a run holding a failure, which opens
+ * itself because a failure inside a closed group is one the reader has to go
+ * looking for.
+ */
+const meta = {
+  title: "Code/Activity group",
+  component: CodeActivityGroup,
+  args: {
+    tools: SETTLED,
+    signature: "settled",
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl pt-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CodeActivityGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Four calls, one line, and the run's total time. */
+export const Settled: Story = {};
+
+/**
+ * While the phase is live the line names the call still running, so a
+ * supervisor sees what the engine is doing without opening anything.
+ */
+export const Running: Story = {
+  args: {
+    tools: [
+      ...SETTLED.slice(0, 3),
+      call(
+        "g4",
+        {
+          kind: "command",
+          cmd: "cargo test -p tidebreak-server code::recovery",
+          cwd: "/repo",
+        },
+        { status: "running", durationMs: null },
+      ),
+    ],
+    signature: "running",
+  },
+};
+
+/** A failure anywhere in the run opens the group and its own row with it. */
+export const HoldsAFailure: Story = {
+  args: {
+    tools: [
+      ...SETTLED.slice(0, 3),
+      call(
+        "g4",
+        { kind: "command", cmd: "cargo check -p tidebreak-core", cwd: "/repo" },
+        {
+          status: "failed",
+          durationMs: 4_400,
+          preview:
+            "error[E0308]: mismatched types\n  --> src/lib.rs:41:9\n   |\n41 |         Ok(())\n   |         ^^^^^^ expected `Turn`, found `()`\n\nexit code 1",
+        },
+      ),
+    ],
+    signature: "failed",
+  },
+};
+
+/** The smallest run that groups at all: two calls, one line. */
+export const TwoCalls: Story = {
+  args: {
+    tools: SETTLED.slice(0, 2),
+    signature: "pair",
+  },
+};


### PR DESCRIPTION
## What changed

A running code session filled the viewport with open reasoning blocks and one row per tool call, pushing the answer off the bottom: reasoning now arrives folded, and `CodeSessionReducer` settles a block when the next call or the answer starts rather than only at turn end, so a turn no longer shows four blocks all pulsing and all claiming to be the live one. A contiguous run of tool calls collapses behind one line naming its newest call plus a count, and opens to the same rows — a run of one stays a plain row, a run holding a failure opens itself, and a call an approval is parked on is held out so the card still hangs off a visible command. `MiddleTruncate` also dropped the space when its split landed on one, rendering `cargo test -p tidebreak-server code::recovery` as a single word.

## Validation

`pnpm --dir crates/tidebreak-desktop/ui test` (217 files, 1634 tests), `biome format`/`lint`, `tsc --noEmit`, and `storybook:build`; the new `Code/Activity group` story was rendered and reviewed in its live, settled, failed, and two-call states.

## Compatibility and risk

None — presentation only. No wire, persisted-format, or platform changes.