### PR TITLE
feat: schema changes are migrations, not database resets

### DIFF
--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -578,11 +578,11 @@ mod tests {
         let existing = std::fs::read_to_string(&path).unwrap_or_default();
         assert_eq!(
             existing, rendered,
-            "the code journal event shape changed, and rows in this shape \
-             already exist in databases nothing deletes; make the change \
-             readable from the old shape with #[serde(alias)], or migrate the \
-             rows, then regenerate with UPDATE_CODE_JOURNAL_FIXTURE=1 cargo \
-             test -p tidebreak-core"
+            "the code journal event shape changed; rows written in the old shape \
+             now survive a schema change, so make the new shape readable from \
+             the old one with #[serde(alias)], or migrate the rows. Then \
+             regenerate with UPDATE_CODE_JOURNAL_FIXTURE=1 cargo test -p \
+             tidebreak-core"
         );
     }
 }

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -557,8 +557,12 @@ mod tests {
     /// `CodeEvent` is written into `code_event.event` and read back, so its
     /// field names are a storage format. Rows in the old shape survive a
     /// schema change now, so a diff here needs a `#[serde(alias)]` or a
-    /// migration, not a refreshed fixture on its own — see the same test on
-    /// `AgentEvent` in [`crate::event`].
+    /// migration, not a refreshed fixture on its own. The chat journal's own
+    /// copy of this test says the same thing.
+    ///
+    /// Do not name the chat payload type here, even in prose:
+    /// `chat_and_code_entities_do_not_cross_reference` scans this file as
+    /// text, and it cannot tell a doc comment from a use.
     ///
     /// Regenerate with
     /// `UPDATE_CODE_JOURNAL_FIXTURE=1 cargo test -p tidebreak-core`.

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -555,9 +555,10 @@ mod tests {
     const JOURNAL_FIXTURE: &str = "fixtures/code-journal-events.json";
 
     /// `CodeEvent` is written into `code_event.event` and read back, so its
-    /// field names are a storage format. Pre-v1 this test is a change
-    /// detector: a payload change that ships without a
-    /// `DESKTOP_SCHEMA_EPOCH` bump would make old rows unreadable.
+    /// field names are a storage format. Rows in the old shape survive a
+    /// schema change now, so a diff here needs a `#[serde(alias)]` or a
+    /// migration, not a refreshed fixture on its own — see the same test on
+    /// `AgentEvent` in [`crate::event`].
     ///
     /// Regenerate with
     /// `UPDATE_CODE_JOURNAL_FIXTURE=1 cargo test -p tidebreak-core`.
@@ -577,9 +578,10 @@ mod tests {
         let existing = std::fs::read_to_string(&path).unwrap_or_default();
         assert_eq!(
             existing, rendered,
-            "the code journal event shape changed; if this is deliberate, bump \
-             DESKTOP_SCHEMA_EPOCH in tidebreak-server so existing databases are \
-             discarded, then regenerate with UPDATE_CODE_JOURNAL_FIXTURE=1 cargo \
+            "the code journal event shape changed, and rows in this shape \
+             already exist in databases nothing deletes; make the change \
+             readable from the old shape with #[serde(alias)], or migrate the \
+             rows, then regenerate with UPDATE_CODE_JOURNAL_FIXTURE=1 cargo \
              test -p tidebreak-core"
         );
     }

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -7,9 +7,10 @@
 //! The ordering is the point. SeaORM records one name per migration and cannot
 //! tell that the statements behind an already-recorded name changed, so an
 //! in-place baseline edit reaches a fresh database and no existing one. The
-//! desktop profile survives that because `DESKTOP_SCHEMA_EPOCH` deletes and
-//! rebuilds it. The self-host PostgreSQL store is durable and has no reset, so
-//! an appended migration is the only thing that reaches it.
+//! desktop profile used to survive that by being deleted and rebuilt. It is
+//! not deleted any more, and the self-host PostgreSQL store never was, so an
+//! appended migration is the only thing that reaches either of them.
+//! [`Baseline`] is frozen; `the_schema_baseline_is_pinned` fails on an edit.
 //!
 //! The two owner migrations below used to be branches inside `Baseline::up`,
 //! each guarded by whether its column existed yet. One such branch works.
@@ -408,35 +409,26 @@ mod tests {
             .unwrap();
         assert_eq!(row.try_get::<String>("", "owner").unwrap(), "local");
     }
-    /// The baseline *is* the desktop schema, and nothing notices when it moves.
-    /// `Migrator::up` records one migration name, so SeaORM cannot tell that
-    /// the statements behind that name changed; the reset that repairs an
-    /// existing database is keyed on `DESKTOP_SCHEMA_EPOCH`, an integer a
-    /// contributor has to remember to bump in a different crate.
+    /// The baseline is frozen, and this is what holds it still.
     ///
-    /// Decision record 2 names this gap in its own validation section: "no
-    /// test fails if a baseline edit ships without an epoch bump. Reviewers
-    /// of a change touching `db/migration/baseline/` should confirm
-    /// `DESKTOP_SCHEMA_EPOCH` moved in the same diff." This is that test, and
-    /// it retires that review instruction.
+    /// `Migrator::up` records one name per migration and cannot tell that the
+    /// statements behind an already-recorded name changed. So an edit here
+    /// reaches a fresh database and no existing one — the two then run
+    /// different schemas against the same queries, each internally consistent,
+    /// with nothing to notice. That used to be survivable because an epoch
+    /// bump deleted the local database. Nothing deletes it now.
     ///
-    /// Like the journal shape fixtures it is a change *detector*, not a
-    /// compatibility contract. It does not know what the epoch is. It knows
-    /// the schema moved, and that a human owes it a decision.
+    /// The fix for a diff here is therefore not a regenerated fixture. It is
+    /// an appended migration in [`Migrator::migrations`], which reaches both.
     ///
-    /// Both backends are rendered. The epoch guards the desktop profile, so
-    /// SQLite is what a bump repairs — but the self-host store is PostgreSQL
-    /// and durable, and the two builders do not agree on everything: a type
-    /// that collapses in SQLite, or a constraint it parses and ignores, is a
-    /// real schema difference that a SQLite-only fixture cannot see. The
-    /// second render costs one file and closes that gap ahead of the
-    /// migration chain, which will be written against PostgreSQL first.
+    /// Both backends are rendered, because the two builders do not agree on
+    /// everything: a type that collapses in SQLite, or a constraint it parses
+    /// and ignores, is a real difference on PostgreSQL that a SQLite-only
+    /// fixture cannot see.
     ///
-    /// Regenerate with `UPDATE_SCHEMA_FIXTURE=1 cargo test -p tidebreak-core`.
-    ///
-    /// At v1 this inverts with the rest of decision record 2: the baseline
-    /// becomes the first entry in a real chain, and the fix for a diff here
-    /// becomes an ordered migration rather than a bump.
+    /// Regenerate with `UPDATE_SCHEMA_FIXTURE=1 cargo test -p tidebreak-core`
+    /// only when squashing the chain for a release, which is the one time the
+    /// baseline is supposed to move.
     #[test]
     fn the_schema_baseline_is_pinned() {
         // sea-query renders one statement per line. Break each column and
@@ -498,10 +490,11 @@ mod tests {
             let existing = std::fs::read_to_string(&path).unwrap_or_default();
             assert_eq!(
                 existing, rendered,
-                "the schema baseline changed; if this is deliberate, bump \
-             DESKTOP_SCHEMA_EPOCH in tidebreak-server so existing databases are \
-             discarded, then regenerate with UPDATE_SCHEMA_FIXTURE=1 cargo \
-             test -p tidebreak-core"
+                "the schema baseline changed, and it is frozen; an edit here \
+             reaches a fresh database and no existing one. Append a migration \
+             in db/migration.rs instead. Regenerate with \
+             UPDATE_SCHEMA_FIXTURE=1 cargo test -p tidebreak-core only when \
+             squashing the chain for a release."
             );
         }
     }

--- a/crates/tidebreak-core/src/event.rs
+++ b/crates/tidebreak-core/src/event.rs
@@ -496,9 +496,9 @@ mod tests {
         let existing = std::fs::read_to_string(&path).unwrap_or_default();
         assert_eq!(
             existing, rendered,
-            "the journal event shape changed, and rows in this shape already \
-             exist in databases nothing deletes; make the change readable from \
-             the old shape with #[serde(alias)], or migrate the rows, then \
+            "the journal event shape changed; rows written in the old shape \
+             now survive a schema change, so make the new shape readable from \
+             the old one with #[serde(alias)], or migrate the rows. Then \
              regenerate with UPDATE_JOURNAL_FIXTURE=1 cargo test -p \
              tidebreak-core"
         );

--- a/crates/tidebreak-core/src/event.rs
+++ b/crates/tidebreak-core/src/event.rs
@@ -467,21 +467,19 @@ mod tests {
     /// names are a storage format, not only a wire format — and nothing else
     /// pins them.
     ///
-    /// Pre-v1 this test is a change *detector*, not a compatibility contract:
-    /// bumping `DESKTOP_SCHEMA_EPOCH` deletes the whole database, journal rows
-    /// included, so no row written under an older shape can reach this code.
-    /// What still bites is a payload change that ships *without* the bump —
+    /// Rows written by an older binary now survive, so this is a compatibility
+    /// contract again, not only a change detector. Nothing deletes the local
+    /// database for a format change any more, and the failure is not graceful:
     /// `list_events` collects into `Result<Vec<_>>`, so one unreadable row
     /// fails a whole chat's history rather than one message, silently until
     /// someone opens an old chat.
     ///
-    /// Regenerate with `UPDATE_JOURNAL_FIXTURE=1 cargo test -p tidebreak-core`.
-    /// A diff here means the journal format changed, which needs an epoch bump
-    /// — not a refreshed fixture on its own.
-    ///
-    /// At v1 this inverts: databases stop being disposable, and the fix for a
-    /// diff becomes a `#[serde(alias)]` or a migration. See
-    /// `docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md`.
+    /// So a diff here is a question, not a chore. Either the change is
+    /// backward-compatible — a `#[serde(alias)]`, an added optional field —
+    /// or the rows already written need a migration. Regenerate with
+    /// `UPDATE_JOURNAL_FIXTURE=1 cargo test -p tidebreak-core` once one of
+    /// those is true. See
+    /// `docs/decisions/0061-schema-changes-are-migrations.md`.
     #[test]
     fn the_journal_event_shape_is_pinned() {
         let rendered = format!(
@@ -498,10 +496,11 @@ mod tests {
         let existing = std::fs::read_to_string(&path).unwrap_or_default();
         assert_eq!(
             existing, rendered,
-            "the journal event shape changed; if this is deliberate, bump \
-             DESKTOP_SCHEMA_EPOCH in tidebreak-server so existing databases are \
-             discarded, then regenerate with UPDATE_JOURNAL_FIXTURE=1 cargo \
-             test -p tidebreak-core"
+            "the journal event shape changed, and rows in this shape already \
+             exist in databases nothing deletes; make the change readable from \
+             the old shape with #[serde(alias)], or migrate the rows, then \
+             regenerate with UPDATE_JOURNAL_FIXTURE=1 cargo test -p \
+             tidebreak-core"
         );
     }
 }

--- a/crates/tidebreak-server/src/code/worktree_orphans.rs
+++ b/crates/tidebreak-server/src/code/worktree_orphans.rs
@@ -1,12 +1,15 @@
-//! What a pre-v1 epoch reset is about to lose track of.
+//! What a reset is about to lose track of.
 //!
 //! Code worktrees do not live in the data directory. Decision 53 moved them to
 //! a user-visible root on purpose, because a worktree is user work —
 //! uncommitted code on a real branch. The reset in [`crate::desktop_schema`]
-//! deletes the database and nothing outside the data directory, so every
-//! epoch bump drops the `code_workspace` rows and leaves the trees behind:
-//! directories full of possibly-uncommitted work, entries in each source
-//! repository's `.git/worktrees`, and branches on the user's real repository.
+//! deletes the database and nothing outside the data directory, so it drops
+//! the `code_workspace` rows and leaves the trees behind: directories full of
+//! possibly-uncommitted work, entries in each source repository's
+//! `.git/worktrees`, and branches on the user's real repository.
+//!
+//! Only a profile below the migration pin still takes a reset (decision 61),
+//! so this runs once per such profile and then never again.
 //!
 //! Deleting them is not the answer, and neither is silence. So the reset
 //! writes them down. Right before the database goes, read the rows that name

--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -1,19 +1,27 @@
-//! Pre-v1 lifecycle for the local SQLite profile.
+//! The lifecycle for the local SQLite profile.
 //!
-//! During `0.0.0` development we intentionally edit the schema baseline.
-//! SeaORM cannot detect that an already-recorded baseline changed, so the
-//! local profile keeps a small schema epoch outside SQLite. An older pre-v1
-//! epoch (or a database from before epochs existed) is disposable and gets
-//! rebuilt. Once the lifecycle changes for v1, pre-v1 binaries fail closed
-//! instead.
+//! A schema change is an appended migration in `tidebreak-core`'s
+//! `db::migration` chain, and an appended migration reaches an existing
+//! database without deleting it. So this file no longer decides whether to
+//! keep local data. It decides one thing: whether a database predates the pin
+//! the chain starts from.
+//!
+//! [`LAST_RESET_EPOCH`] is that pin. Before it, a schema change was an
+//! in-place baseline edit plus an epoch bump, and the bump deleted the
+//! database because no migration could reach it. A profile still sitting below
+//! the pin holds some baseline revision nothing recorded, so there is no
+//! migration anyone could write for it — it gets one last reset. A profile at
+//! the pin holds exactly the baseline the chain starts from, so it converges:
+//! the marker is re-stamped and the chain takes it from there. Neither case
+//! happens twice, and the epoch never moves again.
 //!
 //! The reset deletes the SQLite files (and the host-broker's durable
 //! authority, which keys on conversation ids the reset invalidates) — and
-//! nothing else in the data directory. Durable state that must survive an
-//! epoch bump lives in sidecar files here by design: the schema marker
-//! itself, and the provisioned gateway policy (`gateway-policy.json`, see
-//! [`crate::managed_policy`]), whose loss would resolve the profile
-//! unmanaged and orphan the gateway session it authorized.
+//! nothing else in the data directory. Durable state that must survive it
+//! lives in sidecar files here by design: the schema marker itself, and the
+//! provisioned gateway policy (`gateway-policy.json`, see
+//! [`crate::managed_policy`]), whose loss would resolve the profile unmanaged
+//! and orphan the gateway session it authorized.
 //!
 //! The data directory is not the whole story, though. Code worktrees live
 //! outside it on purpose (Decision 53), so dropping the database strands every
@@ -34,12 +42,24 @@ use tidebreak_core::{AgentError, Config, DbStore, Result};
 
 const DATABASE_FILE: &str = "tidebreak.db";
 const MARKER_FILE: &str = "tidebreak-schema.json";
+/// A profile whose schema still came from an in-place baseline edit, kept
+/// current by deleting it. Nothing writes this any more; it is read so a
+/// profile written before the pin can be recognized and converged.
 const PRE_V1_LIFECYCLE: &str = "pre_v1";
+/// A profile the migration chain maintains. Its schema changes by appended
+/// migration, and its data survives.
+const MIGRATED_LIFECYCLE: &str = "migrations";
 const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
-/// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 41;
+/// The last epoch that ever deleted a local database, and the baseline the
+/// migration chain starts from.
+///
+/// Frozen. Do not bump it for a schema change — append a migration instead, so
+/// the change reaches a database that already exists rather than only a fresh
+/// one. It moves again only at the `1.0.0` squash, when the chain collapses
+/// back into a single baseline.
+const LAST_RESET_EPOCH: u32 = 41;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -51,9 +71,15 @@ struct SchemaMarker {
 impl SchemaMarker {
     fn current() -> Self {
         Self {
-            lifecycle: PRE_V1_LIFECYCLE.to_owned(),
-            epoch: DESKTOP_SCHEMA_EPOCH,
+            lifecycle: MIGRATED_LIFECYCLE.to_owned(),
+            epoch: LAST_RESET_EPOCH,
         }
+    }
+
+    /// A profile written before the pin, by a binary that kept the schema
+    /// current by deleting the database.
+    fn is_pre_pin(&self) -> bool {
+        self.lifecycle == PRE_V1_LIFECYCLE && self.epoch <= LAST_RESET_EPOCH
     }
 }
 
@@ -89,7 +115,7 @@ async fn prepare(data_dir: &Path) -> Result<bool> {
 async fn prepare_for_product_major(data_dir: &Path, product_major: &str) -> Result<bool> {
     if product_major != "0" {
         return Err(AgentError::config(format!(
-            "pre-v1 local SQLite schema lifecycle is disabled for product major {product_major}"
+            "local SQLite schema lifecycle is disabled for product major {product_major}"
         )));
     }
     let database = data_dir.join(DATABASE_FILE);
@@ -103,16 +129,25 @@ async fn prepare_for_product_major(data_dir: &Path, product_major: &str) -> Resu
             remove_retired_vectors(&data_dir.join(VECTOR_DIRECTORY))?;
             Ok(false)
         }
-        Some(saved)
-            if saved.lifecycle == PRE_V1_LIFECYCLE && saved.epoch < DESKTOP_SCHEMA_EPOCH =>
-        {
+        // At the pin, written by a binary from before the chain existed. The
+        // tables are already the ones the chain starts from, so there is
+        // nothing to repair: re-stamp the marker and let the migrations run.
+        // This is the only path that keeps a pre-v1 profile's data.
+        Some(saved) if saved.is_pre_pin() && saved.epoch == LAST_RESET_EPOCH => {
+            remove_retired_vectors(&data_dir.join(VECTOR_DIRECTORY))?;
+            Ok(true)
+        }
+        // Below the pin. The schema is some baseline revision that was edited
+        // in place and never recorded, so no migration can know what it holds.
+        // One last reset, and this profile never takes another.
+        Some(saved) if saved.is_pre_pin() => {
             remove_retired_vectors(&data_dir.join(VECTOR_DIRECTORY))?;
             reset_pre_v1_state(&database).await?;
             Ok(true)
         }
         None if database.exists() => {
             // Databases predating this marker are from the disposable pre-v1
-            // development line. The v1 lifecycle will always retain a marker.
+            // development line, below the pin by definition.
             remove_retired_vectors(&data_dir.join(VECTOR_DIRECTORY))?;
             reset_pre_v1_state(&database).await?;
             Ok(true)
@@ -125,8 +160,8 @@ async fn prepare_for_product_major(data_dir: &Path, product_major: &str) -> Resu
             Ok(true)
         }
         Some(saved) => Err(AgentError::config(format!(
-            "refusing to reset local SQLite database for schema marker lifecycle {:?}, epoch {}; this binary supports {:?}, epoch {}",
-            saved.lifecycle, saved.epoch, PRE_V1_LIFECYCLE, DESKTOP_SCHEMA_EPOCH
+            "refusing to open local SQLite database for schema marker lifecycle {:?}, epoch {}; this binary maintains {:?}, epoch {}",
+            saved.lifecycle, saved.epoch, MIGRATED_LIFECYCLE, LAST_RESET_EPOCH
         ))),
     }
 }
@@ -144,13 +179,13 @@ fn read_marker(marker: &Path) -> Result<Option<SchemaMarker>> {
     };
     if !metadata.is_file() || metadata.file_type().is_symlink() {
         return Err(AgentError::config(format!(
-            "refusing to reset local SQLite database with non-regular schema marker {}",
+            "refusing to open local SQLite database with non-regular schema marker {}",
             marker.display()
         )));
     }
     if metadata.len() > MAX_MARKER_BYTES {
         return Err(AgentError::config(format!(
-            "refusing to reset local SQLite database with oversized schema marker {}",
+            "refusing to open local SQLite database with oversized schema marker {}",
             marker.display()
         )));
     }
@@ -165,7 +200,7 @@ fn read_marker(marker: &Path) -> Result<Option<SchemaMarker>> {
         })?;
     if bytes.len() as u64 > MAX_MARKER_BYTES {
         return Err(AgentError::config(format!(
-            "refusing to reset local SQLite database with oversized schema marker {}",
+            "refusing to open local SQLite database with oversized schema marker {}",
             marker.display()
         )));
     }
@@ -173,7 +208,7 @@ fn read_marker(marker: &Path) -> Result<Option<SchemaMarker>> {
         .map(Some)
         .map_err(|error| {
             AgentError::config(format!(
-                "refusing to reset local SQLite database with unreadable schema marker {}: {error}",
+                "refusing to open local SQLite database with unreadable schema marker {}: {error}",
                 marker.display()
             ))
         })
@@ -623,7 +658,7 @@ mod tests {
             data_dir.join(MARKER_FILE),
             serde_json::to_vec(&SchemaMarker {
                 lifecycle: PRE_V1_LIFECYCLE.to_owned(),
-                epoch: DESKTOP_SCHEMA_EPOCH - 1,
+                epoch: LAST_RESET_EPOCH - 1,
             })
             .unwrap(),
         )
@@ -631,7 +666,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn current_schema_epoch_preserves_database_and_removes_retired_vectors() {
+    async fn a_migrated_profile_is_kept_and_its_retired_vectors_removed() {
         let dir = tempfile::tempdir().unwrap();
         let config = Config::desktop(dir.path());
         let first = connect(&config).await.unwrap();
@@ -651,8 +686,11 @@ mod tests {
         assert!(!vector.exists());
     }
 
+    /// Below the pin the schema is some in-place baseline revision nothing
+    /// recorded, so there is no migration anyone could write for it. This is
+    /// the last reset such a profile ever takes.
     #[tokio::test]
-    async fn older_pre_v1_epoch_resets_database() {
+    async fn a_profile_below_the_pin_takes_one_last_reset() {
         let dir = tempfile::tempdir().unwrap();
         let config = Config::desktop(dir.path());
         let first = connect(&config).await.unwrap();
@@ -665,6 +703,46 @@ mod tests {
         let reset = connect(&config).await.unwrap();
 
         assert!(reset.list_chats().await.unwrap().is_empty());
+    }
+
+    /// The promise the posture rests on: a profile written by the last pre-v1
+    /// binary holds exactly the baseline the chain starts from, so it keeps
+    /// its data and is re-stamped rather than deleted.
+    ///
+    /// This is the one migration path nobody gets to test twice. Every
+    /// contributor's profile is sitting at this marker right now, and the
+    /// arm that reads it runs once per profile and then never again.
+    #[tokio::test]
+    async fn a_pre_v1_profile_at_the_pin_keeps_its_data_and_converges() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Config::desktop(dir.path());
+        let first = connect(&config).await.unwrap();
+        let expected = chat();
+        first.create_chat(&expected).await.unwrap();
+        drop(first);
+        // What the last epoch-driven binary left behind.
+        std::fs::write(
+            dir.path().join(MARKER_FILE),
+            serde_json::to_vec(&SchemaMarker {
+                lifecycle: PRE_V1_LIFECYCLE.to_owned(),
+                epoch: LAST_RESET_EPOCH,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let converged = connect(&config).await.unwrap();
+
+        assert_eq!(
+            converged.get_chat(expected.id).await.unwrap(),
+            Some(expected),
+            "a profile at the pin must survive the switch to migrations"
+        );
+        assert_eq!(
+            read_marker(&dir.path().join(MARKER_FILE)).unwrap(),
+            Some(SchemaMarker::current()),
+            "the profile must be re-stamped, so the next boot takes the migrated path"
+        );
     }
 
     #[tokio::test]
@@ -689,7 +767,7 @@ mod tests {
             Ok(_) => panic!("future lifecycle marker was accepted"),
             Err(error) => error,
         };
-        assert!(error.to_string().contains("refusing to reset"));
+        assert!(error.to_string().contains("refusing to open"));
 
         let unchanged = DbStore::connect(&config.database_url().unwrap())
             .await
@@ -705,7 +783,7 @@ mod tests {
         assert_rejected_marker_preserves_database(
             serde_json::to_vec(&SchemaMarker {
                 lifecycle: PRE_V1_LIFECYCLE.to_owned(),
-                epoch: DESKTOP_SCHEMA_EPOCH + 1,
+                epoch: LAST_RESET_EPOCH + 1,
             })
             .unwrap(),
         )
@@ -742,7 +820,7 @@ mod tests {
         let config = Config::desktop(dir.path());
         let older = SchemaMarker {
             lifecycle: PRE_V1_LIFECYCLE.to_owned(),
-            epoch: DESKTOP_SCHEMA_EPOCH - 1,
+            epoch: LAST_RESET_EPOCH - 1,
         };
         std::fs::write(
             dir.path().join(MARKER_FILE),
@@ -770,7 +848,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let old = serde_json::to_vec(&SchemaMarker {
             lifecycle: PRE_V1_LIFECYCLE.to_owned(),
-            epoch: DESKTOP_SCHEMA_EPOCH - 1,
+            epoch: LAST_RESET_EPOCH - 1,
         })
         .unwrap();
         std::fs::write(dir.path().join(MARKER_FILE), &old).unwrap();
@@ -788,7 +866,7 @@ mod tests {
             dir.path().join(MARKER_FILE),
             serde_json::to_vec(&SchemaMarker {
                 lifecycle: PRE_V1_LIFECYCLE.to_owned(),
-                epoch: DESKTOP_SCHEMA_EPOCH - 1,
+                epoch: LAST_RESET_EPOCH - 1,
             })
             .unwrap(),
         )
@@ -869,7 +947,7 @@ mod tests {
             Ok(_) => panic!("unsupported schema marker was accepted"),
             Err(error) => error,
         };
-        assert!(error.to_string().contains("refusing to reset"));
+        assert!(error.to_string().contains("refusing to open"));
 
         let unchanged = DbStore::connect(&config.database_url().unwrap())
             .await

--- a/crates/tidebreak-server/src/gateway_runtime.rs
+++ b/crates/tidebreak-server/src/gateway_runtime.rs
@@ -4478,12 +4478,12 @@ mod tests {
         );
     }
 
-    /// The durability the policy file exists for: a pre-v1 schema-epoch
-    /// reset deletes the SQLite profile, and the provisioned policy — a
-    /// sidecar file in the data directory — must survive it. The session it
-    /// authorizes is then retained: before the policy lived in the file, the
-    /// reset resolved the profile unmanaged and boot retired the session,
-    /// forcing a full re-pair after every epoch bump.
+    /// The durability the policy file exists for: a profile below the
+    /// migration pin is deleted and rebuilt on first boot, and the
+    /// provisioned policy — a sidecar file in the data directory — must
+    /// survive that. The session it authorizes is then retained: before the
+    /// policy lived in the file, the reset resolved the profile unmanaged and
+    /// boot retired the session, forcing a full re-pair.
     #[tokio::test]
     async fn a_schema_epoch_reset_keeps_the_policy_and_its_session() {
         let directory = tempfile::tempdir().unwrap();

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1616,8 +1616,8 @@ async fn bind_inner(
     let os_policy: Arc<dyn managed_policy::OsPolicySource> =
         managed_policy::platform_source(&config);
     // The provisioned policy's durable home is the sidecar file in the data
-    // directory, not the SQLite profile: a pre-v1 schema-epoch reset deletes
-    // the database, and the policy (and with it the gateway session's
+    // directory, not the SQLite profile: a profile below the migration pin is
+    // deleted and rebuilt, and the policy (and with it the gateway session's
     // authorization) must survive that. One instance, shared the same way.
     let provisioned_policy: Arc<dyn managed_policy::ProvisionedPolicySource> = Arc::new(
         managed_policy::ProvisionedPolicyFile::in_data_dir(&config.data_dir),

--- a/crates/tidebreak-server/src/managed_policy.rs
+++ b/crates/tidebreak-server/src/managed_policy.rs
@@ -1109,7 +1109,8 @@ pub(crate) async fn import_legacy_setting(
         Err(_) => {
             tracing::warn!(
                 "legacy provisioned policy setting does not decode; \
-                 leaving it for the next schema-epoch reset to remove"
+                 leaving it, since the sidecar file is what this profile \
+                 reads and the row is inert"
             );
             Ok(())
         }

--- a/crates/tidebreak-server/src/managed_policy.rs
+++ b/crates/tidebreak-server/src/managed_policy.rs
@@ -41,9 +41,11 @@ const PROVISIONED_POLICY_FILE: &str = "gateway-policy.json";
 
 /// The settings key the provisioned policy lived under before it moved to
 /// [`PROVISIONED_POLICY_FILE`]. Read once per boot by
-/// [`import_legacy_setting`]; never written or deleted — pre-v1 epoch
-/// squashes remove the row naturally, and the [`Store`] API grows no delete
-/// for this.
+/// [`import_legacy_setting`]; never written or deleted. It used to be swept by
+/// the next epoch reset, which no longer happens for a profile at or above the
+/// migration pin (decision 61), so on those the row simply stays. It is inert
+/// while the sidecar exists, which is the case for every profile that has
+/// booted since the move.
 const LEGACY_SETTING_KEY: &str = "managed_policy_v1";
 
 /// The key every OS artifact stores the asserted URL under: the Windows

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -98,8 +98,9 @@ pair. Nothing else: no git library, no editor component, no diff library
 
 ## Data model
 
-Baseline schema edit plus a `DESKTOP_SCHEMA_EPOCH` bump, per
-[`0002`](decisions/0002-pre-v1-schema-and-persisted-format-mutability.md).
+A schema change here is an appended migration, per
+[`0061`](decisions/0061-schema-changes-are-migrations.md). The tables below
+describe the current schema, not the frozen baseline.
 
 - **`code_repo`** — `id`, `root_path` (unique, canonical toplevel),
   `display_name`, `default_base_ref`, `branch_prefix`, `setup_script`,

--- a/docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md
+++ b/docs/decisions/0002-pre-v1-schema-and-persisted-format-mutability.md
@@ -1,6 +1,6 @@
 # 2. Pre-v1 Schema and Persisted-Format Mutability
 
-- Status: Accepted
+- Status: Superseded by [decision 61](0061-schema-changes-are-migrations.md)
 - Date: 2026-08-07
 - Owners: core
 - Related: [`crates/tidebreak-core/src/db/migration.rs`](../../crates/tidebreak-core/src/db/migration.rs)

--- a/docs/decisions/0061-schema-changes-are-migrations.md
+++ b/docs/decisions/0061-schema-changes-are-migrations.md
@@ -1,0 +1,180 @@
+# 61. Schema Changes Are Migrations, Not Database Resets
+
+- Status: Proposed
+- Date: 2026-08-21
+- Owners: core
+- Related: [`crates/tidebreak-core/src/db/migration.rs`](../../crates/tidebreak-core/src/db/migration.rs)
+  (the chain and its frozen baseline),
+  [`crates/tidebreak-server/src/desktop_schema.rs`](../../crates/tidebreak-server/src/desktop_schema.rs)
+  (`LAST_RESET_EPOCH` and the convergence it drives),
+  [1.0.0 checklist](../releases.md#preparing-and-shipping-100) item 2
+- Supersedes: [decision 2](0002-pre-v1-schema-and-persisted-format-mutability.md)
+
+## Context
+
+Decision 2 made a pre-v1 schema change a baseline edit plus a
+`DESKTOP_SCHEMA_EPOCH` bump, and the bump deleted the local database. It said
+the window closes at `1.0.0` and put the inversion on the 1.0 checklist.
+
+**What the window actually cost.** Eleven epoch bumps between 2026-08-12 and
+2026-08-21, eight of them after the baseline squash on 2026-08-14 — roughly one
+wipe a day. Eight are code-mode work. Each one deletes every local chat, every
+code session, and every code turn on every contributor's machine, and strands
+the worktrees those sessions were driving.
+
+**The bump is a judgment call, and it has been missed twice.** Auditing every
+baseline-touching commit since the 2026-08-14 squash against the epoch in the
+same commit: #2289 added `code_session.kind` and #2453 added
+`code_session.reasoning_effort` and its CHECK, and neither moved the integer.
+Both regenerated the fixture instead, which is what a green run looks like
+either way — the fixture makes a baseline edit visible, it cannot decide
+whether the epoch owes a bump. Both were repaired by chance, because the next
+change that *did* bump rebuilt the profile from the current baseline. The
+window between an un-bumped edit and the next bump is a contributor booting
+into a schema that is missing a column, and the only symptom is a query
+failing.
+
+Freezing the baseline removes the judgment call rather than reinforcing it.
+After this, a fixture diff does not mean "decide whether to bump" — it means
+"you edited the wrong file".
+
+**The window was never open for self-host.** The epoch is a file beside SQLite;
+PostgreSQL has no equivalent and no reset. `Baseline::up` handles an existing
+self-host database by returning early, so it holds whatever the baseline said
+on the day it first ran and gains nothing added since. Decision 2 described
+local data as disposable and said nothing about this, because when it was
+written self-host did not exist. The durable backend has been running without a
+schema lifecycle the whole time.
+
+**The four steps that justified waiting have landed.** Decision 48's remaining
+steps were the argument for keeping the window open: they churn the schema, and
+migrating each intermediate shape buys nothing. Steps 2, 3, and 4 are merged
+(#2450, #2474, #2487). Step 5 (#2313) is the one change still big enough to be
+worth a squash rather than a migration, and a squash is available at any time
+while the product major is `0` — it is not a single shot that has to be saved.
+
+## Decision
+
+**A schema change is an appended migration.** `Baseline` is frozen. Anything
+that changes the schema goes into `Migrator::migrations`, in order, where it
+reaches a database that already exists as well as a fresh one.
+
+**`LAST_RESET_EPOCH` is a pin, not a counter.** It names the baseline the chain
+starts from, and it does not move for a schema change. It moves once more, at
+the `1.0.0` squash, when the chain collapses back into a single baseline.
+
+**Every existing profile converges or is reset exactly once, on the next
+boot.** A profile at the pin holds precisely the baseline the chain starts
+from, so its marker is re-stamped and its data kept. A profile below the pin
+holds a baseline revision that was edited in place and never recorded, so no
+migration can know what it contains; it takes one last reset. Neither path runs
+twice.
+
+Convergence rests on one thing being true at the moment this lands: the last
+baseline edit on `main` is the one that set the pin. An un-bumped edit merged
+after it would mean profiles at the pin are missing a column and would now keep
+missing it, since the reset that used to repair that by accident is gone. That
+is checkable before merging, and it is the last time it needs checking —
+afterwards the baseline is frozen and `the_schema_baseline_is_pinned` refuses
+the edit outright.
+
+**Compatibility obligations for persisted formats resume.** Decision 2
+suspended `#[serde(alias)]`, backfills, and data-preserving migrations because
+the epoch deleted the rows. It no longer does. A journal payload change now
+either stays readable from the shape already on disk, or migrates the rows that
+hold it. The two journal fixtures' failure messages say so.
+
+**Self-host keeps the gap it already has, and it is now bounded.** Nothing here
+repairs a PostgreSQL database created before the pin — the tables it is missing
+depend on the day it first ran, which nothing recorded. What changes is that
+every schema change from here reaches it. Closing the pre-pin gap is tracked
+separately (#2490); it needs a schema pin inside the database, which SQLite got
+as a sidecar file and PostgreSQL never got at all.
+
+Deliberately excluded: the product-major guard stays. A `1.0.0` binary still
+refuses to open a local profile until the rest of the 1.0 checklist is done,
+because this record settles how the schema changes, not what compatibility
+surface the release commits to.
+
+## Alternatives Considered
+
+**Keep the epoch until #2313 lands, as #2428 originally said.** The order this
+record follows instead. Rejected because the gate was never the squash — it was
+churn, and the three steps that churned the schema hardest have landed. Waiting
+for #2313 buys one tidier chain and costs another wipe a day until it merges,
+on a step whose own timing depends on remote hosting (#2320–#2322).
+
+**Flip at `1.0.0`, as decision 2 planned.** The status quo, and the cheapest
+option to write down. Rejected for the self-host reason above: the durable
+backend has no lifecycle at all today, and "we will build one at 1.0" leaves
+every self-host deployment between now and then holding a schema nothing
+maintains. It also front-loads the entire migration apparatus into the release
+that can least afford surprises.
+
+**Re-squash the baseline under a new name as part of this change.** Tidier: the
+chain would start from today's schema rather than August 14's, and the two
+owner migrations would disappear into it. Rejected because a rename makes
+SeaORM re-run the baseline against every database that recorded the old name,
+which is every database that exists. The rename has to happen where a reset is
+already happening — at the 1.0 squash, or alongside #2313.
+
+**Reset every profile once at the flip, rather than converging the ones at the
+pin.** Simpler by one match arm, and it would make the transition uniform.
+Rejected because it throws away exactly the data this record exists to keep,
+on the one boot where keeping it is free: a profile at the pin already holds
+the baseline the chain starts from. Spending a wipe to avoid an arm that a test
+covers is the wrong trade.
+
+## Consequences
+
+Local data survives a schema change, and so a schema change costs more to
+write. Adding a table means writing it once as a migration rather than editing
+a baseline file, and a change to an existing column means saying how the rows
+already in it get there.
+
+The journal payload becomes a compatibility surface again. That is the sharpest
+new constraint, and the one most likely to be forgotten: `list_events` collects
+into `Result<Vec<_>>`, so a single unreadable row fails a whole chat's history
+rather than one message. The fixtures make the change visible; they cannot make
+it compatible.
+
+The pre-pin self-host gap is unchanged and now stated. Anyone running a
+PostgreSQL deployment created before this lands should recreate it; #2490 is
+what removes the "should".
+
+`reset_pre_v1_state` stays reachable, for profiles below the pin and for a
+database with no marker at all. It stops being reachable when those profiles
+are gone, which is not a date anyone can name — so the code keeps its tests
+rather than being deleted on a guess.
+
+Revisit this at the `1.0.0` squash, which is the next time the baseline is
+supposed to move, or earlier if the pre-pin self-host gap turns out to need a
+different shape than a pin row.
+
+## Validation
+
+`a_pre_v1_profile_at_the_pin_keeps_its_data_and_converges` boots a profile
+carrying the last epoch-driven marker and asserts both halves: the chat is
+still there, and the marker has been re-stamped so the next boot takes the
+migrated path. This is the one path that runs once per profile and then never
+again, which is why it is pinned by a test rather than by a manual check.
+
+`a_profile_below_the_pin_takes_one_last_reset` covers the other side, and
+`future_epoch_fails_closed_without_destroying_database` covers a marker this
+binary does not understand — it refuses to open rather than resetting, so a
+newer profile is never destroyed by an older binary.
+
+`a_stepwise_upgrade_lands_on_the_fresh_schema` asserts that a database that
+stopped at the baseline and later took the rest of the chain describes the same
+schema as one built in a single pass. Without it the chain and the baseline can
+disagree with nothing to notice, because each database is internally
+consistent.
+
+`the_schema_baseline_is_pinned` fails on any baseline edit, on both backends,
+and its message says to append a migration instead of regenerating the fixture.
+
+The case a plausible wrong implementation still passes: regenerating any of
+these fixtures with its `UPDATE_*` variable is green. The fixtures make a change
+visible; they cannot decide whether it is compatible. A green suite is not
+evidence this record is being followed — the absence of a fixture diff in a
+schema-touching PR is.

--- a/docs/gateway-boundary.md
+++ b/docs/gateway-boundary.md
@@ -48,12 +48,12 @@ Policy resolution has three tiers, strongest first:
 2. **Provisioned.** The sticky policy file `gateway-policy.json` in the
    profile's data directory, written only by a completed pairing (below).
    User-consented, and replaceable by the same consent that created it. It
-   is deliberately a sidecar file rather than a database row: a pre-v1
-   schema-epoch reset deletes the SQLite profile, and the policy must
-   survive that — losing it would resolve the profile unmanaged and orphan
-   the session below. Profiles paired before the move are imported once at
-   boot from the legacy `managed_policy_v1` settings row, which the next
-   epoch reset then removes naturally.
+   is deliberately a sidecar file rather than a database row: a profile
+   below the migration pin is deleted and rebuilt on first boot, and the
+   policy must survive that — losing it would resolve the profile unmanaged
+   and orphan the session below. Profiles paired before the move are imported
+   once at boot from the legacy `managed_policy_v1` settings row, which stays
+   put and inert once the sidecar exists.
 3. **Open.** Neither present; the unmanaged product, which has no gateway
    surface at all.
 

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -100,19 +100,19 @@ The main local data is easy to recognize:
 | Location | Meaning |
 | --- | --- |
 | `tidebreak.db` | SQLite operational source of truth |
-| `tidebreak-schema.json` | pre-v1 local SQLite schema epoch |
-| `orphaned-code-worktrees.json` | code worktrees an epoch reset left on disk |
+| `tidebreak-schema.json` | which schema pin this profile holds |
+| `orphaned-code-worktrees.json` | code worktrees a reset left on disk |
 | `blobs/` | retained immutable document bytes |
 | `tidebreak.lock` | proof that one process owns this data directory |
 | OS keychain | provider credentials, kept outside the database — one item per profile |
 
-While the app remains at version `0.0.0`, baseline migrations may be rewritten
-instead of accumulated. The local SQLite schema epoch makes that explicit for
-both the desktop app and a headless `tidebreak serve` using the desktop profile.
-Opening an older pre-v1 database rebuilds `tidebreak.db` and its SQLite journals
-so stale state cannot survive the reset. A current epoch preserves both stores.
-Startup also removes the retired `vectors/` directory when it is safe to open
-the current schema. Code worktrees are the exception to "rebuilt": they live
+A schema change is an appended migration, so local data survives it
+([decision 61](decisions/0061-schema-changes-are-migrations.md)). The marker
+records which pin the profile holds. A profile at the pin is kept and its
+marker re-stamped; a profile below it predates the migration chain and holds a
+schema nothing recorded, so opening it rebuilds `tidebreak.db` and its SQLite
+journals once, and never again. Startup also removes the retired `vectors/`
+directory when it is safe to open the current schema. Code worktrees are the exception to "rebuilt": they live
 outside the data directory because they hold uncommitted user work, so a reset
 records them in `orphaned-code-worktrees.json` and leaves the trees, their
 `.git/worktrees` entries, and their branches alone. Unknown, newer, or post-v1 lifecycle markers fail closed so
@@ -128,11 +128,12 @@ executor identity, broker grants, and the broker audit log are preserved;
 native recovery still has to validate them against the new canonical database
 and fails closed when their old conversation no longer exists.
 
-When the baseline changes incompatibly during pre-v1 development, bump
-`DESKTOP_SCHEMA_EPOCH` in `crates/tidebreak-server/src/desktop_schema.rs` in the
-same change. `the_schema_baseline_is_pinned` fails until you do, and names the
-bump in its message. The epoch is a deliberate reset boundary, not a
-replacement for migrations after the schema stabilizes for v1.
+To change the schema, append a migration to `Migrator::migrations` in
+`crates/tidebreak-core/src/db/migration.rs`. Do not edit the baseline —
+`the_schema_baseline_is_pinned` fails on that, and says so, because an edit
+there reaches a fresh database and no existing one. `LAST_RESET_EPOCH` in
+`crates/tidebreak-server/src/desktop_schema.rs` names the baseline the chain
+starts from and does not move for a schema change.
 
 Non-secret provider settings and the default model live in the operational
 store and can change while the process runs. Model routing observes those
@@ -948,13 +949,10 @@ SQLite coverage, and PostgreSQL coverage when database locking or transactional
 semantics are involved. Keep public routes thin: orchestration belongs in the
 server, while reusable state transitions belong in `tidebreak-core`.
 
-Before v1, there are no deployed desktop users to migrate. Schema work edits
-the baseline in place and bumps the epoch above, which makes the already-written
-local database disposable. A durable database has no such reset, so anything
-that must reach one is an appended migration in
-`crates/tidebreak-core/src/db/migration.rs` instead — the baseline already ran
-there under a recorded name, and SeaORM cannot see that the statements behind
-that name changed. `a_stepwise_upgrade_lands_on_the_fresh_schema` fails when an
+Schema work appends a migration rather than editing the baseline, because a
+baseline edit reaches a fresh database and no existing one: SeaORM records one
+name per migration and cannot see that the statements behind an already-recorded
+name changed. `a_stepwise_upgrade_lands_on_the_fresh_schema` fails when an
 appended migration and the baseline disagree. Squash the chain back into one
 baseline when the schema stabilizes for v1.
 

--- a/docs/how-tidebreak-works.md
+++ b/docs/how-tidebreak-works.md
@@ -109,15 +109,18 @@ The main local data is easy to recognize:
 A schema change is an appended migration, so local data survives it
 ([decision 61](decisions/0061-schema-changes-are-migrations.md)). The marker
 records which pin the profile holds. A profile at the pin is kept and its
-marker re-stamped; a profile below it predates the migration chain and holds a
-schema nothing recorded, so opening it rebuilds `tidebreak.db` and its SQLite
-journals once, and never again. Startup also removes the retired `vectors/`
-directory when it is safe to open the current schema. Code worktrees are the exception to "rebuilt": they live
-outside the data directory because they hold uncommitted user work, so a reset
-records them in `orphaned-code-worktrees.json` and leaves the trees, their
-`.git/worktrees` entries, and their branches alone. Unknown, newer, or post-v1 lifecycle markers fail closed so
-a prerelease binary cannot silently erase a future stable database, and the
-destructive path is disabled at runtime for package major version 1 and later.
+marker re-stamped. A profile below the pin predates the migration chain and
+holds a schema nothing recorded, so opening it rebuilds `tidebreak.db` and its
+SQLite journals once, and never again. Startup also removes the retired
+`vectors/` directory when it is safe to open the current schema.
+
+Code worktrees are the exception to "rebuilt": they live outside the data
+directory because they hold uncommitted user work, so a reset records them in
+`orphaned-code-worktrees.json` and leaves the trees, their `.git/worktrees`
+entries, and their branches alone. Unknown or newer lifecycle markers fail
+closed so a prerelease binary cannot silently erase a future stable database,
+and the destructive path is disabled at runtime for package major version 1
+and later.
 
 Source bytes under `blobs/` are physically retained during the reset, but their
 database records are gone. They are therefore unreachable through the product

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -598,15 +598,16 @@ its local profile until this checklist is complete:
 1. Define the stable compatibility surface: persisted local data,
    configuration, CLI/API behavior, extension protocols, and supported upgrade
    window.
-2. Replace the pre-v1-only guard in
-   `crates/tidebreak-server/src/desktop_schema.rs` with the durable v1 lifecycle.
-   Re-squash the in-place `Baseline` again into a single clean first
-   migration — the public-opening squash is not the last v0 edit — and invert
-   [decision record 2](decisions/0002-pre-v1-schema-and-persisted-format-mutability.md)
-   in the same change: the journal and schema-baseline fixtures' failure
-   messages flip back from "bump the epoch" to "add an alias or write a
-   migration", the baseline becomes the first entry in a real migration chain,
-   and `reset_pre_v1_state` stops being reachable.
+2. Replace the product-major guard in
+   `crates/tidebreak-server/src/desktop_schema.rs` with the v1 lifecycle. Most
+   of what this item used to describe is already done:
+   [decision 61](decisions/0061-schema-changes-are-migrations.md) froze the
+   baseline, made every schema change an appended migration, and flipped the
+   journal fixtures' failure messages back to "add an alias or write a
+   migration". What is left is the release commitment itself — squash the chain
+   into a single clean first migration for `1.0.0`, move `LAST_RESET_EPOCH` to
+   that squash, and decide whether `reset_pre_v1_state` can finally go, which
+   depends on whether any profile below the pin can still reach a v1 binary.
    The lifecycle must preserve supported data, migrate transactionally, fail
    safely, and test upgrades from the latest 0.x state.
 3. Verify the provisioned release pipeline with clean install and 0.x upgrade


### PR DESCRIPTION
Closes #2428. Decision record 61 supersedes record 2.

A schema change stops deleting your database. `Baseline` is frozen, every
change after it is an appended migration, and the epoch becomes a pin that does
not move.

## Why now

The window has been running at about one wipe a day — eleven epoch bumps
between Aug 12 and Aug 21, eight of them since the squash. And it never covered
self-host: the epoch is a file beside SQLite, PostgreSQL has neither the file
nor a reset, so the durable backend has had no schema lifecycle at all.

#2428 originally gated this on #2313. That order came from treating the squash
as one-shot; it isn't, while the product major is `0`. The real gate was churn,
and the three steps that churned the schema hardest — #2450, #2474, #2487 —
have landed.

## What happens to an existing profile

Once, on the next boot, and then never again:

| Marker | What happens |
|---|---|
| At the pin (`pre_v1`, 41) | Re-stamped. Chats, sessions and turns kept. |
| Below the pin | One last reset — its schema is a baseline revision nothing recorded. |
| No marker | Reset, as before. |
| Anything else | Refuses to open. Never destroys. |

The convergence arm is the point, and it is the one path that runs once per
profile and can never be re-tested afterwards, so
`a_pre_v1_profile_at_the_pin_keeps_its_data_and_converges` asserts both halves:
the chat is still there, and the marker moved.

## What the audit turned up

Every baseline-touching commit since the Aug 14 squash, checked against the
epoch in the same commit:

```
#2289  code_session.kind              epoch stayed 33
#2453  code_session.reasoning_effort  epoch stayed 39
#2487  code_session_image             epoch stayed 40   (fixed by #2494)
```

Each added a real column or table and regenerated the fixture without bumping.
The first two were repaired by luck — the next change that did bump rebuilt the
profile from the current baseline. The third reached `main` and broke image
attachments on every existing profile until #2494. In between, a contributor is
booting into a schema missing a column.

That is the failure mode decision record 2 named and accepted: the fixture makes
a baseline edit visible, it cannot decide whether the epoch owes a bump.
Freezing the baseline removes the judgment call instead of reinforcing it —
afterwards a fixture diff means "you edited the wrong file", not "decide
something".

## The tripwires flip with it

- `the_schema_baseline_is_pinned` says the baseline is frozen and to append a
  migration, because an edit there now reaches a fresh database and no existing
  one.
- Both journal fixtures stop being change detectors and become compatibility
  contracts again. Rows written by an older binary survive now, so a payload
  change needs a `#[serde(alias)]` or a migration for the rows already on disk.
  `list_events` collects into `Result<Vec<_>>`, so one unreadable row still
  fails a whole chat's history.

## Precondition, now satisfied

Convergence is only safe if `main`'s last baseline edit is the one that set the
pin. #2487 broke that — it added `code_session_image` to the baseline and left
the epoch at 40, so a converged profile would have been missing that table
permanently. #2494 bumped to 41 after it, so `main`'s baseline is again exactly
what the pin rebuilds to, and this branch pins 41.

That is the last time anyone has to check. Afterwards the baseline is frozen and
the tripwire refuses the edit outright.

## Deliberately not in scope

A self-host database created before the pin still holds whatever the baseline
said the day it first ran. Nothing here repairs that — the fix needs a pin row
inside the database, which SQLite got as a sidecar and PostgreSQL never got.
Filed as #2490, and it rides the next squash since adding the row is itself a
baseline edit.
