### PR TITLE
fix(desktop): a machine that refuses you no longer traps the window

### DIFF
--- a/crates/tidebreak-desktop/src/deep_link.rs
+++ b/crates/tidebreak-desktop/src/deep_link.rs
@@ -279,6 +279,13 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
             }
             Ok(PendingRegistration::AlreadyManaged) => {
                 log_pairing(&app, &format!("{origin} already manages this device"));
+                // Nothing to provision, but the click still means "connect me
+                // to this gateway" — and the profile may be managed by it
+                // with no session behind that, which is exactly when someone
+                // reaches for the link again. Nudging the gate makes it
+                // re-read policy now and present its sign-in, instead of the
+                // link reading as the app ignoring them until the next poll.
+                notify_pairing_changed(&app);
             }
             Err(PairingError::Conflict {
                 provisioned_url,

--- a/crates/tidebreak-desktop/ui/src/AppContext.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppContext.tsx
@@ -1,6 +1,13 @@
 import { createContext, useContext } from "react";
 
-import type { ApiClient, Chat, ModelInfo, Project, ProviderInfo } from "./api";
+import type {
+  ApiClient,
+  Attachment,
+  Chat,
+  ModelInfo,
+  Project,
+  ProviderInfo,
+} from "./api";
 import type { DesktopUpdateState } from "./updates";
 
 /**
@@ -18,6 +25,17 @@ import type { DesktopUpdateState } from "./updates";
  */
 export type AppContextValue = {
   client: ApiClient;
+  /**
+   * Which machine this window works on.
+   *
+   * Host authority — the folder broker, the client executor, native export,
+   * computer use — reaches the computer the window runs on, and while
+   * attached the conversation is somewhere else. Surfaces that reach the host
+   * must branch on this, not on {@link hasNativeHost}: that one answers "am I
+   * a native shell", which stays true while attached, so using it as the gate
+   * offers a control that then fails.
+   */
+  attachment: Attachment;
   models: ModelInfo[];
   /**
    * The catalog key a chat without an override runs against, so the picker can
@@ -70,4 +88,14 @@ export function useApp(): AppContextValue {
   const value = useContext(AppContext);
   if (!value) throw new Error("useApp must be used inside the app shell");
   return value;
+}
+
+/**
+ * Whether this window works on a machine other than this computer.
+ *
+ * The one gate for host authority. Attaching and detaching both reload the
+ * window, so this never changes under a mounted component.
+ */
+export function useAttachedRemotely(): boolean {
+  return useApp().attachment === "remote";
 }

--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -232,6 +232,9 @@ vi.mock("./host", () => ({
   hasMacOverlayTitlebar: () => false,
   requestUserAttention,
   onPairingChanged: () => () => undefined,
+  setAttachedRemotely: () => undefined,
+  attachedRemotely: () => false,
+  hasLocalHostAuthority: () => hasNativeHost(),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({

--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -61,7 +61,11 @@ import { useComposerDrafts } from "./ComposerDrafts";
 import { useConfirm } from "./components/ConfirmDialog";
 import { ComputerUseIndicator } from "./ComputerUseIndicator";
 import { useDesktopNavigation } from "./DesktopNavigation";
-import { hasMacOverlayTitlebar, hasNativeHost } from "./host";
+import {
+  hasMacOverlayTitlebar,
+  hasNativeHost,
+  setAttachedRemotely,
+} from "./host";
 import { friendlyErrorMessage } from "./lib/utils";
 import { useInterfaceZoom } from "./InterfaceZoom";
 import { Logomark } from "./Logomark";
@@ -388,6 +392,10 @@ export function AppShell() {
           gatewayAuth: server.gatewayAuth,
         });
         setInfo(server);
+        // Before the client, and before anything can call one of them: the
+        // three host callers that sit outside React read this flag rather
+        // than a hook. See `host.ts`.
+        setAttachedRemotely(server.attachment === "remote");
         setClient(new ApiClient(server.baseUrl, server.token));
         // Outputs are read over the same API; their module holds the
         // connection because they are called from places with no client.
@@ -872,7 +880,10 @@ export function AppShell() {
     );
   }
 
-  if (!client) {
+  // `info` rides with `client`: boot sets both in one step, and the context
+  // below reads the attachment off it. Guarding on both keeps that a fact
+  // rather than an assumption.
+  if (!client || !info) {
     return (
       <div className="boot">
         <WindowDragStrip />
@@ -899,6 +910,7 @@ export function AppShell() {
       <AppContextProvider
         value={{
           client,
+          attachment: info.attachment,
           models,
           defaultModelKey,
           providers,

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type ReactNode } from "react";
-import { ExternalLink, RefreshCw } from "lucide-react";
+import { ExternalLink, Laptop, RefreshCw } from "lucide-react";
 
 import type { ApiClient, GatewayStatus, ManagedPolicy } from "./api";
 import { Button } from "@/components/ui/button";
@@ -7,6 +7,7 @@ import { Logomark } from "./Logomark";
 import { ManagedPolicyContext } from "./managedPolicy";
 import { onPairingChanged } from "./host";
 import { openInBrowser } from "./openInBrowser";
+import { disconnectRemoteMachine, remoteMachineState } from "./remoteMachine";
 import { WindowDragStrip } from "./WindowDragStrip";
 
 /** While the browser flow is pending the exchange lands out of band, so the
@@ -119,6 +120,15 @@ export function ManagedGate({
   // reader is still looking at.
   const [statusError, setStatusError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  // The machine this window is pointed at, or `null` for this computer.
+  //
+  // Read from the shell rather than through the API client on purpose. When
+  // the client is attached to a machine that refuses it — a gateway session
+  // that ended, access revoked — every read through the client fails, and
+  // this is the one fact still legible. It is also what makes the escape
+  // hatch below possible: detaching is a host command, so it works no matter
+  // what the machine says.
+  const [attachedMachine, setAttachedMachine] = useState<string | null>(null);
 
   const policy = policyState.kind === "resolved" ? policyState.policy : null;
   const managed = policy?.managed === true;
@@ -132,6 +142,24 @@ export function ManagedGate({
   // it ("Not now") is what returns the app.
   const pendingPairingUrl = policy?.pending_gateway_url ?? null;
   const gateActive = managed || pendingPairingUrl !== null;
+
+  // Once, on mount. The attachment only changes by a path that reloads the
+  // window, so there is nothing here to watch.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const state = await remoteMachineState();
+        if (!cancelled) setAttachedMachine(state.baseUrl);
+      } catch {
+        // Not knowing leaves the local copy below, which is the safe read:
+        // it offers no escape hatch rather than a broken one.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (policyState.kind !== "loading") return;
@@ -297,6 +325,72 @@ export function ManagedGate({
       (policy.managed && !policy.gateway_url));
 
   if (policyState.kind === "blocked" || policyMisconfigured) {
+    // Attached to a machine, and it will not answer. Naming the managed
+    // policy here would be a lie — the policy on this computer is fine, and
+    // the reader cannot act on the machine's copy anyway. What they can
+    // always do is come back to this computer, and until this screen offered
+    // it there was no way to: the Machine settings sit behind this gate, so
+    // a machine that stopped accepting the session locked the window with
+    // nothing but a Retry that retried the same refusal.
+    if (attachedMachine !== null) {
+      return (
+        <div className="boot" aria-label="Machine unavailable">
+          <WindowDragStrip />
+          <div className="boot-brand">
+            <Logomark />
+            <h1>Tidebreak</h1>
+          </div>
+          <div className="welcome-copy">
+            <h2>That machine is not answering</h2>
+            <p>
+              This window works on{" "}
+              <code className="font-medium">{attachedMachine}</code>, and that
+              machine refused it. Your access may have ended, or the machine may
+              be down.
+            </p>
+            <p>
+              Come back to this computer to sign in again. Work on the machine
+              keeps running, and you can reattach once it answers.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              disabled={working}
+              onClick={() =>
+                void (async () => {
+                  setWorking(true);
+                  setActionError(null);
+                  try {
+                    await disconnectRemoteMachine();
+                    // Same reason the settings panel reloads: the API client
+                    // and the event stream were built against the machine
+                    // this window opened on.
+                    window.location.reload();
+                  } catch (err) {
+                    setActionError(String(err));
+                    setWorking(false);
+                  }
+                })()
+              }
+            >
+              <Laptop size={14} />
+              Work on this computer
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={working}
+              onClick={() => setPolicyState({ kind: "loading" })}
+            >
+              <RefreshCw size={14} />
+              Retry
+            </Button>
+          </div>
+          {actionError && <p className="boot-error-detail">{actionError}</p>}
+        </div>
+      );
+    }
     return (
       <div className="boot" aria-label="Managed policy unavailable">
         <WindowDragStrip />

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -1,5 +1,7 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
 
+import { attachedRemotely } from "../host";
+
 import {
   APP_INVOKE_REFUSAL_KINDS,
   AppInvokeRefusalError,
@@ -593,7 +595,13 @@ export class ApiClient {
   }
 
   putMcpServers(servers: McpServerDefinition[]): Promise<McpServersInfo> {
-    if (isTauri()) {
+    // The native command exists to put an OS confirmation in front of stdio
+    // commands that would run on this computer, and it writes to the server
+    // embedded in this app. Neither is right while attached: the commands
+    // would run on the machine, and writing here would save the reader's
+    // edit to a config they were not looking at — `listMcpServers` reads the
+    // machine's, so the panel would re-read and show the edit gone.
+    if (isTauri() && !attachedRemotely()) {
       return invoke<McpServersInfo>("put_native_mcp_servers", {
         config: { servers },
       });

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
@@ -54,6 +54,7 @@ function app(
       error: null,
       enabled: false,
     }),
+    attachment: "local",
     restartForUpdate: async () => {},
   };
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -51,6 +51,7 @@ function app(): AppContextValue {
       error: null,
       enabled: false,
     }),
+    attachment: "local",
     restartForUpdate: async () => {},
   };
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
@@ -113,6 +113,7 @@ function app(
       error: null,
       enabled: false,
     }),
+    attachment: "local",
     restartForUpdate: async () => {},
   };
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -118,6 +118,7 @@ const app: AppContextValue = {
     error: null,
     enabled: false,
   }),
+  attachment: "local",
   restartForUpdate: async () => {},
 };
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -431,6 +431,7 @@ function appContext(client: ReturnType<typeof makeClient>): AppContextValue {
       error: null,
       enabled: false,
     }),
+    attachment: "local",
     restartForUpdate: async () => {},
   };
 }

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -137,6 +137,7 @@ function app(client: Partial<AppContextValue["client"]>): AppContextValue {
       error: null,
       enabled: false,
     }),
+    attachment: "local",
     restartForUpdate: async () => {},
   } as AppContextValue;
 }

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -43,6 +43,7 @@ function app(): AppContextValue {
       error: null,
       enabled: false,
     }),
+    attachment: "local",
     restartForUpdate: async () => {},
   };
 }

--- a/crates/tidebreak-desktop/ui/src/host.ts
+++ b/crates/tidebreak-desktop/ui/src/host.ts
@@ -59,6 +59,40 @@ export function hasNativeHost(): boolean {
   return isTauri();
 }
 
+/**
+ * Whether this window works on a machine other than this computer.
+ *
+ * The module-level twin of `useAttachedRemotely`, for the three callers that
+ * sit outside React and cannot use a hook: the API client, the image
+ * attachment hook's non-component branch, and the code-mode browser host.
+ * Boot resolves the attachment before any of them runs and records it here.
+ *
+ * Defaults to `false`, which is what a browser tab is and what the desktop is
+ * until told otherwise. The default has to be the permissive one: attachment
+ * changes always reload the window, so a stale `true` could never be cleared,
+ * while a stale `false` cannot outlive boot.
+ */
+let attachedRemotelyFlag = false;
+
+export function setAttachedRemotely(attached: boolean): void {
+  attachedRemotelyFlag = attached;
+}
+
+export function attachedRemotely(): boolean {
+  return attachedRemotelyFlag;
+}
+
+/**
+ * Whether host authority applies to what this window is working on.
+ *
+ * Prefer this to a bare {@link hasNativeHost} anywhere the call reaches this
+ * computer's files, screen, or input. `hasNativeHost` alone stays true while
+ * attached to another machine, so it offers controls that then refuse.
+ */
+export function hasLocalHostAuthority(): boolean {
+  return hasNativeHost() && !attachedRemotely();
+}
+
 /** Native directory picker for code-mode repo registration and clone destinations. */
 export async function pickCodeDirectory(): Promise<string | null> {
   if (!isTauri()) return null;

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -725,6 +725,7 @@ function appContext(client: ApiClient): AppContextValue {
       error: null,
       enabled: false,
     }),
+    attachment: "local",
     restartForUpdate: async () => {},
   };
 }

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -230,6 +230,7 @@ function appContext(client: ApiClient): AppContextValue {
       error: null,
       enabled: false,
     }),
+    attachment: "local",
     restartForUpdate: async () => {},
   };
 }


### PR DESCRIPTION
Attaching to a machine points every read through it, including the managed gate's `/policy`. When that machine stops accepting the session — access ended, gateway down — the gate reads the HTTP error as an unreadable policy and blocks the whole app with "Managed policy unavailable. This device's managed policy is misconfigured. Contact your administrator."

Both sentences are wrong. The policy on this computer is fine; the machine refused the token. And the only control on screen is a Retry that retries the same refusal, while the Machine settings that would detach sit behind the gate. The only way out is to edit the address file by hand, which is how this was found.

The blocked screen now names what happened and offers **Work on this computer**. Detaching is a host command, so it works no matter what the machine says.

## Three things behind it

**Surfaces could not tell they were attached.** The only way to ask was an async Tauri call that three places made and kept to themselves, so everything else used `hasNativeHost()` — which is `isTauri()`, and stays true while attached. `attachment` now rides on the app context with `useAttachedRemotely`, and `host.ts` carries the module-level twin for the three callers outside React.

**Saving MCP servers wrote to the wrong machine.** The panel read the attached machine's servers over HTTP but saved through the native command, which writes to the server embedded in this app. A reader edited the machine's config, saved it to their laptop, and watched the edit disappear on the next read. It takes the HTTP branch while attached; the OS confirmation it skips exists to guard stdio commands that would run on this computer, which these would not.

**A provision link into an already-managed profile did nothing visible.** One log line, no dialog, no gate nudge — and that is exactly the state someone reaches for the link from, so it read as the app ignoring them. It now nudges the gate, which re-reads policy and presents its sign-in.

## Not in scope

The remaining remote-attachment gaps are filed as #2508 through #2513. This PR adds the signal the UI gating work (#2512) needs; it does not do that gating.

## Verification

`tsc --noEmit` clean. Full renderer suite: 216 files, 1652 tests, all passing. `biome format` and `lint` clean. `cargo fmt --check` clean; Rust compilation left to CI.