### PR TITLE
feat(code): sweeps consume the pull-request store before fetching

### DIFF
--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -22,8 +22,9 @@ use tidebreak_core::db::code::{
 };
 use tidebreak_core::{
     CodePullRequestAttribution, CodePullRequestDiscovery, CodePullRequestId,
-    CodePullRequestRelation, CodeRepo, CodeWorkspace, CodeWorkspaceStatus, DbStore, OwnerId,
-    PullRequestCheckBucket, PullRequestComment, PullRequestCommentKind, RepoId, WorkspaceId,
+    CodePullRequestRelation, CodeRepo, CodeWorkspace, CodeWorkspaceStatus, OwnerId,
+    PullRequestCheck, PullRequestCheckBucket, PullRequestComment, PullRequestCommentKind,
+    PullRequestDigest, RepoId, WorkspaceId,
 };
 
 use super::gh::{self, GhObservation};
@@ -480,7 +481,7 @@ pub(crate) async fn query_pull_requests_by_number(
     // keys on `stack_parent_number` (decision 62) — so this path persists and
     // annotates the same way the list read does.
     let workspaces_gaining_links =
-        persist_and_augment_pull_request_facts(&runtime.db, owner, &workspaces, &mut items).await;
+        persist_and_augment_pull_request_facts(runtime, owner, &workspaces, &mut items).await;
     for workspace_id in workspaces_gaining_links {
         super::attention::emit_workspace_digests(&runtime.db, &runtime.bus, owner, workspace_id)
             .await;
@@ -727,7 +728,7 @@ pub(crate) async fn query_pull_requests(
                     .then_with(|| left.id.cmp(&right.id))
             });
             let workspaces_gaining_links = persist_and_augment_pull_request_facts(
-                &runtime.db,
+                runtime,
                 owner,
                 &workspace_index,
                 &mut items,
@@ -803,7 +804,7 @@ pub(crate) async fn pull_request_detail(
         .await
         .map_err(|message| ServerError::bad_request_kind("github", message))?;
     let minted = persist_and_augment_pull_request_facts(
-        &runtime.db,
+        runtime,
         owner,
         &workspace_index,
         std::slice::from_mut(&mut summary),
@@ -2521,6 +2522,42 @@ fn workspace_links(
     links.into_iter().map(|(_, link)| link).collect()
 }
 
+/// Project one delivery summary into the digest vocabulary (decision 66):
+/// the same shape a workspace read stores, so the live tier and its
+/// write-through take one path no matter who observed the pull request.
+pub(crate) fn digest_from_summary(item: &CodeDeliveryPullRequestSummary) -> PullRequestDigest {
+    PullRequestDigest {
+        number: item.number,
+        url: Some(item.url.clone()),
+        state: item.state.clone(),
+        title: Some(item.title.clone()),
+        checks_summary: None,
+        checks: Some(
+            item.checks
+                .iter()
+                .map(|check| PullRequestCheck {
+                    name: check.name.clone(),
+                    bucket: check.bucket,
+                    detail: check.detail.clone(),
+                    url: check.url.clone(),
+                })
+                .collect(),
+        ),
+        draft: Some(item.draft),
+        // `state` alone cannot separate merged from closed on every host
+        // response, which is why the summary carries `merged_at`.
+        merged: Some(item.merged_at.is_some()),
+        review_decision: item.review_decision.clone(),
+        mergeable: item.mergeable.clone(),
+        merge_state_status: item.merge_state_status.clone(),
+        head_branch: Some(item.head_branch.clone()),
+        base_branch: Some(item.base_branch.clone()),
+        head_sha: item.head_sha.clone(),
+        auto_merge_enabled: Some(item.auto_merge_enabled),
+        in_merge_queue: None,
+    }
+}
+
 /// Persist durable facts for the page's tracked pull requests and fold the
 /// stored attribution back into every item's workspace links (decision 62).
 ///
@@ -2531,11 +2568,12 @@ fn workspace_links(
 /// restate their digests. Best-effort throughout: a store failure degrades
 /// to the live heuristic links.
 async fn persist_and_augment_pull_request_facts(
-    db: &DbStore,
+    runtime: &CodeRuntime,
     owner: &OwnerId,
     workspaces: &[WorkspaceIndexEntry],
     items: &mut [CodeDeliveryPullRequestSummary],
 ) -> Vec<WorkspaceId> {
+    let db = &runtime.db;
     let mut minted = Vec::new();
     let now = Utc::now();
 
@@ -2590,6 +2628,13 @@ async fn persist_and_augment_pull_request_facts(
                     continue;
                 }
             };
+            // The summary is a fresh host observation: write it onto the
+            // row's live tier and fan real change out to every workspace
+            // holding the pull request (decision 66). One list read per
+            // repository is what keeps every surface fresh.
+            runtime
+                .record_pull_request_live_state(owner, None, &digest_from_summary(item))
+                .await;
             // Keep the local fact set current with what was just written, so
             // stack derivation below sees this pass's own observations.
             match repo_facts

--- a/crates/tidebreak-server/src/code/pr_facts.rs
+++ b/crates/tidebreak-server/src/code/pr_facts.rs
@@ -706,6 +706,31 @@ pub(crate) fn pull_request_identity_from_url(url: &str) -> Option<(String, Strin
     Some((host.to_owned(), owner.to_owned(), name.to_owned(), number))
 }
 
+/// Project one fact row into the digest vocabulary every consumer already
+/// reads. The snapshot fields fill the identity; the live tier (decision 66)
+/// fills checks, review, and mergeability when a read has written it.
+pub(crate) fn digest_from_fact(fact: &CodePullRequestFact) -> tidebreak_core::PullRequestDigest {
+    let live = fact.live.as_ref();
+    tidebreak_core::PullRequestDigest {
+        number: fact.number,
+        url: Some(fact.url.clone()),
+        state: fact.state.as_str().to_owned(),
+        title: Some(fact.title.clone()),
+        checks_summary: live.and_then(|live| live.checks_summary.clone()),
+        checks: live.and_then(|live| live.checks.clone()),
+        draft: Some(fact.draft),
+        merged: Some(fact.state == CodePullRequestState::Merged),
+        review_decision: live.and_then(|live| live.review_decision.clone()),
+        mergeable: live.and_then(|live| live.mergeable.clone()),
+        merge_state_status: live.and_then(|live| live.merge_state_status.clone()),
+        head_branch: Some(fact.head_branch.clone()),
+        base_branch: Some(fact.base_branch.clone()),
+        head_sha: fact.head_sha.clone(),
+        auto_merge_enabled: live.and_then(|live| live.auto_merge_enabled),
+        in_merge_queue: live.and_then(|live| live.in_merge_queue),
+    }
+}
+
 fn timestamp(value: &Value, field: &str) -> Option<DateTime<Utc>> {
     value
         .get(field)
@@ -863,5 +888,86 @@ mod tests {
 
         let partial = serde_json::json!({"number": 12, "state": "OPEN"});
         assert!(fact_from_gh_value(&owner, &target, &partial, now).is_none());
+    }
+
+    #[test]
+    fn identity_parses_only_plain_pull_urls() {
+        assert_eq!(
+            pull_request_identity_from_url("https://github.com/acme/tools/pull/412"),
+            Some((
+                "github.com".to_owned(),
+                "acme".to_owned(),
+                "tools".to_owned(),
+                412
+            ))
+        );
+        assert_eq!(
+            pull_request_identity_from_url("https://ghe.corp.example/acme/tools/pull/7/files"),
+            Some((
+                "ghe.corp.example".to_owned(),
+                "acme".to_owned(),
+                "tools".to_owned(),
+                7
+            ))
+        );
+        assert!(
+            pull_request_identity_from_url("https://github.com/acme/tools/issues/412").is_none()
+        );
+        assert!(pull_request_identity_from_url("https://github.com/acme/tools/pull/0").is_none());
+        assert!(pull_request_identity_from_url("not a url").is_none());
+    }
+
+    #[test]
+    fn fact_digests_carry_the_live_tier_when_present() {
+        let owner = OwnerId::local();
+        let now = Utc::now();
+        let mut fact = CodePullRequestFact {
+            id: CodePullRequestId::new(),
+            owner,
+            host: "github.com".into(),
+            repo_owner: "acme".into(),
+            repo_name: "tools".into(),
+            number: 412,
+            url: "https://github.com/acme/tools/pull/412".into(),
+            title: "First".into(),
+            state: CodePullRequestState::Open,
+            draft: false,
+            author: None,
+            head_branch: "feat/x".into(),
+            base_branch: "main".into(),
+            head_sha: Some("aaa111".into()),
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            closed_at: None,
+            first_seen_at: now,
+            last_seen_at: now,
+            live: None,
+        };
+        let bare = digest_from_fact(&fact);
+        assert_eq!(bare.number, 412);
+        assert!(bare.checks.is_none());
+        assert!(bare.merge_state_status.is_none());
+
+        fact.live = Some(tidebreak_core::CodePullRequestLiveState {
+            checks_summary: Some("1 pending".into()),
+            checks: Some(vec![tidebreak_core::PullRequestCheck {
+                name: "ci".into(),
+                bucket: tidebreak_core::PullRequestCheckBucket::Pending,
+                detail: None,
+                url: None,
+            }]),
+            review_decision: Some("review_required".into()),
+            mergeable: Some("mergeable".into()),
+            merge_state_status: Some("blocked".into()),
+            auto_merge_enabled: Some(true),
+            in_merge_queue: Some(false),
+            observed_at: now,
+        });
+        let enriched = digest_from_fact(&fact);
+        assert_eq!(enriched.merge_state_status.as_deref(), Some("blocked"));
+        assert_eq!(enriched.review_decision.as_deref(), Some("review_required"));
+        assert_eq!(enriched.checks.as_ref().unwrap().len(), 1);
+        assert_eq!(enriched.auto_merge_enabled, Some(true));
     }
 }

--- a/crates/tidebreak-server/src/code/reconcile.rs
+++ b/crates/tidebreak-server/src/code/reconcile.rs
@@ -30,6 +30,19 @@ use crate::routes::code::types::{
 /// sweeps never land on the same tick.
 pub(crate) const RECONCILE_SWEEP_INTERVAL: Duration = Duration::from_secs(61);
 
+/// A live tier younger than this answers a sweep without a host read
+/// (decision 66): two reconcile intervals plus slack, so one missed pass
+/// degrades to a fetch rather than a stale verdict.
+const LIVE_TIER_FRESH_SECS: i64 = (RECONCILE_SWEEP_INTERVAL.as_secs() as i64) * 2 + 30;
+
+/// Whether a sweep may consume this live tier instead of fetching.
+pub(crate) fn live_tier_is_fresh(
+    live: &tidebreak_core::CodePullRequestLiveState,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    now - live.observed_at <= chrono::Duration::seconds(LIVE_TIER_FRESH_SECS)
+}
+
 /// Abort the reconcile sweep when the runtime is dropped.
 ///
 /// The loop holds a [`Weak`] runtime handle: an `Arc` would keep the runtime

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -1533,7 +1533,7 @@ impl CodeRuntime {
             // A digest that moved is a fresh host observation: write it onto
             // the fact row's live tier and fan the change out (decision 66).
             if let Some(digest) = &status.pr {
-                self.record_pull_request_live_state(owner, workspace.id, digest)
+                self.record_pull_request_live_state(owner, Some(workspace.id), digest)
                     .await;
             }
         }
@@ -1610,7 +1610,7 @@ impl CodeRuntime {
     pub(crate) async fn record_pull_request_live_state(
         &self,
         owner: &OwnerId,
-        source: WorkspaceId,
+        source: Option<WorkspaceId>,
         digest: &PullRequestDigest,
     ) {
         let Some(url) = digest.url.as_deref() else {
@@ -1653,7 +1653,7 @@ impl CodeRuntime {
             Err(_) => return,
         };
         for mut workspace in workspaces {
-            if workspace.id == source || workspace.status != CodeWorkspaceStatus::Active {
+            if source == Some(workspace.id) || workspace.status != CodeWorkspaceStatus::Active {
                 continue;
             }
             let holds = workspace

--- a/crates/tidebreak-server/src/code/trigger.rs
+++ b/crates/tidebreak-server/src/code/trigger.rs
@@ -29,8 +29,8 @@ use tidebreak_core::{
     CodePullRequestFact, CodePullRequestId, CodeSession, CodeSessionId, CodeSessionKind,
     CodeSessionLifecycle, CodeTrigger, CodeTriggerAction, CodeTriggerCondition,
     CodeTriggerDeliveryId, CodeTriggerFire, CodeTriggerFireIdentity, CodeTriggerFirePayload,
-    CodeTurnId, CodeWorkspaceStatus, HarnessNoticeLevel, OwnerId, PullRequestCheck,
-    PullRequestDigest, RepoId, WorkspaceId,
+    CodeTurnId, CodeWorkspaceStatus, HarnessNoticeLevel, OwnerId, PullRequestDigest, RepoId,
+    WorkspaceId,
 };
 use tracing::{debug, warn};
 
@@ -84,12 +84,16 @@ struct RepositoryWork {
     triggers: Vec<CodeTrigger>,
     workspace_ids: HashSet<WorkspaceId>,
     pr_numbers: HashSet<u64>,
+    /// Eligible workspaces by the pull-request number their column holds,
+    /// so a durable-row fire aims at exactly the holders (decision 66).
+    workspaces_by_number: HashMap<u64, HashSet<WorkspaceId>>,
 }
 
 #[derive(Default)]
 struct EligibleWorkspaces {
     workspace_ids: HashSet<WorkspaceId>,
     pr_numbers: HashSet<u64>,
+    workspaces_by_number: HashMap<u64, HashSet<WorkspaceId>>,
 }
 
 /// One pass over every enabled trigger. A failure on one repository never
@@ -193,6 +197,10 @@ async fn sweep_owner(
             work.workspace_ids.insert(workspace.id);
             if let Some(pr) = workspace.pr.as_ref() {
                 work.pr_numbers.insert(pr.number);
+                work.workspaces_by_number
+                    .entry(pr.number)
+                    .or_default()
+                    .insert(workspace.id);
             }
         }
     }
@@ -240,6 +248,7 @@ async fn sweep_owner(
                         triggers,
                         workspace_ids: eligible.workspace_ids,
                         pr_numbers: eligible.pr_numbers,
+                        workspaces_by_number: eligible.workspaces_by_number,
                     },
                 )),
                 Err(message) => {
@@ -433,7 +442,7 @@ async fn fire_fact_edge(
             if fact.created_at < trigger.created_at || fact.first_seen_at < trigger.created_at {
                 return Ok(());
             }
-            let digest = digest_from_fact(fact);
+            let digest = super::pr_facts::digest_from_fact(fact);
             fire_one(
                 runtime,
                 owner,
@@ -476,44 +485,77 @@ async fn fire_fact_edge(
                 insert_settled_trigger_fire(&runtime.db, &identity, Utc::now()).await?;
                 return Ok(());
             }
-            let digest = digest_from_fact(fact);
+            let digest = super::pr_facts::digest_from_fact(fact);
             fire_one(runtime, owner, trigger, workspace_id, &digest, head).await
         }
         _ => Ok(()),
     }
 }
 
-/// The minimal digest a fact-edge message composes from: identity and title,
-/// no checks — the fact store deliberately never carries check state.
-fn digest_from_fact(fact: &CodePullRequestFact) -> PullRequestDigest {
-    PullRequestDigest {
-        number: fact.number,
-        url: Some(fact.url.clone()),
-        state: fact.state.as_str().to_owned(),
-        title: Some(fact.title.clone()),
-        checks_summary: None,
-        checks: None,
-        draft: Some(fact.draft),
-        merged: Some(fact.state == tidebreak_core::CodePullRequestState::Merged),
-        review_decision: None,
-        mergeable: None,
-        merge_state_status: None,
-        head_branch: Some(fact.head_branch.clone()),
-        base_branch: Some(fact.base_branch.clone()),
-        head_sha: fact.head_sha.clone(),
-        auto_merge_enabled: None,
-        in_merge_queue: None,
-    }
-}
-
-/// Fetch one exact-number aggregate and deliver its matching facts.
+/// Consume the durable rows first (decision 66): a fresh live tier answers
+/// without a host read, and only the rows the store cannot answer freshly
+/// fall back to one exact-number read — which itself lands back on the
+/// store through the delivery path's persistence.
 async fn sweep_pull_requests(
     runtime: &Arc<CodeRuntime>,
     owner: &OwnerId,
     repositories: Vec<(CodeGitHubRepositoryTarget, Vec<u64>)>,
     work_by_repository: &HashMap<RepositoryKey, Vec<RepositoryWork>>,
 ) -> Result<(), ServerError> {
-    let page = query_pull_requests_by_number(runtime, owner, repositories).await?;
+    let now = Utc::now();
+    let mut residual: Vec<(CodeGitHubRepositoryTarget, Vec<u64>)> = Vec::new();
+    for (target, numbers) in repositories {
+        let key = RepositoryKey::from_target(&target);
+        let Some(repository_work) = work_by_repository.get(&key) else {
+            continue;
+        };
+        let repo_facts = match tidebreak_core::db::code::list_pull_request_facts_for_repo(
+            &runtime.db,
+            owner,
+            &target.host,
+            &target.owner,
+            &target.name,
+        )
+        .await
+        {
+            Ok(facts) => facts,
+            Err(err) => {
+                debug!(error = %err, "code-mode trigger sweep could not read fact rows");
+                residual.push((target, numbers));
+                continue;
+            }
+        };
+        let parents = super::reconcile::stack_parents_by_head(&repo_facts);
+        let mut stale = Vec::new();
+        for number in numbers {
+            let fresh = repo_facts.iter().find(|fact| {
+                fact.number == number
+                    && fact
+                        .live
+                        .as_ref()
+                        .is_some_and(|live| super::reconcile::live_tier_is_fresh(live, now))
+            });
+            let Some(fact) = fresh else {
+                stale.push(number);
+                continue;
+            };
+            let digest = super::pr_facts::digest_from_fact(fact);
+            let stack_parent = parents
+                .get(&fact.base_branch)
+                .copied()
+                .filter(|parent| *parent != fact.number);
+            for work in repository_work {
+                claim_fires_from_row(runtime, owner, work, &digest, stack_parent).await;
+            }
+        }
+        if !stale.is_empty() {
+            residual.push((target, stale));
+        }
+    }
+    if residual.is_empty() {
+        return Ok(());
+    }
+    let page = query_pull_requests_by_number(runtime, owner, residual).await?;
     if !github_available(owner, &page) {
         return Ok(());
     }
@@ -567,6 +609,63 @@ fn warn_source_errors(owner: &OwnerId, page: &CodeDeliveryPullRequestsPage) {
     }
 }
 
+/// Claim and deliver fires for one durable row's digest (decision 66): the
+/// same classification and the same stacked-child hold as the fetched path,
+/// aimed at the eligible workspaces whose column holds the pull request.
+async fn claim_fires_from_row(
+    runtime: &Arc<CodeRuntime>,
+    owner: &OwnerId,
+    work: &RepositoryWork,
+    digest: &PullRequestDigest,
+    stack_parent: Option<u64>,
+) {
+    // Without a head SHA the fire cannot be fingerprinted, and a fire that
+    // cannot be bounded would repeat every tick.
+    let Some(head_sha) = digest.head_sha.clone() else {
+        return;
+    };
+    let Some(condition) = classify_trigger_condition(digest) else {
+        return;
+    };
+    // A stacked child is behind or blocked *because of its parent*
+    // (decision 62). Firing Behind or ReviewRequired at it would send an
+    // agent to rebase onto a branch that moves with every parent push.
+    if stack_parent.is_some()
+        && matches!(
+            condition,
+            CodeTriggerCondition::Behind | CodeTriggerCondition::ReviewRequired
+        )
+    {
+        debug!(
+            number = digest.number,
+            parent = stack_parent,
+            "code-mode trigger held a stacked child's fire"
+        );
+        return;
+    }
+    let Some(workspaces) = work.workspaces_by_number.get(&digest.number) else {
+        return;
+    };
+    for trigger in work
+        .triggers
+        .iter()
+        .filter(|trigger| trigger.condition == condition)
+    {
+        for workspace_id in workspaces {
+            if let Err(err) =
+                fire_one(runtime, owner, trigger, *workspace_id, digest, &head_sha).await
+            {
+                warn!(
+                    trigger = %trigger.id,
+                    workspace = %workspace_id,
+                    error = %err.message(),
+                    "code-mode trigger sweep could not deliver a fire"
+                );
+            }
+        }
+    }
+}
+
 /// Claim and deliver one fire per matching trigger per linked workspace.
 async fn claim_fires(
     runtime: &Arc<CodeRuntime>,
@@ -579,7 +678,7 @@ async fn claim_fires(
     let Some(head_sha) = item.head_sha.clone() else {
         return;
     };
-    let digest = digest_from(item);
+    let digest = super::delivery::digest_from_summary(item);
     let Some(condition) = classify_trigger_condition(&digest) else {
         return;
     };
@@ -1072,39 +1171,6 @@ fn linked_workspaces(
 ///
 /// Both paths lowercase their host tokens already — `normalized_optional` here
 /// and `lower_token` in `gh.rs` — so the tokens pass straight through.
-fn digest_from(item: &CodeDeliveryPullRequestSummary) -> PullRequestDigest {
-    PullRequestDigest {
-        number: item.number,
-        url: Some(item.url.clone()),
-        state: item.state.clone(),
-        title: Some(item.title.clone()),
-        checks_summary: None,
-        checks: Some(
-            item.checks
-                .iter()
-                .map(|check| PullRequestCheck {
-                    name: check.name.clone(),
-                    bucket: check.bucket,
-                    detail: check.detail.clone(),
-                    url: check.url.clone(),
-                })
-                .collect(),
-        ),
-        draft: Some(item.draft),
-        // `state` alone cannot separate merged from closed on every host
-        // response, which is why the summary carries `merged_at`.
-        merged: Some(item.merged_at.is_some()),
-        review_decision: item.review_decision.clone(),
-        mergeable: item.mergeable.clone(),
-        merge_state_status: item.merge_state_status.clone(),
-        head_branch: Some(item.head_branch.clone()),
-        base_branch: Some(item.base_branch.clone()),
-        head_sha: item.head_sha.clone(),
-        auto_merge_enabled: Some(item.auto_merge_enabled),
-        in_merge_queue: None,
-    }
-}
-
 /// Abort the trigger sweep when the runtime is dropped.
 ///
 /// The loop holds a [`Weak`] runtime handle: an `Arc` would keep the runtime
@@ -1141,6 +1207,7 @@ mod tests {
     use super::*;
     use tidebreak_core::{CodeTriggerCondition, PullRequestCheckBucket};
 
+    use crate::code::delivery::digest_from_summary;
     use crate::routes::code::types::{CodeDeliveryCheck, CodeGitHubRepositoryRef};
 
     fn repository() -> CodeGitHubRepositoryRef {
@@ -1212,7 +1279,7 @@ mod tests {
             workflow_run_id: Some(1),
         }];
 
-        let digest = digest_from(&item);
+        let digest = digest_from_summary(&item);
         assert_eq!(digest.number, 12);
         assert_eq!(digest.head_sha.as_deref(), Some("abc123"));
         assert_eq!(digest.mergeable.as_deref(), Some("mergeable"));
@@ -1234,14 +1301,14 @@ mod tests {
         item.merged_at = Some(Utc::now());
 
         assert_eq!(
-            classify_trigger_condition(&digest_from(&item)),
+            classify_trigger_condition(&digest_from_summary(&item)),
             Some(CodeTriggerCondition::Merged)
         );
 
         let mut closed = summary();
         closed.state = "closed".to_owned();
         assert_eq!(
-            classify_trigger_condition(&digest_from(&closed)),
+            classify_trigger_condition(&digest_from_summary(&closed)),
             Some(CodeTriggerCondition::Closed)
         );
     }

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -433,13 +433,24 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
     let turn_in_flight = sessions
         .iter()
         .any(|other| other.lifecycle == CodeSessionLifecycle::Running);
-    let status = runtime
-        .refresh_workspace_pr(&owner, watch.workspace_id)
-        .await?;
+    // The store answers first (decision 66): the reconcile sweep's one list
+    // read per repository keeps the live tier fresh, and write-through keeps
+    // the workspace column equal to it. Only a missing or stale tier pays a
+    // host read here — which itself lands back on the store for every other
+    // consumer.
+    let pr = match fresh_stored_digest(runtime, &owner, &workspace).await {
+        Some(digest) => Some(digest),
+        None => {
+            runtime
+                .refresh_workspace_pr(&owner, watch.workspace_id)
+                .await?
+                .pr
+        }
+    };
     if turn_in_flight {
         return Ok(());
     }
-    let Some(pr) = status.pr else {
+    let Some(pr) = pr else {
         return park_watch(
             runtime.as_ref(),
             watch,
@@ -564,6 +575,36 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
             Ok(())
         }
     }
+}
+
+/// The workspace's stored pull-request digest, when the fact row behind it
+/// confirms the live tier is fresh (decision 66). `None` sends the caller to
+/// a host read: no stored digest, no joinable URL, no fact row, or a tier
+/// older than the reconcile cadence promises.
+async fn fresh_stored_digest(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    workspace: &tidebreak_core::CodeWorkspace,
+) -> Option<PullRequestDigest> {
+    let stored = workspace.pr.as_ref()?;
+    let url = stored.url.as_deref()?;
+    let (host, repo_owner, repo_name, number) =
+        super::pr_facts::pull_request_identity_from_url(url)?;
+    let fact = tidebreak_core::db::code::get_pull_request_fact(
+        &runtime.db,
+        owner,
+        &host,
+        &repo_owner,
+        &repo_name,
+        number,
+    )
+    .await
+    .ok()??;
+    let live = fact.live.as_ref()?;
+    if !super::reconcile::live_tier_is_fresh(live, Utc::now()) {
+        return None;
+    }
+    Some(super::pr_facts::digest_from_fact(&fact))
 }
 
 /// The open pull request this workspace's pull request is stacked on, when


### PR DESCRIPTION
Slice 3 of [decision 66](docs/decisions/0066-pull-request-state-is-one-store.md): the watch and trigger sweeps consume the pull-request store, and delivery reads feed it.

## What changes

- Delivery reads persist each summary's live tier. `persist_and_augment_pull_request_facts` now writes the live tier through the decision-66 seam after each fact upsert, so the reconcile sweep's one list read per repository per 61 seconds refreshes checks, review state, and mergeability for every stored pull request — and fans real change out to every workspace holding it.
- The watch sweep answers from the store first. When the workspace's fact row carries a live tier younger than two reconcile intervals plus slack, the sweep classifies that digest instead of paying a host read. Stale or missing rows fall back to the host read, which itself lands back on the store.
- The trigger sweep does the same: fresh rows classify directly (including stack-parent holds), and only the residual numbers take the old by-number query path.
- `digest_from_fact` moves to `pr_facts` and now projects the live tier onto the digest, so a stored row answers with the same fields a host read would.
- `record_pull_request_live_state` takes an optional source workspace: delivery-path writes have no workspace to exclude from the fanout.

## Why

Decision 66 wants one fetch schedule feeding every surface. After this slice, the three background sweeps stop fetching independently: reconcile reads, the store remembers, and watch and trigger consume — the same answer everywhere, at a fraction of the GitHub traffic. Slice 4 makes the remaining reads conditional REST behind one gate; slice 5 drops the UI poll timers.

## Testing

- `pr_facts` unit tests cover URL identity parsing and the live tier riding `digest_from_fact`.
- Existing watch, trigger, and reconcile suites cover the fallback paths; the freshness gate is exercised by the store tests from slice 2.
