### PR TITLE
feat(ui): map the delivery notification rules onto triggers

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { CodeGitHubRepositoryRef } from "@/api/types";
+import type { CodeDeliveryNotificationRule } from "@/code/CodeDeliveryStore";
+import { triggersForNotificationRules } from "@/code/CodeTriggerMigration";
+
+function repository(
+  name: string,
+  tidebreakRepoId?: string,
+): CodeGitHubRepositoryRef {
+  return {
+    host: "github.com",
+    owner: "brightwave-inc",
+    name,
+    name_with_owner: `brightwave-inc/${name}`,
+    url: `https://github.com/brightwave-inc/${name}`,
+    ...(tidebreakRepoId ? { tidebreak_repo_id: tidebreakRepoId } : {}),
+  };
+}
+
+function rule(
+  id: CodeDeliveryNotificationRule["id"],
+  patch: Partial<Omit<CodeDeliveryNotificationRule, "id">> = {},
+): CodeDeliveryNotificationRule {
+  return {
+    id,
+    enabled: true,
+    repositoryKeys: [],
+    tidebreakLinkedOnly: false,
+    ...patch,
+  };
+}
+
+describe("triggersForNotificationRules", () => {
+  it("migrates every rule as notify, never as deliver", () => {
+    const armed = triggersForNotificationRules(
+      [rule("run_failure")],
+      [repository("tidebreak", "repo-1")],
+    );
+    expect(armed).toEqual([
+      { repoId: "repo-1", condition: "checks_failed", action: "notify" },
+    ]);
+  });
+
+  it("keeps both facts an attention rule covered", () => {
+    const armed = triggersForNotificationRules(
+      [rule("pull_request_attention")],
+      [repository("tidebreak", "repo-1")],
+    );
+    expect(armed.map((entry) => entry.condition).sort()).toEqual([
+      "changes_requested",
+      "conflicts",
+    ]);
+  });
+
+  it("drops a disabled rule", () => {
+    expect(
+      triggersForNotificationRules(
+        [rule("run_failure", { enabled: false })],
+        [repository("tidebreak", "repo-1")],
+      ),
+    ).toEqual([]);
+  });
+
+  it("treats an empty scope as every repository", () => {
+    const armed = triggersForNotificationRules(
+      [rule("run_failure")],
+      [repository("tidebreak", "repo-1"), repository("orca", "repo-2")],
+    );
+    expect(armed.map((entry) => entry.repoId).sort()).toEqual([
+      "repo-1",
+      "repo-2",
+    ]);
+  });
+
+  it("honours an explicit scope", () => {
+    const armed = triggersForNotificationRules(
+      [
+        rule("run_failure", {
+          repositoryKeys: ["github.com/brightwave-inc/orca"],
+        }),
+      ],
+      [repository("tidebreak", "repo-1"), repository("orca", "repo-2")],
+    );
+    expect(armed).toEqual([
+      { repoId: "repo-2", condition: "checks_failed", action: "notify" },
+    ]);
+  });
+
+  it("skips a repository triggers cannot bind to", () => {
+    expect(
+      triggersForNotificationRules(
+        [rule("run_failure")],
+        [repository("unregistered")],
+      ),
+    ).toEqual([]);
+  });
+
+  it("arms one row per repository and condition", () => {
+    // Both rules reach `conflicts` for the same repository. The server is
+    // unique on (repository, condition), so arming twice would be a no-op at
+    // best and a double notification at worst.
+    const armed = triggersForNotificationRules(
+      [rule("pull_request_attention"), rule("pull_request_attention")],
+      [repository("tidebreak", "repo-1")],
+    );
+    expect(armed).toHaveLength(2);
+    expect(new Set(armed.map((entry) => entry.condition)).size).toBe(2);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.test.ts
@@ -73,6 +73,31 @@ describe("triggersForNotificationRules", () => {
     ]);
   });
 
+  it("matches a scope key whatever case it was stored in", () => {
+    // Persisted keys are lowercased by `codeDeliveryRepositoryKey`; the
+    // repository ref keeps the host's own casing.
+    const armed = triggersForNotificationRules(
+      [
+        rule("run_failure", {
+          repositoryKeys: ["github.com/brightwave-inc/orca"],
+        }),
+      ],
+      [
+        {
+          host: "GitHub.com",
+          owner: "BrightWave-Inc",
+          name: "Orca",
+          name_with_owner: "BrightWave-Inc/Orca",
+          url: "https://github.com/BrightWave-Inc/Orca",
+          tidebreak_repo_id: "repo-2",
+        },
+      ],
+    );
+    expect(armed).toEqual([
+      { repoId: "repo-2", condition: "checks_failed", action: "notify" },
+    ]);
+  });
+
   it("honours an explicit scope", () => {
     const armed = triggersForNotificationRules(
       [

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.ts
@@ -1,0 +1,88 @@
+import type {
+  CodeGitHubRepositoryRef,
+  CodeTriggerAction,
+  CodeTriggerCondition,
+} from "@/api/types";
+import type {
+  CodeDeliveryNotificationRule,
+  CodeDeliveryNotificationRuleKind,
+} from "@/code/CodeDeliveryStore";
+
+/**
+ * One trigger to arm on the server, derived from a client-side rule.
+ *
+ * Record 60 folds the `localStorage` notification rules into the trigger
+ * substrate so there is one rule engine rather than two. This is the mapping,
+ * kept pure so the migration can be tested without a server.
+ */
+export type TriggerToArm = {
+  repoId: string;
+  condition: CodeTriggerCondition;
+  action: CodeTriggerAction;
+};
+
+/**
+ * What each old rule watched for, in trigger vocabulary.
+ *
+ * `pull_request_attention` covered more than one fact, so it maps to more than
+ * one condition. Dropping either would silently narrow what a user already
+ * asked to hear about.
+ */
+const RULE_CONDITIONS: Record<
+  CodeDeliveryNotificationRuleKind,
+  CodeTriggerCondition[]
+> = {
+  pull_request_attention: ["changes_requested", "conflicts"],
+  pull_request_ready: ["ready_to_merge"],
+  run_failure: ["checks_failed"],
+};
+
+function repositoryKey(repository: CodeGitHubRepositoryRef): string {
+  return `${repository.host}/${repository.owner}/${repository.name}`;
+}
+
+/**
+ * Turn the persisted notification rules into the triggers that reproduce them.
+ *
+ * Every result uses `notify`: these rules raised a notification and never sent
+ * the agent anything, so migrating them to `deliver` would start interrupting
+ * work the user never agreed to interrupt.
+ *
+ * A disabled rule produces nothing. An empty `repositoryKeys` means the rule
+ * applied everywhere, so it maps to every repository Tidebreak knows; a
+ * repository with no `tidebreak_repo_id` is not one triggers can bind to and is
+ * skipped rather than guessed at.
+ */
+export function triggersForNotificationRules(
+  rules: CodeDeliveryNotificationRule[],
+  repositories: CodeGitHubRepositoryRef[],
+): TriggerToArm[] {
+  const armed = new Map<string, TriggerToArm>();
+  for (const rule of rules) {
+    if (!rule.enabled) {
+      continue;
+    }
+    const scoped =
+      rule.repositoryKeys.length === 0
+        ? repositories
+        : repositories.filter((repository) =>
+            rule.repositoryKeys.includes(repositoryKey(repository)),
+          );
+    for (const repository of scoped) {
+      const repoId = repository.tidebreak_repo_id;
+      if (!repoId) {
+        continue;
+      }
+      for (const condition of RULE_CONDITIONS[rule.id]) {
+        // One row per (repository, condition) — the server's own unique key.
+        // Two rules mapping onto one condition must not arm it twice.
+        armed.set(`${repoId}:${condition}`, {
+          repoId,
+          condition,
+          action: "notify",
+        });
+      }
+    }
+  }
+  return [...armed.values()];
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.ts
@@ -3,9 +3,10 @@ import type {
   CodeTriggerAction,
   CodeTriggerCondition,
 } from "@/api/types";
-import type {
-  CodeDeliveryNotificationRule,
-  CodeDeliveryNotificationRuleKind,
+import {
+  codeDeliveryRepositoryKey,
+  type CodeDeliveryNotificationRule,
+  type CodeDeliveryNotificationRuleKind,
 } from "@/code/CodeDeliveryStore";
 
 /**
@@ -37,10 +38,6 @@ const RULE_CONDITIONS: Record<
   run_failure: ["checks_failed"],
 };
 
-function repositoryKey(repository: CodeGitHubRepositoryRef): string {
-  return `${repository.host}/${repository.owner}/${repository.name}`;
-}
-
 /**
  * Turn the persisted notification rules into the triggers that reproduce them.
  *
@@ -66,7 +63,10 @@ export function triggersForNotificationRules(
       rule.repositoryKeys.length === 0
         ? repositories
         : repositories.filter((repository) =>
-            rule.repositoryKeys.includes(repositoryKey(repository)),
+            // The stored keys are folded by `codeDeliveryRepositoryKey`, so
+            // comparing against a hand-built key would miss any repository
+            // whose host or owner is not already lowercase.
+            rule.repositoryKeys.includes(codeDeliveryRepositoryKey(repository)),
           );
     for (const repository of scoped) {
       const repoId = repository.tidebreak_repo_id;


### PR DESCRIPTION
Part of #2481. Follows #2496.

Record 0060 folds the client-side notification rules into the trigger
substrate so there is one rule engine rather than two. This is the mapping,
kept as a pure function so it can be tested without a server.

## Decisions worth reviewing

- **Everything migrates as `notify`, never `deliver`.** These rules raised a
  notification and never sent the agent anything. Migrating them to `deliver`
  would start interrupting work the user never agreed to interrupt.
- **`pull_request_attention` maps to two conditions**, `changes_requested` and
  `conflicts`. It covered more than one fact, and dropping either would
  silently narrow what someone already asked to hear about.
- **An empty scope means every repository**, matching what the rule already
  meant. A repository with no `tidebreak_repo_id` is not something a trigger
  can bind to, so it is skipped rather than guessed at.
- **Results are keyed on `(repository, condition)`** — the server's own unique
  key — so two rules reaching one condition arm it once.

## Scope

The mapping and its tests. Running it once on first read, and then dropping the
client-side evaluation, is the next commit; the `localStorage` write is
one-way, so it is worth landing the mapping under test before anything reads it
for real.

Checks: 7 new tests pass, `tsc --noEmit` clean, `biome lint` clean.