### PR TITLE
fix(self-host): ship the tools code mode spawns in the server image

### DIFF
--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -54,7 +54,10 @@ FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639
 # ca-certificates: the binary's TLS stack is rustls (no OpenSSL anywhere in
 # the lockfile), but parts of the graph resolve platform roots, so the system
 # trust store must exist for outbound model-provider calls.
-# curl: the container healthcheck below, and nothing else.
+# curl: the container healthcheck below, and the two downloads that follow.
+# git: code mode's only VCS. Clone, worktree, checkpoint, commit, and push all
+# spawn it (crates/tidebreak-server/src/code/{clone,worktree,checkpoint,gh}.rs),
+# so without it a repository cannot even be registered.
 #
 # Debian snapshots are immutable, so the digest-pinned base plus this dated
 # repository set resolve the same transitive packages on every rebuild. Bump
@@ -70,9 +73,81 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources \
     && apt-get install -y --no-install-recommends \
        ca-certificates=20250419~deb12u1 \
        curl=7.88.1-10+deb12u15 \
+       git=1:2.39.5-0+deb12u3 \
     && rm -rf /var/lib/apt/lists/*
 
+# The GitHub CLI, which code mode spawns for pull-request create, status,
+# review reads, and merge (crates/tidebreak-server/src/code/gh.rs), and which
+# the coding agents reach for themselves. Tidebreak observes its
+# authentication and never reads or stores a token (decision record 34), so a
+# container authenticates it the way `gh` supports without a terminal:
+# `GH_TOKEN` in the environment. See docs/self-hosting.md.
+#
+# This comes from the project's own release rather than Debian, which carries
+# 2.23.0. That build has no `autoMergeRequest` JSON field, and Tidebreak asks
+# for it in one request with every other field, so the whole pull-request
+# digest fails against it. Pinned by version and SHA-256 from the release's
+# published checksums; bump both together as a deliberate update.
+RUN set -eu; \
+    version=2.98.0; \
+    case "$(dpkg --print-architecture)" in \
+      amd64) platform=linux_amd64; \
+             sha256=3b8ac6b30336802fc1a858d7c084e11cdf24ac1a761ca90b68022d7d729208de ;; \
+      arm64) platform=linux_arm64; \
+             sha256=cf689084f3a3618f7eae4a2420d335d74626d65f5e594b9828d125d69f800d86 ;; \
+      *) echo "no gh pin for $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac; \
+    archive="gh_${version}_${platform}.tar.gz"; \
+    curl -fsSL --proto '=https' --tlsv1.2 -o "/tmp/${archive}" \
+        "https://github.com/cli/cli/releases/download/v${version}/${archive}"; \
+    printf '%s  /tmp/%s\n' "${sha256}" "${archive}" | sha256sum --check --strict -; \
+    tar -xzf "/tmp/${archive}" -C /tmp "gh_${version}_${platform}/bin/gh"; \
+    install -m 0755 "/tmp/gh_${version}_${platform}/bin/gh" /usr/local/bin/gh; \
+    rm -rf "/tmp/${archive}" "/tmp/gh_${version}_${platform}"; \
+    gh --version
+
+# The managed Node runtime code mode installs its pinned harness packages with.
+#
+# Only the desktop downloads Node; the server never does. So a server image
+# without it answers every harness install with "the verified managed Node
+# runtime is not installed in this Tidebreak data directory" and code mode
+# stays gated. The contract the server verifies lives in
+# crates/tidebreak-code-execution/src/managed_node.rs: one exact directory
+# carrying `bin/node`, `bin/npm`, and an `installed.json` naming this version
+# and the digest of the artifact the tree was unpacked from. Nothing is
+# scanned and `PATH` is never consulted, so a Node that is merely installed
+# somewhere does not count.
+#
+# The artifact is the official nodejs.org tarball, pinned by version and
+# SHA-256 exactly as the desktop pins it. These three constants must match
+# `MANAGED_NODE_VERSION` and the Linux entries of `CURRENT_PIN`; bump them
+# together, and scripts/self-host-image-pins.test.mjs fails the build when
+# they drift apart.
+RUN set -eu; \
+    version=20.20.2; \
+    case "$(dpkg --print-architecture)" in \
+      amd64) platform=linux-x64; \
+             sha256=19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b ;; \
+      arm64) platform=linux-arm64; \
+             sha256=47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d ;; \
+      *) echo "no managed Node pin for $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac; \
+    archive="node-v${version}-${platform}.tar.gz"; \
+    curl -fsSL --proto '=https' --tlsv1.2 \
+        -o "/tmp/${archive}" "https://nodejs.org/dist/v${version}/${archive}"; \
+    printf '%s  /tmp/%s\n' "${sha256}" "${archive}" | sha256sum --check --strict -; \
+    mkdir -p /opt/tidebreak/node; \
+    tar -xzf "/tmp/${archive}" -C /opt/tidebreak/node; \
+    mv "/opt/tidebreak/node/node-v${version}-${platform}" "/opt/tidebreak/node/${version}"; \
+    rm -f "/tmp/${archive}"; \
+    printf '{\n  "version": "%s",\n  "artifactSha256": "%s"\n}\n' \
+        "${version}" "${sha256}" > "/opt/tidebreak/node/${version}/installed.json"; \
+    export PATH="/opt/tidebreak/node/${version}/bin:${PATH}"; \
+    node --version; \
+    npm --version
+
 COPY --from=build /src/target/release/tidebreak /usr/local/bin/tidebreak
+COPY deploy/self-host/entrypoint.sh /usr/local/bin/tidebreak-entrypoint
 
 # The server runs unprivileged. The uid is fixed rather than assigned by
 # adduser so a data volume initialized from this layer carries an ownership
@@ -80,6 +155,7 @@ COPY --from=build /src/target/release/tidebreak /usr/local/bin/tidebreak
 RUN groupadd --gid 10001 tidebreak \
     && useradd --uid 10001 --gid 10001 --home-dir /home/tidebreak --create-home \
        --shell /usr/sbin/nologin tidebreak \
+    && chmod 0755 /usr/local/bin/tidebreak-entrypoint \
     && mkdir -p /var/lib/tidebreak \
     && chown -R tidebreak:tidebreak /var/lib/tidebreak /home/tidebreak
 
@@ -105,4 +181,8 @@ USER tidebreak:tidebreak
 HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=5 \
     CMD curl -fsS http://127.0.0.1:8080/healthz || exit 1
 
-ENTRYPOINT ["/usr/local/bin/tidebreak", "serve"]
+# The entrypoint publishes the image's managed Node runtime into the data
+# directory before starting the server; see entrypoint.sh for why that cannot
+# happen at build time. Arguments still append to `serve`, and overriding
+# `--entrypoint` reaches the binary directly.
+ENTRYPOINT ["/usr/local/bin/tidebreak-entrypoint"]

--- a/deploy/self-host/Dockerfile.dockerignore
+++ b/deploy/self-host/Dockerfile.dockerignore
@@ -30,6 +30,12 @@
 !plugins/*/
 !plugins/*/PLUGIN.md
 
+# The container entrypoint, copied into the runtime stage. Named exactly, so
+# nothing else in deploy/ reaches the daemon.
+!deploy/
+!deploy/self-host/
+!deploy/self-host/entrypoint.sh
+
 # Never admit hidden files or common credential files, even below an allowed
 # source directory. Keep these after the allow rules so they win. The explicit
 # credential names are defense in depth for future changes to the hidden-file

--- a/deploy/self-host/entrypoint.sh
+++ b/deploy/self-host/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Publish the image's managed Node runtime into the data directory, then start
+# the server.
+#
+# The server resolves the runtime from one exact path,
+# `{TIDEBREAK_DATA_DIR}/tools/node/{version}`, and refuses to look anywhere
+# else (crates/tidebreak-code-execution/src/managed_node.rs). That path is
+# inside the data directory, which every real deployment mounts a volume over
+# — and a mount hides whatever the image layer put underneath it. Unpacking
+# Node there at build time would therefore work only on a container whose data
+# volume is brand new, and break on exactly the upgrade path operators take.
+#
+# So the image keeps one copy under /opt and this script points the data
+# directory at it on every start. The link costs nothing, survives a volume
+# that already has content, and leaves a real install already sitting at that
+# path untouched.
+#
+# Keep `node_version` equal to the version the Dockerfile installs and to
+# `MANAGED_NODE_VERSION`; scripts/self-host-image-pins.test.mjs enforces it.
+set -eu
+
+node_version=20.20.2
+image_node_dir="/opt/tidebreak/node/${node_version}"
+data_dir="${TIDEBREAK_DATA_DIR:-/var/lib/tidebreak}"
+link="${data_dir}/tools/node/${node_version}"
+
+link_managed_node() {
+    if [ ! -d "${image_node_dir}" ]; then
+        echo "tidebreak: this image carries no managed Node runtime at ${image_node_dir}" >&2
+        return 1
+    fi
+    # Already resolvable, either from an earlier start or because someone
+    # installed a real runtime there. The server verifies whatever it finds
+    # against the same pin, so leave it alone. `-d` follows the link, so a
+    # link whose target went away is replaced rather than kept.
+    if [ -d "${link}" ]; then
+        return 0
+    fi
+    mkdir -p "${data_dir}/tools/node" || return 1
+    ln -sfn "${image_node_dir}" "${link}" || return 1
+}
+
+# Code mode is one feature of the server, so a data directory this process
+# cannot write is worth a loud warning, not a refusal to boot: chat still
+# works, and the server's own startup checks are what own the data directory.
+if ! link_managed_node; then
+    echo "tidebreak: could not publish the managed Node runtime to ${link};" \
+         "code mode will report every engine as not found" >&2
+fi
+
+exec /usr/local/bin/tidebreak serve "$@"

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -225,6 +225,51 @@ The stack publishes `127.0.0.1:8080` deliberately. Nothing in
 `docker-compose.yml` terminates TLS, and the database port is not published
 at all.
 
+## What the image provides
+
+Code mode runs agents on the machine, so the image carries the tools it
+spawns. Read this before you swap in a base image of your own: the server
+does not install any of it, and reports a missing piece as an unavailable
+engine rather than an installation prompt.
+
+| Tool | Version | Why it is there |
+| --- | --- | --- |
+| Managed Node runtime | 20.20.2, at `/opt/tidebreak/node/20.20.2` | The runtime every harness install runs `npm` from. |
+| `git` | 2.39.5 (Debian bookworm) | Clone, worktree, checkpoint, commit, and push. |
+| `gh` | 2.98.0 (the project's own release) | Pull-request create, status, review reads, and merge. |
+| `curl`, `ca-certificates` | Debian bookworm | The container healthcheck and the system trust store. |
+
+The Node runtime is the strict one. The server accepts it from exactly one
+path, `$TIDEBREAK_DATA_DIR/tools/node/<version>`, and only when that directory
+holds `bin/node`, `bin/npm`, and an `installed.json` naming the version and
+the SHA-256 of the official nodejs.org artifact it was unpacked from. Nothing
+is scanned and `PATH` is never consulted, so a Node installed elsewhere in
+your image does not count. The image keeps its copy under `/opt` and the
+container entrypoint links the data directory at it on every start, because
+that path sits under a volume mount and anything the image layer puts there
+disappears the moment an operator mounts one.
+
+Harness packages install into the data directory on demand, at the versions
+Tidebreak pins, so give the volume room for them — a few hundred megabytes
+per engine.
+
+Two things the image deliberately does not decide for you:
+
+- **A GitHub identity.** Tidebreak observes `gh`'s authentication and never
+  reads or stores a token ([decision record
+  34](decisions/0034-harness-discovery-credentials.md)), and a container has
+  no terminal to run `gh auth login` in. Set `GH_TOKEN` in the server's
+  environment and `gh` picks it up. Everyone on the deployment then acts as
+  that one account; per-user GitHub identity is not built yet.
+- **A commit identity.** `git commit` needs a name and an email, and the image
+  invents neither. Set `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`,
+  `GIT_COMMITTER_NAME`, and `GIT_COMMITTER_EMAIL` in the server's environment,
+  or mount a `.gitconfig` into the container's home directory. Without one,
+  commits from code mode fail and the checkpoint history is what still works.
+
+The image ships no SSH client and no known-hosts file, so clone over HTTPS.
+An SSH clone URL fails.
+
 ## Putting it behind a reverse proxy
 
 Terminate TLS in front of the server, on infrastructure you already operate,
@@ -289,12 +334,14 @@ docker compose up -d --build
 docker image prune -f     # optional
 ```
 
-The runtime image pins both Debian base images by digest and installs its small
+The runtime image pins both Debian base images by digest and installs its
 runtime package set from a dated Debian snapshot with exact direct versions.
-That keeps a rebuild of one commit from silently picking up different `curl`,
-CA-certificate, or transitive package bytes. Updating the snapshot date and
-package pins is therefore an explicit dependency-maintenance change rather
-than an incidental effect of rebuilding.
+The two artifacts it fetches from outside Debian — the managed Node runtime
+and `gh` — are pinned by version and SHA-256 and verified before they are
+unpacked. That keeps a rebuild of one commit from silently picking up
+different `curl`, CA-certificate, Node, `gh`, or transitive package bytes.
+Updating the snapshot date and the pins is therefore an explicit
+dependency-maintenance change rather than an incidental effect of rebuilding.
 
 The server applies its own schema migrations on boot. Take a database backup
 before an upgrade: Tidebreak is pre-1.0 and persisted formats may change

--- a/scripts/self-host-image-pins.test.mjs
+++ b/scripts/self-host-image-pins.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// The self-host image ships the tools code mode spawns: the managed Node
+// runtime it installs pinned harness packages with, git, and the GitHub CLI.
+// The server verifies that Node runtime against one exact version and one
+// exact artifact digest per platform, and resolves it from one exact path — so
+// an image whose pin drifts from the Rust constant does not fall back to
+// something workable, it reports every engine as not found. These tests make
+// the drift loud at PR time instead of leaving it to an operator's first
+// code-mode session.
+
+const dockerfile = readFileSync(
+  new URL("../deploy/self-host/Dockerfile", import.meta.url),
+  "utf8",
+);
+const entrypoint = readFileSync(
+  new URL("../deploy/self-host/entrypoint.sh", import.meta.url),
+  "utf8",
+);
+const managedNode = readFileSync(
+  new URL(
+    "../crates/tidebreak-code-execution/src/managed_node.rs",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+/** The `RUN` block that mentions `marker`, with its line continuations intact. */
+function runBlock(marker) {
+  const lines = dockerfile.split("\n");
+  const blocks = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!lines[index].startsWith("RUN ")) {
+      continue;
+    }
+    const block = [lines[index]];
+    while (block.at(-1).endsWith("\\") && index + 1 < lines.length) {
+      index += 1;
+      block.push(lines[index]);
+    }
+    blocks.push(block.join("\n"));
+  }
+  const block = blocks.find((candidate) => candidate.includes(marker));
+  assert.ok(block, `the Dockerfile must carry a RUN block installing ${marker}`);
+  return block;
+}
+
+function pinnedNodeVersion() {
+  const match = managedNode.match(/MANAGED_NODE_VERSION: &str = "([^"]+)"/);
+  assert.ok(match, "managed_node.rs must declare MANAGED_NODE_VERSION");
+  return match[1];
+}
+
+function pinnedNodeDigest(architecture) {
+  const match = managedNode.match(
+    new RegExp(
+      `target_os = "linux", target_arch = "${architecture}"[\\s\\S]*?artifact_sha256: "([0-9a-f]{64})"`,
+    ),
+  );
+  assert.ok(match, `managed_node.rs must pin the linux ${architecture} digest`);
+  return match[1];
+}
+
+/** The `platform` and `sha256` a RUN block selects for a Debian architecture. */
+function architectureBranch(block, debianArchitecture) {
+  const branch = block.match(
+    new RegExp(
+      `${debianArchitecture}\\) platform=(\\S+); \\\\\\n\\s*sha256=([0-9a-f]{64})`,
+    ),
+  );
+  assert.ok(branch, `no ${debianArchitecture} branch in this install step`);
+  return { platform: branch[1], sha256: branch[2] };
+}
+
+test("the image installs the Node version the server verifies", () => {
+  const version = pinnedNodeVersion();
+  const escaped = version.replaceAll(".", "\\.");
+  assert.match(
+    runBlock("nodejs.org"),
+    new RegExp(`^\\s*version=${escaped};`, "m"),
+    `the Dockerfile must install Node ${version}`,
+  );
+  assert.match(
+    entrypoint,
+    new RegExp(`^node_version=${escaped}$`, "m"),
+    `entrypoint.sh must publish Node ${version}`,
+  );
+});
+
+test("each architecture takes the Node digest its platform pin names", () => {
+  const block = runBlock("nodejs.org");
+  for (const [architecture, debian, platform] of [
+    ["x86_64", "amd64", "linux-x64"],
+    ["aarch64", "arm64", "linux-arm64"],
+  ]) {
+    const branch = architectureBranch(block, debian);
+    assert.equal(branch.platform, platform);
+    assert.equal(
+      branch.sha256,
+      pinnedNodeDigest(architecture),
+      `the ${debian} Node digest does not match the ${architecture} pin`,
+    );
+  }
+});
+
+test("the Node install marker carries the field names the server reads", () => {
+  const block = runBlock("nodejs.org");
+  // managed_node.rs deserializes `version` and `artifactSha256`; a marker with
+  // any other shape reads as no install at all.
+  assert.match(block, /"version": "%s"/);
+  assert.match(block, /"artifactSha256": "%s"/);
+  // The digest is checked before a byte is unpacked, and the tree is what the
+  // marker then vouches for.
+  assert.match(block, /sha256sum --check --strict/);
+});
+
+test("git comes from the pinned Debian snapshot", () => {
+  // Clone, worktree, checkpoint, commit, and push all spawn git, and the
+  // snapshot pin is what keeps a rebuild of one commit reproducible.
+  assert.match(
+    dockerfile,
+    /^\s+git=1:\S+ \\$/m,
+    "the runtime stage must install git at an exact version",
+  );
+});
+
+test("gh comes from the project's own release, digest-pinned", () => {
+  // Debian bookworm carries gh 2.23.0, which has no `autoMergeRequest` JSON
+  // field. Tidebreak asks for it alongside every other field in one request,
+  // so that build fails the whole pull-request digest.
+  assert.doesNotMatch(
+    dockerfile,
+    /^\s+gh=/m,
+    "gh from apt is too old for the fields Tidebreak requests",
+  );
+  const block = runBlock("cli/cli/releases");
+  assert.match(block, /^\s*version=\d+\.\d+\.\d+;/m);
+  assert.match(block, /sha256sum --check --strict/);
+  for (const [debian, platform] of [
+    ["amd64", "linux_amd64"],
+    ["arm64", "linux_arm64"],
+  ]) {
+    assert.equal(architectureBranch(block, debian).platform, platform);
+  }
+});


### PR DESCRIPTION
The self-host image installed only `ca-certificates` and `curl`, so a machine deployed from it could not run a coding agent or clone a repository. Every harness install failed with "the verified managed Node runtime is not installed in this Tidebreak data directory", and a clone died on "failed to spawn git".

## What the image carries now

| Tool | Version | Source |
| --- | --- | --- |
| Managed Node runtime | 20.20.2 | nodejs.org tarball, SHA-256 pinned |
| `git` | 1:2.39.5-0+deb12u3 | the dated Debian snapshot already in this file |
| `gh` | 2.98.0 | the project's own release, SHA-256 pinned |

Both downloads are verified before anything is unpacked, per architecture, so a rebuild of one commit still resolves the same bytes.

## Why Node needs an entrypoint

The server resolves the runtime from exactly one path, `$TIDEBREAK_DATA_DIR/tools/node/<version>`, and only trusts it when the directory holds `bin/node`, `bin/npm`, and an `installed.json` naming the version and the artifact digest. It never scans and never reads `PATH`.

That path sits under the data directory, which every real deployment mounts a volume over — and a mount hides whatever the image layer put underneath. Unpacking Node there at build time would work only on a brand-new volume and break on exactly the upgrade path operators take. So the image keeps one copy under `/opt` and `deploy/self-host/entrypoint.sh` links the data directory at it on each start. A data directory the process cannot write gets a warning, not a refused boot: chat still works without code mode.

## Why gh is in, and what it does not fix

Tidebreak spawns `gh` for pull-request create, status, review reads, and merge, and the coding agents reach for it themselves. With it in the image, an operator sets `GH_TOKEN` in the server's environment and those paths work — `gh` reads that variable without a terminal, and Tidebreak still only observes the authentication (decision record 34).

It comes from upstream rather than Debian, which carries 2.23.0. That build has no `autoMergeRequest` JSON field, and Tidebreak asks for it alongside every other field in one request, so the whole pull-request digest fails against it. Confirmed by listing the fields each build accepts.

This does not give the machine a GitHub identity: everyone on the deployment acts as whatever account `GH_TOKEN` names. #2510 is the per-user identity work, and its "no `gh` on the machine" outcome replaces the credential path rather than the binary the agents use.

## Test

`scripts/self-host-image-pins.test.mjs` keeps the image's Node version and per-architecture digests in lockstep with `managed_node.rs`, and holds the marker's field names and the digest check. A drifted pin does not degrade to something workable — it reports every engine as not found — so the drift is worth failing on.

## Verified

CI compiles the binary the image builds but never builds the image itself, so the runtime stage was exercised locally on both architectures with the Dockerfile's own apt and download steps:

- `linux/amd64` and `linux/arm64` build clean; every pinned package and both tarball digests resolve.
- `git clone` of a public repository with the flags `clone.rs` uses, then `npm install @anthropic-ai/claude-code@2.1.234` through the managed npm from the directory and `PATH` `pin.rs` uses. The resulting `node_modules/.bin/claude` runs and reports 2.1.234.
- `gh` accepts every field `PR_VIEW_FIELDS` requests.
- The entrypoint publishes the runtime into a fresh named volume, a fresh bind mount, and a directory that already carries it; a read-only data directory warns and boots.
- The build context probe confirms `Dockerfile.dockerignore` admits the new entrypoint and nothing else under `deploy/`.

Closes #2508
