### PR TITLE
feat(code): pick delivery authors from a list instead of typing logins

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { StrictMode } from "react";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -175,6 +181,45 @@ describe("delivery pull request list", () => {
     expect(listCodeTriggers).toHaveBeenCalledWith(
       deliveryRepositoriesSnapshot.repositories[0]!.tidebreak_repo_id,
     );
+  });
+
+  it("filters by a picked author instead of a memorized login", async () => {
+    const user = userEvent.setup();
+    const query = vi.fn(async (_body: unknown) => ({
+      capability: deliveryRepositoriesSnapshot.capability,
+      items: deliveryPullRequests,
+      errors: [],
+      fetched_at: "2026-08-20T15:20:00.000Z",
+    }));
+    const client = {
+      ...storyClient(),
+      queryCodeDeliveryPullRequests: query,
+    } as unknown as ApiClient;
+    useCodeDeliveryStore.setState({
+      knownAuthors: [
+        { login: "mara", avatarUrl: "https://avatars.test/mara" },
+        { login: "devon" },
+      ],
+    });
+    renderList(client);
+
+    await user.click(await screen.findByRole("button", { name: /Filters/ }));
+    await user.click(await screen.findByRole("checkbox", { name: "mara" }));
+    await waitFor(() =>
+      expect(query.mock.calls.at(-1)?.[0]).toMatchObject({ authors: ["mara"] }),
+    );
+
+    // A login the pool has never seen still works, typed and entered.
+    await user.type(
+      screen.getByRole("textbox", { name: "Search authors" }),
+      "octocat{Enter}",
+    );
+    await waitFor(() =>
+      expect(query.mock.calls.at(-1)?.[0]).toMatchObject({
+        authors: ["mara", "octocat"],
+      }),
+    );
+    expect(screen.getByRole("checkbox", { name: "octocat" })).toBeChecked();
   });
 
   // The reported bug: every settled pull request rendered "Review Pending",

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -74,8 +74,10 @@ import type {
 import {
   codeDeliveryRepositoryKey,
   codeDeliveryRepositoryTarget,
+  deliveryAuthorSightings,
   trackedCodeDeliveryRepositories,
   useCodeDeliveryStore,
+  type CodeDeliveryAuthor,
   type CodeDeliveryPrViewFilters,
   type CodeDeliveryRunViewFilters,
   type CodeDeliverySavedView,
@@ -94,6 +96,7 @@ import {
 import {
   checkCounts,
   checkSummary,
+  githubAvatarUrl,
   pullRequestLifecycle,
   pullRequestReviewSummary,
   pullRequestSettledAt,
@@ -835,6 +838,9 @@ function PullRequestsSurface({
         ...(cursor ? { cursor } : {}),
       });
       if (token !== generation.current) return;
+      useCodeDeliveryStore
+        .getState()
+        .rememberDeliveryAuthors(deliveryAuthorSightings(page.items, []));
       setItems((current) => {
         let nextItems = append ? [...current, ...page.items] : page.items;
         const exactItem = target
@@ -1144,6 +1150,9 @@ function RunsSurface({
         ...(cursor ? { cursor } : {}),
       });
       if (token !== generation.current) return;
+      useCodeDeliveryStore
+        .getState()
+        .rememberDeliveryAuthors(deliveryAuthorSightings([], page.items));
       setItems((current) => {
         let nextItems = append ? [...current, ...page.items] : page.items;
         const exactItem = target
@@ -2031,13 +2040,12 @@ function PullRequestFilters({
             onChange={(checkStates) => onChange({ ...filters, checkStates })}
           />
         </FilterSection>
-        <FilterSection title="Author logins">
-          <Input
-            value={filters.authors.join(", ")}
-            placeholder="octocat, teammate"
-            onChange={(event) =>
-              onChange({ ...filters, authors: commaList(event.target.value) })
-            }
+        <FilterSection title="Authors">
+          <AuthorFilterOptions
+            noun="author"
+            emptyNote="Authors appear here as pull requests load. Type a login to filter by hand."
+            selected={filters.authors}
+            onChange={(authors) => onChange({ ...filters, authors })}
           />
         </FilterSection>
         <div className="mt-3 flex flex-col gap-2 border-t border-border-subtle pt-3">
@@ -2166,12 +2174,14 @@ function RunFilters({
           placeholder="push, pull_request"
           onChange={(events) => onChange({ ...filters, events })}
         />
-        <AdvancedTextFilter
-          label="Actors"
-          value={filters.actors}
-          placeholder="octocat, dependabot[bot]"
-          onChange={(actors) => onChange({ ...filters, actors })}
-        />
+        <FilterSection title="Actors">
+          <AuthorFilterOptions
+            noun="actor"
+            emptyNote="Actors appear here as runs load. Type a login to filter by hand."
+            selected={filters.actors}
+            onChange={(actors) => onChange({ ...filters, actors })}
+          />
+        </FilterSection>
         <div className="mt-3 flex flex-col gap-2 border-t border-border-subtle pt-3">
           <FilterSwitch
             label="Needs attention"
@@ -2245,6 +2255,150 @@ function RepositoryCheckboxes({
         );
       })}
     </div>
+  );
+}
+
+/**
+ * Login selection without the memory test: the checkable pool is every login
+ * Delivery has seen on a pull request or run, drawn with avatars, and the
+ * search box narrows it. A login the pool has never seen — a teammate who has
+ * not pushed lately, a bot — can still be typed and added by hand, which is
+ * all the old free-text field could do.
+ */
+function AuthorFilterOptions({
+  noun,
+  emptyNote,
+  selected,
+  onChange,
+}: {
+  noun: "author" | "actor";
+  emptyNote: string;
+  selected: string[];
+  onChange: (selected: string[]) => void;
+}) {
+  const knownAuthors = useCodeDeliveryStore((state) => state.knownAuthors);
+  const [query, setQuery] = useState("");
+  const trimmed = query.trim();
+  const isSelected = (login: string) =>
+    selected.some((entry) => entry.toLowerCase() === login.toLowerCase());
+
+  const options = useMemo(() => {
+    // Selected logins stay listed even when the pool has never seen them —
+    // a saved view's author must be visible to be uncheckable.
+    const byKey = new Map<string, CodeDeliveryAuthor>();
+    for (const login of selected) byKey.set(login.toLowerCase(), { login });
+    for (const author of knownAuthors) {
+      const key = author.login.toLowerCase();
+      const existing = byKey.get(key);
+      if (!existing) byKey.set(key, author);
+      else if (author.avatarUrl && !existing.avatarUrl) {
+        byKey.set(key, { ...existing, avatarUrl: author.avatarUrl });
+      }
+    }
+    const needle = trimmed.toLowerCase();
+    const chosen = new Set(selected.map((entry) => entry.toLowerCase()));
+    return [...byKey.values()]
+      .filter(
+        (author) => !needle || author.login.toLowerCase().includes(needle),
+      )
+      .sort((left, right) => {
+        const bySelection =
+          Number(chosen.has(right.login.toLowerCase())) -
+          Number(chosen.has(left.login.toLowerCase()));
+        if (bySelection !== 0) return bySelection;
+        return left.login.localeCompare(right.login);
+      });
+  }, [knownAuthors, selected, trimmed]);
+
+  const toggle = (login: string, enabled: boolean) => {
+    const rest = selected.filter(
+      (entry) => entry.toLowerCase() !== login.toLowerCase(),
+    );
+    onChange(enabled ? [...rest, login] : rest);
+  };
+
+  const exactMatchListed = options.some(
+    (author) => author.login.toLowerCase() === trimmed.toLowerCase(),
+  );
+  const addTyped = () => {
+    if (!trimmed) return;
+    toggle(trimmed, true);
+    setQuery("");
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Input
+        value={query}
+        placeholder={`Search ${noun}s or type a login`}
+        aria-label={`Search ${noun}s`}
+        onChange={(event) => setQuery(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter") return;
+          event.preventDefault();
+          if (!exactMatchListed) addTyped();
+          else if (trimmed) {
+            toggle(trimmed, !isSelected(trimmed));
+            setQuery("");
+          }
+        }}
+      />
+      {options.length > 0 && (
+        <div className="flex max-h-36 flex-col gap-1 overflow-auto pr-1">
+          {options.map((author) => (
+            <label
+              key={author.login.toLowerCase()}
+              className="flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-xs hover:bg-muted/40"
+            >
+              <Checkbox
+                checked={isSelected(author.login)}
+                onCheckedChange={(checked) =>
+                  toggle(author.login, checked === true)
+                }
+              />
+              <AuthorAvatar login={author.login} url={author.avatarUrl} />
+              <span className="min-w-0 truncate">{author.login}</span>
+            </label>
+          ))}
+        </div>
+      )}
+      {options.length === 0 && !trimmed && (
+        <p className="text-xs text-muted-foreground">{emptyNote}</p>
+      )}
+      {trimmed && !exactMatchListed && (
+        <button
+          type="button"
+          className="cursor-pointer rounded-md px-1.5 py-1 text-left text-xs text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+          onClick={addTyped}
+        >
+          Filter by “{trimmed}”
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** A login's face at list scale, with initials when there is no image. */
+function AuthorAvatar({ login, url }: { login: string; url?: string }) {
+  const [failed, setFailed] = useState(false);
+  const source = url ?? githubAvatarUrl(login);
+  if (!source || failed) {
+    return (
+      <span
+        className="grid size-5 shrink-0 place-items-center rounded-full bg-muted text-[9px] font-semibold uppercase text-muted-foreground"
+        aria-hidden
+      >
+        {login.slice(0, 2)}
+      </span>
+    );
+  }
+  return (
+    <img
+      src={source}
+      alt=""
+      className="size-5 shrink-0 rounded-full object-cover"
+      onError={() => setFailed(true)}
+    />
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "../api/types";
 import {
   codeDeliveryRepositoryKey,
+  mergeKnownAuthors,
   trackedCodeDeliveryRepositories,
   unreadCodeDeliveryNotifications,
   useCodeDeliveryStore,
@@ -219,5 +220,67 @@ describe("delivery notifications", () => {
       useCodeDeliveryStore.getState().ingestDeliveryPoll([], recent, NOW),
     ).toBe(506);
     expect(useCodeDeliveryStore.getState().notifications).toHaveLength(500);
+  });
+});
+
+describe("known delivery authors", () => {
+  it("dedupes logins case-insensitively and keeps the freshest avatar", () => {
+    const first = mergeKnownAuthors(
+      [],
+      [
+        { login: "mara", avatarUrl: "https://avatars.test/mara" },
+        { login: "devon" },
+      ],
+    );
+    expect(first.map((author) => author.login)).toEqual(["mara", "devon"]);
+
+    // A resighting under different casing is the same person: no duplicate
+    // row, the sighting moves to the front, and its avatar fills the gap.
+    const next = mergeKnownAuthors(first, [
+      { login: "Devon", avatarUrl: "https://avatars.test/devon" },
+    ]);
+    expect(next.map((author) => author.login)).toEqual(["Devon", "mara"]);
+    expect(next[0]!.avatarUrl).toBe("https://avatars.test/devon");
+    // A later sighting without an avatar must not erase a known one.
+    const kept = mergeKnownAuthors(next, [{ login: "devon" }]);
+    expect(kept[0]!.avatarUrl).toBe("https://avatars.test/devon");
+  });
+
+  it("bounds the pool and drops the oldest sighting past the cap", () => {
+    const crowd = Array.from({ length: 60 }, (_, index) => ({
+      login: `login-${index}`,
+    }));
+    const merged = mergeKnownAuthors([], crowd);
+    expect(merged).toHaveLength(50);
+    expect(merged[0]!.login).toBe("login-0");
+    expect(merged.some((author) => author.login === "login-59")).toBe(false);
+  });
+
+  it("harvests authors and actors from a completed poll and persists them", () => {
+    const repo = repository("brightwave-inc", "alpha", "repo-alpha");
+    useCodeDeliveryStore.getState().completeDeliveryPoll(
+      [
+        pullRequest(1, repo, {
+          author: "mara",
+          author_avatar_url: "https://avatars.test/mara",
+        }),
+      ],
+      [run(11, repo, { actor: "dependabot[bot]" })],
+      NOW,
+    );
+
+    expect(
+      useCodeDeliveryStore.getState().knownAuthors.map((a) => a.login),
+    ).toEqual(["mara", "dependabot[bot]"]);
+    expect(
+      JSON.parse(
+        window.localStorage.getItem("tidebreak.code-delivery") ?? "{}",
+      ),
+    ).toMatchObject({
+      knownAuthors: [
+        { login: "mara", avatarUrl: "https://avatars.test/mara" },
+        { login: "dependabot[bot]" },
+      ],
+    });
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.ts
@@ -13,11 +13,22 @@ import type {
 const STORAGE_KEY = "tidebreak.code-delivery";
 const STORAGE_VERSION = 1;
 const MAX_NOTIFICATIONS = 500;
+const MAX_KNOWN_AUTHORS = 50;
 const MAX_SEEN_FINGERPRINTS = 5_000;
 const MAX_NOTIFICATION_AGE_MS = 30 * 24 * 60 * 60 * 1_000;
 const REPOSITORY_CACHE_MS = 2 * 60 * 1_000;
 
 export type CodeDeliverySurface = "pull_requests" | "runs";
+
+/**
+ * A login Delivery has seen on a pull request or run, kept so the author
+ * filter can offer people instead of expecting logins typed from memory.
+ * Recency-ordered and bounded; the newest sighting's avatar wins.
+ */
+export type CodeDeliveryAuthor = {
+  login: string;
+  avatarUrl?: string;
+};
 
 export type CodeDeliveryPrViewFilters = {
   search: string;
@@ -134,6 +145,7 @@ type PersistedCodeDeliveryState = {
   notifications: CodeDeliveryNotification[];
   seenFingerprints: Record<string, string>;
   lastPollAt: string | null;
+  knownAuthors: CodeDeliveryAuthor[];
 };
 
 type CodeDeliveryStore = Omit<PersistedCodeDeliveryState, "version"> & {
@@ -169,6 +181,7 @@ type CodeDeliveryStore = Omit<PersistedCodeDeliveryState, "version"> & {
     runs: readonly CodeDeliveryRunSummary[],
     at: string,
   ) => number;
+  rememberDeliveryAuthors: (authors: readonly CodeDeliveryAuthor[]) => void;
   markNotificationRead: (id: string, read?: boolean) => void;
   markAllNotificationsRead: () => void;
   clearNotifications: () => void;
@@ -190,6 +203,7 @@ function emptyPersistedState(): PersistedCodeDeliveryState {
     notifications: [],
     seenFingerprints: {},
     lastPollAt: null,
+    knownAuthors: [],
   };
 }
 
@@ -216,6 +230,7 @@ function persist(state: CodeDeliveryStore): string | null {
     notifications: state.notifications,
     seenFingerprints: state.seenFingerprints,
     lastPollAt: state.lastPollAt,
+    knownAuthors: state.knownAuthors,
   };
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
@@ -373,6 +388,10 @@ export const useCodeDeliveryStore = create<CodeDeliveryStore>()((set, get) => {
       set({
         notifications: next.notifications,
         seenFingerprints: next.seenFingerprints,
+        knownAuthors: mergeKnownAuthors(
+          get().knownAuthors,
+          deliveryAuthorSightings(pullRequests, runs),
+        ),
         polling: false,
         monitorError: null,
         lastPollAt: at,
@@ -380,6 +399,20 @@ export const useCodeDeliveryStore = create<CodeDeliveryStore>()((set, get) => {
       });
       persistCurrent();
       return next.added;
+    },
+    rememberDeliveryAuthors: (authors) => {
+      const merged = mergeKnownAuthors(get().knownAuthors, authors);
+      const current = get().knownAuthors;
+      const unchanged =
+        merged.length === current.length &&
+        merged.every(
+          (author, index) =>
+            author.login === current[index]!.login &&
+            author.avatarUrl === current[index]!.avatarUrl,
+        );
+      if (unchanged) return;
+      set({ knownAuthors: merged });
+      persistCurrent();
     },
     markNotificationRead: (id, read = true) => {
       const at = new Date().toISOString();
@@ -734,6 +767,91 @@ export function unreadCodeDeliveryNotifications(
   );
 }
 
+/**
+ * Fold new sightings into the known-author pool: dedupe logins
+ * case-insensitively, move a resighted login to the front, let a sighting
+ * that carries an avatar refresh a stale one, and drop the oldest past the
+ * cap. Returns the current array unchanged when nothing moved, so callers
+ * can skip a persist.
+ */
+export function mergeKnownAuthors(
+  current: readonly CodeDeliveryAuthor[],
+  sightings: readonly CodeDeliveryAuthor[],
+): CodeDeliveryAuthor[] {
+  const incoming = new Map<string, CodeDeliveryAuthor>();
+  for (const sighting of sightings) {
+    const login = sighting.login.trim();
+    if (!login) continue;
+    const key = login.toLowerCase();
+    const previous = incoming.get(key);
+    incoming.set(key, {
+      login,
+      ...(sighting.avatarUrl || previous?.avatarUrl
+        ? { avatarUrl: sighting.avatarUrl ?? previous?.avatarUrl }
+        : {}),
+    });
+  }
+  if (incoming.size === 0) return [...current];
+  const merged: CodeDeliveryAuthor[] = [];
+  for (const [key, sighting] of incoming) {
+    const known = current.find((author) => author.login.toLowerCase() === key);
+    const avatarUrl = sighting.avatarUrl ?? known?.avatarUrl;
+    merged.push({ login: sighting.login, ...(avatarUrl ? { avatarUrl } : {}) });
+  }
+  for (const author of current) {
+    if (!incoming.has(author.login.toLowerCase())) merged.push(author);
+  }
+  const bounded = merged.slice(0, MAX_KNOWN_AUTHORS);
+  const unchanged =
+    bounded.length === current.length &&
+    bounded.every(
+      (author, index) =>
+        author.login === current[index]!.login &&
+        author.avatarUrl === current[index]!.avatarUrl,
+    );
+  return unchanged ? [...current] : bounded;
+}
+
+/** The logins one page of delivery rows contributes to the author pool. */
+export function deliveryAuthorSightings(
+  pullRequests: readonly CodeDeliveryPullRequestSummary[],
+  runs: readonly CodeDeliveryRunSummary[],
+): CodeDeliveryAuthor[] {
+  return [
+    ...pullRequests.flatMap((item) =>
+      item.author
+        ? [
+            {
+              login: item.author,
+              ...(item.author_avatar_url
+                ? { avatarUrl: item.author_avatar_url }
+                : {}),
+            },
+          ]
+        : [],
+    ),
+    ...runs.flatMap((item) => (item.actor ? [{ login: item.actor }] : [])),
+  ];
+}
+
+/** Tolerant: a blob written before authors existed hydrates to an empty pool. */
+function parseKnownAuthors(value: unknown): CodeDeliveryAuthor[] {
+  if (!Array.isArray(value)) return [];
+  const authors: CodeDeliveryAuthor[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry) || typeof entry.login !== "string") continue;
+    const login = entry.login.trim();
+    if (!login) continue;
+    authors.push({
+      login,
+      ...(typeof entry.avatarUrl === "string" && entry.avatarUrl
+        ? { avatarUrl: entry.avatarUrl }
+        : {}),
+    });
+  }
+  return authors.slice(0, MAX_KNOWN_AUTHORS);
+}
+
 function parsePersistedState(
   value: unknown,
 ): PersistedCodeDeliveryState | null {
@@ -768,6 +886,7 @@ function parsePersistedState(
     notifications,
     seenFingerprints: { ...value.seenFingerprints },
     lastPollAt: value.lastPollAt,
+    knownAuthors: parseKnownAuthors(value.knownAuthors),
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -1215,8 +1215,11 @@ function DiffPatch({ patch }: { patch: string }) {
         return (
           <code
             key={index}
+            // `w-max min-w-full`: a block child of a scrolling <pre> otherwise
+            // sizes to the visible width, so long lines ran past their own
+            // background and scrolling right left colored stubs behind.
             className={cn(
-              "block px-3 whitespace-pre",
+              "block w-max min-w-full px-3 whitespace-pre",
               kind === "add" && "bg-success/10",
               kind === "remove" && "bg-critical/10",
               kind === "hunk" && "bg-info/10 text-info-foreground-muted",

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -330,6 +330,16 @@ function resetStoryState(scenario: DeliveryScenario): void {
     composerActionScope: null,
   });
   useUiStore.setState({ sidebarCollapsed: false, sidebarWidth: 280 });
+  // The author filter offers logins Delivery has already seen; seed the pool
+  // the way a prior visit would have.
+  useCodeDeliveryStore.setState({
+    knownAuthors: [
+      { login: "mara" },
+      { login: "devon" },
+      { login: "ines" },
+      { login: "dependabot[bot]" },
+    ],
+  });
 
   if (scenario === "notifications") {
     useCodeDeliveryStore.setState({
@@ -785,5 +795,23 @@ export const NarrowPullRequestDetail: Story = {
     await expect(
       await body.findByRole("heading", { name: "Build the delivery center" }),
     ).toBeVisible();
+  },
+};
+
+/**
+ * The author filter is a lookup over logins Delivery has seen — avatars and
+ * checkboxes — with typing kept as the fallback for a login it has not.
+ */
+export const PullRequestAuthorFilter: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: /Filters/ }),
+    );
+    await expect(
+      await body.findByRole("checkbox", { name: "mara" }),
+    ).toBeVisible();
+    await userEvent.click(await body.findByRole("checkbox", { name: "mara" }));
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -922,6 +922,8 @@ const deliveryFiles: CodeDeliveryPullRequestFile[] = [
     status: "modified",
     additions: 184,
     deletions: 61,
+    // The second hunk carries lines far wider than the sheet: the diff view
+    // must scroll them with full-width line backgrounds, not clip them.
     patch: [
       "@@ -858,12 +858,18 @@ function PullRequestList({",
       "       <span>Pull request</span>",
@@ -929,6 +931,10 @@ const deliveryFiles: CodeDeliveryPullRequestFile[] = [
       "+      <span>Status</span>",
       "       <span>Checks</span>",
       '       <span className="text-right">Updated</span>',
+      "@@ -1020,6 +1026,8 @@ function PullRequestRow({",
+      "-  const summary = usePullRequestSummary(item, { includeChecks: true, includeReviewDecision: true, includeMergeState: true, includeWorkspaceLinks: true });",
+      "+  const summary = usePullRequestSummary(item, { includeChecks: true, includeReviewDecision: true, includeMergeState: true, includeWorkspaceLinks: true, includeAttentionReasons: true });",
+      "+  const checks = checkSummary(checkCounts(item.checks));",
     ].join("\n"),
   },
   {
@@ -1008,6 +1014,29 @@ export const deliveryPullRequestDetails: Record<
         body: "Keep repository failures visible without hiding usable results.",
         path: "src/code/CodeDeliveryPage.tsx",
         line: 702,
+      },
+      // A fenced, language-tagged block: the newest comment, and the one the
+      // syntax palette has to render readably inside a comment card.
+      {
+        kind: "review",
+        author: "mara",
+        created_at: "2026-08-20T15:26:00.000Z",
+        review_state: "commented",
+        url: "https://github.com/brightwave-inc/tidebreak/pull/2251#pullrequestreview-2",
+        body: [
+          "The lifecycle helper reads better as a lookup. Something like:",
+          "",
+          "```ts",
+          "const LIFECYCLE_BADGE_VARIANT: Record<PullRequestLifecycle, BadgeVariant> = {",
+          '  draft: "outline",',
+          '  open: "success",',
+          '  merged: "merged",',
+          '  closed: "critical",',
+          "};",
+          "```",
+          "",
+          "Not blocking. :rocket:",
+        ].join("\n"),
       },
     ],
     errors: [],


### PR DESCRIPTION
## What changed

Rebased onto `main` after #2538 landed the delivery sheet, comment ordering, admin merge, agent quick actions, and the tab-icon fix — that work is now dropped from this branch, and what remains is what #2538 did not cover. The author and actor filters were free-text boxes that required knowing a login and spelling it exactly; they are now a checkable list of the logins Delivery has already seen, each with its avatar, narrowed by a search box, with hand-typing kept as the fallback for a login the list has never seen. The pool lives in the delivery store — filled from every pull-request and run page and from the notification poll, deduped case-insensitively, most recent first, capped at fifty, and persisted with the other delivery settings. This also fixes diff lines clipping in the pull request sheet, which `main` still has: a block child of a scrolling `<pre>` sizes to the visible width, so a long line ran past its own red or green background.

## Validation

`pnpm test` (1740 pass), `tsc --noEmit`, `biome lint`/`format`, `pnpm build`, and `storybook:build` all pass on the rebased branch by exit code. New coverage: merge/dedupe/cap semantics and poll harvesting with persistence in the store test, and a pick-then-type flow through the real filter popover in the page test. A `PullRequestAuthorFilter` story renders the picker, and I screenshotted it in dark mode before the rebase.

## Compatibility and risk

The delivery store's persisted blob gains `knownAuthors`; a blob written before it hydrates to an empty pool, and the field is bounded at fifty entries so it cannot grow without limit. Avatars come from data GitHub already sends on the summaries, or fall back to initials — no new request, no new server surface, no wire-format change.