### PR TITLE
feat(desktop): reach everything from one Cmd+K palette

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -77,11 +77,13 @@ import { WindowDragStrip } from "./WindowDragStrip";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
 import {
+  hasOpenModalDialog,
   numberedTabIndex,
   useShellShortcuts,
   type ShellShortcutHandlers,
   type ShellShortcutMode,
 } from "./ShellShortcuts";
+import { CommandPaletteDialog } from "./CommandPaletteDialog";
 import { ShortcutsDialog } from "./ShortcutsDialog";
 import { useUiStore } from "./UiStore";
 import { UPDATE_CHECK_REQUESTED_EVENT, useDesktopUpdates } from "./updates";
@@ -380,6 +382,15 @@ export function AppShell() {
       }),
     "code-split-editor": () => applyCodeLayout(splitFocusedEditor),
     "close-tab": closeTab,
+    "open-command-palette": () => {
+      // The chord is allowed through the modal guard so it can close the
+      // palette. Any other dialog on screen means the reader is mid-decision,
+      // so the key is declined rather than opening a second surface over it.
+      const ui = useUiStore.getState();
+      if (ui.commandPaletteOpen) ui.setCommandPaletteOpen(false);
+      else if (hasOpenModalDialog(document)) return false;
+      else ui.setCommandPaletteOpen(true);
+    },
     "focus-composer": focusComposer,
     "zoom-in": zoom.zoomIn,
     "zoom-out": zoom.zoomOut,
@@ -993,6 +1004,7 @@ export function AppShell() {
             open={shortcutsOpen}
             onOpenChange={setShortcutsOpen}
           />
+          <CommandPaletteDialog />
           {nativeTitlebar && !sidebarCollapsed && (
             <Titlebar
               macOverlay={macOverlayTitlebar}

--- a/crates/tidebreak-desktop/ui/src/CommandPalette.test.ts
+++ b/crates/tidebreak-desktop/ui/src/CommandPalette.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PALETTE_SECTION_ORDER,
+  parsePaletteQuery,
+  rankPaletteRows,
+  rememberPaletteRow,
+  type PaletteRow,
+  type PaletteSection,
+} from "./CommandPalette";
+
+function row(
+  id: string,
+  section: PaletteSection,
+  label: string,
+  keywords?: string,
+): PaletteRow {
+  return { id, section, label, keywords, onSelect: () => {} };
+}
+
+const ROWS: PaletteRow[] = [
+  row("suggested:push", "suggested", "Push"),
+  row("workspace:a", "workspaces", "Pluggable memory system", "feat/memory"),
+  row("workspace:b", "workspaces", "Pr state sync lag", "fix/pr-state"),
+  row("action:rename", "actions", "Rename"),
+  row("action:terminal", "actions", "Toggle terminal"),
+  row("ship:merge", "ship", "Merge, or auto-merge once the checks pass"),
+  row("settings:models", "settings", "Models", "settings"),
+  row("settings:appearance", "settings", "Appearance", "settings"),
+  row("navigate:runs", "navigate", "Runs"),
+];
+
+describe("palette query", () => {
+  it("reads a leading prefix as a scope and strips it from the search", () => {
+    expect(parsePaletteQuery(">merge")).toMatchObject({
+      prefix: ">",
+      scopeLabel: "commands",
+      query: "merge",
+    });
+    expect(parsePaletteQuery("@ mem")).toMatchObject({
+      prefix: "@",
+      query: "mem",
+    });
+  });
+
+  it("leaves a prefix character in the middle of a query alone", () => {
+    // Issue numbers and colors both carry one. Treating it as a scope would
+    // make the list jump as the reader typed.
+    const parsed = parsePaletteQuery("fix #2519");
+    expect(parsed.prefix).toBeNull();
+    expect(parsed.query).toBe("fix #2519");
+  });
+});
+
+describe("palette ranking", () => {
+  it("groups into the order the sections are listed in", () => {
+    const groups = rankPaletteRows(ROWS, "");
+    const seen = groups.map((group) => group.section);
+    const expected = PALETTE_SECTION_ORDER.filter((section) =>
+      seen.includes(section),
+    );
+    expect(seen).toEqual(expected);
+    expect(seen[0]).toBe("suggested");
+  });
+
+  it("matches labels and keywords, so a branch finds its workspace", () => {
+    const groups = rankPaletteRows(ROWS, "memory");
+    const workspaces = groups.find((group) => group.section === "workspaces");
+    expect(workspaces?.rows.map((entry) => entry.id)).toEqual(["workspace:a"]);
+
+    const byBranch = rankPaletteRows(ROWS, "pr-state");
+    expect(
+      byBranch.find((group) => group.section === "workspaces")?.rows[0]?.id,
+    ).toBe("workspace:b");
+  });
+
+  it("shows one suggestion, never a list of them", () => {
+    const many = [
+      ...ROWS,
+      row("suggested:merge", "suggested", "Merge"),
+      row("suggested:watch", "suggested", "Watch"),
+    ];
+    const groups = rankPaletteRows(many, "");
+    expect(groups[0]?.rows).toHaveLength(1);
+  });
+
+  it("caps a section until a prefix says it is the only one being read", () => {
+    const many = [
+      ...ROWS,
+      ...Array.from({ length: 10 }, (_unused, index) =>
+        row(`workspace:extra-${index}`, "workspaces", `Extra ${index}`),
+      ),
+    ];
+    const mixed = rankPaletteRows(many, "");
+    expect(
+      mixed.find((group) => group.section === "workspaces")?.rows,
+    ).toHaveLength(5);
+
+    const scoped = rankPaletteRows(many, "@");
+    expect(scoped.every((group) => group.section === "workspaces")).toBe(true);
+    expect(scoped[0]?.rows.length).toBeGreaterThan(5);
+  });
+
+  it("drops every section a prefix did not ask for", () => {
+    const groups = rankPaletteRows(ROWS, ">");
+    expect(groups.map((group) => group.section)).toEqual(["actions", "ship"]);
+  });
+
+  it("floats a recently picked row when nothing is typed", () => {
+    const groups = rankPaletteRows(ROWS, "", {
+      recents: ["action:terminal"],
+    });
+    const actions = groups.find((group) => group.section === "actions");
+    expect(actions?.rows[0]?.id).toBe("action:terminal");
+  });
+
+  it("lets a real text match beat the memory", () => {
+    // A reader who types is describing what they want, not asking for their
+    // history.
+    const groups = rankPaletteRows(ROWS, "rename", {
+      recents: ["action:terminal"],
+    });
+    const actions = groups.find((group) => group.section === "actions");
+    expect(actions?.rows[0]?.id).toBe("action:rename");
+  });
+
+  it("finds every settings section under the word settings", () => {
+    const groups = rankPaletteRows(ROWS, "settings");
+    const settings = groups.find((group) => group.section === "settings");
+    expect(settings?.rows.map((entry) => entry.id)).toEqual([
+      "settings:models",
+      "settings:appearance",
+    ]);
+  });
+});
+
+describe("palette recents", () => {
+  it("moves a repeat pick to the front rather than duplicating it", () => {
+    const once = rememberPaletteRow("a", []);
+    const twice = rememberPaletteRow("b", once);
+    expect(twice).toEqual(["b", "a"]);
+    expect(rememberPaletteRow("a", twice)).toEqual(["a", "b"]);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/CommandPalette.ts
+++ b/crates/tidebreak-desktop/ui/src/CommandPalette.ts
@@ -1,0 +1,255 @@
+import type { ComponentType } from "react";
+
+import { fuzzyScore } from "./fuzzy";
+import type { ShellShortcutAction } from "./ShellShortcuts";
+import type { StatusTone } from "./code/statusTone";
+
+/**
+ * The command palette's data model, kept apart from the dialog that draws it.
+ *
+ * Everything here is pure: rows in, ordered sections out. The palette is the
+ * one surface that reaches every other one, so the temptation is to let it
+ * import every store and decide what it can see. Instead each half of the app
+ * hands it rows it already knows how to build, and this file only decides what
+ * the reader is looking for and which rows answer it.
+ *
+ * That split is what makes the ordering testable without a DOM, and what keeps
+ * a new command a change to one source rather than to the palette.
+ */
+
+/**
+ * A band of related rows, drawn under its own heading.
+ *
+ * A section is a kind of answer, not a place the row came from: workspace
+ * commands and repo quick actions are both "Actions" because a reader looking
+ * for something to do does not care which list defined it.
+ */
+export type PaletteSection =
+  | "suggested"
+  | "workspaces"
+  | "chats"
+  | "actions"
+  | "ship"
+  | "files"
+  | "settings"
+  | "navigate";
+
+/** The order sections appear in. Empty ones are dropped rather than drawn. */
+export const PALETTE_SECTION_ORDER: readonly PaletteSection[] = [
+  "suggested",
+  "workspaces",
+  "chats",
+  "actions",
+  "ship",
+  "files",
+  "settings",
+  "navigate",
+];
+
+export const PALETTE_SECTION_LABELS: Record<PaletteSection, string> = {
+  suggested: "Suggested",
+  workspaces: "Workspaces",
+  chats: "Recent work",
+  actions: "Actions",
+  ship: "Ship",
+  files: "Files",
+  settings: "Settings",
+  navigate: "Go to",
+};
+
+/** A lucide glyph, typed the way the settings table already types its icons. */
+export type PaletteIcon = ComponentType<{ size?: number; className?: string }>;
+
+export type PaletteRow = {
+  /**
+   * Stable across renders and queries — this is what the recents list
+   * remembers, so a generated id would quietly disable the memory.
+   */
+  id: string;
+  section: PaletteSection;
+  label: string;
+  /**
+   * Words the query may match that the row does not print: a branch name, a
+   * repo, the old name of a renamed command. Matching on more than the label
+   * is what lets `wsp` find a workspace whose title never says "workspace".
+   */
+  keywords?: string;
+  /** Muted trailing text — a repo, a parent path, a relative age. */
+  hint?: string;
+  /** The accent this row's state carries, matching the rail's own tones. */
+  tone?: StatusTone;
+  icon?: PaletteIcon;
+  /**
+   * The chord that does this without the palette, drawn from the shortcut
+   * table. A palette that teaches its own shortcuts is how a reader stops
+   * needing it.
+   */
+  shortcut?: ShellShortcutAction;
+  /** What picking the row does. */
+  onSelect: () => void;
+  /** Kept out of the recents memory — a row nobody means to repeat. */
+  transient?: boolean;
+};
+
+/**
+ * The typed prefixes that narrow the list to one kind of answer.
+ *
+ * Sections already tell the reader what kinds exist, so these are an
+ * accelerator rather than the only way through — which is why they are listed
+ * in the footer instead of being drawn as tabs. Tabs would say the same thing
+ * twice and only the mouse could press them.
+ */
+export const PALETTE_PREFIXES: readonly {
+  char: string;
+  sections: readonly PaletteSection[];
+  label: string;
+}[] = [
+  { char: ">", sections: ["actions", "ship"], label: "commands" },
+  { char: "@", sections: ["workspaces", "chats"], label: "go to" },
+  { char: "#", sections: ["files"], label: "files" },
+];
+
+export type ParsedPaletteQuery = {
+  /** The sections a prefix limits the list to, or `null` for all of them. */
+  sections: readonly PaletteSection[] | null;
+  /** The prefix that did the limiting, for the scope chip. */
+  prefix: string | null;
+  scopeLabel: string | null;
+  /** What rows are actually matched against, with the prefix stripped. */
+  query: string;
+};
+
+/**
+ * Split a raw input into the scope it asks for and the words to match.
+ *
+ * Only a leading prefix counts. A `#` in the middle of a query is part of what
+ * the reader is searching for — issue numbers and CSS colors both have one —
+ * and treating it as a scope would make the list jump as they typed.
+ */
+export function parsePaletteQuery(raw: string): ParsedPaletteQuery {
+  const trimmed = raw.trimStart();
+  for (const prefix of PALETTE_PREFIXES) {
+    if (!trimmed.startsWith(prefix.char)) continue;
+    return {
+      sections: prefix.sections,
+      prefix: prefix.char,
+      scopeLabel: prefix.label,
+      query: trimmed.slice(prefix.char.length).trim(),
+    };
+  }
+  return { sections: null, prefix: null, scopeLabel: null, query: raw.trim() };
+}
+
+/** How many rows a section shows before the reader has to narrow. */
+const SECTION_CAP = 5;
+/** The cap once a prefix says this is the only kind being looked at. */
+const SCOPED_CAP = 12;
+/** The suggestion is one row by definition; two would not be a suggestion. */
+const SUGGESTED_CAP = 1;
+
+export type PaletteGroup = {
+  section: PaletteSection;
+  label: string;
+  rows: PaletteRow[];
+};
+
+/**
+ * The rows that answer a query, grouped and capped.
+ *
+ * Scoring is per section rather than across the whole list, because sections
+ * are ordered by what the reader most likely wants and a strong text match on
+ * a settings page should not push the workspace they are looking at below it.
+ * Recents break ties: with nothing typed every score is zero, so the memory is
+ * the only thing ordering rows, and the palette opens on what was used last.
+ */
+export function rankPaletteRows(
+  rows: readonly PaletteRow[],
+  raw: string,
+  options: { recents?: readonly string[] } = {},
+): PaletteGroup[] {
+  const parsed = parsePaletteQuery(raw);
+  const recents = options.recents ?? [];
+  const scored = new Map<PaletteSection, { row: PaletteRow; rank: number }[]>();
+
+  for (const row of rows) {
+    if (parsed.sections && !parsed.sections.includes(row.section)) continue;
+    const haystack = row.keywords ? `${row.label} ${row.keywords}` : row.label;
+    const score = fuzzyScore(haystack, parsed.query);
+    if (score < 0) continue;
+    const bucket = scored.get(row.section) ?? [];
+    bucket.push({ row, rank: score + recentBonus(row.id, recents) });
+    scored.set(row.section, bucket);
+  }
+
+  const cap = parsed.sections ? SCOPED_CAP : SECTION_CAP;
+  return PALETTE_SECTION_ORDER.flatMap((section) => {
+    const bucket = scored.get(section);
+    if (!bucket || bucket.length === 0) return [];
+    // A stable sort keeps the source's own order — workspaces by recency,
+    // settings in rail order — wherever the ranks come out equal.
+    const ordered = bucket
+      .slice()
+      .sort((left, right) => right.rank - left.rank)
+      .slice(0, section === "suggested" ? SUGGESTED_CAP : cap)
+      .map((entry) => entry.row);
+    return [
+      {
+        section,
+        label: PALETTE_SECTION_LABELS[section],
+        rows: ordered,
+      },
+    ];
+  });
+}
+
+/**
+ * How much a recently picked row floats.
+ *
+ * Small enough that a real text match still wins — a reader who types is
+ * describing what they want, not asking for their history — and large enough
+ * to decide an otherwise flat list.
+ */
+function recentBonus(id: string, recents: readonly string[]): number {
+  const index = recents.indexOf(id);
+  return index < 0 ? 0 : (recents.length - index) * 40;
+}
+
+/** Every row in the groups, flattened into the order they are drawn. */
+export function flattenPaletteGroups(
+  groups: readonly PaletteGroup[],
+): PaletteRow[] {
+  return groups.flatMap((group) => group.rows);
+}
+
+const RECENTS_KEY = "tidebreak.command-palette-recents";
+/** Long enough to cover a working session's habits, short enough to turn over. */
+const RECENTS_LIMIT = 24;
+
+export function readPaletteRecents(): string[] {
+  try {
+    const raw = window.localStorage.getItem(RECENTS_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string");
+  } catch {
+    return [];
+  }
+}
+
+/** Move `id` to the front of the memory and return the new list. */
+export function rememberPaletteRow(
+  id: string,
+  recents: readonly string[],
+): string[] {
+  const next = [id, ...recents.filter((entry) => entry !== id)].slice(
+    0,
+    RECENTS_LIMIT,
+  );
+  try {
+    window.localStorage.setItem(RECENTS_KEY, JSON.stringify(next));
+  } catch {
+    // Preference persistence is best-effort.
+  }
+  return next;
+}

--- a/crates/tidebreak-desktop/ui/src/CommandPaletteDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/CommandPaletteDialog.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+
+import { useApp } from "@/AppContext";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useChatListStore } from "./ChatListStore";
+import { useProjectListStore } from "./ProjectListStore";
+import { useCodeCatalogStore } from "./code/CodeCatalogStore";
+import { useCodeUiStore } from "./code/CodeUiStore";
+import { useWorkspaceDigests } from "./code/CodeUpdatesStore";
+import {
+  codeNavigationPaletteRows,
+  shipPaletteRows,
+  suggestedShipRow,
+  workspaceActionPaletteRows,
+  workspacePaletteRows,
+} from "./code/codePaletteRows";
+import { codeWorkspaceIdFromPath, shellShortcutMode } from "./code/routes";
+import { arrangeWorkspaces } from "./code/workspaceCards";
+import { useWorkspaceCardCommands } from "./code/workspaceActions";
+import {
+  chatNavigationPaletteRows,
+  chatPaletteRows,
+  projectPaletteRows,
+} from "./chatPaletteRows";
+import {
+  parsePaletteQuery,
+  rankPaletteRows,
+  readPaletteRecents,
+  rememberPaletteRow,
+  type PaletteRow,
+} from "./CommandPalette";
+import { CommandPaletteList } from "./CommandPaletteList";
+import { settingsPaletteRows } from "./settingsPaletteRows";
+import { useManagedPolicy } from "./managedPolicy";
+import { useUiStore } from "./UiStore";
+
+/** The tree read is bounded the same way the file picker's is. */
+const TREE_LIMIT = 5000;
+
+/**
+ * The command palette: one keyboard surface over everything the app can do.
+ *
+ * Rows come from each half of the app rather than from here, so this file only
+ * decides what the reader is in front of — which mode, which workspace, which
+ * conversation — and hands that to the sources. Adding a command is a change
+ * to `codePaletteRows` or `chatPaletteRows`, never to this file.
+ *
+ * Mounted once in the shell. Cmd+K is in the shell keymap rather than a
+ * listener here, so it appears in the shortcuts dialog and closes the palette
+ * as well as opening it.
+ */
+export function CommandPaletteDialog() {
+  const { client } = useApp();
+  const navigate = useNavigate();
+  const { managed } = useManagedPolicy();
+  const open = useUiStore((state) => state.commandPaletteOpen);
+  const setOpen = useUiStore((state) => state.setCommandPaletteOpen);
+  const [query, setQuery] = useState("");
+  const [recents, setRecents] = useState<string[]>([]);
+
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const mode = shellShortcutMode(pathname);
+  const workspaceId = codeWorkspaceIdFromPath(pathname);
+
+  const workspaces = useCodeCatalogStore((state) => state.workspaces);
+  const repos = useCodeCatalogStore((state) => state.repos);
+  const digests = useWorkspaceDigests();
+  const railPrefs = useCodeUiStore((state) => state.railPrefs);
+  const suggestion = useCodeUiStore((state) => state.workflowSuggestion);
+  const chats = useChatListStore((state) => state.chats);
+  const projects = useProjectListStore((state) => state.projects);
+  // The same runner the card context menu and the header overflow use, with
+  // its own rename box and archive confirmation. The palette picks a command;
+  // it does not learn how to carry one out.
+  const workspaceRunner = useWorkspaceCardCommands();
+
+  // Read on open rather than on mount: another window may have picked
+  // something since, and the memory is only consulted while the list is up.
+  useEffect(() => {
+    if (open) setRecents(readPaletteRecents());
+    else setQuery("");
+  }, [open]);
+
+  const parsed = parsePaletteQuery(query);
+  const filesWanted = open && (parsed.sections?.includes("files") ?? false);
+  const files = useWorkspaceFilePaths(client, workspaceId, filesWanted);
+
+  const rows = useMemo<PaletteRow[]>(() => {
+    // Settings sections are addressed from a runtime table and never enter the
+    // router's generated path union, so the cast happens once, here.
+    const go = (path: string) => void navigate({ to: path as "/" });
+    const settings = settingsPaletteRows({ managed, navigate: go });
+    // Store actions are stable for the store's lifetime, so reading them here
+    // keeps the memo from re-running on every unrelated store write.
+    const codeUi = useCodeUiStore.getState();
+
+    if (mode === "chat") {
+      return [
+        ...chatPaletteRows({
+          chats,
+          projects,
+          activeChatId: chatIdFromPath(pathname),
+          onOpen: (chat) => go(`/c/${chat.id}`),
+        }),
+        ...projectPaletteRows({
+          projects,
+          onOpen: (project) => go(`/p/${project.id}`),
+        }),
+        ...chatNavigationPaletteRows({
+          navigate: go,
+          onNewChat: () => go("/"),
+        }),
+        ...settings,
+      ];
+    }
+
+    const arranged = arrangeWorkspaces(
+      railPrefs.sortMode,
+      repos,
+      workspaces,
+      digests,
+    );
+    const workspace = workspaces.find((entry) => entry.id === workspaceId);
+    const repo = repos.find((entry) => entry.id === workspace?.repo_id);
+    const digest = workspace ? digests[workspace.id] : undefined;
+
+    return [
+      ...suggestedShipRow({
+        suggestion,
+        workspaceId,
+        onRun: (shortcut) => {
+          if (workspaceId)
+            codeUi.requestWorkflowShortcut(workspaceId, shortcut);
+        },
+      }),
+      ...workspacePaletteRows({
+        workspaces: arranged.flatMap((group) => group.workspaces),
+        repos,
+        digests,
+        activeWorkspaceId: workspaceId,
+        onOpen: (id) => go(`/code/w/${id}`),
+      }),
+      ...(workspace
+        ? workspaceActionPaletteRows({
+            workspace,
+            hasPr: Boolean(workspace.pr),
+            hasSession: Boolean(digest),
+            attentionPinned: digest?.attention.state.type === "manual",
+            quickActions: repo?.quick_actions ?? [],
+            onCommand: (command) =>
+              workspaceRunner.run(command.id, {
+                workspace,
+                title: workspace.title,
+                pr: workspace.pr,
+                actionName: command.actionName,
+              }),
+          })
+        : []),
+      ...(workspaceId
+        ? shipPaletteRows({
+            onRun: (shortcut) => {
+              codeUi.requestWorkflowShortcut(workspaceId, shortcut);
+            },
+          })
+        : []),
+      ...codeNavigationPaletteRows({
+        navigate: go,
+        onNewWorkspace: () => codeUi.startNewWorkspace(repo?.id),
+        onQuickOpen: () => codeUi.requestQuickOpen(),
+      }),
+      ...files.map<PaletteRow>((path) => ({
+        id: `file:${path}`,
+        section: "files",
+        label: path,
+        // A path is a place, not a habit worth floating to the top later.
+        transient: true,
+        onSelect: () => codeUi.requestOpenFilePath(path),
+      })),
+      ...settings,
+    ];
+  }, [
+    mode,
+    managed,
+    navigate,
+    pathname,
+    workspaceId,
+    workspaces,
+    repos,
+    digests,
+    railPrefs,
+    suggestion,
+    chats,
+    projects,
+    files,
+    workspaceRunner,
+  ]);
+
+  const groups = useMemo(
+    () => rankPaletteRows(rows, query, { recents }),
+    [rows, query, recents],
+  );
+
+  function choose(row: PaletteRow) {
+    setOpen(false);
+    if (!row.transient) setRecents(rememberPaletteRow(row.id, recents));
+    row.onSelect();
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          withCloseButton={false}
+          className="top-1/2 max-w-2xl gap-0 overflow-hidden rounded-xl p-0 shadow-2xl"
+          overlayClassName="bg-black/45 backdrop-blur-[1px]"
+        >
+          <DialogTitle className="sr-only">Command palette</DialogTitle>
+          <DialogDescription className="sr-only">
+            Search commands, workspaces, files, and settings.
+          </DialogDescription>
+          <CommandPaletteList
+            groups={groups}
+            query={query}
+            onQueryChange={setQuery}
+            onSelect={choose}
+            scopeLabel={parsed.scopeLabel}
+            mode={mode}
+            loading={filesWanted && files.length === 0}
+            emptyLabel={
+              parsed.query
+                ? `Nothing matches “${parsed.query}”.`
+                : "Nothing here yet."
+            }
+          />
+        </DialogContent>
+      </Dialog>
+      {workspaceRunner.dialogs}
+    </>
+  );
+}
+
+/**
+ * The worktree's paths, read only once the reader asks for files.
+ *
+ * A palette that loaded the tree on every open would pay for a search nobody
+ * requested, on a surface whose whole point is that it opens instantly. The
+ * `#` scope is the ask, and the result is kept for as long as the palette
+ * stays on that workspace.
+ */
+function useWorkspaceFilePaths(
+  client: {
+    listCodeWorkspaceTree: (
+      id: string,
+      options: { limit: number },
+    ) => Promise<{ paths: string[] }>;
+  },
+  workspaceId: string | undefined,
+  wanted: boolean,
+): string[] {
+  const [paths, setPaths] = useState<string[]>([]);
+  const [loadedFor, setLoadedFor] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!wanted || !workspaceId || loadedFor === workspaceId) return;
+    let cancelled = false;
+    void client
+      .listCodeWorkspaceTree(workspaceId, { limit: TREE_LIMIT })
+      .then((tree) => {
+        if (cancelled) return;
+        setPaths(tree.paths);
+        setLoadedFor(workspaceId);
+      })
+      .catch(() => {
+        // The palette still answers with everything else; a failed tree read
+        // is not worth taking the surface down for.
+        if (!cancelled) setLoadedFor(workspaceId);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, workspaceId, wanted, loadedFor]);
+
+  return loadedFor === workspaceId ? paths : [];
+}
+
+/** The conversation a path is showing, when it is showing one. */
+function chatIdFromPath(pathname: string): string | undefined {
+  return /^\/(?:p\/[^/]+\/)?c\/([^/]+)$/.exec(pathname)?.[1];
+}

--- a/crates/tidebreak-desktop/ui/src/CommandPaletteList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/CommandPaletteList.dom.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { rankPaletteRows, type PaletteRow } from "./CommandPalette";
+import { CommandPaletteList } from "./CommandPaletteList";
+
+afterEach(cleanup);
+
+function row(
+  id: string,
+  section: PaletteRow["section"],
+  label: string,
+  extra: Partial<PaletteRow> = {},
+): PaletteRow {
+  return { id, section, label, onSelect: vi.fn(), ...extra };
+}
+
+const ROWS: PaletteRow[] = [
+  row("suggested:push", "suggested", "Push", { tone: "ready" }),
+  row("workspace:a", "workspaces", "Pluggable memory system"),
+  row("action:archive", "actions", "Archive", {
+    shortcut: "code-archive-workspace",
+  }),
+  row("settings:models", "settings", "Models"),
+];
+
+function mount(props: Partial<Parameters<typeof CommandPaletteList>[0]> = {}) {
+  const onQueryChange = vi.fn();
+  const onSelect = vi.fn();
+  render(
+    <CommandPaletteList
+      groups={rankPaletteRows(ROWS, "")}
+      query=""
+      onQueryChange={onQueryChange}
+      onSelect={onSelect}
+      command
+      {...props}
+    />,
+  );
+  return { onQueryChange, onSelect };
+}
+
+describe("command palette list", () => {
+  it("draws each section under its own heading, suggestion first", () => {
+    mount();
+    for (const heading of ["Suggested", "Workspaces", "Actions", "Settings"]) {
+      expect(screen.getByText(heading)).toBeInTheDocument();
+    }
+    const options = screen.getAllByRole("option").map((node) => node.ariaLabel);
+    expect(options[0]).toBe("Push");
+  });
+
+  it("teaches the chord a row already has", () => {
+    // Drawn from the shortcut table rather than written here, so a row can
+    // never advertise a key that does something else.
+    mount();
+    const archive = screen.getByRole("option", { name: "Archive" });
+    expect(archive).toHaveTextContent("⌘");
+    expect(archive).toHaveTextContent("⇧");
+    expect(archive).toHaveTextContent("A");
+  });
+
+  it("hands the whole row back on pick, not just its id", () => {
+    const { onSelect } = mount();
+    screen.getByRole("option", { name: "Models" }).click();
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "settings:models" }),
+    );
+  });
+
+  it("names the scope a prefix put the reader in", () => {
+    mount({
+      query: ">",
+      scopeLabel: "commands",
+      groups: rankPaletteRows(ROWS, ">"),
+    });
+    expect(screen.getByText("commands")).toBeInTheDocument();
+    // Inside a scope the footer explains the way out rather than listing the
+    // other prefixes.
+    expect(screen.getByText("back")).toBeInTheDocument();
+  });
+
+  it("drops the scope on backspace at an empty query", () => {
+    const { onQueryChange } = mount({
+      query: "",
+      scopeLabel: "commands",
+      groups: rankPaletteRows(ROWS, ">"),
+    });
+    screen.getByRole("combobox").focus();
+    return userEvent.keyboard("{Backspace}").then(() => {
+      expect(onQueryChange).toHaveBeenCalledWith("");
+    });
+  });
+
+  it("says what did not match, in the reader's own words", () => {
+    mount({
+      query: "zzzz",
+      groups: rankPaletteRows(ROWS, "zzzz"),
+      emptyLabel: "Nothing matches “zzzz”.",
+    });
+    expect(screen.getByText("Nothing matches “zzzz”.")).toBeInTheDocument();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/CommandPaletteList.tsx
+++ b/crates/tidebreak-desktop/ui/src/CommandPaletteList.tsx
@@ -1,0 +1,219 @@
+import { CornerDownLeft } from "lucide-react";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import { STATUS_DOT } from "./code/statusTone";
+import {
+  PALETTE_PREFIXES,
+  type PaletteGroup,
+  type PaletteRow,
+} from "./CommandPalette";
+import {
+  shellShortcutFor,
+  shortcutKeycaps,
+  usesCommandModifier,
+  type ShellShortcutMode,
+} from "./ShellShortcuts";
+
+/**
+ * The palette's list, with no idea where its rows came from.
+ *
+ * Split from the wired dialog for the reason `ShortcutsList` is split from
+ * `ShortcutsDialog`: a story can draw every state of it — loading, empty, a
+ * scoped query — without standing up a router, a client, or a catalog.
+ * Everything here is props.
+ */
+export function CommandPaletteList({
+  groups,
+  query,
+  onQueryChange,
+  onSelect,
+  scopeLabel = null,
+  mode = "code",
+  loading = false,
+  emptyLabel = "Nothing here matches that.",
+  command = usesCommandModifier(navigator.userAgent),
+}: {
+  groups: readonly PaletteGroup[];
+  query: string;
+  onQueryChange: (query: string) => void;
+  onSelect: (row: PaletteRow) => void;
+  /** The prefix's own word, drawn as a chip so the scope is never invisible. */
+  scopeLabel?: string | null;
+  /** Which mode's chords the rows draw. */
+  mode?: ShellShortcutMode;
+  loading?: boolean;
+  emptyLabel?: string;
+  /** Fixed per story so keycaps look the same wherever they are opened. */
+  command?: boolean;
+}) {
+  return (
+    <Command
+      shouldFilter={false}
+      label="Search commands, workspaces, and settings"
+      className="rounded-none bg-transparent"
+      // Backspace on an empty query drops the scope, which is how the reader
+      // gets out of one without reaching for Escape and losing the whole
+      // palette.
+      onKeyDown={(event) => {
+        if (event.key !== "Backspace" || query.length > 0) return;
+        if (!scopeLabel) return;
+        event.preventDefault();
+        onQueryChange("");
+      }}
+    >
+      {/* Block, not a flex row: the field and the rule under it have to span
+          the palette's whole width, and a flex sibling beside them would make
+          both stop short. The esc cap and the spinner float over the field's
+          right end instead, with the text padded clear of them. */}
+      <div className="relative">
+        <CommandInput
+          value={query}
+          onValueChange={onQueryChange}
+          placeholder="Type a command or search…"
+          autoComplete="off"
+          spellCheck={false}
+          className="h-12 pr-20"
+          leading={
+            scopeLabel ? (
+              <span className="shrink-0 rounded bg-muted px-1.5 py-1 text-xs text-muted-foreground">
+                {scopeLabel}
+              </span>
+            ) : undefined
+          }
+        />
+        {loading && (
+          <Spinner
+            className="absolute top-1/2 right-12 size-4 -translate-y-1/2"
+            aria-label="Loading"
+          />
+        )}
+        <kbd className="absolute top-1/2 right-3 -translate-y-1/2 shrink-0 rounded border px-1.5 py-0.5 font-sans text-[10px] text-muted-foreground">
+          esc
+        </kbd>
+      </div>
+
+      <CommandList className="max-h-[min(60vh,32rem)] min-h-24 p-1.5">
+        <CommandEmpty className="px-3 py-6 text-sm text-muted-foreground">
+          {emptyLabel}
+        </CommandEmpty>
+        {groups.map((group) => (
+          <CommandGroup
+            key={group.section}
+            heading={group.label}
+            className="p-0"
+          >
+            {group.rows.map((row) => (
+              <PaletteItem
+                key={row.id}
+                row={row}
+                mode={mode}
+                command={command}
+                onSelect={onSelect}
+              />
+            ))}
+          </CommandGroup>
+        ))}
+      </CommandList>
+
+      <PaletteFooter scoped={Boolean(scopeLabel)} />
+    </Command>
+  );
+}
+
+function PaletteItem({
+  row,
+  mode,
+  command,
+  onSelect,
+}: {
+  row: PaletteRow;
+  mode: ShellShortcutMode;
+  command: boolean;
+  onSelect: (row: PaletteRow) => void;
+}) {
+  const Icon = row.icon;
+  const def = row.shortcut ? shellShortcutFor(row.shortcut, mode) : null;
+  const caps = def ? shortcutKeycaps(def, command) : [];
+  return (
+    <CommandItem
+      value={row.id}
+      aria-label={row.label}
+      onSelect={() => onSelect(row)}
+      className="gap-2.5 px-2.5 py-2"
+    >
+      {row.tone ? (
+        <span
+          className={cn(
+            "h-4 w-0.5 shrink-0 rounded-full",
+            STATUS_DOT[row.tone],
+          )}
+          aria-hidden
+        />
+      ) : (
+        Icon && (
+          <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        )
+      )}
+      <span className="min-w-0 flex-1 truncate text-sm">{row.label}</span>
+      {row.hint && (
+        <span className="min-w-0 max-w-[45%] shrink-0 truncate text-[11px] text-muted-foreground">
+          {row.hint}
+        </span>
+      )}
+      {caps.length > 0 && (
+        <span className="flex shrink-0 items-center gap-0.5">
+          {caps.map((cap) => (
+            <kbd
+              key={cap}
+              className="inline-flex h-5 min-w-5 items-center justify-center rounded border bg-muted/60 px-1 font-sans text-[10px] leading-none text-muted-foreground"
+            >
+              {cap}
+            </kbd>
+          ))}
+        </span>
+      )}
+    </CommandItem>
+  );
+}
+
+/**
+ * The prefixes, spelled out.
+ *
+ * They are the palette's only invisible affordance, so they live here rather
+ * than in a tour nobody reads. Inside a scope the row explains the way out
+ * instead, which is the thing a reader in one actually needs.
+ */
+function PaletteFooter({ scoped }: { scoped: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-t px-3 py-1.5 text-[10px] text-muted-foreground">
+      <span className="flex items-center gap-2.5">
+        {scoped ? (
+          <span>
+            <kbd className="font-sans">⌫</kbd> back
+          </span>
+        ) : (
+          PALETTE_PREFIXES.map((prefix) => (
+            <span key={prefix.char}>
+              <kbd className="font-sans">{prefix.char}</kbd> {prefix.label}
+            </span>
+          ))
+        )}
+      </span>
+      <span className="flex items-center gap-2.5">
+        <span>↑↓ navigate</span>
+        <span className="flex items-center gap-1">
+          <CornerDownLeft className="size-3" aria-hidden /> run
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.test.ts
@@ -59,7 +59,8 @@ describe("shell shortcut resolution", () => {
     const cases: Array<[Partial<KeyboardEvent>, ShellShortcutAction]> = [
       [{ key: "b", code: "KeyB" }, "toggle-sidebar"],
       [{ key: "n", code: "KeyN" }, "new-chat"],
-      [{ key: "k", code: "KeyK" }, "focus-composer"],
+      [{ key: "k", code: "KeyK" }, "open-command-palette"],
+      [{ key: "l", code: "KeyL" }, "focus-composer"],
       [{ key: "/", code: "Slash" }, "show-shortcuts"],
       [{ key: "0", code: "Digit0" }, "zoom-reset"],
       [{ key: "r", code: "KeyR" }, "reload-app"],
@@ -236,9 +237,13 @@ describe("shell shortcut resolution", () => {
     const dvorakN = keyEvent({ key: "l", code: "KeyN" });
     expect(resolveShellShortcut(dvorakN, context())?.id).toBe("new-chat");
 
-    // And the key that does produce "n" on Dvorak is not a new chat.
+    // And the key that does produce "n" on Dvorak is not a new chat. Dvorak's
+    // "n" sits on the physical L, which chat mode leaves to the composer
+    // shortcut rather than to anything that makes something.
     const dvorakElsewhere = keyEvent({ key: "n", code: "KeyL" });
-    expect(resolveShellShortcut(dvorakElsewhere, context())).toBeNull();
+    expect(resolveShellShortcut(dvorakElsewhere, context())?.id).toBe(
+      "focus-composer",
+    );
   });
 
   it("matches punctuation on the character, which has no fixed position", () => {
@@ -301,6 +306,22 @@ describe("shell shortcut resolution", () => {
       },
     );
     expect(resolved).toBeNull();
+  });
+
+  it("lets the palette's own chord through the modal guard, so it can close", () => {
+    // Every other chord acts behind the dialog and stays suppressed; this one
+    // acts on it. The handler still declines when the open dialog is somebody
+    // else's, which the guard alone cannot tell.
+    const resolved = resolveShellShortcut(
+      keyEvent({ key: "k", code: "KeyK" }),
+      {
+        editable: false,
+        modalOpen: true,
+        command: true,
+        mode: "code",
+      },
+    );
+    expect(resolved?.id).toBe("open-command-palette");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -33,6 +33,7 @@ export type ShellShortcutAction =
   | "code-source-control"
   | "code-archive-workspace"
   | "close-tab"
+  | "open-command-palette"
   | "focus-composer"
   | "zoom-in"
   | "zoom-out"
@@ -124,6 +125,14 @@ export type ShellShortcutDef = ShellShortcutBinding & {
    * so the composer's own focus never swallows them.
    */
   allowInEditable: boolean;
+  /**
+   * Whether the shortcut still fires while a modal dialog is open. Almost
+   * nothing should: the reader is mid-decision, and acting behind the dialog
+   * would be a surprise. The exception is a chord that acts *on* a dialog
+   * rather than behind it — the palette's own toggle closes the palette, which
+   * is the one thing the reader can mean by pressing it again.
+   */
+  allowInModal?: boolean;
 };
 
 export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
@@ -415,8 +424,27 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     allowInEditable: true,
   },
   {
-    id: "focus-composer",
+    // The one chord that reaches everything else: workspaces, the commands
+    // that act on them, settings, and the files. Cmd+K is where a reader
+    // trained on any other tool of this shape looks for it, which is why the
+    // composer gave the chord up.
+    id: "open-command-palette",
     codes: ["KeyK"],
+    mod: true,
+    description: "Search commands, workspaces, and settings",
+    group: "Navigation",
+    allowInEditable: true,
+    // Pressing it again closes the palette. Every other shortcut stays
+    // suppressed while it is open.
+    allowInModal: true,
+  },
+  {
+    // Cmd+L, next to the palette's Cmd+K and matching what the editors this
+    // app sits beside use to reach their agent. It takes the chord from
+    // Monaco's expand-line-selection, which is reachable with Home and
+    // Shift+Down; getting back to the composer from anywhere is not.
+    id: "focus-composer",
+    codes: ["KeyL"],
     mod: true,
     description: "Focus the message composer",
     group: "Work",
@@ -569,6 +597,24 @@ function inScope(def: ShellShortcutDef, mode: ShellShortcutMode): boolean {
   return def.scope === undefined || def.scope === mode;
 }
 
+/**
+ * The definition an action is reached by in a mode, or `null` when none is.
+ *
+ * The command palette draws each row's chord from here, so a row and the help
+ * dialog can never name different keys for the same command. Scoped by mode
+ * for the same reason the help dialog is: an action can be bound differently
+ * on the two sides of the app, and the first match is the one that fires.
+ */
+export function shellShortcutFor(
+  action: ShellShortcutAction,
+  mode: ShellShortcutMode,
+): ShellShortcutDef | null {
+  return (
+    SHELL_SHORTCUTS.find((def) => def.id === action && inScope(def, mode)) ??
+    null
+  );
+}
+
 type ShortcutKeyEvent = Pick<
   KeyboardEvent,
   "key" | "code" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey"
@@ -613,12 +659,12 @@ export function isEditableTarget(target: EventTarget | null): boolean {
 /**
  * The shortcut a key event should trigger, or `null` when none should.
  *
- * A modal dialog on screen suppresses every shell shortcut: the reader is
- * mid-decision, and toggling the frame or starting a new chat behind the
- * dialog would be a surprise. `mode` decides which scoped definitions are live,
- * and is required rather than defaulted so every caller has to say which half
- * of the app the key was pressed in. Kept pure so the guard is testable without
- * a DOM.
+ * A modal dialog on screen suppresses every shell shortcut but the ones marked
+ * `allowInModal`: the reader is mid-decision, and toggling the frame or
+ * starting a new chat behind the dialog would be a surprise. `mode` decides
+ * which scoped definitions are live, and is required rather than defaulted so
+ * every caller has to say which half of the app the key was pressed in. Kept
+ * pure so the guard is testable without a DOM.
  */
 export function resolveShellShortcut(
   event: ShortcutKeyEvent,
@@ -629,8 +675,8 @@ export function resolveShellShortcut(
     mode: ShellShortcutMode;
   },
 ): ShellShortcutDef | null {
-  if (context.modalOpen) return null;
   for (const def of SHELL_SHORTCUTS) {
+    if (context.modalOpen && !def.allowInModal) continue;
     if (!inScope(def, context.mode)) continue;
     if (!matchesShellShortcut(event, def, context.command)) continue;
     if (context.editable && !def.allowInEditable) return null;
@@ -639,8 +685,14 @@ export function resolveShellShortcut(
   return null;
 }
 
-/** A radix dialog or alert dialog currently open on screen. */
-function hasOpenModalDialog(doc: Document): boolean {
+/**
+ * A radix dialog or alert dialog currently open on screen.
+ *
+ * Exported for the palette's own handler: its chord is allowed through the
+ * modal guard so it can close itself, which means the handler has to ask the
+ * question the guard would otherwise have asked for it.
+ */
+export function hasOpenModalDialog(doc: Document): boolean {
   return (
     doc.querySelector(
       '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]',

--- a/crates/tidebreak-desktop/ui/src/UiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/UiStore.ts
@@ -120,6 +120,14 @@ export type UiStore = {
   /** What Enter and the single composer action do while a response is running. */
   activeTurnSendMode: ActiveTurnSendMode;
   setActiveTurnSendMode: (mode: ActiveTurnSendMode) => void;
+  /**
+   * Whether the command palette is up. Here rather than in the code store
+   * because the palette spans both modes, and because the native browser
+   * webview has to know something is drawn over the editor area.
+   */
+  commandPaletteOpen: boolean;
+  setCommandPaletteOpen: (open: boolean) => void;
+  toggleCommandPalette: () => void;
 };
 
 export function createUiStore() {
@@ -149,6 +157,10 @@ export function createUiStore() {
       storeActiveTurnSendMode(mode);
       set({ activeTurnSendMode: mode });
     },
+    commandPaletteOpen: false,
+    setCommandPaletteOpen: (commandPaletteOpen) => set({ commandPaletteOpen }),
+    toggleCommandPalette: () =>
+      set((state) => ({ commandPaletteOpen: !state.commandPaletteOpen })),
   }));
 }
 

--- a/crates/tidebreak-desktop/ui/src/chatPaletteRows.ts
+++ b/crates/tidebreak-desktop/ui/src/chatPaletteRows.ts
@@ -1,0 +1,123 @@
+import {
+  Blocks,
+  FolderOpen,
+  Inbox,
+  MessageSquare,
+  Plus,
+  SquareTerminal,
+} from "lucide-react";
+
+import type { Chat, Project } from "./api";
+import type { PaletteRow } from "./CommandPalette";
+
+/**
+ * What chat mode offers the palette.
+ *
+ * The mirror of `codePaletteRows`, and deliberately smaller: chat mode has one
+ * kind of thing in it. A conversation is reached by name, and everything else
+ * is a place to go.
+ */
+
+/** The untitled fallback the rails already use, so the palette agrees with them. */
+const UNTITLED = "New chat";
+
+/**
+ * Recent conversations, as rows that open them.
+ *
+ * Left in the order the caller passed — the chat list is already sorted by
+ * what happened last — so with nothing typed the palette opens on the same
+ * conversations the sidebar is showing.
+ */
+export function chatPaletteRows(input: {
+  chats: readonly Chat[];
+  projects: readonly Project[];
+  activeChatId?: string | null;
+  onOpen: (chat: Chat) => void;
+}): PaletteRow[] {
+  const projectNames = new Map(
+    input.projects.map((project) => [project.id, project.title ?? "Project"]),
+  );
+  return (
+    input.chats
+      // The conversation already on screen is not somewhere to go.
+      .filter((chat) => chat.id !== input.activeChatId)
+      .map((chat) => {
+        const project = chat.project_id
+          ? projectNames.get(chat.project_id)
+          : undefined;
+        return {
+          id: `chat:${chat.id}`,
+          section: "chats" as const,
+          label: chat.title ?? UNTITLED,
+          hint: project,
+          keywords: project,
+          icon: MessageSquare,
+          onSelect: () => input.onOpen(chat),
+        };
+      })
+  );
+}
+
+/** Projects, as rows that open them. */
+export function projectPaletteRows(input: {
+  projects: readonly Project[];
+  onOpen: (project: Project) => void;
+}): PaletteRow[] {
+  return input.projects.map((project) => ({
+    id: `project:${project.id}`,
+    section: "chats",
+    label: project.title ?? "Project",
+    hint: "Project",
+    keywords: "project folder",
+    icon: FolderOpen,
+    onSelect: () => input.onOpen(project),
+  }));
+}
+
+/** What chat mode does, and where else it goes. */
+export function chatNavigationPaletteRows(input: {
+  navigate: (path: string) => void;
+  onNewChat: () => void;
+}): PaletteRow[] {
+  return [
+    {
+      id: "navigate:new-chat",
+      section: "actions",
+      label: "Start new work",
+      keywords: "new chat conversation",
+      icon: Plus,
+      shortcut: "new-chat",
+      onSelect: input.onNewChat,
+    },
+    {
+      id: "navigate:inbox",
+      section: "navigate",
+      label: "Inbox",
+      icon: Inbox,
+      onSelect: () => input.navigate("/inbox"),
+    },
+    {
+      id: "navigate:apps",
+      section: "navigate",
+      label: "Apps",
+      icon: Blocks,
+      onSelect: () => input.navigate("/apps"),
+    },
+    {
+      id: "navigate:plugins",
+      section: "navigate",
+      label: "Plugins",
+      keywords: "skills prompts library",
+      icon: Blocks,
+      onSelect: () => input.navigate("/plugins"),
+    },
+    {
+      id: "navigate:code",
+      section: "navigate",
+      label: "Go to code",
+      keywords: "workspaces worktrees",
+      icon: SquareTerminal,
+      onSelect: () => input.navigate("/code"),
+    },
+  ];
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import { fuzzyTokenScore, queryTokens } from "@/fuzzy";
 import { friendlyErrorMessage } from "@/lib/utils";
 
 const QUICK_OPEN_LIMIT = 5000;
@@ -214,7 +215,7 @@ export function rankQuickOpenPaths(
   paths: readonly string[],
   query: string,
 ): string[] {
-  const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  const tokens = queryTokens(query);
   if (tokens.length === 0) return [...paths].sort(pathSort);
   const pathQuery = query.includes("/") || query.includes("\\");
   return paths
@@ -232,26 +233,6 @@ export function rankQuickOpenPaths(
         right.score - left.score || pathSort(left.path, right.path),
     )
     .map((entry) => entry.path);
-}
-
-function fuzzyTokenScore(target: string, token: string): number {
-  if (target === token) return 2000;
-  const contiguous = target.indexOf(token);
-  if (contiguous >= 0) {
-    return 1200 - contiguous * 8 - (target.length - token.length);
-  }
-  let cursor = 0;
-  let score = 0;
-  let previous = -2;
-  for (const char of token) {
-    const index = target.indexOf(char, cursor);
-    if (index < 0) return -1;
-    score += index === previous + 1 ? 24 : Math.max(2, 14 - index);
-    if (index === 0 || /[-_.]/.test(target[index - 1] ?? "")) score += 16;
-    previous = index;
-    cursor = index + 1;
-  }
-  return score - target.length;
 }
 
 function fileName(path: string): string {

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import type { HarnessKind } from "../api/types";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
+import type { StatusTone } from "./statusTone";
 import type { WorkflowShortcut } from "./workspaceWorkflow";
 import {
   isCardDensity,
@@ -299,6 +300,37 @@ export type CodeUiStore = {
   archivePending: boolean;
   requestArchiveWorkspace: () => void;
   takeArchiveWorkspace: () => boolean;
+  /**
+   * What the workspace header says the next step is, republished for the
+   * command palette.
+   *
+   * The workflow control already resolves this from the branch and pull-request
+   * state to label its own primary button. The palette leads with the same
+   * answer rather than fetching the snapshot a second time and risking a
+   * different one — a palette that offered "Push" while the header said
+   * "Merge" would be worse than offering nothing.
+   */
+  workflowSuggestion: WorkflowSuggestion | null;
+  publishWorkflowSuggestion: (suggestion: WorkflowSuggestion | null) => void;
+  /**
+   * A path the palette picked, taken by the workspace page that owns the tabs.
+   *
+   * The palette can rank a worktree's files but has nowhere to put one: which
+   * editor group a file opens into is the page's business. So it names the
+   * path and the page opens it, the same way every other cross-surface ask
+   * here works.
+   */
+  openFilePending: string | null;
+  requestOpenFilePath: (path: string) => void;
+  takeOpenFilePath: () => string | null;
+};
+
+/** The header's primary action, as the palette's leading row. */
+export type WorkflowSuggestion = {
+  workspaceId: string;
+  label: string;
+  summary: string;
+  tone: StatusTone;
 };
 
 export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
@@ -346,6 +378,17 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
     if (!get().archivePending) return false;
     set({ archivePending: false });
     return true;
+  },
+  workflowSuggestion: null,
+  publishWorkflowSuggestion: (workflowSuggestion) =>
+    set({ workflowSuggestion }),
+  openFilePending: null,
+  requestOpenFilePath: (path) => set({ openFilePending: path }),
+  takeOpenFilePath: () => {
+    const pending = get().openFilePending;
+    if (pending === null) return null;
+    set({ openFilePending: null });
+    return pending;
   },
   offerComposerPrompt: (scope, prompt) =>
     set({ pendingComposerPrompt: { scope, text: prompt, submit: false } }),

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -234,6 +234,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     (state) => state.setReviewSidebarOpen,
   );
   const quickOpenPending = useCodeUiStore((state) => state.quickOpenPending);
+  const openFilePending = useCodeUiStore((state) => state.openFilePending);
   const archivePending = useCodeUiStore((state) => state.archivePending);
   const terminalPending = useCodeUiStore((state) => state.terminalPending);
   const shortcutHints = useCodeShortcutHints();
@@ -670,6 +671,14 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     if (!useCodeUiStore.getState().takeQuickOpen()) return;
     requestNewTab(splitFocused ? "secondary" : "primary");
   }, [quickOpenPending, splitFocused]);
+
+  // The palette ranks worktree files but has nowhere to put one; the tabs live
+  // here, so it names a path and this opens it.
+  useEffect(() => {
+    if (!openFilePending) return;
+    const path = useCodeUiStore.getState().takeOpenFilePath();
+    if (path) openFile(path);
+  }, [openFilePending]);
 
   // The chord and the rail command both raise the ask above the route, because
   // starting a shell is a server call neither of them can make.

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -116,6 +116,32 @@ export function WorkspaceWorkflowControl({
     model.pr?.checks?.filter(
       (check) => check.bucket === "fail" || check.bucket === "pending",
     ) ?? [];
+
+  // Republish the primary action for the command palette, which leads with it.
+  // Cleared on unmount so the palette never offers a step for a workspace the
+  // reader has already navigated away from.
+  const publishWorkflowSuggestion = useCodeUiStore(
+    (state) => state.publishWorkflowSuggestion,
+  );
+  useEffect(() => {
+    publishWorkflowSuggestion(
+      primaryLabel
+        ? {
+            workspaceId,
+            label: primaryLabel,
+            summary: statusLabel,
+            tone: model.tone,
+          }
+        : null,
+    );
+    return () => publishWorkflowSuggestion(null);
+  }, [
+    publishWorkflowSuggestion,
+    workspaceId,
+    primaryLabel,
+    statusLabel,
+    model.tone,
+  ]);
   // While a watch runs, agent actions would contend for the same worktree;
   // local Git and navigation actions stay available.
   const secondaryActions = watchActive

--- a/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
@@ -1,0 +1,285 @@
+import {
+  Archive,
+  Bell,
+  FileText,
+  GitPullRequest,
+  MessageSquare,
+  Play,
+  Plus,
+  Terminal,
+} from "lucide-react";
+
+import type {
+  CodeRepoSnapshot,
+  CodeSessionDigest,
+  CodeWorkspaceSnapshot,
+} from "../api/types";
+import type { PaletteRow } from "@/CommandPalette";
+import { SHELL_SHORTCUTS, type ShellShortcutAction } from "@/ShellShortcuts";
+import { digestStatusTone } from "./statusTone";
+import type { WorkflowSuggestion } from "./CodeUiStore";
+import { formatCompactAge } from "./workspaceCards";
+import type { WorkflowShortcut } from "./workspaceWorkflow";
+import {
+  workspaceCommands,
+  type WorkspaceCommand,
+  type WorkspaceCommandId,
+} from "./workspaceActions";
+
+/**
+ * What code mode offers the palette.
+ *
+ * Rows are built here rather than in the palette so the palette never has to
+ * know what a workspace is. Everything is a plain function over snapshots the
+ * caller already holds, which is also what lets the ordering be tested without
+ * a store.
+ */
+
+/**
+ * The Ship chords, as palette rows.
+ *
+ * Both the label and the keycaps come from the shortcut table, so a command
+ * that moves keys moves in the palette too and the row can never advertise a
+ * chord that does something else.
+ */
+const SHIP_ROWS: readonly {
+  action: ShellShortcutAction;
+  shortcut: WorkflowShortcut;
+}[] = [
+  { action: "code-workflow-next", shortcut: "next" },
+  { action: "code-create-pr", shortcut: "pull_request" },
+  { action: "code-source-control", shortcut: "source_control" },
+  { action: "code-update-branch", shortcut: "update_branch" },
+  { action: "code-watch-pr", shortcut: "watch" },
+  { action: "code-merge-pr", shortcut: "merge" },
+  { action: "code-view-pr", shortcut: "view_pr" },
+];
+
+function shortcutDescription(action: ShellShortcutAction): string {
+  return (
+    SHELL_SHORTCUTS.find((def) => def.id === action && def.scope === "code")
+      ?.description ?? action
+  );
+}
+
+/**
+ * The single row that leads the list: whatever this workspace's next step is.
+ *
+ * The workflow control already computes it for the header's primary button and
+ * republishes it, so the palette shows the same answer rather than a second
+ * opinion. Opening the palette on a branch that is ready to push and being
+ * offered "Push" first is the whole reason to reach for it mid-flow.
+ */
+export function suggestedShipRow(input: {
+  suggestion: WorkflowSuggestion | null;
+  workspaceId?: string;
+  onRun: (shortcut: WorkflowShortcut) => void;
+}): PaletteRow[] {
+  const { suggestion } = input;
+  if (!suggestion || suggestion.workspaceId !== input.workspaceId) return [];
+  return [
+    {
+      id: `suggested:${suggestion.label}`,
+      section: "suggested",
+      label: suggestion.label,
+      hint: suggestion.summary,
+      tone: suggestion.tone,
+      shortcut: "code-workflow-next",
+      // What is next changes with the branch, so remembering this row would
+      // float a step the workspace has already moved past.
+      transient: true,
+      onSelect: () => input.onRun("next"),
+    },
+  ];
+}
+
+/** The Ship chords for the open workspace. */
+export function shipPaletteRows(input: {
+  onRun: (shortcut: WorkflowShortcut) => void;
+}): PaletteRow[] {
+  return SHIP_ROWS.map(({ action, shortcut }) => ({
+    id: `ship:${shortcut}`,
+    section: "ship",
+    label: shortcutDescription(action),
+    icon: GitPullRequest,
+    shortcut: action,
+    onSelect: () => input.onRun(shortcut),
+  }));
+}
+
+/**
+ * Every workspace, as a row that jumps to it.
+ *
+ * Ordered by the caller — the rail's own arrangement — and left that way,
+ * because with nothing typed the palette should open on the same list the
+ * reader already has a mental picture of. The digest supplies the accent, so a
+ * workspace waiting on an answer is as visible here as it is on the rail.
+ */
+export function workspacePaletteRows(input: {
+  workspaces: readonly CodeWorkspaceSnapshot[];
+  repos: readonly CodeRepoSnapshot[];
+  digests: Readonly<Record<string, CodeSessionDigest | undefined>>;
+  activeWorkspaceId?: string;
+  nowMs?: number;
+  onOpen: (workspaceId: string) => void;
+}): PaletteRow[] {
+  const repoNames = new Map(
+    input.repos.map((repo) => [repo.id, repo.display_name]),
+  );
+  return (
+    input.workspaces
+      // The one already on screen is not somewhere to go.
+      .filter((workspace) => workspace.id !== input.activeWorkspaceId)
+      .map((workspace) => {
+        const digest = input.digests[workspace.id];
+        const age = formatCompactAge(workspace.created_at, input.nowMs);
+        const repo = repoNames.get(workspace.repo_id);
+        return {
+          id: `workspace:${workspace.id}`,
+          section: "workspaces" as const,
+          label: workspace.title,
+          keywords: [workspace.branch_name, repo].filter(Boolean).join(" "),
+          hint: [repo, age].filter(Boolean).join(" · "),
+          tone: digestStatusTone(digest),
+          onSelect: () => input.onOpen(workspace.id),
+        };
+      })
+  );
+}
+
+/**
+ * The open workspace's own commands, and the repo's quick actions.
+ *
+ * `workspaceCommands` is the same list the card's context menu reads, so the
+ * palette is a third surface over one definition rather than a third
+ * definition. A command that needs a name or a confirmation still gets one —
+ * the palette only picks it, and `useWorkspaceCardCommands` runs it.
+ *
+ * `fork-agent` is left out: it opens into a tab, which only the workspace page
+ * knows how to place.
+ */
+export function workspaceActionPaletteRows(input: {
+  workspace: CodeWorkspaceSnapshot;
+  hasPr: boolean;
+  hasSession: boolean;
+  attentionPinned: boolean;
+  quickActions: readonly { name: string }[];
+  onCommand: (command: WorkspaceCommand) => void;
+}): PaletteRow[] {
+  const archived = input.workspace.status === "archived";
+  const commands = workspaceCommands({
+    hasPr: input.hasPr,
+    archived,
+    hasSession: input.hasSession,
+    attentionPinned: input.attentionPinned,
+  });
+  const quick: WorkspaceCommand[] = archived
+    ? []
+    : input.quickActions.map((action) => ({
+        id: "run-quick-action" as const,
+        label: `Run: ${action.name}`,
+        actionName: action.name,
+      }));
+  return [...commands, ...quick]
+    .filter(
+      // "Open workspace" is where the reader already is, and a fork needs a
+      // tab to land in.
+      (command) => command.id !== "open" && command.id !== "fork-agent",
+    )
+    .map((command) => ({
+      id: `action:${command.id}${command.actionName ? `:${command.actionName}` : ""}`,
+      section: "actions" as const,
+      label: command.label.replace(/…$/, ""),
+      icon: ACTION_ICONS[command.id],
+      shortcut: ACTION_SHORTCUTS[command.id],
+      onSelect: () => input.onCommand(command),
+    }));
+}
+
+const ACTION_ICONS: Partial<Record<WorkspaceCommandId, PaletteRow["icon"]>> = {
+  "new-session": Plus,
+  "toggle-terminal": Terminal,
+  "open-pr": GitPullRequest,
+  "run-quick-action": Play,
+  archive: Archive,
+  "force-archive": Archive,
+  restore: Archive,
+};
+
+/** The commands a chord already reaches, so the row can teach it. */
+const ACTION_SHORTCUTS: Partial<
+  Record<WorkspaceCommandId, ShellShortcutAction>
+> = {
+  "toggle-terminal": "toggle-code-terminal",
+  "open-pr": "code-view-pr",
+  archive: "code-archive-workspace",
+};
+
+/** Where else code mode goes. */
+export function codeNavigationPaletteRows(input: {
+  navigate: (path: string) => void;
+  onNewWorkspace: () => void;
+  onQuickOpen: () => void;
+}): PaletteRow[] {
+  return [
+    {
+      id: "navigate:code-new-workspace",
+      section: "actions",
+      label: "New workspace",
+      icon: Plus,
+      shortcut: "code-new-workspace",
+      onSelect: input.onNewWorkspace,
+    },
+    {
+      id: "navigate:pull-requests",
+      section: "navigate",
+      label: "Pull requests",
+      keywords: "delivery prs",
+      icon: GitPullRequest,
+      onSelect: () => input.navigate("/code/delivery/pull-requests"),
+    },
+    {
+      id: "navigate:runs",
+      section: "navigate",
+      label: "Runs",
+      keywords: "delivery checks ci",
+      icon: Play,
+      onSelect: () => input.navigate("/code/delivery/runs"),
+    },
+    {
+      id: "navigate:notifications",
+      section: "navigate",
+      label: "Notifications",
+      icon: Bell,
+      onSelect: () => input.navigate("/code/notifications"),
+    },
+    {
+      id: "navigate:archive",
+      section: "navigate",
+      label: "Archived workspaces",
+      icon: Archive,
+      onSelect: () => input.navigate("/code/archive"),
+    },
+    {
+      id: "navigate:chat",
+      section: "navigate",
+      label: "Go to chat",
+      keywords: "work conversations",
+      icon: MessageSquare,
+      onSelect: () => input.navigate("/"),
+    },
+    {
+      id: "navigate:quick-open",
+      section: "files",
+      label: "Open a file by name…",
+      keywords: "quick open goto file",
+      icon: FileText,
+      shortcut: "code-quick-open",
+      // The tree is thousands of paths and a palette that loaded it on every
+      // open would pay for a search nobody asked for. This row is the same
+      // picker Cmd+P opens, for a reader who did not know the chord.
+      transient: true,
+      onSelect: input.onQuickOpen,
+    },
+  ];
+}

--- a/crates/tidebreak-desktop/ui/src/components/ui/command.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/command.tsx
@@ -21,10 +21,23 @@ Command.displayName = CommandPrimitive.displayName;
 
 const CommandInput = React.forwardRef<
   React.ComponentRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
-  <div className="flex items-center gap-2 border-b px-3" cmdk-input-wrapper="">
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & {
+    /**
+     * Drawn inside the field, between the search glyph and the text. For a
+     * scope chip or token that belongs to what is being typed rather than
+     * beside it — putting one outside the wrapper makes the field, and the
+     * rule under it, stop short of the surface's own width.
+     */
+    leading?: React.ReactNode;
+    wrapperClassName?: string;
+  }
+>(({ className, leading, wrapperClassName, ...props }, ref) => (
+  <div
+    className={cn("flex items-center gap-2 border-b px-3", wrapperClassName)}
+    cmdk-input-wrapper=""
+  >
     <SearchIcon className="size-4 shrink-0 opacity-50" aria-hidden />
+    {leading}
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/crates/tidebreak-desktop/ui/src/fuzzy.ts
+++ b/crates/tidebreak-desktop/ui/src/fuzzy.ts
@@ -1,0 +1,66 @@
+/**
+ * The one fuzzy matcher the keyboard surfaces rank with.
+ *
+ * The file picker and the command palette are the same interaction over
+ * different rows — type a few letters, take the first hit — so they score the
+ * same way. Two scorers would mean `wsp` finding a file and missing the
+ * workspace command named after it, and nobody would be able to say why.
+ *
+ * Scores are comparable only within one call site's candidate set: they carry
+ * a length penalty, so a short label and a long path are not on one scale.
+ */
+
+/**
+ * How well `target` matches a single `token`, or `-1` for no match at all.
+ *
+ * Exact beats prefix beats substring beats scattered letters, and a letter
+ * landing on a word boundary counts for more than one in the middle — `cpr`
+ * should find `create-pr` ahead of anything that merely contains those three
+ * letters in order.
+ */
+export function fuzzyTokenScore(target: string, token: string): number {
+  if (target === token) return 2000;
+  const contiguous = target.indexOf(token);
+  if (contiguous >= 0) {
+    return 1200 - contiguous * 8 - (target.length - token.length);
+  }
+  let cursor = 0;
+  let score = 0;
+  let previous = -2;
+  for (const char of token) {
+    const index = target.indexOf(char, cursor);
+    if (index < 0) return -1;
+    score += index === previous + 1 ? 24 : Math.max(2, 14 - index);
+    if (index === 0 || /[-_.]/.test(target[index - 1] ?? "")) score += 16;
+    previous = index;
+    cursor = index + 1;
+  }
+  return score - target.length;
+}
+
+/**
+ * How well `target` matches a whole query, or `-1` when any word misses.
+ *
+ * Words are scored independently and added, so the query reads as a set of
+ * things that must all be true rather than a phrase — "pr merge" finds the
+ * merge command whichever order the row happens to name them in. An empty
+ * query matches everything at zero, which leaves the caller's own ordering
+ * intact.
+ */
+export function fuzzyScore(target: string, query: string): number {
+  const tokens = queryTokens(query);
+  if (tokens.length === 0) return 0;
+  const haystack = target.toLocaleLowerCase();
+  let total = 0;
+  for (const token of tokens) {
+    const score = fuzzyTokenScore(haystack, token);
+    if (score < 0) return -1;
+    total += score;
+  }
+  return total;
+}
+
+/** The lowercased words of a query, with the whitespace thrown away. */
+export function queryTokens(query: string): string[] {
+  return query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+}

--- a/crates/tidebreak-desktop/ui/src/settingsPaletteRows.ts
+++ b/crates/tidebreak-desktop/ui/src/settingsPaletteRows.ts
@@ -1,0 +1,31 @@
+import { settingsSectionsFor } from "./settings/sections";
+import type { PaletteRow } from "./CommandPalette";
+
+/**
+ * Every settings section as its own palette row.
+ *
+ * Settings is a rail of a dozen panels, and reaching one has always meant
+ * opening settings and then finding it. Naming each section here makes the
+ * panel the target instead of the trip: "appear" lands on Appearance without
+ * the reader deciding which section a thing lives in first.
+ *
+ * The list is the same one the settings rail draws, filtered the same way, so
+ * a managed profile does not get offered a section it cannot open. `navigate`
+ * is a callback because settings sections come from a runtime table and never
+ * enter the router's generated path union.
+ */
+export function settingsPaletteRows(input: {
+  managed: boolean;
+  navigate: (path: string) => void;
+}): PaletteRow[] {
+  return settingsSectionsFor(input.managed).map((section) => ({
+    id: `settings:${section.path}`,
+    section: "settings",
+    label: section.label,
+    // So that typing the word finds every section, not only the ones whose
+    // label happens to contain it.
+    keywords: `settings ${section.path.replace(/-/g, " ")}`,
+    icon: section.icon,
+    onSelect: () => input.navigate(`/settings/${section.path}`),
+  }));
+}

--- a/crates/tidebreak-desktop/ui/src/stories/CommandPalette.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CommandPalette.stories.tsx
@@ -1,0 +1,323 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { Archive, GitPullRequest, Plus, Terminal } from "lucide-react";
+
+import { CommandPaletteList } from "@/CommandPaletteList";
+import { rankPaletteRows, type PaletteRow } from "@/CommandPalette";
+
+/**
+ * The Cmd+K palette's list.
+ *
+ * Rows are fixtures here rather than store reads, and `command` is fixed per
+ * story, so what the story draws is the same wherever it is opened. The
+ * ranking is the real one: each story passes its rows through
+ * `rankPaletteRows`, so section order, the per-section cap, and the fuzzy
+ * match are what ship rather than a hand-arranged list.
+ */
+
+const workspaceRows: PaletteRow[] = [
+  {
+    id: "workspace:ws-2",
+    section: "workspaces",
+    label: "Pluggable memory system",
+    hint: "tidebreak · 5m",
+    tone: "running",
+    onSelect: fn(),
+  },
+  {
+    id: "workspace:ws-3",
+    section: "workspaces",
+    label: "feat(web): step the New app dialog instead of one long scroll",
+    hint: "tidebreak · 12m",
+    tone: "warning",
+    onSelect: fn(),
+  },
+  {
+    id: "workspace:ws-4",
+    section: "workspaces",
+    label: "feat(code): draft the create-PR request into the composer",
+    hint: "tidebreak · 14m",
+    tone: "ready",
+    onSelect: fn(),
+  },
+  {
+    id: "workspace:ws-5",
+    section: "workspaces",
+    label: "Sentry catalog gaps",
+    hint: "gateway · 2h",
+    tone: "neutral",
+    onSelect: fn(),
+  },
+  {
+    id: "workspace:ws-6",
+    section: "workspaces",
+    label: "Pr state sync lag",
+    hint: "tidebreak · 1d",
+    tone: "critical",
+    onSelect: fn(),
+  },
+];
+
+const actionRows: PaletteRow[] = [
+  {
+    id: "action:new-session",
+    section: "actions",
+    label: "New session",
+    icon: Plus,
+    onSelect: fn(),
+  },
+  {
+    id: "action:toggle-terminal",
+    section: "actions",
+    label: "Toggle terminal",
+    icon: Terminal,
+    shortcut: "toggle-code-terminal",
+    onSelect: fn(),
+  },
+  {
+    id: "action:rename",
+    section: "actions",
+    label: "Rename",
+    onSelect: fn(),
+  },
+  {
+    id: "action:archive",
+    section: "actions",
+    label: "Archive",
+    icon: Archive,
+    shortcut: "code-archive-workspace",
+    onSelect: fn(),
+  },
+];
+
+const shipRows: PaletteRow[] = [
+  {
+    id: "ship:pull_request",
+    section: "ship",
+    label: "Push and open a pull request",
+    icon: GitPullRequest,
+    shortcut: "code-create-pr",
+    onSelect: fn(),
+  },
+  {
+    id: "ship:merge",
+    section: "ship",
+    label: "Merge, or auto-merge once the checks pass",
+    icon: GitPullRequest,
+    shortcut: "code-merge-pr",
+    onSelect: fn(),
+  },
+  {
+    id: "ship:watch",
+    section: "ship",
+    label: "Watch the pull request and fix failures",
+    icon: GitPullRequest,
+    shortcut: "code-watch-pr",
+    onSelect: fn(),
+  },
+];
+
+const settingsRows: PaletteRow[] = [
+  {
+    id: "settings:models",
+    section: "settings",
+    label: "Models",
+    onSelect: fn(),
+  },
+  {
+    id: "settings:appearance",
+    section: "settings",
+    label: "Appearance",
+    onSelect: fn(),
+  },
+  {
+    id: "settings:coding-harnesses",
+    section: "settings",
+    label: "Coding harnesses",
+    onSelect: fn(),
+  },
+];
+
+const navigateRows: PaletteRow[] = [
+  {
+    id: "navigate:pull-requests",
+    section: "navigate",
+    label: "Pull requests",
+    onSelect: fn(),
+  },
+  { id: "navigate:runs", section: "navigate", label: "Runs", onSelect: fn() },
+  {
+    id: "navigate:chat",
+    section: "navigate",
+    label: "Go to chat",
+    onSelect: fn(),
+  },
+];
+
+const suggestedRow: PaletteRow = {
+  id: "suggested:create_pr",
+  section: "suggested",
+  label: "Open pull request",
+  hint: "2 commits ahead of main",
+  tone: "ready",
+  shortcut: "code-workflow-next",
+  onSelect: fn(),
+};
+
+const codeRows: PaletteRow[] = [
+  suggestedRow,
+  ...workspaceRows,
+  ...actionRows,
+  ...shipRows,
+  ...navigateRows,
+  ...settingsRows,
+];
+
+const chatRows: PaletteRow[] = [
+  {
+    id: "chat:c-1",
+    section: "chats",
+    label: "Pricing page copy",
+    hint: "Marketing",
+    onSelect: fn(),
+  },
+  {
+    id: "chat:c-2",
+    section: "chats",
+    label: "Postgres index review",
+    onSelect: fn(),
+  },
+  {
+    id: "navigate:new-chat",
+    section: "actions",
+    label: "Start new work",
+    icon: Plus,
+    shortcut: "new-chat",
+    onSelect: fn(),
+  },
+  { id: "navigate:inbox", section: "navigate", label: "Inbox", onSelect: fn() },
+  {
+    id: "navigate:code",
+    section: "navigate",
+    label: "Go to code",
+    onSelect: fn(),
+  },
+  ...settingsRows,
+];
+
+const meta = {
+  component: CommandPaletteList,
+  title: "Foundations/Command palette",
+  args: {
+    query: "",
+    onQueryChange: fn(),
+    onSelect: fn(),
+    command: true,
+    mode: "code",
+    groups: rankPaletteRows(codeRows, ""),
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl overflow-hidden rounded-xl border border-border-subtle bg-popover shadow-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CommandPaletteList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Code mode at rest. The workspace's next ship step leads, because that is what
+ * a reader mid-flow reaches the palette for; the rail's workspaces follow.
+ */
+export const CodeMode: Story = {};
+
+/**
+ * Typing narrows every section at once, which is the point of not making the
+ * reader pick a kind first.
+ */
+export const Filtered: Story = {
+  args: {
+    query: "pr",
+    groups: rankPaletteRows(codeRows, "pr"),
+  },
+};
+
+/** `>` drops everything that is not a command, and says so in the chip. */
+export const CommandScope: Story = {
+  args: {
+    query: ">merge",
+    scopeLabel: "commands",
+    groups: rankPaletteRows(codeRows, ">merge"),
+  },
+};
+
+/** `@` scopes to workspaces, and lifts the five-row cap now that it is the only section. */
+export const WorkspaceScope: Story = {
+  args: {
+    query: "@",
+    scopeLabel: "go to",
+    groups: rankPaletteRows(codeRows, "@"),
+  },
+};
+
+/** Quick access to settings: every section is its own row. */
+export const Settings: Story = {
+  args: {
+    query: "settings",
+    groups: rankPaletteRows(
+      [
+        ...codeRows,
+        ...[
+          "Providers",
+          "Model Gateway",
+          "Context",
+          "Agents",
+          "Permissions",
+        ].map<PaletteRow>((label) => ({
+          id: `settings:${label}`,
+          section: "settings",
+          label,
+          keywords: "settings",
+          onSelect: fn(),
+        })),
+      ],
+      "settings",
+    ),
+  },
+};
+
+/** `#` reads the worktree, which is the one thing here that takes a moment. */
+export const FilesLoading: Story = {
+  args: {
+    query: "#",
+    scopeLabel: "files",
+    loading: true,
+    groups: [],
+    emptyLabel: "Reading the worktree…",
+  },
+};
+
+/** Nothing matched, named so the reader can see what they typed. */
+export const NoMatches: Story = {
+  args: {
+    query: "zzzz",
+    groups: rankPaletteRows(codeRows, "zzzz"),
+    emptyLabel: "Nothing matches “zzzz”.",
+  },
+};
+
+/** Chat mode, where conversations are the things and there is nothing to ship. */
+export const ChatMode: Story = {
+  args: {
+    mode: "chat",
+    groups: rankPaletteRows(chatRows, ""),
+  },
+};
+
+/** The same list on a keyboard whose modifier is Ctrl rather than Cmd. */
+export const WindowsKeycaps: Story = {
+  args: { command: false },
+};


### PR DESCRIPTION
## What

Cmd+K opens a command palette across both modes. Cmd+L takes over focusing the composer.

Cmd+K used to focus the composer — something the composer's own click target already does. The palette is the higher-value use of the chord, and Cmd+L is where the tools this app sits beside put "get me to the agent". It takes the chord from Monaco's expand-line-selection, which is reachable with Home and Shift+Down; getting back to the composer from anywhere is not.

## How

`CommandPalette.ts` is the pure core — prefix parsing, per-section fuzzy ranking, caps, and a recents memory. `CommandPaletteList.tsx` is presentational and is what Storybook renders. `CommandPaletteDialog.tsx` wires it to the stores.

Rows come from sources each half of the app owns (`code/codePaletteRows.ts`, `chatPaletteRows.ts`, `settingsPaletteRows.ts`), so adding a command changes a source rather than the palette.

Code mode leads with the workspace's next ship step. The workflow control already resolves it to label its primary button, so it republishes it through the store rather than the palette fetching the snapshot again and risking a different answer. Then the rail's workspaces with their status accents, that workspace's commands via the same `useWorkspaceCardCommands()` runner the context menu uses, the Ship chords, navigation, and every settings section as its own row.

`>` scopes to commands, `@` to workspaces or chats, `#` to files. Only `#` reads the worktree — the tree is thousands of paths and the palette has to open instantly.

Rows that a chord already reaches draw their keycaps from `shortcutKeycaps()`, so the palette cannot advertise a key that does something else.

### Notable

- `ShellShortcutDef` gains `allowInModal`. Only the palette's own chord sets it, so Cmd+K can close the palette; every other shortcut stays suppressed behind a dialog. The handler still declines when the open dialog belongs to someone else, which the guard alone cannot tell.
- `fuzzyTokenScore` moves out of `CodeQuickOpen` into `fuzzy.ts`, shared by both surfaces.
- `CommandInput` gains an optional `leading` slot so a scope chip sits inside the field. Additive — the plugins panel, quick open, and add-repo palette are unchanged.
- `fork-agent` is left out of the palette: it opens into a tab only the workspace page can place.

## Checks

`tsc`, biome lint and format, `storybook:build`, and all 1765 tests pass locally.

Nine stories under `Foundations/Command palette`: code mode at rest, filtered, each scope, settings, files loading, no matches, chat mode, and Ctrl keycaps. Each passes its fixtures through the real `rankPaletteRows`, so they show shipped ordering rather than a hand-arranged list.