### PR TITLE
feat(code): draft the create-PR request into the composer on dirty worktrees

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -248,6 +248,7 @@ export function CodeSidebar() {
                       action === "open_source" ||
                       action === "push" ||
                       action === "create_pr" ||
+                      action === "compose_pr" ||
                       action === "merge" ||
                       action === "mark_ready"
                     ) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -1000,7 +1000,7 @@ describe("CodeWorkspacePage", () => {
     expect(client.archiveCodeWorkspace).toHaveBeenCalledWith("ws-1", false);
   });
 
-  it("opens Source control for local changes without crowding the composer", async () => {
+  it("drafts the Create PR request into the composer for local changes", async () => {
     const client = makeClient();
     client.getCodeWorkspacePr.mockResolvedValue({
       dirty: true,
@@ -1020,17 +1020,35 @@ describe("CodeWorkspacePage", () => {
       expect(control).toHaveTextContent("Uncommitted changes"),
     );
     await user.click(
-      within(control).getByRole("button", { name: "Review & commit" }),
+      within(control).getByRole("button", { name: "Create PR" }),
     );
 
+    // Offered, not sent: the request lands as an editable draft and no turn
+    // starts until the reader submits it.
+    const composer = await waitFor(() => {
+      const input = document.querySelector<HTMLTextAreaElement>(
+        "[data-composer-input]",
+      );
+      expect(input?.value).toContain("open a pull request against `main`");
+      return input!;
+    });
+    expect(composer.value).toContain("Do not merge.");
+    expect(client.submitCodeTurn).not.toHaveBeenCalled();
+
+    // Hand review is one step away: the menu still opens Source control, and
+    // the suggested commit message still does not crowd the composer — the
+    // draft stays exactly what Create PR put there.
+    await user.click(
+      within(control).getByRole("button", { name: "More workspace actions" }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Review & commit" }),
+    );
     expect(screen.getByRole("tab", { name: "Source control" })).toHaveAttribute(
       "aria-selected",
       "true",
     );
-    expect(
-      (screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement)
-        .value,
-    ).toBe("");
+    expect(composer.value).not.toContain("improve login flow");
 
     await user.click(screen.getByRole("tab", { name: "Files" }));
     await user.click(screen.getByRole("button", { name: "Review sidebar" }));

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -38,6 +38,7 @@ import { useCodeUiStore } from "./CodeUiStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import {
   checkSummary,
+  composePrPrompt,
   resolveWorkflowShortcut,
   workspaceWorkflowActionLabel,
   workspaceWorkflowModel,
@@ -88,6 +89,9 @@ export function WorkspaceWorkflowControl({
   const popoverTitleId = useId();
   const { confirm, dialog: confirmDialog } = useConfirm();
   const runComposerPrompt = useCodeUiStore((state) => state.runComposerPrompt);
+  const offerComposerPrompt = useCodeUiStore(
+    (state) => state.offerComposerPrompt,
+  );
   const workflowShortcutPending = useCodeUiStore(
     (state) => state.workflowShortcutPending,
   );
@@ -310,6 +314,13 @@ export function WorkspaceWorkflowControl({
       case "open_source":
         setDetailsOpen(false);
         onOpenSourceControl();
+        return;
+      case "compose_pr":
+        // A draft, not a turn: the request lands in the composer for the
+        // reader to edit and send, because opening a pull request publishes
+        // the branch.
+        setDetailsOpen(false);
+        offerComposerPrompt(workspaceId, composePrPrompt(baseRef));
         return;
       case "open_pr": {
         setDetailsOpen(false);
@@ -663,14 +674,16 @@ export function WorkspaceWorkflowControl({
             title={
               primary === "watch_and_fix"
                 ? "Start an agent task that watches this pull request and fixes actionable failures."
-                : primary === "mark_ready" ||
-                    primary === "merge" ||
-                    primary === "fix_errors" ||
-                    primary === "address_feedback" ||
-                    primary === "update_branch" ||
-                    primary === "resolve_conflicts"
-                  ? `Start an agent task to ${primaryLabel.toLowerCase()}.`
-                  : undefined
+                : primary === "compose_pr"
+                  ? "Draft a request in the composer to commit, push, and open a pull request. You review and send it."
+                  : primary === "mark_ready" ||
+                      primary === "merge" ||
+                      primary === "fix_errors" ||
+                      primary === "address_feedback" ||
+                      primary === "update_branch" ||
+                      primary === "resolve_conflicts"
+                    ? `Start an agent task to ${primaryLabel.toLowerCase()}.`
+                    : undefined
             }
             disabled={
               busy !== null ||

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CodeWorkspacePrSnapshot, PullRequestDigest } from "../api/types";
 import {
+  composePrPrompt,
   resolveWorkflowShortcut,
   workspaceWorkflowActionLabel,
   workspaceWorkflowModel,
@@ -27,8 +28,14 @@ describe("workspaceWorkflowModel", () => {
   it("walks local work through review, push, and pull-request creation", () => {
     const dirty = workspaceWorkflowModel({ ...CLEAN, dirty: true });
     expect(dirty.summary).toBe("Uncommitted changes");
-    expect(dirty.primary).toBe("open_source");
+    expect(dirty.primary).toBe("compose_pr");
     expect(workspaceWorkflowActionLabel(dirty.primary!, dirty.stage)).toBe(
+      "Create PR",
+    );
+    // Hand review does not vanish behind the drafted request; it moves one
+    // step away into the menu.
+    expect(dirty.secondary).toEqual(["open_source"]);
+    expect(workspaceWorkflowActionLabel("open_source", dirty.stage)).toBe(
       "Review & commit",
     );
 
@@ -136,6 +143,8 @@ describe("workspaceWorkflowModel", () => {
       pr: existing,
     });
     expect(dirty.summary).toBe("#41 · Changes");
+    // With a pull request open there is nothing to create: new local changes
+    // go through the commit box to update it.
     expect(dirty.primary).toBe("open_source");
 
     const unpushed = workspaceWorkflowModel({
@@ -208,9 +217,10 @@ describe("resolveWorkflowShortcut", () => {
   it("carries one chord through commit, push, create, and view", () => {
     // Cmd+Shift+P names an intent, not an action: the reader means "get this in
     // front of reviewers" at every stage, and the action that serves it changes
-    // under them. Uncommitted work goes to the commit box rather than being
-    // refused, because that is the actual next step towards a pull request.
-    expect(chord("pull_request", { ...CLEAN, dirty: true })).toBe(
+    // under them. Uncommitted work with no pull request gets the drafted
+    // commit-and-open request; with one open, it goes to the commit box.
+    expect(chord("pull_request", { ...CLEAN, dirty: true })).toBe("compose_pr");
+    expect(chord("pull_request", { ...CLEAN, dirty: true, pr: pr({}) })).toBe(
       "open_source",
     );
     expect(chord("pull_request", { ...CLEAN, unpushed: true, ahead: 1 })).toBe(
@@ -362,5 +372,15 @@ describe("resolveWorkflowShortcut", () => {
     expect(chord("merge", null)).toBe(
       "blocked: Still reading this workspace's status",
     );
+  });
+});
+
+describe("composePrPrompt", () => {
+  it("names the base branch and keeps merging off the agent", () => {
+    const prompt = composePrPrompt("main");
+    expect(prompt).toContain("open a pull request against `main`");
+    expect(prompt).toContain("Do not merge.");
+    // A workspace without a recorded base still gets a sendable request.
+    expect(composePrPrompt(" ")).toContain("the default branch");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -11,6 +11,7 @@ export type WorkspaceWorkflowAction =
   | "open_source"
   | "push"
   | "create_pr"
+  | "compose_pr"
   | "open_pr";
 
 export type WorkspaceWorkflowTone =
@@ -69,17 +70,30 @@ export function workspaceWorkflowModel(
     };
   }
   if (snapshot.dirty) {
+    if (pr) {
+      return {
+        stage: "dirty",
+        tone: "warning",
+        summary: `#${pr.number} · Changes`,
+        title: `Pull request #${pr.number} has local changes`,
+        detail: "Review the worktree and choose a commit message.",
+        primary: "open_source",
+        secondary: pr.url ? ["open_pr"] : [],
+        pr,
+      };
+    }
+    // No pull request yet, so the useful next step is the whole trip: Create
+    // PR drafts the commit-push-open request into the composer for the reader
+    // to send. Hand review stays one step away in the menu.
     return {
       stage: "dirty",
       tone: "warning",
-      summary: pr ? `#${pr.number} · Changes` : "Uncommitted changes",
-      title: pr
-        ? `Pull request #${pr.number} has local changes`
-        : "Changes need review",
-      detail: "Review the worktree and choose a commit message.",
-      primary: "open_source",
-      secondary: pr?.url ? ["open_pr"] : [],
-      pr,
+      summary: "Uncommitted changes",
+      title: "Changes need a pull request",
+      detail:
+        "Create PR drafts a request in the composer to commit, push, and open a pull request.",
+      primary: "compose_pr",
+      secondary: ["open_source"],
     };
   }
   if (snapshot.unpushed) {
@@ -289,10 +303,11 @@ function pullRequestWorkflow(pr: PullRequestDigest): WorkspaceWorkflowModel {
  * A keyboard ask against the workflow.
  *
  * A chord names an intent, not an action: `pull_request` means "get this
- * branch in front of reviewers", which is a push on an unpushed branch, a
- * create on a pushed one, and a trip to GitHub once the pull request exists.
- * Binding chords to intents rather than to actions is what lets the reader
- * press the same key at every stage and always get the useful thing.
+ * branch in front of reviewers", which is a drafted commit-and-open request on
+ * a dirty worktree, a push on an unpushed branch, a create on a pushed one,
+ * and a trip to GitHub once the pull request exists. Binding chords to intents
+ * rather than to actions is what lets the reader press the same key at every
+ * stage and always get the useful thing.
  */
 export type WorkflowShortcut =
   | "next"
@@ -355,11 +370,13 @@ export function resolveWorkflowShortcut(
       return model.primary ? { run: model.primary } : { blocked: model.title };
     case "pull_request":
       // Commit and push come first whether or not a pull request exists, so
-      // these stages lead — reaching a pull request from uncommitted work
-      // means going through the commit box.
-      if (model.stage === "dirty" || model.stage === "github_setup") {
-        return { run: "open_source" };
+      // these stages lead. With no pull request yet, uncommitted work gets the
+      // drafted request that carries it all the way; with one open, new local
+      // changes go through the commit box to update it.
+      if (model.stage === "dirty") {
+        return { run: model.pr ? "open_source" : "compose_pr" };
       }
+      if (model.stage === "github_setup") return { run: "open_source" };
       if (model.stage === "unpushed") return { run: "push" };
       if (model.stage === "ready_for_pr") return { run: "create_pr" };
       if (model.pr) {
@@ -464,6 +481,8 @@ export function workspaceWorkflowActionLabel(
       return "Push";
     case "create_pr":
       return "Open PR";
+    case "compose_pr":
+      return "Create PR";
     case "open_pr":
       if (stage === "queued") return "View queue";
       return "View PR";
@@ -483,4 +502,24 @@ export function workspaceWorkflowActionLabel(
     case "resolve_conflicts":
       return "Resolve conflicts";
   }
+}
+
+/**
+ * The request the Create PR control drafts into the composer.
+ *
+ * Offered as a draft rather than run: opening a pull request publishes the
+ * branch, so the reader reads, edits, and sends the request instead of the
+ * button firing it. The agent it reaches sits in the worktree and can see the
+ * diff, so the prompt says what to do with the changes rather than repeating
+ * them. Merging stays with the user per decision 42.
+ */
+export function composePrPrompt(base?: string): string {
+  const target = base?.trim() ? `\`${base.trim()}\`` : "the default branch";
+  return [
+    "Review the uncommitted changes in this workspace, run focused validation,",
+    "commit with a clear message (split unrelated work into separate commits),",
+    `push the branch, and open a pull request against ${target}.`,
+    "Give the pull request a title and description that summarize what changed",
+    "and why. Do not merge.",
+  ].join(" ");
 }


### PR DESCRIPTION
## What changed

On a worktree with uncommitted changes and no open pull request, the workspace header's primary control is now **Create PR** instead of Review & commit. Clicking it — or pressing Cmd+Shift+P — drops an editable request into the composer to commit, run focused validation, push, and open a pull request against the workspace's base branch; nothing is sent until the user submits it. Review & commit moves to the header's secondary menu and keeps its Cmd+Shift+G chord, and a dirty worktree with an open pull request keeps the commit-box primary since there is no pull request to create. Cmd+Shift+Enter (run the next step) resolves to the same drafted request in that state.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/code/workspaceWorkflow.test.ts src/code/CodeWorkspacePage.dom.test.tsx` — 61 tests pass, including new coverage for the drafted request, the chord resolution, and the menu path back to Source control
- `pnpm lint` and `pnpm format` clean
- `pnpm storybook:build` succeeds; the existing `Uncommitted` story renders the new state
- Full UI suite and Rust lanes left to CI

## Compatibility and risk

None. UI-only; no wire or persisted-format changes. Merging stays a user action per decision 42 — the drafted prompt ends with "Do not merge", and the request is offered as a draft rather than auto-submitted.