### PR TITLE
test(desktop): expand Storybook state coverage

### DIFF
--- a/crates/tidebreak-desktop/ui/.storybook/preview.tsx
+++ b/crates/tidebreak-desktop/ui/.storybook/preview.tsx
@@ -45,7 +45,23 @@ const preview: Preview = {
     },
     options: {
       storySort: {
-        order: ["Foundations", "Conversation", "Code"],
+        order: [
+          "Foundations",
+          "Shell",
+          "Navigation",
+          "Conversation",
+          "Composer",
+          "Chat",
+          "Code",
+          "Outputs",
+          "Documents",
+          "Sources",
+          "Attachments",
+          "Apps",
+          "Plugins",
+          "Settings",
+          "Modes",
+        ],
       },
     },
     viewport: {
@@ -54,9 +70,17 @@ const preview: Preview = {
           name: "Desktop canvas",
           styles: { width: "1280px", height: "800px" },
         },
+        wideDesktop: {
+          name: "Wide desktop",
+          styles: { width: "1440px", height: "900px" },
+        },
         conversation: {
           name: "Conversation pane",
           styles: { width: "760px", height: "800px" },
+        },
+        minimumWindow: {
+          name: "Minimum window (720 × 480)",
+          styles: { width: "720px", height: "480px" },
         },
         compact: {
           name: "Compact pane",

--- a/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
@@ -1424,7 +1424,7 @@ describe("file attachment chips", () => {
       </SourceNavProvider>,
     );
 
-    await user.click(screen.getByRole("button", { name: "brief.pdf" }));
+    await user.click(screen.getByRole("button", { name: "Open brief.pdf" }));
     expect(openDocument).toHaveBeenCalledWith("document-1");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/TranscriptFileAttachments.tsx
+++ b/crates/tidebreak-desktop/ui/src/TranscriptFileAttachments.tsx
@@ -22,7 +22,9 @@ export function TranscriptFileAttachments({
         <li key={file.documentId}>
           <button
             type="button"
-            className="flex max-w-64 items-center gap-2 rounded-lg border border-border bg-background/70 px-3 py-2 text-left text-xs text-foreground hover:bg-accent"
+            className="flex max-w-full items-center gap-2 rounded-lg border border-border bg-background/70 px-3 py-2 text-left text-xs text-foreground transition-colors hover:bg-accent disabled:cursor-default disabled:opacity-60 disabled:hover:bg-background/70 sm:max-w-64"
+            aria-label={`Open ${file.name}`}
+            disabled={!navigation}
             onClick={() => navigation?.openDocument(file.documentId)}
           >
             <DocumentIcon mediaType={file.mediaType} className="size-4" />

--- a/crates/tidebreak-desktop/ui/src/components/document/FileDownloadProgress.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/document/FileDownloadProgress.tsx
@@ -21,12 +21,14 @@ export function FileDownloadProgressIndicator({
   return (
     <div
       className={cn(
-        "flex h-64 items-center justify-center text-muted-foreground",
+        "flex h-64 items-center justify-center px-4 text-muted-foreground",
         className,
       )}
+      role="status"
+      aria-live="polite"
       {...props}
     >
-      <div className="flex flex-col items-center gap-3">
+      <div className="flex w-full max-w-64 flex-col items-center gap-3 text-center">
         <Loader2Icon className="size-6 animate-spin" />
         <div className="flex flex-col items-center gap-1">
           <p>Downloading document…</p>
@@ -40,7 +42,7 @@ export function FileDownloadProgressIndicator({
         <Progress
           value={percentage}
           aria-label="Download progress"
-          className="w-64"
+          className="w-full"
         />
       </div>
     </div>

--- a/crates/tidebreak-desktop/ui/src/components/document/error.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/document/error.tsx
@@ -3,8 +3,11 @@ import type { PropsWithChildren } from "react";
 
 export function DocumentError(props: PropsWithChildren) {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 py-10 font-bold text-muted-foreground">
-      <CircleAlertIcon className="size-4" />
+    <div
+      className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center text-sm text-muted-foreground"
+      role="alert"
+    >
+      <CircleAlertIcon className="size-5" aria-hidden="true" />
       {props.children}
     </div>
   );

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputRevisionSources.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputRevisionSources.tsx
@@ -50,7 +50,8 @@ export function OutputRevisionSources({
                   type="button"
                   title={source.label}
                   aria-label={source.label}
-                  className="inline-flex max-w-64 items-center gap-1.5 rounded-full border bg-card px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                  className="inline-flex max-w-64 items-center gap-1.5 rounded-full border bg-card px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-default disabled:hover:bg-card disabled:hover:text-muted-foreground"
+                  disabled={!onOpenWeb}
                   onClick={() => onOpenWeb?.(source.url)}
                 >
                   <DomainFavicon url={source.url} className="size-3.5" />

--- a/crates/tidebreak-desktop/ui/src/stories/Apps.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Apps.stories.tsx
@@ -1,0 +1,271 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import type { AppDetail, AppGrantState, AppSummary } from "@/api";
+import { AppDetailView } from "@/apps/AppDetailView";
+import { AppsView } from "@/apps/AppsView";
+import type { AppsApis } from "@/apps/appsApis";
+import { ManagedPolicyContext } from "@/managedPolicy";
+
+const appRows: AppSummary[] = [
+  {
+    id: "release-brief",
+    name: "Release brief",
+    revision_count: 4,
+    updated_at: "2026-08-23T16:40:00.000Z",
+    granted: true,
+  },
+  {
+    id: "incident-map",
+    name: "Incident map",
+    revision_count: 1,
+    updated_at: "2026-08-22T09:15:00.000Z",
+    granted: false,
+  },
+  {
+    id: "research-table",
+    name: "Research source table with a deliberately long title",
+    revision_count: 7,
+    updated_at: "2026-08-19T18:20:00.000Z",
+    granted: true,
+  },
+  {
+    id: "cost-model",
+    name: "Provider cost model",
+    revision_count: 2,
+    updated_at: "2026-08-17T12:05:00.000Z",
+    granted: false,
+  },
+  {
+    id: "launch-checklist",
+    name: "Launch checklist",
+    revision_count: 3,
+    updated_at: "2026-08-12T08:30:00.000Z",
+    granted: true,
+  },
+];
+
+const detail: AppDetail = {
+  id: "release-brief",
+  name: "Release brief",
+  created_at: "2026-08-18T10:10:00.000Z",
+  updated_at: "2026-08-23T16:40:00.000Z",
+  current_revision: "revision-4",
+  revisions: [
+    {
+      id: "revision-4",
+      ordinal: 4,
+      created_at: "2026-08-23T16:40:00.000Z",
+    },
+    {
+      id: "revision-3",
+      ordinal: 3,
+      created_at: "2026-08-22T15:20:00.000Z",
+    },
+    {
+      id: "revision-2",
+      ordinal: 2,
+      created_at: "2026-08-20T13:00:00.000Z",
+    },
+    {
+      id: "revision-1",
+      ordinal: 1,
+      created_at: "2026-08-18T10:10:00.000Z",
+    },
+  ],
+};
+
+const consentRequired: AppGrantState = {
+  granted: false,
+  bindings: [
+    {
+      app: null,
+      folder: "folder-release-notes",
+      gateway_app: null,
+      access: "read_write",
+      name: "Release notes",
+      operation_ids: null,
+      granted: true,
+      definition_changed: true,
+    },
+    {
+      app: null,
+      folder: null,
+      gateway_app: "github",
+      access: null,
+      name: "GitHub",
+      operation_ids: ["pulls.list", "pulls.comment", "checks.read"],
+      granted: false,
+      definition_changed: false,
+    },
+  ],
+};
+
+const granted: AppGrantState = {
+  granted: true,
+  bindings: consentRequired.bindings.map((binding) => ({
+    ...binding,
+    granted: true,
+    definition_changed: false,
+  })),
+};
+
+function pending<T>(): Promise<T> {
+  return new Promise(() => undefined);
+}
+
+function appApis({
+  apps = appRows,
+  appDetail = detail,
+  grant = granted,
+  listError,
+  detailError,
+  frame = "ready",
+}: {
+  apps?: AppSummary[];
+  appDetail?: AppDetail;
+  grant?: AppGrantState;
+  listError?: Error;
+  detailError?: Error;
+  frame?: "ready" | "loading" | "failed";
+} = {}): AppsApis {
+  return {
+    baseUrl: "",
+    list: async () => {
+      if (listError) throw listError;
+      return { apps };
+    },
+    get: async () => {
+      if (detailError) throw detailError;
+      return appDetail;
+    },
+    deleteApp: fn(async () => {}),
+    grantState: async () => grant,
+    consent: async () => granted,
+    revoke: fn(async () => {}),
+    viewSession: async () => {
+      if (frame === "loading") return pending();
+      if (frame === "failed") throw new Error("stored bundle is unavailable");
+      const markup = encodeURIComponent(`<!doctype html>
+        <html><body style="margin:0;background:#f4f1e8;color:#25241f;font:14px system-ui">
+        <main style="padding:28px;display:grid;gap:18px">
+          <header><div style="font-size:12px;color:#6f6b61">RELEASE BRIEF</div>
+          <h1 style="font-size:26px;margin:5px 0 0">Desktop release readiness</h1></header>
+          <section style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px">
+            <article style="background:white;padding:16px;border-radius:10px"><b>17</b><div>checks passed</div></article>
+            <article style="background:white;padding:16px;border-radius:10px"><b>2</b><div>reviews open</div></article>
+            <article style="background:white;padding:16px;border-radius:10px"><b>1</b><div>release blocker</div></article>
+          </section>
+          <section style="background:white;padding:18px;border-radius:10px">
+            <b>Next decision</b><p style="color:#6f6b61">Confirm the updater migration before the release branch is cut.</p>
+          </section>
+        </main></body></html>`);
+      return { frame_path: `data:text/html;charset=utf-8,${markup}` };
+    },
+    invokeOperation: async () => ({ is_error: false }),
+    invokeGatewayOperation: async () => ({ is_error: false }),
+    invokeFolder: async () => ({ is_error: false }),
+    gatewayBaseUrl: async () => "https://gateway.example.com",
+    gatewayPage: async () => ({
+      outcome: "ready",
+      url: "https://gateway.example.com/apps/release-brief",
+    }),
+  };
+}
+
+const meta = {
+  title: "Apps/Library",
+  component: AppsView,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="flex h-screen min-h-0 bg-page-background">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    apis: appApis(),
+    onOpen: fn(),
+  },
+} satisfies Meta<typeof AppsView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  args: {
+    apis: { ...appApis(), list: pending },
+  },
+};
+
+export const Empty: Story = {
+  args: { apis: appApis({ apps: [] }) },
+};
+
+export const DenseLibrary: Story = {};
+
+export const LoadFailure: Story = {
+  args: {
+    apis: appApis({
+      apps: [],
+      listError: new Error("The app library did not answer."),
+    }),
+  },
+};
+
+export const ConsentRequired: Story = {
+  render: () => (
+    <AppDetailView
+      appId={detail.id}
+      apis={appApis({ grant: consentRequired })}
+      onBack={fn()}
+    />
+  ),
+};
+
+export const GrantedApp: Story = {
+  render: () => (
+    <ManagedPolicyContext.Provider
+      value={{
+        managed: true,
+        source: "provisioned",
+        misconfigured: false,
+        allow_local_mcp_servers: false,
+        gateway_url: "https://gateway.example.com",
+      }}
+    >
+      <AppDetailView appId={detail.id} apis={appApis()} onBack={fn()} />
+    </ManagedPolicyContext.Provider>
+  ),
+};
+
+export const AppOpening: Story = {
+  render: () => (
+    <AppDetailView
+      appId={detail.id}
+      apis={appApis({ frame: "loading" })}
+      onBack={fn()}
+    />
+  ),
+};
+
+export const AppFrameFailure: Story = {
+  render: () => (
+    <AppDetailView
+      appId={detail.id}
+      apis={appApis({ frame: "failed" })}
+      onBack={fn()}
+    />
+  ),
+};
+
+export const DetailFailure: Story = {
+  render: () => (
+    <AppDetailView
+      appId={detail.id}
+      apis={appApis({ detailError: new Error("404: app not found") })}
+      onBack={fn()}
+    />
+  ),
+};

--- a/crates/tidebreak-desktop/ui/src/stories/ChatView.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ChatView.stories.tsx
@@ -1,0 +1,1145 @@
+import { useMemo, useRef, useState, type ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import {
+  ApiClient,
+  type AgentActivityHistoryEntry,
+  type AgentRun,
+  type AgentRunProgress,
+  type AgentRunTaskPlan,
+  type Chat,
+  type ExecConfigInfo,
+  type ManagedPolicy,
+  type ModelInfo,
+  type PendingFolderAccessRequest,
+  type PendingOutputWritebackRequest,
+  type PendingPlanApproval,
+  type PendingUserQuestions,
+  type PlanDecision,
+  type PluginCatalog,
+  type PluginEnableUpdate,
+  type PromptBody,
+  type ProviderInfo,
+  type QueuedTurn,
+  RENDERER_FOLDER_ACCESS_REASON,
+  type SandboxAgentCancellation,
+  type TaskPlan,
+  type UserQuestionAnswer,
+} from "@/api";
+import { ChatView } from "@/ChatView";
+import { useChatSessionStore } from "@/ChatSessionStore";
+import { initialChatSessionState } from "@/ChatSessionReducer";
+import {
+  useComposerDrafts,
+  type ComposerAttachmentDraft,
+} from "@/ComposerDrafts";
+import type {
+  ComposerFiles,
+  ComposerFolders,
+  ComposerImages,
+} from "@/Composer";
+import type { ImageAttachment } from "@/ImageAttachments";
+import { ManagedPolicyContext } from "@/managedPolicy";
+import type { ChatMessage, RetryableTurn } from "@/MessageList";
+import { ModelMenu } from "@/ModelMenu";
+import { usePendingPrompts } from "@/PendingPrompts";
+import { PermissionModeMenu } from "@/PermissionModeMenu";
+import { useUiStore, type ActiveTurnSendMode } from "@/UiStore";
+import { contextUsageWarning, taskPlan, userQuestions } from "./fixtures";
+
+const CHAT_ID = "storybook-chat";
+const ACTIVE_TURN_ID = "turn-storybook";
+
+const storyChat = {
+  id: CHAT_ID,
+  project_id: null,
+  title: "Conversation design review",
+  model: "model_gateway::gpt-5.6-sol",
+  reasoning_effort: "high",
+  permission_mode: "ask",
+  network_policy: { mode: "open" },
+  attachment_revision: 1,
+  root_attachments: [],
+  created_at: "2026-08-24T13:00:00Z",
+} satisfies Chat;
+
+const storyPolicy = {
+  managed: false,
+  source: "unmanaged",
+  misconfigured: false,
+  allow_local_mcp_servers: false,
+} satisfies ManagedPolicy;
+
+const storyModels = [
+  {
+    key: "model_gateway::gpt-5.6-sol",
+    id: "gpt-5.6-sol",
+    display_name: "GPT-5.6 Sol",
+    provider: "model_gateway",
+    vendor: "openai",
+    verification: "verified",
+    context_window: 200_000,
+    max_output_tokens: 64_000,
+    input_modalities: ["text", "image"],
+    supports_reasoning: true,
+    supports_tools: true,
+    supports_structured_output: true,
+    reasoning_efforts: ["low", "medium", "high"],
+    multimodal: true,
+    available: true,
+    recommended: true,
+  },
+  {
+    key: "model_gateway::claude-sonnet-4-6",
+    id: "claude-sonnet-4-6",
+    display_name: "Claude Sonnet 4.6",
+    provider: "model_gateway",
+    vendor: "anthropic",
+    verification: "verified",
+    context_window: 200_000,
+    max_output_tokens: 64_000,
+    input_modalities: ["text", "image"],
+    supports_reasoning: true,
+    supports_tools: true,
+    supports_structured_output: true,
+    reasoning_efforts: ["low", "medium", "high"],
+    multimodal: true,
+    available: true,
+    recommended: true,
+  },
+] satisfies ModelInfo[];
+
+const storyProviders = [
+  {
+    kind: "model_gateway",
+    enabled: true,
+    has_credential: true,
+    models: [],
+  },
+] satisfies ProviderInfo[];
+
+const emptyPlugins: PluginCatalog = { plugins: [], skills: [], prompts: [] };
+
+const imageAttachment: ImageAttachment = {
+  id: "image-local",
+  name: "compact-layout.png",
+  byteLen: 248_000,
+  uploadedBytes: 248_000,
+  status: "ready",
+  previewUrl: null,
+  attachmentId: "image-published",
+  mediaType: "image/png",
+  width: 1440,
+  height: 900,
+  error: null,
+};
+
+const baseMessages: ChatMessage[] = [
+  {
+    id: "message-user",
+    role: "user",
+    text: "Audit the conversation flow and keep the dense states easy to scan.",
+    createdAt: "2026-08-24T13:02:00Z",
+  },
+  {
+    id: "message-assistant",
+    role: "assistant",
+    text: "I am grouping routine activity and keeping decisions beside the composer.",
+    reasoning:
+      "The transcript, queue, and pending prompts need to share one visual hierarchy.",
+    sources: [],
+    createdAt: "2026-08-24T13:02:10Z",
+  },
+];
+
+const streamingMessages: ChatMessage[] = [
+  ...baseMessages,
+  {
+    id: "message-stream-user",
+    role: "user",
+    text: "Check the active response and compact pressure next.",
+    createdAt: "2026-08-24T13:04:00Z",
+  },
+  {
+    id: "message-stream-assistant",
+    role: "assistant",
+    text: "The active response keeps the stop action visible while the composer offers queued guidance.",
+    sources: [],
+    createdAt: "2026-08-24T13:04:08Z",
+  },
+];
+
+const retryableMessages: ChatMessage[] = [
+  {
+    id: "message-failure-user",
+    role: "user",
+    text: "Generate the compact conversation review.",
+    files: [
+      {
+        documentId: "brief-document",
+        name: "conversation-brief.pdf",
+        mediaType: "application/pdf",
+      },
+    ],
+    invokedSkills: ["browser"],
+    createdAt: "2026-08-24T13:08:00Z",
+  },
+  {
+    id: "message-failure",
+    role: "turn_failure",
+    category: "transient",
+    detail: "The provider closed the stream before the response completed.",
+    model: { id: "gpt-5.6-sol", provider: "model_gateway" },
+    invokedSkills: ["browser"],
+  },
+];
+
+const pendingApprovalMessages: ChatMessage[] = [
+  ...baseMessages,
+  {
+    id: "message-approval",
+    role: "approval",
+    callId: "approval-storybook",
+    summary: "Run the focused Storybook checks",
+    preview: {
+      tool: "exec",
+      command: "pnpm",
+      args: ["storybook:build"],
+      cwd: "crates/tidebreak-desktop/ui",
+      files: ["src/stories/ChatView.stories.tsx"],
+      summary: "Build the conversation stories",
+    },
+    canApprove: true,
+    canRemember: false,
+    grantRungs: [],
+  },
+];
+
+const queuedTurn: QueuedTurn = {
+  id: "queued-storybook",
+  chat_id: CHAT_ID,
+  content: "After this response, verify the 420-pixel layout.",
+  attachments: [],
+  file_attachments: [],
+  invoked_skills: [],
+  voice_input_used: false,
+  position: 1,
+  created_at: "2026-08-24T13:05:00Z",
+  updated_at: "2026-08-24T13:05:00Z",
+};
+
+const pendingQuestion = {
+  ...userQuestions,
+  callId: "questions-storybook",
+  turnId: ACTIVE_TURN_ID,
+  questions: [userQuestions.questions[0]!],
+} satisfies PendingUserQuestions;
+
+const pendingPlan = {
+  callId: "plan-storybook",
+  turnId: ACTIVE_TURN_ID,
+  title: "Review the conversation-state coverage plan",
+  plan: `## Story coverage
+
+1. Mount the production composer controls and pending decisions.
+2. Show folder and output consent beside background-agent progress.
+3. Verify desktop and compact layouts before publishing the review.`,
+  proposedAt: "2026-08-24T13:09:00Z",
+} satisfies PendingPlanApproval;
+
+const pendingFolderAccess = {
+  callId: "folder-access-storybook",
+  turnId: ACTIVE_TURN_ID,
+  reason: RENDERER_FOLDER_ACCESS_REASON,
+  folderHint: "documents",
+  claimedByDesktop: false,
+} satisfies PendingFolderAccessRequest;
+
+const pendingOutputWriteback = {
+  callId: "output-writeback-storybook",
+  turnId: ACTIVE_TURN_ID,
+  mode: "replace",
+  claimedByDesktop: false,
+} satisfies PendingOutputWritebackRequest;
+
+const agentMessages: ChatMessage[] = [
+  ...baseMessages,
+  {
+    id: "message-agent-request",
+    role: "user",
+    text: "Delegate the visual audit and keep every result visible here.",
+    createdAt: "2026-08-24T13:06:00Z",
+  },
+  {
+    id: "message-agent-running",
+    role: "tool",
+    callId: "spawn-running",
+    name: "spawn_sandbox_agent",
+    status: "completed",
+    backgroundAgentRunId: "agent-running",
+  },
+  {
+    id: "message-agent-waiting",
+    role: "tool",
+    callId: "spawn-waiting",
+    name: "spawn_sandbox_agent",
+    status: "completed",
+    backgroundAgentRunId: "agent-waiting",
+  },
+  {
+    id: "message-agent-completed",
+    role: "tool",
+    callId: "spawn-completed",
+    name: "spawn_sandbox_agent",
+    status: "completed",
+    backgroundAgentRunId: "agent-completed",
+  },
+  {
+    id: "message-agent-failed",
+    role: "tool",
+    callId: "spawn-failed",
+    name: "spawn_sandbox_agent",
+    status: "completed",
+    backgroundAgentRunId: "agent-failed",
+  },
+  {
+    id: "message-agent-summary",
+    role: "assistant",
+    text: "The visual audit is running across the conversation surfaces.",
+    sources: [],
+    createdAt: "2026-08-24T13:06:10Z",
+  },
+];
+
+function agentRun(
+  id: string,
+  spawnCallId: string,
+  status: AgentRun["status"],
+  task: string,
+): AgentRun {
+  const live = [
+    "active",
+    "queued",
+    "running",
+    "cancelling",
+    "waiting",
+    "retry_wait",
+    "needs_input",
+  ].includes(status);
+  return {
+    id,
+    parent_id: "foreground-storybook",
+    spawn_call_id: spawnCallId,
+    tier: "background",
+    execution_location: "in_process",
+    code_execution_provider: "local",
+    status,
+    model_steps: status === "completed" ? 5 : 2,
+    usage: {
+      input_tokens: 8_200,
+      output_tokens: 1_900,
+      cache_read_input_tokens: 5_600,
+      cache_creation_input_tokens: 0,
+    },
+    task,
+    started_at: "2026-08-24T13:06:00Z",
+    finished_at: live ? null : "2026-08-24T13:10:00Z",
+    last_error_code: status === "failed" ? "provider_stream_closed" : null,
+    activity: status === "running" ? { kind: "exec", status: "running" } : null,
+    submitted_outputs:
+      status === "completed"
+        ? [
+            {
+              output_id: "output-visual-review",
+              filename: "visual-review.md",
+            },
+          ]
+        : [],
+    task_plan:
+      status === "running"
+        ? {
+            completed: 2,
+            total: 4,
+            current: "Compare compact decision states",
+            updated_at: "2026-08-24T13:08:00Z",
+          }
+        : undefined,
+    terminal_text:
+      status === "completed"
+        ? "The desktop conversation review is complete."
+        : status === "failed"
+          ? "The compact capture stopped before the final state rendered."
+          : null,
+    created_at: "2026-08-24T13:05:30Z",
+    updated_at: "2026-08-24T13:09:00Z",
+  };
+}
+
+const agentRuns = [
+  agentRun(
+    "agent-running",
+    "spawn-running",
+    "running",
+    "Audit the active conversation hierarchy",
+  ),
+  agentRun(
+    "agent-waiting",
+    "spawn-waiting",
+    "needs_input",
+    "Review the compact focus order",
+  ),
+  agentRun(
+    "agent-completed",
+    "spawn-completed",
+    "completed",
+    "Assess production primitives and spacing",
+  ),
+  agentRun(
+    "agent-failed",
+    "spawn-failed",
+    "failed",
+    "Capture the overloaded decision state",
+  ),
+] satisfies AgentRun[];
+
+const agentProgress = {
+  "agent-running": {
+    entries: [
+      {
+        sequence: 1,
+        text: "Comparing prompt replacement at desktop and compact widths",
+        at: "2026-08-24T13:08:30Z",
+      },
+    ],
+    nextSequence: 1,
+  },
+} satisfies Record<string, AgentRunProgress>;
+
+const agentTaskPlans = {
+  "agent-running": {
+    run_id: "agent-running",
+    steps: taskPlan.steps,
+    updated_at: "2026-08-24T13:08:00Z",
+  },
+} satisfies Record<string, AgentRunTaskPlan>;
+
+const agentActivity = {
+  "agent-running": [
+    {
+      kind: "web_search",
+      outcome: "completed",
+      at: "2026-08-24T13:07:00Z",
+    },
+    {
+      kind: "exec",
+      outcome: "running",
+      at: "2026-08-24T13:08:00Z",
+    },
+  ],
+} satisfies Record<string, AgentActivityHistoryEntry[]>;
+
+type DecisionOutcome = "success" | "pending" | "failure";
+
+type StoryScenario = {
+  id: string;
+  messages: ChatMessage[];
+  draft?: string;
+  busy?: boolean;
+  activeTurnId?: string | null;
+  lastSeq?: number;
+  sendMode?: ActiveTurnSendMode;
+  attachments?: Partial<ComposerAttachmentDraft>;
+  queue?: QueuedTurn[];
+  plan?: TaskPlan | null;
+  userQuestions?: PendingUserQuestions[];
+  planApprovals?: PendingPlanApproval[];
+  folderAccess?: PendingFolderAccessRequest[];
+  outputWritebacks?: PendingOutputWritebackRequest[];
+  questionOutcome?: DecisionOutcome;
+  planOutcome?: DecisionOutcome;
+  agentRuns?: AgentRun[];
+  agentActivity?: Record<string, AgentActivityHistoryEntry[]>;
+  agentTaskPlans?: Record<string, AgentRunTaskPlan>;
+  agentProgress?: Record<string, AgentRunProgress>;
+  agentRunsError?: string;
+  nativeHost?: boolean;
+};
+
+function pendingDecision(): Promise<void> {
+  return new Promise(() => undefined);
+}
+
+class StoryApiClient extends ApiClient {
+  private queued: QueuedTurn[];
+  private paused = false;
+
+  constructor(private readonly scenario: StoryScenario) {
+    super("http://storybook.invalid", "storybook-token");
+    this.queued = [...(scenario.queue ?? [])];
+  }
+
+  enqueue(content: string): void {
+    this.queued.push({
+      ...queuedTurn,
+      id: `queued-${this.queued.length + 1}`,
+      content,
+      position: this.queued.length + 1,
+    });
+  }
+
+  override listPlugins(): Promise<PluginCatalog> {
+    return Promise.resolve(emptyPlugins);
+  }
+
+  override getPromptBody(name: string): Promise<PromptBody> {
+    return Promise.resolve({ name, body: "Review the conversation flow." });
+  }
+
+  override setPluginsEnabled(
+    _update: PluginEnableUpdate,
+  ): Promise<PluginCatalog> {
+    return Promise.resolve(emptyPlugins);
+  }
+
+  override getExecConfig(): Promise<ExecConfigInfo> {
+    return Promise.resolve({
+      provider: "local",
+      timeout_ms: 30_000,
+      available: true,
+      has_credential: true,
+      providers: [
+        { provider: "local", available: true },
+        { provider: "e2b", available: true },
+        { provider: "daytona", available: true },
+      ],
+      egress: {
+        policy: { mode: "open" },
+        enforcement: [],
+      },
+      detached_admission: [],
+    } satisfies ExecConfigInfo);
+  }
+
+  override getTaskPlan(_chatId: string): Promise<TaskPlan | null> {
+    return Promise.resolve(this.scenario.plan ?? null);
+  }
+
+  override listQueuedTurns(): Promise<{
+    queued: QueuedTurn[];
+    paused: boolean;
+  }> {
+    return Promise.resolve({ queued: [...this.queued], paused: this.paused });
+  }
+
+  override putQueuePaused(_chatId: string, paused: boolean): Promise<void> {
+    this.paused = paused;
+    return Promise.resolve();
+  }
+
+  override patchQueuedTurn(
+    _chatId: string,
+    turnId: string,
+    update: { content?: string; position?: number },
+  ): Promise<QueuedTurn> {
+    const current = this.queued.find((turn) => turn.id === turnId)!;
+    const next = { ...current, ...update };
+    this.queued = this.queued.map((turn) => (turn.id === turnId ? next : turn));
+    return Promise.resolve(next);
+  }
+
+  override deleteQueuedTurn(_chatId: string, turnId: string): Promise<void> {
+    this.queued = this.queued.filter((turn) => turn.id !== turnId);
+    return Promise.resolve();
+  }
+
+  override sendQueuedNow(): Promise<void> {
+    this.paused = false;
+    this.queued = [];
+    return Promise.resolve();
+  }
+
+  override cancel(): Promise<void> {
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      busy: false,
+      activeTurnId: null,
+    }));
+    return Promise.resolve();
+  }
+
+  override steer(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  override decideApproval(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  override listPendingUserQuestions(): Promise<PendingUserQuestions[]> {
+    return Promise.resolve(this.scenario.userQuestions ?? []);
+  }
+
+  override listPendingPlanApprovals(): Promise<PendingPlanApproval[]> {
+    return Promise.resolve(this.scenario.planApprovals ?? []);
+  }
+
+  override listPendingFolderAccessRequests(): Promise<
+    PendingFolderAccessRequest[]
+  > {
+    return Promise.resolve(this.scenario.folderAccess ?? []);
+  }
+
+  override listPendingOutputWritebackRequests(): Promise<
+    PendingOutputWritebackRequest[]
+  > {
+    return Promise.resolve(this.scenario.outputWritebacks ?? []);
+  }
+
+  override answerUserQuestions(
+    _chatId: string,
+    _callId: string,
+    _answers: UserQuestionAnswer[],
+  ): Promise<void> {
+    if (this.scenario.questionOutcome === "pending") {
+      return pendingDecision();
+    }
+    if (this.scenario.questionOutcome === "failure") {
+      return Promise.reject(new Error("The question response was not saved."));
+    }
+    usePendingPrompts.getState().setUserQuestions(CHAT_ID, []);
+    return Promise.resolve();
+  }
+
+  override decidePlan(
+    _chatId: string,
+    _callId: string,
+    _decision: PlanDecision,
+  ): Promise<void> {
+    if (this.scenario.planOutcome === "pending") {
+      return pendingDecision();
+    }
+    if (this.scenario.planOutcome === "failure") {
+      return Promise.reject(new Error("The plan decision was not saved."));
+    }
+    usePendingPrompts.getState().setPlanApprovals(CHAT_ID, []);
+    return Promise.resolve();
+  }
+
+  override listAgentRuns(): Promise<AgentRun[]> {
+    if (this.scenario.agentRunsError) {
+      return Promise.reject(new Error(this.scenario.agentRunsError));
+    }
+    return Promise.resolve(this.scenario.agentRuns ?? []);
+  }
+
+  override listAgentRunActivity(
+    _chatId: string,
+    runId: string,
+  ): Promise<AgentActivityHistoryEntry[]> {
+    return Promise.resolve(this.scenario.agentActivity?.[runId] ?? []);
+  }
+
+  override getAgentRunTaskPlan(
+    _chatId: string,
+    runId: string,
+  ): Promise<AgentRunTaskPlan | null> {
+    return Promise.resolve(this.scenario.agentTaskPlans?.[runId] ?? null);
+  }
+
+  override listAgentRunProgress(
+    _chatId: string,
+    runId: string,
+    afterSequence = 0,
+  ): Promise<AgentRunProgress> {
+    const page = this.scenario.agentProgress?.[runId];
+    if (!page || afterSequence >= page.nextSequence) {
+      return Promise.resolve({ entries: [], nextSequence: afterSequence });
+    }
+    return Promise.resolve(page);
+  }
+
+  override cancelAgentRun(
+    _chatId: string,
+    runId: string,
+  ): Promise<SandboxAgentCancellation> {
+    return Promise.resolve({ id: runId, status: "cancelling" });
+  }
+}
+
+function seedScenario(scenario: StoryScenario): void {
+  useChatSessionStore.getState().update(() => ({
+    ...initialChatSessionState(),
+    messages: scenario.messages,
+    busy: scenario.busy ?? false,
+    activeTurnId: scenario.activeTurnId ?? null,
+    lastSeq: scenario.lastSeq ?? 0,
+  }));
+  useComposerDrafts.getState().clearDraft(CHAT_ID);
+  useComposerDrafts.getState().setDraft(CHAT_ID, scenario.draft ?? "");
+  useComposerDrafts
+    .getState()
+    .setImages(CHAT_ID, scenario.attachments?.images ?? []);
+  useComposerDrafts
+    .getState()
+    .setFiles(CHAT_ID, scenario.attachments?.files ?? []);
+  useComposerDrafts
+    .getState()
+    .setSkills(CHAT_ID, scenario.attachments?.skills ?? []);
+  useComposerDrafts
+    .getState()
+    .setFolders(CHAT_ID, scenario.attachments?.folders ?? []);
+  usePendingPrompts.getState().reset(CHAT_ID);
+  usePendingPrompts
+    .getState()
+    .setUserQuestions(CHAT_ID, scenario.userQuestions ?? []);
+  usePendingPrompts
+    .getState()
+    .setPlanApprovals(CHAT_ID, scenario.planApprovals ?? []);
+  usePendingPrompts
+    .getState()
+    .setFolderAccess(CHAT_ID, scenario.folderAccess ?? []);
+  usePendingPrompts
+    .getState()
+    .setOutputWritebacks(CHAT_ID, scenario.outputWritebacks ?? []);
+  useUiStore.getState().setActiveTurnSendMode(scenario.sendMode ?? "queue");
+}
+
+function storyRouter(children: ReactNode) {
+  const rootRoute = createRootRoute();
+  const chatRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/c/$chatId",
+    validateSearch: (search: Record<string, unknown>) => ({
+      focus: typeof search.focus === "string" ? search.focus : undefined,
+      at: typeof search.at === "string" ? search.at : undefined,
+    }),
+    component: () => <>{children}</>,
+  });
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings/providers",
+    component: () => <>{children}</>,
+  });
+  return createRouter({
+    routeTree: rootRoute.addChildren([chatRoute, settingsRoute]),
+    history: createMemoryHistory({ initialEntries: [`/c/${CHAT_ID}`] }),
+  });
+}
+
+function StoryChat({
+  client,
+  scenario,
+}: {
+  client: StoryApiClient;
+  scenario: StoryScenario;
+}) {
+  const [chat, setChat] = useState<Chat>(() => ({ ...storyChat }));
+  const draftRef = useRef(scenario.draft ?? "");
+  const images: ComposerImages = {
+    items: scenario.attachments?.images ?? [],
+    error: null,
+    unsupportedModel: null,
+    onAttachFiles: fn(),
+    onRemove: (id) =>
+      useComposerDrafts.getState().setImages(
+        CHAT_ID,
+        (scenario.attachments?.images ?? []).filter((image) => image.id !== id),
+      ),
+    onRetry: fn(),
+  };
+  const files: ComposerFiles = {
+    items: scenario.attachments?.files ?? [],
+    attaching: false,
+    onAttach: fn(),
+    onRemove: (documentId) =>
+      useComposerDrafts.getState().setFiles(
+        CHAT_ID,
+        (scenario.attachments?.files ?? []).filter(
+          (file) => file.documentId !== documentId,
+        ),
+      ),
+  };
+  const folderItems: ComposerFolders["items"] = [
+    {
+      rootId: "folder-research",
+      displayName: "Research notes",
+      status: "connected",
+      statements: [],
+    },
+  ];
+  const folders: ComposerFolders = {
+    items: folderItems,
+    pendingIds: scenario.attachments?.folders ?? [],
+    working: false,
+    error: null,
+    onAttach: fn(),
+    onRemove: fn(),
+  };
+
+  const updateDraft = (value: string) => {
+    draftRef.current = value;
+    useComposerDrafts.getState().setDraft(CHAT_ID, value);
+  };
+  const submitDraft = async () => {
+    const text = draftRef.current.trim();
+    if (!text) return;
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      messages: [
+        ...session.messages,
+        {
+          id: `submitted-${session.messages.length}`,
+          role: "user",
+          text,
+          createdAt: "2026-08-24T13:12:00Z",
+        },
+      ],
+    }));
+    updateDraft("");
+  };
+  const queueDraft = async () => {
+    const text = draftRef.current.trim();
+    if (!text) return;
+    client.enqueue(text);
+    updateDraft("");
+  };
+  const retryTurn = (turn: RetryableTurn) => updateDraft(turn.text);
+
+  return (
+    <ManagedPolicyContext.Provider value={storyPolicy}>
+      <div className="h-screen min-h-0 bg-page-background">
+        <div className="mx-auto h-full max-w-6xl border-x border-border bg-background">
+          <ChatView
+            key={scenario.id}
+            client={client}
+            chat={chat}
+            hydrated
+            nativeHost={scenario.nativeHost ?? false}
+            deletingChat={false}
+            draftRef={draftRef}
+            composerModelMenu={
+              <ModelMenu
+                models={storyModels}
+                value={chat.model}
+                defaultKey={storyModels[0]!.key}
+                providers={storyProviders}
+                onSetUpProvider={() => undefined}
+                onChange={(model) =>
+                  setChat((current) => ({ ...current, model }))
+                }
+              />
+            }
+            composerPermissionMenu={
+              <PermissionModeMenu
+                scopeKey={chat.id}
+                value={chat.permission_mode}
+                onChange={(permission_mode) =>
+                  setChat((current) => ({ ...current, permission_mode }))
+                }
+              />
+            }
+            contextUsage={contextUsageWarning}
+            composerImages={images}
+            files={files}
+            folders={folders}
+            voiceInputUsed={false}
+            onVoiceInputAccepted={fn()}
+            attachError={null}
+            onDraftChange={updateDraft}
+            onSelectPrompt={(prompt) => updateDraft(prompt)}
+            onSend={submitDraft}
+            onQueue={queueDraft}
+            onRetryTurn={retryTurn}
+            onOpenAgentPanel={fn()}
+            onOpenOutput={fn()}
+          />
+        </div>
+      </div>
+    </ManagedPolicyContext.Provider>
+  );
+}
+
+function ChatViewStory({ scenario }: { scenario: StoryScenario }) {
+  const [client] = useState(() => {
+    seedScenario(scenario);
+    return new StoryApiClient(scenario);
+  });
+  const router = useMemo(
+    () => storyRouter(<StoryChat client={client} scenario={scenario} />),
+    [client, scenario],
+  );
+  return <RouterProvider router={router as never} />;
+}
+
+const meta = {
+  title: "Conversation/ChatView",
+  component: ChatViewStory,
+  parameters: { layout: "fullscreen" },
+  render: ({ scenario }) => (
+    <ChatViewStory key={scenario.id} scenario={scenario} />
+  ),
+} satisfies Meta<typeof ChatViewStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AttachmentsAndDraft: Story = {
+  args: {
+    scenario: {
+      id: "attachments-and-draft",
+      messages: baseMessages,
+      draft:
+        "Use the attached layout, brief, skill, and research folder to tighten the compact conversation hierarchy.",
+      attachments: {
+        images: [imageAttachment],
+        files: [
+          {
+            documentId: "document-storybook",
+            displayName: "conversation-review.pdf",
+            mediaType: "application/pdf",
+            byteLen: 482_000,
+          },
+        ],
+        skills: ["browser"],
+        folders: ["folder-research"],
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const composer = await canvas.findByRole("textbox", { name: "Message" });
+    await userEvent.click(composer);
+    await expect(composer).toHaveFocus();
+  },
+};
+
+export const ActiveStreamingQueueAndStop: Story = {
+  args: {
+    scenario: {
+      id: "active-streaming-queue-stop",
+      messages: streamingMessages,
+      draft: "Also compare the queued state against the live transcript.",
+      busy: true,
+      activeTurnId: ACTIVE_TURN_ID,
+      lastSeq: 12,
+      sendMode: "queue",
+      queue: [queuedTurn],
+      plan: taskPlan,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("button", { name: "Stop response" }),
+    ).toBeEnabled();
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: "Queue message for after this response",
+      }),
+    );
+    await waitFor(
+      () =>
+        expect(
+          canvas.getByText(
+            "Also compare the queued state against the live transcript.",
+          ),
+        ).toBeInTheDocument(),
+      { timeout: 3_000 },
+    );
+    await expect(
+      canvas.getByRole("button", { name: "Stop response" }),
+    ).toBeEnabled();
+  },
+};
+
+export const PendingApprovalReturnsToComposer: Story = {
+  args: {
+    scenario: {
+      id: "pending-approval",
+      messages: pendingApprovalMessages,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const composer = await canvas.findByRole("textbox", { name: "Message" });
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Yes, run it once" }),
+    );
+    await waitFor(() =>
+      expect(
+        canvas.queryByRole("group", { name: "Approval choices" }),
+      ).not.toBeInTheDocument(),
+    );
+    await userEvent.click(composer);
+    await expect(composer).toHaveFocus();
+  },
+};
+
+export const PendingQuestionReturnsToComposer: Story = {
+  args: {
+    scenario: {
+      id: "pending-question-return",
+      messages: baseMessages,
+      userQuestions: [pendingQuestion],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByText("Conversation states", { exact: true }),
+    );
+    await userEvent.click(canvas.getByRole("button", { name: "Continue" }));
+    const composer = await canvas.findByRole("textbox", { name: "Message" });
+    await userEvent.click(composer);
+    await expect(composer).toHaveFocus();
+  },
+};
+
+export const PendingPlanReturnsToComposer: Story = {
+  args: {
+    scenario: {
+      id: "pending-plan-return",
+      messages: baseMessages,
+      planApprovals: [pendingPlan],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Execute plan" }),
+    );
+    const composer = await canvas.findByRole("textbox", { name: "Message" });
+    await userEvent.click(composer);
+    await expect(composer).toHaveFocus();
+  },
+};
+
+export const CompactCrowdedPromptReplacement: Story = {
+  args: {
+    scenario: {
+      id: "compact-crowded-prompt-replacement",
+      messages: baseMessages,
+      plan: taskPlan,
+      userQuestions: [pendingQuestion],
+      planApprovals: [pendingPlan],
+    },
+  },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const CompactPlanDecisionFailure: Story = {
+  args: {
+    scenario: {
+      id: "compact-plan-decision-failure",
+      messages: baseMessages,
+      planApprovals: [pendingPlan],
+      planOutcome: "failure",
+    },
+  },
+  globals: { viewport: { value: "compact", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Execute plan" }),
+    );
+    await expect(await canvas.findByRole("alert")).toHaveTextContent(
+      "The plan decision was not saved.",
+    );
+    await expect(
+      canvas.getByRole("button", { name: "Execute plan" }),
+    ).toBeEnabled();
+  },
+};
+
+const crowdedAgentScenario = {
+  id: "crowded-agent-lifecycle",
+  messages: agentMessages,
+  draft: "Summarize the final agent findings after every decision is resolved.",
+  plan: taskPlan,
+  folderAccess: [pendingFolderAccess],
+  outputWritebacks: [pendingOutputWriteback],
+  agentRuns,
+  agentActivity,
+  agentTaskPlans,
+  agentProgress,
+  nativeHost: true,
+} satisfies StoryScenario;
+
+export const CrowdedDecisionsAndAgentLifecycle: Story = {
+  args: { scenario: crowdedAgentScenario },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(
+        "Comparing prompt replacement at desktop and compact widths",
+      ),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("region", { name: "Background agents" }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const CompactCrowdedDecisionsAndAgentLifecycle: Story = {
+  args: {
+    scenario: {
+      ...crowdedAgentScenario,
+      id: "compact-crowded-agent-lifecycle",
+    },
+  },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const RetryableFailure: Story = {
+  args: {
+    scenario: {
+      id: "retryable-failure",
+      messages: retryableMessages,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: "Retry" }));
+    await expect(
+      await canvas.findByRole("textbox", { name: "Message" }),
+    ).toHaveValue("Generate the compact conversation review.");
+  },
+};
+
+export const CompactPressure: Story = {
+  args: {
+    scenario: {
+      id: "compact-pressure",
+      messages: streamingMessages,
+      draft:
+        "Keep the approval, queue, task plan, attachments, context meter, and stop action readable without hiding the response.",
+      busy: true,
+      activeTurnId: ACTIVE_TURN_ID,
+      lastSeq: 18,
+      queue: [queuedTurn],
+      plan: taskPlan,
+      attachments: {
+        images: [imageAttachment],
+        files: [
+          {
+            documentId: "compact-document",
+            displayName: "compact-review.pdf",
+            mediaType: "application/pdf",
+            byteLen: 482_000,
+          },
+        ],
+        skills: ["browser"],
+        folders: ["folder-research"],
+      },
+    },
+  },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
@@ -198,7 +198,9 @@ function CodeHomeStory({ scenario }: { scenario: HomeScenario }) {
   return (
     <AppContextProvider value={appContext(state.client)}>
       <div className="app-shell h-full min-h-0 w-full overflow-hidden">
-        <RouterProvider router={state.router as never} />
+        <div className="app-body">
+          <RouterProvider router={state.router as never} />
+        </div>
       </div>
     </AppContextProvider>
   );
@@ -266,5 +268,5 @@ export const DenseSidebar: Story = {
 
 export const CompactFirstRepository: Story = {
   args: { scenario: "empty" },
-  parameters: { viewport: { defaultViewport: "compact" } },
+  globals: { viewport: { value: "compact", isRotated: false } },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeHome.stories.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { expect, within } from "storybook/test";
+
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import type { ApiClient } from "@/api/client";
+import type { HarnessKind } from "@/api/types";
+import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
+import { CodeHome } from "@/code/CodeHome";
+import { DEFAULT_RAIL_PREFS, useCodeUiStore } from "@/code/CodeUiStore";
+import {
+  disconnectCodeUpdates,
+  useCodeUpdatesStore,
+} from "@/code/CodeUpdatesStore";
+import { useUiStore } from "@/UiStore";
+import {
+  codeRepositories,
+  codeSidebarWorkspaces,
+  harnessDoctor,
+  harnessDoctorDegraded,
+} from "./fixtures";
+
+type HomeScenario =
+  | "registered"
+  | "empty"
+  | "loading"
+  | "failure"
+  | "needs-harness"
+  | "dense-sidebar";
+
+function pending<T>(): Promise<T> {
+  return new Promise(() => {});
+}
+
+function storySocket(): WebSocket {
+  return {
+    close: () => {},
+    onclose: null,
+    onerror: null,
+    onmessage: null,
+    onopen: null,
+  } as unknown as WebSocket;
+}
+
+function storyClient(scenario: HomeScenario): ApiClient {
+  const loading = scenario === "loading";
+  const failure = scenario === "failure";
+  const repos =
+    scenario === "empty" || scenario === "needs-harness"
+      ? []
+      : codeRepositories;
+  const workspaces = scenario === "dense-sidebar" ? codeSidebarWorkspaces : [];
+  const doctor =
+    scenario === "needs-harness" ? harnessDoctorDegraded : harnessDoctor;
+
+  return {
+    listCodeRepos: async () => {
+      if (loading) return pending();
+      if (failure) throw new Error("The repository catalog could not load.");
+      return repos;
+    },
+    listCodeWorkspaces: async () => {
+      if (loading) return pending();
+      if (failure) throw new Error("The repository catalog could not load.");
+      return workspaces;
+    },
+    getHarnessDoctor: async () => (loading ? pending() : doctor),
+    refreshHarnessDoctor: async () => doctor,
+    listCodeHarnessModels: async (kind: HarnessKind) => ({
+      kind,
+      models: [],
+      reasoning_efforts: [],
+    }),
+    getCodeSubscriptionUsage: async () => ({
+      source: "model_gateway",
+      diagnostics: [],
+      providers: [],
+    }),
+    getCodeCloneDefaults: async () => ({
+      parent_dir: "/Users/sam/src",
+      gh_found: true,
+      gh_authenticated: true,
+      gh_remediation: "",
+    }),
+    getCodeRepoSources: async () => ({
+      sources: [
+        { kind: "local", available: true },
+        { kind: "git_url", available: true },
+        { kind: "github", available: true },
+      ],
+      chooses_destination: false,
+    }),
+    openCodeUpdates: storySocket,
+  } as unknown as ApiClient;
+}
+
+function appContext(client: ApiClient): AppContextValue {
+  return {
+    client,
+    models: [],
+    defaultModelKey: null,
+    providers: [],
+    refreshCatalog: async () => {},
+    refreshChats: async () => {},
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: { status: "idle", version: null, error: null, enabled: false },
+    updateUpToDate: false,
+    checkForUpdate: async () => ({
+      status: "idle",
+      version: null,
+      error: null,
+      enabled: false,
+    }),
+    attachment: "local",
+    restartForUpdate: async () => {},
+  };
+}
+
+function storyRouter() {
+  const rootRoute = createRootRoute();
+  const codeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code",
+    component: CodeHome,
+  });
+  const stub = (path: string, label: string) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path,
+      component: () => <p className="p-6">{label}</p>,
+    });
+
+  return createRouter({
+    routeTree: rootRoute.addChildren([
+      stub("/", "Work"),
+      codeRoute,
+      stub("/settings", "Settings"),
+      stub("/code/w/$workspaceId", "Workspace"),
+      stub("/code/delivery/pull-requests", "Delivery"),
+      stub("/code/archive", "Archive"),
+      stub("/code/notifications", "Notifications"),
+    ]),
+    history: createMemoryHistory({ initialEntries: ["/code"] }),
+  });
+}
+
+function resetStoryState(scenario: HomeScenario): void {
+  disconnectCodeUpdates();
+  useCodeCatalogStore.getState().reset();
+  useCodeUpdatesStore.getState().reset();
+  useCodeUiStore.setState({
+    railPrefs:
+      scenario === "dense-sidebar"
+        ? { ...DEFAULT_RAIL_PREFS, density: "compact" }
+        : DEFAULT_RAIL_PREFS,
+    newWorkspaceOpen: false,
+    addRepoOpen: false,
+    pendingComposerPrompt: null,
+    composerActionScope: null,
+  });
+  useUiStore.setState({ sidebarCollapsed: false, sidebarWidth: 280 });
+}
+
+function CodeHomeStory({ scenario }: { scenario: HomeScenario }) {
+  const [state] = useState(() => {
+    resetStoryState(scenario);
+    return { client: storyClient(scenario), router: storyRouter() };
+  });
+
+  useEffect(
+    () => () => {
+      disconnectCodeUpdates();
+      useCodeCatalogStore.getState().reset();
+    },
+    [],
+  );
+
+  return (
+    <AppContextProvider value={appContext(state.client)}>
+      <div className="app-shell h-full min-h-0 w-full overflow-hidden">
+        <RouterProvider router={state.router as never} />
+      </div>
+    </AppContextProvider>
+  );
+}
+
+const meta = {
+  title: "Code/Home",
+  component: CodeHomeStory,
+  args: { scenario: "registered" },
+  parameters: { layout: "fullscreen" },
+  render: (args) => <CodeHomeStory key={args.scenario} {...args} />,
+} satisfies Meta<typeof CodeHomeStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RegisteredRepositories: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("heading", { name: "Repos" }),
+    ).toBeVisible();
+    await expect(await canvas.findByText("model-gateway")).toBeVisible();
+  },
+};
+
+export const FirstRepository: Story = {
+  args: { scenario: "empty" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("heading", { name: "Start with a repository" }),
+    ).toBeVisible();
+  },
+};
+
+export const Loading: Story = { args: { scenario: "loading" } };
+
+export const Failure: Story = {
+  args: { scenario: "failure" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("The repository catalog could not load."),
+    ).toBeVisible();
+  },
+};
+
+export const NeedsHarness: Story = {
+  args: { scenario: "needs-harness" },
+};
+
+export const DenseSidebar: Story = {
+  args: { scenario: "dense-sidebar" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("Audit Storybook coverage"),
+    ).toBeVisible();
+    await expect(
+      await canvas.findByText("Recover provider errors"),
+    ).toBeVisible();
+  },
+};
+
+export const CompactFirstRepository: Story = {
+  args: { scenario: "empty" },
+  parameters: { viewport: { defaultViewport: "compact" } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/CodeQuickOpen.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeQuickOpen.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import type { ApiClient } from "@/api/client";
+import { CodeQuickOpen } from "@/code/CodeQuickOpen";
+import { codeWorkspaceFilePaths } from "./fixtures";
+
+type QuickOpenScenario = "ready" | "loading" | "empty" | "failure";
+
+function pending<T>(): Promise<T> {
+  return new Promise(() => {});
+}
+
+function quickOpenClient(scenario: QuickOpenScenario) {
+  return {
+    listCodeWorkspaceTree: async () => {
+      if (scenario === "loading") return pending();
+      if (scenario === "failure") {
+        throw new Error("The workspace file index is unavailable.");
+      }
+      return {
+        paths: scenario === "empty" ? [] : [...codeWorkspaceFilePaths],
+        truncated: false,
+      };
+    },
+  } satisfies Pick<ApiClient, "listCodeWorkspaceTree">;
+}
+
+function QuickOpenStory({ scenario }: { scenario: QuickOpenScenario }) {
+  return (
+    <div className="app-shell h-full min-h-[28rem] w-full bg-page-background">
+      <CodeQuickOpen
+        client={quickOpenClient(scenario)}
+        workspaceId="ws-storybook-audit"
+        contentRevision={0}
+        openRequest={1}
+        onOpenFile={() => {}}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Code/Quick open",
+  component: QuickOpenStory,
+  args: { scenario: "ready" },
+  parameters: { layout: "fullscreen" },
+  render: (args) => <QuickOpenStory key={args.scenario} {...args} />,
+} satisfies Meta<typeof QuickOpenStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Files: Story = {
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(
+      await body.findByRole("option", {
+        name: "crates/tidebreak-desktop/ui/src/code/CodeHome.tsx",
+      }),
+    ).toBeVisible();
+  },
+};
+
+export const FilteredResults: Story = {
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.type(
+      await body.findByRole("combobox", { name: "Search files by name" }),
+      "workspace page",
+    );
+    await expect(
+      await body.findByRole("option", {
+        name: "crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx",
+      }),
+    ).toBeVisible();
+  },
+};
+
+export const Loading: Story = { args: { scenario: "loading" } };
+
+export const Empty: Story = { args: { scenario: "empty" } };
+
+export const Failure: Story = {
+  args: { scenario: "failure" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(
+      await body.findByText("The workspace file index is unavailable."),
+    ).toBeVisible();
+  },
+};
+
+export const Compact: Story = {
+  parameters: { viewport: { defaultViewport: "compact" } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/CodeQuickOpen.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeQuickOpen.stories.tsx
@@ -92,5 +92,5 @@ export const Failure: Story = {
 };
 
 export const Compact: Story = {
-  parameters: { viewport: { defaultViewport: "compact" } },
+  globals: { viewport: { value: "compact", isRotated: false } },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
@@ -1,0 +1,371 @@
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn, userEvent, within } from "storybook/test";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import {
+  MessageList,
+  type ChatMessage,
+  type RetryableTurn,
+} from "@/MessageList";
+import {
+  TranscriptNavigation,
+  transcriptNavigationEntries,
+} from "@/TranscriptNavigation";
+
+type ConversationTranscriptProps = {
+  messages: ChatMessage[];
+  busy?: boolean;
+  hydrated?: boolean;
+  compacting?: boolean;
+  streamStalled?: boolean;
+  pinLastTurn?: boolean;
+  onRetryTurn?: (turn: RetryableTurn) => void;
+};
+
+function withRouter(children: ReactNode) {
+  const rootRoute = createRootRoute({ component: () => children });
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+  return <RouterProvider router={router as never} />;
+}
+
+function ConversationTranscript({
+  messages,
+  busy = false,
+  hydrated = true,
+  compacting = false,
+  streamStalled = false,
+  pinLastTurn = false,
+  onRetryTurn,
+}: ConversationTranscriptProps) {
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const [activeAnchor, setActiveAnchor] = useState<string>();
+  const navigationEntries = useMemo(
+    () => transcriptNavigationEntries(messages),
+    [messages],
+  );
+  const attachScrollRef = useCallback((node: HTMLDivElement | null) => {
+    setScrollElement(node);
+  }, []);
+  const jumpToMessage = useCallback(
+    (anchorId: string) => {
+      setActiveAnchor(anchorId);
+      const target = scrollElement
+        ? Array.from(
+            scrollElement.querySelectorAll<HTMLElement>(
+              "[data-transcript-anchor]",
+            ),
+          ).find((element) => element.dataset.transcriptAnchor === anchorId)
+        : null;
+      target?.scrollIntoView({ block: "start", behavior: "smooth" });
+    },
+    [scrollElement],
+  );
+
+  return (
+    <section className="chat-pane mx-auto h-full w-full max-w-5xl overflow-hidden border-x border-border bg-background">
+      <div className="message-view">
+        <MessageList
+          messages={messages}
+          folderAccessRequests={[]}
+          nativeHost={false}
+          nativeBusy={false}
+          resolvingFolderCalls={new Set()}
+          folderAccessErrors={{}}
+          decidingApprovalCalls={new Set()}
+          approvalErrors={{}}
+          busy={busy}
+          hydrated={hydrated}
+          compacting={compacting}
+          streamStalled={streamStalled}
+          pinLastTurn={pinLastTurn}
+          scrollRef={attachScrollRef}
+          onScroll={fn()}
+          onApproval={fn()}
+          onFolderAccessDecision={fn()}
+          onFolderAccessCancel={fn()}
+          onSelectPrompt={fn()}
+          onRetryTurn={onRetryTurn}
+        />
+        <TranscriptNavigation
+          entries={navigationEntries}
+          scrollElement={scrollElement}
+          activeAnchor={activeAnchor}
+          onJump={jumpToMessage}
+        />
+      </div>
+    </section>
+  );
+}
+
+const sourceA = {
+  id: "source-a",
+  ordinal: 1,
+  documentId: "design-audit",
+  locator: { kind: "pages", start: 8, end: 10 } as const,
+};
+
+const sourceB = {
+  id: "source-b",
+  ordinal: 2,
+  documentId: "accessibility-notes",
+  locator: { kind: "page", page: 4 } as const,
+};
+
+const streamingMessages: ChatMessage[] = [
+  {
+    id: "stream-user",
+    role: "user",
+    text: "Audit the conversation experience and explain the highest-impact improvements.",
+    createdAt: "2026-08-24T14:02:00.000Z",
+  },
+  {
+    id: "stream-assistant",
+    role: "assistant",
+    reasoning:
+      "I am comparing the dense tool phase with the compact transcript and checking which details should stay collapsed.",
+    text: "The main hierarchy problem is that long-running work gives each activity equal visual weight. I am grouping routine tool calls and keeping decisions visible.",
+    sources: [],
+    createdAt: "2026-08-24T14:02:08.000Z",
+  },
+];
+
+const toolHeavyMessages: ChatMessage[] = [
+  {
+    id: "tools-user",
+    role: "user",
+    text: "Review the current Storybook coverage, run the focused checks, and summarize the gaps.",
+    createdAt: "2026-08-24T14:10:00.000Z",
+  },
+  {
+    id: "tools-search",
+    role: "tool",
+    callId: "call-search",
+    name: "search",
+    status: "completed",
+    preview: {
+      tool: "search",
+      query: "title: Conversation/ OR title: Composer/ OR title: Chat/",
+    },
+  },
+  {
+    id: "tools-read",
+    role: "tool",
+    callId: "call-read",
+    name: "read_file",
+    status: "completed",
+  },
+  {
+    id: "tools-exec",
+    role: "tool",
+    callId: "call-exec",
+    name: "exec",
+    status: "completed",
+    preview: {
+      tool: "exec",
+      command: "pnpm",
+      args: ["exec", "biome", "check", "src/stories"],
+      cwd: "crates/tidebreak-desktop/ui",
+      files: [],
+    },
+    result: {
+      tool: "exec",
+      exitCode: 0,
+      timedOut: false,
+      outputTruncated: false,
+      stdout: "Checked 12 files in 41ms. No fixes applied.\n",
+      stderr: "",
+      backend: "local",
+    },
+  },
+  {
+    id: "tools-assistant",
+    role: "assistant",
+    text: "The focused checks pass. The largest coverage gap is the transcript as a system: empty, loading, streaming, tool-heavy, failure, and compact states were not visible together.",
+    sources: [sourceA],
+    createdAt: "2026-08-24T14:10:18.000Z",
+  },
+];
+
+const failureMessages: ChatMessage[] = [
+  {
+    id: "failure-user",
+    role: "user",
+    text: "Generate the screenshots for every dense conversation state.",
+    invokedSkills: ["browser"],
+    createdAt: "2026-08-24T14:18:00.000Z",
+  },
+  {
+    id: "failure-turn",
+    role: "turn_failure",
+    category: "transient",
+    detail: "The provider closed the stream before the response completed.",
+    model: { id: "gpt-5.6-sol", provider: "model_gateway" },
+    invokedSkills: ["browser"],
+  },
+];
+
+const denseMessages: ChatMessage[] = [
+  {
+    id: "dense-user-1",
+    role: "user",
+    text: "Map the conversation surfaces before changing them.",
+    files: [
+      {
+        documentId: "contract",
+        name: "storybook-review-contract.md",
+        mediaType: "text/markdown",
+      },
+    ],
+    invokedSkills: ["redesign-existing-projects", "browser"],
+    createdAt: "2026-08-24T13:20:00.000Z",
+  },
+  {
+    id: "dense-assistant-1",
+    role: "assistant",
+    text: "The transcript has strong isolated cards, but no composed story shows how those cards compete for attention during a long session.",
+    sources: [sourceA, sourceB],
+    createdAt: "2026-08-24T13:20:12.000Z",
+  },
+  { id: "dense-compaction", role: "compaction" },
+  {
+    id: "dense-user-2",
+    role: "user",
+    text: "Add the missing states and keep routine activity quiet.",
+    createdAt: "2026-08-24T13:36:00.000Z",
+  },
+  {
+    id: "dense-tool-1",
+    role: "tool",
+    callId: "dense-call-1",
+    name: "search",
+    status: "completed",
+    preview: { tool: "search", query: "conversation components" },
+  },
+  {
+    id: "dense-tool-2",
+    role: "tool",
+    callId: "dense-call-2",
+    name: "read_file",
+    status: "completed",
+  },
+  {
+    id: "dense-assistant-2",
+    role: "assistant",
+    text: "Routine reads and searches now collapse into one activity phase. Decisions, failures, and published results remain visible because they change what you do next.",
+    sources: [],
+    createdAt: "2026-08-24T13:36:26.000Z",
+  },
+  {
+    id: "dense-user-3",
+    role: "user",
+    text: "Check the compact pane and call out any remaining limitation.",
+    createdAt: "2026-08-24T13:44:00.000Z",
+  },
+  {
+    id: "dense-refusal",
+    role: "refusal",
+    category: "general_harms",
+    partialOutput: false,
+  },
+  {
+    id: "dense-user-4",
+    role: "user",
+    text: "Continue with the UI review only.",
+    createdAt: "2026-08-24T13:46:00.000Z",
+  },
+  {
+    id: "dense-assistant-3",
+    role: "assistant",
+    reasoning:
+      "The compact pane keeps the same order, but I am checking whether tool labels and source pills still leave enough room for the answer.",
+    text: "The compact pane remains readable. The transcript rail hides below the desktop breakpoint, and the contents menu keeps navigation available without taking horizontal space.",
+    sources: [sourceB],
+    createdAt: "2026-08-24T13:46:19.000Z",
+  },
+];
+
+const meta = {
+  title: "Conversation/Transcript",
+  component: ConversationTranscript,
+  parameters: { layout: "fullscreen" },
+  args: {
+    messages: toolHeavyMessages,
+    busy: false,
+    hydrated: true,
+    compacting: false,
+    streamStalled: false,
+    pinLastTurn: false,
+    onRetryTurn: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-screen min-h-0 bg-page-background">
+        {withRouter(<Story />)}
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ConversationTranscript>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NewConversation: Story = {
+  args: { messages: [] },
+};
+
+export const LoadingHistory: Story = {
+  args: { messages: [], hydrated: false },
+};
+
+export const StreamingResponse: Story = {
+  args: { messages: streamingMessages, busy: true, pinLastTurn: true },
+};
+
+export const StalledStream: Story = {
+  args: {
+    messages: streamingMessages,
+    busy: true,
+    streamStalled: true,
+    pinLastTurn: true,
+  },
+};
+
+export const CompactingConversation: Story = {
+  args: { messages: toolHeavyMessages, busy: true, compacting: true },
+};
+
+export const ToolHeavySession: Story = {};
+
+export const RetryableFailure: Story = {
+  args: { messages: failureMessages },
+};
+
+export const DenseLongRunningSession: Story = {
+  args: { messages: denseMessages },
+};
+
+export const CompactWidth: Story = {
+  args: { messages: denseMessages },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const TranscriptContents: Story = {
+  args: { messages: denseMessages },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Transcript contents" }),
+    );
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/DocumentDetail.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DocumentDetail.stories.tsx
@@ -1,0 +1,492 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import {
+  ApiClient,
+  HttpError,
+  type Chat,
+  type DocumentDetail,
+  type Project,
+} from "@/api";
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import { useChatListStore } from "@/ChatListStore";
+import { useChatSessionStore } from "@/ChatSessionStore";
+import { clearFileDownloadCache } from "@/document/useFileDownload";
+import { DocumentDetailRoot } from "@/document-detail/DocumentDetailRoot";
+import {
+  layoutFromSearch,
+  panelSearchFrom,
+  type PanelSearch,
+} from "@/panel/panelUrl";
+import { useProjectListStore } from "@/ProjectListStore";
+
+const CHAT_ID = "chat-storybook";
+const DOCUMENT_ID = "document-renewals";
+const PROJECT_ID = "project-renewals";
+const CITATION_ID = "citation-renewal-risk";
+
+const renewalMemo = `Renewal operating memo
+
+Summary
+The next 90 days contain 62% of forecast renewal value. Five enterprise accounts represent $1.8M in annual recurring revenue and need named executive sponsors.
+
+Account priorities
+Northstar Health — Adoption is strong, but legal review has not started.
+Fieldline Logistics — Pricing approval expires on September 12.
+Juniper Public Media — Security review is complete; procurement owns the next step.
+Harbor Energy — Product usage fell 14% after the July rollout.
+Canopy Systems — Expansion depends on the analytics migration plan.
+
+Recommended actions
+Assign an executive sponsor to each priority account.
+Confirm the procurement timeline before September 5.
+Review adoption risk with customer success every Friday.`;
+
+type Scenario =
+  | "success"
+  | "loading"
+  | "retriable"
+  | "not-found"
+  | "download-rejected"
+  | "sharing-success"
+  | "sharing-deferred"
+  | "sharing-rejected"
+  | "citation"
+  | "original-success"
+  | "original-loading"
+  | "original-failed";
+
+function documentInfo(scenario: Scenario): DocumentDetail {
+  return {
+    document_id: DOCUMENT_ID,
+    media_type: "application/pdf",
+    title: "Q3 renewal operating memo.pdf",
+    readable: true,
+    has_original_bytes:
+      scenario === "original-success" ||
+      scenario === "original-loading" ||
+      scenario === "original-failed",
+    updated_at: "2026-08-21T15:30:00.000Z",
+    content: renewalMemo,
+  };
+}
+
+function pending<T>(): Promise<T> {
+  return new Promise(() => {});
+}
+
+async function originalPdfBytes(): Promise<Uint8Array> {
+  const document = await PDFDocument.create();
+  const page = document.addPage([612, 792]);
+  const font = await document.embedFont(StandardFonts.Helvetica);
+  page.drawText("Q3 renewal operating memo", {
+    x: 72,
+    y: 700,
+    size: 22,
+    font,
+    color: rgb(0.13, 0.16, 0.14),
+  });
+  page.drawText("Five priority accounts need named executive sponsors.", {
+    x: 72,
+    y: 660,
+    size: 12,
+    font,
+    color: rgb(0.3, 0.35, 0.31),
+  });
+  return document.save();
+}
+
+function storyClient(scenario: Scenario): ApiClient {
+  const info = documentInfo(scenario);
+  const client = new ApiClient("https://storybook.invalid", "storybook");
+  let documentAttempts = 0;
+
+  client.getChatDocument = async () => {
+    if (scenario === "loading") return pending<DocumentDetail>();
+    if (scenario === "not-found") {
+      throw new HttpError(404, "404: document not found");
+    }
+    if (scenario === "retriable" && documentAttempts++ === 0) {
+      throw new HttpError(503, "503: service unavailable");
+    }
+    return info;
+  };
+  client.getChatDocumentFile = async () => {
+    if (scenario === "original-loading") {
+      return pending<{ bytes: Uint8Array; contentType: string | null }>();
+    }
+    if (scenario === "original-failed") {
+      throw new Error("Original file download failed.");
+    }
+    return {
+      bytes:
+        scenario === "original-success"
+          ? await originalPdfBytes()
+          : new TextEncoder().encode(info.content),
+      contentType: info.media_type,
+    };
+  };
+  client.promoteDocumentToProject = async () => {
+    if (scenario === "sharing-deferred") {
+      return pending<{ document_id: string }>();
+    }
+    if (scenario === "sharing-rejected") {
+      throw new Error("The file could not be added to the project.");
+    }
+    return { document_id: "project-document-renewals" };
+  };
+
+  return client;
+}
+
+function storyDownload(scenario: Scenario) {
+  let attempts = 0;
+  return async () => {
+    if (scenario === "download-rejected" && attempts++ === 0) {
+      throw new Error("Could not save that source.");
+    }
+    return true;
+  };
+}
+
+function appContext(client: ApiClient): AppContextValue {
+  return {
+    client,
+    models: [],
+    defaultModelKey: null,
+    providers: [],
+    refreshCatalog: async () => {},
+    refreshChats: async () => {},
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: { status: "idle", version: null, error: null, enabled: false },
+    updateUpToDate: false,
+    checkForUpdate: async () => ({
+      status: "idle",
+      version: null,
+      error: null,
+      enabled: false,
+    }),
+    attachment: "local",
+    restartForUpdate: async () => {},
+  };
+}
+
+function resetStoryStores() {
+  useChatListStore.setState({
+    chats: [],
+    chatsLoaded: false,
+    chatsError: null,
+    creatingChat: false,
+    deletingChatId: null,
+    renamingChatId: null,
+    renameChatDraft: "",
+    savingTitle: false,
+    derivedTitleChatId: null,
+    streamedTitles: {},
+  });
+  useProjectListStore.setState({
+    projects: [],
+    projectsLoaded: false,
+    creatingProject: false,
+    deletingProjectId: null,
+    renamingProjectId: null,
+    renameProjectDraft: "",
+    savingProjectTitle: false,
+    expandedProjectIds: [],
+  });
+  useChatSessionStore.getState().reset();
+  clearFileDownloadCache();
+}
+
+function seedStoryStores(scenario: Scenario) {
+  resetStoryStores();
+
+  const projectId = scenario.startsWith("sharing-") ? PROJECT_ID : null;
+  const chat: Chat = {
+    id: CHAT_ID,
+    project_id: projectId,
+    title: "Renewal planning",
+    model: null,
+    reasoning_effort: null,
+    permission_mode: "ask",
+    network_policy: { mode: "off" },
+    attachment_revision: 0,
+    root_attachments: [],
+    created_at: "2026-08-21T15:30:00.000Z",
+  };
+  useChatListStore.getState().setChats([chat]);
+
+  const projects: Project[] = projectId
+    ? [
+        {
+          id: PROJECT_ID,
+          title: "Renewal operations",
+          attachment_revision: 0,
+          root_attachments: [],
+          created_at: "2026-08-20T13:00:00.000Z",
+        },
+      ]
+    : [];
+  useProjectListStore.getState().setProjects(projects);
+
+  if (scenario === "citation") {
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      messages: [
+        {
+          id: "message-renewal-summary",
+          role: "assistant",
+          text: "Two accounts need immediate commercial follow-up.",
+          sources: [
+            {
+              id: CITATION_ID,
+              ordinal: 1,
+              documentId: DOCUMENT_ID,
+              locator: { kind: "lines", start: 6, end: 8 },
+            },
+          ],
+          createdAt: "2026-08-21T15:34:00.000Z",
+        },
+      ],
+    }));
+  }
+}
+
+function storyUrl(scenario: Scenario): string {
+  const citation = scenario === "citation" ? `.${CITATION_ID}` : "";
+  return `/c/${CHAT_ID}?tabs=document.${DOCUMENT_ID}${citation}`;
+}
+
+function storyRouter(
+  initialUrl: string,
+  download: (chatId: string, documentId: string) => Promise<boolean>,
+) {
+  const rootRoute = createRootRoute();
+  const chatRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/c/$chatId",
+    validateSearch: (search: Record<string, unknown>): PanelSearch =>
+      panelSearchFrom(search),
+    component: function DocumentRoute() {
+      const { chatId } = chatRoute.useParams();
+      const layout = layoutFromSearch(chatRoute.useSearch());
+      const panel = layout.tabs[layout.activeIndex];
+      if (panel?.type !== "document") return null;
+
+      return (
+        <DocumentDetailRoot
+          chatId={chatId}
+          documentID={panel.documentId}
+          citationId={panel.citationId}
+          download={download}
+          canDownload
+        />
+      );
+    },
+  });
+
+  return createRouter({
+    routeTree: rootRoute.addChildren([chatRoute]),
+    history: createMemoryHistory({ initialEntries: [initialUrl] }),
+  });
+}
+
+function DocumentDetailRootStory({ scenario }: { scenario: Scenario }) {
+  const [state] = useState(() => {
+    seedStoryStores(scenario);
+    const client = storyClient(scenario);
+    const download = storyDownload(scenario);
+    return {
+      client,
+      router: storyRouter(storyUrl(scenario), download),
+    };
+  });
+
+  useEffect(() => () => resetStoryStores(), []);
+
+  return (
+    <AppContextProvider value={appContext(state.client)}>
+      <div className="app-shell h-screen min-h-0 w-full overflow-hidden bg-page-background text-foreground">
+        <RouterProvider router={state.router as never} />
+      </div>
+    </AppContextProvider>
+  );
+}
+
+const meta = {
+  title: "Documents/Detail",
+  component: DocumentDetailRootStory,
+  parameters: { layout: "fullscreen" },
+  args: { scenario: "success" },
+  render: (args) => <DocumentDetailRootStory key={args.scenario} {...args} />,
+} satisfies Meta<typeof DocumentDetailRootStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/62% of forecast renewal value/),
+    ).toBeVisible();
+  },
+};
+
+export const Loading: Story = {
+  args: { scenario: "loading" },
+};
+
+export const RetriableFailure: Story = {
+  args: { scenario: "retriable" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("The document could not be loaded (503)."),
+    ).toBeVisible();
+    await expect(
+      canvas.getByRole("button", { name: "Try again" }),
+    ).toBeVisible();
+    await userEvent.click(canvas.getByRole("button", { name: "Try again" }));
+    await expect(
+      await canvas.findByText(/62% of forecast renewal value/),
+    ).toBeVisible();
+  },
+};
+
+export const TerminalNotFound: Story = {
+  args: { scenario: "not-found" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("The document is no longer available."),
+    ).toBeVisible();
+    await expect(
+      canvas.queryByRole("button", { name: "Try again" }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const DownloadFailureAndRetry: Story = {
+  args: { scenario: "download-rejected" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText(/62% of forecast renewal value/);
+    const download = canvas.getByRole("button", { name: "Download" });
+
+    await userEvent.click(download);
+    await expect(await canvas.findByRole("alert")).toHaveTextContent(
+      "Could not save that source.",
+    );
+    await expect(download).toBeEnabled();
+
+    await userEvent.click(download);
+    await waitFor(() => {
+      expect(canvas.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    await expect(download).toBeEnabled();
+  },
+};
+
+export const ProjectSharing: Story = {
+  args: { scenario: "sharing-success" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Add to project" }),
+    );
+    await expect(
+      await canvas.findByRole("button", { name: "In the project" }),
+    ).toBeDisabled();
+  },
+};
+
+export const ProjectSharingPending: Story = {
+  args: { scenario: "sharing-deferred" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const share = await canvas.findByRole("button", {
+      name: "Add to project",
+    });
+    await expect(share).toBeEnabled();
+    await userEvent.click(share);
+    await expect(share).toBeDisabled();
+  },
+};
+
+export const ProjectSharingFailure: Story = {
+  args: { scenario: "sharing-rejected" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const share = await canvas.findByRole("button", {
+      name: "Add to project",
+    });
+    await userEvent.click(share);
+    await waitFor(() => expect(share).toBeEnabled());
+    await expect(share).toHaveAccessibleName("Add to project");
+  },
+};
+
+export const CitationHighlight: Story = {
+  args: { scenario: "citation" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByLabelText("Cited passage"),
+    ).toHaveTextContent("Account priorities");
+  },
+};
+
+export const OriginalFileLoading: Story = {
+  args: { scenario: "original-loading" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Loading document…")).toBeVisible();
+  },
+};
+
+export const OriginalFileSuccess: Story = {
+  args: { scenario: "original-success" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("button", { name: "Rotate clockwise" }),
+    ).toBeVisible();
+  },
+};
+
+export const OriginalFileFailure: Story = {
+  args: { scenario: "original-failed" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("This document could not be loaded."),
+    ).toBeVisible();
+  },
+};
+
+export const Compact: Story = {
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/DocumentViewerChrome.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DocumentViewerChrome.stories.tsx
@@ -1,0 +1,171 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { useState } from "react";
+
+import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
+import {
+  DocumentDetailActions,
+  DocumentDetailBreadcrumb,
+} from "@/document-detail/DocumentDetailHeader";
+import { PdfHeaderControls } from "@/document/PdfHeaderControls";
+import { SpreadsheetShortcutsInfoBar } from "@/document/SpreadsheetShortcutsInfo";
+
+type ChromeVariant = "pdf" | "spreadsheet" | "download" | "shared";
+
+function PdfChrome() {
+  const [page, setPage] = useState(7);
+  return (
+    <>
+      <header className="flex h-11 shrink-0 items-center justify-between gap-3 border-b px-3">
+        <DocumentDetailBreadcrumb documentName="Board packet.pdf" />
+        <div className="flex min-w-0 items-center gap-2">
+          <PdfHeaderControls
+            page={{ currentPage: page, numPages: 24, setPage }}
+          />
+          <DocumentDetailActions
+            canDownload
+            onDownload={fn()}
+            onAddToProject={fn()}
+          />
+        </div>
+      </header>
+      <div className="min-h-0 grow overflow-auto bg-muted/35 p-6">
+        <div className="mx-auto flex max-w-3xl flex-col gap-5">
+          {[page, page + 1].map((pageNumber) => (
+            <article
+              key={pageNumber}
+              className="aspect-[8.5/11] rounded-sm border bg-background p-10 shadow-xs"
+            >
+              <p className="text-xs font-medium text-muted-foreground">
+                Board packet · Page {pageNumber}
+              </p>
+              <h2 className="mt-8 text-2xl font-semibold tracking-tight">
+                Renewal health and account actions
+              </h2>
+              <div className="mt-8 grid grid-cols-3 gap-3">
+                {["$4.8M", "62%", "18 days"].map((value) => (
+                  <div key={value} className="rounded-md bg-muted/50 p-4">
+                    <p className="text-xl font-semibold tabular-nums">
+                      {value}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Operating signal
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function DocumentViewerChromeStory({ variant }: { variant: ChromeVariant }) {
+  return (
+    <div className="flex h-screen min-h-0 flex-col overflow-hidden bg-page-background text-foreground">
+      {variant === "pdf" ? (
+        <PdfChrome />
+      ) : variant === "download" ? (
+        <>
+          <header className="flex h-11 shrink-0 items-center justify-between border-b px-3">
+            <DocumentDetailBreadcrumb documentName="Research archive.pdf" />
+          </header>
+          <FileDownloadProgressIndicator
+            progress={{
+              loaded: 12.6 * 1024 * 1024,
+              total: 28.4 * 1024 * 1024,
+              percentage: 44.4,
+            }}
+            className="grow"
+          />
+        </>
+      ) : (
+        <>
+          <header className="flex h-11 shrink-0 items-center justify-between gap-3 border-b px-3">
+            <DocumentDetailBreadcrumb documentName="Account forecast.xlsx" />
+            <DocumentDetailActions
+              canDownload
+              canAddToProject
+              shared={variant === "shared"}
+              onDownload={fn()}
+              onAddToProject={fn()}
+            />
+          </header>
+          <SpreadsheetShortcutsInfoBar onAutofit={fn()} />
+          <div className="min-h-0 grow overflow-auto bg-background p-4 font-mono text-xs">
+            <div className="min-w-[760px] overflow-hidden rounded-md border">
+              <div className="grid grid-cols-[3rem_12rem_repeat(4,8rem)] bg-muted/60 font-medium">
+                {["", "Account", "ARR", "Renewal", "Risk", "Owner"].map(
+                  (cell) => (
+                    <div key={cell || "corner"} className="border-r px-2 py-2">
+                      {cell}
+                    </div>
+                  ),
+                )}
+              </div>
+              {Array.from({ length: 12 }, (_, index) => (
+                <div
+                  key={index}
+                  className="grid grid-cols-[3rem_12rem_repeat(4,8rem)] border-t"
+                >
+                  <div className="bg-muted/35 px-2 py-2 text-muted-foreground">
+                    {index + 1}
+                  </div>
+                  <div className="border-l px-2 py-2">Account {index + 1}</div>
+                  <div className="border-l px-2 py-2 tabular-nums">
+                    ${(428 - index * 17).toLocaleString()}K
+                  </div>
+                  <div className="border-l px-2 py-2">2026-10-{15 + index}</div>
+                  <div className="border-l px-2 py-2">
+                    {index % 3 === 0 ? "High" : "Medium"}
+                  </div>
+                  <div className="border-l px-2 py-2">CS {index + 1}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+const meta = {
+  title: "Documents/Viewer chrome",
+  component: DocumentViewerChromeStory,
+  parameters: { layout: "fullscreen" },
+  args: { variant: "pdf" },
+} satisfies Meta<typeof DocumentViewerChromeStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PdfHeader: Story = {};
+
+export const SpreadsheetHeader: Story = {
+  args: { variant: "spreadsheet" },
+};
+
+export const DownloadProgress: Story = {
+  args: { variant: "download" },
+};
+
+export const AddedToProject: Story = {
+  args: { variant: "shared" },
+};
+
+export const CompactPdfHeader: Story = {
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const CompactDownloadProgress: Story = {
+  args: { variant: "download" },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const CompactSpreadsheetHeader: Story = {
+  args: { variant: "spreadsheet" },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/DocumentViewers.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DocumentViewers.stories.tsx
@@ -1,0 +1,276 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ImageViewer } from "@/components/document/image-viewer";
+import { JsonViewer } from "@/components/document/json-viewer";
+import { MarkdownViewer } from "@/components/document/markdown-viewer";
+import { XmlViewer } from "@/components/document/xml-viewer";
+import type { FileBytesSource } from "@/document/useFileDownload";
+
+type ViewerVariant =
+  | "markdown"
+  | "plain-citation"
+  | "json"
+  | "invalid-json"
+  | "xml"
+  | "unsupported"
+  | "download-progress"
+  | "download-failure"
+  | "image";
+
+const markdown = `# Customer evidence review
+
+This source combines interview notes, usage data, and renewal context.
+
+## What changed
+
+Enterprise teams adopted shared workspaces faster after the permissions update.
+
+## Evidence
+
+1. Weekly active collaborators increased from 4.2 to 7.8.
+2. Review turnaround fell from 31 hours to 18 hours.
+3. Renewal risk moved from high to medium for three accounts.
+
+## Next questions
+
+- Which teams still depend on exported files?
+- Where does review ownership remain unclear?
+`;
+
+const plainText = `Interview notes
+Participant: Operations lead
+Date: August 19, 2026
+
+The permissions update reduced the number of manual exports.
+Reviewers now stay inside the workspace for most approval cycles.
+Two teams still export spreadsheets because their finance partners do not have access.
+
+Follow-up
+Confirm whether guest access covers the finance review workflow.`;
+
+const json = JSON.stringify(
+  {
+    account: {
+      name: "Northstar Health",
+      renewal: {
+        date: "2026-10-15",
+        annualRecurringRevenue: 428_000,
+        risk: "medium",
+      },
+      adoption: {
+        activeUsers: 184,
+        weeklyCollaborators: 7.8,
+        workflows: ["Research", "Review", "Executive briefing"],
+      },
+      owners: [
+        { function: "Customer success", name: "Mara Chen" },
+        { function: "Executive sponsor", name: "Devon Price" },
+      ],
+    },
+  },
+  null,
+  2,
+);
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<renewal-plan account="Northstar Health">
+  <summary risk="medium" annual-recurring-revenue="428000" />
+  <owners>
+    <owner function="customer-success">Mara Chen</owner>
+    <owner function="executive-sponsor">Devon Price</owner>
+  </owners>
+  <actions>
+    <action due="2026-09-05">Confirm legal review owner</action>
+    <action due="2026-09-12">Approve pricing exception</action>
+  </actions>
+</renewal-plan>`;
+
+const imageSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#e7ebe5"/>
+  <rect x="56" y="52" width="848" height="436" rx="18" fill="#fbfcfa" stroke="#c9d1c8"/>
+  <text x="96" y="116" font-family="system-ui, sans-serif" font-size="22" font-weight="600" fill="#243027">Renewal health by account</text>
+  <text x="96" y="148" font-family="system-ui, sans-serif" font-size="13" fill="#718076">90-day operating review</text>
+  <line x1="96" y1="424" x2="848" y2="424" stroke="#c9d1c8"/>
+  <rect x="132" y="226" width="88" height="198" rx="6" fill="#688b70"/>
+  <rect x="278" y="276" width="88" height="148" rx="6" fill="#86a08b"/>
+  <rect x="424" y="310" width="88" height="114" rx="6" fill="#9fb3a2"/>
+  <rect x="570" y="338" width="88" height="86" rx="6" fill="#b8c5b9"/>
+  <rect x="716" y="366" width="88" height="58" rx="6" fill="#cad3cb"/>
+  <text x="138" y="454" font-family="system-ui, sans-serif" font-size="12" fill="#526157">Northstar</text>
+  <text x="293" y="454" font-family="system-ui, sans-serif" font-size="12" fill="#526157">Fieldline</text>
+  <text x="439" y="454" font-family="system-ui, sans-serif" font-size="12" fill="#526157">Juniper</text>
+  <text x="584" y="454" font-family="system-ui, sans-serif" font-size="12" fill="#526157">Harbor</text>
+  <text x="732" y="454" font-family="system-ui, sans-serif" font-size="12" fill="#526157">Canopy</text>
+</svg>`;
+
+function source(
+  id: string,
+  content: string,
+  contentType: string,
+): FileBytesSource {
+  return {
+    id,
+    cacheKey: `storybook/${id}`,
+    fetch: async () => ({
+      bytes: new TextEncoder().encode(content),
+      contentType,
+    }),
+  };
+}
+
+const progressSource: FileBytesSource = {
+  id: "progress",
+  cacheKey: "storybook/progress",
+  fetch: async (_signal, onProgress) => {
+    onProgress?.({
+      loaded: 12.6 * 1024 * 1024,
+      total: 28.4 * 1024 * 1024,
+      percentage: 44.4,
+    });
+    return new Promise(() => undefined);
+  },
+};
+
+const failureSource: FileBytesSource = {
+  id: "failure",
+  cacheKey: "storybook/failure",
+  fetch: async () => {
+    throw new Error("The source download was interrupted.");
+  },
+};
+
+function DocumentViewerStory({ variant }: { variant: ViewerVariant }) {
+  const className = "h-[680px] min-h-0 rounded-lg border bg-page-background";
+
+  switch (variant) {
+    case "markdown":
+      return (
+        <MarkdownViewer
+          source={source("markdown", markdown, "text/markdown")}
+          markdown
+          className={className}
+        />
+      );
+    case "plain-citation":
+      return (
+        <MarkdownViewer
+          source={source("plain", plainText, "text/plain")}
+          targetLines={{ start: 5, end: 7 }}
+          className={className}
+        />
+      );
+    case "json":
+      return (
+        <JsonViewer
+          source={source("json", json, "application/json")}
+          highlightPath="account.renewal.risk"
+          className={className}
+        />
+      );
+    case "invalid-json":
+      return (
+        <JsonViewer
+          source={source(
+            "invalid-json",
+            "{ not valid json",
+            "application/json",
+          )}
+          className={className}
+        />
+      );
+    case "xml":
+      return (
+        <XmlViewer
+          source={source("xml", xml, "application/xml")}
+          highlightPath="/renewal-plan/actions/action[2]"
+          className={className}
+        />
+      );
+    case "unsupported":
+      return (
+        <MarkdownViewer
+          source={source(
+            "unsupported",
+            "Binary bytes are not rendered as text.",
+            "application/octet-stream",
+          )}
+          className={className}
+        />
+      );
+    case "download-progress":
+      return <MarkdownViewer source={progressSource} className={className} />;
+    case "download-failure":
+      return <MarkdownViewer source={failureSource} className={className} />;
+    case "image":
+      return (
+        <ImageViewer
+          source={source("image", imageSvg, "image/svg+xml")}
+          className={className}
+        />
+      );
+  }
+}
+
+const meta = {
+  title: "Documents/Viewer content",
+  component: DocumentViewerStory,
+  args: { variant: "markdown" },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: [
+        "markdown",
+        "plain-citation",
+        "json",
+        "invalid-json",
+        "xml",
+        "unsupported",
+        "download-progress",
+        "download-failure",
+        "image",
+      ],
+    },
+  },
+} satisfies Meta<typeof DocumentViewerStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MarkdownWithOutline: Story = {};
+
+export const PlainTextCitation: Story = {
+  args: { variant: "plain-citation" },
+};
+
+export const JsonTree: Story = {
+  args: { variant: "json" },
+};
+
+export const InvalidJson: Story = {
+  args: { variant: "invalid-json" },
+};
+
+export const XmlTree: Story = {
+  args: { variant: "xml" },
+};
+
+export const UnsupportedFormat: Story = {
+  args: { variant: "unsupported" },
+};
+
+export const DownloadProgress: Story = {
+  args: { variant: "download-progress" },
+};
+
+export const DownloadFailure: Story = {
+  args: { variant: "download-failure" },
+};
+
+export const Image: Story = {
+  args: { variant: "image" },
+};
+
+export const CompactJson: Story = {
+  args: { variant: "json" },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/FacetFilter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/FacetFilter.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+import { useMemo, useState } from "react";
+
+import type { Facet } from "@/lib/facets";
+import { FacetFilter } from "@/sources/FacetFilter";
+
+const counts = {
+  PDF: 18,
+  Spreadsheet: 12,
+  "Word document": 9,
+  Presentation: 7,
+  Markdown: 5,
+  JSON: 4,
+  Image: 3,
+  "Plain text": 2,
+};
+
+function FacetFilterStory({
+  initialSelected = [],
+}: {
+  initialSelected?: string[];
+}) {
+  const [selected, setSelected] = useState(new Set(initialSelected));
+  const [search, setSearch] = useState("");
+  const facet = useMemo<Facet>(
+    () => ({
+      selected,
+      setSelected,
+      search,
+      setSearch,
+      counts,
+      toggle(value) {
+        setSelected((current) => {
+          const next = new Set(current);
+          if (next.has(value)) next.delete(value);
+          else next.add(value);
+          return next;
+        });
+      },
+    }),
+    [search, selected],
+  );
+
+  return (
+    <div className="flex min-h-64 items-start justify-center rounded-lg border bg-page-background p-10">
+      <FacetFilter label="Type" facet={facet} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Sources/Facet filter",
+  component: FacetFilterStory,
+} satisfies Meta<typeof FacetFilterStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SelectedValues: Story = {
+  args: { initialSelected: ["PDF", "Spreadsheet", "Presentation"] },
+};
+
+export const SearchNoMatches: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Type" }));
+    await userEvent.type(
+      await within(document.body).findByPlaceholderText("Search type…"),
+      "audio",
+    );
+    await expect(within(document.body).getByText("No matches.")).toBeVisible();
+  },
+};
+
+export const Compact: Story = {
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/Navigation.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Navigation.stories.tsx
@@ -1,0 +1,254 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { RouteFrame } from "@/RouteFrame";
+import { AppSidebar } from "@/sidebar/AppSidebar";
+import { NewProjectDialog } from "@/sidebar/NewProjectDialog";
+import { SidebarExpandStrip } from "@/sidebar/SidebarExpandStrip";
+import {
+  denseInboxEntries,
+  denseRouteChats,
+  resetRouteStoryStores,
+  routeChats,
+  RouteStoryProviders,
+  storyClient,
+} from "./routeStoryHarness";
+
+type NavigationScenario =
+  | "active-work"
+  | "loading"
+  | "empty"
+  | "dense"
+  | "failure"
+  | "narrow"
+  | "collapsed";
+
+function NavigationSurface({ activeChatId }: { activeChatId?: string }) {
+  const activeChat = routeChats.find((chat) => chat.id === activeChatId);
+  return (
+    <RouteFrame sidebar={<AppSidebar chat={activeChat} />}>
+      <div className="content-container grid h-full min-h-0 place-items-center p-8">
+        <div className="max-w-md text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Navigation review surface
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            This canvas keeps the production rail in context while you inspect
+            active routes, list density, loading, and failure states.
+          </p>
+        </div>
+      </div>
+    </RouteFrame>
+  );
+}
+
+function createNavigationRouter(initialPath: string) {
+  const rootRoute = createRootRoute();
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: NavigationSurface,
+  });
+  const inboxRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/inbox",
+    component: NavigationSurface,
+  });
+  const appsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/apps",
+    component: NavigationSurface,
+  });
+  const pluginsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/plugins",
+    component: NavigationSurface,
+  });
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings",
+    component: NavigationSurface,
+  });
+  const codeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code",
+    component: NavigationSurface,
+  });
+  const projectRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/p/$projectId",
+    component: NavigationSurface,
+  });
+  const chatRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/c/$chatId",
+    component: () => <NavigationSurface activeChatId="chat-1" />,
+  });
+  const projectChatRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/p/$projectId/c/$chatId",
+    component: () => <NavigationSurface activeChatId="chat-3" />,
+  });
+
+  return createRouter({
+    routeTree: rootRoute.addChildren([
+      homeRoute,
+      inboxRoute,
+      appsRoute,
+      pluginsRoute,
+      settingsRoute,
+      codeRoute,
+      projectRoute,
+      chatRoute,
+      projectChatRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+function NavigationStory({ scenario }: { scenario: NavigationScenario }) {
+  const [state] = useState(() => {
+    const dense = scenario === "dense";
+    resetRouteStoryStores({
+      chats:
+        scenario === "empty" || scenario === "loading"
+          ? []
+          : dense
+            ? denseRouteChats
+            : routeChats,
+      chatsLoaded: scenario !== "loading",
+      chatsError:
+        scenario === "failure"
+          ? "Work could not be loaded from this machine."
+          : null,
+      projects: scenario === "empty" || scenario === "loading" ? [] : undefined,
+      projectsLoaded: scenario !== "loading",
+      inboxEntries: dense ? denseInboxEntries : [],
+      inboxLoaded: scenario !== "loading",
+      attentionChatIds: dense ? ["chat-2", "dense-chat-2"] : ["chat-2"],
+      sidebarWidth: scenario === "narrow" ? 220 : 280,
+      sidebarCollapsed: scenario === "collapsed",
+    });
+
+    const initialPath =
+      scenario === "active-work"
+        ? "/c/chat-1"
+        : scenario === "dense"
+          ? "/inbox"
+          : scenario === "narrow"
+            ? "/apps"
+            : scenario === "collapsed"
+              ? "/apps"
+              : "/";
+    return {
+      client: storyClient(),
+      router: createNavigationRouter(initialPath),
+    };
+  });
+
+  return (
+    <RouteStoryProviders client={state.client}>
+      <div className="app-shell h-full min-h-0 w-full overflow-hidden">
+        <SidebarExpandStrip macOverlay={false} />
+        <div className="app-body">
+          <RouterProvider router={state.router as never} />
+        </div>
+      </div>
+    </RouteStoryProviders>
+  );
+}
+
+const meta = {
+  title: "Navigation/Sidebar",
+  component: NavigationStory,
+  args: { scenario: "active-work" },
+  parameters: { layout: "fullscreen" },
+  render: (args) => <NavigationStory key={args.scenario} {...args} />,
+} satisfies Meta<typeof NavigationStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ActiveWork: Story = {};
+
+export const LoadingLists: Story = {
+  args: { scenario: "loading" },
+};
+
+export const EmptyLists: Story = {
+  args: { scenario: "empty" },
+};
+
+export const DenseLists: Story = {
+  args: { scenario: "dense" },
+};
+
+export const ChatLoadFailure: Story = {
+  args: { scenario: "failure" },
+};
+
+export const NarrowRail: Story = {
+  args: { scenario: "narrow" },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The rail stays fully featured at its narrower saved width. This replaces the misleading compact-rail name; compact now refers only to viewport stories.",
+      },
+    },
+  },
+};
+
+export const CollapsedRail: Story = {
+  args: { scenario: "collapsed" },
+};
+
+export const CollapseAndRestoreActiveRoute: Story = {
+  args: { scenario: "narrow" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const appsLink = await canvas.findByRole("button", { name: "Apps" });
+    await expect(appsLink).toHaveAttribute("aria-current", "page");
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Collapse sidebar" }),
+    );
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Expand sidebar" }),
+    );
+
+    await expect(
+      await canvas.findByRole("button", { name: "Apps" }),
+    ).toHaveAttribute("aria-current", "page");
+  },
+};
+
+export const NewProject: Story = {
+  render: () => (
+    <NewProjectDialog
+      open
+      creating={false}
+      onOpenChange={fn()}
+      onCreate={fn(async () => true)}
+    />
+  ),
+};
+
+export const CreatingProject: Story = {
+  render: () => (
+    <NewProjectDialog
+      open
+      creating
+      onOpenChange={fn()}
+      onCreate={fn(async () => true)}
+    />
+  ),
+};

--- a/crates/tidebreak-desktop/ui/src/stories/OutputContent.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/OutputContent.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { DeliverablePreview } from "@/deliverables";
+import { OutputContent } from "@/outputs/OutputContent";
+
+const markdown = `# Renewal analysis
+
+Enterprise renewals remain the main driver of expansion revenue.
+
+## Recommendation
+
+Prioritize the 18 accounts with adoption above 70% and renewal dates inside 90 days.
+
+| Segment | Accounts | Expansion potential |
+| --- | ---: | ---: |
+| Enterprise | 18 | $1.42M |
+| Growth | 31 | $684K |
+| Emerging | 47 | $212K |
+`;
+
+const code = `{
+  "generated_at": "2026-08-21T15:30:00Z",
+  "segments": [
+    { "name": "Enterprise", "accounts": 18, "pipeline": 1420000 },
+    { "name": "Growth", "accounts": 31, "pipeline": 684000 },
+    { "name": "Emerging", "accounts": 47, "pipeline": 212000 }
+  ]
+}`;
+
+const chart = JSON.stringify({
+  data: [
+    {
+      type: "bar",
+      x: ["Enterprise", "Growth", "Emerging"],
+      y: [1.42, 0.684, 0.212],
+      marker: { color: ["#6f9277", "#96aa9a", "#c4cec5"] },
+      hovertemplate: "%{x}<br>$%{y:.3f}M<extra></extra>",
+    },
+  ],
+  layout: {
+    title: { text: "Expansion pipeline by segment", x: 0 },
+    yaxis: { title: "Pipeline ($M)", rangemode: "tozero" },
+    margin: { t: 64, r: 24, b: 56, l: 64 },
+  },
+});
+
+function preview(
+  mediaType: string,
+  content: string,
+  options: Partial<DeliverablePreview> = {},
+): DeliverablePreview {
+  return {
+    outputId: "output-storybook",
+    filename: "renewal-analysis.md",
+    mediaType,
+    revisionCount: 3,
+    revisionId: "revision-3",
+    content,
+    truncated: false,
+    ...options,
+  };
+}
+
+function ContentStory({ preview }: { preview: DeliverablePreview }) {
+  return (
+    <div className="flex h-[680px] min-h-0 overflow-hidden rounded-lg border bg-page-background">
+      <OutputContent chatId="chat-storybook" preview={preview} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Outputs/Content",
+  component: ContentStory,
+  args: { preview: preview("text/markdown", markdown) },
+} satisfies Meta<typeof ContentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MarkdownReport: Story = {};
+
+export const CodeAndData: Story = {
+  args: {
+    preview: preview("application/json", code, {
+      filename: "account-segments.json",
+    }),
+  },
+};
+
+export const Chart: Story = {
+  args: {
+    preview: preview("application/vnd.tidebreak.chart+json", chart, {
+      filename: "expansion-pipeline.chart.json",
+    }),
+  },
+};
+
+export const InvalidChartSource: Story = {
+  args: {
+    preview: preview(
+      "application/vnd.tidebreak.chart+json",
+      '{"data":[],"layout":{"title":"Missing traces"}}',
+      { filename: "invalid.chart.json" },
+    ),
+  },
+};
+
+export const TruncatedChartSource: Story = {
+  args: {
+    preview: preview(
+      "application/vnd.tidebreak.chart+json",
+      chart.slice(0, 180),
+      {
+        filename: "large-chart.chart.json",
+        truncated: true,
+      },
+    ),
+  },
+};
+
+export const UnsupportedFormat: Story = {
+  args: {
+    preview: preview("application/zip", "", {
+      filename: "research-archive.zip",
+    }),
+  },
+};
+
+export const TruncatedText: Story = {
+  args: {
+    preview: preview("text/markdown", markdown, { truncated: true }),
+  },
+};
+
+export const CompactCode: Story = {
+  args: {
+    preview: preview("application/json", code, {
+      filename: "account-segments.json",
+    }),
+  },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/OutputDetail.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/OutputDetail.stories.tsx
@@ -1,0 +1,264 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { useState } from "react";
+
+import type {
+  DeliverablePreview,
+  DeliverableSummary,
+  OutputRevisionInfo,
+} from "@/deliverables";
+import {
+  OutputDetailRoot,
+  type OutputDetailApis,
+} from "@/outputs/OutputDetailRoot";
+import { SourceNavProvider } from "@/panel/SourceNav";
+
+const markdown = `# Q3 renewal plan
+
+The renewal pipeline is healthy, but the next 90 days carry most of the risk.
+
+## Recommended actions
+
+1. Assign an executive sponsor to the five accounts above $250K ARR.
+2. Confirm product adoption plans before September 15.
+3. Review pricing exceptions with finance each Friday.
+`;
+
+const currentPreview: DeliverablePreview = {
+  outputId: "renewal-plan",
+  filename: "q3-renewal-plan.md",
+  mediaType: "text/markdown",
+  revisionCount: 3,
+  revisionId: "revision-3",
+  content: markdown,
+  truncated: false,
+};
+
+const historicalPreview: DeliverablePreview = {
+  ...currentPreview,
+  revisionId: "revision-1",
+  content: `# Q3 renewal plan\n\nStart with the largest renewals and confirm ownership.`,
+};
+
+const revisions: OutputRevisionInfo[] = [
+  {
+    revisionId: "revision-3",
+    ordinal: 3,
+    sizeBytes: 8_420,
+    createdAt: "2026-08-24T13:40:00.000Z",
+    producedBy: "agent",
+    isCurrent: true,
+    sources: [
+      {
+        kind: "document",
+        citationId: "citation-renewal-table",
+        documentId: "document-renewals",
+        locator: { kind: "pages", start: 4, end: 6 },
+      },
+      {
+        kind: "web",
+        url: "https://www.sec.gov/example",
+        label: "Quarterly filing",
+        domain: "sec.gov",
+      },
+    ],
+  },
+  {
+    revisionId: "revision-2",
+    ordinal: 2,
+    sizeBytes: 7_940,
+    createdAt: "2026-08-23T18:15:00.000Z",
+    producedBy: "user",
+    isCurrent: false,
+    sources: [],
+  },
+  {
+    revisionId: "revision-1",
+    ordinal: 1,
+    sizeBytes: 6_112,
+    createdAt: "2026-08-22T15:10:00.000Z",
+    producedBy: "agent",
+    isCurrent: false,
+    sources: [
+      {
+        kind: "document",
+        citationId: "citation-renewal-summary",
+        documentId: "document-renewals",
+        locator: { kind: "page", page: 2 },
+      },
+    ],
+  },
+];
+
+const summary: DeliverableSummary = {
+  outputId: currentPreview.outputId,
+  filename: currentPreview.filename,
+  mediaType: currentPreview.mediaType,
+  sizeBytes: 8_420,
+  revisionCount: currentPreview.revisionCount,
+  updatedAt: "2026-08-24T13:40:00.000Z",
+  producingRunId: null,
+};
+
+function outputApis(
+  overrides: Partial<OutputDetailApis> = {},
+): OutputDetailApis {
+  return {
+    read: async () => currentPreview,
+    export: async () => ({
+      operationId: "export-renewal-plan",
+      outputId: currentPreview.outputId,
+      revisionId: currentPreview.revisionId,
+      status: "completed",
+    }),
+    listRevisions: async () => ({
+      outputId: currentPreview.outputId,
+      revisions,
+    }),
+    readRevision: async (_chatId, _outputId, revisionId) =>
+      revisionId === historicalPreview.revisionId
+        ? historicalPreview
+        : currentPreview,
+    restoreRevision: async () => summary,
+    save: async (_chatId, _outputId, _expectedRevisionId, content) => ({
+      status: "saved",
+      preview: {
+        ...currentPreview,
+        revisionCount: 4,
+        revisionId: "revision-4",
+        content,
+      },
+    }),
+    ...overrides,
+  };
+}
+
+type OutputDetailStoryProps = {
+  apis: OutputDetailApis;
+};
+
+function OutputDetailStory({ apis }: OutputDetailStoryProps) {
+  const [router] = useState(() => {
+    const rootRoute = createRootRoute();
+    const outputRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/c/$chatId",
+      component: () => (
+        <SourceNavProvider value={{ openCitation: fn(), openDocument: fn() }}>
+          <OutputDetailRoot
+            chatId="chat-storybook"
+            outputId="renewal-plan"
+            apis={apis}
+          />
+        </SourceNavProvider>
+      ),
+    });
+    return createRouter({
+      routeTree: rootRoute.addChildren([outputRoute]),
+      history: createMemoryHistory({
+        initialEntries: ["/c/chat-storybook"],
+      }),
+    });
+  });
+
+  return (
+    <div className="h-screen min-h-0 bg-page-background text-foreground">
+      <RouterProvider router={router as never} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Outputs/Detail",
+  component: OutputDetailStory,
+  parameters: { layout: "fullscreen" },
+  args: { apis: outputApis() },
+  render: (args) => <OutputDetailStory key={String(args.apis)} {...args} />,
+} satisfies Meta<typeof OutputDetailStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CurrentRevision: Story = {};
+
+export const Loading: Story = {
+  args: {
+    apis: outputApis({
+      read: async () => new Promise<DeliverablePreview>(() => undefined),
+      listRevisions: async () => new Promise(() => undefined),
+    }),
+  },
+};
+
+export const Failure: Story = {
+  args: {
+    apis: outputApis({
+      read: async () => {
+        throw new Error("The output revision is unavailable.");
+      },
+    }),
+  },
+};
+
+export const VersionHistoryOpen: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Version history" }),
+    );
+    await expect(await canvas.findByText("Current version")).toBeVisible();
+  },
+};
+
+export const HistoricalRevision: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Version history" }),
+    );
+    await userEvent.click(await canvas.findByRole("button", { name: /v1/i }));
+    await expect(await canvas.findByText(/Viewing v1/)).toBeVisible();
+  },
+};
+
+export const EditMode: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: "Edit" }));
+    await expect(
+      await canvas.findByRole("textbox", { name: /Edit q3-renewal-plan/ }),
+    ).toBeVisible();
+  },
+};
+
+export const EditConflict: Story = {
+  args: {
+    apis: outputApis({
+      save: async () => ({
+        status: "conflict",
+        currentRevisionId: "revision-4",
+      }),
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: "Edit" }));
+    const editor = await canvas.findByRole("textbox", {
+      name: /Edit q3-renewal-plan/,
+    });
+    await userEvent.type(editor, "\nOwner: Customer success");
+    await userEvent.click(canvas.getByRole("button", { name: "Save" }));
+    await expect(await canvas.findByRole("alert")).toBeVisible();
+  },
+};
+
+export const Compact: Story = {
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/OutputRevisionSources.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/OutputRevisionSources.stories.tsx
@@ -1,10 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 
 import type { OutputRevisionSource } from "@/deliverables";
 import { OutputRevisionSources } from "@/outputs/OutputRevisionSources";
 
-function RevisionPanel({ sources }: { sources: OutputRevisionSource[] }) {
+function RevisionPanel({
+  sources,
+  navigation,
+}: {
+  sources: OutputRevisionSource[];
+  navigation: boolean;
+}) {
   return (
     <div className="flex h-80 flex-col overflow-hidden rounded-lg border bg-page-background">
       <div className="min-h-0 flex-1 overflow-auto p-6">
@@ -17,8 +23,8 @@ function RevisionPanel({ sources }: { sources: OutputRevisionSource[] }) {
       </div>
       <OutputRevisionSources
         sources={sources}
-        onOpenDocument={fn()}
-        onOpenWeb={fn()}
+        onOpenDocument={navigation ? fn() : undefined}
+        onOpenWeb={navigation ? fn() : undefined}
       />
     </div>
   );
@@ -42,7 +48,7 @@ const sourcedRevision: OutputRevisionSource[] = [
 const meta = {
   title: "Outputs/Revision sources",
   component: RevisionPanel,
-  args: { sources: sourcedRevision },
+  args: { sources: sourcedRevision, navigation: true },
   decorators: [
     (Story) => (
       <div className="mx-auto max-w-4xl p-8">
@@ -61,4 +67,13 @@ export const WithDocumentAndWebEvidence: Story = {};
 /** User edits and background-agent revisions do not borrow another turn's sources. */
 export const WithoutTurnEvidence: Story = {
   args: { sources: [] },
+};
+
+/** Sources remain legible when their original navigation boundary is unavailable. */
+export const NavigationUnavailable: Story = {
+  args: { navigation: false },
+  play: async ({ canvasElement }) => {
+    const buttons = within(canvasElement).getAllByRole("button");
+    await Promise.all(buttons.map((button) => expect(button).toBeDisabled()));
+  },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/OutputsCatalog.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/OutputsCatalog.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import type { DeliverablesCatalog, DeliverableSummary } from "@/deliverables";
+import { OutputsView, type OutputsApis } from "@/outputs/OutputsView";
+
+const BASE_TIME = Date.parse("2026-08-21T15:30:00.000Z");
+
+const outputKinds = [
+  ["Board update.md", "text/markdown", 18_420],
+  ["Pipeline health.csv", "text/csv", 82_114],
+  ["Revenue mix.chart.json", "application/vnd.tidebreak.chart+json", 4_812],
+  ["Account segments.json", "application/json", 36_720],
+  ["Launch checklist.txt", "text/plain", 6_904],
+  ["Pricing analysis.html", "text/html", 24_612],
+] as const;
+
+const denseOutputs: DeliverableSummary[] = Array.from(
+  { length: 24 },
+  (_, index) => {
+    const [filename, mediaType, sizeBytes] =
+      outputKinds[index % outputKinds.length]!;
+    const copy = Math.floor(index / outputKinds.length);
+    return {
+      outputId: `output-${index + 1}`,
+      filename: copy === 0 ? filename : filename.replace(".", ` ${copy + 1}.`),
+      mediaType,
+      sizeBytes: sizeBytes + index * 977,
+      revisionCount: index % 5 === 0 ? 4 : index % 3 === 0 ? 2 : 1,
+      updatedAt: new Date(BASE_TIME - index * 37 * 60_000).toISOString(),
+      producingRunId: index % 4 === 0 ? `run-${index + 1}` : null,
+    };
+  },
+);
+
+function catalogApis(catalog: DeliverablesCatalog): OutputsApis {
+  return {
+    list: async () => catalog,
+    export: async (_chatId, outputId) => ({
+      operationId: `export-${outputId}`,
+      outputId,
+      revisionId: `revision-${outputId}`,
+      status: "completed",
+    }),
+    delete: async (_chatId, outputId) =>
+      catalog.deliverables.find((output) => output.outputId === outputId)!,
+    restore: async (_chatId, outputId) =>
+      catalog.deliverables.find((output) => output.outputId === outputId)!,
+  };
+}
+
+const loadingApis: OutputsApis = {
+  list: async () => new Promise<DeliverablesCatalog>(() => undefined),
+  export: async () => new Promise(() => undefined),
+  delete: async () => new Promise(() => undefined),
+  restore: async () => new Promise(() => undefined),
+};
+
+const failureApis: OutputsApis = {
+  ...catalogApis({ deliverables: [], truncated: false }),
+  list: async () => {
+    throw new Error("The output catalog did not respond.");
+  },
+};
+
+const meta = {
+  title: "Outputs/Catalog",
+  component: OutputsView,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="h-screen min-h-0 bg-page-background text-foreground">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    chatId: "chat-storybook",
+    onOpen: fn(),
+    apis: catalogApis({ deliverables: denseOutputs, truncated: false }),
+  },
+  render: (args) => <OutputsView key={String(args.apis)} {...args} />,
+} satisfies Meta<typeof OutputsView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DenseCatalog: Story = {};
+
+export const Loading: Story = {
+  args: { apis: loadingApis },
+};
+
+export const Empty: Story = {
+  args: {
+    apis: catalogApis({ deliverables: [], truncated: false }),
+  },
+};
+
+export const Failure: Story = {
+  args: { apis: failureApis },
+};
+
+export const TruncatedCatalog: Story = {
+  args: {
+    apis: catalogApis({ deliverables: denseOutputs, truncated: true }),
+  },
+};
+
+export const NoMatchingResults: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const search = await canvas.findByPlaceholderText("Search outputs…");
+    await userEvent.type(search, "quarterly board deck");
+    await expect(
+      canvas.getByText("No outputs match your search."),
+    ).toBeVisible();
+  },
+};
+
+export const Compact: Story = {
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/Plugins.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Plugins.stories.tsx
@@ -1,0 +1,254 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import type { PluginCatalog, PluginSkillInfo } from "@/api";
+import { PluginDetailView } from "@/plugins/PluginDetailView";
+import { PluginsView } from "@/plugins/PluginsView";
+import { SkillDialog } from "@/plugins/SkillDialog";
+import type { PluginCatalogState } from "@/plugins/usePluginCatalog";
+
+const documentSkills: PluginSkillInfo[] = [
+  {
+    name: "documents",
+    description: "Create, edit, and review Word documents.",
+    origin: "builtin",
+    enabled: true,
+  },
+  {
+    name: "pdf",
+    description: "Read, create, render, and inspect PDF files.",
+    origin: "builtin",
+    enabled: true,
+  },
+  {
+    name: "presentations",
+    description: "Build and revise presentation decks.",
+    origin: "builtin",
+    enabled: false,
+  },
+];
+
+const catalog: PluginCatalog = {
+  plugins: [
+    {
+      name: "document-work",
+      display_name: "Document work",
+      description: "Create, inspect, and revise office documents and PDFs.",
+      category: "documents",
+      origin: "builtin",
+      capabilities: ["write-files"],
+      compatibility: { status: "compatible", issues: [] },
+      enabled: true,
+      skills: documentSkills,
+    },
+    {
+      name: "data-workbench",
+      display_name: "Data workbench",
+      description: "Analyze spreadsheets and produce verified data outputs.",
+      category: "data",
+      origin: "builtin",
+      capabilities: ["write-files", "host-install"],
+      compatibility: {
+        status: "limited",
+        issues: [
+          {
+            kind: "missing_sandbox_dependency",
+            skill: "spreadsheets",
+            dependency: "libreoffice",
+          },
+        ],
+      },
+      enabled: false,
+      skills: [
+        {
+          name: "spreadsheets",
+          description: "Create, edit, analyze, and verify spreadsheet files.",
+          origin: "builtin",
+          enabled: true,
+        },
+      ],
+    },
+    {
+      name: "browser-research",
+      display_name: "Browser research",
+      description: "Inspect websites and collect evidence from live sources.",
+      category: "other",
+      origin: "user",
+      capabilities: ["network", "live-control", "mcp"],
+      compatibility: { status: "unchecked", issues: [] },
+      enabled: true,
+      skills: [
+        {
+          name: "browser-audit",
+          description: "Review a web flow with screenshots and notes.",
+          origin: "user",
+          enabled: true,
+        },
+      ],
+    },
+    {
+      name: "visual-studio",
+      display_name: "Visual studio",
+      description: "Generate visual references and interactive diagrams.",
+      category: "visualization",
+      origin: "builtin",
+      capabilities: [],
+      compatibility: { status: "compatible", issues: [] },
+      enabled: true,
+      skills: [],
+    },
+  ],
+  skills: [
+    {
+      name: "release-notes",
+      description: "Turn a set of merged changes into release notes.",
+      origin: "user",
+      enabled: true,
+    },
+    {
+      name: "accessibility-review",
+      description: "Check interaction states and keyboard access.",
+      origin: "builtin",
+      enabled: false,
+    },
+  ],
+  prompts: [],
+};
+
+function state(values: Partial<PluginCatalogState> = {}): PluginCatalogState {
+  return {
+    catalog,
+    loading: false,
+    error: null,
+    reload: fn(),
+    setEnabled: fn(),
+    ...values,
+  };
+}
+
+const loadInstructions = async (name: string) => ({
+  name,
+  instructions: `# Review a document
+
+Read the source once before you edit it.
+
+## Checklist
+
+- Keep the document's voice.
+- Preserve facts and links.
+- Render the final document and inspect every page.
+`,
+});
+
+const meta = {
+  title: "Plugins/Library",
+  component: PluginsView,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="flex h-screen min-h-0 bg-page-background">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    state: state(),
+    loadInstructions,
+    onOpen: fn(),
+  },
+} satisfies Meta<typeof PluginsView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  args: { state: state({ catalog: null, loading: true }) },
+};
+
+export const Empty: Story = {
+  args: {
+    state: state({ catalog: { plugins: [], skills: [], prompts: [] } }),
+  },
+};
+
+export const DenseCatalog: Story = {};
+
+export const LoadFailure: Story = {
+  args: {
+    state: state({
+      catalog: null,
+      error: "The plugin catalog did not answer.",
+    }),
+  },
+};
+
+export const EnabledPlugin: Story = {
+  render: () => (
+    <PluginDetailView
+      pluginId="document-work"
+      state={state()}
+      loadInstructions={loadInstructions}
+      onBack={fn()}
+    />
+  ),
+};
+
+export const DisabledPlugin: Story = {
+  render: () => (
+    <PluginDetailView
+      pluginId="data-workbench"
+      state={state()}
+      loadInstructions={loadInstructions}
+      onBack={fn()}
+    />
+  ),
+};
+
+export const MissingPlugin: Story = {
+  render: () => (
+    <PluginDetailView
+      pluginId="not-installed"
+      state={state()}
+      loadInstructions={loadInstructions}
+      onBack={fn()}
+    />
+  ),
+};
+
+export const SkillInstructions: Story = {
+  render: () => (
+    <SkillDialog
+      skill={documentSkills[0]}
+      gated={false}
+      onOpenChange={fn()}
+      onToggle={fn()}
+      loadInstructions={loadInstructions}
+    />
+  ),
+};
+
+export const SkillInstructionsLoading: Story = {
+  render: () => (
+    <SkillDialog
+      skill={documentSkills[0]}
+      gated={false}
+      onOpenChange={fn()}
+      onToggle={fn()}
+      loadInstructions={() => new Promise(() => undefined)}
+    />
+  ),
+};
+
+export const SkillInstructionsFailure: Story = {
+  render: () => (
+    <SkillDialog
+      skill={documentSkills[0]}
+      gated
+      onOpenChange={fn()}
+      onToggle={fn()}
+      loadInstructions={async () => {
+        throw new Error("instructions unavailable");
+      }}
+    />
+  ),
+};

--- a/crates/tidebreak-desktop/ui/src/stories/Primitives.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Primitives.stories.tsx
@@ -1,0 +1,539 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Bell,
+  Check,
+  ChevronDown,
+  CircleAlert,
+  FileText,
+  MoreHorizontal,
+  Search,
+  Settings2,
+  Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { SegmentedControl } from "@/components/ui/segmented";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { WithTooltip } from "@/components/ui/tooltip";
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="grid gap-4">
+      <div className="max-w-xl">
+        <h2 className="text-base font-semibold tracking-tight">{title}</h2>
+        <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function ControlsCatalog() {
+  const [mode, setMode] = useState<"focus" | "review" | "ship">("review");
+  const [notifications, setNotifications] = useState(true);
+  const [includeLogs, setIncludeLogs] = useState<boolean | "indeterminate">(
+    "indeterminate",
+  );
+
+  return (
+    <div className="mx-auto grid w-full max-w-5xl gap-10 p-8">
+      <Section
+        title="Action hierarchy"
+        description="Use one clear primary action. Keep secondary and destructive actions visually quieter until the user needs them."
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <Button>Continue</Button>
+          <Button variant="secondary">Save draft</Button>
+          <Button variant="outline">Review changes</Button>
+          <Button variant="ghost">Open details</Button>
+          <Button variant="link">Read guidance</Button>
+          <Button variant="destructive">
+            <Trash2 aria-hidden="true" /> Remove
+          </Button>
+          <Button disabled>Unavailable</Button>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <WithTooltip label="Search conversations">
+            <Button size="icon" variant="outline" aria-label="Search">
+              <Search aria-hidden="true" />
+            </Button>
+          </WithTooltip>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline">
+                View options <ChevronDown aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-52">
+              <DropdownMenuCheckboxItem
+                checked={notifications}
+                onCheckedChange={(checked) =>
+                  setNotifications(checked === true)
+                }
+              >
+                Notify on completion
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuItem>
+                <Settings2 aria-hidden="true" /> Configure tools
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem variant="destructive">
+                <Trash2 aria-hidden="true" /> Clear history
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="ghost-destructive">Delete workspace</Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete this workspace?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Tidebreak removes the local workspace. The remote branch and
+                  pull request stay available.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Keep workspace</AlertDialogCancel>
+                <AlertDialogAction variant="destructive">
+                  Delete workspace
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </Section>
+
+      <Section
+        title="Forms and selection"
+        description="Labels state the decision. Supporting text explains consequences without competing with the control."
+      >
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader className="items-start">
+              <div>
+                <CardTitle>Session defaults</CardTitle>
+                <CardDescription>
+                  These values apply to the next conversation.
+                </CardDescription>
+              </div>
+            </CardHeader>
+            <CardContent className="gap-4">
+              <div className="grid gap-1.5">
+                <Label htmlFor="session-name">Session name</Label>
+                <Input id="session-name" defaultValue="Review release flow" />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="provider">Provider</Label>
+                <Select defaultValue="gateway">
+                  <SelectTrigger id="provider">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="gateway">Model Gateway</SelectItem>
+                    <SelectItem value="direct">Direct provider</SelectItem>
+                    <SelectItem value="managed">Managed default</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="instructions">Instructions</Label>
+                <Textarea
+                  id="instructions"
+                  rows={4}
+                  defaultValue="Inspect the current flow, reproduce failures, and keep changes focused."
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="items-start">
+              <div>
+                <CardTitle>Review behavior</CardTitle>
+                <CardDescription>
+                  Choose how much context the reviewer sees.
+                </CardDescription>
+              </div>
+            </CardHeader>
+            <CardContent className="gap-5">
+              <SegmentedControl
+                aria-label="Review mode"
+                value={mode}
+                onValueChange={setMode}
+                options={[
+                  { value: "focus", label: "Focus" },
+                  { value: "review", label: "Review" },
+                  { value: "ship", label: "Ship" },
+                ]}
+              />
+              <RadioGroup defaultValue="changes" className="gap-3">
+                <Label className="flex items-start gap-3 font-normal">
+                  <RadioGroupItem value="changes" className="mt-0.5" />
+                  <span>
+                    <span className="block font-medium">Changed files</span>
+                    <span className="mt-0.5 block text-sm text-muted-foreground">
+                      Review the focused diff and nearby contracts.
+                    </span>
+                  </span>
+                </Label>
+                <Label className="flex items-start gap-3 font-normal">
+                  <RadioGroupItem value="workspace" className="mt-0.5" />
+                  <span>
+                    <span className="block font-medium">Whole workspace</span>
+                    <span className="mt-0.5 block text-sm text-muted-foreground">
+                      Include unchanged files that shape the user flow.
+                    </span>
+                  </span>
+                </Label>
+              </RadioGroup>
+              <div className="flex items-start justify-between gap-4 border-t pt-4">
+                <div>
+                  <Label htmlFor="notifications">
+                    Completion notifications
+                  </Label>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Show a desktop notification when the run stops.
+                  </p>
+                </div>
+                <Switch
+                  id="notifications"
+                  checked={notifications}
+                  onCheckedChange={setNotifications}
+                />
+              </div>
+              <Label className="flex items-center gap-2 font-normal">
+                <Checkbox
+                  checked={includeLogs}
+                  onCheckedChange={setIncludeLogs}
+                />
+                Include relevant command output
+              </Label>
+            </CardContent>
+            <CardFooter>Selected mode: {mode}</CardFooter>
+          </Card>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function FeedbackCatalog() {
+  return (
+    <div className="mx-auto grid w-full max-w-5xl gap-10 p-8">
+      <Section
+        title="Status and progress"
+        description="Status uses both words and color. Progress stays tied to a clear task and next step."
+      >
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="success">Ready</Badge>
+          <Badge variant="warning">Waiting</Badge>
+          <Badge variant="critical">Failed</Badge>
+          <Badge variant="info">Running</Badge>
+          <Badge variant="merged">Merged</Badge>
+          <Badge variant="outline">Not started</Badge>
+        </div>
+        <Card className="max-w-2xl">
+          <CardHeader className="items-start justify-between">
+            <div>
+              <CardTitle>Building Storybook</CardTitle>
+              <CardDescription>
+                Compiling page stories and visual fixtures.
+              </CardDescription>
+            </div>
+            <Badge variant="info">68%</Badge>
+          </CardHeader>
+          <Progress value={68} aria-label="Storybook build progress" />
+          <CardFooter>18 of 26 story modules compiled</CardFooter>
+        </Card>
+      </Section>
+
+      <Section
+        title="Loading and empty states"
+        description="Loading preserves the final layout. Empty states explain the value and offer one useful next action."
+      >
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card aria-label="Loading workspace list">
+            <div className="flex items-center gap-3">
+              <Skeleton className="size-9 rounded-lg" />
+              <div className="grid flex-1 gap-2">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-3 w-56 max-w-full" />
+              </div>
+            </div>
+            <Skeleton className="h-24 w-full" />
+            <div className="flex gap-2">
+              <Skeleton className="h-7 w-24" />
+              <Skeleton className="h-7 w-20" />
+            </div>
+          </Card>
+          <Empty className="min-h-56 bg-background ring-1 ring-foreground/10">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <FileText aria-hidden="true" />
+              </EmptyMedia>
+              <EmptyTitle>No review notes</EmptyTitle>
+              <EmptyDescription>
+                Notes appear here when an agent finds a decision that needs your
+                attention.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button variant="outline">Review recent runs</Button>
+            </EmptyContent>
+          </Empty>
+        </div>
+      </Section>
+
+      <Section
+        title="Progressive disclosure"
+        description="Keep the summary visible. Put details behind a labeled control so dense views stay calm."
+      >
+        <Accordion
+          type="single"
+          collapsible
+          defaultValue="decision"
+          className="max-w-2xl rounded-xl bg-background px-4 ring-1 ring-foreground/10"
+        >
+          <AccordionItem value="decision">
+            <AccordionTrigger>Why does this need review?</AccordionTrigger>
+            <AccordionContent className="text-muted-foreground">
+              The change alters how Tidebreak resumes interrupted sessions. The
+              reviewer needs to confirm that queued prompts remain in order.
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="evidence">
+            <AccordionTrigger>Evidence and checks</AccordionTrigger>
+            <AccordionContent className="text-muted-foreground">
+              The focused reducer tests pass. The desktop integration lane has
+              not finished yet.
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </Section>
+    </div>
+  );
+}
+
+const runRows = [
+  {
+    name: "Conversation states",
+    owner: "Design review",
+    status: "Ready",
+    tone: "success" as const,
+  },
+  {
+    name: "Document viewers",
+    owner: "Visual review",
+    status: "Running",
+    tone: "info" as const,
+  },
+  {
+    name: "Settings pages",
+    owner: "Accessibility",
+    status: "Needs input",
+    tone: "warning" as const,
+  },
+  {
+    name: "Code workspace",
+    owner: "Interaction review",
+    status: "Failed",
+    tone: "critical" as const,
+  },
+];
+
+function DenseDataCatalog() {
+  return (
+    <div className="mx-auto grid w-full max-w-5xl gap-8 p-8">
+      <Section
+        title="Dense information"
+        description="Tabs separate modes. Rows align repeated facts so the user can scan status before opening details."
+      >
+        <Tabs defaultValue="active">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <TabsList aria-label="Run state">
+              <TabsTrigger value="active">Active</TabsTrigger>
+              <TabsTrigger value="attention">
+                Needs attention <Badge variant="critical">1</Badge>
+              </TabsTrigger>
+              <TabsTrigger value="complete">Complete</TabsTrigger>
+            </TabsList>
+            <Button size="sm" variant="outline">
+              <Bell aria-hidden="true" /> Notification settings
+            </Button>
+          </div>
+          <TabsContent value="active">
+            <div className="overflow-hidden rounded-xl bg-background ring-1 ring-foreground/10">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Area</TableHead>
+                    <TableHead>Review lens</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="w-12">
+                      <span className="sr-only">Actions</span>
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {runRows.map((row) => (
+                    <TableRow key={row.name}>
+                      <TableCell className="font-medium">{row.name}</TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {row.owner}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={row.tone}>{row.status}</Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          size="icon-sm"
+                          variant="ghost"
+                          aria-label={`Open actions for ${row.name}`}
+                        >
+                          <MoreHorizontal aria-hidden="true" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </TabsContent>
+          <TabsContent value="attention">
+            <Card className="max-w-2xl border-critical-border bg-critical-background">
+              <CardHeader className="items-start">
+                <CircleAlert
+                  className="mt-0.5 size-4 text-critical"
+                  aria-hidden="true"
+                />
+                <div>
+                  <CardTitle>Code workspace needs attention</CardTitle>
+                  <CardDescription className="text-critical-foreground-muted">
+                    The compact browser toolbar hides the active viewport label.
+                  </CardDescription>
+                </div>
+              </CardHeader>
+              <CardFooter className="flex-row gap-2">
+                <Button size="sm">Open story</Button>
+                <Button size="sm" variant="outline">
+                  View screenshot
+                </Button>
+              </CardFooter>
+            </Card>
+          </TabsContent>
+          <TabsContent value="complete">
+            <Empty className="min-h-48 bg-background ring-1 ring-foreground/10">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Check aria-hidden="true" />
+                </EmptyMedia>
+                <EmptyTitle>No completed reviews yet</EmptyTitle>
+                <EmptyDescription>
+                  Completed areas move here after their P1 and P2 findings are
+                  resolved.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          </TabsContent>
+        </Tabs>
+      </Section>
+    </div>
+  );
+}
+
+const meta = {
+  title: "Foundations/Primitives",
+  component: ControlsCatalog,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof ControlsCatalog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Controls: Story = {};
+
+export const FeedbackAndDisclosure: Story = {
+  render: () => <FeedbackCatalog />,
+};
+
+export const DenseData: Story = {
+  render: () => <DenseDataCatalog />,
+};

--- a/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
@@ -303,5 +303,5 @@ export const NewWorkspaceNeedsHarness: Story = {
 
 export const CompactNewWorkspace: Story = {
   args: { scenario: "workspace" },
-  parameters: { viewport: { defaultViewport: "compact" } },
+  globals: { viewport: { value: "compact", isRotated: false } },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
@@ -1,0 +1,307 @@
+import { useEffect, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { expect, userEvent, within } from "storybook/test";
+
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import type { ApiClient } from "@/api/client";
+import type { HarnessKind } from "@/api/types";
+import { AddRepoPalette } from "@/code/AddRepoPalette";
+import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
+import { useCodeUiStore } from "@/code/CodeUiStore";
+import { useCodeUpdatesStore } from "@/code/CodeUpdatesStore";
+import { NewWorkspaceDialog } from "@/code/NewWorkspaceDialog";
+import {
+  codeRepositories,
+  harnessDoctor,
+  harnessDoctorDegraded,
+} from "./fixtures";
+
+type SetupScenario =
+  | "add"
+  | "github-hint"
+  | "local-only"
+  | "clone-failure"
+  | "clone-progress"
+  | "workspace"
+  | "workspace-needs-harness";
+
+function pending<T>(): Promise<T> {
+  return new Promise(() => {});
+}
+
+function setupClient(scenario: SetupScenario): ApiClient {
+  const localOnly = scenario === "local-only";
+  const githubHint = scenario === "github-hint";
+  return {
+    getCodeCloneDefaults: async () => ({
+      parent_dir: "/Users/sam/src",
+      gh_found: !githubHint,
+      gh_authenticated: !githubHint,
+      gh_remediation: githubHint
+        ? "GitHub CLI is not signed in on this machine."
+        : "",
+    }),
+    getCodeRepoSources: async () => ({
+      sources: localOnly
+        ? [
+            { kind: "local", available: true },
+            {
+              kind: "git_url",
+              available: false,
+              remediation: "Install git on this machine to clone a remote.",
+            },
+            {
+              kind: "github",
+              available: false,
+              remediation: "Install git on this machine to clone a remote.",
+            },
+          ]
+        : [
+            { kind: "local", available: true },
+            { kind: "git_url", available: true },
+            {
+              kind: "github",
+              available: true,
+              remediation: githubHint
+                ? "GitHub CLI is not signed in on this machine."
+                : undefined,
+            },
+          ],
+      chooses_destination: false,
+    }),
+    startCodeClone: async () => {
+      if (scenario === "clone-failure") {
+        throw new Error("The remote repository could not be reached.");
+      }
+      return {
+        id: "clone-story",
+        phase: "Receiving objects",
+        percent: 38,
+        done: false,
+      };
+    },
+    getCodeRepo: async () => codeRepositories[0]!,
+    createCodeRepo: async () => codeRepositories[0]!,
+    listCodeHarnessModels: async (kind: HarnessKind) => ({
+      kind,
+      models: [
+        {
+          id: kind === "claude_code" ? "claude-sonnet-5" : "gpt-5.6-sol",
+          label: kind === "claude_code" ? "Claude Sonnet 5" : "GPT 5.6 Sol",
+          default: true,
+          reasoning_efforts: [],
+          fast_mode: false,
+        },
+      ],
+      reasoning_efforts: [],
+    }),
+    createCodeWorkspace: async (
+      body: Parameters<ApiClient["createCodeWorkspace"]>[0],
+    ) => ({
+      id: "ws-new-story",
+      repo_id: body.repo_id,
+      title: body.title ?? "Focused workspace",
+      worktree_path: "/Users/sam/tidebreak/worktrees/focused-workspace",
+      branch_name: "thet/focused-workspace",
+      base_ref: body.base_ref ?? "main",
+      status: "active",
+      created_at: "2026-08-24T14:10:00.000Z",
+    }),
+    createCodeSession: async (
+      workspaceId: string,
+      body: Parameters<ApiClient["createCodeSession"]>[1],
+    ) => ({
+      id: "session-new-story",
+      workspace_id: workspaceId,
+      kind: "interactive",
+      harness_kind: body.harness,
+      permission_mode: body.permission_mode,
+      lifecycle: "idle",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      unrecognized_event_count: 0,
+      created_at: "2026-08-24T14:10:10.000Z",
+    }),
+    startHarnessInstall: async () => pending(),
+    getHarnessDoctor: async () =>
+      scenario === "workspace-needs-harness"
+        ? harnessDoctorDegraded
+        : harnessDoctor,
+  } as unknown as ApiClient;
+}
+
+function appContext(client: ApiClient): AppContextValue {
+  return {
+    client,
+    models: [],
+    defaultModelKey: null,
+    providers: [],
+    refreshCatalog: async () => {},
+    refreshChats: async () => {},
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: { status: "idle", version: null, error: null, enabled: false },
+    updateUpToDate: false,
+    checkForUpdate: async () => ({
+      status: "idle",
+      version: null,
+      error: null,
+      enabled: false,
+    }),
+    attachment: "local",
+    restartForUpdate: async () => {},
+  };
+}
+
+function setupRouter() {
+  const rootRoute = createRootRoute();
+  const codeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code",
+    component: () => <p>Code</p>,
+  });
+  const workspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code/w/$workspaceId",
+    component: () => <p>Workspace created</p>,
+  });
+  return createRouter({
+    routeTree: rootRoute.addChildren([codeRoute, workspaceRoute]),
+    history: createMemoryHistory({ initialEntries: ["/code"] }),
+  });
+}
+
+function RepositorySetupStory({ scenario }: { scenario: SetupScenario }) {
+  const [state] = useState(() => {
+    useCodeCatalogStore.getState().reset();
+    useCodeUpdatesStore.getState().reset();
+    useCodeUiStore.setState({ lastCreate: null, pendingComposerPrompt: null });
+    useCodeCatalogStore.setState({
+      repos: codeRepositories,
+      workspaces: [],
+      doctor:
+        scenario === "workspace-needs-harness"
+          ? harnessDoctorDegraded
+          : harnessDoctor,
+      loaded: true,
+    });
+    return { client: setupClient(scenario), router: setupRouter() };
+  });
+
+  useEffect(
+    () => () => {
+      useCodeCatalogStore.getState().reset();
+      useCodeUpdatesStore.getState().reset();
+    },
+    [],
+  );
+
+  const workspace = scenario.startsWith("workspace");
+  return (
+    <AppContextProvider value={appContext(state.client)}>
+      <RouterProvider router={state.router as never} />
+      {workspace ? (
+        <NewWorkspaceDialog
+          open
+          onOpenChange={() => {}}
+          repos={codeRepositories}
+        />
+      ) : (
+        <AddRepoPalette open onOpenChange={() => {}} />
+      )}
+    </AppContextProvider>
+  );
+}
+
+const meta = {
+  title: "Code/Repository setup",
+  component: RepositorySetupStory,
+  args: { scenario: "add" },
+  parameters: { layout: "fullscreen" },
+  render: (args) => <RepositorySetupStory key={args.scenario} {...args} />,
+} satisfies Meta<typeof RepositorySetupStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AddRepository: Story = {};
+
+export const GitHubWithoutCredential: Story = {
+  args: { scenario: "github-hint" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await body.findByRole("option", { name: /GitHub repository/ }),
+    );
+    await expect(await body.findByTestId("gh-absent-hint")).toBeVisible();
+  },
+};
+
+export const LocalOnlyMachine: Story = {
+  args: { scenario: "local-only" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(
+      await body.findByText("Install git on this machine to clone a remote."),
+    ).toBeVisible();
+  },
+};
+
+export const CloneFailure: Story = {
+  args: { scenario: "clone-failure" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await body.findByRole("option", { name: /Git URL/ }));
+    await userEvent.type(
+      await body.findByPlaceholderText("https://example.com/acme/app.git"),
+      "https://github.com/brightwave-inc/missing.git",
+    );
+    await userEvent.click(await body.findByRole("button", { name: "Clone" }));
+    await expect(
+      await body.findByText("The remote repository could not be reached."),
+    ).toBeVisible();
+  },
+};
+
+export const CloneProgress: Story = {
+  args: { scenario: "clone-progress" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await body.findByRole("option", { name: /Git URL/ }));
+    await userEvent.type(
+      await body.findByPlaceholderText("https://example.com/acme/app.git"),
+      "https://github.com/brightwave-inc/tidebreak.git",
+    );
+    await userEvent.click(await body.findByRole("button", { name: "Clone" }));
+    await expect(await body.findByText("Receiving objects")).toBeVisible();
+  },
+};
+
+export const NewWorkspace: Story = { args: { scenario: "workspace" } };
+
+export const NewWorkspaceNeedsHarness: Story = {
+  args: { scenario: "workspace-needs-harness" },
+};
+
+export const CompactNewWorkspace: Story = {
+  args: { scenario: "workspace" },
+  parameters: { viewport: { defaultViewport: "compact" } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/Routes.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Routes.stories.tsx
@@ -206,7 +206,9 @@ function RoutesStory({ scenario }: { scenario: RouteScenario }) {
   return (
     <RouteStoryProviders client={state.client} policy={state.policy}>
       <div className="app-shell h-full min-h-0 w-full overflow-hidden">
-        <RouterProvider router={state.router as never} />
+        <div className="app-body">
+          <RouterProvider router={state.router as never} />
+        </div>
       </div>
     </RouteStoryProviders>
   );

--- a/crates/tidebreak-desktop/ui/src/stories/Routes.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Routes.stories.tsx
@@ -1,0 +1,307 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { expect, within } from "storybook/test";
+
+import type { ApiClient, ManagedPolicy } from "@/api";
+import { AppsPage } from "@/apps/AppsPage";
+import { HomeRoute } from "@/HomeRoute";
+import { InboxView } from "@/InboxView";
+import { PluginsPage } from "@/plugins/PluginsPage";
+import { ProjectFilesView } from "@/ProjectFilesView";
+import { RouteFrame } from "@/RouteFrame";
+import { SETTINGS_SECTIONS } from "@/settings/sections";
+import { SettingsRoute } from "@/SettingsRoute";
+import { AppSidebar } from "@/sidebar/AppSidebar";
+import {
+  denseInboxEntries,
+  managedPolicy,
+  pending,
+  resetRouteStoryStores,
+  routeProjectDocuments,
+  RouteStoryProviders,
+  storyClient,
+  unmanagedPolicy,
+} from "./routeStoryHarness";
+
+type RouteScenario =
+  | "home"
+  | "inbox-loading"
+  | "inbox-empty"
+  | "inbox-dense"
+  | "project-loading"
+  | "project-empty"
+  | "project-failure"
+  | "project-dense"
+  | "settings-unmanaged"
+  | "settings-managed"
+  | "settings-connected-apps"
+  | "apps-list"
+  | "apps-detail"
+  | "plugins-list"
+  | "plugins-detail";
+
+function InboxRouteComposition() {
+  return (
+    <RouteFrame sidebar={<AppSidebar />}>
+      <div className="content-container min-h-0 w-full min-w-0 flex-1 overflow-hidden">
+        <InboxView />
+      </div>
+    </RouteFrame>
+  );
+}
+
+function createRouteRouter(initialPath: string) {
+  const rootRoute = createRootRoute();
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: HomeRoute,
+  });
+  const inboxRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/inbox",
+    component: InboxRouteComposition,
+  });
+  const projectRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/p/$projectId",
+    component: () => {
+      const { projectId } = projectRoute.useParams();
+      return (
+        <RouteFrame sidebar={<AppSidebar />}>
+          <div className="content-container min-h-0 w-full min-w-0 flex-1 overflow-auto">
+            <ProjectFilesView projectId={projectId} />
+          </div>
+        </RouteFrame>
+      );
+    },
+  });
+  const appsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/apps",
+    component: () => <AppsPage />,
+  });
+  const appDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/apps/$appId",
+    component: () => {
+      const { appId } = appDetailRoute.useParams();
+      return <AppsPage appId={appId} />;
+    },
+  });
+  const pluginsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/plugins",
+    component: () => <PluginsPage />,
+  });
+  const pluginDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/plugins/$pluginId",
+    component: () => {
+      const { pluginId } = pluginDetailRoute.useParams();
+      return <PluginsPage pluginId={pluginId} />;
+    },
+  });
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings",
+    component: SettingsRoute,
+  });
+  const settingsSectionRoutes = SETTINGS_SECTIONS.map((section) =>
+    createRoute({
+      getParentRoute: () => settingsRoute,
+      path: section.path,
+      component: section.Component,
+      ...(section.validateSearch
+        ? { validateSearch: section.validateSearch }
+        : {}),
+    }),
+  );
+
+  return createRouter({
+    routeTree: rootRoute.addChildren([
+      homeRoute,
+      inboxRoute,
+      projectRoute,
+      appsRoute,
+      appDetailRoute,
+      pluginsRoute,
+      pluginDetailRoute,
+      settingsRoute.addChildren(settingsSectionRoutes),
+    ]),
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+function clientForScenario(scenario: RouteScenario): ApiClient {
+  if (scenario === "project-loading") {
+    return storyClient({ listProjectDocuments: async () => pending() });
+  }
+  if (scenario === "project-failure") {
+    return storyClient({
+      listProjectDocuments: async () => {
+        throw new Error("Project files could not be loaded from this machine.");
+      },
+    });
+  }
+  if (scenario === "project-empty") {
+    return storyClient({
+      listProjectDocuments: async () => ({
+        documents: [],
+        next_cursor: null,
+      }),
+    });
+  }
+  if (scenario === "project-dense") {
+    return storyClient({
+      listProjectDocuments: async () => ({
+        documents: routeProjectDocuments,
+        next_cursor: null,
+      }),
+    });
+  }
+  return storyClient();
+}
+
+function initialPathFor(scenario: RouteScenario): string {
+  if (scenario.startsWith("inbox")) return "/inbox";
+  if (scenario.startsWith("project")) return "/p/project-1";
+  if (scenario === "settings-managed") return "/settings/gateway";
+  if (scenario === "settings-connected-apps") return "/settings/connected-apps";
+  if (scenario === "settings-unmanaged") return "/settings/providers";
+  if (scenario === "apps-list") return "/apps";
+  if (scenario === "apps-detail") return "/apps/release-brief";
+  if (scenario === "plugins-list") return "/plugins";
+  if (scenario === "plugins-detail") return "/plugins/document-work";
+  return "/";
+}
+
+function policyFor(scenario: RouteScenario): ManagedPolicy {
+  return scenario === "settings-managed" ? managedPolicy : unmanagedPolicy;
+}
+
+function RoutesStory({ scenario }: { scenario: RouteScenario }) {
+  const [state] = useState(() => {
+    const inboxLoading = scenario === "inbox-loading";
+    const inboxDense = scenario === "inbox-dense";
+    resetRouteStoryStores({
+      inboxEntries: inboxDense ? denseInboxEntries : [],
+      inboxLoaded: !inboxLoading,
+      attentionChatIds: inboxDense ? ["chat-2"] : [],
+    });
+    return {
+      client: clientForScenario(scenario),
+      policy: policyFor(scenario),
+      router: createRouteRouter(initialPathFor(scenario)),
+    };
+  });
+
+  return (
+    <RouteStoryProviders client={state.client} policy={state.policy}>
+      <div className="app-shell h-full min-h-0 w-full overflow-hidden">
+        <RouterProvider router={state.router as never} />
+      </div>
+    </RouteStoryProviders>
+  );
+}
+
+const meta = {
+  title: "Navigation/Routes",
+  component: RoutesStory,
+  args: { scenario: "home" },
+  parameters: { layout: "fullscreen" },
+  render: (args) => <RoutesStory key={args.scenario} {...args} />,
+} satisfies Meta<typeof RoutesStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const HomeDesktop: Story = {
+  play: async ({ canvasElement }) => {
+    await expect(
+      within(canvasElement).findByRole("heading", { name: "How can I help?" }),
+    ).resolves.toBeTruthy();
+  },
+};
+
+export const HomeMinimumWindow: Story = {
+  globals: { viewport: { value: "minimumWindow", isRotated: false } },
+};
+
+export const InboxLoading: Story = {
+  args: { scenario: "inbox-loading" },
+};
+
+export const InboxEmpty: Story = {
+  args: { scenario: "inbox-empty" },
+};
+
+export const InboxDense: Story = {
+  args: { scenario: "inbox-dense" },
+};
+
+export const InboxDenseMinimumWindow: Story = {
+  args: { scenario: "inbox-dense" },
+  globals: { viewport: { value: "minimumWindow", isRotated: false } },
+};
+
+export const ProjectFilesLoading: Story = {
+  args: { scenario: "project-loading" },
+};
+
+export const ProjectFilesEmpty: Story = {
+  args: { scenario: "project-empty" },
+};
+
+export const ProjectFilesFailure: Story = {
+  args: { scenario: "project-failure" },
+};
+
+export const ProjectFilesDense: Story = {
+  args: { scenario: "project-dense" },
+};
+
+export const ProjectFilesDenseMinimumWindow: Story = {
+  args: { scenario: "project-dense" },
+  globals: { viewport: { value: "minimumWindow", isRotated: false } },
+};
+
+export const SettingsProvidersUnmanaged: Story = {
+  args: { scenario: "settings-unmanaged" },
+};
+
+export const SettingsModelGatewayManaged: Story = {
+  args: { scenario: "settings-managed" },
+};
+
+export const SettingsConnectedApps: Story = {
+  args: { scenario: "settings-connected-apps" },
+};
+
+export const SettingsConnectedAppsMinimumWindow: Story = {
+  args: { scenario: "settings-connected-apps" },
+  globals: { viewport: { value: "minimumWindow", isRotated: false } },
+};
+
+export const AppsRegisteredList: Story = {
+  args: { scenario: "apps-list" },
+};
+
+export const AppsRegisteredDetail: Story = {
+  args: { scenario: "apps-detail" },
+};
+
+export const PluginsRegisteredList: Story = {
+  args: { scenario: "plugins-list" },
+};
+
+export const PluginsRegisteredDetail: Story = {
+  args: { scenario: "plugins-detail" },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsAdvanced.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsAdvanced.stories.tsx
@@ -1,0 +1,264 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+
+import { CodingHarnessesPanel } from "@/settings/CodingHarnessesPanel";
+import { ConnectedAppsPanel } from "@/settings/ConnectedAppsPanel";
+import { ExecPanel } from "@/settings/ExecPanel";
+import { ModelsPanel } from "@/settings/ModelsPanel";
+import { PermissionsPanel } from "@/settings/PermissionsPanel";
+import { ProvidersPanel } from "@/settings/ProvidersPanel";
+import { VoiceTranscriptionPanel } from "@/settings/VoiceTranscriptionPanel";
+import {
+  SettingsStoryHarness,
+  type SettingsStoryState,
+  storyModels,
+  storyProviders,
+} from "./SettingsStoryHarness";
+
+type SettingsAdvancedShowcaseProps = {
+  panel:
+    | "providers"
+    | "models"
+    | "voice"
+    | "exec"
+    | "harnesses"
+    | "connected-apps"
+    | "permissions";
+  state?: SettingsStoryState;
+  managed?: boolean;
+};
+
+function SettingsAdvancedShowcase({
+  panel,
+  state = "configured",
+  managed = false,
+}: SettingsAdvancedShowcaseProps) {
+  return (
+    <SettingsStoryHarness state={state}>
+      {(client) => {
+        switch (panel) {
+          case "providers":
+            return (
+              <ProvidersPanel
+                providers={storyProviders}
+                models={storyModels}
+                client={client}
+                managed={managed}
+                onChanged={fn()}
+                expandProvider={managed ? undefined : "openai"}
+              />
+            );
+          case "models":
+            return (
+              <ModelsPanel
+                client={client}
+                models={storyModels}
+                managed={managed}
+                onChanged={fn()}
+              />
+            );
+          case "voice":
+            return <VoiceTranscriptionPanel client={client} />;
+          case "exec":
+            return <ExecPanel client={client} />;
+          case "harnesses":
+            return <CodingHarnessesPanel client={client} />;
+          case "connected-apps":
+            return <ConnectedAppsPanel client={client} managed={managed} />;
+          case "permissions":
+            return (
+              <PermissionsPanel
+                client={client}
+                knownChatIds={new Set(["chat-filings"])}
+                knownProjectIds={new Set(["project-launch"])}
+              />
+            );
+        }
+      }}
+    </SettingsStoryHarness>
+  );
+}
+
+const meta = {
+  title: "Settings/Advanced panels",
+  component: SettingsAdvancedShowcase,
+  parameters: { layout: "fullscreen" },
+  args: { panel: "providers", state: "configured", managed: false },
+} satisfies Meta<typeof SettingsAdvancedShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ProvidersConfigured: Story = {};
+
+export const ProvidersManaged: Story = {
+  args: { managed: true, state: "managed" },
+};
+
+export const ModelsConfigured: Story = {
+  args: { panel: "models" },
+};
+
+export const ModelsLoading: Story = {
+  args: { panel: "models", state: "loading" },
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByText("Loading model settings…"),
+    ).toBeVisible();
+  },
+};
+
+export const ModelsFailure: Story = {
+  args: { panel: "models", state: "failed" },
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByText(
+        "Error: Settings could not be loaded.",
+      ),
+    ).toBeVisible();
+  },
+};
+
+export const ModelsManagedCompact: Story = {
+  args: { panel: "models", managed: true, state: "managed" },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const VoiceConfigured: Story = {
+  args: { panel: "voice" },
+};
+
+export const VoiceFailure: Story = {
+  args: { panel: "voice", state: "failed" },
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByText(
+        "Error: Settings could not be loaded.",
+      ),
+    ).toBeVisible();
+  },
+};
+
+export const VoiceUnavailableCompact: Story = {
+  args: { panel: "voice", state: "disabled" },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const CodeExecutionConfigured: Story = {
+  args: { panel: "exec" },
+};
+
+export const CodeExecutionFailure: Story = {
+  args: { panel: "exec", state: "failed" },
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByText(
+        "Error: Settings could not be loaded.",
+      ),
+    ).toBeVisible();
+  },
+};
+
+export const CodeExecutionUnavailableCompact: Story = {
+  args: { panel: "exec", state: "disabled" },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const CodingHarnessesConfigured: Story = {
+  args: { panel: "harnesses" },
+};
+
+export const CodingHarnessesLoading: Story = {
+  args: { panel: "harnesses", state: "loading" },
+  play: async ({ canvasElement }) => {
+    const heading = await within(canvasElement).findByRole("heading", {
+      name: "Coding harnesses",
+    });
+    await expect(heading.closest("[aria-busy]")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+  },
+};
+
+export const CodingHarnessesFailureCompact: Story = {
+  args: { panel: "harnesses", state: "failed" },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const ConnectedAppsConfigured: Story = {
+  args: { panel: "connected-apps" },
+};
+
+export const ConnectedAppsLoading: Story = {
+  args: { panel: "connected-apps", state: "loading" },
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByText("Loading connected apps…"),
+    ).toBeVisible();
+  },
+};
+
+export const ConnectedAppsEmpty: Story = {
+  args: { panel: "connected-apps", state: "empty" },
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByText(
+        "No apps connected. Add a REST API here, or configure MCP servers in the editor below.",
+      ),
+    ).toBeVisible();
+  },
+};
+
+export const ConnectedAppsFailure: Story = {
+  args: { panel: "connected-apps", state: "failed" },
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findAllByText(
+        "Settings could not be loaded.",
+      ),
+    ).not.toHaveLength(0);
+  },
+};
+
+export const ConnectedAppsManagedCompact: Story = {
+  args: {
+    panel: "connected-apps",
+    managed: true,
+    state: "managed",
+  },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const PermissionsConfigured: Story = {
+  args: { panel: "permissions" },
+};
+
+export const PermissionsLoading: Story = {
+  args: { panel: "permissions", state: "loading" },
+  play: async ({ canvasElement }) => {
+    const heading = await within(canvasElement).findByRole("heading", {
+      name: "Permissions",
+    });
+    await expect(heading.closest("[aria-busy]")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+  },
+};
+
+export const PermissionsEmpty: Story = {
+  args: { panel: "permissions", state: "empty" },
+  play: async ({ canvasElement }) => {
+    await expect(
+      await within(canvasElement).findByText(
+        "Nothing saved yet. When you answer an approval with “always allow” or connect a folder, it appears here.",
+      ),
+    ).toBeVisible();
+  },
+};
+
+export const PermissionsFailureCompact: Story = {
+  args: { panel: "permissions", state: "failed" },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsPanels.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsPanels.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn, userEvent, within } from "storybook/test";
+
+import { AgentsPanel } from "@/settings/AgentsPanel";
+import { AppearancePanel } from "@/settings/AppearancePanel";
+import { CompactionPanel } from "@/settings/CompactionPanel";
+import { UpdatesPanel } from "@/settings/UpdatesPanel";
+import type { ThemeMode } from "@/theme";
+import type { DesktopUpdateState } from "@/updates";
+import { SettingsStoryHarness } from "./SettingsStoryHarness";
+
+const idleUpdate: DesktopUpdateState = {
+  status: "idle",
+  version: null,
+  error: null,
+  enabled: true,
+};
+
+type SettingsShowcaseProps = {
+  panel: "appearance" | "agents" | "context" | "updates";
+  loadState?: "ready" | "loading" | "failed";
+  theme?: ThemeMode;
+  updateState?: DesktopUpdateState;
+  upToDate?: boolean;
+};
+
+function SettingsShowcase({
+  panel,
+  loadState = "ready",
+  theme = "system",
+  updateState = idleUpdate,
+  upToDate = false,
+}: SettingsShowcaseProps) {
+  if (panel === "appearance") {
+    return <AppearancePanel mode={theme} onChange={fn()} />;
+  }
+  if (panel === "agents") {
+    return (
+      <SettingsStoryHarness
+        state={loadState === "ready" ? "configured" : loadState}
+      >
+        {(client) => <AgentsPanel client={client} />}
+      </SettingsStoryHarness>
+    );
+  }
+  if (panel === "context") {
+    return (
+      <SettingsStoryHarness
+        state={loadState === "ready" ? "configured" : loadState}
+      >
+        {(client) => <CompactionPanel client={client} />}
+      </SettingsStoryHarness>
+    );
+  }
+  return (
+    <UpdatesPanel
+      state={updateState}
+      upToDate={upToDate}
+      onCheck={fn(async () => updateState)}
+      onRestart={fn(async () => {})}
+    />
+  );
+}
+
+const meta = {
+  title: "Settings/Core panels",
+  component: SettingsShowcase,
+  parameters: { layout: "fullscreen" },
+  args: { panel: "appearance" },
+} satisfies Meta<typeof SettingsShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AppearanceSystem: Story = {};
+
+export const AppearanceDark: Story = {
+  args: { theme: "dark" },
+  globals: { theme: "dark" },
+};
+
+export const Agents: Story = {
+  args: { panel: "agents" },
+};
+
+export const AgentsLoading: Story = {
+  args: { panel: "agents", loadState: "loading" },
+};
+
+export const AgentsFailure: Story = {
+  args: { panel: "agents", loadState: "failed" },
+};
+
+export const ContextDefaults: Story = {
+  args: { panel: "context" },
+};
+
+export const ContextAdvanced: Story = {
+  args: { panel: "context" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Advanced" }),
+    );
+  },
+};
+
+export const ContextFailure: Story = {
+  args: { panel: "context", loadState: "failed" },
+};
+
+export const UpdateReady: Story = {
+  args: {
+    panel: "updates",
+    updateState: {
+      status: "ready",
+      version: "0.59.0",
+      error: null,
+      enabled: true,
+    },
+  },
+};
+
+export const UpdateDownloading: Story = {
+  args: {
+    panel: "updates",
+    updateState: {
+      status: "downloading",
+      version: "0.59.0",
+      error: null,
+      enabled: true,
+    },
+  },
+};
+
+export const UpdateFailure: Story = {
+  args: {
+    panel: "updates",
+    updateState: {
+      ...idleUpdate,
+      error: "The update signature could not be verified.",
+    },
+  },
+};
+
+export const UpdatesDisabled: Story = {
+  args: {
+    panel: "updates",
+    updateState: { ...idleUpdate, enabled: false },
+  },
+};
+
+export const UpToDate: Story = {
+  args: { panel: "updates", upToDate: true },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
@@ -1,0 +1,581 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import { useLayoutEffect, useMemo } from "react";
+
+import {
+  ApiClient,
+  type ConnectedAppsInfo,
+  type ConsentStatementSnapshot,
+  type ExecConfigInfo,
+  type ExecCredentialReadiness,
+  type McpServerInfo,
+  type ModelInfo,
+  type ModelRoleInfo,
+  type ProviderInfo,
+  type RuntimeSettings,
+  type VoiceTranscriptionInfo,
+} from "@/api";
+import { useVoiceInputStore } from "@/VoiceInputStore";
+import { harnessDoctor } from "./fixtures";
+
+export type SettingsStoryState =
+  | "configured"
+  | "loading"
+  | "managed"
+  | "disabled"
+  | "empty"
+  | "failed";
+
+type SettingsClientMethods = Pick<
+  ApiClient,
+  | "getSettings"
+  | "putSettings"
+  | "putProvider"
+  | "deleteCredential"
+  | "getOpenaiChatgptStatus"
+  | "openaiChatgptSignIn"
+  | "openaiChatgptSignOut"
+  | "listModels"
+  | "putModelRole"
+  | "getVoiceTranscription"
+  | "putVoiceTranscription"
+  | "installLocalVoice"
+  | "getExecConfig"
+  | "putExecConfig"
+  | "listExecCredentials"
+  | "putExecCredential"
+  | "deleteExecCredential"
+  | "getHarnessDoctor"
+  | "refreshHarnessDoctor"
+  | "getCodeWorktreeRoot"
+  | "setCodeWorktreeRoot"
+  | "listConnectedApps"
+  | "putRestConnectedApp"
+  | "previewRestSpec"
+  | "deleteRestConnectedApp"
+  | "listMcpServers"
+  | "putMcpServers"
+  | "reconnectMcpServer"
+  | "getGatewayStatus"
+  | "getGatewayApps"
+  | "listConsentStatements"
+  | "revokeStandingGrant"
+>;
+
+export const storySettings: RuntimeSettings = {
+  model: null,
+  has_api_key: false,
+  chat_defaults: {
+    model: null,
+    reasoning_effort: null,
+    permission_mode: null,
+    network_policy: null,
+  },
+  max_active_background_agents: 6,
+  sandbox_agent_checkin_steps: 18,
+  sandbox_agent_error_checkin: 4,
+  compaction: {
+    threshold_fraction: 0.78,
+    target_fraction: 0.52,
+    min_threshold_tokens: 16_000,
+    protect_recent_messages: 8,
+  },
+  model_visibility_overrides: {},
+  computer_use_enabled: true,
+};
+
+function model(
+  provider: ModelInfo["provider"],
+  id: string,
+  displayName: string,
+  available = true,
+): ModelInfo {
+  return {
+    key: `${provider}::${id}`,
+    id,
+    display_name: displayName,
+    provider,
+    vendor: null,
+    verification: "verified",
+    available,
+    context_window: 200_000,
+    max_output_tokens: 32_000,
+    input_modalities: ["text", "image"],
+    supports_reasoning: true,
+    supports_tools: true,
+    supports_structured_output: true,
+    reasoning_efforts: ["low", "medium", "high"],
+    multimodal: true,
+    recommended: true,
+  };
+}
+
+const openModels: ModelInfo[] = [
+  model("anthropic", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
+  model("openai", "gpt-5.4", "GPT-5.4"),
+  model("gemini", "gemini-3.6-pro", "Gemini 3.6 Pro"),
+  model("openrouter", "moonshotai/kimi-k3", "Kimi K3"),
+];
+
+const managedModels: ModelInfo[] = [
+  model("model_gateway", "flagship", "Gateway Flagship"),
+  model("model_gateway", "fast", "Gateway Fast"),
+];
+
+const openRoles: ModelRoleInfo[] = [
+  {
+    role: "chat",
+    selection: "anthropic::claude-sonnet-4-6",
+    resolved_key: "anthropic::claude-sonnet-4-6",
+  },
+  {
+    role: "utility",
+    selection: null,
+    resolved_key: "openai::gpt-5.4",
+  },
+];
+
+const managedRoles: ModelRoleInfo[] = [
+  {
+    role: "chat",
+    selection: null,
+    resolved_key: "model_gateway::flagship",
+  },
+  {
+    role: "utility",
+    selection: null,
+    resolved_key: "model_gateway::fast",
+  },
+];
+
+export const storyProviders: ProviderInfo[] = [
+  {
+    kind: "anthropic",
+    enabled: true,
+    has_credential: true,
+    models: [],
+  },
+  {
+    kind: "openai",
+    enabled: true,
+    has_credential: true,
+    auth_mode: "chatgpt",
+    models: [],
+  },
+  {
+    kind: "gemini",
+    enabled: false,
+    has_credential: false,
+    models: [],
+  },
+  {
+    kind: "ollama",
+    enabled: true,
+    has_credential: false,
+    base_url: "http://127.0.0.1:11434/v1",
+    models: [
+      {
+        id: "qwen3:8b",
+        display_name: "Qwen 3 8B",
+        context_window: 32_768,
+        max_output_tokens: 8_192,
+        input_modalities: ["text"],
+        supports_reasoning: true,
+        reasoning_efforts: ["low", "medium", "high"],
+      },
+    ],
+  },
+  {
+    kind: "openrouter",
+    enabled: true,
+    has_credential: true,
+    base_url: "https://openrouter.ai/api/v1",
+    models: [],
+  },
+];
+
+export const storyModels = openModels;
+
+const readyVoice: VoiceTranscriptionInfo = {
+  model: "local",
+  local_model: "whisper-base-en",
+  local_models: [
+    {
+      id: "whisper-base-en",
+      label: "Whisper Base English",
+      description: "A balanced local model for everyday dictation.",
+      total_bytes: 148_000_000,
+      english_only: true,
+      recommended: true,
+      state: "ready",
+      downloaded_bytes: 148_000_000,
+      error: null,
+    },
+    {
+      id: "whisper-large-v3",
+      label: "Whisper Large v3",
+      description: "Higher accuracy across languages with a larger download.",
+      total_bytes: 1_550_000_000,
+      english_only: false,
+      recommended: false,
+      state: "not_installed",
+      downloaded_bytes: null,
+      error: null,
+    },
+  ],
+  openai_ready: true,
+  gemini_ready: true,
+};
+
+const disabledVoice: VoiceTranscriptionInfo = {
+  ...readyVoice,
+  local_models: readyVoice.local_models.map((entry) => ({
+    ...entry,
+    state: "unavailable" as const,
+    downloaded_bytes: null,
+  })),
+  openai_ready: false,
+  gemini_ready: false,
+};
+
+const configuredExec: ExecConfigInfo = {
+  provider: "daytona",
+  timeout_ms: 30_000,
+  available: true,
+  has_credential: true,
+  providers: [
+    { provider: "local", available: true },
+    { provider: "e2b", available: true },
+    { provider: "daytona", available: true },
+    { provider: "docker", available: true },
+  ],
+  egress: {
+    policy: { mode: "open" },
+    enforcement: [
+      {
+        provider: "e2b",
+        status: "applied_with_gaps",
+        gaps: ["DNS resolution"],
+      },
+      {
+        provider: "daytona",
+        status: "conditional_boundary",
+        gaps: [],
+        requirement: "Daytona org tier 3+",
+      },
+    ],
+  },
+  detached_admission: [
+    { provider: "local", admitted: false, denials: ["image_not_verified"] },
+    { provider: "e2b", admitted: false, denials: ["image_not_verified"] },
+    { provider: "daytona", admitted: false, denials: ["image_not_verified"] },
+    { provider: "docker", admitted: false, denials: ["image_not_verified"] },
+  ],
+};
+
+const disabledExec: ExecConfigInfo = {
+  ...configuredExec,
+  provider: undefined,
+  available: false,
+  has_credential: false,
+  providers: [
+    {
+      provider: "local",
+      available: false,
+      unavailable_reason: "unsupported_platform",
+    },
+    {
+      provider: "e2b",
+      available: false,
+      unavailable_reason: "missing_credential",
+    },
+    {
+      provider: "daytona",
+      available: false,
+      unavailable_reason: "missing_credential",
+    },
+    {
+      provider: "docker",
+      available: false,
+      unavailable_reason: "missing_container_runtime",
+    },
+  ],
+};
+
+const execCredentials: ExecCredentialReadiness[] = [
+  { provider: "e2b", has_credential: true },
+  { provider: "daytona", has_credential: true },
+];
+
+const docsServer: McpServerInfo = {
+  name: "docs",
+  command: "/usr/local/bin/docs-mcp",
+  args: [],
+  env: [],
+  env_from: [],
+  cwd: null,
+  url: null,
+  bearer_token_env: null,
+  gateway_endpoint: null,
+  request_timeout_ms: 60_000,
+  enabled: true,
+  plugin: null,
+  health: "healthy",
+  tool_count: 3,
+  diagnostic: null,
+  curated: null,
+};
+
+const gatewayServer: McpServerInfo = {
+  ...docsServer,
+  name: "primary",
+  command: null,
+  gateway_endpoint: "primary",
+  tool_count: 4,
+};
+
+const connectedApps: ConnectedAppsInfo = {
+  apps: [
+    {
+      kind: "mcp_server",
+      id: "app-docs",
+      name: "docs",
+      health: "healthy",
+      tool_count: 3,
+      tools: ["search", "fetch", "list_documents"],
+      diagnostic: null,
+      curated: null,
+      gateway_endpoint: null,
+      gateway_apps: [],
+      used_by_app_count: 2,
+    },
+    {
+      kind: "mcp_server",
+      id: "app-primary",
+      name: "primary",
+      health: "healthy",
+      tool_count: 4,
+      tools: ["search_issues", "create_issue", "get_customer", "post_note"],
+      diagnostic: null,
+      curated: null,
+      gateway_endpoint: "primary",
+      gateway_apps: ["Linear", "Salesforce"],
+      used_by_app_count: 3,
+    },
+    {
+      kind: "rest_api",
+      id: "app-sentry",
+      name: "Sentry",
+      base_url: "https://api.sentry.example/v2",
+      operation_count: 12,
+      document_sha256: "ab".repeat(32),
+      credential_status: "configured",
+      placement: "bearer",
+      updated_at: "2026-08-20T12:00:00Z",
+      used_by_app_count: 1,
+    },
+  ],
+};
+
+const consentStatements: ConsentStatementSnapshot[] = [
+  {
+    handle: { kind: "tool_grant", call_id: "grant-cargo" },
+    level: { level: "chat", chat_id: "chat-filings" },
+    level_title: "Quarterly filings",
+    verb: {
+      kind: "tool",
+      action: "exec",
+      approval: "exec_may_run_networked_command",
+    },
+    resource: {
+      kind: "action_scope",
+      scope: { scope: "any_args_for", command: "cargo" },
+    },
+    method: "approval_card",
+    granted_at: "2026-08-18T12:00:00Z",
+  },
+  {
+    handle: { kind: "tool_grant", call_id: "grant-web" },
+    level: { level: "project", project_id: "project-launch" },
+    level_title: "Launch readiness",
+    verb: {
+      kind: "tool",
+      action: "web_extract",
+      approval: "web_extract_may_fetch_url",
+    },
+    resource: {
+      kind: "action_scope",
+      scope: { scope: "whole_tool" },
+    },
+    method: "carried_forward",
+    granted_at: "2026-08-19T16:30:00Z",
+  },
+];
+
+function pending<T>(): Promise<T> {
+  return new Promise(() => undefined);
+}
+
+function createSettingsStoryClient(state: SettingsStoryState): ApiClient {
+  const read = <T,>(value: T): Promise<T> => {
+    if (state === "loading") return pending();
+    if (state === "failed") {
+      return Promise.reject(new Error("Settings could not be loaded."));
+    }
+    return Promise.resolve(value);
+  };
+  const write = <T,>(value: T): Promise<T> => {
+    if (state === "failed") {
+      return Promise.reject(new Error("Settings could not be saved."));
+    }
+    return Promise.resolve(value);
+  };
+  const models = state === "managed" ? managedModels : openModels;
+  const roles = state === "managed" ? managedRoles : openRoles;
+  const voice = state === "disabled" ? disabledVoice : readyVoice;
+  const exec = state === "disabled" ? disabledExec : configuredExec;
+  const servers = state === "managed" ? [gatewayServer] : [docsServer];
+
+  const methods: SettingsClientMethods = {
+    getSettings: () => read(storySettings),
+    putSettings: () => write(storySettings),
+    putProvider: (kind) =>
+      write(storyProviders.find((provider) => provider.kind === kind)!),
+    deleteCredential: () => write(undefined),
+    getOpenaiChatgptStatus: () =>
+      read({ signed_in: true, account_hint: "alex@example.com" }),
+    openaiChatgptSignIn: () =>
+      write({ authorization_url: "https://auth.example.test" }),
+    openaiChatgptSignOut: () => write(undefined),
+    listModels: () => read({ models, roles }),
+    putModelRole: (role, selection) =>
+      write({
+        role,
+        selection,
+        resolved_key:
+          selection ?? roles.find((entry) => entry.role === role)!.resolved_key,
+      }),
+    getVoiceTranscription: () => read(voice),
+    putVoiceTranscription: (selection, localModel) =>
+      write({
+        ...voice,
+        model: selection,
+        local_model: localModel ?? voice.local_model,
+      }),
+    installLocalVoice: () =>
+      write({
+        state: "ready",
+        downloaded_bytes: 148_000_000,
+        total_bytes: 148_000_000,
+        error: null,
+      }),
+    getExecConfig: () => read(exec),
+    putExecConfig: () => write(exec),
+    listExecCredentials: () => read({ credentials: execCredentials }),
+    putExecCredential: (provider) => write({ provider, has_credential: true }),
+    deleteExecCredential: (provider) =>
+      write({ provider, has_credential: false }),
+    getHarnessDoctor: () => read(harnessDoctor),
+    refreshHarnessDoctor: () => read(harnessDoctor),
+    getCodeWorktreeRoot: () =>
+      read({
+        root: "/Users/alex/Code/worktrees",
+        effective_root: "/Users/alex/Code/worktrees",
+        default_root: "/Users/alex/.tidebreak/worktrees",
+      }),
+    setCodeWorktreeRoot: (root) =>
+      write({
+        ...(root ? { root } : {}),
+        effective_root: root ?? "/Users/alex/.tidebreak/worktrees",
+        default_root: "/Users/alex/.tidebreak/worktrees",
+      }),
+    listConnectedApps: () =>
+      read(state === "empty" ? { apps: [] } : connectedApps),
+    putRestConnectedApp: () => write(connectedApps),
+    previewRestSpec: () =>
+      write({
+        document_sha256: "cd".repeat(32),
+        operations: [],
+        unlistable: 0,
+        truncated: false,
+      }),
+    deleteRestConnectedApp: () => write(undefined),
+    listMcpServers: () => read({ servers: state === "empty" ? [] : servers }),
+    putMcpServers: () => write({ servers }),
+    reconnectMcpServer: () => write({ servers }),
+    getGatewayStatus: () =>
+      read({
+        base_url: "https://gateway.example.test",
+        signed_in: state === "managed",
+        account_hint: "alex@example.com",
+        installation_id: "installation-story",
+        model_count: managedModels.length,
+        member_catalog: "2026-08-01",
+        sign_in: { state: "idle" },
+      }),
+    getGatewayApps: () =>
+      read({
+        supported: true,
+        apps:
+          state === "empty"
+            ? []
+            : [
+                {
+                  id: "gateway-linear",
+                  name: "Linear",
+                  app_kind: "mcp_server",
+                  enabled: true,
+                  mcp_endpoint_slugs: ["primary"],
+                  connection: "ready",
+                  used_by_app_count: 2,
+                },
+              ],
+      }),
+    listConsentStatements: () =>
+      read(state === "empty" ? [] : consentStatements),
+    revokeStandingGrant: () => write(undefined),
+  };
+
+  return Object.assign(
+    new ApiClient("https://settings-story.invalid", "storybook"),
+    methods,
+  );
+}
+
+function SettingsStoryRouter({ children }: { children: ReactNode }) {
+  const router = useMemo(() => {
+    const rootRoute = createRootRoute({ component: () => children });
+    return createRouter({
+      routeTree: rootRoute,
+      history: createMemoryHistory({ initialEntries: ["/settings"] }),
+    });
+  }, [children]);
+  return <RouterProvider router={router as never} />;
+}
+
+export function SettingsStoryHarness({
+  state = "configured",
+  children,
+}: {
+  state?: SettingsStoryState;
+  children: (client: ApiClient) => ReactNode;
+}) {
+  const client = useMemo(() => createSettingsStoryClient(state), [state]);
+
+  useLayoutEffect(() => {
+    useVoiceInputStore.setState({
+      info: null,
+      loading: false,
+      installing: null,
+      error: null,
+    });
+  }, [client]);
+
+  window.localStorage.removeItem("tidebreak.settings.providers-expanded");
+  return <SettingsStoryRouter>{children(client)}</SettingsStoryRouter>;
+}

--- a/crates/tidebreak-desktop/ui/src/stories/ShellStates.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ShellStates.stories.tsx
@@ -1,0 +1,224 @@
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn, userEvent, within } from "storybook/test";
+
+import type { ApiClient, GatewayStatus, ManagedPolicy } from "@/api";
+import { ErrorBoundary } from "@/ErrorBoundary";
+import { ManagedGate } from "@/ManagedGate";
+import { NetworkPolicyDialog } from "@/NetworkPolicyDialog";
+import { gatewaySignedIn, gatewaySignedOut } from "./fixtures";
+
+const unmanaged: ManagedPolicy = {
+  managed: false,
+  source: "unmanaged",
+  misconfigured: false,
+  allow_local_mcp_servers: false,
+};
+
+const managed: ManagedPolicy = {
+  managed: true,
+  source: "provisioned",
+  misconfigured: false,
+  allow_local_mcp_servers: false,
+  gateway_url: "https://gateway.example.com",
+};
+
+function pending<T>(): Promise<T> {
+  return new Promise(() => undefined);
+}
+
+function gateClient({
+  policy = managed,
+  status = gatewaySignedOut,
+  policyLoad = "ready",
+}: {
+  policy?: ManagedPolicy;
+  status?: GatewayStatus;
+  policyLoad?: "ready" | "loading" | "failed";
+} = {}): ApiClient {
+  return {
+    getPolicy: async () => {
+      if (policyLoad === "loading") return pending();
+      if (policyLoad === "failed") {
+        throw new Error("503: managed policy could not be read");
+      }
+      return policy;
+    },
+    getGatewayStatus: async () => status,
+    gatewaySignIn: async () => ({
+      authorization_url: "https://gateway.example.com/sign-in",
+    }),
+    dismissGatewayPairing: async () => unmanaged,
+  } as unknown as ApiClient;
+}
+
+function ProductReady({ children }: { children?: ReactNode }) {
+  return (
+    <div className="grid h-screen place-items-center bg-page-background p-8">
+      <div className="max-w-lg rounded-xl border border-border-subtle bg-background p-8 text-center">
+        <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          Managed session ready
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold tracking-tight">
+          Tidebreak is available
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {children ??
+            "The shell renders after the gateway session matches policy."}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ThrowsOnRender(): never {
+  throw new Error("The conversation view could not render this result.");
+}
+
+const meta = {
+  title: "Shell/Managed gate and recovery",
+  component: ManagedGate,
+  parameters: { layout: "fullscreen" },
+  args: {
+    client: gateClient(),
+    children: <ProductReady />,
+  },
+} satisfies Meta<typeof ManagedGate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Starting: Story = {
+  args: { client: gateClient({ policyLoad: "loading" }) },
+};
+
+export const SignInRequired: Story = {};
+
+export const SignInPending: Story = {
+  args: {
+    client: gateClient({
+      status: {
+        ...gatewaySignedOut,
+        sign_in: {
+          state: "pending",
+          authorization_url: "https://gateway.example.com/sign-in/continue",
+        },
+      },
+    }),
+  },
+};
+
+export const SignInFailure: Story = {
+  args: {
+    client: gateClient({
+      status: {
+        ...gatewaySignedOut,
+        sign_in: {
+          state: "failed",
+          message: "Your organization did not grant access to this gateway.",
+        },
+      },
+    }),
+  },
+};
+
+export const PairingRequested: Story = {
+  args: {
+    client: gateClient({
+      policy: {
+        ...unmanaged,
+        pending_gateway_url: "https://gateway.new-company.example.com",
+      },
+    }),
+  },
+};
+
+export const ManagedPolicyUnavailable: Story = {
+  args: { client: gateClient({ policyLoad: "failed" }) },
+};
+
+export const ManagedPolicyMisconfigured: Story = {
+  args: {
+    client: gateClient({
+      policy: { ...managed, gateway_url: undefined, misconfigured: true },
+    }),
+  },
+};
+
+export const ManagedSessionReady: Story = {
+  args: { client: gateClient({ status: gatewaySignedIn }) },
+};
+
+export const UnexpectedShellError: Story = {
+  render: () => (
+    <ErrorBoundary onReload={fn()}>
+      <ThrowsOnRender />
+    </ErrorBoundary>
+  ),
+};
+
+export const ContainedViewError: Story = {
+  render: () => (
+    <div className="mx-auto mt-10 max-w-xl rounded-xl border bg-background p-6">
+      <h1 className="text-lg font-semibold">Conversation</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        The rest of the view stays available when one result fails.
+      </p>
+      <ErrorBoundary
+        fallback={
+          <p className="mt-4 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted">
+            This result could not be shown.
+          </p>
+        }
+      >
+        <ThrowsOnRender />
+      </ErrorBoundary>
+    </div>
+  ),
+};
+
+export const CustomNetworkPolicy: Story = {
+  render: () => (
+    <NetworkPolicyDialog
+      open
+      value={{
+        mode: "allowed_hosts",
+        allowed_hosts: ["api.github.com", "objects.githubusercontent.com"],
+        package_managers: true,
+      }}
+      onOpenChange={fn()}
+      onChange={fn(async () => {})}
+    />
+  ),
+};
+
+export const ManagedNetworkPolicy: Story = {
+  render: () => (
+    <NetworkPolicyDialog
+      open
+      disabled
+      value={{ mode: "package_managers" }}
+      onOpenChange={fn()}
+      onChange={fn(async () => {})}
+    />
+  ),
+};
+
+export const NetworkPolicyFailure: Story = {
+  render: () => (
+    <NetworkPolicyDialog
+      open
+      value={{ mode: "open" }}
+      onOpenChange={fn()}
+      onChange={fn(async () => {
+        throw new Error("This machine rejected the network policy update.");
+      })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await body.findByRole("button", { name: "Apply network policy" }),
+    );
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/Shortcuts.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Shortcuts.stories.tsx
@@ -12,7 +12,7 @@ import { ShortcutsList } from "@/ShortcutsDialog";
  * story is opened.
  */
 const meta = {
-  title: "Foundations/Keyboard shortcuts",
+  title: "Navigation/Keyboard shortcuts",
   component: ShortcutsList,
   args: { command: true },
   decorators: [

--- a/crates/tidebreak-desktop/ui/src/stories/TranscriptFileAttachments.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TranscriptFileAttachments.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+
+import {
+  TranscriptFileAttachments,
+  type TranscriptFileAttachment,
+} from "@/TranscriptFileAttachments";
+import { SourceNavProvider } from "@/panel/SourceNav";
+
+const files: TranscriptFileAttachment[] = [
+  {
+    documentId: "document-board-packet",
+    name: "Q3 board packet.pdf",
+    mediaType: "application/pdf",
+  },
+  {
+    documentId: "document-forecast",
+    name: "Account forecast and renewal risk.xlsx",
+    mediaType:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  },
+  {
+    documentId: "document-plan",
+    name: "Customer success operating plan.docx",
+    mediaType:
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  },
+  {
+    documentId: "document-review",
+    name: "Executive renewal review.pptx",
+    mediaType:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  },
+  {
+    documentId: "document-notes",
+    name: "Interview notes.md",
+    mediaType: "text/markdown",
+  },
+  {
+    documentId: "document-data",
+    name: "account-signals.json",
+    mediaType: "application/json",
+  },
+];
+
+function AttachmentStory({
+  attachments,
+  navigation,
+}: {
+  attachments: TranscriptFileAttachment[];
+  navigation: boolean;
+}) {
+  const content = (
+    <div className="max-w-2xl rounded-xl bg-muted p-3">
+      <TranscriptFileAttachments files={attachments} />
+    </div>
+  );
+  return navigation ? (
+    <SourceNavProvider value={{ openCitation: fn(), openDocument: fn() }}>
+      {content}
+    </SourceNavProvider>
+  ) : (
+    content
+  );
+}
+
+const meta = {
+  title: "Attachments/Transcript files",
+  component: AttachmentStory,
+  args: { attachments: files.slice(0, 3), navigation: true },
+} satisfies Meta<typeof AttachmentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CommonFormats: Story = {};
+
+export const Dense: Story = {
+  args: { attachments: files },
+};
+
+export const LongFilename: Story = {
+  args: { attachments: [files[1]!] },
+};
+
+export const Compact: Story = {
+  args: { attachments: files.slice(0, 4) },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
+
+export const NavigationUnavailable: Story = {
+  args: { attachments: files, navigation: false },
+  play: async ({ canvasElement }) => {
+    const buttons = within(canvasElement).getAllByRole("button");
+    await Promise.all(buttons.map((button) => expect(button).toBeDisabled()));
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -286,6 +286,120 @@ export const codeWorkspace: CodeWorkspaceSnapshot = {
   created_at: "2026-08-20T09:00:00.000Z",
 };
 
+/** Repositories shared by the home, setup, and sidebar stories. */
+export const codeRepositories: CodeRepoSnapshot[] = [
+  {
+    id: "repo-tidebreak",
+    root_path: "/Users/sam/src/brightwave/tidebreak",
+    display_name: "tidebreak",
+    default_base_ref: "main",
+    branch_prefix: "thet",
+    quick_actions: [],
+    created_at: "2026-08-10T12:00:00.000Z",
+  },
+  {
+    id: "repo-model-gateway",
+    root_path: "/Users/sam/src/platform/model-gateway",
+    display_name: "model-gateway",
+    default_base_ref: "main",
+    branch_prefix: "thet",
+    quick_actions: [],
+    created_at: "2026-08-08T15:30:00.000Z",
+  },
+  {
+    id: "repo-design-system",
+    root_path:
+      "/Users/sam/src/brightwave/product-foundations/design-system-components",
+    display_name: "design-system-components",
+    default_base_ref: "main",
+    branch_prefix: "thet",
+    quick_actions: [],
+    created_at: "2026-08-03T10:15:00.000Z",
+  },
+];
+
+/** A realistic worktree for quick open and file-panel stories. */
+export const codeWorkspaceFilePaths = [
+  "README.md",
+  "crates/tidebreak-desktop/ui/src/code/CodeHome.tsx",
+  "crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx",
+  "crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx",
+  "crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx",
+  "crates/tidebreak-desktop/ui/src/stories/fixtures.ts",
+  "docs/decisions/0062-pull-request-stacks.md",
+  "scripts/storybook.sh",
+] as const;
+
+/** A busy but readable rail for density and progressive-disclosure review. */
+export const codeSidebarWorkspaces: CodeWorkspaceSnapshot[] = [
+  {
+    ...codeWorkspace,
+    id: "ws-storybook-audit",
+    repo_id: "repo-tidebreak",
+    title: "Audit Storybook coverage",
+    branch_name: "thet/storybook-audit",
+    created_at: "2026-08-24T13:40:00.000Z",
+  },
+  {
+    ...codeWorkspace,
+    id: "ws-browser-recovery",
+    repo_id: "repo-tidebreak",
+    title: "Make browser recovery clear",
+    branch_name: "thet/browser-recovery",
+    created_at: "2026-08-24T12:20:00.000Z",
+    pr: {
+      number: 2314,
+      url: "https://github.com/brightwave-inc/tidebreak/pull/2314",
+      state: "open",
+      title: "Make browser recovery clear",
+      review_decision: "changes_requested",
+      checks_summary: "7 passing, 1 failing",
+    },
+  },
+  {
+    ...codeWorkspace,
+    id: "ws-delivery-density",
+    repo_id: "repo-tidebreak",
+    title: "Clarify delivery density",
+    branch_name: "thet/delivery-density",
+    created_at: "2026-08-24T11:05:00.000Z",
+    pr: {
+      number: 2311,
+      url: "https://github.com/brightwave-inc/tidebreak/pull/2311",
+      state: "open",
+      title: "Clarify delivery density",
+      review_decision: "approved",
+      mergeable: "mergeable",
+      merge_state_status: "clean",
+      checks_summary: "9 passing",
+    },
+  },
+  {
+    ...codeWorkspace,
+    id: "ws-provider-errors",
+    repo_id: "repo-model-gateway",
+    title: "Recover provider errors",
+    branch_name: "thet/provider-errors",
+    created_at: "2026-08-23T17:45:00.000Z",
+  },
+  {
+    ...codeWorkspace,
+    id: "ws-usage-progress",
+    repo_id: "repo-model-gateway",
+    title: "Show subscription progress",
+    branch_name: "thet/usage-progress",
+    created_at: "2026-08-23T16:10:00.000Z",
+  },
+  {
+    ...codeWorkspace,
+    id: "ws-token-rhythm",
+    repo_id: "repo-design-system",
+    title: "Tune dense panel rhythm",
+    branch_name: "thet/panel-rhythm",
+    created_at: "2026-08-22T14:30:00.000Z",
+  },
+];
+
 export const codeSession: CodeSessionSnapshot = {
   id: "sess-1",
   workspace_id: "ws-1",

--- a/crates/tidebreak-desktop/ui/src/stories/routeStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/routeStoryHarness.tsx
@@ -1,0 +1,958 @@
+import type { ReactNode } from "react";
+
+import {
+  ApiClient,
+  type AppDetail,
+  type AppGrantState,
+  type AppSummary,
+  Chat,
+  type ConnectedAppsInfo,
+  ExecConfigInfo,
+  InboxEntry,
+  ManagedPolicy,
+  type McpServerInfo,
+  type ModelRoleInfo,
+  PluginCatalog,
+  Project,
+  ProjectDocument,
+  type VoiceTranscriptionInfo,
+} from "@/api";
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import { useChatAttention } from "@/ChatAttention";
+import { useChatListStore } from "@/ChatListStore";
+import { HOME_DRAFT_KEY, useComposerDrafts } from "@/ComposerDrafts";
+import { useFirstMessage } from "@/FirstMessage";
+import {
+  FIRST_TASK_WALKTHROUGH_KEY,
+  useFirstTaskGuide,
+} from "@/FirstTaskWalkthrough";
+import { useInbox } from "@/Inbox";
+import { ManagedPolicyContext } from "@/managedPolicy";
+import { useNewChatSettings } from "@/NewChatSettings";
+import { useProjectListStore } from "@/ProjectListStore";
+import { useChatsSectionState } from "@/sidebar/ChatsSection";
+import { useUiStore } from "@/UiStore";
+import { useVoiceInputStore } from "@/VoiceInputStore";
+import { harnessDoctor } from "./fixtures";
+import {
+  storyModels,
+  storyProviders,
+  storySettings,
+} from "./SettingsStoryHarness";
+
+export const routeProjects = [
+  {
+    id: "project-1",
+    title: "Desktop release",
+    attachment_revision: 4,
+    root_attachments: [],
+    created_at: "2026-08-20T10:00:00.000Z",
+  },
+  {
+    id: "project-2",
+    title: "Research archive",
+    attachment_revision: 2,
+    root_attachments: [],
+    created_at: "2026-08-18T14:30:00.000Z",
+  },
+  {
+    id: "project-3",
+    title: "Customer onboarding and launch readiness",
+    attachment_revision: 1,
+    root_attachments: [],
+    created_at: "2026-08-16T09:15:00.000Z",
+  },
+] satisfies Project[];
+
+const baseChats = [
+  {
+    id: "chat-1",
+    project_id: null,
+    title: "Review the updater migration",
+    model: null,
+    reasoning_effort: null,
+    permission_mode: "ask",
+    network_policy: { mode: "package_managers" },
+    attachment_revision: 0,
+    root_attachments: [],
+    created_at: "2026-08-24T13:10:00.000Z",
+  },
+  {
+    id: "chat-2",
+    project_id: null,
+    title: "Map plugin permission states",
+    model: null,
+    reasoning_effort: null,
+    permission_mode: "plan",
+    network_policy: { mode: "off" },
+    attachment_revision: 0,
+    root_attachments: [],
+    created_at: "2026-08-23T18:30:00.000Z",
+  },
+  {
+    id: "chat-3",
+    project_id: "project-1",
+    title: "Make the dense sidebar easier to scan",
+    model: null,
+    reasoning_effort: null,
+    permission_mode: "ask",
+    network_policy: {
+      mode: "allowed_hosts",
+      allowed_hosts: ["github.com"],
+      package_managers: false,
+    },
+    attachment_revision: 0,
+    root_attachments: [],
+    created_at: "2026-08-22T09:40:00.000Z",
+  },
+] satisfies Chat[];
+
+export const routeChats: Chat[] = baseChats;
+
+export const denseRouteChats: Chat[] = [
+  ...baseChats,
+  ...Array.from(
+    { length: 12 },
+    (_, index): Chat => ({
+      ...baseChats[index % baseChats.length],
+      id: `dense-chat-${index + 1}`,
+      project_id: index % 4 === 0 ? "project-2" : null,
+      title: [
+        "Trace the shell loading state",
+        "Prepare the release brief",
+        "Check the connected app contract",
+        "Audit navigation at narrow widths",
+        "Summarize the permission review",
+        "Organize the research handoff",
+      ][index % 6],
+      created_at: `2026-08-${String(21 - index).padStart(2, "0")}T12:00:00.000Z`,
+    }),
+  ),
+];
+
+function waitingEntry(
+  index: number,
+  kind: InboxEntry["items"][number]["kind"],
+  title: string,
+): InboxEntry {
+  const requestedAt = `2026-08-24T${String(12 - index).padStart(2, "0")}:00:00.000Z`;
+  return {
+    conversation: { surface: "chat", chatId: `waiting-chat-${index}` },
+    title,
+    attention: {
+      state: {
+        type: "needs_you",
+        prompt: "Waiting for your decision",
+        source: "structured",
+      },
+      source: "structured",
+    },
+    items: [
+      {
+        turnId: `turn-${index}`,
+        callId: `call-${index}`,
+        kind,
+        action: null,
+        requestedAt,
+      },
+    ],
+    waitingSince: requestedAt,
+  };
+}
+
+export const denseInboxEntries: InboxEntry[] = [
+  waitingEntry(1, "tool_approval", "Publish the release candidate"),
+  waitingEntry(2, "question", "Choose the onboarding audience"),
+  waitingEntry(3, "plan_review", "Review the settings migration plan"),
+  waitingEntry(4, "folder_access", "Connect the customer research folder"),
+  waitingEntry(5, "output_writeback", "Save the launch brief"),
+  {
+    conversation: {
+      surface: "code",
+      sessionId: "code-session-1",
+      workspaceId: "workspace-1",
+    },
+    title: "Fix the desktop release workflow",
+    attention: {
+      state: {
+        type: "needs_you",
+        prompt: "Review the proposed changes",
+        source: "structured",
+      },
+      source: "structured",
+    },
+    items: [],
+    waitingSince: "2026-08-24T06:00:00.000Z",
+  },
+];
+
+export const routeProjectDocuments = [
+  {
+    document_id: "document-1",
+    media_type: "application/pdf",
+    title: "Desktop release readiness.pdf",
+    source_byte_len: 2_840_336,
+    readable: true,
+    created_at: "2026-08-24T12:00:00.000Z",
+    updated_at: "2026-08-24T12:00:00.000Z",
+  },
+  {
+    document_id: "document-2",
+    media_type:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    title: "Launch risks and owners.xlsx",
+    source_byte_len: 468_412,
+    readable: true,
+    created_at: "2026-08-23T16:30:00.000Z",
+    updated_at: "2026-08-23T16:30:00.000Z",
+  },
+  {
+    document_id: "document-3",
+    media_type:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    title: "Executive launch review.pptx",
+    source_byte_len: 8_451_920,
+    readable: true,
+    created_at: "2026-08-22T11:15:00.000Z",
+    updated_at: "2026-08-22T11:15:00.000Z",
+  },
+  {
+    document_id: "document-4",
+    media_type: "text/markdown",
+    title: "Release checklist and rollback notes.md",
+    source_byte_len: 18_902,
+    readable: true,
+    created_at: "2026-08-21T09:45:00.000Z",
+    updated_at: "2026-08-21T09:45:00.000Z",
+  },
+  {
+    document_id: "document-5",
+    media_type: "text/plain",
+    title: null,
+    source_byte_len: null,
+    readable: false,
+    created_at: "2026-08-20T08:10:00.000Z",
+    updated_at: "2026-08-20T08:10:00.000Z",
+  },
+] satisfies ProjectDocument[];
+
+export const unmanagedPolicy: ManagedPolicy = {
+  managed: false,
+  source: "unmanaged",
+  misconfigured: false,
+  allow_local_mcp_servers: false,
+};
+
+export const managedPolicy: ManagedPolicy = {
+  managed: true,
+  source: "provisioned",
+  gateway_url: "https://gateway.example.com",
+  misconfigured: false,
+  allow_local_mcp_servers: false,
+};
+
+export const routePluginCatalog: PluginCatalog = {
+  plugins: [
+    {
+      name: "document-work",
+      display_name: "Document work",
+      description: "Create, inspect, and revise office documents and PDFs.",
+      category: "documents",
+      origin: "builtin",
+      capabilities: ["write-files"],
+      compatibility: { status: "compatible", issues: [] },
+      enabled: true,
+      skills: [
+        {
+          name: "documents",
+          description: "Create, edit, and review Word documents.",
+          origin: "builtin",
+          enabled: true,
+        },
+        {
+          name: "pdf",
+          description: "Read, create, render, and inspect PDF files.",
+          origin: "builtin",
+          enabled: true,
+        },
+      ],
+    },
+    {
+      name: "data-workbench",
+      display_name: "Data workbench",
+      description: "Analyze spreadsheets and produce verified data outputs.",
+      category: "data",
+      origin: "builtin",
+      capabilities: ["write-files", "host-install"],
+      compatibility: {
+        status: "limited",
+        issues: [
+          {
+            kind: "missing_sandbox_dependency",
+            skill: "spreadsheets",
+            dependency: "libreoffice",
+          },
+        ],
+      },
+      enabled: false,
+      skills: [
+        {
+          name: "spreadsheets",
+          description: "Create, edit, analyze, and verify spreadsheet files.",
+          origin: "builtin",
+          enabled: true,
+        },
+      ],
+    },
+    {
+      name: "browser-research",
+      display_name: "Browser research",
+      description: "Inspect websites and collect evidence from live sources.",
+      category: "other",
+      origin: "user",
+      capabilities: ["network", "live-control", "mcp"],
+      compatibility: { status: "unchecked", issues: [] },
+      enabled: true,
+      skills: [],
+    },
+  ],
+  skills: [
+    {
+      name: "release-notes",
+      description: "Turn merged changes into release notes.",
+      origin: "user",
+      enabled: true,
+    },
+  ],
+  prompts: [],
+};
+
+export const routeApps = [
+  {
+    id: "release-brief",
+    name: "Release brief",
+    revision_count: 4,
+    updated_at: "2026-08-23T16:40:00.000Z",
+    granted: true,
+  },
+  {
+    id: "incident-map",
+    name: "Incident map",
+    revision_count: 1,
+    updated_at: "2026-08-22T09:15:00.000Z",
+    granted: false,
+  },
+  {
+    id: "research-table",
+    name: "Research source table with a deliberately long title",
+    revision_count: 7,
+    updated_at: "2026-08-19T18:20:00.000Z",
+    granted: true,
+  },
+] satisfies AppSummary[];
+
+export const routeAppDetail = {
+  id: "release-brief",
+  name: "Release brief",
+  created_at: "2026-08-18T10:10:00.000Z",
+  updated_at: "2026-08-23T16:40:00.000Z",
+  current_revision: "revision-4",
+  revisions: [
+    {
+      id: "revision-4",
+      ordinal: 4,
+      created_at: "2026-08-23T16:40:00.000Z",
+    },
+    {
+      id: "revision-3",
+      ordinal: 3,
+      created_at: "2026-08-22T15:20:00.000Z",
+    },
+    {
+      id: "revision-2",
+      ordinal: 2,
+      created_at: "2026-08-20T13:00:00.000Z",
+    },
+  ],
+} satisfies AppDetail;
+
+const routeAppGrant = {
+  granted: true,
+  bindings: [
+    {
+      app: null,
+      folder: "folder-release-notes",
+      gateway_app: null,
+      access: "read_write",
+      name: "Release notes",
+      operation_ids: null,
+      granted: true,
+      definition_changed: false,
+    },
+    {
+      app: null,
+      folder: null,
+      gateway_app: "github",
+      access: null,
+      name: "GitHub",
+      operation_ids: ["pulls.list", "pulls.comment", "checks.read"],
+      granted: true,
+      definition_changed: false,
+    },
+  ],
+} satisfies AppGrantState;
+
+const routeModelRoles = [
+  {
+    role: "chat",
+    selection: storyModels[0].key,
+    resolved_key: storyModels[0].key,
+  },
+  {
+    role: "utility",
+    selection: null,
+    resolved_key: storyModels[1].key,
+  },
+] satisfies ModelRoleInfo[];
+
+const routeVoiceInfo = {
+  model: "local",
+  local_model: "whisper-base-en",
+  local_models: [
+    {
+      id: "whisper-base-en",
+      label: "Whisper Base English",
+      description: "A balanced local model for everyday dictation.",
+      total_bytes: 148_000_000,
+      english_only: true,
+      recommended: true,
+      state: "ready",
+      downloaded_bytes: 148_000_000,
+      error: null,
+    },
+  ],
+  openai_ready: true,
+  gemini_ready: true,
+} satisfies VoiceTranscriptionInfo;
+
+const executionConfig = {
+  provider: "daytona",
+  timeout_ms: 30_000,
+  available: true,
+  has_credential: true,
+  providers: [
+    { provider: "local", available: true },
+    { provider: "e2b", available: true },
+    { provider: "daytona", available: true },
+    { provider: "docker", available: true },
+  ],
+  egress: {
+    policy: { mode: "open" },
+    enforcement: [
+      {
+        provider: "e2b",
+        status: "applied_with_gaps",
+        gaps: ["DNS resolution"],
+      },
+      {
+        provider: "daytona",
+        status: "conditional_boundary",
+        gaps: [],
+        requirement: "Daytona org tier 3+",
+      },
+    ],
+  },
+  detached_admission: [
+    { provider: "local", admitted: false, denials: ["image_not_verified"] },
+    { provider: "e2b", admitted: false, denials: ["image_not_verified"] },
+    {
+      provider: "daytona",
+      admitted: false,
+      denials: ["image_not_verified"],
+    },
+    { provider: "docker", admitted: false, denials: ["image_not_verified"] },
+  ],
+} satisfies ExecConfigInfo;
+
+const routeMcpServer = {
+  name: "docs",
+  command: "/usr/local/bin/docs-mcp",
+  args: [],
+  env: [],
+  env_from: [],
+  cwd: null,
+  url: null,
+  bearer_token_env: null,
+  gateway_endpoint: null,
+  request_timeout_ms: 60_000,
+  enabled: true,
+  plugin: null,
+  health: "healthy",
+  tool_count: 3,
+  diagnostic: null,
+  curated: null,
+} satisfies McpServerInfo;
+
+const routeConnectedApps = {
+  apps: [
+    {
+      kind: "mcp_server",
+      id: "app-docs",
+      name: "docs",
+      health: "healthy",
+      tool_count: 3,
+      tools: ["search", "fetch", "list_documents"],
+      diagnostic: null,
+      curated: null,
+      gateway_endpoint: null,
+      gateway_apps: [],
+      used_by_app_count: 2,
+    },
+    {
+      kind: "mcp_server",
+      id: "app-primary",
+      name: "primary",
+      health: "healthy",
+      tool_count: 4,
+      tools: ["search_issues", "create_issue", "get_customer", "post_note"],
+      diagnostic: null,
+      curated: null,
+      gateway_endpoint: "primary",
+      gateway_apps: ["Linear", "Salesforce"],
+      used_by_app_count: 3,
+    },
+    {
+      kind: "rest_api",
+      id: "app-sentry",
+      name: "Sentry",
+      base_url: "https://api.sentry.example/v2",
+      operation_count: 12,
+      document_sha256: "ab".repeat(32),
+      credential_status: "configured",
+      placement: "bearer",
+      updated_at: "2026-08-20T12:00:00Z",
+      used_by_app_count: 1,
+    },
+  ],
+} satisfies ConnectedAppsInfo;
+
+type RouteClientMethods = Pick<
+  ApiClient,
+  | "getSettings"
+  | "putSettings"
+  | "listProviders"
+  | "putProvider"
+  | "deleteCredential"
+  | "getOpenaiChatgptStatus"
+  | "openaiChatgptSignIn"
+  | "openaiChatgptSignOut"
+  | "listModels"
+  | "putModelRole"
+  | "getVoiceTranscription"
+  | "putVoiceTranscription"
+  | "installLocalVoice"
+  | "getWebSearchConfig"
+  | "putWebSearchConfig"
+  | "listWebSearchCredentials"
+  | "putWebSearchCredential"
+  | "deleteWebSearchCredential"
+  | "getExecConfig"
+  | "putExecConfig"
+  | "listExecCredentials"
+  | "putExecCredential"
+  | "deleteExecCredential"
+  | "getHarnessDoctor"
+  | "refreshHarnessDoctor"
+  | "getCodeWorktreeRoot"
+  | "setCodeWorktreeRoot"
+  | "listConnectedApps"
+  | "putRestConnectedApp"
+  | "previewRestSpec"
+  | "deleteRestConnectedApp"
+  | "listMcpServers"
+  | "putMcpServers"
+  | "reconnectMcpServer"
+  | "getGatewayStatus"
+  | "gatewaySignIn"
+  | "gatewaySignOut"
+  | "getGatewayMachine"
+  | "syncGatewayModels"
+  | "getGatewayApps"
+  | "listConsentStatements"
+  | "revokeStandingGrant"
+  | "listProjectDocuments"
+  | "listApps"
+  | "getApp"
+  | "deleteApp"
+  | "getAppGrant"
+  | "consentAppGrant"
+  | "revokeAppGrant"
+  | "createAppViewFrame"
+  | "invokeAppOperation"
+  | "invokeAppGatewayOperation"
+  | "invokeAppFolder"
+  | "appGatewayPage"
+  | "listPlugins"
+  | "setPluginsEnabled"
+  | "getSkillInstructions"
+  | "getPromptBody"
+>;
+
+export function pending<T>(): Promise<T> {
+  return new Promise(() => undefined);
+}
+
+export function storyClient(
+  overrides: Partial<RouteClientMethods> = {},
+): ApiClient {
+  const methods: RouteClientMethods = {
+    getSettings: async () => storySettings,
+    putSettings: async () => storySettings,
+    listProviders: async () => ({ providers: storyProviders }),
+    putProvider: async (kind) =>
+      storyProviders.find((provider) => provider.kind === kind) ??
+      storyProviders[0],
+    deleteCredential: async () => {},
+    getOpenaiChatgptStatus: async () => ({
+      signed_in: true,
+      account_hint: "alex@example.com",
+    }),
+    openaiChatgptSignIn: async () => ({
+      authorization_url: "https://auth.example.test",
+    }),
+    openaiChatgptSignOut: async () => {},
+    listModels: async () => ({
+      models: storyModels,
+      roles: routeModelRoles,
+    }),
+    putModelRole: async (role, selection) => ({
+      role,
+      selection,
+      resolved_key:
+        selection ??
+        routeModelRoles.find((entry) => entry.role === role)?.resolved_key ??
+        storyModels[0].key,
+    }),
+    getVoiceTranscription: async () => routeVoiceInfo,
+    putVoiceTranscription: async (model, localModel) => ({
+      ...routeVoiceInfo,
+      model,
+      local_model: localModel ?? routeVoiceInfo.local_model,
+    }),
+    installLocalVoice: async () => ({
+      state: "ready",
+      downloaded_bytes: 148_000_000,
+      total_bytes: 148_000_000,
+      error: null,
+    }),
+    getWebSearchConfig: async () => ({
+      provider: "exa",
+      mode: "host",
+      timeout_ms: 20_000,
+      has_credential: true,
+      available: true,
+    }),
+    putWebSearchConfig: async () => ({
+      provider: "exa",
+      mode: "host",
+      timeout_ms: 20_000,
+      has_credential: true,
+      available: true,
+    }),
+    listWebSearchCredentials: async () => ({
+      credentials: [
+        { provider: "exa", has_credential: true },
+        { provider: "tavily", has_credential: false },
+        { provider: "brave", has_credential: false },
+        { provider: "searxng", has_credential: false },
+        { provider: "model_provider", has_credential: false },
+      ],
+    }),
+    putWebSearchCredential: async (provider) => ({
+      provider,
+      has_credential: true,
+    }),
+    deleteWebSearchCredential: async (provider) => ({
+      provider,
+      has_credential: false,
+    }),
+    getExecConfig: async () => executionConfig,
+    putExecConfig: async () => executionConfig,
+    listExecCredentials: async () => ({
+      credentials: [
+        { provider: "e2b", has_credential: true },
+        { provider: "daytona", has_credential: true },
+      ],
+    }),
+    putExecCredential: async (provider) => ({
+      provider,
+      has_credential: true,
+    }),
+    deleteExecCredential: async (provider) => ({
+      provider,
+      has_credential: false,
+    }),
+    getHarnessDoctor: async () => harnessDoctor,
+    refreshHarnessDoctor: async () => harnessDoctor,
+    getCodeWorktreeRoot: async () => ({
+      root: "/Users/alex/Code/worktrees",
+      effective_root: "/Users/alex/Code/worktrees",
+      default_root: "/Users/alex/.tidebreak/worktrees",
+    }),
+    setCodeWorktreeRoot: async (root) => ({
+      ...(root ? { root } : {}),
+      effective_root: root ?? "/Users/alex/.tidebreak/worktrees",
+      default_root: "/Users/alex/.tidebreak/worktrees",
+    }),
+    listConnectedApps: async () => routeConnectedApps,
+    putRestConnectedApp: async () => routeConnectedApps,
+    previewRestSpec: async () => ({
+      document_sha256: "cd".repeat(32),
+      operations: [],
+      unlistable: 0,
+      truncated: false,
+    }),
+    deleteRestConnectedApp: async () => {},
+    listMcpServers: async () => ({ servers: [routeMcpServer] }),
+    putMcpServers: async () => ({ servers: [routeMcpServer] }),
+    reconnectMcpServer: async () => ({ servers: [routeMcpServer] }),
+    getGatewayStatus: async () => ({
+      base_url: "https://gateway.example.test",
+      signed_in: true,
+      account_hint: "alex@example.com",
+      installation_id: "installation-story",
+      model_count: 2,
+      member_catalog: "2026-08-01",
+      sign_in: { state: "idle" },
+    }),
+    gatewaySignIn: async () => ({
+      authorization_url: "https://gateway.example.test/sign-in",
+    }),
+    gatewaySignOut: async () => ({
+      base_url: "https://gateway.example.test",
+      signed_in: false,
+      model_count: 0,
+      sign_in: { state: "idle" },
+    }),
+    getGatewayMachine: async () => ({
+      url: "https://machine.gateway.example.test",
+    }),
+    syncGatewayModels: async () => ({
+      base_url: "https://gateway.example.test",
+      signed_in: true,
+      account_hint: "alex@example.com",
+      installation_id: "installation-story",
+      model_count: 2,
+      member_catalog: "2026-08-01",
+      sign_in: { state: "idle" },
+    }),
+    getGatewayApps: async () => ({
+      supported: true,
+      apps: [
+        {
+          id: "gateway-linear",
+          name: "Linear",
+          app_kind: "mcp_server",
+          enabled: true,
+          mcp_endpoint_slugs: ["primary"],
+          connection: "ready",
+          used_by_app_count: 2,
+        },
+      ],
+    }),
+    listConsentStatements: async () => [],
+    revokeStandingGrant: async () => {},
+    listProjectDocuments: async () => ({
+      documents: routeProjectDocuments,
+      next_cursor: null,
+    }),
+    listApps: async () => ({ apps: routeApps }),
+    getApp: async () => routeAppDetail,
+    deleteApp: async () => {},
+    getAppGrant: async () => routeAppGrant,
+    consentAppGrant: async () => routeAppGrant,
+    revokeAppGrant: async () => {},
+    createAppViewFrame: async () => ({
+      frame_path: `data:text/html;charset=utf-8,${encodeURIComponent(
+        "<!doctype html><html><body><main><h1>Desktop release readiness</h1><p>17 checks passed. Two reviews remain open.</p></main></body></html>",
+      )}`,
+    }),
+    invokeAppOperation: async () => ({ is_error: false }),
+    invokeAppGatewayOperation: async () => ({ is_error: false }),
+    invokeAppFolder: async () => ({ is_error: false }),
+    appGatewayPage: async () => ({
+      outcome: "ready",
+      url: "https://gateway.example.test/apps/release-brief",
+    }),
+    listPlugins: async () => routePluginCatalog,
+    setPluginsEnabled: async () => routePluginCatalog,
+    getSkillInstructions: async (name) => ({
+      name,
+      instructions:
+        "# Review the source\n\nRead the source before you edit it. Preserve facts and links.",
+    }),
+    getPromptBody: async (name) => ({
+      name,
+      body: "Summarize the launch risks and assign a clear owner to each one.",
+    }),
+    ...overrides,
+  };
+
+  return Object.assign(
+    new ApiClient("https://route-story.invalid", "storybook"),
+    methods,
+  );
+}
+
+const idleUpdateState: AppContextValue["updateState"] = {
+  status: "idle",
+  version: null,
+  error: null,
+  enabled: true,
+};
+
+export function storyAppContext(
+  client: ApiClient,
+  overrides: Partial<AppContextValue> = {},
+): AppContextValue {
+  return {
+    client,
+    attachment: "local",
+    models: storyModels,
+    defaultModelKey: null,
+    providers: storyProviders,
+    refreshCatalog: async () => {},
+    refreshChats: async () => {
+      useChatListStore.setState({ chatsError: null });
+    },
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: idleUpdateState,
+    updateUpToDate: false,
+    checkForUpdate: async () => idleUpdateState,
+    restartForUpdate: async () => {},
+    ...overrides,
+  };
+}
+
+type StoreFixture = {
+  chats?: Chat[];
+  chatsLoaded?: boolean;
+  chatsError?: string | null;
+  creatingChat?: boolean;
+  projects?: Project[];
+  projectsLoaded?: boolean;
+  expandedProjectIds?: string[];
+  inboxEntries?: InboxEntry[];
+  inboxLoaded?: boolean;
+  attentionChatIds?: string[];
+  sidebarWidth?: number;
+  sidebarCollapsed?: boolean;
+};
+
+export function resetRouteStoryStores({
+  chats = routeChats,
+  chatsLoaded = true,
+  chatsError = null,
+  creatingChat = false,
+  projects = routeProjects,
+  projectsLoaded = true,
+  expandedProjectIds = ["project-1"],
+  inboxEntries = [],
+  inboxLoaded = true,
+  attentionChatIds = [],
+  sidebarWidth = 280,
+  sidebarCollapsed = false,
+}: StoreFixture = {}): void {
+  useChatListStore.setState({
+    chats,
+    chatsLoaded,
+    chatsError,
+    creatingChat,
+    deletingChatId: null,
+    renamingChatId: null,
+    renameChatDraft: "",
+    savingTitle: false,
+    derivedTitleChatId: null,
+    streamedTitles: {},
+  });
+  useProjectListStore.setState({
+    projects,
+    projectsLoaded,
+    creatingProject: false,
+    deletingProjectId: null,
+    renamingProjectId: null,
+    renameProjectDraft: "",
+    savingProjectTitle: false,
+    expandedProjectIds,
+  });
+  useInbox.setState({ entries: inboxEntries, loaded: inboxLoaded });
+  useChatAttention.setState({
+    chatIdsWithPendingPrompts: new Set(attentionChatIds),
+  });
+  useChatsSectionState.setState({
+    collapsed: false,
+    filtering: false,
+    query: "",
+  });
+  useUiStore.setState({
+    sidebarCollapsed,
+    sidebarWidth,
+    modelMenuNotConnectedCollapsed: false,
+    activeTurnSendMode: "queue",
+  });
+  useComposerDrafts.getState().clearDraft(HOME_DRAFT_KEY);
+  useComposerDrafts.setState({ drafts: {}, attachments: {} });
+  useNewChatSettings.setState({
+    defaults: null,
+    model: null,
+    reasoningEffort: null,
+    permissionMode: null,
+    networkPolicy: null,
+  });
+  useFirstMessage.setState({ chatId: null, pending: null });
+  useFirstTaskGuide.setState({ surface: null });
+  useVoiceInputStore.setState({
+    info: null,
+    loading: false,
+    installing: null,
+    error: null,
+  });
+  try {
+    window.localStorage.setItem(FIRST_TASK_WALKTHROUGH_KEY, "skipped");
+  } catch {
+    // Story fixtures remain deterministic even when storage is unavailable.
+  }
+}
+
+export function RouteStoryProviders({
+  client,
+  context,
+  policy = unmanagedPolicy,
+  children,
+}: {
+  client: ApiClient;
+  context?: Partial<AppContextValue>;
+  policy?: ManagedPolicy;
+  children: ReactNode;
+}) {
+  return (
+    <ManagedPolicyContext.Provider value={policy}>
+      <AppContextProvider value={storyAppContext(client, context)}>
+        {children}
+      </AppContextProvider>
+    </ManagedPolicyContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

- Add route and component stories for shell, navigation, conversations, code, outputs, documents, apps, plugins, and settings.
- Add shared typed fixtures and harnesses for realistic loading, empty, success, failure, compact, and minimum-window states.
- Add Storybook viewport presets and small accessibility fixes exposed while building the stories.
- Mirror the production `.app-body` shell in route stories so the 720 × 480 viewport reflects the real desktop layout.

## Scope

This pull request expands Storybook coverage. It does not attempt the visual redesign. A follow-up pass will assess the rendered stories and improve the product UI.

## Verification

- `pnpm --dir crates/tidebreak-desktop/ui exec biome check .storybook src`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui test` — 223 files, 1,751 tests passed
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm --dir crates/tidebreak-desktop/ui storybook:build`