### PR TITLE
fix(code): the create dialog, the model picker, and image pastes

### DIFF
--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -779,13 +779,14 @@ async fn resolve_run_session(
         .ok_or_else(|| AgentError::msg(format!("workspace {workspace} has no active session")))
 }
 
-/// Desktop create default: Ask when the engine can honor it, otherwise the
-/// most autonomous non-bypass mode. Allow is an explicit `--mode`.
+/// Desktop create default: the most autonomous posture the engine honors,
+/// walking Allow -> Auto -> Ask -> Plan (decision 0039, amended 2026-08-18).
+/// `resolve_start_mode` states whichever posture that is before the turn runs.
 fn default_create_permission_mode(caps: Option<&HarnessCaps>) -> PermissionMode {
     match caps {
-        Some(caps) if caps.structured_approvals == CapLevel::Supported => PermissionMode::Ask,
+        Some(caps) if caps.allow_mode == CapLevel::Supported => PermissionMode::Allow,
         Some(caps) if caps.auto_mode == CapLevel::Supported => PermissionMode::Auto,
-        Some(caps) if caps.plan_mode == CapLevel::Supported => PermissionMode::Plan,
+        Some(caps) if caps.structured_approvals == CapLevel::Supported => PermissionMode::Ask,
         _ => PermissionMode::Plan,
     }
 }
@@ -2694,12 +2695,24 @@ mod tests {
                 slash_commands: CapLevel::Unknown,
             }
         }
+        // Every engine honors Allow, so every engine starts there.
         assert_eq!(
             default_create_permission_mode(Some(&caps(
                 CapLevel::Supported,
                 CapLevel::Supported,
                 CapLevel::Supported,
                 CapLevel::Supported,
+            ))),
+            PermissionMode::Allow
+        );
+        // Ask is the fallback for an engine with an approval channel and no
+        // more autonomous posture, not the default.
+        assert_eq!(
+            default_create_permission_mode(Some(&caps(
+                CapLevel::Supported,
+                CapLevel::Supported,
+                CapLevel::Unsupported,
+                CapLevel::Unsupported,
             ))),
             PermissionMode::Ask
         );

--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -329,6 +329,13 @@ export type ComposerProps = {
   plugins?: ComposerPlugins;
   slash?: ComposerSlash;
   images?: ComposerImages;
+  /**
+   * Why this surface has no image path, when it has none. A paste or drop
+   * carrying an image is claimed and answered with this sentence instead of
+   * falling through to the textarea, where the clipboard's text flavour — a
+   * file URL — lands in the draft and reads as an attachment that worked.
+   */
+  imagesUnavailable?: string;
   files?: ComposerFiles;
   /** Paths the agent can already read, shown as chips and named on send. */
   workspaceFiles?: ComposerWorkspaceFiles;
@@ -377,6 +384,7 @@ export function Composer({
   plugins,
   slash,
   images,
+  imagesUnavailable,
   files,
   workspaceFiles,
   folders,
@@ -428,6 +436,7 @@ export function Composer({
   // is its own: there is no token in the draft to read one from.
   const [panelQuery, setPanelQuery] = useState<string | null>(null);
   const { confirm, dialog: confirmDialog } = useConfirm();
+  const [imagesRefused, setImagesRefused] = useState<string | null>(null);
   const inputDisabled = disabled;
   const active = busy && activeTurnId !== null;
   const sendMode = useUiStore((state) => state.activeTurnSendMode);
@@ -461,6 +470,7 @@ export function Composer({
     savedDraftRef.current = "";
     setSlashToken(null);
     setMentionToken(null);
+    setImagesRefused(null);
   }, [resetKey]);
 
   const invokedSkills = slash?.invoked ?? [];
@@ -792,6 +802,9 @@ export function Composer({
     historyIndexRef.current = null;
     rememberSelection(event.target);
     syncSlashToken(event.target.value, event.target.selectionStart);
+    // Typing is the acknowledgement: a refusal from the last paste has been
+    // read by the time the reader is writing again.
+    setImagesRefused(null);
     onDraftChange(event.target.value);
   }
 
@@ -814,9 +827,18 @@ export function Composer({
    * reader chose. A paste that carries no image is left alone: it is text.
    */
   function acceptTransfer(transfer: DataTransfer | null): boolean {
-    if (!images || inputDisabled) return false;
+    if (inputDisabled) return false;
     const files = imageFilesFrom(transfer);
     if (files.length === 0) return false;
+    if (!images) {
+      // Nothing here can hold an image. Claim it anyway where there is an
+      // answer to give, so the reader gets the answer instead of a file URL
+      // in the draft.
+      if (!imagesUnavailable) return false;
+      setImagesRefused(imagesUnavailable);
+      return true;
+    }
+    setImagesRefused(null);
     images.onAttachFiles(files);
     return true;
   }
@@ -1302,6 +1324,11 @@ export function Composer({
         <span className="text-xs text-destructive" role="alert">
           {"Couldn’t attach image: "}
           {images.error}
+        </span>
+      )}
+      {imagesRefused && (
+        <span className="text-xs text-destructive" role="alert">
+          {imagesRefused}
         </span>
       )}
       {images?.unsupportedModel && images.items.length > 0 && (

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -701,6 +701,42 @@ describe("CodeComposer", () => {
     expect(text.defaultPrevented).toBe(false);
   });
 
+  it("answers an image paste on an engine with no image path", () => {
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        harness="opencode"
+        sessionId="sess-1"
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    // Left alone, the clipboard's text flavour — a file URL — would land in
+    // the draft and read as an attachment that took.
+    const image = pasteOn(box, [
+      new File([new Uint8Array([1, 2, 3, 4])], "shot.png", {
+        type: "image/png",
+      }),
+    ]);
+    expect(image.defaultPrevented).toBe(true);
+    expect(screen.queryByLabelText("Attached images")).toBeNull();
+    expect(
+      screen.getByText("Tidebreak can’t send images to opencode yet."),
+    ).toBeInTheDocument();
+
+    // Writing again is the acknowledgement.
+    fireEvent.change(box, { target: { value: "describe it instead" } });
+    expect(
+      screen.queryByText("Tidebreak can’t send images to opencode yet."),
+    ).toBeNull();
+
+    const text = pasteOn(box, []);
+    expect(text.defaultPrevented).toBe(false);
+  });
+
   it("opens the image picker from the tools menu", async () => {
     const user = userEvent.setup();
     renderComposer(

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useMemo, useRef, useState, useEffect } from "react";
-import { Check, ChevronDown, Gauge, Search, Sparkles } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  Gauge,
+  List,
+  Search,
+  Sparkles,
+} from "lucide-react";
 
 import type {
   PermissionMode,
@@ -39,6 +46,7 @@ import {
   codeModelVendor,
   effortLadder,
   groupCodeModelOptions,
+  noImagePathNote,
   type CodeModelOption,
   PERMISSION_MODE_UNAVAILABLE_REASON,
   SESSION_PERMISSION_MODE_LOCKED,
@@ -105,6 +113,9 @@ export function PermissionModePicker({
   );
 }
 
+/** Rail entry that lifts the vendor filter off a mixed catalog. */
+const ALL_MODELS = "all";
+
 const HARNESS_ICONS: Record<HarnessKind, typeof ClaudeIcon> = {
   claude_code: ClaudeIcon,
   codex: OpenAIIcon,
@@ -169,16 +180,28 @@ export function HarnessModelMenu({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const searchInput = useRef<HTMLInputElement>(null);
+  const currentRow = useRef<HTMLDivElement>(null);
   const groups = useMemo(() => groupCodeModelOptions(options), [options]);
   const currentGroupId =
     groups.find((group) =>
       group.options.some((option) => option.id === current?.id),
     )?.id ?? null;
+  // A vendor-neutral engine lists a mixed catalog, and opening on the current
+  // model's vendor showed one block of it — a menu with a single row, next to
+  // a rail of unlabelled marks. Such a catalog opens on everything instead,
+  // and the rail narrows from there.
+  const mixed = groups.length > 1;
+  const openingGroupId = mixed ? ALL_MODELS : currentGroupId;
   const [activeGroupId, setActiveGroupId] = useState<string | null>(
-    currentGroupId,
+    openingGroupId,
   );
   const activeGroup =
-    groups.find((group) => group.id === activeGroupId) ?? groups[0] ?? null;
+    activeGroupId === ALL_MODELS && mixed
+      ? null
+      : (groups.find((group) => group.id === activeGroupId) ??
+        groups[0] ??
+        null);
+  const showingAll = activeGroup === null && mixed;
   const searching = query.trim().length > 0;
   const matches = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -192,8 +215,21 @@ export function HarnessModelMenu({
           option.source.toLowerCase().includes(needle),
       );
   }, [groups, query]);
-  const visible = searching ? matches : (activeGroup?.options ?? []);
+  const visible = searching
+    ? matches
+    : showingAll
+      ? groups.flatMap((group) => group.options)
+      : (activeGroup?.options ?? []);
   const locked = disabled || !onChange;
+  useEffect(() => {
+    // A mixed catalog opens on the whole list, which runs past the fold. The
+    // row the session is on is put on screen rather than left to be found.
+    if (!open) return;
+    const frame = requestAnimationFrame(() =>
+      currentRow.current?.scrollIntoView({ block: "nearest" }),
+    );
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
   if (!current) {
     if (variant !== "field" && !loading) return null;
     const label = loading ? "Loading models…" : "Default model";
@@ -220,6 +256,7 @@ export function HarnessModelMenu({
     return (
       <DropdownMenuItem
         key={`${option.source}:${option.id}`}
+        ref={selected ? currentRow : undefined}
         onSelect={() => onChange?.(option.id)}
         className="flex items-center gap-2"
       >
@@ -248,7 +285,7 @@ export function HarnessModelMenu({
         setOpen(next);
         if (next) {
           setQuery("");
-          setActiveGroupId(currentGroupId);
+          setActiveGroupId(openingGroupId);
         }
       }}
     >
@@ -316,6 +353,29 @@ export function HarnessModelMenu({
             role="tablist"
             aria-label="Vendors"
           >
+            {mixed && (
+              <WithTooltip label="All models" side="right">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={showingAll}
+                  aria-label="All models"
+                  className={cn(
+                    "relative flex size-9 items-center justify-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    showingAll ? "bg-accent" : "hover:bg-accent/60",
+                  )}
+                  onClick={() => setActiveGroupId(ALL_MODELS)}
+                >
+                  <List className="size-4" />
+                  {showingAll && (
+                    <span
+                      aria-hidden
+                      className="absolute -right-1 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-l-full bg-primary"
+                    />
+                  )}
+                </button>
+              </WithTooltip>
+            )}
             {groups.map((group) => {
               const selected = activeGroup?.id === group.id;
               return (
@@ -869,6 +929,9 @@ export function CodeComposer({
         contextUsage={contextUsage}
         pathMentions={pathMentions}
         slash={slash}
+        imagesUnavailable={
+          harness && !imageInput ? noImagePathNote(harness) : undefined
+        }
         images={
           imageInput
             ? {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -518,6 +518,123 @@ describe("NewWorkspaceDialog", () => {
     );
   });
 
+  it("keeps plain Enter in a text field out of create", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const createCodeWorkspace = vi.fn(async () =>
+      workspace("ws-typed", "repo-new", "2026-08-21T00:00:00.000Z"),
+    );
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace,
+          createCodeSession: vi.fn(async () =>
+            session("ws-typed", "claude_code", "2026-08-21T00:00:00.000Z"),
+          ),
+          listCodeHarnessModels: vi.fn(async () => ({
+            kind: "claude_code" as const,
+            models: [
+              {
+                id: "sonnet",
+                label: "Sonnet",
+                default: true,
+                reasoning_efforts: [],
+              },
+            ],
+            reasoning_efforts: [],
+          })),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const user = userEvent.setup();
+    // Enter on a single-line field would submit the form around it, cutting a
+    // worktree from a keystroke that only meant "done typing".
+    await user.click(screen.getByRole("textbox", { name: "Title" }));
+    await user.keyboard("rail polish{Enter}");
+    await user.click(screen.getByRole("textbox", { name: "Base ref" }));
+    await user.keyboard("{Enter}");
+    expect(createCodeWorkspace).not.toHaveBeenCalled();
+
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+    await waitFor(() =>
+      expect(createCodeWorkspace).toHaveBeenCalledWith({
+        repo_id: "repo-new",
+        title: "rail polish",
+        base_ref: "main",
+      }),
+    );
+  });
+
+  it("opens a mixed model catalog on every vendor at once", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("opencode")],
+        notices: [],
+      } as never,
+    });
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          listCodeHarnessModels: vi.fn(async () => ({
+            kind: "opencode" as HarnessKind,
+            models: [
+              {
+                id: "gpt-5.6-sol",
+                label: "GPT 5.6 Sol",
+                default: true,
+                reasoning_efforts: [],
+              },
+              {
+                id: "claude-opus-5",
+                label: "Claude Opus 5",
+                default: false,
+                reasoning_efforts: [],
+              },
+            ],
+            reasoning_efforts: [],
+          })),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const user = userEvent.setup();
+    await user.click(
+      await screen.findByRole("button", { name: "Model: GPT 5.6 Sol" }),
+    );
+    // Both vendors are one click away, not hidden behind the rail.
+    expect(
+      screen.getByRole("menuitem", { name: /Claude Opus 5/ }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("menuitem", { name: /Claude Opus 5/ }));
+    expect(
+      await screen.findByRole("button", { name: "Model: Claude Opus 5" }),
+    ).toBeInTheDocument();
+
+    // The rail still narrows to one vendor.
+    await user.click(
+      screen.getByRole("button", { name: "Model: Claude Opus 5" }),
+    );
+    await user.click(screen.getByRole("tab", { name: "OpenAI" }));
+    expect(
+      screen.queryByRole("menuitem", { name: /Claude Opus 5/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("lets the reader search the model list", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -330,12 +330,29 @@ export function NewWorkspaceDialog({
           trigger.focus();
         }}
         onKeyDownCapture={(event) => {
+          if (event.key !== "Enter") return;
           // Cmd+Enter (Ctrl+Enter off macOS) creates with what is on screen,
-          // whichever field has focus. Plain Enter stays field-local.
-          if (event.key !== "Enter" || !(event.metaKey || event.ctrlKey))
+          // whichever field has focus. An open picker portals its list out of
+          // this element, but React still routes the key through here, so the
+          // chord works with a dropdown up as well.
+          if (event.metaKey || event.ctrlKey) {
+            event.preventDefault();
+            void create();
             return;
-          event.preventDefault();
-          void create();
+          }
+          // Plain Enter stays field-local. A single-line input inside a form
+          // submits it, so Enter on Title or Base ref used to cut a worktree
+          // from a keystroke that only meant "done typing" — and the create
+          // it started left the chord looking broken for the rest of the
+          // dialog's life. The check is on this element rather than on each
+          // field so a picker's own search box, which lives in a portal, is
+          // left to handle its own Enter.
+          if (
+            event.target instanceof HTMLInputElement &&
+            event.currentTarget.contains(event.target)
+          ) {
+            event.preventDefault();
+          }
         }}
       >
         <DialogHeader>

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -103,6 +103,18 @@ export const SESSION_PERMISSION_MODE_LOCKED =
 export const UNSUPERVISED_AUTO_NOTE =
   "This engine has no approval channel: in Auto, every action runs without asking.";
 
+/**
+ * Stated when a paste or drop carries an image the engine has no path for.
+ *
+ * Only Claude Code declares `image_input: supported`, and an adapter may not
+ * declare it without a captured image round-trip. On the rest, an image the
+ * composer accepted would be dropped on the way to the engine, so the paste is
+ * refused where the reader can see it instead.
+ */
+export function noImagePathNote(kind: HarnessKind): string {
+  return `Tidebreak can’t send images to ${HARNESS_LABELS[kind]} yet.`;
+}
+
 /** Stated wherever Allow is offered (decision 0039). */
 export const ALLOW_ALL_NOTE =
   "This engine's permission system is off: every action runs without asking.";

--- a/crates/tidebreak-desktop/ui/src/stories/HarnessModelMenu.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HarnessModelMenu.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { HarnessModelMenu } from "@/code/CodeComposer";
+import type { CodeModelOption } from "@/code/labels";
+
+/**
+ * The code composer's model picker, and the same control as a form row in the
+ * New workspace dialog.
+ *
+ * A vendor rail on the left narrows the list; a search box on top crosses
+ * every vendor at once. Which rail entry opens depends on the catalog. An
+ * engine confined to one vendor has nothing to narrow, so it opens on its only
+ * block. A vendor-neutral engine opens on All: its catalog spans vendors, and
+ * opening on the current model's block showed one row next to a rail of
+ * unlabelled marks, which reads as a model that cannot be changed.
+ */
+const meta = {
+  title: "Composer/Model",
+  component: HarnessModelMenu,
+  decorators: [
+    (Story) => (
+      <div className="flex items-center gap-3 p-10">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HarnessModelMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Claude Code takes Claude models and nothing else. */
+const CLAUDE_CODE: CodeModelOption[] = [
+  {
+    id: "claude-opus-5",
+    label: "Opus 5",
+    source: "Claude Code",
+    vendor: "anthropic",
+    default: true,
+  },
+  {
+    id: "claude-sonnet-5",
+    label: "Sonnet 5",
+    source: "Claude Code",
+    vendor: "anthropic",
+  },
+  {
+    id: "claude-haiku-4-5",
+    label: "Haiku 4.5",
+    source: "Claude Code",
+    vendor: "anthropic",
+  },
+];
+
+/** opencode drives whatever its providers are signed in to. */
+const OPENCODE: CodeModelOption[] = [
+  {
+    id: "anthropic/claude-opus-5",
+    label: "Opus 5",
+    source: "opencode",
+    vendor: "anthropic",
+  },
+  {
+    id: "anthropic/claude-sonnet-5",
+    label: "Sonnet 5",
+    source: "opencode",
+    vendor: "anthropic",
+  },
+  {
+    id: "openai/gpt-5.6-sol",
+    label: "GPT 5.6 Sol",
+    source: "opencode",
+    vendor: "openai",
+    default: true,
+  },
+  {
+    id: "xai/grok-4.5",
+    label: "Grok 4.5",
+    source: "opencode",
+    vendor: "xai",
+  },
+  {
+    id: "gemini/gemini-3-pro",
+    label: "Gemini 3 Pro",
+    source: "opencode",
+    vendor: "gemini",
+  },
+];
+
+/** One vendor: no All entry, because there is nothing to lift. */
+export const SingleVendor: Story = {
+  args: {
+    harness: "claude_code",
+    options: CLAUDE_CODE,
+    value: "claude-opus-5",
+    onChange: () => undefined,
+  },
+};
+
+/** A mixed catalog: every row is in the list, and the rail narrows it. */
+export const MixedCatalog: Story = {
+  args: {
+    harness: "opencode",
+    options: OPENCODE,
+    value: "openai/gpt-5.6-sol",
+    onChange: () => undefined,
+  },
+};
+
+/** The form-row shape the New workspace dialog uses. */
+export const FormField: Story = {
+  args: {
+    harness: "opencode",
+    options: OPENCODE,
+    value: "openai/gpt-5.6-sol",
+    variant: "field",
+    onChange: () => undefined,
+  },
+};
+
+/** The engine is being asked what it can drive. */
+export const Loading: Story = {
+  args: {
+    harness: "opencode",
+    options: [],
+    loading: true,
+    variant: "field",
+    onChange: () => undefined,
+  },
+};
+
+/**
+ * No handler: this engine takes its model when the session starts and cannot
+ * be moved off it per turn. The trigger says so on hover rather than
+ * disappearing.
+ */
+export const SetAtSessionStart: Story = {
+  args: {
+    harness: "opencode",
+    options: OPENCODE,
+    value: "openai/gpt-5.6-sol",
+  },
+};

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -448,6 +448,19 @@ pub trait HarnessAdapter: Send + Sync {
         prefer_gateway_models(list_cli_models(binary, &["models"], &probe.env).await)
     }
 
+    /// Whether relaunching a session composes a permission mode that changed
+    /// after it started.
+    ///
+    /// True for every engine that takes its posture from the launch plan: a
+    /// relaunch rebuilds that plan from the stored mode, so the new one lands.
+    /// False where the engine fixes its posture when the session is *created*
+    /// and resuming an existing one does not re-apply it — there the relaunch
+    /// is silent about the change, and the caller must refuse rather than let
+    /// the record and the engine disagree.
+    fn relaunch_composes_permission_mode(&self) -> bool {
+        true
+    }
+
     /// Spawn or connect for one session.
     async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError>;
 }

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -96,6 +96,15 @@ impl HarnessAdapter for OpencodeAdapter {
         }
     }
 
+    /// The agent and permission ruleset ride `POST /session`, and resuming is
+    /// `GET /session/{id}` — 1.18.18 captured no way to re-apply either to a
+    /// session that already exists. A relaunch onto a stored resume ref would
+    /// therefore keep the posture the session was created with while the
+    /// record said otherwise, so the change is refused instead.
+    fn relaunch_composes_permission_mode(&self) -> bool {
+        false
+    }
+
     async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
         if !spec.binary.is_absolute() {
             return Err(HarnessError::NotFound);

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1906,6 +1906,20 @@ impl CodeRuntime {
             return Ok(session);
         }
 
+        // A relaunch is the fallback, and it only works where rebuilding the
+        // launch plan carries the mode. An engine that fixed its posture when
+        // it created the session, and cannot re-apply it on resume, would come
+        // back running the old one while the record claimed the new one.
+        if !adapter.relaunch_composes_permission_mode() && session.harness_resume_ref.is_some() {
+            return Err(ServerError::conflict_kind(
+                "permission_mode_fixed",
+                format!(
+                    "{} fixes its permission mode when the session starts; start a new session to pick a different one",
+                    session.harness_kind
+                ),
+            ));
+        }
+
         let handle = self.workers.lock().expect("code workers").remove(&id);
         if let Some(handle) = handle {
             Self::shut_down_worker(id, handle).await;

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -85,6 +85,9 @@ pub(crate) struct ScriptedAdapter {
     reasoning_levels: CapLevel,
     /// Whether this engine takes a new mode without being relaunched.
     live_mode_switch: bool,
+    /// Whether this engine fixes its posture when it creates its session and
+    /// keeps it across a resume, the way opencode does.
+    posture_fixed: bool,
     /// The effort each turn ran at, and every mode a live switch moved this
     /// engine onto. Shared with the session so both survive a relaunch.
     turns: Arc<std::sync::Mutex<Vec<Option<ReasoningEffort>>>>,
@@ -116,6 +119,7 @@ impl ScriptedAdapter {
             image_input: CapLevel::Unknown,
             reasoning_levels: CapLevel::Unsupported,
             live_mode_switch: false,
+            posture_fixed: false,
             turns: Arc::new(std::sync::Mutex::new(Vec::new())),
             modes: Arc::new(std::sync::Mutex::new(Vec::new())),
             child_pid: None,
@@ -189,6 +193,14 @@ impl ScriptedAdapter {
     /// the way Claude Code and Codex do. Left off, the runtime relaunches.
     pub(crate) fn with_live_mode_switch(mut self) -> Self {
         self.live_mode_switch = true;
+        self
+    }
+
+    /// Model opencode: the posture rides session creation, the session reports
+    /// a resume ref, and resuming it does not re-apply the posture — so a
+    /// relaunch would come back running the old mode.
+    pub(crate) fn with_posture_fixed_at_session_start(mut self) -> Self {
+        self.posture_fixed = true;
         self
     }
 
@@ -297,6 +309,10 @@ impl HarnessAdapter for ScriptedAdapter {
         }
     }
 
+    fn relaunch_composes_permission_mode(&self) -> bool {
+        !self.posture_fixed
+    }
+
     async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
         self.launched_approvals
             .lock()
@@ -323,6 +339,7 @@ impl HarnessAdapter for ScriptedAdapter {
             unrecognized_per_turn: self.unrecognized_per_turn,
             approver: self.approver.clone(),
             live_mode_switch: self.live_mode_switch,
+            posture_fixed: self.posture_fixed,
             turns: self.turns.clone(),
             modes: self.modes.clone(),
         }))
@@ -346,6 +363,7 @@ struct ScriptedSession {
     unrecognized_per_turn: u64,
     approver: Arc<ScriptedApprover>,
     live_mode_switch: bool,
+    posture_fixed: bool,
     /// Shared with the adapter so a test can read what the engine was told
     /// after the runtime has dropped and relaunched the session.
     turns: Arc<std::sync::Mutex<Vec<Option<ReasoningEffort>>>>,
@@ -469,7 +487,11 @@ impl HarnessSession for ScriptedSession {
     }
 
     fn resume_ref(&self) -> Option<String> {
-        None
+        // Only the posture-fixed engine reports one: it is what makes a
+        // relaunch resume rather than create, and therefore what makes the
+        // relaunch silent about a mode change.
+        self.posture_fixed
+            .then(|| "scripted-fixed-posture".to_owned())
     }
 
     fn child_pid(&self) -> Option<i64> {

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1697,6 +1697,69 @@ async fn a_session_can_leave_plan_mode_and_the_engine_relaunches_under_the_new_o
     );
 }
 
+/// opencode takes its agent and permission ruleset on `POST /session`, and
+/// resuming is a plain `GET` — nothing captured re-applies either. The runtime
+/// used to relaunch anyway, which resumed the old posture while the row, the
+/// picker, and the journal all said the new one had taken.
+#[tokio::test]
+async fn a_mode_change_a_relaunch_cannot_carry_is_refused_rather_than_recorded() {
+    let (router, token, _runtime, dir) = code_app_with(
+        ScriptedAdapter::new(plain_text_script())
+            .with_auto_mode(CapLevel::Supported)
+            .with_posture_fixed_at_session_start(),
+    )
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = create_sibling_sessions(&client, addr, &token, &workspace, 1)
+        .await
+        .remove(0);
+
+    // A turn is what gives the engine a session to resume into.
+    let accepted = client
+        .post(format!("http://{addr}/code/sessions/{session}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "one" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(accepted.status(), reqwest::StatusCode::ACCEPTED);
+
+    let response = client
+        .post(format!("http://{addr}/code/sessions/{session}/mode"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "permission_mode": "auto" }))
+        .send()
+        .await
+        .unwrap();
+    let status = response.status();
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(status, reqwest::StatusCode::CONFLICT, "{body}");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("start a new session"),
+        "the refusal says what to do instead: {body}"
+    );
+
+    let still: serde_json::Value = client
+        .get(format!("http://{addr}/code/sessions/{session}/debug"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        still["session"]["permission_mode"], "plan",
+        "a refused change must not move the row: {still}"
+    );
+}
+
 /// The engines set an effort per turn, so a level chosen mid-conversation has
 /// to reach the next turn without a new session. Before this the picker was a
 /// local map that forgot on reload and never left the renderer.


### PR DESCRIPTION
Four things a code session would not let you do, reported from one opencode session.

## Plain Enter created a workspace

Title and Base ref are single-line inputs inside the New workspace dialog's form, so Enter on either submitted it. A keystroke meant to end typing cut a worktree, and the create it started left Cmd+Enter looking dead for the rest of the dialog's life — which is how this was reported. Enter is field-local now, the way the dialog's own docstring already claimed. Cmd+Enter was never broken: React routes it here even from a picker's portal.

## The model picker showed one row

It opened on the current model's vendor block and left every other vendor behind the unlabelled icon rail. Claude Code lists one vendor and never noticed; opencode lists a mixed catalog, so the menu looked like a model that could not be changed. A mixed catalog now opens on a new All entry with every row in it, the rail still narrows to one vendor, and the row the session is on is scrolled into view.

## A pasted image left a file URL in the draft

Only Claude Code's adapter puts `TurnInput::images` on the wire; codex, opencode, and grok drop them. The composer gates its image path on `caps.image_input`, so on those three a paste was not claimed and the clipboard's text flavour — a `file://` URL — landed in the draft, reading as an attachment that had worked. The paste is claimed and answered instead: "Tidebreak can't send images to opencode yet."

Making it actually work is adapter-side and gated on a captured image round-trip per engine (`no_adapter_declares_image_input_without_an_image_fixture`). Not in this PR.

## A mode change opencode never took

opencode takes its agent and permission ruleset on `POST /session`; resuming is a plain `GET /session/{id}`, and 1.18.18 captured nothing that re-applies either. It has no in-place mode switch, so the runtime relaunched — onto the stored resume ref, which came back running the posture the session was created with while the row, the picker, and the journal all said the new mode had taken. Dial down to Plan and the engine stayed in Allow.

`HarnessAdapter` now states whether relaunching composes a mode changed after the session started. It defaults true, because every other engine takes its posture from the launch plan; opencode says false. The runtime refuses the change once the session has a resume ref rather than recording one the engine never took. A session that has not opened yet still moves, since its relaunch creates rather than resumes.

## Allow all is the create default from the CLI too

`tidebreak code`'s `default_create_permission_mode` walked Ask → Auto → Plan and its doc comment claimed to be the desktop default. It never picked up the [decision 0039 amendment](docs/decisions/0039-allow-is-a-first-class-code-permission-mode.md#amendment-2026-08-18), which made the default the most autonomous posture the engine honors. Every engine declares `allow_mode: supported`, so CLI sessions opened in Ask while desktop sessions opened in Allow all. It walks Allow → Auto → Ask → Plan now, and `resolve_start_mode` already had the sentence that states it.

## Tests

Each fix has a test that fails without it: the dialog keeping Enter out of create, the mixed catalog opening on every vendor, the paste being answered, the refused mode change not moving the row, and the CLI default. New `HarnessModelMenu` story covers single-vendor, mixed, field, loading, and set-at-session-start.