### PR TITLE
docs: renumber the queue decision from duplicate 0065 to 0069

### DIFF
--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -1360,7 +1360,7 @@ fn code_trigger_fire_outbox_indexes() -> Vec<IndexCreateStatement> {
     ]
 }
 
-/// Durable per-session queued follow-ups (decision 65).
+/// Durable per-session queued follow-ups (decision 69).
 ///
 /// Mirrors the chat `queued_turn` contract onto code sessions: a message
 /// accepted while the session or its workspace checkout is busy parks as a

--- a/crates/tidebreak-core/src/db/ops/code/queued.rs
+++ b/crates/tidebreak-core/src/db/ops/code/queued.rs
@@ -1,6 +1,6 @@
 //! Durable queued follow-ups for code sessions: messages accepted while the
 //! session or its workspace checkout was busy, promoted into real turns
-//! strictly FIFO once the session worker is free (decision 65).
+//! strictly FIFO once the session worker is free (decision 69).
 //!
 //! The chat queue (decision 9) proves promotion through the turn-admission
 //! table because any process may promote. A code session has exactly one

--- a/crates/tidebreak-desktop/ui/src/QueueTray.tsx
+++ b/crates/tidebreak-desktop/ui/src/QueueTray.tsx
@@ -54,7 +54,7 @@ export function chatQueueApi(client: ApiClient, chatId: string): QueueTrayApi {
   };
 }
 
-/** The code-session queue (`/code/sessions/{id}/queued`), decision 65. */
+/** The code-session queue (`/code/sessions/{id}/queued`), decision 69. */
 export function codeQueueApi(
   client: ApiClient,
   sessionId: string,

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -538,7 +538,7 @@ describe("CodeWorkspacePage", () => {
     expect(pane).not.toBeNull();
     expect(view?.parentElement?.className).toMatch(/flex/);
     // The queue tray's slot sits between the transcript and the composer
-    // (decision 65); the composer stays next in the same column.
+    // (decision 69); the composer stays next in the same column.
     expect(view?.nextElementSibling?.nextElementSibling).toContainElement(
       screen.getByRole("button", { name: "Send message" }),
     );

--- a/crates/tidebreak-desktop/ui/src/stories/QueueTray.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/QueueTray.stories.tsx
@@ -4,7 +4,7 @@ import { QueueTray, type QueueTrayApi, type QueueTrayRow } from "@/QueueTray";
 
 /**
  * The durable message queue above the composer, shared by chat and code
- * sessions (decisions 9 and 65).
+ * sessions (decisions 9 and 69).
  *
  * Every row is a server-owned queued turn: edit, reorder, delete, and
  * send-now are real API calls behind the adapter, and the tray only observes.

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -126,7 +126,7 @@ pub(crate) enum SubmitTurnOutcome {
     /// The session was idle; the turn ran to a terminal event.
     Ran(Box<CodeTurn>),
     /// The session or its workspace was busy; the message parked as a
-    /// durable queue row (decision 65).
+    /// durable queue row (decision 69).
     Queued(Box<CodeQueuedTurn>),
     /// The durable trigger delivery behind this submit was already accepted
     /// by an earlier attempt; nothing new was written.
@@ -2194,7 +2194,7 @@ impl CodeRuntime {
         .await
     }
 
-    /// Park a message as a durable queue row (decision 65).
+    /// Park a message as a durable queue row (decision 69).
     ///
     /// The row id is minted here and becomes the promoted turn's id. The cap
     /// is checked before the insert so an overfull queue answers with a typed

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -127,7 +127,7 @@ pub(crate) struct WorkerHandle {
 /// How a worker gets its next turn, and when it may start one.
 ///
 /// Queued follow-ups are durable `code_queued_turn` rows the worker drains
-/// FIFO (decision 65); `wake` is how an enqueue, a resume, or a send-now
+/// FIFO (decision 69); `wake` is how an enqueue, a resume, or a send-now
 /// tells the worker to look again. `worktree` is shared with every other
 /// session in the workspace, and holding it is what keeps two agents from
 /// editing one checkout at the same time (record 55).
@@ -814,7 +814,7 @@ async fn set_permission_mode(
     }
 }
 
-/// Run every promotable queued row, oldest first (decision 65).
+/// Run every promotable queued row, oldest first (decision 69).
 ///
 /// Each round snapshots the durable FIFO head and drives it as a turn;
 /// [`promote_queued_turn`] deletes the row and inserts the turn together, so
@@ -1084,7 +1084,7 @@ async fn drive_turn_inner(
     let mut turn = CodeTurn {
         // A promoted queue row already carries the turn's id: inserting under
         // it is what lets the row deletion and the turn insertion commit as
-        // one write (decision 65).
+        // one write (decision 69).
         id: queued_row
             .as_ref()
             .map_or_else(CodeTurnId::new, |row| row.id),

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -1423,7 +1423,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
         .expect("a queued row is addressable")
         .to_owned();
 
-    // Depth is no longer one (decision 65): a second mid-turn send parks
+    // Depth is no longer one (decision 69): a second mid-turn send parks
     // behind the first instead of refusing with queue_full.
     let second = client
         .post(format!("http://{addr}/code/sessions/{session_id}/turns"))

--- a/docs/decisions/0069-durable-code-session-queue.md
+++ b/docs/decisions/0069-durable-code-session-queue.md
@@ -1,4 +1,4 @@
-# 65. Code sessions queue follow-ups durably, on the chat queue's contract
+# 69. Code sessions queue follow-ups durably, on the chat queue's contract
 
 - Status: Accepted
 - Date: 2026-08-24


### PR DESCRIPTION
## What changed

PR #2545 merged its decision record as 0065, which decision 0065 (hosted git acts as the person) already holds — the repository's third numbering collision. This renames the record to 0069, the next free number, updates its title line, and repoints the ten queue-feature code comments that cited decision 65 (migration, queued ops, session worker, runtime, QueueTray, and two tests). Every remaining "decision 65" reference belongs to the hosted-git record and is untouched, including the generated wire.ts doc comments.

## Validation

Comment-and-filename changes only; biome check passes on the two edited UI files, and a repo-wide grep confirms all ten queue references now cite 69 while the hosted-git references still cite 65. CI compiles the Rust; nothing behavioral changed.

## Compatibility and risk

None — no code paths, schemas, or wire formats change.