### PR TITLE
fix(server): arming a trigger returns the row that exists

### DIFF
--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -2132,26 +2132,45 @@ impl CodeRuntime {
         action: CodeTriggerAction,
     ) -> Result<CodeTrigger, ServerError> {
         self.get_repo(owner, repo_id).await?;
-        let existing = list_triggers_for_repo(&self.db, owner, repo_id).await?;
-        if let Some(found) = existing
+        // Match the store's unique key, which is (owner, repo, condition) —
+        // not the condition and action together. `save_trigger` upserts on
+        // that key and updates action and enabled without touching the stored
+        // id, so re-arming one condition with a different action keeps the row
+        // that is already there.
+        let existing = list_triggers_for_repo(&self.db, owner, repo_id)
+            .await?
             .into_iter()
-            .find(|t| t.condition == condition && t.action == action)
-        {
-            return Ok(found);
-        }
+            .find(|trigger| trigger.condition == condition);
         let now = Utc::now();
-        let trigger = CodeTrigger {
-            id: CodeTriggerId::new(),
-            owner: owner.clone(),
-            repo_id,
-            condition,
-            action,
-            enabled: true,
-            created_at: now,
-            updated_at: now,
+        let trigger = match existing {
+            Some(found) if found.action == action && found.enabled => return Ok(found),
+            Some(mut found) => {
+                found.action = action;
+                found.enabled = true;
+                found.updated_at = now;
+                found
+            }
+            None => CodeTrigger {
+                id: CodeTriggerId::new(),
+                owner: owner.clone(),
+                repo_id,
+                condition,
+                action,
+                enabled: true,
+                created_at: now,
+                updated_at: now,
+            },
         };
         save_trigger(&self.db, &trigger).await?;
-        Ok(trigger)
+        // Read back rather than returning what we just built. Two arms of the
+        // same condition racing each other both see no row and both mint an
+        // id; only one is stored, and the loser would otherwise answer 201
+        // with an id that GET, PATCH and DELETE cannot find.
+        list_triggers_for_repo(&self.db, owner, repo_id)
+            .await?
+            .into_iter()
+            .find(|trigger| trigger.condition == condition)
+            .ok_or_else(|| ServerError::internal("the trigger vanished after it was saved"))
     }
 
     /// Switch a trigger on or off, keeping the row so the scoping survives.

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -6967,3 +6967,76 @@ async fn a_session_cannot_attach_an_image_published_to_another_session() {
         "the refusal must name authority, not blob absence: {body}"
     );
 }
+
+/// Arming one condition twice must answer with the row that exists.
+///
+/// `save_trigger` upserts on `(owner, repo, condition)` and updates action and
+/// enabled without touching the stored id. Returning the freshly minted id
+/// instead would answer 201 with a trigger that `GET`, `PATCH` and `DELETE`
+/// cannot find.
+#[tokio::test]
+async fn re_arming_a_condition_keeps_the_stored_trigger_id() {
+    let adapter = ScriptedAdapter::new(plain_text_script());
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo_path = init_git_repo(dir.path());
+    let (repo, _workspace) = register_and_workspace(&client, addr, &token, &repo_path).await;
+    let repo_id = json_id(&repo).to_owned();
+
+    let armed = client
+        .post(format!("http://{addr}/code/repos/{repo_id}/triggers"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "condition": "checks_failed", "action": "deliver" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(armed.status(), reqwest::StatusCode::CREATED);
+    let first: serde_json::Value = armed.json().await.unwrap();
+
+    // Same condition, different action: the store's unique key collides.
+    let rearmed = client
+        .post(format!("http://{addr}/code/repos/{repo_id}/triggers"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "condition": "checks_failed", "action": "notify" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(rearmed.status(), reqwest::StatusCode::CREATED);
+    let second: serde_json::Value = rearmed.json().await.unwrap();
+
+    assert_eq!(
+        json_id(&second),
+        json_id(&first),
+        "re-arming a condition must keep the stored id"
+    );
+    assert_eq!(
+        second["action"], "notify",
+        "the action is the one just armed"
+    );
+
+    let listed = client
+        .get(format!("http://{addr}/code/repos/{repo_id}/triggers"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    let rows: Vec<serde_json::Value> = listed.json().await.unwrap();
+    assert_eq!(rows.len(), 1, "one row per condition, not one per action");
+    assert_eq!(json_id(&rows[0]), json_id(&first));
+
+    // The id it answered with has to be one the other routes can reach.
+    let patched = client
+        .patch(format!(
+            "http://{addr}/code/repos/{repo_id}/triggers/{}",
+            json_id(&second)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "enabled": false }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(patched.status(), reqwest::StatusCode::OK);
+    let patched_body: serde_json::Value = patched.json().await.unwrap();
+    assert_eq!(patched_body["enabled"], false);
+}


### PR DESCRIPTION
Follow-up to the NO GO on #2486. That review was right and the PR merged over
it — my watcher gated on CI checks only and used `--admin`, so it never read
the review. This fixes it forward.

## The bug

`create_trigger` treated uniqueness as `(repository, condition, action)`. The
store does not: `save_trigger` upserts on `(owner, repo_id, condition)` and
updates `action` and `enabled` **without touching the stored id**.

So re-arming one condition with a different action fell through the
short-circuit, minted a fresh `CodeTriggerId`, wrote nothing under it, and
answered `201` naming a trigger that `GET`, `PATCH` and `DELETE` could not
find.

## The fix

Two parts, and both are load-bearing.

1. **The lookup matches the store's key** — condition only. Re-arming a
   condition now updates the row already there.
2. **The row is read back after the write** rather than returning what was just
   built. This covers the case the lookup cannot: two arms of one condition
   racing each other both see no row and both mint an id, and only one is
   stored.

## Test

A route-level regression test that arms `checks_failed` as `deliver`, re-arms
it as `notify`, and asserts the second response carries the same id, that
listing returns one row rather than two, and that `PATCH` can reach the id it
was handed.

Verified both ways rather than assumed: against the previous implementation it
fails with the two ids differing, which is the phantom exactly. Against this
one it passes. Reverting only the lookup half still passes, which is why the
read-back is there.