### PR TITLE
fix(desktop): stop Cmd+W from quitting the app

### DIFF
--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -42,6 +42,7 @@ mod documents;
 mod host_access;
 mod host_authority;
 mod image_attachments;
+mod menu;
 mod node_install;
 mod office_install;
 mod office_pdf;
@@ -840,7 +841,7 @@ pub fn run() {
             updater::check_for_update,
             updater::restart_for_update
         ])
-        .on_menu_event(updater::handle_menu_event)
+        .on_menu_event(menu::handle_menu_event)
         .setup(move |app| {
             // The dev server's origin is remote as far as the IPC is
             // concerned, so `tauri dev` needs it granted explicitly. Added
@@ -852,7 +853,7 @@ pub fn run() {
             let handle = app.handle().clone();
             deep_link::install(&handle);
             #[cfg(target_os = "macos")]
-            updater::install_app_menu(app)?;
+            menu::install_app_menu(app)?;
             updater::spawn_update_loop(handle.clone());
             let data = data_dir(&handle)?;
             // Before anything that can warn: the embedded server's tracing

--- a/crates/tidebreak-desktop/src/menu.rs
+++ b/crates/tidebreak-desktop/src/menu.rs
@@ -1,0 +1,181 @@
+//! The app's native menu bar, and what its items do.
+//!
+//! Tauri's default menu is close to right, but its Close item takes Cmd+W and
+//! closes the window. Tidebreak has one window, so closing it ends the app —
+//! and on macOS a menu accelerator is claimed before the key ever reaches the
+//! webview, which is why the shell's own "close the tab" binding never ran.
+//! The menu is therefore built here rather than patched onto the default:
+//! Cmd+W is a Close Tab item the renderer answers, and closing the window is
+//! an item with no accelerator behind it.
+//!
+//! Only macOS gets a menu bar; the app ships no menu on Windows or Linux, so
+//! `install_app_menu` is macOS-only and the event handler simply never fires
+//! elsewhere.
+
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::updater::UPDATE_CHECK_REQUESTED_EVENT;
+
+/// Raised when the reader presses Cmd+W. The renderer closes whichever tab it
+/// has in front of them, and does nothing when there is none — the window
+/// survives either way, because the key must not be able to end the app.
+const CLOSE_TAB_REQUESTED_EVENT: &str = "desktop-close-tab-requested";
+
+const MENU_CHECK_FOR_UPDATES_ID: &str = "check-for-updates";
+const MENU_RELOAD_ID: &str = "reload-app";
+const MENU_CLOSE_TAB_ID: &str = "close-tab";
+const MENU_CLOSE_WINDOW_ID: &str = "close-window";
+
+/// Build and install the menu bar.
+///
+/// Everything Tauri's default menu carries is here, so the items macOS readers
+/// reach for — Services, Hide, the Edit menu's clipboard commands, full
+/// screen, Minimize — behave as they always did.
+#[cfg(target_os = "macos")]
+pub(crate) fn install_app_menu(app: &tauri::App) -> tauri::Result<()> {
+    use tauri::menu::{AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu};
+
+    let handle = app.handle();
+    let pkg = app.package_info();
+    let bundle = &app.config().bundle;
+    let about = AboutMetadata {
+        name: Some(pkg.name.clone()),
+        version: Some(pkg.version.to_string()),
+        copyright: bundle.copyright.clone(),
+        authors: bundle.publisher.clone().map(|publisher| vec![publisher]),
+        ..Default::default()
+    };
+
+    let app_menu = Submenu::with_items(
+        handle,
+        pkg.name.clone(),
+        true,
+        &[
+            &PredefinedMenuItem::about(handle, None, Some(about))?,
+            &MenuItem::with_id(
+                handle,
+                MENU_CHECK_FOR_UPDATES_ID,
+                "Check for Updates…",
+                true,
+                None::<&str>,
+            )?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::services(handle, None)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::hide(handle, None)?,
+            &PredefinedMenuItem::hide_others(handle, None)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::quit(handle, None)?,
+        ],
+    )?;
+
+    // Cmd+W closes a tab, the way it does in a browser. Closing the window is
+    // the item under it and carries no accelerator: Cmd+Shift+W already starts
+    // a pull-request watch in code mode, and a menu accelerator there would
+    // take that chord before the webview saw it.
+    let file_menu = Submenu::with_items(
+        handle,
+        "File",
+        true,
+        &[
+            &MenuItem::with_id(
+                handle,
+                MENU_CLOSE_TAB_ID,
+                "Close Tab",
+                true,
+                Some("CmdOrCtrl+W"),
+            )?,
+            &MenuItem::with_id(
+                handle,
+                MENU_CLOSE_WINDOW_ID,
+                "Close Window",
+                true,
+                None::<&str>,
+            )?,
+        ],
+    )?;
+
+    let edit_menu = Submenu::with_items(
+        handle,
+        "Edit",
+        true,
+        &[
+            &PredefinedMenuItem::undo(handle, None)?,
+            &PredefinedMenuItem::redo(handle, None)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::cut(handle, None)?,
+            &PredefinedMenuItem::copy(handle, None)?,
+            &PredefinedMenuItem::paste(handle, None)?,
+            &PredefinedMenuItem::select_all(handle, None)?,
+        ],
+    )?;
+
+    let view_menu = Submenu::with_items(
+        handle,
+        "View",
+        true,
+        &[
+            &MenuItem::with_id(handle, MENU_RELOAD_ID, "Reload", true, Some("CmdOrCtrl+R"))?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::fullscreen(handle, None)?,
+        ],
+    )?;
+
+    let window_menu = Submenu::with_items(
+        handle,
+        "Window",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(handle, None)?,
+            &PredefinedMenuItem::maximize(handle, None)?,
+        ],
+    )?;
+
+    // Empty, as in Tauri's default: macOS fills the Help menu with its own
+    // search field and the app has nothing to add above it.
+    let help_menu = Submenu::new(handle, "Help", true)?;
+
+    let menu = Menu::with_items(
+        handle,
+        &[
+            &app_menu,
+            &file_menu,
+            &edit_menu,
+            &view_menu,
+            &window_menu,
+            &help_menu,
+        ],
+    )?;
+    app.set_menu(menu)?;
+    Ok(())
+}
+
+pub(crate) fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
+    match event.id().as_ref() {
+        MENU_CHECK_FOR_UPDATES_ID => {
+            if let Err(error) = app.emit(UPDATE_CHECK_REQUESTED_EVENT, ()) {
+                eprintln!("tidebreak-desktop: could not raise the update-check request: {error}");
+            }
+        }
+        MENU_CLOSE_TAB_ID => {
+            if let Err(error) = app.emit(CLOSE_TAB_REQUESTED_EVENT, ()) {
+                eprintln!("tidebreak-desktop: could not raise the close-tab request: {error}");
+            }
+        }
+        MENU_CLOSE_WINDOW_ID => {
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(error) = window.close() {
+                    eprintln!("tidebreak-desktop: could not close the window: {error}");
+                }
+            }
+        }
+        MENU_RELOAD_ID => {
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(error) = window.reload() {
+                    eprintln!("tidebreak-desktop: could not reload the app: {error}");
+                }
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/tidebreak-desktop/src/updater.rs
+++ b/crates/tidebreak-desktop/src/updater.rs
@@ -32,9 +32,7 @@ const UPDATE_STATE_EVENT: &str = "desktop-update-state";
 /// Raised to the renderer when the native "Check for Updates…" menu item is
 /// chosen; the UI opens the Updates settings panel and runs an explicit check
 /// there so the outcome (up to date, or an update staged) is visible.
-const UPDATE_CHECK_REQUESTED_EVENT: &str = "desktop-update-check-requested";
-const MENU_CHECK_FOR_UPDATES_ID: &str = "check-for-updates";
-const MENU_RELOAD_ID: &str = "reload-app";
+pub(crate) const UPDATE_CHECK_REQUESTED_EVENT: &str = "desktop-update-check-requested";
 const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs(15);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const UPDATE_CHECK_ERROR: &str = "Could not check for updates. Try again later.";
@@ -287,60 +285,6 @@ async fn run_update_check(app: AppHandle) -> DesktopUpdateState {
         .busy
         .store(false, Ordering::Release);
     current_update_state(&app)
-}
-
-/// Install the app's native menu additions on macOS.
-///
-/// "Check for Updates…" sits in the application submenu directly under
-/// "About", while "Reload" leads the View menu with the browser-standard
-/// Cmd+R accelerator. The rest of Tauri's default menu stays intact.
-#[cfg(target_os = "macos")]
-pub(crate) fn install_app_menu(app: &tauri::App) -> tauri::Result<()> {
-    use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
-
-    let handle = app.handle();
-    let menu = Menu::default(handle)?;
-    let items = menu.items()?;
-    if let Some(app_submenu) = items.first().and_then(|item| item.as_submenu().cloned()) {
-        let check = MenuItem::with_id(
-            handle,
-            MENU_CHECK_FOR_UPDATES_ID,
-            "Check for Updates…",
-            true,
-            None::<&str>,
-        )?;
-        app_submenu.insert(&check, 1)?;
-    }
-    if let Some(view_submenu) = items.iter().find_map(|item| {
-        let submenu = item.as_submenu()?;
-        matches!(submenu.text().as_deref(), Ok("View")).then(|| submenu.clone())
-    }) {
-        let reload =
-            MenuItem::with_id(handle, MENU_RELOAD_ID, "Reload", true, Some("CmdOrCtrl+R"))?;
-        let separator = PredefinedMenuItem::separator(handle)?;
-        view_submenu.prepend(&separator)?;
-        view_submenu.prepend(&reload)?;
-    }
-    app.set_menu(menu)?;
-    Ok(())
-}
-
-pub(crate) fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
-    match event.id().as_ref() {
-        MENU_CHECK_FOR_UPDATES_ID => {
-            if let Err(error) = app.emit(UPDATE_CHECK_REQUESTED_EVENT, ()) {
-                eprintln!("tidebreak-desktop: could not raise the update-check request: {error}");
-            }
-        }
-        MENU_RELOAD_ID => {
-            if let Some(window) = app.get_webview_window("main") {
-                if let Err(error) = window.reload() {
-                    eprintln!("tidebreak-desktop: could not reload the app: {error}");
-                }
-            }
-        }
-        _ => {}
-    }
 }
 
 pub(crate) fn spawn_update_loop(app: AppHandle) {

--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -239,6 +239,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 
 vi.mock("./updates", () => ({
+  UPDATE_CHECK_REQUESTED_EVENT: "desktop-update-check-requested",
   useDesktopUpdates: () => ({
     state: desktopUpdateState,
     check: vi.fn(),

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -82,6 +82,41 @@ import { ShortcutsDialog } from "./ShortcutsDialog";
 import { useUiStore } from "./UiStore";
 import { UPDATE_CHECK_REQUESTED_EVENT, useDesktopUpdates } from "./updates";
 
+/**
+ * Raised by the native "Close Tab" menu item, which owns Cmd+W.
+ *
+ * The item exists so that chord can never reach macOS's close-window command:
+ * this app has one window, so closing it ends the app, and a reader reaching
+ * for Cmd+W means the tab in front of them.
+ */
+const CLOSE_TAB_REQUESTED_EVENT = "desktop-close-tab-requested";
+
+/**
+ * Run `handler` whenever the native host raises `event`.
+ *
+ * The handler is read through a ref so the listener registers once for the
+ * shell's lifetime instead of being torn down and rebound every time a
+ * callback changes identity between renders. Outside the desktop app there is
+ * no host to raise anything, so nothing is registered at all.
+ */
+function useNativeHostEvent(event: string, handler: () => void): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+  useEffect(() => {
+    if (!isTauri()) return;
+    let cancelled = false;
+    let unlisten: UnlistenFn | undefined;
+    void listen(event, () => handlerRef.current()).then((stop) => {
+      if (cancelled) stop();
+      else unlisten = stop;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [event]);
+}
+
 /** Move focus to whichever composer the current route has on screen. */
 function focusComposer(): void {
   document.querySelector<HTMLTextAreaElement>("[data-composer-input]")?.focus();
@@ -194,25 +229,11 @@ export function AppShell() {
   // The native "Check for Updates…" menu item lands the reader on the
   // Updates settings panel and runs the same explicit check the panel's
   // button does, so the result (up to date, or an update staged) is visible.
-  const checkForUpdateRef = useRef(desktopUpdates.check);
-  checkForUpdateRef.current = desktopUpdates.check;
-  useEffect(() => {
-    if (!isTauri()) return;
-    let cancelled = false;
-    let unlisten: UnlistenFn | undefined;
-    void listen(UPDATE_CHECK_REQUESTED_EVENT, () => {
-      const updatesPath: string = "/settings/updates";
-      void navigate({ to: updatesPath });
-      void checkForUpdateRef.current();
-    }).then((stop) => {
-      if (cancelled) stop();
-      else unlisten = stop;
-    });
-    return () => {
-      cancelled = true;
-      unlisten?.();
-    };
-  }, [navigate]);
+  useNativeHostEvent(UPDATE_CHECK_REQUESTED_EVENT, () => {
+    const updatesPath: string = "/settings/updates";
+    void navigate({ to: updatesPath });
+    void desktopUpdates.check();
+  });
 
   /**
    * Put the workspace's layout through one change and write it back.
@@ -271,6 +292,27 @@ export function AppShell() {
       params: { workspaceId: next },
     });
   }
+
+  /**
+   * Close whichever tab the reader is looking at.
+   *
+   * A closed tab is the one case the pure function reports with `null`, since
+   * "nothing here to close" is not the same as "closing changed nothing".
+   * Finding nothing declines the key and does nothing else: Cmd+W used to
+   * reach the native close-window item and end the app, which is never what
+   * the reader meant by it.
+   */
+  function closeTab(): boolean | void {
+    return applyCodeLayout((layout) => closeFocusedCodeTab(layout) ?? layout);
+  }
+
+  // macOS claims a menu accelerator before the key reaches the webview, so on
+  // the packaged app Cmd+W arrives as this event and never as a keydown the
+  // shortcut table could match. Both paths run the same close, so the chord
+  // means one thing whether the menu or the browser delivered it.
+  useNativeHostEvent(CLOSE_TAB_REQUESTED_EVENT, () => {
+    closeTab();
+  });
 
   // Shell shortcuts are defined here because these actions outlive any one
   // route: toggling the frame, starting a chat, reaching the composer, and
@@ -333,9 +375,7 @@ export function AppShell() {
         return position === null ? layout : selectCenterTab(layout, position);
       }),
     "code-split-editor": () => applyCodeLayout(splitFocusedEditor),
-    // A closed tab is the one case the pure function reports with `null`, since
-    // "nothing here to close" is not the same as "closing changed nothing".
-    "close-tab": () => applyCodeLayout((l) => closeFocusedCodeTab(l) ?? l),
+    "close-tab": closeTab,
     "focus-composer": focusComposer,
     "zoom-in": zoom.zoomIn,
     "zoom-out": zoom.zoomOut,


### PR DESCRIPTION
## What changed

On macOS a menu accelerator is claimed before the key reaches the webview, so Tauri's default Close Window item always won Cmd+W and the shell's own close-tab binding never ran — and since Tidebreak has one window, the chord quit the app. The new `menu.rs` builds the menu bar explicitly instead of patching Tauri's default: Cmd+W is a Close Tab item the renderer answers, Close Window sits under it with no accelerator (Cmd+Shift+W already starts a pull-request watch in code mode), and everything the default carried — Services, Hide, the Edit clipboard commands, Full Screen, Minimize, Zoom, plus the existing Check for Updates… and Reload items — is preserved. The renderer runs one close for both the menu event and the keydown path, so the chord means the same thing in the packaged app and in a browser dev build, and with no tab to close it does nothing. The menu code moved out of `updater.rs`, which is now only about updates.

## Validation

`tsc --noEmit`, `biome format` and `biome lint` over `crates/tidebreak-desktop/ui/src`, `cargo fmt --check`, and the AppShell, ShellShortcuts, and codeChrome test files (64 passing). Rust was not compiled locally; CI covers it.

## Compatibility and risk

macOS only — no menu bar ships on Windows or Linux. Cmd+W no longer closes the window: use the red button, the File > Close Window item, or Cmd+Q. No persisted or wire-format changes.