### PR TITLE
docs: memory records, scopes, and a pluggable backend boundary

### DIFF
--- a/docs/decisions/0067-memory-records-and-scopes.md
+++ b/docs/decisions/0067-memory-records-and-scopes.md
@@ -1,0 +1,143 @@
+# 67. Memory Records and Scopes
+
+- Status: Proposed
+- Date: 2026-08-24
+- Owners: memory
+- Related: decisions 19, 31, 48, 59, 61; [docs/code-mode.md](../code-mode.md)
+
+## Context
+
+Nothing durable and curated survives a session. Chats have transcripts and
+semantic checkpoints (decision 19); code sessions have journals and per-turn
+recaps. All of it is episodic: a compression of one conversation, owned by
+that conversation. A preference the user states in one chat is relearned in
+the next. A fact about a repository proven in one workspace is rediscovered
+in the next worktree. The knowledge exists in the product's own records; no
+structure carries it forward.
+
+Whatever carries it forward inherits standing constraints. It must be
+engine-neutral (decisions 30 and 31): external harnesses consume it too, so
+the format cannot assume the internal loop or a coding agent. It must be
+owner-scoped and code-shaped (decision 48), or convergence step 5 has to
+translate it. Schema changes are appended migrations (decision 61). And it
+is user data: the user must be able to see, edit, and truly delete every
+piece of it.
+
+The failure modes are well documented wherever long-lived agent memory has
+shipped. Stores grow without bound until whatever selects from them starts
+missing. Model-written entries acquire authority nobody granted: one wrong
+"fact" silently degrades every later session. Derived summaries hide what
+the system believes from the person it believes it about. Deleting a source
+does not delete what was already distilled from it. Stale entries mislead
+with the confidence of fresh ones. And memory is a persistence vector:
+content planted in a store today shapes behavior weeks later, across
+sessions — which is what separates memory poisoning from ordinary prompt
+injection and makes provenance and review load-bearing rather than nice.
+
+## Decision
+
+**A memory record is a markdown document with a typed envelope.** The body
+is plain markdown, capped near 2 KiB. The envelope carries: `id`; `scope`;
+`kind` (`fact | preference | lesson | reference`); `status`; `title` — one
+line, written as a retrieval hook that says when the record matters;
+provenance (`author`: user, model, or import; origin session, turn, and
+workspace ids where present; `evidence`: references to the specific journal
+events or messages that justify the record); optional links to other
+records; optional `expires`; created and updated timestamps. Markdown plus
+this envelope is the interchange contract every storage backend must speak;
+indexes of any kind stay backend-internal, mirroring the flatten-on-switch
+rule in [docs/model-providers.md](../model-providers.md).
+
+**Evidence is enforced at the storage layer.** A model-authored record
+without resolvable evidence references is rejected — not stored with the
+references stripped, and not stored evidence-less. A memory the system
+cannot justify is not expressible. User-authored records carry authorship
+instead.
+
+**Status is a lifecycle: `tracking → proposed → active → archived`, plus
+`rejected`.** Only `active` records carry authority. Model-authored records
+enter as `proposed` and require user action to activate; a per-scope
+auto-commit opt-in exists and defaults to off. Weak signals do not reach
+review at all: a single observation of a pattern becomes a `tracking`
+record — a durable hypothesis carrying an observation count and its
+evidence — and graduates to `proposed` only after the pattern repeats
+across distinct sessions. Hypotheses are visible in the manager, never
+injected, and expire mechanically when not re-observed. Dismissed
+proposals persist as `rejected` for a horizon so capture can see them and
+not re-propose. A record superseded by a merge is archived with a
+`superseded_by` pointer; every mutation appends a revision, so what the
+system believes, on what evidence, and since when is always answerable.
+
+**Scopes are `personal` and `repo`, and the enum is non-exhaustive.**
+Personal records follow the owner across every surface. Repo records bind
+to a registered repository — the durable identity — never to a workspace,
+which reclaim tiers (decision 59) can erase. Chats use the personal scope;
+when decision 48 reaches step 5, a conversation bound to a repo-backed
+workspace picks up that repo's scope with no new structure. Wider scopes
+are future enum variants, not a redesign.
+
+**The store is bounded, and overflow coaches instead of evicting.** Each
+scope has an active-record cap and a digest byte cap. A write that would
+breach the cap fails with an error that names the outs — consolidate
+overlapping records, archive something no longer true, or update an
+existing record instead of adding — and nothing is ever silently evicted
+or truncated.
+
+**The digest is a derived render, never a stored artifact.** What injects
+into context is a deterministic render of the active records: title lines
+with absolute dates, grouped by kind, ordered by recency of update,
+framed as dated point-in-time claims rather than current truth. Because
+the digest is recomputed from records, deleting a record deletes it
+everywhere; there is no distilled copy that survives its source.
+
+Deliberately excluded: any hidden derived profile the user cannot read and
+edit; ingestion of external documents or knowledge sources (records derive
+from the user's own work in this product); and mirroring an engine's own
+instruction or memory files into records — files in a worktree are
+repository-owned changes, reviewed as code.
+
+## Alternatives Considered
+
+**An unbounded store with retrieval ranking.** Rejected. Once the store
+outgrows its context budget, a selection step exists, and every selection
+step can miss — important-but-dissimilar entries vanish exactly when they
+matter, and stale entries accumulate instead of being confronted. The
+bounded active set makes recall exhaustive (every record's title is always
+present) and moves precision to write time, where thresholds and review
+are cheap.
+
+**A rolling profile summary.** One model-maintained text rewritten in
+place is compact but unauditable: entries cannot be individually deleted
+or dated, a bad rewrite silently drops or inverts beliefs with no trail,
+and the user cannot see what changed. Every failure mode in the Context
+section lands on this shape.
+
+**Workspace scope.** Rejected: workspaces are deliberately ephemeral.
+Knowledge keyed to them fragments across worktrees and dies with reclaim.
+
+**Do nothing — checkpoints and recaps suffice.** Rejected. Both are
+episodic and conversation-owned. Neither is scoped, curated, reviewable,
+or injectable across sessions, and decision 19 deliberately scopes
+checkpoints to a conversation's own cache.
+
+## Consequences
+
+New tables arrive as appended migrations (decision 61). The review queue
+becomes mandatory product surface: a memory system whose writes wait for
+review without a place to review them is not shipped. Caps mean curation
+pressure is a user-visible experience, by design. Evidence-at-storage
+makes audit possible and deletion total, and costs a resolution step on
+every model write. Chat-side structure beyond the personal scope waits for
+decision 48 step 5; demand for a project-like scope before then would
+force this record open again.
+
+## Validation
+
+Deleting a record removes it from the next digest render and from search
+results, with nothing derived retaining it. A plausible wrong
+implementation stores the rendered digest as its own artifact and keeps
+serving deleted content; the deletion test must force a render and assert
+absence. A model-authored write with unresolvable evidence is rejected
+loudly. At the cap, a create fails with the coaching error and the store
+is unchanged. `tracking` records never appear in any digest render. Two
+renders of an identical store are byte-identical.

--- a/docs/decisions/0068-memory-backend-boundary.md
+++ b/docs/decisions/0068-memory-backend-boundary.md
@@ -1,0 +1,160 @@
+# 68. Memory: One Record Vocabulary Behind a Backend Boundary
+
+- Status: Proposed
+- Date: 2026-08-24
+- Owners: memory
+- Related: decisions 19, 21, 31, 33, 35, 48, 50, 53, 60, 61, 67;
+  [docs/model-providers.md](../model-providers.md)
+
+## Context
+
+Decision 67 defines what a memory record is. This record defines where
+records live, how they reach a session, and how they get written — under
+constraints this repository has already committed to. Engines are external
+and varied, and a session's engine may not be a local child process
+(decision 31; the remote-execution entry in
+[docs/deferred.md](../deferred.md)). Some installs run with zero model
+configuration, because harnesses bring their own authentication. Prompt
+caching economics punish any per-turn churn in the composed prompt
+(decision 19 exists because of them). The session journal has a single
+writer (decision 35). Background work is a durable sweep reading rows, not
+a prompt loop (decisions 50 and 60), and anything an agent receives that
+the user did not type names its own origin (decision 60). Users also
+already run their own memory tooling as MCP servers; the product should
+compose with that, not fight it.
+
+## Decision
+
+**One trait, exhaustive capabilities, in-tree backends.** Storage sits
+behind a `MemoryBackend` trait in `tidebreak-core`, with the record types
+beside the domain model. Operations: verbatim put, ingest (extraction
+intent, optional), get, list, update, set-status, delete, search,
+assemble-context (the digest render), and revision history. Each backend
+states a `MemoryCaps` value for every capability flag — extraction,
+lexical search, semantic search, consolidation, context assembly, revision
+history, verified delete, asynchronous writes, agent-editable surfaces —
+as `Supported`, `Unsupported`, or `Unknown`, constructed exhaustively with
+no `Default`, exactly as decision 31 requires of harness adapters. An
+unsupported capability degrades visibly. Backends are in-tree; a
+third-party store lands as a PR, not a plugin. Write receipts are honest
+about the layer they guarantee: `Committed` or `Pending`, and the default
+backend commits row, digest render, and revision in one transaction.
+
+**The default backend is rows plus lexical search.** Records live in
+owner-scoped database rows holding the markdown documents verbatim.
+Search scores full bodies in-process and returns the record id, title,
+date, and matching line — an injectable bundle in one call. No embeddings,
+no vector store, no graph, and no model calls on the read path. Semantic
+retrieval is a capability a future or third-party backend declares, and it
+must ship with a readiness signal that distinguishes "index not ready"
+from "no results".
+
+**Third parties plug in at two depths, and never as mirrors.** Tool depth:
+any memory MCP server mounts through the existing MCP runtime today, zero
+code. Backend depth: the trait. What is rejected in both cases is a live
+synchronization with an engine's native memory files — semantics we
+cannot honor (no proposed state, no provenance, no review) drifting in
+both directions. The session journal is the neutral observation point;
+one-time import through the export format covers migration.
+
+**Injection is a pinned snapshot.** Work mode: the digest renders into one
+section of the composed prompt, pinned per conversation — rendered at the
+first turn and reused verbatim until a boundary that already rebuilds the
+prefix (a new conversation, a compaction checkpoint per decision 19, a
+model switch, an explicit refresh). A record saved mid-conversation
+reaches the store immediately and the prompt at the next boundary; its
+content is already in the transcript that produced it. Code mode: the
+digest and record bodies materialize as read-only markdown files in the
+session's private read root — never inside the worktree, so the repository
+cannot index them — and the path is named once in the first turn's engine
+text. Engines with a config-injected MCP surface additionally get a memory
+verb (propose, search, read) over the loopback bridge that decision 33
+established for approvals, gated per adapter by an honest capability flag.
+Every injected digest names its origin and frames records as dated
+point-in-time claims the current conversation overrides.
+
+**Capture is post-turn, model-supplied by this product, and bounded.**
+After a turn's journal write commits, one structured-output derivation
+runs on the utility model role: the same machinery that produces titles
+and recaps, one-shot cache mode, claim-gated per session, skipped for
+turns with no substantive activity. It reads the turn's journaled material
+plus the current digest, tracked hypotheses, and recently rejected titles,
+and yields nothing, an update to an existing record, a proposal, or a
+hypothesis observation — under decision 67's thresholds. No engine ever
+runs memory derivation: the memory plane works identically for every
+harness and for installs with no harness at all. Where no utility model
+resolves, capture and maintenance are off and the settings surface says
+so; injection and explicit writes, which need no model, keep working.
+
+**Maintenance is a durable sweep.** Consolidation and expiry follow the
+decision 50/60 shape: work list read from rows each tick, a per-scope
+fingerprint so a standing condition fires once, one bounded utility-model
+step per tick, running only while the owner has no active turn. Merge
+suggestions are proposals citing their source records; approval activates
+the merge and archives the sources with `superseded_by` in one
+transaction. Dismissal parks the scope until its record set changes.
+Passes are rate-bounded and the last run is visible.
+
+Deliberately excluded: multi-call write-time adjudication pipelines (an
+extraction call plus a per-candidate judgment call on every write — the
+cost and fragility live on the hot path and the failure modes are silent);
+a long-lived curator agent whose own conversation is the store of record
+(unbounded hidden state, with invariants enforced only by prompt rules);
+and auto-committed model writes, per decision 67.
+
+## Alternatives Considered
+
+**Adopt an external memory service as the default store.** Rejected. The
+product surface — capture, review, injection, materialization, the
+manager, scoping, governance — exists in every variant and is the bulk of
+the work; a service default adds a runtime dependency a local-first
+desktop app cannot carry, cannot express the proposed/active lifecycle or
+storage-enforced evidence, and would make one vendor's schema the neutral
+contract every other backend must translate to. External systems remain
+first-class through MCP today and the trait when demand shows.
+
+**Re-render the digest every turn.** Rejected: every accepted record would
+invalidate the conversation's prompt cache from the system prompt down.
+The pinned snapshot costs a bounded staleness window that the transcript
+itself covers.
+
+**Let the working engine write memories mid-turn.** Rejected: it burns
+foreground latency and context, couples capture to engine cooperation the
+capability flags say we do not have everywhere, and judges signal at the
+moment of maximum recency bias. Post-turn distance plus repetition
+thresholds is the deliberate posture.
+
+**Do nothing and rely on user-mounted MCP memory tools.** Rejected as the
+default: nothing injects, so recall depends on the model deciding to
+search; nothing is reviewed, so writes accrue authority ungated; and
+nothing spans engines that lack MCP support. It remains fully supported as
+an option.
+
+## Consequences
+
+Work-mode turn completion gains its first post-completion hook, beside the
+existing front-of-turn derivations. `HarnessCaps` grows a flag for
+config-injected MCP tools, which every adapter must answer; engines
+without it show a stated limitation on the memory verb. The journal stays
+single-writer — capture reads events and writes memory rows, never journal
+events. Model cost is one small structured call per qualifying turn plus
+rate-bounded maintenance, both on the cheapest configured route and both
+visible. Zero-model installs get a reduced but honest feature. Revisit if
+a provider ships a server-side memory primitive worth delegating to, or if
+a real third-party backend cannot be expressed in the capability
+vocabulary.
+
+## Validation
+
+The cache invariant is the test that matters most: activate, update, and
+delete records mid-conversation, then assert the next turn's composed
+prompt fingerprint is byte-identical to the previous turn's. A plausible
+wrong implementation re-renders the digest from the live store on every
+turn — it passes every functional test and silently pays a full cache
+rewrite on each memory change; only the fingerprint assertion fails it.
+`MemoryCaps` construction is compile-exhaustive, so a new flag breaks
+every backend until answered. With no resolvable utility model, the
+settings surface reports capture as not configured rather than silently
+idle. Materialized memory files never resolve to a path inside the
+worktree. A turn with no substantive activity produces no derivation
+call.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -271,6 +271,32 @@ purpose:
   steer, review completion — is a thin client of a reachable deployment and
   waits on the self-host member-client path above.
 
+## Memory that outlives a session
+
+Decision records
+[67](decisions/0067-memory-records-and-scopes.md) and
+[68](decisions/0068-memory-backend-boundary.md) specify durable,
+reviewable memory: scoped records captured from completed turns, reviewed
+before they gain authority, and injected as a bounded digest into both
+surfaces. The first slices are ordinary issues. What stays parked here:
+
+- An organization-scoped shared store with deliberate promotion of
+  personal records and review on the way up, behind the same backend
+  boundary, once a governed remote store exists to host it. Promotion is
+  explicit and record-by-record; nothing is ever derived from observed
+  traffic.
+- Episodic search: read-only lexical search across past sessions'
+  journals and recaps, as a recall tier beneath the curated records.
+- A continuous one-way mirror of memory records into a user-chosen
+  folder, and a folder-backed storage backend for users who keep
+  knowledge in versioned plain files. The mirror is derived output, never
+  read back.
+- Semantic retrieval as a declared backend capability, only with a
+  readiness signal that distinguishes an unready index from an empty
+  result, and retrieval diagnostics that make degradation visible.
+- A dedicated memory model role, if maintenance judgment outgrows what
+  the utility role's models deliver.
+
 ## What this means for planning
 
 V1 is not a claim that Tidebreak has every kind of automation or connector. It


### PR DESCRIPTION
Two decision records specifying durable, reviewable memory across chat and code, plus the parked tail in deferred.md.

- **Record 67 — Memory records and scopes.** A memory record is a markdown document with a typed envelope: kinds, a tracking/proposed/active/archived/rejected lifecycle, evidence enforced at the storage layer (a model-authored record without resolvable evidence is not expressible), personal and repo scopes, hard caps with a coached overflow error instead of silent eviction, and a digest that is always a derived render so deleting a record deletes it everywhere.
- **Record 68 — One record vocabulary behind a backend boundary.** A MemoryBackend trait with exhaustive capability flags on the decision-31 pattern; a default backend of owner-scoped rows with in-process lexical search and one-transaction writes; injection as a per-conversation pinned digest (work mode) and read-only files in the session's private read root plus a loopback MCP verb (code mode); post-turn capture on the utility model with repetition thresholds; maintenance as a durable sweep per decisions 50/60. Third parties plug in via MCP or the trait — never as live mirrors of engine-native stores.
- **deferred.md** gains the parked tail: org-scoped shared store with explicit promotion, episodic search, a one-way file mirror and folder backend, semantic retrieval as a declared capability, a dedicated memory model role.

Slice 0 of #2551. Closes #2552.