### PR TITLE
feat(code): a machine says which repo sources it can serve

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -103,6 +103,7 @@ import {
   type CodePrMergeMethod,
   type CodeWorkspaceSnapshot,
   type CodeCloneDefaults,
+  type CodeRepoSources,
   type CodeWorktreeRoot,
   type CodeForkTranscript,
   type CodeCloneJobSnapshot,
@@ -142,6 +143,7 @@ import {
 import {
   parseCodeApproval,
   parseCodeCloneDefaults,
+  parseCodeRepoSources,
   parseCodeWorktreeRoot,
   parseCodeForkTranscript,
   parseCodeCloneJob,
@@ -1919,6 +1921,22 @@ export class ApiClient {
     });
   }
 
+  /**
+   * What this machine can add a repository from.
+   *
+   * Member-plane, unlike `getCodeCloneDefaults`, which is administrator-only:
+   * on a shared machine the person adding a repository is usually not an
+   * administrator, and a dialog that cannot read its own options is no dialog.
+   */
+  async getCodeRepoSources(): Promise<CodeRepoSources> {
+    return requireParsed(
+      parseCodeRepoSources(
+        await this.json("/code/repos/sources", { headers: this.headers() }),
+      ),
+      "repo sources",
+    );
+  }
+
   async getCodeCloneDefaults(): Promise<CodeCloneDefaults> {
     return requireParsed(
       parseCodeCloneDefaults(
@@ -1930,10 +1948,14 @@ export class ApiClient {
     );
   }
 
+  /**
+   * Start a clone. `parent_dir` is omitted when the machine places clones
+   * itself — see `CodeRepoSources.chooses_destination`.
+   */
   async startCodeClone(body: {
     url?: string;
     github?: string;
-    parent_dir: string;
+    parent_dir?: string;
     name?: string;
   }): Promise<CodeCloneJobSnapshot> {
     return requireParsed(

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -167,6 +167,8 @@ import {
   type CodeSessionDigest as WireCodeSessionDigest,
   type CodeUpdateNotice as WireCodeUpdateNotice,
   type CodeCloneDefaults as WireCodeCloneDefaults,
+  type CodeRepoSource as WireCodeRepoSource,
+  type CodeRepoSources as WireCodeRepoSources,
   type CodeCloneJobSnapshot as WireCodeCloneJobSnapshot,
   type CodeHarnessInstallSnapshot as WireCodeHarnessInstallSnapshot,
   type CodeWorktreeRoot as WireCodeWorktreeRoot,
@@ -1198,6 +1200,8 @@ export type CodeTerminalActivityNotice = WireCodeTerminalActivityNotice;
 export type CodeSessionDigest = WireCodeSessionDigest;
 export type CodeUpdateNotice = WireCodeUpdateNotice;
 export type CodeCloneDefaults = WireCodeCloneDefaults;
+export type CodeRepoSource = WireCodeRepoSource;
+export type CodeRepoSources = WireCodeRepoSources;
 export type CodeCloneJobSnapshot = WireCodeCloneJobSnapshot;
 /** Where the warm install of one pinned engine stands. */
 export type CodeHarnessInstallSnapshot = WireCodeHarnessInstallSnapshot;

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
@@ -22,6 +22,14 @@ function app(
         gh_found: false,
         gh_remediation: "gh is not installed. Install the GitHub CLI.",
       })),
+      getCodeRepoSources: vi.fn(async () => ({
+        sources: [
+          { kind: "local", available: true },
+          { kind: "git_url", available: true },
+          { kind: "github", available: true },
+        ],
+        chooses_destination: false,
+      })),
       startCodeClone: vi.fn(),
       getCodeRepo: vi.fn(),
       createCodeRepo: vi.fn(),
@@ -177,6 +185,100 @@ describe("AddRepoPalette", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(
       screen.getByPlaceholderText("https://example.com/acme/app.git"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("AddRepoPalette on a machine that answers for itself", () => {
+  it("hides a source the machine cannot serve and says what would fix it", async () => {
+    await renderPalette(
+      app({
+        getCodeRepoSources: vi.fn(async () => ({
+          sources: [
+            { kind: "local", available: true },
+            {
+              kind: "git_url",
+              available: false,
+              remediation: "This machine has no git.",
+            },
+            {
+              kind: "github",
+              available: false,
+              remediation: "This machine has no git.",
+            },
+          ],
+          chooses_destination: false,
+        })),
+      } as never),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("option", { name: /Git URL/ }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("option", { name: /GitHub repository/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /Local folder/ }),
+    ).toBeInTheDocument();
+    // Absent with no reason reads as a broken dialog; the machine's own
+    // sentence is what makes it legible.
+    expect(
+      screen.getAllByText(/This machine has no git\./).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("asks for no destination when the machine places clones itself", async () => {
+    const startCodeClone = vi.fn(async (_body: { parent_dir?: string }) => ({
+      id: "job-1",
+      phase: "starting",
+      done: false,
+    }));
+    await renderPalette(
+      app({
+        startCodeClone,
+        getCodeRepoSources: vi.fn(async () => ({
+          sources: [
+            { kind: "local", available: true },
+            { kind: "git_url", available: true },
+            { kind: "github", available: true },
+          ],
+          chooses_destination: true,
+        })),
+      } as never),
+    );
+    const search = await screen.findByPlaceholderText("Filter sources");
+    fireEvent.change(search, { target: { value: "Git URL" } });
+    fireEvent.keyDown(search, { key: "Enter" });
+
+    const url = await screen.findByPlaceholderText(
+      "https://example.com/acme/app.git",
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("Destination folder")).not.toBeInTheDocument(),
+    );
+    fireEvent.change(url, {
+      target: { value: "https://example.com/acme/app.git" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Clone" }));
+    await waitFor(() => expect(startCodeClone).toHaveBeenCalled());
+    // The machine owns its filesystem layout, so the request names no path.
+    expect(startCodeClone.mock.calls[0]?.[0].parent_dir).toBeUndefined();
+  });
+
+  it("stays usable when the administrator-only defaults read is refused", async () => {
+    await renderPalette(
+      app({
+        getCodeCloneDefaults: vi.fn(async () => {
+          throw new Error("403: forbidden");
+        }),
+      } as never),
+    );
+    // A member on a shared machine gets that refusal every time. The dialog
+    // is the thing they came for, so it must survive it.
+    expect(
+      await screen.findByRole("option", { name: /Local folder/ }),
     ).toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
@@ -282,3 +282,38 @@ describe("AddRepoPalette on a machine that answers for itself", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("AddRepoPalette and a machine without a GitHub credential", () => {
+  it("still offers owner/repo, and says what the missing credential costs", async () => {
+    await renderPalette(
+      app({
+        getCodeRepoSources: vi.fn(async () => ({
+          sources: [
+            { kind: "local", available: true },
+            { kind: "git_url", available: true },
+            {
+              kind: "github",
+              available: true,
+              remediation: "gh is not installed. Install the GitHub CLI.",
+            },
+          ],
+          chooses_destination: false,
+        })),
+        // Administrator-only, and refused here: the hint must come from the
+        // member-plane probe or a member sees nothing.
+        getCodeCloneDefaults: vi.fn(async () => {
+          throw new Error("403: forbidden");
+        }),
+      } as never),
+    );
+    // The clone path falls back to the public HTTPS URL without gh, so
+    // hiding this form would take away something that works.
+    const github = await screen.findByRole("option", {
+      name: /GitHub repository/,
+    });
+    fireEvent.click(github);
+    expect(await screen.findByTestId("gh-absent-hint")).toHaveTextContent(
+      /gh is not installed/,
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import { Folder, GitBranch, Link2 } from "lucide-react";
 
-import type { CodeCloneDefaults, CodeCloneJobSnapshot } from "../api/types";
+import type {
+  CodeCloneDefaults,
+  CodeCloneJobSnapshot,
+  CodeRepoSources,
+} from "../api/types";
 import { useApp } from "@/AppContext";
 import type { OptionRow } from "@/components/OptionListbox";
 import { Button } from "@/components/ui/button";
@@ -22,7 +26,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
-import { hasNativeHost, pickCodeDirectory } from "@/host";
+import { hasLocalHostAuthority, pickCodeDirectory } from "@/host";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
@@ -77,20 +81,52 @@ export function AddRepoPalette({
   const [parentDir, setParentDir] = useState("");
   const [cloneName, setCloneName] = useState("");
   const [defaults, setDefaults] = useState<CodeCloneDefaults | null>(null);
+  const [sources, setSources] = useState<CodeRepoSources | null>(null);
   const [jobId, setJobId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const job = jobId ? cloneJobs[jobId] : undefined;
+  // Whether this window can name a path the machine would resolve. Browsing
+  // is the host's, resolving is the machine's, and they are the same computer
+  // only when the window is not attached elsewhere.
+  const canBrowse = hasLocalHostAuthority();
+  // The machine places clones itself when its operator configured a
+  // destination, which is what lets someone who cannot see its filesystem
+  // clone at all. Until the probe answers, assume it does not, so a desktop
+  // working on its own machine never loses the field it has always had.
+  const machineChoosesDestination = sources?.chooses_destination === true;
+  const offered = useMemo(() => {
+    // Before the probe answers, offer everything: the machine is the
+    // authority, and a dialog that showed nothing while asking would read as
+    // a broken dialog rather than a pending one.
+    if (!sources) return SOURCES;
+    const available = new Map(
+      sources.sources.map((source) => [source.kind, source] as const),
+    );
+    return SOURCES.filter((row) => available.get(row.key)?.available !== false);
+  }, [sources]);
   const rows = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    if (!needle) return SOURCES;
-    return SOURCES.filter(
+    if (!needle) return offered;
+    return offered.filter(
       (row) =>
         row.label.toLowerCase().includes(needle) ||
         (row.description ?? "").toLowerCase().includes(needle),
     );
-  }, [query]);
+  }, [query, offered]);
+  // What the machine says would make a hidden source usable. Shown rather
+  // than swallowed: "GitHub is missing" with no reason is worse than absent.
+  const unavailable = useMemo(
+    () =>
+      (sources?.sources ?? []).filter(
+        (source) =>
+          !source.available &&
+          source.remediation &&
+          SOURCES.some((row) => row.key === source.kind),
+      ),
+    [sources],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -104,10 +140,21 @@ export function AddRepoPalette({
     setJobId(null);
     setBusy(false);
     setError(null);
-    void client.getCodeCloneDefaults().then((next) => {
-      setDefaults(next);
-      setParentDir(next.parent_dir ?? "");
-    });
+    setSources(null);
+    void client
+      .getCodeRepoSources()
+      .then(setSources)
+      .catch(() => setSources(null));
+    // Administrator-only, and the person adding a repo on a shared machine
+    // usually is not one. A refusal leaves the remembered destination unknown,
+    // which the machine fills in for itself.
+    void client
+      .getCodeCloneDefaults()
+      .then((next) => {
+        setDefaults(next);
+        setParentDir(next.parent_dir ?? "");
+      })
+      .catch(() => setDefaults(null));
   }, [open, client]);
 
   useEffect(() => {
@@ -174,16 +221,22 @@ export function AddRepoPalette({
   async function startClone(body: {
     url?: string;
     github?: string;
-    parent_dir: string;
+    parent_dir?: string;
     name?: string;
   }) {
-    if (!body.parent_dir.trim()) return;
+    // A field nobody was shown must not be sent. `parentDir` may still hold
+    // whatever the defaults read seeded it with, and sending that would put
+    // the checkout somewhere the reader never chose.
+    const parent = machineChoosesDestination
+      ? undefined
+      : body.parent_dir?.trim();
+    if (!parent && !machineChoosesDestination) return;
     setBusy(true);
     setError(null);
     try {
       const started = await client.startCodeClone({
         ...body,
-        parent_dir: body.parent_dir.trim(),
+        parent_dir: parent || undefined,
         name: body.name?.trim() || undefined,
       });
       useCodeUpdatesStore.getState().apply({
@@ -206,7 +259,7 @@ export function AddRepoPalette({
     if (!row) return;
     if (row.key === "local") {
       setStage("local");
-      if (hasNativeHost()) void pickDirectory("path");
+      if (canBrowse) void pickDirectory("path");
       return;
     }
     if (row.key === "git_url") setStage("git_url");
@@ -305,6 +358,18 @@ export function AddRepoPalette({
                   );
                 })}
               </CommandGroup>
+              {unavailable.length > 0 && (
+                <div className="border-t px-3 py-2">
+                  {unavailable.map((source) => (
+                    <p
+                      key={source.kind}
+                      className="text-xs text-muted-foreground"
+                    >
+                      {source.remediation}
+                    </p>
+                  ))}
+                </div>
+              )}
             </CommandList>
           </Command>
         )}
@@ -317,6 +382,7 @@ export function AddRepoPalette({
             error={error}
             onPath={setPath}
             onDisplayName={setDisplayName}
+            canBrowse={canBrowse}
             onBrowse={() => void pickDirectory("path")}
             onSubmit={() => void registerLocal()}
           />
@@ -332,6 +398,8 @@ export function AddRepoPalette({
             onUrl={setUrl}
             onParentDir={setParentDir}
             onName={setCloneName}
+            canBrowse={canBrowse}
+            machineChoosesDestination={machineChoosesDestination}
             onBrowse={() => void pickDirectory("parent")}
             onSubmit={() =>
               void startClone({
@@ -354,6 +422,8 @@ export function AddRepoPalette({
             onGithub={setGithub}
             onParentDir={setParentDir}
             onName={setCloneName}
+            canBrowse={canBrowse}
+            machineChoosesDestination={machineChoosesDestination}
             onBrowse={() => void pickDirectory("parent")}
             onSubmit={() =>
               void startClone({
@@ -395,6 +465,7 @@ function LocalStage({
   error,
   onPath,
   onDisplayName,
+  canBrowse,
   onBrowse,
   onSubmit,
 }: {
@@ -404,6 +475,8 @@ function LocalStage({
   error: string | null;
   onPath: (value: string) => void;
   onDisplayName: (value: string) => void;
+  /** Whether this window can open a picker the machine would resolve. */
+  canBrowse: boolean;
   onBrowse: () => void;
   onSubmit: () => void;
 }) {
@@ -421,11 +494,13 @@ function LocalStage({
           <Input
             value={path}
             onChange={(event) => onPath(event.target.value)}
-            placeholder="/Users/you/src/app"
+            placeholder={
+              canBrowse ? "/Users/you/src/app" : "a path on the machine"
+            }
             disabled={busy}
             autoFocus
           />
-          {hasNativeHost() && (
+          {canBrowse && (
             <Button
               type="button"
               variant="outline"
@@ -466,6 +541,8 @@ function GitUrlStage({
   onUrl,
   onParentDir,
   onName,
+  canBrowse,
+  machineChoosesDestination,
   onBrowse,
   onSubmit,
 }: {
@@ -477,6 +554,8 @@ function GitUrlStage({
   onUrl: (value: string) => void;
   onParentDir: (value: string) => void;
   onName: (value: string) => void;
+  canBrowse: boolean;
+  machineChoosesDestination: boolean;
   onBrowse: () => void;
   onSubmit: () => void;
 }) {
@@ -498,12 +577,15 @@ function GitUrlStage({
           autoFocus
         />
       </label>
-      <ParentDirField
-        value={parentDir}
-        busy={busy}
-        onChange={onParentDir}
-        onBrowse={onBrowse}
-      />
+      {!machineChoosesDestination && (
+        <ParentDirField
+          value={parentDir}
+          busy={busy}
+          canBrowse={canBrowse}
+          onChange={onParentDir}
+          onBrowse={onBrowse}
+        />
+      )}
       <label className="flex flex-col gap-1 text-sm">
         <span className="font-medium">Name</span>
         <Input
@@ -516,7 +598,11 @@ function GitUrlStage({
       {error && <p className="text-sm text-critical">{error}</p>}
       <Button
         type="submit"
-        disabled={busy || !url.trim() || !parentDir.trim()}
+        disabled={
+          busy ||
+          !url.trim() ||
+          (!machineChoosesDestination && !parentDir.trim())
+        }
         className="self-start"
       >
         {busy ? "Starting…" : "Clone"}
@@ -535,6 +621,8 @@ function GithubStage({
   onGithub,
   onParentDir,
   onName,
+  canBrowse,
+  machineChoosesDestination,
   onBrowse,
   onSubmit,
 }: {
@@ -547,6 +635,8 @@ function GithubStage({
   onGithub: (value: string) => void;
   onParentDir: (value: string) => void;
   onName: (value: string) => void;
+  canBrowse: boolean;
+  machineChoosesDestination: boolean;
   onBrowse: () => void;
   onSubmit: () => void;
 }) {
@@ -580,12 +670,15 @@ function GithubStage({
           {ghHint} You can still clone over HTTPS.
         </p>
       )}
-      <ParentDirField
-        value={parentDir}
-        busy={busy}
-        onChange={onParentDir}
-        onBrowse={onBrowse}
-      />
+      {!machineChoosesDestination && (
+        <ParentDirField
+          value={parentDir}
+          busy={busy}
+          canBrowse={canBrowse}
+          onChange={onParentDir}
+          onBrowse={onBrowse}
+        />
+      )}
       <label className="flex flex-col gap-1 text-sm">
         <span className="font-medium">Name</span>
         <Input
@@ -598,7 +691,11 @@ function GithubStage({
       {error && <p className="text-sm text-critical">{error}</p>}
       <Button
         type="submit"
-        disabled={busy || !github.trim() || !parentDir.trim()}
+        disabled={
+          busy ||
+          !github.trim() ||
+          (!machineChoosesDestination && !parentDir.trim())
+        }
         className="self-start"
       >
         {busy ? "Starting…" : "Clone"}
@@ -610,11 +707,13 @@ function GithubStage({
 function ParentDirField({
   value,
   busy,
+  canBrowse,
   onChange,
   onBrowse,
 }: {
   value: string;
   busy: boolean;
+  canBrowse: boolean;
   onChange: (value: string) => void;
   onBrowse: () => void;
 }) {
@@ -625,10 +724,10 @@ function ParentDirField({
         <Input
           value={value}
           onChange={(event) => onChange(event.target.value)}
-          placeholder="/Users/you/src"
+          placeholder={canBrowse ? "/Users/you/src" : "a path on the machine"}
           disabled={busy}
         />
-        {hasNativeHost() && (
+        {canBrowse && (
           <Button
             type="button"
             variant="outline"

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -127,6 +127,15 @@ export function AddRepoPalette({
       ),
     [sources],
   );
+  // What the machine says about GitHub while still offering it: no `gh`
+  // credential means public repositories only. Read from the probe rather
+  // than from `getCodeCloneDefaults`, which is administrator-only — a member
+  // on a shared machine would otherwise be told nothing at all.
+  const githubHint = useMemo(() => {
+    const github = sources?.sources.find((source) => source.kind === "github");
+    if (github?.available && github.remediation) return github.remediation;
+    return null;
+  }, [sources]);
 
   useEffect(() => {
     if (!open) return;
@@ -417,6 +426,7 @@ export function AddRepoPalette({
             parentDir={parentDir}
             name={cloneName}
             defaults={defaults}
+            hint={githubHint}
             busy={busy}
             error={error}
             onGithub={setGithub}
@@ -616,6 +626,7 @@ function GithubStage({
   parentDir,
   name,
   defaults,
+  hint,
   busy,
   error,
   onGithub,
@@ -630,6 +641,8 @@ function GithubStage({
   parentDir: string;
   name: string;
   defaults: CodeCloneDefaults | null;
+  /** The machine's note about GitHub, when it still offers it. */
+  hint: string | null;
   busy: boolean;
   error: string | null;
   onGithub: (value: string) => void;
@@ -640,10 +653,13 @@ function GithubStage({
   onBrowse: () => void;
   onSubmit: () => void;
 }) {
+  // The machine's own note first; the administrator-only defaults read is
+  // the fallback for a profile whose probe predates this field.
   const ghHint =
-    defaults && (!defaults.gh_found || defaults.gh_authenticated === false)
+    hint ??
+    (defaults && (!defaults.gh_found || defaults.gh_authenticated === false)
       ? defaults.gh_remediation
-      : null;
+      : null);
   return (
     <form
       className="flex flex-col gap-3"

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -52,6 +52,8 @@ import type {
   CodeSubagentSummary,
   CodeUpdateNotice,
   CodeCloneDefaults,
+  CodeRepoSource,
+  CodeRepoSources,
   CodeCloneJobSnapshot,
   CodeHarnessInstallSnapshot,
   CodeWorktreeRoot,
@@ -119,6 +121,8 @@ import type {
   CodeSessionDigest as WireCodeSessionDigest,
   CodeUpdateNotice as WireCodeUpdateNotice,
   CodeCloneDefaults as WireCodeCloneDefaults,
+  CodeRepoSource as WireCodeRepoSource,
+  CodeRepoSources as WireCodeRepoSources,
   CodeCloneJobSnapshot as WireCodeCloneJobSnapshot,
   CodeHarnessInstallSnapshot as WireCodeHarnessInstallSnapshot,
   CodeWorktreeRoot as WireCodeWorktreeRoot,
@@ -1177,6 +1181,55 @@ export function parseCodeCloneDefaults(
       ? { gh_authenticated: value.gh_authenticated }
       : {}),
   };
+}
+
+/**
+ * One source the machine reports.
+ *
+ * An unfamiliar `kind` parses fine and is dropped by the caller rather than
+ * rejected here: the set of sources is the machine's to grow, and a client
+ * that refused the whole envelope over one unknown member could never be
+ * older than its machine.
+ */
+function parseCodeRepoSource(value: unknown): CodeRepoSource | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeRepoSource>(value, [
+      "kind",
+      "available",
+      "remediation",
+    ]) ||
+    typeof value.kind !== "string" ||
+    typeof value.available !== "boolean" ||
+    !optionalString(value.remediation)
+  ) {
+    return null;
+  }
+  return {
+    kind: value.kind,
+    available: value.available,
+    ...(value.remediation !== undefined
+      ? { remediation: value.remediation }
+      : {}),
+  };
+}
+
+export function parseCodeRepoSources(value: unknown): CodeRepoSources | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeRepoSources>(value, ["sources", "chooses_destination"]) ||
+    !Array.isArray(value.sources) ||
+    typeof value.chooses_destination !== "boolean"
+  ) {
+    return null;
+  }
+  const sources: CodeRepoSource[] = [];
+  for (const entry of value.sources) {
+    const source = parseCodeRepoSource(entry);
+    if (!source) return null;
+    sources.push(source);
+  }
+  return { sources, chooses_destination: value.chooses_destination };
 }
 
 export function parseCodeForkTranscript(

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1236,6 +1236,33 @@ export type CodePushSnapshot = { branch: string, remote: string, };
 export type CodeRepoSnapshot = { id: RepoId, root_path: string, display_name: string, default_base_ref: string, branch_prefix: string, setup_script?: string, archive_script?: string, quick_actions: Array<QuickAction>, created_at: string, };
 
 /**
+ * One way of adding a repository, and whether this machine can serve it.
+ *
+ * `kind` is `local`, `git_url`, or `github`. `remediation` says what would
+ * make an unavailable source available, and is absent when it is available.
+ */
+export type CodeRepoSource = { kind: string, available: boolean, remediation?: string, };
+
+/**
+ * What this machine can add a repository from: `GET /code/repos/sources`.
+ *
+ * The machine answers for itself — whether it can spawn `git`, whether it has
+ * a GitHub credential — and the client decides separately whether it can
+ * offer a picker for any of it. Those are different questions: a desktop on
+ * the same computer as its machine can browse for a path, and a window
+ * attached to a machine elsewhere cannot, while the machine's own answer is
+ * identical either way.
+ *
+ * `chooses_destination` says the machine places clones under the destination
+ * its operator configured, so a caller names no path — which is what lets a
+ * shared machine keep its filesystem layout to itself.
+ *
+ * Unknown source kinds are ignored by clients rather than rendered, so this
+ * set may grow without a client release (decision 17).
+ */
+export type CodeRepoSources = { sources: Array<CodeRepoSource>, chooses_destination: boolean, };
+
+/**
  * What a running interactive session is actually occupied with. This is
  * intentionally coarser than a transcript tool name: list surfaces need to
  * distinguish agent generation, a shell, a passive monitor, and delegated

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1238,8 +1238,10 @@ export type CodeRepoSnapshot = { id: RepoId, root_path: string, display_name: st
 /**
  * One way of adding a repository, and whether this machine can serve it.
  *
- * `kind` is `local`, `git_url`, or `github`. `remediation` says what would
- * make an unavailable source available, and is absent when it is available.
+ * `kind` is `local`, `git_url`, or `github`. `remediation` says what stands in
+ * the way, and rides on an available source too: `github` clones anything
+ * public without a `gh` credential, so its absence is a note about private
+ * repositories rather than a reason to withhold the form.
  */
 export type CodeRepoSource = { kind: string, available: boolean, remediation?: string, };
 

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -20,9 +20,14 @@ use super::bus::{CloneProgress, CodeLiveUpdate};
 use super::gh::{self, resolve_github_clone_url};
 use super::runtime::CodeRuntime;
 use crate::error::ServerError;
-use crate::routes::code::{CodeCloneDefaults, CodeCloneJobSnapshot};
+use crate::routes::code::{
+    CodeCloneDefaults, CodeCloneJobSnapshot, CodeRepoSource, CodeRepoSources,
+};
 
 const CLONE_TIMEOUT: Duration = Duration::from_secs(900);
+/// Long enough for a cold binary to answer, short enough that a machine
+/// without git reports so rather than stalling the dialog that asked.
+const GIT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_STDERR_CHARS: usize = 4_096;
 pub(crate) const CLONE_PARENT_DIR_SETTING: &str = "code_clone_parent_dir";
 
@@ -118,7 +123,10 @@ pub(crate) fn owner_dir(parent: &Path, owner: &OwnerId) -> PathBuf {
 pub(crate) struct CloneRequest {
     pub url: Option<String>,
     pub github: Option<String>,
-    pub parent_dir: String,
+    /// Where to put the checkout. Optional: a machine whose operator
+    /// configured a destination places clones itself, so a caller who cannot
+    /// see the machine's filesystem — anyone attached to it — names nothing.
+    pub parent_dir: Option<String>,
     pub name: Option<String>,
 }
 
@@ -134,6 +142,73 @@ impl CodeRuntime {
         })
     }
 
+    /// What this machine can add a repository from.
+    ///
+    /// Every answer here is about the machine, never about who is asking or
+    /// from where. A client pairs it with what it knows about itself — whether
+    /// it can open a directory picker the machine would resolve — and renders
+    /// the intersection.
+    pub(crate) async fn repo_sources(&self) -> Result<CodeRepoSources, ServerError> {
+        let git = git_available().await;
+        let gh = gh::observe_gh(self.gh_search_path().as_deref()).await;
+        let no_git = || {
+            Some(
+                "This machine has no git. Install it there, or use a machine that has it."
+                    .to_owned(),
+            )
+        };
+        let github_available = git && gh.found && gh.authenticated == Some(true);
+        let sources = vec![
+            // Always offered: a machine can always register a checkout that
+            // is already on its own disk. Whether the caller can name one is
+            // the caller's question, not this one.
+            CodeRepoSource {
+                kind: "local".to_owned(),
+                available: true,
+                remediation: None,
+            },
+            CodeRepoSource {
+                kind: "git_url".to_owned(),
+                available: git,
+                remediation: if git { None } else { no_git() },
+            },
+            CodeRepoSource {
+                kind: "github".to_owned(),
+                available: github_available,
+                remediation: if github_available {
+                    None
+                } else if !git {
+                    no_git()
+                } else {
+                    Some(gh.remediation.clone())
+                },
+            },
+        ];
+        Ok(CodeRepoSources {
+            sources,
+            chooses_destination: read_clone_parent_dir(&*self.db).await?.is_some(),
+        })
+    }
+
+    /// The parent directory a clone lands under: what the caller asked for, or
+    /// the destination the machine already remembers.
+    ///
+    /// Preferring the caller keeps a desktop working on its own machine
+    /// exactly as before. Falling back to the setting is what lets a caller
+    /// who cannot see the filesystem clone at all.
+    async fn clone_parent(&self, requested: Option<&str>) -> Result<PathBuf, ServerError> {
+        if let Some(value) = requested.map(str::trim).filter(|value| !value.is_empty()) {
+            return Ok(PathBuf::from(value));
+        }
+        match read_clone_parent_dir(&*self.db).await? {
+            Some(configured) => Ok(PathBuf::from(configured)),
+            None => Err(ServerError::bad_request_kind(
+                "clone_parent_missing",
+                "this machine has no clone destination configured, so the request must name one",
+            )),
+        }
+    }
+
     pub(crate) fn get_clone_job(&self, id: Uuid) -> Result<CodeCloneJobSnapshot, ServerError> {
         self.clone_jobs
             .snapshot(id)
@@ -146,7 +221,7 @@ impl CodeRuntime {
         owner: &OwnerId,
         request: CloneRequest,
     ) -> Result<CodeCloneJobSnapshot, ServerError> {
-        let parent = PathBuf::from(request.parent_dir.trim());
+        let parent = self.clone_parent(request.parent_dir.as_deref()).await?;
         validate_parent_dir(&parent).await?;
         let source = resolve_clone_source(&request, self.gh_search_path()).await?;
         let name = request
@@ -315,6 +390,29 @@ async fn resolve_clone_source(
                 })
         }
     }
+}
+
+/// Whether this machine can spawn `git` at all.
+///
+/// Probed by running it rather than by walking `PATH`. What matters is that
+/// the clone below can spawn it, and a `PATH` entry that is not executable —
+/// or a Windows extension a walk missed — would answer a different question
+/// than the one asked.
+pub(crate) async fn git_available() -> bool {
+    matches!(
+        timeout(
+            GIT_PROBE_TIMEOUT,
+            Command::new("git")
+                .arg("--version")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .kill_on_drop(true)
+                .status(),
+        )
+        .await,
+        Ok(Ok(status)) if status.success()
+    )
 }
 
 async fn validate_parent_dir(parent: &Path) -> Result<(), ServerError> {

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -157,7 +157,13 @@ impl CodeRuntime {
                     .to_owned(),
             )
         };
-        let github_available = git && gh.found && gh.authenticated == Some(true);
+        // GitHub needs exactly what a git URL needs. Without a `gh`
+        // credential `resolve_github_clone_url` falls back to the public
+        // HTTPS URL, so `owner/repo` still clones anything public — hiding
+        // the form would take away a path that works. What `gh` buys is
+        // private repositories, so its absence rides along as a hint on an
+        // available source rather than as unavailability.
+        let github_credential = gh.found && gh.authenticated == Some(true);
         let sources = vec![
             // Always offered: a machine can always register a checkout that
             // is already on its own disk. Whether the caller can name one is
@@ -174,11 +180,11 @@ impl CodeRuntime {
             },
             CodeRepoSource {
                 kind: "github".to_owned(),
-                available: github_available,
-                remediation: if github_available {
-                    None
-                } else if !git {
+                available: git,
+                remediation: if !git {
                     no_git()
+                } else if github_credential {
+                    None
                 } else {
                     Some(gh.remediation.clone())
                 },

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -42,7 +42,8 @@ use crate::routes::code::types::{
     CodeDeliveryPullRequestActionBody, CodeDeliveryPullRequestDetail, CodeDeliveryPullRequestQuery,
     CodeDeliveryPullRequestTarget, CodeDeliveryPullRequestsPage, CodeDeliveryRepositoriesSnapshot,
     CodeDeliveryRunActionBody, CodeDeliveryRunDetail, CodeDeliveryRunQuery, CodeDeliveryRunTarget,
-    CodeDeliveryRunsPage, CodeHarnessInstallSnapshot, ResolveCodeDeliveryRepositoriesBody,
+    CodeDeliveryRunsPage, CodeHarnessInstallSnapshot, CodeRepoSources,
+    ResolveCodeDeliveryRepositoriesBody,
 };
 use crate::state::AppState;
 
@@ -127,6 +128,10 @@ impl ScopedCode {
 
     pub(crate) async fn clone_defaults(&self) -> Result<CodeCloneDefaults, ServerError> {
         self.runtime.clone_defaults().await
+    }
+
+    pub(crate) async fn repo_sources(&self) -> Result<CodeRepoSources, ServerError> {
+        self.runtime.repo_sources().await
     }
 
     pub(crate) async fn start_clone(

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -800,6 +800,7 @@ pub fn app(state: AppState) -> Router {
             "/code/repos",
             post(routes::code::create_repo).get(routes::code::list_repos),
         )
+        .route("/code/repos/sources", get(routes::code::repo_sources))
         .route("/code/repos/clone", post(routes::code::start_clone))
         .route("/code/repos/clone/{job}", get(routes::code::get_clone_job))
         .route(

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -49,7 +49,7 @@ pub(crate) use harnesses::{
 };
 pub(crate) use repos::{
     clone_defaults, create_repo, delete_repo, get_clone_job, get_repo, list_repos, patch_repo,
-    start_clone,
+    repo_sources, start_clone,
 };
 pub(crate) use session_events::session_events;
 pub(crate) use sessions::{
@@ -74,13 +74,14 @@ pub(crate) use types::{
     CodeDeliveryRepositoriesSnapshot, CodeDeliveryRunActionBody, CodeDeliveryRunDetail,
     CodeDeliveryRunQuery, CodeDeliveryRunTarget, CodeDeliveryRunsPage, CodeFileChange,
     CodeForkTranscript, CodeHarnessInstallSnapshot, CodePrCommentsSnapshot, CodePushSnapshot,
-    CodeRepoSnapshot, CodeSessionDebug, CodeSessionDigest, CodeSessionSnapshot,
-    CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot, CodeTriggerSnapshot,
-    CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
-    CodeWorkspacePrSnapshot, CodeWorkspaceSearch, CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot,
-    CodeWorkspaceTree, CodeWorktreeRoot, CreateCodeTriggerBody, HarnessDoctorReport,
-    HarnessModelList, MergeCodePrBody, QueuedCodeTurn, ResolveCodeDeliveryRepositoriesBody,
-    SequencedCodeEventFrame, SetCodeWorktreeRootBody, UpdateCodeTriggerBody,
+    CodeRepoSnapshot, CodeRepoSource, CodeRepoSources, CodeSessionDebug, CodeSessionDigest,
+    CodeSessionSnapshot, CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot,
+    CodeTriggerSnapshot, CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff,
+    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSearch, CodeWorkspaceSearchMatch,
+    CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot, CreateCodeTriggerBody,
+    HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
+    ResolveCodeDeliveryRepositoriesBody, SequencedCodeEventFrame, SetCodeWorktreeRootBody,
+    UpdateCodeTriggerBody,
 };
 pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;

--- a/crates/tidebreak-server/src/routes/code/repos.rs
+++ b/crates/tidebreak-server/src/routes/code/repos.rs
@@ -9,8 +9,8 @@ use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 
 use super::types::{
-    CloneRepoBody, CodeCloneDefaults, CodeCloneJobSnapshot, CodeRepoSnapshot, CreateRepoBody,
-    PatchRepoBody, RemoveRepoQuery,
+    CloneRepoBody, CodeCloneDefaults, CodeCloneJobSnapshot, CodeRepoSnapshot, CodeRepoSources,
+    CreateRepoBody, PatchRepoBody, RemoveRepoQuery,
 };
 use tidebreak_core::RepoId;
 
@@ -109,6 +109,10 @@ pub async fn delete_repo(
 
 pub async fn clone_defaults(code: ScopedCode) -> Result<Json<CodeCloneDefaults>, ServerError> {
     Ok(Json(code.clone_defaults().await?))
+}
+
+pub async fn repo_sources(code: ScopedCode) -> Result<Json<CodeRepoSources>, ServerError> {
+    Ok(Json(code.repo_sources().await?))
 }
 
 pub async fn start_clone(

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -293,7 +293,10 @@ pub struct CloneRepoBody {
     pub url: Option<String>,
     #[serde(default)]
     pub github: Option<String>,
-    pub parent_dir: String,
+    /// Absent when the machine places clones itself; see
+    /// [`CodeRepoSources::chooses_destination`].
+    #[serde(default)]
+    pub parent_dir: Option<String>,
     #[serde(default)]
     pub name: Option<String>,
 }
@@ -346,6 +349,40 @@ pub struct CodeCloneDefaults {
     #[ts(optional)]
     pub gh_authenticated: Option<bool>,
     pub gh_remediation: String,
+}
+
+/// What this machine can add a repository from: `GET /code/repos/sources`.
+///
+/// The machine answers for itself — whether it can spawn `git`, whether it has
+/// a GitHub credential — and the client decides separately whether it can
+/// offer a picker for any of it. Those are different questions: a desktop on
+/// the same computer as its machine can browse for a path, and a window
+/// attached to a machine elsewhere cannot, while the machine's own answer is
+/// identical either way.
+///
+/// `chooses_destination` says the machine places clones under the destination
+/// its operator configured, so a caller names no path — which is what lets a
+/// shared machine keep its filesystem layout to itself.
+///
+/// Unknown source kinds are ignored by clients rather than rendered, so this
+/// set may grow without a client release (decision 17).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeRepoSources {
+    pub sources: Vec<CodeRepoSource>,
+    pub chooses_destination: bool,
+}
+
+/// One way of adding a repository, and whether this machine can serve it.
+///
+/// `kind` is `local`, `git_url`, or `github`. `remediation` says what would
+/// make an unavailable source available, and is absent when it is available.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeRepoSource {
+    pub kind: String,
+    pub available: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub remediation: Option<String>,
 }
 
 /// A written fork transcript: `POST /code/sessions/{id}/fork`.

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -374,8 +374,10 @@ pub struct CodeRepoSources {
 
 /// One way of adding a repository, and whether this machine can serve it.
 ///
-/// `kind` is `local`, `git_url`, or `github`. `remediation` says what would
-/// make an unavailable source available, and is absent when it is available.
+/// `kind` is `local`, `git_url`, or `github`. `remediation` says what stands in
+/// the way, and rides on an available source too: `github` clones anything
+/// public without a `gh` credential, so its absence is a note about private
+/// repositories rather than a reason to withhold the form.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub struct CodeRepoSource {
     pub kind: String,

--- a/crates/tidebreak-server/src/tests/code_clone.rs
+++ b/crates/tidebreak-server/src/tests/code_clone.rs
@@ -349,3 +349,96 @@ exit 3
     assert!(finished["error"].is_null(), "{finished}");
     assert!(finished["repo_id"].is_string());
 }
+
+#[tokio::test]
+async fn a_machine_that_remembers_a_destination_clones_without_being_given_one() {
+    let (router, token, _runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let origin = init_bare_origin(dir.path());
+    let parent = dir.path().join("checkouts");
+    std::fs::create_dir_all(&parent).unwrap();
+
+    // Nothing remembered yet, and nothing named: refuse rather than invent a
+    // directory. This is the state a fresh machine is in.
+    let sources: serde_json::Value = client
+        .get(format!("http://{addr}/code/repos/sources"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(sources["chooses_destination"], false);
+    let kinds: Vec<&str> = sources["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|source| source["kind"].as_str().unwrap())
+        .collect();
+    assert!(
+        kinds.contains(&"local"),
+        "a machine can always register a checkout it already holds"
+    );
+    assert!(kinds.contains(&"git_url"));
+    assert!(kinds.contains(&"github"));
+
+    let unaimed = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "url": origin }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unaimed.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = unaimed.json().await.unwrap();
+    assert_eq!(body["kind"], "clone_parent_missing");
+
+    // One clone that names a destination is what teaches the machine where
+    // its checkouts live.
+    let first = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "url": origin,
+            "parent_dir": parent,
+            "name": "first",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), reqwest::StatusCode::ACCEPTED);
+    let job: serde_json::Value = first.json().await.unwrap();
+    let finished = wait_job(&client, addr, &token, job["id"].as_str().unwrap()).await;
+    assert!(finished["error"].is_null(), "{finished:?}");
+
+    let sources: serde_json::Value = client
+        .get(format!("http://{addr}/code/repos/sources"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(sources["chooses_destination"], true);
+
+    // Now a caller who cannot see the machine's filesystem can clone: no
+    // path, and the checkout still lands under the remembered destination.
+    let second = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "url": origin, "name": "second" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second.status(), reqwest::StatusCode::ACCEPTED);
+    let job: serde_json::Value = second.json().await.unwrap();
+    let finished = wait_job(&client, addr, &token, job["id"].as_str().unwrap()).await;
+    assert!(finished["error"].is_null(), "{finished:?}");
+    assert!(
+        parent.join("second").exists(),
+        "the clone lands under the remembered destination"
+    );
+}

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -464,6 +464,7 @@ mod tests {
         generate::collect_from::<crate::routes::code::CodeCloneJobSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeHarnessInstallSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeCloneDefaults>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeRepoSources>(&cfg, &mut out);
         // Where new worktrees land, and the body that moves it.
         generate::collect_from::<crate::routes::code::CodeWorktreeRoot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeForkTranscript>(&cfg, &mut out);


### PR DESCRIPTION
Closes #2511.

Add-repo offered Local folder, Git URL, and GitHub unconditionally, and two of them could not work on a machine that is not this computer. The local picker filled a path field the machine resolves on its own disk, and both clone stages asked for a destination directory the caller had no way to name.

A member could not even open the dialog cleanly. It fetched `clone-defaults` with no `.catch`, that route is administrator plane, and a 403 left the destination empty with both clone forms disabled and nothing said.

## What the machine now answers

`GET /code/repos/sources` is a member-plane read of what this machine can serve: whether it can spawn `git`, whether it has a GitHub credential, and whether it places clones under a destination its operator already configured. The palette filters its source list from that answer and shows the machine's own remediation for whatever it drops, so a missing source reads as a fact about the machine rather than a broken dialog.

Unknown source kinds are ignored rather than rendered, so the set can grow without a client release — decision 17's rule, applied to the client-to-machine wire as decision 47 extends it.

## Clones no longer demand a path

`parent_dir` is optional on the clone request. A machine that remembers a destination places checkouts itself, which is what lets someone who cannot see its filesystem clone at all, and keeps a shared machine's layout to itself. A desktop working on its own machine still names its own path; that field is unchanged.

A field nobody was shown is never sent. The palette drops the remembered value rather than posting it — a test caught that, and without it a hidden field would have put checkouts somewhere the reader never chose.

## The axis

Availability is the machine's answer, not the window's. Whether a picker can name a path the machine would resolve is a separate question, and the client answers that one with `hasLocalHostAuthority()`. Branching on attachment alone would be wrong in both directions: a browser tab against a headless deployment reports local, and a laptop-hosted machine without `git` is as unable to clone as a container is.

## Verification

`tsc --noEmit` clean. Full renderer suite: 216 files, 1655 tests. New coverage for a source the machine cannot serve, a machine that places clones itself, and the administrator-only defaults read being refused. `biome format` and `lint` clean, `cargo fmt --check` clean.

The generated wire types are hand-written to match `ts-rs` output rather than regenerated locally; the `the_generated_bindings_are_current` test is the check on that.