### PR TITLE
docs(decisions): renumber the code session queue record to 0067

### DIFF
--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -1360,7 +1360,7 @@ fn code_trigger_fire_outbox_indexes() -> Vec<IndexCreateStatement> {
     ]
 }
 
-/// Durable per-session queued follow-ups (decision 65).
+/// Durable per-session queued follow-ups (decision 67).
 ///
 /// Mirrors the chat `queued_turn` contract onto code sessions: a message
 /// accepted while the session or its workspace checkout is busy parks as a

--- a/crates/tidebreak-core/src/db/ops/code/queued.rs
+++ b/crates/tidebreak-core/src/db/ops/code/queued.rs
@@ -1,6 +1,6 @@
 //! Durable queued follow-ups for code sessions: messages accepted while the
 //! session or its workspace checkout was busy, promoted into real turns
-//! strictly FIFO once the session worker is free (decision 65).
+//! strictly FIFO once the session worker is free (decision 67).
 //!
 //! The chat queue (decision 9) proves promotion through the turn-admission
 //! table because any process may promote. A code session has exactly one

--- a/crates/tidebreak-desktop/ui/src/QueueTray.tsx
+++ b/crates/tidebreak-desktop/ui/src/QueueTray.tsx
@@ -54,7 +54,7 @@ export function chatQueueApi(client: ApiClient, chatId: string): QueueTrayApi {
   };
 }
 
-/** The code-session queue (`/code/sessions/{id}/queued`), decision 65. */
+/** The code-session queue (`/code/sessions/{id}/queued`), decision 67. */
 export function codeQueueApi(
   client: ApiClient,
   sessionId: string,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -538,7 +538,7 @@ describe("CodeWorkspacePage", () => {
     expect(pane).not.toBeNull();
     expect(view?.parentElement?.className).toMatch(/flex/);
     // The queue tray's slot sits between the transcript and the composer
-    // (decision 65); the composer stays next in the same column.
+    // (decision 67); the composer stays next in the same column.
     expect(view?.nextElementSibling?.nextElementSibling).toContainElement(
       screen.getByRole("button", { name: "Send message" }),
     );

--- a/crates/tidebreak-desktop/ui/src/stories/QueueTray.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/QueueTray.stories.tsx
@@ -4,7 +4,7 @@ import { QueueTray, type QueueTrayApi, type QueueTrayRow } from "@/QueueTray";
 
 /**
  * The durable message queue above the composer, shared by chat and code
- * sessions (decisions 9 and 65).
+ * sessions (decisions 9 and 67).
  *
  * Every row is a server-owned queued turn: edit, reorder, delete, and
  * send-now are real API calls behind the adapter, and the tray only observes.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -126,7 +126,7 @@ pub(crate) enum SubmitTurnOutcome {
     /// The session was idle; the turn ran to a terminal event.
     Ran(Box<CodeTurn>),
     /// The session or its workspace was busy; the message parked as a
-    /// durable queue row (decision 65).
+    /// durable queue row (decision 67).
     Queued(Box<CodeQueuedTurn>),
     /// The durable trigger delivery behind this submit was already accepted
     /// by an earlier attempt; nothing new was written.
@@ -2104,7 +2104,7 @@ impl CodeRuntime {
         if let Some(reason) = self.workspace_fence_reason(owner, &session).await? {
             return Err(ServerError::conflict_kind("workspace_fenced", reason));
         }
-        // Queue-default (0009, 0065): a send while a turn is in flight parks
+        // Queue-default (0009, 0067): a send while a turn is in flight parks
         // as a durable queue row. This does not consult mid_turn_steering —
         // that cap gates the separate /steer route only. A backlog parks the
         // send even with no open turn: rows ahead of this message must run
@@ -2194,7 +2194,7 @@ impl CodeRuntime {
         .await
     }
 
-    /// Park a message as a durable queue row (decision 65).
+    /// Park a message as a durable queue row (decision 67).
     ///
     /// The row id is minted here and becomes the promoted turn's id. The cap
     /// is checked before the insert so an overfull queue answers with a typed

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -127,7 +127,7 @@ pub(crate) struct WorkerHandle {
 /// How a worker gets its next turn, and when it may start one.
 ///
 /// Queued follow-ups are durable `code_queued_turn` rows the worker drains
-/// FIFO (decision 65); `wake` is how an enqueue, a resume, or a send-now
+/// FIFO (decision 67); `wake` is how an enqueue, a resume, or a send-now
 /// tells the worker to look again. `worktree` is shared with every other
 /// session in the workspace, and holding it is what keeps two agents from
 /// editing one checkout at the same time (record 55).
@@ -814,7 +814,7 @@ async fn set_permission_mode(
     }
 }
 
-/// Run every promotable queued row, oldest first (decision 65).
+/// Run every promotable queued row, oldest first (decision 67).
 ///
 /// Each round snapshots the durable FIFO head and drives it as a turn;
 /// [`promote_queued_turn`] deletes the row and inserts the turn together, so
@@ -1084,7 +1084,7 @@ async fn drive_turn_inner(
     let mut turn = CodeTurn {
         // A promoted queue row already carries the turn's id: inserting under
         // it is what lets the row deletion and the turn insertion commit as
-        // one write (decision 65).
+        // one write (decision 67).
         id: queued_row
             .as_ref()
             .map_or_else(CodeTurnId::new, |row| row.id),

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1423,7 +1423,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
         .expect("a queued row is addressable")
         .to_owned();
 
-    // Depth is no longer one (decision 65): a second mid-turn send parks
+    // Depth is no longer one (decision 67): a second mid-turn send parks
     // behind the first instead of refusing with queue_full.
     let second = client
         .post(format!("http://{addr}/code/sessions/{session_id}/turns"))

--- a/docs/decisions/0067-durable-code-session-queue.md
+++ b/docs/decisions/0067-durable-code-session-queue.md
@@ -1,4 +1,4 @@
-# 65. Code sessions queue follow-ups durably, on the chat queue's contract
+# 67. Code sessions queue follow-ups durably, on the chat queue's contract
 
 - Status: Accepted
 - Date: 2026-08-24


### PR DESCRIPTION
PR #2545 (durable code session queue) and the hosted-git person record both merged as decision 0065; hosted-git landed first, and the pull-request-state record already moved to 0066 for the same collision (#2549). The queue record takes the next free number, 0067, and the code comments that cite it move with it. The hosted-git references to decision 65 are untouched. No behavior changes.