### PR TITLE
feat(desktop): carry the trigger types to the renderer

### DIFF
--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1338,6 +1338,33 @@ export type CodeTerminalRead = { id: CodeTerminalId, workspace_id: WorkspaceId, 
 export type CodeTerminalSnapshot = { id: CodeTerminalId, workspace_id: WorkspaceId, cols: number, rows: number, ended: boolean, created_at: string, };
 
 /**
+ * What a trigger does when its condition fires.
+ *
+ * Two actions in v1. Merge, auto-merge, and mark-ready stay with the user
+ * (decision 42), and shell commands and webhooks need their own record.
+ */
+export type CodeTriggerAction = "deliver" | "notify";
+
+/**
+ * A pull-request fact a trigger fires on.
+ *
+ * The vocabulary is the watch classifier's, minus the states nothing can act
+ * on. A trigger fires on the *transition* into one of these, once per head
+ * SHA — see [`CodeTriggerFire`] (decision 60).
+ */
+export type CodeTriggerCondition = "checks_failed" | "conflicts" | "changes_requested" | "review_required" | "behind" | "ready_to_merge" | "merged" | "closed";
+
+/**
+ * Identifies one durable trigger rule bound to a repository.
+ */
+export type CodeTriggerId = string;
+
+/**
+ * One armed trigger, as the interface reads it.
+ */
+export type CodeTriggerSnapshot = { id: CodeTriggerId, repo_id: RepoId, condition: CodeTriggerCondition, action: CodeTriggerAction, enabled: boolean, created_at: string, updated_at: string, };
+
+/**
  * Identifies one user→engine cycle inside a code session.
  */
 export type CodeTurnId = string;
@@ -1703,6 +1730,11 @@ method: ConsentMethodSnapshot, granted_at: string, };
  * The class of action a consent statement allows.
  */
 export type ConsentVerb = { "kind": "tool", action: RendererToolName, approval: ToolApprovalKind, } | { "kind": "capability", capability: HostCapability, };
+
+/**
+ * Arm a trigger on a repository.
+ */
+export type CreateCodeTriggerBody = { condition: CodeTriggerCondition, action: CodeTriggerAction, };
 
 /**
  * Where the resolved credential value is placed on the request.
@@ -4099,6 +4131,12 @@ export type TurnFailureCategory = "rate_limited" | "auth" | "provider_access" | 
  * Identifies one turn: a single user input through to the final answer.
  */
 export type TurnId = string;
+
+/**
+ * Switch a trigger on or off. The row survives either way, so the scoping
+ * does not have to be rebuilt to turn a rule back on.
+ */
+export type UpdateCodeTriggerBody = { enabled: boolean, };
 
 /**
  * One bounded question shown to the user.

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -75,12 +75,12 @@ pub(crate) use types::{
     CodeDeliveryRunQuery, CodeDeliveryRunTarget, CodeDeliveryRunsPage, CodeFileChange,
     CodeForkTranscript, CodeHarnessInstallSnapshot, CodePrCommentsSnapshot, CodePushSnapshot,
     CodeRepoSnapshot, CodeSessionDebug, CodeSessionDigest, CodeSessionSnapshot,
-    CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTurnSnapshot,
-    CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
+    CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTriggerSnapshot,
+    CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
     CodeWorkspacePrSnapshot, CodeWorkspaceSearch, CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot,
-    CodeWorkspaceTree, CodeWorktreeRoot, HarnessDoctorReport, HarnessModelList, MergeCodePrBody,
-    QueuedCodeTurn, ResolveCodeDeliveryRepositoriesBody, SequencedCodeEventFrame,
-    SetCodeWorktreeRootBody,
+    CodeWorkspaceTree, CodeWorktreeRoot, CreateCodeTriggerBody, HarnessDoctorReport,
+    HarnessModelList, MergeCodePrBody, QueuedCodeTurn, ResolveCodeDeliveryRepositoriesBody,
+    SequencedCodeEventFrame, SetCodeWorktreeRootBody, UpdateCodeTriggerBody,
 };
 pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -468,6 +468,10 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodeWorktreeRoot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeForkTranscript>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::SetCodeWorktreeRootBody>(&cfg, &mut out);
+        // Triggers: the rules the sweep reads, and the bodies that arm them.
+        generate::collect_from::<crate::routes::code::CodeTriggerSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CreateCodeTriggerBody>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::UpdateCodeTriggerBody>(&cfg, &mut out);
         out
     }
 


### PR DESCRIPTION
Part of #2480. Unblocks the trigger surface and #2481's migration, both of
which need these names in TypeScript.

The routes landed in #2486 but the desktop app has no way to name a trigger.
`wire.ts` is generated from an explicit `collect_from` list in
`wire_types.rs`, and the trigger types were never on it.

This re-exports `CodeTriggerSnapshot`, `CreateCodeTriggerBody` and
`UpdateCodeTriggerBody` from `routes::code`, registers all three for
generation, and commits the regenerated file. The registration and the
regenerated output have to land together — `the_generated_bindings_are_current`
fails otherwise.

Purely additive: 38 generated lines, no existing type changed. Generated with
`UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server`; all 12 wire tests pass.

Nothing consumes these yet. The client methods, validators, and the surface
itself follow.