### PR TITLE
fix(server): bump the schema epoch for the session-image table

### DIFF
--- a/crates/tidebreak-server/src/desktop_schema.rs
+++ b/crates/tidebreak-server/src/desktop_schema.rs
@@ -39,7 +39,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 40;
+const DESKTOP_SCHEMA_EPOCH: u32 = 41;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
#2487 added `code_session_image` to the baseline and regenerated both fixtures, but left `DESKTOP_SCHEMA_EPOCH` at 40 — the value already on `main`.

An unchanged epoch takes the `saved == SchemaMarker::current()` arm in `prepare_for_product_major`, so no reset fires, so an existing profile never runs `Baseline::up` again and never gets the table.

**What breaks:** `publish_session_image` reads and writes `code_session_image` on `POST /code/sessions/{id}/images`, and `resolve_turn_attachments` now requires the reservation before it will resolve an attachment. So pasting an image into a code session fails against a missing table on every profile that existed before #2487 merged.

A fresh profile is fine, which is why the suite is green — every test builds its own database.

## Third time

```
#2289  code_session.kind              epoch stayed 33
#2453  code_session.reasoning_effort  epoch stayed 39
#2487  code_session_image             epoch stayed 40   ← this one
```

The first two were repaired by luck: a later change bumped, and a reset rebuilds from the *current* baseline, not the one in force when the bump was missed. This one had no later bump behind it.

This is the failure decision record 2 named and accepted — the fixture makes a baseline edit visible, it cannot decide whether the epoch owes a bump. #2491 removes the judgment call by freezing the baseline, and it needs this bump landed first: converging a profile at 40 would bless a schema that is permanently missing this table.