### PR TITLE
feat(desktop): codify the UI design system and enforce it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ that list onto the board.
 
 ## Desktop UI workflow
 
+- Read [`crates/tidebreak-desktop/ui/DESIGN.md`](crates/tidebreak-desktop/ui/DESIGN.md)
+  before visual work. It defines the palette, type scale, and status
+  vocabulary; `src/stylesContract.test.ts` enforces the mechanical rules, so
+  arbitrary font sizes and raw Tailwind palette classes fail CI.
 - When adding or changing a reusable visual component or a meaningful UI state,
   add or update its Storybook story under
   `crates/tidebreak-desktop/ui/src/stories/`.

--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -1,0 +1,132 @@
+# Tidebreak desktop design system
+
+The tokens live in `src/styles.css` (`:root`, `.dark`, `@theme inline`); this
+file says what they mean and the rules that keep the app coherent. The rules
+that can be checked mechanically are checked: `src/stylesContract.test.ts`
+fails the build on arbitrary font sizes and raw palette classes, so the
+vocabulary below is the whole vocabulary.
+
+Storybook shows the system: `Foundations/Palette`, `Foundations/Typography`,
+`Foundations/Surfaces`, and `Foundations/Controls and status`. Run
+`scripts/storybook.sh` from the repository root.
+
+## Identity
+
+Four decisions carry the app's character. Everything else follows from them.
+
+1. The neutrals are cool. Every gray carries a trace of blue (oklch hue 240)
+   at chroma too small to read as color on any one surface. It is the
+   temperature of the whole app, in both themes. Do not add a pure gray
+   (chroma 0) or a warm gray; match the ramp.
+2. One accent is ours: `live` teal. It means an agent is doing something
+   right now, and it appears nowhere else. Status hues (green, amber, red,
+   blue, purple) mean outcomes and states; teal means "working, this second."
+   Rationing is what keeps it a signal.
+3. Two voices. Geist is how the product speaks; Geist Mono is how the machine
+   speaks. Branch names, SHAs, file paths, diffs, terminal output, model
+   identifiers, and keyboard shortcuts render in `font-mono`. Prose,
+   labels, and controls render in the sans.
+4. Depth is drawn with hairlines, not shadows. Borders and surface steps
+   separate regions; shadows are reserved for things that genuinely float.
+
+## Color
+
+Semantic tokens only. Components never use Tailwind's raw palette
+(`text-emerald-600`, `bg-sky-500`); the contract test allows exactly three
+exceptions, all of them document-viewer conventions: syntax colors in
+`json-viewer.tsx` and `xml-viewer.tsx`, and the highlighter yellow in
+`citationMark.ts`.
+
+Status is a six-tone vocabulary, and every tone ships the same five-member
+quad (`--x`, `--x-foreground`, `--x-foreground-muted`, `--x-background`,
+`--x-border`) in both themes:
+
+| Tone | Means |
+| --- | --- |
+| `success` | finished well; checks green |
+| `warning` | needs a look; stalled, fenced |
+| `critical` | failed, or needs you now |
+| `info` | in flight but waiting on something external |
+| `merged` | settled outcome distinct from success (GitHub's purple) |
+| `live` | an agent is doing work right now |
+
+In code mode, never pick rungs by hand: `src/code/statusTone.ts` is the one
+place a state becomes a color, and its maps (`STATUS_TEXT`, `STATUS_MARK`,
+`STATUS_DOT`, `STATUS_CHIP`) pick the rung for the surface being painted.
+Elsewhere, the `Badge` variants carry the same tones.
+
+Identity is not status. File types, repository swatches, and engine badges
+use the `--icon-*` family (`icon-blue` through `icon-green`), which lifts
+from the 600 step in light to the 400 step in dark. A `.json` file must
+never read as a warning.
+
+If you reach for a `dark:` override on a color, first check whether a token
+already models both themes; most do.
+
+## Type
+
+The root is 14px and the scale is pinned in px, because the app is a dense
+desktop tool and rem-derived sizes landed between the rungs people actually
+wanted. Zoom scales the webview, so px sizes zoom correctly.
+
+| Token | Size / line | Job |
+| --- | --- | --- |
+| `text-2xs` | 10 / 14 | micro labels, counters, avatar initials |
+| `text-xs` | 11 / 15 | dense metadata, timestamps, eyebrows |
+| `text-sm` | 12.5 / 18 | the working size for chrome: rows, menus, buttons |
+| `text-md` | 13.5 / 20 | content: transcript bodies, card titles, approval prose |
+| `text-base` | 14 / 21 | body text |
+| `text-lg`–`text-3xl` | 16–24 | headings, welcome screens |
+
+Arbitrary sizes (`text-[13px]`) are a contract-test failure. If a real new
+rung emerges, add it to the scale in `styles.css` and to this table, and say
+what its job is.
+
+Weights: 400 for text, 500 for emphasis and control labels, 600 for titles.
+Nothing heavier; hierarchy comes from size, weight stops at semibold.
+Eyebrow labels are `text-2xs`/`text-xs` uppercase with `tracking-wide`, and
+usually mono when they label machine output.
+
+## Surfaces and elevation
+
+Two surface tokens do the structural work. `page-background` is the app
+canvas; `background` is the reading surface (panes, cards, composer) and
+sits one step off the canvas in both themes — lighter in light mode, darker
+in dark mode. `muted` recesses a region within a surface; `popover` is the
+overlay surface.
+
+Regions separate on `border-border` hairlines; `border-subtle` divides
+within a card. There are exactly three shadows — `shadow-sm`, `shadow`,
+`shadow-lg` (Tailwind's other steps alias onto them deliberately) — and
+they belong to things that float: menus, dialogs, drag previews, the
+computer-use HUD. Cards on a surface take a border, not a shadow.
+
+## Shape and controls
+
+`--radius` is 8px; the derived steps (4, 6, 8, 12) and full pills are the
+whole radius vocabulary. Status chips and badges are pills; cards are
+`rounded-xl` at most.
+
+Controls sit on the two pinned heights, `h-control` (32px) and
+`h-control-sm` (28px). The primary button is neutral (near-black in light,
+near-white in dark); `destructive` is the only chromatic button. Focus is
+the `ring` token, darker than stock so it survives hovered rows.
+
+## Don't
+
+- Don't add a new hue, a chromatic button fill, or a second accent.
+- Don't use `live` for anything that is not running right now.
+- Don't put drop shadows on resting cards.
+- Don't use raw palette classes or arbitrary font sizes; the contract test
+  fails both.
+- Don't exceed weight 600.
+- Don't hand-pick status rungs in code mode; go through `statusTone.ts`.
+
+## Extending the system
+
+A new status tone is a five-member quad in both themes in `styles.css`, an
+entry in each `@source inline(...)` line, a row in the `statusTone.ts` maps,
+a `Badge` variant, and a swatch row in `Foundations/Palette`. A new scale
+rung is a `--text-*` pair in `styles.css` plus its row here and in
+`Foundations/Typography`. If a rule in this file and the code disagree, fix
+one of them in the same change.

--- a/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentActivityTimeline.tsx
@@ -299,7 +299,7 @@ function ExecActivityCard({
           // is still running, an empty pane would read as a finished command
           // that said nothing.
           settled && (
-            <p className="text-muted-foreground px-0.5 text-[11px]">
+            <p className="text-muted-foreground px-0.5 text-xs">
               No output captured.
             </p>
           )

--- a/crates/tidebreak-desktop/ui/src/AgentRunProgress.tsx
+++ b/crates/tidebreak-desktop/ui/src/AgentRunProgress.tsx
@@ -202,7 +202,7 @@ export function AgentRunProgressStream({
       className={cn("flex flex-col gap-1.5", className)}
       aria-label="Progress"
     >
-      <p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+      <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
         Progress
       </p>
       <ol className="flex flex-col gap-1.5 text-xs" role="list">

--- a/crates/tidebreak-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -270,7 +270,7 @@ function BackgroundAgentDetail({
         />
         {run.terminal_text && (
           <section className="mt-4 border-t pt-3.5">
-            <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
               Result
             </p>
             <div className="break-words text-foreground [&_.message-markdown]:text-sm">

--- a/crates/tidebreak-desktop/ui/src/ChangeSummaryCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChangeSummaryCard.tsx
@@ -197,7 +197,7 @@ function FileChangeRow({
           <p className="truncate font-mono text-xs" title={file.relative_path}>
             {file.relative_path}
           </p>
-          <p className="mt-0.5 text-[11px] text-muted-foreground">
+          <p className="mt-0.5 text-xs text-muted-foreground">
             {file.folder_name} · {fileStatus(file)}
           </p>
         </div>
@@ -248,7 +248,7 @@ function TextDiff({ diff }: { diff: string }) {
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <pre className="mt-2 max-h-72 overflow-auto rounded-md border border-border bg-muted/40 py-2 text-[11px] leading-4">
+        <pre className="mt-2 max-h-72 overflow-auto rounded-md border border-border bg-muted/40 py-2 text-xs leading-4">
           {diff.split("\n").map((line, index) => (
             <span
               // A unified diff can contain identical lines; position is the
@@ -258,10 +258,10 @@ function TextDiff({ diff }: { diff: string }) {
                 "block min-h-4 px-2",
                 line.startsWith("+") &&
                   !line.startsWith("+++") &&
-                  "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+                  "bg-success/10 text-success-foreground",
                 line.startsWith("-") &&
                   !line.startsWith("---") &&
-                  "bg-red-500/10 text-red-700 dark:text-red-300",
+                  "bg-critical/10 text-critical-foreground",
                 line.startsWith("@@") && "text-muted-foreground",
               )}
             >
@@ -391,7 +391,7 @@ function RevisionPreview({
   const label = revision === "before" ? "Before" : "After";
   return (
     <figure className="overflow-hidden rounded-md border border-border bg-muted/20">
-      <figcaption className="border-b border-border px-2 py-1.5 text-[11px] font-medium text-muted-foreground">
+      <figcaption className="border-b border-border px-2 py-1.5 text-xs font-medium text-muted-foreground">
         {label}
       </figcaption>
       <div className="flex min-h-36 items-center justify-center p-2">

--- a/crates/tidebreak-desktop/ui/src/ChatStatusChip.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatStatusChip.tsx
@@ -208,7 +208,7 @@ export function ChatStatusChip({
                 />
               ))}
               {overflowRuns > 0 && (
-                <span className="text-[0.65rem] leading-none">{`+${overflowRuns}`}</span>
+                <span className="text-2xs leading-none">{`+${overflowRuns}`}</span>
               )}
             </span>
           )}

--- a/crates/tidebreak-desktop/ui/src/CommandPaletteList.tsx
+++ b/crates/tidebreak-desktop/ui/src/CommandPaletteList.tsx
@@ -96,7 +96,7 @@ export function CommandPaletteList({
             aria-label="Loading"
           />
         )}
-        <kbd className="absolute top-1/2 right-3 -translate-y-1/2 shrink-0 rounded border px-1.5 py-0.5 font-sans text-[10px] text-muted-foreground">
+        <kbd className="absolute top-1/2 right-3 -translate-y-1/2 shrink-0 rounded border px-1.5 py-0.5 font-sans text-2xs text-muted-foreground">
           esc
         </kbd>
       </div>
@@ -165,7 +165,7 @@ function PaletteItem({
       )}
       <span className="min-w-0 flex-1 truncate text-sm">{row.label}</span>
       {row.hint && (
-        <span className="min-w-0 max-w-[45%] shrink-0 truncate text-[11px] text-muted-foreground">
+        <span className="min-w-0 max-w-[45%] shrink-0 truncate text-xs text-muted-foreground">
           {row.hint}
         </span>
       )}
@@ -174,7 +174,7 @@ function PaletteItem({
           {caps.map((cap) => (
             <kbd
               key={cap}
-              className="inline-flex h-5 min-w-5 items-center justify-center rounded border bg-muted/60 px-1 font-sans text-[10px] leading-none text-muted-foreground"
+              className="inline-flex h-5 min-w-5 items-center justify-center rounded border bg-muted/60 px-1 font-sans text-2xs leading-none text-muted-foreground"
             >
               {cap}
             </kbd>
@@ -194,7 +194,7 @@ function PaletteItem({
  */
 function PaletteFooter({ scoped }: { scoped: boolean }) {
   return (
-    <div className="flex items-center justify-between gap-3 border-t px-3 py-1.5 text-[10px] text-muted-foreground">
+    <div className="flex items-center justify-between gap-3 border-t px-3 py-1.5 text-2xs text-muted-foreground">
       <span className="flex items-center gap-2.5">
         {scoped ? (
           <span>

--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -1366,7 +1366,7 @@ function InvokedSkillChip({
       >
         {label}
       </span>
-      <small className="text-[0.68rem]">Skill</small>
+      <small className="text-2xs">Skill</small>
       <button
         type="button"
         className="absolute right-1 top-1/2 inline-flex -translate-y-1/2 items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground"
@@ -1400,7 +1400,7 @@ function FolderAttachmentChip({
         >
           {folder.displayName}
         </strong>
-        <small className="text-[0.68rem]">
+        <small className="text-2xs">
           {folderAccessLabel(folderReach(folder.statements))}
         </small>
       </span>
@@ -1444,7 +1444,7 @@ function FileAttachmentChip({
             size — the transcript records what a document is, not how big it
             was. An unknown size is left unsaid rather than reported as zero. */}
         {file.byteLen > 0 && (
-          <small className="text-[0.68rem]">{formatBytes(file.byteLen)}</small>
+          <small className="text-2xs">{formatBytes(file.byteLen)}</small>
         )}
       </span>
       <button
@@ -1487,7 +1487,7 @@ function WorkspaceFileChip({
         >
           {name}
         </strong>
-        <small className="max-w-[14rem] truncate text-[0.68rem]">
+        <small className="max-w-[14rem] truncate text-2xs">
           {file.detail ?? folder}
         </small>
       </span>
@@ -1560,7 +1560,7 @@ function ImageAttachmentChip({
         {/* Only the outcome is announced. A live region on the percentage
             would read every tick of a bar that is already on screen. */}
         <small
-          className={cn("text-[0.68rem]", failed && "text-destructive")}
+          className={cn("text-2xs", failed && "text-destructive")}
           role={failed ? "alert" : uploading ? undefined : "status"}
         >
           {describeImageAttachment(attachment)}
@@ -1577,7 +1577,7 @@ function ImageAttachmentChip({
       {failed && (
         <button
           type="button"
-          className="shrink-0 rounded-full border border-border bg-background px-2 py-px text-[0.68rem] text-foreground"
+          className="shrink-0 rounded-full border border-border bg-background px-2 py-px text-2xs text-foreground"
           onClick={onRetry}
         >
           Try again

--- a/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComputerUseIndicator.tsx
@@ -77,7 +77,7 @@ export function ComputerUseIndicator() {
               className={`size-2.5 shrink-0 rounded-full ${
                 snapshot.halted
                   ? "bg-muted-foreground"
-                  : "bg-emerald-400 shadow-[0_0_0_4px_rgba(52,211,153,0.18)]"
+                  : "bg-live ring-4 ring-live/20"
               }`}
               aria-hidden="true"
             />
@@ -90,7 +90,7 @@ export function ComputerUseIndicator() {
                       snapshot.active?.bundleId ?? "",
                     )}`}
               </p>
-              <p className="text-muted-foreground text-[0.6875rem]">
+              <p className="text-muted-foreground text-2xs">
                 {snapshot.halted
                   ? "Resume only when you want the agent to continue."
                   : "You can stop before the next action."}

--- a/crates/tidebreak-desktop/ui/src/ContextUsageIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/ContextUsageIndicator.tsx
@@ -86,7 +86,7 @@ export function ContextUsageIndicator({
             <div className="truncate text-xs font-medium leading-tight">
               {modelName ?? "Context window"}
             </div>
-            <div className="shrink-0 font-mono text-[11px] tabular-nums opacity-80">
+            <div className="shrink-0 font-mono text-xs tabular-nums opacity-80">
               {metered ? (
                 <>
                   {percent}%<span className="mx-1 opacity-50">·</span>
@@ -115,13 +115,13 @@ export function ContextUsageIndicator({
               />
             </div>
           ) : (
-            <p className="text-[11px] leading-snug opacity-70">
+            <p className="text-xs leading-snug opacity-70">
               {resident === null
                 ? "This engine reports no context reading"
                 : "No published context window"}
             </p>
           )}
-          <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-0.5 border-t border-primary-foreground/15 pt-2 text-[11px] leading-relaxed">
+          <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-0.5 border-t border-primary-foreground/15 pt-2 text-xs leading-relaxed">
             <div className="col-span-2 grid grid-cols-subgrid">
               <dt className="opacity-70">Context</dt>
               <dd className="font-mono tabular-nums">
@@ -138,10 +138,10 @@ export function ContextUsageIndicator({
               {/* Labeled, because these are not the ring's numbers: they sum
                   every model call the turn made, and on a long turn they run
                   well past what the window ever held. */}
-              <p className="text-[10px] uppercase tracking-wide opacity-60">
+              <p className="text-2xs uppercase tracking-wide opacity-60">
                 Turn spend
               </p>
-              <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-0.5 text-[11px] leading-relaxed">
+              <dl className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-0.5 text-xs leading-relaxed">
                 {parts.map((part) => (
                   <div
                     key={part.label}

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
@@ -67,7 +67,7 @@ export function ModelToolCapabilityChip({ model }: { model: ModelInfo }) {
       side="top"
     >
       <span
-        className="text-muted-foreground border-border rounded-full border px-1.5 py-0.5 text-[0.65rem] leading-none"
+        className="text-muted-foreground border-border rounded-full border px-1.5 py-0.5 text-2xs leading-none"
         aria-label="Conversation only. Function tools are unsupported or cannot yet be continued safely in Tidebreak."
       >
         Conversation only
@@ -512,7 +512,7 @@ export function ModelMenu({
           {model.display_name}
         </span>
         {showProvider && (
-          <span className="text-muted-foreground shrink-0 text-[0.65rem]">
+          <span className="text-muted-foreground shrink-0 text-2xs">
             {providerLabel(model.provider)}
           </span>
         )}

--- a/crates/tidebreak-desktop/ui/src/QueueTray.tsx
+++ b/crates/tidebreak-desktop/ui/src/QueueTray.tsx
@@ -184,7 +184,7 @@ export function QueueTray({
           </span>
         </span>
         {paused && (
-          <span className="rounded-full border border-warning-border/45 bg-warning-background px-1.5 py-px text-[10px] font-medium leading-4 text-warning-foreground">
+          <span className="rounded-full border border-warning-border/45 bg-warning-background px-1.5 py-px text-2xs font-medium leading-4 text-warning-foreground">
             Paused
           </span>
         )}
@@ -214,7 +214,7 @@ export function QueueTray({
       <ul className="divide-y divide-border/60 px-3">
         {queued.map((row, index) => (
           <li key={row.id} className="group flex h-8 items-center gap-2">
-            <span className="w-3 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+            <span className="w-3 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
               {index + 1}
             </span>
             {editing === row.id ? (

--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -75,7 +75,7 @@ export function ToolCardShell({
       <button
         type="button"
         className={cn(
-          "-mx-1.5 flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-0.5 text-left text-[13.5px] hover:bg-muted/50",
+          "-mx-1.5 flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-0.5 text-left text-md hover:bg-muted/50",
           FOCUS_RING_TIGHT,
           HOVER_TINT,
         )}
@@ -98,7 +98,7 @@ export function ToolCardShell({
             title
           )}
         </span>
-        <span className="text-muted-foreground ml-auto flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums">
+        <span className="text-muted-foreground ml-auto flex shrink-0 items-center gap-1.5 text-xs tabular-nums">
           {trailing}
           <ChevronDown
             className={cn(

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -65,7 +65,7 @@ export function ToolOutputPreview({
           aria-label={label}
           className={
             bare
-              ? "text-muted-foreground overflow-x-auto pr-7 font-mono text-[13.5px] break-words whitespace-pre-wrap [overflow-anchor:none]"
+              ? "text-muted-foreground overflow-x-auto pr-7 font-mono text-md break-words whitespace-pre-wrap [overflow-anchor:none]"
               : "bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-xs break-words whitespace-pre-wrap"
           }
         >
@@ -86,7 +86,7 @@ export function ToolOutputPreview({
       {hiddenCount > 0 && (
         <button
           type="button"
-          className="text-muted-foreground hover:text-foreground ring-offset-background focus-visible:ring-ring cursor-pointer rounded-sm text-[11px] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-safe:transition-colors motion-safe:duration-[140ms] motion-safe:ease-out"
+          className="text-muted-foreground hover:text-foreground ring-offset-background focus-visible:ring-ring cursor-pointer rounded-sm text-xs focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-safe:transition-colors motion-safe:duration-[140ms] motion-safe:ease-out"
           aria-expanded={expanded}
           aria-controls={bodyId}
           onClick={() => {

--- a/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
+++ b/crates/tidebreak-desktop/ui/src/WelcomeState.tsx
@@ -122,7 +122,7 @@ function PromptCard({
       <span className="min-w-0 flex-1 pt-0.5">
         <span className="block font-medium tracking-[-0.01em]">{label}</span>
         {description && (
-          <span className="mt-0.5 block text-[0.8rem] leading-5 font-normal text-muted-foreground">
+          <span className="mt-0.5 block text-xs leading-5 font-normal text-muted-foreground">
             {description}
           </span>
         )}

--- a/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeApprovalCard.tsx
@@ -48,7 +48,7 @@ export function CodeApprovalCard({
       data-testid="code-approval-card"
     >
       <div className="flex items-baseline justify-between gap-3">
-        <h3 className="text-[13.5px] font-medium break-words">
+        <h3 className="text-md font-medium break-words">
           {approvalTitle(approval)}
         </h3>
         <ApprovalState approval={approval} />
@@ -59,10 +59,10 @@ export function CodeApprovalCard({
         decidedAt={approval.decided_at}
       />
       {approval.state === "denied" && approval.feedback && (
-        <p className="text-[13.5px] break-words">{approval.feedback}</p>
+        <p className="text-md break-words">{approval.feedback}</p>
       )}
       {approval.state === "abandoned" && (
-        <p className="text-muted-foreground text-[13.5px] break-words">
+        <p className="text-muted-foreground text-md break-words">
           The engine stopped waiting for this one, so a decision can no longer
           reach it. Whatever it asked for did not run on your say-so.
         </p>
@@ -71,7 +71,7 @@ export function CodeApprovalCard({
         <button
           type="button"
           className={cn(
-            "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-[11px]",
+            "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-xs",
             FOCUS_RING,
             HOVER_TINT,
           )}
@@ -93,7 +93,7 @@ export function CodeApprovalCard({
           */}
           <ScrollableContainer
             id={payloadId}
-            className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 font-mono text-[11px] break-words whitespace-pre-wrap"
+            className="bg-muted text-muted-foreground mt-2 max-h-48 rounded-md p-3 font-mono text-xs break-words whitespace-pre-wrap"
           >
             {prettyRaw(approval.harness_raw_json)}
           </ScrollableContainer>
@@ -154,7 +154,7 @@ export function CodeApprovalCard({
       )}
       {error && (
         <p
-          className="text-critical-foreground text-[11px] break-words"
+          className="text-critical-foreground text-xs break-words"
           role="alert"
         >
           {error}
@@ -166,18 +166,14 @@ export function CodeApprovalCard({
 
 function ApprovalState({ approval }: { approval: CodeApprovalSnapshot }) {
   if (approval.state === "approved") {
-    return (
-      <p className="text-success-foreground shrink-0 text-[11px]">Approved</p>
-    );
+    return <p className="text-success-foreground shrink-0 text-xs">Approved</p>;
   }
   if (approval.state === "denied") {
-    return (
-      <p className="text-warning-foreground shrink-0 text-[11px]">Denied</p>
-    );
+    return <p className="text-warning-foreground shrink-0 text-xs">Denied</p>;
   }
   if (approval.state === "abandoned") {
     return (
-      <p className="text-muted-foreground shrink-0 text-[11px]">Not decided</p>
+      <p className="text-muted-foreground shrink-0 text-xs">Not decided</p>
     );
   }
   return null;
@@ -188,11 +184,11 @@ function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
     case "command":
       return (
         <div className="flex flex-col gap-1">
-          <pre className="bg-muted overflow-x-auto rounded-md p-2 font-mono text-[13.5px] break-words whitespace-pre-wrap">
+          <pre className="bg-muted overflow-x-auto rounded-md p-2 font-mono text-md break-words whitespace-pre-wrap">
             {approval.kind.cmd || "Command"}
           </pre>
           {approval.kind.cwd && (
-            <p className="text-muted-foreground font-mono text-[11px] break-words">
+            <p className="text-muted-foreground font-mono text-xs break-words">
               cwd {approval.kind.cwd}
             </p>
           )}
@@ -203,17 +199,17 @@ function ApprovalKindBody({ approval }: { approval: CodeApprovalSnapshot }) {
         <ul className="space-y-0.5">
           {approval.kind.paths.map((path) => (
             <li key={path}>
-              <MiddleTruncate text={path} className="font-mono text-[13.5px]" />
+              <MiddleTruncate text={path} className="font-mono text-md" />
             </li>
           ))}
         </ul>
       ) : (
-        <p className="text-muted-foreground text-[13.5px]">File write</p>
+        <p className="text-muted-foreground text-md">File write</p>
       );
     case "network":
     case "other":
       return (
-        <p className="text-muted-foreground text-[13.5px] break-words">
+        <p className="text-muted-foreground text-md break-words">
           {otherSummary(approval.kind.summary)}
         </p>
       );
@@ -233,7 +229,7 @@ function ApprovalTimes({
     : null;
   if (!requested && !decided) return null;
   return (
-    <p className="text-muted-foreground text-[11px]">
+    <p className="text-muted-foreground text-xs">
       {requested && (
         <WithTooltip label={requested.full}>
           <time dateTime={requestedAt}>{requested.short}</time>

--- a/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
@@ -213,7 +213,7 @@ function CodeArchiveBody() {
             aria-label="Archived workspaces"
             className="min-w-[760px]"
           >
-            <div className="sticky top-0 z-10 grid grid-cols-[minmax(260px,1fr)_170px_150px_180px] gap-4 border-b border-border-subtle bg-background/95 px-5 py-2 text-[11px] font-medium text-muted-foreground backdrop-blur">
+            <div className="sticky top-0 z-10 grid grid-cols-[minmax(260px,1fr)_170px_150px_180px] gap-4 border-b border-border-subtle bg-background/95 px-5 py-2 text-xs font-medium text-muted-foreground backdrop-blur">
               <span>Workspace</span>
               <span>Repository</span>
               <span>Archived</span>

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1044,7 +1044,7 @@ export function CodeComposer({
       {notice && (
         <p
           role="alert"
-          className="text-critical-foreground mx-auto max-w-3xl pt-1 text-[11px]"
+          className="text-critical-foreground mx-auto max-w-3xl pt-1 text-xs"
         >
           {notice.text}
         </p>

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -1520,7 +1520,7 @@ function PullRequestList({
     <div role="list" aria-label="Pull requests" className="min-w-[760px]">
       <div
         className={cn(
-          "sticky top-0 z-10 grid gap-4 border-b border-border-subtle bg-background/95 px-5 py-2 text-[11px] font-medium text-muted-foreground backdrop-blur",
+          "sticky top-0 z-10 grid gap-4 border-b border-border-subtle bg-background/95 px-5 py-2 text-xs font-medium text-muted-foreground backdrop-blur",
           PR_GRID,
         )}
       >
@@ -1638,12 +1638,12 @@ function PullRequestRow({
           <span className="tabular-nums">#{item.number}</span>
           <span className="truncate font-mono">{item.head_branch}</span>
           {stackedOn !== undefined && (
-            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] tabular-nums">
+            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-2xs tabular-nums">
               Stacked on #{stackedOn}
             </span>
           )}
           {item.workspace_links.length > 0 && (
-            <span className="shrink-0 rounded bg-info-background px-1.5 py-0.5 text-[10px] text-info-foreground-muted">
+            <span className="shrink-0 rounded bg-info-background px-1.5 py-0.5 text-2xs text-info-foreground-muted">
               Tidebreak
             </span>
           )}
@@ -1690,7 +1690,7 @@ function RunList({
     >
       <div
         className={cn(
-          "sticky top-0 z-10 grid gap-4 border-b border-border-subtle bg-background/95 px-5 py-2 text-[11px] font-medium text-muted-foreground backdrop-blur",
+          "sticky top-0 z-10 grid gap-4 border-b border-border-subtle bg-background/95 px-5 py-2 text-xs font-medium text-muted-foreground backdrop-blur",
           RUN_GRID,
         )}
       >
@@ -1984,7 +1984,7 @@ export function RunDetailSheet({
                           {job.name}
                         </span>
                         {job.failed_steps.length > 0 && (
-                          <span className="mt-1 block text-[11px] text-critical">
+                          <span className="mt-1 block text-xs text-critical">
                             {job.failed_steps.join(", ")}
                           </span>
                         )}
@@ -2007,7 +2007,7 @@ export function RunDetailSheet({
                     >
                       <div className="flex items-center justify-between gap-2">
                         <RunStateText value={status.state} />
-                        <span className="text-[11px] text-muted-foreground">
+                        <span className="text-xs text-muted-foreground">
                           {relativeTime(status.created_at)}
                         </span>
                       </div>
@@ -2078,7 +2078,7 @@ function PullRequestFilters({
           <Filter />
           Filters
           {count > 0 && (
-            <span className="rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground">
+            <span className="rounded-full bg-primary px-1.5 text-2xs text-primary-foreground">
               {count}
             </span>
           )}
@@ -2179,7 +2179,7 @@ function RunFilters({
           <Filter />
           Filters
           {count > 0 && (
-            <span className="rounded-full bg-primary px-1.5 text-[10px] text-primary-foreground">
+            <span className="rounded-full bg-primary px-1.5 text-2xs text-primary-foreground">
               {count}
             </span>
           )}
@@ -2289,7 +2289,7 @@ function FilterSection({
 }) {
   return (
     <fieldset className="mb-3 border-b border-border-subtle pb-3 last:mb-0 last:border-b-0 last:pb-0">
-      <legend className="mb-2 text-[11px] font-medium text-muted-foreground">
+      <legend className="mb-2 text-xs font-medium text-muted-foreground">
         {title}
       </legend>
       {children}
@@ -2472,7 +2472,7 @@ function AuthorAvatar({
     return (
       <span
         className={cn(
-          "grid size-5 shrink-0 place-items-center rounded-full bg-muted text-[9px] font-semibold uppercase text-muted-foreground",
+          "grid size-5 shrink-0 place-items-center rounded-full bg-muted text-2xs font-semibold uppercase text-muted-foreground",
           className,
         )}
         aria-hidden
@@ -2583,7 +2583,7 @@ function AdvancedTextFilter({
 }) {
   return (
     <div className="mb-3 flex flex-col gap-1.5">
-      <Label className="text-[11px] text-muted-foreground">{label}</Label>
+      <Label className="text-xs text-muted-foreground">{label}</Label>
       <Input
         value={value.join(", ")}
         placeholder={placeholder}
@@ -2827,7 +2827,7 @@ function RepositorySettingRow({
         <p className="truncate text-sm font-medium">
           {repository.name_with_owner}
         </p>
-        <p className="truncate text-[11px] text-muted-foreground">
+        <p className="truncate text-xs text-muted-foreground">
           {repository.host}
         </p>
       </div>
@@ -2967,7 +2967,7 @@ function FreshnessBar({
   onRefresh: () => void;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 px-5 py-1.5 text-[11px] text-muted-foreground">
+    <div className="flex items-center justify-between gap-3 px-5 py-1.5 text-xs text-muted-foreground">
       <span>
         {count === 0 ? "" : `${count} ${noun}${count === 1 ? "" : "s"}`}
         {fetchedAt && count > 0 && ` · updated ${relativeTime(fetchedAt)}`}
@@ -3113,7 +3113,7 @@ function DetailStat({
 }) {
   return (
     <div className="min-w-0">
-      <dt className="text-[11px] text-muted-foreground">{label}</dt>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
       <dd className={cn("mt-0.5 truncate", mono && "font-mono")}>{value}</dd>
     </div>
   );
@@ -3125,7 +3125,7 @@ function RunStatusBadge({ item }: { item: CodeDeliveryRunSummary }) {
   return (
     <span
       className={cn(
-        "rounded-md px-2 py-1 text-[11px] font-medium",
+        "rounded-md px-2 py-1 text-xs font-medium",
         tone === "success" &&
           "bg-success-background text-success-foreground-muted",
         tone === "critical" &&

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -213,7 +213,7 @@ export function CodeRepoEmptyState({ onAddRepo }: { onAddRepo: () => void }) {
         >
           Start with a repository
         </h1>
-        <p className="mt-4 max-w-lg text-[0.95rem] leading-6 text-muted-foreground text-pretty">
+        <p className="mt-4 max-w-lg text-md leading-6 text-muted-foreground text-pretty">
           Register a local checkout or clone one from a remote. Tidebreak uses
           it to create isolated workspaces for agent tasks.
         </p>
@@ -241,7 +241,7 @@ export function CodeRepoEmptyState({ onAddRepo }: { onAddRepo: () => void }) {
               <span className="block text-sm font-medium tracking-[-0.01em]">
                 {title}
               </span>
-              <span className="mt-0.5 block text-[0.8rem] leading-5 text-muted-foreground text-pretty">
+              <span className="mt-0.5 block text-xs leading-5 text-muted-foreground text-pretty">
                 {description}
               </span>
             </span>

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -202,7 +202,7 @@ export function CodeInspector({
               <button
                 type="button"
                 className={cn(
-                  "text-muted-foreground hover:bg-background hover:text-foreground cursor-pointer truncate rounded-lg border border-border-subtle bg-background/60 px-2 py-1 font-mono text-[11px]",
+                  "text-muted-foreground hover:bg-background hover:text-foreground cursor-pointer truncate rounded-lg border border-border-subtle bg-background/60 px-2 py-1 font-mono text-xs",
                   FOCUS_RING,
                   HOVER_TINT,
                 )}
@@ -635,7 +635,7 @@ export function PrTab({
             </span>
             <div className="min-w-0 flex-1">
               <p className="text-xs font-medium">Merge pull request</p>
-              <p className="text-muted-foreground mt-0.5 text-[11px] leading-4">
+              <p className="text-muted-foreground mt-0.5 text-xs leading-4">
                 {mergeControls.explanation ??
                   `Ready to land on ${pr.base_branch ?? "the base branch"}.`}
               </p>
@@ -647,7 +647,7 @@ export function PrTab({
                 disabled={mutationBusy}
               >
                 <SelectTrigger
-                  className="h-7 w-[116px] shrink-0 text-[11px]"
+                  className="h-7 w-[116px] shrink-0 text-xs"
                   aria-label="Merge method"
                 >
                   <SelectValue />
@@ -693,7 +693,7 @@ export function PrTab({
             <button
               type="button"
               className={cn(
-                "text-muted-foreground hover:text-foreground cursor-pointer self-center rounded-sm text-[11px]",
+                "text-muted-foreground hover:text-foreground cursor-pointer self-center rounded-sm text-xs",
                 FOCUS_RING,
                 HOVER_TINT,
               )}
@@ -812,7 +812,7 @@ function CommentsSection({
           <button
             type="button"
             className={cn(
-              "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-[11px]",
+              "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-xs",
               FOCUS_RING,
               HOVER_TINT,
             )}

--- a/crates/tidebreak-desktop/ui/src/code/CodeNotificationsPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeNotificationsPage.tsx
@@ -189,7 +189,7 @@ function CodeNotificationsBody() {
                 Notifications
               </h1>
               {unread > 0 && (
-                <span className="rounded-full bg-primary px-2 py-0.5 text-[11px] font-medium text-primary-foreground">
+                <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
                   {unread} unread
                 </span>
               )}
@@ -421,7 +421,7 @@ function NotificationRow({
         <p className="mt-0.5 truncate text-xs text-muted-foreground">
           {notification.detail}
         </p>
-        <p className="mt-1 text-[11px] text-muted-foreground">
+        <p className="mt-1 text-xs text-muted-foreground">
           {relativeTime(notification.occurredAt)}
         </p>
       </button>

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
@@ -152,7 +152,7 @@ export function CodeQuickOpen({
                 aria-label="Loading files"
               />
             )}
-            <kbd className="text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2 shrink-0 rounded border px-1.5 py-0.5 font-sans text-[10px]">
+            <kbd className="text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2 shrink-0 rounded border px-1.5 py-0.5 font-sans text-2xs">
               esc
             </kbd>
           </div>
@@ -190,7 +190,7 @@ export function CodeQuickOpen({
                           {name}
                         </span>
                         {parent && (
-                          <span className="text-muted-foreground min-w-0 max-w-[55%] truncate text-[11px]">
+                          <span className="text-muted-foreground min-w-0 max-w-[55%] truncate text-xs">
                             {parent}
                           </span>
                         )}
@@ -202,7 +202,7 @@ export function CodeQuickOpen({
             )}
           </CommandList>
         </Command>
-        <div className="text-muted-foreground flex items-center justify-end gap-3 border-t px-3 py-1.5 text-[10px]">
+        <div className="text-muted-foreground flex items-center justify-end gap-3 border-t px-3 py-1.5 text-2xs">
           <span>↑↓ navigate</span>
           <span>↵ open</span>
         </div>

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -148,7 +148,7 @@ export function CodeSidebar() {
           <div key={group.key} className="flex flex-col gap-1">
             {group.label && (
               <div
-                className="truncate px-2 pt-3 pb-1 text-[11px] font-medium text-muted-foreground/90"
+                className="truncate px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground/90"
                 title={group.label}
               >
                 {group.key === "archived"
@@ -402,7 +402,7 @@ function CodeUtilityLinks({
           <link.icon />
           <span className="min-w-0 flex-1 truncate">{link.label}</span>
           {link.to === "/code/notifications" && unreadNotifications > 0 && (
-            <span className="min-w-5 rounded-full bg-primary px-1.5 py-0.5 text-center text-[10px] font-medium leading-none text-primary-foreground">
+            <span className="min-w-5 rounded-full bg-primary px-1.5 py-0.5 text-center text-2xs font-medium leading-none text-primary-foreground">
               {unreadNotifications > 99 ? "99+" : unreadNotifications}
             </span>
           )}

--- a/crates/tidebreak-desktop/ui/src/code/CodeSubscriptionUsage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSubscriptionUsage.tsx
@@ -106,11 +106,11 @@ export function CodeSubscriptionUsage() {
         <div className="flex shrink-0 items-center justify-between gap-3 border-b px-3 py-2.5">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <h2 className="truncate text-[13px] font-semibold">
+              <h2 className="truncate text-md font-semibold">
                 Subscription usage
               </h2>
               {report && (
-                <span className="text-muted-foreground shrink-0 text-[10px] font-medium">
+                <span className="text-muted-foreground shrink-0 text-2xs font-medium">
                   {sourceLabel(report.source)}
                 </span>
               )}
@@ -141,7 +141,7 @@ export function CodeSubscriptionUsage() {
           {report && report.providers.length > 0 && (
             <div className="flex flex-col gap-3">
               {report.diagnostics.length > 0 && (
-                <p className="text-muted-foreground text-[11px]">
+                <p className="text-muted-foreground text-xs">
                   {report.diagnostics[0]}
                 </p>
               )}
@@ -195,7 +195,7 @@ function ProviderUsage({
         <div className="flex min-w-0 flex-1 items-baseline justify-between gap-2">
           <h3 className="truncate text-xs font-semibold">{provider.label}</h3>
           {provider.accounts.length > shown.length && (
-            <span className="text-muted-foreground shrink-0 text-[9px]">
+            <span className="text-muted-foreground shrink-0 text-2xs">
               {provider.accounts.length - shown.length} shared hidden
             </span>
           )}
@@ -229,10 +229,10 @@ function AccountUsage({
       )}
     >
       <div className="flex min-w-0 items-baseline justify-between gap-2">
-        <span className="min-w-0 truncate text-[11px] font-medium">
+        <span className="min-w-0 truncate text-xs font-medium">
           {account.label}
         </span>
-        <span className="text-muted-foreground flex shrink-0 items-center gap-1.5 text-[9px] tabular-nums">
+        <span className="text-muted-foreground flex shrink-0 items-center gap-1.5 text-2xs tabular-nums">
           {account.state !== "available" && (
             <span className={accountStateClass(account.state)}>
               {accountStateLabel(account.state)}
@@ -263,7 +263,7 @@ function UsageWindowRow({ window }: { window: CodeSubscriptionUsageWindow }) {
     ? formatReset(window.resets_at_unix_seconds)
     : null;
   return (
-    <div className="grid min-h-5 grid-cols-[minmax(72px,0.9fr)_minmax(52px,1.1fr)_auto_auto] items-center gap-x-2 text-[10px]">
+    <div className="grid min-h-5 grid-cols-[minmax(72px,0.9fr)_minmax(52px,1.1fr)_auto_auto] items-center gap-x-2 text-2xs">
       <span
         className="text-muted-foreground min-w-0 truncate"
         title={window.label}
@@ -339,7 +339,7 @@ function UnavailableUsage({ diagnostics }: { diagnostics: string[] }) {
         subscription-usage command.
       </p>
       {diagnostics[0] && (
-        <p className="text-muted-foreground text-[11px]">{diagnostics[0]}</p>
+        <p className="text-muted-foreground text-xs">{diagnostics[0]}</p>
       )}
     </div>
   );

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -147,7 +147,7 @@ export function CodeTranscript({
       <div className="messages is-empty" ref={scrollRef} onScroll={onScroll}>
         <div className="flex max-w-sm flex-col items-center gap-1 text-center text-balance">
           <p className="text-sm font-medium">{title}</p>
-          <p className="text-muted-foreground text-[13.5px] leading-relaxed">
+          <p className="text-muted-foreground text-md leading-relaxed">
             {description}
           </p>
           {busy && (
@@ -501,7 +501,7 @@ const TranscriptItem = memo(function TranscriptItem({
           text={item.text}
           anchorId={item.id}
           trailing={
-            <p className="text-muted-foreground mt-1 text-[11px]">
+            <p className="text-muted-foreground mt-1 text-xs">
               Steered mid-turn
             </p>
           }
@@ -881,7 +881,7 @@ function StreamingTail({ text }: { text: string }) {
       // The group role is what makes the label reach assistive tech.
       role="group"
       aria-label="Output"
-      className="text-muted-foreground max-h-[17.4em] overflow-hidden font-mono text-[13.5px] break-words whitespace-pre-wrap [overflow-anchor:none]"
+      className="text-muted-foreground max-h-[17.4em] overflow-hidden font-mono text-md break-words whitespace-pre-wrap [overflow-anchor:none]"
     >
       {tail}
     </pre>
@@ -1057,7 +1057,7 @@ function FileActivityRow({
   const { count, insertions, deletions } = fileActivityTotals(files);
   const noun = count === 1 ? "file" : "files";
   return (
-    <div className="text-muted-foreground max-w-prose text-[11px]">
+    <div className="text-muted-foreground max-w-prose text-xs">
       <button
         type="button"
         aria-expanded={open}

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -2057,7 +2057,7 @@ function CodeSessionPane({
         {connectionState === "reconnecting" && (
           <p
             role="status"
-            className="text-info-foreground pointer-events-none absolute inset-x-0 top-2 z-[1] text-center text-[11px] [animation:code-reveal_140ms_ease-out] motion-reduce:animate-none"
+            className="text-info-foreground pointer-events-none absolute inset-x-0 top-2 z-[1] text-center text-xs [animation:code-reveal_140ms_ease-out] motion-reduce:animate-none"
           >
             Reconnecting to the session…
           </p>
@@ -2312,9 +2312,7 @@ function SubagentContextBar({
             {label}
           </Badge>
         </div>
-        <p className="text-muted-foreground text-[11px]">
-          Read-only subagent view
-        </p>
+        <p className="text-muted-foreground text-xs">Read-only subagent view</p>
       </div>
       <Button type="button" variant="ghost" size="sm" onClick={onBack}>
         Back to main agent

--- a/crates/tidebreak-desktop/ui/src/code/DiffOverview.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffOverview.tsx
@@ -91,12 +91,12 @@ export function DiffOverview({
           <div className="flex items-baseline gap-1.5">
             <h2 className="text-sm font-medium">Changes</h2>
             {payload && (
-              <span className="text-muted-foreground font-mono text-[11px] tabular-nums">
+              <span className="text-muted-foreground font-mono text-xs tabular-nums">
                 {payload.files.length}
               </span>
             )}
           </div>
-          <p className="text-muted-foreground truncate font-mono text-[11px]">
+          <p className="text-muted-foreground truncate font-mono text-xs">
             {scopeCaption}
           </p>
         </div>
@@ -284,7 +284,7 @@ function ChangeDirectoryRow({
         />
         <DirectoryIcon className="size-3.5 shrink-0" aria-hidden />
         <span className="min-w-0 flex-1 truncate font-mono">{node.name}</span>
-        <span className="shrink-0 font-mono text-[10px] tabular-nums">
+        <span className="shrink-0 font-mono text-2xs tabular-nums">
           {node.count}
         </span>
       </button>
@@ -340,8 +340,8 @@ function ChangeFileRow({
         onClick={() => onOpenFile(file.path)}
       >
         <CodeFileIcon path={file.path} className={kind.className} />
-        <span className="min-w-0 flex-1 truncate text-[13px]">{node.name}</span>
-        <span className="flex shrink-0 items-center gap-1.5 font-mono text-[10px] tabular-nums">
+        <span className="min-w-0 flex-1 truncate text-md">{node.name}</span>
+        <span className="flex shrink-0 items-center gap-1.5 font-mono text-2xs tabular-nums">
           {file.insertions > 0 && (
             <span className="text-success-foreground">+{file.insertions}</span>
           )}

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.tsx
@@ -85,7 +85,7 @@ export function DiffPanel({
           <h2 className="text-sm font-medium">Diff</h2>
           <MiddleTruncate
             text={scopeCaption}
-            className="text-muted-foreground font-mono text-[11px]"
+            className="text-muted-foreground font-mono text-xs"
           />
         </div>
         <div className="flex items-center gap-2">
@@ -100,7 +100,7 @@ export function DiffPanel({
             <button
               type="button"
               className={cn(
-                "text-muted-foreground hover:bg-muted hover:text-foreground flex cursor-pointer items-center gap-1 rounded-md px-1.5 py-1 text-[11px]",
+                "text-muted-foreground hover:bg-muted hover:text-foreground flex cursor-pointer items-center gap-1 rounded-md px-1.5 py-1 text-xs",
                 FOCUS_RING_TIGHT,
                 HOVER_TINT,
               )}
@@ -224,7 +224,7 @@ function FileDiffSection({
             // the path to tell them apart.
             aria-label={`Open ${group.path}`}
             className={cn(
-              "text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded-sm text-[11px] underline-offset-2 hover:underline",
+              "text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded-sm text-xs underline-offset-2 hover:underline",
               FOCUS_RING_TIGHT,
               HOVER_TINT,
             )}
@@ -233,7 +233,7 @@ function FileDiffSection({
             Open
           </button>
         )}
-        <span className="shrink-0 font-mono text-[11px] tabular-nums">
+        <span className="shrink-0 font-mono text-xs tabular-nums">
           {/*
             `--success` and `--critical` are mark colours: they clear 3:1
             against either background, which an icon needs and a numeral this
@@ -265,10 +265,7 @@ function FileDiffSection({
 
 function DiffBody({ group, id }: { group: DiffFileGroup; id?: string }) {
   return (
-    <pre
-      id={id}
-      className="overflow-x-auto py-1 font-mono text-[13px] leading-5"
-    >
+    <pre id={id} className="overflow-x-auto py-1 font-mono text-md leading-5">
       {group.lines.map((line, index) => (
         <DiffLineRow key={`${group.path}:${index}`} line={line} />
       ))}
@@ -294,17 +291,17 @@ function DiffLineRow({ line }: { line: DiffLine }) {
         line.kind === "hunk" &&
           "border-info-border/60 bg-info-background/45 text-info-foreground my-1 border-y border-l-0",
         line.kind === "meta" &&
-          "text-muted-foreground bg-muted/20 border-l-0 text-[11px]",
+          "text-muted-foreground bg-muted/20 border-l-0 text-xs",
       )}
     >
       <span
-        className="text-muted-foreground/80 bg-background/35 w-[5.25ch] shrink-0 select-none border-r px-1 text-right text-[11px] tabular-nums"
+        className="text-muted-foreground/80 bg-background/35 w-[5.25ch] shrink-0 select-none border-r px-1 text-right text-xs tabular-nums"
         data-diff-gutter="old"
       >
         {line.oldNo ?? ""}
       </span>
       <span
-        className="text-muted-foreground/80 bg-background/35 w-[5.25ch] shrink-0 select-none border-r px-1 text-right text-[11px] tabular-nums"
+        className="text-muted-foreground/80 bg-background/35 w-[5.25ch] shrink-0 select-none border-r px-1 text-right text-xs tabular-nums"
         data-diff-gutter="new"
       >
         {line.newNo ?? ""}

--- a/crates/tidebreak-desktop/ui/src/code/FileViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FileViewer.tsx
@@ -57,7 +57,7 @@ export function FileViewer({
           <h2 className="text-sm font-medium">File</h2>
           <MiddleTruncate
             text={path}
-            className="text-muted-foreground font-mono text-[11px]"
+            className="text-muted-foreground font-mono text-xs"
           />
         </div>
         <span className="grid size-3.5 shrink-0 place-items-center">

--- a/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FilesPanel.tsx
@@ -398,7 +398,7 @@ function SearchResults({
     >
       {groups.map((group) => (
         <section key={group.path} className="mb-2" aria-label={group.path}>
-          <div className="text-muted-foreground flex items-center gap-1.5 px-2 py-1.5 text-[11px]">
+          <div className="text-muted-foreground flex items-center gap-1.5 px-2 py-1.5 text-xs">
             <CodeFileIcon path={group.path} />
             <span
               className="min-w-0 flex-1 truncate font-mono"
@@ -423,10 +423,10 @@ function SearchResults({
                 aria-label={`${group.path}, line ${matched.line_number}`}
                 onClick={() => onOpenFile(group.path, matched.line_number)}
               >
-                <span className="text-muted-foreground w-7 shrink-0 text-right font-mono text-[10px] leading-5 tabular-nums">
+                <span className="text-muted-foreground w-7 shrink-0 text-right font-mono text-2xs leading-5 tabular-nums">
                   {matched.line_number}
                 </span>
-                <span className="min-w-0 flex-1 truncate font-mono text-[11px] leading-5">
+                <span className="min-w-0 flex-1 truncate font-mono text-xs leading-5">
                   <LiteralMatch text={matched.line} query={query} />
                 </span>
               </button>
@@ -487,7 +487,7 @@ function ContentSearchEmpty({
       <button
         type="button"
         className={cn(
-          "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-[11px]",
+          "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-xs",
           FOCUS_RING,
           HOVER_TINT,
         )}
@@ -537,7 +537,7 @@ function FilesEmpty({
       <button
         type="button"
         className={cn(
-          "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-[11px]",
+          "text-muted-foreground hover:text-foreground cursor-pointer rounded-sm text-xs",
           FOCUS_RING,
           HOVER_TINT,
         )}
@@ -608,7 +608,7 @@ function TreeRow({
       <div
         style={{ paddingLeft: treeIndentPx(depth) }}
         className={cn(
-          "ring-offset-background flex min-h-7 w-full cursor-pointer items-center gap-1.5 rounded-md py-1 pr-2 text-left text-[12.5px]",
+          "ring-offset-background flex min-h-7 w-full cursor-pointer items-center gap-1.5 rounded-md py-1 pr-2 text-left text-sm",
           "group-focus-visible/row:ring-ring group-focus-visible/row:ring-2 group-focus-visible/row:ring-offset-0",
           HOVER_TINT,
           current && "bg-muted/60",

--- a/crates/tidebreak-desktop/ui/src/code/PrCommentCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCommentCard.tsx
@@ -55,7 +55,7 @@ export function PrCommentCard({
       )}
     >
       <div className="flex min-w-0 items-start gap-2">
-        <span className="bg-muted text-muted-foreground grid size-7 shrink-0 place-items-center overflow-hidden rounded-full text-[10px] font-semibold uppercase">
+        <span className="bg-muted text-muted-foreground grid size-7 shrink-0 place-items-center overflow-hidden rounded-full text-2xs font-semibold uppercase">
           {avatar && !avatarFailed ? (
             <img
               src={avatar}
@@ -73,25 +73,25 @@ export function PrCommentCard({
               {author}
             </span>
             {comment.kind === "review" && comment.review_state && (
-              <span className="text-muted-foreground shrink-0 text-[11px] capitalize">
+              <span className="text-muted-foreground shrink-0 text-xs capitalize">
                 {comment.review_state.replaceAll("_", " ")}
               </span>
             )}
             {resolved && (
-              <span className="text-success-foreground flex shrink-0 items-center gap-1 text-[10px] font-medium">
+              <span className="text-success-foreground flex shrink-0 items-center gap-1 text-2xs font-medium">
                 <CircleCheck className="size-3" />
                 Resolved here
               </span>
             )}
             {when && (
-              <span className="text-muted-foreground ml-auto shrink-0 text-[10px] tabular-nums">
+              <span className="text-muted-foreground ml-auto shrink-0 text-2xs tabular-nums">
                 {when}
               </span>
             )}
           </div>
           {anchor && (
             <div
-              className="text-muted-foreground mt-0.5 truncate font-mono text-[10px]"
+              className="text-muted-foreground mt-0.5 truncate font-mono text-2xs"
               title={anchor}
             >
               {anchor}
@@ -100,7 +100,7 @@ export function PrCommentCard({
         </div>
         {actions}
       </div>
-      <div className="review-comment-markdown mt-2 pl-9 text-[13px] leading-5">
+      <div className="review-comment-markdown mt-2 pl-9 text-md leading-5">
         <MessageMarkdown>
           {expandGithubEmojiShortcodes(comment.body)}
         </MessageMarkdown>

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -566,7 +566,7 @@ function PrDetailHeader({
           </Badge>
         )}
         {detail && (
-          <span className="font-mono text-[11px] tabular-nums">
+          <span className="font-mono text-xs tabular-nums">
             <span className={STATUS_TEXT.ready}>+{detail.additions}</span>{" "}
             <span className={STATUS_TEXT.critical}>−{detail.deletions}</span>
           </span>
@@ -595,7 +595,7 @@ function PrDetailHeader({
         )}
       </p>
 
-      <p className="mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
+      <p className="mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-xs text-muted-foreground">
         <GitBranch className="size-3 shrink-0" />
         <MiddleTruncate className="min-w-0" text={summary.base_branch} />
         <span aria-hidden>←</span>
@@ -614,7 +614,7 @@ function PrDetailHeader({
           {detail?.assignees.map((login) => (
             <span
               key={`assignee:${login}`}
-              className="flex items-center gap-1 text-[11px] text-muted-foreground"
+              className="flex items-center gap-1 text-xs text-muted-foreground"
             >
               <Avatar login={login} className="size-4" />
               {login}
@@ -623,12 +623,12 @@ function PrDetailHeader({
           {detail?.requested_reviewers.map((login) => (
             <span
               key={`reviewer:${login}`}
-              className="flex items-center gap-1 text-[11px] text-muted-foreground"
+              className="flex items-center gap-1 text-xs text-muted-foreground"
               title={`Review requested from ${login}`}
             >
               <Avatar login={login} className="size-4" />
               {login}
-              <span className="text-[10px]">(review requested)</span>
+              <span className="text-2xs">(review requested)</span>
             </span>
           ))}
         </div>
@@ -733,7 +733,7 @@ function PrAgentMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        <div className="max-w-64 px-2 py-1.5 text-[11px] text-muted-foreground">
+        <div className="max-w-64 px-2 py-1.5 text-xs text-muted-foreground">
           {link
             ? `Runs in ${link.title}, the linked workspace.`
             : `Starts a fresh workspace on ${summary.repository.name_with_owner}.`}
@@ -994,7 +994,7 @@ function PrDescription({ body }: { body: string }) {
     <section>
       <h3 className="text-sm font-medium">Description</h3>
       {trimmed ? (
-        <div className="review-comment-markdown mt-2 text-[13px] leading-5">
+        <div className="review-comment-markdown mt-2 text-md leading-5">
           <MessageMarkdown>
             {expandGithubEmojiShortcodes(trimmed)}
           </MessageMarkdown>
@@ -1159,7 +1159,7 @@ function PrFileCard({ file }: { file: CodeDeliveryPullRequestFile }) {
       >
         <span
           className={cn(
-            "shrink-0 text-[10px] font-medium uppercase",
+            "shrink-0 text-2xs font-medium uppercase",
             STATUS_TEXT[fileStatusTone(file.status)],
           )}
         >
@@ -1173,7 +1173,7 @@ function PrFileCard({ file }: { file: CodeDeliveryPullRequestFile }) {
               : file.path
           }
         />
-        <span className="shrink-0 font-mono text-[11px] tabular-nums">
+        <span className="shrink-0 font-mono text-xs tabular-nums">
           <span className={STATUS_TEXT.ready}>+{file.additions}</span>{" "}
           <span className={STATUS_TEXT.critical}>−{file.deletions}</span>
         </span>
@@ -1202,7 +1202,7 @@ function PrFileCard({ file }: { file: CodeDeliveryPullRequestFile }) {
 function DiffPatch({ patch }: { patch: string }) {
   const lines = useMemo(() => patch.split("\n"), [patch]);
   return (
-    <pre className="overflow-x-auto py-1 font-mono text-[11px] leading-[1.45]">
+    <pre className="overflow-x-auto py-1 font-mono text-xs leading-[1.45]">
       {lines.map((line, index) => {
         const kind =
           line.startsWith("+") && !line.startsWith("+++")
@@ -1342,7 +1342,7 @@ function Avatar({
     return (
       <span
         className={cn(
-          "grid shrink-0 place-items-center rounded-full bg-muted text-[8px] font-semibold uppercase text-muted-foreground",
+          "grid shrink-0 place-items-center rounded-full bg-muted text-2xs font-semibold uppercase text-muted-foreground",
           className,
         )}
         aria-hidden

--- a/crates/tidebreak-desktop/ui/src/code/RailSettingsMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RailSettingsMenu.tsx
@@ -62,7 +62,7 @@ export function RailSettingsMenu() {
         className="flex w-[22rem] max-w-[calc(100vw-24px)] flex-col gap-3 p-3"
       >
         <div className="flex flex-col gap-1.5">
-          <span className="text-[11px] font-medium text-muted-foreground">
+          <span className="text-xs font-medium text-muted-foreground">
             Sort
           </span>
           <SegmentedControl
@@ -73,7 +73,7 @@ export function RailSettingsMenu() {
           />
         </div>
         <div className="flex flex-col gap-1.5">
-          <span className="text-[11px] font-medium text-muted-foreground">
+          <span className="text-xs font-medium text-muted-foreground">
             Cards
           </span>
           <SegmentedControl
@@ -110,7 +110,7 @@ function PrefSwitch({
   onCheckedChange: (checked: boolean) => void;
 }) {
   return (
-    <label className="flex cursor-pointer items-center justify-between gap-3 text-[13px]">
+    <label className="flex cursor-pointer items-center justify-between gap-3 text-md">
       <span>{label}</span>
       <Switch
         checked={checked}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -182,7 +182,7 @@ export function WorkspaceCard({
               >
                 <span className="flex min-w-0 items-center gap-2">
                   <AttentionBadge attention={digest?.attention} compact />
-                  <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium leading-5">
+                  <span className="min-w-0 flex-1 truncate text-md font-medium leading-5">
                     {title}
                   </span>
                   <span
@@ -203,7 +203,7 @@ export function WorkspaceCard({
                 </span>
                 {density === "detailed" &&
                   (visibleMeta.repoChip || visibleMeta.branch) && (
-                    <span className="flex min-w-0 items-center gap-1.5 pl-5 text-[11px] text-muted-foreground">
+                    <span className="flex min-w-0 items-center gap-1.5 pl-5 text-xs text-muted-foreground">
                       {visibleMeta.repoChip && (
                         <span className="min-w-0 max-w-[46%] truncate">
                           {repoName}
@@ -386,7 +386,7 @@ function WorkspaceDetailPanel({
   return (
     <div data-testid="workspace-hover-card">
       <div className="p-3.5">
-        <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+        <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
           <span
             className={cn(
               "size-1.5 shrink-0 rounded-[2px]",
@@ -425,7 +425,7 @@ function WorkspaceDetailPanel({
           ) : null}
         </div>
 
-        <p className="mt-2.5 text-[15px] font-semibold leading-5 text-pretty">
+        <p className="mt-2.5 text-base font-semibold leading-5 text-pretty">
           {title}
         </p>
         {showPrTitle && (
@@ -469,13 +469,13 @@ function WorkspaceDetailPanel({
                     Pull request #{pr.number}
                   </span>
                   {prCountLabel && (
-                    <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground tabular-nums">
+                    <span className="rounded-md bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground tabular-nums">
                       {prCountLabel}
                     </span>
                   )}
                   <span
                     className={cn(
-                      "ml-auto shrink-0 text-[11px] font-medium",
+                      "ml-auto shrink-0 text-xs font-medium",
                       STATUS_TEXT[model.tone],
                     )}
                   >
@@ -488,7 +488,7 @@ function WorkspaceDetailPanel({
               </div>
             </div>
 
-            <div className="mt-2.5 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px] text-muted-foreground">
+            <div className="mt-2.5 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
               {checkLabel && (
                 <WorkspaceStatusFact
                   icon={<CheckCircle2 />}
@@ -520,7 +520,7 @@ function WorkspaceDetailPanel({
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="mt-3 h-7 bg-foreground px-2.5 text-[11px] text-background hover:bg-foreground/88 hover:text-background"
+                  className="mt-3 h-7 bg-foreground px-2.5 text-xs text-background hover:bg-foreground/88 hover:text-background"
                   title={model.detail}
                   onClick={() => onWorkflowAction(primary)}
                 >
@@ -536,7 +536,7 @@ function WorkspaceDetailPanel({
           type="button"
           variant="ghost"
           size="sm"
-          className="h-7 gap-1.5 px-2 text-[11px]"
+          className="h-7 gap-1.5 px-2 text-xs"
           onClick={() => onCommand(archived ? "restore" : "archive")}
         >
           {archived ? (
@@ -552,7 +552,7 @@ function WorkspaceDetailPanel({
             variant="ghost"
             size="sm"
             className={cn(
-              "h-7 gap-1.5 px-2 text-[11px]",
+              "h-7 gap-1.5 px-2 text-xs",
               STATUS_TEXT[prStatusTone(pr)],
             )}
             aria-label={`Open pull request #${pr.number}`}
@@ -565,7 +565,7 @@ function WorkspaceDetailPanel({
         )}
         {age && (
           <span
-            className="ml-auto shrink-0 text-[11px] text-muted-foreground tabular-nums"
+            className="ml-auto shrink-0 text-xs text-muted-foreground tabular-nums"
             title={stamp}
           >
             {age === "now" ? "just now" : `${age} ago`}
@@ -617,7 +617,7 @@ function WorkspaceActivityLine({
   const running = activity.tone === "running";
 
   return (
-    <div className="flex min-w-0 items-center gap-1.5 px-2.5 pb-2 pl-7 text-[11px] text-muted-foreground">
+    <div className="flex min-w-0 items-center gap-1.5 px-2.5 pb-2 pl-7 text-xs text-muted-foreground">
       {activity.needsYou ? (
         <CircleAlert
           className={cn("size-3 shrink-0", STATUS_TEXT.critical)}
@@ -751,7 +751,7 @@ function WorkspaceChildRow({
       type="button"
       aria-label={ariaLabel}
       className={cn(
-        "flex w-full cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-left text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground",
+        "flex w-full cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-left text-xs text-muted-foreground hover:bg-muted hover:text-foreground",
         FOCUS_RING_INSET,
         HOVER_TINT,
       )}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceHeader.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceHeader.tsx
@@ -78,13 +78,13 @@ export function WorkspaceHeader({
         ) : (
           <>
             <h1
-              className="truncate text-[13.5px] font-semibold tracking-[-0.01em]"
+              className="truncate text-md font-semibold tracking-[-0.01em]"
               title={tooltip || undefined}
             >
               {title}
             </h1>
             {(repoName || branchName) && (
-              <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+              <div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
                 {repoName && <span className="shrink-0">{repoName}</span>}
                 {repoName && branchName && (
                   <span className="text-border" aria-hidden>

--- a/crates/tidebreak-desktop/ui/src/code/WorkspacePrList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspacePrList.tsx
@@ -69,12 +69,12 @@ export function WorkspacePrList({
               #{item.number}
             </span>
             <span className="min-w-0 flex-1 truncate">{item.title}</span>
-            <span className="text-muted-foreground shrink-0 truncate text-[10px]">
+            <span className="text-muted-foreground shrink-0 truncate text-2xs">
               {item.repo_owner}/{item.repo_name}
             </span>
             <span
               className={cn(
-                "shrink-0 rounded-full px-1.5 py-px text-[10px] font-medium",
+                "shrink-0 rounded-full px-1.5 py-px text-2xs font-medium",
                 PR_CHIP_TONE_CLASSES[tone],
               )}
             >

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -482,7 +482,7 @@ export function WorkspaceWorkflowControl({
               <div className="min-w-0 flex-1">
                 <h2
                   id={popoverTitleId}
-                  className="text-[13px] font-semibold leading-5"
+                  className="text-md font-semibold leading-5"
                 >
                   {model.title}
                 </h2>
@@ -510,7 +510,7 @@ export function WorkspaceWorkflowControl({
               <div className="flex items-center gap-3 py-2.5">
                 <dt className="text-foreground-subtle shrink-0">Branch</dt>
                 <dd
-                  className="min-w-0 flex-1 truncate text-right font-mono text-[11px]"
+                  className="min-w-0 flex-1 truncate text-right font-mono text-xs"
                   title={branchName}
                 >
                   {branchName}
@@ -519,7 +519,7 @@ export function WorkspaceWorkflowControl({
               {(model.pr?.base_branch ?? baseRef) ? (
                 <div className="flex items-center gap-3 py-2.5">
                   <dt className="text-foreground-subtle shrink-0">Base</dt>
-                  <dd className="min-w-0 flex-1 truncate text-right font-mono text-[11px]">
+                  <dd className="min-w-0 flex-1 truncate text-right font-mono text-xs">
                     {model.pr?.base_branch ?? baseRef}
                   </dd>
                 </div>
@@ -547,7 +547,7 @@ export function WorkspaceWorkflowControl({
 
             {activeChecks.length > 0 ? (
               <div className="border-t border-border-subtle px-3 py-2.5">
-                <p className="text-foreground-subtle mb-1.5 text-[11px] font-medium">
+                <p className="text-foreground-subtle mb-1.5 text-xs font-medium">
                   Active checks
                 </p>
                 <ul className="flex flex-col gap-1.5">
@@ -571,7 +571,7 @@ export function WorkspaceWorkflowControl({
                       </span>
                       <span
                         className={cn(
-                          "shrink-0 text-[11px] font-medium",
+                          "shrink-0 text-xs font-medium",
                           check.bucket === "fail"
                             ? STATUS_TEXT.critical
                             : STATUS_TEXT.pending,
@@ -583,7 +583,7 @@ export function WorkspaceWorkflowControl({
                   ))}
                 </ul>
                 {activeChecks.length > 4 ? (
-                  <p className="text-foreground-subtle mt-1.5 text-[11px]">
+                  <p className="text-foreground-subtle mt-1.5 text-xs">
                     +{activeChecks.length - 4} more
                   </p>
                 ) : null}

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -349,7 +349,7 @@ export function BrowserToolbar({
                       {entry.title || entry.url}
                     </span>
                     {entry.title && (
-                      <span className="block truncate text-[11px] text-muted-foreground">
+                      <span className="block truncate text-xs text-muted-foreground">
                         {entry.url}
                       </span>
                     )}
@@ -378,7 +378,7 @@ export function BrowserToolbar({
         <p
           id={addressErrorId}
           role="alert"
-          className="border-t border-critical-border/45 bg-critical-background/55 px-3 py-1 text-[11px] text-critical-foreground"
+          className="border-t border-critical-border/45 bg-critical-background/55 px-3 py-1 text-xs text-critical-foreground"
         >
           {addressError}
         </p>
@@ -450,7 +450,7 @@ function BrowserAgentAccessControl({
   if (access.paused) {
     return (
       <div
-        className="flex h-7 min-w-0 shrink-0 items-center gap-1 rounded-md border border-warning-border/70 bg-warning-background/72 px-1.5 text-[10px] font-medium text-warning-foreground"
+        className="flex h-7 min-w-0 shrink-0 items-center gap-1 rounded-md border border-warning-border/70 bg-warning-background/72 px-1.5 text-2xs font-medium text-warning-foreground"
         aria-label={`Agent paused before ${access.origin}`}
       >
         <Pause className="size-3 shrink-0" />
@@ -493,7 +493,7 @@ function BrowserAgentAccessControl({
         : `${originLabel} shared`;
     return (
       <div
-        className="flex h-7 min-w-0 shrink-0 items-center gap-1 rounded-md bg-success-background/65 px-1.5 text-[10px] font-medium text-success-foreground"
+        className="flex h-7 min-w-0 shrink-0 items-center gap-1 rounded-md bg-success-background/65 px-1.5 text-2xs font-medium text-success-foreground"
         aria-label={`Shared with agent: ${access.origin}`}
       >
         <ShieldCheck className="size-3 shrink-0" />
@@ -518,7 +518,7 @@ function BrowserAgentAccessControl({
       type="button"
       variant="outline"
       size={compact ? "icon-xs" : "xs"}
-      className="h-7 bg-background/72 text-[10px]"
+      className="h-7 bg-background/72 text-2xs"
       aria-label="Share with agent"
       onClick={onShare}
     >
@@ -590,7 +590,7 @@ function CompactAgentAccessControl({
             <Icon />
             <span className="min-w-0">
               <span className="block text-xs font-medium">{displayLabel}</span>
-              <span className="block truncate text-[11px] text-muted-foreground">
+              <span className="block truncate text-xs text-muted-foreground">
                 {originLabel}
               </span>
             </span>
@@ -669,7 +669,7 @@ export function BrowserAgentControlRow({
       </span>
       <span className="min-w-0 flex-1">
         <span className="font-medium text-foreground">{status}</span>
-        <span className="ml-2 hidden truncate text-[11px] opacity-80 sm:inline">
+        <span className="ml-2 hidden truncate text-xs opacity-80 sm:inline">
           {detail}
         </span>
       </span>

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
@@ -109,7 +109,7 @@ export function BrowserViewportControl({
             variant="ghost"
             size={compact ? "icon-xs" : "xs"}
             className={
-              compact ? "size-7" : "h-7 gap-1.5 px-2 text-[10px] font-medium"
+              compact ? "size-7" : "h-7 gap-1.5 px-2 text-2xs font-medium"
             }
             disabled={disabled}
             aria-label={triggerAriaLabel}
@@ -288,7 +288,7 @@ function CustomWidthField({
         <label
           id={`${controlGroupId}-custom-label`}
           htmlFor={`${controlGroupId}-custom-input`}
-          className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground"
+          className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground"
         >
           <SlidersHorizontal className="size-3" />
           Custom width
@@ -316,18 +316,18 @@ function CustomWidthField({
           }}
           onFocus={(event) => event.currentTarget.select()}
         />
-        <span className="text-[10px] text-muted-foreground/70">px</span>
+        <span className="text-2xs text-muted-foreground/70">px</span>
       </div>
       {error && (
         <p
           id={errorId}
           role="alert"
-          className="mt-1 text-[10px] text-critical-foreground"
+          className="mt-1 text-2xs text-critical-foreground"
         >
           {error}
         </p>
       )}
-      <p className="mt-1 text-[10px] text-muted-foreground/60">
+      <p className="mt-1 text-2xs text-muted-foreground/60">
         {MIN_CUSTOM_WIDTH}–{MAX_CUSTOM_WIDTH} px
       </p>
     </form>

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -860,7 +860,7 @@ export function BrowserFallback({
         >
           <Icon className="size-4.5" />
         </div>
-        <p className="mt-5 text-[10px] font-semibold tracking-[0.16em] text-muted-foreground uppercase">
+        <p className="mt-5 text-2xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
           Workspace browser
         </p>
         <h2 className="mt-1.5 max-w-md text-xl font-semibold tracking-[-0.025em] text-balance">
@@ -873,7 +873,7 @@ export function BrowserFallback({
             "Open a local preview, documentation, or a pull request here. The browser stays attached to this workspace so you and its agents can work from the same page."}
         </p>
         {!error && (
-          <div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-[11px] text-muted-foreground">
+          <div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-xs text-muted-foreground">
             <span className="inline-flex items-center gap-1.5">
               <Braces className="size-3.5 text-foreground/70" />
               Local previews

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.ts
@@ -39,7 +39,7 @@ export type StatusTone =
  */
 export const STATUS_TEXT: Record<StatusTone, string> = {
   neutral: "text-muted-foreground",
-  running: "text-info-foreground",
+  running: "text-live-foreground",
   ready: "text-success-foreground",
   pending: "text-info-foreground",
   warning: "text-warning-foreground",
@@ -53,7 +53,7 @@ export const STATUS_TEXT: Record<StatusTone, string> = {
  */
 export const STATUS_MARK: Record<StatusTone, string> = {
   neutral: "text-muted-foreground",
-  running: "text-info",
+  running: "text-live",
   ready: "text-success",
   pending: "text-info",
   warning: "text-warning",
@@ -64,7 +64,7 @@ export const STATUS_MARK: Record<StatusTone, string> = {
 /** A filled dot. Same reasoning as a mark, in a background rather than ink. */
 export const STATUS_DOT: Record<StatusTone, string> = {
   neutral: "bg-muted-foreground/60",
-  running: "bg-info",
+  running: "bg-live",
   ready: "bg-success",
   pending: "bg-info",
   warning: "bg-warning",
@@ -75,7 +75,7 @@ export const STATUS_DOT: Record<StatusTone, string> = {
 /** A pill: a tinted field with text that has to stay legible on it. */
 export const STATUS_CHIP: Record<StatusTone, string> = {
   neutral: "bg-muted text-muted-foreground",
-  running: "bg-info-background text-info-foreground-muted",
+  running: "bg-live-background text-live-foreground-muted",
   ready: "bg-success-background text-success-foreground-muted",
   pending: "bg-info-background text-info-foreground-muted",
   warning: "bg-warning-background text-warning-foreground-muted",
@@ -86,9 +86,9 @@ export const STATUS_CHIP: Record<StatusTone, string> = {
 /**
  * Motion, for the tones that mean something is happening right now.
  *
- * Running and pending share the info ramp because both are in flight, and hue
- * alone cannot separate them. Movement can: a running agent is doing work this
- * second, while a pending check is only waiting to be told. Callers spread this
+ * Running paints the live ramp — the one accent reserved for an agent doing
+ * work this second — while pending stays on info's blue: it is only waiting
+ * to be told. Motion still reinforces the difference; callers spread this
  * onto the same element they tone.
  */
 export const STATUS_MOTION: Partial<Record<StatusTone, string>> = {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -207,7 +207,7 @@ export function WorkspaceOverflowMenu({
               )}
               {context.worktreePath && (
                 <span
-                  className="text-muted-foreground truncate font-mono text-[10px]"
+                  className="text-muted-foreground truncate font-mono text-2xs"
                   title={context.worktreePath}
                 >
                   {context.worktreePath}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -420,12 +420,12 @@ export function formatCompactAge(
 }
 
 const REPO_ACCENT_CLASSES = [
-  "bg-sky-500/80",
-  "bg-teal-500/80",
-  "bg-amber-500/80",
-  "bg-rose-500/80",
-  "bg-indigo-500/80",
-  "bg-lime-600/80",
+  "bg-icon-blue/80",
+  "bg-icon-cyan/80",
+  "bg-icon-amber/80",
+  "bg-icon-rose/80",
+  "bg-icon-violet/80",
+  "bg-icon-green/80",
 ] as const;
 
 /** Stable identity swatch for a repo chip. Not a status color. */

--- a/crates/tidebreak-desktop/ui/src/components/OptionListbox.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/OptionListbox.tsx
@@ -99,7 +99,7 @@ export function OptionListbox({
                 // the part that gives way. A hint carrying a hyphen would
                 // otherwise break across two lines the moment the list is
                 // narrow, while the label sat there un-truncated.
-                <span className="ml-auto shrink-0 pl-2 text-[0.68rem] whitespace-nowrap text-muted-foreground">
+                <span className="ml-auto shrink-0 pl-2 text-2xs whitespace-nowrap text-muted-foreground">
                   {row.hint}
                 </span>
               )}

--- a/crates/tidebreak-desktop/ui/src/components/extend/docx-annotation-card.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/extend/docx-annotation-card.tsx
@@ -84,7 +84,7 @@ function DocxAnnotationCard({
     >
       <div className="flex min-w-0 items-start justify-between gap-2">
         <div
-          className="min-w-0 text-[11px] leading-tight font-medium"
+          className="min-w-0 text-xs leading-tight font-medium"
           style={{ color: mutedTextColor }}
         >
           <div className="truncate">{meta}</div>
@@ -100,7 +100,7 @@ function DocxAnnotationCard({
       </div>
       {anchorText ? (
         <div
-          className="rounded-md px-2 py-1 text-[11px] leading-snug italic"
+          className="rounded-md px-2 py-1 text-xs leading-snug italic"
           style={anchorStyle}
         >
           {anchorText}

--- a/crates/tidebreak-desktop/ui/src/components/ui/badge.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/badge.tsx
@@ -23,6 +23,7 @@ const badgeVariants = cva(
         info: "border-transparent bg-info-background text-info-foreground-muted",
         merged:
           "border-transparent bg-merged-background text-merged-foreground-muted",
+        live: "border-transparent bg-live-background text-live-foreground-muted",
       },
       size: {
         default: "px-2.5 py-0.5 font-semibold",

--- a/crates/tidebreak-desktop/ui/src/components/ui/button.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/button.tsx
@@ -21,7 +21,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-control px-2.5",
-        sm: "h-control-sm rounded-md px-2.5 text-[0.8rem] [&_svg]:size-3.5",
+        sm: "h-control-sm rounded-md px-2.5 text-xs [&_svg]:size-3.5",
         lg: "h-9 px-3",
         icon: "size-control",
         "icon-sm": "size-control-sm",

--- a/crates/tidebreak-desktop/ui/src/components/ui/context-menu.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/context-menu.tsx
@@ -18,7 +18,7 @@ const ContextMenuLabel = React.forwardRef<
   <ContextMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "text-muted-foreground px-2 py-1.5 text-[11px] font-medium tracking-wide",
+      "text-muted-foreground px-2 py-1.5 text-xs font-medium tracking-wide",
       className,
     )}
     {...props}

--- a/crates/tidebreak-desktop/ui/src/components/ui/segmented.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/segmented.tsx
@@ -86,7 +86,7 @@ export function SegmentedControl<T extends string>({
             tabIndex={checked ? 0 : -1}
             data-state={checked ? "on" : "off"}
             className={cn(
-              "inline-flex min-w-0 cursor-pointer items-center justify-center gap-1.5 rounded-[5px] px-2 py-1 text-[12px] font-medium",
+              "inline-flex min-w-0 cursor-pointer items-center justify-center gap-1.5 rounded-[5px] px-2 py-1 text-sm font-medium",
               "ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none",
               "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-out",
               checked

--- a/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.tsx
@@ -447,7 +447,7 @@ function WorkbookToolbar({
           ))}
         </div>
         {selectedTab?.kind === "chartsheet" ? (
-          <span className="flex shrink-0 items-center border-l px-3 text-[11px] text-muted-foreground">
+          <span className="flex shrink-0 items-center border-l px-3 text-xs text-muted-foreground">
             Chart sheet
           </span>
         ) : null}

--- a/crates/tidebreak-desktop/ui/src/plugins/PluginsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/plugins/PluginsPanel.tsx
@@ -140,7 +140,7 @@ export function PluginsPanel({
                     )}
                   </span>
                   {hint && (
-                    <span className="ml-auto shrink-0 pl-2 text-[0.68rem] whitespace-nowrap text-muted-foreground">
+                    <span className="ml-auto shrink-0 pl-2 text-2xs whitespace-nowrap text-muted-foreground">
                       {hint}
                     </span>
                   )}

--- a/crates/tidebreak-desktop/ui/src/settings/AppearancePanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AppearancePanel.tsx
@@ -44,7 +44,7 @@ export function AppearancePanel({
                 <Label
                   key={option.mode}
                   className={cn(
-                    "inline-flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-background px-3.5 py-2 text-[0.85rem] font-medium text-foreground transition-[border-color,background-color] duration-[120ms] ease-in-out hover:bg-accent [&_svg]:text-muted-foreground",
+                    "inline-flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-background px-3.5 py-2 text-sm font-medium text-foreground transition-[border-color,background-color] duration-[120ms] ease-in-out hover:bg-accent [&_svg]:text-muted-foreground",
                     active &&
                       "border-primary bg-accent [&_svg]:text-foreground",
                   )}

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
@@ -63,7 +63,7 @@ type Transport = "stdio" | "http" | "gateway";
 export function McpHealthChip({ health }: { health: McpHealth }) {
   const dot =
     health === "healthy"
-      ? "text-emerald-600 dark:text-emerald-400"
+      ? "text-success"
       : health === "degraded"
         ? "text-destructive"
         : "text-muted-foreground";
@@ -104,7 +104,7 @@ export function McpTierChip({ curated }: { curated: McpCuration | null }) {
     <span
       className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${
         tested
-          ? "border-emerald-600/40 text-emerald-700 dark:border-emerald-400/40 dark:text-emerald-400"
+          ? "border-success-border/40 text-success-foreground"
           : "text-muted-foreground"
       }`}
       title={

--- a/crates/tidebreak-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
@@ -280,7 +280,7 @@ function LocalModelItem({ model }: { model: LocalVoiceModelInfo }) {
             {formatModelSize(model.total_bytes)}
           </span>
           {model.recommended && (
-            <span className="rounded-full border px-1.5 text-[0.68rem] text-muted-foreground">
+            <span className="rounded-full border px-1.5 text-2xs text-muted-foreground">
               Recommended
             </span>
           )}

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -375,9 +375,7 @@ function DeveloperPage({ compact }: { compact: boolean }) {
           <span>Contracts</span>
           <span>Runs</span>
         </nav>
-        <span className="font-mono text-[10px] text-black/45">
-          localhost:4173
-        </span>
+        <span className="font-mono text-2xs text-black/45">localhost:4173</span>
       </header>
       <main
         className={cn(
@@ -385,7 +383,7 @@ function DeveloperPage({ compact }: { compact: boolean }) {
           compact && "py-10",
         )}
       >
-        <p className="font-mono text-[10px] tracking-[0.16em] text-[#7b5e36] uppercase">
+        <p className="font-mono text-2xs tracking-[0.16em] text-[#7b5e36] uppercase">
           deterministic browser fixture
         </p>
         <h1 className="mt-3 max-w-3xl text-[clamp(2rem,6vw,4.75rem)] font-semibold leading-[0.96] tracking-[-0.055em] text-balance">
@@ -406,7 +404,7 @@ function DeveloperPage({ compact }: { compact: boolean }) {
         {!compact && (
           <div className="mt-16 grid gap-px overflow-hidden rounded-xl border border-black/10 bg-black/10 sm:grid-cols-[1.25fr_0.75fr]">
             <section className="bg-[#f8f5ee] p-6 sm:p-8">
-              <p className="font-mono text-[10px] text-black/45">
+              <p className="font-mono text-2xs text-black/45">
                 latest snapshot
               </p>
               <p className="mt-8 text-3xl font-medium tracking-[-0.04em]">
@@ -418,9 +416,7 @@ function DeveloperPage({ compact }: { compact: boolean }) {
               </p>
             </section>
             <section className="bg-[#ded8cc] p-6 sm:p-8">
-              <p className="font-mono text-[10px] text-black/45">
-                document epoch
-              </p>
+              <p className="font-mono text-2xs text-black/45">document epoch</p>
               <p className="mt-8 font-mono text-3xl tracking-[-0.04em]">008</p>
               <p className="mt-2 text-sm leading-6 text-black/55">
                 Every navigation retires the old refs.

--- a/crates/tidebreak-desktop/ui/src/stories/Foundations.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Foundations.stories.tsx
@@ -38,9 +38,11 @@ function Foundations() {
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="success">Passing</Badge>
-          <Badge variant="warning">Waiting</Badge>
+          <Badge variant="warning">Stalled</Badge>
           <Badge variant="critical">Failed</Badge>
-          <Badge variant="info">Running</Badge>
+          <Badge variant="info">Waiting</Badge>
+          <Badge variant="merged">Merged</Badge>
+          <Badge variant="live">Working</Badge>
           <Badge variant="outline">Neutral</Badge>
         </div>
       </section>

--- a/crates/tidebreak-desktop/ui/src/stories/FoundationsPalette.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/FoundationsPalette.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+/**
+ * The color vocabulary, rendered from the live tokens so this page cannot
+ * drift from styles.css. DESIGN.md carries the rules; this shows them.
+ */
+
+function Swatch({
+  className,
+  name,
+  role,
+}: {
+  className: string;
+  name: string;
+  role: string;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <div
+        className={`size-9 shrink-0 rounded-md border border-border ${className}`}
+      />
+      <div className="min-w-0">
+        <p className="font-mono text-xs">{name}</p>
+        <p className="text-xs text-muted-foreground">{role}</p>
+      </div>
+    </div>
+  );
+}
+
+const NEUTRALS: [string, string, string][] = [
+  ["bg-page-background", "page-background", "the app canvas"],
+  ["bg-background", "background", "reading surfaces: panes, cards, composer"],
+  ["bg-muted", "muted", "recessed regions, hover washes"],
+  ["bg-popover", "popover", "overlays: menus, dialogs"],
+  ["bg-border", "border", "hairlines between regions"],
+  ["bg-primary", "primary", "the one filled button"],
+  ["bg-muted-foreground", "muted-foreground", "secondary text"],
+  ["bg-foreground", "foreground", "primary text"],
+];
+
+const TONES = [
+  ["success", "finished well"],
+  ["warning", "needs a look"],
+  ["critical", "failed, or needs you"],
+  ["info", "waiting on something external"],
+  ["merged", "settled outcome"],
+  ["live", "an agent is working right now"],
+] as const;
+
+const ICONS = ["blue", "cyan", "violet", "amber", "rose", "green"] as const;
+
+function Palette() {
+  return (
+    <div className="grid max-w-3xl gap-10">
+      <section className="grid gap-3">
+        <div>
+          <h2 className="text-base font-medium">Neutrals</h2>
+          <p className="text-sm text-muted-foreground">
+            Every gray carries a trace of cool blue (hue 240). The temperature
+            is the identity; no pure or warm grays.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-x-8 gap-y-3">
+          {NEUTRALS.map(([className, name, role]) => (
+            <Swatch key={name} className={className} name={name} role={role} />
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-3">
+        <div>
+          <h2 className="text-base font-medium">Status tones</h2>
+          <p className="text-sm text-muted-foreground">
+            Six tones, each a five-member quad. Code mode picks rungs through
+            statusTone.ts, never by hand. Live is the one accent that is
+            Tidebreak&apos;s own; ration it to things running this second.
+          </p>
+        </div>
+        <div className="grid gap-2">
+          {TONES.map(([tone, meaning]) => (
+            <div key={tone} className="flex items-center gap-2">
+              <span className="w-16 font-mono text-xs">{tone}</span>
+              <span className={`size-4 rounded-full bg-${tone}`} />
+              <span
+                className={`rounded-full bg-${tone}-background px-2.5 py-0.5 text-xs text-${tone}-foreground-muted`}
+              >
+                Chip
+              </span>
+              <span className={`text-sm text-${tone}-foreground`}>
+                Label text
+              </span>
+              <span className="ml-2 text-xs text-muted-foreground">
+                {meaning}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-3">
+        <div>
+          <h2 className="text-base font-medium">Identity inks</h2>
+          <p className="text-sm text-muted-foreground">
+            File types, repository swatches, and engine badges are identity, not
+            state: the icon family, never a status tone.
+          </p>
+        </div>
+        <div className="flex items-center gap-4">
+          {ICONS.map((name) => (
+            <div key={name} className="flex items-center gap-1.5">
+              <span className={`size-3.5 rounded-full bg-icon-${name}`} />
+              <span className="font-mono text-xs text-muted-foreground">
+                {name}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+const meta = {
+  title: "Foundations/Palette",
+  component: Palette,
+} satisfies Meta<typeof Palette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Catalog: Story = {};

--- a/crates/tidebreak-desktop/ui/src/stories/FoundationsSurfaces.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/FoundationsSurfaces.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+/**
+ * Surfaces, hairlines, shadows, and the radius vocabulary. Depth is drawn
+ * with borders and surface steps; shadows belong to things that float.
+ */
+
+function Surfaces() {
+  return (
+    <div className="grid max-w-3xl gap-10">
+      <section className="grid gap-3">
+        <div>
+          <h2 className="text-base font-medium">Surface steps</h2>
+          <p className="text-sm text-muted-foreground">
+            The canvas is page-background; panes and cards read on background,
+            one step off the canvas in both themes. Muted recesses a region;
+            popover floats above with the large shadow.
+          </p>
+        </div>
+        <div className="rounded-xl border border-border bg-page-background p-6">
+          <p className="mb-3 font-mono text-xs text-muted-foreground">
+            page-background
+          </p>
+          <div className="rounded-lg border border-border bg-background p-4">
+            <p className="mb-3 font-mono text-xs text-muted-foreground">
+              background · border, not shadow
+            </p>
+            <div className="mb-4 rounded-md bg-muted p-3">
+              <p className="font-mono text-xs text-muted-foreground">
+                muted · recessed
+              </p>
+            </div>
+            <div className="w-56 rounded-md border border-border bg-popover p-3 shadow-lg">
+              <p className="font-mono text-xs text-muted-foreground">
+                popover · shadow-lg, it floats
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-3">
+        <div>
+          <h2 className="text-base font-medium">Hairlines and shadows</h2>
+          <p className="text-sm text-muted-foreground">
+            border separates regions; border-subtle divides within a card. Three
+            shadows exist, for menus, dialogs, and drag previews — resting cards
+            take a border.
+          </p>
+        </div>
+        <div className="grid grid-cols-3 gap-4">
+          {(["shadow-sm", "shadow", "shadow-lg"] as const).map((name) => (
+            <div
+              key={name}
+              className={`rounded-lg border border-border-subtle bg-background p-4 ${name}`}
+            >
+              <p className="font-mono text-xs text-muted-foreground">{name}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-3">
+        <div>
+          <h2 className="text-base font-medium">Radius</h2>
+          <p className="text-sm text-muted-foreground">
+            Four steps and the pill. Cards stop at rounded-xl.
+          </p>
+        </div>
+        <div className="flex items-end gap-4">
+          {(
+            [
+              ["rounded-sm", "sm · 4"],
+              ["rounded-md", "md · 6"],
+              ["rounded-lg", "lg · 8"],
+              ["rounded-xl", "xl · 12"],
+              ["rounded-full", "pill"],
+            ] as const
+          ).map(([className, label]) => (
+            <div key={label} className="grid justify-items-center gap-1.5">
+              <div
+                className={`size-14 border border-border bg-muted ${className}`}
+              />
+              <span className="font-mono text-2xs text-muted-foreground">
+                {label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+const meta = {
+  title: "Foundations/Surfaces",
+  component: Surfaces,
+} satisfies Meta<typeof Surfaces>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Catalog: Story = {};

--- a/crates/tidebreak-desktop/ui/src/stories/FoundationsTypography.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/FoundationsTypography.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+/**
+ * The pinned type scale and the two voices. The rungs and their jobs live in
+ * DESIGN.md; sizes here come from the tokens, so what renders is what ships.
+ */
+
+const SCALE: [string, string, string, string][] = [
+  ["text-2xs", "2xs", "10 / 14", "micro labels, counters, avatar initials"],
+  ["text-xs", "xs", "11 / 15", "dense metadata, timestamps, eyebrows"],
+  ["text-sm", "sm", "12.5 / 18", "the working size for chrome"],
+  ["text-md", "md", "13.5 / 20", "content: transcripts, card titles"],
+  ["text-base", "base", "14 / 21", "body text"],
+  ["text-lg", "lg", "16 / 24", "section headings"],
+  ["text-xl", "xl", "18 / 26", "pane headings"],
+  ["text-2xl", "2xl", "20 / 28", "welcome and empty states"],
+  ["text-3xl", "3xl", "24 / 30", "display"],
+];
+
+function Typography() {
+  return (
+    <div className="grid max-w-3xl gap-10">
+      <section className="grid gap-3">
+        <div>
+          <h2 className="text-base font-medium">Scale</h2>
+          <p className="text-sm text-muted-foreground">
+            Pinned in px on a 14px root. Arbitrary sizes fail the styles
+            contract test; a genuine new rung goes into the scale instead.
+          </p>
+        </div>
+        <div className="grid gap-2">
+          {SCALE.map(([className, name, size, job]) => (
+            <div
+              key={name}
+              className="flex items-baseline gap-4 border-b border-border-subtle pb-2"
+            >
+              <span className="w-10 shrink-0 font-mono text-xs text-muted-foreground">
+                {name}
+              </span>
+              <span className="w-14 shrink-0 whitespace-nowrap font-mono text-xs text-muted-foreground">
+                {size}
+              </span>
+              <span className={`${className} truncate`}>
+                Agents work while you watch
+              </span>
+              <span className="ml-auto hidden shrink-0 text-xs text-muted-foreground sm:block">
+                {job}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-3">
+        <div>
+          <h2 className="text-base font-medium">Weights</h2>
+          <p className="text-sm text-muted-foreground">
+            Hierarchy comes from size; weight stops at semibold.
+          </p>
+        </div>
+        <div className="flex items-baseline gap-6 text-md">
+          <span className="font-normal">400 text</span>
+          <span className="font-medium">500 emphasis</span>
+          <span className="font-semibold">600 titles</span>
+        </div>
+      </section>
+
+      <section className="grid gap-3">
+        <div>
+          <h2 className="text-base font-medium">Two voices</h2>
+          <p className="text-sm text-muted-foreground">
+            Geist is how the product speaks; Geist Mono is how the machine
+            speaks. Identifiers the machine produced render in mono.
+          </p>
+        </div>
+        <div className="grid gap-2 rounded-lg border border-border bg-background p-4">
+          <p className="text-md">
+            Merge when the checks pass, then delete the branch.
+          </p>
+          <p className="font-mono text-xs text-muted-foreground">
+            thet/read-refero-style-page · 5f4129cae · claude-sonnet-5 · 42.3k
+            tokens
+          </p>
+          <p className="text-2xs font-mono uppercase tracking-wide text-muted-foreground">
+            Waiting on checks
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+const meta = {
+  title: "Foundations/Typography",
+  component: Typography,
+} satisfies Meta<typeof Typography>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Catalog: Story = {};

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -7,45 +7,53 @@
    utility quad even when no component currently uses a member, so components
    and development stories can rely on the whole family rather than whichever
    members the app happens to use today. */
-@source inline("text-{success,warning,critical,info}");
-@source inline("text-{success,warning,critical,info}-foreground");
-@source inline("text-{success,warning,critical,info}-foreground-muted");
-@source inline("bg-{success,warning,critical,info}-background");
-@source inline("border-{success,warning,critical,info}-border");
+@source inline("text-{success,warning,critical,info,merged,live}");
+@source inline("text-{success,warning,critical,info,merged,live}-foreground");
+@source inline("text-{success,warning,critical,info,merged,live}-foreground-muted");
+@source inline("bg-{success,warning,critical,info,merged,live}");
+@source inline("bg-{success,warning,critical,info,merged,live}-background");
+@source inline("border-{success,warning,critical,info,merged,live}-border");
+/* Identity inks, composed dynamically by repo swatches and the palette story. */
+@source inline("bg-icon-{blue,cyan,violet,amber,rose,green}");
 
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
   /* --- Gateway design system (oklch, light mode) --- */
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --foreground-subtle: oklch(0.62 0 0);
-  --page-background: oklch(0.985 0 0);
+  /* Every neutral carries a trace of cool blue (hue 240). The chroma is too
+     small to read as color on any one surface — it is the temperature of the
+     whole app. Chroma scales with darkness: near-white surfaces get ~0.002,
+     mid grays ~0.012, so text reads slate rather than tinted paper. See
+     DESIGN.md for the ramp and the rules. */
+  --background: oklch(0.997 0.002 240);
+  --foreground: oklch(0.145 0.008 240);
+  --foreground-subtle: oklch(0.62 0.012 240);
+  --page-background: oklch(0.984 0.003 240);
 
-  --border: oklch(0.922 0 0);
-  --border-subtle: oklch(0.945 0 0);
-  --input: oklch(0.922 0 0);
+  --border: oklch(0.921 0.005 240);
+  --border-subtle: oklch(0.944 0.004 240);
+  --input: oklch(0.921 0.005 240);
   /* Darker than the prototype's neutral ring so focus remains clear against
      both the white canvas and a hovered muted row. */
-  --ring: oklch(0.52 0 0);
+  --ring: oklch(0.52 0.015 240);
 
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.205 0.01 240);
+  --primary-foreground: oklch(0.985 0.002 240);
 
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.968 0.004 240);
+  --secondary-foreground: oklch(0.205 0.01 240);
 
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted: oklch(0.968 0.004 240);
+  --muted-foreground: oklch(0.556 0.014 240);
 
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --accent: oklch(0.968 0.004 240);
+  --accent-foreground: oklch(0.205 0.01 240);
 
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card: oklch(0.997 0.002 240);
+  --card-foreground: oklch(0.145 0.008 240);
 
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
+  --popover: oklch(0.997 0.002 240);
+  --popover-foreground: oklch(0.145 0.008 240);
 
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.984 0.003 247.858);
@@ -99,10 +107,24 @@
   );
   --merged-background: oklch(0.943 0.029 294.588);
   --merged-border: oklch(0.432 0.232 292.759);
+  /* Live is the one accent that is Tidebreak's own: it means an agent is
+     doing something right now. Teal sits in the gap the status hues leave
+     open — distinct from info's blue (waiting on something external) and
+     success's green (finished). It appears on running indicators and
+     nowhere else; rationing is what keeps it a signal. */
+  --live: oklch(0.6 0.125 195);
+  --live-foreground: oklch(0.4 0.08 196);
+  --live-foreground-muted: color-mix(
+    in oklch,
+    var(--live-foreground) 75%,
+    transparent
+  );
+  --live-background: oklch(0.952 0.03 194);
+  --live-border: oklch(0.4 0.08 196);
 
   /* Citations retain a visible highlight without introducing a second accent. */
-  --brand-accent: oklch(0.9 0 0);
-  --citation-mark: oklch(0.87 0 0);
+  --brand-accent: oklch(0.9 0.006 240);
+  --citation-mark: oklch(0.87 0.006 240);
   --citation-mark-active-ink: var(--foreground);
 
   /* Categorical icon ink follows the Gateway prototype's color treatment:
@@ -167,33 +189,35 @@
   /* --- Gateway design system (oklch, dark mode) --- */
   color-scheme: dark;
 
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --foreground-subtle: oklch(0.6 0 0);
-  --page-background: oklch(0.205 0 0);
+  /* Same cool temperature as light mode, slightly stronger: dark surfaces
+     can carry more chroma before they read as colored. */
+  --background: oklch(0.147 0.007 240);
+  --foreground: oklch(0.985 0.003 240);
+  --foreground-subtle: oklch(0.6 0.012 240);
+  --page-background: oklch(0.206 0.008 240);
 
   --border: oklch(1 0 0 / 10%);
   --border-subtle: oklch(1 0 0 / 6%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.68 0 0);
+  --ring: oklch(0.68 0.012 240);
 
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.922 0.005 240);
+  --primary-foreground: oklch(0.206 0.008 240);
 
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.27 0.009 240);
+  --secondary-foreground: oklch(0.985 0.003 240);
 
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
+  --muted: oklch(0.27 0.009 240);
+  --muted-foreground: oklch(0.708 0.012 240);
 
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --accent: oklch(0.27 0.009 240);
+  --accent-foreground: oklch(0.985 0.003 240);
 
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
+  --card: oklch(0.206 0.008 240);
+  --card-foreground: oklch(0.985 0.003 240);
 
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.206 0.008 240);
+  --popover-foreground: oklch(0.985 0.003 240);
 
   --destructive: oklch(0.55 0.21 27.325);
   --destructive-foreground: oklch(0.95 0.005 247.858);
@@ -244,9 +268,18 @@
   );
   --merged-background: oklch(0.432 0.232 292.759);
   --merged-border: oklch(0.702 0.183 293.541);
+  --live: oklch(0.75 0.13 195);
+  --live-foreground: oklch(0.952 0.03 194);
+  --live-foreground-muted: color-mix(
+    in oklch,
+    var(--live-foreground) 75%,
+    transparent
+  );
+  --live-background: oklch(0.4 0.08 196);
+  --live-border: oklch(0.75 0.13 195);
 
-  --brand-accent: oklch(0.32 0 0);
-  --citation-mark: oklch(0.34 0 0);
+  --brand-accent: oklch(0.32 0.01 240);
+  --citation-mark: oklch(0.34 0.01 240);
   --citation-mark-active-ink: var(--background);
 
   /* Vivian's dark treatments lift colored ink to the 400 step. */
@@ -333,6 +366,12 @@
   --color-merged-background: var(--merged-background);
   --color-merged-border: var(--merged-border);
 
+  --color-live: var(--live);
+  --color-live-foreground: var(--live-foreground);
+  --color-live-foreground-muted: var(--live-foreground-muted);
+  --color-live-background: var(--live-background);
+  --color-live-border: var(--live-border);
+
   --color-brand-accent: var(--brand-accent);
 
   --color-icon-blue: var(--icon-blue);
@@ -348,7 +387,34 @@
   --spacing-control: var(--control-height);
   --spacing-control-sm: var(--control-height-sm);
 
+  /* The type scale, pinned in px. The root is 14px, so Tailwind's rem-based
+     defaults land on sizes nobody asks for (text-xs would be 10.5px) and the
+     app routed around them with arbitrary values. These are the rungs the UI
+     actually uses; `stylesContract.test.ts` keeps new arbitrary sizes out.
+     Zoom is safe: InterfaceZoom scales the webview, not the root font size.
+       2xs — micro labels, counters, avatar initials
+       xs  — dense metadata, timestamps, eyebrow labels
+       sm  — the working size for chrome: rows, menus, buttons
+       md  — content text: transcript bodies, card titles, approval prose
+       base and up — body and headings */
   --text-2xs: 10px;
+  --text-2xs--line-height: 14px;
+  --text-xs: 11px;
+  --text-xs--line-height: 15px;
+  --text-sm: 12.5px;
+  --text-sm--line-height: 18px;
+  --text-md: 13.5px;
+  --text-md--line-height: 20px;
+  --text-base: 14px;
+  --text-base--line-height: 21px;
+  --text-lg: 16px;
+  --text-lg--line-height: 24px;
+  --text-xl: 18px;
+  --text-xl--line-height: 26px;
+  --text-2xl: 20px;
+  --text-2xl--line-height: 28px;
+  --text-3xl: 24px;
+  --text-3xl--line-height: 30px;
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/crates/tidebreak-desktop/ui/src/stylesContract.test.ts
+++ b/crates/tidebreak-desktop/ui/src/stylesContract.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The design system's mechanical rules, enforced where prose cannot reach.
+ * DESIGN.md says what the vocabulary means; this test keeps the vocabulary
+ * closed. If a failure here is the right change, the fix is to grow the
+ * system — a scale rung in styles.css, a tone quad, an allowlist entry with
+ * a reason — never to reword a class until the regex misses it.
+ */
+
+const SRC = join(import.meta.dirname, ".");
+
+/** Document-viewer conventions that legitimately sit outside the tokens. */
+const RAW_PALETTE_ALLOWLIST = new Set([
+  // Syntax highlighting: JSON and XML keys/values are code, not UI state.
+  "components/document/json-viewer.tsx",
+  "components/document/xml-viewer.tsx",
+  // The highlighter-pen yellow marking cited passages inside documents.
+  "components/document/citationMark.ts",
+]);
+
+/**
+ * Tailwind's raw palette, e.g. `text-emerald-600`. State goes through the
+ * status tones, identity through `--icon-*`; a raw step is neither.
+ */
+const RAW_PALETTE =
+  /\b(?:text|bg|border|ring|fill|stroke|from|via|to|outline|decoration|caret|shadow)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-[0-9]{2,3}\b/;
+
+/** An arbitrary font size, e.g. `text-[13px]` — the scale is pinned. */
+const ARBITRARY_TEXT_SIZE = /\btext-\[[0-9]/;
+
+function sourceFiles(): string[] {
+  return readdirSync(SRC, { recursive: true, encoding: "utf8" })
+    .filter((path) => /\.(ts|tsx)$/.test(path) && !path.includes("generated/"))
+    .map((path) => path.replaceAll("\\", "/"));
+}
+
+function offenders(pattern: RegExp, skip?: ReadonlySet<string>): string[] {
+  const hits: string[] = [];
+  for (const file of sourceFiles()) {
+    if (skip?.has(file)) continue;
+    if (file === relative(SRC, import.meta.filename).replaceAll("\\", "/")) {
+      continue;
+    }
+    const lines = readFileSync(join(SRC, file), "utf8").split("\n");
+    lines.forEach((line, index) => {
+      const match = pattern.exec(line);
+      if (match) hits.push(`${file}:${index + 1}  ${match[0]}`);
+    });
+  }
+  return hits;
+}
+
+describe("styles contract (see DESIGN.md)", () => {
+  it("uses the pinned type scale, not arbitrary sizes", () => {
+    expect(
+      offenders(ARBITRARY_TEXT_SIZE),
+      "Use a text-* rung from the scale in styles.css. If a real new rung " +
+        "emerged, add it to the scale and DESIGN.md instead.",
+    ).toEqual([]);
+  });
+
+  it("uses semantic tokens, not the raw Tailwind palette", () => {
+    expect(
+      offenders(RAW_PALETTE, RAW_PALETTE_ALLOWLIST),
+      "Color state through the status tones (statusTone.ts, Badge) and " +
+        "identity through --icon-*. See DESIGN.md; allowlist a genuine " +
+        "document-viewer convention here with a reason.",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What changed

The desktop UI had a disciplined oklch token layer but no written rules, a gray-on-gray identity, and a type scale people routed around (~160 arbitrary `text-[Npx]` uses). This change adds `crates/tidebreak-desktop/ui/DESIGN.md` as the agent-oriented contract: cool (hue 240) neutrals in both themes, a px-pinned scale (10–24px), six status tones including a new `live` teal reserved for agents working right now, and Geist Mono as the machine voice. A vitest contract test (`stylesContract.test.ts`) fails the build on arbitrary font sizes and raw palette classes, and new foundations stories document palette, typography, and surfaces. ~55 files are swept onto the scale rungs and status tokens, fixing the emerald/red leaks in `ComputerUseIndicator`, `McpPanel`, and `ChangeSummaryCard`.

## Validation

`pnpm test` (226 files, 1778 tests), `tsc --noEmit`, and `biome lint` all pass; `storybook:build` succeeds. All four foundations stories were screenshotted in light and dark from the static build and read as designed. The app itself was not run.

## Compatibility and risk

Visual-only: token values shift slightly (cool chroma in the neutrals, 12.5px/13.5px rungs) so screenshots will diff, but no persisted or wire-format changes.