### PR TITLE
feat(code): open Delivery on your own pull requests

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
@@ -183,6 +183,81 @@ describe("delivery pull request list", () => {
     );
   });
 
+  it("opens on your own open pull requests, drafts included", async () => {
+    const query = vi.fn(async (_body: unknown) => ({
+      capability: deliveryRepositoriesSnapshot.capability,
+      items: deliveryPullRequests,
+      errors: [],
+      fetched_at: "2026-08-20T15:20:00.000Z",
+    }));
+    renderList({
+      ...storyClient(),
+      queryCodeDeliveryPullRequests: query,
+    } as unknown as ApiClient);
+
+    expect(await screen.findByRole("button", { name: "Yours" })).toBeTruthy();
+    // `states: ["open"]` and nothing else: a draft is open on the wire, and
+    // neither the attention nor the ready gate may narrow the first screen.
+    await waitFor(() =>
+      expect(query.mock.calls.at(-1)?.[0]).toMatchObject({
+        authors: ["mara"],
+        states: ["open"],
+        attention_only: false,
+        ready_only: false,
+      }),
+    );
+  });
+
+  it("drops the viewer view when gh cannot report a login", async () => {
+    const query = vi.fn(async (_body: unknown) => ({
+      capability: deliveryRepositoriesSnapshot.capability,
+      items: deliveryPullRequests,
+      errors: [],
+      fetched_at: "2026-08-20T15:20:00.000Z",
+    }));
+    renderList({
+      ...storyClient(),
+      getCodeDeliveryRepositories: async () => ({
+        ...deliveryRepositoriesSnapshot,
+        capability: {
+          ...deliveryRepositoriesSnapshot.capability,
+          viewer_login: undefined,
+        },
+      }),
+      queryCodeDeliveryPullRequests: query,
+    } as unknown as ApiClient);
+
+    // "Yours" without a login would read as everybody's, so it goes and the
+    // attention view takes the default back.
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Yours" })).toBeNull(),
+    );
+    await waitFor(() =>
+      expect(query.mock.calls.at(-1)?.[0]).toMatchObject({
+        authors: [],
+        attention_only: true,
+      }),
+    );
+  });
+
+  it("names the author on every row, with a face beside it", async () => {
+    renderList();
+    const mara = await rowFor("Build the delivery center");
+    expect(within(mara).getByText("mara")).toBeInTheDocument();
+    // The avatar sits next to the login it belongs to, so it is decorative
+    // and carries no alt text — find it by source. These summaries have no
+    // avatar URL on the wire, which is the case that has to derive one.
+    expect(
+      mara.querySelector('img[src^="https://github.com/mara.png"]'),
+    ).not.toBeNull();
+
+    const devon = await rowFor("Make workspace deep links durable");
+    expect(within(devon).getByText("devon")).toBeInTheDocument();
+    expect(
+      devon.querySelector('img[src^="https://github.com/devon.png"]'),
+    ).not.toBeNull();
+  });
+
   it("filters by a picked author instead of a memorized login", async () => {
     const user = userEvent.setup();
     const query = vi.fn(async (_body: unknown) => ({
@@ -203,6 +278,9 @@ describe("delivery pull request list", () => {
     });
     renderList(client);
 
+    // Off the viewer view first: it already carries the signed-in login, and
+    // this is about picking somebody.
+    await user.click(await screen.findByRole("button", { name: "Open" }));
     await user.click(await screen.findByRole("button", { name: /Filters/ }));
     await user.click(await screen.findByRole("checkbox", { name: "mara" }));
     await waitFor(() =>

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -106,11 +106,39 @@ import {
 import { arrangeStackLanes } from "./pullRequestStacks";
 import { STATUS_MARK, STATUS_TEXT } from "./statusTone";
 
-const PR_BUILT_IN_VIEWS: readonly {
+type PrBuiltInView = {
   id: string;
   label: string;
+  /**
+   * Fill `authors` with the signed-in GitHub login. The login only arrives
+   * with the repository snapshot, so the view carries the intent and the
+   * page resolves it once `gh` reports who you are.
+   */
+  viewerAuthored?: boolean;
   filters: CodeDeliveryPrViewFilters;
-}[] = [
+};
+
+/**
+ * The first entry is the default view. Delivery opens on your own open work —
+ * drafts included, because `state` is still `open` on a draft — rather than on
+ * everyone's review queue.
+ */
+const PR_BUILT_IN_VIEWS: readonly PrBuiltInView[] = [
+  {
+    id: "mine",
+    label: "Yours",
+    viewerAuthored: true,
+    filters: {
+      search: "",
+      repositoryKeys: [],
+      states: ["open"],
+      reviewStates: [],
+      checkStates: [],
+      authors: [],
+      attentionOnly: false,
+      readyOnly: false,
+    },
+  },
   {
     id: "attention",
     label: "Needs attention",
@@ -331,21 +359,32 @@ function CodeDeliveryBody({
   >([]);
   const [repositoriesDialogOpen, setRepositoriesDialogOpen] = useState(false);
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
-  const [activeViewId, setActiveViewId] = useState(
-    surface === "pull_requests" ? "attention" : "failures",
+  // Who `gh` is signed in as. Undefined until the repository snapshot lands,
+  // and undefined for good against a `gh` too old to report it.
+  const viewerLogin = repositorySnapshot?.capability.viewer_login;
+  // A view that filters by "you" cannot mean anything without a login, so it
+  // leaves the row rather than quietly widening to everybody's pull requests.
+  // It stays put while the snapshot is still loading, because that is the
+  // default and the common answer is that a login exists.
+  const prViews = useMemo(
+    () =>
+      repositorySnapshot && !viewerLogin
+        ? PR_BUILT_IN_VIEWS.filter((view) => !view.viewerAuthored)
+        : PR_BUILT_IN_VIEWS,
+    [repositorySnapshot, viewerLogin],
   );
+  const builtInViews =
+    surface === "pull_requests" ? prViews : RUN_BUILT_IN_VIEWS;
+  const defaultViewId = builtInViews[0]!.id;
+  const [activeViewId, setActiveViewId] = useState(defaultViewId);
   const [prFilters, setPrFilters] = useState<CodeDeliveryPrViewFilters>(() =>
-    clonePrFilters(PR_BUILT_IN_VIEWS[0]!.filters),
+    builtInPrFilters(PR_BUILT_IN_VIEWS[0]!, viewerLogin),
   );
   const [runFilters, setRunFilters] = useState<CodeDeliveryRunViewFilters>(() =>
     cloneRunFilters(RUN_BUILT_IN_VIEWS[0]!.filters),
   );
 
   useEffect(() => {
-    const builtInViews =
-      surface === "pull_requests" ? PR_BUILT_IN_VIEWS : RUN_BUILT_IN_VIEWS;
-    const defaultViewId =
-      surface === "pull_requests" ? "attention" : "failures";
     const viewId = builtInViews.some((view) => view.id === search.view)
       ? search.view!
       : defaultViewId;
@@ -354,14 +393,36 @@ function CodeDeliveryBody({
       const view = PR_BUILT_IN_VIEWS.find(
         (candidate) => candidate.id === viewId,
       );
-      setPrFilters(clonePrFilters((view ?? PR_BUILT_IN_VIEWS[0]!).filters));
+      setPrFilters(
+        builtInPrFilters(view ?? PR_BUILT_IN_VIEWS[0]!, viewerLogin),
+      );
     } else {
       const view = RUN_BUILT_IN_VIEWS.find(
         (candidate) => candidate.id === viewId,
       );
       setRunFilters(cloneRunFilters((view ?? RUN_BUILT_IN_VIEWS[0]!).filters));
     }
-  }, [search.view, surface]);
+    // The login is read, not tracked: it lands after this effect has already
+    // seeded the filters, and rerunning here would throw away edits made in
+    // between. The effect below fills it in instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search.view, surface, defaultViewId]);
+
+  // The signed-in login arrives with the repository snapshot, a beat after the
+  // viewer view was applied. Fill the author in then, and only while the view
+  // is still the untouched one — anything the reader picked outranks it.
+  useEffect(() => {
+    if (surface !== "pull_requests" || !viewerLogin) return;
+    const view = PR_BUILT_IN_VIEWS.find(
+      (candidate) => candidate.id === activeViewId,
+    );
+    if (!view?.viewerAuthored) return;
+    setPrFilters((current) =>
+      current.authors.length === 0
+        ? { ...current, authors: [viewerLogin] }
+        : current,
+    );
+  }, [activeViewId, surface, viewerLogin]);
 
   const loadRepositories = async (force = false, notify = false) => {
     try {
@@ -422,7 +483,7 @@ function CodeDeliveryBody({
     setActiveViewId(id);
     if (surface === "pull_requests") {
       const view = PR_BUILT_IN_VIEWS.find((candidate) => candidate.id === id);
-      if (view) setPrFilters(clonePrFilters(view.filters));
+      if (view) setPrFilters(builtInPrFilters(view, viewerLogin));
     } else {
       const view = RUN_BUILT_IN_VIEWS.find((candidate) => candidate.id === id);
       if (view) setRunFilters(cloneRunFilters(view.filters));
@@ -500,13 +561,11 @@ function CodeDeliveryBody({
 
       <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border-subtle px-5 py-3">
         <div className="flex min-w-0 flex-wrap items-center gap-1 rounded-lg bg-muted/35 p-0.5">
-          {(surface === "pull_requests"
-            ? PR_BUILT_IN_VIEWS
-            : RUN_BUILT_IN_VIEWS
-          ).map((view) => (
+          {builtInViews.map((view) => (
             <button
               key={view.id}
               type="button"
+              aria-pressed={activeViewId === view.id}
               className={cn(
                 "h-7 cursor-pointer rounded-md px-2.5 text-xs font-medium whitespace-nowrap text-muted-foreground transition-colors hover:text-foreground",
                 activeViewId === view.id &&
@@ -1556,6 +1615,25 @@ function PullRequestRow({
           ) : null}
         </span>
         <span className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+          {item.author && (
+            // Leading the metadata line rather than taking a column: the
+            // avatars line up as their own strip down the list, and the table
+            // keeps the width it has.
+            <>
+              <AuthorAvatar
+                login={item.author}
+                url={item.author_avatar_url}
+                className="size-4"
+              />
+              {/* The login holds its width while the repository and branch
+                  give theirs up: a login truncated to one letter identifies
+                  nobody, and those two read fine clipped. */}
+              <span className="max-w-32 shrink-0 truncate">{item.author}</span>
+              <span className="shrink-0" aria-hidden>
+                ·
+              </span>
+            </>
+          )}
           <span className="truncate">{item.repository.name_with_owner}</span>
           <span className="tabular-nums">#{item.number}</span>
           <span className="truncate font-mono">{item.head_branch}</span>
@@ -2379,13 +2457,24 @@ function AuthorFilterOptions({
 }
 
 /** A login's face at list scale, with initials when there is no image. */
-function AuthorAvatar({ login, url }: { login: string; url?: string }) {
+function AuthorAvatar({
+  login,
+  url,
+  className,
+}: {
+  login: string;
+  url?: string;
+  className?: string;
+}) {
   const [failed, setFailed] = useState(false);
   const source = url ?? githubAvatarUrl(login);
   if (!source || failed) {
     return (
       <span
-        className="grid size-5 shrink-0 place-items-center rounded-full bg-muted text-[9px] font-semibold uppercase text-muted-foreground"
+        className={cn(
+          "grid size-5 shrink-0 place-items-center rounded-full bg-muted text-[9px] font-semibold uppercase text-muted-foreground",
+          className,
+        )}
         aria-hidden
       >
         {login.slice(0, 2)}
@@ -2396,7 +2485,7 @@ function AuthorAvatar({ login, url }: { login: string; url?: string }) {
     <img
       src={source}
       alt=""
-      className="size-5 shrink-0 rounded-full object-cover"
+      className={cn("size-5 shrink-0 rounded-full object-cover", className)}
       onError={() => setFailed(true)}
     />
   );
@@ -3173,6 +3262,20 @@ function clonePrFilters(
     checkStates: [...filters.checkStates],
     authors: [...filters.authors],
   };
+}
+
+/**
+ * A built-in view's filters, with the viewer view pointed at the signed-in
+ * login. Resolving to a plain `authors` entry is what keeps the author chip,
+ * the filter count, and a saved copy of the view all reading the same thing.
+ */
+function builtInPrFilters(
+  view: PrBuiltInView,
+  viewerLogin: string | undefined,
+): CodeDeliveryPrViewFilters {
+  const filters = clonePrFilters(view.filters);
+  if (view.viewerAuthored && viewerLogin) filters.authors = [viewerLogin];
+  return filters;
 }
 
 function cloneRunFilters(

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -50,6 +50,7 @@ type DeliveryScenario =
   | "pull-requests-empty"
   | "pull-requests-stacked"
   | "pull-requests-partial"
+  | "pull-requests-no-viewer"
   | "github-unavailable"
   | "runs"
   | "archive"
@@ -59,6 +60,25 @@ type DeliveryScenario =
 
 function pending<T>(): Promise<T> {
   return new Promise(() => {});
+}
+
+/**
+ * A socket that opens and then says nothing.
+ *
+ * The rail subscribes to code updates on mount, so every Delivery story needs
+ * one. Without it the page renders its error boundary instead of the list.
+ */
+function idleSocket(): WebSocket {
+  const socket = {
+    onopen: null as WebSocket["onopen"],
+    onclose: null as WebSocket["onclose"],
+    onerror: null as WebSocket["onerror"],
+    close() {},
+    addEventListener() {},
+    removeEventListener() {},
+  } as unknown as WebSocket;
+  queueMicrotask(() => socket.onopen?.(new Event("open")));
+  return socket;
 }
 
 function prActionMessage(action: CodeDeliveryPullRequestAction): string {
@@ -89,6 +109,16 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
     errors: [],
     fetched_at: "2026-08-20T15:20:00.000Z",
   };
+  // Signed in, but `gh` never said who: the old `gh auth status` has no
+  // `--json`, so the login is missing while everything else works.
+  const viewerlessRepositories: CodeDeliveryRepositoriesSnapshot = {
+    ...deliveryRepositoriesSnapshot,
+    capability: {
+      found: true,
+      authenticated: true,
+      remediation: "",
+    },
+  };
   const workspaces =
     scenario === "archive-empty"
       ? deliveryWorkspaces.filter(
@@ -97,6 +127,7 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
       : deliveryWorkspaces;
 
   return {
+    openCodeUpdates: () => idleSocket(),
     listCodeRepos: async () => [deliveryCodeRepo],
     listCodeWorkspaces: async () => workspaces,
     getHarnessDoctor: async () => harnessDoctor,
@@ -135,7 +166,9 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
     getCodeDeliveryRepositories: async () =>
       scenario === "github-unavailable"
         ? unavailableRepositories
-        : deliveryRepositoriesSnapshot,
+        : scenario === "pull-requests-no-viewer"
+          ? viewerlessRepositories
+          : deliveryRepositoriesSnapshot,
     resolveCodeDeliveryRepositories: async () => deliveryRepositoriesSnapshot,
     queryCodeDeliveryPullRequests: async () => {
       if (scenario === "pull-requests-loading") {
@@ -700,6 +733,34 @@ export const BlockedMergePullRequestDetail: Story = {
     await expect(
       await body.findByRole("button", { name: "Merge" }),
     ).toBeDisabled();
+  },
+};
+
+/**
+ * The default view: your own open pull requests, drafts included. The author
+ * comes from the login `gh` is signed in as, so "Yours" needs no typing.
+ */
+export const PullRequestsYours: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("button", { name: "Yours", pressed: true }),
+    ).toBeVisible();
+  },
+};
+
+/**
+ * No login to filter on, so "Yours" is not offered and Delivery opens on the
+ * attention view instead of quietly showing everybody's pull requests.
+ */
+export const PullRequestsWithoutViewerLogin: Story = {
+  args: { scenario: "pull-requests-no-viewer" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("button", { name: "Needs attention" }),
+    ).toBeVisible();
+    await expect(canvas.queryByRole("button", { name: "Yours" })).toBeNull();
   },
 };
 

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -62,23 +62,32 @@ const TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(700);
 const PR_LIST_FIELDS: &str = "number,url,state,title,isDraft,author,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRefName,headRefOid,baseRefName,updatedAt,createdAt,mergedAt,closedAt,labels";
 const PR_LIST_FIELDS_WITH_CHECKS: &str = "number,url,state,title,isDraft,author,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRefName,headRefOid,baseRefName,updatedAt,createdAt,mergedAt,closedAt,labels,statusCheckRollup";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct PullRequestRemotePlan {
     state: &'static str,
     fields: &'static str,
     checks_loaded: bool,
+    /// The one author to ask GitHub for, when the query names exactly one.
+    ///
+    /// `gh pr list` caps at 100 rows per repository. Filtering an unscoped
+    /// page down to one author afterwards silently loses that author's older
+    /// pull requests in a busy repository — which is exactly what the default
+    /// "Yours" view asks for. Pushing the login into the remote read keeps the
+    /// cap on the rows the reader wanted.
+    author: Option<String>,
 }
 
 impl PullRequestRemotePlan {
-    fn cache_scope(self) -> String {
+    fn cache_scope(&self) -> String {
         format!(
-            "{}:{}",
+            "{}:{}:{}",
             self.state,
             if self.checks_loaded {
                 "checks"
             } else {
                 "summary"
-            }
+            },
+            self.author.as_deref().unwrap_or("*")
         )
     }
 }
@@ -682,6 +691,7 @@ pub(crate) async fn query_pull_requests(
                 .clone()
                 .expect("authenticated gh has a binary");
             let workspace_index = workspace_index(runtime, owner, force_refresh).await?;
+            let remote_plan = &remote_plan;
             let results = stream::iter(targets.clone())
                 .map(|target| {
                     let binary = binary.clone();
@@ -1919,14 +1929,14 @@ async fn fetch_pull_requests(
     binary: &Path,
     target: &CodeGitHubRepositoryTarget,
     workspaces: &[WorkspaceIndexEntry],
-    plan: PullRequestRemotePlan,
+    plan: &PullRequestRemotePlan,
     force_refresh: bool,
 ) -> Result<Vec<CodeDeliveryPullRequestSummary>, String> {
     let repository =
         resolve_repository_cached(runtime, binary, target, None, force_refresh).await?;
     let cli_repository = gh::cli_repository(&target.host, &target.owner, &target.name);
     let limit = MAX_REMOTE_ITEMS_PER_REPO.to_string();
-    let args = [
+    let mut args = vec![
         "pr",
         "list",
         "--repo",
@@ -1938,6 +1948,10 @@ async fn fetch_pull_requests(
         "--json",
         plan.fields,
     ];
+    if let Some(author) = plan.author.as_deref() {
+        args.push("--author");
+        args.push(author);
+    }
     let raw =
         with_transient_retry(|| gh::run_gh(Path::new("."), binary, &args, GH_READ_TIMEOUT)).await?;
     let value: Value = serde_json::from_str(&raw)
@@ -1964,6 +1978,13 @@ fn pull_request_remote_plan(query: &CodeDeliveryPullRequestQuery) -> PullRequest
         "all"
     };
     let checks_loaded = state == "open" || !query.check_states.is_empty();
+    // Only a single author pushes down: `gh pr list` takes one `--author`,
+    // while the query's list is a union. Several authors still page the
+    // unscoped read and match locally.
+    let author = match query.authors.as_slice() {
+        [only] if !only.trim().is_empty() => Some(only.trim().to_owned()),
+        _ => None,
+    };
     PullRequestRemotePlan {
         state,
         fields: if checks_loaded {
@@ -1972,6 +1993,7 @@ fn pull_request_remote_plan(query: &CodeDeliveryPullRequestQuery) -> PullRequest
             PR_LIST_FIELDS
         },
         checks_loaded,
+        author,
     }
 }
 
@@ -3429,6 +3451,28 @@ mod tests {
         assert_eq!(run_remote_scope(&runs), ("deployments", false, true));
         runs.kinds.clear();
         assert_eq!(run_remote_scope(&runs), ("all", true, true));
+    }
+
+    /// The default Delivery view is one author's open pull requests. Asking
+    /// GitHub for everyone's and narrowing afterwards would spend the 100-row
+    /// per-repository cap on other people's work, so a lone author reaches the
+    /// remote read — and takes its own cache scope, because the rows it comes
+    /// back with are not the unscoped aggregate.
+    #[test]
+    fn a_single_author_reaches_the_remote_read() {
+        let mut query = pull_request_query();
+        query.states = vec!["open".into()];
+        let everyone = pull_request_remote_plan(&query);
+        assert_eq!(everyone.author, None);
+
+        query.authors = vec![" mara ".into()];
+        let mine = pull_request_remote_plan(&query);
+        assert_eq!(mine.author.as_deref(), Some("mara"));
+        assert_ne!(mine.cache_scope(), everyone.cache_scope());
+
+        // A union of authors is not something `gh pr list` can express.
+        query.authors = vec!["mara".into(), "devon".into()];
+        assert_eq!(pull_request_remote_plan(&query).author, None);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

The pull-request page opened on "Needs attention" — everybody's review queue. It now opens on "Yours": your open pull requests, drafts included, with the author taken from the login `gh` is signed in as, and every row names its author with an avatar and login leading the metadata line. A lone author now reaches the remote read as `gh pr list --author`, because otherwise the new default would spend the 100-row per-repository cap on other people's work and silently drop your older open pull requests in a busy repository. When `gh` cannot report a login the "Yours" view is not offered and the attention view takes the default back, so it never quietly widens to everybody. Along the way the view chips gained `aria-pressed`, and the Delivery stories gained the code-updates socket the rail subscribes to on mount — without it every story in that file rendered its error boundary instead of the list.

## Validation

`pnpm exec biome format src`, `pnpm lint`, `pnpm exec tsc --noEmit`, and all 1751 vitest tests pass; `pnpm storybook:build` succeeds and `cargo fmt --all --check` is clean. I reviewed the two new stories rendered at 1440px light and 1100px dark to confirm the chip row, the author strip, and the unchanged row height. The Rust was not compiled locally — CI covers it.

## Compatibility and risk

No wire or persisted-format change. The author push-down gives that read its own aggregate cache scope, so a "Yours" query no longer shares the unscoped entry — the first load after this lands refetches rather than reusing it.