### PR TITLE
fix(code): show pending checks over blocked and drop stale PR caches

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -209,14 +209,24 @@ it.each([
     true,
   ],
   [
-    "a blocked requirement",
+    "a required review approval",
     {
       ...OPEN_PR,
       mergeable: "mergeable",
       merge_state_status: "blocked",
       review_decision: "review_required",
     },
-    "A review or repository requirement is still blocking a direct merge.",
+    "The pull request needs a review approval before merging directly.",
+    true,
+  ],
+  [
+    "a blocked repository requirement",
+    {
+      ...OPEN_PR,
+      mergeable: "mergeable",
+      merge_state_status: "blocked",
+    },
+    "A repository requirement is still blocking a direct merge.",
     true,
   ],
   [

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -127,6 +127,38 @@ describe("prWorkflowStatus", () => {
     );
   });
 
+  it("ranks pending checks above the blocked merge state", () => {
+    // The motivating mismatch (decision 66): GitHub reports the merge state
+    // as blocked while required checks run, and ranking blocked above
+    // pending made every open pull request read "Blocked" for its whole
+    // life. The reader wants the pending count, auto-merge armed or not.
+    const digest = pr({
+      merge_state_status: "blocked",
+      review_decision: "review_required",
+      auto_merge_enabled: true,
+      checks: [
+        { name: "ci / rust", bucket: "pass" },
+        { name: "ci / ui", bucket: "pending" },
+        { name: "ci / release", bucket: "pending" },
+      ],
+    });
+    expect(prWorkflowStatus(digest).state).toBe("pending");
+  });
+
+  it("names a required review approval once checks are green", () => {
+    const digest = pr({
+      merge_state_status: "blocked",
+      review_decision: "review_required",
+      checks: [{ name: "ci / rust", bucket: "pass" }],
+    });
+    expect(prWorkflowStatus(digest).state).toBe("needs_approval");
+    // Without the review requirement the same merge state stays a generic
+    // block.
+    expect(
+      prWorkflowStatus({ ...digest, review_decision: undefined }).state,
+    ).toBe("blocked");
+  });
+
   it("keeps incomplete host data in a checking state", () => {
     expect(prWorkflowStatus(pr({})).state).toBe("checking");
     expect(

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -22,6 +22,7 @@ export type PrWorkflowState =
   | "conflict"
   | "behind"
   | "blocked"
+  | "needs_approval"
   | "changes_requested"
   | "draft"
   | "queued"
@@ -83,12 +84,12 @@ export function prIsBehind(pr: PullRequestDigest): boolean {
 
 export function prIsBlocked(pr: PullRequestDigest): boolean {
   const mergeState = pr.merge_state_status?.trim().toLowerCase();
-  const review = pr.review_decision?.trim().toLowerCase();
-  return (
-    mergeState === "blocked" ||
-    mergeState === "unstable" ||
-    review === "review_required"
-  );
+  return mergeState === "blocked" || mergeState === "unstable";
+}
+
+/** GitHub still wants a review approval on this pull request. */
+export function prNeedsApproval(pr: PullRequestDigest): boolean {
+  return pr.review_decision?.trim().toLowerCase() === "review_required";
 }
 
 export function prHasChangesRequested(pr: PullRequestDigest): boolean {
@@ -158,7 +159,14 @@ export function prMergeControls(state: PrWorkflowState): {
         canMerge: false,
         canEnableAutoMerge: true,
         explanation:
-          "A review or repository requirement is still blocking a direct merge.",
+          "A repository requirement is still blocking a direct merge.",
+      };
+    case "needs_approval":
+      return {
+        canMerge: false,
+        canEnableAutoMerge: true,
+        explanation:
+          "The pull request needs a review approval before merging directly.",
       };
     case "changes_requested":
       return {
@@ -393,9 +401,15 @@ function workflowState(
   if (checks.failing > 0) return "failing";
   if (prIsQueued(pr)) return "queued";
   if (prIsBehind(pr)) return "behind";
+  // GitHub reports the merge state as blocked while required checks run, so
+  // pending checks must outrank it or every open pull request reads
+  // "Blocked" for its whole life (decision 66).
+  if (checks.pending > 0) return "pending";
+  // With no checks left to wait for, a required review is its own state,
+  // said in those words, rather than a generic block.
+  if (prNeedsApproval(pr)) return "needs_approval";
   if (prIsBlocked(pr)) return "blocked";
   if (pr.auto_merge_enabled) return "auto_merge";
-  if (checks.pending > 0) return "pending";
   const mergeable = pr.mergeable?.trim().toLowerCase();
   const mergeState = pr.merge_state_status?.trim().toLowerCase();
   return mergeable === "mergeable" && mergeState === "clean"

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
@@ -186,6 +186,42 @@ describe("workspaceWorkflowModel", () => {
     expect(model.secondary).not.toContain("merge");
   });
 
+  it("shows the pending count while blocked, then names the approval", () => {
+    // The decision-66 screenshot: GitHub says blocked whenever required
+    // checks are still running, so the header shows the pending count; once
+    // the checks are green, the missing review approval is named in those
+    // words instead of a lifelong "Blocked".
+    const running = workspaceWorkflowModel({
+      ...CLEAN,
+      pr: pr({
+        url: "https://github.com/acme/app/pull/41",
+        merge_state_status: "blocked",
+        review_decision: "review_required",
+        auto_merge_enabled: true,
+        checks: [
+          { name: "ci / rust", bucket: "pending" },
+          { name: "ci / ui", bucket: "pending" },
+          { name: "lint", bucket: "pass" },
+        ],
+      }),
+    });
+    expect(running.stage).toBe("pending");
+    expect(running.summary).toBe("#41 · 2 pending");
+
+    const green = workspaceWorkflowModel({
+      ...CLEAN,
+      pr: pr({
+        url: "https://github.com/acme/app/pull/41",
+        merge_state_status: "blocked",
+        review_decision: "review_required",
+        checks: [{ name: "ci / rust", bucket: "pass" }],
+      }),
+    });
+    expect(green.stage).toBe("needs_approval");
+    expect(green.summary).toBe("#41 · Needs approval");
+    expect(green.primary).toBe("open_pr");
+  });
+
   it("lets a loaded no-PR snapshot clear a stale fallback", () => {
     const model = workspaceWorkflowModel(
       CLEAN,

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -34,6 +34,7 @@ export type WorkspaceWorkflowModel = {
     | "conflict"
     | "behind"
     | "blocked"
+    | "needs_approval"
     | "changes_requested"
     | "failing"
     | "queued"
@@ -204,9 +205,21 @@ function pullRequestWorkflow(pr: PullRequestDigest): WorkspaceWorkflowModel {
         tone: "warning",
         summary: `#${pr.number} · Blocked`,
         title: `Pull request #${pr.number} is blocked`,
-        detail: "A review or repository requirement is still outstanding.",
+        detail: "A repository requirement is still outstanding.",
         primary: "watch_and_fix",
         secondary: withOpenPr(pr, []),
+      };
+    case "needs_approval":
+      return {
+        ...common,
+        stage: "needs_approval",
+        tone: "warning",
+        summary: `#${pr.number} · Needs approval`,
+        title: `Pull request #${pr.number} needs approval`,
+        detail:
+          "GitHub requires a review approval before this pull request can merge.",
+        primary: pr.url ? "open_pr" : "watch_and_fix",
+        secondary: pr.url ? ["watch_and_fix"] : [],
       };
     case "changes_requested":
       return {

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -12,6 +12,7 @@ import {
   dirtyGit,
   failingChecksPrGit,
   fixingPrGit,
+  needsApprovalPrGit,
   openPrGit,
   readyForPrGit,
   watchingPrGit,
@@ -100,6 +101,11 @@ export const ReadyForPullRequest: Story = {
 };
 
 export const PullRequestOpen: Story = {};
+
+/** Checks are green; GitHub still wants a review approval (decision 66). */
+export const NeedsApproval: Story = {
+  args: { snapshot: needsApprovalPrGit },
+};
 
 /** A durable watch task is polling; the segment links into the fork. */
 export const Watching: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -225,13 +225,26 @@ export const blockedWatchPrGit: CodeWorkspacePrSnapshot = {
   ...openPrGit,
   pr: {
     ...openPrGit.pr!,
+    checks_summary: "9 passing, 0 pending, 0 failing",
     review_decision: "review_required",
   },
   watch: {
     ...watchBase,
     state: "blocked",
-    detail: "a review or repository requirement is outstanding",
+    detail: "the pull request needs a review approval",
     cycles: 1,
+  },
+};
+
+/** Checks are green and GitHub still wants a review approval (decision 66). */
+export const needsApprovalPrGit: CodeWorkspacePrSnapshot = {
+  ...openPrGit,
+  pr: {
+    ...openPrGit.pr!,
+    checks_summary: "9 passing, 0 pending, 0 failing",
+    review_decision: "review_required",
+    mergeable: "mergeable",
+    merge_state_status: "blocked",
   },
 };
 

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -998,7 +998,7 @@ fn workflow_run_count(count: usize) -> String {
 }
 
 pub(crate) async fn act_on_pull_request(
-    runtime: &CodeRuntime,
+    runtime: &Arc<CodeRuntime>,
     owner: &OwnerId,
     allow_unscoped_delivery: bool,
     body: CodeDeliveryPullRequestActionBody,
@@ -1012,6 +1012,12 @@ pub(crate) async fn act_on_pull_request(
     .await?;
     let search_path = runtime.gh_search_path_owned();
     let target = body.target;
+    // The canonical URL of the pull request being acted on: the key the
+    // workspace-side digest refresh matches on (decision 66).
+    let pull_request_url = format!(
+        "https://{}/{}/{}/pull/{}",
+        target.repository.host, target.repository.owner, target.repository.name, target.number
+    );
     match body.action {
         CodeDeliveryPullRequestAction::MarkReady => {
             gh::mark_pull_request_ready(
@@ -1024,6 +1030,7 @@ pub(crate) async fn act_on_pull_request(
             .await
             .map_err(map_gh_error)?;
             runtime.delivery_cache.invalidate();
+            runtime.refresh_workspaces_for_pull_request(owner, &pull_request_url);
             Ok(delivery_action_result(format!(
                 "Pull request #{} is ready for review",
                 target.number
@@ -1057,6 +1064,7 @@ pub(crate) async fn act_on_pull_request(
             .await
             .map_err(map_gh_error)?;
             runtime.delivery_cache.invalidate();
+            runtime.refresh_workspaces_for_pull_request(owner, &pull_request_url);
             Ok(delivery_action_result(if auto {
                 format!("Auto-merge enabled for pull request #{}", target.number)
             } else if admin {
@@ -1100,6 +1108,7 @@ pub(crate) async fn act_on_pull_request(
             let any_success = results.iter().any(|(_, result)| result.is_ok());
             if any_success {
                 runtime.delivery_cache.invalidate();
+                runtime.refresh_workspaces_for_pull_request(owner, &pull_request_url);
             }
             let outcomes = results
                 .into_iter()
@@ -1136,6 +1145,7 @@ pub(crate) async fn act_on_pull_request(
             .await
             .map_err(map_gh_error)?;
             runtime.delivery_cache.invalidate();
+            runtime.refresh_workspaces_for_pull_request(owner, &pull_request_url);
             Ok(delivery_action_result(format!(
                 "Pull request #{} closed",
                 target.number
@@ -1152,6 +1162,7 @@ pub(crate) async fn act_on_pull_request(
             .await
             .map_err(map_gh_error)?;
             runtime.delivery_cache.invalidate();
+            runtime.refresh_workspaces_for_pull_request(owner, &pull_request_url);
             Ok(delivery_action_result(format!(
                 "Pull request #{} reopened",
                 target.number
@@ -2183,7 +2194,13 @@ fn pull_request_attention(
     if merge_state_status == Some("behind") {
         reasons.push(CodeDeliveryPrAttentionReason::Behind);
     }
-    if merge_state_status == Some("blocked") {
+    // GitHub reports the merge state as blocked while required checks run
+    // (decision 66): checks in flight are ordinary progress, not attention.
+    if merge_state_status == Some("blocked")
+        && !checks
+            .iter()
+            .any(|check| check.bucket == PullRequestCheckBucket::Pending)
+    {
         reasons.push(CodeDeliveryPrAttentionReason::Blocked);
     }
     reasons
@@ -3755,6 +3772,27 @@ mod tests {
             &checks,
         )
         .is_empty());
+    }
+
+    #[test]
+    fn a_blocked_merge_state_is_not_attention_while_checks_run() {
+        // GitHub says blocked whenever required checks are still running
+        // (decision 66); only a blocked state with no checks in flight is
+        // something the reader can act on.
+        let running = vec![CodeDeliveryCheck {
+            name: "test".into(),
+            bucket: PullRequestCheckBucket::Pending,
+            detail: None,
+            url: None,
+            workflow_run_id: None,
+        }];
+        assert!(
+            pull_request_attention("open", false, None, None, Some("blocked"), &running).is_empty()
+        );
+        assert_eq!(
+            pull_request_attention("open", false, None, None, Some("blocked"), &[]),
+            vec![CodeDeliveryPrAttentionReason::Blocked]
+        );
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1308,6 +1308,11 @@ impl CodeRuntime {
         let outcome = gh::push_branch(&worktree, &workspace.branch_name, credential.as_ref())
             .await
             .map_err(map_gh)?;
+        // The digest cached before the push describes the old head. Drop it
+        // and the delivery lists so the next reader sees checks pending on
+        // the new head rather than the pre-push snapshot (decision 66).
+        self.pr_cache.invalidate(id);
+        self.delivery_cache.invalidate();
         // Best-effort contributed fact (decision 62): a user push to a branch
         // that is a pull request's head is the same act the detector mints
         // for. Failures are silent; the reconcile sweep corrects. On a hosted
@@ -1539,6 +1544,56 @@ impl CodeRuntime {
         self.workspace_pr(owner, id).await
     }
 
+    /// After a pull-request state change on the delivery surface, make every
+    /// live workspace holding that pull request read fresh: drop each one's
+    /// digest cache entry and take the normal status path, which persists
+    /// the digest and broadcasts the change (decision 66). Matching is by
+    /// the digest's own URL, so a same-numbered pull request in another
+    /// repository stays untouched. Detached and best-effort: the action's
+    /// response never waits on it, and a failed re-read leaves the next
+    /// sweep to correct.
+    pub(crate) fn refresh_workspaces_for_pull_request(
+        self: &Arc<Self>,
+        owner: &OwnerId,
+        pull_request_url: &str,
+    ) {
+        let runtime = Arc::clone(self);
+        let owner = owner.clone();
+        let url = pull_request_url.to_owned();
+        tokio::spawn(async move {
+            let workspaces = match list_workspaces(&runtime.db, &owner, None).await {
+                Ok(workspaces) => workspaces,
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        "code-mode: could not list workspaces after a delivery action"
+                    );
+                    return;
+                }
+            };
+            for workspace in workspaces {
+                if workspace.status != CodeWorkspaceStatus::Active {
+                    continue;
+                }
+                let holds = workspace
+                    .pr
+                    .as_ref()
+                    .and_then(|pr| pr.url.as_deref())
+                    .is_some_and(|value| value.eq_ignore_ascii_case(&url));
+                if !holds {
+                    continue;
+                }
+                if let Err(err) = runtime.refresh_workspace_pr(&owner, workspace.id).await {
+                    tracing::warn!(
+                        workspace = %workspace.id,
+                        error = %err.message(),
+                        "code-mode: workspace digest refresh after a delivery action failed"
+                    );
+                }
+            }
+        });
+    }
+
     pub(crate) async fn workspace_pr_comments(
         &self,
         owner: &OwnerId,
@@ -1605,6 +1660,9 @@ impl CodeRuntime {
         )
         .await
         .map_err(map_gh)?;
+        // The merge helper already dropped this workspace's digest cache
+        // entry; the delivery lists hold the pre-merge row (decision 66).
+        self.delivery_cache.invalidate();
         self.workspace_pr(owner, id).await
     }
 
@@ -1627,6 +1685,7 @@ impl CodeRuntime {
         )
         .await
         .map_err(map_gh)?;
+        self.delivery_cache.invalidate();
         self.workspace_pr(owner, id).await
     }
 
@@ -1682,6 +1741,7 @@ impl CodeRuntime {
                 (digest, None)
             }
         };
+        self.delivery_cache.invalidate();
         let created_number = digest.number;
         workspace.pr = Some(digest);
         self.save_workspace(&workspace).await?;

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -117,20 +117,22 @@ pub(crate) fn assess(pr: &PullRequestDigest) -> WatchAssessment {
     if merge_state == "behind" {
         return WatchAssessment::Actionable(WatchReason::Behind);
     }
-    if merge_state == "blocked"
-        || merge_state == "unstable"
-        || pr.review_decision.as_deref().map(str::trim) == Some("review_required")
-    {
-        return WatchAssessment::NeedsUser("a review or repository requirement is outstanding");
-    }
-    if pr.auto_merge_enabled == Some(true) {
-        return WatchAssessment::Waiting;
-    }
+    // GitHub reports the merge state as blocked while required checks run
+    // (decision 66): running checks are a wait, not a park.
     let pending = checks
         .iter()
         .filter(|check| check.bucket == tidebreak_core::PullRequestCheckBucket::Pending)
         .count();
     if pending > 0 {
+        return WatchAssessment::Waiting;
+    }
+    if pr.review_decision.as_deref().map(str::trim) == Some("review_required") {
+        return WatchAssessment::NeedsUser("the pull request needs a review approval");
+    }
+    if merge_state == "blocked" || merge_state == "unstable" {
+        return WatchAssessment::NeedsUser("a repository requirement is outstanding");
+    }
+    if pr.auto_merge_enabled == Some(true) {
         return WatchAssessment::Waiting;
     }
     if mergeable == "mergeable" && merge_state == "clean" {
@@ -393,10 +395,12 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
             )
             .await;
         }
-        // A fix turn (or its recovery) is still in flight; check back next
-        // sweep rather than hammering the host meanwhile.
-        CodeSessionLifecycle::Running => return Ok(()),
-        CodeSessionLifecycle::Created | CodeSessionLifecycle::Idle => {}
+        // A running fix turn no longer skips the sweep: the state read below
+        // still happens, and only the transitions that need an idle worktree
+        // hold (decision 66).
+        CodeSessionLifecycle::Running
+        | CodeSessionLifecycle::Created
+        | CodeSessionLifecycle::Idle => {}
     }
     let workspace = match runtime.get_workspace(&owner, watch.workspace_id).await {
         Ok(workspace) => workspace,
@@ -419,19 +423,22 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
         )
         .await;
     }
-    // Another session's turn owns the worktree right now; wait. The turn lock
-    // in the worker is what actually serializes the checkout (record 55);
-    // skipping the cycle here avoids waking a harness that would only queue.
+    // A turn in flight — the watch's own fix turn or another session's —
+    // holds every transition below: submitting a fix turn would queue on the
+    // worktree the turn owns (record 55), and parking or finishing mid-turn
+    // would judge a head the turn is about to move. The state read still
+    // runs (decision 66): the pull requests being actively fixed are exactly
+    // the ones whose digest the reader is watching.
     let sessions = list_sessions_for_workspace(&runtime.db, &owner, watch.workspace_id).await?;
-    if sessions
+    let turn_in_flight = sessions
         .iter()
-        .any(|other| other.lifecycle == CodeSessionLifecycle::Running)
-    {
-        return Ok(());
-    }
+        .any(|other| other.lifecycle == CodeSessionLifecycle::Running);
     let status = runtime
         .refresh_workspace_pr(&owner, watch.workspace_id)
         .await?;
+    if turn_in_flight {
+        return Ok(());
+    }
     let Some(pr) = status.pr else {
         return park_watch(
             runtime.as_ref(),
@@ -753,6 +760,21 @@ mod tests {
         let mut pr = base_pr();
         pr.review_decision = Some("review_required".to_owned());
         assert!(matches!(assess(&pr), WatchAssessment::NeedsUser(_)));
+    }
+
+    #[test]
+    fn running_checks_wait_even_while_the_merge_state_is_blocked() {
+        // The decision-66 screenshot: GitHub says blocked whenever required
+        // checks are still running, so blocked plus a required review while
+        // checks run is a wait, not a park.
+        let mut pr = base_pr();
+        pr.merge_state_status = Some("blocked".to_owned());
+        pr.review_decision = Some("review_required".to_owned());
+        pr.checks = Some(vec![
+            check(PullRequestCheckBucket::Pass),
+            check(PullRequestCheckBucket::Pending),
+        ]);
+        assert_eq!(assess(&pr), WatchAssessment::Waiting);
     }
 
     #[test]

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -932,3 +932,126 @@ async fn a_hosted_pull_request_create_fails_closed_with_the_gateway_refusal() {
     assert_eq!(kind, "git_forge_refused");
     assert!(message.contains("connect your GitHub account"), "{message}");
 }
+
+/// The moments after a push are when the reader most wants "checks pending
+/// on the new head", and the digest cache used to keep serving the pre-push
+/// snapshot for its whole TTL (decision 66).
+#[tokio::test]
+async fn a_push_drops_the_cached_pull_request_digest() {
+    let (router, token, runtime, dir) = code_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "digest freshness").await;
+    let id = json_id(&workspace);
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    // A gh shim that answers `pr view` from a file, so the test moves
+    // GitHub's state without waiting out any cache.
+    let shim_dir = tempfile::TempDir::new().unwrap();
+    let answer = shim_dir.path().join("view.json");
+    std::fs::write(
+        &answer,
+        r#"{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN","headRefOid":"aaaaaaaa"}"#,
+    )
+    .unwrap();
+    write_executable(
+        &shim_dir.path().join("gh"),
+        &format!(
+            r#"#!/bin/sh
+if [ "$1" = auth ]; then
+  echo '{{"hosts":{{"github.com":[{{"active":true,"state":"success","login":"tester"}}]}}}}'
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = view ]; then
+  cat {answer}
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = checks ]; then
+  printf 'lint\tpass\t1s\thttps://example.test/lint\n'
+  exit 0
+fi
+exit 3
+"#,
+            answer = answer.display()
+        ),
+    );
+    runtime.set_gh_search_path(Some(shim_dir.path().display().to_string()));
+
+    std::fs::write(path.join("extra.txt"), "one\n").unwrap();
+    let committed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(committed.status(), reqwest::StatusCode::OK);
+    let pushed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/push"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(pushed.status(), reqwest::StatusCode::OK);
+
+    let first = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(first["pr"]["head_sha"], "aaaaaaaa");
+
+    // GitHub's answer moves, as it does when new commits land on the head.
+    std::fs::write(
+        &answer,
+        r#"{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN","headRefOid":"bbbbbbbb"}"#,
+    )
+    .unwrap();
+
+    // Within the TTL the cache still serves the old head...
+    let cached = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(cached["pr"]["head_sha"], "aaaaaaaa");
+
+    // ...and a push drops it, so the next read carries the new head.
+    std::fs::write(path.join("extra.txt"), "two\n").unwrap();
+    let committed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(committed.status(), reqwest::StatusCode::OK);
+    let pushed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/push"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(pushed.status(), reqwest::StatusCode::OK);
+
+    let fresh = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(fresh["pr"]["head_sha"], "bbbbbbbb");
+}


### PR DESCRIPTION
Slice 1 of [decision 66](docs/decisions/0066-pull-request-state-is-one-store.md): the classifier ranking and the cache-invalidation holes, no schema.

## Classifier

GitHub reports `mergeStateStatus: BLOCKED` whenever any protection requirement is unmet — including required checks that are still running, and the review approval this repository never receives — so ranking `blocked` above `pending` made every open pull request read "Blocked" for its whole life while the pane beside it showed the pending count.

- Pending checks now outrank the generic blocked state: the header in the motivating screenshot reads `#2539 · 9 pending` while CI runs.
- A green pull request whose only block is the required review is its own state, said in those words: `#2539 · Needs approval`, with matching merge-box copy.
- The same ranking fix lands in the watch assessment (running checks are a wait, not a park; the park reason now names the approval) and in the delivery attention reasons (a blocked merge state with checks in flight is progress, not attention).

## Invalidation holes

- A push drops the workspace digest cache and the delivery lists, so the moments after a push stop serving the pre-push head for the cache TTL.
- Workspace-side merge, mark-ready, and create drop the delivery lists (the digest cache was already handled).
- A delivery-sheet action (ready, merge, rerun, close, reopen) refreshes and rebroadcasts the digest of every live workspace holding that pull request, matched by the digest's own URL so same-numbered pull requests in other repositories stay untouched.
- The watch sweep no longer skips its state read while a turn runs; transitions that need an idle worktree still hold. The pull requests being actively fixed were the ones that updated least.

## Validation

- `prActions` and `workspaceWorkflow` tests assert the screenshot-as-a-test cases from the record: blocked + review_required + pending checks → `pending`; the same digest green → `needs_approval`.
- A new integration test drives a file-backed `gh` shim: the cached digest keeps the old head within the TTL, and a push drops it so the next read carries the new head.
- Watch and delivery unit tests cover the reordered assessment and the attention change.
- New `NeedsApproval` Storybook story; `storybook:build`, `tsc`, biome, and the four touched vitest suites pass locally.