### PR TITLE
feat: one inbox over chat and code

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -107,15 +107,29 @@ const desktopUpdateState = vi.hoisted(() => ({
 const restartDesktop = vi.hoisted(() => vi.fn(async () => {}));
 
 /** One waiting question, as the shell's cross-chat read returns it. */
+/** One chat-surface inbox entry holding a single parked question. */
 function parked(chatId: string, callId: string) {
   return {
-    chatId,
-    chatTitle: null,
-    turnId: "turn-1",
-    callId,
-    kind: "question" as const,
-    action: null,
-    requestedAt: "2026-08-04T00:00:00Z",
+    conversation: { surface: "chat" as const, chatId },
+    title: null,
+    attention: {
+      state: {
+        type: "needs_you" as const,
+        prompt: "waiting",
+        source: "structured" as const,
+      },
+      source: "structured" as const,
+    },
+    items: [
+      {
+        turnId: "turn-1",
+        callId,
+        kind: "question" as const,
+        action: null,
+        requestedAt: "2026-08-04T00:00:00Z",
+      },
+    ],
+    waitingSince: "2026-08-04T00:00:00Z",
   };
 }
 const postMessage = vi.fn(async () => {});

--- a/crates/tidebreak-desktop/ui/src/Inbox.ts
+++ b/crates/tidebreak-desktop/ui/src/Inbox.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-import type { InboxItem } from "./api";
+import { inboxConversationKey, type InboxEntry } from "./api";
 
 /**
  * Everything parked on the reader, in one place.
@@ -12,28 +12,44 @@ import type { InboxItem } from "./api";
  * the next poll no longer finds its journal row parked.
  */
 export type InboxStore = {
-  items: InboxItem[];
+  entries: InboxEntry[];
   /** Whether a first read has landed, so an empty list can be told from "not yet". */
   loaded: boolean;
-  setItems: (items: InboxItem[]) => void;
+  setEntries: (entries: InboxEntry[]) => void;
   clear: () => void;
 };
 
-function sameItems(left: InboxItem[], right: InboxItem[]): boolean {
+/**
+ * Whether two reads describe the same queue.
+ *
+ * Compares the conversation and its attention, not the parked calls: a chat
+ * can change what it is waiting on without the queue changing, and a code
+ * conversation has no calls here at all.
+ */
+function sameEntries(left: InboxEntry[], right: InboxEntry[]): boolean {
   return (
     left.length === right.length &&
-    left.every((item, index) => item.callId === right[index]?.callId)
+    left.every((entry, index) => {
+      const other = right[index];
+      if (!other) return false;
+      return (
+        inboxConversationKey(entry.conversation) ===
+          inboxConversationKey(other.conversation) &&
+        entry.attention.state.type === other.attention.state.type &&
+        entry.items.length === other.items.length
+      );
+    })
   );
 }
 
 export const useInbox = create<InboxStore>()((set) => ({
-  items: [],
+  entries: [],
   loaded: false,
-  setItems: (items) =>
+  setEntries: (entries) =>
     set((state) =>
-      state.loaded && sameItems(state.items, items)
+      state.loaded && sameEntries(state.entries, entries)
         ? state
-        : { items, loaded: true },
+        : { entries, loaded: true },
     ),
-  clear: () => set({ items: [], loaded: false }),
+  clear: () => set({ entries: [], loaded: false }),
 }));

--- a/crates/tidebreak-desktop/ui/src/InboxView.tsx
+++ b/crates/tidebreak-desktop/ui/src/InboxView.tsx
@@ -10,7 +10,12 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
-import type { InboxItem, InboxItemKind } from "./api";
+import {
+  inboxConversationKey,
+  type InboxEntry,
+  type InboxItemKind,
+} from "./api";
+import { attentionLabel } from "./code/labels";
 import {
   Empty,
   EmptyDescription,
@@ -68,10 +73,10 @@ const KIND_PRESENTATION: Record<
  */
 export function InboxView() {
   const navigate = useNavigate();
-  const items = useInbox((state) => state.items);
+  const entries = useInbox((state) => state.entries);
   const loaded = useInbox((state) => state.loaded);
 
-  if (items.length === 0) {
+  if (entries.length === 0) {
     return (
       <Empty className="h-full">
         <EmptyHeader>
@@ -94,17 +99,27 @@ export function InboxView() {
     <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-6">
       <h1 className="text-lg font-medium">Inbox</h1>
       <ul className="flex flex-col gap-2">
-        {items.map((item) => (
-          <li key={item.callId}>
+        {entries.map((entry) => (
+          <li key={inboxConversationKey(entry.conversation)}>
             <InboxRow
-              item={item}
-              onOpen={() =>
+              entry={entry}
+              onOpen={() => {
+                if (entry.conversation.surface === "chat") {
+                  // The first item is the longest-waiting one, which is the
+                  // card the reader is being sent to answer.
+                  const focus = entry.items[0]?.callId;
+                  void navigate({
+                    to: "/c/$chatId",
+                    params: { chatId: entry.conversation.chatId },
+                    ...(focus ? { search: { focus } } : {}),
+                  });
+                  return;
+                }
                 void navigate({
-                  to: "/c/$chatId",
-                  params: { chatId: item.chatId },
-                  search: { focus: item.callId },
-                })
-              }
+                  to: "/code/w/$workspaceId",
+                  params: { workspaceId: entry.conversation.workspaceId },
+                });
+              }}
             />
           </li>
         ))}
@@ -113,10 +128,23 @@ export function InboxView() {
   );
 }
 
-function InboxRow({ item, onOpen }: { item: InboxItem; onOpen: () => void }) {
-  const presentation = KIND_PRESENTATION[item.kind];
-  const Icon = presentation.icon;
-  const title = item.chatTitle?.trim() || "New work";
+function InboxRow({
+  entry,
+  onOpen,
+}: {
+  entry: InboxEntry;
+  onOpen: () => void;
+}) {
+  // A chat entry names the card the reader is being sent to; a code entry has
+  // no items here, so its attention is the whole story.
+  const kind = entry.items[0]?.kind;
+  const presentation = kind ? KIND_PRESENTATION[kind] : undefined;
+  const Icon = presentation?.icon ?? ShieldQuestion;
+  const title = entry.title?.trim() || "New work";
+  const label = presentation?.label ?? attentionLabel(entry.attention);
+  const description =
+    presentation?.description ?? attentionLabel(entry.attention);
+  const more = entry.items.length > 1 ? ` +${entry.items.length - 1} more` : "";
   return (
     <button
       type="button"
@@ -126,25 +154,26 @@ function InboxRow({ item, onOpen }: { item: InboxItem; onOpen: () => void }) {
       <span className="flex size-8 shrink-0 items-center justify-center">
         <Icon
           aria-hidden="true"
-          className={`${presentation.iconClass} size-5`}
+          className={`${presentation?.iconClass ?? "text-icon-amber"} size-5`}
         />
       </span>
       <span className="flex min-w-0 flex-col">
         <span className="flex min-w-0 items-center gap-2">
-          <span className="text-sm font-medium">{presentation.label}</span>
+          <span className="text-sm font-medium">
+            {label}
+            {more}
+          </span>
           <span className="text-muted-foreground truncate text-sm">
             {title}
           </span>
         </span>
-        <span className="text-muted-foreground text-xs">
-          {presentation.description}
-        </span>
+        <span className="text-muted-foreground text-xs">{description}</span>
       </span>
       <time
-        dateTime={item.requestedAt}
+        dateTime={entry.waitingSince}
         className="text-muted-foreground ml-auto shrink-0 text-xs"
       >
-        {waitedFor(item.requestedAt)}
+        {waitedFor(entry.waitingSince)}
       </time>
     </button>
   );

--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -6,7 +6,7 @@ import {
   parseAgentActivityHistory,
   parseAgentRunTaskPlan,
   parseFolderAccessRequest,
-  parseInboxItem,
+  parseInboxEntry,
   parsePendingChatPrompt,
   parseOutputWritebackRequest,
   parsePendingUserQuestions,
@@ -109,40 +109,99 @@ describe("parseFolderAccessRequest", () => {
   });
 });
 
-describe("inbox items", () => {
-  const safe = {
-    chat_id: "chat-1",
-    chat_title: "Quarterly review",
+describe("inbox entries", () => {
+  const item = {
     turn_id: "turn-1",
     call_id: "call-1",
     kind: "tool_approval",
     action: "exec",
     requested_at: "2026-08-04T00:00:00Z",
   };
+  const chatEntry = {
+    conversation: { surface: "chat", chat_id: "chat-1" },
+    title: "Quarterly review",
+    attention: {
+      state: { type: "needs_you", prompt: "waiting", source: "structured" },
+      source: "structured",
+    },
+    items: [item],
+    waiting_since: "2026-08-04T00:00:00Z",
+  };
 
-  it("accepts the read model, with its optional fields absent", () => {
-    expect(parseInboxItem(safe)).toEqual({
-      chatId: "chat-1",
-      chatTitle: "Quarterly review",
-      turnId: "turn-1",
-      callId: "call-1",
-      kind: "tool_approval",
-      action: "exec",
-      requestedAt: "2026-08-04T00:00:00Z",
+  it("accepts a chat entry, with its optional fields absent", () => {
+    expect(parseInboxEntry(chatEntry)).toEqual({
+      conversation: { surface: "chat", chatId: "chat-1" },
+      title: "Quarterly review",
+      attention: {
+        state: { type: "needs_you", prompt: "waiting", source: "structured" },
+        source: "structured",
+      },
+      items: [
+        {
+          turnId: "turn-1",
+          callId: "call-1",
+          kind: "tool_approval",
+          action: "exec",
+          requestedAt: "2026-08-04T00:00:00Z",
+        },
+      ],
+      waitingSince: "2026-08-04T00:00:00Z",
     });
-    const { chat_title: _title, action: _action, ...untitled } = safe;
-    expect(parseInboxItem({ ...untitled, kind: "question" })).toMatchObject({
-      chatTitle: null,
-      action: null,
-      kind: "question",
+    const { title: _title, ...untitled } = chatEntry;
+    expect(parseInboxEntry(untitled)).toMatchObject({ title: null });
+  });
+
+  it("accepts a code entry, which carries its workspace and no items", () => {
+    expect(
+      parseInboxEntry({
+        conversation: {
+          surface: "code",
+          session_id: "sess-1",
+          workspace_id: "ws-1",
+        },
+        title: "Fix the flake",
+        attention: {
+          state: { type: "done_unreviewed" },
+          source: "lifecycle",
+        },
+        items: [],
+        waiting_since: "2026-08-04T00:00:00Z",
+      }),
+    ).toMatchObject({
+      conversation: {
+        surface: "code",
+        sessionId: "sess-1",
+        workspaceId: "ws-1",
+      },
+      items: [],
     });
   });
 
-  it("rejects an unknown kind, an unknown tool, and smuggled detail", () => {
-    expect(parseInboxItem({ ...safe, kind: "everything" })).toBeNull();
-    expect(parseInboxItem({ ...safe, action: "rm_rf" })).toBeNull();
+  it("rejects an unknown surface, an unknown kind, and smuggled detail", () => {
     expect(
-      parseInboxItem({ ...safe, questions: [{ question: "private" }] }),
+      parseInboxEntry({
+        ...chatEntry,
+        conversation: { surface: "email", chat_id: "chat-1" },
+      }),
+    ).toBeNull();
+    expect(
+      parseInboxEntry({
+        ...chatEntry,
+        items: [{ ...item, kind: "everything" }],
+      }),
+    ).toBeNull();
+    expect(
+      parseInboxEntry({ ...chatEntry, items: [{ ...item, action: "rm_rf" }] }),
+    ).toBeNull();
+    // The entry stays opaque: no question prose, plan text, or arguments.
+    expect(
+      parseInboxEntry({ ...chatEntry, questions: [{ question: "private" }] }),
+    ).toBeNull();
+    expect(
+      parseInboxEntry({
+        ...chatEntry,
+        items: [{ ...item, questions: [{ question: "private" }] }],
+      }),
     ).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -73,7 +73,8 @@ import {
   type AgentRun,
   type AgentRunProgress,
   type LocalVoiceInfo,
-  type InboxItem,
+  type InboxEntry,
+  inboxConversationKey,
   type AgentRunTaskPlan,
   type PendingChatPrompt,
   type TaskPlan,
@@ -123,7 +124,7 @@ import {
   parseAgentActivityHistory,
   parseAgentRunProgress,
   parseFolderAccessRequest,
-  parseInboxItem,
+  parseInboxEntry,
   parseOutputWritebackRequest,
   parsePendingChatPrompt,
   parsePendingPlanApproval,
@@ -991,24 +992,28 @@ export class ApiClient {
    * whole set to badge the inbox and mark the rail, and asking each chat in
    * turn would make that cost grow with the profile.
    */
-  async listInbox(): Promise<InboxItem[]> {
+  async listInbox(): Promise<InboxEntry[]> {
     const body = await this.json<unknown>("/inbox", {
       headers: this.headers(),
     });
     if (!Array.isArray(body)) {
       throw new Error("inbox response is not an array");
     }
-    const items: InboxItem[] = [];
+    const entries: InboxEntry[] = [];
     const seen = new Set<string>();
     for (const value of body) {
-      const item = parseInboxItem(value);
-      if (!item || seen.has(item.callId)) {
+      const entry = parseInboxEntry(value);
+      if (!entry) {
         throw new Error("inbox response contains invalid data");
       }
-      seen.add(item.callId);
-      items.push(item);
+      const key = inboxConversationKey(entry.conversation);
+      if (seen.has(key)) {
+        throw new Error("inbox response lists a conversation twice");
+      }
+      seen.add(key);
+      entries.push(entry);
     }
-    return items;
+    return entries;
   }
 
   async listPendingChatPrompts(): Promise<PendingChatPrompt[]> {

--- a/crates/tidebreak-desktop/ui/src/api/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/api/parsers.ts
@@ -1,3 +1,4 @@
+import { parseAttention } from "../code/parsers";
 import {
   RENDERER_TOOL_NAMES,
   type AgentActivityDetail,
@@ -27,6 +28,8 @@ import {
   type ApprovalGrantRung,
   type ExecBackend,
   type ExecDegradation,
+  type InboxConversation,
+  type InboxEntry,
   type InboxItem,
   type InboxItemKind,
   type NetworkPolicy,
@@ -135,23 +138,12 @@ export function parseInboxItem(value: unknown): InboxItem | null {
   if (
     !isRecord(value) ||
     !onlyKeys<{
-      chat_id: string;
-      chat_title?: string;
       turn_id: string;
       call_id: string;
       kind: InboxItemKind;
       action?: RendererToolName;
       requested_at: string;
-    }>(value, [
-      "chat_id",
-      "chat_title",
-      "turn_id",
-      "call_id",
-      "kind",
-      "action",
-      "requested_at",
-    ]) ||
-    !nonEmptyBounded(value.chat_id, 128) ||
+    }>(value, ["turn_id", "call_id", "kind", "action", "requested_at"]) ||
     !nonEmptyBounded(value.turn_id, 128) ||
     !nonEmptyBounded(value.call_id, 128) ||
     !nonEmptyBounded(value.requested_at, 64) ||
@@ -160,15 +152,7 @@ export function parseInboxItem(value: unknown): InboxItem | null {
   ) {
     return null;
   }
-  // Both are optional on the wire, and neither may arrive as anything but its
-  // own declared shape — an untitled chat omits the key rather than sending an
-  // empty title, and only the closed tool vocabulary may name an action.
-  if (
-    value.chat_title !== undefined &&
-    !nonEmptyBounded(value.chat_title, 256)
-  ) {
-    return null;
-  }
+  // Only the closed tool vocabulary may name an action.
   if (
     value.action !== undefined &&
     !RENDERER_TOOL_NAMES.includes(value.action as RendererToolName)
@@ -176,13 +160,94 @@ export function parseInboxItem(value: unknown): InboxItem | null {
     return null;
   }
   return {
-    chatId: value.chat_id,
-    chatTitle: (value.chat_title as string | undefined) ?? null,
     turnId: value.turn_id,
     callId: value.call_id,
     kind: value.kind as InboxItemKind,
     action: (value.action as RendererToolName | undefined) ?? null,
     requestedAt: value.requested_at,
+  };
+}
+
+/** The tagged conversation an entry belongs to. */
+function parseInboxConversation(value: unknown): InboxConversation | null {
+  if (!isRecord(value)) return null;
+  if (value.surface === "chat") {
+    if (
+      !onlyKeys<{ surface: string; chat_id: string }>(value, [
+        "surface",
+        "chat_id",
+      ])
+    ) {
+      return null;
+    }
+    if (!nonEmptyBounded(value.chat_id, 128)) return null;
+    return { surface: "chat", chatId: value.chat_id };
+  }
+  if (value.surface === "code") {
+    if (
+      !onlyKeys<{ surface: string; session_id: string; workspace_id: string }>(
+        value,
+        ["surface", "session_id", "workspace_id"],
+      )
+    ) {
+      return null;
+    }
+    if (
+      !nonEmptyBounded(value.session_id, 128) ||
+      !nonEmptyBounded(value.workspace_id, 128)
+    ) {
+      return null;
+    }
+    return {
+      surface: "code",
+      sessionId: value.session_id,
+      workspaceId: value.workspace_id,
+    };
+  }
+  return null;
+}
+
+export function parseInboxEntry(value: unknown): InboxEntry | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<{
+      conversation: unknown;
+      title?: string;
+      attention: unknown;
+      items: unknown;
+      waiting_since: string;
+    }>(value, [
+      "conversation",
+      "title",
+      "attention",
+      "items",
+      "waiting_since",
+    ]) ||
+    !nonEmptyBounded(value.waiting_since, 64) ||
+    !Array.isArray(value.items)
+  ) {
+    return null;
+  }
+  const conversation = parseInboxConversation(value.conversation);
+  if (!conversation) return null;
+  const attention = parseAttention(value.attention);
+  if (!attention) return null;
+  // An untitled conversation omits the key rather than sending an empty title.
+  if (value.title !== undefined && !nonEmptyBounded(value.title, 256)) {
+    return null;
+  }
+  const items: InboxItem[] = [];
+  for (const raw of value.items) {
+    const item = parseInboxItem(raw);
+    if (!item) return null;
+    items.push(item);
+  }
+  return {
+    conversation,
+    title: (value.title as string | undefined) ?? null,
+    attention,
+    items,
+    waitingSince: value.waiting_since,
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -991,15 +991,42 @@ export type PendingOutputWritebackRequest = {
  * are read from the conversation the item points at, by the card that owns
  * them — which is also the only place the item can be answered.
  */
+/**
+ * Which conversation an inbox entry belongs to.
+ *
+ * Tagged because chat and code still have separate id spaces. Decision 48
+ * step 5 collapses this to one id when the entities merge; until then the tag
+ * is the only place either surface's shape shows through.
+ */
+export type InboxConversation =
+  | { surface: "chat"; chatId: string }
+  | { surface: "code"; sessionId: string; workspaceId: string };
+
+/** One parked call behind an entry's attention. */
 export type InboxItem = {
-  chatId: string;
-  chatTitle: string | null;
   turnId: string;
   callId: string;
   kind: InboxItemKind;
   action: RendererToolName | null;
   requestedAt: string;
 };
+
+/** One conversation waiting on the reader, and why. */
+export type InboxEntry = {
+  conversation: InboxConversation;
+  title: string | null;
+  attention: Attention;
+  /** Empty for a code conversation, whose approvals have their own route. */
+  items: InboxItem[];
+  waitingSince: string;
+};
+
+/** A stable key for an entry, whichever surface it lives on. */
+export function inboxConversationKey(conversation: InboxConversation): string {
+  return conversation.surface === "chat"
+    ? `chat:${conversation.chatId}`
+    : `code:${conversation.sessionId}`;
+}
 
 /** Opaque prompt state used to mark another chat as needing attention. */
 export type PendingChatPrompt = {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2753,7 +2753,11 @@ function parseUsage(value: unknown): CodeUsage | null {
   };
 }
 
-function parseAttention(value: unknown): Attention | null {
+// Shared with the inbox parser: the attention vocabulary is no longer
+// code-private (decision 48 step 3). It stays defined here rather than moving
+// so this change does not collide with the `idle` fix in flight; the move
+// belongs with whichever lands second.
+export function parseAttention(value: unknown): Attention | null {
   if (!isRecord(value) || !isMember(value.source, ATTENTION_SOURCES)) {
     return null;
   }

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2348,6 +2348,36 @@ height: number,
 byte_len: number, };
 
 /**
+ * Which conversation an entry belongs to.
+ *
+ * Tagged because chat ids and code session ids are still separate spaces
+ * (the repository check `chat_and_code_entities_do_not_cross_reference`
+ * enforces it). When step 5 merges the entities this collapses to one id.
+ */
+export type InboxConversation = { "surface": "chat", chat_id: ChatId, } | { "surface": "code", session_id: CodeSessionId, workspace_id: WorkspaceId, };
+
+/**
+ * One conversation that wants the reader, and why.
+ */
+export type InboxEntrySnapshot = { conversation: InboxConversation, 
+/**
+ * Absent, not null, while the conversation is still untitled.
+ */
+title?: string, attention: Attention, 
+/**
+ * The parked calls behind this attention, oldest first.
+ *
+ * Empty for a code conversation: its approvals are answered through the
+ * code approval route, which carries the verbatim payload decision 33
+ * requires and which a deep link reaches.
+ */
+items: Array<InboxItemSnapshot>, 
+/**
+ * When the oldest thing here started waiting, for ordering.
+ */
+waiting_since: string, };
+
+/**
  * What kind of decision one inbox item is waiting for.
  *
  * The set is closed and each variant names an existing park/resume surface,
@@ -2361,14 +2391,10 @@ export type InboxItemKind = "tool_approval" | "question" | "plan_review" | "fold
  */
 export type InboxItemSnapshot = { 
 /**
- * The conversation to open. With `call_id`, the deep link back to the
- * exact transcript position the item paused at.
+ * With the entry's conversation, the deep link back to the exact
+ * transcript position the item paused at.
  */
-chat_id: ChatId, 
-/**
- * Absent, not null, while the conversation is still untitled.
- */
-chat_title?: string, turn_id: TurnId, call_id: CallId, kind: InboxItemKind, 
+turn_id: TurnId, call_id: CallId, kind: InboxItemKind, 
 /**
  * The tool under review, for an approval. Absent for the other kinds,
  * whose tool is implied by the kind. Closed renderer vocabulary: an

--- a/crates/tidebreak-desktop/ui/src/sidebar/InboxButton.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/InboxButton.tsx
@@ -18,7 +18,7 @@ export function InboxButton() {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
-  const waiting = useInbox((state) => state.items.length);
+  const waiting = useInbox((state) => state.entries.length);
   const active = pathname === "/inbox";
 
   return (

--- a/crates/tidebreak-desktop/ui/src/useChatPromptWatcher.test.ts
+++ b/crates/tidebreak-desktop/ui/src/useChatPromptWatcher.test.ts
@@ -23,19 +23,33 @@ function folderRequest(callId: string) {
 }
 
 /** One parked item as the cross-chat read returns it. */
-function inboxItem(
+/** One chat-surface inbox entry, with the calls parked behind it. */
+function inboxEntry(
   chatId: string,
-  callId: string,
-  kind: "question" | "folder_access" | "tool_approval" = "question",
+  calls: Array<{
+    callId: string;
+    kind?: "question" | "folder_access" | "tool_approval";
+  }>,
 ) {
   return {
-    chatId,
-    chatTitle: null,
-    turnId: "turn-1",
-    callId,
-    kind,
-    action: null,
-    requestedAt: "2026-08-04T00:00:00Z",
+    conversation: { surface: "chat" as const, chatId },
+    title: null,
+    attention: {
+      state: {
+        type: "needs_you" as const,
+        prompt: "waiting",
+        source: "structured" as const,
+      },
+      source: "structured" as const,
+    },
+    items: calls.map(({ callId, kind = "question" as const }) => ({
+      turnId: "turn-1",
+      callId,
+      kind,
+      action: null,
+      requestedAt: "2026-08-04T00:00:00Z",
+    })),
+    waitingSince: "2026-08-04T00:00:00Z",
   };
 }
 
@@ -98,7 +112,9 @@ describe("useChatPromptWatcher", () => {
 
   it("asks for attention once per question, not once per read", async () => {
     const client = stubClient({
-      listInbox: vi.fn().mockResolvedValue([inboxItem("chat-2", "call-1")]),
+      listInbox: vi
+        .fn()
+        .mockResolvedValue([inboxEntry("chat-2", [{ callId: "call-1" }])]),
     });
     renderHook(() => useChatPromptWatcher(client, "chat-1"));
     await waitFor(() =>
@@ -116,7 +132,7 @@ describe("useChatPromptWatcher", () => {
     // long session accumulates the id of every question ever asked.
     const listInbox = vi
       .fn()
-      .mockResolvedValueOnce([inboxItem("chat-1", "call-1")])
+      .mockResolvedValueOnce([inboxEntry("chat-1", [{ callId: "call-1" }])])
       .mockResolvedValue([]);
     const client = stubClient({ listInbox });
     renderHook(() => useChatPromptWatcher(client, "chat-1"));
@@ -129,7 +145,7 @@ describe("useChatPromptWatcher", () => {
       expect(usePendingPrompts.getState().userQuestions).toHaveLength(0),
     );
 
-    listInbox.mockResolvedValue([inboxItem("chat-1", "call-2")]);
+    listInbox.mockResolvedValue([inboxEntry("chat-1", [{ callId: "call-2" }])]);
     act(() => useRefreshSignals.getState().signal("userQuestions"));
 
     await waitFor(() =>
@@ -190,13 +206,13 @@ describe("useChatPromptWatcher", () => {
 
   it("marks parked chats even when no conversation is open", async () => {
     const client = stubClient({
-      listInbox: vi
-        .fn()
-        .mockResolvedValue([
-          inboxItem("chat-2", "call-question"),
-          inboxItem("chat-3", "call-folder", "folder_access"),
-          inboxItem("chat-3", "call-approval", "tool_approval"),
+      listInbox: vi.fn().mockResolvedValue([
+        inboxEntry("chat-2", [{ callId: "call-question" }]),
+        inboxEntry("chat-3", [
+          { callId: "call-folder", kind: "folder_access" },
+          { callId: "call-approval", kind: "tool_approval" },
         ]),
+      ]),
     });
     renderHook(() => useChatPromptWatcher(client, null));
 
@@ -207,7 +223,12 @@ describe("useChatPromptWatcher", () => {
     );
     // The rail's markers and the inbox come from the same read, so a chat
     // parked on an approval is marked exactly like one parked on a question.
-    expect(useInbox.getState().items).toHaveLength(3);
+    // Two entries, three calls: the queue is conversations now, and chat-3 is
+    // one row holding two parked calls rather than two rows.
+    expect(useInbox.getState().entries).toHaveLength(2);
+    expect(
+      useInbox.getState().entries.flatMap((entry) => entry.items),
+    ).toHaveLength(3);
     expect(host.requestUserAttention).toHaveBeenCalledTimes(1);
     expect(client.listPendingUserQuestions).not.toHaveBeenCalled();
     expect(usePendingPrompts.getState().userQuestions).toEqual([]);

--- a/crates/tidebreak-desktop/ui/src/useChatPromptWatcher.ts
+++ b/crates/tidebreak-desktop/ui/src/useChatPromptWatcher.ts
@@ -62,11 +62,18 @@ export function useChatPromptWatcher(
         const pending = await client.listInbox();
         if (cancelled || seq !== summarySeq) return;
 
-        inboxActions.setItems(pending);
+        inboxActions.setEntries(pending);
+        // The rail marks chats, so only chat-surface entries reach it. A code
+        // conversation is marked on its own rail by its session digest.
         attentionActions.setChatIdsWithPendingPrompts(
-          pending.map((item) => item.chatId),
+          pending
+            .map((entry) => entry.conversation)
+            .filter((conversation) => conversation.surface === "chat")
+            .map((conversation) => conversation.chatId),
         );
-        const pendingPromptIds = new Set(pending.map((item) => item.callId));
+        const pendingPromptIds = new Set(
+          pending.flatMap((entry) => entry.items.map((item) => item.callId)),
+        );
         const unannounced = [...pendingPromptIds].filter(
           (callId) => !announcedCallIdsRef.current.has(callId),
         );

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -69,6 +69,18 @@ impl ScopedCode {
         })
     }
 
+    /// Bind an already-resolved runtime to a principal.
+    ///
+    /// For callers that have decided for themselves what to do when code mode
+    /// is not configured — the inbox lists chats either way, so it must not
+    /// take the extractor's all-or-nothing rejection.
+    pub(crate) fn for_owner(
+        runtime: std::sync::Arc<super::runtime::CodeRuntime>,
+        owner: OwnerId,
+    ) -> Self {
+        Self { runtime, owner }
+    }
+
     /// The principal's durable owner key, for the seams that take it directly:
     /// the live buses, and background naming.
     pub(crate) fn owner(&self) -> &OwnerId {

--- a/crates/tidebreak-server/src/routes/inbox.rs
+++ b/crates/tidebreak-server/src/routes/inbox.rs
@@ -1,34 +1,60 @@
-//! The single list of what is waiting on the reader, across their chats.
+//! The single list of what is waiting on the reader, across every
+//! conversation.
 //!
-//! A read model, not a store: every row here is projected from the journal
-//! state the per-chat recovery routes already serve, and each item is resolved
-//! through that same chat's existing route — the approval gate, the question
+//! A read model, not a store: every entry here is projected from state the
+//! per-conversation routes already serve, and each item is resolved through
+//! that same conversation's existing route — the approval gate, the question
 //! answer, the plan decision, the native folder grant. Resolving is therefore
 //! first-responder by construction: whoever commits first wins, and a second
-//! attempt meets the same conflict the in-chat card would have met.
+//! attempt meets the same conflict the in-conversation card would have met.
 //!
-//! Items stay as opaque as the per-chat attention summary. Identity, kind, the
-//! conversation's title, and when it parked are enough to triage; question
-//! prose, plan text, and canonical tool arguments stay behind the chat the
-//! item deep-links to.
+//! Decision 48 step 3 made this one queue over both surfaces. An entry is a
+//! conversation carrying an [`Attention`] in the shared vocabulary, with the
+//! parked items behind it for deep links. Chat and code still have separate
+//! id spaces, so the conversation reference is tagged; that tag is the seam
+//! step 5 removes when the entities merge, and it is deliberately the only
+//! place either surface's shape shows through.
+//!
+//! Entries stay as opaque as the per-conversation attention summary.
+//! Identity, kind, the title, and when it parked are enough to triage;
+//! question prose, plan text, and canonical tool arguments stay behind the
+//! conversation the entry deep-links to.
 
 use serde::Serialize;
-use tidebreak_core::{CallId, ChatId, InboxItemKind, TurnId};
+use tidebreak_core::{
+    Attention, AttentionState, CallId, ChatId, CodeSessionId, InboxItemKind, TurnId, WorkspaceId,
+};
 
 use crate::error::ServerError;
 use crate::extract::Json;
 use crate::scoped_store::ScopedStore;
+use crate::state::AppState;
+
+/// Which conversation an entry belongs to.
+///
+/// Tagged because chat ids and code session ids are still separate spaces
+/// (the repository check `chat_and_code_entities_do_not_cross_reference`
+/// enforces it). When step 5 merges the entities this collapses to one id.
+#[derive(Debug, Serialize, ts_rs::TS)]
+#[serde(tag = "surface", rename_all = "snake_case")]
+pub enum InboxConversation {
+    /// A conversation with the internal engine.
+    Chat { chat_id: ChatId },
+    /// A conversation with an external agent engine.
+    ///
+    /// Carries the workspace too: a code conversation is reached through its
+    /// workspace, so a session id alone is not a link the reader can follow.
+    Code {
+        session_id: CodeSessionId,
+        workspace_id: WorkspaceId,
+    },
+}
 
 /// One item waiting on the reader, and where to go to answer it.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct InboxItemSnapshot {
-    /// The conversation to open. With `call_id`, the deep link back to the
-    /// exact transcript position the item paused at.
-    pub chat_id: ChatId,
-    /// Absent, not null, while the conversation is still untitled.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[ts(optional)]
-    pub chat_title: Option<String>,
+    /// With the entry's conversation, the deep link back to the exact
+    /// transcript position the item paused at.
     pub turn_id: TurnId,
     pub call_id: CallId,
     pub kind: InboxItemKind,
@@ -41,25 +67,141 @@ pub struct InboxItemSnapshot {
     pub requested_at: chrono::DateTime<chrono::Utc>,
 }
 
-/// `GET /inbox` — everything parked on the reader, oldest first.
-pub async fn list_inbox(store: ScopedStore) -> Result<Json<Vec<InboxItemSnapshot>>, ServerError> {
-    Ok(Json(
-        store
-            .list_inbox_items()
-            .await?
-            .into_iter()
-            .map(|item| InboxItemSnapshot {
-                chat_id: item.chat_id,
-                chat_title: item.chat_title,
-                turn_id: item.turn_id,
-                call_id: item.call_id,
-                kind: item.kind,
-                action: item
-                    .tool_name
-                    .as_deref()
-                    .map(tidebreak_core::RendererToolName::from),
-                requested_at: item.requested_at,
-            })
-            .collect(),
-    ))
+/// One conversation that wants the reader, and why.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct InboxEntrySnapshot {
+    pub conversation: InboxConversation,
+    /// Absent, not null, while the conversation is still untitled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub title: Option<String>,
+    pub attention: Attention,
+    /// The parked calls behind this attention, oldest first.
+    ///
+    /// Empty for a code conversation: its approvals are answered through the
+    /// code approval route, which carries the verbatim payload decision 33
+    /// requires and which a deep link reaches.
+    pub items: Vec<InboxItemSnapshot>,
+    /// When the oldest thing here started waiting, for ordering.
+    pub waiting_since: chrono::DateTime<chrono::Utc>,
+}
+
+/// `GET /inbox` — every conversation waiting on the reader, longest first.
+pub async fn list_inbox(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    store: ScopedStore,
+) -> Result<Json<Vec<InboxEntrySnapshot>>, ServerError> {
+    let items = store.list_inbox_items().await?;
+    let attention = store.chat_attention(&items).await?;
+
+    let mut entries: Vec<InboxEntrySnapshot> = Vec::new();
+    let mut by_chat: std::collections::HashMap<ChatId, usize> = std::collections::HashMap::new();
+
+    for item in items {
+        let index = match by_chat.get(&item.chat_id) {
+            Some(index) => *index,
+            None => {
+                let attention = attention
+                    .get(&item.chat_id)
+                    .cloned()
+                    // A parked item is why this conversation is listed, so it
+                    // has an attention by construction; fall back rather than
+                    // drop the entry if the two reads ever disagree.
+                    .unwrap_or_else(|| {
+                        Attention::needs_you(
+                            "something is waiting",
+                            tidebreak_core::AttentionSource::Structured,
+                        )
+                    });
+                entries.push(InboxEntrySnapshot {
+                    conversation: InboxConversation::Chat {
+                        chat_id: item.chat_id,
+                    },
+                    title: item.chat_title.clone(),
+                    attention,
+                    items: Vec::new(),
+                    waiting_since: item.requested_at,
+                });
+                by_chat.insert(item.chat_id, entries.len() - 1);
+                entries.len() - 1
+            }
+        };
+        entries[index].items.push(InboxItemSnapshot {
+            turn_id: item.turn_id,
+            call_id: item.call_id,
+            kind: item.kind,
+            action: item
+                .tool_name
+                .as_deref()
+                .map(tidebreak_core::RendererToolName::from),
+            requested_at: item.requested_at,
+        });
+    }
+
+    // Code sessions carry their attention on the row, so the same question —
+    // is this waiting on the reader? — is asked of the state rather than of a
+    // projection. Only states that want a person are listed; `Working` and
+    // `Idle` are not the reader's problem.
+    // Code mode is optional on a deployment, and a server without it still has
+    // an inbox. Absent means the queue is chats only, not that the read fails.
+    let code = state
+        .code
+        .clone()
+        .map(|runtime| crate::code::ScopedCode::for_owner(runtime, store.owner().clone()));
+    if let Some(code) = code {
+        let sessions = code.list_sessions().await?;
+        if sessions
+            .iter()
+            .any(|session| wants_the_reader(&session.attention.state))
+        {
+            // One read for the titles: a session has none of its own, and an
+            // entry the reader cannot recognize is not worth listing.
+            let titles = code
+                .list_workspaces(None)
+                .await?
+                .into_iter()
+                .map(|workspace| (workspace.id, workspace.title))
+                .collect::<std::collections::HashMap<_, _>>();
+            for session in sessions {
+                if !wants_the_reader(&session.attention.state) {
+                    continue;
+                }
+                entries.push(InboxEntrySnapshot {
+                    title: titles.get(&session.workspace_id).cloned(),
+                    conversation: InboxConversation::Code {
+                        session_id: session.id,
+                        workspace_id: session.workspace_id,
+                    },
+                    attention: session.attention,
+                    items: Vec::new(),
+                    waiting_since: session.created_at,
+                });
+            }
+        }
+    }
+
+    // Longest-waiting first: the thing blocked longest is what the reader most
+    // needs to see, and it is what survives any cap a client applies.
+    entries.sort_by(|left, right| {
+        left.waiting_since.cmp(&right.waiting_since).then_with(|| {
+            format!("{:?}", left.conversation).cmp(&format!("{:?}", right.conversation))
+        })
+    });
+    Ok(Json(entries))
+}
+
+/// Whether an attention state is asking for a person.
+///
+/// `Manual` counts: the reader pinned it precisely so it would keep showing
+/// up. `Stalled` counts because a silent engine is a decision waiting to be
+/// made. `DoneUnreviewed` counts because unreviewed work is the reader's.
+fn wants_the_reader(state: &AttentionState) -> bool {
+    match state {
+        AttentionState::NeedsYou { .. }
+        | AttentionState::Stalled { .. }
+        | AttentionState::Fenced { .. }
+        | AttentionState::DoneUnreviewed
+        | AttentionState::Manual { .. } => true,
+        AttentionState::Working | AttentionState::Idle => false,
+    }
 }

--- a/crates/tidebreak-server/src/scoped_store.rs
+++ b/crates/tidebreak-server/src/scoped_store.rs
@@ -422,6 +422,20 @@ impl ScopedStore {
         self.store.list_inbox_items_scoped(&self.owner).await
     }
 
+    /// The principal this read is scoped to.
+    pub fn owner(&self) -> &OwnerId {
+        &self.owner
+    }
+
+    /// One attention value per chat that has something to say, derived from
+    /// the same parked rows the inbox projects (decision 48 step 3).
+    pub async fn chat_attention(
+        &self,
+        items: &[tidebreak_core::InboxItem],
+    ) -> Result<std::collections::HashMap<tidebreak_core::ChatId, tidebreak_core::Attention>> {
+        self.store.chat_attention_scoped(&self.owner, items).await
+    }
+
     /// The per-conversation attention summary over the principal's own chats.
     /// Another owner's parked prompt is not merely unreadable here, it is
     /// absent, so the summary cannot even reveal that their chat exists.

--- a/crates/tidebreak-server/src/tests/lifecycle.rs
+++ b/crates/tidebreak-server/src/tests/lifecycle.rs
@@ -1942,8 +1942,11 @@ async fn the_inbox_lists_parked_work_until_its_own_route_resolves_it() {
     let approval_call = park_tool_approval_for_route_test(&*store, approval_chat.id).await;
 
     let listed = list_inbox(&router, &bearer).await;
+    // The queue is conversations now (decision 48 step 3), each carrying the
+    // calls parked behind it. Four chats, one parked call each.
     let kinds = listed
         .iter()
+        .flat_map(|entry| entry["items"].as_array().expect("items is a list"))
         .map(|item| {
             (
                 item["call_id"].as_str().unwrap().to_owned(),
@@ -1966,14 +1969,28 @@ async fn the_inbox_lists_parked_work_until_its_own_route_resolves_it() {
         .collect::<std::collections::BTreeMap<_, _>>(),
     );
 
-    // Each item carries the chat and the parked call, which is what a deep
-    // link needs to reopen the transcript where it stopped.
-    let approval_item = listed
+    // Every entry states why it is listed, in the vocabulary code mode uses.
+    for entry in &listed {
+        assert_eq!(
+            entry["attention"]["state"]["type"], "needs_you",
+            "a parked call must read as needs-you: {entry}"
+        );
+    }
+
+    // An entry carries its conversation and the parked call, which is what a
+    // deep link needs to reopen the transcript where it stopped. The
+    // conversation is tagged because chat and code ids are still separate
+    // spaces; step 5 collapses that.
+    let approval_entry = listed
         .iter()
-        .find(|item| item["call_id"] == approval_call.to_string())
+        .find(|entry| entry["conversation"]["chat_id"] == approval_chat.id.to_string())
         .expect("the parked approval is listed");
-    assert_eq!(approval_item["chat_id"], approval_chat.id.to_string());
-    assert_eq!(approval_item["action"], "search");
+    assert_eq!(approval_entry["conversation"]["surface"], "chat");
+    assert_eq!(
+        approval_entry["items"][0]["call_id"],
+        approval_call.to_string()
+    );
+    assert_eq!(approval_entry["items"][0]["action"], "search");
 
     // Resolution goes through each kind's established route, unchanged.
     assert_eq!(

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -347,6 +347,8 @@ mod tests {
         );
         // The cross-chat attention read model. It shares the tool vocabulary
         // with the approval card it points at, and nothing else.
+        generate::collect_from::<crate::routes::InboxEntrySnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::InboxConversation>(&cfg, &mut out);
         generate::collect_from::<crate::routes::InboxItemSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::CompactionRun>(&cfg, &mut out);
         // Configuration, catalog, and project surfaces. These carry no shared


### PR DESCRIPTION
Closes #2314. Last of the stack, after #2460, #2463, and #2466.

## What

The queue becomes conversations rather than parked calls keyed on `ChatId`. `GET /inbox` returns one entry per conversation that wants the reader:

```
{ conversation: {surface: "chat", chat_id}    | {surface: "code", session_id, workspace_id},
  title, attention, items[], waiting_since }
```

- **Chat entries** derive attention from the rows the inbox already projects, and carry the parked calls behind it — which is what a deep link needs to reopen the transcript where it stopped.
- **Code entries** read attention off the session, and are listed only when the state asks for a person. `Working` and `Idle` stay out of the reader's way.

`InboxItemKind` and the resolution routes are unchanged: an item is still answered through the card that owns it, so resolving stays first-responder by construction.

## The tag, and why it is there

The conversation reference is tagged because chat and code ids are still separate spaces — `chat_and_code_entities_do_not_cross_reference` still holds, and retiring it is step 5.

I said earlier I would stop and say so if step 3 turned out to need the id merge. It doesn't, but it does need *something* to name which space an id belongs to, and this tag is it. It is deliberately the only place either surface's shape shows through, and it is what step 5 collapses.

## A bug this surfaced

The route first took `ScopedCode`, whose extractor rejects the whole request when code mode is unconfigured. That would have made a chat-only deployment answer 500 for its own inbox. It now reads the runtime from state, so absent code mode means the queue is chats only.

## Client

`listInbox` returns entries; the store keys on conversation identity rather than call id; the view renders one row per conversation, showing `+N more` when several calls are parked behind it, and navigates to the chat or the code workspace. Parsers reject an unknown surface, and still reject smuggled detail at both the entry and item level.

## Tests

`tidebreak-core` 720, `tidebreak-server --lib` 1198, UI 1628. Clippy, rustfmt, `tsc`, `biome check` clean.

Two known-flaky tests fail locally under load and are unrelated: `code_terminals::create_write_read_and_two_cursors` (#2467) and `configuration::api_key_put_configures_it_and_delete_reverts`, which passes 4/4 in isolation.

**One caveat worth reviewing:** `the_inbox_lists_parked_work_until_its_own_route_resolves_it` is itself flaky on `main` — six consecutive runs there gave `FAILED FAILED FAILED ok FAILED FAILED`. My updated version passes at the same rate. It races its own turn claim in setup, before reaching any assertion; filed as #2473. If CI goes red on that test, that is why — but it is worth confirming rather than assuming, since I updated its assertions in this PR.