### PR TITLE
feat(server): a hosted machine offers each caller their own gateway models

### DIFF
--- a/crates/tidebreak-server/src/approval_judge.rs
+++ b/crates/tidebreak-server/src/approval_judge.rs
@@ -298,6 +298,9 @@ fn user_prompt(action: &str, context: &[JudgeContextMessage]) -> String {
 
 /// Polls for judge-owned approvals and lands one verdict per call.
 pub(crate) struct ApprovalJudgeWorker {
+    /// Per-caller gateway capabilities on a hosted machine (decisions 51 and
+    /// 62): the judge runs as the caller whose approval it reads.
+    on_behalf_of: Option<Arc<crate::obo_gateway::OboGateway>>,
     store: Arc<dyn Store>,
     resolver: Arc<dyn ProviderResolver>,
     secrets: Arc<dyn tidebreak_core::SecretProvider>,
@@ -317,6 +320,7 @@ impl ApprovalJudgeWorker {
         approvals: Arc<ApprovalBroker>,
     ) -> Self {
         Self {
+            on_behalf_of: None,
             store,
             resolver,
             secrets,
@@ -325,6 +329,14 @@ impl ApprovalJudgeWorker {
             approvals,
             poll: Duration::from_millis(750),
         }
+    }
+
+    pub(crate) fn with_on_behalf_of_gateway(
+        mut self,
+        gateway: Option<Arc<crate::obo_gateway::OboGateway>>,
+    ) -> Self {
+        self.on_behalf_of = gateway;
+        self
     }
 
     pub(crate) async fn run(self) {
@@ -377,19 +389,32 @@ impl ApprovalJudgeWorker {
         let Some(action) = action_description(preview) else {
             return Ok(false);
         };
-        // No utility model configured means no judge, not a cheaper gate.
+        // The judge runs as the caller whose approval it reads: their own
+        // entitlements pick the utility model, and their credential drives it
+        // (decision 62). No utility model configured means no judge, not a
+        // cheaper gate.
+        let owner = self
+            .store
+            .chat_owner(approval.chat_id)
+            .await
+            .unwrap_or_default();
+        let caller_gateway = match (self.on_behalf_of.as_ref(), owner.as_ref()) {
+            (Some(gateway), Some(owner)) => gateway.snapshot_for(owner).await.ok().flatten(),
+            _ => None,
+        };
         let Some(utility) = crate::model_roles::resolve_utility_model(
             &*self.store,
             &*self.secrets,
             &*self.provisioned_policy,
             &*self.os_policy,
+            caller_gateway.as_ref(),
         )
         .await?
         else {
             return Ok(false);
         };
         let context = conversation_digest(&self.store.list_messages(approval.chat_id).await?);
-        let provider = self.resolver.resolve().await;
+        let provider = self.resolver.resolve_for(owner.as_ref()).await;
         let verdict = request_verdict(
             provider.as_ref(),
             &utility,

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -146,11 +146,12 @@ pub async fn require_token(
                 let bearer: std::sync::Arc<str> = presented
                     .expect("a resolved principal had a presented token")
                     .into();
-                // Remember the live caller token so this caller's turns can be
-                // driven on their own gateway authority (decision 51). The
-                // token stays in process memory and is never persisted.
-                if let Some(inference) = state.on_behalf_of_inference.as_ref() {
-                    inference.record_caller(&principal.owner_id(), bearer.clone());
+                // Remember the live caller token so this caller's turns and
+                // catalog reads run on their own gateway authority (decisions
+                // 51 and 62). The token stays in process memory and is never
+                // persisted.
+                if let Some(gateway) = state.on_behalf_of_gateway.as_ref() {
+                    gateway.record_caller(&principal.owner_id(), bearer.clone());
                 }
                 request.extensions_mut().insert(GatewayAuthLease {
                     bearer,

--- a/crates/tidebreak-server/src/chat_titling.rs
+++ b/crates/tidebreak-server/src/chat_titling.rs
@@ -230,7 +230,10 @@ impl ChatTitler {
         let Some(material) = user_message_digest(&self.store.list_messages(chat_id).await?) else {
             return Ok(None);
         };
-        let provider = self.resolver.resolve().await;
+        // The title runs as the chat's owner: on a hosted machine that is
+        // the caller whose credential can actually drive it (decision 62).
+        let owner = self.store.chat_owner(chat_id).await.unwrap_or_default();
+        let provider = self.resolver.resolve_for(owner.as_ref()).await;
         let title = derive_title_with_retries(
             provider.as_ref(),
             utility,

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -125,17 +125,21 @@ async fn derive_workspace_title(
     }
     // Resolved per call, like every consumer of the utility role: `None` means
     // this install has no model for background work, and the placeholder stays.
+    // On a hosted machine both the role and the provider resolve as the
+    // workspace's owner (decision 62).
+    let caller_gateway = state.caller_gateway_snapshot(owner).await.ok().flatten();
     let Some(utility) = crate::model_roles::resolve_utility_model(
         &*state.store,
         &*state.secrets,
         &*state.provisioned_policy,
         &*state.os_policy,
+        caller_gateway.as_ref(),
     )
     .await?
     else {
         return Ok(Outcome::NotApplicable);
     };
-    let provider = state.resolver.resolve().await;
+    let provider = state.resolver.resolve_for(Some(owner)).await;
     let title = derive_title_with_retries(
         provider.as_ref(),
         &utility,

--- a/crates/tidebreak-server/src/gateway_runtime.rs
+++ b/crates/tidebreak-server/src/gateway_runtime.rs
@@ -788,7 +788,7 @@ impl GatewayRuntime {
             // Lock order matches the sign-in task's sync path: the sign-in
             // state lock is already held, the snapshot lock nests inside it.
             let _lock = providers::GATEWAY_STATE_WRITES.lock().await;
-            if !providers::gateway_models(&*self.store, &policy)
+            if !providers::gateway_models(&*self.store, &policy, None)
                 .await?
                 .is_empty()
             {
@@ -968,46 +968,9 @@ impl GatewayRuntime {
             GatewayCatalogFetch::Fresh { catalog, etag } => {
                 member_catalog = Some(MEMBER_CATALOG_V1.to_owned());
                 catalog_etag = etag;
-                catalog
-                    .models
-                    .into_iter()
-                    .filter_map(|model| {
-                        let protocols: Vec<_> = model
-                            .protocols
-                            .iter()
-                            .filter_map(|protocol| {
-                                providers::GatewayModelProtocol::parse(protocol)
-                            })
-                            .collect();
-                        // A dual-protocol model routes through Anthropic
-                        // Messages, the richer adapter; a model with no
-                        // protocol this client speaks is skipped, exactly as
-                        // on the older surface.
-                        let protocol = if protocols
-                            .contains(&providers::GatewayModelProtocol::AnthropicMessages)
-                        {
-                            providers::GatewayModelProtocol::AnthropicMessages
-                        } else {
-                            *protocols.first()?
-                        };
-                        let id = model.id;
-                        model_protocols.insert(id.clone(), protocol);
-                        Some(CustomModelConfig {
-                            id,
-                            display_name: Some(model.name),
-                            // The catalog reports gateway-id aliases instead
-                            // of the provider-side id; both exist to match a
-                            // curated row.
-                            upstream_id: None,
-                            aliases: model.aliases,
-                            context_window: clamp_u32(model.context_window, 32_768),
-                            max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
-                            input_modalities: vec![crate::model_registry::InputModality::Text],
-                            supports_reasoning: false,
-                            reasoning_efforts: Vec::new(),
-                        })
-                    })
-                    .collect()
+                let (models, protocols) = providers::member_catalog_models(catalog);
+                model_protocols = protocols;
+                models
             }
             GatewayCatalogFetch::Unsupported => connection
                 .models(None)
@@ -1030,8 +993,8 @@ impl GatewayRuntime {
                         // its curated row; gateways older than the field send none.
                         upstream_id: model.upstream_id,
                         aliases: Vec::new(),
-                        context_window: clamp_u32(model.context_window, 32_768),
-                        max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
+                        context_window: providers::clamp_u32(model.context_window, 32_768),
+                        max_output_tokens: providers::clamp_u32(model.max_output_tokens, 4_096),
                         input_modalities: vec![crate::model_registry::InputModality::Text],
                         supports_reasoning: false,
                         reasoning_efforts: Vec::new(),
@@ -1559,13 +1522,6 @@ fn require_managed(policy: &crate::managed_policy::ManagedPolicy) -> Result<Stri
             "the managed gateway policy has no usable gateway URL; repair the policy authority",
         )
     })
-}
-
-fn clamp_u32(value: Option<i64>, default: u32) -> u32 {
-    value
-        .and_then(|value| u32::try_from(value).ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default)
 }
 
 /// Router-facing supplier of the gateway's `llm`-resource token. Refresh and
@@ -2370,7 +2326,9 @@ mod tests {
         assert_eq!(runtime.sync_models().await.unwrap(), 2);
 
         let policy = runtime.policy().unwrap();
-        let models = providers::gateway_models(&*store, &policy).await.unwrap();
+        let models = providers::gateway_models(&*store, &policy, None)
+            .await
+            .unwrap();
         assert_eq!(models.len(), 2);
         assert_eq!(models[0].id, "sample-claude");
         assert_eq!(models[0].display_name.as_deref(), Some("Sample Claude"));
@@ -2393,7 +2351,7 @@ mod tests {
 
         // The synced snapshot resolves as a model policy under the gateway key.
         let policy =
-            providers::resolve_model_policy(&*store, "model_gateway::sample-claude", false)
+            providers::resolve_model_policy(&*store, "model_gateway::sample-claude", false, None)
                 .await
                 .unwrap()
                 .expect("synced model resolves");
@@ -2488,7 +2446,7 @@ mod tests {
         // The catalog's alias matches the curated registry row, so the
         // policy carries curated capabilities under the gateway's own id.
         let policy =
-            providers::resolve_model_policy(&*store, "model_gateway::sample-claude", false)
+            providers::resolve_model_policy(&*store, "model_gateway::sample-claude", false, None)
                 .await
                 .unwrap()
                 .expect("synced model resolves");
@@ -2681,7 +2639,7 @@ mod tests {
             .unwrap();
 
         let policy = runtime.policy().unwrap();
-        assert!(providers::gateway_models(&*store, &policy)
+        assert!(providers::gateway_models(&*store, &policy, None)
             .await
             .unwrap()
             .is_empty());
@@ -3168,7 +3126,7 @@ mod tests {
         .unwrap();
 
         let matched =
-            providers::resolve_model_policy(&*store, "model_gateway::claude-opus-5", false)
+            providers::resolve_model_policy(&*store, "model_gateway::claude-opus-5", false, None)
                 .await
                 .unwrap()
                 .expect("the gateway row resolves");
@@ -3201,6 +3159,7 @@ mod tests {
             &*store,
             "model_gateway::anthropic-us-claude-opus-5",
             false,
+            None,
         )
         .await
         .unwrap()
@@ -3234,11 +3193,15 @@ mod tests {
         assert!(aliased.supports_structured_output);
         assert_eq!(aliased.context_window, 200_000);
 
-        let unmatched =
-            providers::resolve_model_policy(&*store, "model_gateway::acme-inhouse-llm", false)
-                .await
-                .unwrap()
-                .expect("the unmatched gateway row still resolves");
+        let unmatched = providers::resolve_model_policy(
+            &*store,
+            "model_gateway::acme-inhouse-llm",
+            false,
+            None,
+        )
+        .await
+        .unwrap()
+        .expect("the unmatched gateway row still resolves");
         assert_eq!(unmatched.vendor, None);
         assert_eq!(
             unmatched.verification,
@@ -3389,7 +3352,8 @@ mod tests {
             &*store,
             &*runtime.secrets,
             crate::providers::ProviderKind::ModelGateway,
-            &policy
+            &policy,
+            None
         )
         .await
         .unwrap());
@@ -3560,7 +3524,7 @@ mod tests {
         assert_eq!(status.model_count, 0);
         assert!(status.account_hint.is_none());
         let policy = runtime.policy().unwrap();
-        assert!(providers::gateway_models(&*store, &policy)
+        assert!(providers::gateway_models(&*store, &policy, None)
             .await
             .unwrap()
             .is_empty());
@@ -4148,12 +4112,12 @@ mod tests {
         assert!(routes
             .iter()
             .all(|route| route.kind != tidebreak_router::RouteKind::ModelGateway));
-        assert!(providers::catalog_models(&*store, &*secrets, &policy)
+        assert!(providers::catalog_models(&*store, &*secrets, &policy, None)
             .await
             .unwrap()
             .iter()
             .all(|model| model.policy.provider != crate::providers::ProviderKind::ModelGateway));
-        assert!(providers::list_providers(&*store, &*secrets, &policy)
+        assert!(providers::list_providers(&*store, &*secrets, &policy, None)
             .await
             .unwrap()
             .iter()
@@ -4162,7 +4126,8 @@ mod tests {
             &*store,
             &*secrets,
             crate::providers::ProviderKind::ModelGateway,
-            &policy
+            &policy,
+            None
         )
         .await
         .unwrap());
@@ -4238,7 +4203,9 @@ mod tests {
         providers::retire_legacy_gateway_row(&*store, &policy)
             .await
             .unwrap();
-        let models = providers::gateway_models(&*store, &policy).await.unwrap();
+        let models = providers::gateway_models(&*store, &policy, None)
+            .await
+            .unwrap();
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "carried-model");
 
@@ -4264,7 +4231,9 @@ mod tests {
         providers::retire_legacy_gateway_row(&*store, &policy)
             .await
             .unwrap();
-        let models = providers::gateway_models(&*store, &policy).await.unwrap();
+        let models = providers::gateway_models(&*store, &policy, None)
+            .await
+            .unwrap();
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "carried-model");
     }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -58,7 +58,7 @@ mod mcp_curated;
 pub mod media_type;
 mod model_registry;
 mod model_roles;
-mod obo_inference;
+mod obo_gateway;
 /// OpenAPI ingest into the bounded operation catalog a `rest_api` connected
 /// app stores and the governed REST executor validates against.
 pub mod openapi_catalog;
@@ -1669,9 +1669,10 @@ async fn bind_inner(
         store.clone(),
         secrets.clone(),
     )?);
-    // One instance, shared by the resolver that builds each caller's routes
-    // and the authentication middleware that records each caller's live token.
-    let on_behalf_of_inference = obo_inference::OboInference::from_config(&config)?;
+    // One instance, shared by the resolver that builds each caller's routes,
+    // the authentication middleware that records each caller's live token,
+    // and every surface that reads a caller's own entitlements (decision 62).
+    let on_behalf_of_gateway = obo_gateway::OboGateway::from_config(&config)?;
     let resolver = Arc::new(
         KeyedResolver::new(
             store.clone(),
@@ -1681,7 +1682,7 @@ async fn bind_inner(
             provisioned_policy.clone(),
             os_policy.clone(),
         )
-        .with_on_behalf_of_inference(on_behalf_of_inference.clone()),
+        .with_on_behalf_of_gateway(on_behalf_of_gateway.clone()),
     );
     // Under the `scripted-provider` feature only — absent from every released
     // binary — a scripted provider stands in for configured routing so a test
@@ -1793,7 +1794,7 @@ async fn bind_inner(
         provisioned_policy,
         os_policy,
     )?
-    .with_on_behalf_of_inference(on_behalf_of_inference);
+    .with_on_behalf_of_gateway(on_behalf_of_gateway);
     state.agent_run_wake = agent_run_wake;
     state.sandbox_attempts = sandbox_attempts;
     state.sandbox_steering = sandbox_steering;
@@ -1861,7 +1862,8 @@ async fn bind_inner(
         state.provisioned_policy.clone(),
         state.os_policy.clone(),
         state.approvals.clone(),
-    );
+    )
+    .with_on_behalf_of_gateway(state.on_behalf_of_gateway.clone());
     let blob_orphan_auditor = blob_orphan_auditor::BlobOrphanAuditor::new(
         state.store.clone(),
         state.config.data_dir.join("blobs"),
@@ -1888,6 +1890,7 @@ async fn bind_inner(
             ..turn_worker::TurnWorkerConfig::default()
         },
     )
+    .with_on_behalf_of_gateway(state.on_behalf_of_gateway.clone())
     .with_blobs(state.blobs.clone())
     .with_blob_write_locks(state.blob_writes.clone())
     .with_mcp_runtime(state.mcp.clone())

--- a/crates/tidebreak-server/src/model_roles.rs
+++ b/crates/tidebreak-server/src/model_roles.rs
@@ -166,6 +166,13 @@ pub async fn write_selection(
 /// for every managed install. The walk is the same shape either way: first
 /// usable wins, and nothing usable degrades to `None`.
 ///
+/// On a gateway-authenticated hosted machine, `caller_gateway` is the
+/// triggering caller's own entitlement snapshot (decision 62): background
+/// work runs as the caller whose turn asked for it, walking their entitled
+/// models the same way the managed walk covers a deployment's. Work with no
+/// caller to bill resolves to `None` and is skipped, never run as somebody
+/// else.
+///
 /// `None` means this install has no model for the role. Callers skip the work.
 pub async fn resolve(
     store: &dyn Store,
@@ -173,12 +180,45 @@ pub async fn resolve(
     provisioned_policy: &dyn crate::managed_policy::ProvisionedPolicySource,
     os_policy: &dyn crate::managed_policy::OsPolicySource,
     role: ModelRole,
+    caller_gateway: Option<&crate::providers::GatewayModelSnapshot>,
 ) -> Result<Option<ResolvedModelPolicy>> {
     let managed = crate::managed_policy::resolve(provisioned_policy, os_policy)?;
+    if let Some(snapshot) = caller_gateway.filter(|_| !managed.managed) {
+        // The hosted caller's walk: their explicit selection when their own
+        // catalog can serve it, else their entitled models cheapest-first —
+        // the same shape as the managed walk below, over their snapshot.
+        if let Some(selection) = read_selection(store, role).await? {
+            if let Some(policy) =
+                effective_chat_policy(store, secrets, &managed, &selection, true, caller_gateway)
+                    .await?
+            {
+                if role.supports_model(&policy) {
+                    return Ok(Some(policy));
+                }
+            }
+        }
+        if role.defaults().is_empty() {
+            return Ok(None);
+        }
+        let mut models: Vec<_> = snapshot.models.iter().collect();
+        models.sort_by_key(|model| model.context_window);
+        for model in models {
+            let key = crate::model_registry::selection_key(
+                providers::ProviderKind::ModelGateway,
+                &model.id,
+            );
+            if let Some(policy) = providers::gateway_execution_policy(snapshot, &key) {
+                if role.supports_model(&policy) {
+                    return Ok(Some(policy));
+                }
+            }
+        }
+        return Ok(None);
+    }
     if managed.managed {
         if let Some(selection) = read_selection(store, role).await? {
             if let Some(policy) =
-                effective_chat_policy(store, secrets, &managed, &selection, true).await?
+                effective_chat_policy(store, secrets, &managed, &selection, true, None).await?
             {
                 if role.supports_model(&policy) {
                     return Ok(Some(policy));
@@ -191,6 +231,7 @@ pub async fn resolve(
                 secrets,
                 providers::ProviderKind::ModelGateway,
                 &managed,
+                None,
             )
             .await?
         {
@@ -219,7 +260,7 @@ pub async fn resolve(
         // credential, or whose capabilities no longer satisfy the role, falls
         // through to the defaults rather than issuing a request that would
         // fail or silently skip the work.
-        if let Some(policy) = usable_policy(store, secrets, &managed, &selection).await? {
+        if let Some(policy) = usable_policy(store, secrets, &managed, &selection, None).await? {
             if role.supports_model(&policy) {
                 return Ok(Some(policy));
             }
@@ -234,7 +275,7 @@ pub async fn resolve(
         .map(|key| (*key).to_owned())
         .collect();
     for key in defaults {
-        if let Some(policy) = usable_policy(store, secrets, &managed, &key).await? {
+        if let Some(policy) = usable_policy(store, secrets, &managed, &key, None).await? {
             if role.supports_model(&policy) {
                 return Ok(Some(policy));
             }
@@ -264,12 +305,16 @@ pub async fn effective_chat_policy(
     managed: &crate::managed_policy::ManagedPolicy,
     selection: &str,
     explicit: bool,
+    caller_gateway: Option<&crate::providers::GatewayModelSnapshot>,
 ) -> Result<Option<ResolvedModelPolicy>> {
-    let resolved = providers::resolve_model_policy(store, selection, true).await?;
-    if !managed.managed {
+    let resolved = providers::resolve_model_policy(store, selection, true, caller_gateway).await?;
+    if !managed.managed && caller_gateway.is_none() {
         return Ok(resolved);
     }
-    let snapshot = providers::gateway_snapshot_for_policy(store, managed).await?;
+    // One shape for both gateway-bound profiles (decision 62): a managed
+    // profile freezes against the deployment-wide snapshot, a hosted caller
+    // against their own.
+    let snapshot = providers::gateway_snapshot_for(store, managed, caller_gateway).await?;
     let Some(snapshot) = snapshot.as_ref() else {
         return Ok(None);
     };
@@ -281,6 +326,7 @@ pub async fn effective_chat_policy(
             secrets,
             providers::ProviderKind::ModelGateway,
             managed,
+            caller_gateway,
         )
         .await?
         .then_some(equivalent));
@@ -294,6 +340,7 @@ pub async fn effective_chat_policy(
                     secrets,
                     providers::ProviderKind::ModelGateway,
                     managed,
+                    caller_gateway,
                 )
                 .await?
             {
@@ -309,6 +356,7 @@ pub async fn effective_chat_policy(
         secrets,
         providers::ProviderKind::ModelGateway,
         managed,
+        caller_gateway,
     )
     .await?
     {
@@ -328,13 +376,18 @@ async fn usable_policy(
     secrets: &dyn SecretProvider,
     managed: &crate::managed_policy::ManagedPolicy,
     selection: &str,
+    caller_gateway: Option<&crate::providers::GatewayModelSnapshot>,
 ) -> Result<Option<ResolvedModelPolicy>> {
-    let Some(policy) = providers::resolve_model_policy(store, selection, false).await? else {
+    let Some(policy) =
+        providers::resolve_model_policy(store, selection, false, caller_gateway).await?
+    else {
         return Ok(None);
     };
-    Ok(providers::model_is_usable(store, secrets, &policy, managed)
-        .await?
-        .then_some(policy))
+    Ok(
+        providers::model_is_usable(store, secrets, &policy, managed, caller_gateway)
+            .await?
+            .then_some(policy),
+    )
 }
 
 /// Resolve the `utility` role into the shape its callers carry.
@@ -349,9 +402,19 @@ pub async fn resolve_utility_model(
     secrets: &dyn SecretProvider,
     provisioned_policy: &dyn crate::managed_policy::ProvisionedPolicySource,
     os_policy: &dyn crate::managed_policy::OsPolicySource,
+    caller_gateway: Option<&crate::providers::GatewayModelSnapshot>,
 ) -> Result<Option<UtilityModel>> {
     let role = ModelRole::Utility;
-    let Some(policy) = resolve(store, secrets, provisioned_policy, os_policy, role).await? else {
+    let Some(policy) = resolve(
+        store,
+        secrets,
+        provisioned_policy,
+        os_policy,
+        role,
+        caller_gateway,
+    )
+    .await?
+    else {
         return Ok(None);
     };
     Ok(Some(UtilityModel {
@@ -435,7 +498,7 @@ mod tests {
         .await
         .unwrap();
 
-        let utility = resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy)
+        let utility = resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy, None)
             .await
             .unwrap()
             .expect("the capable Together default keeps utility work enabled");
@@ -452,7 +515,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let utility = resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy)
+        let utility = resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy, None)
             .await
             .unwrap()
             .expect("Kimi K3 supports the strict utility response contract");
@@ -498,7 +561,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy)
+            resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy, None)
                 .await
                 .unwrap()
                 .map(|model| model.model),
@@ -509,7 +572,7 @@ mod tests {
         // there is nothing to fall back to, so consumers skip their work.
         crate::managed_policy::provision(&*provisioned, "https://corp.gateway").unwrap();
         assert!(
-            resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy)
+            resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy, None)
                 .await
                 .unwrap()
                 .is_none()
@@ -561,7 +624,7 @@ mod tests {
         providers::write_gateway_snapshot(&*store, &snapshot)
             .await
             .unwrap();
-        let utility = resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy)
+        let utility = resolve_utility_model(&*store, &*secrets, &*provisioned, &os_policy, None)
             .await
             .unwrap()
             .expect("a managed profile resolves the utility role to a gateway model");

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -1,13 +1,19 @@
-//! On-behalf-of inference for gateway-authenticated hosted machines
-//! (`docs/decisions/0051-on-behalf-of-inference-for-hosted-machines.md`).
+//! Per-caller gateway capabilities for gateway-authenticated hosted machines
+//! (decisions 51 and 62).
 //!
 //! A hosted machine that authenticates callers against a Model Gateway
 //! (decision 49) already holds each caller's short-lived, machine-bound
-//! token. This module turns that token into inference authority for the same
-//! user: it exchanges the caller's bearer for a short-lived, inference-only
-//! gateway token and hands that token to the router as the credential for the
-//! caller's turns. The deployment needs no inference secret of its own, and
-//! the gateway meters every turn to the user who drove it.
+//! token. This module turns that token into two capabilities for the same
+//! user, each through the gateway's RFC 8693 exchange:
+//!
+//! - **Inference** (decision 51): a short-lived, inference-only token the
+//!   router presents as the credential for the caller's turns.
+//! - **Entitlements** (decision 62): a short-lived catalog capability that
+//!   reads the caller's own member catalog, so the picker offers exactly the
+//!   models their account entitles them to.
+//!
+//! The deployment needs no inference secret of its own, and the gateway
+//! meters every turn to the user who drove it.
 //!
 //! Three rules are load-bearing:
 //!
@@ -41,8 +47,24 @@ const EXPIRY_LEEWAY_SECONDS: u64 = 60;
 /// object; anything larger is a misconfigured endpoint, not a token.
 const RESPONSE_LIMIT: usize = 16 * 1024;
 
-/// The audience the exchanged token is minted for. Inference only.
+/// The audience the exchanged inference token is minted for.
 const INFERENCE_AUDIENCE: &str = "llm";
+
+/// The audience of the exchanged catalog capability (decision 62).
+const CATALOG_AUDIENCE: &str = "catalog";
+
+/// How long one caller's fetched catalog stays fresh before the next read
+/// revalidates it against the gateway.
+const CATALOG_FRESH_SECONDS: u64 = 300;
+
+/// How long a held catalog keeps serving after revalidation starts failing on
+/// transport. Refusals never coast on this grace: a revoked session stops the
+/// caller at the next revalidation.
+const CATALOG_STALE_GRACE_SECONDS: u64 = 3600;
+
+/// Cap on a member-catalog response body. Far above any real catalog, far
+/// below anything that could stall the process.
+const CATALOG_RESPONSE_LIMIT: usize = 1024 * 1024;
 
 /// The OAuth token-exchange grant the gateway accepts for this flow.
 const TOKEN_EXCHANGE_GRANT: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
@@ -80,6 +102,25 @@ impl CachedToken {
 struct UserSlot {
     subject: std::sync::Mutex<Arc<str>>,
     token: tokio::sync::Mutex<Option<CachedToken>>,
+    catalog: tokio::sync::Mutex<Option<CachedCatalog>>,
+}
+
+/// One caller's fetched entitlement snapshot and its revalidation state.
+struct CachedCatalog {
+    snapshot: crate::providers::GatewayModelSnapshot,
+    etag: Option<String>,
+    fetched_at_unix: u64,
+}
+
+/// What one member-catalog read came back as.
+enum CatalogFetch {
+    /// Unchanged since the `If-None-Match` revision the caller holds.
+    NotModified,
+    /// A fresh snapshot, with the `ETag` for the next conditional read.
+    Fresh {
+        snapshot: crate::providers::GatewayModelSnapshot,
+        etag: Option<String>,
+    },
 }
 
 /// The OAuth error shape the gateway returns for a refused exchange.
@@ -98,21 +139,26 @@ struct ExchangeResponse {
 
 /// Per-caller inference credentials for a gateway-authenticated deployment.
 ///
-/// Construct one per process with [`OboInference::from_config`], record each
-/// authenticated caller's bearer with [`OboInference::record_caller`], and ask
+/// Construct one per process with [`OboGateway::from_config`], record each
+/// authenticated caller's bearer with [`OboGateway::record_caller`], and ask
 /// for a caller's credential supplier with
-/// [`OboInference::token_source_for`].
-pub(crate) struct OboInference {
+/// [`OboGateway::token_source_for`].
+pub(crate) struct OboGateway {
     /// Where the exchange is POSTed. Honors the verifier override, because
     /// this is a server-to-server call like principal validation.
     token_url: reqwest::Url,
     /// Anthropic-compatible inference base for exchanged tokens.
     inference_base_url: String,
+    /// The member catalog a caller's exchanged capability reads.
+    catalog_url: reqwest::Url,
+    /// The normalized gateway base, stamped onto per-caller snapshots so
+    /// their frozen model identities digest a stable deployment URL.
+    gateway_base_url: String,
     client: reqwest::Client,
     users: std::sync::Mutex<HashMap<OwnerId, Arc<UserSlot>>>,
 }
 
-impl OboInference {
+impl OboGateway {
     /// Build the per-caller inference path this deployment's configuration
     /// asks for, or `None` when it asks for none.
     ///
@@ -149,6 +195,8 @@ impl OboInference {
         let base = normalized_gateway_base(base_url)?;
         let token_url = join_below(&base, "oauth/token")?;
         let inference_base_url = join_below(&base, "compat/anthropic")?.to_string();
+        let catalog_url = join_below(&base, "api/v1/me/catalog")?;
+        let gateway_base_url = base.as_str().trim_end_matches('/').to_owned();
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
             .redirect(reqwest::redirect::Policy::none())
@@ -159,9 +207,16 @@ impl OboInference {
         Ok(Self {
             token_url,
             inference_base_url,
+            catalog_url,
+            gateway_base_url,
             client,
             users: std::sync::Mutex::new(HashMap::new()),
         })
+    }
+
+    /// The normalized gateway base URL, as stamped onto per-caller snapshots.
+    pub(crate) fn gateway_base_url(&self) -> &str {
+        &self.gateway_base_url
     }
 
     /// The Anthropic-compatible base URL exchanged tokens authenticate against.
@@ -191,6 +246,7 @@ impl OboInference {
                     Arc::new(UserSlot {
                         subject: std::sync::Mutex::new(bearer),
                         token: tokio::sync::Mutex::new(None),
+                        catalog: tokio::sync::Mutex::new(None),
                     }),
                 );
             }
@@ -249,7 +305,7 @@ impl OboInference {
             })?;
             subject.clone()
         };
-        let minted = self.exchange(&subject).await?;
+        let minted = self.exchange(&subject, INFERENCE_AUDIENCE).await?;
         let token = minted.token.to_string();
         *cached = Some(minted);
         Ok(token)
@@ -262,12 +318,12 @@ impl OboInference {
     /// gone; that becomes the sign-in-required shape the client already
     /// handles. Every other non-success is a refusal too — this never retries
     /// onto another credential.
-    async fn exchange(&self, subject: &str) -> Result<CachedToken> {
+    async fn exchange(&self, subject: &str, audience: &str) -> Result<CachedToken> {
         let form: [(&str, &str); 4] = [
             ("grant_type", TOKEN_EXCHANGE_GRANT),
             ("subject_token", subject),
             ("subject_token_type", SUBJECT_TOKEN_TYPE),
-            ("audience", INFERENCE_AUDIENCE),
+            ("audience", audience),
         ];
         let response = self
             .client
@@ -279,7 +335,7 @@ impl OboInference {
                 AgentError::msg(format!("on-behalf-of token exchange failed: {error}"))
             })?;
         let status = response.status();
-        let body = read_bounded(response).await?;
+        let body = read_bounded(response, RESPONSE_LIMIT).await?;
         if !status.is_success() {
             return Err(exchange_refusal(&body));
         }
@@ -297,6 +353,203 @@ impl OboInference {
             token: exchanged.access_token.into(),
             expires_at_unix: unix_time().saturating_add(exchanged.expires_in),
         })
+    }
+
+    /// This caller's own entitled-model snapshot, read from the gateway's
+    /// member catalog with a `catalog` capability exchanged from their live
+    /// machine-bound token (decision 62).
+    ///
+    /// Fresh for [`CATALOG_FRESH_SECONDS`], then revalidated with the held
+    /// `ETag`. Revalidation that fails on transport keeps serving the held
+    /// snapshot for [`CATALOG_STALE_GRACE_SECONDS`] — the same user's
+    /// slightly stale entitlements, never another identity. A gateway
+    /// refusal always propagates instead: a revoked session stops the caller
+    /// at the next revalidation rather than coasting on grace.
+    ///
+    /// `Ok(None)` means this process has seen no live token for `owner`. The
+    /// caller is offered no gateway models, which fails closed.
+    ///
+    /// # Errors
+    /// Fails when the gateway refuses the exchange or the read, and on
+    /// transport failure with nothing inside the stale grace to serve.
+    pub(crate) async fn snapshot_for(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<Option<crate::providers::GatewayModelSnapshot>> {
+        let slot = {
+            let users = self.users.lock().map_err(|_| {
+                AgentError::msg("on-behalf-of gateway state is unavailable in this process")
+            })?;
+            users.get(owner).cloned()
+        };
+        let Some(slot) = slot else {
+            return Ok(None);
+        };
+        // Holding this across the fetch is the single-flight gate, exactly
+        // like the inference token: a second surface for the same caller
+        // waits here and then finds a fresh snapshot.
+        let mut cached = slot.catalog.lock().await;
+        let now = unix_time();
+        if let Some(held) = cached.as_ref() {
+            if now.saturating_sub(held.fetched_at_unix) < CATALOG_FRESH_SECONDS {
+                return Ok(Some(held.snapshot.clone()));
+            }
+        }
+        let subject = {
+            let subject = slot.subject.lock().map_err(|_| {
+                AgentError::msg("on-behalf-of gateway state is unavailable in this process")
+            })?;
+            subject.clone()
+        };
+        let held_etag = cached.as_ref().and_then(|held| held.etag.clone());
+        let outcome = async {
+            let capability = self.exchange(&subject, CATALOG_AUDIENCE).await?;
+            self.fetch_catalog(&capability.token, held_etag.as_deref())
+                .await
+        }
+        .await;
+        match outcome {
+            Ok(CatalogFetch::NotModified) => {
+                let Some(held) = cached.as_mut() else {
+                    // A 304 with nothing held is a protocol fault, not a
+                    // snapshot.
+                    return Err(AgentError::msg(
+                        "the Model Gateway answered not-modified to an unconditional catalog read",
+                    ));
+                };
+                held.fetched_at_unix = now;
+                Ok(Some(held.snapshot.clone()))
+            }
+            Ok(CatalogFetch::Fresh { snapshot, etag }) => {
+                *cached = Some(CachedCatalog {
+                    snapshot: snapshot.clone(),
+                    etag,
+                    fetched_at_unix: now,
+                });
+                Ok(Some(snapshot))
+            }
+            Err(error) => {
+                let refusal = matches!(
+                    error,
+                    AgentError::SignInRequired(_) | AgentError::InvalidTarget(_)
+                );
+                if !refusal {
+                    if let Some(held) = cached.as_ref() {
+                        if now.saturating_sub(held.fetched_at_unix) < CATALOG_STALE_GRACE_SECONDS {
+                            return Ok(Some(held.snapshot.clone()));
+                        }
+                    }
+                }
+                Err(error)
+            }
+        }
+    }
+
+    /// One member-catalog read with the exchanged capability.
+    ///
+    /// # Errors
+    /// `401`/`403` and `404` are refusals — a dead session and a gateway
+    /// without the route — and never fall back. Transport failures and other
+    /// statuses are transient and eligible for the caller's stale grace.
+    async fn fetch_catalog(
+        &self,
+        bearer: &str,
+        if_none_match: Option<&str>,
+    ) -> Result<CatalogFetch> {
+        let mut request = self
+            .client
+            .get(self.catalog_url.clone())
+            .bearer_auth(bearer);
+        if let Some(etag) = if_none_match {
+            request = request.header(reqwest::header::IF_NONE_MATCH, etag);
+        }
+        let response = request.send().await.map_err(|error| {
+            AgentError::msg(format!("the Model Gateway catalog read failed: {error}"))
+        })?;
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_MODIFIED {
+            return Ok(CatalogFetch::NotModified);
+        }
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(AgentError::InvalidTarget(
+                "the Model Gateway does not serve the member catalog; update the deployment".into(),
+            ));
+        }
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            return Err(AgentError::SignInRequired(
+                "the Model Gateway refused the catalog read for your session; sign in again".into(),
+            ));
+        }
+        let etag = response
+            .headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        let body = read_bounded(response, CATALOG_RESPONSE_LIMIT).await?;
+        if !status.is_success() {
+            return Err(AgentError::msg(format!(
+                "the Model Gateway catalog read failed with status {status}"
+            )));
+        }
+        let catalog: crate::connectors::GatewayCatalog =
+            serde_json::from_slice(&body).map_err(|error| {
+                AgentError::msg(format!(
+                    "the Model Gateway returned an unreadable catalog: {error}"
+                ))
+            })?;
+        let (models, model_protocols) = crate::providers::member_catalog_models(catalog);
+        // The gateway is trusted for entitlements, not for shapes: the
+        // caller's set is held to the same bounds as user-entered custom
+        // models, exactly like the managed sync.
+        crate::providers::validate_custom_models(&models).map_err(|error| {
+            AgentError::msg(format!("the Model Gateway catalog was rejected: {error:?}"))
+        })?;
+        Ok(CatalogFetch::Fresh {
+            snapshot: crate::providers::GatewayModelSnapshot {
+                gateway_url: self.gateway_base_url.clone(),
+                installation_id: None,
+                models,
+                model_protocols,
+                member_catalog: Some(crate::connectors::MEMBER_CATALOG_V1.to_owned()),
+                catalog_etag: etag.clone(),
+            },
+            etag,
+        })
+    }
+
+    /// Seed a caller's snapshot directly, for tests that need routes without
+    /// a live fake gateway behind them.
+    #[cfg(test)]
+    pub(crate) async fn seed_snapshot_for_test(
+        &self,
+        owner: &OwnerId,
+        snapshot: crate::providers::GatewayModelSnapshot,
+    ) {
+        let slot = {
+            let users = self.users.lock().unwrap();
+            users.get(owner).cloned()
+        };
+        if let Some(slot) = slot {
+            *slot.catalog.lock().await = Some(CachedCatalog {
+                snapshot,
+                etag: None,
+                fetched_at_unix: unix_time(),
+            });
+        }
+    }
+
+    /// Force the next [`OboGateway::snapshot_for`] to revalidate, from tests.
+    #[cfg(test)]
+    async fn expire_catalog_for_test(&self, owner: &OwnerId) {
+        let slot = {
+            let users = self.users.lock().unwrap();
+            users.get(owner).cloned()
+        };
+        if let Some(slot) = slot {
+            if let Some(held) = slot.catalog.lock().await.as_mut() {
+                held.fetched_at_unix = 0;
+            }
+        }
     }
 }
 
@@ -324,14 +577,14 @@ fn exchange_refusal(body: &[u8]) -> AgentError {
     }
 }
 
-/// Read at most [`RESPONSE_LIMIT`] bytes, refusing anything larger.
+/// Read at most `limit` bytes, refusing anything larger.
 ///
 /// # Errors
 /// Fails when the body is oversized or the connection breaks mid-read.
-async fn read_bounded(response: reqwest::Response) -> Result<Vec<u8>> {
+async fn read_bounded(response: reqwest::Response, limit: usize) -> Result<Vec<u8>> {
     if response
         .content_length()
-        .is_some_and(|length| length > RESPONSE_LIMIT as u64)
+        .is_some_and(|length| length > limit as u64)
     {
         return Err(AgentError::msg(
             "the Model Gateway token exchange response exceeded the size limit",
@@ -345,7 +598,7 @@ async fn read_bounded(response: reqwest::Response) -> Result<Vec<u8>> {
                 "the Model Gateway token exchange response failed: {error}"
             ))
         })?;
-        if bytes.len().saturating_add(chunk.len()) > RESPONSE_LIMIT {
+        if bytes.len().saturating_add(chunk.len()) > limit {
             return Err(AgentError::msg(
                 "the Model Gateway token exchange response exceeded the size limit",
             ));
@@ -410,7 +663,7 @@ fn join_below(base: &reqwest::Url, path: &str) -> Result<reqwest::Url> {
 /// mid-turn is replaced without rebuilding the route, and a session revoked
 /// mid-turn fails the next request closed.
 struct OboTokenSource {
-    inference: Arc<OboInference>,
+    inference: Arc<OboGateway>,
     owner: OwnerId,
 }
 
@@ -448,6 +701,10 @@ mod tests {
         refusal: Arc<std::sync::Mutex<String>>,
         /// How long each exchange takes to answer.
         latency: Duration,
+        /// How many member-catalog reads it has served (304s included).
+        catalog_reads: Arc<AtomicUsize>,
+        /// The member catalog it serves, with a fixed `ETag` of `"fake-1"`.
+        catalog: Arc<std::sync::Mutex<serde_json::Value>>,
     }
 
     impl FakeGateway {
@@ -457,6 +714,34 @@ mod tests {
                 lifetime: Arc::new(AtomicUsize::new(3600)),
                 refusal: Arc::new(std::sync::Mutex::new(String::new())),
                 latency: Duration::ZERO,
+                catalog_reads: Arc::new(AtomicUsize::new(0)),
+                catalog: Arc::new(std::sync::Mutex::new(serde_json::json!({
+                    "models": [
+                        {
+                            "id": "acme-opus",
+                            "name": "Acme Opus",
+                            "protocols": ["anthropic_messages"],
+                            "aliases": [],
+                            "supports_tools": true,
+                            "supports_vision": true,
+                            "context_window": 200_000,
+                            "max_output_tokens": 32_000,
+                            "provider_name": "Anthropic",
+                        },
+                        {
+                            "id": "acme-gpt",
+                            "name": "Acme GPT",
+                            "protocols": ["openai_responses"],
+                            "aliases": [],
+                            "supports_tools": true,
+                            "supports_vision": false,
+                            "context_window": 128_000,
+                            "max_output_tokens": 16_000,
+                            "provider_name": "OpenAI",
+                        },
+                    ],
+                    "apps": [],
+                }))),
             }
         }
 
@@ -472,7 +757,7 @@ mod tests {
 
         /// Serve this gateway on loopback and return an exchange client
         /// pointed at it, plus the running server's handle.
-        async fn start(self) -> (Arc<OboInference>, tokio::task::JoinHandle<()>) {
+        async fn start(self) -> (Arc<OboGateway>, tokio::task::JoinHandle<()>) {
             let state = self.clone();
             let app = Router::new().route(
                 "/oauth/token",
@@ -490,9 +775,10 @@ mod tests {
                             form.get("subject_token_type").map(String::as_str),
                             Some(SUBJECT_TOKEN_TYPE)
                         );
-                        assert_eq!(
-                            form.get("audience").map(String::as_str),
-                            Some(INFERENCE_AUDIENCE)
+                        let audience = form.get("audience").cloned().unwrap_or_default();
+                        assert!(
+                            audience == INFERENCE_AUDIENCE || audience == CATALOG_AUDIENCE,
+                            "unexpected audience {audience:?}"
                         );
                         let subject = form
                             .get("subject_token")
@@ -519,8 +805,13 @@ mod tests {
                                 .into_response();
                         }
                         let serial = state.mints.fetch_add(1, Ordering::SeqCst);
+                        let label = if audience == CATALOG_AUDIENCE {
+                            "catalog"
+                        } else {
+                            "inference"
+                        };
                         Json(serde_json::json!({
-                            "access_token": format!("mg_at_inference_{serial}_for_{subject}"),
+                            "access_token": format!("mg_at_{label}_{serial}_for_{subject}"),
                             "token_type": "Bearer",
                             "expires_in": state.lifetime.load(Ordering::SeqCst),
                             "scope": "inference:invoke",
@@ -529,12 +820,49 @@ mod tests {
                     }
                 }),
             );
+            let catalog_state = self.clone();
+            let app = app.route(
+                "/api/v1/me/catalog",
+                axum::routing::get(move |headers: axum::http::HeaderMap| {
+                    let state = catalog_state.clone();
+                    async move {
+                        // The read must ride an exchanged catalog capability,
+                        // never the machine-bound subject or an inference
+                        // token — asserted server-side so a drifted client
+                        // fails the test.
+                        let bearer = headers
+                            .get(axum::http::header::AUTHORIZATION)
+                            .and_then(|value| value.to_str().ok())
+                            .and_then(|value| value.strip_prefix("Bearer "))
+                            .unwrap_or_default()
+                            .to_owned();
+                        assert!(
+                            bearer.starts_with("mg_at_catalog_"),
+                            "the catalog read must present a catalog capability, got {bearer:?}"
+                        );
+                        state.catalog_reads.fetch_add(1, Ordering::SeqCst);
+                        if headers
+                            .get(axum::http::header::IF_NONE_MATCH)
+                            .and_then(|value| value.to_str().ok())
+                            == Some("\"fake-1\"")
+                        {
+                            return axum::http::StatusCode::NOT_MODIFIED.into_response();
+                        }
+                        let body = state
+                            .catalog
+                            .lock()
+                            .map(|catalog| catalog.clone())
+                            .unwrap_or_default();
+                        ([(axum::http::header::ETAG, "\"fake-1\"")], Json(body)).into_response()
+                    }
+                }),
+            );
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
             let address = listener.local_addr().unwrap();
             let server = tokio::spawn(async move {
                 axum::serve(listener, app).await.unwrap();
             });
-            let inference = Arc::new(OboInference::new(&format!("http://{address}")).unwrap());
+            let inference = Arc::new(OboGateway::new(&format!("http://{address}")).unwrap());
             (inference, server)
         }
     }
@@ -778,19 +1106,19 @@ mod tests {
         config.profile = Profile::Desktop;
         config.auth_gateway_url = Some("https://gateway.example".to_owned());
         assert!(
-            OboInference::from_config(&config).unwrap().is_none(),
+            OboGateway::from_config(&config).unwrap().is_none(),
             "the desktop profile is unchanged"
         );
 
         config.profile = Profile::SelfHost;
         config.auth_gateway_url = None;
         assert!(
-            OboInference::from_config(&config).unwrap().is_none(),
+            OboGateway::from_config(&config).unwrap().is_none(),
             "a static-token server is unchanged"
         );
 
         config.auth_gateway_url = Some("https://gateway.example".to_owned());
-        let inference = OboInference::from_config(&config).unwrap().unwrap();
+        let inference = OboGateway::from_config(&config).unwrap().unwrap();
         assert_eq!(
             inference.inference_base_url(),
             "https://gateway.example/compat/anthropic"
@@ -807,7 +1135,7 @@ mod tests {
         config.auth_gateway_url = Some("https://public.example".to_owned());
         config.auth_gateway_verifier_url = Some("https://gateway.internal".to_owned());
 
-        let inference = OboInference::from_config(&config).unwrap().unwrap();
+        let inference = OboGateway::from_config(&config).unwrap().unwrap();
         assert_eq!(
             inference.token_url.as_str(),
             "https://gateway.internal/oauth/token"
@@ -821,7 +1149,7 @@ mod tests {
     /// A gateway deployed under a subpath keeps its prefix.
     #[test]
     fn a_subpath_deployment_keeps_its_prefix() {
-        let inference = OboInference::new("https://example.test/gateway").unwrap();
+        let inference = OboGateway::new("https://example.test/gateway").unwrap();
         assert_eq!(
             inference.token_url.as_str(),
             "https://example.test/gateway/oauth/token"
@@ -836,9 +1164,118 @@ mod tests {
     /// assembly, not at the first turn.
     #[test]
     fn an_unusable_gateway_url_is_refused_at_assembly() {
-        assert!(OboInference::new("https://user:pass@example.test").is_err());
-        assert!(OboInference::new("https://example.test?probe=1").is_err());
-        assert!(OboInference::new("http://gateway.example").is_err());
-        assert!(OboInference::new("http://127.0.0.1:8080").is_ok());
+        assert!(OboGateway::new("https://user:pass@example.test").is_err());
+        assert!(OboGateway::new("https://example.test?probe=1").is_err());
+        assert!(OboGateway::new("http://gateway.example").is_err());
+        assert!(OboGateway::new("http://127.0.0.1:8080").is_ok());
+    }
+
+    /// Decision 62's happy path: a recorded caller's snapshot is their own
+    /// member catalog, read with an exchanged catalog capability and shaped
+    /// exactly like the managed sync would store it.
+    #[tokio::test]
+    async fn a_caller_reads_their_own_entitlement_snapshot() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        obo.record_caller(&alice, "mg_at_alice".into());
+
+        let snapshot = obo.snapshot_for(&alice).await.unwrap().unwrap();
+        assert_eq!(snapshot.gateway_url, obo.gateway_base_url());
+        let ids: Vec<_> = snapshot
+            .models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect();
+        assert_eq!(ids, ["acme-opus", "acme-gpt"]);
+        assert_eq!(
+            snapshot.model_protocols.get("acme-gpt").copied(),
+            Some(crate::providers::GatewayModelProtocol::OpenaiResponses)
+        );
+        assert_eq!(gateway.catalog_reads.load(Ordering::SeqCst), 1);
+        assert_eq!(gateway.served(), 1, "one catalog capability was minted");
+        server.abort();
+    }
+
+    /// A fresh snapshot is served from memory; an expired one revalidates
+    /// with the held `ETag` and keeps the snapshot on not-modified.
+    #[tokio::test]
+    async fn a_fresh_snapshot_is_memory_and_a_stale_one_revalidates() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        obo.record_caller(&alice, "mg_at_alice".into());
+
+        let first = obo.snapshot_for(&alice).await.unwrap().unwrap();
+        let second = obo.snapshot_for(&alice).await.unwrap().unwrap();
+        assert_eq!(first.models.len(), second.models.len());
+        assert_eq!(
+            gateway.catalog_reads.load(Ordering::SeqCst),
+            1,
+            "a fresh snapshot must not refetch"
+        );
+
+        obo.expire_catalog_for_test(&alice).await;
+        let third = obo.snapshot_for(&alice).await.unwrap().unwrap();
+        assert_eq!(third.models.len(), first.models.len());
+        assert_eq!(
+            gateway.catalog_reads.load(Ordering::SeqCst),
+            2,
+            "a stale snapshot must revalidate"
+        );
+        server.abort();
+    }
+
+    /// A caller this process has never authenticated has no snapshot, which
+    /// offers them no models rather than somebody else's.
+    #[tokio::test]
+    async fn an_unknown_caller_has_no_snapshot() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let stranger = owner("user:stranger");
+        assert!(obo.snapshot_for(&stranger).await.unwrap().is_none());
+        assert_eq!(gateway.served(), 0);
+        server.abort();
+    }
+
+    /// A refused exchange stops the catalog too: a revoked session becomes
+    /// sign-in-required, and nothing is served on grace past a refusal.
+    #[tokio::test]
+    async fn a_dead_session_stops_the_catalog_closed() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        obo.record_caller(&alice, "mg_at_alice".into());
+        obo.snapshot_for(&alice).await.unwrap().unwrap();
+
+        gateway.refuse_with("invalid_grant");
+        obo.expire_catalog_for_test(&alice).await;
+        let error = obo.snapshot_for(&alice).await.unwrap_err();
+        assert!(
+            matches!(error, AgentError::SignInRequired(_)),
+            "expected sign-in-required, got {error:?}"
+        );
+        server.abort();
+    }
+
+    /// Two callers hold two snapshots: one caller's fetch never serves the
+    /// other's surfaces.
+    #[tokio::test]
+    async fn each_caller_holds_their_own_snapshot() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        let bob = owner("user:bob");
+        obo.record_caller(&alice, "mg_at_alice".into());
+        obo.record_caller(&bob, "mg_at_bob".into());
+
+        obo.snapshot_for(&alice).await.unwrap().unwrap();
+        obo.snapshot_for(&bob).await.unwrap().unwrap();
+        assert_eq!(
+            gateway.catalog_reads.load(Ordering::SeqCst),
+            2,
+            "each caller fetches their own catalog"
+        );
+        server.abort();
     }
 }

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -147,8 +147,6 @@ pub(crate) struct OboGateway {
     /// Where the exchange is POSTed. Honors the verifier override, because
     /// this is a server-to-server call like principal validation.
     token_url: reqwest::Url,
-    /// Anthropic-compatible inference base for exchanged tokens.
-    inference_base_url: String,
     /// The member catalog a caller's exchanged capability reads.
     catalog_url: reqwest::Url,
     /// The normalized gateway base, stamped onto per-caller snapshots so
@@ -194,7 +192,6 @@ impl OboGateway {
     pub(crate) fn new(base_url: &str) -> Result<Self> {
         let base = normalized_gateway_base(base_url)?;
         let token_url = join_below(&base, "oauth/token")?;
-        let inference_base_url = join_below(&base, "compat/anthropic")?.to_string();
         let catalog_url = join_below(&base, "api/v1/me/catalog")?;
         let gateway_base_url = base.as_str().trim_end_matches('/').to_owned();
         let client = reqwest::Client::builder()
@@ -206,7 +203,6 @@ impl OboGateway {
             })?;
         Ok(Self {
             token_url,
-            inference_base_url,
             catalog_url,
             gateway_base_url,
             client,
@@ -217,11 +213,6 @@ impl OboGateway {
     /// The normalized gateway base URL, as stamped onto per-caller snapshots.
     pub(crate) fn gateway_base_url(&self) -> &str {
         &self.gateway_base_url
-    }
-
-    /// The Anthropic-compatible base URL exchanged tokens authenticate against.
-    pub(crate) fn inference_base_url(&self) -> &str {
-        &self.inference_base_url
     }
 
     /// Remember the bearer `owner` just authenticated with.
@@ -886,9 +877,6 @@ mod tests {
         let token = inference.bearer_for(&alice).await.unwrap();
         assert!(token.starts_with("mg_at_inference_"));
         assert!(token.ends_with("mg_at_alice"));
-        assert!(inference
-            .inference_base_url()
-            .ends_with("/compat/anthropic"));
         assert_eq!(gateway.served(), 1);
         server.abort();
     }
@@ -1119,10 +1107,7 @@ mod tests {
 
         config.auth_gateway_url = Some("https://gateway.example".to_owned());
         let inference = OboGateway::from_config(&config).unwrap().unwrap();
-        assert_eq!(
-            inference.inference_base_url(),
-            "https://gateway.example/compat/anthropic"
-        );
+        assert_eq!(inference.gateway_base_url(), "https://gateway.example");
     }
 
     /// The exchange is a server-to-server call, so it honors the same
@@ -1140,10 +1125,7 @@ mod tests {
             inference.token_url.as_str(),
             "https://gateway.internal/oauth/token"
         );
-        assert_eq!(
-            inference.inference_base_url(),
-            "https://gateway.internal/compat/anthropic"
-        );
+        assert_eq!(inference.gateway_base_url(), "https://gateway.internal");
     }
 
     /// A gateway deployed under a subpath keeps its prefix.
@@ -1154,10 +1136,7 @@ mod tests {
             inference.token_url.as_str(),
             "https://example.test/gateway/oauth/token"
         );
-        assert_eq!(
-            inference.inference_base_url(),
-            "https://example.test/gateway/compat/anthropic"
-        );
+        assert_eq!(inference.gateway_base_url(), "https://example.test/gateway");
     }
 
     /// A URL that cannot carry a server-to-server credential is refused at

--- a/crates/tidebreak-server/src/pairing.rs
+++ b/crates/tidebreak-server/src/pairing.rs
@@ -815,7 +815,7 @@ mod tests {
 
         // The stale snapshot carries the old deployment's stamp, so the new
         // policy reads no models until sign-in resyncs the entitled set.
-        assert!(providers::gateway_models(&*store, &policy)
+        assert!(providers::gateway_models(&*store, &policy, None)
             .await
             .unwrap()
             .is_empty());

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -159,17 +159,92 @@ pub(crate) async fn write_gateway_snapshot(
         .await
 }
 
-/// The entitled models of the gateway the resolved policy names: empty for
-/// an unmanaged profile, for a misconfigured policy, and for a snapshot
-/// stamped by a different deployment.
+/// Convert a member catalog (`/api/v1/me/catalog`) into snapshot rows.
+///
+/// One conversion for both consumers — the deployment-wide managed sync and
+/// the per-caller hosted fetch (decision 62) — so a model a hosted caller is
+/// offered is shaped exactly like a model the sync would have stored.
+pub(crate) fn member_catalog_models(
+    catalog: crate::connectors::GatewayCatalog,
+) -> (
+    Vec<CustomModelConfig>,
+    BTreeMap<String, GatewayModelProtocol>,
+) {
+    let mut model_protocols = BTreeMap::new();
+    let models = catalog
+        .models
+        .into_iter()
+        .filter_map(|model| {
+            let protocols: Vec<_> = model
+                .protocols
+                .iter()
+                .filter_map(|protocol| GatewayModelProtocol::parse(protocol))
+                .collect();
+            // A dual-protocol model routes through Anthropic Messages, the
+            // richer adapter; a model with no protocol this client speaks is
+            // skipped, exactly as on the older surface.
+            let protocol = if protocols.contains(&GatewayModelProtocol::AnthropicMessages) {
+                GatewayModelProtocol::AnthropicMessages
+            } else {
+                *protocols.first()?
+            };
+            let id = model.id;
+            model_protocols.insert(id.clone(), protocol);
+            Some(CustomModelConfig {
+                id,
+                display_name: Some(model.name),
+                // The catalog reports gateway-id aliases instead of the
+                // provider-side id; both exist to match a curated row.
+                upstream_id: None,
+                aliases: model.aliases,
+                context_window: clamp_u32(model.context_window, 32_768),
+                max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
+                input_modalities: vec![crate::model_registry::InputModality::Text],
+                supports_reasoning: false,
+                reasoning_efforts: Vec::new(),
+            })
+        })
+        .collect();
+    (models, model_protocols)
+}
+
+/// Clamp a gateway-reported limit into the u32 the config carries; zero and
+/// out-of-range values fall back to the default.
+pub(crate) fn clamp_u32(value: Option<i64>, default: u32) -> u32 {
+    value
+        .and_then(|value| u32::try_from(value).ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+/// The entitled models of the gateway serving the current caller: the managed
+/// deployment-wide snapshot, or the caller's own snapshot on a hosted machine
+/// (decision 62). Empty for an unmanaged profile with no caller snapshot, a
+/// misconfigured policy, and a snapshot stamped by a different deployment.
 pub(crate) async fn gateway_models(
     store: &dyn Store,
     policy: &crate::managed_policy::ManagedPolicy,
+    caller_gateway: Option<&GatewayModelSnapshot>,
 ) -> Result<Vec<CustomModelConfig>> {
-    Ok(gateway_snapshot_for_policy(store, policy)
+    Ok(gateway_snapshot_for(store, policy, caller_gateway)
         .await?
         .map(|snapshot| snapshot.models)
         .unwrap_or_default())
+}
+
+/// The gateway snapshot the current caller's surfaces read: the managed
+/// deployment-wide snapshot, or — on a gateway-authenticated hosted machine —
+/// the caller's own entitlements, resolved per request and held only in
+/// process memory (decision 62).
+pub(crate) async fn gateway_snapshot_for(
+    store: &dyn Store,
+    policy: &crate::managed_policy::ManagedPolicy,
+    caller_gateway: Option<&GatewayModelSnapshot>,
+) -> Result<Option<GatewayModelSnapshot>> {
+    if policy.managed {
+        return gateway_snapshot_for_policy(store, policy).await;
+    }
+    Ok(caller_gateway.cloned())
 }
 
 pub(crate) async fn gateway_snapshot_for_policy(
@@ -1495,11 +1570,30 @@ pub async fn list_providers(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
     policy: &crate::managed_policy::ManagedPolicy,
+    caller_gateway: Option<&GatewayModelSnapshot>,
 ) -> Result<Vec<ProviderInfo>> {
     let mut out = Vec::with_capacity(ProviderKind::ALL.len());
     for &kind in ProviderKind::ALL {
         if kind == ProviderKind::ModelGateway {
             if !policy.managed {
+                // A hosted machine reports the caller's own gateway: present
+                // exactly when their entitlement snapshot resolved, with
+                // their models (decision 62). Absent on every other
+                // unmanaged profile.
+                let Some(snapshot) = caller_gateway else {
+                    continue;
+                };
+                out.push(ProviderInfo {
+                    kind,
+                    enabled: true,
+                    base_url: policy
+                        .hosted_gateway_url
+                        .clone()
+                        .or_else(|| Some(snapshot.gateway_url.clone())),
+                    has_credential: true,
+                    auth_mode: None,
+                    models: snapshot.models.clone(),
+                });
                 continue;
             }
             out.push(ProviderInfo {
@@ -1515,7 +1609,7 @@ pub async fn list_providers(
                     None => false,
                 },
                 auth_mode: None,
-                models: gateway_models(store, policy).await?,
+                models: gateway_models(store, policy, caller_gateway).await?,
             });
             continue;
         }
@@ -1873,13 +1967,17 @@ pub fn route_kind(kind: ProviderKind) -> tidebreak_router::RouteKind {
     }
 }
 
-/// A per-caller inference path offered where the deployment states no other
-/// one: the caller's rotating credential and the base URL it authenticates
-/// against.
-pub type OnBehalfOfInference = (
-    std::sync::Arc<dyn tidebreak_router::BearerTokenSource>,
-    String,
-);
+/// A hosted caller's gateway path: their rotating inference credential, the
+/// gateway base it authenticates against, and their own entitlement snapshot
+/// (decision 62). Resolved per caller and held only in process memory.
+pub struct OnBehalfOfGateway {
+    /// The caller's exchanged inference credential (decision 51).
+    pub source: std::sync::Arc<dyn tidebreak_router::BearerTokenSource>,
+    /// The gateway base URL the compat routes are joined below.
+    pub gateway_base_url: String,
+    /// The caller's own entitled models, from their member catalog.
+    pub snapshot: GatewayModelSnapshot,
+}
 
 /// Collect enabled, credentialed routes for the composite router.
 ///
@@ -1895,10 +1993,12 @@ pub type OnBehalfOfInference = (
 /// all: policy is the only gateway source, and a legacy stored row is never
 /// read.
 ///
-/// `on_behalf_of` is the hosted machine's per-caller credential (decision 51).
-/// It becomes an Anthropic route only where the deployment states no other
-/// inference path for that provider — see
-/// [`on_behalf_of_states_the_only_path`].
+/// `on_behalf_of` is a hosted machine's per-caller gateway path (decisions 51
+/// and 62): the caller's exchanged credential and their own entitlement
+/// snapshot become the same per-protocol gateway routes a managed profile
+/// gets from its deployment-wide snapshot. No caller means no gateway route,
+/// which fails an unnamed turn closed rather than running it as somebody
+/// else.
 pub async fn collect_routes(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
@@ -1907,13 +2007,29 @@ pub async fn collect_routes(
         std::sync::Arc<dyn tidebreak_router::BearerTokenSource>,
         String,
     )>,
-    on_behalf_of: Option<OnBehalfOfInference>,
+    on_behalf_of: Option<OnBehalfOfGateway>,
     policy: &crate::managed_policy::ManagedPolicy,
 ) -> Vec<tidebreak_router::Route> {
     let mut routes = Vec::new();
     for &kind in ProviderKind::ALL {
         if kind == ProviderKind::ModelGateway {
             if !policy.managed {
+                // A gateway-authenticated hosted machine routes each caller
+                // through their own entitlements and credential (decision
+                // 62). The routes are the same shape a managed profile gets —
+                // both compat protocols, frozen identities included — built
+                // from the caller's snapshot instead of the deployment-wide
+                // one. No caller path means no gateway route, which fails an
+                // unnamed turn closed rather than running it as somebody
+                // else.
+                let Some(obo) = on_behalf_of.as_ref() else {
+                    continue;
+                };
+                routes.extend(gateway_snapshot_routes(
+                    Some(&obo.snapshot),
+                    obo.gateway_base_url.trim_end_matches('/'),
+                    obo.source.clone(),
+                ));
                 continue;
             }
             // The gateway route rides its live token source; without a signed-in
@@ -1931,96 +2047,15 @@ pub async fn collect_routes(
                 .await
                 .unwrap_or_default()
                 .filter(|snapshot| snapshot.installation_id.as_deref() == source.binding_id());
-            let mut anthropic_models = Vec::new();
-            let mut openai_models = Vec::new();
-            let mut anthropic_rewrites = HashMap::new();
-            let mut openai_rewrites = HashMap::new();
-            if let Some(snapshot) = snapshot.as_ref() {
-                for model in &snapshot.models {
-                    let protocol = snapshot
-                        .model_protocols
-                        .get(&model.id)
-                        .copied()
-                        .unwrap_or_default();
-                    let frozen = frozen_gateway_route_model(snapshot, model, protocol);
-                    match protocol {
-                        GatewayModelProtocol::AnthropicMessages => {
-                            anthropic_models.push(model.id.clone());
-                            anthropic_models.push(frozen.clone());
-                            anthropic_rewrites.insert(frozen, model.id.clone());
-                        }
-                        GatewayModelProtocol::OpenaiResponses => {
-                            openai_models.push(model.id.clone());
-                            openai_models.push(frozen.clone());
-                            openai_rewrites.insert(frozen, model.id.clone());
-                        }
-                    }
-                }
-            }
-            let base = base.trim_end_matches('/');
-            // Preserve the pre-protocol route shape before the first sync (or
-            // for an empty entitlement set): it still selects no model, but a
-            // signed-in managed profile has one inert gateway adapter rather
-            // than looking indistinguishable from missing credentials.
-            if anthropic_models.is_empty() && openai_models.is_empty() {
-                routes.push(tidebreak_router::Route {
-                    kind: route_kind(kind),
-                    api_key: String::new(),
-                    base_url: Some(format!("{base}/compat/anthropic")),
-                    curated_models: Vec::new(),
-                    model_rewrites: HashMap::new(),
-                    token_source: Some(source),
-                    chatgpt_account_id: None,
-                });
-            } else {
-                if !anthropic_models.is_empty() {
-                    routes.push(tidebreak_router::Route {
-                        kind: route_kind(kind),
-                        api_key: String::new(),
-                        base_url: Some(format!("{base}/compat/anthropic")),
-                        curated_models: anthropic_models,
-                        model_rewrites: anthropic_rewrites,
-                        token_source: Some(source.clone()),
-                        chatgpt_account_id: None,
-                    });
-                }
-                if !openai_models.is_empty() {
-                    routes.push(tidebreak_router::Route {
-                        kind: tidebreak_router::RouteKind::ModelGatewayOpenai,
-                        api_key: String::new(),
-                        base_url: Some(format!("{base}/compat/openai/v1")),
-                        curated_models: openai_models,
-                        model_rewrites: openai_rewrites,
-                        token_source: Some(source),
-                        chatgpt_account_id: None,
-                    });
-                }
-            }
+            routes.extend(gateway_snapshot_routes(
+                snapshot.as_ref(),
+                base.trim_end_matches('/'),
+                source,
+            ));
             continue;
         }
         if policy.managed {
             continue;
-        }
-        // A hosted machine resolves this provider per caller only where the
-        // deployment states no other path to it (decision 51, rule 3).
-        if kind == ON_BEHALF_OF_PROVIDER {
-            if let Some((source, base_url)) = on_behalf_of.clone() {
-                if on_behalf_of_states_the_only_path(store, secrets, kind).await {
-                    routes.push(tidebreak_router::Route {
-                        kind: route_kind(kind),
-                        // The credential rotates; there is no key to snapshot.
-                        api_key: String::new(),
-                        base_url: Some(base_url),
-                        curated_models: model_registry::models_for(kind)
-                            .map(|spec| spec.id.to_string())
-                            .collect(),
-                        model_rewrites: HashMap::new(),
-                        token_source: Some(source),
-                        chatgpt_account_id: None,
-                    });
-                    continue;
-                }
-            }
         }
         let config = match read_config(store, kind).await {
             Ok(c) => c,
@@ -2100,68 +2135,79 @@ pub async fn collect_routes(
     routes
 }
 
-/// The provider a hosted machine's on-behalf-of route serves.
-///
-/// One statement of it, read by both halves that must agree: the route
-/// [`collect_routes`] builds, and the availability
-/// [`provider_is_usable`] reports for it. The gateway's Anthropic-compatible
-/// surface is what an exchanged inference token authenticates against
-/// ([`crate::obo_inference::OboInference::inference_base_url`]).
-const ON_BEHALF_OF_PROVIDER: ProviderKind = ProviderKind::Anthropic;
-
-/// Whether this deployment serves `kind` with the caller's own gateway
-/// credential.
-///
-/// True only on a gateway-authenticated hosted machine, only for the provider
-/// the on-behalf-of route serves, and only where the deployment states no
-/// other path to it (decision 51, rule 3).
-///
-/// This reads the policy projection where [`collect_routes`] reads the
-/// runtime handle, and the two agree by construction: `OboInference` is
-/// assembled for exactly the configuration `Config::hosted_gateway_url`
-/// answers for. Disagreement would show a caller a model no route serves.
-async fn on_behalf_of_is_the_path(
-    store: &dyn Store,
-    secrets: &dyn SecretProvider,
-    kind: ProviderKind,
-    policy: &crate::managed_policy::ManagedPolicy,
-) -> bool {
-    if policy.managed || policy.hosted_gateway_url.is_none() {
-        return false;
+/// Routes for one gateway snapshot: a per-protocol compat route carrying both
+/// the raw and frozen model ids, or one inert Anthropic-compat route for an
+/// empty snapshot — it still selects no model, but a signed-in profile then
+/// has one gateway adapter rather than looking indistinguishable from
+/// missing credentials. One builder for both snapshot sources, so a hosted
+/// caller's routes and a managed profile's cannot drift apart (decision 62).
+fn gateway_snapshot_routes(
+    snapshot: Option<&GatewayModelSnapshot>,
+    base: &str,
+    source: std::sync::Arc<dyn tidebreak_router::BearerTokenSource>,
+) -> Vec<tidebreak_router::Route> {
+    let mut routes = Vec::new();
+    let mut anthropic_models = Vec::new();
+    let mut openai_models = Vec::new();
+    let mut anthropic_rewrites = HashMap::new();
+    let mut openai_rewrites = HashMap::new();
+    if let Some(snapshot) = snapshot {
+        for model in &snapshot.models {
+            let protocol = snapshot
+                .model_protocols
+                .get(&model.id)
+                .copied()
+                .unwrap_or_default();
+            let frozen = frozen_gateway_route_model(snapshot, model, protocol);
+            match protocol {
+                GatewayModelProtocol::AnthropicMessages => {
+                    anthropic_models.push(model.id.clone());
+                    anthropic_models.push(frozen.clone());
+                    anthropic_rewrites.insert(frozen, model.id.clone());
+                }
+                GatewayModelProtocol::OpenaiResponses => {
+                    openai_models.push(model.id.clone());
+                    openai_models.push(frozen.clone());
+                    openai_rewrites.insert(frozen, model.id.clone());
+                }
+            }
+        }
     }
-    if kind != ON_BEHALF_OF_PROVIDER {
-        return false;
+    if anthropic_models.is_empty() && openai_models.is_empty() {
+        routes.push(tidebreak_router::Route {
+            kind: tidebreak_router::RouteKind::ModelGateway,
+            api_key: String::new(),
+            base_url: Some(format!("{base}/compat/anthropic")),
+            curated_models: Vec::new(),
+            model_rewrites: HashMap::new(),
+            token_source: Some(source),
+            chatgpt_account_id: None,
+        });
+        return routes;
     }
-    on_behalf_of_states_the_only_path(store, secrets, kind).await
-}
-
-/// Whether per-caller inference is the only path this deployment states to
-/// `kind`.
-///
-/// Three statements outrank it, in the order a deployment makes them: a stored
-/// provider configuration row, a stored credential, and the environment
-/// fallbacks for the credential and the base URL. Any one of them means the
-/// operator has named an inference path, and decision 51 leaves it in force —
-/// including a row that disables the provider outright.
-///
-/// Every read failure answers `false`, so an unreadable store or secret skips
-/// the provider rather than routing a caller's turn on a guess.
-async fn on_behalf_of_states_the_only_path(
-    store: &dyn Store,
-    secrets: &dyn SecretProvider,
-    kind: ProviderKind,
-) -> bool {
-    if !matches!(store.get_setting(&kind.setting_key()).await, Ok(None)) {
-        return false;
+    if !anthropic_models.is_empty() {
+        routes.push(tidebreak_router::Route {
+            kind: tidebreak_router::RouteKind::ModelGateway,
+            api_key: String::new(),
+            base_url: Some(format!("{base}/compat/anthropic")),
+            curated_models: anthropic_models,
+            model_rewrites: anthropic_rewrites,
+            token_source: Some(source.clone()),
+            chatgpt_account_id: None,
+        });
     }
-    if !matches!(read_credential(secrets, kind).await, Ok(None)) {
-        return false;
+    if !openai_models.is_empty() {
+        routes.push(tidebreak_router::Route {
+            kind: tidebreak_router::RouteKind::ModelGatewayOpenai,
+            api_key: String::new(),
+            base_url: Some(format!("{base}/compat/openai/v1")),
+            curated_models: openai_models,
+            model_rewrites: openai_rewrites,
+            token_source: Some(source),
+            chatgpt_account_id: None,
+        });
     }
-    if env_api_key(kind).is_some() {
-        return false;
-    }
-    kind.env_base_url_from(|name| std::env::var(name).ok())
-        .is_none()
+    routes
 }
 
 /// One-shot boot migration for authentication that can outlive provider config.
@@ -2206,12 +2252,18 @@ pub async fn resolve_model_policy(
     store: &dyn Store,
     value: &str,
     allow_legacy_custom: bool,
+    caller_gateway: Option<&GatewayModelSnapshot>,
 ) -> Result<Option<ResolvedModelPolicy>> {
     if let Some((provider, id)) = model_registry::parse_selection_key(value) {
         if let Some(spec) = model_registry::find_for(provider, id) {
             return Ok(Some(ResolvedModelPolicy::curated(spec)));
         }
         if provider == ProviderKind::ModelGateway && id.starts_with(FROZEN_GATEWAY_MODEL_PREFIX) {
+            // A hosted caller's frozen selections resolve against their own
+            // snapshot (decision 62); nothing writes the stored one there.
+            if let Some(snapshot) = caller_gateway {
+                return Ok(resolve_frozen_gateway_policy(snapshot, id));
+            }
             return Ok(read_gateway_snapshot(store)
                 .await?
                 .as_ref()
@@ -2222,10 +2274,13 @@ pub async fn resolve_model_policy(
             // Resolution is not an offer: usability and routing gate the
             // gateway on policy separately, so the raw snapshot read here
             // only keeps stored selections legible.
-            ProviderKind::ModelGateway => read_gateway_snapshot(store)
-                .await?
-                .map(|snapshot| snapshot.models)
-                .unwrap_or_default(),
+            ProviderKind::ModelGateway => match caller_gateway {
+                Some(snapshot) => snapshot.models.clone(),
+                None => read_gateway_snapshot(store)
+                    .await?
+                    .map(|snapshot| snapshot.models)
+                    .unwrap_or_default(),
+            },
             _ => return Ok(None),
         };
         return Ok(models
@@ -2257,14 +2312,16 @@ pub async fn resolve_model_policy(
 /// usable would advertise models no route can serve.
 ///
 /// A gateway-authenticated hosted machine is the one profile that is usable
-/// with nothing stored at all: it resolves the credential per caller
-/// (`on_behalf_of_is_the_path`), so the stored-row walk below would call
-/// every provider unusable and leave every caller's picker empty.
+/// with nothing stored at all: `caller_gateway` is the requesting caller's
+/// own entitlement snapshot (decision 62), resolved per request from their
+/// live credential, and its presence is what makes the gateway usable for
+/// them. Every other deployment passes `None` and keeps the stored-row walk.
 pub async fn provider_is_usable(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
     kind: ProviderKind,
     policy: &crate::managed_policy::ManagedPolicy,
+    caller_gateway: Option<&GatewayModelSnapshot>,
 ) -> Result<bool> {
     if policy.managed {
         if kind != ProviderKind::ModelGateway {
@@ -2285,10 +2342,10 @@ pub async fn provider_is_usable(
             }));
     }
     if kind == ProviderKind::ModelGateway {
-        return Ok(false);
-    }
-    if on_behalf_of_is_the_path(store, secrets, kind, policy).await {
-        return Ok(true);
+        // A hosted machine's gateway is usable exactly when this caller's own
+        // entitlement snapshot resolved (decision 62): the snapshot exists
+        // only because the caller's live token just exchanged and fetched it.
+        return Ok(caller_gateway.is_some());
     }
     let config = read_config(store, kind).await?;
     if !config.enabled {
@@ -2318,12 +2375,13 @@ pub async fn model_is_usable(
     secrets: &dyn SecretProvider,
     model: &ResolvedModelPolicy,
     policy: &crate::managed_policy::ManagedPolicy,
+    caller_gateway: Option<&GatewayModelSnapshot>,
 ) -> Result<bool> {
-    if !provider_is_usable(store, secrets, model.provider, policy).await? {
+    if !provider_is_usable(store, secrets, model.provider, policy, caller_gateway).await? {
         return Ok(false);
     }
     if model.provider == ProviderKind::ModelGateway {
-        let Some(snapshot) = gateway_snapshot_for_policy(store, policy).await? else {
+        let Some(snapshot) = gateway_snapshot_for(store, policy, caller_gateway).await? else {
             return Ok(false);
         };
         let matches_snapshot = if model.route_model.starts_with(FROZEN_GATEWAY_MODEL_PREFIX) {
@@ -2360,10 +2418,12 @@ pub async fn catalog_models(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
     policy: &crate::managed_policy::ManagedPolicy,
+    caller_gateway: Option<&GatewayModelSnapshot>,
 ) -> Result<Vec<CatalogModel>> {
     let mut models = Vec::new();
     for &kind in ProviderKind::ALL {
-        let provider_usable = provider_is_usable(store, secrets, kind, policy).await?;
+        let provider_usable =
+            provider_is_usable(store, secrets, kind, policy, caller_gateway).await?;
         let chatgpt = matches!(
             auth_mode_for(secrets, kind).await,
             Some(ProviderAuthMode::Chatgpt)
@@ -2380,7 +2440,7 @@ pub async fn catalog_models(
         // unmanaged profile, so no gateway row ever reaches the catalog there.
         let configured = match kind {
             kind if kind.accepts_configured_models() => read_config(store, kind).await?.models,
-            ProviderKind::ModelGateway => gateway_models(store, policy).await?,
+            ProviderKind::ModelGateway => gateway_models(store, policy, caller_gateway).await?,
             _ => Vec::new(),
         };
         models.extend(configured.iter().map(|model| CatalogModel {
@@ -2531,11 +2591,11 @@ mod tests {
         )
         .unwrap();
         assert!(
-            provider_is_usable(&store, &secrets, ProviderKind::Openai, &policy)
+            provider_is_usable(&store, &secrets, ProviderKind::Openai, &policy, None)
                 .await
                 .unwrap()
         );
-        assert!(catalog_models(&store, &secrets, &policy)
+        assert!(catalog_models(&store, &secrets, &policy, None)
             .await
             .unwrap()
             .iter()
@@ -2686,7 +2746,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let resolved = resolve_model_policy(&store, "claude-opus-5", false)
+        let resolved = resolve_model_policy(&store, "claude-opus-5", false, None)
             .await
             .unwrap()
             .expect("the unique bare id resolves to Anthropic");
@@ -2708,7 +2768,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let mutable = resolve_model_policy(&store, "model_gateway::sample-claude", false)
+        let mutable = resolve_model_policy(&store, "model_gateway::sample-claude", false, None)
             .await
             .unwrap()
             .expect("the current catalog still contains the local id");
@@ -2721,7 +2781,7 @@ mod tests {
             .expect("the canonical model has one gateway equivalent");
         assert!(is_valid_execution_policy(&frozen));
 
-        let direct = resolve_model_policy(&store, "anthropic::claude-opus-5", false)
+        let direct = resolve_model_policy(&store, "anthropic::claude-opus-5", false, None)
             .await
             .unwrap()
             .expect("the direct curated route is registered");
@@ -2752,7 +2812,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(resolve_model_policy(&store, "claude-opus-5", false)
+        assert!(resolve_model_policy(&store, "claude-opus-5", false, None)
             .await
             .unwrap()
             .is_none());

--- a/crates/tidebreak-server/src/resolver.rs
+++ b/crates/tidebreak-server/src/resolver.rs
@@ -76,7 +76,7 @@ pub struct ConfiguredResolver {
     chatgpt: Arc<crate::chatgpt_runtime::ChatGptRuntime>,
     provisioned_policy: Arc<dyn crate::managed_policy::ProvisionedPolicySource>,
     os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
-    on_behalf_of: Option<Arc<crate::obo_inference::OboInference>>,
+    on_behalf_of: Option<Arc<crate::obo_gateway::OboGateway>>,
     cached: Mutex<CachedProviders>,
 }
 
@@ -108,15 +108,15 @@ impl ConfiguredResolver {
         }
     }
 
-    /// Resolve model credentials per caller through `on_behalf_of` wherever the
-    /// deployment states no other inference path (decision 51).
+    /// Resolve model credentials and entitlements per caller through
+    /// `on_behalf_of` (decisions 51 and 62).
     ///
     /// Only a gateway-authenticated hosted machine supplies one. Every other
     /// deployment leaves this unset and keeps its configured providers.
     #[must_use]
-    pub(crate) fn with_on_behalf_of_inference(
+    pub(crate) fn with_on_behalf_of_gateway(
         mut self,
-        on_behalf_of: Option<Arc<crate::obo_inference::OboInference>>,
+        on_behalf_of: Option<Arc<crate::obo_gateway::OboGateway>>,
     ) -> Self {
         self.on_behalf_of = on_behalf_of;
         self
@@ -144,15 +144,30 @@ impl ProviderResolver for ConfiguredResolver {
         let chatgpt = self.chatgpt.route_auth().await;
         // Per-caller credentials need a caller. An unnamed turn is offered
         // none, which fails it closed instead of running it as somebody else.
-        let on_behalf_of = self
-            .on_behalf_of
-            .as_ref()
-            .zip(owner)
-            .and_then(|(inference, owner)| {
-                inference
+        // The caller's routes are built from their own entitlement snapshot
+        // (decision 62); a snapshot that cannot be resolved right now — the
+        // gateway unreachable past the stale grace, or the caller's session
+        // dead — yields no gateway route, which also fails closed.
+        let on_behalf_of = match (self.on_behalf_of.as_ref(), owner) {
+            (Some(gateway), Some(owner)) => {
+                let snapshot = match gateway.snapshot_for(owner).await {
+                    Ok(snapshot) => snapshot,
+                    Err(error) => {
+                        tracing::warn!("per-caller gateway entitlements are unavailable: {error}");
+                        None
+                    }
+                };
+                gateway
                     .token_source_for(owner)
-                    .map(|source| (source, inference.inference_base_url().to_owned()))
-            });
+                    .zip(snapshot)
+                    .map(|(source, snapshot)| crate::providers::OnBehalfOfGateway {
+                        source,
+                        gateway_base_url: gateway.gateway_base_url().to_owned(),
+                        snapshot,
+                    })
+            }
+            _ => None,
+        };
         let routes = providers::collect_routes(
             &*self.store,
             &*self.secrets,

--- a/crates/tidebreak-server/src/routes/compaction.rs
+++ b/crates/tidebreak-server/src/routes/compaction.rs
@@ -84,7 +84,21 @@ pub async fn post_compact(
 
     let mut config = state.agent_config.clone();
     let model = resolve_executable_chat_model(&state, &chat).await?;
-    match crate::providers::resolve_model_policy(&*state.store, &model, true).await? {
+    // A hosted caller's frozen gateway selection resolves only through their
+    // own entitlement snapshot (decision 62).
+    let owner = state.store.chat_owner(chat.id).await.unwrap_or_default();
+    let caller_gateway = match owner.as_ref() {
+        Some(owner) => state.caller_gateway_snapshot(owner).await?,
+        None => None,
+    };
+    match crate::providers::resolve_model_policy(
+        &*state.store,
+        &model,
+        true,
+        caller_gateway.as_ref(),
+    )
+    .await?
+    {
         Some(policy) => {
             crate::providers::apply_model_policy(&mut config, &policy, chat.reasoning_effort)?;
         }

--- a/crates/tidebreak-server/src/routes/projects_chats.rs
+++ b/crates/tidebreak-server/src/routes/projects_chats.rs
@@ -205,7 +205,8 @@ pub async fn create_chat(
         store.require_project(project_id).await?;
     }
     if let Some(model) = body.model.as_mut() {
-        *model = validate_model_selection(&state, model, false).await?;
+        *model = validate_model_selection(&state, model, false, Some(&auth.principal.owner_id()))
+            .await?;
     }
     refuse_permission_mode_over_ceiling(&state, body.permission_mode).await?;
     if let Some(policy) = body.network_policy.as_mut() {
@@ -222,7 +223,14 @@ pub async fn create_chat(
         // ambiguous/unmatched selection honestly.
         None => match read_sticky_default::<String>(&*state.store, &owner, STICKY_MODEL_KEY).await?
         {
-            Some(sticky) => match validate_model_selection(&state, &sticky, false).await {
+            Some(sticky) => match validate_model_selection(
+                &state,
+                &sticky,
+                false,
+                Some(&auth.principal.owner_id()),
+            )
+            .await
+            {
                 Ok(model) => Some(model),
                 Err(_) if managed.managed => Some(sticky),
                 Err(_) => None,
@@ -350,7 +358,8 @@ pub async fn patch_chat(
     // Validate every supplied field before touching durable state. This keeps a
     // mixed request all-or-nothing from the user's point of view.
     if let Some(Some(model)) = body.model.as_mut() {
-        *model = validate_model_selection(&state, model, false).await?;
+        *model = validate_model_selection(&state, model, false, Some(&auth.principal.owner_id()))
+            .await?;
     }
     if let Some(policy) = body.network_policy.as_mut() {
         crate::code_execution::normalize_network_policy(policy)?;

--- a/crates/tidebreak-server/src/routes/providers_models.rs
+++ b/crates/tidebreak-server/src/routes/providers_models.rs
@@ -72,20 +72,29 @@ pub(crate) async fn resolve_executable_chat_model(
         return Ok(selected);
     }
     let managed = state.managed_policy()?;
-    let executable = if managed.managed {
+    // A hosted caller's turn freezes its model against their own entitlement
+    // snapshot, exactly as a managed profile freezes against the
+    // deployment-wide one (decision 62).
+    let owner = state.store.chat_owner(chat.id).await.unwrap_or_default();
+    let caller_gateway = match owner.as_ref() {
+        Some(owner) => state.caller_gateway_snapshot(owner).await?,
+        None => None,
+    };
+    let executable = if managed.managed || caller_gateway.is_some() {
         let policy = model_roles::effective_chat_policy(
             &*state.store,
             &*state.secrets,
             &managed,
             &selected,
             explicit,
+            caller_gateway.as_ref(),
         )
         .await?
         .ok_or_else(|| {
             ServerError::conflict_kind(
                 "model_provider_unavailable",
                 format!(
-                    "the managed model gateway cannot serve selected model `{selected}` with its current catalog or credential"
+                    "the model gateway cannot serve selected model `{selected}` with its current catalog or credential"
                 ),
             )
         })?;
@@ -93,16 +102,18 @@ pub(crate) async fn resolve_executable_chat_model(
     } else {
         selected
     };
-    validate_execution_selection(state, &executable, true).await
+    validate_execution_selection(state, &executable, true, caller_gateway.as_ref()).await
 }
 
 async fn validate_execution_selection(
     state: &AppState,
     value: &str,
     allow_legacy_custom: bool,
+    caller_gateway: Option<&providers::GatewayModelSnapshot>,
 ) -> Result<String, ServerError> {
     let Some(policy) =
-        providers::resolve_model_policy(&*state.store, value, allow_legacy_custom).await?
+        providers::resolve_model_policy(&*state.store, value, allow_legacy_custom, caller_gateway)
+            .await?
     else {
         return Err(ServerError::bad_request_kind(
             "unknown_model",
@@ -116,7 +127,15 @@ async fn validate_execution_selection(
         ));
     }
     let managed = state.managed_policy()?;
-    if !providers::model_is_usable(&*state.store, &*state.secrets, &policy, &managed).await? {
+    if !providers::model_is_usable(
+        &*state.store,
+        &*state.secrets,
+        &policy,
+        &managed,
+        caller_gateway,
+    )
+    .await?
+    {
         return Err(ServerError::conflict_kind(
             "model_provider_unavailable",
             format!(
@@ -136,6 +155,7 @@ pub(super) async fn validate_model_selection(
     state: &AppState,
     value: &str,
     allow_legacy_custom: bool,
+    owner: Option<&tidebreak_core::OwnerId>,
 ) -> Result<String, ServerError> {
     if value.is_empty() {
         return Err(ServerError::bad_request("model must not be empty"));
@@ -143,8 +163,20 @@ pub(super) async fn validate_model_selection(
     if !state.resolver.enforces_model_registry() {
         return Ok(value.to_owned());
     }
-    let Some(policy) =
-        providers::resolve_model_policy(&*state.store, value, allow_legacy_custom).await?
+    // On a hosted machine a selection is validated against the requesting
+    // caller's own entitlements (decision 62); everywhere else the snapshot
+    // is `None` and nothing changes.
+    let caller_gateway = match owner {
+        Some(owner) => state.caller_gateway_snapshot(owner).await?,
+        None => None,
+    };
+    let Some(policy) = providers::resolve_model_policy(
+        &*state.store,
+        value,
+        allow_legacy_custom,
+        caller_gateway.as_ref(),
+    )
+    .await?
     else {
         return Err(ServerError::bad_request_kind(
             "unknown_model",
@@ -152,7 +184,15 @@ pub(super) async fn validate_model_selection(
         ));
     };
     let managed = state.managed_policy()?;
-    if !providers::model_is_usable(&*state.store, &*state.secrets, &policy, &managed).await? {
+    if !providers::model_is_usable(
+        &*state.store,
+        &*state.secrets,
+        &policy,
+        &managed,
+        caller_gateway.as_ref(),
+    )
+    .await?
+    {
         return Err(ServerError::conflict_kind(
             "model_provider_unavailable",
             format!(
@@ -309,10 +349,20 @@ pub struct ProvidersList {
 /// model gateway appears only on a managed profile, projected from policy.
 pub async fn list_providers(
     State(state): State<AppState>,
+    auth: crate::principal::AuthContext,
 ) -> Result<Json<ProvidersList>, ServerError> {
     let policy = state.managed_policy()?;
+    let caller_gateway = state
+        .caller_gateway_snapshot(&auth.principal.owner_id())
+        .await?;
     Ok(Json(ProvidersList {
-        providers: providers::list_providers(&*state.store, &*state.secrets, &policy).await?,
+        providers: providers::list_providers(
+            &*state.store,
+            &*state.secrets,
+            &policy,
+            caller_gateway.as_ref(),
+        )
+        .await?,
     }))
 }
 
@@ -532,11 +582,18 @@ pub struct ModelCatalog {
 ///
 /// All typed registry rows plus current availability. Clients may explain
 /// unavailable rows, but must never offer them as usable selections.
-pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCatalog>, ServerError> {
+pub async fn list_models(
+    State(state): State<AppState>,
+    auth: crate::principal::AuthContext,
+) -> Result<Json<ModelCatalog>, ServerError> {
+    let caller_gateway = state
+        .caller_gateway_snapshot(&auth.principal.owner_id())
+        .await?;
     let mut roles = Vec::with_capacity(ModelRole::ALL.len());
     for &role in ModelRole::ALL {
         let selection = model_roles::read_selection(&*state.store, role).await?;
-        let resolved_key = resolved_role_key(&state, role, selection.as_deref()).await?;
+        let resolved_key =
+            resolved_role_key(&state, role, selection.as_deref(), caller_gateway.as_ref()).await?;
         roles.push(ModelRoleInfo {
             role,
             selection,
@@ -544,31 +601,36 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCata
         });
     }
     let policy = state.managed_policy()?;
-    let models = providers::catalog_models(&*state.store, &*state.secrets, &policy)
-        .await?
-        .into_iter()
-        .map(|entry| ModelInfo {
-            key: entry.policy.key,
-            id: entry.policy.id,
-            display_name: entry.policy.display_name,
-            provider: entry.policy.provider,
-            vendor: entry.policy.vendor,
-            verification: entry.policy.verification,
-            recommended: entry.policy.recommended,
-            available: entry.available,
-            context_window: entry.policy.context_window,
-            max_output_tokens: entry.policy.max_output_tokens,
-            input_modalities: entry.policy.input_modalities.clone(),
-            supports_reasoning: entry.policy.supports_reasoning,
-            supports_tools: entry.policy.supports_tools,
-            supports_structured_output: entry.policy.supports_structured_output,
-            reasoning_efforts: entry.policy.reasoning_efforts.clone(),
-            multimodal: entry
-                .policy
-                .input_modalities
-                .contains(&crate::model_registry::InputModality::Image),
-        })
-        .collect();
+    let models = providers::catalog_models(
+        &*state.store,
+        &*state.secrets,
+        &policy,
+        caller_gateway.as_ref(),
+    )
+    .await?
+    .into_iter()
+    .map(|entry| ModelInfo {
+        key: entry.policy.key,
+        id: entry.policy.id,
+        display_name: entry.policy.display_name,
+        provider: entry.policy.provider,
+        vendor: entry.policy.vendor,
+        verification: entry.policy.verification,
+        recommended: entry.policy.recommended,
+        available: entry.available,
+        context_window: entry.policy.context_window,
+        max_output_tokens: entry.policy.max_output_tokens,
+        input_modalities: entry.policy.input_modalities.clone(),
+        supports_reasoning: entry.policy.supports_reasoning,
+        supports_tools: entry.policy.supports_tools,
+        supports_structured_output: entry.policy.supports_structured_output,
+        reasoning_efforts: entry.policy.reasoning_efforts.clone(),
+        multimodal: entry
+            .policy
+            .input_modalities
+            .contains(&crate::model_registry::InputModality::Image),
+    })
+    .collect();
     Ok(Json(ModelCatalog { models, roles }))
 }
 
@@ -590,23 +652,32 @@ pub struct ModelRoleUpdate {
 /// writes the same setting as `PUT /settings`.
 pub async fn put_model_role(
     State(state): State<AppState>,
+    auth: crate::principal::AuthContext,
     Path(role): Path<String>,
     Json(body): Json<ModelRoleUpdate>,
 ) -> Result<Json<ModelRoleInfo>, ServerError> {
     let role = ModelRole::parse(&role)
         .ok_or_else(|| ServerError::not_found(format!("unknown model role: {role}")))?;
+    let owner = auth.principal.owner_id();
+    let caller_gateway = state.caller_gateway_snapshot(&owner).await?;
     let selection = match body.selection {
         Some(selection) => {
-            let selection = validate_model_selection(&state, &selection, false).await?;
+            let selection =
+                validate_model_selection(&state, &selection, false, Some(&owner)).await?;
             if role == ModelRole::Utility && state.resolver.enforces_model_registry() {
-                let policy = providers::resolve_model_policy(&*state.store, &selection, false)
-                    .await?
-                    .ok_or_else(|| {
-                        ServerError::bad_request_kind(
-                            "unknown_model",
-                            unknown_model_message(&selection),
-                        )
-                    })?;
+                let policy = providers::resolve_model_policy(
+                    &*state.store,
+                    &selection,
+                    false,
+                    caller_gateway.as_ref(),
+                )
+                .await?
+                .ok_or_else(|| {
+                    ServerError::bad_request_kind(
+                        "unknown_model",
+                        unknown_model_message(&selection),
+                    )
+                })?;
                 if !role.supports_model(&policy) {
                     return Err(ServerError::conflict_kind(
                         "model_structured_output_unsupported",
@@ -622,7 +693,8 @@ pub async fn put_model_role(
         None => None,
     };
     model_roles::write_selection(&*state.store, role, selection.as_deref()).await?;
-    let resolved_key = resolved_role_key(&state, role, selection.as_deref()).await?;
+    let resolved_key =
+        resolved_role_key(&state, role, selection.as_deref(), caller_gateway.as_ref()).await?;
     Ok(Json(ModelRoleInfo {
         role,
         selection,
@@ -640,6 +712,7 @@ async fn resolved_role_key(
     state: &AppState,
     role: ModelRole,
     selection: Option<&str>,
+    caller_gateway: Option<&providers::GatewayModelSnapshot>,
 ) -> Result<Option<String>, ServerError> {
     match role {
         // The chat role goes through the same seam a new execution does, minus
@@ -660,6 +733,7 @@ async fn resolved_role_key(
                 &managed,
                 &fallback,
                 selection.is_some(),
+                caller_gateway,
             )
             .await?
             .map(|policy| policy.key))
@@ -670,6 +744,7 @@ async fn resolved_role_key(
             &*state.provisioned_policy,
             &*state.os_policy,
             role,
+            caller_gateway,
         )
         .await?
         .map(|policy| policy.key)),

--- a/crates/tidebreak-server/src/routes/settings.rs
+++ b/crates/tidebreak-server/src/routes/settings.rs
@@ -235,7 +235,8 @@ pub async fn put_settings(
     Json(mut body): Json<SettingsUpdate>,
 ) -> Result<Json<Settings>, ServerError> {
     if let Some(Some(model)) = body.model.as_mut() {
-        *model = validate_model_selection(&state, model, false).await?;
+        *model = validate_model_selection(&state, model, false, Some(&auth.principal.owner_id()))
+            .await?;
     }
     match body.model {
         // Absent: leave the model unchanged.

--- a/crates/tidebreak-server/src/routes/turn_control.rs
+++ b/crates/tidebreak-server/src/routes/turn_control.rs
@@ -216,11 +216,25 @@ async fn resolve_file_attachments(
 /// answer's author behind the user's back. Refusing is the only option that
 /// leaves the user in control, so the error is machine-readable and the client
 /// can offer to change the model or drop the attachments.
-async fn require_image_capable_model(state: &AppState, model: &str) -> Result<(), ServerError> {
+async fn require_image_capable_model(
+    state: &AppState,
+    chat: &tidebreak_core::Chat,
+    model: &str,
+) -> Result<(), ServerError> {
     if !state.resolver.enforces_model_registry() {
         return Ok(());
     }
-    let Some(policy) = providers::resolve_model_policy(&*state.store, model, true).await? else {
+    // A hosted caller's frozen gateway selection resolves only through their
+    // own entitlement snapshot (decision 62).
+    let owner = state.store.chat_owner(chat.id).await.unwrap_or_default();
+    let caller_gateway = match owner.as_ref() {
+        Some(owner) => state.caller_gateway_snapshot(owner).await?,
+        None => None,
+    };
+    let Some(policy) =
+        providers::resolve_model_policy(&*state.store, model, true, caller_gateway.as_ref())
+            .await?
+    else {
         return Err(ServerError::bad_request_kind(
             "unknown_model",
             format!("model `{model}` is not registered for that provider"),
@@ -387,7 +401,7 @@ pub async fn post_message(
             let images = resolve_message_attachments(&state, id, &body.attachments).await?;
             let documents = resolve_file_attachments(&store, id, &body.file_attachments).await?;
             if !images.is_empty() {
-                require_image_capable_model(&state, &model).await?;
+                require_image_capable_model(&state, &chat, &model).await?;
             }
             Ok::<_, ServerError>((model, images, documents))
         }

--- a/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
+++ b/crates/tidebreak-server/src/sandbox_agent_run_worker/worker.rs
@@ -444,8 +444,11 @@ impl SandboxAgentRunWorker {
             }
         }
         let search_capabilities = if self.resolver.enforces_model_registry() {
+            // Sandbox runs resolve without a caller snapshot: on a hosted
+            // machine their model path has no per-caller route yet either.
+            // Decision 62 names this gap and leaves it open.
             let Some(policy) =
-                crate::providers::resolve_model_policy(&*self.store, &model, true).await?
+                crate::providers::resolve_model_policy(&*self.store, &model, true, None).await?
             else {
                 return Err(AgentError::config(
                     "sandbox model is not registered for its provider",

--- a/crates/tidebreak-server/src/sandbox_container_run.rs
+++ b/crates/tidebreak-server/src/sandbox_container_run.rs
@@ -1442,8 +1442,11 @@ impl SandboxContainerRunner {
             .ok_or_else(|| AgentError::msg("container agent run has no chat"))?;
         let mut config = AgentConfig::default();
         if self.resolver.enforces_model_registry() {
+            // Container sandboxes resolve without a caller snapshot: on a
+            // hosted machine their model proxy has no per-caller route yet
+            // either. Decision 62 names this gap and leaves it open.
             let Some(policy) =
-                crate::providers::resolve_model_policy(&*self.store, &model, true).await?
+                crate::providers::resolve_model_policy(&*self.store, &model, true, None).await?
             else {
                 return Err(AgentError::config(
                     "container sandbox model is not registered for its provider",

--- a/crates/tidebreak-server/src/state.rs
+++ b/crates/tidebreak-server/src/state.rs
@@ -199,10 +199,11 @@ pub struct AppState {
     /// checks live account state; static-token mode remains for standalone
     /// deployments. Desktop never consults it.
     pub(crate) principal_authenticator: Arc<crate::auth::PrincipalAuthenticator>,
-    /// Per-caller inference credentials on a gateway-authenticated hosted
-    /// machine (decision 51). `None` everywhere else, which is what keeps
+    /// Per-caller gateway capabilities — inference credentials and
+    /// entitlement snapshots — on a gateway-authenticated hosted machine
+    /// (decisions 51 and 62). `None` everywhere else, which is what keeps
     /// static-token and desktop deployments on their configured providers.
-    pub(crate) on_behalf_of_inference: Option<Arc<crate::obo_inference::OboInference>>,
+    pub(crate) on_behalf_of_gateway: Option<Arc<crate::obo_gateway::OboGateway>>,
     /// A second per-launch secret required for native-only operations.
     pub(crate) client_executor_token: Arc<str>,
     /// A per-launch capability limited to publishing caller-supplied bytes.
@@ -429,7 +430,7 @@ impl AppState {
             agent_config,
             token: Uuid::new_v4().to_string().into(),
             principal_authenticator,
-            on_behalf_of_inference: None,
+            on_behalf_of_gateway: None,
             client_executor_token: mint_client_executor_token(),
             local_import_token: mint_local_import_token(),
             client_executor_id,
@@ -467,19 +468,36 @@ impl AppState {
         )
     }
 
-    /// Resolve model credentials per caller through `inference` (decision 51).
+    /// Resolve model credentials and entitlements per caller through
+    /// `gateway` (decisions 51 and 62).
     ///
     /// Pass the same instance the resolver holds: the authentication
     /// middleware records each caller's live gateway token here, and the
     /// resolver reads it back when it builds that caller's routes. Two
     /// instances would leave every turn without a credential.
     #[must_use]
-    pub(crate) fn with_on_behalf_of_inference(
+    pub(crate) fn with_on_behalf_of_gateway(
         mut self,
-        inference: Option<Arc<crate::obo_inference::OboInference>>,
+        gateway: Option<Arc<crate::obo_gateway::OboGateway>>,
     ) -> Self {
-        self.on_behalf_of_inference = inference;
+        self.on_behalf_of_gateway = gateway;
         self
+    }
+
+    /// The requesting caller's own gateway entitlement snapshot (decision
+    /// 62): `None` off a gateway-authenticated hosted machine, and for
+    /// callers this process has not authenticated.
+    ///
+    /// # Errors
+    /// Fails when the gateway refuses the caller's exchange or catalog read.
+    pub(crate) async fn caller_gateway_snapshot(
+        &self,
+        owner: &tidebreak_core::OwnerId,
+    ) -> tidebreak_core::Result<Option<crate::providers::GatewayModelSnapshot>> {
+        match self.on_behalf_of_gateway.as_ref() {
+            Some(gateway) => gateway.snapshot_for(owner).await,
+            None => Ok(None),
+        }
     }
 }
 

--- a/crates/tidebreak-server/src/tests/compaction.rs
+++ b/crates/tidebreak-server/src/tests/compaction.rs
@@ -191,7 +191,7 @@ async fn managed_compaction_and_message_admission_share_the_frozen_gateway_ident
         compaction_model.starts_with("model_gateway::__tidebreak_gateway_v1."),
         "managed execution should freeze the gateway route: {compaction_model}"
     );
-    let compaction_policy = providers::resolve_model_policy(&*store, &compaction_model, true)
+    let compaction_policy = providers::resolve_model_policy(&*store, &compaction_model, true, None)
         .await
         .unwrap()
         .expect("the frozen gateway selector should resolve against its snapshot");

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -1573,7 +1573,7 @@ async fn chatgpt_auth_marks_api_only_openai_models_unavailable() {
         &crate::managed_policy::NoOsPolicy,
     )
     .unwrap();
-    let catalog = providers::catalog_models(&*store, &*secrets, &policy)
+    let catalog = providers::catalog_models(&*store, &*secrets, &policy, None)
         .await
         .unwrap();
     let nano = catalog
@@ -1595,7 +1595,7 @@ async fn chatgpt_auth_marks_api_only_openai_models_unavailable() {
         crate::model_registry::find_for(providers::ProviderKind::Openai, "gpt-5.4-nano").unwrap(),
     );
     assert!(
-        !providers::model_is_usable(&*store, &*secrets, &nano_policy, &policy)
+        !providers::model_is_usable(&*store, &*secrets, &nano_policy, &policy, None)
             .await
             .unwrap()
     );
@@ -1769,12 +1769,12 @@ async fn xai_config_builds_a_provider_qualified_native_route() {
     assert_eq!(routes[0].base_url, None);
     assert_eq!(routes[0].curated_models, ["grok-4.6", "grok-4.5"]);
 
-    let grok = providers::resolve_model_policy(&*store, "grok-4.5", false)
+    let grok = providers::resolve_model_policy(&*store, "grok-4.5", false, None)
         .await
         .unwrap()
         .expect("a bare curated xAI id resolves to its direct provider");
     assert_eq!(grok.provider, providers::ProviderKind::Xai);
-    let curated = providers::resolve_model_policy(&*store, "gpt-5.6-sol", false)
+    let curated = providers::resolve_model_policy(&*store, "gpt-5.6-sol", false, None)
         .await
         .unwrap()
         .expect("a bare curated id keeps the registry's direct owner");
@@ -2389,7 +2389,7 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
         .model;
     assert!(gateway_override_model.starts_with("model_gateway::__tidebreak_gateway_v1."));
     assert_eq!(
-        providers::resolve_model_policy(&*store, &gateway_override_model, false)
+        providers::resolve_model_policy(&*store, &gateway_override_model, false, None)
             .await
             .unwrap()
             .unwrap()
@@ -2443,7 +2443,7 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
         .model;
     assert!(sticky_model.starts_with("model_gateway::__tidebreak_gateway_v1."));
     assert_eq!(
-        providers::resolve_model_policy(&*store, &sticky_model, false)
+        providers::resolve_model_policy(&*store, &sticky_model, false, None)
             .await
             .unwrap()
             .unwrap()
@@ -2523,7 +2523,7 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
         .model;
     assert!(fallback_model.starts_with("model_gateway::__tidebreak_gateway_v1."));
     assert_eq!(
-        providers::resolve_model_policy(&*store, &fallback_model, false)
+        providers::resolve_model_policy(&*store, &fallback_model, false, None)
             .await
             .unwrap()
             .unwrap()
@@ -2907,7 +2907,8 @@ async fn ollama_is_usable_without_a_credential_and_serves_only_configured_models
             &*store,
             &*secrets,
             providers::ProviderKind::Ollama,
-            &policy
+            &policy,
+            None
         )
         .await
         .unwrap(),
@@ -2934,7 +2935,8 @@ async fn ollama_is_usable_without_a_credential_and_serves_only_configured_models
         &*store,
         &*secrets,
         providers::ProviderKind::Ollama,
-        &policy
+        &policy,
+        None
     )
     .await
     .unwrap());
@@ -2943,7 +2945,7 @@ async fn ollama_is_usable_without_a_credential_and_serves_only_configured_models
         "usability must not invent a stored credential"
     );
 
-    let listed = providers::list_providers(&*store, &*secrets, &policy)
+    let listed = providers::list_providers(&*store, &*secrets, &policy, None)
         .await
         .unwrap();
     let ollama = listed
@@ -2957,7 +2959,7 @@ async fn ollama_is_usable_without_a_credential_and_serves_only_configured_models
         Some("http://127.0.0.1:11434/v1")
     );
 
-    let catalog = providers::catalog_models(&*store, &*secrets, &policy)
+    let catalog = providers::catalog_models(&*store, &*secrets, &policy, None)
         .await
         .unwrap();
     let model = catalog
@@ -3040,12 +3042,13 @@ async fn openrouter_uses_its_fixed_endpoint_and_serves_only_configured_models() 
         &*store,
         &*secrets,
         providers::ProviderKind::Openrouter,
-        &policy
+        &policy,
+        None
     )
     .await
     .unwrap());
 
-    let listed = providers::list_providers(&*store, &*secrets, &policy)
+    let listed = providers::list_providers(&*store, &*secrets, &policy, None)
         .await
         .unwrap();
     let openrouter = listed
@@ -3059,7 +3062,7 @@ async fn openrouter_uses_its_fixed_endpoint_and_serves_only_configured_models() 
         Some("https://openrouter.ai/api/v1")
     );
 
-    let catalog = providers::catalog_models(&*store, &*secrets, &policy)
+    let catalog = providers::catalog_models(&*store, &*secrets, &policy, None)
         .await
         .unwrap();
     let model = catalog
@@ -3242,7 +3245,8 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
         &*store,
         &*secrets,
         providers::ProviderKind::Anthropic,
-        &policy
+        &policy,
+        None
     )
     .await
     .unwrap());
@@ -3747,11 +3751,12 @@ async fn a_superseded_gateway_session_never_reads_usable() {
         &*store,
         &*secrets,
         providers::ProviderKind::ModelGateway,
-        &policy
+        &policy,
+        None
     )
     .await
     .unwrap());
-    let gateway = providers::list_providers(&*store, &*secrets, &policy)
+    let gateway = providers::list_providers(&*store, &*secrets, &policy, None)
         .await
         .unwrap()
         .into_iter()
@@ -3787,7 +3792,8 @@ async fn a_superseded_gateway_session_never_reads_usable() {
         &*store,
         &*secrets,
         providers::ProviderKind::ModelGateway,
-        &policy
+        &policy,
+        None
     )
     .await
     .unwrap());
@@ -5650,13 +5656,54 @@ impl tidebreak_router::BearerTokenSource for FakeCallerCredential {
     }
 }
 
-/// The per-caller inference path a gateway-authenticated hosted machine
-/// offers, as `collect_routes` receives it.
-fn on_behalf_of() -> Option<providers::OnBehalfOfInference> {
-    Some((
-        Arc::new(FakeCallerCredential) as Arc<dyn tidebreak_router::BearerTokenSource>,
-        "https://gateway.example/compat/anthropic".to_string(),
-    ))
+/// One hosted caller's entitlement snapshot: an Anthropic-protocol model that
+/// maps to a curated row, and an OpenAI-protocol one that does not.
+fn caller_snapshot() -> providers::GatewayModelSnapshot {
+    providers::GatewayModelSnapshot {
+        gateway_url: "https://gateway.example".to_owned(),
+        installation_id: None,
+        models: vec![
+            providers::CustomModelConfig {
+                id: "acme-opus".into(),
+                display_name: Some("Acme Opus".into()),
+                aliases: vec!["claude-opus-5".into()],
+                context_window: 200_000,
+                max_output_tokens: 32_000,
+                ..Default::default()
+            },
+            providers::CustomModelConfig {
+                id: "acme-gpt".into(),
+                display_name: Some("Acme GPT".into()),
+                context_window: 128_000,
+                max_output_tokens: 16_000,
+                ..Default::default()
+            },
+        ],
+        model_protocols: [
+            (
+                "acme-opus".to_owned(),
+                providers::GatewayModelProtocol::AnthropicMessages,
+            ),
+            (
+                "acme-gpt".to_owned(),
+                providers::GatewayModelProtocol::OpenaiResponses,
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        member_catalog: Some("v1".into()),
+        catalog_etag: None,
+    }
+}
+
+/// The per-caller gateway path a hosted machine offers, as `collect_routes`
+/// receives it (decision 62).
+fn on_behalf_of() -> Option<providers::OnBehalfOfGateway> {
+    Some(providers::OnBehalfOfGateway {
+        source: Arc::new(FakeCallerCredential) as Arc<dyn tidebreak_router::BearerTokenSource>,
+        gateway_base_url: "https://gateway.example".to_owned(),
+        snapshot: caller_snapshot(),
+    })
 }
 
 /// A store and secrets pair with nothing configured in either.
@@ -5672,11 +5719,11 @@ async fn empty_deployment(dir: &tempfile::TempDir) -> (Arc<dyn Store>, Arc<dyn S
     (store, Arc::new(MemSecrets::default()))
 }
 
-/// Decision 51, rule 1: with gateway authentication and nothing else stated,
-/// the caller's own credential drives their turns against the gateway's
-/// Anthropic-compatible surface.
+/// Decision 62: a hosted caller's routes are their own entitlements, in the
+/// same per-protocol gateway shape a managed profile gets — frozen identities
+/// included — and nothing impersonates the curated Anthropic route.
 #[tokio::test]
-async fn on_behalf_of_inference_serves_a_deployment_that_states_no_other_path() {
+async fn on_behalf_of_routes_serve_the_callers_own_entitlements() {
     let dir = tempfile::tempdir().unwrap();
     let (store, secrets) = empty_deployment(&dir).await;
 
@@ -5687,38 +5734,271 @@ async fn on_behalf_of_inference_serves_a_deployment_that_states_no_other_path() 
     let policy =
         crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
 
-    let route = providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy)
-        .await
-        .into_iter()
-        .find(|route| route.kind == tidebreak_router::RouteKind::Anthropic)
-        .expect("per-caller inference must offer an Anthropic route");
-
+    let routes =
+        providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy).await;
+    let anthropic = routes
+        .iter()
+        .find(|route| route.kind == tidebreak_router::RouteKind::ModelGateway)
+        .expect("the caller's Anthropic-protocol models must route");
     assert_eq!(
-        route.base_url.as_deref(),
+        anthropic.base_url.as_deref(),
         Some("https://gateway.example/compat/anthropic")
     );
     assert!(
-        route.api_key.is_empty(),
+        anthropic.api_key.is_empty(),
         "the credential rotates; no key may be snapshotted into the route"
     );
-    let source = route
+    let source = anthropic
         .token_source
         .as_ref()
         .expect("the route must carry the caller's rotating credential");
     assert_eq!(source.binding_id(), Some("user:alice"));
     assert!(
-        route
+        anthropic
             .curated_models
             .iter()
-            .any(|model| model.starts_with("claude-")),
-        "the route must serve the curated Anthropic catalog"
+            .any(|model| model == "acme-opus"),
+        "the route must serve the caller's own entitled models"
+    );
+    assert!(
+        anthropic
+            .curated_models
+            .iter()
+            .any(|model| model.starts_with("__tidebreak_gateway_v1.")),
+        "frozen identities must ride the route"
+    );
+    let openai = routes
+        .iter()
+        .find(|route| route.kind == tidebreak_router::RouteKind::ModelGatewayOpenai)
+        .expect("the caller's OpenAI-protocol models must route too");
+    assert_eq!(
+        openai.base_url.as_deref(),
+        Some("https://gateway.example/compat/openai/v1")
+    );
+    assert!(openai
+        .curated_models
+        .iter()
+        .any(|model| model == "acme-gpt"));
+    assert!(
+        !routes
+            .iter()
+            .any(|route| route.kind == tidebreak_router::RouteKind::Anthropic),
+        "nothing impersonates the curated Anthropic route"
     );
 }
 
-/// Rule 3: a stored provider configuration always wins, so the deployment's
-/// own credential drives every caller's turns exactly as before.
+/// A caller entitled to nothing is offered nothing: one inert gateway
+/// adapter, no models, and no selectable catalog row (decision 62).
 #[tokio::test]
-async fn a_stored_provider_configuration_outranks_on_behalf_of_inference() {
+async fn a_caller_entitled_to_nothing_is_offered_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let policy =
+        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
+
+    let mut nothing = on_behalf_of().unwrap();
+    nothing.snapshot.models.clear();
+    nothing.snapshot.model_protocols.clear();
+    let empty_snapshot = nothing.snapshot.clone();
+    let routes =
+        providers::collect_routes(&*store, &*secrets, None, None, Some(nothing), &policy).await;
+    let gateway = routes
+        .iter()
+        .find(|route| route.kind == tidebreak_router::RouteKind::ModelGateway)
+        .expect("a signed-in caller keeps one inert gateway adapter");
+    assert!(gateway.curated_models.is_empty());
+
+    let catalog = providers::catalog_models(
+        &*store,
+        &*secrets,
+        &hosted_machine_policy(),
+        Some(&empty_snapshot),
+    )
+    .await
+    .unwrap();
+    assert!(
+        !catalog.iter().any(|entry| entry.available),
+        "a caller entitled to nothing must be offered nothing"
+    );
+}
+
+/// Two callers on one machine see two catalogs (decision 62), and neither is
+/// written to deployment-wide state.
+#[tokio::test]
+async fn two_callers_see_their_own_catalogs() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let hosted = hosted_machine_policy();
+
+    let alice = caller_snapshot();
+    let mut bob = caller_snapshot();
+    bob.models.retain(|model| model.id == "acme-gpt");
+    bob.model_protocols.remove("acme-opus");
+
+    let alice_models: Vec<_> = providers::catalog_models(&*store, &*secrets, &hosted, Some(&alice))
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|entry| entry.policy.provider == providers::ProviderKind::ModelGateway)
+        .map(|entry| entry.policy.id)
+        .collect();
+    let bob_models: Vec<_> = providers::catalog_models(&*store, &*secrets, &hosted, Some(&bob))
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|entry| entry.policy.provider == providers::ProviderKind::ModelGateway)
+        .map(|entry| entry.policy.id)
+        .collect();
+    assert_eq!(alice_models, ["acme-opus", "acme-gpt"]);
+    assert_eq!(bob_models, ["acme-gpt"]);
+    assert!(
+        providers::read_gateway_snapshot(&*store)
+            .await
+            .unwrap()
+            .is_none(),
+        "no per-caller catalog may reach deployment-wide state"
+    );
+}
+
+/// A hosted caller's explicit selection freezes against their own snapshot
+/// and resolves back through it — and through nobody else's (decision 62).
+#[tokio::test]
+async fn a_hosted_selection_freezes_through_the_caller_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let hosted = hosted_machine_policy();
+    let snapshot = caller_snapshot();
+
+    let policy = model_roles::effective_chat_policy(
+        &*store,
+        &*secrets,
+        &hosted,
+        "model_gateway::acme-opus",
+        true,
+        Some(&snapshot),
+    )
+    .await
+    .unwrap()
+    .expect("an entitled selection must freeze");
+    assert!(policy.route_model.starts_with("__tidebreak_gateway_v1."));
+
+    let resolved =
+        providers::resolve_model_policy(&*store, &policy.execution_key(), false, Some(&snapshot))
+            .await
+            .unwrap()
+            .expect("the frozen key must resolve through the caller's snapshot");
+    assert_eq!(resolved.id, "acme-opus");
+
+    let mut foreign = caller_snapshot();
+    foreign.models.retain(|model| model.id != "acme-opus");
+    foreign.model_protocols.remove("acme-opus");
+    assert!(
+        providers::resolve_model_policy(&*store, &policy.execution_key(), false, Some(&foreign),)
+            .await
+            .unwrap()
+            .is_none(),
+        "another caller's snapshot must refuse a model it does not entitle"
+    );
+}
+
+/// Background roles run as the caller who triggered them (decision 62): the
+/// utility role walks the caller's own entitlements, and with no caller it
+/// resolves to nothing, so the work is skipped rather than run as somebody
+/// else.
+#[tokio::test]
+async fn background_roles_walk_the_callers_entitlements() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let snapshot = caller_snapshot();
+
+    let utility = model_roles::resolve(
+        &*store,
+        &*secrets,
+        &*provisioned,
+        &crate::managed_policy::NoOsPolicy,
+        model_roles::ModelRole::Utility,
+        Some(&snapshot),
+    )
+    .await
+    .unwrap()
+    .expect("the caller's entitlements must serve the utility role");
+    assert_eq!(utility.provider, providers::ProviderKind::ModelGateway);
+    assert_eq!(utility.id, "acme-opus");
+
+    assert!(
+        model_roles::resolve(
+            &*store,
+            &*secrets,
+            &*provisioned,
+            &crate::managed_policy::NoOsPolicy,
+            model_roles::ModelRole::Utility,
+            None,
+        )
+        .await
+        .unwrap()
+        .is_none(),
+        "background work with no caller must be skipped, never run as somebody else"
+    );
+}
+
+/// The providers surface names the caller's gateway (decision 62): present
+/// with their models exactly when their snapshot resolved, absent otherwise.
+#[tokio::test]
+async fn the_providers_list_names_the_callers_gateway() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let hosted = hosted_machine_policy();
+    let snapshot = caller_snapshot();
+
+    let listed = providers::list_providers(&*store, &*secrets, &hosted, Some(&snapshot))
+        .await
+        .unwrap();
+    let gateway = listed
+        .iter()
+        .find(|provider| provider.kind == providers::ProviderKind::ModelGateway)
+        .expect("the caller's gateway must be listed");
+    assert!(gateway.enabled);
+    assert!(gateway.has_credential);
+    assert_eq!(gateway.models.len(), 2);
+
+    let without_caller = providers::list_providers(&*store, &*secrets, &hosted, None)
+        .await
+        .unwrap();
+    assert!(
+        !without_caller
+            .iter()
+            .any(|provider| provider.kind == providers::ProviderKind::ModelGateway),
+        "no caller snapshot means no gateway to offer"
+    );
+}
+
+/// A stored provider configuration keeps its own route beside the caller's
+/// gateway path (decision 62): the caller path no longer impersonates a
+/// direct provider, so neither displaces the other.
+#[tokio::test]
+async fn a_stored_provider_and_the_caller_path_coexist() {
     let dir = tempfile::tempdir().unwrap();
     let (store, secrets) = empty_deployment(&dir).await;
     providers::write_credential(
@@ -5747,100 +6027,22 @@ async fn a_stored_provider_configuration_outranks_on_behalf_of_inference() {
     let policy =
         crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
 
-    let route = providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy)
-        .await
-        .into_iter()
+    let routes =
+        providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy).await;
+    let stored = routes
+        .iter()
         .find(|route| route.kind == tidebreak_router::RouteKind::Anthropic)
-        .expect("the stored key must still offer an Anthropic route");
-
-    assert_eq!(route.api_key, "sk-stored");
+        .expect("the stored key must keep its Anthropic route");
+    assert_eq!(stored.api_key, "sk-stored");
     assert!(
-        route.token_source.is_none(),
-        "a stored configuration must not be displaced by per-caller inference"
+        stored.token_source.is_none(),
+        "the stored route keeps the deployment's own credential"
     );
-}
-
-/// Rule 3: a provider row that disables the provider is a statement too. The
-/// deployment said no, and per-caller inference does not overrule it.
-#[tokio::test]
-async fn a_disabled_provider_row_outranks_on_behalf_of_inference() {
-    let dir = tempfile::tempdir().unwrap();
-    let (store, secrets) = empty_deployment(&dir).await;
-    providers::write_config(
-        &*store,
-        providers::ProviderKind::Anthropic,
-        &providers::ProviderConfig {
-            enabled: false,
-            base_url: None,
-            models: Vec::new(),
-        },
-    )
-    .await
-    .unwrap();
-
-    let _env = ENV_LOCK.lock().await;
-    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
-    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
-    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
-    let policy =
-        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
-
-    let routes =
-        providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy).await;
     assert!(
-        !routes
+        routes
             .iter()
-            .any(|route| route.kind == tidebreak_router::RouteKind::Anthropic),
-        "a disabled provider row must leave the provider unrouted"
-    );
-}
-
-/// Rule 3: the environment fallbacks keep their semantics. An environment
-/// credential names an inference path, so per-caller inference stays out of
-/// the way — including where the environment key alone routes nothing,
-/// because that is the behavior this record leaves in force.
-#[tokio::test]
-async fn an_environment_credential_outranks_on_behalf_of_inference() {
-    let dir = tempfile::tempdir().unwrap();
-    let (store, secrets) = empty_deployment(&dir).await;
-
-    let _env = ENV_LOCK.lock().await;
-    let _key = ScopedEnv::set("ANTHROPIC_API_KEY", "sk-from-the-environment");
-    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
-    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
-    let policy =
-        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
-
-    let routes =
-        providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy).await;
-    assert!(
-        !routes.iter().any(|route| route.token_source.is_some()),
-        "an environment credential must not be displaced by per-caller inference"
-    );
-}
-
-/// Rule 3: an environment base URL names an inference path of its own, even
-/// with no credential beside it, so per-caller inference stays out of the way.
-#[tokio::test]
-async fn an_environment_base_url_outranks_on_behalf_of_inference() {
-    let dir = tempfile::tempdir().unwrap();
-    let (store, secrets) = empty_deployment(&dir).await;
-
-    let _env = ENV_LOCK.lock().await;
-    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
-    let _base = ScopedEnv::set("ANTHROPIC_BASE_URL", "https://relay.example/v1");
-    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
-    let policy =
-        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
-
-    let routes =
-        providers::collect_routes(&*store, &*secrets, None, None, on_behalf_of(), &policy).await;
-    assert!(
-        !routes
-            .iter()
-            .any(|route| route.kind == tidebreak_router::RouteKind::Anthropic
-                && route.token_source.is_some()),
-        "an environment endpoint must not be displaced by per-caller inference"
+            .any(|route| route.kind == tidebreak_router::RouteKind::ModelGateway),
+        "the caller's gateway path rides beside the stored provider"
     );
 }
 
@@ -5874,12 +6076,18 @@ async fn a_cached_provider_is_never_shared_between_callers() {
 
     let dir = tempfile::tempdir().unwrap();
     let (store, secrets) = empty_deployment(&dir).await;
-    let inference =
-        Arc::new(crate::obo_inference::OboInference::new("https://gateway.example").unwrap());
+    let gateway_obo =
+        Arc::new(crate::obo_gateway::OboGateway::new("https://gateway.example").unwrap());
     let alice = tidebreak_core::OwnerId::new("user:alice").unwrap();
     let bob = tidebreak_core::OwnerId::new("user:bob").unwrap();
-    inference.record_caller(&alice, "mg_at_alice".into());
-    inference.record_caller(&bob, "mg_at_bob".into());
+    gateway_obo.record_caller(&alice, "mg_at_alice".into());
+    gateway_obo.record_caller(&bob, "mg_at_bob".into());
+    gateway_obo
+        .seed_snapshot_for_test(&alice, caller_snapshot())
+        .await;
+    gateway_obo
+        .seed_snapshot_for_test(&bob, caller_snapshot())
+        .await;
 
     let resolver = resolver::ConfiguredResolver::new(
         store.clone(),
@@ -5896,7 +6104,7 @@ async fn a_cached_provider_is_never_shared_between_callers() {
         crate::managed_policy::MemoryProvisionedPolicy::new(),
         Arc::new(crate::managed_policy::NoOsPolicy),
     )
-    .with_on_behalf_of_inference(Some(inference.clone()));
+    .with_on_behalf_of_gateway(Some(gateway_obo.clone()));
 
     let _env = ENV_LOCK.lock().await;
     let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
@@ -6051,13 +6259,11 @@ async fn app_state_projects_the_deployments_own_gateway() {
     assert!(!policy.managed);
 }
 
-/// The picker a caller starts a conversation from.
-///
-/// A hosted machine stores no provider configuration of its own — it resolves
-/// the credential per caller — so the stored-row walk would call every
-/// provider unusable and offer nobody a model to select.
+/// The picker a caller starts a conversation from (decision 62): their own
+/// snapshot makes the gateway usable and fills the catalog; without one, the
+/// machine offers nothing rather than guessing.
 #[tokio::test]
-async fn a_hosted_machine_offers_the_caller_a_model_to_start_with() {
+async fn a_hosted_machine_offers_the_caller_their_own_models() {
     let dir = tempfile::tempdir().unwrap();
     let (store, secrets) = empty_deployment(&dir).await;
 
@@ -6065,77 +6271,55 @@ async fn a_hosted_machine_offers_the_caller_a_model_to_start_with() {
     let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
     let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
     let hosted = hosted_machine_policy();
+    let snapshot = caller_snapshot();
 
     assert!(
         providers::provider_is_usable(
             &*store,
             &*secrets,
-            providers::ProviderKind::Anthropic,
+            providers::ProviderKind::ModelGateway,
             &hosted,
+            Some(&snapshot),
         )
         .await
         .unwrap(),
-        "the provider the caller's own credential serves must be usable"
+        "a resolved caller snapshot makes the gateway usable"
     );
 
-    let catalog = providers::catalog_models(&*store, &*secrets, &hosted)
+    let catalog = providers::catalog_models(&*store, &*secrets, &hosted, Some(&snapshot))
         .await
         .unwrap();
     assert!(
-        catalog
-            .iter()
-            .any(|entry| entry.available
-                && entry.policy.provider == providers::ProviderKind::Anthropic),
-        "the catalog must offer at least one selectable model"
+        catalog.iter().any(|entry| entry.available
+            && entry.policy.provider == providers::ProviderKind::ModelGateway
+            && entry.policy.id == "acme-opus"),
+        "the catalog must offer the caller's own entitled models"
+    );
+    assert!(
+        !catalog.iter().any(|entry| entry.available
+            && entry.policy.provider != providers::ProviderKind::ModelGateway),
+        "no other provider is selectable with nothing configured"
     );
 
-    // The same deployment without gateway authentication is unchanged: a
-    // self-host server on static tokens states no path to this provider.
-    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
-    let unmanaged =
-        crate::managed_policy::resolve(&*provisioned, &crate::managed_policy::NoOsPolicy).unwrap();
-    assert!(!providers::provider_is_usable(
-        &*store,
-        &*secrets,
-        providers::ProviderKind::Anthropic,
-        &unmanaged,
-    )
-    .await
-    .unwrap());
-}
-
-/// Decision 51, rule 3, in the catalog as well as in route collection: a
-/// stored provider configuration states the deployment's inference path, and
-/// per-caller availability does not overrule it.
-#[tokio::test]
-async fn a_stored_provider_configuration_still_decides_availability() {
-    let dir = tempfile::tempdir().unwrap();
-    let (store, secrets) = empty_deployment(&dir).await;
-    providers::write_config(
-        &*store,
-        providers::ProviderKind::Anthropic,
-        &providers::ProviderConfig {
-            enabled: false,
-            base_url: None,
-            models: Vec::new(),
-        },
-    )
-    .await
-    .unwrap();
-
-    let _env = ENV_LOCK.lock().await;
-    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
-    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
-
+    // Without a caller snapshot — an unnamed request, or a caller whose
+    // exchange failed — the same machine offers nothing.
     assert!(
         !providers::provider_is_usable(
             &*store,
             &*secrets,
-            providers::ProviderKind::Anthropic,
-            &hosted_machine_policy(),
+            providers::ProviderKind::ModelGateway,
+            &hosted,
+            None,
         )
         .await
         .unwrap(),
-        "a disabled provider row must leave the provider unusable"
+        "no caller snapshot means no usable gateway"
+    );
+    let catalog = providers::catalog_models(&*store, &*secrets, &hosted, None)
+        .await
+        .unwrap();
+    assert!(
+        !catalog.iter().any(|entry| entry.available),
+        "no caller snapshot means nothing selectable"
     );
 }

--- a/crates/tidebreak-server/src/tests/image_attachment.rs
+++ b/crates/tidebreak-server/src/tests/image_attachment.rs
@@ -777,7 +777,7 @@ async fn an_exact_image_turn_retry_survives_a_managed_gateway_route_retarget() {
     .await
     .unwrap();
     assert!(
-        providers::resolve_model_policy(&*store, &original_model, false)
+        providers::resolve_model_policy(&*store, &original_model, false, None)
             .await
             .unwrap()
             .is_none(),
@@ -1060,10 +1060,11 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
     let router = app(state);
     let chat = make_chat(&router, &bearer).await;
 
-    let policy = providers::resolve_model_policy(&*store, "openai_compatible::vendor/model", false)
-        .await
-        .unwrap()
-        .expect("a registered custom model resolves");
+    let policy =
+        providers::resolve_model_policy(&*store, "openai_compatible::vendor/model", false, None)
+            .await
+            .unwrap()
+            .expect("a registered custom model resolves");
     assert!(!policy
         .input_modalities
         .contains(&crate::model_registry::InputModality::Image));

--- a/crates/tidebreak-server/src/turn_worker.rs
+++ b/crates/tidebreak-server/src/turn_worker.rs
@@ -90,6 +90,10 @@ pub(crate) enum TurnWorkerOutcome {
 
 #[derive(Clone)]
 pub(crate) struct TurnWorker {
+    /// Per-caller gateway capabilities on a hosted machine (decisions 51 and
+    /// 62): the turn's model resolution and utility role read the owner's
+    /// own entitlement snapshot through this. `None` everywhere else.
+    on_behalf_of: Option<Arc<crate::obo_gateway::OboGateway>>,
     store: Arc<dyn Store>,
     resolver: Arc<dyn ProviderResolver>,
     secrets: Arc<dyn SecretProvider>,
@@ -402,6 +406,7 @@ impl TurnWorker {
             events.clone(),
         ));
         Self {
+            on_behalf_of: None,
             store,
             resolver,
             secrets,
@@ -431,6 +436,14 @@ impl TurnWorker {
     ///
     /// Without it an agent evicts every image block to a text stand-in, so a
     /// turn still runs but the model is told the image is unavailable.
+    pub(crate) fn with_on_behalf_of_gateway(
+        mut self,
+        gateway: Option<Arc<crate::obo_gateway::OboGateway>>,
+    ) -> Self {
+        self.on_behalf_of = gateway;
+        self
+    }
+
     pub(crate) fn with_blobs(mut self, blobs: Arc<dyn BlobStore>) -> Self {
         self.blobs = Some(blobs);
         self
@@ -790,8 +803,24 @@ impl TurnWorker {
             Some(provider) => provider.current_timeout_ms().await,
             None => crate::code_execution::DEFAULT_TIMEOUT_MS,
         };
+        // The turn's owner and, on a hosted machine, their own entitlement
+        // snapshot — resolved once here so the model re-resolution, the
+        // utility role, and the per-caller router all read the same answer
+        // (decision 62). A snapshot that cannot be resolved reads as `None`
+        // and fails the gateway-bound paths closed.
+        let owner = self.store.chat_owner(chat.id).await.unwrap_or_default();
+        let caller_gateway = match (self.on_behalf_of.as_ref(), owner.as_ref()) {
+            (Some(gateway), Some(owner)) => gateway.snapshot_for(owner).await.ok().flatten(),
+            _ => None,
+        };
         let model_policy = if self.resolver.enforces_model_registry() {
-            crate::providers::resolve_model_policy(&*self.store, &turn.model, true).await?
+            crate::providers::resolve_model_policy(
+                &*self.store,
+                &turn.model,
+                true,
+                caller_gateway.as_ref(),
+            )
+            .await?
         } else {
             None
         };
@@ -892,6 +921,7 @@ impl TurnWorker {
                 &*self.secrets,
                 &*self.provisioned_policy,
                 &*self.os_policy,
+                caller_gateway.as_ref(),
             )
             .await?
         } else {
@@ -995,7 +1025,6 @@ impl TurnWorker {
             // ignored; on one that resolves them per caller, an owner that
             // cannot be named yields no route and fails the turn closed
             // rather than running it on somebody else's authority.
-            let owner = self.store.chat_owner(chat.id).await.unwrap_or_default();
             let provider = self.resolver.resolve_for(owner.as_ref()).await;
             let steer = active.steer_inbox();
             let mut agent = Agent::new(provider, surface.tools.clone(), self.store.clone(), config)

--- a/crates/tidebreak-server/src/web_search/host.rs
+++ b/crates/tidebreak-server/src/web_search/host.rs
@@ -594,7 +594,10 @@ async fn chat_search_model(
             .flatten()
             .unwrap_or_else(|| default_model.to_owned()),
     };
-    let policy = crate::providers::resolve_model_policy(store, &selected, true)
+    // Hosted callers' gateway selections resolve to nothing here: the search
+    // sub-request rides the deployment-resolved provider, which a hosted
+    // machine does not have. Decision 62 names this gap and leaves it open.
+    let policy = crate::providers::resolve_model_policy(store, &selected, true, None)
         .await
         .ok()
         .flatten()?;

--- a/docs/decisions/0051-on-behalf-of-inference-for-hosted-machines.md
+++ b/docs/decisions/0051-on-behalf-of-inference-for-hosted-machines.md
@@ -8,6 +8,9 @@
   [`../gateway-boundary.md`](../gateway-boundary.md)
 - Supersedes: the deployment-scoped inference credential as the default for
   gateway-authenticated hosted machines
+- Amended by: [`0062-per-caller-gateway-entitlements.md`](0062-per-caller-gateway-entitlements.md)
+  — the route presentation and rule 3; the exchange, attribution, and
+  fail-closed rules stand
 
 ## Context
 

--- a/docs/decisions/0062-per-caller-gateway-entitlements.md
+++ b/docs/decisions/0062-per-caller-gateway-entitlements.md
@@ -1,0 +1,95 @@
+# 62. Per-caller gateway entitlements on hosted machines
+
+- Status: Proposed
+- Date: 2026-08-22
+- Owners: server
+- Related: [`0049-gateway-authenticated-hosted-machines.md`](0049-gateway-authenticated-hosted-machines.md),
+  [`0051-on-behalf-of-inference-for-hosted-machines.md`](0051-on-behalf-of-inference-for-hosted-machines.md),
+  [`../gateway-boundary.md`](../gateway-boundary.md)
+- Supersedes: decision 51's presentation of per-caller inference as a curated
+  Anthropic route, and its rule 3 — a stored provider statement no longer
+  silences the per-caller path, because the two no longer compete for one
+  provider. Decision 51's exchange, its attribution, and its fail-closed
+  rules stand unchanged.
+
+## Context
+
+Decision 51 gave hosted machines per-caller inference but not per-caller
+choice. The route it built posed as the curated Anthropic catalog: every
+caller was offered the same hard-coded list, models their own gateway account
+never entitled them to were offered and refused at the turn, and models the
+deployment's gateway does serve — through either compat protocol — were
+missing. Background roles resolved against stored provider rows a hosted
+machine never has, so chat titling and the approval judge silently did
+nothing.
+
+The gateway now mints a second capability from the same machine-bound token
+decision 51 exchanges: audience `catalog` returns a short-lived,
+`models:read`-scoped token that reads exactly one thing, the caller's own
+member catalog at `/api/v1/me/catalog` (model-gateway ADR 0082). That makes
+the right question answerable per caller: which models does this person's
+account entitle them to, right now.
+
+## Decision
+
+1. **The machine reads each caller's member catalog.** It exchanges the
+   caller's live machine-bound token for a `catalog` capability and fetches
+   `/api/v1/me/catalog`, converting the answer with the same code the managed
+   sync uses, so a hosted caller's model rows are shaped exactly like a
+   managed profile's. Snapshots live in process memory keyed by owner, beside
+   the inference token they parallel: fresh for five minutes, revalidated
+   with the held `ETag` after that, served up to an hour stale only across
+   transport failure. A gateway refusal always propagates — a revoked
+   session stops the caller rather than coasting on grace — and nothing is
+   ever written to the store.
+
+2. **A caller's routes are gateway routes.** Route collection builds the
+   caller's routes from their snapshot with the same builder the managed
+   profile uses: a route per compat protocol, raw and frozen model
+   identities, the caller's rotating credential, and one inert adapter for a
+   caller entitled to nothing. Nothing impersonates a direct provider
+   anymore, which retires decision 51's rule 3 — a stored BYOK configuration
+   keeps its own route beside the caller's gateway path, and neither
+   displaces the other.
+
+3. **Every catalog surface resolves per caller.** The picker, the providers
+   list, selection validation, the turn-accept freeze, and the turn worker's
+   re-resolution all take the requesting caller's snapshot. A hosted
+   caller's explicit selection freezes against their own snapshot and
+   resolves back through it and nobody else's. Without a resolvable
+   snapshot, every one of these surfaces offers nothing: an unnamed request,
+   a dead session, and a gateway outage past the grace all fail closed.
+
+4. **Background work runs as the caller who triggered it.** Chat titling,
+   workspace titling, and the approval judge resolve their utility model by
+   walking the triggering chat's owner's entitlements, and drive it on that
+   owner's credential. Work that can name no caller is skipped — never run
+   as somebody else, never billed to the deployment.
+
+5. **Named gaps, left open.** The web-search sub-request and the container
+   sandbox's model proxy still resolve without a caller and therefore stay
+   unavailable on hosted machines. Both need a caller-aware seam of their
+   own; this record makes their absence explicit rather than accidental.
+
+## Rejected
+
+- **Reusing the deployment-wide snapshot.** One caller's entitlements served
+  to everybody, written by a sync no hosted machine can run. Rejected before
+  this record; recorded here because the store key still exists for managed
+  profiles and must never be written per caller.
+- **A client-supplied catalog.** The attached desktop could push its own
+  catalog, but the server validates every selection, and background work has
+  no attached client to borrow from.
+- **Keeping the curated-Anthropic presentation with per-caller filtering.**
+  Smaller diff, but it keeps offering one protocol, keeps the impersonation
+  that forced rule 3, and forks gateway-model handling from the managed
+  path that already does it right.
+
+## Revisit when
+
+- A hosted deployment needs the web-search sub-request or container
+  sandboxes; either lifts a named gap from decision 5.
+- The gateway serves per-caller MCP entitlements the same way; the apps half
+  of the member catalog is already fetched and discarded here.
+- Entitlement changes need to land faster than the five-minute freshness
+  window; the revalidation cadence is a constant, not a contract.


### PR DESCRIPTION
Closes #2517.

A caller on a gateway-authenticated hosted machine saw the curated Anthropic list, not what their own Model Gateway account entitles them to. Models their next turn would be refused for were offered, models the deployment's gateway does serve were missing, and background roles (chat titling, the approval judge) resolved to nothing because they walked stored provider rows a hosted machine never has.

## The contract question, settled

Decision 62 (in this PR) answers the issue's open question with the gateway's new capability: the machine exchanges the caller's live machine-bound token for a `catalog` capability (model-gateway ADR 0082, merged as brightwave-inc/model-gateway#1279) and reads `/api/v1/me/catalog` as that caller. Option 1 (accepting machine-bound tokens at the catalog) and a client-supplied catalog are rejected in the record.

## What changed

- `obo_inference.rs` becomes `obo_gateway.rs`: the same per-caller exchange machinery now mints two capabilities — inference (decision 51, unchanged) and the entitlement snapshot. Snapshots are cached per owner in process memory: fresh 300 s, ETag revalidation, a transport-only stale grace of 3600 s, and refusals always propagate, so a revoked session stops the caller.
- The caller's routes are real gateway routes: `collect_routes` builds them with the same per-protocol, frozen-identity builder the managed profile uses (factored into one `gateway_snapshot_routes`), from the caller's snapshot. Nothing impersonates the curated Anthropic route anymore, so a stored BYOK configuration coexists instead of outranking — decision 51's rule 3 retires with the impersonation that forced it.
- Catalog surfaces resolve per caller: `catalog_models`, `list_providers`, `provider_is_usable`, `model_is_usable`, `resolve_model_policy`, `effective_chat_policy`, selection validation, the turn-accept freeze, the turn worker's re-resolution, and the image-capability gate all take the requesting caller's snapshot.
- Background roles run as the caller who triggered them: the turn worker, chat titler, workspace titler, and approval judge resolve the utility role over the triggering owner's entitlements and drive it on their credential (`resolve_for`). No caller means the work is skipped.
- Named gaps, left open in the record: the web-search sub-request and the sandbox model paths still resolve without a caller.

## Tests

- `obo_gateway`: snapshot fetch shape and conversion, memory freshness, ETag revalidation on 304, refusal fails closed with no grace, per-caller isolation, unknown caller gets nothing — against a fake gateway that asserts the catalog read presents a catalog capability.
- `tests/configuration`: per-protocol routes with frozen identities from the caller snapshot; a caller entitled to nothing offered nothing; two callers see two catalogs and nothing reaches deployment-wide state; a hosted selection freezes through the caller's snapshot and a foreign snapshot refuses it; background roles walk the caller's entitlements and skip without one; the providers list names the caller's gateway; stored BYOK and the caller path coexist; per-caller provider cache isolation (seeded snapshots).

Depends on the gateway serving audience `catalog` (already on model-gateway main; deployments predating it get the explicit member-catalog refusal, and callers are offered nothing rather than a guess).