### PR TITLE
feat(code): hosted machines create and read pull requests over REST

### DIFF
--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -1,0 +1,429 @@
+//! Pull-request reads and creation over the forge REST API (decision 65).
+//!
+//! A gateway-authenticated hosted machine has no `gh`. Where decision 63 gave
+//! its git transport a borrowed credential, this module gives its
+//! pull-request surfaces the same: each function drives one operation against
+//! the forge's REST API with a per-operation borrowed credential, and shapes
+//! every answer exactly like the `gh --json` payload code mode already
+//! parses — one JSON vocabulary, however the host was asked.
+//!
+//! Deliberately narrow: creation, the PR-card digest, and the fact reads
+//! (decision 62). Merge, ready, close, comments, CI logs, and the
+//! repository-wide delivery panel stay `gh`-only and keep answering exactly
+//! as they do today on machines without it.
+
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use serde_json::Value;
+
+use crate::obo_gateway::GitCredential;
+use crate::routes::code::CodeGitHubRepositoryTarget;
+use tidebreak_core::{PullRequestCheck, PullRequestCheckBucket, PullRequestDigest};
+
+/// Timeout for one REST call — the same bound the `gh` runner gets.
+const REST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Cap on one REST response body. PR and check payloads are kilobytes; the
+/// bound exists so a confused origin cannot grow the process.
+const RESPONSE_LIMIT: usize = 2 * 1024 * 1024;
+
+/// The REST base for a forge host: `api.github.com` for github.com, the
+/// GHES `/api/v3/` convention for anything else.
+///
+/// Today the lending gate pins the host to github.com before any credential
+/// exists, so the second arm is spelled for honesty, not reach.
+pub(crate) fn default_api_base(host: &str) -> String {
+    if host.eq_ignore_ascii_case("github.com") || host.eq_ignore_ascii_case("www.github.com") {
+        "https://api.github.com".to_owned()
+    } else {
+        format!("https://{host}/api/v3")
+    }
+}
+
+/// One authenticated REST call, bounded and JSON-decoded.
+///
+/// Errors are strings for the caller to wrap: this module does not know
+/// whether it is failing a create, a status read, or a fact sweep.
+async fn request(
+    method: reqwest::Method,
+    url: String,
+    credential: &GitCredential,
+    body: Option<&Value>,
+) -> Result<(reqwest::StatusCode, Value), String> {
+    let client = reqwest::Client::builder()
+        .timeout(REST_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .user_agent(concat!("tidebreak/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|error| format!("the forge REST client could not be built: {error}"))?;
+    let mut request = client
+        .request(method, url)
+        .bearer_auth(&credential.secret)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .header("x-github-api-version", "2022-11-28");
+    if let Some(body) = body {
+        request = request.json(body);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|error| format!("the forge could not be reached: {error}"))?;
+    let status = response.status();
+    let mut bytes = Vec::new();
+    let mut chunks = response.bytes_stream();
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk.map_err(|error| format!("the forge response broke mid-read: {error}"))?;
+        if bytes.len() + chunk.len() > RESPONSE_LIMIT {
+            return Err("the forge response passed the size ceiling".to_owned());
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    Ok((status, value))
+}
+
+/// The forge's own message for a refused call, bounded, or the status alone.
+fn forge_message(status: reqwest::StatusCode, value: &Value) -> String {
+    let detail = value
+        .get("errors")
+        .and_then(Value::as_array)
+        .and_then(|errors| errors.first())
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+        .or_else(|| value.get("message").and_then(Value::as_str))
+        .unwrap_or_default();
+    if detail.is_empty() {
+        format!("the forge answered {status}")
+    } else {
+        let mut bounded = detail.chars().take(300).collect::<String>();
+        if bounded.len() < detail.len() {
+            bounded.push('…');
+        }
+        bounded
+    }
+}
+
+/// Create a pull request and return it in the fact shape.
+pub(crate) async fn create_pull_request(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    title: &str,
+    body: &str,
+    base: &str,
+    head: &str,
+) -> Result<Value, String> {
+    let (status, value) = request(
+        reqwest::Method::POST,
+        format!("{api_base}/repos/{}/{}/pulls", target.owner, target.name),
+        credential,
+        Some(&serde_json::json!({
+            "title": title,
+            "body": body,
+            "base": base,
+            "head": head,
+        })),
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    Ok(fact_value(&value))
+}
+
+/// List the pull requests whose head is one branch, in the fact shape.
+///
+/// `state=all` so a push confirmed just after a merge still resolves; the
+/// caller picks among the handful of results.
+pub(crate) async fn list_pull_requests_for_head(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    head_branch: &str,
+) -> Result<Vec<Value>, String> {
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/pulls?head={}:{}&state=all&per_page=5",
+            target.owner, target.name, target.owner, head_branch
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    Ok(value
+        .as_array()
+        .map(|values| values.iter().map(fact_value).collect())
+        .unwrap_or_default())
+}
+
+/// The PR-card digest for one branch: the branch's current pull request,
+/// its checks keyed to the head it names, and its merge-queue state.
+///
+/// Simpler than the `gh` loader's verify-head dance on purpose: REST checks
+/// are read for the exact head SHA the pull request named, so the two cannot
+/// disagree the way two implicit `gh` resolutions can.
+pub(crate) async fn pull_request_digest(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    head_branch: &str,
+) -> Result<Option<PullRequestDigest>, String> {
+    let (status, listed) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/pulls?head={}:{}&state=all&per_page=10",
+            target.owner, target.name, target.owner, head_branch
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &listed));
+    }
+    let empty = Vec::new();
+    let listed = listed.as_array().unwrap_or(&empty);
+    // The branch's current pull request: the open one when it exists, and
+    // the newest closed one otherwise — the same answer `gh pr view`
+    // resolves a branch to.
+    let current = listed
+        .iter()
+        .find(|value| value.get("state").and_then(Value::as_str) == Some("open"))
+        .or_else(|| listed.first());
+    let Some(number) = current
+        .and_then(|value| value.get("number"))
+        .and_then(Value::as_u64)
+    else {
+        return Ok(None);
+    };
+    let (status, detail) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/pulls/{number}",
+            target.owner, target.name
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &detail));
+    }
+    let head_sha = detail
+        .pointer("/head/sha")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let checks = match &head_sha {
+        Some(sha) => check_runs(api_base, target, credential, sha).await?,
+        None => Vec::new(),
+    };
+    let state = if detail.get("merged").and_then(Value::as_bool) == Some(true) {
+        "merged".to_owned()
+    } else {
+        detail
+            .get("state")
+            .and_then(Value::as_str)
+            .unwrap_or("open")
+            .to_ascii_lowercase()
+    };
+    let open = state == "open";
+    let in_merge_queue = if open {
+        merge_queue_state(api_base, target, credential, number).await
+    } else {
+        Some(false)
+    };
+    let text = |pointer: &str| {
+        detail
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    Ok(Some(PullRequestDigest {
+        number,
+        url: text("/html_url"),
+        merged: Some(state == "merged"),
+        state,
+        title: text("/title"),
+        checks_summary: super::gh::summarize_checks(&checks),
+        checks: (!checks.is_empty()).then_some(checks),
+        draft: detail.get("draft").and_then(Value::as_bool),
+        // REST has no review-decision projection; the field stays unstated
+        // rather than approximated from raw reviews.
+        review_decision: None,
+        mergeable: match detail.get("mergeable") {
+            Some(Value::Bool(true)) => Some("mergeable".to_owned()),
+            Some(Value::Bool(false)) => Some("conflicting".to_owned()),
+            _ => None,
+        },
+        merge_state_status: text("/mergeable_state"),
+        head_branch: text("/head/ref"),
+        base_branch: text("/base/ref"),
+        head_sha,
+        auto_merge_enabled: Some(
+            detail
+                .get("auto_merge")
+                .is_some_and(|value| !value.is_null()),
+        ),
+        in_merge_queue,
+    }))
+}
+
+/// One head's check runs, bucketed exactly as the `gh` table parser buckets.
+async fn check_runs(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    sha: &str,
+) -> Result<Vec<PullRequestCheck>, String> {
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/commits/{sha}/check-runs?per_page=100",
+            target.owner, target.name
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    let empty = Vec::new();
+    let runs = value
+        .get("check_runs")
+        .and_then(Value::as_array)
+        .unwrap_or(&empty);
+    Ok(runs
+        .iter()
+        .filter_map(|run| {
+            let name = run.get("name").and_then(Value::as_str)?.to_owned();
+            let conclusion = run.get("conclusion").and_then(Value::as_str);
+            let bucket = match conclusion {
+                Some("success") => PullRequestCheckBucket::Pass,
+                Some("neutral" | "cancelled" | "skipped") => PullRequestCheckBucket::Skipped,
+                Some(_) => PullRequestCheckBucket::Fail,
+                None => PullRequestCheckBucket::Pending,
+            };
+            let detail = conclusion
+                .or_else(|| run.get("status").and_then(Value::as_str))
+                .map(ToOwned::to_owned);
+            let url = run
+                .get("html_url")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            Some(PullRequestCheck {
+                name,
+                bucket,
+                detail,
+                url,
+            })
+        })
+        .collect())
+}
+
+/// Whether the pull request currently sits in a merge queue, from the same
+/// timeline events the `gh` loader reads. `None` when the read fails — the
+/// digest states nothing rather than guessing.
+async fn merge_queue_state(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    number: u64,
+) -> Option<bool> {
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/issues/{number}/timeline?per_page=100",
+            target.owner, target.name
+        ),
+        credential,
+        None,
+    )
+    .await
+    .ok()?;
+    if !status.is_success() {
+        return None;
+    }
+    let last = value.as_array()?.iter().rev().find_map(|event| {
+        match event.get("event").and_then(Value::as_str) {
+            Some(event @ ("added_to_merge_queue" | "removed_from_merge_queue")) => Some(event),
+            _ => None,
+        }
+    });
+    Some(last == Some("added_to_merge_queue"))
+}
+
+/// One REST pull request restated in the `gh --json` fact shape
+/// ([`super::gh::PR_FACT_FIELDS`]), so the fact store parses one vocabulary
+/// however the host was asked. `state` stays REST's own `open`/`closed`;
+/// the parser already reads closed-with-merged-at as merged.
+pub(crate) fn fact_value(pr: &Value) -> Value {
+    serde_json::json!({
+        "number": pr.get("number").cloned().unwrap_or(Value::Null),
+        "url": pr.get("html_url").cloned().unwrap_or(Value::Null),
+        "title": pr.get("title").cloned().unwrap_or(Value::Null),
+        "state": pr.get("state").cloned().unwrap_or(Value::Null),
+        "isDraft": pr.get("draft").cloned().unwrap_or(Value::Null),
+        "author": { "login": pr.pointer("/user/login").cloned().unwrap_or(Value::Null) },
+        "headRefName": pr.pointer("/head/ref").cloned().unwrap_or(Value::Null),
+        "headRefOid": pr.pointer("/head/sha").cloned().unwrap_or(Value::Null),
+        "baseRefName": pr.pointer("/base/ref").cloned().unwrap_or(Value::Null),
+        "createdAt": pr.get("created_at").cloned().unwrap_or(Value::Null),
+        "updatedAt": pr.get("updated_at").cloned().unwrap_or(Value::Null),
+        "mergedAt": pr.get("merged_at").cloned().unwrap_or(Value::Null),
+        "closedAt": pr.get("closed_at").cloned().unwrap_or(Value::Null),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The REST shape lands byte-compatible with the `gh --json` vocabulary
+    /// the fact parser reads (decision 62): a merged REST answer must read
+    /// as merged through `closed` + `mergedAt`.
+    #[test]
+    fn a_rest_pull_request_restates_as_the_gh_fact_shape() {
+        let rest = serde_json::json!({
+            "number": 7,
+            "html_url": "https://github.com/acme/demo/pull/7",
+            "title": "Add the thing",
+            "state": "closed",
+            "draft": false,
+            "user": { "login": "mira-chen" },
+            "head": { "ref": "feature", "sha": "abc123" },
+            "base": { "ref": "main" },
+            "created_at": "2026-08-24T10:00:00Z",
+            "updated_at": "2026-08-24T11:00:00Z",
+            "merged_at": "2026-08-24T11:00:00Z",
+            "closed_at": "2026-08-24T11:00:00Z",
+        });
+        let fact = fact_value(&rest);
+        assert_eq!(fact["number"], 7);
+        assert_eq!(fact["url"], "https://github.com/acme/demo/pull/7");
+        assert_eq!(fact["state"], "closed");
+        assert_eq!(fact["mergedAt"], "2026-08-24T11:00:00Z");
+        assert_eq!(fact["author"]["login"], "mira-chen");
+        assert_eq!(fact["headRefName"], "feature");
+        assert_eq!(fact["headRefOid"], "abc123");
+    }
+
+    /// github.com maps to the public API origin; any other forge host keeps
+    /// the GHES convention.
+    #[test]
+    fn the_api_base_follows_the_forge_host() {
+        assert_eq!(default_api_base("github.com"), "https://api.github.com");
+        assert_eq!(default_api_base("www.github.com"), "https://api.github.com");
+        assert_eq!(
+            default_api_base("ghe.acme.test"),
+            "https://ghe.acme.test/api/v3"
+        );
+    }
+}

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -18,7 +18,7 @@ use futures::StreamExt as _;
 use serde_json::Value;
 
 use crate::obo_gateway::GitCredential;
-use crate::routes::code::CodeGitHubRepositoryTarget;
+use crate::routes::code::types::CodeGitHubRepositoryTarget;
 use tidebreak_core::{PullRequestCheck, PullRequestCheckBucket, PullRequestDigest};
 
 /// Timeout for one REST call — the same bound the `gh` runner gets.

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -495,6 +495,91 @@ pub(crate) async fn create_pull_request(
     Ok(digest)
 }
 
+/// [`create_pull_request`] over the forge REST API with a borrowed
+/// credential (decision 65), for machines without `gh`.
+///
+/// The title and body come from exactly the same generation as the `gh`
+/// path, the created pull request comes back beside the digest in the fact
+/// shape so the caller can persist the authored fact without a second host
+/// read, and the digest read after creation is best-effort exactly as it is
+/// with `gh` — a light digest from the creation answer serves until the next
+/// status read.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn create_pull_request_rest(
+    worktree: &Path,
+    workspace_id: WorkspaceId,
+    title: &str,
+    branch: &str,
+    base_ref: &str,
+    requested_title: Option<&str>,
+    requested_body: Option<&str>,
+    cache: &PrDigestCache,
+    api_base: &str,
+    target: &crate::routes::code::CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+) -> Result<(PullRequestDigest, serde_json::Value), GhError> {
+    let inspect = inspect_git(worktree, base_ref, title).await?;
+    let pr_title = requested_title
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| generate_pr_title(title, branch));
+    let pr_body = requested_body
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or(inspect.suggested_pr_body);
+    let base = gh_base_branch(base_ref);
+    let fact = super::forge_rest::create_pull_request(
+        api_base, target, credential, &pr_title, &pr_body, base, branch,
+    )
+    .await
+    .map_err(|reason| GhError::user(format!("the pull request was not created: {reason}")))?;
+    cache.invalidate(workspace_id);
+    if let Ok(Some(digest)) =
+        super::forge_rest::pull_request_digest(api_base, target, credential, branch).await
+    {
+        cache.put(workspace_id, digest.clone());
+        return Ok((digest, fact));
+    }
+    let number = fact.get("number").and_then(serde_json::Value::as_u64);
+    let digest = PullRequestDigest {
+        number: number.unwrap_or(0),
+        url: fact
+            .get("url")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        state: "open".into(),
+        title: fact
+            .get("title")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        checks_summary: None,
+        checks: None,
+        draft: fact.get("isDraft").and_then(serde_json::Value::as_bool),
+        merged: Some(false),
+        review_decision: None,
+        mergeable: None,
+        merge_state_status: None,
+        head_branch: fact
+            .get("headRefName")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        base_branch: fact
+            .get("baseRefName")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        head_sha: fact
+            .get("headRefOid")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        auto_merge_enabled: None,
+        in_merge_queue: None,
+    };
+    cache.put(workspace_id, digest.clone());
+    Ok((digest, fact))
+}
+
 /// Merge strategy for the user-initiated merge operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MergeMethod {

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -515,7 +515,7 @@ pub(crate) async fn create_pull_request_rest(
     requested_body: Option<&str>,
     cache: &PrDigestCache,
     api_base: &str,
-    target: &crate::routes::code::CodeGitHubRepositoryTarget,
+    target: &crate::routes::code::types::CodeGitHubRepositoryTarget,
     credential: &GitCredential,
 ) -> Result<(PullRequestDigest, serde_json::Value), GhError> {
     let inspect = inspect_git(worktree, base_ref, title).await?;

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod checkpoint;
 pub(crate) mod ci_logs;
 pub(crate) mod clone;
 pub(crate) mod delivery;
+pub(crate) mod forge_rest;
 pub(crate) mod fork;
 pub(crate) mod gh;
 pub(crate) mod harness_install;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1427,7 +1427,7 @@ impl CodeRuntime {
         worktree: &std::path::Path,
     ) -> Result<
         Option<(
-            crate::routes::code::CodeGitHubRepositoryTarget,
+            crate::routes::code::types::CodeGitHubRepositoryTarget,
             crate::obo_gateway::GitCredential,
         )>,
         ServerError,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -178,6 +178,10 @@ pub(crate) struct CodeRuntime {
     pub(super) harness_installs: HarnessInstallJobs,
     #[cfg(test)]
     pub(crate) gh_search_path: Mutex<Option<String>>,
+    /// Forge REST base override, so tests point decision 65's reads at a
+    /// loopback fake while the lending gate still names github.com.
+    #[cfg(test)]
+    forge_api_base: Mutex<Option<String>>,
     stall_sweep: Mutex<Option<super::attention::StallSweepGuard>>,
     stall_started: AtomicBool,
     watch_sweep: Mutex<Option<super::watch::WatchSweepGuard>>,
@@ -261,6 +265,8 @@ impl CodeRuntime {
             harness_installs: HarnessInstallJobs::default(),
             #[cfg(test)]
             gh_search_path: Mutex::new(None),
+            #[cfg(test)]
+            forge_api_base: Mutex::new(None),
             stall_sweep: Mutex::new(None),
             stall_started: AtomicBool::new(false),
             watch_sweep: Mutex::new(None),
@@ -374,6 +380,8 @@ impl CodeRuntime {
             harness_installs: HarnessInstallJobs::default(),
             #[cfg(test)]
             gh_search_path: Mutex::new(None),
+            #[cfg(test)]
+            forge_api_base: Mutex::new(None),
             stall_sweep: Mutex::new(None),
             stall_started: AtomicBool::new(false),
             watch_sweep: Mutex::new(None),
@@ -401,6 +409,23 @@ impl CodeRuntime {
     #[cfg(test)]
     pub(crate) fn set_gh_search_path(&self, path: Option<String>) {
         *self.gh_search_path.lock().expect("gh search path") = path;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_forge_api_base(&self, base: Option<String>) {
+        *self.forge_api_base.lock().expect("forge api base") = base;
+    }
+
+    /// The REST base decision 65's pull-request operations drive: the
+    /// forge's own, or a test override.
+    fn forge_api_base_for(&self, host: &str) -> String {
+        #[cfg(test)]
+        {
+            if let Some(base) = self.forge_api_base.lock().expect("forge api base").clone() {
+                return base;
+            }
+        }
+        super::forge_rest::default_api_base(host)
     }
 
     /// Return the installed browser adapter, if any.
@@ -1281,32 +1306,45 @@ impl CodeRuntime {
             .map_err(map_gh)?;
         // Best-effort contributed fact (decision 62): a user push to a branch
         // that is a pull request's head is the same act the detector mints
-        // for. Failures are silent; the reconcile sweep corrects.
-        let gh_path = self.gh_search_path_owned();
+        // for. Failures are silent; the reconcile sweep corrects. On a hosted
+        // machine the read rides the forge REST API with the same credential
+        // the push just used (decision 65) — one borrow, one operation.
         if let Ok(target) = super::delivery::repository_target_from_path(&worktree).await {
-            if let Ok(values) = gh::list_pull_requests_for_head_raw(
-                &target.host,
-                &target.owner,
-                &target.name,
-                &workspace.branch_name,
-                gh_path.as_deref(),
-            )
-            .await
-            {
-                if let Some(value) = values.first() {
-                    super::pr_facts::record_confirmed_fact(
-                        &self.db,
-                        owner,
-                        workspace.id,
-                        None,
-                        None,
-                        &target,
-                        value,
-                        tidebreak_core::CodePullRequestRelation::Contributed,
-                        tidebreak_core::CodePullRequestDiscovery::Command,
+            let values = match credential.as_ref() {
+                Some(credential) => super::forge_rest::list_pull_requests_for_head(
+                    &self.forge_api_base_for(&target.host),
+                    &target,
+                    credential,
+                    &workspace.branch_name,
+                )
+                .await
+                .ok(),
+                None => {
+                    let gh_path = self.gh_search_path_owned();
+                    gh::list_pull_requests_for_head_raw(
+                        &target.host,
+                        &target.owner,
+                        &target.name,
+                        &workspace.branch_name,
+                        gh_path.as_deref(),
                     )
-                    .await;
+                    .await
+                    .ok()
                 }
+            };
+            if let Some(value) = values.as_ref().and_then(|values| values.first()) {
+                super::pr_facts::record_confirmed_fact(
+                    &self.db,
+                    owner,
+                    workspace.id,
+                    None,
+                    None,
+                    &target,
+                    value,
+                    tidebreak_core::CodePullRequestRelation::Contributed,
+                    tidebreak_core::CodePullRequestDiscovery::Command,
+                )
+                .await;
             }
         }
         Ok(outcome)
@@ -1377,6 +1415,41 @@ impl CodeRuntime {
         }
     }
 
+    /// The REST context for a pull-request operation in `worktree`
+    /// (decision 65): the forge repository the checkout names plus one
+    /// borrowed credential. `Ok(None)` is every machine with its own
+    /// credentials and every checkout outside the lending gate — those keep
+    /// `gh` exactly as it is. A gateway refusal fails the operation with its
+    /// reason, exactly as a push does.
+    async fn forge_rest_context(
+        &self,
+        owner: &OwnerId,
+        worktree: &std::path::Path,
+    ) -> Result<
+        Option<(
+            crate::routes::code::CodeGitHubRepositoryTarget,
+            crate::obo_gateway::GitCredential,
+        )>,
+        ServerError,
+    > {
+        if self.git_credentials().is_none() {
+            return Ok(None);
+        }
+        let Some(target) = forge_lending_target(worktree).await else {
+            return Ok(None);
+        };
+        let credential = self
+            .borrow_git_credential(owner, worktree)
+            .await?
+            .ok_or_else(|| {
+                ServerError::unprocessable_kind(
+                    "git_forge_refused",
+                    "this checkout's origin is not a lendable forge repository",
+                )
+            })?;
+        Ok(Some((target, credential)))
+    }
+
     pub(crate) async fn workspace_pr(
         &self,
         owner: &OwnerId,
@@ -1396,6 +1469,32 @@ impl CodeRuntime {
         )
         .await
         .map_err(map_gh)?;
+        // On a hosted machine the digest comes from the forge REST API with
+        // a borrowed credential (decision 65) — there is no `gh` here to
+        // refresh it. Cache-aware exactly like the `gh` path, borrowing only
+        // on a miss; failures leave the persisted digest and the next read
+        // asks again.
+        if self.git_credentials().is_some() {
+            let worktree = std::path::Path::new(&workspace.worktree_path);
+            if let Some(cached) = self.pr_cache.get(workspace.id) {
+                status.pr = Some(cached);
+            } else if let Ok(Some((target, credential))) =
+                self.forge_rest_context(owner, worktree).await
+            {
+                let api_base = self.forge_api_base_for(&target.host);
+                if let Ok(Some(digest)) = super::forge_rest::pull_request_digest(
+                    &api_base,
+                    &target,
+                    &credential,
+                    &workspace.branch_name,
+                )
+                .await
+                {
+                    self.pr_cache.put(workspace.id, digest.clone());
+                    status.pr = Some(digest);
+                }
+            }
+        }
         // On a hosted machine, say whose identity a push would act as
         // (decisions 63 and 65) — only for a checkout the machine would
         // actually lend an identity to, so the sentence is never wider than
@@ -1535,29 +1634,72 @@ impl CodeRuntime {
         body: Option<String>,
     ) -> Result<WorkspaceGitStatus, ServerError> {
         let mut workspace = self.require_live_workspace(owner, id).await?;
-        let gh_path = self.gh_search_path_owned();
-        let digest = gh::create_pull_request(
-            std::path::Path::new(&workspace.worktree_path),
-            workspace.id,
-            &workspace.title,
-            &workspace.branch_name,
-            &workspace.base_ref,
-            title.as_deref(),
-            body.as_deref(),
-            &self.pr_cache,
-            gh_path.as_deref(),
-        )
-        .await
-        .map_err(map_gh)?;
+        let worktree = std::path::PathBuf::from(&workspace.worktree_path);
+        // On a hosted machine the pull request rides the forge REST API with
+        // a borrowed credential (decision 65) and lands as the caller; the
+        // authored fact comes straight from the creation answer, with no
+        // second host read. Everywhere else `gh` does exactly what it always
+        // has (decision 34), including its own best-effort fact read below.
+        let (digest, rest_fact) = match self.forge_rest_context(owner, &worktree).await? {
+            Some((target, credential)) => {
+                let api_base = self.forge_api_base_for(&target.host);
+                let (digest, fact) = gh::create_pull_request_rest(
+                    &worktree,
+                    workspace.id,
+                    &workspace.title,
+                    &workspace.branch_name,
+                    &workspace.base_ref,
+                    title.as_deref(),
+                    body.as_deref(),
+                    &self.pr_cache,
+                    &api_base,
+                    &target,
+                    &credential,
+                )
+                .await
+                .map_err(map_gh)?;
+                (digest, Some((target, fact)))
+            }
+            None => {
+                let gh_path = self.gh_search_path_owned();
+                let digest = gh::create_pull_request(
+                    &worktree,
+                    workspace.id,
+                    &workspace.title,
+                    &workspace.branch_name,
+                    &workspace.base_ref,
+                    title.as_deref(),
+                    body.as_deref(),
+                    &self.pr_cache,
+                    gh_path.as_deref(),
+                )
+                .await
+                .map_err(map_gh)?;
+                (digest, None)
+            }
+        };
         let created_number = digest.number;
         workspace.pr = Some(digest);
         self.save_workspace(&workspace).await?;
         // Best-effort authored fact (decision 62). The digest just came from
-        // the host, and the repository-qualified re-read gives the row full
-        // identity and timestamps. Failures are silent; the reconcile sweep
-        // corrects.
-        let worktree = std::path::PathBuf::from(&workspace.worktree_path);
-        if let Ok(target) = super::delivery::repository_target_from_path(&worktree).await {
+        // the host; the REST path already holds the full row, and the `gh`
+        // path re-reads it repository-qualified for full identity and
+        // timestamps. Failures are silent; the reconcile sweep corrects.
+        if let Some((target, fact)) = rest_fact {
+            super::pr_facts::record_confirmed_fact(
+                &self.db,
+                owner,
+                workspace.id,
+                None,
+                None,
+                &target,
+                &fact,
+                tidebreak_core::CodePullRequestRelation::Authored,
+                tidebreak_core::CodePullRequestDiscovery::Command,
+            )
+            .await;
+        } else if let Ok(target) = super::delivery::repository_target_from_path(&worktree).await {
+            let gh_path = self.gh_search_path_owned();
             if let Ok(value) = gh::view_pull_request_raw(
                 &target.host,
                 &target.owner,

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -472,8 +472,12 @@ async fn auto_run_on_create_runs_after_setup() {
 #[tokio::test]
 async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
     let lender = Arc::new(FakeLender::offering("acme-ship[bot]"));
-    let (router, token, _runtime, dir) =
+    let (router, token, runtime, dir) =
         code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    // Status reads on a forge checkout now refresh the digest over REST
+    // (decision 65); a dead loopback port keeps this test off the network
+    // while the borrow accounting below stays observable.
+    runtime.set_forge_api_base(Some("http://127.0.0.1:9/".to_owned()));
     let addr = serve(router).await;
     let client = reqwest::Client::new();
     let repo = init_paired_repo(dir.path());
@@ -538,6 +542,18 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
         body["pushes_as_self"].is_null(),
         "the App's identity is never claimed as the caller's own: {body}"
     );
+    // The forge checkout's status read borrows once for the REST digest
+    // (decision 65); the read fails on the dead port and degrades silently.
+    let digest_borrows = lender.minted().len();
+    assert!(digest_borrows > 0, "the digest read borrows per operation");
+    assert!(
+        lender
+            .minted()
+            .iter()
+            .all(|repository| repository == "acme/demo"),
+        "every borrow names the one forge repository: {:?}",
+        lender.minted()
+    );
 
     // A rewritten origin on a foreign host — the exact move an agent in the
     // workspace could make — is outside the lending: no identity is claimed
@@ -560,8 +576,9 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
         .unwrap();
     let body: serde_json::Value = status.json().await.unwrap();
     assert!(body["pushes_as"].is_null(), "{body}");
-    assert!(
-        lender.minted().is_empty(),
+    assert_eq!(
+        lender.minted().len(),
+        digest_borrows,
         "a foreign host must never reach the gateway"
     );
     run(
@@ -588,7 +605,19 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
     assert_eq!(status, reqwest::StatusCode::UNPROCESSABLE_ENTITY);
     assert_eq!(kind, "git_forge_refused");
     assert!(message.contains("no git forge"), "{message}");
-    assert_eq!(lender.minted(), vec!["acme/demo".to_owned()]);
+    assert_eq!(
+        lender.minted().len(),
+        digest_borrows + 1,
+        "the refused push asked exactly once more"
+    );
+    assert!(
+        lender
+            .minted()
+            .iter()
+            .all(|repository| repository == "acme/demo"),
+        "{:?}",
+        lender.minted()
+    );
 }
 
 /// Decision 65: once the caller's own account acts, the git card names them
@@ -596,8 +625,9 @@ async fn a_hosted_push_borrows_only_for_forge_origins_and_fails_closed() {
 #[tokio::test]
 async fn a_hosted_git_card_names_the_person_once_connected() {
     let lender = Arc::new(FakeLender::offering_person("mira-chen"));
-    let (router, token, _runtime, dir) =
+    let (router, token, runtime, dir) =
         code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    runtime.set_forge_api_base(Some("http://127.0.0.1:9/".to_owned()));
     let addr = serve(router).await;
     let client = reqwest::Client::new();
     let repo = init_paired_repo(dir.path());
@@ -690,4 +720,215 @@ async fn a_workspace_without_a_person_identity_keeps_the_checkouts_own() {
         let signature = run_stdout(&path, &["git", "log", "-1", "--format=%an <%ae>"]);
         assert_eq!(signature, "Dev <dev@example.com>");
     }
+}
+
+/// Decision 65: with no `gh` anywhere, a hosted machine creates the pull
+/// request over the forge REST API with a borrowed credential, persists the
+/// authored fact from the creation answer, and the card's digest — state,
+/// checks, queue — reads over the same surface. A gateway refusal fails the
+/// operation with the gateway's reason before anything reaches the forge.
+#[tokio::test]
+async fn a_hosted_machine_creates_and_reads_the_pull_request_over_rest() {
+    type Recorded = Arc<std::sync::Mutex<Vec<serde_json::Value>>>;
+    let recorded: Recorded = Arc::default();
+
+    fn rest_pull_request(head_ref: &str) -> serde_json::Value {
+        serde_json::json!({
+            "number": 7,
+            "html_url": "https://github.com/acme/demo/pull/7",
+            "title": "Add the hosted change",
+            "state": "open",
+            "merged": false,
+            "draft": false,
+            "user": { "login": "mira-chen" },
+            "head": { "ref": head_ref, "sha": "feedfeedfeedfeedfeed" },
+            "base": { "ref": "main" },
+            "mergeable": true,
+            "mergeable_state": "clean",
+            "auto_merge": null,
+            "created_at": "2026-08-24T10:00:00Z",
+            "updated_at": "2026-08-24T10:00:00Z",
+            "merged_at": null,
+            "closed_at": null,
+        })
+    }
+
+    let create_recorded = Arc::clone(&recorded);
+    let create = move |headers: axum::http::HeaderMap,
+                       axum::Json(body): axum::Json<serde_json::Value>| {
+        let recorded = Arc::clone(&create_recorded);
+        async move {
+            // The borrowed credential rides as the bearer — asserted
+            // server-side so a drifted client fails the test.
+            let bearer = headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default();
+            assert_eq!(bearer, "Bearer ghs_fake_borrowed");
+            let head = body["head"].as_str().unwrap_or_default().to_owned();
+            recorded
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(body);
+            (
+                axum::http::StatusCode::CREATED,
+                axum::Json(rest_pull_request(&head)),
+            )
+        }
+    };
+    let list = || async { axum::Json(serde_json::json!([rest_pull_request("hosted-branch")])) };
+    let detail = || async { axum::Json(rest_pull_request("hosted-branch")) };
+    let checks = || async {
+        axum::Json(serde_json::json!({
+            "check_runs": [
+                { "name": "test", "status": "completed", "conclusion": "success",
+                  "html_url": "https://github.com/acme/demo/runs/1" },
+                { "name": "clippy", "status": "in_progress", "conclusion": null,
+                  "html_url": "https://github.com/acme/demo/runs/2" },
+            ]
+        }))
+    };
+    let timeline = || async { axum::Json(serde_json::json!([])) };
+    let router = axum::Router::new()
+        .route("/repos/acme/demo/pulls", axum::routing::post(create))
+        .route("/repos/acme/demo/pulls", axum::routing::get(list))
+        .route("/repos/acme/demo/pulls/7", axum::routing::get(detail))
+        .route(
+            "/repos/acme/demo/commits/{sha}/check-runs",
+            axum::routing::get(checks),
+        )
+        .route(
+            "/repos/acme/demo/issues/7/timeline",
+            axum::routing::get(timeline),
+        );
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let api = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+
+    let lender = Arc::new(FakeLender::offering_person("mira-chen"));
+    let (router, token, runtime, dir) =
+        code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    runtime.set_forge_api_base(Some(format!("http://{api}")));
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "hosted change").await;
+    let id = json_id(&workspace);
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+
+    std::fs::write(path.join("feature.txt"), "line\n").unwrap();
+    let committed = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(committed.status(), reqwest::StatusCode::OK);
+    run(
+        &path,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/acme/demo.git",
+        ],
+    );
+
+    let created = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/pr"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "title": "Add the hosted change" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(body["pr"]["number"], 7, "{body}");
+    assert_eq!(
+        body["pr"]["url"], "https://github.com/acme/demo/pull/7",
+        "{body}"
+    );
+    assert_eq!(
+        body["pr"]["checks_summary"], "1 passing, 1 pending, 0 failing",
+        "the digest's checks ride REST too: {body}"
+    );
+
+    let sent = recorded
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    assert_eq!(sent.len(), 1, "one create request reached the forge");
+    assert_eq!(sent[0]["title"], "Add the hosted change");
+    assert_eq!(sent[0]["base"], "main");
+    assert_eq!(sent[0]["head"], workspace["branch_name"]);
+    assert!(
+        lender
+            .minted()
+            .iter()
+            .all(|repository| repository == "acme/demo"),
+        "every borrow names the one repository: {:?}",
+        lender.minted()
+    );
+
+    // The authored fact came straight from the creation answer — no `gh`
+    // exists here to re-read it (decision 62 meets decision 65).
+    let facts: serde_json::Value = client
+        .get(format!("http://{addr}/code/workspaces/{id}/pull-requests"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let fact = &facts["items"][0];
+    assert_eq!(fact["number"], 7, "{facts}");
+    assert_eq!(fact["author"], "mira-chen", "{facts}");
+    assert_eq!(fact["relation"], "authored", "{facts}");
+}
+
+/// Decision 65: a gateway refusal fails the pull-request creation with the
+/// gateway's reason, before anything reaches the forge.
+#[tokio::test]
+async fn a_hosted_pull_request_create_fails_closed_with_the_gateway_refusal() {
+    let lender = Arc::new(FakeLender::refusing(GitForgeError::NotConnected {
+        connect_url: Some("https://gateway.example/account/apps".to_owned()),
+    }));
+    let (router, token, runtime, dir) =
+        code_app_with(Some(lender.clone() as Arc<dyn GitCredentialLender>)).await;
+    runtime.set_forge_api_base(Some("http://127.0.0.1:9/".to_owned()));
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_paired_repo(dir.path());
+    let (_repo, workspace) =
+        register_and_workspace(&client, addr, &token, &repo, "refused change").await;
+    let id = json_id(&workspace);
+    let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    run(
+        &path,
+        &[
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/acme/demo.git",
+        ],
+    );
+
+    let refused = client
+        .post(format!("http://{addr}/code/workspaces/{id}/git/pr"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    let (status, kind, message) = error_kind(refused).await;
+    assert_eq!(status, reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(kind, "git_forge_refused");
+    assert!(message.contains("connect your GitHub account"), "{message}");
 }

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -846,7 +846,7 @@ async fn a_hosted_machine_creates_and_reads_the_pull_request_over_rest() {
         .send()
         .await
         .unwrap();
-    assert_eq!(created.status(), reqwest::StatusCode::OK);
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let body: serde_json::Value = created.json().await.unwrap();
     assert_eq!(body["pr"]["number"], 7, "{body}");
     assert_eq!(


### PR DESCRIPTION
## Why

Decision 65 rule 4 — the slice that makes person attribution real end to end. A hosted machine has no `gh`, so pull-request creation and the delivery reads were simply unavailable there (decision 63 rule 5 left them as "the next slice"). With the gateway lending the caller's own user token (model-gateway#1326) and clone/push/commits already person-attributed (#2534, #2541, #2544), this makes the pull request itself the person's.

## What

- **`code/forge_rest`** — a deliberately narrow REST surface driven by a per-operation borrowed credential: create, list-for-head, and the PR-card digest (state, checks keyed to the exact head SHA the pull request names, merge-queue state from the same timeline events `gh` reads). Every answer is shaped like the `gh --json` payloads the fact store and digest parsers already consume — one JSON vocabulary, however the host was asked. No verify-head dance: REST checks are read for the named SHA, so they cannot disagree with it.
- **Create** (`create_pull_request_rest`): identical title/body generation to the `gh` path, one borrow, and the authored fact (decision 62) persists straight from the creation answer — no second host read.
- **Status**: the workspace PR read refreshes the digest over REST behind the same 20-second cache as `gh`, borrowing only on a miss and degrading silently on failure, exactly as `gh` does. `review_decision` stays unstated on REST rather than approximated.
- **Push**: the contributed-fact read reuses the push's own borrowed credential — one borrow, one operation.
- **Refusals**: a gateway refusal fails the operation as `git_forge_refused` with the gateway's reason (e.g. the connect-your-account remediation), never an uncredentialed retry.

`gh` paths are byte-for-byte untouched where `gh` exists. Merge, ready, close, comments, CI logs, the delivery panel, and the background reconcile sweep stay `gh`-only for now and keep answering exactly as they do today on machines without it; they are named follow-ups, not accidents.

## Tests

- `a_hosted_machine_creates_and_reads_the_pull_request_over_rest`: a loopback fake forge asserts the borrowed bearer server-side, captures the create body (title/base/head), and serves list/detail/check-runs/timeline; the card digest reads "1 passing, 1 pending, 0 failing" and the authored fact lands with the person as author — with no `gh` anywhere.
- `a_hosted_pull_request_create_fails_closed_with_the_gateway_refusal`: a not-connected caller's create fails with the gateway's connect remediation.
- The existing hosted push/identity tests now pin the digest-read borrows (every borrow names the one repository; a foreign-host origin still borrows nothing) against a dead loopback REST base.
- `forge_rest` unit tests pin the fact-shape restatement (merged-as-closed+mergedAt) and the API-base rule.