### PR TITLE
feat(code): read person attribution from the gateway git probe

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
@@ -317,3 +317,63 @@ describe("AddRepoPalette and a machine without a GitHub credential", () => {
     );
   });
 });
+
+describe("AddRepoPalette on a hosted machine that acts as the person", () => {
+  it("carries the person attribution sentence on the offered source", async () => {
+    await renderPalette(
+      app({
+        getCodeRepoSources: vi.fn(async () => ({
+          sources: [
+            { kind: "local", available: true },
+            { kind: "git_url", available: true },
+            {
+              kind: "github",
+              available: true,
+              remediation:
+                "Clones and pushes use your own GitHub account: work lands as mira-chen.",
+            },
+          ],
+          chooses_destination: true,
+        })),
+        getCodeCloneDefaults: vi.fn(async () => {
+          throw new Error("403: forbidden");
+        }),
+      } as never),
+    );
+    const github = await screen.findByRole("option", {
+      name: /GitHub repository/,
+    });
+    fireEvent.click(github);
+    expect(await screen.findByTestId("gh-absent-hint")).toHaveTextContent(
+      /work lands as mira-chen/,
+    );
+  });
+
+  it("hides GitHub until the caller connects, and points at the gateway", async () => {
+    await renderPalette(
+      app({
+        getCodeRepoSources: vi.fn(async () => ({
+          sources: [
+            { kind: "local", available: true },
+            { kind: "git_url", available: true },
+            {
+              kind: "github",
+              available: false,
+              remediation:
+                "To use GitHub as yourself here, connect your GitHub account at the Model Gateway: https://gateway.example/account/apps",
+            },
+          ],
+          chooses_destination: true,
+        })),
+      } as never),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("option", { name: /GitHub repository/ }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/connect your GitHub account at the Model Gateway/),
+    ).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
@@ -102,6 +102,23 @@ describe("PrCard", () => {
     expect(screen.getByText(/not as your GitHub account/)).toBeInTheDocument();
   });
 
+  it("names the caller when pushes land as their own account", () => {
+    renderState({
+      ...BASE,
+      unpushed: true,
+      ahead: 1,
+      gh_found: false,
+      gh_authenticated: undefined,
+      pushes_as: "mira-chen",
+      pushes_as_self: true,
+    });
+    expect(screen.getByText("mira-chen")).toBeInTheDocument();
+    expect(screen.getByText(/your own GitHub account/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/not as your GitHub account/),
+    ).not.toBeInTheDocument();
+  });
+
   it("names no acting identity on a machine with its own credentials", () => {
     renderState({ ...BASE, unpushed: true, ahead: 1 });
     expect(

--- a/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
@@ -299,7 +299,9 @@ export function PrCardView({
           <span className="text-foreground font-medium">
             {snapshot.pushes_as}
           </span>
-          , the deployment&apos;s GitHub App — not as your GitHub account.
+          {snapshot.pushes_as_self
+            ? " — your own GitHub account."
+            : ", the deployment's GitHub App — not as your GitHub account."}
         </p>
       )}
       {snapshot?.dirty ? (

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1757,6 +1757,7 @@ export function parseCodeWorkspacePr(
       "gh_authenticated",
       "remediation",
       "pushes_as",
+      "pushes_as_self",
       "watch",
     ]) ||
     typeof value.dirty !== "boolean" ||
@@ -1768,7 +1769,9 @@ export function parseCodeWorkspacePr(
     (value.gh_authenticated !== undefined &&
       typeof value.gh_authenticated !== "boolean") ||
     typeof value.remediation !== "string" ||
-    (value.pushes_as !== undefined && typeof value.pushes_as !== "string")
+    (value.pushes_as !== undefined && typeof value.pushes_as !== "string") ||
+    (value.pushes_as_self !== undefined &&
+      typeof value.pushes_as_self !== "boolean")
   ) {
     return null;
   }
@@ -1784,6 +1787,9 @@ export function parseCodeWorkspacePr(
       ? { gh_authenticated: value.gh_authenticated }
       : {}),
     ...(value.pushes_as !== undefined ? { pushes_as: value.pushes_as } : {}),
+    ...(value.pushes_as_self !== undefined
+      ? { pushes_as_self: value.pushes_as_self }
+      : {}),
   };
   if (value.pr !== undefined) {
     const pr = parsePullRequestDigest(value.pr);

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1632,11 +1632,16 @@ export type CodeWorkspaceFiles = { files: Array<CodeFileChange>, truncated: bool
  */
 export type CodeWorkspacePrSnapshot = { dirty: boolean, unpushed: boolean, ahead: number, has_upstream: boolean, suggested_commit_message: string, pr?: PullRequestDigest, gh_found: boolean, gh_authenticated?: boolean, remediation: string, 
 /**
- * The identity a push from this machine acts as, when it is not the
- * caller: the deployment's GitHub App bot account (decision 63). The UI
- * states this plainly beside the push control.
+ * The identity a push from this machine acts as: the deployment's
+ * GitHub App bot account (decision 63) or the caller's own login
+ * (decision 65). The UI states this plainly beside the push control.
  */
-pushes_as?: string, watch?: CodeWatchSnapshot, };
+pushes_as?: string, 
+/**
+ * Whether `pushes_as` is the caller's own account (decision 65)
+ * rather than the deployment's App.
+ */
+pushes_as_self?: boolean, watch?: CodeWatchSnapshot, };
 
 /**
  * One pull request attributed to a workspace, from the durable fact store

--- a/crates/tidebreak-desktop/ui/src/stories/PrCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/PrCard.stories.tsx
@@ -8,6 +8,7 @@ import {
   cleanGit,
   dirtyGit,
   hostedAppGit,
+  hostedPersonGit,
   openPrGit,
   readyForPrGit,
   unpushedGit,
@@ -77,6 +78,14 @@ export const Unpushed: Story = {
  */
 export const HostedPushesAsApp: Story = {
   args: { snapshot: hostedAppGit },
+};
+
+/**
+ * A hosted machine whose caller connected their own GitHub account at the
+ * gateway pushes as that person, and the card names them (decision 65).
+ */
+export const HostedPushesAsYou: Story = {
+  args: { snapshot: hostedPersonGit },
 };
 
 export const ReadyForPullRequest: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -133,6 +133,15 @@ export const hostedAppGit: CodeWorkspacePrSnapshot = {
   pushes_as: "tidebreak-ship[bot]",
 };
 
+/** A hosted machine whose pushes land as the caller's own account. */
+export const hostedPersonGit: CodeWorkspacePrSnapshot = {
+  ...unpushedGit,
+  gh_found: false,
+  gh_authenticated: undefined,
+  pushes_as: "mira-chen",
+  pushes_as_self: true,
+};
+
 export const readyForPrGit: CodeWorkspacePrSnapshot = {
   ...cleanGit,
   ahead: 1,

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -20,7 +20,7 @@ use super::bus::{CloneProgress, CodeLiveUpdate};
 use super::gh::{self, resolve_github_clone_url};
 use super::runtime::CodeRuntime;
 use crate::error::ServerError;
-use crate::obo_gateway::{GitCredential, GitForgeError, GitForgeIdentity};
+use crate::obo_gateway::{GitCredential, GitForgeAttribution, GitForgeError, GitForgeIdentity};
 use crate::routes::code::{
     CodeCloneDefaults, CodeCloneJobSnapshot, CodeRepoSource, CodeRepoSources,
 };
@@ -493,17 +493,22 @@ fn hosted_github_source(
     }
 }
 
-/// The sentence a hosted machine states its git identity with (decision 63).
+/// The sentence a hosted machine states its git identity with.
 ///
-/// Issue #2510's contract: an `installation_only` deployment cannot
-/// attribute work to the person, so the UI must say plainly that it lands as
-/// the App.
+/// Issue #2510's contract, extended by decision 65: the add-repository
+/// dialog says out loud whose account work lands as — the deployment's App
+/// (decision 63), or the caller's own once they have connected it.
 pub(crate) fn hosted_attribution_sentence(identity: &GitForgeIdentity) -> String {
-    match identity.bot_login.as_deref() {
-        Some(bot_login) => format!(
+    match &identity.attribution {
+        GitForgeAttribution::Person { login, .. } => format!(
+            "Clones and pushes use your own GitHub account: work lands as {login}."
+        ),
+        GitForgeAttribution::Bot {
+            bot_login: Some(bot_login),
+        } => format!(
             "Clones and pushes use this deployment's GitHub App: work lands as {bot_login}, not as your GitHub account."
         ),
-        None => format!(
+        GitForgeAttribution::Bot { bot_login: None } => format!(
             "Clones and pushes use this deployment's GitHub App ({}): work lands as the App's bot account, not as your GitHub account.",
             identity.app_name
         ),
@@ -526,11 +531,20 @@ pub(crate) fn git_forge_refusal_message(refusal: &GitForgeError) -> String {
                                              administrator can disable the extras."
             .to_owned(),
         GitForgeError::ConnectModeForge => "This deployment's git forge identifies each person \
-                                            individually, and a personal identity is never lent \
-                                            to a shared machine. An administrator can register a \
-                                            second, installation-mode forge app on the Model \
-                                            Gateway."
+                                            individually, and its gateway does not lend personal \
+                                            credentials to this machine. An administrator can \
+                                            update the Model Gateway to one that serves personal \
+                                            git credentials."
             .to_owned(),
+        GitForgeError::NotConnected { connect_url } => match connect_url {
+            Some(url) => format!(
+                "To use GitHub as yourself here, connect your GitHub account at the Model \
+                 Gateway: {url}"
+            ),
+            None => "To use GitHub as yourself here, connect your GitHub account at the Model \
+                     Gateway."
+                .to_owned(),
+        },
         GitForgeError::ForgeAppNotInstalled => "This deployment's git forge app has no approved \
                                                 GitHub App installation yet. An administrator can \
                                                 finish installing it on GitHub."

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -202,10 +202,14 @@ pub(crate) struct WorkspaceGitStatus {
     pub gh_found: bool,
     pub gh_authenticated: Option<bool>,
     pub remediation: String,
-    /// The identity a push from this machine acts as, when it is not the
-    /// caller: the deployment's GitHub App bot account (decision 63). `None`
-    /// on every machine where git speaks for whoever configured it.
+    /// The identity a push from this machine acts as, when git does not
+    /// speak for whoever configured it: the deployment's GitHub App bot
+    /// account (decision 63), or the caller's own login (decision 65).
+    /// `None` on every machine where git speaks for whoever configured it.
     pub pushes_as: Option<String>,
+    /// `Some(true)` when `pushes_as` is the caller's own account
+    /// (decision 65) rather than the deployment's App.
+    pub pushes_as_self: Option<bool>,
 }
 
 /// Outcome of one named quick action.
@@ -363,6 +367,7 @@ pub(crate) async fn workspace_git_status(
         // Decorated by the runtime, which knows whether this machine lends
         // gateway credentials; this module only observes local state.
         pushes_as: None,
+        pushes_as_self: None,
     })
 }
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1359,8 +1359,8 @@ impl CodeRuntime {
         .await
         .map_err(map_gh)?;
         // On a hosted machine, say whose identity a push would act as
-        // (decision 63) — only for a checkout the machine would actually
-        // lend the App's identity to, so the sentence is never wider than
+        // (decisions 63 and 65) — only for a checkout the machine would
+        // actually lend an identity to, so the sentence is never wider than
         // the lending. Probed per caller and held fresh by the lender; a
         // refusal simply leaves the field empty — the push itself reports
         // refusals with their reasons.
@@ -1368,7 +1368,15 @@ impl CodeRuntime {
             let worktree = std::path::Path::new(&workspace.worktree_path);
             if forge_lending_target(worktree).await.is_some() {
                 if let Ok(identity) = lender.git_forge_identity(owner).await {
-                    status.pushes_as = Some(identity.bot_login.unwrap_or(identity.app_name));
+                    match identity.attribution {
+                        crate::obo_gateway::GitForgeAttribution::Person { login, .. } => {
+                            status.pushes_as = Some(login);
+                            status.pushes_as_self = Some(true);
+                        }
+                        crate::obo_gateway::GitForgeAttribution::Bot { bot_login } => {
+                            status.pushes_as = Some(bot_login.unwrap_or(identity.app_name));
+                        }
+                    }
                 }
             }
         }

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -164,17 +164,39 @@ struct ExchangeResponse {
     expires_in: u64,
 }
 
-/// The forge identity a hosted machine's git operations act as (decision 63).
+/// The forge identity a hosted machine's git operations act as.
 ///
-/// Work done with a borrowed credential lands as the deployment's GitHub App,
-/// not as the caller — this is what the UI says so with.
+/// Work done with a borrowed credential lands as the deployment's GitHub App
+/// (decision 63) or, once the caller has connected their own account at the
+/// gateway, as the caller (decision 65) — this is what the UI names the
+/// acting identity with.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GitForgeIdentity {
     /// The gateway's display name for the forge app.
     pub app_name: String,
-    /// The bot account work lands as, `<slug>[bot]`, when the gateway has
-    /// recorded the App slug.
-    pub bot_login: Option<String>,
+    /// Whose account work lands as.
+    pub attribution: GitForgeAttribution,
+}
+
+/// Whose account work done with a borrowed forge credential lands as.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GitForgeAttribution {
+    /// The App's bot account (decision 63): `<slug>[bot]` when the gateway
+    /// has recorded the App slug.
+    Bot {
+        /// The bot account work lands as, when known.
+        bot_login: Option<String>,
+    },
+    /// The caller's own account (decision 65), lent per operation from
+    /// their gateway connection.
+    Person {
+        /// The forge login work lands as.
+        login: String,
+        /// The account's display name, when the forge records one.
+        display_name: Option<String>,
+        /// The no-reply email commits should name the person by.
+        commit_email: Option<String>,
+    },
 }
 
 /// One borrowed, repository-scoped forge credential (decision 63).
@@ -214,9 +236,13 @@ pub(crate) enum GitForgeError {
     NoGitForge,
     /// More than one forge is available; the gateway refuses to pick.
     AmbiguousGitForge,
-    /// The forge's identity is a person's own Connect, never lent to a
-    /// shared machine.
+    /// The forge's identity is a person's own Connect, and this machine did
+    /// not or could not ask to act as them.
     ConnectModeForge,
+    /// The forge acts as each caller individually, and this caller has not
+    /// connected their account at the gateway yet (decision 65). Carries
+    /// the gateway page where they connect, when the gateway names one.
+    NotConnected { connect_url: Option<String> },
     /// The forge has no approved GitHub App installation yet.
     ForgeAppNotInstalled,
     /// The App installation does not cover the requested repository.
@@ -662,6 +688,7 @@ impl OboGateway {
                 GitForgeError::NoGitForge
                 | GitForgeError::AmbiguousGitForge
                 | GitForgeError::ConnectModeForge
+                | GitForgeError::NotConnected { .. }
                 | GitForgeError::ForgeAppNotInstalled
                 | GitForgeError::RepositoryNotInstalled,
             ) => {
@@ -705,6 +732,11 @@ impl OboGateway {
             .json(&serde_json::json!({
                 "resource": self.resource,
                 "repository": repository,
+                // This machine renders person attribution (decision 65), so
+                // a connect-mode forge may lend the caller's own credential.
+                // A gateway that predates the field ignores it and refuses
+                // connect-mode forges exactly as before.
+                "attribution": "person",
             }))
             .send()
             .await
@@ -743,11 +775,19 @@ impl OboGateway {
 
     /// One probe of the gateway's git-forge surface with the caller's
     /// machine-bound token.
+    ///
+    /// The `attribution=person` parameter declares that this machine renders
+    /// person attribution (decision 65): a connect-mode forge may answer with
+    /// the caller's own identity instead of refusing. A gateway that predates
+    /// the parameter ignores it.
     async fn fetch_git_forge(&self, subject: &str) -> Result<GitForgeIdentity, GitForgeError> {
         let response = self
             .client
             .get(self.git_forge_url.clone())
-            .query(&[("resource", self.resource.as_str())])
+            .query(&[
+                ("resource", self.resource.as_str()),
+                ("attribution", "person"),
+            ])
             .bearer_auth(subject)
             .send()
             .await
@@ -768,15 +808,50 @@ impl OboGateway {
             app_name: String,
             #[serde(default)]
             bot_login: Option<String>,
+            #[serde(default)]
+            attribution: Option<String>,
+            #[serde(default)]
+            acts_as: Option<String>,
+            #[serde(default)]
+            display_name: Option<String>,
+            #[serde(default)]
+            commit_email: Option<String>,
         }
         let answer: GitForgeAnswer = serde_json::from_slice(&body).map_err(|error| {
             GitForgeError::Unavailable(format!(
                 "the Model Gateway returned an unreadable git-forge answer: {error}"
             ))
         })?;
+        // Person attribution is trusted only when the gateway states it
+        // (decision 65); an answer without the field is the App's bot
+        // (decision 63). An attribution this build does not know is refused
+        // rather than guessed — a wrong identity on screen is worse than a
+        // retryable error.
+        let attribution = match answer.attribution.as_deref() {
+            None | Some("bot") => GitForgeAttribution::Bot {
+                bot_login: answer.bot_login,
+            },
+            Some("person") => {
+                let Some(login) = answer.acts_as.filter(|login| !login.is_empty()) else {
+                    return Err(GitForgeError::Unavailable(
+                        "the Model Gateway answered person attribution with no login".into(),
+                    ));
+                };
+                GitForgeAttribution::Person {
+                    login,
+                    display_name: answer.display_name.filter(|name| !name.is_empty()),
+                    commit_email: answer.commit_email.filter(|email| !email.is_empty()),
+                }
+            }
+            Some(other) => {
+                return Err(GitForgeError::Unavailable(format!(
+                    "the Model Gateway answered an attribution this machine does not know: {other}"
+                )));
+            }
+        };
         Ok(GitForgeIdentity {
             app_name: answer.app_name,
-            bot_login: answer.bot_login,
+            attribution,
         })
     }
 
@@ -893,6 +968,22 @@ fn git_refusal(status: reqwest::StatusCode, body: &[u8]) -> GitForgeError {
             "no_git_forge" => return GitForgeError::NoGitForge,
             "ambiguous_git_forge" => return GitForgeError::AmbiguousGitForge,
             "connect_mode_forge" => return GitForgeError::ConnectModeForge,
+            "not_connected" => {
+                // The refusal names where the caller connects, when the
+                // gateway knows the page. Parsed beside the OAuth error
+                // shape rather than inside it: the field is this refusal's
+                // alone.
+                #[derive(serde::Deserialize)]
+                struct NotConnectedAnswer {
+                    #[serde(default)]
+                    connect_url: Option<String>,
+                }
+                let connect_url = serde_json::from_slice::<NotConnectedAnswer>(body)
+                    .ok()
+                    .and_then(|answer| answer.connect_url)
+                    .filter(|url| !url.is_empty());
+                return GitForgeError::NotConnected { connect_url };
+            }
             "forge_app_not_installed" => return GitForgeError::ForgeAppNotInstalled,
             "repository_not_installed" => return GitForgeError::RepositoryNotInstalled,
             "forge_credential_mint_failed" => {
@@ -982,7 +1073,26 @@ pub(crate) mod test_support {
             Self {
                 identity: std::sync::Mutex::new(Ok(GitForgeIdentity {
                     app_name: "Acme Forge".to_owned(),
-                    bot_login: Some(bot_login.to_owned()),
+                    attribution: GitForgeAttribution::Bot {
+                        bot_login: Some(bot_login.to_owned()),
+                    },
+                })),
+                mint_refusal: std::sync::Mutex::new(None),
+                minted: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        /// A deployment whose forge acts as this caller's own account
+        /// (decision 65).
+        pub(crate) fn offering_person(login: &str) -> Self {
+            Self {
+                identity: std::sync::Mutex::new(Ok(GitForgeIdentity {
+                    app_name: "Acme Forge".to_owned(),
+                    attribution: GitForgeAttribution::Person {
+                        login: login.to_owned(),
+                        display_name: Some("Mira Chen".to_owned()),
+                        commit_email: Some(format!("8675309+{login}@users.noreply.github.com")),
+                    },
                 })),
                 mint_refusal: std::sync::Mutex::new(None),
                 minted: std::sync::Mutex::new(Vec::new()),
@@ -1168,6 +1278,9 @@ mod tests {
         /// The `error` code the git surfaces refuse with, with its status, or
         /// empty to succeed.
         git_refusal: Arc<std::sync::Mutex<Option<(u16, String)>>>,
+        /// The probe answer the git-forge route serves, or `None` for the
+        /// default bot-attributed answer.
+        forge_answer: Arc<std::sync::Mutex<Option<serde_json::Value>>>,
     }
 
     impl FakeGateway {
@@ -1181,6 +1294,7 @@ mod tests {
                 forge_probes: Arc::new(AtomicUsize::new(0)),
                 credential_mints: Arc::new(AtomicUsize::new(0)),
                 git_refusal: Arc::new(std::sync::Mutex::new(None)),
+                forge_answer: Arc::new(std::sync::Mutex::new(None)),
                 catalog: Arc::new(std::sync::Mutex::new(serde_json::json!({
                     "models": [
                         {
@@ -1343,14 +1457,28 @@ mod tests {
                                 query.get("resource").map(String::as_str),
                                 Some(TEST_RESOURCE)
                             );
+                            // The machine declares it renders person
+                            // attribution (decision 65) — asserted server-side
+                            // so a drifted client fails the test.
+                            assert_eq!(
+                                query.get("attribution").map(String::as_str),
+                                Some("person")
+                            );
                             state.forge_probes.fetch_add(1, Ordering::SeqCst);
                             if let Some(refused) = state.next_git_refusal() {
                                 return refused;
                             }
-                            Json(serde_json::json!({
-                                "app_id": "0193a1c0-0000-7000-8000-000000000001",
-                                "app_name": "Acme Forge",
-                                "bot_login": "acme-ship[bot]",
+                            let scripted = state
+                                .forge_answer
+                                .lock()
+                                .map(|answer| answer.clone())
+                                .unwrap_or_default();
+                            Json(scripted.unwrap_or_else(|| {
+                                serde_json::json!({
+                                    "app_id": "0193a1c0-0000-7000-8000-000000000001",
+                                    "app_name": "Acme Forge",
+                                    "bot_login": "acme-ship[bot]",
+                                })
                             }))
                             .into_response()
                         }
@@ -1376,6 +1504,8 @@ mod tests {
                                 repository.split('/').count() == 2,
                                 "the mint must name owner/repo, got {repository:?}"
                             );
+                            // Decision 65's opt-in rides every mint.
+                            assert_eq!(body["attribution"], "person");
                             state.credential_mints.fetch_add(1, Ordering::SeqCst);
                             if let Some(refused) = state.next_git_refusal() {
                                 return refused;
@@ -1404,6 +1534,9 @@ mod tests {
         }
 
         /// The configured git refusal as a ready response, or `None`.
+        ///
+        /// A `not_connected` refusal carries the connect page beside the
+        /// OAuth error shape, exactly as the gateway sends it.
         fn next_git_refusal(&self) -> Option<axum::response::Response> {
             let held = self
                 .git_refusal
@@ -1411,14 +1544,19 @@ mod tests {
                 .map(|refusal| refusal.clone())
                 .unwrap_or_default()?;
             let (status, code) = held;
+            let mut body = serde_json::json!({
+                "error": code,
+                "error_description": "the fake gateway refused",
+            });
+            if code == "not_connected" {
+                body["connect_url"] =
+                    serde_json::Value::String("https://gateway.example/account/apps".to_owned());
+            }
             Some(
                 (
                     axum::http::StatusCode::from_u16(status)
                         .unwrap_or(axum::http::StatusCode::BAD_REQUEST),
-                    Json(serde_json::json!({
-                        "error": code,
-                        "error_description": "the fake gateway refused",
-                    })),
+                    Json(body),
                 )
                     .into_response(),
             )
@@ -1888,7 +2026,13 @@ mod tests {
 
         let identity = obo.git_forge_identity(&alice).await.unwrap();
         assert_eq!(identity.app_name, "Acme Forge");
-        assert_eq!(identity.bot_login.as_deref(), Some("acme-ship[bot]"));
+        assert_eq!(
+            identity.attribution,
+            GitForgeAttribution::Bot {
+                bot_login: Some("acme-ship[bot]".to_owned())
+            },
+            "an answer without an attribution field is the App's bot"
+        );
         obo.git_forge_identity(&alice).await.unwrap();
         assert_eq!(
             gateway.forge_probes.load(Ordering::SeqCst),
@@ -1899,6 +2043,82 @@ mod tests {
         obo.expire_git_forge_for_test(&alice).await;
         obo.git_forge_identity(&alice).await.unwrap();
         assert_eq!(gateway.forge_probes.load(Ordering::SeqCst), 2);
+        server.abort();
+    }
+
+    /// Decision 65: a gateway that states person attribution is read as the
+    /// caller's own account, and an attribution this build does not know is
+    /// refused rather than guessed.
+    #[tokio::test]
+    async fn the_probe_reads_person_attribution_only_when_the_gateway_states_it() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        obo.record_caller(&alice, "mg_at_alice".into());
+
+        *gateway.forge_answer.lock().unwrap() = Some(serde_json::json!({
+            "app_id": "0193a1c0-0000-7000-8000-000000000001",
+            "app_name": "Acme Forge",
+            "attribution": "person",
+            "acts_as": "mira-chen",
+            "display_name": "Mira Chen",
+            "commit_email": "8675309+mira-chen@users.noreply.github.com",
+        }));
+        let identity = obo.git_forge_identity(&alice).await.unwrap();
+        assert_eq!(
+            identity.attribution,
+            GitForgeAttribution::Person {
+                login: "mira-chen".to_owned(),
+                display_name: Some("Mira Chen".to_owned()),
+                commit_email: Some("8675309+mira-chen@users.noreply.github.com".to_owned()),
+            }
+        );
+
+        *gateway.forge_answer.lock().unwrap() = Some(serde_json::json!({
+            "app_id": "0193a1c0-0000-7000-8000-000000000001",
+            "app_name": "Acme Forge",
+            "attribution": "org",
+            "acts_as": "acme",
+        }));
+        obo.expire_git_forge_for_test(&alice).await;
+        assert!(
+            matches!(
+                obo.git_forge_identity(&alice).await.unwrap_err(),
+                GitForgeError::Unavailable(_)
+            ),
+            "an unknown attribution must refuse, never guess an identity"
+        );
+        server.abort();
+    }
+
+    /// Decision 65: the not-connected refusal is typed, carries the gateway
+    /// page where the caller connects, and is held like any settled answer.
+    #[tokio::test]
+    async fn a_not_connected_refusal_names_the_connect_page_and_is_held() {
+        let gateway = FakeGateway::new();
+        let (obo, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        obo.record_caller(&alice, "mg_at_alice".into());
+
+        *gateway.git_refusal.lock().unwrap() = Some((403, "not_connected".to_owned()));
+        let refusal = obo.git_forge_identity(&alice).await.unwrap_err();
+        assert_eq!(
+            refusal,
+            GitForgeError::NotConnected {
+                connect_url: Some("https://gateway.example/account/apps".to_owned()),
+            }
+        );
+        obo.git_forge_identity(&alice).await.unwrap_err();
+        assert_eq!(
+            gateway.forge_probes.load(Ordering::SeqCst),
+            1,
+            "not-connected is settled until the caller acts; it must not re-probe"
+        );
+        assert_eq!(
+            obo.git_credential(&alice, "acme/demo").await.unwrap_err(),
+            refusal,
+            "the mint refuses with the same typed cause"
+        );
         server.abort();
     }
 

--- a/crates/tidebreak-server/src/routes/code/git.rs
+++ b/crates/tidebreak-server/src/routes/code/git.rs
@@ -223,6 +223,7 @@ fn pr_snapshot(
         gh_authenticated: status.gh_authenticated,
         remediation: status.remediation,
         pushes_as: status.pushes_as,
+        pushes_as_self: status.pushes_as_self,
         watch: watch.map(CodeWatchSnapshot::from),
     }
 }

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -553,12 +553,17 @@ pub struct CodeWorkspacePrSnapshot {
     #[ts(optional)]
     pub gh_authenticated: Option<bool>,
     pub remediation: String,
-    /// The identity a push from this machine acts as, when it is not the
-    /// caller: the deployment's GitHub App bot account (decision 63). The UI
-    /// states this plainly beside the push control.
+    /// The identity a push from this machine acts as: the deployment's
+    /// GitHub App bot account (decision 63) or the caller's own login
+    /// (decision 65). The UI states this plainly beside the push control.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub pushes_as: Option<String>,
+    /// Whether `pushes_as` is the caller's own account (decision 65)
+    /// rather than the deployment's App.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub pushes_as_self: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub watch: Option<CodeWatchSnapshot>,

--- a/crates/tidebreak-server/src/tests/code_clone.rs
+++ b/crates/tidebreak-server/src/tests/code_clone.rs
@@ -514,6 +514,43 @@ async fn a_hosted_machine_offers_github_per_caller_from_the_gateway() {
     assert!(reason.contains("no git forge"), "{reason}");
 }
 
+/// Decision 65: a caller who connected their own account reads the person
+/// attribution sentence, and a caller who has not reads "not offered" with
+/// the gateway's connect page as the remediation — never a silent fall back
+/// to another identity.
+#[tokio::test]
+async fn a_hosted_machine_offers_github_as_the_person_per_caller() {
+    let lender = Arc::new(FakeLender::offering_person("mira-chen"));
+    let (router, token, _runtime, _dir) =
+        code_app_with(Some(lender as Arc<dyn GitCredentialLender>)).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+
+    let sources = fetch_sources(&client, addr, &token).await;
+    let github = source(&sources, "github");
+    assert_eq!(github["available"], true);
+    let hint = github["remediation"].as_str().unwrap();
+    assert!(hint.contains("your own GitHub account"), "{hint}");
+    assert!(hint.contains("mira-chen"), "{hint}");
+    assert!(!hint.contains("not as your GitHub account"), "{hint}");
+
+    let unconnected = Arc::new(FakeLender::refusing(GitForgeError::NotConnected {
+        connect_url: Some("https://gateway.example/account/apps".to_owned()),
+    }));
+    let (router, token, _runtime, _dir) =
+        code_app_with(Some(unconnected as Arc<dyn GitCredentialLender>)).await;
+    let addr = serve(router).await;
+    let sources = fetch_sources(&client, addr, &token).await;
+    let github = source(&sources, "github");
+    assert_eq!(github["available"], false);
+    let reason = github["remediation"].as_str().unwrap();
+    assert!(reason.contains("connect your GitHub account"), "{reason}");
+    assert!(
+        reason.contains("https://gateway.example/account/apps"),
+        "{reason}"
+    );
+}
+
 /// Decision 63 rule 4: a clone the gateway refuses fails with the gateway's
 /// reason — before any network is touched — and the mint was asked for
 /// exactly the repository the caller named.

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -519,6 +519,10 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
         .unwrap();
     let body: serde_json::Value = status.json().await.unwrap();
     assert_eq!(body["pushes_as"], "acme-ship[bot]", "{body}");
+    assert!(
+        body["pushes_as_self"].is_null(),
+        "the App's identity is never claimed as the caller's own: {body}"
+    );
 
     // A rewritten origin on a foreign host — the exact move an agent in the
     // workspace could make — is outside the lending: no identity is claimed
@@ -570,4 +574,40 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
     assert_eq!(kind, "git_forge_refused");
     assert!(message.contains("no git forge"), "{message}");
     assert_eq!(lender.minted(), vec!["acme/demo".to_owned()]);
+}
+
+/// Decision 65: once the caller's own account acts, the git card names them
+/// and states the identity is their own rather than the App's.
+#[tokio::test]
+async fn a_hosted_git_card_names_the_person_once_connected() {
+    let lender = Arc::new(FakeLender::offering_person("mira-chen"));
+    let (router, token, _runtime, dir) =
+        code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "person change").await;
+    let id = json_id(&workspace);
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    run(
+        &path,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/acme/demo.git",
+        ],
+    );
+    let status = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = status.json().await.unwrap();
+    assert_eq!(body["pushes_as"], "mira-chen", "{body}");
+    assert_eq!(body["pushes_as_self"], true, "{body}");
 }

--- a/docs/decisions/0065-hosted-git-acts-as-the-person.md
+++ b/docs/decisions/0065-hosted-git-acts-as-the-person.md
@@ -1,0 +1,115 @@
+# 65. Hosted git and pull requests act as the person
+
+- Status: Proposed
+- Date: 2026-08-24
+- Owners: server, desktop
+- Related: [`0034-harness-discovery-credentials.md`](0034-harness-discovery-credentials.md),
+  [`0049-gateway-authenticated-hosted-machines.md`](0049-gateway-authenticated-hosted-machines.md),
+  [`0063-hosted-machines-borrow-forge-credentials.md`](0063-hosted-machines-borrow-forge-credentials.md),
+  [`../gateway-boundary.md`](../gateway-boundary.md)
+
+## Context
+
+On a local machine, work lands as the person. Decision 34 observes the
+caller's own `gh` login and git configuration, so a commit, a push, and a
+pull request all carry the identity of whoever drove them. Decision 63 gave
+hosted machines their first GitHub identity — per-operation installation
+tokens from the deployment's GitHub App — and work landed as the App's bot
+account, because installation tokens were the one credential the gateway
+could mint without asking any person to authorize anything.
+
+Bot attribution is a stopgap, not the product. The person who drives a
+hosted workspace is accountable for the work: they steer the agent, review
+the diff, and see the pull request through, even when the AI writes and
+pushes every line. Credit and review conventions key on the author —
+CODEOWNERS, approve-your-own-PR rules, contribution history — and a hosted
+machine should read exactly like the same person working locally.
+
+The mechanism exists. The deployment's forge app is a GitHub App, and a
+GitHub App mints two credential kinds: installation tokens, which act as
+the App, and user access tokens, which act as a person who authorized the
+App once. The forge app's OAuth client is already registered with the
+gateway, people already authorize this same forge and drive gateway
+sandboxes as themselves with it, and the gateway already distinguishes
+personal from installation credentials per app. The gateway's git
+surfaces grow a personal mode (successor to gateway ADR 0083): the
+git-credential mint returns the caller's user token, and the git-forge
+probe answers the caller's own connection state.
+
+Decision 63 rejected lending a person's identity to a shared machine
+because work would land as a person who never acted from their own device.
+That objection is about unattended and cross-user lending, and it stands.
+It does not describe this record: every borrow is driven by the caller's
+own live, machine-bound session — the person is acting from their own
+device, through the machine that hosts their workspace — and the gateway
+audits every mint to them.
+
+## Decision
+
+1. **The borrowed credential is the caller's own user token.** On a
+   gateway-authenticated hosted machine, a clone, a push, and a pull-request
+   operation borrow a short-lived GitHub user access token minted for the
+   requesting caller. Decision 63's handling discipline is unchanged: held
+   in memory for the one operation, injected through a one-shot credential
+   helper over an emptied helper list, answered only for `https` on the
+   forge's exact host, never stored. A user token cannot be scoped to one
+   repository the way an installation token can — its ceiling is the App's
+   permission set intersected with the person's own repository access — so
+   the App's permissions stay minimal and the host gates carry the
+   confinement.
+
+2. **Authorization is explicit, once per person, and revocable.** A person
+   authorizes the deployment's forge App through the gateway's existing
+   delegated-OAuth flow. The per-caller probe then answers connected,
+   naming the login work will land as. A caller who has not authorized
+   reads "not offered", with connecting as the remediation — never a silent
+   fall back to another identity. Disconnecting at the gateway ends the
+   machine's ability to act as them at the next borrow.
+
+3. **Commits carry the person's identity.** A hosted workspace configures
+   its git author and committer from the caller's GitHub account when the
+   workspace is created, so history names the person rather than an
+   image-wide environment identity.
+
+4. **Pull requests ride REST on the same borrowed token.** Pull-request
+   creation and the delivery reads stop requiring `gh` and drive the
+   forge's REST API with the same per-operation credential. A pull request
+   opened from a hosted machine is authored by the person.
+
+5. **The UI still names the acting identity.** The attribution seam from
+   decision 63 stays: the add-repository source and the workspace git card
+   say whose identity acts — now the caller's own login. Legibility was the
+   bargain for bot attribution, and it holds for person attribution too.
+
+## Rejected
+
+- **Keeping the App's bot identity for user-driven work.** Misattributes
+  credit and accountability, and breaks every author-keyed convention.
+  Decision 63's bot attribution stands only until this ships, and remains
+  the honest shape for work no person drove.
+- **Falling back to the bot when a person has not connected.** Two
+  attribution states behind one push button; a reader could not know which
+  identity acted without checking. Not-offered-with-remediation is legible.
+- **Person-authored commits pushed by the bot.** Setting the person as
+  commit author while the bot pushes and opens the pull request splits
+  attribution across two identities and forges authorship without the
+  person's consent.
+- **Registering a second, installation-mode forge app.** The previous
+  slice's remaining checklist step. Unnecessary now: the existing forge App
+  already carries the OAuth client this record needs, and the machine
+  deliberately serves exactly one forge.
+
+## Revisit when
+
+- Unattended hosted work — triggers, scheduled jobs, anything with no live
+  caller session — needs a git identity. Installation tokens are the right
+  shape for it, and decision 63's machinery is already built.
+- A deployment needs a policy forcing bot attribution (environments where
+  individual identity must not appear on the forge); that is a gateway
+  policy switch over the same surfaces.
+- The forge is not GitHub. User-token mechanics are App-specific, and
+  another forge kind needs its own consent story.
+- The harness agent's own `git push` inside a hosted workspace should act
+  as the person too. That needs a credential seam through shell policy,
+  which denies helper configuration by design today; open it deliberately,
+  not as a side effect of this record.


### PR DESCRIPTION
## Why

Decision 65 (`docs/decisions/0065-hosted-git-acts-as-the-person.md`, included here): work from a hosted machine should land as the person who drove it, not as the deployment's GitHub App. This is slice B of that record — the machine-side probe states and the attribution UI. The gateway's personal-mode surface (probe + mint) lands separately in model-gateway.

## What

- The git-forge probe and credential mint declare `attribution=person`. A gateway that predates the field ignores it and refuses connect-mode forges exactly as before, so nothing changes against today's deployments in either direction.
- A probe answer stating `attribution: "person"` parses to the caller's login, display name, and commit email. Answers without the field remain the App's bot (decision 63), byte-for-byte; an unknown attribution value refuses rather than guessing an identity.
- New typed `not_connected` refusal, cached like the other settled answers, carrying the gateway's `connect_url`. The add-repository GitHub source then reads "To use GitHub as yourself here, connect your GitHub account at the Model Gateway: …" instead of silently acting as anything else.
- The `connect_mode_forge` remediation stops advising a second forge app registration (decision 65 rejects that path) and points at updating the gateway instead.
- The PR card names the person plainly — `pushes_as` becomes their login and the new optional `pushes_as_self` wire field switches the sentence to "— your own GitHub account."

## Tests

- `obo_gateway`: person attribution parses only when stated; unknown attribution refuses; `not_connected` is typed, held fresh, and carries the connect page; the fake gateway asserts the opt-in rides both requests server-side.
- `code_clone`: per-caller source answers for a connected person and for a not-connected caller (connect URL surfaces in the remediation).
- `code_git`: the git card names the person with `pushes_as_self`, and never claims the App's identity as the caller's own.
- DOM tests for the PR card person sentence and both palette states; Storybook story `HostedPushesAsYou`; storybook build, biome, tsc all green locally.