### PR TITLE
ci: stop cancelling superseded runs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,12 +530,6 @@ jobs:
     #
     if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'windows-ci') || needs.changes.outputs.windows == 'true') }}
     runs-on: windows-latest
-    # Every Rust-scoped main push contains the prior main state, so the newest
-    # Windows run proves everything an older in-progress one would have proven.
-    # PRs, schedules, and manual dispatches remain isolated by run id.
-    concurrency:
-      group: ${{ github.event_name == 'push' && 'windows-check-main' || format('windows-check-run-{0}', github.run_id) }}
-      cancel-in-progress: ${{ github.event_name == 'push' }}
     # The persistence steps below compile tidebreak-server's test target, which
     # is the heaviest codegen this lane pays; leave headroom over the
     # check-plus-broker baseline.
@@ -547,17 +541,43 @@ jobs:
       SCCACHE_GHA_RW_MODE: READ_WRITE
       RUSTC_WRAPPER: sccache
     steps:
+      # A newer main commit contains this one, so its own Windows run proves
+      # everything this run would. Bailing out with success is what keeps that
+      # off main's commit list: a concurrency group reports `cancelled`, and
+      # GitHub rolls a cancelled check up as a red X on a commit whose checks
+      # all passed. Fail open — an unreadable tip runs the lane.
+      - name: Skip a push that main has already moved past
+        id: tip
+        if: ${{ github.event_name == 'push' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tip="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha || true)"
+          if [[ -z "$tip" ]]; then
+            echo "Could not read main's tip; running the lane."
+            exit 0
+          fi
+          if [[ "$tip" != "$GITHUB_SHA" ]]; then
+            echo "main is at $tip, past $GITHUB_SHA; skipping this superseded run."
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
       - name: Install toolchain (honors rust-toolchain.toml)
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         run: rustup show
       - name: Set up compiler cache
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.16.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         with:
           node-version: 22
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         with:
           shared-key: windows-check-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
           add-job-id-key: "false"
@@ -570,6 +590,7 @@ jobs:
       # from a clean checkout. Prepare the real Windows artifact first so the
       # desktop check exercises Tauri's target-suffixed sidecar resolution.
       - name: Prepare target-named sidecar binaries
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         shell: pwsh
         env:
           TAURI_ENV_TARGET_TRIPLE: x86_64-pc-windows-msvc
@@ -584,6 +605,7 @@ jobs:
             throw "prepare-sidecar did not produce $cli"
           }
       - name: Check Windows-gated crates
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         run: >-
           cargo check --target x86_64-pc-windows-msvc
           -p tidebreak-core
@@ -598,6 +620,7 @@ jobs:
       # closes. Deliberately one crate: this lane is for checks that need the
       # native host, not a second copy of the workspace suite.
       - name: Host broker Windows tests
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         run: cargo test -p tidebreak-host-broker --locked
       # Code mode crosses Windows-native executable, environment, PowerShell,
       # path-identity, and process-tree boundaries. A cross-target check cannot
@@ -606,6 +629,7 @@ jobs:
       # Process-tree teardown races PowerShell startup on a loaded runner.
       # Three attempts cover that without dropping the Windows contract.
       - name: Code mode Windows lifecycle tests
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Continue"
@@ -637,12 +661,14 @@ jobs:
       # crate's windows-native backend. Targeted filters on two crates — not a
       # second copy of the workspace suite.
       - name: SQLite profile open and migrations
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         run: cargo test -p tidebreak-server --lib desktop_schema --locked
       # `-- --ignored` runs the native round trip alone, so the process-global
       # in-memory keyring mock installed by the ordinary unit test never
       # activates and the test reaches the real Credential Manager available
       # under the hosted runner session.
       - name: Credential Manager round trip
+        if: ${{ steps.tip.outputs.superseded != 'true' }}
         run: cargo test -p tidebreak-core --lib keychain --locked -- --ignored
 
   test:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,30 +3,27 @@ name: Publish staging desktop
 run-name: Publish staging desktop ${{ github.sha }}
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - .cargo/**
-      - .github/workflows/release.yml
-      - .github/workflows/staging-publish.yml
-      - .github/workflows/staging.yml
-      - Cargo.lock
-      - Cargo.toml
-      - crates/**
-      - legal/**
-      - plugins/**
-      - rust-toolchain.toml
-      - scripts/**
-      - skills/**
-      - LICENSE
-      - NOTICE
+  # A staging build takes about 45 minutes and every build serializes on one
+  # publish group, so a per-push trigger could only queue merges behind each
+  # other. GitHub keeps at most one pending run per group and cancels the rest,
+  # which reddened main's commit list for builds that never ran a step. Poll
+  # main's tip instead and build it only when a staged path has moved since the
+  # build the staging channel already hosts.
+  schedule:
+    - cron: "23 * * * *"
   workflow_dispatch:
+    inputs:
+      force:
+        description: Build main's tip even when no staged path has changed since the hosted build
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
 concurrency:
-  # Unique per run so a later merge cannot cancel this caller — that would
+  # Unique per run so a later poll cannot cancel this caller — that would
   # also cancel the reusable publish it started. The publish workflow
   # serializes on its own group without dropping an in-flight notarization.
   group: tidebreak-desktop-staging-${{ github.run_id }}
@@ -38,6 +35,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     outputs:
+      changed: ${{ steps.scope.outputs.changed }}
       sha: ${{ steps.version.outputs.sha }}
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -46,8 +44,72 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.sha }}
 
+      # The hosted manifest is the only record of which commit staging users
+      # are actually running, so it is what a poll must compare against. The
+      # path list below is the one the push trigger used to filter on.
+      - name: Decide whether a staged path moved since the hosted build
+        id: scope
+        env:
+          FORCE: ${{ github.event.inputs.force }}
+          STAGING_SHA: ${{ github.sha }}
+        run: |
+          build() {
+            printf '%s\n' "$1"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          if [[ "$FORCE" = "true" ]]; then
+            build "Forced by workflow_dispatch."
+          fi
+
+          hosted=""
+          if curl --fail --silent --show-error --max-time 30 \
+            "https://downloads.brightwave.io/tidebreak/staging/manifest.json?poll=$GITHUB_RUN_ID" \
+            --output "$RUNNER_TEMP/hosted-manifest.json"; then
+            hosted="$(jq -r '.sha // empty' "$RUNNER_TEMP/hosted-manifest.json" || true)"
+          fi
+          if [[ -z "$hosted" ]]; then
+            build "The staging channel hosts no readable build; building main's tip."
+          fi
+          if ! git cat-file -e "$hosted^{commit}" 2>/dev/null; then
+            build "Hosted staging commit $hosted is not in this history; building main's tip."
+          fi
+          if ! git merge-base --is-ancestor "$hosted" "$STAGING_SHA"; then
+            build "Hosted staging commit $hosted is not an ancestor of $STAGING_SHA; building main's tip."
+          fi
+          if [[ "$hosted" = "$STAGING_SHA" ]]; then
+            echo "Staging already hosts $STAGING_SHA."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "$hosted" "$STAGING_SHA" -- \
+            .cargo \
+            .github/workflows/release.yml \
+            .github/workflows/staging-publish.yml \
+            .github/workflows/staging.yml \
+            Cargo.lock \
+            Cargo.toml \
+            crates \
+            legal \
+            plugins \
+            rust-toolchain.toml \
+            scripts \
+            skills \
+            LICENSE \
+            NOTICE)"
+          if [[ -z "$changed" ]]; then
+            echo "No staged path changed between $hosted and $STAGING_SHA."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf 'Staged paths changed since %s:\n%s\n' "$hosted" "$changed"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
       - name: Derive the staging product version
         id: version
+        if: ${{ steps.scope.outputs.changed == 'true' }}
         env:
           STAGING_RUN_NUMBER: ${{ github.run_number }}
           STAGING_SHA: ${{ github.sha }}
@@ -70,6 +132,7 @@ jobs:
   publish:
     name: publish staging
     needs: resolve
+    if: ${{ needs.resolve.outputs.changed == 'true' }}
     uses: ./.github/workflows/staging-publish.yml
     permissions:
       contents: read

--- a/docs/decisions/0016-desktop-staging-channel.md
+++ b/docs/decisions/0016-desktop-staging-channel.md
@@ -1,6 +1,6 @@
 # 16. Desktop Staging Channel from Main
 
-- Status: Accepted
+- Status: Accepted (amended 2026-08-21, see [Amendment](#amendment-2026-08-21))
 - Date: 2026-08-13
 - Owners: desktop and release
 - Related: [releases](../releases.md), [decision 15](0015-tidebreak-product-and-technical-identity.md)
@@ -187,3 +187,27 @@ release line (LTS, beta) needs a fourth identity.
 - A newer staging version may replace `latest.json`; an older one may not.
 - Deep-link parsing in a staging build accepts `tidebreak-staging://` and
   refuses `tidebreak://`. Production still refuses both extra schemes.
+
+## Amendment (2026-08-21)
+
+**Staging builds from a poll of `main`'s tip, not from every relevant push.**
+The "When" column for staging above should read that way; the rest of this
+record stands unchanged.
+
+A staging build takes about 45 minutes, and every build serializes on
+`tidebreak-desktop-staging-build`. A per-push trigger could therefore only
+queue merges behind each other, and GitHub keeps at most one pending run per
+concurrency group: on a busy day each merge evicted the run queued before it.
+Over one 25-commit stretch, 20 commits carried a cancelled staging check that
+had never run a step, and GitHub rolls a cancelled check up as a red X, so
+`main`'s commit list read as broken when it was not.
+
+**Publish staging desktop** now runs on an hourly `schedule` and on
+`workflow_dispatch`. Each poll reads the commit recorded in the hosted staging
+manifest, compares it against `main`'s tip over the path list the push trigger
+used to filter on, and builds only when one of those paths moved. A manual run
+takes a `force` input to build a tip the poll would skip.
+
+The concurrency rules above are unchanged: the caller still uses a per-run
+group, and the publish workflow still serializes with
+`cancel-in-progress: false` so an in-flight notarization finishes.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -419,9 +419,9 @@ the configured distribution. No long-lived AWS access key belongs in GitHub.
 
 ### Staging desktop from main
 
-Every relevant push to `main` also publishes a packaged **staging** app, a
-third desktop identity that can run beside both `cargo tauri dev` and an
-installed release. The contract is recorded in
+Tidebreak publishes a packaged **staging** app from `main`, a third desktop
+identity that can run beside both `cargo tauri dev` and an installed
+release. The contract is recorded in
 [decision record 16](decisions/0016-desktop-staging-channel.md).
 
 Staging is a release-profile build with a blue icon, product name
@@ -429,16 +429,22 @@ Staging is a release-profile build with a blue icon, product name
 service `tidebreak.staging`, and the `tidebreak-staging://` scheme. It does
 not share a single-instance lock, app-data directory, updater feed, or
 updater signing key with production. Its versions are
-`0.0.0-staging.{run_number}` — monotonic for the Tauri updater, and not a
-production `vMAJOR.MINOR.PATCH` tag.
+`0.0.0-staging.{run_number}` — monotonic for the Tauri updater, not
+contiguous, and not a production `vMAJOR.MINOR.PATCH` tag.
 
-The caller is **Publish staging desktop**. It derives the version, then
-invokes the `workflow_call`-only **Publish staging desktop build** workflow
-with `channel: staging`. Staging publishes serialize so an in-flight
-notarization is not cancelled by the next merge; `latest.json` still only
-advances if that commit is still `main`. Production's concurrency group is
-untouched. Staging artifacts live under
-`https://downloads.brightwave.io/tidebreak/staging/`; the publish step
+The caller is **Publish staging desktop**. It polls `main` hourly rather
+than running on every push. A staging build takes about 45 minutes and every
+build serializes on one publish group, so a per-push trigger could only queue
+merges behind each other, and GitHub cancels the runs it cannot keep pending.
+Each poll compares `main`'s tip against the commit recorded in the hosted
+staging manifest and builds only when a staged path moved between them. To
+build a commit the poll skips, run the workflow by hand with `force`.
+
+The caller derives the version, then invokes the `workflow_call`-only
+**Publish staging desktop build** workflow with `channel: staging`. Staging
+publishes serialize so an in-flight notarization is not cancelled by the next
+build. Production's concurrency group is untouched. Staging artifacts live
+under `https://downloads.brightwave.io/tidebreak/staging/`; the publish step
 refuses any other prefix and will not advance `latest.json` if `main` has
 already moved on.
 

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -534,21 +534,13 @@ test("merge queue groups re-run required CI", () => {
 });
 
 // A main push that a newer commit has already replaced must not keep an
-// expensive lane busy. Two shapes stop it. A concurrency group cancels the
-// older run. A guard step reads main's tip and skips the run instead, which is
-// the shape that also keeps the lane off main's commit list: GitHub rolls a
-// cancelled check up as a red X on a commit whose own checks all passed.
-function cancelsSupersededPush(job, group) {
-  return (
-    new RegExp(
-      `group: \\$\\{\\{ github\\.event_name == 'push' && '${group}'`,
-    ).test(job) &&
-    /cancel-in-progress: \$\{\{ github\.event_name == 'push' \}\}/.test(job)
-  );
-}
-
-// The guard shape only holds if every step the guard exists to avoid is gated
-// on it. One ungated expensive step and a superseded run does its work anyway.
+// expensive lane busy, and must not report `cancelled` when it stops: GitHub
+// rolls a cancelled check up as a red X on a commit whose own checks all
+// passed, so main's commit list reads as broken when it is not. A guard step
+// reads main's tip and skips the run, which reports success.
+//
+// The shape only holds if every step the guard exists to avoid is gated on it.
+// One ungated expensive step and a superseded run does its work anyway.
 function skipsSupersededPush(job) {
   const guard =
     /^ {6}- name: [^\n]*\n {8}id: tip\n {8}if: \$\{\{ github\.event_name == 'push' \}\}\n/m.exec(
@@ -613,9 +605,13 @@ test("native Windows CI is scope-triggered, label-overridable, with a main backs
     );
   }
   assert.ok(
-    cancelsSupersededPush(windows, "windows-check-main") ||
-      skipsSupersededPush(windows),
-    "a superseded main push must stop the Windows lane",
+    skipsSupersededPush(windows),
+    "a superseded main push must skip the Windows lane, not cancel it",
+  );
+  assert.doesNotMatch(
+    windows,
+    /cancel-in-progress/,
+    "cancelling this lane reddens a commit whose own checks all passed",
   );
   assert.match(windows, /SCCACHE_GHA_ENABLED: "true"/);
   assert.match(windows, /SCCACHE_GHA_RW_MODE: READ_WRITE/);
@@ -2209,12 +2205,21 @@ test("the packaged updater trusts the production signing key and endpoint", () =
 test("staging desktop publishes only under the staging prefix", () => {
   const staging = workflows["staging.yml"];
   assert.ok(staging);
-  // Staging builds main, either on every relevant push or on a poll of main's
-  // tip. It must never build a pull request's code.
-  assert.ok(
-    /^on:\n  push:\n    branches: \[main\]/m.test(staging) ||
-      /^on:\n(?:  #[^\n]*\n)*  schedule:\n    - cron: "[^"]+"$/m.test(staging),
-    "staging must build main",
+  // Staging polls main's tip. A per-push trigger only queued merges behind
+  // each other on the one publish group, and GitHub cancelled the runs it
+  // could not keep pending. It must never build a pull request's code.
+  assert.match(
+    staging,
+    /^on:\n(?:  #[^\n]*\n)*  schedule:\n    - cron: "[^"]+"$/m,
+  );
+  assert.doesNotMatch(staging, /^\s*push:/m);
+  // The poll builds only when a staged path moved since the build the channel
+  // already hosts, which is the filter the push trigger's `paths` list was.
+  assert.match(staging, /staging\/manifest\.json\?poll=/);
+  assert.match(staging, /git diff --name-only "\$hosted" "\$STAGING_SHA"/);
+  assert.match(
+    staging,
+    /if: \$\{\{ needs\.resolve\.outputs\.changed == 'true' \}\}/,
   );
   assert.match(staging, /^  workflow_dispatch:$/m);
   assert.doesNotMatch(staging, /^\s*pull_request(?:_target)?:/m);


### PR DESCRIPTION
Stacked on #2499, which relaxes the policy assertions this change needs.
Retarget to `main` once that merges.

## The problem

Over the last 25 commits on main, 20 carried a cancelled staging check and 11
a cancelled Windows check. Neither is a required check, so nothing was ever
blocked — but GitHub rolls a cancelled check up as a red X, so main's commit
list read as broken on 22 of 25 commits. Two genuine `desktop UI` failures sat
in that column unnoticed.

## Staging polls main instead of running on every push

A staging build takes about 45 minutes and every build serializes on
`tidebreak-desktop-staging-build`. A per-push trigger could therefore only
queue merges behind each other, and GitHub keeps at most one pending run per
concurrency group: each merge evicted the run queued behind it. Those 20
cancelled jobs had run zero steps.

**Publish staging desktop** now runs hourly on a `schedule`, plus
`workflow_dispatch`. Each poll reads the commit recorded in the hosted staging
manifest, diffs it against main's tip over the path list the push trigger
filtered on, and builds only when one of those paths moved. A manual run takes
a `force` input to build a tip the poll would skip. When the poll finds
nothing, `publish` is skipped and the run is green.

The concurrency rules are unchanged: the caller still uses a per-run group,
and the publish workflow still serializes with `cancel-in-progress: false` so
an in-flight notarization finishes.

## The Windows lane skips instead of cancelling

`windows-check` drops its cancelling concurrency group for a guard step that
reads main's tip and skips a run the branch has already moved past. A
superseded run reports success rather than `cancelled`. The lane also gets a
backstop that finishes: it was being superseded so often that the post-merge
run it exists for almost never completed.

The check runs inside the job, not ahead of it, because a run is almost always
main's tip when it is created and goes stale while it waits for a runner or
while it works. It fails open — an unreadable tip runs the lane.

Both shapes are pinned by the policy test, which no longer accepts a lane that
cancels itself on a main push.

## Also

- `docs/releases.md` describes the poll and the `force` input.
- Decision record 16 gets a dated amendment. Its identity, signing, and
  concurrency decisions stand; only the "When" column changes.

## Verification

`node --test scripts/*.test.mjs` — 187 pass. Also ran #2499's copy of
`workflow-security.test.mjs` against this branch's workflows the way the
`release policy` job will, and every new shell step through `bash -n`.

## Not fixed here

Staging has not published since `f2e32cf6` at 10:28 today. `publish_staging`
advances `latest.json` only if the built commit is still main's tip, and a
45-minute build rarely is. Polling does not change that.