### PR TITLE
fix(code): keep tool rows folded and honor model selection

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -165,7 +165,7 @@ describe("CodeTranscript", () => {
     expect(verb.parentElement?.className).toContain("flex");
   });
 
-  it("announces the turn's lifecycle and nothing that streams", () => {
+  it("announces the turn's lifecycle and nothing that streams", async () => {
     // A tool line changes on every streamed byte. Wrapping it in a live region
     // reads the whole session out, over and over, and buries the one thing a
     // supervisor has to hear. The turn's start and end go through one region;
@@ -192,6 +192,9 @@ describe("CodeTranscript", () => {
     expect(screen.getByTestId("code-turn-announcer")).toHaveTextContent("");
 
     rerender(<CodeTranscript items={running} busy />);
+    const tool = screen.getByRole("button", { name: /Command run.*running/ });
+    expect(screen.queryByLabelText("Output")).toBeNull();
+    await userEvent.click(tool);
     expect(
       screen
         .getByLabelText("Output")
@@ -327,6 +330,38 @@ describe("CodeTranscript", () => {
     expect(line).not.toHaveTextContent(`'"'`);
   });
 
+  it("keeps a folded multi-line command on one visible line", () => {
+    const command = "python3 - <<'PY'\nprint('ok')\nPY";
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "tool",
+            id: "tool-heredoc",
+            turnId: "t1",
+            callId: "c6",
+            parentCallId: null,
+            name: "commandExecution",
+            detail: { kind: "command", cmd: command, cwd: "/tmp" },
+            status: "succeeded",
+            preview: "ok",
+            startedAt: null,
+            durationMs: null,
+          },
+        ]}
+      />,
+    );
+
+    const line = screen.getByRole("button", {
+      name: /Command run.*succeeded/,
+    });
+    const subject = line.querySelector("[title]");
+    expect(subject).toHaveAttribute("title", command);
+    expect(subject).toHaveTextContent("python3 - <<'PY' print('ok') PY");
+    expect(subject?.textContent).not.toMatch(/[\r\n]/);
+    expect(line).toHaveAttribute("aria-expanded", "false");
+  });
+
   it("holds the transcript's shape until the session hydrates", () => {
     const { container, rerender } = render(
       <CodeTranscript items={items} hydrated={false} />,
@@ -340,7 +375,7 @@ describe("CodeTranscript", () => {
     expect(screen.getByText("Looking at the tree.")).toBeInTheDocument();
   });
 
-  it("expands a failed tool, clamps long output, and stops the transcript following", async () => {
+  it("keeps a failed tool folded until the reader opens it", async () => {
     const preview = Array.from(
       { length: 13 },
       (_, index) => `line ${index + 1}`,
@@ -367,10 +402,16 @@ describe("CodeTranscript", () => {
       />,
     );
 
+    const line = screen.getByRole("button", { name: /Command run.*failed/ });
+    expect(line).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByLabelText("Output")).toBeNull();
+
+    await userEvent.click(line);
     const body = screen.getByLabelText("Output");
     expect(body.textContent).toContain("line 12");
     expect(body.textContent).not.toContain("line 13");
     expect(screen.getByRole("button", { name: "Copy output" })).toBeTruthy();
+    expect(reveals).toHaveLength(1);
 
     await userEvent.click(
       screen.getByRole("button", { name: "· · · 1 more line" }),
@@ -378,18 +419,17 @@ describe("CodeTranscript", () => {
     expect(screen.getByLabelText("Output").textContent).toContain("line 13");
     // Growing the column under the reader's cursor must not drag them to the
     // tail, so every reveal reaches the host that owns the scroll.
-    expect(reveals).toHaveLength(1);
+    expect(reveals).toHaveLength(2);
 
     // Collapsing the line leaves the reader on the line they collapsed: the
     // toggle is the row itself, so there is nothing for focus to fall out of.
-    const line = screen.getByRole("button", { name: /Command run.*failed/ });
     expect(line).toHaveAttribute("aria-expanded", "true");
     await userEvent.click(line);
     expect(line).toHaveAttribute("aria-expanded", "false");
     expect(line).toHaveFocus();
   });
 
-  it("keeps a successful call closed and names a denial with the constant verb", () => {
+  it("keeps a denial closed and names it with the constant verb", async () => {
     render(
       <CodeTranscript
         items={[
@@ -410,12 +450,16 @@ describe("CodeTranscript", () => {
       />,
     );
     expect(screen.getByText("Command denied")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Output")).toBeNull();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Command denied.*denied/ }),
+    );
     expect(screen.getByLabelText("Output")).toHaveTextContent(
       "denied by policy",
     );
   });
 
-  it("streams the tail of a running command without showing the head", () => {
+  it("keeps a running command folded until the reader opens its tail", async () => {
     const preview = Array.from(
       { length: 16 },
       (_, index) => `line ${index + 1}`,
@@ -440,6 +484,11 @@ describe("CodeTranscript", () => {
       />,
     );
     expect(screen.getByText("Command run")).toBeInTheDocument();
+    const line = screen.getByRole("button", { name: /Command run.*running/ });
+    expect(line).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByLabelText("Output")).toBeNull();
+
+    await userEvent.click(line);
     const body = screen.getByLabelText("Output");
     expect(body.textContent?.split("\n")[0]).toBe("line 5");
     expect(body.textContent).toContain("line 16");
@@ -552,7 +601,7 @@ describe("CodeTranscript", () => {
     expect(screen.getByText("2.2s")).toBeInTheDocument();
   });
 
-  it("opens a run that holds a failure", () => {
+  it("keeps a run with a failure folded until the reader opens it", async () => {
     const middle = run("succeeded")[1]!;
     const items: CodeToolItem[] = [
       run("succeeded")[0]!,
@@ -561,11 +610,16 @@ describe("CodeTranscript", () => {
     ];
     render(<CodeTranscript items={items} />);
 
-    // A failure inside a closed group is a failure the reader has to go
-    // looking for.
-    expect(
-      screen.getByRole("button", { name: /and 2 more.*failed/ }),
-    ).toHaveAttribute("aria-expanded", "true");
+    const group = screen.getByRole("button", { name: /and 2 more.*failed/ });
+    expect(group).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("no such file")).toBeNull();
+
+    await userEvent.click(group);
+    const failed = screen.getByRole("button", {
+      name: /File read.*docs\/code-mode\.md.*failed/,
+    });
+    expect(failed).toHaveAttribute("aria-expanded", "false");
+    await userEvent.click(failed);
     expect(screen.getByText("no such file")).toBeInTheDocument();
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -599,8 +599,9 @@ const TranscriptItem = memo(function TranscriptItem({
  * the group's own icon column.
  *
  * Closed by default, because the reason to group at all is that a burst of
- * calls is not what the reader came for. A run holding a failure is the
- * exception: it opens itself, the same way a failed row does.
+ * calls is not what the reader came for. Status never changes that choice: a
+ * failure is visible on the folded line, and the reader opens the detail when
+ * they need it.
  */
 export const CodeActivityGroup = memo(
   function CodeActivityGroup({
@@ -612,15 +613,7 @@ export const CodeActivityGroup = memo(
     signature: string;
     onReveal?: () => void;
   }) {
-    const unresolved = tools.some(
-      (tool) => tool.status === "failed" || tool.status === "denied",
-    );
-    const [expanded, setExpanded] = useState(unresolved);
-    useEffect(() => {
-      // A failure inside a closed group is a failure the reader has to go
-      // looking for. Opening is one-way: once they close it, it stays closed.
-      if (unresolved) setExpanded(true);
-    }, [unresolved]);
+    const [expanded, setExpanded] = useState(false);
 
     const lead = leadingCall(tools);
     const status = groupStatus(tools);
@@ -727,8 +720,7 @@ function totalDurationMs(tools: readonly CodeToolItem[]): number | null {
 /**
  * One engine action as a boxless line. The verb is a constant; the muted mono
  * subject is the command or path; the right slot is meta, one status glyph,
- * and a quiet chevron. Failed and denied open. Success stays closed. A running
- * call streams the last lines of output without growing the row.
+ * and a quiet chevron. Every status stays folded until the reader opens it.
  */
 export function CodeToolCard({
   name,
@@ -747,9 +739,7 @@ export function CodeToolCard({
   durationMs?: number | null;
   onReveal?: () => void;
 }) {
-  const [expanded, setExpanded] = useState(
-    status === "failed" || status === "denied",
-  );
+  const [expanded, setExpanded] = useState(false);
   const verb = toolVerb(detail, status);
   const subject = toolSubject(detail, name);
   const hasOutput = preview.trim().length > 0;
@@ -757,13 +747,7 @@ export function CodeToolCard({
   const duration = formatTurnDuration(durationMs);
   const exitCode = parseExitCode(preview);
 
-  useEffect(() => {
-    if (status === "succeeded") setExpanded(false);
-    if (status === "failed" || status === "denied") setExpanded(true);
-  }, [status]);
-
-  const showTail = status === "running" && hasOutput;
-  const showExpanded = expanded && status !== "running" && hasOutput;
+  const showExpanded = expanded && hasOutput;
 
   return (
     // Deliberately not a live region. A tool line changes on every streamed
@@ -796,7 +780,7 @@ export function CodeToolCard({
           <StatusGlyph status={status} />
         </>
       }
-      expanded={expanded || showTail}
+      expanded={expanded}
       onExpandedChange={(next) => {
         onReveal?.();
         setExpanded(next);
@@ -804,15 +788,16 @@ export function CodeToolCard({
       label={`${verb} ${subject} ${status}`}
       announce={false}
     >
-      {showTail && <StreamingTail text={preview} />}
-      {showExpanded && (
+      {showExpanded && status === "running" ? (
+        <StreamingTail text={preview} />
+      ) : showExpanded ? (
         <ToolOutputPreview
           text={preview}
           collapsedLines={12}
           bare
           onToggle={onReveal}
         />
-      )}
+      ) : null}
     </ToolCardShell>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -14,6 +14,12 @@ const REVIEW_SIDEBAR_OPEN_KEY = "tidebreak.code-review-sidebar-open";
 const LAST_CREATE_KEY = "tidebreak.code-last-create";
 const WORKSPACE_SORT_KEY = "tidebreak.code-workspace-sort";
 const RAIL_PREFS_KEY = "tidebreak.code-rail-prefs";
+const HARNESS_KINDS: readonly HarnessKind[] = [
+  "claude_code",
+  "codex",
+  "opencode",
+  "grok",
+];
 
 /**
  * How the reader shaped the workspace rail: order, card density, which meta
@@ -39,7 +45,16 @@ export const DEFAULT_RAIL_PREFS: CodeRailPrefs = {
 export type CodeCreateDefaults = {
   repoId?: string;
   harness?: HarnessKind;
+  modelsByHarness: Partial<Record<HarnessKind, string>>;
+};
+
+/** What one successful create adds to the remembered defaults. */
+export type CodeCreateSelection = {
+  repoId?: string;
+  harness: HarnessKind;
   model?: string;
+  /** Picks made before the final harness, kept for the next switch back. */
+  modelsByHarness?: Partial<Record<HarnessKind, string>>;
 };
 
 /** Inspector filter for one turn's files and diff. `label` is the ordinal, never the id. */
@@ -63,10 +78,32 @@ function readStoredCreateDefaults(): CodeCreateDefaults | null {
     const record = parsed as Record<string, unknown>;
     const text = (value: unknown) =>
       typeof value === "string" && value.length > 0 ? value : undefined;
+    const harness = text(record.harness);
+    const rememberedHarness = HARNESS_KINDS.includes(harness as HarnessKind)
+      ? (harness as HarnessKind)
+      : undefined;
+    const modelsByHarness: Partial<Record<HarnessKind, string>> = {};
+    const storedModels = record.modelsByHarness;
+    if (storedModels && typeof storedModels === "object") {
+      const modelRecord = storedModels as Record<string, unknown>;
+      for (const kind of HARNESS_KINDS) {
+        const model = text(modelRecord[kind]);
+        if (model) modelsByHarness[kind] = model;
+      }
+    }
+    // Migrate the earlier one-model shape into the harness it belonged to.
+    const legacyModel = text(record.model);
+    if (
+      rememberedHarness &&
+      legacyModel &&
+      !modelsByHarness[rememberedHarness]
+    ) {
+      modelsByHarness[rememberedHarness] = legacyModel;
+    }
     return {
       repoId: text(record.repoId),
-      harness: text(record.harness) as HarnessKind | undefined,
-      model: text(record.model),
+      harness: rememberedHarness,
+      modelsByHarness,
     };
   } catch {
     return null;
@@ -203,7 +240,7 @@ export type CodeUiStore = {
   setInspectorScope: (scope: InspectorScope | null) => void;
   setRailPrefs: (patch: Partial<CodeRailPrefs>) => void;
   /** Record a successful create so the next dialog opens on the same choices. */
-  rememberCreate: (defaults: CodeCreateDefaults) => void;
+  rememberCreate: (selection: CodeCreateSelection) => void;
   requestTerminal: () => void;
   takeTerminal: () => boolean;
   /**
@@ -367,7 +404,19 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
       storeRailPrefs(railPrefs);
       return { railPrefs };
     }),
-  rememberCreate: (defaults) => {
+  rememberCreate: (selection) => {
+    const modelsByHarness = {
+      ...get().lastCreate?.modelsByHarness,
+      ...selection.modelsByHarness,
+    };
+    if (selection.model) {
+      modelsByHarness[selection.harness] = selection.model;
+    }
+    const defaults: CodeCreateDefaults = {
+      repoId: selection.repoId,
+      harness: selection.harness,
+      modelsByHarness,
+    };
     storeCreateDefaults(defaults);
     set({ lastCreate: defaults });
   },

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -619,7 +619,7 @@ describe("CodeWorkspacePage", () => {
     expect(within(utilities).queryByText("Running")).not.toBeInTheDocument();
   });
 
-  it("shows the Codex session model even before its native catalog loads", async () => {
+  it("keeps the Codex session model selectable before its catalog loads", async () => {
     const client = makeClient();
     client.listCodeWorkspaceSessions.mockResolvedValue([
       {
@@ -637,10 +637,73 @@ describe("CodeWorkspacePage", () => {
     const model = await screen.findByRole("button", {
       name: "Model: GPT 5.6 Luna",
     });
-    expect(model).toBeDisabled();
-    expect(model).toHaveAttribute(
-      "title",
-      "Model: GPT 5.6 Luna (set when this session started)",
+    expect(model).toBeEnabled();
+    expect(model).toHaveAttribute("title", "Model: GPT 5.6 Luna");
+  });
+
+  it.each([
+    {
+      harness: "codex" as const,
+      current: "gpt-5.6-luna",
+      currentLabel: "GPT 5.6 Luna",
+      next: "gpt-5.6-sol",
+      nextLabel: "GPT 5.6 Sol",
+    },
+    {
+      harness: "opencode" as const,
+      current: "model-gateway/kimi-k3",
+      currentLabel: "Kimi K3",
+      next: "model-gateway/deepseek-v4-pro",
+      nextLabel: "DeepSeek V4 Pro",
+    },
+  ])("switches models on $harness for the next turn", async (choice) => {
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([
+      {
+        ...SESSION,
+        harness_kind: choice.harness,
+        model: choice.current,
+      },
+    ]);
+    client.listCodeHarnessModels.mockResolvedValue({
+      kind: choice.harness,
+      models: [
+        {
+          id: choice.current,
+          label: choice.currentLabel,
+          default: true,
+          reasoning_efforts: [],
+        },
+        {
+          id: choice.next,
+          label: choice.nextLabel,
+          default: false,
+          reasoning_efforts: [],
+        },
+      ],
+      reasoning_efforts: [],
+    } as never);
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Model: ${choice.currentLabel}`,
+      }),
+    );
+    await user.click(
+      screen.getByRole("menuitem", { name: new RegExp(choice.nextLabel) }),
+    );
+    await user.type(screen.getByRole("textbox", { name: "Message" }), "go");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(client.submitCodeTurn).toHaveBeenCalledWith(
+        "sess-1",
+        "go",
+        choice.next,
+        undefined,
+      ),
     );
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -171,9 +171,9 @@ import {
   fenceReasonText,
   gatewayCodeModels,
   harnessCodeModels,
-  harnessHonorsTurnModel,
   HARNESS_LABELS,
   LIFECYCLE_LABELS,
+  preferredCodeModels,
   sessionLifecycleTooltip,
 } from "./labels";
 
@@ -497,10 +497,11 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     setStarting(true);
     try {
       const gateway = gatewayCodeModels(models, harness, defaultModelKey);
-      const listed =
-        gateway.length > 0
-          ? gateway
-          : await catalog.ensureHarnessModels(client, harness);
+      const native =
+        harness === "opencode" || gateway.length === 0
+          ? await catalog.ensureHarnessModels(client, harness)
+          : [];
+      const listed = preferredCodeModels(harness, native, gateway);
       const posted =
         model ?? listed.find((option) => option.default)?.id ?? listed[0]?.id;
       const created = await client.createCodeSession(workspaceId, {
@@ -1764,7 +1765,14 @@ function CodeSessionPane({
       session.harness_kind,
       defaultModelKey,
     );
-    const listed = gateway.length > 0 ? gateway : (cachedModels ?? []);
+    const listed =
+      session.harness_kind === "opencode" && cachedModels === undefined
+        ? []
+        : preferredCodeModels(
+            session.harness_kind,
+            cachedModels ?? [],
+            gateway,
+          );
     if (
       !session.model ||
       listed.some((option) => option.id === session.model)
@@ -2089,6 +2097,9 @@ function CodeSessionPane({
           harness={session.harness_kind}
           model={model ?? undefined}
           modelOptions={modelOptions}
+          modelLoading={
+            session.harness_kind === "opencode" && cachedModels === undefined
+          }
           promptScope={workspaceId}
           sessionId={session.id}
           history={composerHistory}
@@ -2100,9 +2111,7 @@ function CodeSessionPane({
               .listCodeWorkspaceTree(workspaceId, { query })
               .then((tree) => tree.paths)
           }
-          onModelChange={
-            harnessHonorsTurnModel(session.harness_kind) ? setModel : undefined
-          }
+          onModelChange={setModel}
           onModeChange={changePermissionMode}
           onEffortChange={
             doctorEntry?.caps.reasoning_levels === "unsupported"

--- a/crates/tidebreak-desktop/ui/src/code/MiddleTruncate.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/MiddleTruncate.tsx
@@ -19,26 +19,34 @@ export function MiddleTruncate({
   text: string;
   className?: string;
 }) {
+  // A command summary is one row even when the command is a heredoc or a
+  // multi-line script. Keep the original in the tooltip, but collapse line
+  // breaks before splitting the visible text. The tail uses `whitespace-pre`
+  // to keep a split-leading space, so an uncollapsed newline there would turn
+  // a folded row into several lines.
+  const visibleText = text.replace(/[ \t]*[\r\n]+[ \t]*/g, " ");
   // Short strings have no interesting tail to protect, and splitting them into
   // two boxes only costs the browser a wrap opportunity.
-  if (text.length <= SHORT_ENOUGH) {
+  if (visibleText.length <= SHORT_ENOUGH) {
     return (
       <span className={cn("block truncate", className)} title={text}>
-        {text}
+        {visibleText}
       </span>
     );
   }
   const tail = Math.min(
     TAIL_MAX,
-    Math.max(TAIL_MIN, Math.ceil(text.length / 3)),
+    Math.max(TAIL_MIN, Math.ceil(visibleText.length / 3)),
   );
   return (
     <span className={cn("flex min-w-0", className)} title={text}>
-      <span className="truncate">{text.slice(0, -tail)}</span>
+      <span className="truncate">{visibleText.slice(0, -tail)}</span>
       {/* `whitespace-pre` because the split can land on a space, and a flex
           item drops the whitespace it starts with — which reads as a command
           with two of its words run together. */}
-      <span className="shrink-0 whitespace-pre">{text.slice(-tail)}</span>
+      <span className="shrink-0 whitespace-pre">
+        {visibleText.slice(-tail)}
+      </span>
     </span>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -151,6 +151,28 @@ function deferred<T>() {
 }
 
 describe("NewWorkspaceDialog", () => {
+  it("keeps remembered models keyed by harness", () => {
+    useCodeUiStore.getState().rememberCreate({
+      repoId: "repo-new",
+      harness: "opencode",
+      model: "model-gateway/deepseek-v4-pro",
+    });
+    useCodeUiStore.getState().rememberCreate({
+      repoId: "repo-new",
+      harness: "claude_code",
+      model: "claude-opus-5",
+    });
+
+    expect(useCodeUiStore.getState().lastCreate).toEqual({
+      repoId: "repo-new",
+      harness: "claude_code",
+      modelsByHarness: {
+        opencode: "model-gateway/deepseek-v4-pro",
+        claude_code: "claude-opus-5",
+      },
+    });
+  });
+
   it("opens on the last repo, harness, and model, and creates on Cmd+Enter", async () => {
     const repos = [repo("repo-old", "legacy"), repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({
@@ -240,7 +262,7 @@ describe("NewWorkspaceDialog", () => {
       expect(useCodeUiStore.getState().lastCreate).toEqual({
         repoId: "repo-new",
         harness: "codex",
-        model: "gpt-5.6-sol",
+        modelsByHarness: { codex: "gpt-5.6-sol" },
       }),
     );
     expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
@@ -424,6 +446,86 @@ describe("NewWorkspaceDialog", () => {
     });
     expect(
       await screen.findByRole("button", { name: "Model: GPT 5.6 Luna" }),
+    ).toBeEnabled();
+  });
+
+  it("remembers a separate model for each harness", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code"), harness("opencode")],
+        notices: [],
+      } as never,
+    });
+    const listCodeHarnessModels = vi.fn(async (kind: HarnessKind) => ({
+      kind,
+      models:
+        kind === "opencode"
+          ? [
+              {
+                id: "model-gateway/kimi-k3",
+                label: "Kimi K3",
+                default: true,
+                reasoning_efforts: [],
+                fast_mode: false,
+              },
+              {
+                id: "model-gateway/deepseek-v4-pro",
+                label: "DeepSeek V4 Pro",
+                default: false,
+                reasoning_efforts: [],
+                fast_mode: false,
+              },
+            ]
+          : [
+              {
+                id: "claude-sonnet-5",
+                label: "Claude Sonnet 5",
+                default: true,
+                reasoning_efforts: [],
+                fast_mode: false,
+              },
+              {
+                id: "claude-opus-5",
+                label: "Claude Opus 5",
+                default: false,
+                reasoning_efforts: [],
+                fast_mode: false,
+              },
+            ],
+      reasoning_efforts: [],
+    }));
+    await renderWithRouter(
+      <AppContextProvider value={app({ listCodeHarnessModels })}>
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const user = userEvent.setup();
+    await user.click(
+      await screen.findByRole("button", { name: "Model: Claude Sonnet 5" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /Claude Opus 5/ }));
+
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    await user.click(screen.getByRole("option", { name: /opencode/ }));
+    await user.click(
+      await screen.findByRole("button", { name: "Model: Kimi K3" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /DeepSeek V4 Pro/ }));
+
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    await user.click(screen.getByRole("option", { name: /Claude Code/ }));
+    expect(
+      await screen.findByRole("button", { name: "Model: Claude Opus 5" }),
+    ).toBeEnabled();
+
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    await user.click(screen.getByRole("option", { name: /opencode/ }));
+    expect(
+      await screen.findByRole("button", { name: "Model: DeepSeek V4 Pro" }),
     ).toBeEnabled();
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -43,6 +43,7 @@ import {
   defaultCreatePermissionMode,
   gatewayCodeModels,
   harnessUnusableReason,
+  preferredCodeModels,
   PERMISSION_MODE_LABELS,
   ALLOW_ALL_NOTE,
   UNSUPERVISED_AUTO_NOTE,
@@ -128,7 +129,9 @@ export function NewWorkspaceDialog({
     null,
   );
   const [creating, setCreating] = useState(false);
-  const [model, setModel] = useState<string | undefined>();
+  const [modelsByHarness, setModelsByHarness] = useState<
+    Partial<Record<HarnessKind, string>>
+  >({});
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
   const [modelLoading, setModelLoading] = useState(false);
   const repoTrigger = useRef<HTMLButtonElement>(null);
@@ -147,6 +150,7 @@ export function NewWorkspaceDialog({
       : undefined) ??
     recentHarness(readyHarnesses, sessions, lastCreate?.harness) ??
     "claude_code";
+  const model = modelsByHarness[harness];
 
   useEffect(() => {
     if (!open) return;
@@ -161,7 +165,7 @@ export function NewWorkspaceDialog({
     );
     setPickedHarness(null);
     setPermissionMode(null);
-    setModel(undefined);
+    setModelsByHarness({ ...lastCreate?.modelsByHarness });
     setModelOptions([]);
     setModelLoading(false);
     // Reset against the dialog opening, not against catalog refreshes
@@ -228,38 +232,53 @@ export function NewWorkspaceDialog({
     if (!open || !harness) return;
     // The reader's last model wins where it is still on offer; otherwise the
     // catalog's default, then the first row.
-    const pick = (listed: CodeModelOption[]) => (current?: string) => {
-      for (const candidate of [current, lastCreate?.model]) {
-        if (candidate && listed.some((option) => option.id === candidate)) {
-          return candidate;
-        }
-      }
-      return listed.find((option) => option.default)?.id ?? listed[0]?.id;
+    const apply = (listed: CodeModelOption[]) => {
+      setModelOptions(listed);
+      setModelsByHarness((current) => {
+        const remembered = current[harness];
+        const picked =
+          remembered && listed.some((option) => option.id === remembered)
+            ? remembered
+            : (listed.find((option) => option.default)?.id ?? listed[0]?.id);
+        if (picked === remembered) return current;
+        const next = { ...current };
+        if (picked) next[harness] = picked;
+        else delete next[harness];
+        return next;
+      });
     };
     const gateway = gatewayCodeModels(models, harness, defaultModelKey);
-    if (gateway.length > 0) {
-      setModelOptions(gateway);
-      setModel(pick(gateway));
+    const native = useCodeCatalogStore.getState().modelsByHarness[harness];
+    const needsNative = harness === "opencode" || gateway.length === 0;
+    if (!needsNative) {
+      apply(gateway);
+      setModelLoading(false);
+      return;
+    }
+    if (native !== undefined) {
+      apply(preferredCodeModels(harness, native, gateway));
       setModelLoading(false);
       return;
     }
     setModelOptions([]);
-    setModel(undefined);
     setModelLoading(true);
     let cancelled = false;
     void ensureHarnessModels(client, harness).then((listed) => {
       if (cancelled) return;
-      setModelOptions(listed);
-      setModel(pick(listed));
+      apply(preferredCodeModels(harness, listed, gateway));
       setModelLoading(false);
     });
     return () => {
       cancelled = true;
     };
-    // `lastCreate` is a seed, not a subscription: re-running on it would
-    // undo a deliberate pick the moment another create records one.
+    // `lastCreate` seeds `modelsByHarness` when the dialog opens. Subscribing
+    // this fetch to later writes would undo a deliberate pick after create.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, defaultModelKey, ensureHarnessModels, harness, models, open]);
+
+  function selectModel(next: string) {
+    setModelsByHarness((current) => ({ ...current, [harness]: next }));
+  }
 
   async function create() {
     if (!canCreate) return;
@@ -285,10 +304,11 @@ export function NewWorkspaceDialog({
       }
       try {
         const gateway = gatewayCodeModels(models, harness, defaultModelKey);
-        const listed =
-          gateway.length > 0
-            ? gateway
-            : await ensureHarnessModels(client, harness);
+        const native =
+          harness === "opencode" || gateway.length === 0
+            ? await ensureHarnessModels(client, harness)
+            : [];
+        const listed = preferredCodeModels(harness, native, gateway);
         const posted =
           model ?? listed.find((option) => option.default)?.id ?? listed[0]?.id;
         const session = await client.createCodeSession(workspace.id, {
@@ -297,7 +317,12 @@ export function NewWorkspaceDialog({
           model: posted,
         });
         rememberSession(session);
-        rememberCreate({ repoId, harness, model: posted });
+        rememberCreate({
+          repoId,
+          harness,
+          model: posted,
+          modelsByHarness,
+        });
       } catch (error) {
         toast.error(
           `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
@@ -392,7 +417,6 @@ export function NewWorkspaceDialog({
               value={harness}
               onChange={(next) => {
                 setModelOptions([]);
-                setModel(undefined);
                 setModelLoading(true);
                 setPickedHarness(next);
               }}
@@ -406,7 +430,7 @@ export function NewWorkspaceDialog({
               harness={harness}
               options={modelOptions}
               value={model}
-              onChange={setModel}
+              onChange={selectModel}
               loading={modelLoading}
               disabled={creating}
               variant="field"

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -14,6 +14,7 @@ import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { HarnessDoctorEntry } from "../api/types";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
 import { ALLOW_ALL_NOTE, UNSUPERVISED_AUTO_NOTE } from "./labels";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 import type { ReasoningEffort } from "../api/types";
@@ -61,6 +62,7 @@ function wrap(ui: ReactNode) {
 afterEach(() => {
   cleanup();
   useCodeCatalogStore.getState().reset();
+  useCodeUiStore.setState({ lastCreate: null });
 });
 
 const CAPS = {
@@ -290,7 +292,7 @@ describe("StartSessionPrompt", () => {
     );
   });
 
-  it("never carries a model across a harness switch", async () => {
+  it("keeps each harness model separate across switches", async () => {
     const user = userEvent.setup();
     const codex = deferred<{
       kind: "codex";
@@ -308,6 +310,13 @@ describe("StartSessionPrompt", () => {
                   id: "sonnet",
                   label: "Sonnet",
                   default: true,
+                  reasoning_efforts: [],
+                  fast_mode: false,
+                },
+                {
+                  id: "opus",
+                  label: "Opus",
+                  default: false,
                   reasoning_efforts: [],
                   fast_mode: false,
                 },
@@ -334,6 +343,8 @@ describe("StartSessionPrompt", () => {
     expect(
       await screen.findByRole("button", { name: "Model: Sonnet" }),
     ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Model: Sonnet" }));
+    await user.click(screen.getByRole("menuitem", { name: /Opus/ }));
     await user.click(screen.getByRole("combobox", { name: "Harness" }));
     await user.click(screen.getByRole("option", { name: /Codex CLI/ }));
 
@@ -355,12 +366,35 @@ describe("StartSessionPrompt", () => {
             reasoning_efforts: [],
             fast_mode: false,
           },
+          {
+            id: "gpt-5.6-sol",
+            label: "GPT 5.6 Sol",
+            default: false,
+            reasoning_efforts: [],
+            fast_mode: false,
+          },
         ],
         reasoning_efforts: [],
       });
     });
     expect(
       await screen.findByRole("button", { name: "Model: GPT 5.6 Luna" }),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Model: GPT 5.6 Luna" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /GPT 5.6 Sol/ }));
+
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    await user.click(screen.getByRole("option", { name: /Claude Code/ }));
+    expect(
+      await screen.findByRole("button", { name: "Model: Opus" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    await user.click(screen.getByRole("option", { name: /Codex CLI/ }));
+    expect(
+      await screen.findByRole("button", { name: "Model: GPT 5.6 Sol" }),
     ).toBeInTheDocument();
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -10,6 +10,7 @@ import type {
 import type { ComposerWorkspaceFiles } from "@/Composer";
 import { CodeComposer } from "./CodeComposer";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
 import { HarnessPicker } from "./HarnessPicker";
 import {
   autoIsUnsupervised,
@@ -17,6 +18,7 @@ import {
   defaultCreatePermissionMode,
   gatewayCodeModels,
   harnessUnusableReason,
+  preferredCodeModels,
   type CodeModelOption,
   ALLOW_ALL_NOTE,
   UNSUPERVISED_AUTO_NOTE,
@@ -65,8 +67,13 @@ export function StartSessionPrompt({
   /** Worktree files the first message names — a fork's transcript. */
   workspaceFiles?: ComposerWorkspaceFiles;
 }) {
-  const [picked, setPicked] = useState<HarnessKind | null>(null);
-  const [model, setModel] = useState<string | undefined>();
+  const lastCreate = useCodeUiStore((state) => state.lastCreate);
+  const [picked, setPicked] = useState<HarnessKind | null>(
+    lastCreate?.harness ?? null,
+  );
+  const [modelsByHarness, setModelsByHarness] = useState<
+    Partial<Record<HarnessKind, string>>
+  >({ ...lastCreate?.modelsByHarness });
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
   const [modelLoading, setModelLoading] = useState(false);
   const root = useRef<HTMLDivElement>(null);
@@ -87,39 +94,57 @@ export function StartSessionPrompt({
         : "plan";
 
   const selectedKind = selected?.kind;
+  const model = selectedKind ? modelsByHarness[selectedKind] : undefined;
 
   useEffect(() => {
     if (!selectedKind) {
       setModelOptions([]);
-      setModel(undefined);
       setModelLoading(false);
       return;
     }
+    const apply = (listed: CodeModelOption[]) => {
+      setModelOptions(listed);
+      setModelsByHarness((current) => {
+        const remembered = current[selectedKind];
+        const picked =
+          remembered && listed.some((option) => option.id === remembered)
+            ? remembered
+            : (listed.find((option) => option.default)?.id ?? listed[0]?.id);
+        if (picked === remembered) return current;
+        const next = { ...current };
+        if (picked) next[selectedKind] = picked;
+        else delete next[selectedKind];
+        return next;
+      });
+    };
     const gateway = gatewayCodeModels(
       catalogModels,
       selectedKind,
       defaultModelKey,
     );
-    if (gateway.length > 0) {
-      setModelOptions(gateway);
-      setModel(gateway.find((option) => option.default)?.id ?? gateway[0]?.id);
+    const native = useCodeCatalogStore.getState().modelsByHarness[selectedKind];
+    const needsNative = selectedKind === "opencode" || gateway.length === 0;
+    if (!needsNative) {
+      apply(gateway);
+      setModelLoading(false);
+      return;
+    }
+    if (native !== undefined) {
+      apply(preferredCodeModels(selectedKind, native, gateway));
       setModelLoading(false);
       return;
     }
     if (!client) {
-      setModelOptions([]);
-      setModel(undefined);
+      apply(gateway);
       setModelLoading(false);
       return;
     }
     setModelOptions([]);
-    setModel(undefined);
     setModelLoading(true);
     let cancelled = false;
     void ensureHarnessModels(client, selectedKind).then((listed) => {
       if (cancelled) return;
-      setModelOptions(listed);
-      setModel(listed.find((option) => option.default)?.id ?? listed[0]?.id);
+      apply(preferredCodeModels(selectedKind, listed, gateway));
       setModelLoading(false);
     });
     return () => {
@@ -155,7 +180,6 @@ export function StartSessionPrompt({
           disabled={starting}
           onChange={(next) => {
             setModelOptions([]);
-            setModel(undefined);
             setModelLoading(true);
             setPicked(next);
           }}
@@ -181,7 +205,13 @@ export function StartSessionPrompt({
           modelLoading={modelLoading}
           promptScope={workspaceId}
           workspaceFiles={workspaceFiles}
-          onModelChange={setModel}
+          onModelChange={(next) => {
+            if (!selectedKind) return;
+            setModelsByHarness((current) => ({
+              ...current,
+              [selectedKind]: next,
+            }));
+          }}
           onModeChange={onSelectMode}
           onSend={async (message) => {
             if (!selected) return;

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -10,6 +10,7 @@ import {
   gatewayCodeModels,
   groupCodeModelOptions,
   harnessUnusableReason,
+  preferredCodeModels,
   sessionLifecycleTooltip,
 } from "./labels";
 
@@ -236,6 +237,33 @@ describe("gatewayCodeModels", () => {
     ).toEqual(["gpt-5.6-sol"]);
     // opencode is vendor-neutral: the whole catalog stays.
     expect(gatewayCodeModels(catalog, "opencode")).toHaveLength(4);
+  });
+});
+
+describe("preferredCodeModels", () => {
+  const native = [
+    {
+      id: "model-gateway/deepseek-v4-pro",
+      label: "DeepSeek V4 Pro",
+      source: "opencode",
+    },
+  ];
+  const gateway = [
+    {
+      id: "accounts/fireworks/models/deepseek-v4-pro",
+      label: "DeepSeek V4 Pro",
+      source: "opencode · model-gateway",
+    },
+  ];
+
+  it("uses OpenCode's provider-qualified native ids", () => {
+    expect(preferredCodeModels("opencode", native, gateway)).toEqual(native);
+    expect(preferredCodeModels("opencode", [], gateway)).toEqual(gateway);
+  });
+
+  it("keeps gateway rows for engines that accept their ids directly", () => {
+    expect(preferredCodeModels("codex", native, gateway)).toEqual(gateway);
+    expect(preferredCodeModels("claude_code", native, [])).toEqual(native);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -174,11 +174,6 @@ export function defaultCreatePermissionMode(caps: ModeCaps): PermissionMode {
   return "plan";
 }
 
-/** True when this engine honors `--model` (or equivalent) on each turn. */
-export function harnessHonorsTurnModel(kind: HarnessKind): boolean {
-  return kind === "claude_code" || kind === "grok";
-}
-
 /** The modes create may post for this engine, each on its own flag. */
 export function createPermissionModes(caps: ModeCaps): PermissionMode[] {
   const modes: PermissionMode[] = [];
@@ -302,6 +297,23 @@ export function harnessCodeModels(
     reasoning_efforts: option.reasoning_efforts,
     fast_mode: option.fast_mode,
   }));
+}
+
+/**
+ * Pick the catalog whose identifiers the engine accepts.
+ *
+ * OpenCode needs the provider-qualified ids from `opencode models`; chat's
+ * gateway catalog often carries a bare or upstream id instead. Other engines
+ * keep the gateway catalog when it exists because their adapters accept those
+ * ids directly and the catalog carries the entitled display rows.
+ */
+export function preferredCodeModels(
+  kind: HarnessKind,
+  native: readonly CodeModelOption[],
+  gateway: readonly CodeModelOption[],
+): CodeModelOption[] {
+  if (kind === "opencode" && native.length > 0) return [...native];
+  return gateway.length > 0 ? [...gateway] : [...native];
 }
 
 /** One rail section of the code-mode picker: a vendor and its rows. */

--- a/crates/tidebreak-desktop/ui/src/stories/CodeActivityGroup.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeActivityGroup.stories.tsx
@@ -57,9 +57,8 @@ const SETTLED: CodeToolItem[] = [
  * A run of tool calls behind one line, and the reason the code transcript no
  * longer reads as a log. The states worth looking at are the ones that decide
  * whether the reader has to open it: a live run naming the call still going, a
- * settled one totalling the phase, and a run holding a failure, which opens
- * itself because a failure inside a closed group is one the reader has to go
- * looking for.
+ * settled one totalling the phase, and a run holding a failure. Every state
+ * stays folded until the reader asks for its rows.
  */
 const meta = {
   title: "Code/Activity group",
@@ -105,7 +104,7 @@ export const Running: Story = {
   },
 };
 
-/** A failure anywhere in the run opens the group and its own row with it. */
+/** A failure marks the folded group without opening its rows. */
 export const HoldsAFailure: Story = {
   args: {
     tools: [

--- a/crates/tidebreak-desktop/ui/src/stories/CodeToolCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeToolCard.stories.tsx
@@ -6,7 +6,7 @@ import { CodeToolCard } from "@/code/CodeTranscript";
  * The code transcript's boxless tool line: verb, mono subject, and trailing
  * meta on one row. The states that matter are the ones that stress that row —
  * a worktree-prefixed command long enough to force middle truncation, a
- * running call streaming its tail, and the failed line that opens itself.
+ * running call with a live tail, and a failed line with output to inspect.
  */
 const meta = {
   title: "Code/Tool line",
@@ -53,7 +53,7 @@ export const LongWorktreeCommand: Story = {
   },
 };
 
-/** A running call streams the last lines of output without growing the row. */
+/** A running call stays folded. Open it to inspect the latest output. */
 export const Running: Story = {
   args: {
     status: "running",
@@ -63,7 +63,7 @@ export const Running: Story = {
   },
 };
 
-/** Failure opens itself: the output and exit code are the point. */
+/** Failure stays folded. Open it to inspect the output and exit code. */
 export const Failed: Story = {
   args: {
     status: "failed",

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -301,30 +301,34 @@ pub(crate) fn session_create_body(mode: PermissionMode, model: Option<&str>) -> 
 /// `POST /session` model object. The captured 1.18.18 schema wants
 /// `{ providerID, id }`; `{ modelID }` and `{ providerID, modelID }` are 400.
 fn session_model_field(model: &str) -> Option<Value> {
+    let (provider, id) = opencode_model_parts(model)?;
+    Some(json!({ "providerID": provider, "id": id }))
+}
+
+/// `POST /session/{id}/prompt_async` model object. The prompt schema names the
+/// same model id `modelID`, unlike the session-create schema's `id`.
+fn prompt_model_field(model: &str) -> Option<Value> {
+    let (provider, id) = opencode_model_parts(model)?;
+    Some(json!({ "providerID": provider, "modelID": id }))
+}
+
+fn opencode_model_parts(model: &str) -> Option<(&str, &str)> {
     let trimmed = model.trim();
     if trimmed.is_empty() {
         return None;
     }
-    if let Some((provider, id)) = split_provider_model(trimmed) {
-        return Some(json!({ "providerID": provider, "id": id }));
+    // Tidebreak's Fireworks catalog stores the upstream account path without
+    // OpenCode's provider prefix. OpenCode lists the same id under
+    // `fireworks-ai`, so keep the full path and restore that prefix.
+    if trimmed.starts_with("accounts/fireworks/") {
+        return Some(("fireworks-ai", trimmed));
     }
-    let id = trimmed.rsplit('/').next().unwrap_or(trimmed);
-    let provider = infer_opencode_provider(id)?;
-    Some(json!({ "providerID": provider, "id": id }))
-}
-
-fn split_provider_model(model: &str) -> Option<(&str, &str)> {
-    let (provider, id) = model.split_once('/')?;
-    if provider.is_empty() || id.is_empty() {
-        return None;
+    if let Some((provider, id)) = trimmed.split_once('/') {
+        if !provider.is_empty() && !id.is_empty() {
+            return Some((provider, id));
+        }
     }
-    // A gateway routing handle is not an OpenCode provider.
-    if provider.eq_ignore_ascii_case("model-gateway")
-        || provider.eq_ignore_ascii_case("model_gateway")
-    {
-        return None;
-    }
-    Some((provider, id))
+    Some((infer_opencode_provider(trimmed)?, trimmed))
 }
 
 fn infer_opencode_provider(id: &str) -> Option<&'static str> {
@@ -348,7 +352,25 @@ fn infer_opencode_provider(id: &str) -> Option<&'static str> {
     if leaf.contains("pickle") {
         return Some("opencode");
     }
+    if [
+        "deepseek", "glm", "kimi", "minimax", "qwen", "nemotron", "inkling", "muse",
+    ]
+    .iter()
+    .any(|family| leaf.contains(family))
+    {
+        return Some("model-gateway");
+    }
     None
+}
+
+fn turn_prompt_body(text: &str, model: Option<&str>) -> Value {
+    let mut body = json!({
+        "parts": [{ "type": "text", "text": text }]
+    });
+    if let Some(model) = model.and_then(prompt_model_field) {
+        body["model"] = model;
+    }
+    body
 }
 
 fn openai_o_series(id: &str) -> bool {
@@ -684,9 +706,7 @@ impl HarnessSession for OpencodeSession {
         };
         let path = format!("/session/{session_id}/prompt_async");
         let url = format!("{}{path}", self.base_url());
-        let body = json!({
-            "parts": [{ "type": "text", "text": input.text }]
-        });
+        let body = turn_prompt_body(&input.text, input.model.as_deref());
         let query = self.directory_query();
         let (status, parsed) = self
             .http("POST", &path, &url, Some(body), Some(query.as_slice()))
@@ -1015,11 +1035,34 @@ mod tests {
 
         let gateway =
             session_create_body(PermissionMode::Plan, Some("model-gateway/claude-opus-5"));
-        assert_eq!(gateway["model"]["providerID"], "anthropic");
+        assert_eq!(gateway["model"]["providerID"], "model-gateway");
         assert_eq!(gateway["model"]["id"], "claude-opus-5");
+
+        let fireworks = session_create_body(
+            PermissionMode::Plan,
+            Some("accounts/fireworks/models/deepseek-v4-pro"),
+        );
+        assert_eq!(fireworks["model"]["providerID"], "fireworks-ai");
+        assert_eq!(
+            fireworks["model"]["id"],
+            "accounts/fireworks/models/deepseek-v4-pro"
+        );
+
+        let deepseek = session_create_body(PermissionMode::Plan, Some("deepseek-v4-pro"));
+        assert_eq!(deepseek["model"]["providerID"], "model-gateway");
+        assert_eq!(deepseek["model"]["id"], "deepseek-v4-pro");
 
         let unknown = session_create_body(PermissionMode::Plan, Some("mystery-weights"));
         assert!(unknown.get("model").is_none());
+    }
+
+    #[test]
+    fn turn_model_uses_the_prompt_schema() {
+        let body = turn_prompt_body("inspect the failure", Some("model-gateway/deepseek-v4-pro"));
+        assert_eq!(body["model"]["providerID"], "model-gateway");
+        assert_eq!(body["model"]["modelID"], "deepseek-v4-pro");
+        assert!(body["model"].get("id").is_none());
+        assert_eq!(body["parts"][0]["text"], "inspect the failure");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keep tool rows and activity groups folded until the reader opens them, and render folded multi-line commands on one visible line.
- Enable model changes between turns for Codex and OpenCode. OpenCode now sends the provider-qualified model in each prompt request.
- Remember a separate model for each harness and migrate the earlier single-model preference.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run --reporter=dot` — 1,659 tests passed
- `pnpm --dir crates/tidebreak-desktop/ui lint`
- `pnpm --dir crates/tidebreak-desktop/ui build`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- `cargo fmt --all -- --check`
- `git diff --check`

Rust compilation and tests remain with CI, as required by the repository workflow.