### PR TITLE
feat(code): a hosted machine clones and pushes with the gateway's GitHub App

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
@@ -89,6 +89,26 @@ describe("PrCard", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("states plainly when pushes land as the deployment's GitHub App", () => {
+    renderState({
+      ...BASE,
+      unpushed: true,
+      ahead: 1,
+      gh_found: false,
+      gh_authenticated: undefined,
+      pushes_as: "tidebreak-ship[bot]",
+    });
+    expect(screen.getByText("tidebreak-ship[bot]")).toBeInTheDocument();
+    expect(screen.getByText(/not as your GitHub account/)).toBeInTheDocument();
+  });
+
+  it("names no acting identity on a machine with its own credentials", () => {
+    renderState({ ...BASE, unpushed: true, ahead: 1 });
+    expect(
+      screen.queryByText(/GitHub App — not as your GitHub account/),
+    ).not.toBeInTheDocument();
+  });
+
   it("enables create PR after a push with no pull request", async () => {
     const { onCreatePr } = renderState({
       ...BASE,

--- a/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
@@ -293,6 +293,15 @@ export function PrCardView({
           {error}
         </p>
       )}
+      {snapshot?.pushes_as && (
+        <p className="text-muted-foreground text-xs leading-relaxed">
+          Pushes from this machine land as{" "}
+          <span className="text-foreground font-medium">
+            {snapshot.pushes_as}
+          </span>
+          , the deployment&apos;s GitHub App — not as your GitHub account.
+        </p>
+      )}
       {snapshot?.dirty ? (
         <div className="flex flex-col gap-2">
           <label className="flex flex-col gap-1">

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1676,6 +1676,7 @@ export function parseCodeWorkspacePr(
       "gh_found",
       "gh_authenticated",
       "remediation",
+      "pushes_as",
       "watch",
     ]) ||
     typeof value.dirty !== "boolean" ||
@@ -1686,7 +1687,8 @@ export function parseCodeWorkspacePr(
     typeof value.gh_found !== "boolean" ||
     (value.gh_authenticated !== undefined &&
       typeof value.gh_authenticated !== "boolean") ||
-    typeof value.remediation !== "string"
+    typeof value.remediation !== "string" ||
+    (value.pushes_as !== undefined && typeof value.pushes_as !== "string")
   ) {
     return null;
   }
@@ -1701,6 +1703,7 @@ export function parseCodeWorkspacePr(
     ...(value.gh_authenticated !== undefined
       ? { gh_authenticated: value.gh_authenticated }
       : {}),
+    ...(value.pushes_as !== undefined ? { pushes_as: value.pushes_as } : {}),
   };
   if (value.pr !== undefined) {
     const pr = parsePullRequestDigest(value.pr);

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1578,7 +1578,13 @@ export type CodeWorkspaceFiles = { files: Array<CodeFileChange>, truncated: bool
 /**
  * PR + checks digest plus the local git facts the PR card needs.
  */
-export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, pushes_as?: string, watch?: CodeWatchSnapshot, };
+export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, 
+/**
+ * The identity a push from this machine acts as, when it is not the
+ * caller: the deployment's GitHub App bot account (decision 63). The UI
+ * states this plainly beside the push control.
+ */
+pushes_as?: string, watch?: CodeWatchSnapshot, };
 
 /**
  * One pull request attributed to a workspace, from the durable fact store

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1578,7 +1578,7 @@ export type CodeWorkspaceFiles = { files: Array<CodeFileChange>, truncated: bool
 /**
  * PR + checks digest plus the local git facts the PR card needs.
  */
-export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, watch?: CodeWatchSnapshot, };
+export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, pushes_as?: string, watch?: CodeWatchSnapshot, };
 
 /**
  * One pull request attributed to a workspace, from the durable fact store

--- a/crates/tidebreak-desktop/ui/src/stories/PrCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/PrCard.stories.tsx
@@ -7,6 +7,7 @@ import { PrCardView } from "@/code/PrCard";
 import {
   cleanGit,
   dirtyGit,
+  hostedAppGit,
   openPrGit,
   readyForPrGit,
   unpushedGit,
@@ -67,6 +68,15 @@ export const Committing: Story = {
 
 export const Unpushed: Story = {
   args: { snapshot: unpushedGit },
+};
+
+/**
+ * A gateway-authenticated hosted machine pushes with the deployment's GitHub
+ * App identity, and the card says so plainly: work lands as the App's bot
+ * account, not as the person (issue #2510).
+ */
+export const HostedPushesAsApp: Story = {
+  args: { snapshot: hostedAppGit },
 };
 
 export const ReadyForPullRequest: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -125,6 +125,14 @@ export const unpushedGit: CodeWorkspacePrSnapshot = {
   ahead: 1,
 };
 
+/** A hosted machine whose pushes land as the deployment's GitHub App. */
+export const hostedAppGit: CodeWorkspacePrSnapshot = {
+  ...unpushedGit,
+  gh_found: false,
+  gh_authenticated: undefined,
+  pushes_as: "tidebreak-ship[bot]",
+};
+
 export const readyForPrGit: CodeWorkspacePrSnapshot = {
   ...cleanGit,
   ahead: 1,

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -392,7 +392,10 @@ impl GatewayAuthenticator {
     }
 }
 
-fn canonical_public_url(raw: &str) -> Result<String> {
+/// Normalize the public URL whose digest names this machine's `tidebreak:`
+/// resource. Shared with the on-behalf-of gateway, which names the same
+/// resource in git-credential requests (decision 63).
+pub(crate) fn canonical_public_url(raw: &str) -> Result<String> {
     let url = reqwest::Url::parse(raw.trim())
         .map_err(|error| AgentError::config(format!("invalid Tidebreak public URL: {error}")))?;
     if !matches!(url.scheme(), "http" | "https")

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -20,6 +20,7 @@ use super::bus::{CloneProgress, CodeLiveUpdate};
 use super::gh::{self, resolve_github_clone_url};
 use super::runtime::CodeRuntime;
 use crate::error::ServerError;
+use crate::obo_gateway::{GitCredential, GitForgeError, GitForgeIdentity};
 use crate::routes::code::{
     CodeCloneDefaults, CodeCloneJobSnapshot, CodeRepoSource, CodeRepoSources,
 };
@@ -144,26 +145,47 @@ impl CodeRuntime {
 
     /// What this machine can add a repository from.
     ///
-    /// Every answer here is about the machine, never about who is asking or
-    /// from where. A client pairs it with what it knows about itself — whether
-    /// it can open a directory picker the machine would resolve — and renders
-    /// the intersection.
-    pub(crate) async fn repo_sources(&self) -> Result<CodeRepoSources, ServerError> {
+    /// On a machine with its own credentials, every answer is about the
+    /// machine — a client pairs it with what it knows about itself and
+    /// renders the intersection. On a gateway-authenticated hosted machine
+    /// the `github` answer is about the caller too: it reflects whether the
+    /// deployment's gateway would lend *this* caller the forge's App
+    /// identity (decision 63), probed live rather than assumed.
+    pub(crate) async fn repo_sources(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<CodeRepoSources, ServerError> {
         let git = git_available().await;
-        let gh = gh::observe_gh(self.gh_search_path().as_deref()).await;
         let no_git = || {
             Some(
                 "This machine has no git. Install it there, or use a machine that has it."
                     .to_owned(),
             )
         };
-        // GitHub needs exactly what a git URL needs. Without a `gh`
-        // credential `resolve_github_clone_url` falls back to the public
-        // HTTPS URL, so `owner/repo` still clones anything public — hiding
-        // the form would take away a path that works. What `gh` buys is
-        // private repositories, so its absence rides along as a hint on an
-        // available source rather than as unavailability.
-        let github_credential = gh.found && gh.authenticated == Some(true);
+        let github = if let Some(lender) = self.git_credentials() {
+            let outcome = lender.git_forge_identity(owner).await;
+            hosted_github_source(git, no_git(), outcome)
+        } else {
+            // GitHub needs exactly what a git URL needs. Without a `gh`
+            // credential `resolve_github_clone_url` falls back to the public
+            // HTTPS URL, so `owner/repo` still clones anything public —
+            // hiding the form would take away a path that works. What `gh`
+            // buys is private repositories, so its absence rides along as a
+            // hint on an available source rather than as unavailability.
+            let gh = gh::observe_gh(self.gh_search_path().as_deref()).await;
+            let github_credential = gh.found && gh.authenticated == Some(true);
+            CodeRepoSource {
+                kind: "github".to_owned(),
+                available: git,
+                remediation: if !git {
+                    no_git()
+                } else if github_credential {
+                    None
+                } else {
+                    Some(gh.remediation.clone())
+                },
+            }
+        };
         let sources = vec![
             // Always offered: a machine can always register a checkout that
             // is already on its own disk. Whether the caller can name one is
@@ -178,17 +200,7 @@ impl CodeRuntime {
                 available: git,
                 remediation: if git { None } else { no_git() },
             },
-            CodeRepoSource {
-                kind: "github".to_owned(),
-                available: git,
-                remediation: if !git {
-                    no_git()
-                } else if github_credential {
-                    None
-                } else {
-                    Some(gh.remediation.clone())
-                },
-            },
+            github,
         ];
         Ok(CodeRepoSources {
             sources,
@@ -229,14 +241,19 @@ impl CodeRuntime {
     ) -> Result<CodeCloneJobSnapshot, ServerError> {
         let parent = self.clone_parent(request.parent_dir.as_deref()).await?;
         validate_parent_dir(&parent).await?;
-        let source = resolve_clone_source(&request, self.gh_search_path()).await?;
+        let source = resolve_clone_source(
+            &request,
+            self.gh_search_path(),
+            self.git_credentials().is_some(),
+        )
+        .await?;
         let name = request
             .name
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned)
-            .unwrap_or_else(|| infer_clone_name(&source));
+            .unwrap_or_else(|| infer_clone_name(&source.url));
         if name.is_empty()
             || name.contains('/')
             || name.contains('\\')
@@ -281,15 +298,33 @@ impl CodeRuntime {
         self: std::sync::Arc<Self>,
         owner: &OwnerId,
         id: Uuid,
-        url: String,
+        source: CloneSource,
         target: PathBuf,
     ) {
-        match clone_into(&url, &target, |phase, percent| {
-            self.touch_clone(owner, id, |job| {
-                job.phase = phase.to_owned();
-                job.percent = Some(percent);
-            });
-        })
+        // Borrowed at the moment of use and dropped with this job: a hosted
+        // machine clones a GitHub repository with a dying, repository-scoped
+        // credential the gateway mints for this caller (decision 63).
+        let credential = match (source.github_slug.as_deref(), self.git_credentials()) {
+            (Some(slug), Some(lender)) => match lender.git_credential(owner, slug).await {
+                Ok(credential) => Some(credential),
+                Err(refusal) => {
+                    self.fail_clone(owner, id, git_forge_refusal_message(&refusal));
+                    return;
+                }
+            },
+            _ => None,
+        };
+        match clone_into(
+            &source.url,
+            &target,
+            credential.as_ref(),
+            |phase, percent| {
+                self.touch_clone(owner, id, |job| {
+                    job.phase = phase.to_owned();
+                    job.percent = Some(percent);
+                });
+            },
+        )
         .await
         {
             Ok(()) => match self
@@ -297,7 +332,7 @@ impl CodeRuntime {
                     owner,
                     target,
                     super::runtime::RepoRegistration {
-                        cloned_from: Some(redact_clone_url(&url)),
+                        cloned_from: Some(redact_clone_url(&source.url)),
                         ..Default::default()
                     },
                 )
@@ -358,10 +393,20 @@ impl CodeRuntime {
     }
 }
 
+/// Where a clone reads from, plus the GitHub slug when the caller named one.
+///
+/// The slug survives resolution so a hosted machine can borrow a credential
+/// scoped to exactly that repository at clone time (decision 63).
+struct CloneSource {
+    url: String,
+    github_slug: Option<String>,
+}
+
 async fn resolve_clone_source(
     request: &CloneRequest,
     gh_search_path: Option<String>,
-) -> Result<String, ServerError> {
+    gateway_credentials: bool,
+) -> Result<CloneSource, ServerError> {
     let url = request
         .url
         .as_deref()
@@ -381,7 +426,10 @@ async fn resolve_clone_source(
             "clone_invalid_source",
             "provide url or github",
         )),
-        (Some(url), None) => Ok(url.to_owned()),
+        (Some(url), None) => Ok(CloneSource {
+            url: url.to_owned(),
+            github_slug: None,
+        }),
         (None, Some(github)) => {
             if !valid_github_slug(github) {
                 return Err(ServerError::bad_request_kind(
@@ -389,12 +437,108 @@ async fn resolve_clone_source(
                     "github must be owner/repo",
                 ));
             }
+            if gateway_credentials {
+                // A hosted machine never consults `gh` — there is none, and
+                // nothing to observe if there were. The URL shape is fixed,
+                // and the credential arrives per operation at clone time.
+                return Ok(CloneSource {
+                    url: format!("https://github.com/{github}.git"),
+                    github_slug: Some(github.to_owned()),
+                });
+            }
             resolve_github_clone_url(github, gh_search_path.as_deref())
                 .await
+                .map(|url| CloneSource {
+                    url,
+                    github_slug: None,
+                })
                 .map_err(|err| {
                     ServerError::bad_request_kind("clone_github_unresolved", err.to_string())
                 })
         }
+    }
+}
+
+/// The `github` repo source as a gateway-authenticated hosted machine offers
+/// it to one caller (decision 63).
+///
+/// An identity means the source works and the remediation slot carries the
+/// attribution sentence — the one place the add-repository dialog states out
+/// loud that work lands as the App. Every named refusal keeps the source
+/// hidden and says why, so a deployment with no forge reads as "not
+/// offered", never as an error.
+fn hosted_github_source(
+    git: bool,
+    no_git: Option<String>,
+    outcome: Result<GitForgeIdentity, GitForgeError>,
+) -> CodeRepoSource {
+    if !git {
+        return CodeRepoSource {
+            kind: "github".to_owned(),
+            available: false,
+            remediation: no_git,
+        };
+    }
+    match outcome {
+        Ok(identity) => CodeRepoSource {
+            kind: "github".to_owned(),
+            available: true,
+            remediation: Some(hosted_attribution_sentence(&identity)),
+        },
+        Err(refusal) => CodeRepoSource {
+            kind: "github".to_owned(),
+            available: false,
+            remediation: Some(git_forge_refusal_message(&refusal)),
+        },
+    }
+}
+
+/// The sentence a hosted machine states its git identity with (decision 63).
+///
+/// Issue #2510's contract: an `installation_only` deployment cannot
+/// attribute work to the person, so the UI must say plainly that it lands as
+/// the App.
+pub(crate) fn hosted_attribution_sentence(identity: &GitForgeIdentity) -> String {
+    match identity.bot_login.as_deref() {
+        Some(bot_login) => format!(
+            "Clones and pushes use this deployment's GitHub App: work lands as {bot_login}, not as your GitHub account."
+        ),
+        None => format!(
+            "Clones and pushes use this deployment's GitHub App ({}): work lands as the App's bot account, not as your GitHub account.",
+            identity.app_name
+        ),
+    }
+}
+
+/// One user-facing sentence for a git-forge refusal, phrased for the
+/// operation or offer it stopped.
+pub(crate) fn git_forge_refusal_message(refusal: &GitForgeError) -> String {
+    match refusal {
+        GitForgeError::SignInRequired(detail) | GitForgeError::Unavailable(detail) => {
+            detail.clone()
+        }
+        GitForgeError::NoGitForge => "This deployment has no git forge configured, so GitHub \
+                                      repositories are not offered. An administrator can register \
+                                      an installation-mode git forge app on the Model Gateway."
+            .to_owned(),
+        GitForgeError::AmbiguousGitForge => "This deployment's gateway has more than one git \
+                                             forge, and this machine serves exactly one. An \
+                                             administrator can disable the extras."
+            .to_owned(),
+        GitForgeError::ConnectModeForge => "This deployment's git forge identifies each person \
+                                            individually, and a personal identity is never lent \
+                                            to a shared machine. An administrator can register a \
+                                            second, installation-mode forge app on the Model \
+                                            Gateway."
+            .to_owned(),
+        GitForgeError::ForgeAppNotInstalled => "This deployment's git forge app has no approved \
+                                                GitHub App installation yet. An administrator can \
+                                                finish installing it on GitHub."
+            .to_owned(),
+        GitForgeError::RepositoryNotInstalled => "The deployment's GitHub App installation does \
+                                                  not cover this repository. An administrator can \
+                                                  add it to the installation on GitHub."
+            .to_owned(),
     }
 }
 
@@ -472,9 +616,19 @@ pub(crate) fn redact_clone_url(url: &str) -> String {
 async fn clone_into(
     url: &str,
     target: &Path,
+    credential: Option<&GitCredential>,
     mut on_progress: impl FnMut(&str, u8),
 ) -> Result<(), String> {
     let mut command = Command::new("git");
+    // The credential rides the environment into a one-shot helper, never the
+    // URL: the URL is persisted and shown back, and the helper reset keeps
+    // any configured helper from storing the dying token (decision 63).
+    if let Some(credential) = credential {
+        command.args(gh::GIT_CREDENTIAL_CONFIG_ARGS);
+        command
+            .env(gh::GIT_CREDENTIAL_USERNAME_ENV, &credential.username)
+            .env(gh::GIT_CREDENTIAL_SECRET_ENV, &credential.secret);
+    }
     command
         .args(["clone", "--progress", "--", url])
         .arg(target)

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -627,7 +627,8 @@ async fn clone_into(
         command.args(gh::GIT_CREDENTIAL_CONFIG_ARGS);
         command
             .env(gh::GIT_CREDENTIAL_USERNAME_ENV, &credential.username)
-            .env(gh::GIT_CREDENTIAL_SECRET_ENV, &credential.secret);
+            .env(gh::GIT_CREDENTIAL_SECRET_ENV, &credential.secret)
+            .env(gh::GIT_CREDENTIAL_HOST_ENV, gh::GIT_CREDENTIAL_FORGE_HOST);
     }
     command
         .args(["clone", "--progress", "--", url])

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1,7 +1,9 @@
 //! Git commit/push and `gh` pull-request operations for a workspace.
 //!
 //! Every subprocess is bounded and non-interactive. Arguments are an argv
-//! array, never a shell string. `gh` credentials are observed, never stored.
+//! array, never a shell string. `gh` credentials are observed, never stored;
+//! a hosted machine instead lends each git operation a dying, gateway-minted
+//! credential through the environment (decision 63).
 
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -18,6 +20,7 @@ use tidebreak_core::{Diffstat, PullRequestDigest, QuickAction, WorkspaceId};
 use tidebreak_harness::{filter_child_env, probe_shell, HostEnv};
 
 use super::setup_script::spawn_workspace_script;
+use crate::obo_gateway::GitCredential;
 
 const GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const GIT_PUSH_TIMEOUT: Duration = Duration::from_secs(120);
@@ -29,6 +32,28 @@ const PR_CACHE_TTL: Duration = Duration::from_secs(20);
 const GH_OBSERVATION_TTL: Duration = Duration::from_secs(30);
 pub(crate) const GH_UNAVAILABLE_PREFIX: &str = "gh_unavailable: ";
 pub(crate) const PR_HEAD_CHANGED_PREFIX: &str = "pr_head_changed: ";
+
+/// Environment variables the one-shot credential helper reads a borrowed
+/// credential from. The environment, not argv: another user's `ps` can read
+/// a process's arguments, not its environment.
+pub(crate) const GIT_CREDENTIAL_USERNAME_ENV: &str = "TIDEBREAK_GIT_CREDENTIAL_USERNAME";
+pub(crate) const GIT_CREDENTIAL_SECRET_ENV: &str = "TIDEBREAK_GIT_CREDENTIAL_SECRET";
+
+/// Configuration that lends one borrowed credential to one git subprocess
+/// (decision 63).
+///
+/// The empty helper first resets any inherited helper list. That is
+/// load-bearing twice over: no configured helper can answer ahead of the
+/// borrowed credential, and — because git offers a successful credential to
+/// every helper's `store` — no helper like `git-credential-store` can write
+/// the dying token to disk. The one-shot helper then answers `get` from the
+/// environment and ignores every other action.
+pub(crate) const GIT_CREDENTIAL_CONFIG_ARGS: [&str; 4] = [
+    "-c",
+    "credential.helper=",
+    "-c",
+    "credential.helper=!f() { if [ \"$1\" = get ]; then printf 'username=%s\\npassword=%s\\n' \"$TIDEBREAK_GIT_CREDENTIAL_USERNAME\" \"$TIDEBREAK_GIT_CREDENTIAL_SECRET\"; fi; }; f",
+];
 
 static GH_LAUNCH: OnceLock<GhLaunch> = OnceLock::new();
 static GH_OBSERVATION: OnceLock<AsyncMutex<Option<CachedGhObservation>>> = OnceLock::new();
@@ -161,6 +186,10 @@ pub(crate) struct WorkspaceGitStatus {
     pub gh_found: bool,
     pub gh_authenticated: Option<bool>,
     pub remediation: String,
+    /// The identity a push from this machine acts as, when it is not the
+    /// caller: the deployment's GitHub App bot account (decision 63). `None`
+    /// on every machine where git speaks for whoever configured it.
+    pub pushes_as: Option<String>,
 }
 
 /// Outcome of one named quick action.
@@ -254,14 +283,24 @@ pub(crate) async fn commit_all(
 }
 
 /// Push the workspace branch to `origin` and set upstream.
-pub(crate) async fn push_branch(worktree: &Path, branch: &str) -> Result<PushOutcome, GhError> {
-    git(
-        worktree,
-        &["push", "-u", "origin", branch],
-        GIT_PUSH_TIMEOUT,
-    )
-    .await
-    .map_err(|err| classify_git(err, "push"))?;
+///
+/// `credential` is a borrowed, repository-scoped forge credential for a
+/// hosted machine (decision 63), lent to this one subprocess and dropped.
+/// `None` is every other machine: git authenticates however the operator's
+/// own configuration says.
+pub(crate) async fn push_branch(
+    worktree: &Path,
+    branch: &str,
+    credential: Option<&GitCredential>,
+) -> Result<PushOutcome, GhError> {
+    let mut args: Vec<&str> = Vec::new();
+    if credential.is_some() {
+        args.extend(GIT_CREDENTIAL_CONFIG_ARGS);
+    }
+    args.extend(["push", "-u", "origin", branch]);
+    git_with_credential(worktree, &args, GIT_PUSH_TIMEOUT, credential)
+        .await
+        .map_err(|err| classify_git(err, "push"))?;
     Ok(PushOutcome {
         branch: branch.to_owned(),
         remote: "origin".into(),
@@ -305,6 +344,9 @@ pub(crate) async fn workspace_git_status(
         } else {
             manual_pr_instructions(worktree, branch, title, None, &inspect.diffstat, &gh)
         },
+        // Decorated by the runtime, which knows whether this machine lends
+        // gateway credentials; this module only observes local state.
+        pushes_as: None,
     })
 }
 
@@ -1708,6 +1750,17 @@ fn classify_gh(
 }
 
 async fn git(cwd: &Path, args: &[&str], limit: Duration) -> Result<String, String> {
+    git_with_credential(cwd, args, limit, None).await
+}
+
+/// [`git`], optionally lending a borrowed credential through the environment
+/// the one-shot helper in [`GIT_CREDENTIAL_CONFIG_ARGS`] reads.
+async fn git_with_credential(
+    cwd: &Path,
+    args: &[&str],
+    limit: Duration,
+    credential: Option<&GitCredential>,
+) -> Result<String, String> {
     let mut command = Command::new("git");
     command
         .args(args)
@@ -1717,6 +1770,11 @@ async fn git(cwd: &Path, args: &[&str], limit: Duration) -> Result<String, Strin
         .stderr(Stdio::piped())
         .kill_on_drop(true)
         .env("GIT_TERMINAL_PROMPT", "0");
+    if let Some(credential) = credential {
+        command
+            .env(GIT_CREDENTIAL_USERNAME_ENV, &credential.username)
+            .env(GIT_CREDENTIAL_SECRET_ENV, &credential.secret);
+    }
     let child = command
         .spawn()
         .map_err(|err| format!("failed to spawn git: {err}"))?;
@@ -2115,6 +2173,44 @@ mod tests {
     use std::process::Command as StdCommand;
     use tempfile::TempDir;
 
+    /// The one-shot helper is real shell handed to real git: prove it
+    /// answers `get` with the environment pair, so a clone or push carrying
+    /// [`GIT_CREDENTIAL_CONFIG_ARGS`] authenticates without the secret ever
+    /// touching argv, a URL, or a file (decision 63).
+    #[test]
+    fn the_one_shot_helper_answers_get_from_the_environment() {
+        use std::io::Write as _;
+
+        let dir = TempDir::new().unwrap();
+        let mut command = StdCommand::new("git");
+        command.args(GIT_CREDENTIAL_CONFIG_ARGS);
+        command
+            .args(["credential", "fill"])
+            .current_dir(dir.path())
+            .env(GIT_CREDENTIAL_USERNAME_ENV, "x-access-token")
+            .env(GIT_CREDENTIAL_SECRET_ENV, "ghs_dying_token")
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = command.spawn().unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(b"protocol=https\nhost=github.com\npath=acme/demo.git\n\n")
+            .unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "git credential fill failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let answered = String::from_utf8_lossy(&output.stdout);
+        assert!(answered.contains("username=x-access-token"), "{answered}");
+        assert!(answered.contains("password=ghs_dying_token"), "{answered}");
+    }
+
     fn init_paired_repos() -> (TempDir, PathBuf, PathBuf) {
         let dir = TempDir::new().unwrap();
         let bare = dir.path().join("origin.git");
@@ -2267,7 +2363,9 @@ fatal: Could not read from remote repository.\n";
             &work,
             &["git", "remote", "set-url", "origin", "../no-such-remote"],
         );
-        let err = push_branch(&work, "tidebreak/push-fail").await.unwrap_err();
+        let err = push_branch(&work, "tidebreak/push-fail", None)
+            .await
+            .unwrap_err();
         assert!(
             !matches!(err, GhError::AuthFailed(_)),
             "non-auth push classified as auth: {err}"
@@ -2292,7 +2390,9 @@ fatal: Could not read from remote repository.\n";
         commit_all(&work, "first change", Some("custom message"))
             .await
             .unwrap();
-        let pushed = push_branch(&work, "tidebreak/first-change").await.unwrap();
+        let pushed = push_branch(&work, "tidebreak/first-change", None)
+            .await
+            .unwrap();
         assert_eq!(pushed.remote, "origin");
         let listed = git(
             &bare,
@@ -2477,7 +2577,9 @@ exit 3
         run(&work, &["git", "checkout", "-b", "tidebreak/first-change"]);
         std::fs::write(work.join("extra.txt"), "line\n").unwrap();
         commit_all(&work, "first change", None).await.unwrap();
-        push_branch(&work, "tidebreak/first-change").await.unwrap();
+        push_branch(&work, "tidebreak/first-change", None)
+            .await
+            .unwrap();
 
         let shim_dir = TempDir::new().unwrap();
         let log = shim_dir.path().join("log");

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -39,6 +39,15 @@ pub(crate) const PR_HEAD_CHANGED_PREFIX: &str = "pr_head_changed: ";
 pub(crate) const GIT_CREDENTIAL_USERNAME_ENV: &str = "TIDEBREAK_GIT_CREDENTIAL_USERNAME";
 pub(crate) const GIT_CREDENTIAL_SECRET_ENV: &str = "TIDEBREAK_GIT_CREDENTIAL_SECRET";
 
+/// The one host the one-shot helper may answer for, set beside the pair.
+pub(crate) const GIT_CREDENTIAL_HOST_ENV: &str = "TIDEBREAK_GIT_CREDENTIAL_HOST";
+
+/// The forge host a borrowed credential is confined to (decision 63).
+///
+/// One value for v1 because the gateway mints from exactly one GitHub App;
+/// a GHES forge would thread its own host through here.
+pub(crate) const GIT_CREDENTIAL_FORGE_HOST: &str = "github.com";
+
 /// Configuration that lends one borrowed credential to one git subprocess
 /// (decision 63).
 ///
@@ -46,13 +55,20 @@ pub(crate) const GIT_CREDENTIAL_SECRET_ENV: &str = "TIDEBREAK_GIT_CREDENTIAL_SEC
 /// load-bearing twice over: no configured helper can answer ahead of the
 /// borrowed credential, and — because git offers a successful credential to
 /// every helper's `store` — no helper like `git-credential-store` can write
-/// the dying token to disk. The one-shot helper then answers `get` from the
-/// environment and ignores every other action.
+/// the dying token to disk.
+///
+/// The one-shot helper then answers `get` from the environment — but only
+/// for `https` and only for the exact host named in
+/// [`GIT_CREDENTIAL_HOST_ENV`]. Git re-asks its helpers whenever a fetch or
+/// push needs another host's credential — a rewritten `origin`, a redirect —
+/// and without the check the environment pair would be offered to whatever
+/// host asked. A mismatched description reads to git as "no credential",
+/// never as an error.
 pub(crate) const GIT_CREDENTIAL_CONFIG_ARGS: [&str; 4] = [
     "-c",
     "credential.helper=",
     "-c",
-    "credential.helper=!f() { if [ \"$1\" = get ]; then printf 'username=%s\\npassword=%s\\n' \"$TIDEBREAK_GIT_CREDENTIAL_USERNAME\" \"$TIDEBREAK_GIT_CREDENTIAL_SECRET\"; fi; }; f",
+    "credential.helper=!f() { h=; p=; while IFS= read -r line; do case \"$line\" in host=*) if [ \"${line#host=}\" = \"$TIDEBREAK_GIT_CREDENTIAL_HOST\" ]; then h=1; fi ;; protocol=https) p=1 ;; esac; done; if [ \"$1\" = get ] && [ -n \"$h\" ] && [ -n \"$p\" ]; then printf 'username=%s\\npassword=%s\\n' \"$TIDEBREAK_GIT_CREDENTIAL_USERNAME\" \"$TIDEBREAK_GIT_CREDENTIAL_SECRET\"; fi; }; f",
 ];
 
 static GH_LAUNCH: OnceLock<GhLaunch> = OnceLock::new();
@@ -1773,7 +1789,8 @@ async fn git_with_credential(
     if let Some(credential) = credential {
         command
             .env(GIT_CREDENTIAL_USERNAME_ENV, &credential.username)
-            .env(GIT_CREDENTIAL_SECRET_ENV, &credential.secret);
+            .env(GIT_CREDENTIAL_SECRET_ENV, &credential.secret)
+            .env(GIT_CREDENTIAL_HOST_ENV, GIT_CREDENTIAL_FORGE_HOST);
     }
     let child = command
         .spawn()
@@ -2174,41 +2191,52 @@ mod tests {
     use tempfile::TempDir;
 
     /// The one-shot helper is real shell handed to real git: prove it
-    /// answers `get` with the environment pair, so a clone or push carrying
-    /// [`GIT_CREDENTIAL_CONFIG_ARGS`] authenticates without the secret ever
-    /// touching argv, a URL, or a file (decision 63).
+    /// answers `get` with the environment pair for the forge host over
+    /// `https` — and answers nothing for any other host or protocol, so a
+    /// rewritten origin or a redirect cannot walk the borrowed credential to
+    /// a host an attacker controls (decision 63).
     #[test]
-    fn the_one_shot_helper_answers_get_from_the_environment() {
+    fn the_one_shot_helper_answers_only_the_forge_host_over_https() {
         use std::io::Write as _;
 
-        let dir = TempDir::new().unwrap();
-        let mut command = StdCommand::new("git");
-        command.args(GIT_CREDENTIAL_CONFIG_ARGS);
-        command
-            .args(["credential", "fill"])
-            .current_dir(dir.path())
-            .env(GIT_CREDENTIAL_USERNAME_ENV, "x-access-token")
-            .env(GIT_CREDENTIAL_SECRET_ENV, "ghs_dying_token")
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        let mut child = command.spawn().unwrap();
-        child
-            .stdin
-            .take()
-            .unwrap()
-            .write_all(b"protocol=https\nhost=github.com\npath=acme/demo.git\n\n")
-            .unwrap();
-        let output = child.wait_with_output().unwrap();
-        assert!(
-            output.status.success(),
-            "git credential fill failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let answered = String::from_utf8_lossy(&output.stdout);
+        let fill = |description: &[u8]| {
+            let dir = TempDir::new().unwrap();
+            let mut command = StdCommand::new("git");
+            command.args(GIT_CREDENTIAL_CONFIG_ARGS);
+            command
+                .args(["credential", "fill"])
+                .current_dir(dir.path())
+                .env(GIT_CREDENTIAL_USERNAME_ENV, "x-access-token")
+                .env(GIT_CREDENTIAL_SECRET_ENV, "ghs_dying_token")
+                .env(GIT_CREDENTIAL_HOST_ENV, GIT_CREDENTIAL_FORGE_HOST)
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            let mut child = command.spawn().unwrap();
+            child.stdin.take().unwrap().write_all(description).unwrap();
+            let output = child.wait_with_output().unwrap();
+            (
+                output.status.success(),
+                String::from_utf8_lossy(&output.stdout).into_owned(),
+            )
+        };
+
+        let (ok, answered) = fill(b"protocol=https\nhost=github.com\npath=acme/demo.git\n\n");
+        assert!(ok, "git credential fill failed for the forge host");
         assert!(answered.contains("username=x-access-token"), "{answered}");
         assert!(answered.contains("password=ghs_dying_token"), "{answered}");
+
+        // Any other host — a rewritten origin, a redirect — gets nothing.
+        // `fill` itself fails because no source answered and prompts are off,
+        // which is exactly the refusal a push would surface.
+        let (ok, answered) = fill(b"protocol=https\nhost=evil.example\npath=acme/demo.git\n\n");
+        assert!(!ok, "a foreign host must not fill");
+        assert!(!answered.contains("ghs_dying_token"), "{answered}");
+
+        let (ok, answered) = fill(b"protocol=http\nhost=github.com\npath=acme/demo.git\n\n");
+        assert!(!ok, "cleartext must not fill");
+        assert!(!answered.contains("ghs_dying_token"), "{answered}");
     }
 
     fn init_paired_repos() -> (TempDir, PathBuf, PathBuf) {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -3420,7 +3420,7 @@ fn map_gh(err: GhError) -> ServerError {
 /// re-checks the same host at `get`, so both halves refuse independently.
 async fn forge_lending_target(
     worktree: &std::path::Path,
-) -> Option<crate::routes::code::CodeGitHubRepositoryTarget> {
+) -> Option<crate::routes::code::types::CodeGitHubRepositoryTarget> {
     let target = super::delivery::repository_target_from_path(worktree)
         .await
         .ok()?;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1290,9 +1290,9 @@ impl CodeRuntime {
 
     /// Borrow a repository-scoped forge credential for one git operation in
     /// `worktree`, on a machine that lends them (decision 63). `Ok(None)` is
-    /// every machine that does not — and every checkout whose origin is not
-    /// a forge repository at all (a local path, a bare test origin): those
-    /// pushes carry no credential today and keep working exactly as they do.
+    /// every machine that does not — and every checkout whose origin
+    /// [`forge_lending_target`] rules out: those operations carry no
+    /// credential today and keep working exactly as they do.
     ///
     /// A refusal from the gateway fails the operation with its reason rather
     /// than falling back to an uncredentialed attempt — the attempt would
@@ -1306,7 +1306,7 @@ impl CodeRuntime {
         let Some(lender) = self.git_credentials() else {
             return Ok(None);
         };
-        let Ok(target) = super::delivery::repository_target_from_path(worktree).await else {
+        let Some(target) = forge_lending_target(worktree).await else {
             return Ok(None);
         };
         let repository = format!("{}/{}", target.owner, target.name);
@@ -1339,17 +1339,14 @@ impl CodeRuntime {
         .await
         .map_err(map_gh)?;
         // On a hosted machine, say whose identity a push would act as
-        // (decision 63) — only for a checkout whose origin is a forge
-        // repository, because only those pushes borrow the App's identity.
-        // Probed per caller and held fresh by the lender; a refusal simply
-        // leaves the field empty — the push itself reports refusals with
-        // their reasons.
+        // (decision 63) — only for a checkout the machine would actually
+        // lend the App's identity to, so the sentence is never wider than
+        // the lending. Probed per caller and held fresh by the lender; a
+        // refusal simply leaves the field empty — the push itself reports
+        // refusals with their reasons.
         if let Some(lender) = self.git_credentials() {
             let worktree = std::path::Path::new(&workspace.worktree_path);
-            if super::delivery::repository_target_from_path(worktree)
-                .await
-                .is_ok()
-            {
+            if forge_lending_target(worktree).await.is_some() {
                 if let Ok(identity) = lender.git_forge_identity(owner).await {
                     status.pushes_as = Some(identity.bot_login.unwrap_or(identity.app_name));
                 }
@@ -3409,6 +3406,28 @@ fn map_gh(err: GhError) -> ServerError {
         }
         GhError::Internal(message) => ServerError::internal(message),
     }
+}
+
+/// The origin a hosted machine may lend the forge's App identity to: a
+/// parseable forge repository on the forge's own host, and nothing else
+/// (decision 63).
+///
+/// The host gate is a security boundary, not a convenience. The origin URL
+/// is workspace state an agent can rewrite, and the parser accepts any
+/// `host/owner/repo` shape — without the gate, the next push would mint a
+/// live installation token and offer it to whatever host `origin` names.
+/// Only `owner/name` ever travels to the gateway, and the one-shot helper
+/// re-checks the same host at `get`, so both halves refuse independently.
+async fn forge_lending_target(
+    worktree: &std::path::Path,
+) -> Option<crate::routes::code::CodeGitHubRepositoryTarget> {
+    let target = super::delivery::repository_target_from_path(worktree)
+        .await
+        .ok()?;
+    target
+        .host
+        .eq_ignore_ascii_case(gh::GIT_CREDENTIAL_FORGE_HOST)
+        .then_some(target)
 }
 
 fn map_worktree(err: WorktreeError) -> ServerError {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -152,6 +152,10 @@ pub(crate) struct CodeRuntime {
     browser_bridge_command: Option<PathBuf>,
     host: HostEnv,
     host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
+    /// Per-caller git-forge lending on a gateway-authenticated hosted
+    /// machine (decision 63). `None` everywhere else: a machine with its own
+    /// `git`/`gh` configuration authenticates however the operator says.
+    git_credentials: Option<Arc<dyn crate::obo_gateway::GitCredentialLender>>,
     loopback_base: Mutex<Option<String>>,
     /// Memoized harness probes, one per kind. See [`CodeRuntime::probe`].
     probes: Mutex<HashMap<HarnessKind, HarnessProbe>>,
@@ -212,6 +216,7 @@ impl CodeRuntime {
         host_tool_broker: Option<Arc<dyn tidebreak_code_execution::HostToolBroker>>,
         browser_runtime: Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>>,
         browser_bridge_command: Option<PathBuf>,
+        git_credentials: Option<Arc<dyn crate::obo_gateway::GitCredentialLender>>,
     ) -> Self {
         let browser_tokens = BrowserTokenRegistry::new(&data_dir)
             // Panic on construction failure: the data dir is trusted/absolute
@@ -237,6 +242,7 @@ impl CodeRuntime {
                 ..HostEnv::from_process()
             },
             host_tool_broker,
+            git_credentials,
             loopback_base: Mutex::new(None),
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
@@ -265,6 +271,13 @@ impl CodeRuntime {
         self.browser_tokens.set_loopback_base(&base);
         *self.loopback_base.lock().expect("loopback base") =
             Some(base.trim_end_matches('/').into());
+    }
+
+    /// The per-caller git-forge lender, on a machine that has one.
+    pub(crate) fn git_credentials(
+        &self,
+    ) -> Option<&Arc<dyn crate::obo_gateway::GitCredentialLender>> {
+        self.git_credentials.as_ref()
     }
 
     /// Boot: publish the bound loopback base now, and hand back the recovery
@@ -341,6 +354,7 @@ impl CodeRuntime {
             browser_bridge_command,
             host: HostEnv::from_process(),
             host_tool_broker: None,
+            git_credentials: None,
             loopback_base: Mutex::new(None),
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
@@ -362,6 +376,17 @@ impl CodeRuntime {
             reconcile_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
         }
+    }
+
+    /// Lend gateway git credentials from tests, in place of the on-behalf-of
+    /// handle a hosted deployment wires in.
+    #[cfg(any(test, feature = "scripted-harness"))]
+    pub(crate) fn with_git_credentials(
+        mut self,
+        lender: Arc<dyn crate::obo_gateway::GitCredentialLender>,
+    ) -> Self {
+        self.git_credentials = Some(lender);
+        self
     }
 
     #[cfg(test)]
@@ -1226,7 +1251,8 @@ impl CodeRuntime {
     ) -> Result<PushOutcome, ServerError> {
         let workspace = self.require_live_workspace(owner, id).await?;
         let worktree = std::path::PathBuf::from(&workspace.worktree_path);
-        let outcome = gh::push_branch(&worktree, &workspace.branch_name)
+        let credential = self.borrow_git_credential(owner, &worktree).await?;
+        let outcome = gh::push_branch(&worktree, &workspace.branch_name, credential.as_ref())
             .await
             .map_err(map_gh)?;
         // Best-effort contributed fact (decision 62): a user push to a branch
@@ -1262,6 +1288,37 @@ impl CodeRuntime {
         Ok(outcome)
     }
 
+    /// Borrow a repository-scoped forge credential for one git operation in
+    /// `worktree`, on a machine that lends them (decision 63). `Ok(None)` is
+    /// every machine that does not — and every checkout whose origin is not
+    /// a forge repository at all (a local path, a bare test origin): those
+    /// pushes carry no credential today and keep working exactly as they do.
+    ///
+    /// A refusal from the gateway fails the operation with its reason rather
+    /// than falling back to an uncredentialed attempt — the attempt would
+    /// fail with a worse message, and a fallback would blur which identity
+    /// acted.
+    async fn borrow_git_credential(
+        &self,
+        owner: &OwnerId,
+        worktree: &std::path::Path,
+    ) -> Result<Option<crate::obo_gateway::GitCredential>, ServerError> {
+        let Some(lender) = self.git_credentials() else {
+            return Ok(None);
+        };
+        let Ok(target) = super::delivery::repository_target_from_path(worktree).await else {
+            return Ok(None);
+        };
+        let repository = format!("{}/{}", target.owner, target.name);
+        match lender.git_credential(owner, &repository).await {
+            Ok(credential) => Ok(Some(credential)),
+            Err(refusal) => Err(ServerError::unprocessable_kind(
+                "git_forge_refused",
+                super::clone::git_forge_refusal_message(&refusal),
+            )),
+        }
+    }
+
     pub(crate) async fn workspace_pr(
         &self,
         owner: &OwnerId,
@@ -1269,7 +1326,7 @@ impl CodeRuntime {
     ) -> Result<WorkspaceGitStatus, ServerError> {
         let mut workspace = self.get_workspace(owner, id).await?;
         let gh_path = self.gh_search_path_owned();
-        let status = gh::workspace_git_status(
+        let mut status = gh::workspace_git_status(
             std::path::Path::new(&workspace.worktree_path),
             workspace.id,
             &workspace.title,
@@ -1281,6 +1338,23 @@ impl CodeRuntime {
         )
         .await
         .map_err(map_gh)?;
+        // On a hosted machine, say whose identity a push would act as
+        // (decision 63) — only for a checkout whose origin is a forge
+        // repository, because only those pushes borrow the App's identity.
+        // Probed per caller and held fresh by the lender; a refusal simply
+        // leaves the field empty — the push itself reports refusals with
+        // their reasons.
+        if let Some(lender) = self.git_credentials() {
+            let worktree = std::path::Path::new(&workspace.worktree_path);
+            if super::delivery::repository_target_from_path(worktree)
+                .await
+                .is_ok()
+            {
+                if let Ok(identity) = lender.git_forge_identity(owner).await {
+                    status.pushes_as = Some(identity.bot_login.unwrap_or(identity.app_name));
+                }
+            }
+        }
         if status.pr != workspace.pr {
             workspace.pr = status.pr.clone();
             self.save_workspace(&workspace).await?;
@@ -3613,6 +3687,7 @@ mod managed_node_wait_tests {
         let runtime = CodeRuntime::new(
             Arc::new(db),
             data_dir.path().to_path_buf(),
+            None,
             None,
             None,
             None,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -137,7 +137,7 @@ impl ScopedCode {
     }
 
     pub(crate) async fn repo_sources(&self) -> Result<CodeRepoSources, ServerError> {
-        self.runtime.repo_sources().await
+        self.runtime.repo_sources(&self.owner).await
     }
 
     pub(crate) async fn start_clone(

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1831,6 +1831,13 @@ async fn bind_inner(
         code_host_tool_broker,
         browser_runtime,
         browser_bridge_command,
+        // On a gateway-authenticated hosted machine, git operations borrow
+        // per-caller forge credentials from the same on-behalf-of handle the
+        // router exchanges through (decision 63).
+        state
+            .on_behalf_of_gateway
+            .clone()
+            .map(|gateway| gateway as Arc<dyn obo_gateway::GitCredentialLender>),
     ));
     // Recovery runs after the bind, below: the workers it re-attaches need the
     // bound loopback address to reach their approval endpoint.

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -1,16 +1,21 @@
 //! Per-caller gateway capabilities for gateway-authenticated hosted machines
-//! (decisions 51 and 62).
+//! (decisions 51, 62, and 63).
 //!
 //! A hosted machine that authenticates callers against a Model Gateway
 //! (decision 49) already holds each caller's short-lived, machine-bound
-//! token. This module turns that token into two capabilities for the same
-//! user, each through the gateway's RFC 8693 exchange:
+//! token. This module turns that token into three capabilities for the same
+//! user:
 //!
 //! - **Inference** (decision 51): a short-lived, inference-only token the
-//!   router presents as the credential for the caller's turns.
+//!   router presents as the credential for the caller's turns, through the
+//!   gateway's RFC 8693 exchange.
 //! - **Entitlements** (decision 62): a short-lived catalog capability that
 //!   reads the caller's own member catalog, so the picker offers exactly the
 //!   models their account entitles them to.
+//! - **Git identity** (decision 63): a repository-scoped forge credential
+//!   borrowed per clone or push, presented with the machine-bound token
+//!   directly — the gateway's git-credential surface is authenticated like
+//!   its principal read, not through the exchange.
 //!
 //! The deployment needs no inference secret of its own, and the gateway
 //! meters every turn to the user who drove it.
@@ -18,8 +23,9 @@
 //! Three rules are load-bearing:
 //!
 //! - **Nothing here is durable.** Exchanged tokens live in this process's
-//!   memory, keyed by owner, and are minted again near expiry. They are never
-//!   written to the store, never logged, and never returned to a client.
+//!   memory, keyed by owner, and are minted again near expiry; a borrowed git
+//!   credential lives only for the operation that borrowed it. None of them
+//!   are written to the store, logged, or returned to a client.
 //! - **The exchange never falls back.** A refusal fails the caller's turn
 //!   closed. The server does not retry onto a shared credential, and one
 //!   user's refusal leaves every other user's turns running.
@@ -66,6 +72,15 @@ const CATALOG_STALE_GRACE_SECONDS: u64 = 3600;
 /// below anything that could stall the process.
 const CATALOG_RESPONSE_LIMIT: usize = 1024 * 1024;
 
+/// How long one caller's probed git-forge identity stays fresh.
+///
+/// The identity decorates surfaces that refetch often — the PR card reloads
+/// on every content revision — while the underlying answer changes on the
+/// pace of a deployment registering a forge. Sixty seconds keeps the picker
+/// honest within a minute of a forge appearing without asking the gateway
+/// per render.
+const GIT_FORGE_FRESH_SECONDS: u64 = 60;
+
 /// The OAuth token-exchange grant the gateway accepts for this flow.
 const TOKEN_EXCHANGE_GRANT: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
 
@@ -103,6 +118,18 @@ struct UserSlot {
     subject: std::sync::Mutex<Arc<str>>,
     token: tokio::sync::Mutex<Option<CachedToken>>,
     catalog: tokio::sync::Mutex<Option<CachedCatalog>>,
+    git_forge: tokio::sync::Mutex<Option<CachedGitForge>>,
+}
+
+/// One caller's probed git-forge answer and when it was read.
+///
+/// Refusals are cached beside availability: a deployment with no forge is the
+/// common case, and re-asking the gateway on every PR-card render would turn
+/// "not offered" into traffic. Transport failures are never cached — the next
+/// read asks again.
+struct CachedGitForge {
+    outcome: Result<GitForgeIdentity, GitForgeError>,
+    fetched_at_unix: u64,
 }
 
 /// One caller's fetched entitlement snapshot and its revalidation state.
@@ -137,6 +164,67 @@ struct ExchangeResponse {
     expires_in: u64,
 }
 
+/// The forge identity a hosted machine's git operations act as (decision 63).
+///
+/// Work done with a borrowed credential lands as the deployment's GitHub App,
+/// not as the caller — this is what the UI says so with.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitForgeIdentity {
+    /// The gateway's display name for the forge app.
+    pub app_name: String,
+    /// The bot account work lands as, `<slug>[bot]`, when the gateway has
+    /// recorded the App slug.
+    pub bot_login: Option<String>,
+}
+
+/// One borrowed, repository-scoped forge credential (decision 63).
+///
+/// Held for the length of a single git operation and dropped. Deliberately
+/// no `Clone`, and `Debug` redacts the secret: the secret is the whole
+/// value, and the fewer copies and formatters that can touch it, the better.
+pub(crate) struct GitCredential {
+    /// Login half of the HTTP basic pair — `x-access-token` for GitHub Apps.
+    pub username: String,
+    /// The repository-scoped installation token, dead within about an hour.
+    pub secret: String,
+}
+
+impl std::fmt::Debug for GitCredential {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GitCredential")
+            .field("username", &self.username)
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Why the gateway would not lend a git identity or credential.
+///
+/// The stable codes of the gateway's git-credential surface (gateway ADR
+/// 0083), plus the two local outcomes: a caller this process holds no live
+/// session for, and a gateway that could not be read. Each variant is phrased
+/// by its consumer — the repo-source probe words them as availability, a
+/// clone or push words them as the operation's failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GitForgeError {
+    /// The caller's machine-bound session is gone; they sign in again.
+    SignInRequired(String),
+    /// No forge with a mintable App identity is available to this caller.
+    NoGitForge,
+    /// More than one forge is available; the gateway refuses to pick.
+    AmbiguousGitForge,
+    /// The forge's identity is a person's own Connect, never lent to a
+    /// shared machine.
+    ConnectModeForge,
+    /// The forge has no approved GitHub App installation yet.
+    ForgeAppNotInstalled,
+    /// The App installation does not cover the requested repository.
+    RepositoryNotInstalled,
+    /// The gateway or the forge could not serve the request; retryable.
+    Unavailable(String),
+}
+
 /// Per-caller inference credentials for a gateway-authenticated deployment.
 ///
 /// Construct one per process with [`OboGateway::from_config`], record each
@@ -149,6 +237,15 @@ pub(crate) struct OboGateway {
     token_url: reqwest::Url,
     /// The member catalog a caller's exchanged capability reads.
     catalog_url: reqwest::Url,
+    /// The git-credential mint, presented with the machine-bound token
+    /// directly (decision 63).
+    git_credential_url: reqwest::Url,
+    /// The no-mint git-forge availability probe beside it.
+    git_forge_url: reqwest::Url,
+    /// This machine's `tidebreak:<sha256>` resource, named in every
+    /// git-credential request so the gateway verifies the token lives in
+    /// exactly this machine's resource.
+    resource: String,
     /// The normalized gateway base, stamped onto per-caller snapshots so
     /// their frozen model identities digest a stable deployment URL.
     gateway_base_url: String,
@@ -177,22 +274,37 @@ impl OboGateway {
         let Some(gateway_url) = config.auth_gateway_url.as_deref() else {
             return Ok(None);
         };
+        // The same requirement gateway authentication states at boot
+        // (decision 49): without the public URL there is no machine resource,
+        // and without the resource no git-credential request can name what
+        // the presented token must live in.
+        let Some(public_url) = config.public_url.as_deref() else {
+            return Err(AgentError::config(
+                "TIDEBREAK_PUBLIC_URL is required with TIDEBREAK_AUTH_GATEWAY_URL so user credentials can be bound to this exact machine",
+            ));
+        };
+        let resource = tidebreak_core::config::tidebreak_machine_resource(
+            &crate::auth::canonical_public_url(public_url)?,
+        );
         let base = config
             .auth_gateway_verifier_url
             .as_deref()
             .unwrap_or(gateway_url);
-        Ok(Some(Arc::new(Self::new(base)?)))
+        Ok(Some(Arc::new(Self::new(base, resource)?)))
     }
 
-    /// Build an exchange client against `base_url`.
+    /// Build an exchange client against `base_url`, acting as the machine
+    /// bound to `resource`.
     ///
     /// # Errors
     /// Fails when `base_url` is unparseable, carries credentials, a query, or
     /// a fragment, or is cleartext outside loopback development.
-    pub(crate) fn new(base_url: &str) -> Result<Self> {
+    pub(crate) fn new(base_url: &str, resource: String) -> Result<Self> {
         let base = normalized_gateway_base(base_url)?;
         let token_url = join_below(&base, "oauth/token")?;
         let catalog_url = join_below(&base, "api/v1/me/catalog")?;
+        let git_credential_url = join_below(&base, "api/v1/tidebreak/git-credential")?;
+        let git_forge_url = join_below(&base, "api/v1/tidebreak/git-forge")?;
         let gateway_base_url = base.as_str().trim_end_matches('/').to_owned();
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
@@ -204,6 +316,9 @@ impl OboGateway {
         Ok(Self {
             token_url,
             catalog_url,
+            git_credential_url,
+            git_forge_url,
+            resource,
             gateway_base_url,
             client,
             users: std::sync::Mutex::new(HashMap::new()),
@@ -238,6 +353,7 @@ impl OboGateway {
                         subject: std::sync::Mutex::new(bearer),
                         token: tokio::sync::Mutex::new(None),
                         catalog: tokio::sync::Mutex::new(None),
+                        git_forge: tokio::sync::Mutex::new(None),
                     }),
                 );
             }
@@ -508,6 +624,187 @@ impl OboGateway {
         })
     }
 
+    /// The forge identity this caller's git operations would act as, probed
+    /// from the gateway without minting anything (decision 63).
+    ///
+    /// Settled answers — an identity, or a named refusal like "no forge" —
+    /// are held fresh for [`GIT_FORGE_FRESH_SECONDS`], because the surfaces
+    /// that render them refetch far faster than deployments change. A dead
+    /// session and a transport failure are never held: the next read asks
+    /// again.
+    ///
+    /// # Errors
+    /// Fails when this process holds no live token for `owner`, when the
+    /// gateway names a refusal, and on transport failure.
+    pub(crate) async fn git_forge_identity(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<GitForgeIdentity, GitForgeError> {
+        let Some(slot) = self.slot_for(owner)? else {
+            return Err(GitForgeError::SignInRequired(
+                "this machine holds no live Model Gateway session for you; sign in again".into(),
+            ));
+        };
+        // Holding this across the probe is the single-flight gate, exactly
+        // like the inference token and the catalog.
+        let mut cached = slot.git_forge.lock().await;
+        let now = unix_time();
+        if let Some(held) = cached.as_ref() {
+            if now.saturating_sub(held.fetched_at_unix) < GIT_FORGE_FRESH_SECONDS {
+                return held.outcome.clone();
+            }
+        }
+        let subject = subject_of(&slot)?;
+        let outcome = self.fetch_git_forge(&subject).await;
+        match &outcome {
+            Ok(_)
+            | Err(
+                GitForgeError::NoGitForge
+                | GitForgeError::AmbiguousGitForge
+                | GitForgeError::ConnectModeForge
+                | GitForgeError::ForgeAppNotInstalled
+                | GitForgeError::RepositoryNotInstalled,
+            ) => {
+                *cached = Some(CachedGitForge {
+                    outcome: outcome.clone(),
+                    fetched_at_unix: now,
+                });
+            }
+            Err(GitForgeError::SignInRequired(_) | GitForgeError::Unavailable(_)) => {}
+        }
+        outcome
+    }
+
+    /// Borrow one repository-scoped forge credential for `owner`'s git
+    /// operation against `repository` (`owner/repo`), minted by the gateway
+    /// per request (decision 63).
+    ///
+    /// Deliberately no cache and no single-flight: each clone or push
+    /// borrows its own dying credential, which is the contract that keeps
+    /// nothing durable on this machine. The caller holds the result for the
+    /// length of the operation and drops it.
+    ///
+    /// # Errors
+    /// Fails when this process holds no live token for `owner`, when the
+    /// gateway names a refusal, and on transport failure.
+    pub(crate) async fn git_credential(
+        &self,
+        owner: &OwnerId,
+        repository: &str,
+    ) -> Result<GitCredential, GitForgeError> {
+        let Some(slot) = self.slot_for(owner)? else {
+            return Err(GitForgeError::SignInRequired(
+                "this machine holds no live Model Gateway session for you; sign in again".into(),
+            ));
+        };
+        let subject = subject_of(&slot)?;
+        let response = self
+            .client
+            .post(self.git_credential_url.clone())
+            .bearer_auth(subject.as_ref())
+            .json(&serde_json::json!({
+                "resource": self.resource,
+                "repository": repository,
+            }))
+            .send()
+            .await
+            .map_err(|error| {
+                GitForgeError::Unavailable(format!(
+                    "the Model Gateway git-credential request failed: {error}"
+                ))
+            })?;
+        let status = response.status();
+        let body = read_bounded(response, RESPONSE_LIMIT)
+            .await
+            .map_err(|error| GitForgeError::Unavailable(error.to_string()))?;
+        if !status.is_success() {
+            return Err(git_refusal(status, &body));
+        }
+        #[derive(serde::Deserialize)]
+        struct CredentialAnswer {
+            username: String,
+            secret: String,
+        }
+        let answer: CredentialAnswer = serde_json::from_slice(&body).map_err(|error| {
+            GitForgeError::Unavailable(format!(
+                "the Model Gateway returned an unreadable git credential: {error}"
+            ))
+        })?;
+        if answer.username.is_empty() || answer.secret.is_empty() {
+            return Err(GitForgeError::Unavailable(
+                "the Model Gateway returned an empty git credential".into(),
+            ));
+        }
+        Ok(GitCredential {
+            username: answer.username,
+            secret: answer.secret,
+        })
+    }
+
+    /// One probe of the gateway's git-forge surface with the caller's
+    /// machine-bound token.
+    async fn fetch_git_forge(&self, subject: &str) -> Result<GitForgeIdentity, GitForgeError> {
+        let response = self
+            .client
+            .get(self.git_forge_url.clone())
+            .query(&[("resource", self.resource.as_str())])
+            .bearer_auth(subject)
+            .send()
+            .await
+            .map_err(|error| {
+                GitForgeError::Unavailable(format!(
+                    "the Model Gateway git-forge probe failed: {error}"
+                ))
+            })?;
+        let status = response.status();
+        let body = read_bounded(response, RESPONSE_LIMIT)
+            .await
+            .map_err(|error| GitForgeError::Unavailable(error.to_string()))?;
+        if !status.is_success() {
+            return Err(git_refusal(status, &body));
+        }
+        #[derive(serde::Deserialize)]
+        struct GitForgeAnswer {
+            app_name: String,
+            #[serde(default)]
+            bot_login: Option<String>,
+        }
+        let answer: GitForgeAnswer = serde_json::from_slice(&body).map_err(|error| {
+            GitForgeError::Unavailable(format!(
+                "the Model Gateway returned an unreadable git-forge answer: {error}"
+            ))
+        })?;
+        Ok(GitForgeIdentity {
+            app_name: answer.app_name,
+            bot_login: answer.bot_login,
+        })
+    }
+
+    /// The recorded slot for `owner`, or `None` for a caller this process
+    /// has never authenticated.
+    fn slot_for(&self, owner: &OwnerId) -> Result<Option<Arc<UserSlot>>, GitForgeError> {
+        let users = self.users.lock().map_err(|_| {
+            GitForgeError::Unavailable(
+                "on-behalf-of gateway state is unavailable in this process".into(),
+            )
+        })?;
+        Ok(users.get(owner).cloned())
+    }
+
+    /// Force the next [`OboGateway::git_forge_identity`] to probe, from tests.
+    #[cfg(test)]
+    async fn expire_git_forge_for_test(&self, owner: &OwnerId) {
+        let slot = {
+            let users = self.users.lock().unwrap();
+            users.get(owner).cloned()
+        };
+        if let Some(slot) = slot {
+            if let Some(held) = slot.git_forge.lock().await.as_mut() {
+                held.fetched_at_unix = 0;
+            }
+        }
+    }
+
     /// Seed a caller's snapshot directly, for tests that need routes without
     /// a live fake gateway behind them.
     #[cfg(test)]
@@ -565,6 +862,174 @@ fn exchange_refusal(body: &[u8]) -> AgentError {
         _ => AgentError::msg(format!(
             "the Model Gateway refused the on-behalf-of token exchange: {detail}"
         )),
+    }
+}
+
+/// The newest machine-bound bearer recorded in `slot`.
+fn subject_of(slot: &UserSlot) -> Result<Arc<str>, GitForgeError> {
+    slot.subject
+        .lock()
+        .map(|subject| subject.clone())
+        .map_err(|_| {
+            GitForgeError::Unavailable(
+                "on-behalf-of gateway state is unavailable in this process".into(),
+            )
+        })
+}
+
+/// Turn a refused git-forge or git-credential response into its typed cause.
+///
+/// The gateway's stable codes map one to one; a response without a readable
+/// code falls back on the status — a bare 404 is a gateway too old to serve
+/// the surface, and a bare 401/403 is a dead session. A body that decodes to
+/// nothing recognizable is still a refusal, never a reason to keep going.
+fn git_refusal(status: reqwest::StatusCode, body: &[u8]) -> GitForgeError {
+    if let Ok(refusal) = serde_json::from_slice::<OAuthError>(body) {
+        let detail = refusal
+            .error_description
+            .clone()
+            .unwrap_or_else(|| refusal.error.clone());
+        match refusal.error.as_str() {
+            "no_git_forge" => return GitForgeError::NoGitForge,
+            "ambiguous_git_forge" => return GitForgeError::AmbiguousGitForge,
+            "connect_mode_forge" => return GitForgeError::ConnectModeForge,
+            "forge_app_not_installed" => return GitForgeError::ForgeAppNotInstalled,
+            "repository_not_installed" => return GitForgeError::RepositoryNotInstalled,
+            "forge_credential_mint_failed" => {
+                return GitForgeError::Unavailable(format!(
+                    "the deployment's git forge could not mint a credential: {detail}"
+                ));
+            }
+            _ => {
+                if status == reqwest::StatusCode::UNAUTHORIZED
+                    || status == reqwest::StatusCode::FORBIDDEN
+                {
+                    return GitForgeError::SignInRequired(format!(
+                        "the Model Gateway refused your session for git credentials: {detail}"
+                    ));
+                }
+                return GitForgeError::Unavailable(format!(
+                    "the Model Gateway refused the git-credential request: {detail}"
+                ));
+            }
+        }
+    }
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return GitForgeError::Unavailable(
+            "the Model Gateway does not serve git credentials; update the deployment".into(),
+        );
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return GitForgeError::SignInRequired(
+            "the Model Gateway refused your session for git credentials; sign in again".into(),
+        );
+    }
+    GitForgeError::Unavailable(format!(
+        "the Model Gateway git-credential request failed with status {status}"
+    ))
+}
+
+/// Per-caller git-forge lending, as code mode consumes it (decision 63).
+///
+/// A seam rather than a concrete handle so code-mode tests fake the
+/// gateway's answers without a live server behind them.
+#[async_trait]
+pub(crate) trait GitCredentialLender: Send + Sync {
+    /// The identity work would land as, or the named reason none is offered.
+    async fn git_forge_identity(&self, owner: &OwnerId) -> Result<GitForgeIdentity, GitForgeError>;
+
+    /// Borrow one repository-scoped credential for one git operation against
+    /// `repository` (`owner/repo`).
+    async fn git_credential(
+        &self,
+        owner: &OwnerId,
+        repository: &str,
+    ) -> Result<GitCredential, GitForgeError>;
+}
+
+#[async_trait]
+impl GitCredentialLender for OboGateway {
+    async fn git_forge_identity(&self, owner: &OwnerId) -> Result<GitForgeIdentity, GitForgeError> {
+        OboGateway::git_forge_identity(self, owner).await
+    }
+
+    async fn git_credential(
+        &self,
+        owner: &OwnerId,
+        repository: &str,
+    ) -> Result<GitCredential, GitForgeError> {
+        OboGateway::git_credential(self, owner, repository).await
+    }
+}
+
+/// Scripted git-forge lending for code-mode tests.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    /// A lender whose answers are set by the test: an identity (or refusal)
+    /// for the probe, an optional refusal for mints, and a record of every
+    /// repository a mint was asked for.
+    pub(crate) struct FakeLender {
+        pub(crate) identity: std::sync::Mutex<Result<GitForgeIdentity, GitForgeError>>,
+        pub(crate) mint_refusal: std::sync::Mutex<Option<GitForgeError>>,
+        pub(crate) minted: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl FakeLender {
+        /// A deployment whose forge serves this caller as `bot_login`.
+        pub(crate) fn offering(bot_login: &str) -> Self {
+            Self {
+                identity: std::sync::Mutex::new(Ok(GitForgeIdentity {
+                    app_name: "Acme Forge".to_owned(),
+                    bot_login: Some(bot_login.to_owned()),
+                })),
+                mint_refusal: std::sync::Mutex::new(None),
+                minted: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        /// A deployment whose gateway refuses both surfaces with `error`.
+        pub(crate) fn refusing(error: GitForgeError) -> Self {
+            Self {
+                identity: std::sync::Mutex::new(Err(error.clone())),
+                mint_refusal: std::sync::Mutex::new(Some(error)),
+                minted: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        /// Every repository a mint was asked for, in order.
+        pub(crate) fn minted(&self) -> Vec<String> {
+            self.minted.lock().expect("minted").clone()
+        }
+    }
+
+    #[async_trait]
+    impl GitCredentialLender for FakeLender {
+        async fn git_forge_identity(
+            &self,
+            _owner: &OwnerId,
+        ) -> Result<GitForgeIdentity, GitForgeError> {
+            self.identity.lock().expect("identity").clone()
+        }
+
+        async fn git_credential(
+            &self,
+            _owner: &OwnerId,
+            repository: &str,
+        ) -> Result<GitCredential, GitForgeError> {
+            self.minted
+                .lock()
+                .expect("minted")
+                .push(repository.to_owned());
+            match self.mint_refusal.lock().expect("mint refusal").clone() {
+                Some(error) => Err(error),
+                None => Ok(GitCredential {
+                    username: "x-access-token".to_owned(),
+                    secret: "ghs_fake_borrowed".to_owned(),
+                }),
+            }
+        }
     }
 }
 
@@ -696,6 +1161,13 @@ mod tests {
         catalog_reads: Arc<AtomicUsize>,
         /// The member catalog it serves, with a fixed `ETag` of `"fake-1"`.
         catalog: Arc<std::sync::Mutex<serde_json::Value>>,
+        /// How many git-forge probes it has served.
+        forge_probes: Arc<AtomicUsize>,
+        /// How many git credentials it has minted.
+        credential_mints: Arc<AtomicUsize>,
+        /// The `error` code the git surfaces refuse with, with its status, or
+        /// empty to succeed.
+        git_refusal: Arc<std::sync::Mutex<Option<(u16, String)>>>,
     }
 
     impl FakeGateway {
@@ -706,6 +1178,9 @@ mod tests {
                 refusal: Arc::new(std::sync::Mutex::new(String::new())),
                 latency: Duration::ZERO,
                 catalog_reads: Arc::new(AtomicUsize::new(0)),
+                forge_probes: Arc::new(AtomicUsize::new(0)),
+                credential_mints: Arc::new(AtomicUsize::new(0)),
+                git_refusal: Arc::new(std::sync::Mutex::new(None)),
                 catalog: Arc::new(std::sync::Mutex::new(serde_json::json!({
                     "models": [
                         {
@@ -848,15 +1323,121 @@ mod tests {
                     }
                 }),
             );
+            let forge_state = self.clone();
+            let app = app.route(
+                "/api/v1/tidebreak/git-forge",
+                axum::routing::get(
+                    move |headers: axum::http::HeaderMap,
+                          query: axum::extract::Query<HashMap<String, String>>| {
+                        let state = forge_state.clone();
+                        async move {
+                            // The probe rides the caller's machine-bound
+                            // token directly, never an exchanged capability,
+                            // and names this machine's exact resource.
+                            let bearer = machine_bound_bearer(&headers);
+                            assert!(
+                                bearer.starts_with("mg_at_"),
+                                "the probe must present the machine-bound subject, got {bearer:?}"
+                            );
+                            assert_eq!(
+                                query.get("resource").map(String::as_str),
+                                Some(TEST_RESOURCE)
+                            );
+                            state.forge_probes.fetch_add(1, Ordering::SeqCst);
+                            if let Some(refused) = state.next_git_refusal() {
+                                return refused;
+                            }
+                            Json(serde_json::json!({
+                                "app_id": "0193a1c0-0000-7000-8000-000000000001",
+                                "app_name": "Acme Forge",
+                                "bot_login": "acme-ship[bot]",
+                            }))
+                            .into_response()
+                        }
+                    },
+                ),
+            );
+            let credential_state = self.clone();
+            let app = app.route(
+                "/api/v1/tidebreak/git-credential",
+                axum::routing::post(
+                    move |headers: axum::http::HeaderMap, Json(body): Json<serde_json::Value>| {
+                        let state = credential_state.clone();
+                        async move {
+                            let bearer = machine_bound_bearer(&headers);
+                            assert!(
+                                bearer.starts_with("mg_at_"),
+                                "the mint must present the machine-bound subject, got {bearer:?}"
+                            );
+                            assert_eq!(body["resource"], TEST_RESOURCE);
+                            let repository =
+                                body["repository"].as_str().unwrap_or_default().to_owned();
+                            assert!(
+                                repository.split('/').count() == 2,
+                                "the mint must name owner/repo, got {repository:?}"
+                            );
+                            state.credential_mints.fetch_add(1, Ordering::SeqCst);
+                            if let Some(refused) = state.next_git_refusal() {
+                                return refused;
+                            }
+                            let serial = state.credential_mints.load(Ordering::SeqCst);
+                            Json(serde_json::json!({
+                                "username": "x-access-token",
+                                "secret": format!("ghs_fake_{serial}_for_{repository}"),
+                                "expires_at": "2027-01-01T00:00:00Z",
+                                "app_id": "0193a1c0-0000-7000-8000-000000000001",
+                            }))
+                            .into_response()
+                        }
+                    },
+                ),
+            );
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
             let address = listener.local_addr().unwrap();
             let server = tokio::spawn(async move {
                 axum::serve(listener, app).await.unwrap();
             });
-            let inference = Arc::new(OboGateway::new(&format!("http://{address}")).unwrap());
+            let inference = Arc::new(
+                OboGateway::new(&format!("http://{address}"), TEST_RESOURCE.to_owned()).unwrap(),
+            );
             (inference, server)
         }
+
+        /// The configured git refusal as a ready response, or `None`.
+        fn next_git_refusal(&self) -> Option<axum::response::Response> {
+            let held = self
+                .git_refusal
+                .lock()
+                .map(|refusal| refusal.clone())
+                .unwrap_or_default()?;
+            let (status, code) = held;
+            Some(
+                (
+                    axum::http::StatusCode::from_u16(status)
+                        .unwrap_or(axum::http::StatusCode::BAD_REQUEST),
+                    Json(serde_json::json!({
+                        "error": code,
+                        "error_description": "the fake gateway refused",
+                    })),
+                )
+                    .into_response(),
+            )
+        }
     }
+
+    /// The bearer half of an Authorization header.
+    fn machine_bound_bearer(headers: &axum::http::HeaderMap) -> String {
+        headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .unwrap_or_default()
+            .to_owned()
+    }
+
+    /// The machine resource every git request must name.
+    const TEST_RESOURCE: &str =
+        "tidebreak:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed";
 
     use axum::response::IntoResponse as _;
 
@@ -1106,8 +1687,19 @@ mod tests {
         );
 
         config.auth_gateway_url = Some("https://gateway.example".to_owned());
+        assert!(
+            OboGateway::from_config(&config).is_err(),
+            "a gateway deployment without a public URL cannot name its machine resource"
+        );
+
+        config.public_url = Some("https://machine.example".to_owned());
         let inference = OboGateway::from_config(&config).unwrap().unwrap();
         assert_eq!(inference.gateway_base_url(), "https://gateway.example");
+        assert_eq!(
+            inference.resource,
+            tidebreak_core::config::tidebreak_machine_resource("https://machine.example"),
+            "the git-credential resource is the machine's own"
+        );
     }
 
     /// The exchange is a server-to-server call, so it honors the same
@@ -1119,6 +1711,7 @@ mod tests {
         config.profile = Profile::SelfHost;
         config.auth_gateway_url = Some("https://public.example".to_owned());
         config.auth_gateway_verifier_url = Some("https://gateway.internal".to_owned());
+        config.public_url = Some("https://machine.example".to_owned());
 
         let inference = OboGateway::from_config(&config).unwrap().unwrap();
         assert_eq!(
@@ -1131,10 +1724,15 @@ mod tests {
     /// A gateway deployed under a subpath keeps its prefix.
     #[test]
     fn a_subpath_deployment_keeps_its_prefix() {
-        let inference = OboGateway::new("https://example.test/gateway").unwrap();
+        let inference =
+            OboGateway::new("https://example.test/gateway", TEST_RESOURCE.to_owned()).unwrap();
         assert_eq!(
             inference.token_url.as_str(),
             "https://example.test/gateway/oauth/token"
+        );
+        assert_eq!(
+            inference.git_credential_url.as_str(),
+            "https://example.test/gateway/api/v1/tidebreak/git-credential"
         );
         assert_eq!(inference.gateway_base_url(), "https://example.test/gateway");
     }
@@ -1143,10 +1741,11 @@ mod tests {
     /// assembly, not at the first turn.
     #[test]
     fn an_unusable_gateway_url_is_refused_at_assembly() {
-        assert!(OboGateway::new("https://user:pass@example.test").is_err());
-        assert!(OboGateway::new("https://example.test?probe=1").is_err());
-        assert!(OboGateway::new("http://gateway.example").is_err());
-        assert!(OboGateway::new("http://127.0.0.1:8080").is_ok());
+        let resource = || TEST_RESOURCE.to_owned();
+        assert!(OboGateway::new("https://user:pass@example.test", resource()).is_err());
+        assert!(OboGateway::new("https://example.test?probe=1", resource()).is_err());
+        assert!(OboGateway::new("http://gateway.example", resource()).is_err());
+        assert!(OboGateway::new("http://127.0.0.1:8080", resource()).is_ok());
     }
 
     /// Decision 62's happy path: a recorded caller's snapshot is their own
@@ -1255,6 +1854,121 @@ mod tests {
             2,
             "each caller fetches their own catalog"
         );
+        server.abort();
+    }
+
+    /// Decision 63's happy path: a recorded caller borrows a
+    /// repository-scoped credential, minted per operation — two borrows are
+    /// two mints, because nothing durable is held.
+    #[tokio::test]
+    async fn a_caller_borrows_a_dying_credential_per_operation() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        obo.record_caller(&alice, "mg_at_alice".into());
+
+        let first = obo.git_credential(&alice, "acme/demo").await.unwrap();
+        assert_eq!(first.username, "x-access-token");
+        assert!(first.secret.ends_with("for_acme/demo"));
+        let second = obo.git_credential(&alice, "acme/demo").await.unwrap();
+        assert_ne!(first.secret, second.secret, "each operation borrows anew");
+        assert_eq!(gateway.credential_mints.load(Ordering::SeqCst), 2);
+        assert_eq!(gateway.served(), 0, "no exchange is involved");
+        server.abort();
+    }
+
+    /// The probe names the forge identity for the UI and stays fresh across
+    /// the rapid refetches its surfaces make.
+    #[tokio::test]
+    async fn the_probe_names_the_forge_identity_and_holds_it_fresh() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        obo.record_caller(&alice, "mg_at_alice".into());
+
+        let identity = obo.git_forge_identity(&alice).await.unwrap();
+        assert_eq!(identity.app_name, "Acme Forge");
+        assert_eq!(identity.bot_login.as_deref(), Some("acme-ship[bot]"));
+        obo.git_forge_identity(&alice).await.unwrap();
+        assert_eq!(
+            gateway.forge_probes.load(Ordering::SeqCst),
+            1,
+            "a fresh identity must not re-probe"
+        );
+
+        obo.expire_git_forge_for_test(&alice).await;
+        obo.git_forge_identity(&alice).await.unwrap();
+        assert_eq!(gateway.forge_probes.load(Ordering::SeqCst), 2);
+        server.abort();
+    }
+
+    /// The gateway's stable refusal codes arrive typed, and a settled refusal
+    /// is held like a settled identity — "not offered" is the common case and
+    /// must not turn every render into gateway traffic.
+    #[tokio::test]
+    async fn a_named_git_refusal_is_typed_and_held() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        obo.record_caller(&alice, "mg_at_alice".into());
+
+        *gateway.git_refusal.lock().unwrap() = Some((404, "no_git_forge".to_owned()));
+        assert_eq!(
+            obo.git_forge_identity(&alice).await.unwrap_err(),
+            GitForgeError::NoGitForge
+        );
+        assert_eq!(
+            obo.git_forge_identity(&alice).await.unwrap_err(),
+            GitForgeError::NoGitForge
+        );
+        assert_eq!(
+            gateway.forge_probes.load(Ordering::SeqCst),
+            1,
+            "a settled refusal must not re-probe"
+        );
+
+        *gateway.git_refusal.lock().unwrap() = Some((403, "connect_mode_forge".to_owned()));
+        obo.expire_git_forge_for_test(&alice).await;
+        assert_eq!(
+            obo.git_forge_identity(&alice).await.unwrap_err(),
+            GitForgeError::ConnectModeForge
+        );
+
+        *gateway.git_refusal.lock().unwrap() = Some((422, "repository_not_installed".to_owned()));
+        assert_eq!(
+            obo.git_credential(&alice, "acme/demo").await.unwrap_err(),
+            GitForgeError::RepositoryNotInstalled
+        );
+        server.abort();
+    }
+
+    /// A dead session is sign-in-required on the git surfaces too, and a
+    /// caller this process never authenticated borrows nothing.
+    #[tokio::test]
+    async fn git_credentials_fail_closed_without_a_live_session() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        obo.record_caller(&alice, "mg_at_alice".into());
+
+        *gateway.git_refusal.lock().unwrap() = Some((401, "invalid_token".to_owned()));
+        assert!(matches!(
+            obo.git_credential(&alice, "acme/demo").await.unwrap_err(),
+            GitForgeError::SignInRequired(_)
+        ));
+
+        let stranger = owner("user:stranger");
+        assert!(matches!(
+            obo.git_credential(&stranger, "acme/demo")
+                .await
+                .unwrap_err(),
+            GitForgeError::SignInRequired(_)
+        ));
+        assert!(matches!(
+            obo.git_forge_identity(&stranger).await.unwrap_err(),
+            GitForgeError::SignInRequired(_)
+        ));
+        assert_eq!(gateway.credential_mints.load(Ordering::SeqCst), 1);
         server.abort();
     }
 }

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -183,6 +183,7 @@ fn pr_snapshot(
         gh_found: status.gh_found,
         gh_authenticated: status.gh_authenticated,
         remediation: status.remediation,
+        pushes_as: status.pushes_as,
         watch: watch.map(CodeWatchSnapshot::from),
     }
 }

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -553,6 +553,12 @@ pub struct CodeWorkspacePrSnapshot {
     #[ts(optional)]
     pub gh_authenticated: Option<bool>,
     pub remediation: String,
+    /// The identity a push from this machine acts as, when it is not the
+    /// caller: the deployment's GitHub App bot account (decision 63). The UI
+    /// states this plainly beside the push control.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub pushes_as: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub watch: Option<CodeWatchSnapshot>,

--- a/crates/tidebreak-server/src/tests/code_clone.rs
+++ b/crates/tidebreak-server/src/tests/code_clone.rs
@@ -15,20 +15,30 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 use crate::code::CodeRuntime;
+use crate::obo_gateway::test_support::FakeLender;
+use crate::obo_gateway::{GitCredentialLender, GitForgeError};
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_harness::AdapterRegistry;
 
 async fn code_app() -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    code_app_with(None).await
+}
+
+/// The clone app, optionally on a "hosted machine" that lends gateway git
+/// credentials (decision 63).
+async fn code_app_with(
+    lender: Option<Arc<dyn GitCredentialLender>>,
+) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
     let (dir, store) = temp_db_store("code-clone.db").await;
     let db = Arc::new(store);
     let store_trait: Arc<dyn Store> = db.clone();
     let mut registry = AdapterRegistry::new();
     registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
-    let runtime = Arc::new(CodeRuntime::with_registry(
-        db,
-        dir.path().to_path_buf(),
-        registry,
-    ));
+    let mut runtime = CodeRuntime::with_registry(db, dir.path().to_path_buf(), registry);
+    if let Some(lender) = lender {
+        runtime = runtime.with_git_credentials(lender);
+    }
+    let runtime = Arc::new(runtime);
     let mut state = AppState::new(
         Config::desktop(dir.path()),
         store_trait,
@@ -444,4 +454,94 @@ async fn a_machine_that_remembers_a_destination_clones_without_being_given_one()
         parent.join("second").exists(),
         "the clone lands under the remembered destination"
     );
+}
+
+async fn fetch_sources(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    token: &str,
+) -> serde_json::Value {
+    client
+        .get(format!("http://{addr}/code/repos/sources"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+fn source<'a>(sources: &'a serde_json::Value, kind: &str) -> &'a serde_json::Value {
+    sources["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|source| source["kind"] == kind)
+        .expect(kind)
+}
+
+/// Decision 63: on a hosted machine the `github` source reflects the
+/// gateway's per-caller answer. An offered forge carries the attribution
+/// sentence; a deployment with no forge reads as "not offered, because…",
+/// never as an error.
+#[tokio::test]
+async fn a_hosted_machine_offers_github_per_caller_from_the_gateway() {
+    let lender = Arc::new(FakeLender::offering("acme-ship[bot]"));
+    let (router, token, _runtime, _dir) =
+        code_app_with(Some(lender as Arc<dyn GitCredentialLender>)).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+
+    let sources = fetch_sources(&client, addr, &token).await;
+    let github = source(&sources, "github");
+    assert_eq!(github["available"], true);
+    let hint = github["remediation"].as_str().unwrap();
+    assert!(hint.contains("acme-ship[bot]"), "{hint}");
+    assert!(hint.contains("not as your GitHub account"), "{hint}");
+    // Local registration and plain git URLs stay offered as before.
+    assert_eq!(source(&sources, "local")["available"], true);
+    assert_eq!(source(&sources, "git_url")["available"], true);
+
+    let refused = Arc::new(FakeLender::refusing(GitForgeError::NoGitForge));
+    let (router, token, _runtime, _dir) =
+        code_app_with(Some(refused as Arc<dyn GitCredentialLender>)).await;
+    let addr = serve(router).await;
+    let sources = fetch_sources(&client, addr, &token).await;
+    let github = source(&sources, "github");
+    assert_eq!(github["available"], false);
+    let reason = github["remediation"].as_str().unwrap();
+    assert!(reason.contains("no git forge"), "{reason}");
+}
+
+/// Decision 63 rule 4: a clone the gateway refuses fails with the gateway's
+/// reason — before any network is touched — and the mint was asked for
+/// exactly the repository the caller named.
+#[tokio::test]
+async fn a_hosted_clone_fails_closed_with_the_gateway_refusal() {
+    let lender = Arc::new(FakeLender::refusing(GitForgeError::RepositoryNotInstalled));
+    let (router, token, _runtime, dir) =
+        code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let parent = dir.path().join("checkouts");
+    std::fs::create_dir_all(&parent).unwrap();
+
+    let started = client
+        .post(format!("http://{addr}/code/repos/clone"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "github": "acme/private",
+            "parent_dir": parent,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(started.status(), reqwest::StatusCode::ACCEPTED);
+    let job: serde_json::Value = started.json().await.unwrap();
+    let finished = wait_job(&client, addr, &token, job["id"].as_str().unwrap()).await;
+    assert_eq!(finished["done"], true, "{finished}");
+    let error = finished["error"].as_str().expect("the clone fails");
+    assert!(error.contains("does not cover"), "{error}");
+    assert_eq!(lender.minted(), vec!["acme/private".to_owned()]);
 }

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -10,21 +10,31 @@ use axum::Router;
 use tokio::net::TcpListener;
 
 use crate::code::CodeRuntime;
+use crate::obo_gateway::test_support::FakeLender;
+use crate::obo_gateway::{GitCredentialLender, GitForgeError};
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{QuickAction, RepoId};
 use tidebreak_harness::AdapterRegistry;
 
 async fn code_app() -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    code_app_with(None).await
+}
+
+/// The git app, optionally on a "hosted machine" that lends gateway git
+/// credentials (decision 63).
+async fn code_app_with(
+    lender: Option<Arc<dyn GitCredentialLender>>,
+) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
     let (dir, store) = temp_db_store("code-git.db").await;
     let db = Arc::new(store);
     let store_trait: Arc<dyn Store> = db.clone();
     let mut registry = AdapterRegistry::new();
     registry.register(Arc::new(ScriptedAdapter::new(plain_text_script())));
-    let runtime = Arc::new(CodeRuntime::with_registry(
-        db,
-        dir.path().to_path_buf(),
-        registry,
-    ));
+    let mut runtime = CodeRuntime::with_registry(db, dir.path().to_path_buf(), registry);
+    if let Some(lender) = lender {
+        runtime = runtime.with_git_credentials(lender);
+    }
+    let runtime = Arc::new(runtime);
     let mut state = AppState::new(
         Config::desktop(dir.path()),
         store_trait,
@@ -438,4 +448,90 @@ async fn auto_run_on_create_runs_after_setup() {
     let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
     let stamped = std::fs::read_to_string(path.join("stamp.txt")).unwrap();
     assert_eq!(stamped, "auto\n");
+}
+
+/// Decision 63: a hosted machine's push borrows nothing for a local origin
+/// and keeps working exactly as before; the git card names the acting App
+/// identity only once the checkout's origin is a forge repository; and a
+/// gateway refusal fails the push with its reason before git runs.
+#[tokio::test]
+async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
+    let lender = Arc::new(FakeLender::offering("acme-ship[bot]"));
+    let (router, token, _runtime, dir) =
+        code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "hosted change").await;
+    let id = json_id(&workspace);
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    // A local bare origin is not a forge repository: nothing is borrowed and
+    // the push lands exactly as it always has.
+    std::fs::write(path.join("extra.txt"), "line\n").unwrap();
+    let committed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(committed.status(), reqwest::StatusCode::OK);
+    let pushed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/push"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(pushed.status(), reqwest::StatusCode::OK);
+    assert!(
+        lender.minted().is_empty(),
+        "a local origin must borrow nothing"
+    );
+
+    // The identity line follows the origin: absent for the local origin,
+    // present once the checkout points at a forge repository.
+    let status = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = status.json().await.unwrap();
+    assert!(body["pushes_as"].is_null(), "{body}");
+
+    run(
+        &path,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/acme/demo.git",
+        ],
+    );
+    let status = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = status.json().await.unwrap();
+    assert_eq!(body["pushes_as"], "acme-ship[bot]", "{body}");
+
+    // A refusal stops the push with the gateway's reason before git runs —
+    // nothing reaches the network in this test.
+    *lender.mint_refusal.lock().unwrap() = Some(GitForgeError::NoGitForge);
+    let refused = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/push"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(refused).await;
+    assert_eq!(status, reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(kind, "git_forge_refused");
+    assert!(message.contains("no git forge"), "{message}");
+    assert_eq!(lender.minted(), vec!["acme/demo".to_owned()]);
 }

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -520,6 +520,42 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
     let body: serde_json::Value = status.json().await.unwrap();
     assert_eq!(body["pushes_as"], "acme-ship[bot]", "{body}");
 
+    // A rewritten origin on a foreign host — the exact move an agent in the
+    // workspace could make — is outside the lending: no identity is claimed
+    // and, through the same gate, no credential would be borrowed.
+    run(
+        &path,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://evil.example/acme/private.git",
+        ],
+    );
+    let status = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = status.json().await.unwrap();
+    assert!(body["pushes_as"].is_null(), "{body}");
+    assert!(
+        lender.minted().is_empty(),
+        "a foreign host must never reach the gateway"
+    );
+    run(
+        &path,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/acme/demo.git",
+        ],
+    );
+
     // A refusal stops the push with the gateway's reason before git runs —
     // nothing reaches the network in this test.
     *lender.mint_refusal.lock().unwrap() = Some(GitForgeError::NoGitForge);

--- a/crates/tidebreak-server/src/tests/configuration.rs
+++ b/crates/tidebreak-server/src/tests/configuration.rs
@@ -6076,8 +6076,13 @@ async fn a_cached_provider_is_never_shared_between_callers() {
 
     let dir = tempfile::tempdir().unwrap();
     let (store, secrets) = empty_deployment(&dir).await;
-    let gateway_obo =
-        Arc::new(crate::obo_gateway::OboGateway::new("https://gateway.example").unwrap());
+    let gateway_obo = Arc::new(
+        crate::obo_gateway::OboGateway::new(
+            "https://gateway.example",
+            "tidebreak:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed".to_owned(),
+        )
+        .unwrap(),
+    );
     let alice = tidebreak_core::OwnerId::new("user:alice").unwrap();
     let bob = tidebreak_core::OwnerId::new("user:bob").unwrap();
     gateway_obo.record_caller(&alice, "mg_at_alice".into());

--- a/docs/decisions/0063-hosted-machines-borrow-forge-credentials.md
+++ b/docs/decisions/0063-hosted-machines-borrow-forge-credentials.md
@@ -42,6 +42,14 @@ is `installation_only` cannot attribute it to the person.
    list, so no configured helper can answer ahead of the borrowed credential
    or store it when git offers it back.
 
+   The credential is confined to the forge's own host, twice over. The
+   machine lends only for an origin whose host is the forge's — the origin
+   URL is workspace state an agent can rewrite, and without the gate the
+   next push would offer a live token to whatever host `origin` names. And
+   the helper itself answers `get` only for `https` and that exact host, so
+   a rewrite or a redirect that slips past the first check still collects
+   nothing.
+
 2. **The repo-source probe answers per caller, from the gateway.** On a
    hosted machine the `github` source stops consulting `gh` — there is none —
    and reflects the gateway's probe for the requesting caller:
@@ -63,9 +71,9 @@ is `installation_only` cannot attribute it to the person.
    refusal — no forge, a repository outside the installation, a dead session
    — fails the clone or push with that reason rather than retrying without a
    credential. An uncredentialed retry would fail with a worse message and
-   blur which identity acted. A checkout whose origin is not a forge
-   repository at all — a local path, a bare test origin — borrows nothing
-   and pushes exactly as it does today.
+   blur which identity acted. A checkout whose origin is not a lendable
+   forge repository — a local path, a bare test origin, any host but the
+   forge's — borrows nothing and pushes exactly as it does today.
 
 5. **Nothing else changes.** Static-token self-host machines and desktops
    never build the lender, so every existing git and `gh` path is untouched.

--- a/docs/decisions/0063-hosted-machines-borrow-forge-credentials.md
+++ b/docs/decisions/0063-hosted-machines-borrow-forge-credentials.md
@@ -1,0 +1,101 @@
+# 63. Hosted machines borrow repository-scoped forge credentials
+
+- Status: Proposed
+- Date: 2026-08-23
+- Owners: server, desktop
+- Related: [`0034-harness-discovery-credentials.md`](0034-harness-discovery-credentials.md),
+  [`0049-gateway-authenticated-hosted-machines.md`](0049-gateway-authenticated-hosted-machines.md),
+  [`0062-per-caller-gateway-entitlements.md`](0062-per-caller-gateway-entitlements.md),
+  [`../gateway-boundary.md`](../gateway-boundary.md)
+
+## Context
+
+A hosted machine has no GitHub identity. Decision 34's posture — credentials
+are observed, never brokered — is right for a machine on someone's desk,
+where the person's own `gh` and git configuration answer every question. On a
+shared hosted machine there is nothing to observe: no `gh`, no credential
+helper, no person at the keyboard. A team cannot clone its private
+repositories, and the repo-source probe honestly reports a GitHub source that
+only reaches public repositories.
+
+The deployment's gateway can already hold the right identity. A git-forge
+connected app in `github_app_installation` mode stores a GitHub App and mints
+hour-long installation tokens with no standing secret, and gateway ADR 0083
+gives hosted machines two surfaces over it, both authenticated with the
+caller's live machine-bound token: `POST /api/v1/tidebreak/git-credential`
+mints a token scoped to one named repository, and
+`GET /api/v1/tidebreak/git-forge` answers availability and the App's identity
+without minting. Work done this way lands as the App's bot account — that is
+installation mode's documented posture, and a deployment whose forge policy
+is `installation_only` cannot attribute it to the person.
+
+## Decision
+
+1. **Each git operation borrows a dying credential.** On a
+   gateway-authenticated hosted machine, a GitHub clone and a workspace push
+   each present the caller's machine-bound token to the gateway and receive
+   an installation token scoped to the one repository the operation touches.
+   The credential lives in process memory for the length of that operation,
+   travels to git through the environment into a one-shot credential helper,
+   and is never written to the store, the checkout's configuration, or the
+   persisted clone URL. The helper configuration first empties git's helper
+   list, so no configured helper can answer ahead of the borrowed credential
+   or store it when git offers it back.
+
+2. **The repo-source probe answers per caller, from the gateway.** On a
+   hosted machine the `github` source stops consulting `gh` — there is none —
+   and reflects the gateway's probe for the requesting caller:
+   offered when an entitled installation-mode forge would serve them, and
+   otherwise hidden with the gateway's own reason. A deployment with no
+   forge, a person-bound (Connect-mode) forge, an uninstalled forge app, and
+   an ambiguous pair each read as "not offered, because…", never as an error.
+   Local machines keep decision 34's observation exactly as it was.
+
+3. **The UI says whose identity acts.** The add-repository dialog's GitHub
+   source carries the attribution sentence — work lands as the App's bot
+   account, not the person — and the workspace git card names the acting
+   identity (`pushes_as`) beside the push control. Legibility is the
+   product's half of installation mode's bargain: the gateway audits every
+   mint to the caller, and the machine states on screen that authorship
+   belongs to the App.
+
+4. **Refusals fail the operation, with the gateway's reason.** A mint
+   refusal — no forge, a repository outside the installation, a dead session
+   — fails the clone or push with that reason rather than retrying without a
+   credential. An uncredentialed retry would fail with a worse message and
+   blur which identity acted. A checkout whose origin is not a forge
+   repository at all — a local path, a bare test origin — borrows nothing
+   and pushes exactly as it does today.
+
+5. **Nothing else changes.** Static-token self-host machines and desktops
+   never build the lender, so every existing git and `gh` path is untouched.
+   Pull-request creation and the delivery reads still ride `gh` and remain
+   unavailable on hosted machines; they are the next slice, not this one.
+
+## Rejected
+
+- **Storing a GitHub credential on the machine.** A standing secret the
+  gateway cannot revoke or audit, acting as one identity for every member.
+  Rejected by the gateway's ADR 0083 and by decision 34's posture here.
+- **Lending a person's Connect-mode identity to the machine.** Work would
+  land as a person who never acted from their own device. The gateway
+  refuses this mode by name; the deployment registers a second,
+  installation-mode forge app instead.
+- **Probing availability by minting against a sentinel repository.** Costs a
+  forge round-trip per probe and can mint a real credential when the
+  sentinel exists. The gateway answers availability from storage; the
+  machine asks that surface.
+- **Caching borrowed credentials to expiry.** One fewer mint per hour per
+  repository, but an hour-long secret held in memory beside every workspace,
+  for operations that happen seconds apart at most. Minting per operation
+  keeps the holding window as short as the operation itself.
+
+## Revisit when
+
+- Hosted machines need pull-request creation and delivery reads; those need
+  a REST path driven by the same borrowed credential, not `gh`.
+- The harness agent's own `git push` inside a workspace should work on
+  hosted machines; that needs a credential-helper seam into agent-run git,
+  which shell policy currently denies by design.
+- A deployment registers two forges and the gateway grows its explicit
+  selector; the machine's requests would then need to name one.


### PR DESCRIPTION
Closes #2510.

## Problem

A hosted machine has no GitHub identity. The only GitHub authentication is observing the server's `gh` CLI (decision 34), and a hosted machine has no `gh` and no person at the keyboard — so a team cannot clone its private repositories, and every member acts as nobody.

## What this does (decision 63)

The deployment's gateway already holds the right identity: a git-forge connected app in `github_app_installation` mode mints hour-long, repository-scoped installation tokens (gateway ADR 0083, model-gateway#1281 + model-gateway#1294 for the no-mint probe).

- **Per-operation borrow.** A GitHub clone and a workspace push each present the caller's live machine-bound token to `POST /api/v1/tidebreak/git-credential` and receive a token scoped to the one repository the operation touches. Minted per request, held in memory for the operation, never written to the store, the checkout's config, or the persisted clone URL.
- **Injection without storage.** The credential rides the environment into a one-shot `credential.helper`; the helper list is emptied first, so no configured helper answers ahead of it — or stores the dying token when git offers it back. A real `git credential fill` test pins the helper.
- **Per-caller repo sources.** On hosted machines the `github` source stops consulting `gh` and reflects the gateway's probe for the requesting caller: offered with the attribution sentence, or hidden with the gateway's reason (`no_git_forge` → "not offered", connect-mode → "register an installation-mode forge", etc.). Local machines keep the existing observation path bit for bit.
- **Legible attribution.** The add-repo dialog's GitHub source states that work lands as the App's bot account, and the workspace git card names the acting identity (`pushes_as`) beside the push control — new PrCard story and DOM tests.
- **Fail closed, no blur.** A gateway refusal fails the clone/push with the gateway's reason rather than retrying uncredentialed. Checkouts whose origin is not a forge repository (local bare origins) borrow nothing and push exactly as before — pinned by test.

## Tests

- `obo_gateway`: borrow-per-operation (two borrows are two mints), probe freshness + typed refusal caching, fail-closed on dead sessions and unknown callers, machine-bound bearer + resource asserted server-side in the fake gateway.
- `code_clone`: per-caller sources on hosted machines (offered with attribution / refused with reason), and a refused clone fails with the gateway's reason before any network.
- `code_git`: a local-origin push borrows nothing and keeps working; `pushes_as` follows the origin; a refusal stops the push with `git_forge_refused`.
- `gh`: the one-shot helper answers `git credential fill` from the environment.
- UI: PrCard DOM tests + story (`HostedPushesAsApp`), parser coverage; storybook build passes.

Decision record: `docs/decisions/0063-hosted-machines-borrow-forge-credentials.md`. PR creation and delivery reads still ride `gh` and stay unavailable on hosted machines — named as the next slice in the decision's revisit-when.