### PR TITLE
docs: renumber the one-store decision to 0066

### DIFF
--- a/docs/decisions/0066-pull-request-state-is-one-store.md
+++ b/docs/decisions/0066-pull-request-state-is-one-store.md
@@ -1,4 +1,4 @@
-# 65. Pull-Request State Is One Store with One Fetcher and One Clock
+# 66. Pull-Request State Is One Store with One Fetcher and One Clock
 
 - Status: Accepted
 - Date: 2026-08-24


### PR DESCRIPTION
Two decisions merged as 0065 within the hour: `0065-hosted-git-acts-as-the-person.md` (#2541) and `0065-pull-request-state-is-one-store.md` (#2542). One number should mean one record.

The hosted-git record keeps 0065: fifteen merged code comments across `obo_gateway.rs`/`gh.rs`/`runtime.rs`/`wire.ts` and model-gateway ADR 0087 already cite "decision 65" by that meaning. Nothing cites the one-store file yet (its slices are unbuilt), so it moves to 0066 — filename and title only.