### PR TITLE
fix: restore CI and repair platform regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # Cargo's libgit2 transport intermittently fails TLS handshakes against the
+  # pinned Symphonia revision. The runner's Git client handles the fetch.
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
 concurrency:
   # On a PR ref only the newest commit matters, so supersede in-progress runs.
   # Every other event gets a unique group (keyed by run id) so nothing cancels

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -37,7 +37,12 @@ pub struct Migrator;
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(Baseline), Box::new(AppOwner), Box::new(CodeOwner)]
+        vec![
+            Box::new(Baseline),
+            Box::new(AppOwner),
+            Box::new(CodeOwner),
+            Box::new(BaselineRepair),
+        ]
     }
 }
 
@@ -213,6 +218,54 @@ impl MigrationTrait for CodeOwner {
     }
 }
 
+/// Repair the known gap for a self-host database that predates the frozen
+/// baseline. Such a database makes [`Baseline`] return when it sees `app`, so
+/// tables added to the baseline later never reached it. Create every missing
+/// baseline table and index in dependency order. This repairs additive schema
+/// changes; changed columns still require their own ordered migration.
+struct BaselineRepair;
+
+impl MigrationName for BaselineRepair {
+    fn name(&self) -> &str {
+        "m20260822_000004_baseline_repair"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for BaselineRepair {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for entry in baseline::tables() {
+            let name = entry
+                .table
+                .get_table_name()
+                .expect("every baseline table statement names its table")
+                .sea_orm_table()
+                .to_string();
+            if manager.has_table(&name).await? {
+                continue;
+            }
+            let mut table = entry.table;
+            table.if_not_exists();
+            manager.create_table(table).await?;
+            for mut index in entry.indexes {
+                index.if_not_exists();
+                manager.create_index(index).await?;
+            }
+        }
+        for seed in baseline::SEED_STATEMENTS {
+            manager.get_connection().execute_unprepared(seed).await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // The repair only creates baseline objects that were missing. Removing
+        // them would also remove objects owned by the baseline on a fresh
+        // database.
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
@@ -263,6 +316,7 @@ mod tests {
                 "m20260814_000001_baseline",
                 "m20260814_000002_app_owner",
                 "m20260814_000003_code_owner",
+                "m20260822_000004_baseline_repair",
             ]
         );
         assert!(db
@@ -408,6 +462,66 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(row.try_get::<String>("", "owner").unwrap(), "local");
+    }
+
+    /// A self-host database created before later code tables joined the
+    /// baseline keeps its rows and gains every table that the current schema
+    /// expects.
+    #[tokio::test]
+    async fn a_pre_pin_database_gains_tables_added_to_the_baseline() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        db.execute_unprepared(
+            "CREATE TABLE app (
+                id TEXT PRIMARY KEY NOT NULL,
+                name TEXT NOT NULL,
+                current_revision_id TEXT NOT NULL,
+                revision_count INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT,
+                owner TEXT NOT NULL DEFAULT 'local'
+            )",
+        )
+        .await
+        .unwrap();
+        db.execute_unprepared(concat!(
+            "INSERT INTO app (id, name, current_revision_id, revision_count, ",
+            "created_at, updated_at, deleted_at, owner) VALUES ",
+            "('00000000-0000-0000-0000-000000000001', 'legacy', ",
+            "'00000000-0000-0000-0000-000000000002', 1, ",
+            "'2026-08-14 00:00:00+00:00', '2026-08-14 00:00:00+00:00', NULL, 'local')"
+        ))
+        .await
+        .unwrap();
+
+        Migrator::up(&db, None).await.unwrap();
+
+        for table in [
+            "code_watch",
+            "code_trigger",
+            "code_trigger_fire",
+            "code_session_image",
+        ] {
+            let exists = db
+                .query_one_raw(Statement::from_string(
+                    DbBackend::Sqlite,
+                    format!(
+                        "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = '{table}'"
+                    ),
+                ))
+                .await
+                .unwrap();
+            assert!(exists.is_some(), "repair did not create {table}");
+        }
+        let legacy = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT name FROM app WHERE id = '00000000-0000-0000-0000-000000000001'".to_owned(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(legacy.try_get::<String>("", "name").unwrap(), "legacy");
     }
     /// The baseline is frozen, and this is what holds it still.
     ///

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -515,7 +515,60 @@ async fn a_capped_replay_keeps_the_newest_events_and_admits_the_head_is_gone() {
 /// code-mode entity references a chat table or id type.
 #[test]
 fn chat_and_code_entities_do_not_cross_reference() {
-    let entities = include_str!("../entities.rs");
+    fn without_comments(source: &str) -> String {
+        let mut stripped = String::with_capacity(source.len());
+        let mut chars = source.chars().peekable();
+        let mut block_depth = 0;
+        while let Some(character) = chars.next() {
+            if block_depth > 0 {
+                match (character, chars.peek().copied()) {
+                    ('/', Some('*')) => {
+                        chars.next();
+                        stripped.push_str("  ");
+                        block_depth += 1;
+                    }
+                    ('*', Some('/')) => {
+                        chars.next();
+                        stripped.push_str("  ");
+                        block_depth -= 1;
+                    }
+                    ('\n', _) => stripped.push('\n'),
+                    _ => stripped.push(' '),
+                }
+                continue;
+            }
+            match (character, chars.peek().copied()) {
+                ('/', Some('/')) => {
+                    chars.next();
+                    stripped.push_str("  ");
+                    for comment in chars.by_ref() {
+                        if comment == '\n' {
+                            stripped.push('\n');
+                            break;
+                        }
+                        stripped.push(' ');
+                    }
+                }
+                ('/', Some('*')) => {
+                    chars.next();
+                    stripped.push_str("  ");
+                    block_depth = 1;
+                }
+                _ => stripped.push(character),
+            }
+        }
+        stripped
+    }
+
+    let sample = "/// ChatId in prose is allowed.\n\
+                  /* AgentEvent in a nested /* TurnId */ comment is allowed. */\n\
+                  pub use crate::id::ChatId as ConversationId;";
+    let stripped_sample = without_comments(sample);
+    assert!(!stripped_sample.contains("ChatId in prose"));
+    assert!(!stripped_sample.contains("AgentEvent in a nested"));
+    assert!(stripped_sample.contains("crate::id::ChatId as ConversationId"));
+
+    let entities = without_comments(include_str!("../entities.rs"));
     let mut current_mod = "";
     for line in entities.lines() {
         if let Some(name) = line.strip_prefix("pub mod ") {
@@ -549,7 +602,7 @@ fn chat_and_code_entities_do_not_cross_reference() {
                 walk_rs(&path, visit);
             } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
                 let text = std::fs::read_to_string(&path).unwrap();
-                visit(&path, &text);
+                visit(&path, &without_comments(&text));
             }
         }
     }

--- a/crates/tidebreak-server/src/managed_policy.rs
+++ b/crates/tidebreak-server/src/managed_policy.rs
@@ -41,11 +41,7 @@ const PROVISIONED_POLICY_FILE: &str = "gateway-policy.json";
 
 /// The settings key the provisioned policy lived under before it moved to
 /// [`PROVISIONED_POLICY_FILE`]. Read once per boot by
-/// [`import_legacy_setting`]; never written or deleted. It used to be swept by
-/// the next epoch reset, which no longer happens for a profile at or above the
-/// migration pin (decision 61), so on those the row simply stays. It is inert
-/// while the sidecar exists, which is the case for every profile that has
-/// booted since the move.
+/// [`import_legacy_setting`], then deleted once the sidecar holds a valid copy.
 const LEGACY_SETTING_KEY: &str = "managed_policy_v1";
 
 /// The key every OS artifact stores the asserted URL under: the Windows
@@ -1072,15 +1068,14 @@ pub(crate) fn provisioned_url(provisioned: &dyn ProvisionedPolicySource) -> Resu
 /// survive the move. When the file is absent and the legacy row holds a
 /// decodable policy, the row's URL becomes the file's contents.
 ///
-/// Everything else is deliberately untouched. The legacy row itself is left
-/// in place — the [`Store`] API grows no delete for this, and pre-v1
-/// schema-epoch squashes remove the row naturally. A file that exists but
-/// does not decode is not repaired here: importing over it would launder a
-/// tampered artifact into a fresh policy, and the fail-closed misconfigured
-/// projection plus the [`provision`] repair path already cover it. An
-/// undecodable legacy *row* is skipped with a warning for the same reason —
-/// the only writes this function may make are faithful copies of what the
-/// row actually asserted.
+/// Once the file holds a valid policy, the legacy row is deleted so removing
+/// the file later cannot silently provision the profile again. A file that
+/// exists but does not decode is not repaired here: importing over it would
+/// launder a tampered artifact into a fresh policy, and the fail-closed
+/// misconfigured projection plus the [`provision`] repair path already cover
+/// it. An undecodable legacy *row* is skipped with a warning for the same
+/// reason — the only policy write this function may make is a faithful copy
+/// of what the row actually asserted.
 ///
 /// Boot propagates a failed import rather than starting unmanaged: the boot
 /// path retires gateway sessions the policy no longer stands behind, so
@@ -1091,7 +1086,10 @@ pub(crate) async fn import_legacy_setting(
     store: &dyn Store,
 ) -> Result<()> {
     match provisioned.read() {
-        Ok(Some(_)) => return Ok(()),
+        Ok(Some(_)) => {
+            store.delete_setting(LEGACY_SETTING_KEY).await?;
+            return Ok(());
+        }
         Ok(None) => {}
         Err(error) => {
             tracing::warn!(
@@ -1105,7 +1103,10 @@ pub(crate) async fn import_legacy_setting(
         return Ok(());
     };
     match serde_json::from_value::<ProvisionedPolicy>(value) {
-        Ok(saved) => provisioned.write(&saved.gateway_url),
+        Ok(saved) => {
+            provisioned.write(&saved.gateway_url)?;
+            store.delete_setting(LEGACY_SETTING_KEY).await
+        }
         Err(_) => {
             tracing::warn!(
                 "legacy provisioned policy setting does not decode; \
@@ -1359,11 +1360,10 @@ mod tests {
     }
 
     /// The upgrade import, end to end: a profile paired before the policy
-    /// moved out of the settings table boots onto the file, the legacy row
-    /// is left for the epoch squashes to remove, and the import never
-    /// overwrites what the file already says.
+    /// moved out of the settings table boots onto the file, the legacy row is
+    /// deleted, and the import never overwrites what the file already says.
     #[tokio::test]
-    async fn the_legacy_setting_row_is_imported_once_then_left_alone() {
+    async fn the_legacy_setting_row_is_imported_once_then_deleted() {
         let (store, _store_directory) = test_store().await;
         let directory = tempfile::tempdir().unwrap();
         let provisioned = ProvisionedPolicyFile::in_data_dir(directory.path());
@@ -1383,17 +1383,9 @@ mod tests {
         let policy = resolve(&provisioned, &NoOsPolicy).unwrap();
         assert!(policy.managed && !policy.misconfigured);
         assert_eq!(policy.gateway_url.as_deref(), Some("https://corp.gateway/"));
-        // The row is left in place; the next pre-v1 epoch squash removes it.
-        assert!(
-            store
-                .get_setting(LEGACY_SETTING_KEY)
-                .await
-                .unwrap()
-                .is_some(),
-            "the import copies, never deletes"
-        );
+        assert_eq!(store.get_setting(LEGACY_SETTING_KEY).await.unwrap(), None);
 
-        // Once the file exists it wins: a changed row is not re-imported.
+        // Once the file exists it wins, and any stale row is retired.
         store
             .set_setting(
                 LEGACY_SETTING_KEY,
@@ -1406,6 +1398,7 @@ mod tests {
             provisioned.read().unwrap().as_deref(),
             Some("https://corp.gateway/")
         );
+        assert_eq!(store.get_setting(LEGACY_SETTING_KEY).await.unwrap(), None);
 
         // An undecodable row is skipped, not laundered into policy.
         let directory = tempfile::tempdir().unwrap();

--- a/crates/tidebreak-server/src/tests/lifecycle.rs
+++ b/crates/tidebreak-server/src/tests/lifecycle.rs
@@ -1079,7 +1079,7 @@ async fn accept_and_claim_turn_for_route_test(
     turn_id: TurnId,
     chat_id: ChatId,
     content: &str,
-) -> uuid::Uuid {
+) -> (uuid::Uuid, chrono::DateTime<chrono::Utc>) {
     let accepted = match store
         .accept_turn(turn_id, chat_id, "fake", content)
         .await
@@ -1090,7 +1090,7 @@ async fn accept_and_claim_turn_for_route_test(
         outcome => panic!("route-test turn was not accepted: {outcome:?}"),
     };
     let turn_token = uuid::Uuid::new_v4();
-    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let claimed_at = accepted.available_at;
     let claimed = store
         .claim_turn_run(
             turn_token,
@@ -1102,7 +1102,7 @@ async fn accept_and_claim_turn_for_route_test(
         .turn
         .expect("the accepted route-test turn is due");
     assert_eq!(claimed.id, turn_id);
-    turn_token
+    (turn_token, claimed_at)
 }
 
 async fn park_client_wait_for_route_test(
@@ -1111,7 +1111,7 @@ async fn park_client_wait_for_route_test(
     progress: TurnCheckpointProgress,
 ) -> (TurnId, ClientToolCallRequest) {
     let turn_id = TurnId::new();
-    let turn_token =
+    let (turn_token, claimed_at) =
         accept_and_claim_turn_for_route_test(store, turn_id, chat_id, "native action").await;
     let call = ClientToolCallRequest {
         id: CallId::new(),
@@ -1123,14 +1123,7 @@ async fn park_client_wait_for_route_test(
     };
     assert!(matches!(
         store
-            .park_turn_for_client_tool_call(
-                turn_id,
-                turn_token,
-                0,
-                progress,
-                chrono::Utc::now(),
-                &call,
-            )
+            .park_turn_for_client_tool_call(turn_id, turn_token, 0, progress, claimed_at, &call,)
             .await
             .unwrap()
             .unwrap(),
@@ -1144,7 +1137,7 @@ async fn park_user_questions_for_route_test(
     chat_id: ChatId,
 ) -> (TurnId, ClientToolCallRequest) {
     let turn_id = TurnId::new();
-    let turn_token =
+    let (turn_token, claimed_at) =
         accept_and_claim_turn_for_route_test(store, turn_id, chat_id, "ask a question").await;
     let call = ClientToolCallRequest {
         id: CallId::new(),
@@ -1178,7 +1171,7 @@ async fn park_user_questions_for_route_test(
             turn_token,
             0,
             test_client_checkpoint_progress(1),
-            chrono::Utc::now(),
+            claimed_at,
             &call,
         )
         .await
@@ -2098,7 +2091,7 @@ async fn park_plan_for_route_test(
     chat_id: ChatId,
 ) -> (TurnId, ClientToolCallRequest) {
     let turn_id = TurnId::new();
-    let turn_token =
+    let (turn_token, claimed_at) =
         accept_and_claim_turn_for_route_test(store, turn_id, chat_id, "propose a plan").await;
     let call = ClientToolCallRequest {
         id: CallId::new(),
@@ -2117,7 +2110,7 @@ async fn park_plan_for_route_test(
             turn_token,
             0,
             test_client_checkpoint_progress(1),
-            chrono::Utc::now(),
+            claimed_at,
             &call,
         )
         .await
@@ -2131,7 +2124,7 @@ async fn park_folder_access_for_route_test(
     chat_id: ChatId,
 ) -> ClientToolCallRequest {
     let turn_id = TurnId::new();
-    let turn_token =
+    let (turn_token, claimed_at) =
         accept_and_claim_turn_for_route_test(store, turn_id, chat_id, "read the notes").await;
     let call = ClientToolCallRequest {
         id: CallId::new(),
@@ -2151,7 +2144,7 @@ async fn park_folder_access_for_route_test(
             turn_token,
             0,
             test_client_checkpoint_progress(1),
-            chrono::Utc::now(),
+            claimed_at,
             &call,
         )
         .await

--- a/crates/tidebreak-server/src/tests/lifecycle.rs
+++ b/crates/tidebreak-server/src/tests/lifecycle.rs
@@ -1074,18 +1074,23 @@ pub(super) async fn post_native_json(
 /// claim it straight from the store, which is a scan over the whole queue. The
 /// app under test must therefore have no turn worker running yet, or the two
 /// race for the same queued turn — see `test_app_without_turn_worker`.
-async fn park_client_wait_for_route_test(
+async fn accept_and_claim_turn_for_route_test(
     store: &dyn Store,
+    turn_id: TurnId,
     chat_id: ChatId,
-    progress: TurnCheckpointProgress,
-) -> (TurnId, ClientToolCallRequest) {
-    let turn_id = TurnId::new();
-    store
-        .accept_turn(turn_id, chat_id, "fake", "native action")
+    content: &str,
+) -> uuid::Uuid {
+    let accepted = match store
+        .accept_turn(turn_id, chat_id, "fake", content)
         .await
-        .unwrap();
+        .unwrap()
+    {
+        tidebreak_core::AcceptTurnOutcome::Accepted(turn)
+        | tidebreak_core::AcceptTurnOutcome::Existing(turn) => turn,
+        outcome => panic!("route-test turn was not accepted: {outcome:?}"),
+    };
     let turn_token = uuid::Uuid::new_v4();
-    let claimed_at = chrono::Utc::now();
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
     let claimed = store
         .claim_turn_run(
             turn_token,
@@ -1095,8 +1100,19 @@ async fn park_client_wait_for_route_test(
         .await
         .unwrap()
         .turn
-        .unwrap();
+        .expect("the accepted route-test turn is due");
     assert_eq!(claimed.id, turn_id);
+    turn_token
+}
+
+async fn park_client_wait_for_route_test(
+    store: &dyn Store,
+    chat_id: ChatId,
+    progress: TurnCheckpointProgress,
+) -> (TurnId, ClientToolCallRequest) {
+    let turn_id = TurnId::new();
+    let turn_token =
+        accept_and_claim_turn_for_route_test(store, turn_id, chat_id, "native action").await;
     let call = ClientToolCallRequest {
         id: CallId::new(),
         chat_id,
@@ -1128,22 +1144,8 @@ async fn park_user_questions_for_route_test(
     chat_id: ChatId,
 ) -> (TurnId, ClientToolCallRequest) {
     let turn_id = TurnId::new();
-    store
-        .accept_turn(turn_id, chat_id, "fake", "ask a question")
-        .await
-        .unwrap();
-    let turn_token = uuid::Uuid::new_v4();
-    let claimed_at = chrono::Utc::now();
-    store
-        .claim_turn_run(
-            turn_token,
-            claimed_at,
-            claimed_at + chrono::Duration::minutes(1),
-        )
-        .await
-        .unwrap()
-        .turn
-        .unwrap();
+    let turn_token =
+        accept_and_claim_turn_for_route_test(store, turn_id, chat_id, "ask a question").await;
     let call = ClientToolCallRequest {
         id: CallId::new(),
         chat_id,
@@ -2096,22 +2098,8 @@ async fn park_plan_for_route_test(
     chat_id: ChatId,
 ) -> (TurnId, ClientToolCallRequest) {
     let turn_id = TurnId::new();
-    store
-        .accept_turn(turn_id, chat_id, "fake", "propose a plan")
-        .await
-        .unwrap();
-    let turn_token = uuid::Uuid::new_v4();
-    let claimed_at = chrono::Utc::now();
-    store
-        .claim_turn_run(
-            turn_token,
-            claimed_at,
-            claimed_at + chrono::Duration::minutes(1),
-        )
-        .await
-        .unwrap()
-        .turn
-        .unwrap();
+    let turn_token =
+        accept_and_claim_turn_for_route_test(store, turn_id, chat_id, "propose a plan").await;
     let call = ClientToolCallRequest {
         id: CallId::new(),
         chat_id,
@@ -2143,22 +2131,8 @@ async fn park_folder_access_for_route_test(
     chat_id: ChatId,
 ) -> ClientToolCallRequest {
     let turn_id = TurnId::new();
-    store
-        .accept_turn(turn_id, chat_id, "fake", "read the notes")
-        .await
-        .unwrap();
-    let turn_token = uuid::Uuid::new_v4();
-    let claimed_at = chrono::Utc::now();
-    store
-        .claim_turn_run(
-            turn_token,
-            claimed_at,
-            claimed_at + chrono::Duration::minutes(1),
-        )
-        .await
-        .unwrap()
-        .turn
-        .unwrap();
+    let turn_token =
+        accept_and_claim_turn_for_route_test(store, turn_id, chat_id, "read the notes").await;
     let call = ClientToolCallRequest {
         id: CallId::new(),
         chat_id,

--- a/docs/managed-policy.md
+++ b/docs/managed-policy.md
@@ -61,37 +61,35 @@ Deploy it root-owned and not world-writable, as `/etc` content should be.
 Unlike the macOS reader, the file reader does not verify ownership today —
 the permissions are deployment guidance, not an enforced guarantee.
 
-## Developer flow — the sqlite policy toggle
+## Developer flow — the provisioned policy file
 
 There is no unmanaged gateway settings surface: the hand-typed gateway URL
 field and the additive "use model gateway" toggle are retired, and policy is
 the only way a profile becomes gateway-connected. To exercise the real
-managed path against a local gateway without an MDM profile, write the same
-sticky provisioned state that deep-link pairing commits when its sign-in
-completes — the `managed_policy_v1` row in the profile database:
+managed path against a local gateway without an MDM profile, quit Tidebreak
+and write the same sticky provisioned state that deep-link pairing commits
+when its sign-in completes:
 
 ```sh
-sqlite3 "<data dir>/tidebreak.db" \
-  "INSERT INTO setting(key, value_json) VALUES
-     ('managed_policy_v1', '{\"gateway_url\":\"http://127.0.0.1:8081\"}')
-   ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json;"
+umask 077
+printf '%s\n' '{"gateway_url":"http://127.0.0.1:8081"}' \
+  > "<data dir>/gateway-policy.json"
 ```
 
-Policy is re-resolved on every read, so the profile turns managed
-(`source: provisioned`) on the next `/policy` read — sign-in, model sync,
-and routing all run the genuine managed path against the URL you provided.
-Delete the row to return to the open profile:
+Restart Tidebreak. The profile starts managed (`source: provisioned`), and
+sign-in, model sync, and routing use the gateway URL that you provided. To
+return to the open profile, quit Tidebreak and delete the file:
 
 ```sh
-sqlite3 "<data dir>/tidebreak.db" \
-  "DELETE FROM setting WHERE key = 'managed_policy_v1';"
+rm "<data dir>/gateway-policy.json"
 ```
 
-Note that an OS-managed (MDM) assertion always outranks this row. A profile
+Restart Tidebreak after deleting the file. An OS-managed (MDM) assertion
+always outranks this file. A profile
 provisioned to one gateway refuses a bare provision link for another;
 opening such a link instead asks, in a native dialog naming both gateways,
 whether to re-pair. Confirming parks the replacement, and completing a
 sign-in against the new gateway commits it — the old gateway's session is
-revoked and cleared in the same step. Deleting the row (above) remains the
+revoked and cleared in the same step. Deleting the file remains the
 way to return to the open profile; an OS-asserted gateway can never be
 replaced by re-pairing.


### PR DESCRIPTION
## What changed

Cargo uses the runner's Git client for the pinned Symphonia fetch, and the core migration chain repairs baseline tables missing from pre-pin self-host databases. Managed policy retires the legacy SQLite row after the sidecar holds a valid policy, the developer guide uses `gateway-policy.json`, and route and boundary tests no longer depend on clock timing or scan comments as code.

## Validation

`cargo fmt --all -- --check`, `node --test scripts/workflow-security.test.mjs`, `cargo metadata --locked --no-deps --format-version 1`, and `git diff --check` pass. Rust compilation and tests were not run locally under the repository's Cargo policy; CI provides that coverage.

## Compatibility and risk

This adds an ordered repair migration and deletes only an obsolete managed-policy row after a valid sidecar exists; wire formats do not change.

## Tracking

Closes #2498
Closes #2497
Closes #2490
Closes #2473
