### PR TITLE
feat(code): attachments reach every engine as files in the worktree

### DIFF
--- a/crates/tidebreak-core/src/image.rs
+++ b/crates/tidebreak-core/src/image.rs
@@ -100,6 +100,22 @@ impl ImageMediaType {
         }
     }
 
+    /// The file extension to write these bytes under, without the dot.
+    ///
+    /// Used where an attachment is materialized as a file rather than sent
+    /// over a protocol: an engine that reads the image off disk needs the
+    /// name to say what it is, both for its own sniffing and for a person
+    /// reading the path in the prompt.
+    #[must_use]
+    pub const fn extension(self) -> &'static str {
+        match self {
+            Self::Png => "png",
+            Self::Jpeg => "jpg",
+            Self::Webp => "webp",
+            Self::Gif => "gif",
+        }
+    }
+
     /// Identify a supported raster format from its file signature.
     ///
     /// This deliberately recognizes only the provider-safe formats represented

--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -329,13 +329,6 @@ export type ComposerProps = {
   plugins?: ComposerPlugins;
   slash?: ComposerSlash;
   images?: ComposerImages;
-  /**
-   * Why this surface has no image path, when it has none. A paste or drop
-   * carrying an image is claimed and answered with this sentence instead of
-   * falling through to the textarea, where the clipboard's text flavour — a
-   * file URL — lands in the draft and reads as an attachment that worked.
-   */
-  imagesUnavailable?: string;
   files?: ComposerFiles;
   /** Paths the agent can already read, shown as chips and named on send. */
   workspaceFiles?: ComposerWorkspaceFiles;
@@ -384,7 +377,6 @@ export function Composer({
   plugins,
   slash,
   images,
-  imagesUnavailable,
   files,
   workspaceFiles,
   folders,
@@ -436,7 +428,6 @@ export function Composer({
   // is its own: there is no token in the draft to read one from.
   const [panelQuery, setPanelQuery] = useState<string | null>(null);
   const { confirm, dialog: confirmDialog } = useConfirm();
-  const [imagesRefused, setImagesRefused] = useState<string | null>(null);
   const inputDisabled = disabled;
   const active = busy && activeTurnId !== null;
   const sendMode = useUiStore((state) => state.activeTurnSendMode);
@@ -470,7 +461,6 @@ export function Composer({
     savedDraftRef.current = "";
     setSlashToken(null);
     setMentionToken(null);
-    setImagesRefused(null);
   }, [resetKey]);
 
   const invokedSkills = slash?.invoked ?? [];
@@ -802,9 +792,6 @@ export function Composer({
     historyIndexRef.current = null;
     rememberSelection(event.target);
     syncSlashToken(event.target.value, event.target.selectionStart);
-    // Typing is the acknowledgement: a refusal from the last paste has been
-    // read by the time the reader is writing again.
-    setImagesRefused(null);
     onDraftChange(event.target.value);
   }
 
@@ -827,18 +814,9 @@ export function Composer({
    * reader chose. A paste that carries no image is left alone: it is text.
    */
   function acceptTransfer(transfer: DataTransfer | null): boolean {
-    if (inputDisabled) return false;
+    if (!images || inputDisabled) return false;
     const files = imageFilesFrom(transfer);
     if (files.length === 0) return false;
-    if (!images) {
-      // Nothing here can hold an image. Claim it anyway where there is an
-      // answer to give, so the reader gets the answer instead of a file URL
-      // in the draft.
-      if (!imagesUnavailable) return false;
-      setImagesRefused(imagesUnavailable);
-      return true;
-    }
-    setImagesRefused(null);
     images.onAttachFiles(files);
     return true;
   }
@@ -1324,11 +1302,6 @@ export function Composer({
         <span className="text-xs text-destructive" role="alert">
           {"Couldn’t attach image: "}
           {images.error}
-        </span>
-      )}
-      {imagesRefused && (
-        <span className="text-xs text-destructive" role="alert">
-          {imagesRefused}
         </span>
       )}
       {images?.unsupportedModel && images.items.length > 0 && (

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -681,7 +681,6 @@ describe("CodeComposer", () => {
         running={false}
         permissionMode="ask"
         sessionId="sess-1"
-        imageInput
         onSend={vi.fn()}
         onInterrupt={vi.fn()}
       />,
@@ -701,7 +700,9 @@ describe("CodeComposer", () => {
     expect(text.defaultPrevented).toBe(false);
   });
 
-  it("answers an image paste on an engine with no image path", () => {
+  it("attaches an image on an engine with no protocol for one", () => {
+    // The bytes reach the engine as a file under the checkout, so the
+    // composer offers attachment whatever the engine's own input path is.
     renderComposer(
       <CodeComposer
         running={false}
@@ -714,27 +715,14 @@ describe("CodeComposer", () => {
     );
 
     const box = screen.getByRole("textbox", { name: "Message" });
-    // Left alone, the clipboard's text flavour — a file URL — would land in
-    // the draft and read as an attachment that took.
     const image = pasteOn(box, [
       new File([new Uint8Array([1, 2, 3, 4])], "shot.png", {
         type: "image/png",
       }),
     ]);
     expect(image.defaultPrevented).toBe(true);
-    expect(screen.queryByLabelText("Attached images")).toBeNull();
-    expect(
-      screen.getByText("Tidebreak can’t send images to opencode yet."),
-    ).toBeInTheDocument();
-
-    // Writing again is the acknowledgement.
-    fireEvent.change(box, { target: { value: "describe it instead" } });
-    expect(
-      screen.queryByText("Tidebreak can’t send images to opencode yet."),
-    ).toBeNull();
-
-    const text = pasteOn(box, []);
-    expect(text.defaultPrevented).toBe(false);
+    expect(screen.getByLabelText("Attached images")).toBeInTheDocument();
+    expect(screen.getByText("shot.png")).toBeInTheDocument();
   });
 
   it("opens the image picker from the tools menu", async () => {
@@ -744,7 +732,6 @@ describe("CodeComposer", () => {
         running={false}
         permissionMode="ask"
         sessionId="sess-1"
-        imageInput
         onSend={vi.fn()}
         onInterrupt={vi.fn()}
       />,
@@ -767,7 +754,6 @@ describe("CodeComposer", () => {
         running={false}
         permissionMode="ask"
         sessionId="sess-1"
-        imageInput
         onSend={onSend}
         onInterrupt={vi.fn()}
       />,
@@ -803,7 +789,6 @@ describe("CodeComposer", () => {
         running={false}
         permissionMode="ask"
         sessionId="sess-1"
-        imageInput
         onSend={onSend}
         onInterrupt={vi.fn()}
       />,
@@ -836,7 +821,6 @@ describe("CodeComposer", () => {
         running={false}
         permissionMode="ask"
         sessionId="sess-1"
-        imageInput
         onSend={onSend}
         onInterrupt={vi.fn()}
       />,

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -46,7 +46,6 @@ import {
   codeModelVendor,
   effortLadder,
   groupCodeModelOptions,
-  noImagePathNote,
   type CodeModelOption,
   PERMISSION_MODE_UNAVAILABLE_REASON,
   SESSION_PERMISSION_MODE_LOCKED,
@@ -567,7 +566,6 @@ export function CodeComposer({
   contextUsage,
   slashCommands,
   searchPaths,
-  imageInput = false,
   workspaceFiles,
   onSend,
   onSteer,
@@ -614,8 +612,6 @@ export function CodeComposer({
   slashCommands?: readonly { name: string; description: string }[];
   /** Name-matched workspace paths for `@` completion. */
   searchPaths?: (query: string) => Promise<readonly string[]>;
-  /** The doctor said this engine consumes images on its input path. */
-  imageInput?: boolean;
   /**
    * Files already in the worktree, shown as chips and named after the
    * message. A fork's transcript arrives this way.
@@ -929,31 +925,20 @@ export function CodeComposer({
         contextUsage={contextUsage}
         pathMentions={pathMentions}
         slash={slash}
-        imagesUnavailable={
-          harness && !imageInput ? noImagePathNote(harness) : undefined
-        }
-        images={
-          imageInput
-            ? {
-                items: images.attachments,
-                error: images.error,
-                unsupportedModel: null,
-                onAttachFiles: images.attachFiles,
-                onRemove: images.remove,
-                onRetry: images.retry,
-              }
-            : undefined
-        }
-        files={
-          imageInput
-            ? {
-                items: [],
-                attaching: false,
-                onAttach: () => imageInputRef.current?.click(),
-                onRemove: () => undefined,
-              }
-            : undefined
-        }
+        images={{
+          items: images.attachments,
+          error: images.error,
+          unsupportedModel: null,
+          onAttachFiles: images.attachFiles,
+          onRemove: images.remove,
+          onRetry: images.retry,
+        }}
+        files={{
+          items: [],
+          attaching: false,
+          onAttach: () => imageInputRef.current?.click(),
+          onRemove: () => undefined,
+        }}
         workspaceFiles={workspaceFiles}
         onDraftChange={(value) => {
           draftRef.current = value;
@@ -972,21 +957,19 @@ export function CodeComposer({
         steerPending={steerPending}
         steerStatus={steerStatus}
       />
-      {imageInput && (
-        <input
-          ref={imageInputRef}
-          type="file"
-          accept={IMAGE_MEDIA_TYPES.join(",")}
-          multiple
-          className="hidden"
-          aria-label="Attach images"
-          onChange={(event) => {
-            const files = [...(event.target.files ?? [])];
-            event.target.value = "";
-            images.attachFiles(files);
-          }}
-        />
-      )}
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept={IMAGE_MEDIA_TYPES.join(",")}
+        multiple
+        className="hidden"
+        aria-label="Attach images"
+        onChange={(event) => {
+          const files = [...(event.target.files ?? [])];
+          event.target.value = "";
+          images.attachFiles(files);
+        }}
+      />
       {notice && (
         <p
           role="alert"

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -2054,7 +2054,6 @@ function CodeSessionPane({
           queued={queued}
           lastTurnBeganId={lastTurnBeganId}
           slashCommands={doctorEntry?.commands}
-          imageInput={doctorEntry?.caps.image_input === "supported"}
           searchPaths={(query) =>
             client
               .listCodeWorkspaceTree(workspaceId, { query })

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -103,18 +103,6 @@ export const SESSION_PERMISSION_MODE_LOCKED =
 export const UNSUPERVISED_AUTO_NOTE =
   "This engine has no approval channel: in Auto, every action runs without asking.";
 
-/**
- * Stated when a paste or drop carries an image the engine has no path for.
- *
- * Only Claude Code declares `image_input: supported`, and an adapter may not
- * declare it without a captured image round-trip. On the rest, an image the
- * composer accepted would be dropped on the way to the engine, so the paste is
- * refused where the reader can see it instead.
- */
-export function noImagePathNote(kind: HarnessKind): string {
-  return `Tidebreak can’t send images to ${HARNESS_LABELS[kind]} yet.`;
-}
-
 /** Stated wherever Allow is offered (decision 0039). */
 export const ALLOW_ALL_NOTE =
   "This engine's permission system is off: every action runs without asking.";

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -11,7 +11,7 @@
 //! worktree of the same repository reads.
 
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use tidebreak_core::{
     CodeEvent, CodeSession, CodeTurn, CodeTurnId, HarnessKind, SequencedCodeEvent, ToolDetail,
@@ -58,57 +58,15 @@ pub(crate) async fn write_transcript(
     events: &[SequencedCodeEvent],
 ) -> std::io::Result<WrittenTranscript> {
     let rendered = render_transcript(session, turns, events);
-    let dir = worktree.join(FORKS_DIR);
-    tokio::fs::create_dir_all(&dir).await?;
-    ignore_scratch_dir(worktree).await?;
+    let dir = super::scratch::scratch_dir(worktree, FORKS_DIR).await?;
     let path = dir.join(format!("{}.md", session.id));
-    publish(&path, rendered.markdown.as_bytes()).await?;
+    super::scratch::publish(&path, rendered.markdown.as_bytes()).await?;
     Ok(WrittenTranscript {
         path: format!("{FORKS_DIR}/{}.md", session.id),
         byte_len: rendered.markdown.len() as u64,
         turns: rendered.turns,
         truncated: rendered.truncated,
     })
-}
-
-/// Put bytes at `path` in one step, leaving nothing behind if it fails.
-///
-/// The staged name carries a fresh id rather than a fixed `.part` suffix, so
-/// concurrent writers stage separately and neither can be caught writing over
-/// the other's half-written file.
-async fn publish(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let name = path
-        .file_name()
-        .ok_or_else(|| std::io::Error::other("the transcript path names no file"))?;
-    let staged = path.with_file_name(format!(
-        "{}.{}.part",
-        name.to_string_lossy(),
-        uuid::Uuid::new_v4()
-    ));
-    let written = tokio::fs::write(&staged, bytes).await;
-    let published = match written {
-        Ok(()) => tokio::fs::rename(&staged, path).await,
-        Err(err) => Err(err),
-    };
-    if published.is_err() {
-        let _ = tokio::fs::remove_file(&staged).await;
-    }
-    published
-}
-
-/// Make `.tidebreak/` ignore itself.
-///
-/// A `.gitignore` holding `*` hides the directory and the ignore file with
-/// it. Writing here mutates nothing the reader tracks and nothing shared with
-/// their other worktrees, which the alternatives — the repository's own
-/// `.gitignore`, or `.git/info/exclude` — both do.
-async fn ignore_scratch_dir(worktree: &Path) -> std::io::Result<()> {
-    let scratch: PathBuf = worktree.join(".tidebreak");
-    let marker = scratch.join(".gitignore");
-    if tokio::fs::try_exists(&marker).await? {
-        return Ok(());
-    }
-    tokio::fs::write(&marker, "*\n").await
 }
 
 /// A rendered transcript and what had to be left out of it.

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod harness_install;
 pub(crate) mod recovery;
 pub(crate) mod runtime;
 pub(crate) mod scoped;
+pub(crate) mod scratch;
 pub(crate) mod session_worker;
 pub(crate) mod setup_script;
 pub(crate) mod terminal;

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -646,7 +646,11 @@ mod tests {
             session,
             engine,
             sink,
-            None,
+            crate::code::session_worker::AttachmentStore {
+                blobs: None,
+                worktree: _dir.path().join("wt"),
+                engine_reads_images: false,
+            },
             std::sync::Arc::new(tokio::sync::Mutex::new(())),
         );
         let (reply, _turn) = tokio::sync::oneshot::channel();

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -45,8 +45,8 @@ use super::gh::{
 use super::harness_install::HarnessInstallJobs;
 use super::recovery::{self, RecoveryAction};
 use super::session_worker::{
-    attach_engine, journal_event, queue_follow_up, spawn_session_worker, WorkerCommand,
-    WorkerError, WorkerHandle,
+    attach_engine, journal_event, queue_follow_up, spawn_session_worker, AttachmentStore,
+    WorkerCommand, WorkerError, WorkerHandle,
 };
 #[cfg(windows)]
 use super::worktree::repo_paths_equivalent;
@@ -1628,20 +1628,10 @@ impl CodeRuntime {
                 "session has ended",
             ));
         }
-        if !attachments.is_empty() {
-            let adapter = self.adapter(session.harness_kind)?;
-            let probe = self.probe(adapter.as_ref()).await;
-            let caps = adapter.capabilities(&probe);
-            if caps.image_input != CapLevel::Supported {
-                return Err(ServerError::unprocessable_kind(
-                    "unsupported_attachment",
-                    format!(
-                        "{harness} does not support image attachments",
-                        harness = session.harness_kind
-                    ),
-                ));
-            }
-        }
+        // No capability gate on attachments. An engine that states image input
+        // is handed the bytes on its own protocol; every other one is handed a
+        // file under the checkout and a path in the prompt, which is a thing
+        // each of them can already read. The worker picks between the two.
         let handle = self.require_worker(id)?;
         // Both stick: a composer choice is the session's from here on, exactly
         // as the engines' own pickers behave. The outer `Option` on effort is
@@ -2664,7 +2654,15 @@ impl CodeRuntime {
             attached.clone(),
             engine,
             sink,
-            Some(self.blobs.clone()),
+            AttachmentStore {
+                blobs: Some(self.blobs.clone()),
+                worktree: PathBuf::from(&workspace.worktree_path),
+                // Only an engine that states image input takes the bytes on
+                // its own protocol. The rest are handed paths under the
+                // checkout, which every engine can read.
+                engine_reads_images: adapter.capabilities(&probe).image_input
+                    == CapLevel::Supported,
+            },
             self.worktree_turn_lock(attached.workspace_id),
         );
         self.workers

--- a/crates/tidebreak-server/src/code/scratch.rs
+++ b/crates/tidebreak-server/src/code/scratch.rs
@@ -1,0 +1,67 @@
+//! `.tidebreak/`: the scratch directory Tidebreak writes into a worktree.
+//!
+//! Two things go here so far — a fork's transcript and a turn's attachments —
+//! and both exist for the same reason: an engine reads a file off disk with
+//! the tools it already has, so anything Tidebreak can put on disk reaches
+//! every engine without a protocol for it.
+//!
+//! The directory hides itself. A `.gitignore` holding `*` covers the tree and
+//! the marker with it, which keeps these files out of `git status` without
+//! touching the repository's own tracked ignore file or the shared
+//! `.git/info/exclude` that every other worktree of the same repository reads.
+
+use std::path::{Path, PathBuf};
+
+/// Root of the scratch tree, relative to the worktree.
+pub(crate) const SCRATCH_DIR: &str = ".tidebreak";
+
+/// Create the scratch tree, self-ignoring, and hand back an absolute path to
+/// one directory inside it.
+///
+/// `relative` is the whole path from the worktree root, so callers name their
+/// own subdirectory constant and this stays the only place that knows about
+/// the marker.
+pub(crate) async fn scratch_dir(worktree: &Path, relative: &str) -> std::io::Result<PathBuf> {
+    let dir = worktree.join(relative);
+    tokio::fs::create_dir_all(&dir).await?;
+    ignore_scratch_dir(worktree).await?;
+    Ok(dir)
+}
+
+/// Make `.tidebreak/` ignore itself.
+async fn ignore_scratch_dir(worktree: &Path) -> std::io::Result<()> {
+    let scratch: PathBuf = worktree.join(SCRATCH_DIR);
+    let marker = scratch.join(".gitignore");
+    if tokio::fs::try_exists(&marker).await? {
+        return Ok(());
+    }
+    tokio::fs::write(&marker, "*\n").await
+}
+
+/// Put bytes at `path` in one step, leaving nothing behind if it fails.
+///
+/// A reader can already be on the file — a re-fork writes over a transcript
+/// the last child is reading — so the write is published by rename and a
+/// reader sees one whole version or another, never the middle of one. The
+/// staged name carries a fresh id rather than a fixed `.part` suffix, so
+/// concurrent writers stage separately and neither can be caught writing over
+/// the other's half-written file.
+pub(crate) async fn publish(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::other("the published path names no file"))?;
+    let staged = path.with_file_name(format!(
+        "{}.{}.part",
+        name.to_string_lossy(),
+        uuid::Uuid::new_v4()
+    ));
+    let written = tokio::fs::write(&staged, bytes).await;
+    let published = match written {
+        Ok(()) => tokio::fs::rename(&staged, path).await,
+        Err(err) => Err(err),
+    };
+    if published.is_err() {
+        let _ = tokio::fs::remove_file(&staged).await;
+    }
+    published
+}

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -11,6 +11,7 @@
 //! it: an interrupt's grace period is exactly when the child's stdout most
 //! needs draining.
 
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -145,6 +146,23 @@ enum TurnWait {
 struct WorktreeTurn<'a> {
     lock: &'a tokio::sync::Mutex<()>,
     wait: TurnWait,
+}
+
+/// Where a turn's attachments come from, and where they can be put.
+///
+/// Two routes, and the engine picks which. Claude Code takes image bytes on
+/// its own protocol, so they ride `TurnInput::images`. Every other engine
+/// reads attachments off disk with the file tools it already has, so the bytes
+/// are written under the checkout and the prompt carries paths — the same
+/// route a fork's transcript takes.
+#[derive(Clone)]
+pub(crate) struct AttachmentStore {
+    /// Published bytes, addressed by blob id.
+    pub blobs: Option<Arc<dyn BlobStore>>,
+    /// The session's checkout, where a file-reading engine is handed paths.
+    pub worktree: PathBuf,
+    /// Whether this engine consumes images over its own protocol.
+    pub engine_reads_images: bool,
 }
 
 pub(crate) struct QueuedFollowUp {
@@ -422,7 +440,7 @@ pub(crate) fn spawn_session_worker(
     session: CodeSession,
     engine: Box<dyn HarnessSession>,
     sink: Arc<LiveSink>,
-    blobs: Option<Arc<dyn BlobStore>>,
+    attachments: AttachmentStore,
     worktree_turn: Arc<tokio::sync::Mutex<()>>,
 ) -> WorkerHandle {
     let (tx, rx) = mpsc::channel(8);
@@ -433,7 +451,7 @@ pub(crate) fn spawn_session_worker(
         engine,
         sink.clone(),
         queue.clone(),
-        blobs,
+        attachments,
         rx,
     ));
     WorkerHandle {
@@ -471,7 +489,7 @@ async fn run_worker(
     engine: Box<dyn HarnessSession>,
     sink: Arc<LiveSink>,
     queue: TurnQueue,
-    blobs: Option<Arc<dyn BlobStore>>,
+    store: AttachmentStore,
     mut commands: mpsc::Receiver<WorkerCommand>,
 ) {
     if let Some(pid) = engine.child_pid() {
@@ -488,7 +506,7 @@ async fn run_worker(
             engine.as_ref(),
             &sink,
             &queue,
-            blobs.as_deref(),
+            &store,
             &mut commands,
         )
         .await;
@@ -506,7 +524,7 @@ async fn run_worker(
                         &mut session,
                         engine.as_ref(),
                         &sink,
-                        blobs.as_deref(),
+                        &store,
                         &mut commands,
                         WorktreeTurn {
                             lock: &queue.worktree,
@@ -722,7 +740,7 @@ async fn drain_queued(
     engine: &dyn HarnessSession,
     sink: &LiveSink,
     queue: &TurnQueue,
-    blobs: Option<&dyn BlobStore>,
+    store: &AttachmentStore,
     commands: &mut mpsc::Receiver<WorkerCommand>,
 ) {
     loop {
@@ -734,7 +752,7 @@ async fn drain_queued(
             session,
             engine,
             sink,
-            blobs,
+            store,
             commands,
             WorktreeTurn {
                 lock: &queue.worktree,
@@ -750,7 +768,7 @@ async fn drive_turn(
     session: &mut CodeSession,
     engine: &dyn HarnessSession,
     sink: &LiveSink,
-    blobs: Option<&dyn BlobStore>,
+    store: &AttachmentStore,
     commands: &mut mpsc::Receiver<WorkerCommand>,
     worktree: WorktreeTurn<'_>,
     follow_up: QueuedFollowUp,
@@ -772,7 +790,7 @@ async fn drive_turn(
         tidebreak.duration_ms = tracing::field::Empty,
     );
     let started = Instant::now();
-    let result = drive_turn_inner(session, engine, sink, blobs, commands, worktree, follow_up)
+    let result = drive_turn_inner(session, engine, sink, store, commands, worktree, follow_up)
         .instrument(span.clone())
         .await;
     let duration_ms = started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
@@ -803,7 +821,7 @@ async fn drive_turn_inner(
     session: &mut CodeSession,
     engine: &dyn HarnessSession,
     sink: &LiveSink,
-    blobs: Option<&dyn BlobStore>,
+    store: &AttachmentStore,
     commands: &mut mpsc::Receiver<WorkerCommand>,
     worktree: WorktreeTurn<'_>,
     QueuedFollowUp {
@@ -828,7 +846,9 @@ async fn drive_turn_inner(
     if session.lifecycle == CodeSessionLifecycle::Ended {
         return Err(WorkerError::Conflict("session has ended".into()));
     }
-    let images = hydrate_turn_images(blobs, &attachments).await?;
+    // Bytes first, before the worktree lock: a blob read and a decode should
+    // never be held against a sibling session waiting for the checkout.
+    let hydrated = hydrate_turn_images(store.blobs.as_deref(), &attachments).await?;
 
     // The workspace's checkout takes one turn at a time (record 55). Taking
     // the lock *is* the reservation: a pre-flight database read cannot be,
@@ -914,8 +934,19 @@ async fn drive_turn_inner(
         session.model = Some(model);
     }
     session.reasoning_effort = reasoning_effort;
+    // What the engine is handed is not always what the person wrote: an engine
+    // that cannot take images over its own protocol is given paths instead, and
+    // `turn.user_input` above keeps the message as typed.
+    let (engine_text, images) = if store.engine_reads_images || hydrated.is_empty() {
+        (message, hydrated)
+    } else {
+        let written = write_turn_attachments(&store.worktree, &turn.attachments, &hydrated)
+            .await
+            .map_err(|err| WorkerError::Failed(format!("write attachment: {err}")))?;
+        (message_naming_attachments(&message, &written), Vec::new())
+    };
     let run = engine.run_turn(TurnInput {
-        text: message,
+        text: engine_text,
         model: session.model.clone(),
         reasoning_effort: session.reasoning_effort,
         images,
@@ -1178,6 +1209,59 @@ fn code_turn_is_error(result: &Result<CodeTurn, WorkerError>) -> bool {
             ..
         }) | Err(WorkerError::Failed(_))
     )
+}
+
+/// Directory holding a turn's attachments, relative to the worktree root.
+pub(crate) const ATTACHMENTS_DIR: &str = ".tidebreak/attachments";
+
+/// Write a turn's attachments under the checkout, returning worktree-relative
+/// paths in the order they were attached.
+///
+/// Named by blob id, which is content-addressed: the same image attached twice
+/// is one file, and a re-send after a failed turn overwrites itself rather than
+/// growing the directory. The write is published by rename, so an engine that
+/// is already reading one never catches a half-written file.
+async fn write_turn_attachments(
+    worktree: &Path,
+    attachments: &[tidebreak_core::ImageRef],
+    images: &[TurnImage],
+) -> std::io::Result<Vec<String>> {
+    let dir = super::scratch::scratch_dir(worktree, ATTACHMENTS_DIR).await?;
+    let mut written = Vec::with_capacity(images.len());
+    for (attachment, image) in attachments.iter().zip(images) {
+        let name = format!(
+            "{}.{}",
+            attachment.blob_id,
+            attachment.media_type.extension()
+        );
+        super::scratch::publish(&dir.join(&name), &image.bytes).await?;
+        written.push(format!("{ATTACHMENTS_DIR}/{name}"));
+    }
+    Ok(written)
+}
+
+/// Name the attachment paths after the message, the way a fork names the
+/// transcript it wrote.
+///
+/// The engine reads them from disk, so the prompt carries paths and nothing
+/// else. An empty list leaves the message exactly as the reader wrote it.
+fn message_naming_attachments(message: &str, paths: &[String]) -> String {
+    if paths.is_empty() {
+        return message.to_owned();
+    }
+    let list = paths
+        .iter()
+        .map(|path| format!("- `{path}`"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let noun = if paths.len() == 1 { "image" } else { "images" };
+    let body = format!("{noun} attached to this message, in this worktree:\n{list}");
+    let text = message.trim();
+    if text.is_empty() {
+        body
+    } else {
+        format!("{text}\n\n{body}")
+    }
 }
 
 async fn hydrate_turn_images(

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -92,6 +92,9 @@ pub(crate) struct ScriptedAdapter {
     /// engine onto. Shared with the session so both survive a relaunch.
     turns: Arc<std::sync::Mutex<Vec<Option<ReasoningEffort>>>>,
     modes: Arc<std::sync::Mutex<Vec<PermissionMode>>>,
+    /// What each turn actually handed the engine, for a test that cares how
+    /// an attachment travelled rather than that it was accepted.
+    inputs: Arc<std::sync::Mutex<Vec<ScriptedTurnInput>>>,
     child_pid: Option<i64>,
     unrecognized_per_turn: u64,
     silent_interrupt: bool,
@@ -122,6 +125,7 @@ impl ScriptedAdapter {
             posture_fixed: false,
             turns: Arc::new(std::sync::Mutex::new(Vec::new())),
             modes: Arc::new(std::sync::Mutex::new(Vec::new())),
+            inputs: Arc::new(std::sync::Mutex::new(Vec::new())),
             child_pid: None,
             unrecognized_per_turn: 0,
             silent_interrupt: false,
@@ -202,6 +206,11 @@ impl ScriptedAdapter {
     pub(crate) fn with_posture_fixed_at_session_start(mut self) -> Self {
         self.posture_fixed = true;
         self
+    }
+
+    /// What each turn handed the engine, in order.
+    pub(crate) fn turn_inputs(&self) -> Vec<ScriptedTurnInput> {
+        self.inputs.lock().expect("scripted inputs").clone()
     }
 
     /// The effort each turn actually ran at, in order.
@@ -342,6 +351,7 @@ impl HarnessAdapter for ScriptedAdapter {
             posture_fixed: self.posture_fixed,
             turns: self.turns.clone(),
             modes: self.modes.clone(),
+            inputs: self.inputs.clone(),
         }))
     }
 }
@@ -368,6 +378,16 @@ struct ScriptedSession {
     /// after the runtime has dropped and relaunched the session.
     turns: Arc<std::sync::Mutex<Vec<Option<ReasoningEffort>>>>,
     modes: Arc<std::sync::Mutex<Vec<PermissionMode>>>,
+    inputs: Arc<std::sync::Mutex<Vec<ScriptedTurnInput>>>,
+}
+
+/// One turn as the engine received it.
+#[derive(Clone, Debug)]
+pub(crate) struct ScriptedTurnInput {
+    /// The prompt text, which is not always the message the person typed.
+    pub text: String,
+    /// How many images rode the protocol.
+    pub images: usize,
 }
 
 impl ScriptedSession {
@@ -433,6 +453,13 @@ impl HarnessSession for ScriptedSession {
             .lock()
             .expect("scripted turns")
             .push(_input.reasoning_effort);
+        self.inputs
+            .lock()
+            .expect("scripted inputs")
+            .push(ScriptedTurnInput {
+                text: _input.text.clone(),
+                images: _input.images.len(),
+            });
         if let Some(detail) = &self.lost_resume {
             return Err(HarnessError::ResumeLost(detail.clone()));
         }

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1288,6 +1288,21 @@ async fn turn_statuses(
         .collect()
 }
 
+/// Poll until `ready` holds, or fail the test.
+///
+/// A turn is accepted before it runs, so everything the worker does with it —
+/// writing an attachment, handing the engine its input — lands after the
+/// response the caller already has.
+async fn wait_until(mut ready: impl FnMut() -> bool) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !ready() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("condition never held");
+}
+
 async fn wait_for_open_turn(runtime: &CodeRuntime, session_id: CodeSessionId) -> CodeTurnId {
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
@@ -1806,6 +1821,163 @@ async fn a_mode_change_a_relaunch_cannot_carry_is_refused_rather_than_recorded()
     assert_eq!(
         still["session"]["permission_mode"], "plan",
         "a refused change must not move the row: {still}"
+    );
+}
+
+/// Only Claude Code's adapter puts image bytes on the wire. On every other
+/// engine an attached image used to be dropped between the composer and the
+/// child, because the field it rides is one those adapters never read. The
+/// bytes go to disk instead and the prompt carries the path, which is the
+/// route a fork's transcript already takes.
+#[tokio::test]
+async fn an_engine_with_no_image_protocol_is_handed_the_file_and_its_path() {
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_image_input(CapLevel::Unsupported);
+    let engine = adapter.clone();
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let worktree =
+        std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap().to_owned());
+    let session = create_sibling_sessions(&client, addr, &token, &workspace, 1)
+        .await
+        .remove(0);
+
+    let pixels = crate::routes::image_attachment::png_header(4, 4);
+    let published = client
+        .post(format!(
+            "http://{addr}/code/sessions/{session}/attachments/images"
+        ))
+        .bearer_auth(&token)
+        .header(reqwest::header::CONTENT_TYPE, "image/png")
+        .body(pixels.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(published.status(), reqwest::StatusCode::CREATED);
+    let attachment: serde_json::Value = published.json().await.unwrap();
+    let blob_id = attachment["attachment_id"].as_str().unwrap().to_owned();
+
+    let accepted = client
+        .post(format!("http://{addr}/code/sessions/{session}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "message": "what is in this",
+            "attachments": [{ "blob_id": blob_id, "media_type": "image/png" }],
+        }))
+        .send()
+        .await
+        .unwrap();
+    let accepted_status = accepted.status();
+    let accepted_body: serde_json::Value = accepted.json().await.unwrap();
+    assert_eq!(
+        accepted_status,
+        reqwest::StatusCode::ACCEPTED,
+        "{accepted_body}"
+    );
+
+    let relative = format!(".tidebreak/attachments/{blob_id}.png");
+    let written = worktree.join(&relative);
+    wait_until(|| written.exists()).await;
+    assert_eq!(
+        std::fs::read(&written).unwrap(),
+        pixels,
+        "the engine reads the bytes that were published"
+    );
+
+    wait_until(|| !engine.turn_inputs().is_empty()).await;
+    let handed = engine.turn_inputs().remove(0);
+    assert_eq!(
+        handed.images, 0,
+        "an engine with no image protocol is sent no image bytes"
+    );
+    assert!(
+        handed.text.starts_with("what is in this"),
+        "the message the person wrote leads: {:?}",
+        handed.text
+    );
+    assert!(
+        handed.text.contains(&relative),
+        "the prompt names the path: {:?}",
+        handed.text
+    );
+
+    // The transcript keeps what was typed, not what the engine was handed.
+    let turns: Vec<serde_json::Value> = client
+        .get(format!("http://{addr}/code/sessions/{session}/turns"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(turns[0]["user_input"], "what is in this");
+
+    // `.tidebreak/` hides itself, so none of this shows up as a change.
+    assert_eq!(
+        std::fs::read_to_string(worktree.join(".tidebreak/.gitignore")).unwrap(),
+        "*\n"
+    );
+}
+
+/// The engine that has its own image path keeps it. Bytes in the protocol are
+/// lossless and already captured; writing a file for Claude Code would cost a
+/// tool call to read back something it can already see.
+#[tokio::test]
+async fn an_engine_that_states_image_input_is_still_handed_the_bytes() {
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_image_input(CapLevel::Supported);
+    let engine = adapter.clone();
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let worktree =
+        std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap().to_owned());
+    let session = create_sibling_sessions(&client, addr, &token, &workspace, 1)
+        .await
+        .remove(0);
+
+    let published = client
+        .post(format!(
+            "http://{addr}/code/sessions/{session}/attachments/images"
+        ))
+        .bearer_auth(&token)
+        .header(reqwest::header::CONTENT_TYPE, "image/png")
+        .body(crate::routes::image_attachment::png_header(4, 4))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(published.status(), reqwest::StatusCode::CREATED);
+    let attachment: serde_json::Value = published.json().await.unwrap();
+
+    let accepted = client
+        .post(format!("http://{addr}/code/sessions/{session}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "message": "what is in this",
+            "attachments": [{
+                "blob_id": attachment["attachment_id"],
+                "media_type": "image/png",
+            }],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(accepted.status(), reqwest::StatusCode::ACCEPTED);
+
+    wait_until(|| !engine.turn_inputs().is_empty()).await;
+    let handed = engine.turn_inputs().remove(0);
+    assert_eq!(handed.images, 1, "the bytes ride the protocol");
+    assert_eq!(
+        handed.text, "what is in this",
+        "nothing is appended to a prompt that carries the image itself"
+    );
+    assert!(
+        !worktree.join(".tidebreak/attachments").exists(),
+        "no file is written for an engine that never needs to read one"
     );
 }
 
@@ -5881,61 +6053,6 @@ async fn a_lost_resume_fences_the_session_instead_of_failing_every_turn() {
     assert_eq!(refused.status(), reqwest::StatusCode::CONFLICT);
     let refused_body: serde_json::Value = refused.json().await.unwrap();
     assert_eq!(refused_body["kind"], "session_fenced");
-}
-
-#[tokio::test]
-async fn attachments_are_rejected_unless_the_adapter_declares_image_input() {
-    let adapter = ScriptedAdapter::new(plain_text_script()).with_image_input(CapLevel::Unsupported);
-    let (router, token, _runtime, dir) = code_app_with(adapter).await;
-    let addr = serve(router).await;
-    let client = reqwest::Client::new();
-    let repo = init_git_repo(dir.path());
-    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
-    let session = client
-        .post(format!(
-            "http://{addr}/code/workspaces/{}/sessions",
-            json_id(&workspace)
-        ))
-        .bearer_auth(&token)
-        .json(&serde_json::json!({
-            "harness": "claude_code",
-            "permission_mode": "plan",
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(session.status(), reqwest::StatusCode::CREATED);
-    let session: serde_json::Value = session.json().await.unwrap();
-
-    let blob_id = publish_one_pixel_png(&client, addr, &token, json_id(&session)).await;
-
-    let refused = client
-        .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
-            json_id(&session)
-        ))
-        .bearer_auth(&token)
-        .json(&serde_json::json!({
-            "message": "look at this",
-            "attachments": [{
-                "blob_id": blob_id,
-                "media_type": "image/png",
-            }],
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(refused.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
-    let body: serde_json::Value = refused.json().await.unwrap();
-    assert_eq!(body["kind"], "unsupported_attachment");
-    assert!(
-        body["message"]
-            .as_str()
-            .unwrap_or("")
-            .contains("claude_code"),
-        "{}",
-        body["message"]
-    );
 }
 
 #[tokio::test]

--- a/docs/decisions/0046-rich-turn-input-rides-harness-capabilities.md
+++ b/docs/decisions/0046-rich-turn-input-rides-harness-capabilities.md
@@ -1,6 +1,6 @@
 # 46. Rich Turn Input Rides Harness Capabilities
 
-- Status: Proposed
+- Status: Proposed (amended 2026-08-22, see [Amendment](#amendment-2026-08-22))
 - Date: 2026-08-18
 - Owners: code mode
 - Related: 0031 (adapter capability honesty), 0033 (approvals never paraphrase),
@@ -110,3 +110,28 @@ contract should merge into the chat attachment model rather than diverge.
 - Composer DOM tests: affordances absent when caps are `Unsupported`/
   `Unknown`; paste with support produces an attachment chip; `/` popup lists
   probe-discovered commands and still submits free text without them.
+
+## Amendment (2026-08-22)
+
+**`image_input` no longer gates whether an attachment is offered, only how it
+travels.** The route accepts attachments for every engine, and the composer
+offers the affordance on every session. An adapter that declares `Supported`
+is handed the bytes on its machine-readable input path, exactly as before.
+Every other engine is handed the file: the worker writes it under
+`.tidebreak/attachments/` in the checkout and names the path in the prompt,
+the route a fork's transcript already takes. The `unsupported_attachment`
+refusal is gone.
+
+The rest of this record stands — the capability flag, the fixture rule behind
+`Supported`, the bounded journal reference, and the pass-through contracts for
+slash commands and `@`.
+
+Why: this is the "revisit if" above, reached from the other side. The
+capability was doing two jobs — deciding whether Tidebreak could carry an
+image at all, and deciding which wire carried it — and only the second was
+ever a property of the engine. Every engine reads files off disk with tools it
+already has, so there was never a version of this where an attachment could
+not reach one; there was only a version where Tidebreak declined to try. The
+fixture rule stays exactly as strict, because it now governs the narrower
+claim it was always measuring: that the engine consumed an image on its
+machine-readable input.


### PR DESCRIPTION
Follow-up to #2485, which made an image paste on opencode say "Tidebreak can't send images to opencode yet" instead of dropping a file URL in the draft. This removes the limit that message described.

## The capability was doing two jobs

Only Claude Code's adapter reads `TurnInput::images` — `encode_turn_stdin` base64s them onto the stream-json user line. codex, opencode, and grok never touch the field. So `caps.image_input` gated the whole feature: `POST /code/sessions/{id}/turns` refused attachments with `unsupported_attachment` on those engines, and the composer hid the control.

Only half of that was ever a property of the engine. Every engine reads files off disk with the tools it already has — which is exactly how a fork hands a child its parent's transcript, and `messageWithWorkspaceFiles` says so: "The engine reads them from disk, so the prompt carries paths and nothing else."

So the capability now decides only which wire an attachment takes:

- **States image input** → bytes ride the protocol, unchanged.
- **Does not** → the worker writes the file under `.tidebreak/attachments/<blob-id>.<ext>` in the checkout and names the path in the prompt.

The route no longer gates on the capability, and the composer offers attachment on every session. No adapter changes, no new fixtures — the fixture rule behind `image_input: Supported` stays exactly as strict, now governing the narrower claim it always measured.

## Where the files go

`.tidebreak/attachments/`, a sibling of the existing `.tidebreak/forks/`. The directory already hides itself: a `.gitignore` holding `*` covers the tree and the marker with it, without touching the repo's tracked ignore file or the `.git/info/exclude` every other worktree of the same repository reads. It is a plain directory in the checkout, so an agent can write there too.

`publish` (stage-then-rename) and that marker move out of `fork.rs` into `code/scratch.rs`. A reader can be mid-read of an attachment for the same reason it can be mid-read of a transcript, so it wants the same guarantee: one whole version or another, never the middle of one.

Names are the blob id, which is content-addressed — the same image attached twice is one file, and a re-send after a failed turn overwrites itself rather than growing the directory.

## The transcript keeps what was typed

`CodeTurn::user_input` is the message as written; only `TurnInput::text` carries the appended paths. That split already existed — the turn row and the engine input are assembled separately.

## Tests

- An engine with no image protocol: the file lands under `.tidebreak/attachments/`, holds the published bytes, the prompt names the path, no bytes ride the protocol, `user_input` is unchanged, and `.tidebreak/.gitignore` holds `*`.
- An engine that states image input: bytes ride the protocol, nothing is appended to the prompt, and no file is written.
- `attachments_are_rejected_unless_the_adapter_declares_image_input` is deleted — it asserted the gate this removes, and the pair above covers the replacement contract.
- `ScriptedAdapter` gains `turn_inputs()`, recording what each turn actually handed the engine rather than only that it was accepted.

Decision 0046 is amended: it anticipated this under "revisit if an engine ships attachments only over a non-machine-readable path".

## Next

Attaching any file type, not just images, is the follow-up: `CodeTurnAttachment` needs a filename and a media type outside the image enum, plus an upload route that skips image decoding. The worker-side write needs no change — it already takes bytes, a name, and an extension.

## Unrelated failure on main

`tidebreak-core`'s `hydration_is_bounded_so_a_long_chat_cannot_grow_the_outbound_body` fails on `main` at ab724b1 (3/3 with this branch stashed) — chat image-hydration eviction keeps 2 where it expects 7. Not touched here.