### PR TITLE
feat(server): routes to arm and manage triggers

### DIFF
--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -10,18 +10,19 @@ use chrono::Utc;
 use tokio::sync::oneshot;
 
 use tidebreak_core::db::code::{
-    delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path, get_session,
-    get_workspace, insert_repo, insert_session, insert_workspace, list_approvals, list_events,
-    list_repos, list_repos_all_owners, list_sessions, list_sessions_all_owners,
-    list_sessions_for_workspace, list_turns, list_workspaces, mark_repo_removed, save_approval,
-    save_repo, save_session, save_workspace, MAX_REPLAY_EVENTS,
+    delete_trigger, delete_workspace, get_approval, get_open_turn, get_repo, get_repo_by_root_path,
+    get_session, get_workspace, insert_repo, insert_session, insert_workspace, list_approvals,
+    list_events, list_repos, list_repos_all_owners, list_sessions, list_sessions_all_owners,
+    list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
+    mark_repo_removed, save_approval, save_repo, save_session, save_trigger, save_workspace,
+    MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
     CodeApprovalState, CodeEvent, CodeRepo, CodeSession, CodeSessionId, CodeSessionKind,
-    CodeSessionLifecycle, CodeTurn, CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, DbStore,
-    Diffstat, FenceReason, HarnessKind, OwnerId, PermissionMode, ReasoningEffort, RepoId,
-    WorkspaceId,
+    CodeSessionLifecycle, CodeTrigger, CodeTriggerAction, CodeTriggerCondition, CodeTriggerId,
+    CodeTurn, CodeTurnId, CodeWorkspace, CodeWorkspaceStatus, DbStore, Diffstat, FenceReason,
+    HarnessKind, OwnerId, PermissionMode, ReasoningEffort, RepoId, WorkspaceId,
 };
 use tidebreak_harness::{
     builtin_registry, AdapterRegistry, ApprovalChannelSpec, ApprovalDecision, HarnessAdapter,
@@ -2083,6 +2084,89 @@ impl CodeRuntime {
         }
         let guard = super::watch::WatchSweepGuard::spawn(Arc::downgrade(self));
         *self.watch_sweep.lock().expect("watch sweep") = Some(guard);
+    }
+
+    /// Triggers armed on one repository.
+    pub(crate) async fn list_triggers(
+        &self,
+        owner: &OwnerId,
+        repo_id: RepoId,
+    ) -> Result<Vec<CodeTrigger>, ServerError> {
+        // Refuses an unknown repository rather than returning an empty list,
+        // so a stale id reads as an error and not as "none armed".
+        self.get_repo(owner, repo_id).await?;
+        Ok(list_triggers_for_repo(&self.db, owner, repo_id).await?)
+    }
+
+    /// Arm a trigger on a repository.
+    ///
+    /// One row per `(repository, condition, action)`: arming the same rule
+    /// twice returns the row already there rather than making a second one
+    /// that would deliver the same message twice.
+    pub(crate) async fn create_trigger(
+        &self,
+        owner: &OwnerId,
+        repo_id: RepoId,
+        condition: CodeTriggerCondition,
+        action: CodeTriggerAction,
+    ) -> Result<CodeTrigger, ServerError> {
+        self.get_repo(owner, repo_id).await?;
+        let existing = list_triggers_for_repo(&self.db, owner, repo_id).await?;
+        if let Some(found) = existing
+            .into_iter()
+            .find(|t| t.condition == condition && t.action == action)
+        {
+            return Ok(found);
+        }
+        let now = Utc::now();
+        let trigger = CodeTrigger {
+            id: CodeTriggerId::new(),
+            owner: owner.clone(),
+            repo_id,
+            condition,
+            action,
+            enabled: true,
+            created_at: now,
+            updated_at: now,
+        };
+        save_trigger(&self.db, &trigger).await?;
+        Ok(trigger)
+    }
+
+    /// Switch a trigger on or off, keeping the row so the scoping survives.
+    pub(crate) async fn set_trigger_enabled(
+        &self,
+        owner: &OwnerId,
+        repo_id: RepoId,
+        id: CodeTriggerId,
+        enabled: bool,
+    ) -> Result<CodeTrigger, ServerError> {
+        let mut trigger = list_triggers_for_repo(&self.db, owner, repo_id)
+            .await?
+            .into_iter()
+            .find(|t| t.id == id)
+            .ok_or_else(|| ServerError::not_found("trigger not found"))?;
+        if trigger.enabled == enabled {
+            return Ok(trigger);
+        }
+        trigger.enabled = enabled;
+        trigger.updated_at = Utc::now();
+        save_trigger(&self.db, &trigger).await?;
+        Ok(trigger)
+    }
+
+    /// Remove a trigger. Its recorded fires stay: they are what the transcript
+    /// already explained.
+    pub(crate) async fn delete_trigger(
+        &self,
+        owner: &OwnerId,
+        id: CodeTriggerId,
+    ) -> Result<(), ServerError> {
+        if delete_trigger(&self.db, owner, id).await? {
+            Ok(())
+        } else {
+            Err(ServerError::not_found("trigger not found"))
+        }
     }
 
     /// Start the trigger sweep once. Same weak-handle shape as the watch

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -23,8 +23,9 @@ use axum::http::request::Parts;
 
 use tidebreak_core::{
     CodeApproval, CodeApprovalId, CodeApprovalState, CodeRepo, CodeSession, CodeSessionId,
-    CodeTurn, CodeTurnId, CodeWorkspace, Diffstat, HarnessKind, OwnerId, PermissionMode,
-    ReasoningEffort, RepoId, SequencedCodeEvent, WorkspaceId,
+    CodeTrigger, CodeTriggerAction, CodeTriggerCondition, CodeTriggerId, CodeTurn, CodeTurnId,
+    CodeWorkspace, Diffstat, HarnessKind, OwnerId, PermissionMode, ReasoningEffort, RepoId,
+    SequencedCodeEvent, WorkspaceId,
 };
 use tidebreak_harness::ApprovalDecision;
 
@@ -341,6 +342,39 @@ impl ScopedCode {
 
     pub(crate) async fn push_workspace(&self, id: WorkspaceId) -> Result<PushOutcome, ServerError> {
         self.runtime.push_workspace(&self.owner, id).await
+    }
+
+    pub(crate) async fn list_triggers(
+        &self,
+        repo_id: RepoId,
+    ) -> Result<Vec<CodeTrigger>, ServerError> {
+        self.runtime.list_triggers(&self.owner, repo_id).await
+    }
+
+    pub(crate) async fn create_trigger(
+        &self,
+        repo_id: RepoId,
+        condition: CodeTriggerCondition,
+        action: CodeTriggerAction,
+    ) -> Result<CodeTrigger, ServerError> {
+        self.runtime
+            .create_trigger(&self.owner, repo_id, condition, action)
+            .await
+    }
+
+    pub(crate) async fn set_trigger_enabled(
+        &self,
+        repo_id: RepoId,
+        id: CodeTriggerId,
+        enabled: bool,
+    ) -> Result<CodeTrigger, ServerError> {
+        self.runtime
+            .set_trigger_enabled(&self.owner, repo_id, id, enabled)
+            .await
+    }
+
+    pub(crate) async fn delete_trigger(&self, id: CodeTriggerId) -> Result<(), ServerError> {
+        self.runtime.delete_trigger(&self.owner, id).await
     }
 
     pub(crate) async fn workspace_pr(

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -115,7 +115,7 @@ use std::sync::Arc;
 
 use axum::extract::DefaultBodyLimit;
 use axum::http::{header, Method};
-use axum::routing::{delete, get, post};
+use axum::routing::{delete, get, patch, post};
 use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -917,6 +917,14 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/code/workspaces/{id}/pr/ready",
             post(routes::code::mark_workspace_pr_ready),
+        )
+        .route(
+            "/code/repos/{id}/triggers",
+            get(routes::code::list_repo_triggers).post(routes::code::create_repo_trigger),
+        )
+        .route(
+            "/code/repos/{id}/triggers/{trigger_id}",
+            patch(routes::code::update_repo_trigger).delete(routes::code::delete_repo_trigger),
         )
         .route(
             "/code/workspaces/{id}/watch",

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -21,6 +21,7 @@ mod repos;
 mod session_events;
 mod sessions;
 mod terminals;
+mod triggers;
 pub(crate) mod types;
 mod updates;
 mod usage;
@@ -60,6 +61,9 @@ pub(crate) use sessions::{
 pub(crate) use terminals::{
     close_terminal, close_workspace_terminals, create_terminal, list_terminals, read_terminal,
     resize_terminal, write_terminal,
+};
+pub(crate) use triggers::{
+    create_repo_trigger, delete_repo_trigger, list_repo_triggers, update_repo_trigger,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/crates/tidebreak-server/src/routes/code/triggers.rs
+++ b/crates/tidebreak-server/src/routes/code/triggers.rs
@@ -1,0 +1,59 @@
+//! Arming and managing triggers.
+//!
+//! Triggers bind per repository and apply to workspaces that have a pull
+//! request, so every route here is repository-scoped rather than
+//! workspace-scoped (decision record 60).
+
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use tidebreak_core::{CodeTriggerId, RepoId};
+
+use super::types::{CodeTriggerSnapshot, CreateCodeTriggerBody, UpdateCodeTriggerBody};
+use crate::code::ScopedCode;
+use crate::error::ServerError;
+
+pub async fn list_repo_triggers(
+    code: ScopedCode,
+    Path(repo_id): Path<RepoId>,
+) -> Result<Json<Vec<CodeTriggerSnapshot>>, ServerError> {
+    let triggers = code.list_triggers(repo_id).await?;
+    Ok(Json(
+        triggers
+            .into_iter()
+            .map(CodeTriggerSnapshot::from)
+            .collect(),
+    ))
+}
+
+pub async fn create_repo_trigger(
+    code: ScopedCode,
+    Path(repo_id): Path<RepoId>,
+    Json(body): Json<CreateCodeTriggerBody>,
+) -> Result<impl IntoResponse, ServerError> {
+    let trigger = code
+        .create_trigger(repo_id, body.condition, body.action)
+        .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CodeTriggerSnapshot::from(trigger)),
+    ))
+}
+
+pub async fn update_repo_trigger(
+    code: ScopedCode,
+    Path((repo_id, id)): Path<(RepoId, CodeTriggerId)>,
+    Json(body): Json<UpdateCodeTriggerBody>,
+) -> Result<Json<CodeTriggerSnapshot>, ServerError> {
+    let trigger = code.set_trigger_enabled(repo_id, id, body.enabled).await?;
+    Ok(Json(CodeTriggerSnapshot::from(trigger)))
+}
+
+pub async fn delete_repo_trigger(
+    code: ScopedCode,
+    Path((_repo_id, id)): Path<(RepoId, CodeTriggerId)>,
+) -> Result<StatusCode, ServerError> {
+    code.delete_trigger(id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -6,10 +6,11 @@ use ts_rs::TS;
 use tidebreak_core::{
     Attention, CapLevel, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
     CodeEvent, CodeRepo, CodeSession, CodeSessionKind, CodeSessionLifecycle, CodeSubagentSummary,
-    CodeTerminalId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWatch, CodeWatchId, CodeWatchState,
-    CodeWorkspace, CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps,
-    HarnessKind, HarnessTier, PermissionMode, PullRequestDigest, QuickAction, ReasoningEffort,
-    RepoId, WorkspaceId,
+    CodeTerminalId, CodeTrigger, CodeTriggerAction, CodeTriggerCondition, CodeTriggerId, CodeTurn,
+    CodeTurnId, CodeTurnStatus, CodeWatch, CodeWatchId, CodeWatchState, CodeWorkspace,
+    CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps, HarnessKind,
+    HarnessTier, PermissionMode, PullRequestDigest, QuickAction, ReasoningEffort, RepoId,
+    WorkspaceId,
 };
 
 /// A registered local git repository.
@@ -686,6 +687,48 @@ pub struct CodeDeliveryCheck {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub workflow_run_id: Option<u64>,
+}
+
+/// One armed trigger, as the interface reads it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeTriggerSnapshot {
+    pub id: CodeTriggerId,
+    pub repo_id: RepoId,
+    pub condition: CodeTriggerCondition,
+    pub action: CodeTriggerAction,
+    pub enabled: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<CodeTrigger> for CodeTriggerSnapshot {
+    fn from(trigger: CodeTrigger) -> Self {
+        Self {
+            id: trigger.id,
+            repo_id: trigger.repo_id,
+            condition: trigger.condition,
+            action: trigger.action,
+            enabled: trigger.enabled,
+            created_at: trigger.created_at,
+            updated_at: trigger.updated_at,
+        }
+    }
+}
+
+/// Arm a trigger on a repository.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
+pub struct CreateCodeTriggerBody {
+    pub condition: CodeTriggerCondition,
+    pub action: CodeTriggerAction,
+}
+
+/// Switch a trigger on or off. The row survives either way, so the scoping
+/// does not have to be rebuilt to turn a rule back on.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, TS)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateCodeTriggerBody {
+    pub enabled: bool,
 }
 
 /// Pull request row shared by the overview and notification monitor.


### PR DESCRIPTION
Part of #2480 and #2477. Now rebased onto `main`; #2483 and #2484 have landed,
so this is a single commit.

Until now a trigger row could only be created in a test. These are the routes
behind it.

| Route | Does |
| --- | --- |
| `GET /code/repos/{id}/triggers` | list what is armed |
| `POST /code/repos/{id}/triggers` | arm one |
| `PATCH /code/repos/{id}/triggers/{trigger_id}` | enable or disable |
| `DELETE /code/repos/{id}/triggers/{trigger_id}` | remove |

Owner-scoped through `ScopedCode` like the rest of `/code/*`, and
repository-scoped rather than workspace-scoped: a trigger is a standing
preference about how the user wants to be reached, and record 0060 binds it per
repository.

## Behaviour worth knowing

- **Arming the same rule twice returns the row already there.** One row per
  `(repository, condition, action)`, or a double-armed rule would deliver the
  same message twice.
- **Disabling keeps the row**, so turning a rule back on does not mean
  rebuilding its scoping. That is what the `enabled` column is for.
- **Deleting keeps the recorded fires.** They are what the transcript already
  explained; dropping them would leave journal lines with nothing behind them.
- Listing refuses an unknown repository rather than returning an empty list, so
  a stale id reads as an error instead of "none armed".

## Scope

The server half. The desktop surface is still to come, and it owes two things
record 0060 asks for that only an interface can deliver: naming the target
session when the trigger is armed, and saying which delivery path a given
session is on rather than implying every trigger interrupts.

`CodeTriggerSnapshot`, `CreateCodeTriggerBody`, and `UpdateCodeTriggerBody`
derive `TS` but are not added to the `collect_from` list in `wire_types.rs`, so
`wire.ts` is unchanged. That regeneration belongs with the UI change that first
consumes them.