### PR TITLE
feat(code): reconcile pull-request facts and surface the workspace's set

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -95,6 +95,7 @@ import {
   type CodeWorkspaceBlob,
   type CodeWorkspaceTree,
   type CodeWorkspacePrSnapshot,
+  type CodeWorkspacePullRequests,
   type CodeTriggerAction,
   type CodeTriggerCondition,
   type CodeTriggerSnapshot,
@@ -167,6 +168,7 @@ import {
   parseCodeWorkspaceBlob,
   parseCodeWorkspaceTree,
   parseCodeWorkspacePr,
+  parseCodeWorkspacePullRequests,
   parseCodeTrigger,
   parseCodeTriggers,
   parseCodeWatch,
@@ -2626,6 +2628,23 @@ export class ApiClient {
         ),
       ),
       "code pull request",
+    );
+  }
+
+  /** Every pull request attributed to the workspace (decision 62). */
+  async getCodeWorkspacePullRequests(
+    workspaceId: string,
+  ): Promise<CodeWorkspacePullRequests> {
+    return requireParsed(
+      parseCodeWorkspacePullRequests(
+        await this.json(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/pull-requests`,
+          {
+            headers: this.headers(),
+          },
+        ),
+      ),
+      "code workspace pull requests",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -57,6 +57,9 @@ import {
   type CodeGitHubCapability as WireCodeGitHubCapability,
   type CodeGitHubRepositoryRef as WireCodeGitHubRepositoryRef,
   type CodeGitHubRepositoryTarget as WireCodeGitHubRepositoryTarget,
+  type CodePullRequestRelation as WireCodePullRequestRelation,
+  type CodeWorkspacePullRequestFact as WireCodeWorkspacePullRequestFact,
+  type CodeWorkspacePullRequests as WireCodeWorkspacePullRequests,
   type EgressConfig as WireEgressConfig,
   type CustomModelConfig as WireCustomModelConfig,
   type McpHealth as WireMcpHealth,
@@ -1111,6 +1114,9 @@ export type RepoId = WireRepoId;
 export type CodeGitHubCapability = WireCodeGitHubCapability;
 export type CodeGitHubRepositoryRef = WireCodeGitHubRepositoryRef;
 export type CodeGitHubRepositoryTarget = WireCodeGitHubRepositoryTarget;
+export type CodePullRequestRelation = WireCodePullRequestRelation;
+export type CodeWorkspacePullRequestFact = WireCodeWorkspacePullRequestFact;
+export type CodeWorkspacePullRequests = WireCodeWorkspacePullRequests;
 export type CodeDeliverySourceError = WireCodeDeliverySourceError;
 export type CodeDeliveryWorkspaceLink = WireCodeDeliveryWorkspaceLink;
 export type CodeDeliveryCheck = WireCodeDeliveryCheck;

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -80,6 +80,7 @@ function makeClient(): Pick<
   | "listCodeWorkspaceFiles"
   | "listCodeWorkspaceTree"
   | "getCodeWorkspacePr"
+  | "getCodeWorkspacePullRequests"
 > {
   return {
     getCodePrComments: vi.fn().mockResolvedValue({
@@ -116,6 +117,10 @@ function makeClient(): Pick<
       truncated: false,
     }),
     getCodeWorkspacePr: vi.fn().mockResolvedValue(null),
+    getCodeWorkspacePullRequests: vi.fn().mockResolvedValue({
+      items: [],
+      fetched_at: "2026-08-22T12:00:00Z",
+    }),
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -597,3 +597,82 @@ it("labels a turn by its ordinal among user items", () => {
     ),
   ).toBe("Turn 2");
 });
+
+it("keys the attributed set on full identity, not the number", async () => {
+  const collidingFacts = [
+    {
+      host: "github.com",
+      repo_owner: "acme",
+      repo_name: "app",
+      number: 41,
+      url: "https://github.com/acme/app/pull/41",
+      title: "Fix login flow",
+      state: "open",
+      draft: false,
+      head_branch: "tidebreak/fix-login",
+      base_branch: "main",
+      relation: "authored" as const,
+      created_at: "2026-08-01T00:00:00Z",
+      updated_at: "2026-08-02T00:00:00Z",
+      last_seen_at: "2026-08-02T00:00:00Z",
+    },
+    {
+      host: "github.com",
+      repo_owner: "acme",
+      repo_name: "design-tokens",
+      number: 41,
+      url: "https://github.com/acme/design-tokens/pull/41",
+      title: "Token spacing pass",
+      state: "open",
+      draft: false,
+      head_branch: "tidebreak/tokens",
+      base_branch: "main",
+      relation: "contributed" as const,
+      created_at: "2026-08-01T00:00:00Z",
+      updated_at: "2026-08-02T00:00:00Z",
+      last_seen_at: "2026-08-02T00:00:00Z",
+    },
+  ];
+  const client = {
+    ...makeClient(),
+    getCodeWorkspacePullRequests: vi.fn().mockResolvedValue({
+      items: collidingFacts,
+      fetched_at: "2026-08-02T00:01:00Z",
+    }),
+  };
+  render(
+    <CodeInspector
+      client={client as never}
+      workspaceId="ws-1"
+      workspace={{ ...WORKSPACE, pr: OPEN_PR } as never}
+      contentRevision={0}
+      requestedTab={{ tab: "pr", revision: 1 }}
+    />,
+  );
+
+  const list = await screen.findByRole("navigation", {
+    name: "Pull requests this workspace worked on",
+  });
+  const rows = await waitFor(() => {
+    const buttons = list.querySelectorAll("button");
+    expect(buttons).toHaveLength(2);
+    return buttons;
+  });
+
+  // The live number matches both repositories, so no row may claim to be
+  // current: treating either as the primary would collapse two identities.
+  expect(list.querySelectorAll("[aria-current='true']")).toHaveLength(0);
+
+  // Selecting the cross-repo row shows that row's stored snapshot — never
+  // the live resource its number collides with.
+  await userEvent.click(rows[1]);
+  const panelTitle = await screen.findByRole("link", {
+    name: "Token spacing pass",
+  });
+  expect(panelTitle.getAttribute("href")).toBe(
+    "https://github.com/acme/design-tokens/pull/41",
+  );
+  const current = list.querySelectorAll("[aria-current='true']");
+  expect(current).toHaveLength(1);
+  expect(current[0].textContent).toContain("design-tokens");
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 import { HttpError, type ApiClient } from "../api/client";
 import type {
   CodePrMergeMethod,
+  CodeWorkspacePullRequestFact,
   CodeWorkspaceSnapshot,
   PullRequestCheck,
   PullRequestComment,
@@ -58,6 +59,8 @@ import { PrCommentCard } from "./PrCommentCard";
 import { prMergeControls, prWorkflowStatus } from "./prActions";
 import { useWorkspaceDigest } from "./CodeUpdatesStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
+import { useWorkspacePullRequests } from "./useWorkspacePullRequests";
+import { digestFromFact, WorkspacePrList } from "./WorkspacePrList";
 import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
 
 export type InspectorTab = "files" | "source" | "pr";
@@ -256,12 +259,13 @@ export function CodeInspector({
           value="pr"
           className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
         >
-          <PrTab
+          <WorkspacePrTab
             client={client}
             workspaceId={workspaceId}
             pr={pr}
             branch={workspace?.branch_name}
             prResource={prResource}
+            prCount={digest?.pr_count}
           />
         </TabsContent>
       </Tabs>
@@ -309,6 +313,59 @@ export function inspectorTurnLabel(
     if (item.turnId === turnId) return `Turn ${ordinal}`;
   }
   return "This turn";
+}
+
+/**
+ * The inspector's Pull request tab: the workspace's attributed set above the
+ * single-PR panel (decision 62). With one or no attributed pull requests the
+ * list stays hidden and this is exactly the live panel it always was.
+ * Selecting a non-primary row shows its stored snapshot; the primary row
+ * returns to the live resource.
+ */
+function WorkspacePrTab({
+  client,
+  workspaceId,
+  pr,
+  branch,
+  prResource,
+  prCount,
+}: {
+  client: ApiClient;
+  workspaceId: string;
+  pr?: PullRequestDigest;
+  branch?: string;
+  prResource?: CodeWorkspacePrResource;
+  prCount?: number;
+}) {
+  const attributed = useWorkspacePullRequests(client, workspaceId, prCount);
+  const [selected, setSelected] = useState<CodeWorkspacePullRequestFact | null>(
+    null,
+  );
+  useEffect(() => {
+    setSelected(null);
+  }, [workspaceId]);
+  const items = attributed.data?.items ?? [];
+  const shownPr = selected ? digestFromFact(selected) : pr;
+  return (
+    <>
+      {items.length > 1 && (
+        <WorkspacePrList
+          items={items}
+          selectedNumber={shownPr?.number}
+          onSelect={(item) =>
+            setSelected(item.number === pr?.number ? null : item)
+          }
+        />
+      )}
+      <PrTab
+        client={client}
+        workspaceId={workspaceId}
+        pr={shownPr}
+        branch={branch}
+        prResource={selected ? undefined : prResource}
+      />
+    </>
+  );
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -60,7 +60,7 @@ import { prMergeControls, prWorkflowStatus } from "./prActions";
 import { useWorkspaceDigest } from "./CodeUpdatesStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import { useWorkspacePullRequests } from "./useWorkspacePullRequests";
-import { digestFromFact, WorkspacePrList } from "./WorkspacePrList";
+import { digestFromFact, factKey, WorkspacePrList } from "./WorkspacePrList";
 import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
 
 export type InspectorTab = "files" | "source" | "pr";
@@ -321,6 +321,11 @@ export function inspectorTurnLabel(
  * list stays hidden and this is exactly the live panel it always was.
  * Selecting a non-primary row shows its stored snapshot; the primary row
  * returns to the live resource.
+ *
+ * Numbers repeat across repositories and the live digest carries no
+ * repository identity, so the primary is resolved only when exactly one
+ * attributed fact carries the live number. A colliding row is never treated
+ * as the primary: selecting it shows its own stored snapshot.
  */
 function WorkspacePrTab({
   client,
@@ -345,15 +350,25 @@ function WorkspacePrTab({
     setSelected(null);
   }, [workspaceId]);
   const items = attributed.data?.items ?? [];
+  const primaryMatches =
+    pr === undefined ? [] : items.filter((item) => item.number === pr.number);
+  const primary = primaryMatches.length === 1 ? primaryMatches[0] : undefined;
+  const selectedKey = selected
+    ? factKey(selected)
+    : primary
+      ? factKey(primary)
+      : undefined;
   const shownPr = selected ? digestFromFact(selected) : pr;
   return (
     <>
       {items.length > 1 && (
         <WorkspacePrList
           items={items}
-          selectedNumber={shownPr?.number}
+          selectedKey={selectedKey}
           onSelect={(item) =>
-            setSelected(item.number === pr?.number ? null : item)
+            setSelected(
+              primary && factKey(item) === factKey(primary) ? null : item,
+            )
           }
         />
       )}

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -312,6 +312,7 @@ export function noticeToAction(
         turn_count: notice.turn_count,
         ...(notice.activity !== undefined ? { activity: notice.activity } : {}),
         ...(notice.pr_state !== undefined ? { pr_state: notice.pr_state } : {}),
+        ...(notice.pr_count !== undefined ? { pr_count: notice.pr_count } : {}),
         ...(notice.watch_state !== undefined
           ? { watch_state: notice.watch_state }
           : {}),

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -55,6 +55,7 @@ import {
   sessionRowLabel,
   watchRowLabel,
   workspaceCardLabel,
+  workspacePrChipSummary,
   type CardDensity,
   isPutAway,
 } from "./workspaceCards";
@@ -302,6 +303,7 @@ function WorkspaceStateLine({
       ? workspaceWorkflowActionLabel(primary, model.stage)
       : null;
     const stateLabel = model.summary.replace(/^#\d+\s*·\s*/, "");
+    const prCountLabel = workspacePrChipSummary(digest?.pr_count);
 
     return (
       <>
@@ -314,7 +316,11 @@ function WorkspaceStateLine({
               FOCUS_RING_INSET,
               HOVER_TINT,
             )}
-            aria-label={`Open pull request #${pr.number}`}
+            aria-label={
+              prCountLabel
+                ? `Open pull request #${pr.number}, one of ${digest?.pr_count} this workspace worked on`
+                : `Open pull request #${pr.number}`
+            }
             title={model.detail}
             onClick={() => onCommand("open-pr")}
           >
@@ -323,6 +329,11 @@ function WorkspaceStateLine({
             <span className="min-w-0 truncate text-muted-foreground">
               {stateLabel}
             </span>
+            {prCountLabel && (
+              <span className="bg-muted text-muted-foreground shrink-0 rounded-full px-1.5 text-[10px] font-medium tabular-nums">
+                {prCountLabel}
+              </span>
+            )}
             <ExternalLink
               className="size-2.5 shrink-0 opacity-55"
               aria-hidden

--- a/crates/tidebreak-desktop/ui/src/code/WorkspacePrList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspacePrList.tsx
@@ -14,18 +14,26 @@ import {
 } from "./workspaceCards";
 
 /**
+ * One fact's full identity. Numbers repeat across repositories, so every
+ * selection and highlight decision keys on this, never on the number.
+ */
+export function factKey(fact: CodeWorkspacePullRequestFact): string {
+  return `${fact.host}/${fact.repo_owner}/${fact.repo_name}#${fact.number}`;
+}
+
+/**
  * Every pull request attributed to the workspace (decision 62), as a compact
  * selector above the single-PR panel. Rendered only when there is more than
  * one, so the common one-PR workspace keeps today's surface untouched.
  */
 export function WorkspacePrList({
   items,
-  selectedNumber,
+  selectedKey,
   onSelect,
 }: {
   items: readonly CodeWorkspacePullRequestFact[];
-  /** The pull request the panel below is showing. */
-  selectedNumber?: number;
+  /** Full identity of the pull request the panel below is showing. */
+  selectedKey?: string;
   onSelect: (item: CodeWorkspacePullRequestFact) => void;
 }) {
   return (
@@ -35,10 +43,10 @@ export function WorkspacePrList({
     >
       {items.map((item) => {
         const tone = prTone(item);
-        const selected = item.number === selectedNumber;
+        const selected = factKey(item) === selectedKey;
         return (
           <button
-            key={`${item.host}/${item.repo_owner}/${item.repo_name}#${item.number}`}
+            key={factKey(item)}
             type="button"
             aria-current={selected ? "true" : undefined}
             aria-label={`Pull request #${item.number}: ${item.title}, ${prToneLabel(item)}${

--- a/crates/tidebreak-desktop/ui/src/code/WorkspacePrList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspacePrList.tsx
@@ -1,0 +1,101 @@
+import { GitPullRequest } from "lucide-react";
+
+import type {
+  CodeWorkspacePullRequestFact,
+  PullRequestDigest,
+} from "../api/types";
+import { cn } from "@/lib/utils";
+import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+import {
+  PR_CHIP_TONE_CLASSES,
+  PR_ICON_TONE_CLASSES,
+  prTone,
+  prToneLabel,
+} from "./workspaceCards";
+
+/**
+ * Every pull request attributed to the workspace (decision 62), as a compact
+ * selector above the single-PR panel. Rendered only when there is more than
+ * one, so the common one-PR workspace keeps today's surface untouched.
+ */
+export function WorkspacePrList({
+  items,
+  selectedNumber,
+  onSelect,
+}: {
+  items: readonly CodeWorkspacePullRequestFact[];
+  /** The pull request the panel below is showing. */
+  selectedNumber?: number;
+  onSelect: (item: CodeWorkspacePullRequestFact) => void;
+}) {
+  return (
+    <nav
+      aria-label="Pull requests this workspace worked on"
+      className="border-border-subtle flex flex-col gap-0.5 border-b px-2 pt-1.5 pb-2"
+    >
+      {items.map((item) => {
+        const tone = prTone(item);
+        const selected = item.number === selectedNumber;
+        return (
+          <button
+            key={`${item.host}/${item.repo_owner}/${item.repo_name}#${item.number}`}
+            type="button"
+            aria-current={selected ? "true" : undefined}
+            aria-label={`Pull request #${item.number}: ${item.title}, ${prToneLabel(item)}${
+              item.relation === "authored" ? ", authored here" : ""
+            }`}
+            onClick={() => onSelect(item)}
+            className={cn(
+              "flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-xs",
+              HOVER_TINT,
+              FOCUS_RING_TIGHT,
+              selected &&
+                "bg-background shadow-[inset_0_0_0_1px_var(--border-subtle)]",
+            )}
+          >
+            <GitPullRequest
+              className={cn("size-3.5 shrink-0", PR_ICON_TONE_CLASSES[tone])}
+              aria-hidden
+            />
+            <span className="text-muted-foreground shrink-0 tabular-nums">
+              #{item.number}
+            </span>
+            <span className="min-w-0 flex-1 truncate">{item.title}</span>
+            <span className="text-muted-foreground shrink-0 truncate text-[10px]">
+              {item.repo_owner}/{item.repo_name}
+            </span>
+            <span
+              className={cn(
+                "shrink-0 rounded-full px-1.5 py-px text-[10px] font-medium",
+                PR_CHIP_TONE_CLASSES[tone],
+              )}
+            >
+              {prToneLabel(item)}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+/**
+ * Project a stored fact into the digest shape the single-PR panel reads.
+ * A snapshot view: checks, review, and mergeability stay absent, since the
+ * fact store deliberately never carries them.
+ */
+export function digestFromFact(
+  fact: CodeWorkspacePullRequestFact,
+): PullRequestDigest {
+  return {
+    number: fact.number,
+    url: fact.url,
+    state: fact.state,
+    title: fact.title,
+    draft: fact.draft,
+    merged: fact.state === "merged",
+    head_branch: fact.head_branch,
+    base_branch: fact.base_branch,
+    ...(fact.head_sha !== undefined ? { head_sha: fact.head_sha } : {}),
+  };
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -26,6 +26,7 @@ import {
   parseCodeTurnList,
   parseCodeTurnSubmission,
   parseCodeUpdateNotice,
+  parseCodeWorkspacePullRequests,
   parseCodeWorkspaceBlob,
   parseCodeWorkspaceDiff,
   parseCodeWorkspaceFiles,
@@ -1143,5 +1144,129 @@ describe("parseFenceReason", () => {
       }),
     ).toBeNull();
     expect(parseFenceReason({ type: "who_knows" })).toBeNull();
+  });
+});
+
+describe("pull request facts (decision 62)", () => {
+  const fact = {
+    host: "github.com",
+    repo_owner: "acme",
+    repo_name: "tools",
+    number: 412,
+    url: "https://github.com/acme/tools/pull/412",
+    title: "Add fact tracking",
+    state: "open",
+    draft: false,
+    author: "octocat",
+    head_branch: "feat/x",
+    base_branch: "main",
+    head_sha: "aaa111",
+    relation: "authored",
+    created_at: "2026-08-22T10:00:00Z",
+    updated_at: "2026-08-22T11:00:00Z",
+    last_seen_at: "2026-08-22T11:00:30Z",
+  };
+
+  it("accepts GET /code/workspaces/{id}/pull-requests", () => {
+    const page = { items: [fact], fetched_at: "2026-08-22T11:00:31Z" };
+    expect(parseCodeWorkspacePullRequests(page)).toEqual(page);
+  });
+
+  it("rejects an unknown relation or state instead of guessing", () => {
+    expect(
+      parseCodeWorkspacePullRequests({
+        items: [{ ...fact, relation: "reviewed" }],
+        fetched_at: "2026-08-22T11:00:31Z",
+      }),
+    ).toBeNull();
+    expect(
+      parseCodeWorkspacePullRequests({
+        items: [{ ...fact, state: "OPEN" }],
+        fetched_at: "2026-08-22T11:00:31Z",
+      }),
+    ).toBeNull();
+  });
+
+  it("carries pr_count through a digest notice", () => {
+    const digest = {
+      workspace: "ws-1",
+      session: "sess-1",
+      kind: "interactive",
+      lifecycle: "idle",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      title: "Fix login",
+      turn_count: 3,
+      pr_count: 3,
+    };
+    expect(parseCodeUpdateNotice({ type: "digest", ...digest })).toEqual({
+      type: "digest",
+      ...digest,
+    });
+    expect(
+      parseCodeUpdateNotice({ type: "digest", ...digest, pr_count: "3" }),
+    ).toBeNull();
+  });
+
+  it("carries a durable relation on a delivery workspace link", () => {
+    const page = {
+      capability: {
+        found: true,
+        authenticated: true,
+        remediation: "",
+      },
+      items: [
+        {
+          id: "github.com/acme/tools#412",
+          repository: {
+            host: "github.com",
+            owner: "acme",
+            name: "tools",
+            name_with_owner: "acme/tools",
+            url: "https://github.com/acme/tools",
+          },
+          number: 412,
+          url: "https://github.com/acme/tools/pull/412",
+          title: "Add fact tracking",
+          state: "open",
+          draft: false,
+          head_branch: "feat/x",
+          base_branch: "main",
+          auto_merge_enabled: false,
+          checks: [],
+          attention_reasons: [],
+          ready_to_merge: false,
+          workspace_links: [
+            {
+              workspace_id: "ws-1",
+              repo_id: "repo-1",
+              title: "facts",
+              branch_name: "feat/x",
+              status: "active",
+              exact: true,
+              relation: "contributed",
+            },
+          ],
+          labels: [],
+          created_at: "2026-08-22T10:00:00Z",
+          updated_at: "2026-08-22T11:00:00Z",
+        },
+      ],
+      errors: [],
+      fetched_at: "2026-08-22T11:00:31Z",
+    };
+    expect(parseCodeDeliveryPullRequestsPage(page)).toEqual(page);
+    expect(
+      parseCodeDeliveryPullRequestsPage({
+        ...page,
+        items: [
+          {
+            ...page.items[0],
+            workspace_links: [
+              { ...page.items[0].workspace_links[0], relation: "owner" },
+            ],
+          },
+        ],
+      }),
+    ).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -78,6 +78,9 @@ import type {
   CodeGitHubCapability,
   CodeGitHubRepositoryRef,
   CodeGitHubRepositoryTarget,
+  CodePullRequestRelation,
+  CodeWorkspacePullRequestFact,
+  CodeWorkspacePullRequests,
   PullRequestDigest,
   PullRequestComment,
   PullRequestCommentKind,
@@ -140,6 +143,8 @@ import type {
   CodeDeliverySourceError as WireCodeDeliverySourceError,
   CodeDeliveryWorkflowJob as WireCodeDeliveryWorkflowJob,
   CodeDeliveryWorkspaceLink as WireCodeDeliveryWorkspaceLink,
+  CodeWorkspacePullRequestFact as WireCodeWorkspacePullRequestFact,
+  CodeWorkspacePullRequests as WireCodeWorkspacePullRequests,
   CodeForkTranscript as WireCodeForkTranscript,
   CodeGitHubCapability as WireCodeGitHubCapability,
   CodeGitHubRepositoryRef as WireCodeGitHubRepositoryRef,
@@ -219,6 +224,11 @@ const WORKSPACE_STATUSES = new Set<CodeWorkspaceStatus>([
   "archived",
   "released",
 ]);
+const PULL_REQUEST_RELATIONS = new Set<CodePullRequestRelation>([
+  "authored",
+  "contributed",
+]);
+const PULL_REQUEST_FACT_STATES = new Set<string>(["open", "merged", "closed"]);
 const TURN_STATUSES = new Set<CodeTurnStatus>([
   "running",
   "completed",
@@ -405,13 +415,16 @@ function parseCodeDeliveryWorkspaceLink(
       "branch_name",
       "status",
       "exact",
+      "relation",
     ]) ||
     !nonEmpty(value.workspace_id) ||
     !nonEmpty(value.repo_id) ||
     !nonEmpty(value.title) ||
     !nonEmpty(value.branch_name) ||
     !isMember(value.status, WORKSPACE_STATUSES) ||
-    typeof value.exact !== "boolean"
+    typeof value.exact !== "boolean" ||
+    (value.relation !== undefined &&
+      !isMember(value.relation, PULL_REQUEST_RELATIONS))
   ) {
     return null;
   }
@@ -422,7 +435,96 @@ function parseCodeDeliveryWorkspaceLink(
     branch_name: value.branch_name,
     status: value.status,
     exact: value.exact,
+    ...(value.relation !== undefined ? { relation: value.relation } : {}),
   };
+}
+
+function parseCodeWorkspacePullRequestFact(
+  value: unknown,
+): CodeWorkspacePullRequestFact | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeWorkspacePullRequestFact>(value, [
+      "host",
+      "repo_owner",
+      "repo_name",
+      "number",
+      "url",
+      "title",
+      "state",
+      "draft",
+      "author",
+      "head_branch",
+      "base_branch",
+      "head_sha",
+      "relation",
+      "created_at",
+      "updated_at",
+      "merged_at",
+      "closed_at",
+      "last_seen_at",
+    ]) ||
+    !nonEmpty(value.host) ||
+    !nonEmpty(value.repo_owner) ||
+    !nonEmpty(value.repo_name) ||
+    !isFiniteNumber(value.number) ||
+    !nonEmpty(value.url) ||
+    typeof value.title !== "string" ||
+    !PULL_REQUEST_FACT_STATES.has(value.state as string) ||
+    typeof value.draft !== "boolean" ||
+    !optionalString(value.author) ||
+    typeof value.head_branch !== "string" ||
+    typeof value.base_branch !== "string" ||
+    !optionalString(value.head_sha) ||
+    !isMember(value.relation, PULL_REQUEST_RELATIONS) ||
+    !nonEmpty(value.created_at) ||
+    !nonEmpty(value.updated_at) ||
+    !optionalString(value.merged_at) ||
+    !optionalString(value.closed_at) ||
+    !nonEmpty(value.last_seen_at)
+  ) {
+    return null;
+  }
+  return {
+    host: value.host,
+    repo_owner: value.repo_owner,
+    repo_name: value.repo_name,
+    number: value.number,
+    url: value.url,
+    title: value.title,
+    state: value.state as string,
+    draft: value.draft,
+    ...(value.author !== undefined ? { author: value.author } : {}),
+    head_branch: value.head_branch,
+    base_branch: value.base_branch,
+    ...(value.head_sha !== undefined ? { head_sha: value.head_sha } : {}),
+    relation: value.relation,
+    created_at: value.created_at,
+    updated_at: value.updated_at,
+    ...(value.merged_at !== undefined ? { merged_at: value.merged_at } : {}),
+    ...(value.closed_at !== undefined ? { closed_at: value.closed_at } : {}),
+    last_seen_at: value.last_seen_at,
+  };
+}
+
+export function parseCodeWorkspacePullRequests(
+  value: unknown,
+): CodeWorkspacePullRequests | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeWorkspacePullRequests>(value, ["items", "fetched_at"]) ||
+    !Array.isArray(value.items) ||
+    !nonEmpty(value.fetched_at)
+  ) {
+    return null;
+  }
+  const items: CodeWorkspacePullRequestFact[] = [];
+  for (const item of value.items) {
+    const parsed = parseCodeWorkspacePullRequestFact(item);
+    if (!parsed) return null;
+    items.push(parsed);
+  }
+  return { items, fetched_at: value.fetched_at };
 }
 
 function parseCodeDeliveryCheck(value: unknown): CodeDeliveryCheck | null {
@@ -3090,6 +3192,7 @@ export function parseCodeSessionDigest(
       "turn_count",
       "activity",
       "pr_state",
+      "pr_count",
       "watch_state",
       "watch_detail",
       "watch_cycles",
@@ -3103,6 +3206,7 @@ export function parseCodeSessionDigest(
     !isFiniteNumber(value.turn_count) ||
     (value.activity !== undefined &&
       !isMember(value.activity, SESSION_ACTIVITIES)) ||
+    (value.pr_count !== undefined && !isFiniteNumber(value.pr_count)) ||
     (value.watch_state !== undefined &&
       !isMember(value.watch_state, WATCH_STATES)) ||
     !optionalString(value.watch_detail) ||
@@ -3128,6 +3232,7 @@ export function parseCodeSessionDigest(
     turn_count: value.turn_count,
     ...(value.activity !== undefined ? { activity: value.activity } : {}),
     ...(pr_state ? { pr_state } : {}),
+    ...(value.pr_count !== undefined ? { pr_count: value.pr_count } : {}),
     ...(value.watch_state !== undefined
       ? { watch_state: value.watch_state }
       : {}),
@@ -3175,6 +3280,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
           "turn_count",
           "activity",
           "pr_state",
+          "pr_count",
           "watch_state",
           "watch_detail",
           "watch_cycles",
@@ -3188,6 +3294,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         !isFiniteNumber(value.turn_count) ||
         (value.activity !== undefined &&
           !isMember(value.activity, SESSION_ACTIVITIES)) ||
+        (value.pr_count !== undefined && !isFiniteNumber(value.pr_count)) ||
         (value.watch_state !== undefined &&
           !isMember(value.watch_state, WATCH_STATES)) ||
         !optionalString(value.watch_detail) ||
@@ -3217,6 +3324,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
         turn_count: value.turn_count,
         ...(value.activity !== undefined ? { activity: value.activity } : {}),
         ...(pr_state ? { pr_state } : {}),
+        ...(value.pr_count !== undefined ? { pr_count: value.pr_count } : {}),
         ...(value.watch_state !== undefined
           ? { watch_state: value.watch_state }
           : {}),

--- a/crates/tidebreak-desktop/ui/src/code/useWorkspacePullRequests.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useWorkspacePullRequests.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import type { ApiClient } from "../api/client";
+import type { CodeWorkspacePullRequests } from "../api/types";
+import { useLiveResource, type LiveResource } from "./useLiveContent";
+
+/**
+ * The workspace's attributed pull requests, from the durable fact store
+ * (decision 62). The digest's `pr_count` is the cheap change signal: when it
+ * moves, the list re-reads; the list itself never touches the host.
+ */
+export function useWorkspacePullRequests(
+  client: Pick<ApiClient, "getCodeWorkspacePullRequests">,
+  workspaceId: string,
+  prCount: number | undefined,
+): LiveResource<CodeWorkspacePullRequests> {
+  const load = useCallback(
+    () => client.getCodeWorkspacePullRequests(workspaceId),
+    [client, workspaceId],
+  );
+  const resource = useLiveResource({
+    key: workspaceId,
+    revision: 0,
+    load,
+    errorMessage: "Could not load the workspace's pull requests",
+  });
+  const signature = prCount === undefined ? "" : String(prCount);
+  const seenRef = useRef({ workspaceId, signature });
+
+  useEffect(() => {
+    const seen = seenRef.current;
+    if (seen.workspaceId !== workspaceId) {
+      // The keyed resource is already loading the new workspace.
+      seenRef.current = { workspaceId, signature };
+      return;
+    }
+    if (seen.signature === signature) return;
+    seenRef.current = { workspaceId, signature };
+    void resource.refresh();
+  }, [signature, resource.refresh, workspaceId]);
+
+  return resource;
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -15,6 +15,7 @@ import {
   prChipTone,
   sessionActivityLabel,
   workspaceCardLabel,
+  workspacePrChipSummary,
   workspaceStatusRank,
 } from "./workspaceCards";
 
@@ -376,5 +377,18 @@ describe("workspaceCardLabel", () => {
         attention: { state: { type: "working" }, source: "lifecycle" },
       }),
     ).toBe("Fix login · app · tidebreak/fix-login");
+  });
+});
+
+describe("workspacePrChipSummary", () => {
+  it("stays quiet for one or no attributed pull requests", () => {
+    expect(workspacePrChipSummary(undefined)).toBeNull();
+    expect(workspacePrChipSummary(0)).toBeNull();
+    expect(workspacePrChipSummary(1)).toBeNull();
+  });
+
+  it("counts once the workspace worked on several", () => {
+    expect(workspacePrChipSummary(2)).toBe("2 PRs");
+    expect(workspacePrChipSummary(7)).toBe("7 PRs");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -516,3 +516,15 @@ export const PR_ICON_TONE_CLASSES: Record<PrChipTone, string> =
 /** Chip classes per tone. */
 export const PR_CHIP_TONE_CLASSES: Record<PrChipTone, string> =
   prToneClasses(STATUS_CHIP);
+
+/**
+ * The chip suffix for a workspace's attributed pull-request set
+ * (decision 62): a count once there is more than one, nothing otherwise —
+ * the single-PR chip already names its one pull request.
+ */
+export function workspacePrChipSummary(
+  prCount: number | undefined,
+): string | null {
+  if (prCount === undefined || prCount <= 1) return null;
+  return `${prCount} PRs`;
+}

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1013,7 +1013,13 @@ export type CodeDeliveryWorkflowJob = { id: number, name: string, status: string
 /**
  * One Tidebreak workspace that plausibly produced a remote delivery item.
  */
-export type CodeDeliveryWorkspaceLink = { workspace_id: WorkspaceId, repo_id: RepoId, title: string, branch_name: string, status: CodeWorkspaceStatus, exact: boolean, };
+export type CodeDeliveryWorkspaceLink = { workspace_id: WorkspaceId, repo_id: RepoId, title: string, branch_name: string, status: CodeWorkspaceStatus, exact: boolean, 
+/**
+ * Durable attribution behind this link, when one is stored: the
+ * workspace authored or contributed to the pull request (decision 62).
+ * Absent on links the live heuristic derived.
+ */
+relation?: CodePullRequestRelation, };
 
 /**
  * One event in an external agent-engine session's journal.
@@ -1238,6 +1244,16 @@ comments: Array<PullRequestComment>, };
 export type CodePrMergeMethod = "squash" | "merge" | "rebase";
 
 /**
+ * How strongly a workspace is tied to a pull request (decision 62).
+ *
+ * Only two acts mint attribution: `gh pr create` (authored) and a push whose
+ * branch is or becomes a pull request's head (contributed). Reading,
+ * checking out, commenting on, closing, or merging a pull request never
+ * does, so review and triage agents stay out of the attributed set.
+ */
+export type CodePullRequestRelation = "authored" | "contributed";
+
+/**
  * Result of pushing the workspace branch.
  */
 export type CodePushSnapshot = { branch: string, remote: string, };
@@ -1292,6 +1308,11 @@ export type CodeSessionDigest = { workspace: WorkspaceId, session: CodeSessionId
  * What the live turn is occupied with, while running.
  */
 activity?: CodeSessionActivity, pr_state?: PullRequestDigest, 
+/**
+ * How many pull requests hold a durable attribution to this workspace
+ * (decision 62). Absent when none do.
+ */
+pr_count?: number, 
 /**
  * Watch progress, present only on `kind: watch` digests.
  */
@@ -1444,6 +1465,11 @@ activity?: CodeSessionActivity,
  */
 pr_state?: PullRequestDigest, 
 /**
+ * How many pull requests hold a durable attribution to this
+ * workspace (decision 62). Absent when none do.
+ */
+pr_count?: number, 
+/**
  * Watch progress, present only on `kind: watch` digests.
  */
 watch_state?: CodeWatchState, watch_detail?: string, watch_cycles?: number, 
@@ -1545,6 +1571,30 @@ export type CodeWorkspaceFiles = { files: Array<CodeFileChange>, truncated: bool
  * PR + checks digest plus the local git facts the PR card needs.
  */
 export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, watch?: CodeWatchSnapshot, };
+
+/**
+ * One pull request attributed to a workspace, from the durable fact store
+ * (decision 62). A projection of the stored snapshot — no live host read.
+ */
+export type CodeWorkspacePullRequestFact = { host: string, repo_owner: string, repo_name: string, number: number, url: string, title: string, 
+/**
+ * Coarse lifecycle: `open`, `merged`, or `closed`.
+ */
+state: string, draft: boolean, author?: string, head_branch: string, base_branch: string, head_sha?: string, 
+/**
+ * How the workspace is tied to it.
+ */
+relation: CodePullRequestRelation, created_at: string, updated_at: string, merged_at?: string, closed_at?: string, 
+/**
+ * When the store last confirmed this snapshot against the host.
+ */
+last_seen_at: string, };
+
+/**
+ * Response of `GET /code/workspaces/{id}/pull-requests`: every pull request
+ * this workspace authored or contributed to, open first, newest first.
+ */
+export type CodeWorkspacePullRequests = { items: Array<CodeWorkspacePullRequestFact>, fetched_at: string, };
 
 /**
  * Bounded content-search response for `GET /code/workspaces/{id}/search`.

--- a/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
@@ -13,6 +13,7 @@ import type { CodeWorkspacePrResource } from "@/code/useCodeWorkspacePr";
 type InspectorScenario =
   | "ready"
   | "merge-ready"
+  | "multi-pr"
   | "empty"
   | "loading"
   | "failure";
@@ -46,6 +47,62 @@ const pullRequest: PullRequestDigest = {
     { name: "workspace / integration", bucket: "pending" },
   ],
 };
+
+const workspacePullRequestFacts = [
+  {
+    host: "github.com",
+    repo_owner: "example",
+    repo_name: "tidebreak",
+    number: 2248,
+    url: "https://github.com/example/tidebreak/pull/2248",
+    title: "Rework the code workspace around persistent conversation",
+    state: "open",
+    draft: false,
+    author: "sam",
+    head_branch: "thet/ui-pane-redesign",
+    base_branch: "main",
+    head_sha: "6cf15e2a",
+    relation: "authored" as const,
+    created_at: "2026-08-20T13:10:00.000Z",
+    updated_at: "2026-08-20T15:40:00.000Z",
+    last_seen_at: "2026-08-20T15:41:00.000Z",
+  },
+  {
+    host: "github.com",
+    repo_owner: "example",
+    repo_name: "tidebreak",
+    number: 2244,
+    url: "https://github.com/example/tidebreak/pull/2244",
+    title: "Retire the legacy pane",
+    state: "merged",
+    draft: false,
+    author: "sam",
+    head_branch: "thet/retire-legacy-pane",
+    base_branch: "main",
+    relation: "authored" as const,
+    created_at: "2026-08-19T09:00:00.000Z",
+    updated_at: "2026-08-20T10:00:00.000Z",
+    merged_at: "2026-08-20T10:00:00.000Z",
+    last_seen_at: "2026-08-20T15:41:00.000Z",
+  },
+  {
+    host: "github.com",
+    repo_owner: "example",
+    repo_name: "design-tokens",
+    number: 87,
+    url: "https://github.com/example/design-tokens/pull/87",
+    title: "Pane rhythm spacing tokens",
+    state: "open",
+    draft: true,
+    author: "sam",
+    head_branch: "thet/pane-rhythm",
+    base_branch: "main",
+    relation: "contributed" as const,
+    created_at: "2026-08-20T14:00:00.000Z",
+    updated_at: "2026-08-20T15:00:00.000Z",
+    last_seen_at: "2026-08-20T15:41:00.000Z",
+  },
+];
 
 const prSnapshot: CodeWorkspacePrSnapshot = {
   dirty: true,
@@ -160,6 +217,15 @@ function inspectorClient(scenario: InspectorScenario): ApiClient {
                   }
                 : changedFiles,
     getCodeWorkspacePr: async () => prSnapshot,
+    getCodeWorkspacePullRequests: async () => ({
+      items:
+        scenario === "multi-pr"
+          ? workspacePullRequestFacts
+          : scenario === "empty"
+            ? []
+            : workspacePullRequestFacts.slice(0, 1),
+      fetched_at: "2026-08-20T15:41:00.000Z",
+    }),
     refreshCodeWorkspacePr: async () => prSnapshot,
     commitCodeWorkspace: async () => ({
       sha: "6cf15e2",
@@ -295,6 +361,15 @@ export const Review: Story = {
 /** The same compact merge card when GitHub says the PR can land now. */
 export const ReviewReadyToMerge: Story = {
   args: { tab: "pr", scenario: "merge-ready" },
+};
+
+/**
+ * Several attributed pull requests (decision 62): the set lists above the
+ * panel, the primary stays live, and a selected row shows its stored
+ * snapshot.
+ */
+export const ReviewPullRequestSet: Story = {
+  args: { tab: "pr", scenario: "multi-pr" },
 };
 
 export const ChangesLoading: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -73,6 +73,24 @@ export const PullRequestInRail: Story = {
   },
 };
 
+/**
+ * A workspace that worked on several pull requests (decision 62): the chip
+ * keeps its primary pull request and gains the attributed count.
+ */
+export const SeveralPullRequests: Story = {
+  args: {
+    workspace: { ...codeWorkspace, pr: openPrDigest },
+    digest: { ...runningDigest, pr_state: openPrDigest, pr_count: 3 },
+    session: codeSession,
+    commands: workspaceCommands({
+      hasPr: true,
+      archived: false,
+      hasSession: true,
+    }),
+    onWorkflowAction: fn(),
+  },
+};
+
 /** One click from the rail: an approved, green PR offers Merge. */
 export const ReadyToMerge: Story = {
   args: {

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -10,10 +10,10 @@ use chrono::{DateTime, Utc};
 use tracing::warn;
 
 use tidebreak_core::db::code::{
-    count_turns, get_session, get_workspace, latest_event_created_at, latest_turn,
-    latest_watch_for_session, list_approvals, list_recent_events, list_sessions,
-    list_sessions_by_lifecycle_all_owners, list_sessions_for_workspace, replace_session_attention,
-    save_session,
+    count_attributed_prs_for_workspace, count_turns, get_session, get_workspace,
+    latest_event_created_at, latest_turn, latest_watch_for_session, list_approvals,
+    list_recent_events, list_sessions, list_sessions_by_lifecycle_all_owners,
+    list_sessions_for_workspace, replace_session_attention, save_session,
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeApprovalState, CodeEvent, CodeSession,
@@ -418,6 +418,10 @@ async fn build_digest(
     } else {
         None
     };
+    // One indexed count (decision 62). Zero stays absent so clients that
+    // predate the field and workspaces that never shipped read the same.
+    let pr_count =
+        count_attributed_prs_for_workspace(db, &session.owner, session.workspace_id).await?;
     Ok(SessionDigest {
         workspace: session.workspace_id,
         session: session.id,
@@ -428,6 +432,7 @@ async fn build_digest(
         turn_count,
         activity,
         pr_state: workspace.pr,
+        pr_count: (pr_count > 0).then_some(pr_count),
         watch_state: watch.as_ref().map(|watch| watch.state),
         watch_detail: watch.as_ref().and_then(|watch| watch.detail.clone()),
         watch_cycles: watch.as_ref().map(|watch| watch.cycles),

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -51,6 +51,10 @@ pub(crate) struct SessionDigest {
     /// running; older clients safely fall back to a generic running label.
     pub activity: Option<CodeSessionActivity>,
     pub pr_state: Option<PullRequestDigest>,
+    /// How many pull requests hold a durable attribution to this workspace
+    /// (decision 62). Absent when none do; a change is the client's cheap
+    /// signal to re-read the workspace's pull-request list.
+    pub pr_count: Option<u64>,
     /// Watch progress, set only when `kind` is `Watch`. Lifecycle words
     /// undersell a watch ("running" for hours); these say what it is doing.
     pub watch_state: Option<CodeWatchState>,

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -16,9 +16,14 @@ use serde_json::Value;
 use tokio::process::Command;
 use tokio::time::timeout;
 
+use tidebreak_core::db::code::{
+    get_workspace, insert_pull_request_attribution, list_attributions_for_pull_requests,
+    list_pull_request_facts_for_repo, save_pull_request_fact,
+};
 use tidebreak_core::{
-    CodeRepo, CodeWorkspace, CodeWorkspaceStatus, OwnerId, PullRequestCheckBucket,
-    PullRequestComment, PullRequestCommentKind, RepoId,
+    CodePullRequestAttribution, CodePullRequestDiscovery, CodePullRequestId,
+    CodePullRequestRelation, CodeRepo, CodeWorkspace, CodeWorkspaceStatus, DbStore, OwnerId,
+    PullRequestCheckBucket, PullRequestComment, PullRequestCommentKind, RepoId, WorkspaceId,
 };
 
 use super::gh::{self, GhObservation};
@@ -40,7 +45,7 @@ use crate::routes::code::types::{
 const GH_READ_TIMEOUT: Duration = Duration::from_secs(45);
 const GIT_READ_TIMEOUT: Duration = Duration::from_secs(10);
 const LIST_CACHE_TTL: Duration = Duration::from_secs(30);
-const MAX_REPOSITORIES: usize = 50;
+pub(crate) const MAX_REPOSITORIES: usize = 50;
 const MAX_PAGE_SIZE: usize = 100;
 const MAX_REMOTE_ITEMS_PER_REPO: usize = 100;
 const DELIVERY_CONCURRENCY: usize = 4;
@@ -702,11 +707,27 @@ pub(crate) async fn query_pull_requests(
                     .cmp(&left.updated_at)
                     .then_with(|| left.id.cmp(&right.id))
             });
+            let workspaces_gaining_links = persist_and_augment_pull_request_facts(
+                &runtime.db,
+                owner,
+                &workspace_index,
+                &mut items,
+            )
+            .await;
             runtime.delivery_cache.put_pull_requests(
                 cache_key.clone(),
                 items.clone(),
                 errors.clone(),
             );
+            for workspace_id in workspaces_gaining_links {
+                super::attention::emit_workspace_digests(
+                    &runtime.db,
+                    &runtime.bus,
+                    owner,
+                    workspace_id,
+                )
+                .await;
+            }
             CachedAggregate {
                 fetched_at: Instant::now(),
                 items,
@@ -759,9 +780,21 @@ pub(crate) async fn pull_request_detail(
         .await
         .map_err(|message| ServerError::bad_request_kind("github", message))?;
     let workspace_index = workspace_index(runtime, owner, false).await?;
-    let summary = fetch_pull_request(binary, &repository, target.number, &workspace_index)
+    let mut summary = fetch_pull_request(binary, &repository, target.number, &workspace_index)
         .await
         .map_err(|message| ServerError::bad_request_kind("github", message))?;
+    let minted = persist_and_augment_pull_request_facts(
+        &runtime.db,
+        owner,
+        &workspace_index,
+        std::slice::from_mut(&mut summary),
+    )
+    .await;
+    for workspace_id in minted {
+        super::attention::emit_workspace_digests(&runtime.db, &runtime.bus, owner, workspace_id)
+            .await;
+    }
+    let summary = summary;
 
     let pull_endpoint = api_endpoint(&target.repository, &format!("pulls/{}", target.number));
     let issue_comments_endpoint = api_endpoint(
@@ -2410,6 +2443,7 @@ fn workspace_links(
                     branch_name: entry.workspace.branch_name.clone(),
                     status: entry.workspace.status,
                     exact,
+                    relation: None,
                 },
             ))
         })
@@ -2421,6 +2455,180 @@ fn workspace_links(
             .then_with(|| right_time.cmp(left_time))
     });
     links.into_iter().map(|(_, link)| link).collect()
+}
+
+/// Persist durable facts for the page's tracked pull requests and fold the
+/// stored attribution back into every item's workspace links (decision 62).
+///
+/// Tracked means exact-linked to a workspace (the index's number or head-SHA
+/// tiers) or already holding a fact row — a pull request nobody here worked
+/// on stays a live-only observation. The branch-name tier never mints.
+/// Returns the workspaces that gained an attribution row, so the caller can
+/// restate their digests. Best-effort throughout: a store failure degrades
+/// to the live heuristic links.
+async fn persist_and_augment_pull_request_facts(
+    db: &DbStore,
+    owner: &OwnerId,
+    workspaces: &[WorkspaceIndexEntry],
+    items: &mut [CodeDeliveryPullRequestSummary],
+) -> Vec<WorkspaceId> {
+    let mut minted = Vec::new();
+    let now = Utc::now();
+
+    // One fact read per repository identity on the page.
+    let mut groups: HashMap<String, Vec<usize>> = HashMap::new();
+    for (index, item) in items.iter().enumerate() {
+        groups
+            .entry(repository_key_ref(&item.repository))
+            .or_default()
+            .push(index);
+    }
+    let mut fact_ids: HashMap<usize, CodePullRequestId> = HashMap::new();
+    for indices in groups.values() {
+        let repository = &items[indices[0]].repository;
+        let known: HashMap<u64, CodePullRequestId> = match list_pull_request_facts_for_repo(
+            db,
+            owner,
+            &repository.host,
+            &repository.owner,
+            &repository.name,
+        )
+        .await
+        {
+            Ok(facts) => facts
+                .into_iter()
+                .map(|fact| (fact.number, fact.id))
+                .collect(),
+            Err(err) => {
+                tracing::debug!("fact read failed for a delivery page: {err}");
+                continue;
+            }
+        };
+        for &index in indices {
+            let item = &items[index];
+            let exact_workspaces: Vec<WorkspaceId> = item
+                .workspace_links
+                .iter()
+                .filter(|link| link.exact)
+                .map(|link| link.workspace_id)
+                .collect();
+            if exact_workspaces.is_empty() && !known.contains_key(&item.number) {
+                continue;
+            }
+            let Some(fact) = super::reconcile::fact_from_summary(owner, item, now) else {
+                continue;
+            };
+            let id = match save_pull_request_fact(db, &fact).await {
+                Ok(id) => id,
+                Err(err) => {
+                    tracing::debug!("fact upsert failed for a delivery page: {err}");
+                    continue;
+                }
+            };
+            fact_ids.insert(index, id);
+            for workspace_id in exact_workspaces {
+                match insert_pull_request_attribution(
+                    db,
+                    &CodePullRequestAttribution {
+                        owner: owner.clone(),
+                        pull_request_id: id,
+                        workspace_id,
+                        relation: CodePullRequestRelation::Contributed,
+                        discovered_via: CodePullRequestDiscovery::Reconcile,
+                        session_id: None,
+                        parent_call_id: None,
+                        created_at: now,
+                    },
+                )
+                .await
+                {
+                    Ok(true) => minted.push(workspace_id),
+                    Ok(false) => {}
+                    Err(err) => tracing::debug!("attribution claim failed: {err}"),
+                }
+            }
+        }
+    }
+
+    if fact_ids.is_empty() {
+        return minted;
+    }
+    let ids: Vec<CodePullRequestId> = fact_ids.values().copied().collect();
+    let attributions = match list_attributions_for_pull_requests(db, owner, &ids).await {
+        Ok(attributions) => attributions,
+        Err(err) => {
+            tracing::debug!("attribution read failed for a delivery page: {err}");
+            return minted;
+        }
+    };
+    let mut by_fact: HashMap<CodePullRequestId, Vec<&CodePullRequestAttribution>> = HashMap::new();
+    for attribution in &attributions {
+        by_fact
+            .entry(attribution.pull_request_id)
+            .or_default()
+            .push(attribution);
+    }
+
+    // Workspace metadata for links the live index did not produce — an
+    // archived or foreign-branch workspace whose attribution outlived the
+    // heuristic match.
+    let mut workspace_meta: HashMap<WorkspaceId, CodeWorkspace> = workspaces
+        .iter()
+        .map(|entry| (entry.workspace.id, entry.workspace.clone()))
+        .collect();
+    for attribution in &attributions {
+        if workspace_meta.contains_key(&attribution.workspace_id) {
+            continue;
+        }
+        if let Ok(Some(workspace)) = get_workspace(db, owner, attribution.workspace_id).await {
+            workspace_meta.insert(workspace.id, workspace);
+        }
+    }
+
+    for (index, fact_id) in fact_ids {
+        let Some(attributions) = by_fact.get(&fact_id) else {
+            continue;
+        };
+        let item = &mut items[index];
+        for attribution in attributions {
+            if let Some(link) = item
+                .workspace_links
+                .iter_mut()
+                .find(|link| link.workspace_id == attribution.workspace_id)
+            {
+                link.exact = true;
+                link.relation = Some(attribution.relation);
+                continue;
+            }
+            let Some(workspace) = workspace_meta.get(&attribution.workspace_id) else {
+                continue;
+            };
+            item.workspace_links.push(CodeDeliveryWorkspaceLink {
+                workspace_id: workspace.id,
+                repo_id: workspace.repo_id,
+                title: workspace.title.clone(),
+                branch_name: workspace.branch_name.clone(),
+                status: workspace.status,
+                exact: true,
+                relation: Some(attribution.relation),
+            });
+        }
+        // Restore the established order — status rank, exact first, newest —
+        // because the notifications store routes to the first link.
+        item.workspace_links.sort_by(|left, right| {
+            let left_time = workspace_meta
+                .get(&left.workspace_id)
+                .map(|workspace| workspace.created_at);
+            let right_time = workspace_meta
+                .get(&right.workspace_id)
+                .map(|workspace| workspace.created_at);
+            workspace_status_rank(left.status)
+                .cmp(&workspace_status_rank(right.status))
+                .then_with(|| right.exact.cmp(&left.exact))
+                .then_with(|| right_time.cmp(&left_time))
+        });
+    }
+    minted
 }
 
 fn workspace_status_rank(status: CodeWorkspaceStatus) -> u8 {

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod fork;
 pub(crate) mod gh;
 pub(crate) mod harness_install;
 pub(crate) mod pr_facts;
+pub(crate) mod reconcile;
 pub(crate) mod recovery;
 pub(crate) mod runtime;
 pub(crate) mod scoped;

--- a/crates/tidebreak-server/src/code/reconcile.rs
+++ b/crates/tidebreak-server/src/code/reconcile.rs
@@ -1,0 +1,222 @@
+//! Reconcile sweep: keep pull-request facts fresh and complete (decision 62).
+//!
+//! The post-turn detector catches the acts it can see. This sweep owns the
+//! rest: it re-reads every tracked repository through the delivery read path
+//! on its own interval, which refreshes fact snapshots, mints exact-tier
+//! attribution the detector missed (auxiliary terminals, forks landing in
+//! tracked repositories, pushes that became pull requests later), and keeps
+//! `code_repo`'s origin identity current. Fact persistence itself lives on
+//! the delivery read path, so a user-driven page read and a sweep tick do
+//! the same work through the same seam.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use tracing::debug;
+
+use tidebreak_core::db::code::{
+    list_fact_repo_identities_all_owners, list_repos_all_owners, set_repo_origin,
+};
+use tidebreak_core::{CodePullRequestFact, CodePullRequestId, CodePullRequestState, OwnerId};
+
+use super::delivery::{query_pull_requests, repository_target_from_local, MAX_REPOSITORIES};
+use super::runtime::CodeRuntime;
+use crate::routes::code::types::{
+    CodeDeliveryPullRequestQuery, CodeDeliveryPullRequestSummary, CodeGitHubRepositoryTarget,
+};
+
+/// Coprime with the 47s watch and 53s trigger sweeps, so three GitHub-reading
+/// sweeps never land on the same tick.
+pub(crate) const RECONCILE_SWEEP_INTERVAL: Duration = Duration::from_secs(61);
+
+/// Abort the reconcile sweep when the runtime is dropped.
+///
+/// The loop holds a [`Weak`] runtime handle: an `Arc` would keep the runtime
+/// alive from its own field and the guard's `Drop` could never run.
+pub(crate) struct ReconcileSweepGuard(Option<tokio::task::JoinHandle<()>>);
+
+impl ReconcileSweepGuard {
+    pub(crate) fn spawn(runtime: Weak<CodeRuntime>) -> Self {
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(RECONCILE_SWEEP_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let Some(runtime) = runtime.upgrade() else {
+                    return;
+                };
+                sweep_reconcile(&runtime).await;
+            }
+        });
+        Self(Some(handle))
+    }
+}
+
+impl Drop for ReconcileSweepGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// One reconcile pass: per owner, read every tracked repository through the
+/// delivery path so facts persist and durable links refresh.
+///
+/// Tracked means a live registered repository whose origin resolves to
+/// GitHub, plus every repository identity that already holds a fact row —
+/// which is how a cross-repo pull request the detector observed keeps
+/// itself fresh without a local checkout.
+pub(crate) async fn sweep_reconcile(runtime: &Arc<CodeRuntime>) {
+    let mut targets_by_owner: HashMap<String, Vec<CodeGitHubRepositoryTarget>> = HashMap::new();
+
+    match list_repos_all_owners(&runtime.db).await {
+        Ok(repos) => {
+            for repo in repos {
+                if repo.removed_at.is_some() {
+                    continue;
+                }
+                let target = match repository_target_from_local(&repo).await {
+                    Ok(target) => target,
+                    Err(reason) => {
+                        debug!(repo = %repo.id, "reconcile skipped a repository: {reason}");
+                        continue;
+                    }
+                };
+                let stored = (
+                    repo.origin_host.as_deref(),
+                    repo.origin_owner.as_deref(),
+                    repo.origin_name.as_deref(),
+                );
+                if stored
+                    != (
+                        Some(target.host.as_str()),
+                        Some(target.owner.as_str()),
+                        Some(target.name.as_str()),
+                    )
+                {
+                    let _ = set_repo_origin(
+                        &runtime.db,
+                        &repo.owner,
+                        repo.id,
+                        &target.host,
+                        &target.owner,
+                        &target.name,
+                    )
+                    .await;
+                }
+                targets_by_owner
+                    .entry(repo.owner.as_str().to_owned())
+                    .or_default()
+                    .push(target);
+            }
+        }
+        Err(err) => {
+            debug!("reconcile could not list repositories: {err}");
+        }
+    }
+
+    match list_fact_repo_identities_all_owners(&runtime.db).await {
+        Ok(identities) => {
+            for (owner, host, repo_owner, repo_name) in identities {
+                targets_by_owner
+                    .entry(owner)
+                    .or_default()
+                    .push(CodeGitHubRepositoryTarget {
+                        host,
+                        owner: repo_owner,
+                        name: repo_name,
+                    });
+            }
+        }
+        Err(err) => {
+            debug!("reconcile could not list fact identities: {err}");
+        }
+    }
+
+    for (owner, targets) in targets_by_owner {
+        let Ok(owner) = OwnerId::new(&owner) else {
+            continue;
+        };
+        let mut seen = HashSet::new();
+        let mut deduped: Vec<CodeGitHubRepositoryTarget> = targets
+            .into_iter()
+            .filter(|target| {
+                seen.insert(format!(
+                    "{}/{}/{}",
+                    target.host.to_ascii_lowercase(),
+                    target.owner.to_ascii_lowercase(),
+                    target.name.to_ascii_lowercase()
+                ))
+            })
+            .collect();
+        if deduped.len() > MAX_REPOSITORIES {
+            debug!(
+                dropped = deduped.len() - MAX_REPOSITORIES,
+                "reconcile capped this owner's repository set"
+            );
+            deduped.truncate(MAX_REPOSITORIES);
+        }
+        if deduped.is_empty() {
+            continue;
+        }
+        let query = CodeDeliveryPullRequestQuery {
+            repositories: deduped,
+            search: None,
+            states: Vec::new(),
+            review_states: Vec::new(),
+            check_states: Vec::new(),
+            authors: Vec::new(),
+            attention_only: false,
+            ready_only: false,
+            tidebreak_linked: None,
+            updated_after: None,
+            cursor: None,
+            limit: Some(1),
+            refresh: false,
+        };
+        // A system path: unregistered fact identities must stay readable, so
+        // the registered-target check is bypassed the way other sweeps do.
+        // Fact persistence and link augmentation happen inside the read.
+        if let Err(err) = query_pull_requests(runtime, &owner, true, query).await {
+            debug!("reconcile read failed: {err:?}");
+        }
+    }
+}
+
+/// Build a durable fact from one parsed delivery summary.
+///
+/// `None` when the summary's state token is not one the fact vocabulary
+/// stores — the delivery parser already lowercases and normalizes a merged
+/// close, so an unknown token here is a contract drift worth staying quiet
+/// about rather than guessing.
+pub(crate) fn fact_from_summary(
+    owner: &OwnerId,
+    summary: &CodeDeliveryPullRequestSummary,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<CodePullRequestFact> {
+    let state = CodePullRequestState::from_str(&summary.state)?;
+    Some(CodePullRequestFact {
+        id: CodePullRequestId::new(),
+        owner: owner.clone(),
+        host: summary.repository.host.clone(),
+        repo_owner: summary.repository.owner.clone(),
+        repo_name: summary.repository.name.clone(),
+        number: summary.number,
+        url: summary.url.clone(),
+        title: summary.title.clone(),
+        state,
+        draft: summary.draft,
+        author: summary.author.clone(),
+        head_branch: summary.head_branch.clone(),
+        base_branch: summary.base_branch.clone(),
+        head_sha: summary.head_sha.clone(),
+        created_at: summary.created_at,
+        updated_at: summary.updated_at,
+        merged_at: summary.merged_at,
+        closed_at: summary.closed_at,
+        first_seen_at: now,
+        last_seen_at: now,
+    })
+}

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -179,6 +179,8 @@ pub(crate) struct CodeRuntime {
     watch_started: AtomicBool,
     trigger_sweep: Mutex<Option<super::trigger::TriggerSweepGuard>>,
     trigger_started: AtomicBool,
+    reconcile_sweep: Mutex<Option<super::reconcile::ReconcileSweepGuard>>,
+    reconcile_started: AtomicBool,
     /// Workspaces with a background naming call in flight.
     ///
     /// One call per workspace at a time; a second trigger is dropped rather
@@ -252,6 +254,8 @@ impl CodeRuntime {
             watch_started: AtomicBool::new(false),
             trigger_sweep: Mutex::new(None),
             trigger_started: AtomicBool::new(false),
+            reconcile_sweep: Mutex::new(None),
+            reconcile_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
         }
     }
@@ -294,6 +298,7 @@ impl CodeRuntime {
             // active watches resume with no extra state.
             runtime.ensure_watch_sweep();
             runtime.ensure_trigger_sweep();
+            runtime.ensure_reconcile_sweep();
             actions
         })
     }
@@ -353,6 +358,8 @@ impl CodeRuntime {
             watch_started: AtomicBool::new(false),
             trigger_sweep: Mutex::new(None),
             trigger_started: AtomicBool::new(false),
+            reconcile_sweep: Mutex::new(None),
+            reconcile_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
         }
     }
@@ -1305,6 +1312,35 @@ impl CodeRuntime {
         )
         .await
         .map_err(map_gh)
+    }
+
+    /// Every pull request attributed to the workspace, from the durable fact
+    /// store (decision 62): open first, then newest activity. No host read.
+    pub(crate) async fn workspace_pull_requests(
+        &self,
+        owner: &OwnerId,
+        id: WorkspaceId,
+    ) -> Result<
+        Vec<(
+            tidebreak_core::CodePullRequestFact,
+            tidebreak_core::CodePullRequestRelation,
+        )>,
+        ServerError,
+    > {
+        // The read authorizes through the workspace row: another owner's
+        // workspace is indistinguishable from a missing one.
+        let _ = self.get_workspace(owner, id).await?;
+        let mut facts =
+            tidebreak_core::db::code::list_attributed_facts_for_workspace(&self.db, owner, id)
+                .await?;
+        facts.sort_by(|(left, _), (right, _)| {
+            let left_open = left.state == tidebreak_core::CodePullRequestState::Open;
+            let right_open = right.state == tidebreak_core::CodePullRequestState::Open;
+            right_open
+                .cmp(&left_open)
+                .then_with(|| right.updated_at.cmp(&left.updated_at))
+        });
+        Ok(facts)
     }
 
     /// User-initiated merge (or auto-merge arming) of the workspace PR, then a
@@ -2499,6 +2535,16 @@ impl CodeRuntime {
         }
         let guard = super::trigger::TriggerSweepGuard::spawn(Arc::downgrade(self));
         *self.trigger_sweep.lock().expect("trigger sweep") = Some(guard);
+    }
+
+    /// Start the pull-request reconcile sweep once (decision 62). Same
+    /// weak-handle shape, on a third coprime interval.
+    pub(super) fn ensure_reconcile_sweep(self: &Arc<Self>) {
+        if self.reconcile_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let guard = super::reconcile::ReconcileSweepGuard::spawn(Arc::downgrade(self));
+        *self.reconcile_sweep.lock().expect("reconcile sweep") = Some(guard);
     }
 
     /// End one session: mark the row ended, stop its worker, and re-assert.

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -442,6 +442,19 @@ impl ScopedCode {
         self.runtime.workspace_pr(&self.owner, id).await
     }
 
+    pub(crate) async fn workspace_pull_requests(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<
+        Vec<(
+            tidebreak_core::CodePullRequestFact,
+            tidebreak_core::CodePullRequestRelation,
+        )>,
+        ServerError,
+    > {
+        self.runtime.workspace_pull_requests(&self.owner, id).await
+    }
+
     pub(crate) async fn refresh_workspace_pr(
         &self,
         id: WorkspaceId,

--- a/crates/tidebreak-server/src/code/trigger.rs
+++ b/crates/tidebreak-server/src/code/trigger.rs
@@ -944,6 +944,7 @@ mod tests {
             branch_name: "feature".to_owned(),
             status,
             exact,
+            relation: None,
         }
     }
 

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -905,6 +905,10 @@ pub fn app(state: AppState) -> Router {
             get(routes::code::get_workspace_pr),
         )
         .route(
+            "/code/workspaces/{id}/pull-requests",
+            get(routes::code::list_workspace_pull_requests),
+        )
+        .route(
             "/code/workspaces/{id}/pr/refresh",
             post(routes::code::refresh_workspace_pr),
         )

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -9,8 +9,8 @@ use crate::extract::{Json, Path};
 
 use super::types::{
     CodeActionSnapshot, CodeCommitSnapshot, CodePrCommentsSnapshot, CodePrMergeMethod,
-    CodePushSnapshot, CodeWatchSnapshot, CodeWorkspacePrSnapshot, CommitWorkspaceBody,
-    CreatePullRequestBody, MergeCodePrBody,
+    CodePushSnapshot, CodeWatchSnapshot, CodeWorkspacePrSnapshot, CodeWorkspacePullRequestFact,
+    CodeWorkspacePullRequests, CommitWorkspaceBody, CreatePullRequestBody, MergeCodePrBody,
 };
 use crate::code::gh::{ActionOutcome, CommitOutcome, MergeMethod, PushOutcome, WorkspaceGitStatus};
 use tidebreak_core::WorkspaceId;
@@ -48,6 +48,42 @@ pub async fn get_workspace_pr(
     let status = code.workspace_pr(id).await?;
     let watch = code.latest_watch(id).await?;
     Ok(Json(pr_snapshot(status, watch)))
+}
+
+/// Every pull request attributed to the workspace (decision 62), from the
+/// durable fact store — no live host read.
+pub async fn list_workspace_pull_requests(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+) -> Result<Json<CodeWorkspacePullRequests>, ServerError> {
+    let facts = code.workspace_pull_requests(id).await?;
+    let items = facts
+        .into_iter()
+        .map(|(fact, relation)| CodeWorkspacePullRequestFact {
+            host: fact.host,
+            repo_owner: fact.repo_owner,
+            repo_name: fact.repo_name,
+            number: fact.number,
+            url: fact.url,
+            title: fact.title,
+            state: fact.state.as_str().to_owned(),
+            draft: fact.draft,
+            author: fact.author,
+            head_branch: fact.head_branch,
+            base_branch: fact.base_branch,
+            head_sha: fact.head_sha,
+            relation,
+            created_at: fact.created_at,
+            updated_at: fact.updated_at,
+            merged_at: fact.merged_at,
+            closed_at: fact.closed_at,
+            last_seen_at: fact.last_seen_at,
+        })
+        .collect();
+    Ok(Json(CodeWorkspacePullRequests {
+        items,
+        fetched_at: chrono::Utc::now(),
+    }))
 }
 
 pub async fn refresh_workspace_pr(

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -41,8 +41,8 @@ pub(crate) use delivery::{
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,
-    mark_workspace_pr_ready, merge_workspace_pr, push_workspace, refresh_workspace_pr,
-    run_workspace_action, start_workspace_watch, stop_workspace_watch,
+    list_workspace_pull_requests, mark_workspace_pr_ready, merge_workspace_pr, push_workspace,
+    refresh_workspace_pr, run_workspace_action, start_workspace_watch, stop_workspace_watch,
 };
 pub(crate) use harnesses::{
     install_harness, list_harness_models, list_harnesses, refresh_harnesses,
@@ -77,9 +77,9 @@ pub(crate) use types::{
     CodeRepoSnapshot, CodeRepoSource, CodeRepoSources, CodeSessionDebug, CodeSessionDigest,
     CodeSessionSnapshot, CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot,
     CodeTriggerSnapshot, CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff,
-    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspaceSearch, CodeWorkspaceSearchMatch,
-    CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot, CreateCodeTriggerBody,
-    HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
+    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspacePullRequests, CodeWorkspaceSearch,
+    CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot,
+    CreateCodeTriggerBody, HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
     ResolveCodeDeliveryRepositoriesBody, SequencedCodeEventFrame, SetCodeWorktreeRootBody,
     UpdateCodeTriggerBody,
 };

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -5,12 +5,12 @@ use ts_rs::TS;
 
 use tidebreak_core::{
     Attention, CapLevel, CodeApproval, CodeApprovalId, CodeApprovalKind, CodeApprovalState,
-    CodeEvent, CodeRepo, CodeSession, CodeSessionKind, CodeSessionLifecycle, CodeSubagentSummary,
-    CodeTerminalId, CodeTrigger, CodeTriggerAction, CodeTriggerCondition, CodeTriggerId, CodeTurn,
-    CodeTurnId, CodeTurnStatus, CodeWatch, CodeWatchId, CodeWatchState, CodeWorkspace,
-    CodeWorkspaceStatus, Diffstat, FenceReason, FileChangeKind, HarnessCaps, HarnessKind,
-    HarnessTier, PermissionMode, PullRequestDigest, QuickAction, ReasoningEffort, RepoId,
-    WorkspaceId,
+    CodeEvent, CodePullRequestRelation, CodeRepo, CodeSession, CodeSessionKind,
+    CodeSessionLifecycle, CodeSubagentSummary, CodeTerminalId, CodeTrigger, CodeTriggerAction,
+    CodeTriggerCondition, CodeTriggerId, CodeTurn, CodeTurnId, CodeTurnStatus, CodeWatch,
+    CodeWatchId, CodeWatchState, CodeWorkspace, CodeWorkspaceStatus, Diffstat, FenceReason,
+    FileChangeKind, HarnessCaps, HarnessKind, HarnessTier, PermissionMode, PullRequestDigest,
+    QuickAction, ReasoningEffort, RepoId, WorkspaceId,
 };
 
 /// A registered local git repository.
@@ -558,6 +558,49 @@ pub struct CodeWorkspacePrSnapshot {
     pub watch: Option<CodeWatchSnapshot>,
 }
 
+/// One pull request attributed to a workspace, from the durable fact store
+/// (decision 62). A projection of the stored snapshot — no live host read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeWorkspacePullRequestFact {
+    pub host: String,
+    pub repo_owner: String,
+    pub repo_name: String,
+    pub number: u64,
+    pub url: String,
+    pub title: String,
+    /// Coarse lifecycle: `open`, `merged`, or `closed`.
+    pub state: String,
+    pub draft: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub author: Option<String>,
+    pub head_branch: String,
+    pub base_branch: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub head_sha: Option<String>,
+    /// How the workspace is tied to it.
+    pub relation: CodePullRequestRelation,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub merged_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub closed_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// When the store last confirmed this snapshot against the host.
+    pub last_seen_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Response of `GET /code/workspaces/{id}/pull-requests`: every pull request
+/// this workspace authored or contributed to, open first, newest first.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeWorkspacePullRequests {
+    pub items: Vec<CodeWorkspacePullRequestFact>,
+    pub fetched_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// One durable watch task on a workspace's pull request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub struct CodeWatchSnapshot {
@@ -707,6 +750,12 @@ pub struct CodeDeliveryWorkspaceLink {
     pub branch_name: String,
     pub status: CodeWorkspaceStatus,
     pub exact: bool,
+    /// Durable attribution behind this link, when one is stored: the
+    /// workspace authored or contributed to the pull request (decision 62).
+    /// Absent on links the live heuristic derived.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub relation: Option<CodePullRequestRelation>,
 }
 
 /// Why an open pull request belongs in the default Needs attention view.
@@ -1493,6 +1542,11 @@ pub struct CodeSessionDigest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub pr_state: Option<PullRequestDigest>,
+    /// How many pull requests hold a durable attribution to this workspace
+    /// (decision 62). Absent when none do.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub pr_count: Option<u64>,
     /// Watch progress, present only on `kind: watch` digests.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
@@ -1522,6 +1576,7 @@ impl From<crate::code::bus::SessionDigest> for CodeSessionDigest {
             turn_count: digest.turn_count,
             activity: digest.activity,
             pr_state: digest.pr_state,
+            pr_count: digest.pr_count,
             watch_state: digest.watch_state,
             watch_detail: digest.watch_detail,
             watch_cycles: digest.watch_cycles,
@@ -1559,6 +1614,11 @@ pub enum CodeUpdateNotice {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         pr_state: Option<Box<PullRequestDigest>>,
+        /// How many pull requests hold a durable attribution to this
+        /// workspace (decision 62). Absent when none do.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        pr_count: Option<u64>,
         /// Watch progress, present only on `kind: watch` digests.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
@@ -1643,6 +1703,7 @@ impl CodeUpdateNotice {
             turn_count: wire.turn_count,
             activity: wire.activity,
             pr_state: wire.pr_state.map(Box::new),
+            pr_count: wire.pr_count,
             watch_state: wire.watch_state,
             watch_detail: wire.watch_detail,
             watch_cycles: wire.watch_cycles,

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -48,6 +48,8 @@ mod code_clone;
 mod code_git;
 #[cfg(unix)]
 mod code_pr_facts;
+#[cfg(unix)]
+mod code_reconcile;
 mod code_terminals;
 mod code_titling;
 mod compaction;

--- a/crates/tidebreak-server/src/tests/code_reconcile.rs
+++ b/crates/tidebreak-server/src/tests/code_reconcile.rs
@@ -1,0 +1,316 @@
+//! Reconcile sweep against a shimmed `gh` (decision 62).
+//!
+//! The sweep reads tracked repositories through the delivery path; these
+//! tests assert what that read persists — fact snapshots, exact-tier
+//! attribution, refreshed repo origin identity — and what it must never
+//! mint: attribution from the branch-name guess.
+
+use super::*;
+
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+
+use crate::code::CodeRuntime;
+use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+use tidebreak_core::db::code::{
+    get_pull_request_fact, get_repo, insert_repo, insert_workspace,
+    list_attributed_facts_for_workspace,
+};
+use tidebreak_core::{
+    CodePullRequestRelation, CodeRepo, CodeWorkspace, CodeWorkspaceStatus, OwnerId,
+    PullRequestDigest, RepoId, WorkspaceId,
+};
+use tidebreak_harness::AdapterRegistry;
+
+const LIST_JSON: &str = r#"[{"number":412,"url":"https://github.com/acme/tools/pull/412","state":"OPEN","title":"Tracked work","isDraft":false,"author":{"login":"octocat"},"reviewDecision":null,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","autoMergeRequest":null,"headRefName":"tidebreak/tracked","headRefOid":"aaa111","baseRefName":"main","updatedAt":"2026-08-22T12:00:00Z","createdAt":"2026-08-22T10:00:00Z","mergedAt":null,"closedAt":null,"labels":[]},{"number":500,"url":"https://github.com/acme/tools/pull/500","state":"OPEN","title":"Somebody else","isDraft":false,"author":{"login":"stranger"},"reviewDecision":null,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","autoMergeRequest":null,"headRefName":"tidebreak/fuzzy","headRefOid":"bbb222","baseRefName":"main","updatedAt":"2026-08-22T12:00:00Z","createdAt":"2026-08-22T11:00:00Z","mergedAt":null,"closedAt":null,"labels":[]}]"#;
+
+fn write_executable(path: &std::path::Path, body: &str) {
+    std::fs::write(path, body).unwrap();
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).unwrap();
+}
+
+fn run(cwd: &std::path::Path, args: &[&str]) {
+    let status = std::process::Command::new(args[0])
+        .args(&args[1..])
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .status()
+        .unwrap();
+    assert!(status.success(), "{args:?} failed in {}", cwd.display());
+}
+
+fn init_github_shaped_repo(dir: &std::path::Path) -> std::path::PathBuf {
+    let work = dir.join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    run(&work, &["git", "init", "-b", "main"]);
+    run(&work, &["git", "config", "user.email", "dev@example.com"]);
+    run(&work, &["git", "config", "user.name", "Dev"]);
+    std::fs::write(work.join("README.md"), "hello\n").unwrap();
+    run(&work, &["git", "add", "README.md"]);
+    run(&work, &["git", "commit", "-m", "init"]);
+    run(&work, &["git", "branch", "tidebreak/tracked"]);
+    run(&work, &["git", "branch", "tidebreak/fuzzy"]);
+    run(
+        &work,
+        &[
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/acme/tools.git",
+        ],
+    );
+    work
+}
+
+fn write_gh_shim(dir: &std::path::Path) {
+    let body = "#!/bin/sh\n\
+         if [ \"$1\" = auth ]; then\n\
+           echo '{\"hosts\":{\"github.com\":[{\"active\":true,\"state\":\"success\",\"login\":\"tester\"}]}}'\n\
+           exit 0\n\
+         fi\n\
+         if [ \"$1\" = api ]; then echo '{}'; exit 0; fi\n\
+         if [ \"$1\" = pr ] && [ \"$2\" = list ]; then\n"
+        .to_owned()
+        + &format!("           echo '{LIST_JSON}'\n")
+        + "           exit 0\n\
+         fi\n\
+         echo unexpected \"$@\" >&2\n\
+         exit 3\n";
+    write_executable(&dir.join("gh"), &body);
+}
+
+fn open_pr_digest(number: u64) -> PullRequestDigest {
+    PullRequestDigest {
+        number,
+        url: Some(format!("https://github.com/acme/tools/pull/{number}")),
+        state: "open".into(),
+        title: None,
+        checks_summary: None,
+        checks: None,
+        draft: None,
+        merged: None,
+        review_decision: None,
+        mergeable: None,
+        merge_state_status: None,
+        head_branch: None,
+        base_branch: None,
+        head_sha: None,
+        auto_merge_enabled: None,
+        in_merge_queue: None,
+    }
+}
+
+async fn seeded_runtime() -> (
+    tempfile::TempDir,
+    Arc<CodeRuntime>,
+    Arc<tidebreak_core::DbStore>,
+    RepoId,
+    WorkspaceId,
+    WorkspaceId,
+) {
+    let (dir, store) = temp_db_store("code-reconcile.db").await;
+    let db = Arc::new(store);
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    let runtime = Arc::new(CodeRuntime::with_registry(
+        db.clone(),
+        dir.path().to_path_buf(),
+        registry,
+    ));
+
+    let work = init_github_shaped_repo(dir.path());
+    let shim = dir.path().join("bin");
+    std::fs::create_dir_all(&shim).unwrap();
+    write_gh_shim(&shim);
+    runtime.set_gh_search_path(Some(shim.display().to_string()));
+
+    let owner = OwnerId::local();
+    let repo_id = RepoId::new();
+    insert_repo(
+        &db,
+        &CodeRepo {
+            id: repo_id,
+            owner: owner.clone(),
+            root_path: work.display().to_string(),
+            display_name: "tools".into(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: Vec::new(),
+            created_at: chrono::Utc::now(),
+            removed_at: None,
+            cloned_from: None,
+            origin_host: None,
+            origin_owner: None,
+            origin_name: None,
+        },
+    )
+    .await
+    .unwrap();
+    // Tracked: the persisted digest number matches PR 412 (the exact tier).
+    let tracked = WorkspaceId::new();
+    insert_workspace(
+        &db,
+        &CodeWorkspace {
+            id: tracked,
+            owner: owner.clone(),
+            repo_id,
+            title: "tracked".into(),
+            worktree_path: work.display().to_string(),
+            branch_name: "tidebreak/tracked".into(),
+            base_ref: "main".into(),
+            status: CodeWorkspaceStatus::Active,
+            pr: Some(open_pr_digest(412)),
+            created_at: chrono::Utc::now(),
+            archived_at: None,
+            released_at: None,
+            released_tip: None,
+            bundle_bytes: None,
+        },
+    )
+    .await
+    .unwrap();
+    // Fuzzy: shares PR 500's head branch name but has no digest and, with a
+    // never-pushed branch, no matching head SHA — the branch-name tier only.
+    let fuzzy = WorkspaceId::new();
+    insert_workspace(
+        &db,
+        &CodeWorkspace {
+            id: fuzzy,
+            owner: owner.clone(),
+            repo_id,
+            title: "fuzzy".into(),
+            worktree_path: dir.path().join("fuzzy").display().to_string(),
+            branch_name: "tidebreak/fuzzy".into(),
+            base_ref: "main".into(),
+            status: CodeWorkspaceStatus::Active,
+            pr: None,
+            created_at: chrono::Utc::now(),
+            archived_at: None,
+            released_at: None,
+            released_tip: None,
+            bundle_bytes: None,
+        },
+    )
+    .await
+    .unwrap();
+    (dir, runtime, db, repo_id, tracked, fuzzy)
+}
+
+#[tokio::test]
+async fn the_sweep_persists_facts_and_mints_exact_attribution_only() {
+    let (_dir, runtime, db, repo_id, tracked, fuzzy) = seeded_runtime().await;
+    let owner = OwnerId::local();
+
+    crate::code::reconcile::sweep_reconcile(&runtime).await;
+
+    // Both listed pull requests were read, but only the tracked one — the
+    // exact number tier — persisted and minted.
+    let fact = get_pull_request_fact(&db, &owner, "github.com", "acme", "tools", 412)
+        .await
+        .unwrap()
+        .expect("the exact-linked pull request persists");
+    assert_eq!(fact.head_branch, "tidebreak/tracked");
+    let first_seen = fact.first_seen_at;
+    assert!(
+        get_pull_request_fact(&db, &owner, "github.com", "acme", "tools", 500)
+            .await
+            .unwrap()
+            .is_none(),
+        "a branch-name guess must not persist a fact"
+    );
+
+    let attributed = list_attributed_facts_for_workspace(&db, &owner, tracked)
+        .await
+        .unwrap();
+    assert_eq!(attributed.len(), 1);
+    assert_eq!(attributed[0].1, CodePullRequestRelation::Contributed);
+    assert!(
+        list_attributed_facts_for_workspace(&db, &owner, fuzzy)
+            .await
+            .unwrap()
+            .is_empty(),
+        "the branch-name tier never mints attribution"
+    );
+
+    // The sweep recorded the origin identity it resolved.
+    let repo = get_repo(&db, &owner, repo_id).await.unwrap().unwrap();
+    assert_eq!(repo.origin_host.as_deref(), Some("github.com"));
+    assert_eq!(repo.origin_owner.as_deref(), Some("acme"));
+    assert_eq!(repo.origin_name.as_deref(), Some("tools"));
+
+    // A second pass is idempotent: same single attribution, first_seen holds.
+    runtime.delivery_cache.invalidate_owner(&owner);
+    crate::code::reconcile::sweep_reconcile(&runtime).await;
+    let attributed = list_attributed_facts_for_workspace(&db, &owner, tracked)
+        .await
+        .unwrap();
+    assert_eq!(attributed.len(), 1);
+    let fact = get_pull_request_fact(&db, &owner, "github.com", "acme", "tools", 412)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(fact.first_seen_at, first_seen);
+}
+
+#[tokio::test]
+async fn a_delivery_read_serves_durable_links_with_the_relation() {
+    let (_dir, runtime, db, _repo_id, tracked, _fuzzy) = seeded_runtime().await;
+    let owner = OwnerId::local();
+
+    crate::code::reconcile::sweep_reconcile(&runtime).await;
+    // A fresh read (past the sweep's cache entry) folds the stored
+    // attribution into the links.
+    runtime.delivery_cache.invalidate_owner(&owner);
+    let page = crate::code::delivery::query_pull_requests(
+        &runtime,
+        &owner,
+        true,
+        crate::routes::code::types::CodeDeliveryPullRequestQuery {
+            repositories: vec![crate::routes::code::types::CodeGitHubRepositoryTarget {
+                host: "github.com".into(),
+                owner: "acme".into(),
+                name: "tools".into(),
+            }],
+            search: None,
+            states: Vec::new(),
+            review_states: Vec::new(),
+            check_states: Vec::new(),
+            authors: Vec::new(),
+            attention_only: false,
+            ready_only: false,
+            tidebreak_linked: None,
+            updated_after: None,
+            cursor: None,
+            limit: None,
+            refresh: false,
+        },
+    )
+    .await
+    .unwrap();
+    let item = page
+        .items
+        .iter()
+        .find(|item| item.number == 412)
+        .expect("the tracked pull request is on the page");
+    let link = item
+        .workspace_links
+        .iter()
+        .find(|link| link.workspace_id == tracked)
+        .expect("the tracked workspace stays linked");
+    assert!(link.exact);
+    assert_eq!(link.relation, Some(CodePullRequestRelation::Contributed));
+
+    // The workspace list route's backing read returns the fact.
+    let listed = runtime
+        .workspace_pull_requests(&owner, tracked)
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].0.number, 412);
+    let _ = db;
+}

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -444,6 +444,7 @@ mod tests {
         );
         generate::collect_from::<crate::routes::code::CodeDeliveryPullRequestQuery>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeDeliveryPullRequestsPage>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::code::CodeWorkspacePullRequests>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeDeliveryPullRequestTarget>(
             &cfg, &mut out,
         );


### PR DESCRIPTION
Slice B of #2523 (closes #2525). Builds on the fact substrate from #2529.

The delivery read path now persists what it observes. `query_pull_requests` and `pull_request_detail` upsert fact snapshots for tracked pull requests — exact-linked to a workspace, or already holding a fact row — and mint `contributed` attribution for the exact tiers only (`discovered_via: reconcile`). The branch-name guess stays display-time and never mints. Stored attribution folds back into `workspace_links` before caching, so links survive workspace archive/release, carry an optional `relation`, and keep the established ordering (the notifications store routes to the first link).

A 61-second reconcile sweep (coprime with the 47s watch and 53s trigger sweeps) drives that read per owner over every live registered repository plus every identity already holding facts — which is how a cross-repo pull request the post-turn detector observed keeps itself fresh without a local checkout. The sweep also populates the `code_repo` origin identity columns added in #2529 and refreshes them when origin changes.

Surfaces:
- `GET /code/workspaces/{id}/pull-requests` — the workspace's attributed set from the durable store, open first then newest, no host read.
- `pr_count` on session digests (absent when zero), the cheap client signal to re-read the list. `pr_state` stays single-valued.
- The inspector's Review tab lists the attributed set above the single-PR panel once there is more than one; selecting a non-primary row shows its stored snapshot, the primary row returns to the live resource.
- The workspace card's PR chip gains the attributed count ("3 PRs") while keeping its primary pull request.

Tests: server integration (`code_reconcile.rs`, shimmed gh) — exact tier mints once and is idempotent, branch tier never mints or persists, origin columns populate, a delivery read serves durable links with the relation; UI vitest for the new parsers (unknown relation/state rejected, `pr_count` through digest notices), the chip helper, and the inspector's empty-list fake. Stories: inspector `ReviewPullRequestSet` (multi-PR list with a cross-repo entry), workspace card `SeveralPullRequests`.

Local validation: `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server` regen (committed), incremental `cargo check --all-targets` clean, `pnpm test` (1705), `biome lint`/`format`, `pnpm build`, `storybook:build`. Rust test suites run in CI.

Next: stack lanes (#2526), then `pr_opened`/`pr_updated` trigger conditions (#2527).