### PR TITLE
fix(server): a hosted machine names its gateway without demanding a session

### DIFF
--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -186,6 +186,25 @@ impl Config {
         self.data_dir.join("plugin-data")
     }
 
+    /// The Model Gateway this deployment authenticates its callers against,
+    /// when it is a gateway-authenticated hosted machine.
+    ///
+    /// One reading of "hosted machine" for every surface that describes the
+    /// deployment: the self-host profile with a gateway named by
+    /// [`Config::auth_gateway_url`]. The public identity URL, deliberately —
+    /// [`Config::auth_gateway_verifier_url`] is a server-to-server detour and
+    /// names nothing a person recognizes.
+    ///
+    /// `None` everywhere else: the desktop profile, and a self-host server on
+    /// static tokens. Neither holds a caller's gateway credential.
+    #[must_use]
+    pub fn hosted_gateway_url(&self) -> Option<&str> {
+        if self.profile != Profile::SelfHost {
+            return None;
+        }
+        self.auth_gateway_url.as_deref()
+    }
+
     /// A desktop-profile config rooted at `data_dir`.
     pub fn desktop(data_dir: impl Into<PathBuf>) -> Self {
         Self {

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -75,6 +75,13 @@ function PolicyProbe() {
   return <p>policy: {policy.managed ? "managed" : "unmanaged"}</p>;
 }
 
+/** Stands in for the Model Gateway section, which names the deployment's
+ * gateway from the policy the gate published. */
+function HostedGatewayProbe() {
+  const policy = useManagedPolicy();
+  return <p>gateway: {policy.hosted_gateway_url ?? "none"}</p>;
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -355,6 +362,35 @@ describe("ManagedGate", () => {
 
     expect(await screen.findByText("the open product")).toBeInTheDocument();
     expect(screen.queryByText("Sign in to continue")).not.toBeInTheDocument();
+    expect(client.getGatewayStatus).not.toHaveBeenCalled();
+  });
+
+  it("a hosted machine names its gateway and never asks anyone to sign in", async () => {
+    // The client authenticated *to* this machine with its own gateway token.
+    // The machine holds no session of its own and can never report one, so a
+    // gate here would be one nothing could ever satisfy.
+    const client = api({
+      getPolicy: vi.fn().mockResolvedValue({
+        managed: false,
+        source: "unmanaged",
+        misconfigured: false,
+        allow_local_mcp_servers: false,
+        hosted_gateway_url: "https://gateway.example/",
+      }),
+    });
+    render(
+      <ManagedGate client={client}>
+        <HostedGatewayProbe />
+      </ManagedGate>,
+    );
+
+    expect(
+      await screen.findByText("gateway: https://gateway.example/"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Sign in to continue")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Managed policy unavailable"),
+    ).not.toBeInTheDocument();
     expect(client.getGatewayStatus).not.toHaveBeenCalled();
   });
 

--- a/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.tsx
@@ -84,6 +84,7 @@ function samePolicy(a: ManagedPolicy, b: ManagedPolicy): boolean {
     a.source === b.source &&
     a.misconfigured === b.misconfigured &&
     (a.gateway_url ?? null) === (b.gateway_url ?? null) &&
+    (a.hosted_gateway_url ?? null) === (b.hosted_gateway_url ?? null) &&
     (a.pending_gateway_url ?? null) === (b.pending_gateway_url ?? null)
   );
 }

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2428,7 +2428,25 @@ export type InputModality = "text" | "image";
  * Renderer-safe resolved policy. Carries only what surfaces need to render
  * managed state: the verdict, the locked gateway URL, and its authority.
  */
-export type ManagedPolicy = { managed: boolean, gateway_url?: string, source: ManagedPolicySource, 
+export type ManagedPolicy = { managed: boolean, gateway_url?: string, 
+/**
+ * The gateway a hosted deployment authenticates its own callers against
+ * (`docs/decisions/0049-gateway-authenticated-hosted-machines.md`).
+ *
+ * Deliberately not [`ManagedPolicy::gateway_url`], and deliberately no
+ * effect on `managed`. Those two say "this profile must hold a session
+ * at this gateway", and that is false here: a caller authenticates *to*
+ * a hosted machine with their own gateway token, never *through* it. A
+ * hosted machine can therefore never report a session, so asserting
+ * management over it would raise a sign-in gate nothing could ever
+ * satisfy.
+ *
+ * This names the deployment for the surfaces that describe it, and
+ * nothing else. Surfaces that lock a profile down read `managed`; a
+ * hosted machine locks nothing, and its stored provider configuration
+ * still wins (decision 51, rule 3).
+ */
+hosted_gateway_url?: string, source: ManagedPolicySource, 
 /**
  * True when `source` asserted management but its gateway URL is missing,
  * unreadable, or invalid. The profile stays managed with no usable URL —

--- a/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -38,6 +38,10 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
 }
 
 const local: RemoteMachineState = { attachment: "local", baseUrl: null };
+const attached: RemoteMachineState = {
+  attachment: "remote",
+  baseUrl: "https://machine.example",
+};
 
 /** The native machine commands, stubbed: nothing here reaches a shell. */
 function machineStub(
@@ -116,6 +120,48 @@ describe("GatewayPanel", () => {
     expect(screen.getByLabelText(/Address/)).toHaveValue("");
     expect(
       screen.getByRole("button", { name: /Connect with Model Gateway/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("hosted machine: names the gateway and offers no session to manage", async () => {
+    // Callers authenticate *to* this machine with their own gateway account.
+    // It holds no session of its own, so a sign-in here would start a flow it
+    // could never complete — and the panel must not read a status it has no
+    // session behind either.
+    const client = api();
+    render(
+      <GatewayPanel
+        client={client}
+        managed={false}
+        gatewayUrl={null}
+        hostedGatewayUrl="https://gateway.example/"
+        onChanged={() => undefined}
+        onOpenConnectedApps={() => undefined}
+        machine={machineStub(attached)}
+      />,
+    );
+
+    expect(screen.getByText("https://gateway.example/")).toBeInTheDocument();
+    expect(
+      screen.getByText(/authenticates you with your Model Gateway account/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/not connected to a model gateway/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Connect" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Sync/ }),
+    ).not.toBeInTheDocument();
+    expect(client.getGatewayStatus).not.toHaveBeenCalled();
+
+    // The machine still says where the work runs, and how to come back.
+    expect(
+      await screen.findByText("Attached to a remote machine"),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /Work on this computer/ }),
     ).toBeInTheDocument();
   });
 

--- a/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GatewayPanel.tsx
@@ -114,11 +114,17 @@ function appReadinessLabel(connection: string | undefined): string | null {
  * profile sees the machine sections, including an unmanaged one — a machine
  * behind no gateway is reachable with its own token, and this is the only
  * place in the app that reaches it.
+ *
+ * A gateway-authenticated hosted machine is the third state, and it has no
+ * session of its own to show: the reader signed in to the gateway on their
+ * own computer and attached with that account, so this names the gateway and
+ * leaves the machine sections to say where the work runs.
  */
 export function GatewayPanel({
   client,
   managed,
   gatewayUrl,
+  hostedGatewayUrl = null,
   onChanged,
   onOpenConnectedApps,
   machine = NATIVE_MACHINE,
@@ -128,6 +134,9 @@ export function GatewayPanel({
   managed: boolean;
   /** The policy's locked gateway origin, shown read-only. */
   gatewayUrl: string | null;
+  /** The gateway the machine this window works on authenticates its callers
+   * against. Never a session this profile holds — see the hosted panel. */
+  hostedGatewayUrl?: string | null;
   onChanged: () => void;
   /** Navigates to the Connected apps page, whose MCP section is where
    * entitled endpoints are mounted. Mounting lives beside the health of what
@@ -136,6 +145,30 @@ export function GatewayPanel({
   onOpenConnectedApps: () => void;
   machine?: MachineControls;
 }) {
+  if (!managed && hostedGatewayUrl !== null) {
+    // Read-only, with no sign in and no sign out, because there is nothing
+    // here to sign in to: the reader authenticated to this machine with their
+    // own gateway account, and the machine holds that credential for as long
+    // as the session lasts. A Connect button would start a flow this machine
+    // could never complete.
+    return (
+      <SettingsPanel
+        title="Model Gateway"
+        description="This machine authenticates you with your Model Gateway account."
+      >
+        <p className="text-sm">
+          <code className="font-medium">{hostedGatewayUrl}</code>
+        </p>
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          You signed in to this gateway on your own computer, and this machine
+          runs your work with that account. Models and usage follow your
+          entitlements there, not this machine&apos;s. Your access ends here the
+          moment it ends at the gateway.
+        </p>
+        <MachineSections client={client} managed={false} machine={machine} />
+      </SettingsPanel>
+    );
+  }
   if (!managed) {
     return (
       <SettingsPanel

--- a/crates/tidebreak-desktop/ui/src/settings/sections.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/sections.tsx
@@ -92,6 +92,7 @@ function GatewaySection() {
       client={client}
       managed={policy.managed}
       gatewayUrl={policy.gateway_url ?? null}
+      hostedGatewayUrl={policy.hosted_gateway_url ?? null}
       onChanged={() => void refreshCatalog()}
       onOpenConnectedApps={() => void navigate({ to: connectedAppsPath })}
     />

--- a/crates/tidebreak-desktop/ui/src/stories/GatewayPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/GatewayPanel.stories.tsx
@@ -105,3 +105,21 @@ export const Attached: Story = {
     machine: stubMachine(machineAttached),
   },
 };
+
+/**
+ * Attached to a gateway-authenticated hosted machine.
+ *
+ * The reader signed in to the gateway on their own computer and attached with
+ * that account, so the machine holds their credential and none of its own. It
+ * can never report a session, which is why the gateway is named read-only
+ * with no sign-in, no sign-out, and no sync.
+ */
+export const HostedMachine: Story = {
+  args: {
+    client: stubClient(gatewaySignedOut),
+    managed: false,
+    gatewayUrl: null,
+    hostedGatewayUrl: "https://gateway.example.com/",
+    machine: stubMachine(machineAttached),
+  },
+};

--- a/crates/tidebreak-server/src/managed_policy.rs
+++ b/crates/tidebreak-server/src/managed_policy.rs
@@ -81,6 +81,24 @@ pub(crate) struct ManagedPolicy {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub(crate) gateway_url: Option<String>,
+    /// The gateway a hosted deployment authenticates its own callers against
+    /// (`docs/decisions/0049-gateway-authenticated-hosted-machines.md`).
+    ///
+    /// Deliberately not [`ManagedPolicy::gateway_url`], and deliberately no
+    /// effect on `managed`. Those two say "this profile must hold a session
+    /// at this gateway", and that is false here: a caller authenticates *to*
+    /// a hosted machine with their own gateway token, never *through* it. A
+    /// hosted machine can therefore never report a session, so asserting
+    /// management over it would raise a sign-in gate nothing could ever
+    /// satisfy.
+    ///
+    /// This names the deployment for the surfaces that describe it, and
+    /// nothing else. Surfaces that lock a profile down read `managed`; a
+    /// hosted machine locks nothing, and its stored provider configuration
+    /// still wins (decision 51, rule 3).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub(crate) hosted_gateway_url: Option<String>,
     pub(crate) source: ManagedPolicySource,
     /// True when `source` asserted management but its gateway URL is missing,
     /// unreadable, or invalid. The profile stays managed with no usable URL —
@@ -117,6 +135,7 @@ impl ManagedPolicy {
         Self {
             managed: true,
             gateway_url: None,
+            hosted_gateway_url: None,
             source,
             misconfigured: true,
             pending_gateway_url: None,
@@ -876,7 +895,45 @@ pub(crate) fn resolve(
     provisioned: &dyn ProvisionedPolicySource,
     os_policy: &dyn OsPolicySource,
 ) -> Result<ManagedPolicy> {
+    resolve_with_deployment(provisioned, os_policy, None)
+}
+
+/// [`resolve`], plus the gateway this deployment authenticates its own
+/// callers against — the hosted-machine tier
+/// (`docs/decisions/0049-gateway-authenticated-hosted-machines.md`).
+///
+/// The tier describes; it never governs. It leaves `managed`, `source`, and
+/// `gateway_url` exactly as [`resolve`] left them, so no lockdown, no sign-in
+/// gate, and no route collection changes because a deployment named a
+/// gateway. Only [`ManagedPolicy::hosted_gateway_url`] moves.
+///
+/// Callers that describe the deployment to a client resolve through here;
+/// callers that enforce something use [`resolve`]. Forgetting therefore costs
+/// a surface its description and never its enforcement, which is the failure
+/// direction to have. Routes get it for free: [`crate::state::AppState`]
+/// resolves through this with the deployment's own configuration.
+///
+/// A URL that fails the gateway contract is dropped with a warning rather
+/// than failing the profile closed: the deployment is already up and
+/// authenticating callers against it, so a URL this side cannot render is a
+/// display fault, not an authority in need of repair.
+pub(crate) fn resolve_with_deployment(
+    provisioned: &dyn ProvisionedPolicySource,
+    os_policy: &dyn OsPolicySource,
+    hosted_gateway_url: Option<&str>,
+) -> Result<ManagedPolicy> {
     let mut policy = resolve_gateway(provisioned, os_policy)?;
+    policy.hosted_gateway_url =
+        hosted_gateway_url.and_then(|url| match validated_gateway_url(url) {
+            Ok(url) => Some(url),
+            Err(error) => {
+                tracing::warn!(
+                    "this deployment's own gateway URL fails the gateway contract: \
+                     {error}; clients will not be told which gateway authenticates them"
+                );
+                None
+            }
+        });
     // The ceiling is asserted per key, independent of the gateway verdict: an
     // MDM profile can cap the mode without deploying a gateway URL, and the
     // cap rides on whatever policy the gateway resolution produced. A broken
@@ -941,6 +998,7 @@ fn resolve_gateway(
     Ok(ManagedPolicy {
         managed: false,
         gateway_url: None,
+        hosted_gateway_url: None,
         source: ManagedPolicySource::Unmanaged,
         misconfigured: false,
         pending_gateway_url: None,
@@ -956,6 +1014,7 @@ fn asserted(source: ManagedPolicySource, gateway_url: &str) -> ManagedPolicy {
         Ok(gateway_url) => ManagedPolicy {
             managed: true,
             gateway_url: Some(gateway_url),
+            hosted_gateway_url: None,
             source,
             misconfigured: false,
             pending_gateway_url: None,

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -2003,7 +2003,7 @@ pub async fn collect_routes(
         }
         // A hosted machine resolves this provider per caller only where the
         // deployment states no other path to it (decision 51, rule 3).
-        if kind == ProviderKind::Anthropic {
+        if kind == ON_BEHALF_OF_PROVIDER {
             if let Some((source, base_url)) = on_behalf_of.clone() {
                 if on_behalf_of_states_the_only_path(store, secrets, kind).await {
                     routes.push(tidebreak_router::Route {
@@ -2098,6 +2098,41 @@ pub async fn collect_routes(
         });
     }
     routes
+}
+
+/// The provider a hosted machine's on-behalf-of route serves.
+///
+/// One statement of it, read by both halves that must agree: the route
+/// [`collect_routes`] builds, and the availability
+/// [`provider_is_usable`] reports for it. The gateway's Anthropic-compatible
+/// surface is what an exchanged inference token authenticates against
+/// ([`crate::obo_inference::OboInference::inference_base_url`]).
+const ON_BEHALF_OF_PROVIDER: ProviderKind = ProviderKind::Anthropic;
+
+/// Whether this deployment serves `kind` with the caller's own gateway
+/// credential.
+///
+/// True only on a gateway-authenticated hosted machine, only for the provider
+/// the on-behalf-of route serves, and only where the deployment states no
+/// other path to it (decision 51, rule 3).
+///
+/// This reads the policy projection where [`collect_routes`] reads the
+/// runtime handle, and the two agree by construction: `OboInference` is
+/// assembled for exactly the configuration `Config::hosted_gateway_url`
+/// answers for. Disagreement would show a caller a model no route serves.
+async fn on_behalf_of_is_the_path(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    kind: ProviderKind,
+    policy: &crate::managed_policy::ManagedPolicy,
+) -> bool {
+    if policy.managed || policy.hosted_gateway_url.is_none() {
+        return false;
+    }
+    if kind != ON_BEHALF_OF_PROVIDER {
+        return false;
+    }
+    on_behalf_of_states_the_only_path(store, secrets, kind).await
 }
 
 /// Whether per-caller inference is the only path this deployment states to
@@ -2220,6 +2255,11 @@ pub async fn resolve_model_policy(
 /// The deployment match matters after an MDM re-point: the superseded
 /// session is unroutable (`route_token_source` filters it), so counting it
 /// usable would advertise models no route can serve.
+///
+/// A gateway-authenticated hosted machine is the one profile that is usable
+/// with nothing stored at all: it resolves the credential per caller
+/// (`on_behalf_of_is_the_path`), so the stored-row walk below would call
+/// every provider unusable and leave every caller's picker empty.
 pub async fn provider_is_usable(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
@@ -2246,6 +2286,9 @@ pub async fn provider_is_usable(
     }
     if kind == ProviderKind::ModelGateway {
         return Ok(false);
+    }
+    if on_behalf_of_is_the_path(store, secrets, kind, policy).await {
+        return Ok(true);
     }
     let config = read_config(store, kind).await?;
     if !config.enabled {

--- a/crates/tidebreak-server/src/routes/connected_apps.rs
+++ b/crates/tidebreak-server/src/routes/connected_apps.rs
@@ -206,7 +206,7 @@ pub async fn put_rest_connected_app(
     Path(id): Path<ConnectedAppId>,
     Json(body): Json<RestConnectedAppUpsert>,
 ) -> Result<Json<ConnectedAppsInfo>, ServerError> {
-    let policy = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let policy = state.managed_policy()?;
     if policy.managed {
         return Err(managed_profile_refusal(
             "REST connected apps are managed by your organization's gateway",
@@ -456,7 +456,7 @@ pub async fn post_rest_spec_preview(
     State(state): State<AppState>,
     Json(body): Json<SpecPreviewRequest>,
 ) -> Result<Json<SpecPreviewInfo>, ServerError> {
-    let policy = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let policy = state.managed_policy()?;
     if policy.managed {
         return Err(managed_profile_refusal(
             "REST connected apps are managed by your organization's gateway",

--- a/crates/tidebreak-server/src/routes/mcp_gateway.rs
+++ b/crates/tidebreak-server/src/routes/mcp_gateway.rs
@@ -77,7 +77,7 @@ pub async fn put_mcp_servers(
     // itself re-reads the lockdown under that lock, so such a definition
     // persists inert and never connects. The residue is a millisecond-wide
     // cosmetic entry in durable config, not an execution bypass.
-    let policy = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let policy = state.managed_policy()?;
     // Once validation/startup begins, finish the durable/live commit even if
     // the HTTP client disconnects and drops this handler future.
     let runtime = state.mcp.clone();
@@ -181,7 +181,7 @@ pub async fn get_policy(
 async fn policy_with_pending(
     state: &AppState,
 ) -> Result<crate::managed_policy::ManagedPolicy, ServerError> {
-    let mut policy = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let mut policy = state.managed_policy()?;
     policy.pending_gateway_url = state.gateway.pending_pairing_url().await;
     Ok(policy)
 }

--- a/crates/tidebreak-server/src/routes/projects_chats.rs
+++ b/crates/tidebreak-server/src/routes/projects_chats.rs
@@ -212,7 +212,7 @@ pub async fn create_chat(
         crate::code_execution::normalize_network_policy(policy)?;
     }
     let title = normalize_chat_title(body.title)?;
-    let managed = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let managed = state.managed_policy()?;
     let model = match body.model.as_ref() {
         Some(model) => Some(model.clone()),
         // On an unmanaged profile, preserve the historical recovery behavior
@@ -241,10 +241,7 @@ pub async fn create_chat(
         // mirroring how the turn gate treats stored over-ceiling modes.
         None => match read_sticky_default(&*state.store, &owner, STICKY_PERMISSION_MODE_KEY).await?
         {
-            Some(sticky) => {
-                crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?
-                    .clamp_permission_mode(Some(sticky))
-            }
+            Some(sticky) => state.managed_policy()?.clamp_permission_mode(Some(sticky)),
             None => None,
         },
     };

--- a/crates/tidebreak-server/src/routes/providers_models.rs
+++ b/crates/tidebreak-server/src/routes/providers_models.rs
@@ -71,7 +71,7 @@ pub(crate) async fn resolve_executable_chat_model(
     if !state.resolver.enforces_model_registry() {
         return Ok(selected);
     }
-    let managed = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let managed = state.managed_policy()?;
     let executable = if managed.managed {
         let policy = model_roles::effective_chat_policy(
             &*state.store,
@@ -115,7 +115,7 @@ async fn validate_execution_selection(
             "managed gateway execution requires a frozen model identity",
         ));
     }
-    let managed = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let managed = state.managed_policy()?;
     if !providers::model_is_usable(&*state.store, &*state.secrets, &policy, &managed).await? {
         return Err(ServerError::conflict_kind(
             "model_provider_unavailable",
@@ -151,7 +151,7 @@ pub(super) async fn validate_model_selection(
             unknown_model_message(value),
         ));
     };
-    let managed = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let managed = state.managed_policy()?;
     if !providers::model_is_usable(&*state.store, &*state.secrets, &policy, &managed).await? {
         return Err(ServerError::conflict_kind(
             "model_provider_unavailable",
@@ -212,7 +212,7 @@ pub(super) async fn refuse_permission_mode_over_ceiling(
     let Some(mode) = requested else {
         return Ok(());
     };
-    let policy = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let policy = state.managed_policy()?;
     if !policy.permits_permission_mode(mode) {
         return Err(ServerError::conflict_kind(
             "permission_mode_locked",
@@ -237,7 +237,7 @@ pub(super) async fn refuse_permission_mode_over_ceiling(
 pub(super) async fn refuse_credential_writes_when_managed(
     state: &AppState,
 ) -> Result<(), ServerError> {
-    let policy = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let policy = state.managed_policy()?;
     if policy.managed {
         return Err(providers::managed_profile_refusal(
             "this profile is managed by a model gateway; provider API keys are locked",
@@ -310,7 +310,7 @@ pub struct ProvidersList {
 pub async fn list_providers(
     State(state): State<AppState>,
 ) -> Result<Json<ProvidersList>, ServerError> {
-    let policy = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let policy = state.managed_policy()?;
     Ok(Json(ProvidersList {
         providers: providers::list_providers(&*state.store, &*state.secrets, &policy).await?,
     }))
@@ -543,7 +543,7 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCata
             resolved_key,
         });
     }
-    let policy = crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+    let policy = state.managed_policy()?;
     let models = providers::catalog_models(&*state.store, &*state.secrets, &policy)
         .await?
         .into_iter()
@@ -653,8 +653,7 @@ async fn resolved_role_key(
                 Some(selection) => selection.to_owned(),
                 None => chat_role_model(&*state.store, &state.agent_config.model).await?,
             };
-            let managed =
-                crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?;
+            let managed = state.managed_policy()?;
             Ok(model_roles::effective_chat_policy(
                 &*state.store,
                 &*state.secrets,

--- a/crates/tidebreak-server/src/routes/settings.rs
+++ b/crates/tidebreak-server/src/routes/settings.rs
@@ -929,10 +929,7 @@ pub(super) async fn read_sticky_chat_defaults(
             // policy arrived: a remembered `allow` under an `ask` ceiling seeds
             // (and reads back) `ask`, mirroring the turn gate's treatment of
             // stored over-ceiling modes.
-            Some(mode) => {
-                crate::managed_policy::resolve(&*state.provisioned_policy, &*state.os_policy)?
-                    .clamp_permission_mode(Some(mode))
-            }
+            Some(mode) => state.managed_policy()?.clamp_permission_mode(Some(mode)),
             None => None,
         };
     Ok(StickyChatDefaults {

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -451,6 +451,22 @@ impl AppState {
         self.local_voice = runner;
     }
 
+    /// The resolved managed-mode policy every route reads.
+    ///
+    /// One accessor rather than a `managed_policy::resolve` call per handler,
+    /// because the resolution has a third input a handler cannot see: the
+    /// gateway this deployment authenticates its own callers against
+    /// (`docs/decisions/0049-gateway-authenticated-hosted-machines.md`). That
+    /// tier only describes the deployment — it never asserts management, so
+    /// no route gains a lockdown or a sign-in gate by moving here.
+    pub(crate) fn managed_policy(&self) -> Result<crate::managed_policy::ManagedPolicy> {
+        crate::managed_policy::resolve_with_deployment(
+            &*self.provisioned_policy,
+            &*self.os_policy,
+            self.config.hosted_gateway_url(),
+        )
+    }
+
     /// Resolve model credentials per caller through `inference` (decision 51).
     ///
     /// Pass the same instance the resolver holds: the authentication

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -5918,3 +5918,224 @@ async fn a_cached_provider_is_never_shared_between_callers() {
     // A turn no owner can be named for is offered no credential at all.
     assert_eq!(resolver.resolve_for(None).await.id().0, "unconfigured");
 }
+
+/// A gateway-authenticated hosted machine (decision 49) with the deployment's
+/// own configuration as `AppState` resolves it.
+fn hosted_machine_policy() -> crate::managed_policy::ManagedPolicy {
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    crate::managed_policy::resolve_with_deployment(
+        &*provisioned,
+        &crate::managed_policy::NoOsPolicy,
+        Some("https://gateway.example"),
+    )
+    .unwrap()
+}
+
+/// The projection a client attached to a hosted machine reads: which gateway
+/// authenticates it, and no claim of management over it.
+///
+/// The second half is the load-bearing one. A hosted machine holds no gateway
+/// session and can never report one — its callers authenticate *to* it — so
+/// asserting management would raise a sign-in gate nothing could satisfy.
+#[test]
+fn a_hosted_machine_names_its_gateway_without_asserting_management() {
+    let policy = hosted_machine_policy();
+
+    assert_eq!(
+        policy.hosted_gateway_url.as_deref(),
+        Some("https://gateway.example/"),
+        "the client must be told which gateway authenticates it"
+    );
+    assert!(
+        !policy.managed,
+        "a hosted machine holds no session, so it must never raise the sign-in gate"
+    );
+    assert_eq!(
+        policy.source,
+        crate::managed_policy::ManagedPolicySource::Unmanaged
+    );
+    assert!(
+        policy.gateway_url.is_none(),
+        "no authority locks this profile to a gateway it must sign in to"
+    );
+    assert!(!policy.misconfigured);
+    assert!(
+        policy.pending_gateway_url.is_none(),
+        "the deployment's own gateway is not a pairing awaiting consent"
+    );
+}
+
+/// The deployment tier describes; it never governs. A device-managed profile
+/// keeps its authority, its locked URL, and its lockdown whatever the
+/// deployment names beside it.
+#[test]
+fn the_deployment_tier_never_overrides_an_asserting_authority() {
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    crate::managed_policy::provision(&*provisioned, "https://corp.gateway").unwrap();
+    let policy = crate::managed_policy::resolve_with_deployment(
+        &*provisioned,
+        &crate::managed_policy::NoOsPolicy,
+        Some("https://gateway.example"),
+    )
+    .unwrap();
+
+    assert!(policy.managed);
+    assert_eq!(policy.gateway_url.as_deref(), Some("https://corp.gateway/"));
+    assert_eq!(
+        policy.source,
+        crate::managed_policy::ManagedPolicySource::Provisioned
+    );
+}
+
+/// A deployment URL this side cannot render is a display fault, not an
+/// authority in need of repair: the machine is already up and authenticating
+/// callers against it, so the projection drops the URL rather than failing
+/// the profile closed.
+#[test]
+fn an_unusable_deployment_url_leaves_the_profile_open() {
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let policy = crate::managed_policy::resolve_with_deployment(
+        &*provisioned,
+        &crate::managed_policy::NoOsPolicy,
+        Some("not a url"),
+    )
+    .unwrap();
+
+    assert!(policy.hosted_gateway_url.is_none());
+    assert!(!policy.managed);
+    assert!(!policy.misconfigured);
+}
+
+/// The wiring: a hosted machine's own configuration reaches the policy every
+/// route reads, and a desktop profile's does not.
+#[tokio::test]
+async fn app_state_projects_the_deployments_own_gateway() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+    let hosted = {
+        let mut config = Config::desktop(dir.path());
+        config.profile = Profile::SelfHost;
+        config.auth_gateway_url = Some("https://gateway.example".to_owned());
+        config.public_url = Some("https://machine.example".to_owned());
+        config
+    };
+    let state = AppState::new(
+        hosted,
+        store.clone(),
+        Arc::new(resolver::ConfiguredResolver::new(
+            store.clone(),
+            secrets.clone(),
+            crate::gateway_runtime::GatewayRuntime::new(
+                store.clone(),
+                secrets.clone(),
+                crate::managed_policy::MemoryProvisionedPolicy::new(),
+                Arc::new(crate::managed_policy::NoOsPolicy),
+            ),
+            Arc::new(
+                crate::chatgpt_runtime::ChatGptRuntime::new(store.clone(), secrets.clone())
+                    .unwrap(),
+            ),
+            crate::managed_policy::MemoryProvisionedPolicy::new(),
+            Arc::new(crate::managed_policy::NoOsPolicy),
+        )),
+        secrets.clone(),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig::default(),
+    );
+
+    let policy = state.managed_policy().unwrap();
+    assert_eq!(
+        policy.hosted_gateway_url.as_deref(),
+        Some("https://gateway.example/")
+    );
+    assert!(!policy.managed);
+}
+
+/// The picker a caller starts a conversation from.
+///
+/// A hosted machine stores no provider configuration of its own — it resolves
+/// the credential per caller — so the stored-row walk would call every
+/// provider unusable and offer nobody a model to select.
+#[tokio::test]
+async fn a_hosted_machine_offers_the_caller_a_model_to_start_with() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let hosted = hosted_machine_policy();
+
+    assert!(
+        providers::provider_is_usable(
+            &*store,
+            &*secrets,
+            providers::ProviderKind::Anthropic,
+            &hosted,
+        )
+        .await
+        .unwrap(),
+        "the provider the caller's own credential serves must be usable"
+    );
+
+    let catalog = providers::catalog_models(&*store, &*secrets, &hosted)
+        .await
+        .unwrap();
+    assert!(
+        catalog
+            .iter()
+            .any(|entry| entry.available
+                && entry.policy.provider == providers::ProviderKind::Anthropic),
+        "the catalog must offer at least one selectable model"
+    );
+
+    // The same deployment without gateway authentication is unchanged: a
+    // self-host server on static tokens states no path to this provider.
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let unmanaged =
+        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
+    assert!(!providers::provider_is_usable(
+        &*store,
+        &*secrets,
+        providers::ProviderKind::Anthropic,
+        &unmanaged,
+    )
+    .await
+    .unwrap());
+}
+
+/// Decision 51, rule 3, in the catalog as well as in route collection: a
+/// stored provider configuration states the deployment's inference path, and
+/// per-caller availability does not overrule it.
+#[tokio::test]
+async fn a_stored_provider_configuration_still_decides_availability() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderConfig {
+            enabled: false,
+            base_url: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+
+    assert!(
+        !providers::provider_is_usable(
+            &*store,
+            &*secrets,
+            providers::ProviderKind::Anthropic,
+            &hosted_machine_policy(),
+        )
+        .await
+        .unwrap(),
+        "a disabled provider row must leave the provider unusable"
+    );
+}

--- a/docs/gateway-boundary.md
+++ b/docs/gateway-boundary.md
@@ -57,6 +57,24 @@ Policy resolution has three tiers, strongest first:
 3. **Open.** Neither present; the unmanaged product, which has no gateway
    surface at all.
 
+### A hosted machine names a gateway without being managed by one
+
+A gateway-authenticated hosted machine
+([decision 49](decisions/0049-gateway-authenticated-hosted-machines.md)) is a
+fourth thing, and it is deliberately not a fourth tier of the list above. Its
+callers authenticate *to* it with their own gateway tokens; nobody signs in
+*through* it. It therefore holds no session, can never report one, and must
+never be resolved as managed — a sign-in gate against it is one nothing could
+ever satisfy.
+
+So the deployment's own `TIDEBREAK_AUTH_GATEWAY_URL` reaches the resolved
+policy as a separate fact, `hosted_gateway_url`. It describes: an attached
+client can name the gateway that authenticates it, and the model surfaces know
+the credential is resolved per caller
+([decision 51](decisions/0051-on-behalf-of-inference-for-hosted-machines.md)).
+It governs nothing: `managed` stays false, so no lockdown, no sign-in gate, and
+no change to how routes are collected.
+
 ## Pairing: the provision link is a proposal, not a command
 
 Pairing starts from the gateway's own web UI: a link of exactly one shape,

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -90,6 +90,13 @@ default only for a provider the deployment states no other path to. It also
 requires Gateway authentication: a server running on static tokens has no
 caller token to exchange and keeps its environment-configured providers.
 
+An attached client shows the Gateway under Settings → Model Gateway, read-only:
+the machine names the Gateway it authenticates you against, and there is
+nothing to sign in to or sign out of there. You already signed in on your own
+computer, and the machine runs your work with that account. It never asks a
+client to sign in to it, because it holds no Gateway session of its own and
+could never report one.
+
 ## Generating tokens for standalone compatibility
 
 The token file is the credential-to-principal map, and it is also where roles


### PR DESCRIPTION
Closes #2509. Follow-up for the remaining half: #2517.

A gateway-authenticated hosted machine reported itself unmanaged, so a client attached to it saw no Model Gateway section and no models at all. `TIDEBREAK_AUTH_GATEWAY_URL` reached the authenticator and the on-behalf-of token exchange and stopped there; managed policy resolves from artifacts a container never writes.

## The trap this avoids

Returning `managed: true` would be the wrong repair. `managed` carries two meanings — "an authority governs this profile" and "this profile must hold a gateway session" — and the second is false for a hosted machine. Callers authenticate *to* it with their own gateway tokens; nobody signs in *through* it. It can never report a session, so the sign-in gate would be one nothing could satisfy: the lockout #2514 just fixed.

## What changed

The deployment's gateway reaches the resolved policy as a separate fact, `hosted_gateway_url`. It describes and never governs — `managed`, `source`, and `gateway_url` are untouched, so there is no lockdown, no gate, and no change to how routes are collected. `resolve_with_deployment` is the one place it enters; `resolve` delegates to it with `None`, so every existing caller is byte-identical. Routes go through `AppState::managed_policy`, which is where the deployment's own configuration is in scope. A surface that forgets loses its description, never its enforcement.

The empty picker had a second cause, and it was a contradiction between two conditions. Per-caller inference is offered only where the deployment stores no provider row (`on_behalf_of_states_the_only_path`), while `provider_is_usable` required one with `enabled: true`. The two could never both hold, so a hosted machine had a working Anthropic route and a catalog that marked every model unavailable. `provider_is_usable` now reports the provider the caller's own credential serves as usable, keyed off the same policy fact. A stored row, a stored credential, and the environment fallbacks all still win — decision 51, rule 3, unchanged, and tested.

The Model Gateway section names the gateway read-only for an attached client: no sign-in, no sign-out, and no sync, because there is no session here to manage. The machine sections #2516 put on that page stay exactly as they are, so the reader still sees where their work runs and how to come back to this computer.

## What this does not do

The catalog is the curated Anthropic list, not the caller's own gateway entitlements — so a deployment whose gateway serves other vendors offers none of them. That is #2517, which also carries the open question it turns on: `/api/v1/me/catalog` is read with a `control`-audience token, and a hosted machine holds neither a `control` token nor a way to mint one under decision 51.

Background model roles (chat titling, the approval judge) still resolve to nothing on a hosted machine. They have no caller, and per-caller inference has no credential without one. Unchanged by this PR, and covered by #2517.

## Tests

- The projection: a hosted machine names its gateway, stays unmanaged, and reports no locked URL — the assertion that pins the gate off at the source.
- An asserting authority (MDM, pairing) keeps its verdict and its URL whatever the deployment names beside it.
- A deployment URL that fails the gateway contract is dropped with a warning rather than failing the profile closed.
- `AppState::managed_policy` carries the deployment's own configuration into the policy every route reads.
- The catalog offers a selectable model on a hosted machine, and a disabled provider row still takes it away.
- The gate renders the app and never asks for a sign-in against a hosted machine.
- The panel names the gateway, reads no status behind a session it does not have, and still shows the machine it is attached to.
- A `Settings/Model Gateway` Storybook story for the hosted state.

`tsc --noEmit`, the full vitest suite (216 files, 1658 tests), `biome check`, the Storybook build, and `cargo fmt --check` pass locally. Rust compilation and tests are left to CI.
