### PR TITLE
fix(cli): raise the recursion limit the self-host image build needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,6 +785,50 @@ jobs:
           cargo test -p tidebreak-core --no-default-features --features postgres
           --test postgres_code_owner --locked
 
+  self-host-build:
+    name: self-host server build
+    needs: changes
+    if: ${{ needs.changes.outputs.workspace == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_WRITE
+      RUSTC_WRAPPER: sccache
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install toolchain (honors rust-toolchain.toml)
+        run: rustup show
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.16.0
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: false
+      # The feature set deploy/self-host/Dockerfile builds, which no other job
+      # compiles: clippy and test run default features, and the postgres job
+      # covers tidebreak-core rather than tidebreak-cli. Without this, the
+      # combination first builds inside `Publish server image`, which runs only
+      # after a release is published — so a break there strands a released tag
+      # with no pullable image.
+      #
+      # Debug profile on purpose. This guards compile-time failures such as
+      # trait-resolution and layout-depth limits, which do not vary with
+      # opt-level, and it keeps the job minutes rather than the release build's.
+      # It does not cover the Dockerfile itself or release-only codegen.
+      - name: Build the self-host binary the way the image does
+        run: >-
+          cargo build --locked -p tidebreak-cli
+          --features tidebreak-server/postgres
+
   ui:
     name: desktop UI
     needs: changes

--- a/crates/tidebreak-cli/src/main.rs
+++ b/crates/tidebreak-cli/src/main.rs
@@ -79,6 +79,12 @@
 //! reaches a data directory a desktop app or daemon already owns; two processes
 //! embedding servers over one data directory is refused.
 
+// `tidebreak-server/postgres` deepens the `output_command` async state machine
+// past rustc's default 128-query layout limit, which is how the self-host image
+// build broke while every default-feature build stayed green. The limit is a
+// compile-time bound, so raising it costs nothing at runtime.
+#![recursion_limit = "256"]
+
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::str::FromStr;


### PR DESCRIPTION
`Publish server image v0.60.0` failed, so `ghcr.io/brightwave-inc/tidebreak-server`
has no tag newer than `0.59.0`. The arm64 leg died compiling `tidebreak-cli`:

```
error: queries overflow the depth limit!
  = help: consider increasing the recursion limit by adding a
    `#![recursion_limit = "256"]` attribute to your crate (`tidebreak`)
  = note: query depth increased by 130 when computing layout of
    `{async fn body of output_command<impl Iterator<Item = OsString>>()}`
```

amd64 was cancelled alongside it and the multi-arch manifest was skipped, so
nothing was pushed.

## The fix

`#![recursion_limit = "256"]` in `crates/tidebreak-cli/src/main.rs`. There was
no `recursion_limit` anywhere in the repository before this. Enabling
`tidebreak-server/postgres` deepens the `output_command` async state machine
past rustc's default 128, which is why v0.59.0 built and v0.60.0 did not.

## Why CI missed it

`deploy/self-host/Dockerfile` builds a feature combination no other job
compiles:

```
cargo build --release --locked -p tidebreak-cli --features tidebreak-server/postgres
```

`lint` and `test` run default features. The `postgres` job covers
`tidebreak-core`, not `tidebreak-cli`. And `publish-server-image.yml` triggers
only on `release: published`, schedule, or dispatch — never on a pull request.
So the combination first built at release time, after the release was already
published. That ordering is how a green release tag ends up with no pullable
image.

The new `self-host server build` job compiles exactly that target and feature
set on every workspace-touching pull request.

Debug profile on purpose: this guards compile-time limits like trait
resolution and layout depth, which do not vary with opt-level, and it keeps the
job to minutes instead of the release build's. It does not cover the Dockerfile
itself or release-only codegen.

## What this does not fix

Re-running `Publish server image` against `v0.60.0` or `v0.61.0` will fail the
same way. That workflow checks out the release tag's tree, and neither tree
carries this change. A tidebreak release cut after this merges is what produces
the first server image newer than `0.59.0`.

Worth considering separately: the release publishes before the image builds, so
even with this guard a red image build still leaves a published release behind.
Gating publication on the image would close that, but it restructures the
release flow and is not in this change.