### PR TITLE
feat(code): park idle engine children and spawn them on the first turn

### DIFF
--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -775,6 +775,14 @@ impl HarnessSession for ClaudeSession {
         self.unrecognized.load(Ordering::SeqCst)
     }
 
+    /// Release the idle child (decision 0064). The next turn takes the
+    /// respawn path [`Self::ensure_channel`] already owns, so it resumes the
+    /// engine session exactly like a dead-child replacement.
+    async fn park(&self) -> Result<(), HarnessError> {
+        self.retire_channel().await;
+        Ok(())
+    }
+
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
         let taken = self.channel.lock().await.take();
         if let Some(channel) = taken {
@@ -1708,6 +1716,51 @@ exit 0
                 .count(),
             2,
             "both turns completed"
+        );
+    }
+
+    /// Decision 0064: parking releases the idle child, and the wake turn
+    /// takes the same respawn-and-resume path a dead child does.
+    #[tokio::test]
+    async fn a_parked_child_is_respawned_and_resumed_on_the_next_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let argv_log = dir.path().join("argv.log");
+        let binary = write_engine(
+            dir.path(),
+            &format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> {argv_log}
+while IFS= read -r line; do
+  printf '{{"type":"system","subtype":"init","session_id":"sess-9","claude_code_version":"2.1.238"}}\n'
+  printf '{{"type":"result","subtype":"success","is_error":false,"terminal_reason":"completed","session_id":"sess-9","usage":{{"input_tokens":1,"output_tokens":1}}}}\n'
+done
+"#,
+                argv_log = argv_log.display()
+            ),
+        );
+        let session = session_with(binary, dir.path(), Arc::new(Discard));
+
+        assert!(matches!(
+            session.run_turn(turn("one")).await.unwrap(),
+            TurnOutcome::Clean
+        ));
+        let parked_pid = session.child_pid().expect("the child outlives its turn");
+
+        session.park().await.unwrap();
+        assert_eq!(session.child_pid(), None, "the parked child is gone");
+
+        assert!(matches!(
+            session.run_turn(turn("two")).await.unwrap(),
+            TurnOutcome::Clean
+        ));
+        let woken_pid = session.child_pid().expect("the wake turn spawned a child");
+        assert_ne!(parked_pid, woken_pid, "a new process answered the wake");
+        let launches = read_lines(&argv_log);
+        assert_eq!(launches.len(), 2, "the wake respawns: {launches:?}");
+        assert!(
+            launches[1].contains("--resume sess-9"),
+            "the replacement resumes the session: {}",
+            launches[1]
         );
     }
 }

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -19,7 +19,7 @@ use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use crate::codex::session::attach;
+use crate::codex::session::CodexSession;
 use crate::probe::{observe_version, probe_shell, HostEnv};
 use crate::{
     filter_child_env, spawn_process_tree, HarnessAdapter, HarnessError, HarnessProbe,
@@ -114,7 +114,9 @@ impl HarnessAdapter for CodexAdapter {
         if !spec.binary.is_absolute() {
             return Err(HarnessError::NotFound);
         }
-        Ok(Box::new(attach(spec).await?))
+        // The app-server child spawns on the first turn, not here (decision
+        // 0064), so attaching a session costs no engine runtime.
+        Ok(Box::new(CodexSession::new(spec)))
     }
 }
 

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -2015,7 +2015,7 @@ done
             "FAKE_CODEX_STEER".into(),
             dir.path().join("steer.json").to_string_lossy().into_owned(),
         ));
-        let session = Arc::new(attach(spec).await.unwrap());
+        let session = Arc::new(CodexSession::new(spec));
         let running = tokio::spawn({
             let session = Arc::clone(&session);
             async move {

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -35,7 +35,8 @@ const MAX_STDERR_BYTES: usize = 64 * 1_024;
 /// takes the latter.
 const FAST_SERVICE_TIER: &str = "priority";
 
-/// Live Codex session: one app-server child for the session lifetime.
+/// Live Codex session: one app-server child, spawned on the first turn and
+/// replaced whenever a turn finds it parked or dead (decision 0064).
 pub struct CodexSession {
     spec: SessionSpec,
     /// The session's current permission mode. `turn/start` re-postures a
@@ -43,8 +44,9 @@ pub struct CodexSession {
     /// rides out on the next turn rather than relaunching the child.
     permission_mode: Mutex<PermissionMode>,
     /// Whether the mode has moved since the last turn told the engine about
-    /// it. The first turn on a fresh thread does not need to: `thread/start`
-    /// already carried the posture.
+    /// it. [`Self::handshake`] settles it per child: a started thread was
+    /// just told its posture, while a resumed thread carries whatever it was
+    /// last told and gets a restatement on the next turn.
     posture_unsent: AtomicBool,
     resume_ref: Mutex<Option<String>>,
     /// Whether a turn has actually run on this thread. Codex only writes the
@@ -56,8 +58,8 @@ pub struct CodexSession {
     resume_lost: Mutex<Option<String>>,
     child: AsyncMutex<Option<ProcessTreeChild>>,
     child_pid: AtomicU32,
-    stdin: Option<Arc<AsyncMutex<ChildStdin>>>,
-    stdout: Option<Arc<AsyncMutex<StdoutReader>>>,
+    stdin: Mutex<Option<Arc<AsyncMutex<ChildStdin>>>>,
+    stdout: Mutex<Option<Arc<AsyncMutex<StdoutReader>>>>,
     parser: Arc<Mutex<CodexStreamParser>>,
     next_id: AtomicI64,
     control_state: Arc<Mutex<ControlState>>,
@@ -150,16 +152,16 @@ impl CodexSession {
         Self {
             spec,
             permission_mode: Mutex::new(permission_mode),
-            // A resumed thread carries whatever posture it was last told, so
-            // state the mode on the first turn rather than assume it holds.
+            // Settled per child by `handshake`; until one runs there is no
+            // engine to disagree with.
             posture_unsent: AtomicBool::new(resume_ref.is_some()),
             resume_ref: Mutex::new(resume_ref),
             thread_ran_a_turn: AtomicBool::new(false),
             resume_lost: Mutex::new(None),
             child: AsyncMutex::new(None),
             child_pid: AtomicU32::new(0),
-            stdin: None,
-            stdout: None,
+            stdin: Mutex::new(None),
+            stdout: Mutex::new(None),
             parser: Arc::new(Mutex::new(CodexStreamParser::new())),
             next_id: AtomicI64::new(1),
             control_state: Arc::new(Mutex::new(ControlState {
@@ -197,7 +199,7 @@ impl CodexSession {
     }
 
     async fn write_message(&self, message: &Value) -> Result<(), HarnessError> {
-        let Some(stdin) = &self.stdin else {
+        let Some(stdin) = self.stdin.lock().expect("codex stdin").clone() else {
             return Err(HarnessError::Other("engine child has no stdin".into()));
         };
         let mut line = serde_json::to_vec(message)
@@ -228,7 +230,7 @@ impl CodexSession {
     /// leaves the stream reader responsible for the acknowledgement and
     /// `UserSteered` event.
     async fn request_steer(&self, thread_id: String, text: String) -> Result<(), HarnessError> {
-        let Some(stdin) = self.stdin.clone() else {
+        let Some(stdin) = self.stdin.lock().expect("codex stdin").clone() else {
             return Err(HarnessError::SteeringRejected(
                 "the engine child has no stdin".into(),
             ));
@@ -541,91 +543,136 @@ pub(crate) fn turn_start_policy(mode: PermissionMode) -> (Value, &'static str) {
     (sandbox, approval)
 }
 
-/// Spawn the app-server child and complete initialize + thread/start|resume.
-pub(super) async fn attach(spec: SessionSpec) -> Result<CodexSession, HarnessError> {
-    let mut session = CodexSession::new(spec);
-    let plan = compose_app_server_plan(
-        &session.spec.binary,
-        &session.spec.extra_argv,
-        &session.spec.worktree,
-        &session.spec.extra_env,
-        session.spec.browser.as_ref(),
-    )?;
-    let mut command = Command::new(&plan.argv[0]);
-    command
-        .args(&plan.argv[1..])
-        .current_dir(&plan.cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    apply_child_env_tokio(
-        &mut command,
-        session.spec.env.iter().cloned(),
-        &plan.env,
-        session.spec.browser.as_ref(),
-    );
-    let mut child = spawn_process_tree(&mut command)?;
-    let stdin = child
-        .take_stdin()
-        .ok_or_else(|| HarnessError::Other("engine child has no stdin".into()))?;
-    let stdout = child
-        .take_stdout()
-        .ok_or_else(|| HarnessError::Other("engine child has no stdout".into()))?;
-    let stderr = child
-        .take_stderr()
-        .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
-    session.stdin = Some(Arc::new(AsyncMutex::new(stdin)));
-    session.stdout = Some(Arc::new(AsyncMutex::new(StdoutReader {
-        stdout,
-        lines: StreamLineBuffer::new(),
-    })));
-    session
-        .child_pid
-        .store(child.id().unwrap_or(0), Ordering::SeqCst);
-    *session.child.lock().await = Some(child);
-    tokio::spawn(async move {
-        let _ = drain_capped(stderr, MAX_STDERR_BYTES).await;
-    });
+impl CodexSession {
+    /// A live child, spawned and handshaken if there is none (decision 0064).
+    ///
+    /// The fast path is a running child: nothing to do. Otherwise a parked or
+    /// dead child is replaced and the engine session resumed before the
+    /// turn's own request goes out. The child slot is held across the whole
+    /// ensure, so two callers cannot race two spawns.
+    pub(super) async fn ensure_child(&self) -> Result<(), HarnessError> {
+        let mut slot = self.child.lock().await;
+        if let Some(child) = slot.as_mut() {
+            if matches!(child.try_wait(), Ok(None)) {
+                return Ok(());
+            }
+            // The process is gone; drop the handles that pointed at it.
+            *slot = None;
+            self.child_pid.store(0, Ordering::SeqCst);
+            *self.stdin.lock().expect("codex stdin") = None;
+            *self.stdout.lock().expect("codex stdout") = None;
+        }
+        let plan = compose_app_server_plan(
+            &self.spec.binary,
+            &self.spec.extra_argv,
+            &self.spec.worktree,
+            &self.spec.extra_env,
+            self.spec.browser.as_ref(),
+        )?;
+        let mut command = Command::new(&plan.argv[0]);
+        command
+            .args(&plan.argv[1..])
+            .current_dir(&plan.cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        apply_child_env_tokio(
+            &mut command,
+            self.spec.env.iter().cloned(),
+            &plan.env,
+            self.spec.browser.as_ref(),
+        );
+        let mut child = spawn_process_tree(&mut command)?;
+        let stdin = child
+            .take_stdin()
+            .ok_or_else(|| HarnessError::Other("engine child has no stdin".into()))?;
+        let stdout = child
+            .take_stdout()
+            .ok_or_else(|| HarnessError::Other("engine child has no stdout".into()))?;
+        let stderr = child
+            .take_stderr()
+            .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
+        *self.stdin.lock().expect("codex stdin") = Some(Arc::new(AsyncMutex::new(stdin)));
+        *self.stdout.lock().expect("codex stdout") =
+            Some(Arc::new(AsyncMutex::new(StdoutReader {
+                stdout,
+                lines: StreamLineBuffer::new(),
+            })));
+        self.child_pid
+            .store(child.id().unwrap_or(0), Ordering::SeqCst);
+        *slot = Some(child);
+        tokio::spawn(async move {
+            let _ = drain_capped(stderr, MAX_STDERR_BYTES).await;
+        });
+        if let Err(err) = self.handshake().await {
+            // Leave nothing half-attached: the next ensure starts clean, and
+            // a fenced session does not keep a wedged server alive until it
+            // is reaped.
+            if let Some(mut child) = slot.take() {
+                let _ = child.terminate().await;
+            }
+            self.child_pid.store(0, Ordering::SeqCst);
+            *self.stdin.lock().expect("codex stdin") = None;
+            *self.stdout.lock().expect("codex stdout") = None;
+            return Err(err);
+        }
+        Ok(())
+    }
 
-    let init_id = session
-        .request(
-            "initialize",
-            json!({
-                "clientInfo": { "name": "tidebreak-harness", "version": "0.0.0" },
-                "capabilities": { "experimentalApi": false }
-            }),
-        )
-        .await?;
-    session.read_until_rpc(init_id).await?;
-    session.notify("initialized", None).await?;
+    /// initialize + thread/start|resume on a freshly spawned child.
+    async fn handshake(&self) -> Result<(), HarnessError> {
+        let init_id = self
+            .request(
+                "initialize",
+                json!({
+                    "clientInfo": { "name": "tidebreak-harness", "version": "0.0.0" },
+                    "capabilities": { "experimentalApi": false }
+                }),
+            )
+            .await?;
+        self.read_until_rpc(init_id).await?;
+        self.notify("initialized", None).await?;
 
-    let (method, params) =
-        if let Some(resume) = session.resume_ref.lock().expect("codex resume").clone() {
+        // Resume only a thread the engine has actually written. A thread that
+        // ran no turn was never persisted (see `resume_ref`), so a respawn
+        // after parking one starts a clean thread rather than fencing the
+        // session on "thread not found".
+        let resume = if self.thread_ran_a_turn.load(Ordering::SeqCst) {
+            self.resume_ref.lock().expect("codex resume").clone()
+        } else {
+            self.spec.resume_ref.clone()
+        };
+        let (method, params) = if let Some(resume) = resume {
             ("thread/resume", json!({ "threadId": resume }))
         } else {
-            let (sandbox, approval) = thread_start_policy(session.permission_mode());
+            let (sandbox, approval) = thread_start_policy(self.permission_mode());
             let mut params = json!({
-                "cwd": session.spec.worktree,
+                "cwd": self.spec.worktree,
                 "approvalPolicy": approval,
                 "sandbox": sandbox,
             });
-            if let Some(model) = &session.spec.model {
+            if let Some(model) = &self.spec.model {
                 params["model"] = json!(model);
             }
             ("thread/start", params)
         };
-    let thread_req = session.request(method, params).await?;
-    session.read_until_rpc(thread_req).await?;
-    if let Some(detail) = session.lost_resume() {
-        // The stored thread is gone on the engine side. Every turn on this
-        // child would fail identically, so fail the launch with a reason the
-        // caller can act on instead of attaching a session that cannot run.
-        return Err(HarnessError::ResumeLost(detail));
+        let resumed = method == "thread/resume";
+        let thread_req = self.request(method, params).await?;
+        self.read_until_rpc(thread_req).await?;
+        if let Some(detail) = self.lost_resume() {
+            // The stored thread is gone on the engine side. Every turn on
+            // this child would fail identically, so report the lost resume
+            // for the caller to fence on instead of running a turn that
+            // cannot land.
+            return Err(HarnessError::ResumeLost(detail));
+        }
+        // A resumed thread carries whatever posture it was last told, so the
+        // next turn restates the mode rather than assume it holds. A started
+        // thread was just told its posture.
+        self.posture_unsent.store(resumed, Ordering::SeqCst);
+        Ok(())
     }
-    Ok(session)
-}
 
-impl CodexSession {
     async fn read_until_rpc(&self, rpc_id: i64) -> Result<(), HarnessError> {
         let deadline = tokio::time::Instant::now() + HANDSHAKE_TIMEOUT;
         loop {
@@ -711,7 +758,7 @@ impl CodexSession {
     }
 
     async fn read_lines(&self) -> Result<Vec<String>, HarnessError> {
-        let Some(stdout) = &self.stdout else {
+        let Some(stdout) = self.stdout.lock().expect("codex stdout").clone() else {
             return Err(HarnessError::Other("engine child has no stdout".into()));
         };
         let mut reader = stdout.lock().await;
@@ -823,9 +870,7 @@ impl CodexSession {
 #[async_trait]
 impl HarnessSession for CodexSession {
     async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
-        if self.child_pid.load(Ordering::SeqCst) == 0 {
-            return Err(HarnessError::Other("engine child is not running".into()));
-        }
+        self.ensure_child().await?;
         let Some(thread_id) = self.resume_ref.lock().expect("codex resume").clone() else {
             return Err(HarnessError::Other("thread has no resume ref".into()));
         };
@@ -956,6 +1001,11 @@ impl HarnessSession for CodexSession {
     }
 
     async fn interrupt(&self) -> Result<(), HarnessError> {
+        if self.child_pid.load(Ordering::SeqCst) == 0 {
+            // No child means nothing is running: a stop aimed at a parked
+            // session must not cost it anything (decision 0064).
+            return Ok(());
+        }
         let thread_id = self.resume_ref.lock().expect("codex resume").clone();
         let turn_id = self.active_control_turn_id();
         if let (Some(thread_id), Some(turn_id)) = (thread_id, turn_id) {
@@ -1004,6 +1054,20 @@ impl HarnessSession for CodexSession {
         // One long-lived parser per session, so its own count is already
         // cumulative.
         self.parser.lock().expect("codex parser").unrecognized()
+    }
+
+    /// Terminate the idle server child (decision 0064). The thread stays
+    /// resumable, and the next turn's ensure re-runs the handshake on a
+    /// replacement.
+    async fn park(&self) -> Result<(), HarnessError> {
+        let mut slot = self.child.lock().await;
+        *self.stdin.lock().expect("codex stdin") = None;
+        *self.stdout.lock().expect("codex stdout") = None;
+        self.child_pid.store(0, Ordering::SeqCst);
+        if let Some(mut child) = slot.take() {
+            let _ = child.terminate().await;
+        }
+        Ok(())
     }
 
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
@@ -1323,6 +1387,35 @@ while IFS= read -r line; do
 done
 "#;
 
+    /// The same stand-in, but its `thread/resume` succeeds — the engine still
+    /// holds the thread, as it does after a park (decision 0064).
+    #[cfg(unix)]
+    const FAKE_RESUMABLE_APP_SERVER: &str = r#"#!/bin/sh
+while IFS= read -r line; do
+  id=${line#*\"id\":}
+  id=${id%%,*}
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf 'initialize\n' >>"$FAKE_CODEX_CALLS"
+      printf '{"id":%s,"result":{"userAgent":"fake/0.147.0"}}\n' "$id"
+      ;;
+    *'"method":"thread/start"'*)
+      printf 'thread/start\n' >>"$FAKE_CODEX_CALLS"
+      printf '{"id":%s,"result":{"thread":{"id":"THREAD-1","cliVersion":"0.147.0","turns":[]}}}\n' "$id"
+      ;;
+    *'"method":"thread/resume"'*)
+      printf 'thread/resume\n' >>"$FAKE_CODEX_CALLS"
+      printf '{"id":%s,"result":{"thread":{"id":"THREAD-1","cliVersion":"0.147.0","turns":[]}}}\n' "$id"
+      ;;
+    *'"method":"turn/start"'*)
+      printf 'turn/start\n' >>"$FAKE_CODEX_CALLS"
+      printf '{"id":%s,"result":{"turn":{"id":"TURN-1","status":"inProgress"}}}\n' "$id"
+      printf '{"method":"turn/completed","params":{"threadId":"THREAD-1","turn":{"id":"TURN-1","status":"completed"}}}\n'
+      ;;
+  esac
+done
+"#;
+
     #[cfg(unix)]
     const FAKE_STEERING_APP_SERVER: &str = r#"#!/bin/sh
 while IFS= read -r line; do
@@ -1481,9 +1574,21 @@ done
             .collect()
     }
 
-    /// The wedge from the app-server dying before its first turn: codex never
-    /// persisted the thread, so a thread id that has run no turn must not be
-    /// reported as a resume ref. The next attach then starts a clean thread.
+    #[cfg(unix)]
+    fn turn(text: &str) -> TurnInput {
+        TurnInput {
+            text: text.into(),
+            model: None,
+            reasoning_effort: None,
+            fast_mode: false,
+            images: Vec::new(),
+        }
+    }
+
+    /// The wedge from the app-server dying before its first turn: codex
+    /// never persisted the thread, so a thread id that has run no turn must
+    /// not be reported as a resume ref. The next spawn then starts a clean
+    /// thread.
     #[cfg(unix)]
     #[tokio::test]
     async fn a_thread_that_ran_no_turn_is_not_a_resume_ref() {
@@ -1491,29 +1596,31 @@ done
         let binary = dir.path().join("codex");
         write_fake_app_server(&binary);
 
-        let session = attach(spec_for(dir.path(), &binary, None)).await.unwrap();
-        assert_eq!(calls(dir.path()), ["initialize", "thread/start"]);
+        let session = CodexSession::new(spec_for(dir.path(), &binary, None));
+        assert!(
+            calls(dir.path()).is_empty(),
+            "nothing spawns before the first turn (decision 0064)"
+        );
+        assert_eq!(session.child_pid(), None);
         assert_eq!(
             session.resume_ref(),
             None,
             "a thread with no turns is not resumable and must not be persisted"
         );
 
-        session
-            .run_turn(TurnInput {
-                text: "first turn".into(),
-                model: None,
-                reasoning_effort: None,
-                fast_mode: false,
-                images: Vec::new(),
-            })
-            .await
-            .unwrap();
+        session.run_turn(turn("first turn")).await.unwrap();
+        assert_eq!(
+            calls(dir.path()),
+            ["initialize", "thread/start", "turn/start"],
+            "the first turn spawns, handshakes, and runs"
+        );
         assert_eq!(session.resume_ref().as_deref(), Some("THREAD-1"));
     }
 
     /// A resume ref the engine no longer knows is a lost resume, not a turn
     /// failure: the server fences on this rather than failing every turn.
+    /// With the child spawned on the first turn (decision 0064), that is
+    /// where the stored ref meets the engine.
     #[cfg(unix)]
     #[tokio::test]
     async fn a_stale_resume_ref_reports_a_lost_resume() {
@@ -1521,20 +1628,88 @@ done
         let binary = dir.path().join("codex");
         write_fake_app_server(&binary);
 
-        let attached = attach(spec_for(
+        let session = CodexSession::new(spec_for(
             dir.path(),
             &binary,
             Some("STALE-THREAD".to_owned()),
-        ))
-        .await;
-        let Err(err) = attached else {
-            panic!("attaching to an unknown thread must not succeed");
+        ));
+        let Err(err) = session.run_turn(turn("first turn")).await else {
+            panic!("a turn on an unknown thread must not succeed");
         };
         assert_eq!(calls(dir.path()), ["initialize", "thread/resume"]);
         let HarnessError::ResumeLost(detail) = err else {
             panic!("expected a lost resume, got {err}");
         };
         assert!(detail.contains("thread not found"), "detail: {detail}");
+        assert_eq!(
+            session.child_pid(),
+            None,
+            "a failed handshake leaves no half-attached child behind"
+        );
+    }
+
+    /// Decision 0064: a parked thread that has run resumes on a replacement
+    /// child, with `thread/resume` on the wire and the same thread id kept.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_parked_thread_is_resumed_on_the_next_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("codex");
+        write_app_server(&binary, FAKE_RESUMABLE_APP_SERVER);
+
+        let session = CodexSession::new(spec_for(dir.path(), &binary, None));
+        session.run_turn(turn("one")).await.unwrap();
+        let first_pid = session.child_pid().expect("the child outlives its turn");
+
+        session.park().await.unwrap();
+        assert_eq!(session.child_pid(), None, "the parked child is gone");
+
+        session.run_turn(turn("two")).await.unwrap();
+        assert_eq!(
+            calls(dir.path()),
+            [
+                "initialize",
+                "thread/start",
+                "turn/start",
+                "initialize",
+                "thread/resume",
+                "turn/start"
+            ],
+            "the wake respawns and resumes rather than starting a new thread"
+        );
+        let second_pid = session.child_pid().expect("the wake turn spawned a child");
+        assert_ne!(first_pid, second_pid, "a new process answered the wake");
+        assert_eq!(session.resume_ref().as_deref(), Some("THREAD-1"));
+    }
+
+    /// Codex never persisted a thread that ran no turn, so waking one must
+    /// start clean. Resuming it would fence the session on "thread not
+    /// found" — the fake's own answer catches a wrong ensure here.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_parked_thread_that_never_ran_is_restarted_not_resumed() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("codex");
+        write_fake_app_server(&binary);
+
+        let session = CodexSession::new(spec_for(dir.path(), &binary, None));
+        session.ensure_child().await.unwrap();
+        session.park().await.unwrap();
+        session.ensure_child().await.unwrap();
+        assert_eq!(
+            calls(dir.path()),
+            ["initialize", "thread/start", "initialize", "thread/start"],
+            "an unwritten thread is restarted, never resumed"
+        );
+    }
+
+    /// A stop aimed at a parked session must not fail and must not spawn
+    /// anything (decision 0064).
+    #[tokio::test]
+    async fn an_interrupt_with_no_child_is_a_no_op() {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        session.interrupt().await.unwrap();
+        assert_eq!(session.child_pid(), None);
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -569,6 +569,19 @@ pub trait HarnessSession: Send + Sync {
     /// must say so rather than inherit a silent zero (decision 0031).
     fn unrecognized_events(&self) -> u64;
 
+    /// Release the engine's processes while the session stays attachable, so
+    /// an idle session stops holding a runtime resident (decision 0064).
+    ///
+    /// Called only between turns. A later [`Self::run_turn`] must
+    /// transparently restore whatever this released — respawn and resume from
+    /// the session's ref — so a park is invisible apart from the wake turn's
+    /// spawn latency. Idempotent: parking a session with nothing running is a
+    /// no-op. The default does nothing, for engines with no between-turn
+    /// child to release.
+    async fn park(&self) -> Result<(), HarnessError> {
+        Ok(())
+    }
+
     /// Tear the session down.
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError>;
 }

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -18,7 +18,7 @@ use tidebreak_core::{CapLevel, HarnessCaps, HarnessKind};
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use crate::opencode::session::attach;
+use crate::opencode::session::OpencodeSession;
 use crate::probe::{observe_version, probe_shell, HostEnv};
 use crate::{HarnessAdapter, HarnessError, HarnessProbe, HarnessSession, SessionSpec};
 
@@ -109,7 +109,9 @@ impl HarnessAdapter for OpencodeAdapter {
         if !spec.binary.is_absolute() {
             return Err(HarnessError::NotFound);
         }
-        Ok(Box::new(attach(spec).await?))
+        // The serve child spawns on the first turn, not here (decision 0064),
+        // so attaching a session costs no engine runtime.
+        Ok(Box::new(OpencodeSession::new(spec)))
     }
 }
 

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -32,13 +32,16 @@ const OPENCODE_CONFIG_CONTENT: &str = "OPENCODE_CONFIG_CONTENT";
 /// MCP server name used in the OpenCode config for the browser tool bridge.
 const BROWSER_MCP_SERVER: &str = "tb-browser";
 
-/// Live opencode session: one `serve` child for the session lifetime.
+/// Live opencode session: one `serve` child, spawned on the first turn and
+/// replaced whenever a turn finds it parked or dead (decision 0064).
 pub struct OpencodeSession {
     spec: SessionSpec,
     resume_ref: Mutex<Option<String>>,
     child: AsyncMutex<Option<ProcessTreeChild>>,
     child_pid: AtomicU32,
-    base_url: String,
+    /// Loopback base of the current child. Each spawn binds a fresh port, so
+    /// this is per-child state; empty until the first spawn.
+    base_url: Mutex<String>,
     client: reqwest::Client,
     parser: Mutex<OpencodeStreamParser>,
     events: AsyncMutex<Option<mpsc::UnboundedReceiver<String>>>,
@@ -52,11 +55,15 @@ impl OpencodeSession {
             resume_ref: Mutex::new(resume_ref),
             child: AsyncMutex::new(None),
             child_pid: AtomicU32::new(0),
-            base_url: String::new(),
+            base_url: Mutex::new(String::new()),
             client: reqwest::Client::new(),
             parser: Mutex::new(OpencodeStreamParser::new()),
             events: AsyncMutex::new(None),
         }
+    }
+
+    fn base_url(&self) -> String {
+        self.base_url.lock().expect("opencode base url").clone()
     }
 }
 
@@ -354,59 +361,85 @@ fn pick_loopback_port() -> Result<u16, HarnessError> {
     Ok(listener.local_addr()?.port())
 }
 
-/// Spawn the serve child, wait for `/global/health`, create or resume a session.
-pub(super) async fn attach(spec: SessionSpec) -> Result<OpencodeSession, HarnessError> {
-    let mut session = OpencodeSession::new(spec);
-    let port = pick_loopback_port()?;
-
-    let plan = compose_serve_plan(
-        &session.spec.binary,
-        &session.spec.extra_argv,
-        &session.spec.worktree,
-        &session.spec.env,
-        &session.spec.extra_env,
-        port,
-        session.spec.browser.as_ref(),
-    )?;
-    let mut command = Command::new(&plan.argv[0]);
-    command
-        .args(&plan.argv[1..])
-        .current_dir(&plan.cwd)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    apply_child_env_tokio(
-        &mut command,
-        session.spec.env.iter().cloned(),
-        &plan.env,
-        session.spec.browser.as_ref(),
-    );
-    let mut child = spawn_process_tree(&mut command)?;
-    let stdout = child
-        .take_stdout()
-        .ok_or_else(|| HarnessError::Other("engine child has no stdout".into()))?;
-    let stderr = child
-        .take_stderr()
-        .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
-    if let Some(pid) = child.id() {
-        session.child_pid.store(pid, Ordering::SeqCst);
-    }
-    *session.child.lock().await = Some(child);
-    tokio::spawn(async move {
-        let _ = drain_capped(stdout, MAX_STDERR_BYTES).await;
-    });
-    tokio::spawn(async move {
-        let _ = drain_capped(stderr, MAX_STDERR_BYTES).await;
-    });
-
-    session.base_url = format!("http://127.0.0.1:{port}");
-    session.wait_until_healthy().await?;
-    session.subscribe_events().await?;
-    session.open_or_resume_session().await?;
-    Ok(session)
-}
-
 impl OpencodeSession {
+    /// A live child, spawned and bootstrapped if there is none (decision
+    /// 0064).
+    ///
+    /// The fast path is a running child: nothing to do. Otherwise a parked or
+    /// dead child is replaced — spawn, `/global/health`, event subscription,
+    /// session create-or-resume — before the turn's own request goes out. The
+    /// child slot is held across the whole ensure, so two callers cannot race
+    /// two spawns.
+    pub(super) async fn ensure_child(&self) -> Result<(), HarnessError> {
+        let mut slot = self.child.lock().await;
+        if let Some(child) = slot.as_mut() {
+            if matches!(child.try_wait(), Ok(None)) {
+                return Ok(());
+            }
+            *slot = None;
+            self.child_pid.store(0, Ordering::SeqCst);
+        }
+        let port = pick_loopback_port()?;
+        let plan = compose_serve_plan(
+            &self.spec.binary,
+            &self.spec.extra_argv,
+            &self.spec.worktree,
+            &self.spec.env,
+            &self.spec.extra_env,
+            port,
+            self.spec.browser.as_ref(),
+        )?;
+        let mut command = Command::new(&plan.argv[0]);
+        command
+            .args(&plan.argv[1..])
+            .current_dir(&plan.cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        apply_child_env_tokio(
+            &mut command,
+            self.spec.env.iter().cloned(),
+            &plan.env,
+            self.spec.browser.as_ref(),
+        );
+        let mut child = spawn_process_tree(&mut command)?;
+        let stdout = child
+            .take_stdout()
+            .ok_or_else(|| HarnessError::Other("engine child has no stdout".into()))?;
+        let stderr = child
+            .take_stderr()
+            .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
+        if let Some(pid) = child.id() {
+            self.child_pid.store(pid, Ordering::SeqCst);
+        }
+        *slot = Some(child);
+        tokio::spawn(async move {
+            let _ = drain_capped(stdout, MAX_STDERR_BYTES).await;
+        });
+        tokio::spawn(async move {
+            let _ = drain_capped(stderr, MAX_STDERR_BYTES).await;
+        });
+
+        *self.base_url.lock().expect("opencode base url") = format!("http://127.0.0.1:{port}");
+        let ready = async {
+            self.wait_until_healthy().await?;
+            self.subscribe_events().await?;
+            self.open_or_resume_session().await
+        };
+        if let Err(err) = ready.await {
+            // Leave nothing half-attached: the next ensure starts clean, and
+            // a fenced session does not keep a wedged server alive until it
+            // is reaped.
+            if let Some(mut child) = slot.take() {
+                let _ = child.terminate().await;
+            }
+            self.child_pid.store(0, Ordering::SeqCst);
+            *self.events.lock().await = None;
+            return Err(err);
+        }
+        Ok(())
+    }
+
     fn directory_query(&self) -> [(String, String); 1] {
         [(
             "directory".into(),
@@ -416,7 +449,7 @@ impl OpencodeSession {
 
     async fn wait_until_healthy(&self) -> Result<(), HarnessError> {
         let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
-        let url = format!("{}/global/health", self.base_url);
+        let url = format!("{}/global/health", self.base_url());
         loop {
             if tokio::time::Instant::now() > deadline {
                 return Err(HarnessError::Other(
@@ -433,7 +466,7 @@ impl OpencodeSession {
     }
 
     async fn subscribe_events(&self) -> Result<(), HarnessError> {
-        let url = format!("{}/event", self.base_url);
+        let url = format!("{}/event", self.base_url());
         let response = self
             .client
             .get(&url)
@@ -476,7 +509,7 @@ impl OpencodeSession {
         let resume = self.resume_ref.lock().expect("opencode resume").clone();
         if let Some(resume) = resume {
             let path = format!("/session/{resume}");
-            let url = format!("{}{path}", self.base_url);
+            let url = format!("{}{path}", self.base_url());
             let query = self.directory_query();
             let (status, body) = self
                 .http("GET", &path, &url, None, Some(query.as_slice()))
@@ -497,7 +530,7 @@ impl OpencodeSession {
             return Ok(());
         }
         let path = "/session";
-        let url = format!("{}{path}", self.base_url);
+        let url = format!("{}{path}", self.base_url());
         let body = session_create_body(self.spec.permission_mode, self.spec.model.as_deref());
         let query = self.directory_query();
         let (status, parsed) = self
@@ -644,12 +677,13 @@ impl OpencodeSession {
 #[async_trait]
 impl HarnessSession for OpencodeSession {
     async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
+        self.ensure_child().await?;
         let session_id = self.resume_ref.lock().expect("opencode resume").clone();
         let Some(session_id) = session_id else {
             return Err(HarnessError::Other("session has no resume ref".into()));
         };
         let path = format!("/session/{session_id}/prompt_async");
-        let url = format!("{}{path}", self.base_url);
+        let url = format!("{}{path}", self.base_url());
         let body = json!({
             "parts": [{ "type": "text", "text": input.text }]
         });
@@ -673,7 +707,7 @@ impl HarnessSession for OpencodeSession {
         decision: ApprovalDecision,
     ) -> Result<(), HarnessError> {
         let path = format!("/permission/{}/reply", approval.call_id);
-        let url = format!("{}{path}", self.base_url);
+        let url = format!("{}{path}", self.base_url());
         let body = match &decision {
             ApprovalDecision::Approve => json!({ "reply": "once" }),
             ApprovalDecision::Deny { feedback } => {
@@ -696,10 +730,15 @@ impl HarnessSession for OpencodeSession {
     }
 
     async fn interrupt(&self) -> Result<(), HarnessError> {
+        if self.child_pid.load(Ordering::SeqCst) == 0 {
+            // No child means nothing is running: a stop aimed at a parked
+            // session must not cost it anything (decision 0064).
+            return Ok(());
+        }
         let session_id = self.resume_ref.lock().expect("opencode resume").clone();
         if let Some(session_id) = session_id {
             let path = format!("/session/{session_id}/abort");
-            let url = format!("{}{path}", self.base_url);
+            let url = format!("{}{path}", self.base_url());
             let query = self.directory_query();
             let result = self
                 .http("POST", &path, &url, None, Some(query.as_slice()))
@@ -734,6 +773,19 @@ impl HarnessSession for OpencodeSession {
         // One long-lived parser per session, so its own count is already
         // cumulative.
         self.parser.lock().expect("opencode parser").unrecognized()
+    }
+
+    /// Terminate the idle serve child (decision 0064). The engine session
+    /// stays on disk under the worktree's storage, and the next turn's ensure
+    /// respawns a server and reopens it.
+    async fn park(&self) -> Result<(), HarnessError> {
+        let mut slot = self.child.lock().await;
+        self.child_pid.store(0, Ordering::SeqCst);
+        *self.events.lock().await = None;
+        if let Some(mut child) = slot.take() {
+            let _ = child.terminate().await;
+        }
+        Ok(())
     }
 
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
@@ -806,6 +858,42 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct Discard;
+
+    #[async_trait]
+    impl crate::HarnessEventSink for Discard {
+        async fn emit(&self, _event: HarnessEvent) {}
+    }
+
+    fn unit_session() -> OpencodeSession {
+        OpencodeSession::new(SessionSpec {
+            worktree: std::path::PathBuf::from("."),
+            allowed_read_roots: Vec::new(),
+            permission_mode: PermissionMode::Auto,
+            model: None,
+            reasoning_effort: None,
+            fast_mode: false,
+            resume_ref: None,
+            extra_argv: Vec::new(),
+            extra_env: Vec::new(),
+            env: Vec::new(),
+            approval: None,
+            binary: std::path::PathBuf::from("opencode"),
+            sink: std::sync::Arc::new(Discard),
+            browser: None,
+        })
+    }
+
+    /// Decision 0064: parking and stopping a session with no child must be
+    /// free — no error, no spawn, nothing to clean up.
+    #[tokio::test]
+    async fn park_and_interrupt_without_a_child_are_no_ops() {
+        let session = unit_session();
+        session.park().await.unwrap();
+        session.interrupt().await.unwrap();
+        assert_eq!(session.child_pid(), None);
+    }
 
     #[test]
     fn serve_plan_is_clean() {

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -593,6 +593,13 @@ async fn run_worker(
                 }
                 None => break,
             },
+            // An idle engine child is cache, not an invariant (decision 0064).
+            // The timer only exists while the engine reports a live child, so
+            // a parked session — or an engine with no between-turn child —
+            // arms nothing.
+            _ = tokio::time::sleep(PARK_AFTER_IDLE), if engine.child_pid().is_some() => {
+                park_idle_engine(&mut session, engine.as_ref(), &sink).await;
+            }
         }
     }
     let _ = engine.shutdown().await;
@@ -608,6 +615,34 @@ enum ControlFlow {
 const STEER_CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
 #[cfg(test)]
 const STEER_CONTROL_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// How long a session sits between turns — no turn, no queued follow-up, no
+/// command — before its engine child is released (decision 0064). Sits well
+/// past the documented provider prompt-cache TTL, so a wake in practice pays
+/// spawn latency and not tokens a warm child would have saved.
+#[cfg(not(test))]
+const PARK_AFTER_IDLE: Duration = Duration::from_secs(15 * 60);
+#[cfg(test)]
+const PARK_AFTER_IDLE: Duration = Duration::from_millis(150);
+
+/// Release an idle engine child (decision 0064) and clear the row's pid so
+/// nothing reads the dead process as live. The next turn respawns and
+/// resumes. A park that fails keeps the child and simply retries on the next
+/// idle window.
+async fn park_idle_engine(session: &mut CodeSession, engine: &dyn HarnessSession, sink: &LiveSink) {
+    if let Err(error) = engine.park().await {
+        warn!(
+            session = %session.id,
+            error = %error,
+            "could not park the idle engine child"
+        );
+        return;
+    }
+    tracing::debug!(session = %session.id, "parked the idle engine child");
+    if session.child_pid.take().is_some() {
+        let _ = save_session(&sink.db, session).await;
+    }
+}
 
 /// Stop the engine's current turn, discarding the adapter's error: the turn
 /// is ending either way, and the outcome is what the worker journals.

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -96,6 +96,13 @@ pub(crate) struct ScriptedAdapter {
     /// an attachment travelled rather than that it was accepted.
     inputs: Arc<std::sync::Mutex<Vec<ScriptedTurnInput>>>,
     child_pid: Option<i64>,
+    /// Whether the child outlives its turn, the way the session-long engines
+    /// do. Off by default, so the worker's idle park timer (decision 0064)
+    /// stays disarmed in every test that does not opt in.
+    session_long_child: bool,
+    /// How many times a session of this adapter was parked, shared with the
+    /// sessions so a test can observe the worker's idle reclaim.
+    parks: Arc<AtomicU64>,
     unrecognized_per_turn: u64,
     silent_interrupt: bool,
     lost_resume: Option<String>,
@@ -127,6 +134,8 @@ impl ScriptedAdapter {
             modes: Arc::new(std::sync::Mutex::new(Vec::new())),
             inputs: Arc::new(std::sync::Mutex::new(Vec::new())),
             child_pid: None,
+            session_long_child: false,
+            parks: Arc::new(AtomicU64::new(0)),
             unrecognized_per_turn: 0,
             silent_interrupt: false,
             lost_resume: None,
@@ -258,6 +267,18 @@ impl ScriptedAdapter {
         self
     }
 
+    /// Keep the child pid across turns, the way session-long engines do, so
+    /// the worker's idle park timer (decision 0064) arms for this adapter.
+    pub(crate) fn with_session_long_child(mut self) -> Self {
+        self.session_long_child = true;
+        self
+    }
+
+    /// How many times a session of this adapter has been parked.
+    pub(crate) fn park_count(&self) -> u64 {
+        self.parks.load(Ordering::SeqCst)
+    }
+
     /// Model an engine that asks for an approval and then stops waiting for
     /// one, the way Claude Code's own 60-second permission-prompt timeout
     /// does: the script plays straight past the request.
@@ -339,6 +360,8 @@ impl HarnessAdapter for ScriptedAdapter {
             steering_delay: self.steering_delay,
             steering_rejection: self.steering_rejection.clone(),
             child_pid: self.child_pid,
+            session_long_child: self.session_long_child,
+            parks: self.parks.clone(),
             silent_interrupt: self.silent_interrupt,
             pid: ChildPid::new(),
             lost_resume: self.lost_resume.clone(),
@@ -364,6 +387,10 @@ struct ScriptedSession {
     steering_delay: Duration,
     steering_rejection: Option<String>,
     child_pid: Option<i64>,
+    /// Whether the pid survives the turn (a session-long child).
+    session_long_child: bool,
+    /// Park calls observed, shared with the adapter.
+    parks: Arc<AtomicU64>,
     silent_interrupt: bool,
     pid: ChildPid,
     lost_resume: Option<String>,
@@ -467,11 +494,15 @@ impl HarnessSession for ScriptedSession {
         self.unrecognized
             .fetch_add(self.unrecognized_per_turn, Ordering::SeqCst);
         // A per-turn child exists only while the turn runs; publish it the way
-        // a real one does so the worker records the pid mid-turn.
+        // a real one does so the worker records the pid mid-turn. A
+        // session-long child keeps its pid, which is what arms the worker's
+        // idle park timer (decision 0064).
         self.pid
             .set(self.child_pid.map(|pid| pid as u32).filter(|pid| *pid != 0));
         let outcome = self.play_script().await;
-        self.pid.clear();
+        if !self.session_long_child {
+            self.pid.clear();
+        }
         Ok(outcome)
     }
 
@@ -531,6 +562,14 @@ impl HarnessSession for ScriptedSession {
 
     fn unrecognized_events(&self) -> u64 {
         self.unrecognized.load(Ordering::SeqCst)
+    }
+
+    /// Record the park and drop the pid, the observable half of what a real
+    /// adapter's park does (decision 0064).
+    async fn park(&self) -> Result<(), HarnessError> {
+        self.parks.fetch_add(1, Ordering::SeqCst);
+        self.pid.clear();
+        Ok(())
     }
 
     async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -7330,3 +7330,93 @@ async fn trigger_mutations_require_the_repository_in_the_path() {
     assert_eq!(json_id(&rows[0]), trigger_id);
     assert_eq!(rows[0]["enabled"], true);
 }
+
+/// Decision 0064: a session-long engine child idle past the threshold is
+/// parked — the engine records the call, the row's pid clears — and the next
+/// turn simply runs again. Every other test runs per-turn scripted children,
+/// which keep the park timer disarmed.
+#[tokio::test]
+async fn an_idle_engine_child_is_parked_and_the_next_turn_still_runs() {
+    let adapter = ScriptedAdapter::new(plain_text_script())
+        .with_child_pid(4242)
+        .with_session_long_child();
+    let observer = adapter.clone();
+    let (router, token, runtime, dir) = code_app_with(adapter).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "plan",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let session_id = json_id(&session).to_owned();
+    let parsed: CodeSessionId = session_id.parse().unwrap();
+
+    let first = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "one" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), reqwest::StatusCode::ACCEPTED);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while turn_statuses(&client, addr, &token, &session).await != ["completed"] {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the first turn never completed");
+
+    // The park timer (150 ms under cfg(test)) fires once the worker sits
+    // idle, and the row's pid clears with it.
+    wait_until(|| observer.park_count() > 0).await;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let row = tidebreak_core::db::code::get_session(
+                &runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                parsed,
+            )
+            .await
+            .unwrap()
+            .expect("the parked session row still exists");
+            if row.child_pid.is_none() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("a parked child must leave no pid on the row");
+
+    // Parking is invisible to the caller: the next turn just runs.
+    let second = client
+        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "message": "two" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second.status(), reqwest::StatusCode::ACCEPTED);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while turn_statuses(&client, addr, &token, &session).await != ["completed", "completed"] {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the wake turn never completed");
+}

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -247,6 +247,12 @@ Process models the trait absorbs:
   [`0038`](decisions/0038-auto-is-a-declared-capability.md)); capabilities
   honestly `Unsupported` or `Unknown` where its surface does not carry them.
 
+Session-long children spawn lazily on the first turn, and an idle session's
+child is parked — stopped, then respawned and resumed by the next turn
+([`0064`](decisions/0064-idle-engine-children-are-parked.md)). Resident
+engine processes therefore track sessions doing work, not sessions that
+exist.
+
 All children are pipe-based `tokio::process` with `kill_on_drop`, the
 user's environment minus Tidebreak internals
 ([`0034`](decisions/0034-harness-discovery-credentials.md)), and bounded

--- a/docs/decisions/0064-idle-engine-children-are-parked.md
+++ b/docs/decisions/0064-idle-engine-children-are-parked.md
@@ -1,0 +1,158 @@
+# 64. Idle Engine Children Are Parked and Resumed on Demand
+
+- Status: Accepted
+- Date: 2026-08-24
+- Owners: code mode, harness integration
+- Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),
+  [`0055-multiple-sessions-per-workspace.md`](0055-multiple-sessions-per-workspace.md),
+  [`0057-one-claude-child-per-session.md`](0057-one-claude-child-per-session.md),
+  [`0059-workspace-reclaim-tiers.md`](0059-workspace-reclaim-tiers.md)
+
+## Context
+
+The product goal is dozens of sessions on one machine. What that costs is not
+the adapter boundary — pipes, NDJSON parsing, and the journal are bounded and
+cheap — it is the engine children themselves. Each one is a full JavaScript or
+native runtime holding a session's context, and today their number tracks
+*open* sessions, not *active* ones:
+
+- The Codex and opencode adapters spawn their server child inside `attach`,
+  before any turn exists. Only Claude Code spawns lazily on the first turn
+  ([`0057`](0057-one-claude-child-per-session.md) point 8); Grok has no
+  between-turn child at all.
+- Boot re-attaches a worker for every non-ended, non-fenced session,
+  concurrently and without a cap (`crates/tidebreak-server/src/code/runtime.rs`,
+  `recover`). With eager adapters that is one engine runtime per restored
+  session at every app launch, whether or not the user touches any of them.
+- No child is ever released while its session stays open. [`0057`](0057-one-claude-child-per-session.md)
+  names this as its revisit condition: "if holding a child for a session's
+  lifetime proves too expensive in memory across many open sessions."
+
+The wake price is known. 0057 measured spawn-and-resume at roughly 0.7 s to
+first engine output, and measured the token cost of a respawn as a rewrite of
+the cached prompt prefix — significant only when the worktree changed since
+the cache was written. Both costs shrink to the latency alone once the
+provider's prompt cache has expired on its own: Anthropic documents a
+5-minute default TTL, and a warm child past that window pays the same cache
+re-creation on its next turn that a parked one does. Past the cache window,
+holding the process buys nothing but resident memory.
+
+[`0059`](0059-workspace-reclaim-tiers.md) already answered the same question
+for worktrees: reclaim is safe when what is dropped can be rebuilt from what
+is kept. Every engine here can rebuild a live child from a stored ref —
+Claude Code with `--resume`, Codex with `thread/resume`, opencode by reopening
+its session id — and 0057 already requires the Claude adapter to replace a
+dead child through exactly that path before every turn.
+
+## Decision
+
+**Engine children are a reclaim tier, not a session invariant.** A session
+owns a resumable ref; the child is cache.
+
+1. **Every adapter spawns its child lazily, on the first turn.** 0057 point 8
+   becomes the rule for all adapters, not a Claude special case. `launch`
+   validates and constructs; the first `run_turn` spawns and completes the
+   engine handshake. Boot re-attach therefore launches no engine processes,
+   which dissolves the unbounded-restore concern that kept 0057 from eager
+   spawn rather than bounding the loop.
+2. **`HarnessSession` gains `park`.** Parking stops the engine's processes
+   while the session object stays attachable; a later `run_turn` transparently
+   respawns and resumes from the session's ref. The default implementation
+   does nothing — Grok's per-turn child and the scripted test engine have
+   nothing to release. Claude parks by retiring its channel, the machinery
+   dead-child replacement already uses. Codex and opencode terminate the
+   server child and re-run their handshake on the next ensure.
+3. **The worker parks an idle engine.** The between-turns loop in
+   `session_worker.rs` arms a timer only while the engine reports a live
+   child pid. After `PARK_AFTER_IDLE` — 15 minutes, three times the
+   documented cache TTL, so a wake in practice pays latency and not tokens —
+   with no turn, no queued follow-up, and no command, the worker parks the
+   engine and clears the session row's `child_pid`, so nothing reads a dead
+   pid as live. Resident children then track sessions doing work.
+4. **Parking is invisible on the wire.** No new event, no lifecycle state.
+   The wake turn may journal another `session_started` — the same repeat a
+   dead-child replacement already produces, which consumers fold (0057).
+5. **Posture survives the park.** Claude composes its permission mode into
+   the respawn argv; Codex restates posture on the first turn after a resume
+   (`posture_unsent`); opencode's posture is immutable per engine session and
+   rides its stored session state. A mode switched while parked lands at the
+   next spawn, which the Claude adapter already models.
+6. **A thread that never ran a turn is restarted, not resumed.** Codex does
+   not persist a thread before its first turn, so the ensure path picks its
+   resume target with the same guard `resume_ref` already applies. Parking a
+   session whose engine never ran must not fence it on a ref the engine never
+   wrote.
+
+Deliberately excluded: parking mid-turn (the timer arm exists only in the
+between-turns loop), a user-visible control for the threshold, and any change
+to reap, fence, or shutdown semantics.
+
+## Alternatives Considered
+
+**Do nothing.** Rejected by arithmetic. Dozens of open sessions is the stated
+goal, each idle child is a resident runtime, and 0057 explicitly deferred
+this problem rather than deciding it.
+
+**A global cap on resident children (LRU eviction).** Bounds worst-case
+memory even under load, which idle-parking does not. Rejected here: evicting
+a child that is mid-turn is wrong, so a cap could only ever evict idle
+children — the same set the idle timer reclaims, chosen with a clock instead
+of cross-session coordination. A cap can still be layered on later if
+genuinely concurrent load appears.
+
+**Park by reaping the worker.** Reuses an existing path. Rejected: the worker
+carries the queue slot, the approval endpoint, and the attention contract,
+none of which should churn because a session sat quiet; and reap is a
+user-facing recovery action, not a background one.
+
+**Return to per-turn children.** The maximally aggressive reclaim. Rejected:
+0057 measured why the warm child wins inside the cache window. Parking after
+the window keeps that win and drops the cost.
+
+**One shared server child per harness.** Codex `app-server` and opencode
+`serve` are multi-session by design, so N sessions could share one runtime.
+Parked, not rejected: it is a larger consolidation with real trades — one
+crash takes every session on that harness, per-session environment (browser
+capfiles, credential profiles) rides process env and would need re-plumbing,
+and Claude cannot join. Worth its own record if idle-parking proves
+insufficient.
+
+## Consequences
+
+- A present-but-broken Codex or opencode binary now fails the first turn
+  instead of session attach. The Claude tier already behaves this way, so
+  every surface that reports a failed turn covers it; a missing binary still
+  fails at attach through the probe.
+- An interrupt aimed at an idle Codex session previously took the app-server
+  child and left every later turn failing "engine child is not running"; with
+  ensure-on-turn the next turn respawns, and the idle interrupt itself no
+  longer touches the process.
+- A watch session whose poll cadence exceeds the threshold parks between
+  polls and pays a wake per poll. That is the intended trade: memory is freed
+  for the whole quiet interval.
+- The first turn after a park pays spawn plus handshake latency, in the
+  seconds range. Within the cache window it also pays the prefix rewrite 0057
+  measured; the default threshold sits past that window.
+- `spawn_epoch`, approvals, and recovery are untouched: parking happens
+  inside one worker attachment, and an idle row's pid is already ignored by
+  recovery (0057) — now it is also cleared rather than stale.
+
+Revisit when a harness appears whose session state cannot outlive its
+process, or if wake latency on the reference tier grows enough that the
+threshold needs to be adaptive rather than fixed.
+
+## Validation
+
+- Claude adapter: a parked child's pid is gone, and the next turn respawns
+  with `--resume` on the same engine session — asserted on the fake engine's
+  argv log, beside the dead-child test it mirrors.
+- Codex adapter: nothing spawns before the first turn; a stale ref surfaces
+  `ResumeLost` from the first turn; a parked thread that ran resumes on a new
+  pid with `thread/resume` on the wire; a parked thread that never ran is
+  restarted with `thread/start`, never resumed. A wrong ensure that resumes
+  the unwritten thread fails against the fake server's own "thread not
+  found" answer.
+- Worker: with a session-long scripted child, an idle session parks — the
+  scripted engine records the call and the row's pid clears — and the next
+  turn still runs. The scripted default keeps per-turn pids, so every other
+  worker test exercises the disarmed timer.


### PR DESCRIPTION
## Summary

The product goal is dozens of sessions on one machine, and what that costs is resident engine children, not the adapter boundary. Today Codex and opencode spawn their server child at attach, boot re-attaches every non-ended session concurrently, and no child is ever released while its session stays open — so engine runtimes track sessions that *exist* rather than sessions doing work. Decision 0057 named this as its revisit condition.

This adds decision 0064 and implements it:

- **Every adapter spawns lazily on the first turn.** `launch` constructs and validates only; the first `run_turn` spawns and completes the engine handshake (`ensure_child` on Codex and opencode — Claude already worked this way, Grok has no between-turn child). Boot re-attach now launches no engine processes.
- **`HarnessSession::park`** stops the engine's processes while the session stays attachable; the next turn transparently respawns and resumes from the session's ref. Claude parks via the retire path dead-child replacement already uses; Codex and opencode terminate the server child and re-handshake on the next ensure; the default is a no-op.
- **The worker parks after 15 idle minutes** — an arm in the between-turns select that exists only while the engine reports a live child. Parking clears the row's `child_pid` so nothing reads a dead pid as live. The threshold sits well past the documented provider prompt-cache TTL, so a wake in practice pays spawn latency (~1 s) and not tokens a warm child would have saved.
- **Codex hardening the refactor forced:** an interrupt aimed at an idle session no longer takes the app-server child (previously every later turn failed "engine child is not running"), a failed handshake leaves nothing half-attached, and a thread that never ran a turn is restarted rather than resumed onto a ref the engine never wrote.

Parking is invisible on the wire: no new events, no lifecycle state; the wake turn may repeat `session_started`, which consumers already fold (0057).

## Validation

- Claude: parked child gone, wake turn respawns with `--resume` — asserted on the fake engine's argv log beside the dead-child test it mirrors.
- Codex: nothing spawns before the first turn; a stale ref surfaces `ResumeLost` from the first turn; a parked thread that ran resumes on a new pid with `thread/resume` on the wire; a parked thread that never ran is restarted (the fake's own "thread not found" answer catches a wrong ensure); an idle interrupt is a no-op.
- Worker: with a session-long scripted child, an idle session parks (150 ms under `cfg(test)`), the row's pid clears, and the next turn still runs. The scripted default keeps per-turn pids, so every other worker test exercises the disarmed timer.
- `cargo fmt` clean locally; compile and test runs are CI's per repo practice.