### PR TITLE
fix(desktop): stop offering this computer while the work is elsewhere

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatHeaderTitle.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatHeaderTitle.dom.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Chat } from "./api";
+import { AppContextProvider, type AppContextValue } from "./AppContext";
+import { ChatHeaderTitle } from "./ChatHeaderTitle";
+import { setAttachedRemotely } from "./host";
+import { renderWithRouter } from "./test/router";
+
+// The rows are rendered natively from the event journal on this computer, so
+// the gate is the whole subject of this file.
+const isTauri = vi.hoisted(() => vi.fn(() => true));
+vi.mock("@tauri-apps/api/core", () => ({ isTauri, invoke: vi.fn() }));
+
+const chat = {
+  id: "chat-1",
+  title: "Roadmap",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+} as unknown as Chat;
+
+async function openMenu() {
+  const user = userEvent.setup();
+  await renderWithRouter(
+    <AppContextProvider
+      value={
+        {
+          startRename: vi.fn(),
+          commitRename: vi.fn(),
+          cancelRename: vi.fn(),
+          deleteChat: vi.fn(),
+        } as unknown as AppContextValue
+      }
+    >
+      <ChatHeaderTitle chat={chat} />
+    </AppContextProvider>,
+    { initialUrl: "/c/chat-1" },
+  );
+  await user.click(screen.getByRole("button", { name: "Work menu" }));
+}
+
+describe("ChatHeaderTitle diagnostics", () => {
+  afterEach(() => {
+    cleanup();
+    setAttachedRemotely(false);
+  });
+
+  it("offers the debug bundle for a conversation on this computer", async () => {
+    await openMenu();
+    expect(
+      screen.getByRole("menuitem", { name: "Copy debug info" }),
+    ).toBeInTheDocument();
+  });
+
+  it("leaves the debug bundle out while the work is on another machine", async () => {
+    setAttachedRemotely(true);
+    await openMenu();
+    // The bundle is built from the journal on this computer, so there is
+    // nothing to build for a conversation that lives elsewhere. Hiding beats
+    // offering a row that can only refuse.
+    expect(
+      screen.queryByRole("menuitem", { name: "Copy debug info" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "Save debug bundle…" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Rename" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/ChatHeaderTitle.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatHeaderTitle.tsx
@@ -5,7 +5,7 @@ import type { Chat } from "./api";
 import { useApp } from "./AppContext";
 import { chatDebugDeps, copyChatDebug, saveChatDebug } from "./ChatDebugBundle";
 import { useChatListStore } from "./ChatListStore";
-import { hasNativeHost } from "./host";
+import { hasLocalHostAuthority } from "./host";
 import { useTypewriterOnce } from "./useTypewriterOnce";
 import { Input } from "@/components/ui/input";
 import {
@@ -111,9 +111,11 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
             <Pencil />
             Rename
           </DropdownMenuItem>
-          {/* Diagnostics need the native host to read the journal, so they are
-              absent in a browser build rather than shown and broken. */}
-          {hasNativeHost() && (
+          {/* Diagnostics are rendered natively from the event journal on this
+              computer. A browser build has no journal, and an attached window
+              has the wrong one, so both leave the rows out rather than show
+              them and refuse. */}
+          {hasLocalHostAuthority() && (
             <>
               <DropdownMenuSeparator />
               <DropdownMenuItem

--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -41,14 +41,19 @@ import { OutputsView } from "./outputs/OutputsView";
 import { DocumentDetailRoot } from "./document-detail/DocumentDetailRoot";
 import { warmPresentationConverter } from "./document/officePdf";
 import { FoldersView } from "./FoldersView";
-import { hasNativeHost } from "./host";
+import { hasLocalHostAuthority, hasNativeHost } from "./host";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePortalOverlayOpen } from "@/lib/usePortalOverlayOpen";
 import { foregroundBrowserScope } from "./code/browser/foregroundBrowserScope";
 import { seedBrowserSession } from "./code/browser/browserPersistence";
 
 import { friendlyErrorMessage } from "./lib/utils";
-import { attachChatFiles, type AttachedFiles } from "./attachments";
+import {
+  attachChatFiles,
+  attachHeldChatFiles,
+  pickHeldFiles,
+  type AttachedFiles,
+} from "./attachments";
 import { type ImportedDocument, type LibraryImportSuccess } from "./documents";
 import { DocumentDropTarget } from "./DocumentDropTarget";
 import {
@@ -574,9 +579,18 @@ export function ChatRoute({ chatId }: { chatId: string }) {
    * Which of the two things each file becomes — pixels for the model, or a
    * parsed and readable source — is decided by the host from the bytes, so
    * nothing here has to guess from a name or ask the reader to know first.
+   *
+   * The host route needs the conversation to be on this computer, because it
+   * imports into the store inside this app. A window attached to a machine
+   * takes the browser's own picker instead and posts the bytes to the machine
+   * that holds the conversation — the same operation, aimed at the right host.
    */
   async function onAttach() {
     if (attaching || deletingChatId !== null) return;
+    if (!hasLocalHostAuthority()) {
+      await attachHeldFiles();
+      return;
+    }
     if (!useNativePickerLatch.getState().claim(PICKER_HOLDERS.importSource)) {
       setAttachError(PICKER_BUSY_MESSAGE);
       return;
@@ -591,6 +605,44 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       setAttachError(friendlyAttachError(err));
     } finally {
       useNativePickerLatch.getState().release(PICKER_HOLDERS.importSource);
+      setAttaching(false);
+    }
+  }
+
+  /**
+   * Attach through the browser, for a window whose conversation is elsewhere.
+   *
+   * Nothing is marked as attaching until files are actually chosen, so a
+   * dismissed picker leaves no spinner to clear. Images take the composer's
+   * upload path, which gives them progress and a retry; sources are posted to
+   * the machine and adopted through the same code the host route uses.
+   */
+  async function attachHeldFiles() {
+    const chosen = await pickHeldFiles();
+    if (chosen.length === 0) return;
+    setAttaching(true);
+    setAttachError(null);
+    const room = Math.max(
+      0,
+      MAX_IMAGE_ATTACHMENTS - images.attachments.length - files.length,
+    );
+    const picked = chosen.slice(0, room);
+    try {
+      const held = await attachHeldChatFiles(client, chatId, picked);
+      if (held.images.length > 0) images.attachFiles(held.images);
+      adoptAttached({
+        images: [],
+        documents: held.documents,
+        failedImages: [],
+      });
+      if (picked.length < chosen.length) {
+        setAttachError(
+          `A message can carry at most ${MAX_IMAGE_ATTACHMENTS} attachments.`,
+        );
+      }
+    } catch (err) {
+      setAttachError(friendlyAttachError(err));
+    } finally {
       setAttaching(false);
     }
   }
@@ -751,7 +803,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           files={{
             items: files,
             attaching,
-            onAttach: hasNativeHost() ? onAttach : undefined,
+            onAttach,
             onReattach: onReattachFile,
             onRemove: (documentId) =>
               setComposerFiles((current) =>
@@ -998,7 +1050,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
               onOpenFolders={() => openPanel({ type: "folders" })}
               onOpenPermissions={() => openPanel({ type: "permissions" })}
               onOpenAgents={() => openPanel({ type: "agents" })}
-              onOpenBrowser={nativeHost ? () => openBrowser() : undefined}
+              onOpenBrowser={
+                hasLocalHostAuthority() ? () => openBrowser() : undefined
+              }
             />
           </div>
         </header>

--- a/crates/tidebreak-desktop/ui/src/DocumentDropTarget.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/DocumentDropTarget.dom.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   handler: undefined as ((event: { payload: unknown }) => void) | undefined,
   attachDropped: vi.fn(),
   stop: vi.fn(),
+  localHostAuthority: vi.fn(() => true),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -29,6 +30,7 @@ vi.mock("./attachments", () => ({
 
 vi.mock("./host", () => ({
   hasNativeHost: () => true,
+  hasLocalHostAuthority: mocks.localHostAuthority,
 }));
 
 describe("DocumentDropTarget", () => {
@@ -41,6 +43,7 @@ describe("DocumentDropTarget", () => {
       failedImages: [],
     });
     mocks.stop.mockReset();
+    mocks.localHostAuthority.mockReturnValue(true);
   });
 
   it("offers native files and folders without claiming aliases", async () => {
@@ -95,6 +98,43 @@ describe("DocumentDropTarget", () => {
     // delivered after teardown must not reach the resolver either.
     expect(resolveChatId).not.toHaveBeenCalled();
     expect(mocks.attachDropped).not.toHaveBeenCalled();
+  });
+
+  it("refuses a drop while this window works on another machine", async () => {
+    mocks.localHostAuthority.mockReturnValue(false);
+    const onAttached = vi.fn();
+    const resolveChatId = vi.fn(async () => "chat-1");
+    render(
+      <DocumentDropTarget
+        resolveChatId={resolveChatId}
+        onAttached={onAttached}
+        onError={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(mocks.handler).toBeTypeOf("function"));
+
+    act(() => {
+      mocks.handler?.({
+        payload: { phase: "enter", accepted: true, fileCount: 1 },
+      });
+    });
+    // The reader learns before letting go, and is pointed at the route that
+    // does reach the machine.
+    expect(
+      screen.getByText("These files are on this computer"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Use Attach files/)).toBeInTheDocument();
+
+    act(() => {
+      mocks.handler?.({
+        payload: { phase: "dropped", accepted: true, fileCount: 1 },
+      });
+    });
+    // The host would import these paths into the store inside this app, where
+    // the conversation does not exist, so the claim never goes out.
+    expect(resolveChatId).not.toHaveBeenCalled();
+    expect(mocks.attachDropped).not.toHaveBeenCalled();
+    expect(onAttached).not.toHaveBeenCalled();
   });
 
   it("rejects malformed drop projections", () => {

--- a/crates/tidebreak-desktop/ui/src/DocumentDropTarget.tsx
+++ b/crates/tidebreak-desktop/ui/src/DocumentDropTarget.tsx
@@ -2,7 +2,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef, useState } from "react";
 
 import { attachDroppedChatFiles, type AttachedFiles } from "./attachments";
-import { hasNativeHost } from "./host";
+import { hasLocalHostAuthority, hasNativeHost } from "./host";
 
 type DropPhase = "enter" | "leave" | "dropped";
 
@@ -52,7 +52,7 @@ export function DocumentDropTarget({
       }
       if (next.phase === "dropped") {
         setState(null);
-        if (next.accepted) {
+        if (next.accepted && hasLocalHostAuthority()) {
           void (async () => {
             // Unmounting during this round trip cannot call the conversation
             // back: it is already created, and it shows up in the sidebar
@@ -80,23 +80,36 @@ export function DocumentDropTarget({
   }, []);
 
   if (!state) return null;
+  // A dropped path is a path on this computer, and the host reads it into the
+  // store inside this app. Neither is where the conversation is while this
+  // window works on a machine, so the overlay says so before the reader lets
+  // go rather than failing the import after they have.
+  const accepted = state.accepted && hasLocalHostAuthority();
   return (
     <div
-      className={`absolute inset-0 z-20 flex flex-col items-center justify-center rounded-xl border-2 border-dashed bg-background/95 px-4 text-center ${state.accepted ? "border-primary" : "border-destructive"}`}
+      className={`absolute inset-0 z-20 flex flex-col items-center justify-center rounded-xl border-2 border-dashed bg-background/95 px-4 text-center ${accepted ? "border-primary" : "border-destructive"}`}
       aria-live="assertive"
     >
-      <strong>
-        {state.accepted
-          ? `Attach ${dropItemCountCopy(state.fileCount)}`
-          : "Only regular files and folders can be attached"}
-      </strong>
+      <strong>{dropHeadline(state, accepted)}</strong>
       <span className="text-xs text-muted-foreground">
-        {state.accepted
-          ? "Release to add them to this message."
-          : "Aliases and unavailable items cannot be imported."}
+        {dropDetail(state, accepted)}
       </span>
     </div>
   );
+}
+
+function dropHeadline(state: DropState, accepted: boolean): string {
+  if (accepted) return `Attach ${dropItemCountCopy(state.fileCount)}`;
+  if (state.accepted) return "These files are on this computer";
+  return "Only regular files and folders can be attached";
+}
+
+function dropDetail(state: DropState, accepted: boolean): string {
+  if (accepted) return "Release to add them to this message.";
+  if (state.accepted) {
+    return "Your conversation is on another machine. Use Attach files in the Tools menu to send them to it.";
+  }
+  return "Aliases and unavailable items cannot be imported.";
 }
 
 export function parseDropState(value: unknown): DropState | null {

--- a/crates/tidebreak-desktop/ui/src/ExecDisclosure.ts
+++ b/crates/tidebreak-desktop/ui/src/ExecDisclosure.ts
@@ -1,7 +1,15 @@
 import type { ExecConfigInfo } from "./api";
+import { hostMachineLabel } from "./remoteMachine";
 
-export const MANAGED_EXECUTION_DISCLOSURE =
-  "Code execution runs in an E2B or Daytona cloud sandbox on this device. Files staged for a run leave this machine and are uploaded to that provider.";
+/**
+ * Where code actually runs when the host has no native sandbox, and what
+ * leaves with it. Named at read time rather than fixed at module load: the
+ * files staged for a run leave whichever machine this window works on.
+ */
+export function managedExecutionDisclosure(): string {
+  const host = hostMachineLabel();
+  return `Code execution runs in an E2B or Daytona cloud sandbox rather than on ${host}. Files staged for a run leave ${host} and are uploaded to that provider.`;
+}
 
 /**
  * Whether this host has no native execution path and therefore must use a

--- a/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
@@ -2,7 +2,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "./AppContext";
-import { attachChatFiles } from "./attachments";
+import {
+  attachChatFiles,
+  attachHeldChatFiles,
+  pickHeldFiles,
+} from "./attachments";
 import { useChatListStore } from "./ChatListStore";
 import { Composer, type ComposerImages } from "./Composer";
 import {
@@ -14,7 +18,7 @@ import {
 import { type ImportedDocument, type LibraryImportSuccess } from "./documents";
 import { DocumentDropTarget } from "./DocumentDropTarget";
 import { useFirstMessage } from "./FirstMessage";
-import { hasNativeHost } from "./host";
+import { hasLocalHostAuthority } from "./host";
 import { ModelMenu, useModelSettingsNav } from "./ModelMenu";
 import { modelForSelection, textOnlyModelLabel } from "./ModelSelection";
 import {
@@ -225,8 +229,18 @@ export function HomeRoute() {
     return created.id;
   }
 
+  /**
+   * The host picker imports into the store inside this app, which is not where
+   * the conversation lives while this window is attached to a machine. That
+   * window takes the browser's own picker and posts the bytes to the machine
+   * instead, so the attach succeeds rather than failing once files are chosen.
+   */
   async function onAttach() {
     if (attaching || creatingChat) return;
+    if (!hasLocalHostAuthority()) {
+      await attachHeldFiles();
+      return;
+    }
     setAttaching(true);
     setAttachError(null);
     try {
@@ -234,6 +248,46 @@ export function HomeRoute() {
       const attached = await attachChatFiles(chatId);
       if (!attached) return;
       adoptAttached(attached);
+    } catch (err) {
+      setAttachError(
+        String(err)
+          .replace(/^Error:\s*/, "")
+          .trim() || "Could not attach that file.",
+      );
+    } finally {
+      setAttaching(false);
+    }
+  }
+
+  /**
+   * Nothing is marked as attaching until files are chosen, so a dismissed
+   * picker leaves no spinner behind — and no conversation is created for a
+   * selection the reader abandoned.
+   */
+  async function attachHeldFiles() {
+    const chosen = await pickHeldFiles();
+    if (chosen.length === 0) return;
+    setAttaching(true);
+    setAttachError(null);
+    const room = Math.max(
+      0,
+      MAX_IMAGE_ATTACHMENTS - pendingImages.length - pendingFiles.length,
+    );
+    const picked = chosen.slice(0, room);
+    try {
+      const chatId = await ensurePendingChat();
+      const held = await attachHeldChatFiles(client, chatId, picked);
+      if (held.images.length > 0) images.attachFiles(held.images);
+      adoptAttached({
+        images: [],
+        documents: held.documents,
+        failedImages: [],
+      });
+      if (picked.length < chosen.length) {
+        setAttachError(
+          `A message can carry at most ${MAX_IMAGE_ATTACHMENTS} attachments.`,
+        );
+      }
     } catch (err) {
       setAttachError(
         String(err)
@@ -447,7 +501,7 @@ export function HomeRoute() {
               files={{
                 items: pendingFiles,
                 attaching,
-                onAttach: hasNativeHost() ? onAttach : undefined,
+                onAttach,
                 onRemove: (documentId) =>
                   setPendingFiles((current) =>
                     current.filter((file) => file.documentId !== documentId),

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.test.tsx
@@ -105,7 +105,7 @@ describe("WelcomeState", () => {
     );
 
     expect(
-      await screen.findByText(/Files staged for a run leave this machine/i),
+      await screen.findByText(/Files staged for a run leave this computer/i),
     ).toBeInTheDocument();
   });
 
@@ -119,7 +119,7 @@ describe("WelcomeState", () => {
 
     await waitFor(() => expect(client.getExecConfig).toHaveBeenCalled());
     expect(
-      screen.queryByText(/Files staged for a run leave this machine/i),
+      screen.queryByText(/Files staged for a run leave this computer/i),
     ).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react";
 import type { ApiClient, ExecConfigInfo, PluginPromptInfo } from "./api";
 import {
-  MANAGED_EXECUTION_DISCLOSURE,
+  managedExecutionDisclosure,
   requiresManagedExecutionDisclosure,
 } from "./ExecDisclosure";
 import { Logomark } from "./Logomark";
@@ -231,7 +231,7 @@ export function WelcomeState({
           <h2>{heading}</h2>
           <p>{description}</p>
           {managedExecutionOnly && (
-            <p className="welcome-disclosure">{MANAGED_EXECUTION_DISCLOSURE}</p>
+            <p className="welcome-disclosure">{managedExecutionDisclosure()}</p>
           )}
         </div>
       </div>

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -1190,6 +1190,36 @@ export class ApiClient {
     );
   }
 
+  /**
+   * Publish one file the renderer is already holding as a source on this chat.
+   *
+   * The native picker route reads the bytes in the host and imports them into
+   * the store inside this app. That is the wrong store while this window works
+   * on another machine, so a window in that state posts the bytes here instead
+   * and the machine that owns the conversation parses them.
+   *
+   * The media type decides which parser runs. A browser leaves `File.type`
+   * empty for a name it does not recognize, and the route refuses an empty
+   * `Content-Type`, so an unrecognized file is declared as opaque bytes and
+   * retained without extracted text rather than refused outright.
+   */
+  ingestChatDocument(
+    chatId: string,
+    file: File,
+  ): Promise<{ document_id: string }> {
+    return this.json(
+      `/chats/${encodeURIComponent(chatId)}/documents/raw?title=${encodeURIComponent(file.name)}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          "Content-Type": file.type || "application/octet-stream",
+        },
+        body: file,
+      },
+    );
+  }
+
   /** One source's extracted text and catalog metadata. */
   getChatDocument(chatId: string, documentId: string): Promise<DocumentDetail> {
     return this.json(

--- a/crates/tidebreak-desktop/ui/src/attachments.test.ts
+++ b/crates/tidebreak-desktop/ui/src/attachments.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+
+import type { ApiClient } from "./api";
+import { attachHeldChatFiles, pickHeldFiles } from "./attachments";
+
+function png(name = "chart.png"): File {
+  return new File([new Uint8Array([1, 2, 3, 4])], name, { type: "image/png" });
+}
+
+function pdf(name = "notes.pdf"): File {
+  return new File([new Uint8Array([5, 6])], name, { type: "application/pdf" });
+}
+
+function clientWith(
+  ingestChatDocument: ApiClient["ingestChatDocument"],
+): ApiClient {
+  return { ingestChatDocument } as ApiClient;
+}
+
+describe("attachHeldChatFiles", () => {
+  it("posts sources to the machine and leaves images for the composer to upload", async () => {
+    const ingest = vi.fn(async () => ({ document_id: "doc-1" }));
+    const held = await attachHeldChatFiles(clientWith(ingest), "chat-1", [
+      png(),
+      pdf(),
+    ]);
+
+    // The bytes never reach the host, so the split the host performs on picked
+    // paths is performed here instead.
+    expect(held.images.map((file) => file.name)).toEqual(["chart.png"]);
+    expect(ingest).toHaveBeenCalledWith("chat-1", expect.any(File));
+    expect(held.documents?.results).toEqual([
+      {
+        status: "imported",
+        document: {
+          documentId: "doc-1",
+          displayName: "notes.pdf",
+          mediaType: "application/pdf",
+          byteLen: 2,
+        },
+      },
+    ]);
+  });
+
+  it("declares a file the browser could not type as opaque bytes", async () => {
+    const ingest = vi.fn(async () => ({ document_id: "doc-2" }));
+    const untyped = new File([new Uint8Array([7])], "notes.md", { type: "" });
+    const held = await attachHeldChatFiles(clientWith(ingest), "chat-1", [
+      untyped,
+    ]);
+
+    expect(held.images).toEqual([]);
+    expect(held.documents?.results[0]).toMatchObject({
+      status: "imported",
+      document: { mediaType: "application/octet-stream" },
+    });
+  });
+
+  it("reports one refused file beside the ones that landed", async () => {
+    const ingest = vi.fn(async (_chatId: string, file: File) => {
+      if (file.name === "broken.pdf") throw new Error("Unsupported source");
+      return { document_id: "doc-3" };
+    });
+    const held = await attachHeldChatFiles(clientWith(ingest), "chat-1", [
+      pdf("broken.pdf"),
+      pdf("good.pdf"),
+    ]);
+
+    expect(held.documents?.results).toEqual([
+      {
+        status: "failed",
+        displayName: "broken.pdf",
+        message: "Unsupported source",
+      },
+      {
+        status: "imported",
+        document: {
+          documentId: "doc-3",
+          displayName: "good.pdf",
+          mediaType: "application/pdf",
+          byteLen: 2,
+        },
+      },
+    ]);
+  });
+
+  it("posts nothing when the selection is all images", async () => {
+    const ingest = vi.fn(async () => ({ document_id: "doc-4" }));
+    const held = await attachHeldChatFiles(clientWith(ingest), "chat-1", [
+      png(),
+    ]);
+
+    expect(ingest).not.toHaveBeenCalled();
+    expect(held.documents).toBeNull();
+  });
+});
+
+describe("pickHeldFiles", () => {
+  it("resolves empty when the reader dismisses the picker", async () => {
+    const opened = new Promise<HTMLInputElement>((resolve) => {
+      vi.spyOn(HTMLInputElement.prototype, "click").mockImplementation(
+        function (this: HTMLInputElement) {
+          resolve(this);
+        },
+      );
+    });
+    const picked = pickHeldFiles();
+    const input = await opened;
+    input.dispatchEvent(new Event("cancel"));
+
+    // A dismissal is not a failure, and nothing upstream should have to tell
+    // the two apart.
+    await expect(picked).resolves.toEqual([]);
+    expect(input.isConnected).toBe(false);
+    vi.restoreAllMocks();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/attachments.ts
+++ b/crates/tidebreak-desktop/ui/src/attachments.ts
@@ -1,7 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
 
+import type { ApiClient } from "./api";
 import { parseLibraryImportBatch, type LibraryImportBatch } from "./documents";
 import {
+  isSupportedImageType,
   parseAttachedImage,
   parseHostPublishedImage,
   type PickedImage,
@@ -35,6 +37,98 @@ export async function attachChatFiles(
   return parseAttachedFiles(
     await invoke("attach_chat_files", { request: { chatId } }),
   );
+}
+
+/**
+ * What one browser selection produced.
+ *
+ * The images come back as the files themselves rather than as published
+ * identities: they take the composer's own upload path, which shows byte
+ * progress and can retry, while the native picker publishes in the host and
+ * hands back finished attachments.
+ */
+export type HeldFiles = {
+  images: File[];
+  documents: LibraryImportBatch | null;
+};
+
+/**
+ * Ask for files through the browser's own picker.
+ *
+ * Resolves with an empty list when the reader dismisses it, so nothing on the
+ * way in has to tell a dismissal from a failure.
+ */
+export function pickHeldFiles(): Promise<File[]> {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.multiple = true;
+    // Off screen rather than hidden: a `display: none` input is not clickable
+    // in every engine, and the picker has to open from the reader's gesture.
+    input.style.position = "fixed";
+    input.style.left = "-9999px";
+    document.body.append(input);
+    function settle(files: File[]) {
+      input.remove();
+      resolve(files);
+    }
+    input.addEventListener("change", () =>
+      settle(Array.from(input.files ?? [])),
+    );
+    input.addEventListener("cancel", () => settle([]));
+    input.click();
+  });
+}
+
+/**
+ * Route files the renderer already holds to the machine this window works on.
+ *
+ * This is the split the host performs on picked paths, performed here because
+ * these bytes never reach the host: pixels for the model on one side, sources
+ * to parse and cite on the other. One file that cannot be imported is reported
+ * beside the ones that were, so a bad file does not cost the reader the rest
+ * of the selection.
+ */
+export async function attachHeldChatFiles(
+  client: ApiClient,
+  chatId: string,
+  files: readonly File[],
+): Promise<HeldFiles> {
+  const images = files.filter((file) => isSupportedImageType(file.type));
+  const sources = files.filter((file) => !isSupportedImageType(file.type));
+  if (sources.length === 0) return { images, documents: null };
+  const results = await Promise.all(
+    sources.map(async (file) => {
+      try {
+        const { document_id } = await client.ingestChatDocument(chatId, file);
+        return {
+          status: "imported" as const,
+          document: {
+            documentId: document_id,
+            displayName: file.name,
+            mediaType: file.type || "application/octet-stream",
+            byteLen: file.size,
+          },
+        };
+      } catch (error) {
+        return {
+          status: "failed" as const,
+          displayName: file.name,
+          message: importFailureText(error),
+        };
+      }
+    }),
+  );
+  return { images, documents: { results } };
+}
+
+function importFailureText(error: unknown): string {
+  const message = String(error)
+    .replace(/^Error:\s*/, "")
+    .trim();
+  return message && message.length <= 240
+    ? message
+    : "That file could not be attached.";
 }
 
 /** Claim one just-dropped native path set and attach it to the composer. */

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -45,6 +45,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 
 import { useApp } from "@/AppContext";
 import { copyPlainText } from "@/ClipboardCopyButton";
+import { attachedRemotely } from "@/host";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -876,6 +877,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const openTerminalCount = codeTerminalIds(layout).length;
   const hasTerminal = findCodeTerminalTab(layout) !== null;
   const canNewTerminal = openTerminalCount < MAX_WORKSPACE_TERMINALS;
+  // The browser opens as a child webview on this computer. A window working on
+  // another machine has no such screen to lend — sharing one with an agent that
+  // is not here shares the wrong browser — so the row is absent rather than
+  // present and refusing.
+  const canNewBrowser = !attachedRemotely();
 
   function editorPanel(
     panel: PanelContent,
@@ -1010,7 +1016,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         }
         onCopyPath={copyEditorPath}
         onNewTab={() => requestNewTab("primary")}
-        onNewBrowser={() => openBrowser(undefined, "primary")}
+        onNewBrowser={
+          canNewBrowser ? () => openBrowser(undefined, "primary") : undefined
+        }
         onNewDiff={() =>
           setWorkspaceLayout(
             openCodeEditor(layout, { type: "diff" }, "primary"),
@@ -1172,7 +1180,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
         }
         onCopyPath={copyEditorPath}
         onNewTab={() => requestNewTab("secondary")}
-        onNewBrowser={() => openBrowser(undefined, "secondary")}
+        onNewBrowser={
+          canNewBrowser ? () => openBrowser(undefined, "secondary") : undefined
+        }
         onNewDiff={() =>
           setWorkspaceLayout(
             openCodeEditor(layout, { type: "diff" }, "secondary"),

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -22,6 +22,7 @@ import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { BrowserNoticeRow, BrowserToolbar } from "./BrowserToolbar";
 import { BrowserViewportControl } from "./BrowserViewportControl";
 import {
+  browserUnavailableMessage,
   type BrowserBounds,
   type BrowserHostAction,
   type BrowserHostEvent,
@@ -334,10 +335,7 @@ function CodeBrowserTabSession({
       if (!host.available()) {
         if (current.url) {
           updateSession((value) =>
-            failBrowserSession(
-              value,
-              "The in-app browser is available in the Tidebreak desktop app",
-            ),
+            failBrowserSession(value, browserUnavailableMessage()),
           );
         }
         return;
@@ -582,10 +580,7 @@ function CodeBrowserTabSession({
 
     if (!host.available()) {
       updateSession((current) =>
-        failBrowserSession(
-          current,
-          "The in-app browser is available in the Tidebreak desktop app",
-        ),
+        failBrowserSession(current, browserUnavailableMessage()),
       );
       return;
     }

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
@@ -8,16 +8,16 @@ import {
   nativeCodeBrowserHost,
   type CodeBrowserHost,
 } from "./browserHost";
-
-// The gate is `hasNativeHost() && !attachedRemotely()`, so the native half has
-// to be true for the attachment half to be observable at all.
-const isTauri = vi.hoisted(() => vi.fn(() => true));
-vi.mock("@tauri-apps/api/core", () => ({ isTauri, invoke: vi.fn() }));
 import {
   readStoredBrowserSession,
   writeStoredBrowserSession,
 } from "./browserPersistence";
 import { createBrowserSession } from "./browserSession";
+
+// The gate is `hasNativeHost() && !attachedRemotely()`, so the native half has
+// to be true for the attachment half to be observable at all.
+const isTauri = vi.hoisted(() => vi.fn(() => true));
+vi.mock("@tauri-apps/api/core", () => ({ isTauri, invoke: vi.fn() }));
 
 describe("browser host lifecycle", () => {
   beforeEach(() => window.localStorage.clear());

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.dom.test.ts
@@ -1,7 +1,18 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { closeCodeBrowser, type CodeBrowserHost } from "./browserHost";
+import { setAttachedRemotely } from "@/host";
+import {
+  browserUnavailableMessage,
+  closeCodeBrowser,
+  nativeCodeBrowserHost,
+  type CodeBrowserHost,
+} from "./browserHost";
+
+// The gate is `hasNativeHost() && !attachedRemotely()`, so the native half has
+// to be true for the attachment half to be observable at all.
+const isTauri = vi.hoisted(() => vi.fn(() => true));
+vi.mock("@tauri-apps/api/core", () => ({ isTauri, invoke: vi.fn() }));
 import {
   readStoredBrowserSession,
   writeStoredBrowserSession,
@@ -55,5 +66,32 @@ describe("browser host lifecycle", () => {
 
     expect(readStoredBrowserSession("browser-1")).toBeNull();
     expect(command).not.toHaveBeenCalled();
+  });
+});
+
+describe("browser host availability", () => {
+  afterEach(() => {
+    setAttachedRemotely(false);
+    isTauri.mockReturnValue(true);
+  });
+
+  // Every browser control asks this one predicate, so the gate belongs here
+  // rather than at each of the nine call sites — including "share with agent",
+  // which would otherwise hand an agent elsewhere a browser on this laptop.
+  it("offers no browser while this window works on another machine", () => {
+    expect(nativeCodeBrowserHost.available()).toBe(true);
+    setAttachedRemotely(true);
+    expect(nativeCodeBrowserHost.available()).toBe(false);
+  });
+
+  it("names the machine rather than the build when a tab has to explain", () => {
+    setAttachedRemotely(true);
+    expect(browserUnavailableMessage()).toBe(
+      "The in-app browser runs on this computer, and your work is on another machine",
+    );
+    setAttachedRemotely(false);
+    expect(browserUnavailableMessage()).toBe(
+      "The in-app browser is available in the Tidebreak desktop app",
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
@@ -1,8 +1,8 @@
-import { invoke, isTauri } from "@tauri-apps/api/core";
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
-import { openExternal } from "@/host";
+import { attachedRemotely, hasLocalHostAuthority, openExternal } from "@/host";
 import { removeStoredBrowserSession } from "./browserPersistence";
 
 export const CODE_BROWSER_EVENT = "code-browser:event";
@@ -127,7 +127,13 @@ export type CodeBrowserHost = {
 };
 
 export const nativeCodeBrowserHost: CodeBrowserHost = {
-  available: isTauri,
+  /**
+   * The browser is a child webview on this computer's screen, driven by this
+   * computer's input. None of that belongs to a conversation on another
+   * machine — sharing one with an agent that is not here shares the wrong
+   * screen — so a window attached to a machine has no browser to offer.
+   */
+  available: hasLocalHostAuthority,
   command: async (workspaceId, browserId, action) => {
     const normalized = await logicalBrowserAction(action);
     return invoke<BrowserHostSnapshot>("code_browser_command", {
@@ -182,6 +188,20 @@ async function logicalBrowserAction(
   } catch {
     return action;
   }
+}
+
+/**
+ * Why a browser tab cannot run here, for the tab that has to say so.
+ *
+ * A tab restored from a saved layout opens whether or not a browser can run,
+ * so the reason has to be worded rather than assumed: a browser build has no
+ * host at all, while an attached window has one that would open on the wrong
+ * computer.
+ */
+export function browserUnavailableMessage(): string {
+  return attachedRemotely()
+    ? "The in-app browser runs on this computer, and your work is on another machine"
+    : "The in-app browser is available in the Tidebreak desktop app";
 }
 
 /** Explicit tab close. Tab switches only hide the native child webview. */

--- a/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -238,6 +238,29 @@ async function openCitationThenAnother(
 }
 
 describe("DocumentDetailRoot", () => {
+  // Regression: the refusal reached the reader as the bare reason code
+  // `native_export_authority_unavailable`, while the outputs panel beside this
+  // one already worded the same refusal.
+  it("words a save refused because the work is on another machine", async () => {
+    const user = userEvent.setup();
+    const download = vi
+      .fn()
+      .mockRejectedValue("native_export_authority_unavailable");
+    await openPanel(detail(), download);
+    await screen.findByAltText("Document image");
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    expect(
+      await screen.findByText(
+        /Saving files to this computer is not available while this window is attached to a remote machine/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/native_export_authority_unavailable/),
+    ).not.toBeInTheDocument();
+  });
+
   it("draws and saves the attached original without a catalog breadcrumb", async () => {
     const user = userEvent.setup();
     const { client, download } = await openPanel(detail());

--- a/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -17,7 +17,8 @@ import {
   isPaginatedOriginalViewer,
 } from "@/document/DocumentViewer";
 import { exportLibraryDocument } from "@/documents";
-import { hasNativeHost } from "@/host";
+import { hasLocalHostAuthority } from "@/host";
+import { hostErrorMessage } from "@/remoteMachine";
 import { PanelFrame } from "@/panel/PanelFrame";
 import { useCitationPlacement } from "./citationPlacement";
 import {
@@ -48,7 +49,7 @@ export function DocumentDetailRoot({
   documentID,
   citationId,
   download = exportLibraryDocument,
-  canDownload = hasNativeHost(),
+  canDownload = hasLocalHostAuthority(),
 }: Props) {
   const { client } = useApp();
   const [info, setInfo] = useState<DocumentDetail | null>(null);
@@ -242,11 +243,12 @@ function documentTitle(info: DocumentDetail): string {
   return info.title?.trim() || `Source ${info.document_id.slice(0, 8)}`;
 }
 
+/**
+ * Saving reaches this computer, so a window attached to a machine is refused
+ * rather than writing to the wrong host. The refusal arrives as a bare reason
+ * code; the outputs panel beside this one already words it, and this uses the
+ * same sentence rather than showing the code.
+ */
 function friendlyDownloadError(error: unknown): string {
-  const message = String(error)
-    .replace(/^Error:\s*/, "")
-    .trim();
-  return message && message.length <= 240
-    ? message
-    : "Could not save that source.";
+  return hostErrorMessage(error, "Could not save that source.");
 }

--- a/crates/tidebreak-desktop/ui/src/remoteMachine.ts
+++ b/crates/tidebreak-desktop/ui/src/remoteMachine.ts
@@ -6,7 +6,7 @@ import type {
   RemoteMachineState,
 } from "./api";
 import type { HostAuthority } from "./host";
-import { hostAuthorityRefusal } from "./host";
+import { attachedRemotely, hostAuthorityRefusal } from "./host";
 import { friendlyErrorMessage } from "./lib/utils";
 
 /**
@@ -96,6 +96,18 @@ const CONNECT_COPY: Record<RemoteConnectReason, string> = {
 
 export function connectFailureMessage(error: RemoteConnectError): string {
   return CONNECT_COPY[error.reason];
+}
+
+/**
+ * What to call the computer a settings panel is describing.
+ *
+ * These panels configure the machine this window works on: this computer by
+ * default, and another one while attached. Copy that says "this machine"
+ * regardless names the wrong host, and a reader who believes it makes the
+ * wrong call about where their files, their commands, and their audio go.
+ */
+export function hostMachineLabel(): string {
+  return attachedRemotely() ? "the machine" : "this computer";
 }
 
 /** What each host capability is called where a reader can see it. */

--- a/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
@@ -4,8 +4,9 @@ import { toast } from "sonner";
 import type { ApiClient } from "../api/client";
 import type { CodeWorktreeRoot, HarnessDoctorReport } from "../api/types";
 import { DoctorList } from "@/code/DoctorList";
-import { hasNativeHost, pickCodeDirectory } from "@/host";
+import { hasLocalHostAuthority, pickCodeDirectory } from "@/host";
 import { friendlyErrorMessage } from "@/lib/utils";
+import { hostMachineLabel } from "@/remoteMachine";
 import { SettingsError, SettingsPanel } from "./primitives";
 import { WorktreeRootSection } from "./WorktreeRootSection";
 
@@ -91,7 +92,7 @@ export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
   return (
     <SettingsPanel
       title="Coding harnesses"
-      description="Engines installed on this machine, what they can do, and where the workspaces they run in live."
+      description={`Engines installed on ${hostMachineLabel()}, what they can do, and where the workspaces they run in live.`}
       busy={loading || refreshing}
     >
       {error && <SettingsError>{error}</SettingsError>}
@@ -102,7 +103,7 @@ export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
           defaultRoot={worktreeRoot.default_root}
           inherited={worktreeRoot.root === undefined}
           busy={savingRoot}
-          canBrowse={hasNativeHost()}
+          canBrowse={hasLocalHostAuthority()}
           onChange={setRootDraft}
           onBrowse={() => {
             void (async () => {

--- a/crates/tidebreak-desktop/ui/src/settings/ExecPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ExecPanel.dom.test.tsx
@@ -156,7 +156,7 @@ describe("ExecPanel", () => {
       putExecConfig.mock.invocationCallOrder[0],
     );
     expect(
-      screen.queryByText(/Files staged for a run leave this machine/i),
+      screen.queryByText(/Files staged for a run leave this computer/i),
     ).toBeNull();
   });
 
@@ -284,10 +284,12 @@ describe("ExecPanel", () => {
     // change it — a missing key must be readable here, not archaeological.
     await screen.findByText(/No execution provider configured/i);
     expect(
-      screen.getByText(/Files staged for a run leave this machine/i),
+      screen.getByText(/Files staged for a run leave this computer/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Not supported on this operating system/i),
+      screen.getByText(
+        /The operating system on this computer does not support it/i,
+      ),
     ).toBeInTheDocument();
     expect(screen.getAllByText(/Add an API key above/i)).toHaveLength(2);
     expect(screen.queryByText(/missing_credential/)).toBeNull();

--- a/crates/tidebreak-desktop/ui/src/settings/ExecPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ExecPanel.tsx
@@ -7,11 +7,12 @@ import type {
   ExecProviderKind,
 } from "../api";
 import {
-  MANAGED_EXECUTION_DISCLOSURE,
+  managedExecutionDisclosure,
   requiresManagedExecutionDisclosure,
 } from "../ExecDisclosure";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { hostMachineLabel } from "@/remoteMachine";
 import {
   ActiveProviderField,
   ProviderCredentialField,
@@ -160,7 +161,7 @@ export function ExecPanel({ client }: { client: ApiClient }) {
           {requiresManagedExecutionDisclosure(config.providers) && (
             <SettingsSection title="Where code runs">
               <p className="text-sm leading-relaxed text-muted-foreground">
-                {MANAGED_EXECUTION_DISCLOSURE}
+                {managedExecutionDisclosure()}
               </p>
             </SettingsSection>
           )}
@@ -242,12 +243,12 @@ export function ExecPanel({ client }: { client: ApiClient }) {
             Local execution confines writes to private work scratch and routes
             any granted network access through a loopback broker. E2B and
             Daytona run commands in managed cloud sandboxes and reuse their
-            workspace while it is alive. Docker runs them in a container on this
-            machine, so staged files never leave it, with the same document
-            tooling the cloud sandboxes have — but it does not yet enforce a
-            conversation's network setting. Every provider retains the same
-            direct-command, bounded-output, idempotency, and execution-consent
-            contract.
+            workspace while it is alive. Docker runs them in a container on{" "}
+            {hostMachineLabel()}, so staged files never leave it, with the same
+            document tooling the cloud sandboxes have — but it does not yet
+            enforce a conversation's network setting. Every provider retains the
+            same direct-command, bounded-output, idempotency, and
+            execution-consent contract.
           </p>
         </>
       )}
@@ -278,21 +279,24 @@ type ProviderUnavailableReason = NonNullable<
  * would change it. The codes come from the server's single availability
  * decision, so this list is exactly the set of states execution can be in —
  * the panel never guesses why a provider is dark.
+ *
+ * Read at render rather than fixed at module load: the host whose runtimes
+ * these sentences describe is the machine this window works on, not always
+ * this computer.
  */
-const PROVIDER_UNAVAILABLE_SENTENCES: Record<
+function providerUnavailableSentences(): Record<
   ProviderUnavailableReason,
   string
-> = {
-  unsupported_platform:
-    "Not supported on this operating system. Use a cloud sandbox instead — it runs the same commands with the same staged files.",
-  missing_sandbox_binary:
-    "This host is missing the sandbox binary local execution needs to confine commands.",
-  missing_credential: "Add an API key above to make this provider usable.",
-  missing_container_runtime:
-    "No container runtime was found. Install Docker (or a Docker-compatible runtime) to run commands in a container on this machine.",
-  container_runtime_unreachable:
-    "A container runtime is installed but isn't responding. Start it — Docker Desktop, or the daemon on this host — and this becomes usable.",
-};
+> {
+  const host = hostMachineLabel();
+  return {
+    unsupported_platform: `The operating system on ${host} does not support it. Use a cloud sandbox instead — it runs the same commands with the same staged files.`,
+    missing_sandbox_binary: `Local execution needs a sandbox binary that is missing from ${host}.`,
+    missing_credential: "Add an API key above to make this provider usable.",
+    missing_container_runtime: `No container runtime was found. Install Docker (or a Docker-compatible runtime) on ${host} to run commands in a container there.`,
+    container_runtime_unreachable: `A container runtime is installed but isn't responding. Start it on ${host} — Docker Desktop, or the daemon — and this becomes usable.`,
+  };
+}
 
 /**
  * Per-provider capability, stated plainly: which providers could run here at
@@ -316,7 +320,7 @@ function ProviderAvailabilityDisclosure({
               {PROVIDER_SANDBOX_LABEL[row.provider]}
             </span>
             {row.unavailable_reason &&
-              ` — ${PROVIDER_UNAVAILABLE_SENTENCES[row.unavailable_reason]}`}
+              ` — ${providerUnavailableSentences()[row.unavailable_reason]}`}
           </span>
         </div>
       ))}
@@ -445,7 +449,7 @@ function codeExecutionState(config: ExecConfigInfo | null): {
     label: "Unavailable",
     description: `${codeExecutionProviderLabel(config.provider)} is selected but cannot run: ${
       config.unavailable_reason
-        ? PROVIDER_UNAVAILABLE_SENTENCES[config.unavailable_reason]
+        ? providerUnavailableSentences()[config.unavailable_reason]
         : "the provider reported no reason."
     }`,
   };

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
@@ -297,7 +297,7 @@ describe("McpPanel", () => {
       "http://127.0.0.1/mcp",
     );
     await user.click(
-      screen.getByRole("radio", { name: "Local process (stdio)" }),
+      screen.getByRole("radio", { name: "Process on this computer (stdio)" }),
     );
     await user.type(
       screen.getByPlaceholderText("/absolute/path/to/server"),

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Switch } from "@/components/ui/switch";
+import { hostMachineLabel } from "@/remoteMachine";
 import {
   SettingsError,
   SettingsField,
@@ -617,7 +618,7 @@ export function McpPanel({
 
   return (
     <McpKindSection
-      description="Connect local stdio tool servers or remote HTTP endpoints without a shell or a desktop restart."
+      description={`Connect stdio tool servers that run on ${hostMachineLabel()}, or remote HTTP endpoints, without a shell or a desktop restart.`}
       busy={loading || working}
     >
       {endpointsSection}
@@ -717,7 +718,7 @@ export function McpPanel({
                         >
                           <RadioGroupItem value={transport} />
                           {transport === "stdio"
-                            ? "Local process (stdio)"
+                            ? `Process on ${hostMachineLabel()} (stdio)`
                             : "Remote endpoint (HTTP)"}
                         </Label>
                       ))}
@@ -729,7 +730,7 @@ export function McpPanel({
                   <>
                     <SettingsField
                       label="Executable"
-                      hint="An executable path or command name. Tidebreak never invokes a shell."
+                      hint={`A path or command name on ${hostMachineLabel()}, where the process runs. Tidebreak never invokes a shell.`}
                     >
                       <Input
                         value={server.command ?? ""}

--- a/crates/tidebreak-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -16,6 +16,7 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
+import { hostMachineLabel } from "@/remoteMachine";
 import { useConfirm } from "../components/ConfirmDialog";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 import { ProviderIcon } from "../ProviderIcons";
@@ -129,7 +130,7 @@ export function ProvidersPanel({
   return (
     <SettingsPanel
       title="Providers"
-      description="Credentials stay on this machine. Enable a provider, then save a credential."
+      description={`Credentials stay on ${hostMachineLabel()}. Enable a provider, then save a credential.`}
     >
       <div className="flex flex-col gap-2">
         {providers
@@ -269,7 +270,7 @@ function ProviderRow({
       title: "Remove the saved credential?",
       description: `This deletes the stored ${providerLabel(
         info.kind,
-      )} credential from this machine's keychain. You can add it again at any time.`,
+      )} credential from the keychain on ${hostMachineLabel()}. You can add it again at any time.`,
       confirmLabel: "Remove credential",
       destructive: true,
     });

--- a/crates/tidebreak-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
@@ -18,6 +18,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useConfirm } from "@/components/ConfirmDialog";
+import { attachedRemotely } from "@/host";
+import { hostMachineLabel } from "@/remoteMachine";
 import { cn } from "@/lib/utils";
 import {
   formatModelSize,
@@ -36,6 +38,20 @@ import {
 
 const LOCAL_VALUE_PREFIX = "local:";
 
+/**
+ * Why no speech model can run where the transcription happens.
+ *
+ * The server answers `unavailable` when it has no local runner at all, which
+ * a browser build and a headless machine both report. Naming the desktop app
+ * is the fix in the first case and a false lead in the second, so the two get
+ * different sentences.
+ */
+function localModelsUnavailableCopy(): string {
+  return attachedRemotely()
+    ? "The machine your work is on cannot run a speech model. Pick a cloud model instead."
+    : "Models that run on this computer are only available in the desktop app.";
+}
+
 /** What the closed picker says once a choice is made. */
 export function voiceSelectionLabel(
   info: VoiceTranscriptionInfo | null,
@@ -44,7 +60,8 @@ export function voiceSelectionLabel(
   if (info.model === "gpt4o_transcribe") return "OpenAI · gpt-4o-transcribe";
   if (info.model === "gemini_flash") return "Google · Gemini 3.6 Flash";
   const local = selectedLocalVoiceModel(info);
-  return local ? `On this device · ${local.label}` : "On this device";
+  const host = hostMachineLabel();
+  return local ? `On ${host} · ${local.label}` : `On ${host}`;
 }
 
 export function voiceSelectionValue(
@@ -98,7 +115,7 @@ export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
       title: `Download ${model.label}?`,
       description: `${model.description} The download is about ${formatModelSize(
         model.total_bytes,
-      )} and uses the same amount of disk once installed. Recordings transcribed with it never leave this device.`,
+      )} and uses the same amount of disk once installed. It is downloaded to ${hostMachineLabel()}, and recordings transcribed with it never leave there.`,
       confirmLabel: "Download",
     });
     if (accepted) await useVoiceInputStore.getState().install(client, id);
@@ -107,7 +124,7 @@ export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
   return (
     <SettingsPanel
       title="Voice input"
-      description="Choose how microphone recordings become editable message drafts. Audio stays on this device unless you pick a cloud model."
+      description={`Choose how microphone recordings become editable message drafts. Recordings are transcribed on ${hostMachineLabel()}, and the audio stays there unless you pick a cloud model.`}
       busy={loading}
     >
       <SettingsSection>
@@ -117,14 +134,14 @@ export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
           description={
             ready
               ? "The selected voice input model is ready to transcribe recordings."
-              : "Download a model that runs on this device, or configure a supported cloud provider."
+              : `Download a model that runs on ${hostMachineLabel()}, or configure a supported cloud provider.`
           }
         />
       </SettingsSection>
 
       <SettingsSection
         title="Transcription model"
-        description="Models that run on this device come first. One that has not been downloaded yet is still selectable — choosing it starts the download."
+        description={`Models that run on ${hostMachineLabel()} come first. One that has not been downloaded yet is still selectable — choosing it starts the download.`}
       >
         <SettingsField
           label="Model"
@@ -142,7 +159,7 @@ export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
             </SelectTrigger>
             <SelectContent>
               <SelectGroup>
-                <SelectLabel>On this device</SelectLabel>
+                <SelectLabel>On {hostMachineLabel()}</SelectLabel>
                 {(info?.local_models ?? []).map((model) => (
                   <LocalModelItem key={model.id} model={model} />
                 ))}
@@ -217,7 +234,7 @@ export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
           <SettingsStatus
             tone="disabled"
             label="Not available here"
-            description="Models that run on this device are only available in the desktop app."
+            description={localModelsUnavailableCopy()}
           />
         )}
       </SettingsSection>

--- a/crates/tidebreak-desktop/ui/src/useImageAttachments.test.ts
+++ b/crates/tidebreak-desktop/ui/src/useImageAttachments.test.ts
@@ -67,12 +67,12 @@ class FakeUpload {
 
 const client = { baseUrl: "http://127.0.0.1:9", token: "t" } as ApiClient;
 
-const hasNativeHost = vi.hoisted(() => vi.fn(() => false));
+const hasLocalHostAuthority = vi.hoisted(() => vi.fn(() => false));
 const publishChatImage = vi.hoisted(() => vi.fn());
 
 vi.mock("./host", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./host")>()),
-  hasNativeHost,
+  hasLocalHostAuthority,
 }));
 vi.mock("./attachments", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./attachments")>()),
@@ -89,7 +89,7 @@ beforeEach(() => {
   useComposerDrafts.setState({ drafts: {}, attachments: {} });
   window.sessionStorage.clear();
   FakeUpload.opened = [];
-  hasNativeHost.mockReturnValue(false);
+  hasLocalHostAuthority.mockReturnValue(false);
   publishChatImage.mockReset();
   vi.stubGlobal("XMLHttpRequest", FakeUpload);
   URL.createObjectURL = vi.fn((): string => "blob:preview");
@@ -198,7 +198,7 @@ describe("useImageAttachments", () => {
   // pasted image posted from the renderer came back 401 with an empty body and
   // reached the reader as the generic "Could not attach that image".
   it("publishes through the host rather than the renderer when there is one", async () => {
-    hasNativeHost.mockReturnValue(true);
+    hasLocalHostAuthority.mockReturnValue(true);
     publishChatImage.mockResolvedValue({
       attachmentId: ATTACHMENT_ID,
       mediaType: "image/png",
@@ -218,6 +218,29 @@ describe("useImageAttachments", () => {
     );
     expect(FakeUpload.opened).toHaveLength(0);
     expect(publishChatImage).toHaveBeenCalledWith("chat-1", expect.any(File));
+  });
+
+  // Regression: the host branch was taken on `hasNativeHost` alone, so an
+  // attached window published into the store inside this app — where the
+  // conversation does not exist — and every paste failed after the fact.
+  it("posts to the machine rather than the host while attached to one", async () => {
+    hasLocalHostAuthority.mockReturnValue(false);
+    const { result } = renderHook(() => useImageAttachments(client, "chat-1"));
+
+    act(() => result.current.attachFiles([png()]));
+    await waitFor(() => expect(FakeUpload.opened).toHaveLength(1));
+    expect(FakeUpload.opened[0].url).toBe(
+      "http://127.0.0.1:9/chats/chat-1/attachments/images",
+    );
+    expect(publishChatImage).not.toHaveBeenCalled();
+
+    act(() => FakeUpload.opened[0].finish(201, PUBLISHED));
+    await waitFor(() =>
+      expect(result.current.attachments[0]).toMatchObject({
+        status: "ready",
+        attachmentId: ATTACHMENT_ID,
+      }),
+    );
   });
 
   it("keeps the strip across the remount a chat switch causes", async () => {

--- a/crates/tidebreak-desktop/ui/src/useImageAttachments.ts
+++ b/crates/tidebreak-desktop/ui/src/useImageAttachments.ts
@@ -3,7 +3,7 @@ import { useRef, useState } from "react";
 import type { ApiClient } from "./api";
 import { publishChatImage, publishCodeImage } from "./attachments";
 import { useComposerDrafts } from "./ComposerDrafts";
-import { hasNativeHost } from "./host";
+import { hasLocalHostAuthority } from "./host";
 import {
   imageAttachmentName,
   imageAttachmentRejection,
@@ -162,12 +162,16 @@ export function useImageAttachments(
    * over IPC for the host to publish. In a browser — `pnpm dev`, and the UI
    * tests — the same endpoint sits on the renderer's own bearer, and posting it
    * directly is what gives the chip real byte progress.
+   *
+   * A window attached to a remote machine takes the browser route too. The
+   * host would publish into the store on this computer, where the conversation
+   * does not exist, so the bytes have to go to the machine that holds it.
    */
   async function publish(id: string, file: File, signal: AbortSignal) {
     const chatId = publishTargetRef.current
       ? await publishTargetRef.current()
       : draftKey;
-    if (!hasNativeHost()) {
+    if (!hasLocalHostAuthority()) {
       return uploadImageAttachment(client, chatId, file, {
         onProgress: (uploadedBytes) =>
           update((current) => withUploadProgress(current, id, uploadedBytes)),


### PR DESCRIPTION
Closes #2512.

Every surface that reaches this computer decided with `hasNativeHost()`, which is `isTauri()` and stays true while the window is attached to a machine. Each one offered itself and then failed once the reader had committed to it. They now ask `hasLocalHostAuthority()` — `hasNativeHost() && !attachedRemotely()` — or re-route to the machine that owns the work.

## Re-routes

Attaching succeeds against the machine instead of failing after the fact.

- **Pasted and dropped images.** `useImageAttachments` took the host branch on `hasNativeHost()`, so the host published into the store inside this app, where the conversation does not exist, and every paste failed "Conversation not found". It now takes the browser branch and posts to the machine.
- **File attach.** The native picker reads paths on this computer and imports them locally, so an attached window opened a picker, took a selection, and then refused it. An attached window opens the browser's own picker instead: images join the composer's upload path with progress and retry, and sources are posted to `POST /chats/{id}/documents/raw` on the machine. This also gives the `pnpm dev` browser build a file attach it never had.
- **Native drops** cannot be re-routed — Tauri claims the drop and the paths never reach the renderer — so the overlay refuses before the reader lets go and points at the attach control that does work.

## Hides

- **In-app browser.** `nativeCodeBrowserHost.available()` is false while attached, which closes nine call sites at once. "Share with agent" was the worst of them: it shared a browser on this laptop with an agent that is not on it. The two "New browser" rows in the code workspace and the chat header's browser button go with it, and a tab restored from a saved layout now names the machine rather than blaming the build.
- **Debug bundle.** Built natively from the event journal on this computer, so there is nothing to build for a conversation that lives elsewhere.
- **Harness workspace folder Browse.** The path field stays; only the native picker goes.

## Copy

- A refused document download said `native_export_authority_unavailable`. It now routes through `hostErrorMessage`, the same sentence the outputs panel beside it already used.
- Voice input promised that recordings "never leave this device" — false while attached, since the audio travels to the machine.
- Code execution, MCP stdio, coding harnesses, and provider credentials all described "this machine" while configuring another one. `hostMachineLabel()` in `remoteMachine.ts` names the right host.

## Tests

There was no renderer test asserting remote gating anywhere. Added: the image re-route posts to the machine rather than the host; `attachHeldChatFiles` splits images from sources, declares an untyped file as opaque bytes, and reports one refused file beside the ones that landed; a dismissed picker resolves empty; a drop while attached claims nothing; the browser host offers nothing while attached; the debug rows disappear; a refused download is worded.

`tsc --noEmit`, the full vitest suite (218 files, 1664 tests), `biome format`, and `biome lint` all pass.
