### PR TITLE
feat(code): hand Fix CI the failing job logs

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -106,6 +106,7 @@ import {
   type CodeCloneDefaults,
   type CodeRepoSources,
   type CodeWorktreeRoot,
+  type CodeCheckLogsSnapshot,
   type CodeForkTranscript,
   type CodeCloneJobSnapshot,
   type CodeHarnessInstallSnapshot,
@@ -146,6 +147,7 @@ import {
   parseCodeCloneDefaults,
   parseCodeRepoSources,
   parseCodeWorktreeRoot,
+  parseCodeCheckLogsSnapshot,
   parseCodeForkTranscript,
   parseCodeCloneJob,
   parseCodeHarnessInstall,
@@ -2660,6 +2662,29 @@ export class ApiClient {
         ),
       ),
       "code pull request",
+    );
+  }
+
+  /**
+   * Download the failing checks' job logs into private storage.
+   *
+   * The fix-errors action calls this before it prompts, so the agent opens a
+   * file instead of working out which job failed and asking GitHub itself.
+   * Each call replaces the previous set: only the head being fixed matters.
+   */
+  async writeCodeCheckLogs(
+    workspaceId: string,
+  ): Promise<CodeCheckLogsSnapshot> {
+    return requireParsed(
+      parseCodeCheckLogsSnapshot(
+        // A GitHub read, so it takes the delivery timeout rather than hanging
+        // the button on a `gh` that never answers.
+        await this.deliveryJson(
+          `/code/workspaces/${encodeURIComponent(workspaceId)}/pr/check-logs`,
+          { method: "POST", headers: this.headers() },
+        ),
+      ),
+      "code check logs",
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/api/types.ts
+++ b/crates/tidebreak-desktop/ui/src/api/types.ts
@@ -176,6 +176,9 @@ import {
   type CodeHarnessInstallSnapshot as WireCodeHarnessInstallSnapshot,
   type CodeWorktreeRoot as WireCodeWorktreeRoot,
   type CodeForkTranscript as WireCodeForkTranscript,
+  type CodeCheckLog as WireCodeCheckLog,
+  type CodeCheckLogError as WireCodeCheckLogError,
+  type CodeCheckLogsSnapshot as WireCodeCheckLogsSnapshot,
   type CodeTerminalActivityNotice as WireCodeTerminalActivityNotice,
   type PullRequestDigest as WirePullRequestDigest,
   type PullRequestCheck as WirePullRequestCheck,
@@ -1215,6 +1218,12 @@ export type CodeHarnessInstallSnapshot = WireCodeHarnessInstallSnapshot;
 export type CodeWorktreeRoot = WireCodeWorktreeRoot;
 /** The transcript file a fork wrote into the worktree, ready to hand on. */
 export type CodeForkTranscript = WireCodeForkTranscript;
+/** One failing check's job log, downloaded and waiting on disk. */
+export type CodeCheckLog = WireCodeCheckLog;
+/** One failing check whose job log could not be read. */
+export type CodeCheckLogError = WireCodeCheckLogError;
+/** The failing job logs written for a workspace's pull request. */
+export type CodeCheckLogsSnapshot = WireCodeCheckLogsSnapshot;
 
 /** Subscription quota windows exposed by Model Gateway or a direct harness. */
 export type CodeSubscriptionUsage = {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -37,6 +37,7 @@ import {
   isPutAway,
   workspaceStackParent,
 } from "./workspaceCards";
+import { fetchFixErrorsLogs } from "./checkLogs";
 import { prWorkflowPrompt } from "./prActions";
 import type { WorkspaceWorkflowAction } from "./workspaceWorkflow";
 
@@ -266,6 +267,38 @@ export function CodeSidebar() {
                     if (!pr) return;
                     // Same prepared prompt the header control composes; the
                     // navigation makes the started turn visible.
+                    //
+                    // Fix-errors downloads the failing jobs' logs first, and
+                    // that read takes a second or two the rail cannot show —
+                    // so it navigates first and the turn starts on the
+                    // workspace the reader is already looking at.
+                    if (action === "fix_errors") {
+                      if (
+                        useCodeUiStore.getState().composerActionScope !== null
+                      ) {
+                        toast.error("Another agent action is already running");
+                        return;
+                      }
+                      void navigate({
+                        to: "/code/w/$workspaceId",
+                        params: { workspaceId: workspace.id },
+                      });
+                      void fetchFixErrorsLogs(client, workspace.id).then(
+                        (logs) => {
+                          if (
+                            !runComposerPrompt(
+                              workspace.id,
+                              prWorkflowPrompt(action, pr, logs),
+                            )
+                          ) {
+                            toast.error(
+                              "Another agent action is already running",
+                            );
+                          }
+                        },
+                      );
+                      return;
+                    }
                     if (
                       !runComposerPrompt(
                         workspace.id,

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.dom.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiClient } from "../api/client";
+import type {
+  CodeCheckLogsSnapshot,
+  CodeWorkspacePrSnapshot,
+} from "../api/types";
+import { useCodeUiStore } from "./CodeUiStore";
+import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
+import { WorkspaceWorkflowControl } from "./WorkspaceWorkflowControl";
+
+vi.mock("sonner", () => ({
+  toast: {
+    message: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const failingPr: CodeWorkspacePrSnapshot = {
+  dirty: false,
+  unpushed: false,
+  ahead: 0,
+  has_upstream: true,
+  suggested_commit_message: "Fix login",
+  gh_found: true,
+  gh_authenticated: true,
+  remediation: "",
+  pr: {
+    number: 184,
+    url: "https://github.com/example/app/pull/184",
+    state: "open",
+    title: "Fix login",
+    checks_summary: "7 passing, 1 failing",
+    checks: [
+      { name: "desktop test", bucket: "pass" },
+      {
+        name: "clippy",
+        bucket: "fail",
+        detail: "exit 101",
+        url: "https://github.com/example/app/actions/runs/7/job/9",
+      },
+    ],
+  },
+};
+
+function resource(): CodeWorkspacePrResource {
+  return {
+    data: failingPr,
+    error: null,
+    refreshing: false,
+    refresh: async () => {},
+    adopt: () => {},
+    busy: null,
+    mutationError: null,
+    setMutationError: () => {},
+    refreshFromHost: async () => undefined,
+    runMutation: async () => undefined,
+  };
+}
+
+function renderControl(
+  writeCodeCheckLogs: ApiClient["writeCodeCheckLogs"],
+): void {
+  render(
+    <WorkspaceWorkflowControl
+      client={
+        {
+          pushCodeWorkspace: vi.fn(),
+          createCodePullRequest: vi.fn(),
+          markCodePrReady: vi.fn(),
+          mergeCodePr: vi.fn(),
+          startCodeWatch: vi.fn(),
+          stopCodeWatch: vi.fn(),
+          writeCodeCheckLogs,
+        } as unknown as ApiClient
+      }
+      workspaceId="ws-1"
+      branchName="tidebreak/fix-login"
+      baseRef="main"
+      resource={resource()}
+      onOpenSourceControl={vi.fn()}
+    />,
+  );
+}
+
+const snapshot = (
+  logs: CodeCheckLogsSnapshot["logs"],
+): CodeCheckLogsSnapshot => ({ logs, errors: [] });
+
+beforeEach(() => {
+  useCodeUiStore.setState({
+    pendingComposerPrompt: null,
+    composerActionScope: null,
+  });
+});
+
+afterEach(cleanup);
+
+describe("Fix CI", () => {
+  it("downloads the failing job logs and names them in the prompt", async () => {
+    const write = vi.fn(async () =>
+      snapshot([
+        {
+          check: "clippy",
+          path: "/data/code/private/ws-1/ci-logs/clippy-9.log",
+          byte_len: 4096,
+          truncated: false,
+          url: "https://github.com/example/app/actions/runs/7/job/9",
+        },
+      ]),
+    );
+    renderControl(write);
+
+    await userEvent.click(screen.getByRole("button", { name: /fix ci/i }));
+
+    await waitFor(() =>
+      expect(useCodeUiStore.getState().pendingComposerPrompt).not.toBeNull(),
+    );
+    expect(write).toHaveBeenCalledWith("ws-1");
+    const pending = useCodeUiStore.getState().pendingComposerPrompt;
+    expect(pending?.submit).toBe(true);
+    expect(pending?.text).toContain("/ci-logs/clippy-9.log");
+    expect(pending?.text).toContain("already downloaded");
+  });
+
+  /**
+   * The download is a host read the reader waits on. Without a busy state the
+   * button reads as dead, and a second press would start a second fetch.
+   */
+  it("holds the button through the download", async () => {
+    let release: ((value: CodeCheckLogsSnapshot) => void) | undefined;
+    const write = vi.fn(
+      () =>
+        new Promise<CodeCheckLogsSnapshot>((resolve) => {
+          release = resolve;
+        }),
+    );
+    renderControl(write);
+
+    const button = screen.getByRole("button", { name: /fix ci/i });
+    await userEvent.click(button);
+    const reading = await screen.findByText("Reading logs…");
+    expect(reading).toBeTruthy();
+    expect(screen.getByText("Reading logs…").closest("button")).toBeDisabled();
+
+    release?.(snapshot([]));
+    await waitFor(() =>
+      expect(useCodeUiStore.getState().pendingComposerPrompt).not.toBeNull(),
+    );
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  /** A GitHub outage must not disable the action. */
+  it("still sends the prompt when the download fails", async () => {
+    renderControl(
+      vi.fn(async () => {
+        throw new Error("gh is signed out");
+      }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /fix ci/i }));
+
+    await waitFor(() =>
+      expect(useCodeUiStore.getState().pendingComposerPrompt).not.toBeNull(),
+    );
+    const pending = useCodeUiStore.getState().pendingComposerPrompt;
+    expect(pending?.text).toContain("Inspect the latest failing CI logs");
+    expect(pending?.text).not.toContain("already downloaded");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -32,6 +32,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { openExternal } from "@/host";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
+import { fetchFixErrorsLogs } from "./checkLogs";
 import { prWorkflowPrompt, type PrPromptAction } from "./prActions";
 import { useCodeUiStore } from "./CodeUiStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
@@ -69,6 +70,7 @@ export function WorkspaceWorkflowControl({
     | "mergeCodePr"
     | "startCodeWatch"
     | "stopCodeWatch"
+    | "writeCodeCheckLogs"
   >;
   workspaceId: string;
   branchName: string;
@@ -80,6 +82,9 @@ export function WorkspaceWorkflowControl({
   onOpenWatchTask?: () => void;
 }) {
   const [detailsOpen, setDetailsOpen] = useState(false);
+  // Downloading the failing job logs is a host read the reader waits on, so
+  // the primary button spins through it rather than looking dead.
+  const [attachingLogs, setAttachingLogs] = useState(false);
   const popoverTitleId = useId();
   const { confirm, dialog: confirmDialog } = useConfirm();
   const runComposerPrompt = useCodeUiStore((state) => state.runComposerPrompt);
@@ -154,7 +159,7 @@ export function WorkspaceWorkflowControl({
       void mergePr(true);
       return;
     }
-    if (busy !== null || agentActionRunning) {
+    if (busy !== null || agentActionRunning || attachingLogs) {
       toast.message("Another workspace action is already running");
       return;
     }
@@ -164,11 +169,31 @@ export function WorkspaceWorkflowControl({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workflowShortcutPending, workspaceId]);
 
-  function runAgentAction(action: PrPromptAction) {
+  /**
+   * Hand one prepared prompt to the workspace's agent.
+   *
+   * Fix-errors takes a detour first: the server downloads the failing jobs'
+   * logs so the prompt can name files the agent reads, instead of asking it to
+   * go and find them. The scope is claimed before the download so a second
+   * press cannot start a second fetch, and a failed fetch still sends the
+   * prompt.
+   */
+  async function runAgentAction(action: PrPromptAction) {
     const pr = model.pr;
     if (!pr) return;
     setDetailsOpen(false);
-    runComposerPrompt(workspaceId, prWorkflowPrompt(action, pr));
+    if (action !== "fix_errors") {
+      runComposerPrompt(workspaceId, prWorkflowPrompt(action, pr));
+      return;
+    }
+    if (attachingLogs || agentActionRunning) return;
+    setAttachingLogs(true);
+    try {
+      const logs = await fetchFixErrorsLogs(client, workspaceId);
+      runComposerPrompt(workspaceId, prWorkflowPrompt(action, pr, logs));
+    } finally {
+      setAttachingLogs(false);
+    }
   }
 
   async function startWatch() {
@@ -342,7 +367,7 @@ export function WorkspaceWorkflowControl({
         await markReady();
         return;
       default:
-        runAgentAction(action);
+        await runAgentAction(action);
     }
   }
 
@@ -648,12 +673,15 @@ export function WorkspaceWorkflowControl({
                   : undefined
             }
             disabled={
-              busy !== null || agentActionRunning || model.stage === "loading"
+              busy !== null ||
+              agentActionRunning ||
+              attachingLogs ||
+              model.stage === "loading"
             }
-            aria-busy={busy === primary || agentActionRunning}
+            aria-busy={busy === primary || agentActionRunning || attachingLogs}
             onClick={() => void run(primary)}
           >
-            {busy === primary || agentActionRunning ? (
+            {busy === primary || agentActionRunning || attachingLogs ? (
               <Spinner aria-hidden />
             ) : primary === "watch_and_fix" ? (
               <CircleDotDashed aria-hidden />
@@ -668,7 +696,9 @@ export function WorkspaceWorkflowControl({
                 ? "Pushing…"
                 : busy === "create_pr" && primary === "create_pr"
                   ? "Creating…"
-                  : primaryLabel}
+                  : attachingLogs
+                    ? "Reading logs…"
+                    : primaryLabel}
             </span>
           </Button>
         ) : null}
@@ -682,7 +712,7 @@ export function WorkspaceWorkflowControl({
                 size="sm"
                 className="border-border-subtle rounded-none border-0 border-l bg-transparent px-1.5 hover:bg-background"
                 aria-label="More workspace actions"
-                disabled={busy !== null || agentActionRunning}
+                disabled={busy !== null || agentActionRunning || attachingLogs}
               >
                 <ChevronDown aria-hidden />
               </Button>

--- a/crates/tidebreak-desktop/ui/src/code/checkLogs.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/checkLogs.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+
+import type { ApiClient } from "../api/client";
+import { fetchFixErrorsLogs } from "./checkLogs";
+
+vi.mock("sonner", () => ({
+  toast: { message: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+
+function client(
+  writeCodeCheckLogs: ApiClient["writeCodeCheckLogs"],
+): Pick<ApiClient, "writeCodeCheckLogs"> {
+  return { writeCodeCheckLogs };
+}
+
+const log = {
+  check: "clippy",
+  path: "/data/code/private/ws-1/ci-logs/clippy-1.log",
+  byte_len: 2048,
+  truncated: false,
+  url: "https://github.com/example/app/actions/runs/7/job/9",
+};
+
+describe("fetchFixErrorsLogs", () => {
+  it("returns the downloaded logs", async () => {
+    const logs = await fetchFixErrorsLogs(
+      client(async () => ({ head_sha: "abc123", logs: [log], errors: [] })),
+      "ws-1",
+    );
+    expect(logs).toEqual([log]);
+  });
+
+  /**
+   * A GitHub outage must not disable the shortcut. The reader pressed Fix
+   * errors; they get the turn they asked for, told once that the files are
+   * missing.
+   */
+  it("says so and keeps going when the download fails", async () => {
+    const logs = await fetchFixErrorsLogs(
+      client(async () => {
+        throw new Error("gh is signed out");
+      }),
+      "ws-1",
+    );
+    expect(logs).toEqual([]);
+    expect(toast.message).toHaveBeenCalledWith(
+      "Could not download the failing job logs",
+      expect.objectContaining({ description: "gh is signed out" }),
+    );
+  });
+
+  it("keeps the logs it did get when one job fails", async () => {
+    const logs = await fetchFixErrorsLogs(
+      client(async () => ({
+        logs: [log],
+        errors: [{ check: "desktop UI", message: "HTTP 404" }],
+      })),
+      "ws-1",
+    );
+    expect(logs).toEqual([log]);
+    expect(toast.message).toHaveBeenCalledWith(
+      "Could not download 1 of the failing job logs",
+      expect.objectContaining({ description: "HTTP 404" }),
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/checkLogs.ts
+++ b/crates/tidebreak-desktop/ui/src/code/checkLogs.ts
@@ -1,0 +1,43 @@
+import { toast } from "sonner";
+
+import type { ApiClient } from "../api/client";
+import type { CodeCheckLog } from "../api/types";
+import { friendlyErrorMessage } from "@/lib/utils";
+
+/**
+ * Failing CI logs, fetched before the fix-errors prompt goes out.
+ *
+ * The server downloads each failing GitHub Actions job's log into private
+ * storage and hands back the paths, so the agent's first move is reading the
+ * failure rather than working out which job produced it.
+ *
+ * Every failure here is soft. A GitHub outage, a signed-out `gh`, or a check
+ * from a provider with no downloadable log all leave the reader with the
+ * prompt they pressed for — just without the files. Refusing to send the turn
+ * would be a worse trade than sending it the way it worked before.
+ */
+export async function fetchFixErrorsLogs(
+  client: Pick<ApiClient, "writeCodeCheckLogs">,
+  workspaceId: string,
+): Promise<readonly CodeCheckLog[]> {
+  try {
+    const snapshot = await client.writeCodeCheckLogs(workspaceId);
+    if (snapshot.errors.length > 0) {
+      toast.message(
+        snapshot.logs.length > 0
+          ? `Could not download ${snapshot.errors.length} of the failing job logs`
+          : "Could not download the failing job logs",
+        { description: snapshot.errors[0]?.message },
+      );
+    }
+    return snapshot.logs;
+  } catch (err) {
+    toast.message("Could not download the failing job logs", {
+      description: friendlyErrorMessage(
+        err,
+        "The agent will read them itself.",
+      ),
+    });
+    return [];
+  }
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -35,6 +35,7 @@ import {
   parseCodeWorkspaceTree,
   parseCodeWorktreeRoot,
   parseFenceReason,
+  parseCodeCheckLogsSnapshot,
 } from "./parsers";
 
 const DELIVERY_CAPABILITY = {
@@ -1268,6 +1269,39 @@ describe("pull request facts (decision 62)", () => {
           },
         ],
       }),
+    ).toBeNull();
+  });
+});
+
+describe("parseCodeCheckLogsSnapshot", () => {
+  it("accepts a snapshot with and without the optional fields", () => {
+    const full = {
+      head_sha: "abc123",
+      logs: [
+        {
+          check: "clippy",
+          path: "/data/code/private/ws-1/ci-logs/clippy-1.log",
+          byte_len: 2048,
+          truncated: true,
+          url: "https://github.com/acme/app/actions/runs/7/job/9",
+        },
+      ],
+      errors: [{ check: "desktop UI", message: "HTTP 404" }],
+    };
+    expect(parseCodeCheckLogsSnapshot(full)).toEqual(full);
+    const bare = { logs: [], errors: [] };
+    expect(parseCodeCheckLogsSnapshot(bare)).toEqual(bare);
+  });
+
+  it("rejects a malformed log entry rather than dropping it", () => {
+    expect(
+      parseCodeCheckLogsSnapshot({
+        logs: [{ check: "clippy", path: "", byte_len: 1, truncated: false }],
+        errors: [],
+      }),
+    ).toBeNull();
+    expect(
+      parseCodeCheckLogsSnapshot({ logs: [], errors: [], extra: true }),
     ).toBeNull();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -86,6 +86,9 @@ import type {
   PullRequestCommentKind,
   CodePrCommentsSnapshot,
   QueuedCodeTurn,
+  CodeCheckLog,
+  CodeCheckLogError,
+  CodeCheckLogsSnapshot,
   CodeForkTranscript,
 } from "../api/types";
 import type {
@@ -145,6 +148,9 @@ import type {
   CodeDeliveryWorkspaceLink as WireCodeDeliveryWorkspaceLink,
   CodeWorkspacePullRequestFact as WireCodeWorkspacePullRequestFact,
   CodeWorkspacePullRequests as WireCodeWorkspacePullRequests,
+  CodeCheckLog as WireCodeCheckLog,
+  CodeCheckLogError as WireCodeCheckLogError,
+  CodeCheckLogsSnapshot as WireCodeCheckLogsSnapshot,
   CodeForkTranscript as WireCodeForkTranscript,
   CodeGitHubCapability as WireCodeGitHubCapability,
   CodeGitHubRepositoryRef as WireCodeGitHubRepositoryRef,
@@ -1413,6 +1419,80 @@ export function parseCodeForkTranscript(
     byte_len: value.byte_len,
     turns: value.turns,
     truncated: value.truncated,
+  };
+}
+
+function parseCodeCheckLog(value: unknown): CodeCheckLog | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeCheckLog>(value, [
+      "check",
+      "path",
+      "byte_len",
+      "truncated",
+      "url",
+    ]) ||
+    !nonEmpty(value.check) ||
+    !nonEmpty(value.path) ||
+    typeof value.byte_len !== "number" ||
+    typeof value.truncated !== "boolean" ||
+    typeof value.url !== "string"
+  ) {
+    return null;
+  }
+  return {
+    check: value.check,
+    path: value.path,
+    byte_len: value.byte_len,
+    truncated: value.truncated,
+    url: value.url,
+  };
+}
+
+function parseCodeCheckLogError(value: unknown): CodeCheckLogError | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeCheckLogError>(value, ["check", "message"]) ||
+    !nonEmpty(value.check) ||
+    typeof value.message !== "string"
+  ) {
+    return null;
+  }
+  return { check: value.check, message: value.message };
+}
+
+export function parseCodeCheckLogsSnapshot(
+  value: unknown,
+): CodeCheckLogsSnapshot | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WireCodeCheckLogsSnapshot>(value, [
+      "head_sha",
+      "logs",
+      "errors",
+    ]) ||
+    !optionalString(value.head_sha) ||
+    !Array.isArray(value.logs) ||
+    !Array.isArray(value.errors)
+  ) {
+    return null;
+  }
+  const logs: CodeCheckLog[] = [];
+  for (const entry of value.logs) {
+    const log = parseCodeCheckLog(entry);
+    if (!log) return null;
+    logs.push(log);
+  }
+  const errors: CodeCheckLogError[] = [];
+  for (const entry of value.errors) {
+    const error = parseCodeCheckLogError(entry);
+    if (!error) return null;
+    errors.push(error);
+  }
+  return {
+    ...(value.head_sha === undefined ? {} : { head_sha: value.head_sha }),
+    logs,
+    errors,
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -175,6 +175,47 @@ describe("prWorkflowPrompt", () => {
     );
   });
 
+  it("names the downloaded logs and tells the agent to read them first", () => {
+    const digest = pr({
+      checks: [{ name: "clippy", bucket: "fail", detail: "exit 101" }],
+    });
+    const prompt = prWorkflowPrompt("fix_errors", digest, [
+      {
+        check: "clippy",
+        path: "/data/code/private/ws-1/ci-logs/clippy-97255126659.log",
+        byte_len: 524_288,
+        truncated: true,
+        url: "https://github.com/example/app/actions/runs/7/job/9",
+      },
+      {
+        check: "desktop UI",
+        path: "/data/code/private/ws-1/ci-logs/desktop-ui-97255126660.log",
+        byte_len: 2_048,
+        truncated: false,
+        url: "https://github.com/example/app/actions/runs/7/job/9",
+      },
+    ]);
+    expect(prompt).toMatch(/already downloaded/);
+    expect(prompt).toMatch(
+      /clippy-97255126659\.log`? — clippy \(tail, 512 KB\)/,
+    );
+    expect(prompt).toMatch(
+      /desktop-ui-97255126660\.log`? — desktop UI \(2 KB\)/,
+    );
+    // The check itself is still named above, logs or no logs.
+    expect(prompt).toMatch(/Relevant checks:/);
+  });
+
+  /**
+   * A GitHub outage, a signed-out `gh`, or a provider with no downloadable log
+   * all land here. The action still has to work.
+   */
+  it("falls back to the find-them-yourself wording with no logs", () => {
+    const prompt = prWorkflowPrompt("fix_errors", pr({}), []);
+    expect(prompt).toMatch(/Inspect the latest failing CI logs/);
+    expect(prompt).not.toMatch(/already downloaded/);
+  });
+
   it("has no prompt for the pull-request state changes", () => {
     // Decision 42 keeps merging and readying a draft on user-initiated
     // endpoints. Excluding them from the prompt type is what stops either from

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -1,4 +1,4 @@
-import type { PullRequestDigest } from "../api/types";
+import type { CodeCheckLog, PullRequestDigest } from "../api/types";
 import { prTone } from "./workspaceCards";
 
 export type PrWorkflowAction =
@@ -211,6 +211,7 @@ export type PrPromptAction = Exclude<
 export function prWorkflowPrompt(
   action: PrPromptAction,
   pr: PullRequestDigest,
+  logs: readonly CodeCheckLog[] = [],
 ): string {
   const number = `#${pr.number}`;
   const base = pr.base_branch?.trim() || "the base branch";
@@ -218,7 +219,10 @@ export function prWorkflowPrompt(
   let instruction: string;
   switch (action) {
     case "fix_errors":
-      instruction = `Pull request ${number} has failing checks. Inspect the latest failing CI logs for the current head SHA, reproduce the cause when practical, make the smallest safe fix in this workspace, run focused validation, commit, and push. Do not merge.`;
+      instruction =
+        logs.length > 0
+          ? `Pull request ${number} has failing checks, and their job logs are already downloaded — read them first. Reproduce the cause when practical, make the smallest safe fix in this workspace, run focused validation, commit, and push. Do not merge.`
+          : `Pull request ${number} has failing checks. Inspect the latest failing CI logs for the current head SHA, reproduce the cause when practical, make the smallest safe fix in this workspace, run focused validation, commit, and push. Do not merge.`;
       break;
     case "address_feedback":
       instruction = `Pull request ${number} has requested changes. Inspect the latest unresolved review feedback, implement each actionable request in this workspace, run focused validation, commit, push, and reply where context is useful. Do not merge.`;
@@ -230,7 +234,33 @@ export function prWorkflowPrompt(
       instruction = `Pull request ${number} has merge conflicts with ${base}. Fetch and rebase onto ${base}, resolve every conflict in this workspace, run focused validation, commit if needed, and push the updated head. Do not merge the pull request.`;
       break;
   }
-  return `${instruction}\n\n${context}`;
+  const attached = checkLogSection(logs);
+  return `${instruction}\n\n${context}${attached}`;
+}
+
+/**
+ * Name the downloaded logs after the context block.
+ *
+ * The paths sit outside the Git worktree, in the private storage the session
+ * is already allowed to read, so the prompt carries paths rather than bytes —
+ * the same bargain a fork transcript makes. A log the fetch could not reach is
+ * simply absent; the check itself is still named above.
+ */
+function checkLogSection(logs: readonly CodeCheckLog[]): string {
+  if (logs.length === 0) return "";
+  const lines = logs.map((log) => {
+    const size = `${Math.max(1, Math.round(log.byte_len / 1024))} KB`;
+    const note = log.truncated ? `tail, ${size}` : size;
+    return `- \`${log.path}\` — ${log.check} (${note})`;
+  });
+  return [
+    "",
+    "",
+    "Failure logs already downloaded for you:",
+    ...lines,
+    "",
+    "Read these before running anything — they are the job logs for this head. A failing check not listed here has no downloaded log; fetch that one yourself if you need it.",
+  ].join("\n");
 }
 
 function prWorkflowPromptContext(pr: PullRequestDigest): string {

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -863,6 +863,47 @@ harness_raw_json: string, state: CodeApprovalState, feedback?: string, requested
 export type CodeApprovalState = "pending" | "approved" | "denied" | "abandoned";
 
 /**
+ * One failing check's downloaded job log:
+ * `POST /code/workspaces/{id}/pr/check-logs`.
+ *
+ * `path` is absolute and sits outside the Git worktree, in the same private
+ * storage a fork transcript uses. The prompt names it and the engine opens
+ * it; nothing is uploaded and nothing is indexable.
+ */
+export type CodeCheckLog = { 
+/**
+ * Check name as the host reports it.
+ */
+check: string, path: string, byte_len: number, 
+/**
+ * True when the file holds only the tail of the job log.
+ */
+truncated: boolean, 
+/**
+ * The job's host URL. A check without one has no log to download, so
+ * every entry here has one.
+ */
+url: string, };
+
+/**
+ * One failing check whose log could not be read.
+ */
+export type CodeCheckLogError = { check: string, message: string, };
+
+/**
+ * Failing job logs written for one workspace's pull request.
+ *
+ * A check with no downloadable log — an external CI provider, or a check-run
+ * URL that names no Actions job — is simply absent from both lists. The
+ * caller still names it in the prompt from the digest it already holds.
+ */
+export type CodeCheckLogsSnapshot = { 
+/**
+ * Head the logs were read against, when the host reported one.
+ */
+head_sha?: string, logs: Array<CodeCheckLog>, errors: Array<CodeCheckLogError>, };
+
+/**
  * Remembered clone destination plus observed `gh` status.
  */
 export type CodeCloneDefaults = { parent_dir?: string, gh_found: boolean, gh_authenticated?: boolean, gh_remediation: string, };

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -63,6 +63,7 @@ function HeaderState({
               mergeCodePr: fn(),
               startCodeWatch: fn(),
               stopCodeWatch: fn(),
+              writeCodeCheckLogs: fn(async () => ({ logs: [], errors: [] })),
             }}
             workspaceId="ws-story"
             branchName="thet/ui-pane-redesign"

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { fn, userEvent, within } from "storybook/test";
 
 import type { CodeWorkspacePrSnapshot } from "@/api";
 import { WorkspaceWorkflowControl } from "@/code/WorkspaceWorkflowControl";
@@ -10,6 +10,7 @@ import type {
 import {
   blockedWatchPrGit,
   dirtyGit,
+  failingChecksPrGit,
   fixingPrGit,
   openPrGit,
   readyForPrGit,
@@ -38,11 +39,14 @@ function WorkflowState({
   snapshot,
   busy = null,
   watchTaskLink = false,
+  checkLogsHang = false,
 }: {
   snapshot: CodeWorkspacePrSnapshot | null;
   busy?: CodeWorkspacePrMutation | null;
   /** Offer the "Watching in …" link the workspace page wires up. */
   watchTaskLink?: boolean;
+  /** Leave the check-log download in flight, to hold the reading state. */
+  checkLogsHang?: boolean;
 }) {
   return (
     <WorkspaceWorkflowControl
@@ -53,6 +57,9 @@ function WorkflowState({
         mergeCodePr: fn(),
         startCodeWatch: fn(),
         stopCodeWatch: fn(),
+        writeCodeCheckLogs: checkLogsHang
+          ? () => new Promise(() => {})
+          : fn(async () => ({ logs: [], errors: [] })),
       }}
       workspaceId="ws-1"
       branchName="tidebreak/scoped-ui-workshop"
@@ -111,4 +118,26 @@ export const WatchBlocked: Story = {
 
 export const StoppingWatch: Story = {
   args: { snapshot: watchingPrGit, busy: "stop_watch" },
+};
+
+/** Failing checks with nobody watching: the button offers Fix errors. */
+export const FailingChecks: Story = {
+  args: { snapshot: failingChecksPrGit },
+};
+
+/**
+ * Pressed, and the failing jobs' logs are still downloading.
+ *
+ * The download is a host read the reader waits on before the turn starts, so
+ * the button says so rather than sitting on the action label doing nothing.
+ */
+export const ReadingCheckLogs: Story = {
+  args: { snapshot: failingChecksPrGit, checkLogsHang: true },
+  play: async ({ canvasElement }) => {
+    const button = within(canvasElement).getByRole("button", {
+      name: /fix ci/i,
+    });
+    await userEvent.click(button);
+    await within(canvasElement).findByText("Reading logs…");
+  },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -142,6 +142,24 @@ export const openPrGit: CodeWorkspacePrSnapshot = {
   },
 };
 
+/** Failing checks with nobody watching: the Fix errors action's own state. */
+export const failingChecksPrGit: CodeWorkspacePrSnapshot = {
+  ...openPrGit,
+  pr: {
+    ...openPrGit.pr!,
+    checks_summary: "7 passing, 1 failing",
+    checks: [
+      { name: "desktop test", bucket: "pass" },
+      {
+        name: "clippy",
+        bucket: "fail",
+        detail: "exit 101",
+        url: "https://github.com/example/tidebreak/actions/runs/32664268801/job/97255126659",
+      },
+    ],
+  },
+};
+
 const watchBase: CodeWatchSnapshot = {
   id: "watch-1",
   workspace_id: "ws-1",

--- a/crates/tidebreak-server/src/code/ci_logs.rs
+++ b/crates/tidebreak-server/src/code/ci_logs.rs
@@ -1,0 +1,409 @@
+//! Failing CI job logs, downloaded once and written where an agent can read
+//! them.
+//!
+//! The fix-errors action used to hand an agent check names and URLs and let it
+//! find the logs itself: two or three `gh` calls before it saw an error line,
+//! and then a whole multi-megabyte job log in one read. This module does that
+//! fetch on the agent's behalf and bounds it.
+//!
+//! Files land under the workspace's private root, beside fork transcripts, so
+//! Git cannot index them and the session's `allowed_read_roots` already covers
+//! them. Each fetch replaces the previous one: only the head being fixed right
+//! now is worth keeping on disk.
+
+use std::path::Path;
+use std::time::Duration;
+
+use futures::{stream, StreamExt};
+use tidebreak_core::{PullRequestCheck, PullRequestCheckBucket};
+
+use super::gh;
+
+/// Directory holding downloaded job logs below the workspace's private root.
+const CI_LOGS_DIR: &str = "ci-logs";
+
+/// Failing jobs whose logs are downloaded in one request.
+///
+/// A run that fails wholesale fails every job in it, and the sixth log adds
+/// nothing the first few did not already say. They all go out at once, so the
+/// caller waits one request rather than one per job — which is what keeps the
+/// whole fetch inside the client's own timeout.
+const MAX_JOBS: usize = 6;
+
+/// Largest log written per job, in bytes, header included.
+///
+/// A long build job produces megabytes. The failure and the step summary sit
+/// at the end, so the tail is kept and the header says what was dropped.
+const MAX_JOB_LOG_BYTES: usize = 512 * 1024;
+
+/// Per-job deadline, and so the deadline for the whole fetch. Well inside the
+/// 30 seconds the renderer gives a GitHub read before it gives up.
+const GH_LOG_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// One downloaded job log, as the route reports it.
+pub(crate) struct WrittenCheckLog {
+    /// Check name as the host reports it.
+    pub(crate) check: String,
+    /// Absolute path, in the form the prompt names and the engine opens.
+    pub(crate) path: String,
+    /// Bytes on disk.
+    pub(crate) byte_len: u64,
+    /// True when the file holds only the tail of the job log.
+    pub(crate) truncated: bool,
+    /// The job's host URL. A check without one has no log to download, so
+    /// every written log has one.
+    pub(crate) url: String,
+}
+
+/// One job whose log could not be read. Never fatal: the other logs still land.
+pub(crate) struct CheckLogFailure {
+    pub(crate) check: String,
+    pub(crate) message: String,
+}
+
+pub(crate) struct WrittenCheckLogs {
+    pub(crate) logs: Vec<WrittenCheckLog>,
+    pub(crate) failures: Vec<CheckLogFailure>,
+}
+
+/// A GitHub Actions job, addressed the way its check URL spells it.
+#[derive(Debug)]
+struct JobRef {
+    host: String,
+    owner: String,
+    repo: String,
+    job_id: u64,
+}
+
+impl JobRef {
+    fn endpoint(&self) -> String {
+        format!(
+            "repos/{}/{}/actions/jobs/{}/logs",
+            self.owner, self.repo, self.job_id
+        )
+    }
+}
+
+/// Read the job id out of a check's URL.
+///
+/// `gh pr checks` reports an Actions check as
+/// `https://<host>/<owner>/<repo>/actions/runs/<run>/job/<job>`, which carries
+/// everything the REST log endpoint needs. Anything else — a bare check-run
+/// URL, an external CI provider — has no job log to fetch and yields `None`.
+fn job_ref_from_check_url(url: &str) -> Option<JobRef> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let (host, path) = rest.split_once('/')?;
+    if host.is_empty() {
+        return None;
+    }
+    let segments = path
+        .trim_end_matches('/')
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    // owner / repo / actions / runs / <run> / job / <job>
+    let [owner, repo, "actions", "runs", _run, "job", job] = segments.as_slice() else {
+        return None;
+    };
+    Some(JobRef {
+        host: host.to_owned(),
+        owner: (*owner).to_owned(),
+        repo: (*repo).to_owned(),
+        job_id: job.parse().ok()?,
+    })
+}
+
+/// Download every failing check's job log and publish it under `private_root`.
+///
+/// Stale files from an earlier fetch are removed once the new set is written,
+/// so the directory only ever describes one head.
+pub(crate) async fn write_failing_check_logs(
+    private_root: &Path,
+    binary: &Path,
+    checks: &[PullRequestCheck],
+    head_sha: Option<&str>,
+) -> std::io::Result<WrittenCheckLogs> {
+    let targets = checks
+        .iter()
+        .filter(|check| check.bucket == PullRequestCheckBucket::Fail)
+        .filter_map(|check| {
+            let url = check.url.as_deref()?;
+            Some((check, url.to_owned(), job_ref_from_check_url(url)?))
+        })
+        .take(MAX_JOBS)
+        .collect::<Vec<_>>();
+    if targets.is_empty() {
+        return Ok(WrittenCheckLogs {
+            logs: Vec::new(),
+            failures: Vec::new(),
+        });
+    }
+
+    let fetched = stream::iter(targets)
+        .map(|(check, url, job)| {
+            let binary = binary.to_path_buf();
+            async move {
+                let raw = fetch_job_log(&binary, &job).await;
+                (check, url, job, raw)
+            }
+        })
+        // Ordered, not unordered: the prompt lists the logs, and a list that
+        // reshuffles itself by whichever request finished first reads as noise.
+        .buffered(MAX_JOBS)
+        .collect::<Vec<_>>()
+        .await;
+
+    let dir = super::scratch::scratch_dir(private_root, CI_LOGS_DIR)?;
+    let mut logs = Vec::new();
+    let mut failures = Vec::new();
+    let mut written_names = Vec::new();
+    for (check, url, job, raw) in fetched {
+        let raw = match raw {
+            Ok(raw) => raw,
+            Err(message) => {
+                failures.push(CheckLogFailure {
+                    check: check.name.clone(),
+                    message,
+                });
+                continue;
+            }
+        };
+        let rendered = render_job_log(&check.name, &url, head_sha, &raw);
+        let name = log_file_name(&check.name, job.job_id);
+        dir.publish(std::ffi::OsStr::new(&name), rendered.text.as_bytes())
+            .await?;
+        logs.push(WrittenCheckLog {
+            check: check.name.clone(),
+            path: private_root
+                .join(CI_LOGS_DIR)
+                .join(&name)
+                .display()
+                .to_string(),
+            byte_len: rendered.text.len() as u64,
+            truncated: rendered.truncated,
+            url,
+        });
+        written_names.push(name);
+    }
+    prune_stale_logs(&dir, &written_names)?;
+    Ok(WrittenCheckLogs { logs, failures })
+}
+
+async fn fetch_job_log(binary: &Path, job: &JobRef) -> Result<String, String> {
+    let endpoint = job.endpoint();
+    let mut args = vec!["api".to_owned(), endpoint];
+    if job.host != "github.com" {
+        args.extend(["--hostname".to_owned(), job.host.clone()]);
+    }
+    let borrowed = args.iter().map(String::as_str).collect::<Vec<_>>();
+    // `cwd` is unused by an absolute REST read, and this runs for a workspace
+    // whose worktree may be mid-rebase.
+    gh::run_gh(Path::new("."), binary, &borrowed, GH_LOG_TIMEOUT).await
+}
+
+struct RenderedLog {
+    text: String,
+    truncated: bool,
+}
+
+/// Fit one job log into [`MAX_JOB_LOG_BYTES`], keeping the end.
+///
+/// The header is written first so a reader opening the file sees which check
+/// it belongs to and whether anything is missing before the first log line.
+/// The 128 bytes held back cover the truncation notice, whose own length
+/// depends on how much was dropped.
+fn render_job_log(check: &str, url: &str, head_sha: Option<&str>, raw: &str) -> RenderedLog {
+    let raw = raw.strip_prefix('\u{feff}').unwrap_or(raw);
+    let mut header = format!("# Failing check: {check}\n# Job: {url}\n");
+    if let Some(sha) = head_sha {
+        header.push_str(&format!("# Head: {sha}\n"));
+    }
+    let budget = MAX_JOB_LOG_BYTES.saturating_sub(header.len() + 128);
+    if raw.len() <= budget {
+        header.push('\n');
+        header.push_str(raw);
+        return RenderedLog {
+            text: header,
+            truncated: false,
+        };
+    }
+    // Cut on a character boundary first, then on the next line boundary, so
+    // the first retained line is both valid UTF-8 and whole.
+    let mut cut = raw.len() - budget;
+    while cut < raw.len() && !raw.is_char_boundary(cut) {
+        cut += 1;
+    }
+    let tail = &raw[cut..];
+    let tail = tail.find('\n').map_or(tail, |index| &tail[index + 1..]);
+    let dropped = raw.len() - tail.len();
+    header.push_str(&format!(
+        "# Truncated: the first {dropped} bytes were dropped. This is the tail \
+         of the job log.\n\n"
+    ));
+    header.push_str(tail);
+    RenderedLog {
+        text: header,
+        truncated: true,
+    }
+}
+
+/// `clippy-97078611349.log` — the check name a reader recognizes, plus the job
+/// id that makes it unique when one workflow runs a check name twice.
+fn log_file_name(check: &str, job_id: u64) -> String {
+    let mut slug = String::new();
+    for character in check.chars() {
+        if slug.len() >= 60 {
+            break;
+        }
+        if character.is_ascii_alphanumeric() {
+            slug.push(character.to_ascii_lowercase());
+        } else if !slug.is_empty() && !slug.ends_with('-') {
+            slug.push('-');
+        }
+    }
+    let slug = slug.trim_matches('-');
+    let slug = if slug.is_empty() { "check" } else { slug };
+    format!("{slug}-{job_id}.log")
+}
+
+/// Drop files this fetch did not write, so the directory describes one head.
+///
+/// Only `.log` files are Tidebreak's to remove. Symlinks are unlinked rather
+/// than followed, as they are everywhere else in private storage.
+fn prune_stale_logs(dir: &super::scratch::ScratchDir, keep: &[String]) -> std::io::Result<()> {
+    for entry in dir.read_dir()? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(text) = name.to_str() else { continue };
+        if !text.ends_with(".log") || keep.iter().any(|kept| kept.as_str() == text) {
+            continue;
+        }
+        let metadata = dir.symlink_metadata(&name)?;
+        if metadata.is_dir() && !metadata.file_type().is_symlink() {
+            continue;
+        }
+        dir.remove_file(&name)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_actions_check_url_carries_its_job() {
+        let job = job_ref_from_check_url(
+            "https://github.com/brightwave-inc/tidebreak/actions/runs/32664268801/job/97255126659",
+        )
+        .expect("actions job url");
+        assert_eq!(job.host, "github.com");
+        assert_eq!(job.owner, "brightwave-inc");
+        assert_eq!(job.repo, "tidebreak");
+        assert_eq!(job.job_id, 97_255_126_659);
+        assert_eq!(
+            job.endpoint(),
+            "repos/brightwave-inc/tidebreak/actions/jobs/97255126659/logs"
+        );
+    }
+
+    #[test]
+    fn an_enterprise_host_keeps_its_hostname() {
+        let job = job_ref_from_check_url(
+            "https://github.example.com/acme/widgets/actions/runs/12/job/34",
+        )
+        .expect("enterprise job url");
+        assert_eq!(job.host, "github.example.com");
+        assert_eq!(job.job_id, 34);
+    }
+
+    /// A check-run URL and an external provider have no job log to fetch. The
+    /// check still reaches the prompt by name; it just has no file.
+    #[test]
+    fn a_url_without_a_job_segment_is_skipped() {
+        assert!(job_ref_from_check_url(
+            "https://github.com/brightwave-inc/tidebreak/runs/97078624591"
+        )
+        .is_none());
+        assert!(job_ref_from_check_url(
+            "https://github.com/acme/widgets/actions/runs/12/job/not-a-number"
+        )
+        .is_none());
+        assert!(job_ref_from_check_url("https://buildkite.com/acme/widgets/builds/12").is_none());
+        assert!(job_ref_from_check_url("not a url").is_none());
+    }
+
+    #[test]
+    fn a_short_log_is_written_whole() {
+        let rendered = render_job_log(
+            "clippy",
+            "https://example.test/job",
+            Some("abc123"),
+            "one\ntwo\n",
+        );
+        assert!(!rendered.truncated);
+        assert!(rendered.text.contains("# Failing check: clippy"));
+        assert!(rendered.text.contains("# Head: abc123"));
+        assert!(rendered.text.ends_with("one\ntwo\n"));
+        assert!(!rendered.text.contains("# Truncated"));
+    }
+
+    /// The failure is at the end of a build log, so the tail is what survives.
+    #[test]
+    fn a_long_log_keeps_its_tail() {
+        let mut raw = "filler line that is here only to take up room\n".repeat(20_000);
+        raw.push_str("##[error]the thing that actually broke\n");
+        let rendered = render_job_log("Rust", "https://example.test/job", None, &raw);
+        assert!(rendered.truncated);
+        assert!(rendered.text.len() <= MAX_JOB_LOG_BYTES);
+        assert!(rendered.text.contains("# Truncated: the first "));
+        assert!(rendered
+            .text
+            .ends_with("##[error]the thing that actually broke\n"));
+        // The tail starts on a line boundary rather than mid-word.
+        let body = rendered.text.split("\n\n").nth(1).expect("log body");
+        assert!(body.starts_with("filler line that is here"));
+    }
+
+    #[test]
+    fn a_leading_byte_order_mark_is_dropped() {
+        let rendered = render_job_log(
+            "clippy",
+            "https://example.test/job",
+            None,
+            "\u{feff}first\n",
+        );
+        assert!(rendered.text.ends_with("\nfirst\n"));
+    }
+
+    #[test]
+    fn a_file_name_slugs_the_check_and_keeps_the_job_id() {
+        assert_eq!(log_file_name("clippy", 12), "clippy-12.log");
+        assert_eq!(log_file_name("Analyze (rust)", 12), "analyze-rust-12.log");
+        assert_eq!(log_file_name("ci / ui", 12), "ci-ui-12.log");
+        assert_eq!(log_file_name("///", 12), "check-12.log");
+    }
+
+    #[tokio::test]
+    async fn a_second_fetch_prunes_the_previous_heads_files() {
+        let root = tempfile::tempdir().expect("temp root");
+        let dir = super::super::scratch::scratch_dir(root.path(), CI_LOGS_DIR).expect("dir");
+        dir.publish(std::ffi::OsStr::new("old-1.log"), b"old")
+            .await
+            .expect("publish old");
+        dir.publish(std::ffi::OsStr::new("new-2.log"), b"new")
+            .await
+            .expect("publish new");
+        std::fs::write(root.path().join(CI_LOGS_DIR).join("notes.txt"), b"keep")
+            .expect("unrelated file");
+
+        prune_stale_logs(&dir, &["new-2.log".to_owned()]).expect("prune");
+
+        let logs = root.path().join(CI_LOGS_DIR);
+        assert!(!logs.join("old-1.log").exists());
+        assert!(logs.join("new-2.log").exists());
+        assert!(logs.join("notes.txt").exists());
+    }
+}

--- a/crates/tidebreak-server/src/code/ci_logs.rs
+++ b/crates/tidebreak-server/src/code/ci_logs.rs
@@ -128,9 +128,16 @@ pub(crate) async fn write_failing_check_logs(
     let targets = checks
         .iter()
         .filter(|check| check.bucket == PullRequestCheckBucket::Fail)
+        // Owned, not borrowed: a `&PullRequestCheck` riding through the stream
+        // ties the mapped future to one lifetime, and the handler bound needs
+        // it general over any. The name is all this reads anyway.
         .filter_map(|check| {
             let url = check.url.as_deref()?;
-            Some((check, url.to_owned(), job_ref_from_check_url(url)?))
+            Some((
+                check.name.clone(),
+                url.to_owned(),
+                job_ref_from_check_url(url)?,
+            ))
         })
         .take(MAX_JOBS)
         .collect::<Vec<_>>();
@@ -163,19 +170,16 @@ pub(crate) async fn write_failing_check_logs(
         let raw = match raw {
             Ok(raw) => raw,
             Err(message) => {
-                failures.push(CheckLogFailure {
-                    check: check.name.clone(),
-                    message,
-                });
+                failures.push(CheckLogFailure { check, message });
                 continue;
             }
         };
-        let rendered = render_job_log(&check.name, &url, head_sha, &raw);
-        let name = log_file_name(&check.name, job.job_id);
+        let rendered = render_job_log(&check, &url, head_sha, &raw);
+        let name = log_file_name(&check, job.job_id);
         dir.publish(std::ffi::OsStr::new(&name), rendered.text.as_bytes())
             .await?;
         logs.push(WrittenCheckLog {
-            check: check.name.clone(),
+            check,
             path: private_root
                 .join(CI_LOGS_DIR)
                 .join(&name)

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -546,7 +546,7 @@ pub(crate) async fn load_pr_comments(
     Ok(PrComments { number, comments })
 }
 
-fn require_gh_binary(gh: &GhObservation) -> Result<PathBuf, GhError> {
+pub(crate) fn require_gh_binary(gh: &GhObservation) -> Result<PathBuf, GhError> {
     if !gh.found {
         return Err(GhError::GhAbsent {
             instructions: gh.remediation.clone(),

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod browser_channel;
 pub(crate) mod browser_runtime;
 pub(crate) mod bus;
 pub(crate) mod checkpoint;
+pub(crate) mod ci_logs;
 pub(crate) mod clone;
 pub(crate) mod delivery;
 pub(crate) mod fork;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -36,6 +36,7 @@ use super::checkpoint::{
     delete_workspace_refs, list_changed_files, produce_diff, record_session_baseline,
     resolve_diff_range, sweep_orphaned_refs, ChangedFile, CheckpointError, DiffBounds,
 };
+use super::ci_logs;
 use super::clone::CloneJobs;
 use super::delivery::DeliveryCache;
 use super::fork;
@@ -2668,6 +2669,42 @@ impl CodeRuntime {
         )
         .await
         .map_err(|err| ServerError::internal(format!("could not write the fork transcript: {err}")))
+    }
+
+    /// Download the workspace pull request's failing job logs into private
+    /// storage, and report where they landed.
+    ///
+    /// The fix-errors action calls this before it sends its prompt, so the
+    /// agent opens a file instead of working out which job failed and asking
+    /// GitHub for it. The digest is read fresh: fixing against the logs of a
+    /// head that has already been superseded is worse than not attaching any.
+    pub(crate) async fn workspace_check_logs(
+        &self,
+        owner: &OwnerId,
+        workspace_id: WorkspaceId,
+    ) -> Result<(Option<String>, ci_logs::WrittenCheckLogs), ServerError> {
+        let workspace = self.require_live_workspace(owner, workspace_id).await?;
+        let status = self.refresh_workspace_pr(owner, workspace_id).await?;
+        let Some(pr) = status.pr else {
+            return Err(ServerError::not_found(
+                "no pull request found for this workspace",
+            ));
+        };
+        let gh = gh::observe_gh(self.gh_search_path_owned().as_deref()).await;
+        let binary = gh::require_gh_binary(&gh).map_err(map_gh)?;
+        let private_root =
+            super::scratch::workspace_root(&self.data_dir, workspace.id).map_err(|err| {
+                ServerError::internal(format!("could not open private storage: {err}"))
+            })?;
+        let written = ci_logs::write_failing_check_logs(
+            &private_root,
+            &binary,
+            pr.checks.as_deref().unwrap_or(&[]),
+            pr.head_sha.as_deref(),
+        )
+        .await
+        .map_err(|err| ServerError::internal(format!("could not write the check logs: {err}")))?;
+        Ok((pr.head_sha, written))
     }
 
     pub(crate) async fn workspace_tree(

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -490,6 +490,13 @@ impl ScopedCode {
         self.runtime.workspace_pr_comments(&self.owner, id).await
     }
 
+    pub(crate) async fn workspace_check_logs(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<(Option<String>, super::ci_logs::WrittenCheckLogs), ServerError> {
+        self.runtime.workspace_check_logs(&self.owner, id).await
+    }
+
     pub(crate) async fn merge_workspace_pr(
         &self,
         id: WorkspaceId,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -917,6 +917,10 @@ pub fn app(state: AppState) -> Router {
             get(routes::code::get_workspace_pr_comments),
         )
         .route(
+            "/code/workspaces/{id}/pr/check-logs",
+            post(routes::code::write_workspace_check_logs),
+        )
+        .route(
             "/code/workspaces/{id}/pr/merge",
             post(routes::code::merge_workspace_pr),
         )

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -8,9 +8,10 @@ use crate::error::ServerError;
 use crate::extract::{Json, Path};
 
 use super::types::{
-    CodeActionSnapshot, CodeCommitSnapshot, CodePrCommentsSnapshot, CodePrMergeMethod,
-    CodePushSnapshot, CodeWatchSnapshot, CodeWorkspacePrSnapshot, CodeWorkspacePullRequestFact,
-    CodeWorkspacePullRequests, CommitWorkspaceBody, CreatePullRequestBody, MergeCodePrBody,
+    CodeActionSnapshot, CodeCheckLog, CodeCheckLogError, CodeCheckLogsSnapshot, CodeCommitSnapshot,
+    CodePrCommentsSnapshot, CodePrMergeMethod, CodePushSnapshot, CodeWatchSnapshot,
+    CodeWorkspacePrSnapshot, CodeWorkspacePullRequestFact, CodeWorkspacePullRequests,
+    CommitWorkspaceBody, CreatePullRequestBody, MergeCodePrBody,
 };
 use crate::code::gh::{ActionOutcome, CommitOutcome, MergeMethod, PushOutcome, WorkspaceGitStatus};
 use tidebreak_core::WorkspaceId;
@@ -120,6 +121,44 @@ pub async fn get_workspace_pr_comments(
         number: comments.number,
         comments: comments.comments,
     }))
+}
+
+/// `POST /code/workspaces/{id}/pr/check-logs` — download the failing checks'
+/// job logs and report where they landed.
+///
+/// A write, so a POST. The fix-errors action calls this before it sends its
+/// prompt: the agent then opens a bounded file instead of spending its first
+/// turns working out which job failed and asking GitHub for the whole log.
+pub async fn write_workspace_check_logs(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+) -> Result<(StatusCode, Json<CodeCheckLogsSnapshot>), ServerError> {
+    let (head_sha, written) = code.workspace_check_logs(id).await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CodeCheckLogsSnapshot {
+            head_sha,
+            logs: written
+                .logs
+                .into_iter()
+                .map(|log| CodeCheckLog {
+                    check: log.check,
+                    path: log.path,
+                    byte_len: log.byte_len,
+                    truncated: log.truncated,
+                    url: log.url,
+                })
+                .collect(),
+            errors: written
+                .failures
+                .into_iter()
+                .map(|failure| CodeCheckLogError {
+                    check: failure.check,
+                    message: failure.message,
+                })
+                .collect(),
+        }),
+    ))
 }
 
 pub async fn merge_workspace_pr(

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -43,6 +43,7 @@ pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,
     list_workspace_pull_requests, mark_workspace_pr_ready, merge_workspace_pr, push_workspace,
     refresh_workspace_pr, run_workspace_action, start_workspace_watch, stop_workspace_watch,
+    write_workspace_check_logs,
 };
 pub(crate) use harnesses::{
     install_harness, list_harness_models, list_harnesses, refresh_harnesses,
@@ -67,17 +68,18 @@ pub(crate) use triggers::{
 };
 #[allow(unused_imports)]
 pub(crate) use types::{
-    CodeActionSnapshot, CodeApprovalDecisionBody, CodeApprovalSnapshot, CodeCloneDefaults,
-    CodeCloneJobSnapshot, CodeCommitSnapshot, CodeDeliveryActionResult,
-    CodeDeliveryPullRequestActionBody, CodeDeliveryPullRequestDetail, CodeDeliveryPullRequestFile,
-    CodeDeliveryPullRequestQuery, CodeDeliveryPullRequestTarget, CodeDeliveryPullRequestsPage,
-    CodeDeliveryRepositoriesSnapshot, CodeDeliveryRunActionBody, CodeDeliveryRunDetail,
-    CodeDeliveryRunQuery, CodeDeliveryRunTarget, CodeDeliveryRunsPage, CodeFileChange,
-    CodeForkTranscript, CodeHarnessInstallSnapshot, CodePrCommentsSnapshot, CodePushSnapshot,
-    CodeRepoSnapshot, CodeRepoSource, CodeRepoSources, CodeSessionDebug, CodeSessionDigest,
-    CodeSessionSnapshot, CodeTerminalActivityNotice, CodeTerminalRead, CodeTerminalSnapshot,
-    CodeTriggerSnapshot, CodeTurnSnapshot, CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff,
-    CodeWorkspaceFiles, CodeWorkspacePrSnapshot, CodeWorkspacePullRequests, CodeWorkspaceSearch,
+    CodeActionSnapshot, CodeApprovalDecisionBody, CodeApprovalSnapshot, CodeCheckLog,
+    CodeCheckLogError, CodeCheckLogsSnapshot, CodeCloneDefaults, CodeCloneJobSnapshot,
+    CodeCommitSnapshot, CodeDeliveryActionResult, CodeDeliveryPullRequestActionBody,
+    CodeDeliveryPullRequestDetail, CodeDeliveryPullRequestFile, CodeDeliveryPullRequestQuery,
+    CodeDeliveryPullRequestTarget, CodeDeliveryPullRequestsPage, CodeDeliveryRepositoriesSnapshot,
+    CodeDeliveryRunActionBody, CodeDeliveryRunDetail, CodeDeliveryRunQuery, CodeDeliveryRunTarget,
+    CodeDeliveryRunsPage, CodeFileChange, CodeForkTranscript, CodeHarnessInstallSnapshot,
+    CodePrCommentsSnapshot, CodePushSnapshot, CodeRepoSnapshot, CodeRepoSource, CodeRepoSources,
+    CodeSessionDebug, CodeSessionDigest, CodeSessionSnapshot, CodeTerminalActivityNotice,
+    CodeTerminalRead, CodeTerminalSnapshot, CodeTriggerSnapshot, CodeTurnSnapshot,
+    CodeUpdateNotice, CodeWorkspaceBlob, CodeWorkspaceDiff, CodeWorkspaceFiles,
+    CodeWorkspacePrSnapshot, CodeWorkspacePullRequests, CodeWorkspaceSearch,
     CodeWorkspaceSearchMatch, CodeWorkspaceSnapshot, CodeWorkspaceTree, CodeWorktreeRoot,
     CreateCodeTriggerBody, HarnessDoctorReport, HarnessModelList, MergeCodePrBody, QueuedCodeTurn,
     ResolveCodeDeliveryRepositoriesBody, SequencedCodeEventFrame, SetCodeWorktreeRootBody,

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -663,6 +663,47 @@ pub struct CodePrCommentsSnapshot {
     pub comments: Vec<tidebreak_core::PullRequestComment>,
 }
 
+/// One failing check's downloaded job log:
+/// `POST /code/workspaces/{id}/pr/check-logs`.
+///
+/// `path` is absolute and sits outside the Git worktree, in the same private
+/// storage a fork transcript uses. The prompt names it and the engine opens
+/// it; nothing is uploaded and nothing is indexable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeCheckLog {
+    /// Check name as the host reports it.
+    pub check: String,
+    pub path: String,
+    pub byte_len: u64,
+    /// True when the file holds only the tail of the job log.
+    pub truncated: bool,
+    /// The job's host URL. A check without one has no log to download, so
+    /// every entry here has one.
+    pub url: String,
+}
+
+/// One failing check whose log could not be read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeCheckLogError {
+    pub check: String,
+    pub message: String,
+}
+
+/// Failing job logs written for one workspace's pull request.
+///
+/// A check with no downloadable log — an external CI provider, or a check-run
+/// URL that names no Actions job — is simply absent from both lists. The
+/// caller still names it in the prompt from the digest it already holds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+pub struct CodeCheckLogsSnapshot {
+    /// Head the logs were read against, when the host reported one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub head_sha: Option<String>,
+    pub logs: Vec<CodeCheckLog>,
+    pub errors: Vec<CodeCheckLogError>,
+}
+
 /// GitHub repository identity used by the install-wide delivery surfaces.
 ///
 /// `host` keeps GitHub Enterprise repositories distinct without introducing a

--- a/crates/tidebreak-server/src/wire_types.rs
+++ b/crates/tidebreak-server/src/wire_types.rs
@@ -469,6 +469,8 @@ mod tests {
         // Where new worktrees land, and the body that moves it.
         generate::collect_from::<crate::routes::code::CodeWorktreeRoot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::CodeForkTranscript>(&cfg, &mut out);
+        // Failing CI job logs the fix-errors action downloads before it prompts.
+        generate::collect_from::<crate::routes::code::CodeCheckLogsSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::code::SetCodeWorktreeRootBody>(&cfg, &mut out);
         // Triggers: the rules the sweep reads, and the bodies that arm them.
         generate::collect_from::<crate::routes::code::CodeTriggerSnapshot>(&cfg, &mut out);


### PR DESCRIPTION
## What changed

Fix CI used to name the failing checks and tell the agent to go and find their logs, which cost two or three `gh` calls before it saw an error line and then pulled a whole multi-megabyte job log into context in one read. The action now downloads them first: a new `POST /code/workspaces/{id}/pr/check-logs` reads the job id out of each failing check's URL, fetches that job's log through `gh api`, and writes it into the workspace's private root — beside fork transcripts, outside anything Git indexes, and already on the session's read roots — and the prompt names the paths and opens by telling the agent to read them. Each log is capped at 512 KB, tail-kept, and headed with the check, the job URL, the head SHA, and how much was dropped; every press replaces the previous set, so the directory only ever describes one head. The fetch is best-effort, so a GitHub outage, a signed-out `gh`, or a check from a provider with no downloadable log still sends the turn, with the old find-them-yourself wording and a toast saying the files are missing.

## Validation

Ran the full desktop UI suite (1716 tests, including new coverage for the prompt, the fetch fallback, the parser, and the button's busy state), `tsc --noEmit`, Biome lint and format, and the Storybook build. Rust was not compiled locally: `rustfmt --check` is clean on every changed file, and the hand-written `wire.ts` block was verified line-by-line against the Rust doc comments, so CI owns compilation, the `ci_logs` unit tests, and the wire-type regeneration check.

## Compatibility and risk

Additive wire types (`CodeCheckLog`, `CodeCheckLogError`, `CodeCheckLogsSnapshot`) and one new route; no persisted schema change. Logs land in the existing per-workspace private root rather than the worktree, so Git cannot index them and no new read boundary is opened. The watch task's fix turn still runs the old instruction — the materializer is shaped so it can adopt this later.