### PR TITLE
feat(code): open delivery details as sheets with agent quick actions

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -2023,6 +2023,7 @@ describe("code delivery API", () => {
         type: "merge" as const,
         method: "squash" as const,
         auto: true,
+        admin: false,
         expected_head_sha: "abc123",
       },
     };

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
@@ -24,7 +24,7 @@ import {
 } from "../stories/fixtures";
 import {
   CodeDeliveryPage,
-  RunDetailPanel,
+  RunDetailSheet,
   codeDeliverySearchFrom,
 } from "./CodeDeliveryPage";
 import { useCodeDeliveryStore } from "./CodeDeliveryStore";
@@ -438,7 +438,7 @@ describe("delivery run list", () => {
     const panel = (initialDetail?: typeof baseDetail) => (
       <StrictMode>
         <AppContextProvider value={appContext(client)}>
-          <RunDetailPanel
+          <RunDetailSheet
             summary={deliveryRuns.find((item) => item.github_id === 4401)!}
             initialDetail={initialDetail}
             onClose={vi.fn()}

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -85,9 +85,10 @@ import { CodeSidebar } from "./CodeSidebar";
 import { RepositoryTriggerRules } from "./RepositoryTriggerRules";
 import {
   CheckTone,
+  DetailSheet,
   DetailSkeleton,
   PrLifecycleIcon,
-  PullRequestDetailPanel,
+  PullRequestDetailSheet,
   relativeTime,
 } from "./PullRequestDetail";
 import {
@@ -901,14 +902,8 @@ function PullRequestsSurface({
   if (repositories.length === 0) return <NoDeliveryRepositories />;
 
   return (
-    <DeliverySplit selected={Boolean(selected)}>
-      <div
-        ref={scrollRef}
-        className={cn(
-          "min-h-0 flex-1 overflow-auto",
-          selected && "max-lg:hidden",
-        )}
-      >
+    <div className="flex min-h-0 flex-1">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
         {error && (
           <InlineLoadError message={error} onRetry={() => void query()} />
         )}
@@ -968,14 +963,14 @@ function PullRequestsSurface({
       targetDetailState.pending &&
       !targetDetailState.detail &&
       pullRequestMatchesTarget(selected, target) ? (
-        <PendingDetailPanel
+        <PendingDetailSheet
           context={`${selected.repository.name_with_owner} #${selected.number}`}
           title={selected.title}
           closeLabel="Close pull request details"
           onClose={closeDetail}
         />
       ) : selected ? (
-        <PullRequestDetailPanel
+        <PullRequestDetailSheet
           key={selected.id}
           client={client}
           summary={selected}
@@ -997,7 +992,7 @@ function PullRequestsSurface({
           }
         />
       ) : null}
-    </DeliverySplit>
+    </div>
   );
 }
 
@@ -1218,14 +1213,8 @@ function RunsSurface({
   if (repositories.length === 0) return <NoDeliveryRepositories />;
 
   return (
-    <DeliverySplit selected={Boolean(selected)}>
-      <div
-        ref={scrollRef}
-        className={cn(
-          "min-h-0 flex-1 overflow-auto",
-          selected && "max-lg:hidden",
-        )}
-      >
+    <div className="flex min-h-0 flex-1">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
         {error && (
           <InlineLoadError message={error} onRetry={() => void query()} />
         )}
@@ -1285,7 +1274,7 @@ function RunsSurface({
       targetDetailState.pending &&
       !targetDetailState.detail &&
       runMatchesTarget(selected, target) ? (
-        <PendingDetailPanel
+        <PendingDetailSheet
           context={`${selected.repository.name_with_owner} ${
             selected.kind === "deployment" ? "Deployment" : "Action"
           }`}
@@ -1294,7 +1283,7 @@ function RunsSurface({
           onClose={closeDetail}
         />
       ) : selected ? (
-        <RunDetailPanel
+        <RunDetailSheet
           key={selected.id}
           summary={selected}
           initialDetail={
@@ -1315,30 +1304,16 @@ function RunsSurface({
           }
         />
       ) : null}
-    </DeliverySplit>
-  );
-}
-
-function DeliverySplit({
-  selected,
-  children,
-}: {
-  selected: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "flex min-h-0 flex-1",
-        selected && "lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(360px,430px)]",
-      )}
-    >
-      {children}
     </div>
   );
 }
 
-function PendingDetailPanel({
+/**
+ * The sheet while a route-targeted detail is still loading: the reader
+ * followed a deep link, so the frame opens immediately with what the link
+ * already knew — repository, number, title — and the body fills in.
+ */
+function PendingDetailSheet({
   context,
   title,
   closeLabel,
@@ -1350,8 +1325,8 @@ function PendingDetailPanel({
   onClose: () => void;
 }) {
   return (
-    <aside className="flex min-h-0 w-full flex-col border-l border-border-subtle bg-background lg:w-auto">
-      <div className="flex shrink-0 items-start gap-3 border-b border-border-subtle px-4 py-3">
+    <DetailSheet label={title} onClose={onClose}>
+      <div className="flex shrink-0 items-start gap-3 border-b border-border-subtle px-5 py-3">
         <div className="min-w-0 flex-1">
           <div className="text-xs text-muted-foreground">{context}</div>
           <h2 className="mt-1 text-base font-semibold leading-snug">{title}</h2>
@@ -1361,10 +1336,10 @@ function PendingDetailPanel({
           <span className="sr-only">{closeLabel}</span>
         </Button>
       </div>
-      <div className="min-h-0 flex-1 overflow-auto p-4">
+      <div className="min-h-0 flex-1 overflow-auto p-5">
         <DetailSkeleton />
       </div>
-    </aside>
+    </DetailSheet>
   );
 }
 
@@ -1694,7 +1669,7 @@ function RunList({
   );
 }
 
-export function RunDetailPanel({
+export function RunDetailSheet({
   summary,
   initialDetail,
   onClose,
@@ -1797,8 +1772,11 @@ export function RunDetailPanel({
   };
 
   return (
-    <aside className="flex min-h-0 w-full flex-col border-l border-border-subtle bg-background lg:w-auto">
-      <div className="flex shrink-0 items-start gap-3 border-b border-border-subtle px-4 py-3">
+    <DetailSheet
+      label={`${summary.kind === "deployment" ? "Deployment" : "Action"}: ${summary.name}`}
+      onClose={onClose}
+    >
+      <div className="flex shrink-0 items-start gap-3 border-b border-border-subtle px-5 py-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <span>{summary.repository.name_with_owner}</span>
@@ -1815,7 +1793,7 @@ export function RunDetailPanel({
           <span className="sr-only">Close run details</span>
         </Button>
       </div>
-      <div className="min-h-0 flex-1 overflow-auto p-4">
+      <div className="min-h-0 flex-1 overflow-auto p-5">
         {loading && !detail ? (
           <DetailSkeleton />
         ) : error ? (
@@ -1984,7 +1962,7 @@ export function RunDetailPanel({
           </div>
         ) : null}
       </div>
-    </aside>
+    </DetailSheet>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
@@ -345,4 +345,71 @@ describe("PullRequestDetailSheet", () => {
     expect(within(header).getByText("−83")).toBeInTheDocument();
     expect(within(header).getByText("devon")).toBeInTheDocument();
   });
+
+  /**
+   * The confirmation is inline in the actions card, never a second Radix
+   * modal: the sheet is already one, and stacked modals share a dismiss
+   * layer and the body pointer-events lock.
+   */
+  it("admin-merges only through the inline confirmation, with the bypass flag", async () => {
+    const runAction = vi.fn(
+      async (_body: CodeDeliveryPullRequestActionBody) => ({
+        success: true,
+        message: "Merged.",
+      }),
+    );
+    await renderPanel(
+      2251,
+      client({ runCodeDeliveryPullRequestAction: runAction }),
+    );
+
+    // The plain merge stays disabled while branch protection blocks it.
+    expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
+    await userEvent.click(
+      screen.getByRole("button", { name: "More pull request actions" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("menuitem", {
+        name: /Admin merge \(bypass protections\)/,
+      }),
+    );
+    expect(runAction).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Admin merge" }));
+    await waitFor(() => expect(runAction).toHaveBeenCalledTimes(1));
+    expect(runAction.mock.calls[0]![0]).toMatchObject({
+      action: {
+        type: "merge",
+        admin: true,
+        auto: false,
+        expected_head_sha: "82ab990",
+      },
+    });
+  });
+
+  it("abandons the admin merge on cancel", async () => {
+    const runAction = vi.fn(
+      async (_body: CodeDeliveryPullRequestActionBody) => ({
+        success: true,
+        message: "Merged.",
+      }),
+    );
+    await renderPanel(
+      2251,
+      client({ runCodeDeliveryPullRequestAction: runAction }),
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "More pull request actions" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("menuitem", {
+        name: /Admin merge \(bypass protections\)/,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("button", { name: "Admin merge" })).toBeNull();
+    expect(runAction).not.toHaveBeenCalled();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
@@ -19,7 +19,7 @@ import {
   deliveryPullRequestDetails,
   deliveryPullRequests,
 } from "../stories/fixtures";
-import { PullRequestDetailPanel } from "./PullRequestDetail";
+import { PullRequestDetailSheet } from "./PullRequestDetail";
 
 afterEach(cleanup);
 
@@ -52,7 +52,7 @@ function summaryFor(number: number) {
 
 async function renderPanel(number: number, api = client()) {
   render(
-    <PullRequestDetailPanel
+    <PullRequestDetailSheet
       client={api}
       summary={summaryFor(number)}
       onClose={vi.fn()}
@@ -63,7 +63,7 @@ async function renderPanel(number: number, api = client()) {
   await screen.findByRole("tab", { name: /Conversation/ });
 }
 
-describe("PullRequestDetailPanel", () => {
+describe("PullRequestDetailSheet", () => {
   it("accepts load, refresh, and mutation completions in Strict Mode", async () => {
     vi.mocked(toast.success).mockClear();
     const baseDetail = deliveryPullRequestDetails[2251]!;
@@ -99,7 +99,7 @@ describe("PullRequestDetailPanel", () => {
 
     render(
       <StrictMode>
-        <PullRequestDetailPanel
+        <PullRequestDetailSheet
           client={client({
             getCodeDeliveryPullRequestDetail: getDetail,
             runCodeDeliveryPullRequestAction: runAction,
@@ -278,7 +278,7 @@ describe("PullRequestDetailPanel", () => {
       onOpenWorkspace: vi.fn(),
     };
     const view = render(
-      <PullRequestDetailPanel
+      <PullRequestDetailSheet
         {...props}
         summary={summaryFor(2251)}
         initialDetail={deliveryPullRequestDetails[2251]}
@@ -291,7 +291,7 @@ describe("PullRequestDetailPanel", () => {
     await waitFor(() => expect(runAction).toHaveBeenCalledTimes(1));
 
     view.rerender(
-      <PullRequestDetailPanel
+      <PullRequestDetailSheet
         {...props}
         summary={summaryFor(2247)}
         initialDetail={deliveryPullRequestDetails[2247]}

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
+  Bot,
   Check,
   CircleAlert,
   CircleDot,
@@ -14,6 +16,7 @@ import {
   MoreHorizontal,
   Play,
   RefreshCw,
+  ShieldAlert,
   X,
 } from "lucide-react";
 import { formatDistanceToNowStrict } from "date-fns";
@@ -30,10 +33,18 @@ import type {
 } from "../api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ConfirmDialog";
+import {
+  Dialog,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -49,8 +60,18 @@ import { Textarea } from "@/components/ui/textarea";
 import { MessageMarkdown } from "@/MessageMarkdown";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { openInBrowser } from "@/openInBrowser";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
 import { codeDeliveryRepositoryTarget } from "./CodeDeliveryStore";
+import { fetchFixErrorsLogs } from "./checkLogs";
 import { MiddleTruncate } from "./MiddleTruncate";
+import {
+  deliveryPullRequestDigest,
+  prAgentQuickActions,
+  prFreshAgentPrompt,
+  prWorkflowPrompt,
+  type PrPromptAction,
+} from "./prActions";
 import { PrCommentCard } from "./PrCommentCard";
 import {
   checkCounts,
@@ -59,9 +80,11 @@ import {
   fileStatusTone,
   githubAvatarUrl,
   mergeBlockedReason,
+  orderPullRequestComments,
   pullRequestLifecycle,
   pullRequestSettledAt,
   PULL_REQUEST_LIFECYCLE_LABEL,
+  type PullRequestCommentOrder,
   type PullRequestLifecycle,
 } from "./pullRequestPresentation";
 import { STATUS_MARK, STATUS_TEXT } from "./statusTone";
@@ -80,7 +103,44 @@ const LIFECYCLE_BADGE_VARIANT: Record<
 };
 
 /**
- * The pull request, as close to its GitHub page as a desktop panel gets.
+ * The frame both delivery detail surfaces share: a large sheet floated over
+ * the list rather than a column squeezed beside it. The list keeps its full
+ * width, the detail gets room for a real diff, and closing is the ordinary
+ * dialog vocabulary — Escape, the overlay, or the header's X.
+ */
+export function DetailSheet({
+  label,
+  onClose,
+  children,
+}: {
+  /** Accessible name for the sheet; the visible header carries the title. */
+  label: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogPortal>
+        <DialogOverlay className="bg-black/40" />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          className="fixed top-1/2 left-1/2 z-50 flex h-[min(52rem,calc(100vh-3rem))] w-[min(66rem,calc(100vw-2.5rem))] translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden rounded-xl border border-border-subtle bg-background shadow-lg outline-none duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+        >
+          <DialogTitle className="sr-only">{label}</DialogTitle>
+          {children}
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
+  );
+}
+
+/**
+ * The pull request, as close to its GitHub page as a desktop sheet gets.
  *
  * The point is that a reader finishes here. Everything the GitHub page leads
  * with — lifecycle, who merged it and when, the branch pair, the diffstat,
@@ -88,9 +148,11 @@ const LIFECYCLE_BADGE_VARIANT: Record<
  * every check, every changed file — is on this surface, and the actions that
  * page offers (ready, merge, auto-merge, rerun, close, reopen, comment) run
  * from it. "Open on GitHub" stays, but as an escape hatch rather than the
- * only way to see what happened.
+ * only way to see what happened. Beyond the page itself, the sheet links the
+ * pull request to the Tidebreak workspaces that carry it and can put an
+ * agent — linked or fresh — onto its remaining chores.
  */
-export function PullRequestDetailPanel({
+export function PullRequestDetailSheet({
   client,
   summary,
   initialDetail,
@@ -100,7 +162,10 @@ export function PullRequestDetailPanel({
 }: {
   client: Pick<
     ApiClient,
-    "getCodeDeliveryPullRequestDetail" | "runCodeDeliveryPullRequestAction"
+    | "getCodeDeliveryPullRequestDetail"
+    | "runCodeDeliveryPullRequestAction"
+    | "createCodeWorkspace"
+    | "writeCodeCheckLogs"
   >;
   summary: CodeDeliveryPullRequestSummary;
   initialDetail?: CodeDeliveryPullRequestDetail;
@@ -116,7 +181,10 @@ export function PullRequestDetailPanel({
   const [busy, setBusy] = useState<string | null>(null);
   const [tab, setTab] = useState<DetailTab>("conversation");
   const [mergeMethod, setMergeMethod] = useState<MergeMethod>("squash");
+  const [commentOrder, setCommentOrder] =
+    useState<PullRequestCommentOrder>("newest");
   const [draftComment, setDraftComment] = useState("");
+  const { confirm, dialog: confirmDialog } = useConfirm();
   const generation = useRef(0);
   const activeTarget = useRef(summary.id);
   const mounted = useRef(true);
@@ -160,6 +228,7 @@ export function PullRequestDetailPanel({
 
   useEffect(() => {
     setTab("conversation");
+    setCommentOrder("newest");
     setDraftComment("");
     if (initialDetail?.summary.id === summary.id) {
       setDetail(initialDetail);
@@ -213,7 +282,7 @@ export function PullRequestDetailPanel({
   };
 
   // Prefer the freshly loaded summary: an action just changed it, and the row
-  // behind this panel may still be a poll behind.
+  // behind this sheet may still be a poll behind.
   const current = detail?.summary ?? summary;
   const lifecycle = pullRequestLifecycle(current);
   const counts = checkCounts(current.checks);
@@ -228,8 +297,29 @@ export function PullRequestDetailPanel({
     [current.checks],
   );
 
+  const adminMerge = async () => {
+    if (!current.head_sha) return;
+    const ok = await confirm({
+      title: "Merge, bypassing branch protection?",
+      description: `Admin merge lands pull request #${current.number} immediately and skips any reviews and checks the branch still requires. GitHub records the bypass under your account.`,
+      confirmLabel: "Admin merge",
+      destructive: true,
+    });
+    if (!ok) return;
+    await runAction("admin-merge", {
+      type: "merge",
+      method: mergeMethod,
+      auto: false,
+      admin: true,
+      expected_head_sha: current.head_sha,
+    });
+  };
+
   return (
-    <aside className="flex min-h-0 w-full flex-col border-l border-border-subtle bg-background lg:w-auto">
+    <DetailSheet
+      label={`Pull request #${summary.number}: ${summary.title}`}
+      onClose={onClose}
+    >
       <PrDetailHeader
         summary={current}
         lifecycle={lifecycle}
@@ -237,7 +327,7 @@ export function PullRequestDetailPanel({
         onClose={onClose}
       />
 
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border-subtle px-4 py-2.5">
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border-subtle px-5 py-2.5">
         <Button
           type="button"
           size="xs"
@@ -253,16 +343,23 @@ export function PullRequestDetailPanel({
             type="button"
             size="xs"
             variant="outline"
+            title={`Open the linked workspace on ${workspace.branch_name}`}
             onClick={() => onOpenWorkspace(workspace.workspace_id)}
           >
             <GitBranch />
             Open {workspace.title}
           </Button>
         ))}
+        <PrAgentMenu
+          client={client}
+          summary={current}
+          onOpenWorkspace={onOpenWorkspace}
+        />
         <Button
           type="button"
           size="xs"
           variant="ghost"
+          className="ml-auto"
           disabled={loading}
           onClick={() => void load()}
         >
@@ -273,7 +370,7 @@ export function PullRequestDetailPanel({
 
       <div className="min-h-0 flex-1 overflow-auto">
         {loading && !detail ? (
-          <div className="p-4">
+          <div className="p-5">
             <DetailSkeleton />
           </div>
         ) : error ? (
@@ -285,7 +382,7 @@ export function PullRequestDetailPanel({
               value={tab}
               onValueChange={(value) => setTab(value as DetailTab)}
             >
-              <TabsList className="sticky top-0 z-10 w-full justify-start rounded-none border-b border-border-subtle bg-background/95 px-4 backdrop-blur">
+              <TabsList className="sticky top-0 z-10 w-full justify-start rounded-none border-b border-border-subtle bg-background/95 px-5 backdrop-blur">
                 <TabsTrigger value="conversation">
                   <MessageSquare />
                   Conversation
@@ -322,7 +419,7 @@ export function PullRequestDetailPanel({
 
               <TabsContent
                 value="conversation"
-                className="mt-0 flex flex-col gap-5 p-4"
+                className="mt-0 flex flex-col gap-5 p-5"
               >
                 <PrActions
                   detail={detail}
@@ -332,11 +429,14 @@ export function PullRequestDetailPanel({
                   onMergeMethodChange={setMergeMethod}
                   workflowRunIds={workflowRunIds}
                   onRun={(name, action) => void runAction(name, action)}
+                  onAdminMerge={() => void adminMerge()}
                 />
                 <PrDescription body={detail.body} />
                 <PrConversation
                   detail={detail}
                   busy={busy}
+                  order={commentOrder}
+                  onOrderChange={setCommentOrder}
                   draft={draftComment}
                   onDraftChange={setDraftComment}
                   onComment={() =>
@@ -348,18 +448,19 @@ export function PullRequestDetailPanel({
                 />
               </TabsContent>
 
-              <TabsContent value="files" className="mt-0 p-4">
+              <TabsContent value="files" className="mt-0 p-5">
                 <PrFiles detail={detail} />
               </TabsContent>
 
-              <TabsContent value="checks" className="mt-0 p-4">
+              <TabsContent value="checks" className="mt-0 p-5">
                 <PrChecks checks={current.checks} />
               </TabsContent>
             </Tabs>
           </>
         ) : null}
       </div>
-    </aside>
+      {confirmDialog}
+    </DetailSheet>
   );
 }
 
@@ -407,7 +508,7 @@ function DetailErrors({
   return (
     <div
       role="alert"
-      className="m-4 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2.5 text-xs"
+      className="m-5 mb-0 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2.5 text-xs"
     >
       <p className="font-medium text-warning">Some details could not load.</p>
       <ul className="mt-1 list-disc space-y-1 pl-4 text-muted-foreground">
@@ -434,7 +535,7 @@ function PrDetailHeader({
 }) {
   const settledAt = pullRequestSettledAt(summary);
   return (
-    <div className="shrink-0 border-b border-border-subtle px-4 py-3">
+    <div className="shrink-0 border-b border-border-subtle px-5 py-3">
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
@@ -536,6 +637,129 @@ function PrDetailHeader({
   );
 }
 
+/**
+ * Put an agent onto this pull request's remaining chores.
+ *
+ * The menu offers only what the pull request actually has — conflicts,
+ * failing checks, requested changes, a stale base — and says where the agent
+ * runs before anything starts. A linked active workspace is the natural
+ * target because its branch is the pull request's own; without one, a fresh
+ * workspace is cut from the head branch and the prompt tells the agent how
+ * to push back to it.
+ */
+function PrAgentMenu({
+  client,
+  summary,
+  onOpenWorkspace,
+}: {
+  client: Pick<ApiClient, "createCodeWorkspace" | "writeCodeCheckLogs">;
+  summary: CodeDeliveryPullRequestSummary;
+  onOpenWorkspace: (workspaceId: string) => void;
+}) {
+  const [starting, setStarting] = useState(false);
+  const digest = useMemo(() => deliveryPullRequestDigest(summary), [summary]);
+  const actions = useMemo(() => prAgentQuickActions(digest), [digest]);
+  const link =
+    summary.workspace_links.find(
+      (candidate) => candidate.exact && candidate.status === "active",
+    ) ??
+    summary.workspace_links.find((candidate) => candidate.status === "active");
+  const repoId = summary.repository.tidebreak_repo_id;
+  if (actions.length === 0 || (!link && !repoId)) return null;
+
+  const run = async (action: PrPromptAction) => {
+    if (useCodeUiStore.getState().composerActionScope !== null) {
+      toast.error("Another agent action is already running");
+      return;
+    }
+    setStarting(true);
+    try {
+      if (link) {
+        const logs =
+          action === "fix_errors"
+            ? await fetchFixErrorsLogs(client, link.workspace_id)
+            : [];
+        if (
+          !useCodeUiStore
+            .getState()
+            .runComposerPrompt(
+              link.workspace_id,
+              prWorkflowPrompt(action, digest, logs),
+            )
+        ) {
+          toast.error("Another agent action is already running");
+          return;
+        }
+        onOpenWorkspace(link.workspace_id);
+        return;
+      }
+      // No linked workspace: cut a fresh one from the pull request's head.
+      // Log download is skipped on purpose — it reads the workspace's own
+      // pull request digest, which a just-created workspace does not have;
+      // the prompt's fallback already tells the agent to read CI itself.
+      const workspace = await client.createCodeWorkspace({
+        repo_id: repoId!,
+        title: freshAgentWorkspaceTitle(summary),
+        base_ref: summary.head_branch,
+      });
+      useCodeCatalogStore.getState().upsertWorkspace(workspace);
+      if (
+        !useCodeUiStore
+          .getState()
+          .runComposerPrompt(workspace.id, prFreshAgentPrompt(action, digest))
+      ) {
+        toast.error("Another agent action is already running");
+        return;
+      }
+      onOpenWorkspace(workspace.id);
+    } catch (caught) {
+      toast.error(
+        friendlyErrorMessage(
+          caught,
+          "Could not start an agent on this pull request.",
+        ),
+      );
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" size="xs" variant="outline" disabled={starting}>
+          {starting ? <LoaderCircle className="animate-spin" /> : <Bot />}
+          Fix with an agent
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <div className="max-w-64 px-2 py-1.5 text-[11px] text-muted-foreground">
+          {link
+            ? `Runs in ${link.title}, the linked workspace.`
+            : `Starts a fresh workspace on ${summary.repository.name_with_owner}.`}
+        </div>
+        <DropdownMenuSeparator />
+        {actions.map((item) => (
+          <DropdownMenuItem
+            key={item.action}
+            onSelect={() => void run(item.action)}
+          >
+            {item.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/** Readable in the rail, and short enough to slug into a branch name. */
+function freshAgentWorkspaceTitle(
+  summary: CodeDeliveryPullRequestSummary,
+): string {
+  const base = `PR #${summary.number} ${summary.title}`.trim();
+  return base.length > 60 ? `${base.slice(0, 59).trimEnd()}…` : base;
+}
+
 function PrActions({
   detail,
   summary,
@@ -544,6 +768,7 @@ function PrActions({
   onMergeMethodChange,
   workflowRunIds,
   onRun,
+  onAdminMerge,
 }: {
   detail: CodeDeliveryPullRequestDetail;
   summary: CodeDeliveryPullRequestSummary;
@@ -552,9 +777,11 @@ function PrActions({
   onMergeMethodChange: (method: MergeMethod) => void;
   workflowRunIds: number[];
   onRun: (name: string, action: CodeDeliveryPullRequestAction) => void;
+  onAdminMerge: () => void;
 }) {
   const blocked = mergeBlockedReason(summary);
   const canRerun = detail.can_rerun_failed && workflowRunIds.length > 0;
+  const canAdminMerge = detail.can_merge && Boolean(summary.head_sha);
   const anyAction =
     detail.can_mark_ready ||
     detail.can_merge ||
@@ -603,6 +830,7 @@ function PrActions({
                   type: "merge",
                   method: mergeMethod,
                   auto: false,
+                  admin: false,
                   expected_head_sha: summary.head_sha!,
                 })
               }
@@ -621,6 +849,7 @@ function PrActions({
                   type: "merge",
                   method: mergeMethod,
                   auto: true,
+                  admin: false,
                   expected_head_sha: summary.head_sha!,
                 })
               }
@@ -667,7 +896,7 @@ function PrActions({
             Reopen
           </Button>
         )}
-        {detail.can_close && (
+        {(detail.can_close || canAdminMerge) && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -677,7 +906,7 @@ function PrActions({
                 disabled={Boolean(busy)}
                 aria-label="More pull request actions"
               >
-                {busy === "close" ? (
+                {busy === "close" || busy === "admin-merge" ? (
                   <LoaderCircle className="animate-spin" />
                 ) : (
                   <MoreHorizontal />
@@ -685,13 +914,21 @@ function PrActions({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                variant="destructive"
-                onSelect={() => onRun("close", { type: "close" })}
-              >
-                <GitPullRequestClosed />
-                Close without merging
-              </DropdownMenuItem>
+              {canAdminMerge && (
+                <DropdownMenuItem onSelect={onAdminMerge}>
+                  <ShieldAlert />
+                  Admin merge (bypass protections)…
+                </DropdownMenuItem>
+              )}
+              {detail.can_close && (
+                <DropdownMenuItem
+                  variant="destructive"
+                  onSelect={() => onRun("close", { type: "close" })}
+                >
+                  <GitPullRequestClosed />
+                  Close without merging
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}
@@ -735,24 +972,54 @@ function PrDescription({ body }: { body: string }) {
 function PrConversation({
   detail,
   busy,
+  order,
+  onOrderChange,
   draft,
   onDraftChange,
   onComment,
 }: {
   detail: CodeDeliveryPullRequestDetail;
   busy: string | null;
+  order: PullRequestCommentOrder;
+  onOrderChange: (order: PullRequestCommentOrder) => void;
   draft: string;
   onDraftChange: (value: string) => void;
   onComment: () => void;
 }) {
+  const ordered = useMemo(
+    () => orderPullRequestComments(detail.comments, order),
+    [detail.comments, order],
+  );
   return (
     <section>
-      <h3 className="text-sm font-medium">Conversation</h3>
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-sm font-medium">Conversation</h3>
+        {detail.comments.length > 1 && (
+          <Select
+            value={order}
+            onValueChange={(value) =>
+              onOrderChange(value as PullRequestCommentOrder)
+            }
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-32"
+              aria-label="Comment order"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="newest">Newest first</SelectItem>
+              <SelectItem value="oldest">Oldest first</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
+      </div>
       {detail.comments.length === 0 ? (
         <p className="mt-2 text-xs text-muted-foreground">No comments yet.</p>
       ) : (
         <div className="mt-2 flex flex-col gap-2.5">
-          {detail.comments.map((comment, index) => (
+          {ordered.map((comment, index) => (
             <PrCommentCard
               key={
                 comment.id ?? `${comment.created_at}:${comment.author}:${index}`
@@ -887,28 +1154,50 @@ function PrFileCard({ file }: { file: CodeDeliveryPullRequestFile }) {
   );
 }
 
-/** A unified patch, colored the way a diff should be. */
+/**
+ * A unified patch, colored the way a diff should be: a quiet background tint
+ * per changed line and a colored sign, with the code itself kept in the
+ * ordinary foreground. Recoloring whole lines of code green and red made the
+ * text fight the tint in both themes; the tint alone carries the meaning.
+ */
 function DiffPatch({ patch }: { patch: string }) {
   const lines = useMemo(() => patch.split("\n"), [patch]);
   return (
     <pre className="overflow-x-auto py-1 font-mono text-[11px] leading-[1.45]">
-      {lines.map((line, index) => (
-        <code
-          key={index}
-          className={cn(
-            "block px-3 whitespace-pre",
-            line.startsWith("+") &&
-              !line.startsWith("+++") &&
-              "bg-success-background text-success-foreground-muted",
-            line.startsWith("-") &&
-              !line.startsWith("---") &&
-              "bg-critical-background text-critical-foreground-muted",
-            line.startsWith("@@") && "text-info-foreground",
-          )}
-        >
-          {line || " "}
-        </code>
-      ))}
+      {lines.map((line, index) => {
+        const kind =
+          line.startsWith("+") && !line.startsWith("+++")
+            ? "add"
+            : line.startsWith("-") && !line.startsWith("---")
+              ? "remove"
+              : line.startsWith("@@")
+                ? "hunk"
+                : "context";
+        return (
+          <code
+            key={index}
+            className={cn(
+              "block px-3 whitespace-pre",
+              kind === "add" && "bg-success/10",
+              kind === "remove" && "bg-critical/10",
+              kind === "hunk" && "bg-info/10 text-info-foreground-muted",
+            )}
+          >
+            {kind === "add" || kind === "remove" ? (
+              <>
+                <span
+                  className={kind === "add" ? "text-success" : "text-critical"}
+                >
+                  {line[0]}
+                </span>
+                {line.slice(1)}
+              </>
+            ) : (
+              line || " "
+            )}
+          </code>
+        );
+      })}
     </pre>
   );
 }
@@ -1038,7 +1327,7 @@ function InlineDetailError({
   onRetry: () => void;
 }) {
   return (
-    <div className="m-4 flex items-center justify-between gap-3 rounded-lg border border-critical-border bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted">
+    <div className="m-5 flex items-center justify-between gap-3 rounded-lg border border-critical-border bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted">
       <span>{message}</span>
       <Button type="button" size="xs" variant="outline" onClick={onRetry}>
         Try again

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -33,7 +33,6 @@ import type {
 } from "../api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { useConfirm } from "@/components/ConfirmDialog";
 import {
   Dialog,
   DialogOverlay,
@@ -184,7 +183,11 @@ export function PullRequestDetailSheet({
   const [commentOrder, setCommentOrder] =
     useState<PullRequestCommentOrder>("newest");
   const [draftComment, setDraftComment] = useState("");
-  const { confirm, dialog: confirmDialog } = useConfirm();
+  // Inline rather than a dialog: the sheet is already a modal, and a second
+  // Radix modal stacked on it shares the dismiss layer and the body
+  // pointer-events lock — the class of bug #2537 hit with a dialog over a
+  // dialog. The confirmation renders inside the actions card instead.
+  const [confirmingAdminMerge, setConfirmingAdminMerge] = useState(false);
   const generation = useRef(0);
   const activeTarget = useRef(summary.id);
   const mounted = useRef(true);
@@ -230,6 +233,7 @@ export function PullRequestDetailSheet({
     setTab("conversation");
     setCommentOrder("newest");
     setDraftComment("");
+    setConfirmingAdminMerge(false);
     if (initialDetail?.summary.id === summary.id) {
       setDetail(initialDetail);
       setLoading(false);
@@ -299,13 +303,7 @@ export function PullRequestDetailSheet({
 
   const adminMerge = async () => {
     if (!current.head_sha) return;
-    const ok = await confirm({
-      title: "Merge, bypassing branch protection?",
-      description: `Admin merge lands pull request #${current.number} immediately and skips any reviews and checks the branch still requires. GitHub records the bypass under your account.`,
-      confirmLabel: "Admin merge",
-      destructive: true,
-    });
-    if (!ok) return;
+    setConfirmingAdminMerge(false);
     await runAction("admin-merge", {
       type: "merge",
       method: mergeMethod,
@@ -429,7 +427,10 @@ export function PullRequestDetailSheet({
                   onMergeMethodChange={setMergeMethod}
                   workflowRunIds={workflowRunIds}
                   onRun={(name, action) => void runAction(name, action)}
-                  onAdminMerge={() => void adminMerge()}
+                  confirmingAdminMerge={confirmingAdminMerge}
+                  onAdminMergeRequest={() => setConfirmingAdminMerge(true)}
+                  onAdminMergeCancel={() => setConfirmingAdminMerge(false)}
+                  onAdminMergeConfirm={() => void adminMerge()}
                 />
                 <PrDescription body={detail.body} />
                 <PrConversation
@@ -459,7 +460,6 @@ export function PullRequestDetailSheet({
           </>
         ) : null}
       </div>
-      {confirmDialog}
     </DetailSheet>
   );
 }
@@ -768,7 +768,10 @@ function PrActions({
   onMergeMethodChange,
   workflowRunIds,
   onRun,
-  onAdminMerge,
+  confirmingAdminMerge,
+  onAdminMergeRequest,
+  onAdminMergeCancel,
+  onAdminMergeConfirm,
 }: {
   detail: CodeDeliveryPullRequestDetail;
   summary: CodeDeliveryPullRequestSummary;
@@ -777,7 +780,10 @@ function PrActions({
   onMergeMethodChange: (method: MergeMethod) => void;
   workflowRunIds: number[];
   onRun: (name: string, action: CodeDeliveryPullRequestAction) => void;
-  onAdminMerge: () => void;
+  confirmingAdminMerge: boolean;
+  onAdminMergeRequest: () => void;
+  onAdminMergeCancel: () => void;
+  onAdminMergeConfirm: () => void;
 }) {
   const blocked = mergeBlockedReason(summary);
   const canRerun = detail.can_rerun_failed && workflowRunIds.length > 0;
@@ -915,7 +921,7 @@ function PrActions({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               {canAdminMerge && (
-                <DropdownMenuItem onSelect={onAdminMerge}>
+                <DropdownMenuItem onSelect={onAdminMergeRequest}>
                   <ShieldAlert />
                   Admin merge (bypass protections)…
                 </DropdownMenuItem>
@@ -933,6 +939,39 @@ function PrActions({
           </DropdownMenu>
         )}
       </div>
+      {confirmingAdminMerge && canAdminMerge && (
+        <div className="mt-2.5 flex flex-col gap-2 rounded-md border border-critical-border bg-critical-background/40 p-2.5">
+          <p className="flex items-start gap-1.5 text-xs text-critical-foreground-muted">
+            <ShieldAlert className="mt-0.5 size-3.5 shrink-0" />
+            Admin merge lands this pull request now and skips any reviews and
+            checks the branch still requires. GitHub records the bypass under
+            your account.
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              size="xs"
+              variant="destructive"
+              disabled={Boolean(busy)}
+              onClick={onAdminMergeConfirm}
+            >
+              {busy === "admin-merge" && (
+                <LoaderCircle className="animate-spin" />
+              )}
+              Admin merge
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              disabled={Boolean(busy)}
+              onClick={onAdminMergeCancel}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
       {blocked && detail.can_merge && (
         <p className="mt-2.5 flex items-start gap-1.5 border-t border-border-subtle pt-2.5 text-xs text-warning-foreground">
           <CircleAlert className="mt-0.5 size-3.5 shrink-0" />

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import type { PullRequestDigest } from "../api/types";
 import {
+  prAgentQuickActions,
+  prFreshAgentPrompt,
   prHasConflicts,
   prIsQueued,
   prWorkflowPrompt,
@@ -226,5 +228,66 @@ describe("prWorkflowPrompt", () => {
     expect(() => prWorkflowPrompt("merge", pr({}))).toBeDefined();
     // @ts-expect-error readying a draft is not an agent action
     expect(() => prWorkflowPrompt("mark_ready", pr({}))).toBeDefined();
+  });
+});
+
+describe("prAgentQuickActions", () => {
+  it("offers nothing on a settled pull request", () => {
+    expect(prAgentQuickActions(pr({ state: "merged" }))).toEqual([]);
+    expect(
+      prAgentQuickActions(pr({ state: "closed", mergeable: "conflicting" })),
+    ).toEqual([]);
+  });
+
+  it("maps each live chore to its prompt action, conflicts first", () => {
+    const actions = prAgentQuickActions(
+      pr({
+        mergeable: "conflicting",
+        review_decision: "changes_requested",
+        checks: [{ name: "ci", bucket: "fail" }],
+      }),
+    ).map((item) => item.action);
+    expect(actions).toEqual([
+      "resolve_conflicts",
+      "fix_errors",
+      "address_feedback",
+    ]);
+    expect(
+      prAgentQuickActions(pr({ merge_state_status: "behind" })).map(
+        (item) => item.action,
+      ),
+    ).toEqual(["update_branch"]);
+    expect(prAgentQuickActions(pr({}))).toEqual([]);
+  });
+});
+
+describe("prFreshAgentPrompt", () => {
+  it("names the pull request's head branch as the push target", () => {
+    const prompt = prFreshAgentPrompt(
+      "resolve_conflicts",
+      pr({ head_branch: "devon/shared-status-tone", base_branch: "main" }),
+    );
+    // The fresh workspace's own branch is local-only; a bare push would
+    // publish the wrong branch and leave the pull request untouched.
+    expect(prompt).toMatch(/git push origin HEAD:devon\/shared-status-tone/);
+    expect(prompt).toMatch(/do not open a new pull request/);
+    expect(
+      prompt.startsWith(
+        prWorkflowPrompt(
+          "resolve_conflicts",
+          pr({
+            head_branch: "devon/shared-status-tone",
+            base_branch: "main",
+          }),
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("adds nothing without a head branch to push to", () => {
+    const digest = pr({});
+    expect(prFreshAgentPrompt("update_branch", digest)).toBe(
+      prWorkflowPrompt("update_branch", digest),
+    );
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -1,4 +1,8 @@
-import type { CodeCheckLog, PullRequestDigest } from "../api/types";
+import type {
+  CodeCheckLog,
+  CodeDeliveryPullRequestSummary,
+  PullRequestDigest,
+} from "../api/types";
 import { prTone } from "./workspaceCards";
 
 export type PrWorkflowAction =
@@ -197,6 +201,77 @@ export type PrPromptAction = Exclude<
   PrWorkflowAction,
   "watch_and_fix" | "mark_ready" | "merge"
 >;
+
+/**
+ * A delivery row in the digest vocabulary the workflow prompts consume.
+ *
+ * The assignment is structural and checked: every digest field the prompt
+ * builder reads is present on the delivery summary under the same name. If
+ * either wire type drifts, this stops compiling rather than silently
+ * producing prompts with holes.
+ */
+export function deliveryPullRequestDigest(
+  summary: CodeDeliveryPullRequestSummary,
+): PullRequestDigest {
+  return summary;
+}
+
+export type PrAgentQuickAction = {
+  action: PrPromptAction;
+  label: string;
+};
+
+/**
+ * The agent-runnable chores this pull request currently has, in the order a
+ * reader resolves them: conflicts block everything, then failing checks, then
+ * review feedback, then a stale base. A settled pull request has none.
+ *
+ * More than one can apply at once — a conflicting PR with failing checks
+ * offers both — because each runs as its own prompt.
+ */
+export function prAgentQuickActions(
+  pr: PullRequestDigest,
+): PrAgentQuickAction[] {
+  const tone = prTone(pr);
+  if (tone === "merged" || tone === "closed") return [];
+  const items: PrAgentQuickAction[] = [];
+  if (prHasConflicts(pr)) {
+    items.push({ action: "resolve_conflicts", label: "Resolve conflicts" });
+  }
+  if (prCheckCounts(pr).failing > 0) {
+    items.push({ action: "fix_errors", label: "Fix failing checks" });
+  }
+  if (prHasChangesRequested(pr)) {
+    items.push({
+      action: "address_feedback",
+      label: "Address review feedback",
+    });
+  }
+  if (prIsBehind(pr)) {
+    items.push({ action: "update_branch", label: "Update branch from base" });
+  }
+  return items;
+}
+
+/**
+ * The fresh-agent variant of a workflow prompt.
+ *
+ * A fresh workspace is cut from the pull request's head commit, but onto its
+ * own Tidebreak branch — the server never checks out a shared branch
+ * directly. A bare "push" would therefore publish the wrong branch and leave
+ * the pull request untouched, so the suffix names the real push target.
+ */
+export function prFreshAgentPrompt(
+  action: PrPromptAction,
+  pr: PullRequestDigest,
+  logs: readonly CodeCheckLog[] = [],
+): string {
+  const head = pr.head_branch?.trim();
+  const suffix = head
+    ? `\n\nThis workspace was just created from \`${head}\`, the pull request's head branch, but the workspace branch itself is new and local. Publish your work to the pull request with \`git push origin HEAD:${head}\`. Do not push the workspace branch under its own name, and do not open a new pull request.`
+    : "";
+  return `${prWorkflowPrompt(action, pr, logs)}${suffix}`;
+}
 
 /**
  * Prompt actions run in the workspace's interactive session.

--- a/crates/tidebreak-desktop/ui/src/code/pullRequestPresentation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/pullRequestPresentation.test.ts
@@ -5,6 +5,7 @@ import {
   checkCounts,
   checkSummary,
   mergeBlockedReason,
+  orderPullRequestComments,
   pullRequestLifecycle,
   pullRequestReviewSummary,
   pullRequestSettledAt,
@@ -161,5 +162,32 @@ describe("mergeBlockedReason", () => {
     expect(
       mergeBlockedReason(pr({ checks: [{ name: "ci", bucket: "fail" }] })),
     ).toMatch(/checks are failing/);
+  });
+});
+
+describe("orderPullRequestComments", () => {
+  const comments = [
+    { kind: "issue" as const, id: "a", created_at: "2026-08-20T10:00:00Z" },
+    { kind: "issue" as const, id: "b", created_at: "2026-08-20T15:00:00Z" },
+    { kind: "issue" as const, id: "undated" },
+    { kind: "issue" as const, id: "c", created_at: "2026-08-20T12:00:00Z" },
+  ].map((comment) => ({ ...comment, body: comment.id }));
+
+  it("puts the latest comment on top by default order", () => {
+    expect(
+      orderPullRequestComments(comments, "newest").map((item) => item.id),
+    ).toEqual(["b", "c", "a", "undated"]);
+  });
+
+  it("restores host chronology on oldest-first", () => {
+    expect(
+      orderPullRequestComments(comments, "oldest").map((item) => item.id),
+    ).toEqual(["undated", "a", "c", "b"]);
+  });
+
+  it("keeps the input untouched", () => {
+    const before = comments.map((item) => item.id);
+    orderPullRequestComments(comments, "newest");
+    expect(comments.map((item) => item.id)).toEqual(before);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/pullRequestPresentation.ts
+++ b/crates/tidebreak-desktop/ui/src/code/pullRequestPresentation.ts
@@ -1,6 +1,7 @@
 import type {
   CodeDeliveryCheck,
   CodeDeliveryPullRequestSummary,
+  PullRequestComment,
 } from "../api/types";
 import type { StatusTone } from "./statusTone";
 
@@ -169,6 +170,30 @@ export function mergeBlockedReason(
   const counts = checkCounts(item.checks);
   if (counts.failed > 0) return "Required checks are failing.";
   return null;
+}
+
+export type PullRequestCommentOrder = "newest" | "oldest";
+
+/**
+ * The conversation in the reader's chosen order. Hosts hand comments over
+ * oldest-first; the panel defaults to newest-first because the reason a
+ * reader opens a busy pull request is almost always the latest verdict, not
+ * the greeting. The sort is stable, so comments without a parseable
+ * timestamp keep the host's relative order and sink to the bottom of the
+ * newest-first view rather than claiming the top.
+ */
+export function orderPullRequestComments(
+  comments: readonly PullRequestComment[],
+  order: PullRequestCommentOrder,
+): PullRequestComment[] {
+  const time = (comment: PullRequestComment): number => {
+    if (!comment.created_at) return 0;
+    const parsed = Date.parse(comment.created_at);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+  return [...comments].sort((left, right) =>
+    order === "newest" ? time(right) - time(left) : time(left) - time(right),
+  );
 }
 
 /** GitHub's diff-status vocabulary, as a short verb the row can show. */

--- a/crates/tidebreak-desktop/ui/src/components/ui/tabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg px-2.5 py-1.5 text-sm font-medium whitespace-nowrap ring-offset-background transition-all hover:bg-muted/30 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-muted/50 data-[state=active]:text-foreground",
+      "inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg px-2.5 py-1.5 text-sm font-medium whitespace-nowrap ring-offset-background transition-all hover:bg-muted/30 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-muted/50 data-[state=active]:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
       className,
     )}
     {...props}

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -939,7 +939,7 @@ export type CodeDeliveryPrAttentionReason = "changes_requested" | "checks_failed
  * User-initiated global PR action. Code-changing actions deliberately do not
  * exist here; they remain workspace-scoped agent prompts.
  */
-export type CodeDeliveryPullRequestAction = { "type": "mark_ready" } | { "type": "merge", method: CodePrMergeMethod, auto: boolean, expected_head_sha: string, } | { "type": "rerun_failed", workflow_run_ids: Array<number>, } | { "type": "close" } | { "type": "reopen" } | { "type": "comment", body: string, };
+export type CodeDeliveryPullRequestAction = { "type": "mark_ready" } | { "type": "merge", method: CodePrMergeMethod, auto: boolean, admin: boolean, expected_head_sha: string, } | { "type": "rerun_failed", workflow_run_ids: Array<number>, } | { "type": "close" } | { "type": "reopen" } | { "type": "comment", body: string, };
 
 export type CodeDeliveryPullRequestActionBody = { target: CodeDeliveryPullRequestTarget, action: CodeDeliveryPullRequestAction, };
 

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -177,6 +177,22 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
       success: true,
       message: prActionMessage(action),
     }),
+    createCodeWorkspace: async (body: {
+      repo_id: string;
+      title?: string;
+      base_ref?: string;
+    }) =>
+      ({
+        id: "ws-fresh-agent",
+        repo_id: body.repo_id,
+        title: body.title ?? "Fresh agent",
+        worktree_path: "/Users/sam/tidebreak/worktrees/fresh-agent",
+        branch_name: "thet/fresh-agent",
+        base_ref: body.base_ref ?? "main",
+        status: "active",
+        created_at: "2026-08-20T15:25:00.000Z",
+      }) as CodeWorkspaceSnapshot,
+    writeCodeCheckLogs: async () => ({ logs: [], errors: [] }),
     queryCodeDeliveryRuns: async () => ({
       capability: deliveryRepositoriesSnapshot.capability,
       items: deliveryRuns,
@@ -427,75 +443,200 @@ export const PullRequestStacks: Story = {
 export const PullRequestDetail: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    // The detail is a sheet portaled to the document body, so its content
+    // lives outside the story canvas.
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(
       await canvas.findByText("Make workspace deep links durable"),
     );
     await expect(
-      await canvas.findByRole("heading", {
+      await body.findByRole("heading", {
         name: "Make workspace deep links durable",
       }),
     ).toBeVisible();
   },
 };
 
-/** The full GitHub-shaped panel: lifecycle, diffstat, reviewers, Markdown. */
+/** The full GitHub-shaped sheet: lifecycle, diffstat, reviewers, Markdown. */
 export const PullRequestDetailConversation: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(await canvas.findByText("Build the delivery center"));
     await expect(
-      await canvas.findByRole("heading", { name: "Build the delivery center" }),
+      await body.findByRole("heading", { name: "Build the delivery center" }),
     ).toBeVisible();
     // The description renders as Markdown rather than raw "## Summary" text.
     await expect(
-      await canvas.findByRole("heading", { name: "Summary" }),
+      await body.findByRole("heading", { name: "Summary" }),
     ).toBeVisible();
-    await expect(await canvas.findByText("+2140")).toBeVisible();
+    await expect(await body.findByText("+2140")).toBeVisible();
     await expect(
-      await canvas.findByRole("button", { name: /Comment/ }),
+      await body.findByRole("button", { name: /Comment/ }),
     ).toBeVisible();
+  },
+};
+
+/**
+ * Newest first is the default: the reason a reader opens a busy pull request
+ * is the latest verdict. The select flips back to the host's chronology.
+ */
+export const PullRequestCommentOrdering: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await canvas.findByText("Build the delivery center"));
+    const later = await body.findByText(
+      "Keep repository failures visible without hiding usable results.",
+    );
+    const earlier = await body.findByText(/The narrow detail state still/);
+    await expect(
+      Boolean(
+        later.compareDocumentPosition(earlier) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+
+    await userEvent.click(
+      await body.findByRole("combobox", { name: "Comment order" }),
+    );
+    await userEvent.click(
+      await body.findByRole("option", { name: "Oldest first" }),
+    );
+    await expect(
+      Boolean(
+        earlier.compareDocumentPosition(later) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+  },
+};
+
+/**
+ * Admin merge stays behind the overflow and a confirmation: it bypasses the
+ * branch protection that is otherwise disabling the plain merge button.
+ */
+export const PullRequestAdminMerge: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await canvas.findByText("Build the delivery center"));
+    await expect(
+      await body.findByRole("button", { name: "Merge" }),
+    ).toBeDisabled();
+    await userEvent.click(
+      await body.findByRole("button", { name: "More pull request actions" }),
+    );
+    await userEvent.click(
+      await body.findByRole("menuitem", {
+        name: /Admin merge \(bypass protections\)/,
+      }),
+    );
+    await expect(
+      await body.findByText("Merge, bypassing branch protection?"),
+    ).toBeVisible();
+    await userEvent.click(
+      await body.findByRole("button", { name: "Admin merge" }),
+    );
+  },
+};
+
+/**
+ * A pull request with a linked active workspace routes its chores there; the
+ * menu names the workspace before anything starts.
+ */
+export const PullRequestAgentActions: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await canvas.findByText("Build the delivery center"));
+    await userEvent.click(
+      await body.findByRole("button", { name: "Fix with an agent" }),
+    );
+    await expect(
+      await body.findByText(
+        "Runs in Build the delivery center, the linked workspace.",
+      ),
+    ).toBeVisible();
+    await expect(
+      await body.findByRole("menuitem", { name: "Fix failing checks" }),
+    ).toBeVisible();
+    await expect(
+      await body.findByRole("menuitem", { name: "Address review feedback" }),
+    ).toBeVisible();
+  },
+};
+
+/**
+ * Without a linked workspace the same menu cuts a fresh one from the pull
+ * request's head branch, queues the prompt, and lands on the new workspace.
+ */
+export const PullRequestFreshAgent: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await canvas.findByText("Adopt the shared status tone map"),
+    );
+    await userEvent.click(
+      await body.findByRole("button", { name: "Fix with an agent" }),
+    );
+    await expect(
+      await body.findByText(
+        "Starts a fresh workspace on brightwave-inc/tidebreak.",
+      ),
+    ).toBeVisible();
+    await userEvent.click(
+      await body.findByRole("menuitem", { name: "Resolve conflicts" }),
+    );
+    // The story router's workspace route is a stub; reaching it proves the
+    // workspace was created and the sheet handed the reader over.
+    await expect(await body.findByText("Workspace")).toBeVisible();
   },
 };
 
 export const PullRequestDetailFiles: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(await canvas.findByText("Build the delivery center"));
-    await userEvent.click(await canvas.findByRole("tab", { name: /Files/ }));
-    await expect(await canvas.findByText(/19 files changed/)).toBeVisible();
+    await userEvent.click(await body.findByRole("tab", { name: /Files/ }));
+    await expect(await body.findByText(/19 files changed/)).toBeVisible();
     await userEvent.click(
-      await canvas.findByTitle(
+      await body.findByTitle(
         "crates/tidebreak-desktop/ui/src/code/pullRequestPresentation.ts",
       ),
     );
-    await expect(await canvas.findByText(/@@ -0,0 \+1,8 @@/)).toBeVisible();
+    await expect(await body.findByText(/@@ -0,0 \+1,8 @@/)).toBeVisible();
   },
 };
 
 export const PullRequestDetailChecks: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(await canvas.findByText("Build the delivery center"));
-    await userEvent.click(await canvas.findByRole("tab", { name: /Checks/ }));
-    await expect(await canvas.findByText(/1 of 2 passed/)).toBeVisible();
+    await userEvent.click(await body.findByRole("tab", { name: /Checks/ }));
+    await expect(await body.findByText(/1 of 2 passed/)).toBeVisible();
   },
 };
 
-/** Merged: no merge controls, a reopen-free panel, and who merged it. */
+/** Merged: no merge controls, a reopen-free sheet, and who merged it. */
 export const MergedPullRequestDetail: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(
       await canvas.findByText("Cache the workspace digest between polls"),
     );
     await expect(
-      await canvas.findByRole("heading", {
+      await body.findByRole("heading", {
         name: "Cache the workspace digest between polls",
       }),
     ).toBeVisible();
-    await expect(await canvas.findByText(/merged .* by devon/)).toBeVisible();
+    await expect(await body.findByText(/merged .* by devon/)).toBeVisible();
     await expect(
-      canvas.queryByRole("button", { name: "Merge" }),
+      body.queryByRole("button", { name: "Merge" }),
     ).not.toBeInTheDocument();
   },
 };
@@ -504,11 +645,12 @@ export const MergedPullRequestDetail: Story = {
 export const ClosedPullRequestDetail: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(
       await canvas.findByText("Rewrite the deployment runbook"),
     );
     await expect(
-      await canvas.findByRole("button", { name: "Reopen" }),
+      await body.findByRole("button", { name: "Reopen" }),
     ).toBeVisible();
   },
 };
@@ -517,14 +659,15 @@ export const ClosedPullRequestDetail: Story = {
 export const DraftPullRequestDetail: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(
       await canvas.findByText("Document managed deployments"),
     );
     await expect(
-      await canvas.findByRole("button", { name: "Mark ready" }),
+      await body.findByRole("button", { name: "Mark ready" }),
     ).toBeVisible();
     await expect(
-      await canvas.findByText("No description provided."),
+      await body.findByText("No description provided."),
     ).toBeVisible();
   },
 };
@@ -533,16 +676,17 @@ export const DraftPullRequestDetail: Story = {
 export const BlockedMergePullRequestDetail: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(
       await canvas.findByText("Adopt the shared status tone map"),
     );
     await expect(
-      await canvas.findByText(
+      await body.findByText(
         "Resolve the conflicts with the base branch first.",
       ),
     ).toBeVisible();
     await expect(
-      await canvas.findByRole("button", { name: "Merge" }),
+      await body.findByRole("button", { name: "Merge" }),
     ).toBeDisabled();
   },
 };
@@ -577,13 +721,12 @@ export const RunDetail: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(await canvas.findByText("Desktop CI"));
     await expect(
-      await canvas.findByRole("heading", { name: "Desktop CI" }),
+      await body.findByRole("heading", { name: "Desktop CI" }),
     ).toBeVisible();
-    await expect(
-      await canvas.findByText("Build static Storybook"),
-    ).toBeVisible();
+    await expect(await body.findByText("Build static Storybook")).toBeVisible();
   },
 };
 
@@ -635,9 +778,10 @@ export const NarrowPullRequestDetail: Story = {
   parameters: { viewport: { defaultViewport: "compact" } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(await canvas.findByText("Build the delivery center"));
     await expect(
-      await canvas.findByRole("heading", { name: "Build the delivery center" }),
+      await body.findByRole("heading", { name: "Build the delivery center" }),
     ).toBeVisible();
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -513,8 +513,10 @@ export const PullRequestCommentOrdering: Story = {
 };
 
 /**
- * Admin merge stays behind the overflow and a confirmation: it bypasses the
- * branch protection that is otherwise disabling the plain merge button.
+ * Admin merge stays behind the overflow and an inline confirmation: it
+ * bypasses the branch protection that is otherwise disabling the plain merge
+ * button. Inline rather than a dialog — the sheet is already a modal, and a
+ * second stacked modal shares its dismiss layer.
  */
 export const PullRequestAdminMerge: Story = {
   play: async ({ canvasElement }) => {
@@ -533,7 +535,7 @@ export const PullRequestAdminMerge: Story = {
       }),
     );
     await expect(
-      await body.findByText("Merge, bypassing branch protection?"),
+      await body.findByText(/skips any reviews and checks/),
     ).toBeVisible();
     await userEvent.click(
       await body.findByRole("button", { name: "Admin merge" }),

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -1022,8 +1022,17 @@ pub(crate) async fn act_on_pull_request(
         CodeDeliveryPullRequestAction::Merge {
             method,
             auto,
+            admin,
             expected_head_sha,
         } => {
+            // An admin merge lands now, bypassing branch protection; arming
+            // auto-merge is the opposite ask. `gh` refuses the pair too, but
+            // with a message about flags rather than about the request.
+            if admin && auto {
+                return Err(ServerError::bad_request(
+                    "an admin merge is immediate; it cannot arm auto-merge",
+                ));
+            }
             gh::merge_pull_request_target(
                 &target.repository.host,
                 &target.repository.owner,
@@ -1031,6 +1040,7 @@ pub(crate) async fn act_on_pull_request(
                 target.number,
                 merge_method(method),
                 auto,
+                admin,
                 &expected_head_sha,
                 search_path.as_deref(),
             )
@@ -1039,6 +1049,11 @@ pub(crate) async fn act_on_pull_request(
             runtime.delivery_cache.invalidate();
             Ok(delivery_action_result(if auto {
                 format!("Auto-merge enabled for pull request #{}", target.number)
+            } else if admin {
+                format!(
+                    "Pull request #{} merged, bypassing branch protection",
+                    target.number
+                )
             } else {
                 format!("Pull request #{} merged", target.number)
             }))

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1941,7 +1941,9 @@ pub(crate) async fn comment_on_pull_request_target(
 }
 
 /// Repository-qualified merge for a PR that may not have a local Tidebreak
-/// workspace. The runner still admits only `gh pr merge` argv.
+/// workspace. The runner still admits only `gh pr merge` argv. `admin` is the
+/// user's explicit branch-protection bypass (`--admin`); callers reject the
+/// `admin && auto` pair before it gets here.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn merge_pull_request_target(
     host: &str,
@@ -1950,6 +1952,7 @@ pub(crate) async fn merge_pull_request_target(
     number: u64,
     method: MergeMethod,
     auto: bool,
+    admin: bool,
     expected_head_sha: &str,
     search_path: Option<&str>,
 ) -> Result<(), GhError> {
@@ -1969,6 +1972,9 @@ pub(crate) async fn merge_pull_request_target(
     ];
     if auto {
         args.push("--auto".to_owned());
+    }
+    if admin {
+        args.push("--admin".to_owned());
     }
     let borrowed = args.iter().map(String::as_str).collect::<Vec<_>>();
     run_gh_user_merge(Path::new("."), &binary, &borrowed, GH_TIMEOUT)
@@ -2832,6 +2838,21 @@ exit 3
             42,
             MergeMethod::Squash,
             false,
+            false,
+            "abcdef123456",
+            Some(shim_dir.path().to_str().unwrap()),
+        )
+        .await
+        .unwrap();
+
+        merge_pull_request_target(
+            "github.com",
+            "acme",
+            "app",
+            42,
+            MergeMethod::Squash,
+            false,
+            true,
             "abcdef123456",
             Some(shim_dir.path().to_str().unwrap()),
         )
@@ -2844,7 +2865,13 @@ exit 3
                 .contains("pr merge 42 --repo acme/app --squash --match-head-commit abcdef123456"),
             "{logged}"
         );
-        assert_eq!(logged.matches("pr merge").count(), 1, "{logged}");
+        // The admin bypass is a per-request flag, never a default.
+        assert!(
+            logged.contains("--match-head-commit abcdef123456 --admin"),
+            "{logged}"
+        );
+        assert_eq!(logged.matches("pr merge").count(), 2, "{logged}");
+        assert_eq!(logged.matches("--admin").count(), 1, "{logged}");
         assert!(!logged.contains("pr view"), "{logged}");
     }
 

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -1053,6 +1053,8 @@ pub enum CodeDeliveryPullRequestAction {
         method: CodePrMergeMethod,
         #[serde(default)]
         auto: bool,
+        #[serde(default)]
+        admin: bool,
         expected_head_sha: String,
     },
     RerunFailed {


### PR DESCRIPTION
## What changed

The delivery pull request and run details rendered as a narrow side column squeezed against the list. Both now open as a large sheet over the full-width list (Escape, overlay click, or the header X closes them). Inside the pull request sheet:

- **Comment ordering.** The conversation sorts newest-first by default — the reason you open a busy PR is the latest verdict — with an `Oldest first` select to restore host chronology.
- **Admin merge.** The overflow menu offers *Admin merge (bypass protections)…* behind a confirmation. The server runs `gh pr merge --admin` through the existing merge-only runner, still pinned to the reviewed head SHA, and refuses the `admin && auto` pair. The plain merge button stays disabled while blocked; the bypass is deliberate and recorded by GitHub.
- **Workspace links and agent quick actions.** Linked workspaces stay as open buttons in the action bar. A new *Fix with an agent* menu derives the PR's live chores — resolve conflicts, fix failing checks, address review feedback, update branch — and runs the matching prompt in the linked active workspace, or, when none exists, creates a fresh workspace cut from the PR's head branch and queues the prompt there. The fresh-agent prompt names `git push origin HEAD:<head_branch>` as the push target, since the new workspace branch is local-only.
- **Tab icon sizing.** `TabsTrigger` never sized SVGs, so tab icons (delivery detail, notifications) rendered at lucide's 24px default and threw the row off. The primitive now sizes unsized icons to 16px.
- **Diff coloring.** Patch lines keep the ordinary foreground over a quiet green/red tint with a colored sign, instead of recoloring whole code lines; hunk headers get the info tint.

## Wire and server

`CodeDeliveryPullRequestAction::Merge` gains `admin: bool` (serde-default false). `generated/wire.ts` is hand-edited to match; the wire-types test verifies it in CI. The gh shim test asserts `--admin` reaches the argv only when asked.

## Stories and tests

DeliveryCenter stories updated for the portaled sheet and extended with comment ordering, admin merge, linked-workspace agent actions, and the fresh-agent flow. New unit tests cover `orderPullRequestComments`, `prAgentQuickActions`, and `prFreshAgentPrompt`.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui test` — 223 files, 1734 tests pass
- `tsc --noEmit`, `biome format`, `biome lint` — clean
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — builds
- Rust compiles and `gh.rs` / wire-types tests run in CI