### PR TITLE
feat(ui): a surface for arming triggers

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -93,6 +93,9 @@ import {
   type CodeWorkspaceBlob,
   type CodeWorkspaceTree,
   type CodeWorkspacePrSnapshot,
+  type CodeTriggerAction,
+  type CodeTriggerCondition,
+  type CodeTriggerSnapshot,
   type CodeWatchSnapshot,
   type CodePrCommentsSnapshot,
   type CodePrMergeMethod,
@@ -160,6 +163,8 @@ import {
   parseCodeWorkspaceBlob,
   parseCodeWorkspaceTree,
   parseCodeWorkspacePr,
+  parseCodeTrigger,
+  parseCodeTriggers,
   parseCodeWatch,
   parseCodePrComments,
   parseHarnessModelList,
@@ -2460,6 +2465,68 @@ export class ApiClient {
         ),
       ),
       "code pull request",
+    );
+  }
+
+  /** Triggers armed on a repository, enabled or not. */
+  async listCodeTriggers(repoId: string): Promise<CodeTriggerSnapshot[]> {
+    return requireParsed(
+      parseCodeTriggers(
+        await this.json(`/code/repos/${encodeURIComponent(repoId)}/triggers`, {
+          headers: this.headers(),
+        }),
+      ),
+      "code triggers",
+    );
+  }
+
+  /**
+   * Arm a trigger. Re-arming a condition updates the rule already there
+   * rather than adding a second one, so this is safe to call twice.
+   */
+  async createCodeTrigger(
+    repoId: string,
+    condition: CodeTriggerCondition,
+    action: CodeTriggerAction,
+  ): Promise<CodeTriggerSnapshot> {
+    return requireParsed(
+      parseCodeTrigger(
+        await this.json(`/code/repos/${encodeURIComponent(repoId)}/triggers`, {
+          method: "POST",
+          headers: this.headers(),
+          body: JSON.stringify({ condition, action }),
+        }),
+      ),
+      "code trigger",
+    );
+  }
+
+  /** Switch a trigger on or off. The rule survives either way. */
+  async setCodeTriggerEnabled(
+    repoId: string,
+    triggerId: string,
+    enabled: boolean,
+  ): Promise<CodeTriggerSnapshot> {
+    return requireParsed(
+      parseCodeTrigger(
+        await this.json(
+          `/code/repos/${encodeURIComponent(repoId)}/triggers/${encodeURIComponent(triggerId)}`,
+          {
+            method: "PATCH",
+            headers: this.headers(),
+            body: JSON.stringify({ enabled }),
+          },
+        ),
+      ),
+      "code trigger",
+    );
+  }
+
+  /** Remove a trigger. Its recorded fires stay in the transcript. */
+  deleteCodeTrigger(repoId: string, triggerId: string): Promise<void> {
+    return this.json(
+      `/code/repos/${encodeURIComponent(repoId)}/triggers/${encodeURIComponent(triggerId)}`,
+      { method: "DELETE", headers: this.headers() },
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -155,6 +155,9 @@ import {
   type CodeWorkspaceTree as WireCodeWorkspaceTree,
   type CodeWorkspaceBlob as WireCodeWorkspaceBlob,
   type CodeWorkspacePrSnapshot as WireCodeWorkspacePrSnapshot,
+  type CodeTriggerAction as WireCodeTriggerAction,
+  type CodeTriggerCondition as WireCodeTriggerCondition,
+  type CodeTriggerSnapshot as WireCodeTriggerSnapshot,
   type CodeWatchSnapshot as WireCodeWatchSnapshot,
   type CodeWatchState as WireCodeWatchState,
   type CodeActionSnapshot as WireCodeActionSnapshot,
@@ -1167,6 +1170,9 @@ export type CodeWorkspaceBlob = WireCodeWorkspaceBlob;
 export type CodeWorkspaceDiff = WireCodeWorkspaceDiff;
 export type CodeWorkspacePrSnapshot = WireCodeWorkspacePrSnapshot;
 /** One durable watch task on a workspace's pull request. */
+export type CodeTriggerAction = WireCodeTriggerAction;
+export type CodeTriggerCondition = WireCodeTriggerCondition;
+export type CodeTriggerSnapshot = WireCodeTriggerSnapshot;
 export type CodeWatchSnapshot = WireCodeWatchSnapshot;
 export type CodeWatchState = WireCodeWatchState;
 export type CodeSessionActivity = WireCodeSessionActivity;

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerRules.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerRules.tsx
@@ -102,15 +102,20 @@ export function CodeTriggerRules({
   target,
   busy = false,
   onArm,
-  onDisarm,
+  onSetEnabled,
   onChangeAction,
 }: {
   triggers: CodeTriggerSnapshot[];
   /** Where a fire would land right now, or null when nothing can receive one. */
   target: CodeTriggerTarget | null;
   busy?: boolean;
+  /** Arm a condition that has no rule yet. */
   onArm: (condition: CodeTriggerCondition, action: CodeTriggerAction) => void;
-  onDisarm: (trigger: CodeTriggerSnapshot) => void;
+  /**
+   * Switch an existing rule on or off. Separate from arming because the rule
+   * survives being switched off — turning it back on must not build a new one.
+   */
+  onSetEnabled: (trigger: CodeTriggerSnapshot, enabled: boolean) => void;
   onChangeAction: (
     trigger: CodeTriggerSnapshot,
     action: CodeTriggerAction,
@@ -145,13 +150,16 @@ export function CodeTriggerRules({
                 disabled={busy}
                 aria-label={copy.title}
                 onCheckedChange={(enabled) => {
-                  if (!enabled) {
-                    if (trigger) {
-                      onDisarm(trigger);
-                    }
+                  // A rule that exists is switched, never rebuilt: arming
+                  // again would discard the row the server keeps so its
+                  // scoping survives a toggle.
+                  if (trigger) {
+                    onSetEnabled(trigger, enabled);
                     return;
                   }
-                  onArm(condition, trigger?.action ?? "deliver");
+                  if (enabled) {
+                    onArm(condition, "deliver");
+                  }
                 }}
               />
               <div className="min-w-52 flex-1">

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerRules.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerRules.tsx
@@ -1,0 +1,192 @@
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  CodeTriggerAction,
+  CodeTriggerCondition,
+  CodeTriggerSnapshot,
+} from "@/api/types";
+
+/**
+ * How a fire reaches the session, so the row can say what will happen rather
+ * than implying every trigger interrupts.
+ *
+ * A harness that declares mid-turn steering is interrupted where it stands; one
+ * that does not waits for the workspace to go quiet and then takes a turn.
+ */
+export type CodeTriggerDelivery = "steer" | "next_turn";
+
+export type CodeTriggerTarget = {
+  /** Session a fire would reach, as the interface should name it. */
+  sessionTitle: string;
+  harnessLabel: string;
+  delivery: CodeTriggerDelivery;
+};
+
+/** Every condition, in the order the classifier settles them. */
+const CONDITIONS: CodeTriggerCondition[] = [
+  "checks_failed",
+  "conflicts",
+  "changes_requested",
+  "review_required",
+  "behind",
+  "ready_to_merge",
+  "merged",
+  "closed",
+];
+
+function conditionCopy(condition: CodeTriggerCondition): {
+  title: string;
+  description: string;
+} {
+  switch (condition) {
+    case "checks_failed":
+      return {
+        title: "Checks fail",
+        description: "A check on the pull request reports a failure.",
+      };
+    case "conflicts":
+      return {
+        title: "Conflicts appear",
+        description: "The branch stops merging cleanly into its base.",
+      };
+    case "changes_requested":
+      return {
+        title: "Changes requested",
+        description: "A reviewer asks for changes.",
+      };
+    case "review_required":
+      return {
+        title: "Review outstanding",
+        description: "A review or repository requirement is still unmet.",
+      };
+    case "behind":
+      return {
+        title: "Branch falls behind",
+        description: "The base branch moved ahead of this one.",
+      };
+    case "ready_to_merge":
+      return {
+        title: "Ready to merge",
+        description: "Nothing is outstanding. Merging stays yours.",
+      };
+    case "merged":
+      return {
+        title: "Merged",
+        description: "The pull request merged.",
+      };
+    case "closed":
+      return {
+        title: "Closed",
+        description: "The pull request closed without merging.",
+      };
+  }
+}
+
+function deliveryCopy(target: CodeTriggerTarget | null): string {
+  if (!target) {
+    return "No session is open in a workspace with a pull request, so a fire waits until one is.";
+  }
+  return target.delivery === "steer"
+    ? `Interrupts ${target.sessionTitle} mid-turn (${target.harnessLabel}).`
+    : `Waits for ${target.sessionTitle} to go quiet, then sends a turn (${target.harnessLabel} cannot be interrupted).`;
+}
+
+export function CodeTriggerRules({
+  triggers,
+  target,
+  busy = false,
+  onArm,
+  onDisarm,
+  onChangeAction,
+}: {
+  triggers: CodeTriggerSnapshot[];
+  /** Where a fire would land right now, or null when nothing can receive one. */
+  target: CodeTriggerTarget | null;
+  busy?: boolean;
+  onArm: (condition: CodeTriggerCondition, action: CodeTriggerAction) => void;
+  onDisarm: (trigger: CodeTriggerSnapshot) => void;
+  onChangeAction: (
+    trigger: CodeTriggerSnapshot,
+    action: CodeTriggerAction,
+  ) => void;
+}) {
+  const armed = new Map(
+    triggers.map((trigger) => [trigger.condition, trigger] as const),
+  );
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-4">
+        <h2 className="text-base font-semibold">Triggers</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Tidebreak watches this repository and reaches the agent when one of
+          these happens, so it does not have to keep checking GitHub itself.
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {deliveryCopy(target)}
+        </p>
+      </div>
+      <div className="flex flex-col rounded-lg border border-border-subtle">
+        {CONDITIONS.map((condition) => {
+          const trigger = armed.get(condition);
+          const copy = conditionCopy(condition);
+          return (
+            <div
+              key={condition}
+              className="flex flex-wrap items-center gap-4 border-b border-border-subtle px-4 py-3.5 last:border-b-0"
+            >
+              <Switch
+                checked={Boolean(trigger?.enabled)}
+                disabled={busy}
+                aria-label={copy.title}
+                onCheckedChange={(enabled) => {
+                  if (!enabled) {
+                    if (trigger) {
+                      onDisarm(trigger);
+                    }
+                    return;
+                  }
+                  onArm(condition, trigger?.action ?? "deliver");
+                }}
+              />
+              <div className="min-w-52 flex-1">
+                <h3 className="text-sm font-medium">{copy.title}</h3>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  {copy.description}
+                </p>
+              </div>
+              <Select
+                value={trigger?.action ?? "deliver"}
+                disabled={busy || !trigger?.enabled}
+                onValueChange={(value) => {
+                  const action = value as CodeTriggerAction;
+                  if (trigger) {
+                    onChangeAction(trigger, action);
+                    return;
+                  }
+                  onArm(condition, action);
+                }}
+              >
+                <SelectTrigger
+                  className="w-40"
+                  aria-label={`${copy.title} action`}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="deliver">Tell the agent</SelectItem>
+                  <SelectItem value="notify">Just notify me</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -11,6 +11,9 @@ import type {
   CodeSessionActivity,
   CodeSessionLifecycle,
   CodeSessionKind,
+  CodeTriggerAction,
+  CodeTriggerCondition,
+  CodeTriggerSnapshot,
   CodeWatchState,
   CodeSessionSnapshot,
   CodeFileChange,
@@ -97,6 +100,7 @@ import type {
   ImageRef as WireCodeTurnAttachment,
   CodeWorkspaceSnapshot as WireCodeWorkspaceSnapshot,
   CodeWorkspacePrSnapshot as WireCodeWorkspacePrSnapshot,
+  CodeTriggerSnapshot as WireCodeTriggerSnapshot,
   CodeWatchSnapshot as WireCodeWatchSnapshot,
   CodeActionSnapshot as WireCodeActionSnapshot,
   CodeCommitSnapshot as WireCodeCommitSnapshot,
@@ -1537,6 +1541,73 @@ export function parseCodeWatch(value: unknown): CodeWatchSnapshot | null {
     updated_at: value.updated_at,
     ...(value.detail !== undefined ? { detail: value.detail } : {}),
   };
+}
+
+const TRIGGER_CONDITIONS = new Set<CodeTriggerCondition>([
+  "checks_failed",
+  "conflicts",
+  "changes_requested",
+  "review_required",
+  "behind",
+  "ready_to_merge",
+  "merged",
+  "closed",
+]);
+
+const TRIGGER_ACTIONS = new Set<CodeTriggerAction>(["deliver", "notify"]);
+
+export function parseCodeTrigger(value: unknown): CodeTriggerSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeTriggerSnapshot>(value, [
+      "id",
+      "repo_id",
+      "condition",
+      "action",
+      "enabled",
+      "created_at",
+      "updated_at",
+    ]) ||
+    !nonEmpty(value.id) ||
+    !nonEmpty(value.repo_id) ||
+    !isMember(value.condition, TRIGGER_CONDITIONS) ||
+    !isMember(value.action, TRIGGER_ACTIONS) ||
+    typeof value.enabled !== "boolean" ||
+    !nonEmpty(value.created_at) ||
+    !nonEmpty(value.updated_at)
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    repo_id: value.repo_id,
+    condition: value.condition,
+    action: value.action,
+    enabled: value.enabled,
+    created_at: value.created_at,
+    updated_at: value.updated_at,
+  };
+}
+
+/**
+ * A list where one bad row fails the whole read: a partially parsed rule set
+ * would silently show fewer triggers than are actually armed.
+ */
+export function parseCodeTriggers(
+  value: unknown,
+): CodeTriggerSnapshot[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const triggers: CodeTriggerSnapshot[] = [];
+  for (const item of value) {
+    const trigger = parseCodeTrigger(item);
+    if (!trigger) {
+      return null;
+    }
+    triggers.push(trigger);
+  }
+  return triggers;
 }
 
 const PR_COMMENT_KINDS = new Set<PullRequestCommentKind>([

--- a/crates/tidebreak-desktop/ui/src/stories/CodeTriggerRules.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeTriggerRules.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import type { CodeTriggerSnapshot } from "@/api/types";
+import { CodeTriggerRules } from "@/code/CodeTriggerRules";
+
+function trigger(
+  condition: CodeTriggerSnapshot["condition"],
+  action: CodeTriggerSnapshot["action"],
+  enabled = true,
+): CodeTriggerSnapshot {
+  return {
+    id: `trigger-${condition}`,
+    repo_id: "repo-storybook",
+    condition,
+    action,
+    enabled,
+    created_at: "2026-08-22T00:00:00Z",
+    updated_at: "2026-08-22T00:00:00Z",
+  };
+}
+
+const meta = {
+  title: "Code/Triggers",
+  component: CodeTriggerRules,
+  args: {
+    triggers: [],
+    target: {
+      sessionTitle: "Fix the auth flow",
+      harnessLabel: "Codex",
+      delivery: "steer",
+    },
+    busy: false,
+    onArm: fn(),
+    onDisarm: fn(),
+    onChangeAction: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="px-5 py-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CodeTriggerRules>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Nothing armed yet: every condition off, every action control inert. */
+export const NothingArmed: Story = {};
+
+export const Armed: Story = {
+  args: {
+    triggers: [
+      trigger("checks_failed", "deliver"),
+      trigger("conflicts", "deliver"),
+      trigger("ready_to_merge", "notify"),
+    ],
+  },
+};
+
+/**
+ * A harness that cannot be interrupted. The copy has to say so rather than
+ * implying every trigger reaches the agent mid-turn.
+ */
+export const WaitsForQuiet: Story = {
+  args: {
+    triggers: [trigger("checks_failed", "deliver")],
+    target: {
+      sessionTitle: "Rework the parser",
+      harnessLabel: "Claude Code",
+      delivery: "next_turn",
+    },
+  },
+};
+
+/** No session can receive a fire, so arming still works but nothing lands. */
+export const NoTargetSession: Story = {
+  args: {
+    triggers: [trigger("checks_failed", "deliver")],
+    target: null,
+  },
+};
+
+/** A write is in flight; the controls refuse input rather than racing it. */
+export const Busy: Story = {
+  args: {
+    triggers: [trigger("checks_failed", "deliver")],
+    busy: true,
+  },
+};
+
+/** Armed but switched off: the rule survives so its scoping is not rebuilt. */
+export const Disabled: Story = {
+  args: {
+    triggers: [trigger("checks_failed", "deliver", false)],
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/CodeTriggerRules.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeTriggerRules.stories.tsx
@@ -32,7 +32,7 @@ const meta = {
     },
     busy: false,
     onArm: fn(),
-    onDisarm: fn(),
+    onSetEnabled: fn(),
     onChangeAction: fn(),
   },
   decorators: [


### PR DESCRIPTION
Part of #2480. Follows #2495, which carried the types.

Validators, four client methods, and a rules list with one row per condition.

Each row says what firing does — tell the agent, or just notify — and the
section says how a fire would actually reach the session. A harness that
declares mid-turn steering is named as interrupting; one that does not is
described as waiting for the workspace to go quiet and then taking a turn.
That distinction is what record 0060 asks the interface to make visible, and
Claude Code sits on the second path today.

The component is presentational, so the states worth reviewing are stories:
nothing armed, armed, waiting for quiet, no session available to receive a
fire, busy, and armed-but-switched-off.

`parseCodeTriggers` fails the whole read on one bad row rather than dropping
it, since a partially parsed rule set would show fewer triggers than are armed.

Checks: `tsc --noEmit` clean, `biome lint` clean, 1644 UI tests pass.

Still to come: wiring this into the notifications page against a real
repository, and #2481's migration of the existing `localStorage` rules.