### PR TITLE
feat(code): fire pr_opened and pr_updated from fact edges, hold stacked children

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -1138,6 +1138,14 @@ pub enum CodeTriggerCondition {
     Merged,
     /// The pull request closed without merging.
     Closed,
+    /// A pull request came into existence (decision 62). Edge-sourced from
+    /// the durable fact store's `first_seen_at`, never from
+    /// [`classify_trigger_condition`].
+    PrOpened,
+    /// A tracked pull request's head moved (decision 62). Edge-sourced from
+    /// the fact store, once per distinct head; the first observed head is a
+    /// silent baseline, never a notification.
+    PrUpdated,
 }
 
 impl CodeTriggerCondition {
@@ -1153,6 +1161,8 @@ impl CodeTriggerCondition {
             Self::ReadyToMerge => "ready_to_merge",
             Self::Merged => "merged",
             Self::Closed => "closed",
+            Self::PrOpened => "pr_opened",
+            Self::PrUpdated => "pr_updated",
         }
     }
 
@@ -1169,13 +1179,15 @@ impl CodeTriggerCondition {
             "ready_to_merge" => Some(Self::ReadyToMerge),
             "merged" => Some(Self::Merged),
             "closed" => Some(Self::Closed),
+            "pr_opened" => Some(Self::PrOpened),
+            "pr_updated" => Some(Self::PrUpdated),
             _ => None,
         }
     }
 
     /// Every condition, for enumerating the arming surface.
     #[must_use]
-    pub const fn all() -> [Self; 8] {
+    pub const fn all() -> [Self; 10] {
         [
             Self::ChecksFailed,
             Self::Conflicts,
@@ -1185,6 +1197,8 @@ impl CodeTriggerCondition {
             Self::ReadyToMerge,
             Self::Merged,
             Self::Closed,
+            Self::PrOpened,
+            Self::PrUpdated,
         ]
     }
 
@@ -1203,6 +1217,8 @@ impl CodeTriggerCondition {
             Self::ReadyToMerge => "the pull request is ready to merge",
             Self::Merged => "the pull request merged",
             Self::Closed => "the pull request closed without merging",
+            Self::PrOpened => "a pull request opened",
+            Self::PrUpdated => "the pull request's head moved",
         }
     }
 
@@ -1422,6 +1438,11 @@ impl CodeTriggerFire {
 /// conflicting branch reports conflicts rather than the failing checks that
 /// conflict caused. Returns `None` for a digest nothing is armed for — a draft,
 /// or a pull request merely waiting on pending checks.
+///
+/// Deliberately never returns [`CodeTriggerCondition::PrOpened`] or
+/// [`CodeTriggerCondition::PrUpdated`]: those are edges of the durable fact
+/// store (decision 62), not states a digest can carry, and the trigger
+/// sweep's fact pass fires them without a host read.
 #[must_use]
 pub fn classify_trigger_condition(pr: &PullRequestDigest) -> Option<CodeTriggerCondition> {
     let state = pr.state.trim().to_ascii_lowercase();

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -47,6 +47,7 @@ impl MigratorTrait for Migrator {
             Box::new(TriggerFireOutbox),
             Box::new(TriggerDeliveryReceipts),
             Box::new(CodePullRequestFacts),
+            Box::new(TriggerFactConditions),
         ]
     }
 }
@@ -840,6 +841,235 @@ impl MigrationTrait for TriggerFireOutbox {
 
 const TRIGGER_FIRE_OUTBOX_TEMP_TABLE: &str = "code_trigger_fire_outbox_upgrade";
 
+/// The condition tokens the pre-fact-edge schema accepted (decision 60).
+const BASELINE_TRIGGER_CONDITIONS: &[&str] = &[
+    "checks_failed",
+    "conflicts",
+    "changes_requested",
+    "review_required",
+    "behind",
+    "ready_to_merge",
+    "merged",
+    "closed",
+];
+
+/// The condition tokens including the fact edges (decision 62).
+const FACT_TRIGGER_CONDITIONS: &[&str] = &[
+    "checks_failed",
+    "conflicts",
+    "changes_requested",
+    "review_required",
+    "behind",
+    "ready_to_merge",
+    "merged",
+    "closed",
+    "pr_opened",
+    "pr_updated",
+];
+
+/// Accept the fact-edge conditions `pr_opened` and `pr_updated` (decision 62).
+///
+/// Both condition CHECKs are table-level — `code_trigger.condition` from the
+/// frozen baseline and `code_trigger_fire.delivery_condition` from the outbox
+/// rebuild — and SQLite cannot alter a table-level CHECK in place, so both
+/// tables rebuild. The order matters on PostgreSQL, which enforces the
+/// fire→trigger cascade: the new fire table references the new trigger table
+/// before either old table drops, and nothing is ever dropped while a
+/// foreign key still points at it. SQLite rewrites the new fire table's
+/// reference when the new trigger table takes its final name.
+struct TriggerFactConditions;
+
+impl MigrationName for TriggerFactConditions {
+    fn name(&self) -> &str {
+        "m20260823_000010_trigger_fact_conditions"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for TriggerFactConditions {
+    fn use_transaction(&self) -> Option<bool> {
+        // Either both rebuilt tables land with every row, or neither does.
+        Some(true)
+    }
+
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        widen_trigger_condition_checks(manager).await
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Narrowing the vocabulary would refuse rows that already exist.
+        Ok(())
+    }
+}
+
+const TRIGGER_WIDEN_TEMP_TABLE: &str = "code_trigger_widen_upgrade";
+const TRIGGER_FIRE_WIDEN_TEMP_TABLE: &str = "code_trigger_fire_widen_upgrade";
+
+fn code_trigger_widened_table(name: &str, conditions: &[&str]) -> TableCreateStatement {
+    Table::create()
+        .table(Alias::new(name))
+        .col(
+            ColumnDef::new(idens::CodeTrigger::Id)
+                .uuid()
+                .not_null()
+                .primary_key(),
+        )
+        .col(
+            ColumnDef::new(idens::CodeTrigger::Owner)
+                .text()
+                .not_null()
+                .default("local"),
+        )
+        .col(ColumnDef::new(idens::CodeTrigger::RepoId).uuid().not_null())
+        .col(
+            ColumnDef::new(idens::CodeTrigger::Condition)
+                .text()
+                .not_null(),
+        )
+        .col(ColumnDef::new(idens::CodeTrigger::Action).text().not_null())
+        .col(
+            ColumnDef::new(idens::CodeTrigger::Enabled)
+                .boolean()
+                .not_null()
+                .default(true),
+        )
+        .col(
+            ColumnDef::new(idens::CodeTrigger::CreatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(idens::CodeTrigger::UpdatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_code_trigger_repo")
+                .from(Alias::new(name), idens::CodeTrigger::RepoId)
+                .to(idens::CodeRepo::Table, idens::CodeRepo::Id),
+        )
+        .check(Expr::col(idens::CodeTrigger::Condition).is_in(conditions.iter().copied()))
+        .check(Expr::col(idens::CodeTrigger::Action).is_in(["deliver", "notify"]))
+        .to_owned()
+}
+
+async fn widen_trigger_condition_checks(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    for (table, temp) in [
+        ("code_trigger", TRIGGER_WIDEN_TEMP_TABLE),
+        ("code_trigger_fire", TRIGGER_FIRE_WIDEN_TEMP_TABLE),
+    ] {
+        if !manager.has_table(table).await? {
+            return Err(DbErr::Custom(format!(
+                "the migration chain did not create {table}"
+            )));
+        }
+        if manager.has_table(temp).await? {
+            manager
+                .drop_table(Table::drop().table(Alias::new(temp)).to_owned())
+                .await?;
+        }
+    }
+
+    manager
+        .create_table(code_trigger_widened_table(
+            TRIGGER_WIDEN_TEMP_TABLE,
+            FACT_TRIGGER_CONDITIONS,
+        ))
+        .await?;
+    let copy_triggers = "INSERT INTO {temp} \
+         (id, owner, repo_id, condition, action, enabled, created_at, updated_at) \
+         SELECT id, owner, repo_id, condition, action, enabled, created_at, updated_at \
+         FROM code_trigger"
+        .replace("{temp}", TRIGGER_WIDEN_TEMP_TABLE);
+    manager
+        .get_connection()
+        .execute_unprepared(&copy_triggers)
+        .await?;
+
+    manager
+        .create_table(code_trigger_fire_outbox_table(
+            TRIGGER_FIRE_WIDEN_TEMP_TABLE,
+            TRIGGER_WIDEN_TEMP_TABLE,
+            FACT_TRIGGER_CONDITIONS,
+        ))
+        .await?;
+    let copy_fires = "INSERT INTO {temp} \
+         (owner, trigger_id, workspace_id, pr_number, head_sha, fired_at, delivery_id, \
+          delivery_condition, delivery_action, delivery_message, state, attempt_count, \
+          lease_token, lease_expires_at, next_attempt_at, last_error, delivered_at, \
+          cancelled_at) \
+         SELECT owner, trigger_id, workspace_id, pr_number, head_sha, fired_at, delivery_id, \
+          delivery_condition, delivery_action, delivery_message, state, attempt_count, \
+          lease_token, lease_expires_at, next_attempt_at, last_error, delivered_at, \
+          cancelled_at \
+         FROM code_trigger_fire"
+        .replace("{temp}", TRIGGER_FIRE_WIDEN_TEMP_TABLE);
+    manager
+        .get_connection()
+        .execute_unprepared(&copy_fires)
+        .await?;
+
+    // Old fire first (nothing references it), then the old trigger table,
+    // which by now has zero inbound foreign keys on either backend.
+    manager
+        .drop_table(
+            Table::drop()
+                .table(Alias::new("code_trigger_fire"))
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .drop_table(Table::drop().table(Alias::new("code_trigger")).to_owned())
+        .await?;
+    manager
+        .rename_table(
+            Table::rename()
+                .table(
+                    Alias::new(TRIGGER_WIDEN_TEMP_TABLE),
+                    Alias::new("code_trigger"),
+                )
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .rename_table(
+            Table::rename()
+                .table(
+                    Alias::new(TRIGGER_FIRE_WIDEN_TEMP_TABLE),
+                    Alias::new("code_trigger_fire"),
+                )
+                .to_owned(),
+        )
+        .await?;
+
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_code_trigger_repo")
+                .table(idens::CodeTrigger::Table)
+                .col(idens::CodeTrigger::RepoId)
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .unique()
+                .name("uq_code_trigger_rule")
+                .table(idens::CodeTrigger::Table)
+                .col(idens::CodeTrigger::Owner)
+                .col(idens::CodeTrigger::RepoId)
+                .col(idens::CodeTrigger::Condition)
+                .to_owned(),
+        )
+        .await?;
+    for index in code_trigger_fire_outbox_indexes() {
+        manager.create_index(index).await?;
+    }
+    Ok(())
+}
+
 fn trigger_fire_uuid_expr(
     row: &QueryResult,
     backend: DbBackend,
@@ -868,6 +1098,8 @@ async fn rebuild_code_trigger_fire_outbox(manager: &SchemaManager<'_>) -> Result
     manager
         .create_table(code_trigger_fire_outbox_table(
             TRIGGER_FIRE_OUTBOX_TEMP_TABLE,
+            "code_trigger",
+            BASELINE_TRIGGER_CONDITIONS,
         ))
         .await?;
 
@@ -954,7 +1186,11 @@ async fn rebuild_code_trigger_fire_outbox(manager: &SchemaManager<'_>) -> Result
     Ok(())
 }
 
-fn code_trigger_fire_outbox_table(name: &str) -> TableCreateStatement {
+fn code_trigger_fire_outbox_table(
+    name: &str,
+    trigger_table: &str,
+    conditions: &[&str],
+) -> TableCreateStatement {
     let pending = Expr::col(idens::CodeTriggerFire::State)
         .eq("pending")
         .and(Expr::col(idens::CodeTriggerFire::DeliveredAt).is_null())
@@ -1060,7 +1296,7 @@ fn code_trigger_fire_outbox_table(name: &str) -> TableCreateStatement {
             ForeignKey::create()
                 .name("fk_code_trigger_fire_trigger")
                 .from(Alias::new(name), idens::CodeTriggerFire::TriggerId)
-                .to(idens::CodeTrigger::Table, idens::CodeTrigger::Id)
+                .to(Alias::new(trigger_table), idens::CodeTrigger::Id)
                 .on_delete(ForeignKeyAction::Cascade),
         )
         .foreign_key(
@@ -1087,16 +1323,8 @@ fn code_trigger_fire_outbox_table(name: &str) -> TableCreateStatement {
         .check(
             Expr::col(idens::CodeTriggerFire::DeliveryCondition)
                 .is_null()
-                .or(Expr::col(idens::CodeTriggerFire::DeliveryCondition).is_in([
-                    "checks_failed",
-                    "conflicts",
-                    "changes_requested",
-                    "review_required",
-                    "behind",
-                    "ready_to_merge",
-                    "merged",
-                    "closed",
-                ])),
+                .or(Expr::col(idens::CodeTriggerFire::DeliveryCondition)
+                    .is_in(conditions.iter().copied())),
         )
         .check(
             Expr::col(idens::CodeTriggerFire::DeliveryAction)
@@ -1187,6 +1415,7 @@ mod tests {
                 "m20260822_000007_trigger_fire_outbox",
                 "m20260822_000008_trigger_delivery_receipts",
                 "m20260822_000009_code_pull_request_facts",
+                "m20260823_000010_trigger_fact_conditions",
             ]
         );
         assert!(db
@@ -1687,5 +1916,78 @@ mod tests {
              squashing the chain for a release."
             );
         }
+    }
+
+    /// The condition-widening rebuild keeps every trigger and fire row, keeps
+    /// the outbox identity, accepts the fact-edge tokens, and still refuses a
+    /// garbage token. A wrong rebuild passes a fresh-database test easily —
+    /// only seeded data shows a dropped row or a lost constraint.
+    #[tokio::test]
+    async fn the_condition_widening_keeps_trigger_and_fire_rows() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        // Everything up to, but not including, the widening.
+        Migrator::up(&db, Some(9)).await.unwrap();
+
+        for statement in [
+            "INSERT INTO code_repo (id, owner, root_path, display_name, default_base_ref, \
+             branch_prefix, quick_actions, created_at) VALUES ('repo-1', 'local', '/tmp/r', \
+             'r', 'main', 'tidebreak/', '[]', '2026-08-20T00:00:00Z')",
+            "INSERT INTO code_workspace (id, owner, repo_id, title, worktree_path, branch_name, \
+             base_ref, status, created_at) VALUES ('ws-1', 'local', 'repo-1', 'w', '/tmp/w', \
+             'tidebreak/w', 'main', 'active', '2026-08-20T00:00:00Z')",
+            "INSERT INTO code_trigger (id, owner, repo_id, condition, action, enabled, \
+             created_at, updated_at) VALUES ('trig-1', 'local', 'repo-1', 'checks_failed', \
+             'deliver', TRUE, '2026-08-20T00:00:00Z', '2026-08-20T00:00:00Z')",
+            "INSERT INTO code_trigger_fire (owner, trigger_id, workspace_id, pr_number, \
+             head_sha, fired_at, delivery_id, delivery_condition, delivery_action, \
+             delivery_message, state, attempt_count, next_attempt_at) VALUES ('local', \
+             'trig-1', 'ws-1', 41, 'aaa', '2026-08-21T00:00:00Z', 'deliv-1', 'checks_failed', \
+             'deliver', 'm', 'pending', 0, '2026-08-21T00:00:00Z')",
+        ] {
+            db.execute_unprepared(statement).await.unwrap();
+        }
+
+        Migrator::up(&db, None).await.unwrap();
+
+        let fire = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT head_sha, state, delivery_condition FROM code_trigger_fire \
+                 WHERE trigger_id = 'trig-1'"
+                    .to_owned(),
+            ))
+            .await
+            .unwrap()
+            .expect("the seeded fire survives the rebuild");
+        assert_eq!(fire.try_get::<String>("", "head_sha").unwrap(), "aaa");
+        assert_eq!(fire.try_get::<String>("", "state").unwrap(), "pending");
+
+        // The widened vocabulary is accepted on both rebuilt CHECKs...
+        db.execute_unprepared(
+            "INSERT INTO code_trigger (id, owner, repo_id, condition, action, enabled, \
+             created_at, updated_at) VALUES ('trig-2', 'local', 'repo-1', 'pr_opened', \
+             'notify', TRUE, '2026-08-22T00:00:00Z', '2026-08-22T00:00:00Z')",
+        )
+        .await
+        .unwrap();
+        db.execute_unprepared(
+            "INSERT INTO code_trigger_fire (owner, trigger_id, workspace_id, pr_number, \
+             head_sha, fired_at, delivery_id, delivery_condition, delivery_action, \
+             delivery_message, state, attempt_count, next_attempt_at) VALUES ('local', \
+             'trig-2', 'ws-1', 42, 'opened', '2026-08-22T00:00:00Z', 'deliv-2', 'pr_opened', \
+             'notify', 'm', 'pending', 0, '2026-08-22T00:00:00Z')",
+        )
+        .await
+        .unwrap();
+
+        // ...and a token outside it still fails.
+        assert!(db
+            .execute_unprepared(
+                "INSERT INTO code_trigger (id, owner, repo_id, condition, action, enabled, \
+                 created_at, updated_at) VALUES ('trig-3', 'local', 'repo-1', 'pr_sparkled', \
+                 'notify', TRUE, '2026-08-22T00:00:00Z', '2026-08-22T00:00:00Z')",
+            )
+            .await
+            .is_err());
     }
 }

--- a/crates/tidebreak-core/src/db/ops/code/trigger.rs
+++ b/crates/tidebreak-core/src/db/ops/code/trigger.rs
@@ -830,6 +830,81 @@ pub async fn list_fires_for_workspace(
         .collect()
 }
 
+/// The head SHAs a trigger has already fired (or baselined) against for one
+/// pull request on one workspace. The fact-edge sweep reads this to tell a
+/// new head from one it has already handled (decision 62).
+pub async fn trigger_fire_heads_for_pr(
+    store: &DbStore,
+    owner: &OwnerId,
+    trigger_id: CodeTriggerId,
+    workspace_id: WorkspaceId,
+    pr_number: u64,
+) -> Result<Vec<String>> {
+    let pr_number = i64::try_from(pr_number)
+        .map_err(|_| AgentError::Store(format!("pull request number {pr_number} overflows")))?;
+    let rows: Vec<String> = entities::code_trigger_fire::Entity::find()
+        .select_only()
+        .column(entities::code_trigger_fire::Column::HeadSha)
+        .filter(entities::code_trigger_fire::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_trigger_fire::Column::TriggerId.eq(trigger_id.0))
+        .filter(entities::code_trigger_fire::Column::WorkspaceId.eq(workspace_id.0))
+        .filter(entities::code_trigger_fire::Column::PrNumber.eq(pr_number))
+        .into_tuple()
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(rows)
+}
+
+/// Record a fire that must never notify: the `pr_updated` baseline
+/// (decision 62). The first observed head of a pull request is not an
+/// update, but a later head can only be recognized against a stored one, so
+/// the baseline lands as an already-delivered row with no payload — the
+/// outbox sweep never picks it up, and the conflict identity still
+/// suppresses a duplicate. Returns `true` when this call created the row.
+pub async fn insert_settled_trigger_fire(
+    store: &DbStore,
+    identity: &CodeTriggerFireIdentity,
+    fired_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool> {
+    let pr_number = trigger_fire_pr_number(identity)?;
+    let result =
+        entities::code_trigger_fire::Entity::insert(entities::code_trigger_fire::ActiveModel {
+            trigger_id: Set(identity.trigger_id.0),
+            owner: Set(identity.owner.as_str().to_owned()),
+            workspace_id: Set(identity.workspace_id.0),
+            pr_number: Set(pr_number),
+            head_sha: Set(identity.head_sha.clone()),
+            fired_at: Set(fired_at),
+            delivery_id: Set(CodeTriggerDeliveryId::new().0),
+            delivery_condition: Set(None),
+            delivery_action: Set(None),
+            delivery_message: Set(None),
+            state: Set(CodeTriggerFireState::Delivered.as_str().to_owned()),
+            attempt_count: Set(0),
+            lease_token: Set(None),
+            lease_expires_at: Set(None),
+            next_attempt_at: Set(None),
+            last_error: Set(None),
+            delivered_at: Set(Some(fired_at)),
+            cancelled_at: Set(None),
+        })
+        .on_conflict(
+            OnConflict::columns([
+                entities::code_trigger_fire::Column::TriggerId,
+                entities::code_trigger_fire::Column::WorkspaceId,
+                entities::code_trigger_fire::Column::PrNumber,
+                entities::code_trigger_fire::Column::HeadSha,
+            ])
+            .do_nothing()
+            .to_owned(),
+        )
+        .exec_without_returning(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result == 1)
+}
+
 fn trigger_from_row(row: entities::code_trigger::Model) -> Result<CodeTrigger> {
     let condition = CodeTriggerCondition::from_str(&row.condition).ok_or_else(|| {
         AgentError::Store(format!(

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerRules.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerRules.tsx
@@ -42,6 +42,8 @@ const CONDITIONS: CodeTriggerCondition[] = [
   "ready_to_merge",
   "merged",
   "closed",
+  "pr_opened",
+  "pr_updated",
 ];
 
 function conditionCopy(condition: CodeTriggerCondition): {
@@ -88,6 +90,18 @@ function conditionCopy(condition: CodeTriggerCondition): {
       return {
         title: "Closed",
         description: "The pull request closed without merging.",
+      };
+    case "pr_opened":
+      return {
+        title: "Pull request opens",
+        description:
+          "A pull request this repository's workspaces work on comes into existence.",
+      };
+    case "pr_updated":
+      return {
+        title: "Head moves",
+        description:
+          "A tracked pull request gets a new head. The first observed head never notifies.",
       };
   }
 }

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1426,7 +1426,7 @@ export type CodeTriggerAction = "deliver" | "notify";
  * on. A trigger fires on the *transition* into one of these, once per head
  * SHA — see [`CodeTriggerFire`] (decision 60).
  */
-export type CodeTriggerCondition = "checks_failed" | "conflicts" | "changes_requested" | "review_required" | "behind" | "ready_to_merge" | "merged" | "closed";
+export type CodeTriggerCondition = "checks_failed" | "conflicts" | "changes_requested" | "review_required" | "behind" | "ready_to_merge" | "merged" | "closed" | "pr_opened" | "pr_updated";
 
 /**
  * Identifies one durable trigger rule bound to a repository.

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -467,6 +467,15 @@ pub(crate) async fn query_pull_requests_by_number(
             .cmp(&left.updated_at)
             .then_with(|| left.id.cmp(&right.id))
     });
+    // The trigger sweep reads through here, and its stacked-child suppression
+    // keys on `stack_parent_number` (decision 62) — so this path persists and
+    // annotates the same way the list read does.
+    let workspaces_gaining_links =
+        persist_and_augment_pull_request_facts(&runtime.db, owner, &workspaces, &mut items).await;
+    for workspace_id in workspaces_gaining_links {
+        super::attention::emit_workspace_digests(&runtime.db, &runtime.bus, owner, workspace_id)
+            .await;
+    }
     Ok(CodeDeliveryPullRequestsPage {
         capability,
         items,

--- a/crates/tidebreak-server/src/code/trigger.rs
+++ b/crates/tidebreak-server/src/code/trigger.rs
@@ -18,17 +18,19 @@ use chrono::Utc;
 use futures::{stream, StreamExt};
 use tidebreak_core::db::code::{
     acknowledge_trigger_fire_delivery, get_open_turn, get_session, insert_or_load_trigger_fire,
-    latest_turn, lease_trigger_fire_delivery, list_active_watches_all_owners,
+    insert_settled_trigger_fire, latest_turn, lease_trigger_fire_delivery,
+    list_active_watches_all_owners, list_attributions_for_pull_requests,
     list_due_trigger_fire_deliveries_all_owners, list_enabled_triggers_all_owners,
-    list_sessions_for_workspace, reschedule_trigger_fire_delivery_failure,
-    trigger_delivery_accepted,
+    list_pull_request_facts_for_repo, list_sessions_for_workspace,
+    reschedule_trigger_fire_delivery_failure, trigger_delivery_accepted, trigger_fire_heads_for_pr,
 };
 use tidebreak_core::{
-    classify_trigger_condition, Attention, AttentionSource, CapLevel, CodeEvent, CodeSession,
-    CodeSessionId, CodeSessionKind, CodeSessionLifecycle, CodeTrigger, CodeTriggerAction,
-    CodeTriggerCondition, CodeTriggerDeliveryId, CodeTriggerFire, CodeTriggerFireIdentity,
-    CodeTriggerFirePayload, CodeTurnId, CodeWorkspaceStatus, HarnessNoticeLevel, OwnerId,
-    PullRequestCheck, PullRequestDigest, RepoId, WorkspaceId,
+    classify_trigger_condition, Attention, AttentionSource, CapLevel, CodeEvent,
+    CodePullRequestFact, CodePullRequestId, CodeSession, CodeSessionId, CodeSessionKind,
+    CodeSessionLifecycle, CodeTrigger, CodeTriggerAction, CodeTriggerCondition,
+    CodeTriggerDeliveryId, CodeTriggerFire, CodeTriggerFireIdentity, CodeTriggerFirePayload,
+    CodeTurnId, CodeWorkspaceStatus, HarnessNoticeLevel, OwnerId, PullRequestCheck,
+    PullRequestDigest, RepoId, WorkspaceId,
 };
 use tracing::{debug, warn};
 
@@ -195,6 +197,12 @@ async fn sweep_owner(
         }
     }
 
+    // Fact-edge conditions read only the local store — the reconcile sweep
+    // keeps facts fresh — so they run before the remote-read gate below,
+    // which would drop a repository whose workspaces carry facts but no
+    // persisted digest (decision 62).
+    sweep_fact_edges(runtime, owner, &repositories, &eligible).await;
+
     // An exact remote read needs both an eligible workspace and its persisted
     // pull-request number. Exclude every other repository before reading its
     // origin or asking GitHub for anything.
@@ -276,6 +284,228 @@ async fn sweep_owner(
     Ok(())
 }
 
+/// The fingerprint a `pr_opened` fire carries instead of a head SHA: the edge
+/// is the pull request coming into existence, once, regardless of where its
+/// head moves afterwards. The token cannot collide with a real SHA.
+const PR_OPENED_FINGERPRINT: &str = "opened";
+
+/// Fire the fact-edge conditions from the durable store (decision 62).
+///
+/// `pr_opened` fires once per pull request whose host `created_at` and local
+/// `first_seen_at` both postdate the trigger's arming — arming a trigger over
+/// existing history stays silent. `pr_updated` fires once per distinct head;
+/// the first observed head lands as a settled baseline row so nothing
+/// notifies until the head actually moves. Both deliver to the eligible
+/// workspaces holding a durable attribution to the pull request. Best-effort
+/// throughout: a store failure skips the repository and the next tick
+/// retries.
+async fn sweep_fact_edges(
+    runtime: &Arc<CodeRuntime>,
+    owner: &OwnerId,
+    repositories: &HashMap<RepoId, Vec<CodeTrigger>>,
+    eligible: &HashMap<RepoId, EligibleWorkspaces>,
+) {
+    let interested: Vec<(RepoId, Vec<&CodeTrigger>)> = repositories
+        .iter()
+        .filter_map(|(repo_id, triggers)| {
+            let fact_triggers: Vec<&CodeTrigger> = triggers
+                .iter()
+                .filter(|trigger| {
+                    matches!(
+                        trigger.condition,
+                        CodeTriggerCondition::PrOpened | CodeTriggerCondition::PrUpdated
+                    )
+                })
+                .collect();
+            (!fact_triggers.is_empty()).then_some((*repo_id, fact_triggers))
+        })
+        .collect();
+    if interested.is_empty() {
+        return;
+    }
+    let repos: HashMap<RepoId, tidebreak_core::CodeRepo> = match runtime.list_repos(owner).await {
+        Ok(repos) => repos.into_iter().map(|repo| (repo.id, repo)).collect(),
+        Err(err) => {
+            debug!(error = %err.message(), "fact-edge sweep could not list repositories");
+            return;
+        }
+    };
+
+    for (repo_id, triggers) in interested {
+        let Some(work) = eligible.get(&repo_id) else {
+            continue;
+        };
+        if work.workspace_ids.is_empty() {
+            continue;
+        }
+        let Some(repo) = repos.get(&repo_id) else {
+            continue;
+        };
+        // The reconcile sweep records the origin identity; a cold start falls
+        // back to one local git read.
+        let (host, repo_owner, repo_name) =
+            match (&repo.origin_host, &repo.origin_owner, &repo.origin_name) {
+                (Some(host), Some(repo_owner), Some(repo_name)) => {
+                    (host.clone(), repo_owner.clone(), repo_name.clone())
+                }
+                _ => match repository_target_from_local(repo).await {
+                    Ok(target) => (target.host, target.owner, target.name),
+                    Err(message) => {
+                        debug!(
+                            repo = %repo.id,
+                            error = %message,
+                            "fact-edge sweep skipped a repository without a GitHub origin"
+                        );
+                        continue;
+                    }
+                },
+            };
+        let facts = match list_pull_request_facts_for_repo(
+            &runtime.db,
+            owner,
+            &host,
+            &repo_owner,
+            &repo_name,
+        )
+        .await
+        {
+            Ok(facts) => facts,
+            Err(err) => {
+                debug!("fact-edge sweep could not read facts: {err}");
+                continue;
+            }
+        };
+        if facts.is_empty() {
+            continue;
+        }
+        let ids: Vec<CodePullRequestId> = facts.iter().map(|fact| fact.id).collect();
+        let attributions = match list_attributions_for_pull_requests(&runtime.db, owner, &ids).await
+        {
+            Ok(attributions) => attributions,
+            Err(err) => {
+                debug!("fact-edge sweep could not read attributions: {err}");
+                continue;
+            }
+        };
+        let mut workspaces_by_fact: HashMap<CodePullRequestId, Vec<WorkspaceId>> = HashMap::new();
+        for attribution in attributions {
+            if work.workspace_ids.contains(&attribution.workspace_id) {
+                workspaces_by_fact
+                    .entry(attribution.pull_request_id)
+                    .or_default()
+                    .push(attribution.workspace_id);
+            }
+        }
+
+        for fact in &facts {
+            let Some(targets) = workspaces_by_fact.get(&fact.id) else {
+                continue;
+            };
+            for trigger in &triggers {
+                for workspace_id in targets {
+                    if let Err(err) =
+                        fire_fact_edge(runtime, owner, trigger, *workspace_id, fact).await
+                    {
+                        warn!(
+                            trigger = %trigger.id,
+                            workspace = %workspace_id,
+                            error = %err.message(),
+                            "code-mode fact-edge fire failed"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Fire one fact edge for one trigger on one workspace, or record its
+/// baseline.
+async fn fire_fact_edge(
+    runtime: &Arc<CodeRuntime>,
+    owner: &OwnerId,
+    trigger: &CodeTrigger,
+    workspace_id: WorkspaceId,
+    fact: &CodePullRequestFact,
+) -> Result<(), ServerError> {
+    match trigger.condition {
+        CodeTriggerCondition::PrOpened => {
+            if fact.created_at < trigger.created_at || fact.first_seen_at < trigger.created_at {
+                return Ok(());
+            }
+            let digest = digest_from_fact(fact);
+            fire_one(
+                runtime,
+                owner,
+                trigger,
+                workspace_id,
+                &digest,
+                PR_OPENED_FINGERPRINT,
+            )
+            .await
+        }
+        CodeTriggerCondition::PrUpdated => {
+            // A settled pull request's head is history; merged and closed have
+            // their own conditions.
+            if fact.state != tidebreak_core::CodePullRequestState::Open {
+                return Ok(());
+            }
+            let Some(head) = fact.head_sha.as_deref() else {
+                return Ok(());
+            };
+            let heads = trigger_fire_heads_for_pr(
+                &runtime.db,
+                owner,
+                trigger.id,
+                workspace_id,
+                fact.number,
+            )
+            .await?;
+            if heads.iter().any(|known| known == head) {
+                return Ok(());
+            }
+            if heads.is_empty() {
+                // First sight is the baseline, never a notification.
+                let identity = CodeTriggerFireIdentity {
+                    trigger_id: trigger.id,
+                    owner: owner.clone(),
+                    workspace_id,
+                    pr_number: fact.number,
+                    head_sha: head.to_owned(),
+                };
+                insert_settled_trigger_fire(&runtime.db, &identity, Utc::now()).await?;
+                return Ok(());
+            }
+            let digest = digest_from_fact(fact);
+            fire_one(runtime, owner, trigger, workspace_id, &digest, head).await
+        }
+        _ => Ok(()),
+    }
+}
+
+/// The minimal digest a fact-edge message composes from: identity and title,
+/// no checks — the fact store deliberately never carries check state.
+fn digest_from_fact(fact: &CodePullRequestFact) -> PullRequestDigest {
+    PullRequestDigest {
+        number: fact.number,
+        url: Some(fact.url.clone()),
+        state: fact.state.as_str().to_owned(),
+        title: Some(fact.title.clone()),
+        checks_summary: None,
+        checks: None,
+        draft: Some(fact.draft),
+        merged: Some(fact.state == tidebreak_core::CodePullRequestState::Merged),
+        review_decision: None,
+        mergeable: None,
+        merge_state_status: None,
+        head_branch: Some(fact.head_branch.clone()),
+        base_branch: Some(fact.base_branch.clone()),
+        head_sha: fact.head_sha.clone(),
+        auto_merge_enabled: None,
+        in_merge_queue: None,
+    }
+}
+
 /// Fetch one exact-number aggregate and deliver its matching facts.
 async fn sweep_pull_requests(
     runtime: &Arc<CodeRuntime>,
@@ -353,6 +583,23 @@ async fn claim_fires(
     let Some(condition) = classify_trigger_condition(&digest) else {
         return;
     };
+    // A stacked child is behind or blocked *because of its parent* — the
+    // summary carries the parent from the durable fact set (decision 62).
+    // Firing Behind or ReviewRequired at it would send an agent to rebase
+    // onto a branch that moves with every parent push.
+    if item.stack_parent_number.is_some()
+        && matches!(
+            condition,
+            CodeTriggerCondition::Behind | CodeTriggerCondition::ReviewRequired
+        )
+    {
+        debug!(
+            number = item.number,
+            parent = item.stack_parent_number,
+            "code-mode trigger held a stacked child's fire"
+        );
+        return;
+    }
     let workspaces = linked_workspaces(&item.workspace_links, work.repo_id, &work.workspace_ids);
     if workspaces.is_empty() {
         return;
@@ -765,6 +1012,8 @@ fn describe_condition(condition: CodeTriggerCondition, number: u64) -> String {
         CodeTriggerCondition::ReadyToMerge => format!("#{number} is ready to merge"),
         CodeTriggerCondition::Merged => format!("#{number} merged"),
         CodeTriggerCondition::Closed => format!("#{number} closed without merging"),
+        CodeTriggerCondition::PrOpened => format!("pull request #{number} opened"),
+        CodeTriggerCondition::PrUpdated => format!("#{number} has a new head"),
     }
 }
 

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -22,7 +22,7 @@ use tracing::warn;
 
 use tidebreak_core::db::code::{
     get_session, insert_watch, latest_watch_for_workspace, list_active_watches_all_owners,
-    list_sessions_for_workspace, save_watch,
+    list_pull_request_facts_for_repo, list_sessions_for_workspace, save_watch,
 };
 use tidebreak_core::{
     Attention, AttentionSource, CodeSessionKind, CodeSessionLifecycle, CodeWatch, CodeWatchId,
@@ -503,6 +503,21 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
             Ok(())
         }
         WatchAssessment::Actionable(reason) => {
+            if reason == WatchReason::Behind {
+                // A stacked child is behind *because of its parent*: rebasing
+                // onto a branch that moves with every parent push never
+                // settles (decision 62). Park until the parent lands.
+                if let Some(parent) =
+                    stacked_parent_number(runtime.as_ref(), &owner, watch.workspace_id, &pr).await
+                {
+                    return park_watch(
+                        runtime.as_ref(),
+                        watch,
+                        &format!("waiting on its parent pull request #{parent}"),
+                    )
+                    .await;
+                }
+            }
             let same_head = watch.last_fix_head.is_some()
                 && watch.last_fix_head.as_deref() == pr.head_sha.as_deref();
             if same_head {
@@ -542,6 +557,42 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
             Ok(())
         }
     }
+}
+
+/// The open pull request this workspace's pull request is stacked on, when
+/// the durable fact set knows one (decision 62). `None` on any missing link
+/// — no base branch, unresolved origin, or a store failure — so the watch
+/// behaves exactly as before when the answer is unknown.
+pub(crate) async fn stacked_parent_number(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    workspace_id: WorkspaceId,
+    pr: &PullRequestDigest,
+) -> Option<u64> {
+    let base_branch = pr.base_branch.as_deref()?;
+    let workspace = runtime.get_workspace(owner, workspace_id).await.ok()?;
+    let repo = runtime.get_repo(owner, workspace.repo_id).await.ok()?;
+    let (host, repo_owner, repo_name) =
+        match (&repo.origin_host, &repo.origin_owner, &repo.origin_name) {
+            (Some(host), Some(repo_owner), Some(repo_name)) => {
+                (host.clone(), repo_owner.clone(), repo_name.clone())
+            }
+            _ => {
+                let target = super::delivery::repository_target_from_local(&repo)
+                    .await
+                    .ok()?;
+                (target.host, target.owner, target.name)
+            }
+        };
+    let facts =
+        list_pull_request_facts_for_repo(&runtime.db, owner, &host, &repo_owner, &repo_name)
+            .await
+            .ok()?;
+    let parents = super::reconcile::stack_parents_by_head(&facts);
+    parents
+        .get(base_branch)
+        .copied()
+        .filter(|parent| *parent != pr.number)
 }
 
 /// Park a watch as blocked with a reason, surfacing `NeedsYou` once.

--- a/crates/tidebreak-server/src/tests.rs
+++ b/crates/tidebreak-server/src/tests.rs
@@ -52,6 +52,8 @@ mod code_pr_facts;
 mod code_reconcile;
 mod code_terminals;
 mod code_titling;
+#[cfg(unix)]
+mod code_trigger_facts;
 mod compaction;
 mod configuration;
 mod conformance;

--- a/crates/tidebreak-server/src/tests/code_trigger_facts.rs
+++ b/crates/tidebreak-server/src/tests/code_trigger_facts.rs
@@ -1,0 +1,363 @@
+//! Fact-edge trigger conditions and stack-aware classification (decision 62).
+//!
+//! These drive the real sweeps against a shimmed `gh`: the reconcile sweep
+//! seeds durable facts, then the trigger sweep fires `pr_opened` and
+//! `pr_updated` from the local store — no host read — and holds a stacked
+//! child's `behind` fire. Deliveries stay pending throughout because the
+//! fixture runs no sessions; the rows are the assertions.
+
+use super::*;
+
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+
+use crate::code::CodeRuntime;
+use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+use tidebreak_core::db::code::{
+    arm_trigger, get_pull_request_fact, insert_repo, insert_workspace, list_fires_for_workspace,
+    list_triggers_for_repo, save_pull_request_fact, trigger_fire_heads_for_pr,
+};
+use tidebreak_core::{
+    CodeRepo, CodeTrigger, CodeTriggerAction, CodeTriggerCondition, CodeTriggerFireState,
+    CodeTriggerId, CodeWorkspace, CodeWorkspaceStatus, OwnerId, PullRequestDigest, RepoId,
+    WorkspaceId,
+};
+use tidebreak_harness::AdapterRegistry;
+
+const PR_412: &str = r#"{"number":412,"url":"https://github.com/acme/tools/pull/412","state":"OPEN","title":"Tracked work","isDraft":false,"author":{"login":"octocat"},"reviewDecision":null,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","autoMergeRequest":null,"headRefName":"tidebreak/tracked","headRefOid":"aaa111","baseRefName":"main","updatedAt":"2026-08-22T12:00:00Z","createdAt":"2026-08-22T10:00:00Z","mergedAt":null,"closedAt":null,"labels":[],"statusCheckRollup":[]}"#;
+const PR_413: &str = r#"{"number":413,"url":"https://github.com/acme/tools/pull/413","state":"OPEN","title":"Stacked child","isDraft":false,"author":{"login":"octocat"},"reviewDecision":null,"mergeable":"MERGEABLE","mergeStateStatus":"BEHIND","autoMergeRequest":null,"headRefName":"tidebreak/tracked-child","headRefOid":"ccc333","baseRefName":"tidebreak/tracked","updatedAt":"2026-08-22T12:30:00Z","createdAt":"2026-08-22T12:00:00Z","mergedAt":null,"closedAt":null,"labels":[],"statusCheckRollup":[]}"#;
+
+fn write_executable(path: &std::path::Path, body: &str) {
+    std::fs::write(path, body).unwrap();
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).unwrap();
+}
+
+fn run(cwd: &std::path::Path, args: &[&str]) {
+    let status = std::process::Command::new(args[0])
+        .args(&args[1..])
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .status()
+        .unwrap();
+    assert!(status.success(), "{args:?} failed in {}", cwd.display());
+}
+
+fn init_github_shaped_repo(dir: &std::path::Path) -> std::path::PathBuf {
+    let work = dir.join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    run(&work, &["git", "init", "-b", "main"]);
+    run(&work, &["git", "config", "user.email", "dev@example.com"]);
+    run(&work, &["git", "config", "user.name", "Dev"]);
+    std::fs::write(work.join("README.md"), "hello\n").unwrap();
+    run(&work, &["git", "add", "README.md"]);
+    run(&work, &["git", "commit", "-m", "init"]);
+    run(&work, &["git", "branch", "tidebreak/tracked"]);
+    run(&work, &["git", "branch", "tidebreak/tracked-child"]);
+    run(
+        &work,
+        &[
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/acme/tools.git",
+        ],
+    );
+    work
+}
+
+fn write_gh_shim(dir: &std::path::Path) {
+    let body = "#!/bin/sh\n\
+         if [ \"$1\" = auth ]; then\n\
+           echo '{\"hosts\":{\"github.com\":[{\"active\":true,\"state\":\"success\",\"login\":\"tester\"}]}}'\n\
+           exit 0\n\
+         fi\n\
+         if [ \"$1\" = api ]; then echo '{}'; exit 0; fi\n"
+        .to_owned()
+        + &format!(
+            "         if [ \"$1\" = pr ] && [ \"$2\" = list ]; then\n\
+                        echo '[{PR_412},{PR_413}]'\n\
+                        exit 0\n\
+                      fi\n\
+                      if [ \"$1\" = pr ] && [ \"$2\" = view ] && [ \"$3\" = 412 ]; then\n\
+                        echo '{PR_412}'\n\
+                        exit 0\n\
+                      fi\n\
+                      if [ \"$1\" = pr ] && [ \"$2\" = view ] && [ \"$3\" = 413 ]; then\n\
+                        echo '{PR_413}'\n\
+                        exit 0\n\
+                      fi\n"
+        )
+        + "         echo unexpected \"$@\" >&2\n\
+         exit 3\n";
+    write_executable(&dir.join("gh"), &body);
+}
+
+fn open_pr_digest(number: u64) -> PullRequestDigest {
+    PullRequestDigest {
+        number,
+        url: Some(format!("https://github.com/acme/tools/pull/{number}")),
+        state: "open".into(),
+        title: None,
+        checks_summary: None,
+        checks: None,
+        draft: None,
+        merged: None,
+        review_decision: None,
+        mergeable: None,
+        merge_state_status: None,
+        head_branch: None,
+        base_branch: None,
+        head_sha: None,
+        auto_merge_enabled: None,
+        in_merge_queue: None,
+    }
+}
+
+fn workspace_row(
+    id: WorkspaceId,
+    owner: &OwnerId,
+    repo_id: RepoId,
+    title: &str,
+    worktree: &std::path::Path,
+    branch: &str,
+    pr: Option<PullRequestDigest>,
+) -> CodeWorkspace {
+    CodeWorkspace {
+        id,
+        owner: owner.clone(),
+        repo_id,
+        title: title.into(),
+        worktree_path: worktree.display().to_string(),
+        branch_name: branch.into(),
+        base_ref: "main".into(),
+        status: CodeWorkspaceStatus::Active,
+        pr,
+        created_at: chrono::Utc::now(),
+        archived_at: None,
+        released_at: None,
+        released_tip: None,
+        bundle_bytes: None,
+    }
+}
+
+/// Repo, tracked workspace on PR 412, child workspace on PR 413, shimmed gh.
+async fn seeded_runtime() -> (
+    tempfile::TempDir,
+    Arc<CodeRuntime>,
+    Arc<tidebreak_core::DbStore>,
+    RepoId,
+    WorkspaceId,
+    WorkspaceId,
+) {
+    let (dir, store) = temp_db_store("code-trigger-facts.db").await;
+    let db = Arc::new(store);
+    let mut registry = AdapterRegistry::new();
+    registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
+    let runtime = Arc::new(CodeRuntime::with_registry(
+        db.clone(),
+        dir.path().to_path_buf(),
+        registry,
+    ));
+
+    let work = init_github_shaped_repo(dir.path());
+    let shim = dir.path().join("bin");
+    std::fs::create_dir_all(&shim).unwrap();
+    write_gh_shim(&shim);
+    runtime.set_gh_search_path(Some(shim.display().to_string()));
+
+    let owner = OwnerId::local();
+    let repo_id = RepoId::new();
+    insert_repo(
+        &db,
+        &CodeRepo {
+            id: repo_id,
+            owner: owner.clone(),
+            root_path: work.display().to_string(),
+            display_name: "tools".into(),
+            default_base_ref: "main".into(),
+            branch_prefix: "tidebreak/".into(),
+            setup_script: None,
+            archive_script: None,
+            quick_actions: Vec::new(),
+            created_at: chrono::Utc::now(),
+            removed_at: None,
+            cloned_from: None,
+            origin_host: None,
+            origin_owner: None,
+            origin_name: None,
+        },
+    )
+    .await
+    .unwrap();
+    let tracked = WorkspaceId::new();
+    insert_workspace(
+        &db,
+        &workspace_row(
+            tracked,
+            &owner,
+            repo_id,
+            "tracked",
+            &work,
+            "tidebreak/tracked",
+            Some(open_pr_digest(412)),
+        ),
+    )
+    .await
+    .unwrap();
+    let child = WorkspaceId::new();
+    insert_workspace(
+        &db,
+        &workspace_row(
+            child,
+            &owner,
+            repo_id,
+            "child",
+            &dir.path().join("child"),
+            "tidebreak/tracked-child",
+            Some(open_pr_digest(413)),
+        ),
+    )
+    .await
+    .unwrap();
+    (dir, runtime, db, repo_id, tracked, child)
+}
+
+async fn armed(
+    db: &tidebreak_core::DbStore,
+    owner: &OwnerId,
+    repo_id: RepoId,
+    condition: CodeTriggerCondition,
+) -> CodeTriggerId {
+    arm_trigger(
+        db,
+        owner,
+        &CodeTrigger {
+            id: CodeTriggerId::new(),
+            owner: owner.clone(),
+            repo_id,
+            condition,
+            action: CodeTriggerAction::Notify,
+            enabled: true,
+            // Armed before the fixture pull requests existed, so the
+            // opened-edge watermark admits them.
+            created_at: "2026-08-01T00:00:00Z".parse().unwrap(),
+            updated_at: "2026-08-01T00:00:00Z".parse().unwrap(),
+        },
+    )
+    .await
+    .unwrap();
+    list_triggers_for_repo(db, owner, repo_id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|trigger| trigger.condition == condition)
+        .expect("the armed trigger reads back")
+        .id
+}
+
+#[tokio::test]
+async fn pr_opened_fires_once_per_pull_request() {
+    let (_dir, runtime, db, repo_id, tracked, _child) = seeded_runtime().await;
+    let owner = OwnerId::local();
+    let trigger = armed(&db, &owner, repo_id, CodeTriggerCondition::PrOpened).await;
+
+    crate::code::reconcile::sweep_reconcile(&runtime).await;
+    assert!(
+        get_pull_request_fact(&db, &owner, "github.com", "acme", "tools", 412)
+            .await
+            .unwrap()
+            .is_some(),
+        "the reconcile sweep seeds the fact the edge fires from"
+    );
+
+    crate::code::trigger::sweep_triggers(&runtime).await;
+    let heads = trigger_fire_heads_for_pr(&db, &owner, trigger, tracked, 412)
+        .await
+        .unwrap();
+    assert_eq!(heads, vec!["opened".to_owned()]);
+
+    // A second sweep re-reads the same facts and mints nothing new.
+    crate::code::trigger::sweep_triggers(&runtime).await;
+    let heads = trigger_fire_heads_for_pr(&db, &owner, trigger, tracked, 412)
+        .await
+        .unwrap();
+    assert_eq!(heads.len(), 1);
+}
+
+#[tokio::test]
+async fn pr_updated_baselines_then_fires_on_a_new_head() {
+    let (_dir, runtime, db, repo_id, tracked, _child) = seeded_runtime().await;
+    let owner = OwnerId::local();
+    let trigger = armed(&db, &owner, repo_id, CodeTriggerCondition::PrUpdated).await;
+
+    crate::code::reconcile::sweep_reconcile(&runtime).await;
+    crate::code::trigger::sweep_triggers(&runtime).await;
+
+    // First sight is a settled baseline: the row exists and delivers nothing.
+    let fires = list_fires_for_workspace(&db, &owner, tracked)
+        .await
+        .unwrap();
+    let baseline = fires
+        .iter()
+        .find(|fire| fire.identity.trigger_id == trigger && fire.identity.pr_number == 412)
+        .expect("the baseline row exists");
+    assert_eq!(baseline.identity.head_sha, "aaa111");
+    assert_eq!(baseline.state, CodeTriggerFireState::Delivered);
+    assert!(baseline.payload.is_none());
+
+    // The head moves; the next sweep fires exactly the new head.
+    let mut fact = get_pull_request_fact(&db, &owner, "github.com", "acme", "tools", 412)
+        .await
+        .unwrap()
+        .unwrap();
+    fact.head_sha = Some("bbb999".into());
+    save_pull_request_fact(&db, &fact).await.unwrap();
+    crate::code::trigger::sweep_triggers(&runtime).await;
+
+    let fires = list_fires_for_workspace(&db, &owner, tracked)
+        .await
+        .unwrap();
+    let fired = fires
+        .iter()
+        .find(|fire| fire.identity.trigger_id == trigger && fire.identity.head_sha == "bbb999")
+        .expect("the moved head fires");
+    assert_eq!(fired.state, CodeTriggerFireState::Pending);
+    assert!(fired.payload.is_some());
+}
+
+#[tokio::test]
+async fn a_stacked_child_holds_behind_fires_and_parks_the_watch_lookup() {
+    let (_dir, runtime, db, repo_id, _tracked, child) = seeded_runtime().await;
+    let owner = OwnerId::local();
+    let trigger = armed(&db, &owner, repo_id, CodeTriggerCondition::Behind).await;
+
+    crate::code::reconcile::sweep_reconcile(&runtime).await;
+    crate::code::trigger::sweep_triggers(&runtime).await;
+
+    // PR 413 is BEHIND, but its base is PR 412's head: the fire is held.
+    let heads = trigger_fire_heads_for_pr(&db, &owner, trigger, child, 413)
+        .await
+        .unwrap();
+    assert!(heads.is_empty(), "a stacked child must not fire behind");
+
+    // The watch-side lookup resolves the same parent from the fact set.
+    let digest = PullRequestDigest {
+        base_branch: Some("tidebreak/tracked".into()),
+        ..open_pr_digest(413)
+    };
+    assert_eq!(
+        crate::code::watch::stacked_parent_number(&runtime, &owner, child, &digest).await,
+        Some(412)
+    );
+    let rooted = PullRequestDigest {
+        base_branch: Some("main".into()),
+        ..open_pr_digest(413)
+    };
+    assert_eq!(
+        crate::code::watch::stacked_parent_number(&runtime, &owner, child, &rooted).await,
+        None
+    );
+}


### PR DESCRIPTION
Slice D of #2523 (closes #2527) — the last slice. Builds on the fact substrate (#2529), reconcile path (#2530), and stack derivation (#2531).

Two new trigger conditions are edges of the durable fact store, not digest states — `classify_trigger_condition` deliberately never returns them:

- `pr_opened` fires once per pull request whose host `created_at` and local `first_seen_at` both postdate the trigger's arming, so arming over existing history stays silent. The fire's fingerprint is the sentinel `opened` instead of a head SHA — the edge is existence, not a head.
- `pr_updated` fires once per distinct head. The first observed head lands as a settled baseline row (`insert_settled_trigger_fire`: state `delivered`, no payload — the state-shape CHECK permits it, the outbox sweep never picks it up, and the conflict identity still dedupes), so arming or first sight never notifies; later heads insert pending fires.

The fact pass runs inside `sweep_owner` before the remote-read gate (which requires a persisted `workspace.pr` digest and would drop fact-only repositories). It reads only the local store — repo identity from the `origin_*` columns the reconcile sweep maintains, facts, attributions — and delivers to eligible attributed workspaces through the existing outbox, so leases, bounded retries, and at-most-once receipts apply unchanged.

Schema: both 8-token CHECKs (`code_trigger.condition`, table-level from the frozen baseline, and `code_trigger_fire.delivery_condition` from the outbox rebuild) widen via `m20260823_000010_trigger_fact_conditions` — a paired rebuild ordered so nothing is dropped while referenced (PostgreSQL enforces the cascade FK), reusing the outbox table builder now parameterized by trigger-table name and token list (the shipped migration's rendered DDL is unchanged; the stepwise-vs-fresh schema test guards that).

Stack awareness: `claim_fires` holds `Behind`/`ReviewRequired` when the summary carries `stack_parent_number` — the child is behind *because of its parent*. To make that signal real on the sweep's path, `query_pull_requests_by_number` now persists facts and annotates stacks like the list read. The watch's `Actionable(Behind)` arm parks with "waiting on its parent pull request #N" (resolved from the fact set via the workspace's stored origin) before the rebase loop can start.

Arming surface: the two conditions join `CodeTriggerRules` with copy that states the baseline rule ("The first observed head never notifies").

Tests: a seeded-data migration test (rows survive the paired rebuild, `pr_opened` inserts on both rebuilt CHECKs, a garbage token still fails); integration against shimmed `gh` (`code_trigger_facts.rs`): `pr_opened` fires exactly once across two sweeps and only for attributed workspaces; `pr_updated` baselines silently then fires exactly the moved head; a BEHIND stacked child produces zero fires while the watch-side parent lookup resolves `Some(412)` from the same facts and `None` on a default base. The condition round-trip test covers the new tokens via `all()`.

Deferred, per ADR 0062: triggers on repositories with no local registration, and fires for pull requests with no attributed workspace.

Local validation: incremental `cargo check --all-targets` clean on both crates; wire regen committed; `pnpm test` (1714), lint, format, `pnpm build`, `storybook:build`. Rust suites run in CI.