### PR TITLE
feat(code): hosted workspaces commit as the connected person

### DIFF
--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -190,6 +190,39 @@ pub(crate) struct PushOutcome {
     pub remote: String,
 }
 
+/// Names `name <email>` as this workspace's git author and committer
+/// (decision 65).
+///
+/// `extensions.worktreeConfig` is enabled first so the identity lands in the
+/// worktree's own configuration: sibling workspaces of the same clone can
+/// belong to callers with other identities, and the shared repository
+/// configuration must never name any one of them.
+pub(crate) async fn configure_workspace_identity(
+    worktree: &Path,
+    name: &str,
+    email: &str,
+) -> Result<(), String> {
+    git(
+        worktree,
+        &["config", "extensions.worktreeConfig", "true"],
+        GIT_TIMEOUT,
+    )
+    .await?;
+    git(
+        worktree,
+        &["config", "--worktree", "user.name", name],
+        GIT_TIMEOUT,
+    )
+    .await?;
+    git(
+        worktree,
+        &["config", "--worktree", "user.email", email],
+        GIT_TIMEOUT,
+    )
+    .await?;
+    Ok(())
+}
+
 /// Live git + `gh` observation for the workspace PR card.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WorkspaceGitStatus {

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -909,6 +909,10 @@ impl CodeRuntime {
                 return Err(map_worktree(err));
             }
         }
+        // Before the setup script, which may itself commit: from here on,
+        // anything this workspace commits should already carry the right
+        // name.
+        self.name_workspace_author(owner, &path).await;
         match run_setup_script(&path, repo.setup_script.as_deref()).await {
             Ok(()) => {
                 workspace.status = CodeWorkspaceStatus::Active;
@@ -1306,6 +1310,40 @@ impl CodeRuntime {
             }
         }
         Ok(outcome)
+    }
+
+    /// Name the caller on this workspace's commits (decision 65), on a
+    /// machine that lends gateway git identities and only when the gateway
+    /// states the caller's own account acts.
+    ///
+    /// Best-effort by design: a caller who has not connected, a bot-attributed
+    /// deployment, and a machine with its own credentials all leave the
+    /// checkout exactly as it is, and the commit path reports its own
+    /// failures. An identity the gateway states without a commit email is
+    /// incomplete and configures nothing — half an identity would be worse
+    /// than the checkout's own.
+    async fn name_workspace_author(&self, owner: &OwnerId, worktree: &std::path::Path) {
+        let Some(lender) = self.git_credentials() else {
+            return;
+        };
+        let Ok(identity) = lender.git_forge_identity(owner).await else {
+            return;
+        };
+        let crate::obo_gateway::GitForgeAttribution::Person {
+            login,
+            display_name,
+            commit_email,
+        } = identity.attribution
+        else {
+            return;
+        };
+        let Some(email) = commit_email else {
+            return;
+        };
+        let name = display_name.unwrap_or(login);
+        if let Err(error) = gh::configure_workspace_identity(worktree, &name, &email).await {
+            tracing::debug!(error, "the workspace git identity was not configured");
+        }
     }
 
     /// Borrow a repository-scoped forge credential for one git operation in

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -96,6 +96,21 @@ fn write_executable(path: &std::path::Path, body: &str) {
     std::fs::set_permissions(path, perms).unwrap();
 }
 
+fn run_stdout(cwd: &std::path::Path, args: &[&str]) -> String {
+    let output = std::process::Command::new(args[0])
+        .args(&args[1..])
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{args:?} failed in {}",
+        cwd.display()
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_owned()
+}
+
 fn json_id(value: &serde_json::Value) -> &str {
     value["id"].as_str().expect("id is a string")
 }
@@ -610,4 +625,69 @@ async fn a_hosted_git_card_names_the_person_once_connected() {
     let body: serde_json::Value = status.json().await.unwrap();
     assert_eq!(body["pushes_as"], "mira-chen", "{body}");
     assert_eq!(body["pushes_as_self"], true, "{body}");
+}
+
+/// Decision 65: a workspace on a machine whose gateway names the caller
+/// commits as that person — author and committer both, scoped to the
+/// worktree so the shared clone keeps its own configuration.
+#[tokio::test]
+async fn a_hosted_workspace_commits_as_the_person() {
+    let lender = Arc::new(FakeLender::offering_person("mira-chen"));
+    let (router, token, _runtime, dir) =
+        code_app_with(Some(lender as Arc<dyn GitCredentialLender>)).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "person commit").await;
+    let id = json_id(&workspace);
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    std::fs::write(path.join("named.txt"), "line\n").unwrap();
+    let committed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(committed.status(), reqwest::StatusCode::OK);
+
+    let signature = run_stdout(&path, &["git", "log", "-1", "--format=%an <%ae>|%cn <%ce>"]);
+    let expected = "Mira Chen <8675309+mira-chen@users.noreply.github.com>";
+    assert_eq!(signature, format!("{expected}|{expected}"));
+    // The identity is the worktree's alone: the registered clone still
+    // answers with its own configuration.
+    assert_eq!(run_stdout(&repo, &["git", "config", "user.name"]), "Dev");
+}
+
+/// Machines that lend nothing — and hosted machines whose forge still
+/// attributes to the App — leave the checkout's own identity untouched.
+#[tokio::test]
+async fn a_workspace_without_a_person_identity_keeps_the_checkouts_own() {
+    for lender in [
+        None,
+        Some(Arc::new(FakeLender::offering("acme-ship[bot]")) as Arc<dyn GitCredentialLender>),
+    ] {
+        let (router, token, _runtime, dir) = code_app_with(lender).await;
+        let addr = serve(router).await;
+        let client = reqwest::Client::new();
+        let repo = init_paired_repo(dir.path());
+        let (_repo, workspace) =
+            register_and_workspace(&client, addr, &token, &repo, "own identity").await;
+        let id = json_id(&workspace);
+        let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+        std::fs::write(path.join("plain.txt"), "line\n").unwrap();
+        let committed = client
+            .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(committed.status(), reqwest::StatusCode::OK);
+        let signature = run_stdout(&path, &["git", "log", "-1", "--format=%an <%ae>"]);
+        assert_eq!(signature, "Dev <dev@example.com>");
+    }
 }


### PR DESCRIPTION
## Why

Decision 65 rule 3 (slice C of `docs/decisions/0065-hosted-git-acts-as-the-person.md`, decision doc landed with #2541): commits from a hosted workspace should carry the person's identity. Today they carry nothing — the hosted image has no git identity configured at all, so the user-facing commit path fails outright once a workspace exists on a hosted machine.

## What

- `create_workspace` now names the caller on the worktree right after the worktree exists and before the setup script runs (a setup script may itself commit): display name (login fallback) + the gateway-derived no-reply commit email, taken from the same per-caller probe answer the attribution UI reads (#2541).
- The identity is written with `extensions.worktreeConfig` + `git config --worktree`, so it belongs to the one workspace: sibling workspaces of the same clone can belong to other callers, and the shared repository configuration never names anyone.
- Best-effort: a caller who has not connected, a bot-attributed forge, and a machine with its own credentials all leave the checkout untouched.

## Tests

- `a_hosted_workspace_commits_as_the_person`: author and committer both read the person, and the registered clone's own `user.name` is untouched.
- `a_workspace_without_a_person_identity_keeps_the_checkouts_own`: local machines and bot-attributed lenders keep the checkout's identity byte-for-byte.