### PR TITLE
feat(code): fetch pull-request state over conditional REST behind one gate

### DIFF
--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1716,6 +1716,9 @@ pub mod code_pull_request {
         pub auto_merge_enabled: Option<bool>,
         pub in_merge_queue: Option<bool>,
         pub live_observed_at: Option<DateTimeUtc>,
+        pub pull_etag: Option<String>,
+        pub checks_etag: Option<String>,
+        pub reviews_etag: Option<String>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -50,7 +50,53 @@ impl MigratorTrait for Migrator {
             Box::new(TriggerFactConditions),
             Box::new(CodeQueuedTurns),
             Box::new(CodePullRequestLiveTier),
+            Box::new(CodePullRequestEtags),
         ]
+    }
+}
+
+/// Conditional-request ETags on pull-request facts (decision 66).
+///
+/// The row stores the ETag each fetch endpoint last answered with — the
+/// pull request, its head's check runs, and its reviews — so the next read
+/// sends `If-None-Match` and an unchanged answer costs a free 304.
+struct CodePullRequestEtags;
+
+impl MigrationName for CodePullRequestEtags {
+    fn name(&self) -> &str {
+        "m20260824_000013_code_pull_request_etags"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for CodePullRequestEtags {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // SQLite accepts one ADD COLUMN per ALTER, so each column is its own
+        // guarded statement.
+        for (name, column) in [
+            ("pull_etag", idens::CodePullRequest::PullEtag),
+            ("checks_etag", idens::CodePullRequest::ChecksEtag),
+            ("reviews_etag", idens::CodePullRequest::ReviewsEtag),
+        ] {
+            if manager.has_column("code_pull_request", name).await? {
+                continue;
+            }
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(idens::CodePullRequest::Table)
+                        .add_column(ColumnDef::new(column).text())
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Nothing to reverse: nullable columns on a table whose own
+        // migration's `down` drops it outright.
+        Ok(())
     }
 }
 
@@ -1607,6 +1653,7 @@ mod tests {
                 "m20260823_000010_trigger_fact_conditions",
                 "m20260824_000011_code_queued_turns",
                 "m20260824_000012_code_pull_request_live_tier",
+                "m20260824_000013_code_pull_request_etags",
             ]
         );
         assert!(db

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -844,6 +844,9 @@ pub(crate) enum CodePullRequest {
     AutoMergeEnabled,
     InMergeQueue,
     LiveObservedAt,
+    PullEtag,
+    ChecksEtag,
+    ReviewsEtag,
 }
 
 #[derive(DeriveIden)]

--- a/crates/tidebreak-core/src/db/ops/code/pull_request.rs
+++ b/crates/tidebreak-core/src/db/ops/code/pull_request.rs
@@ -171,6 +171,71 @@ pub async fn set_pull_request_live_state(
     Ok(Some((id, changed)))
 }
 
+/// One observed pull request plus the transport hints the conditional
+/// fetcher sends back to the host (decision 66): the ETag each endpoint
+/// last answered with.
+#[derive(Debug, Clone)]
+pub struct PullRequestFetchState {
+    pub fact: CodePullRequestFact,
+    pub pull_etag: Option<String>,
+    pub checks_etag: Option<String>,
+    pub reviews_etag: Option<String>,
+}
+
+/// Load one observed pull request with its stored fetch ETags.
+pub async fn get_pull_request_fetch_state(
+    store: &DbStore,
+    owner: &OwnerId,
+    host: &str,
+    repo_owner: &str,
+    repo_name: &str,
+    number: u64,
+) -> Result<Option<PullRequestFetchState>> {
+    let number = i64::try_from(number)
+        .map_err(|_| AgentError::Store(format!("pull request number {number} overflows")))?;
+    let Some(row) = find_fact_row(store, owner, host, repo_owner, repo_name, number).await? else {
+        return Ok(None);
+    };
+    let pull_etag = row.pull_etag.clone();
+    let checks_etag = row.checks_etag.clone();
+    let reviews_etag = row.reviews_etag.clone();
+    Ok(Some(PullRequestFetchState {
+        fact: fact_from_row(row)?,
+        pull_etag,
+        checks_etag,
+        reviews_etag,
+    }))
+}
+
+/// Store the ETags one fetch pass ended with (decision 66). The caller
+/// passes each endpoint's current value — the fresh ETag after a 200, the
+/// one it sent after a 304 — so the row always names what the host holds.
+/// `Ok(false)` when no fact row exists for the identity.
+#[allow(clippy::too_many_arguments)]
+pub async fn set_pull_request_etags(
+    store: &DbStore,
+    owner: &OwnerId,
+    host: &str,
+    repo_owner: &str,
+    repo_name: &str,
+    number: u64,
+    pull_etag: Option<&str>,
+    checks_etag: Option<&str>,
+    reviews_etag: Option<&str>,
+) -> Result<bool> {
+    let number = i64::try_from(number)
+        .map_err(|_| AgentError::Store(format!("pull request number {number} overflows")))?;
+    let Some(row) = find_fact_row(store, owner, host, repo_owner, repo_name, number).await? else {
+        return Ok(false);
+    };
+    let mut model: entities::code_pull_request::ActiveModel = row.into();
+    model.pull_etag = Set(pull_etag.map(ToOwned::to_owned));
+    model.checks_etag = Set(checks_etag.map(ToOwned::to_owned));
+    model.reviews_etag = Set(reviews_etag.map(ToOwned::to_owned));
+    model.update(&store.conn).await.map_err(store_err)?;
+    Ok(true)
+}
+
 /// Every observed pull request on one repository identity.
 pub async fn list_pull_request_facts_for_repo(
     store: &DbStore,

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -25,7 +25,6 @@ use crate::obo_gateway::GitCredential;
 const GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const GIT_PUSH_TIMEOUT: Duration = Duration::from_secs(120);
 const GH_TIMEOUT: Duration = Duration::from_secs(30);
-const PR_DIGEST_TIMEOUT: Duration = Duration::from_secs(60);
 const ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_OUTPUT_CHARS: usize = 4_096;
 const PR_CACHE_TTL: Duration = Duration::from_secs(20);
@@ -364,32 +363,24 @@ pub(crate) async fn push_branch(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn workspace_git_status(
     worktree: &Path,
-    workspace_id: WorkspaceId,
     title: &str,
     branch: &str,
     base_ref: &str,
     persisted: Option<PullRequestDigest>,
-    cache: &PrDigestCache,
     gh_search_path: Option<&str>,
 ) -> Result<WorkspaceGitStatus, GhError> {
     let inspect = inspect_git(worktree, base_ref, title).await?;
     let gh = observe_gh(gh_search_path).await;
-    let mut pr = persisted;
-    if gh.found && gh.authenticated == Some(true) {
-        if let Some(cached) = cache.get(workspace_id) {
-            pr = Some(cached);
-        } else if let Some(fresh) = load_pr_digest(worktree, &gh, gh_search_path).await? {
-            cache.put(workspace_id, fresh.clone());
-            pr = Some(fresh);
-        }
-    }
+    // The digest itself comes from the conditional fetcher (decision 66),
+    // which the runtime drives with the fact row's ETags; this observation
+    // only carries the persisted copy and the local git state.
     Ok(WorkspaceGitStatus {
         dirty: inspect.dirty,
         unpushed: inspect.unpushed,
         ahead: inspect.ahead,
         has_upstream: inspect.has_upstream,
         suggested_commit_message: inspect.suggested_commit_message,
-        pr,
+        pr: persisted,
         gh_found: gh.found,
         gh_authenticated: gh.authenticated,
         remediation: if gh.found && gh.authenticated == Some(true) {
@@ -402,6 +393,14 @@ pub(crate) async fn workspace_git_status(
         pushes_as: None,
         pushes_as_self: None,
     })
+}
+
+/// The `gh` binary to drive reads with, when one is present and signed in.
+pub(crate) async fn authenticated_gh_binary(search_path: Option<&str>) -> Option<PathBuf> {
+    let gh = observe_gh(search_path).await;
+    (gh.found && gh.authenticated == Some(true))
+        .then_some(gh.binary)
+        .flatten()
 }
 
 /// Create a pull request from the workspace branch. Never merges.
@@ -462,10 +461,9 @@ pub(crate) async fn create_pull_request(
         )
     })?;
     cache.invalidate(workspace_id);
-    if let Some(digest) = load_pr_digest(worktree, &gh, gh_search_path).await? {
-        cache.put(workspace_id, digest.clone());
-        return Ok(digest);
-    }
+    // A light digest from the creation answer. The caller's next status
+    // read enriches it through the conditional fetcher (decision 66), which
+    // needs exactly this URL to name the pull request.
     let url = stdout
         .lines()
         .map(str::trim)
@@ -491,7 +489,6 @@ pub(crate) async fn create_pull_request(
         auto_merge_enabled: None,
         in_merge_queue: None,
     };
-    cache.put(workspace_id, digest.clone());
     Ok(digest)
 }
 
@@ -1391,270 +1388,8 @@ fn powershell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
-const PR_VIEW_FIELDS: &str = "number,url,state,title,isDraft,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRefName,headRefOid,baseRefName";
-const PR_DIGEST_HEAD_ATTEMPTS: usize = 2;
-
-#[derive(Debug)]
-struct PrViewSnapshot {
-    digest: PullRequestDigest,
-    head_oid: Option<String>,
-}
-
-async fn load_pr_digest(
-    worktree: &Path,
-    gh: &GhObservation,
-    _search_path: Option<&str>,
-) -> Result<Option<PullRequestDigest>, GhError> {
-    let Some(binary) = gh.binary.as_ref() else {
-        return Ok(None);
-    };
-    // The old loader could spend one GH_TIMEOUT on the initial view and one
-    // on its parallel checks/queue reads. Keep that same total wall-clock
-    // bound even though a changed head now causes a bounded retry.
-    Ok(timeout(
-        PR_DIGEST_TIMEOUT,
-        load_head_consistent_pr_digest(worktree, binary),
-    )
-    .await
-    .ok()
-    .flatten())
-}
-
-async fn load_head_consistent_pr_digest(
-    worktree: &Path,
-    binary: &Path,
-) -> Option<PullRequestDigest> {
-    let mut snapshot = load_pr_view_snapshot(worktree, binary).await?;
-
-    for _ in 0..PR_DIGEST_HEAD_ATTEMPTS {
-        let number = snapshot.digest.number;
-        let open = snapshot.digest.state == "open";
-        let checks_read = run_gh(worktree, binary, &["pr", "checks"], GH_TIMEOUT);
-        let queue_read = async {
-            if open {
-                load_merge_queue_state(worktree, binary, number).await
-            } else {
-                Some(false)
-            }
-        };
-        let (checks_table, in_merge_queue) = tokio::join!(checks_read, queue_read);
-
-        let Some(verified) = load_pr_view_snapshot(worktree, binary).await else {
-            return Some(conservative_pr_digest(snapshot.digest));
-        };
-        if same_pr_head(&snapshot, &verified) {
-            let checks = parse_pr_checks(&checks_table.unwrap_or_default());
-            let mut digest = verified.digest;
-            digest.checks_summary = summarize_checks(&checks);
-            digest.checks = (!checks.is_empty()).then_some(checks);
-            digest.in_merge_queue = if digest.state == "open" {
-                in_merge_queue
-            } else {
-                Some(false)
-            };
-            return Some(digest);
-        }
-
-        snapshot = verified;
-    }
-
-    Some(conservative_pr_digest(snapshot.digest))
-}
-
-async fn load_pr_view_snapshot(worktree: &Path, binary: &Path) -> Option<PrViewSnapshot> {
-    let json = run_gh(
-        worktree,
-        binary,
-        &["pr", "view", "--json", PR_VIEW_FIELDS],
-        GH_TIMEOUT,
-    )
-    .await
-    .ok()?;
-    pr_view_snapshot_from_json(&json, "")
-}
-
-fn same_pr_head(before: &PrViewSnapshot, after: &PrViewSnapshot) -> bool {
-    before.digest.number == after.digest.number
-        && before
-            .head_oid
-            .as_deref()
-            .zip(after.head_oid.as_deref())
-            .is_some_and(|(before, after)| before == after)
-}
-
-fn conservative_pr_digest(mut digest: PullRequestDigest) -> PullRequestDigest {
-    digest.checks_summary = None;
-    digest.checks = None;
-    digest.mergeable = None;
-    digest.merge_state_status = None;
-    digest.in_merge_queue = None;
-    digest
-}
-
-async fn load_merge_queue_state(worktree: &Path, binary: &Path, number: u64) -> Option<bool> {
-    let endpoint = format!("repos/{{owner}}/{{repo}}/issues/{number}/timeline?per_page=100");
-    let events = run_gh(
-        worktree,
-        binary,
-        &[
-            "api",
-            &endpoint,
-            "--paginate",
-            "--jq",
-            ".[] | select(.event == \"added_to_merge_queue\" or .event == \"removed_from_merge_queue\") | .event",
-        ],
-        GH_TIMEOUT,
-    )
-    .await
-    .ok()?;
-    Some(in_merge_queue_from_timeline_events(&events))
-}
-
-fn in_merge_queue_from_timeline_events(events: &str) -> bool {
-    events
-        .lines()
-        .map(str::trim)
-        .rfind(|event| matches!(*event, "added_to_merge_queue" | "removed_from_merge_queue"))
-        == Some("added_to_merge_queue")
-}
-
-/// Parse one `gh pr view --json` payload plus a `gh pr checks` table into the
-/// stored digest. Every field beyond the number is optional and tolerated
-/// missing.
-#[cfg(test)]
-pub(crate) fn digest_from_view_json(json: &str, checks_table: &str) -> Option<PullRequestDigest> {
-    pr_view_snapshot_from_json(json, checks_table).map(|snapshot| snapshot.digest)
-}
-
-fn pr_view_snapshot_from_json(json: &str, checks_table: &str) -> Option<PrViewSnapshot> {
-    let parsed: serde_json::Value = serde_json::from_str(json).unwrap_or(serde_json::Value::Null);
-    let number = parsed.get("number").and_then(|value| value.as_u64())?;
-    let url = parsed
-        .get("url")
-        .and_then(|value| value.as_str())
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
-    let state = parsed
-        .get("state")
-        .and_then(|value| value.as_str())
-        .unwrap_or("open")
-        .to_ascii_lowercase();
-    let title = parsed
-        .get("title")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
-    let checks = parse_pr_checks(checks_table);
-    let lower_token = |key: &str| {
-        parsed
-            .get(key)
-            .and_then(|value| value.as_str())
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_ascii_lowercase)
-    };
-    let branch = |key: &str| {
-        parsed
-            .get(key)
-            .and_then(|value| value.as_str())
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned)
-    };
-    let head_oid = branch("headRefOid");
-    let digest = PullRequestDigest {
-        number,
-        url,
-        merged: Some(state == "merged"),
-        state,
-        title,
-        checks_summary: summarize_checks(&checks),
-        checks: if checks.is_empty() {
-            None
-        } else {
-            Some(checks)
-        },
-        draft: parsed.get("isDraft").and_then(|value| value.as_bool()),
-        review_decision: lower_token("reviewDecision"),
-        mergeable: lower_token("mergeable"),
-        merge_state_status: lower_token("mergeStateStatus"),
-        head_branch: branch("headRefName"),
-        base_branch: branch("baseRefName"),
-        head_sha: head_oid.clone(),
-        auto_merge_enabled: Some(
-            parsed
-                .get("autoMergeRequest")
-                .is_some_and(|value| !value.is_null()),
-        ),
-        in_merge_queue: None,
-    };
-    Some(PrViewSnapshot { digest, head_oid })
-}
-
-pub(crate) fn parse_pr_checks(output: &str) -> Vec<tidebreak_core::PullRequestCheck> {
-    use tidebreak_core::{PullRequestCheck, PullRequestCheckBucket};
-
-    let mut checks = Vec::new();
-    for line in output.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let lower = trimmed.to_ascii_lowercase();
-        if lower.starts_with("name\t") || lower.starts_with("check\t") {
-            continue;
-        }
-        let columns: Vec<&str> = trimmed.split('\t').collect();
-        let name = columns.first().copied().unwrap_or(trimmed).trim();
-        if name.is_empty() {
-            continue;
-        }
-        let status = columns.get(1).copied().unwrap_or(trimmed);
-        let status_lower = status.to_ascii_lowercase();
-        let bucket = if status_lower.contains("skip")
-            || status_lower.contains("neutral")
-            || status_lower.contains("cancel")
-        {
-            PullRequestCheckBucket::Skipped
-        } else if status_lower.contains("pass") || status_lower.contains("success") {
-            PullRequestCheckBucket::Pass
-        } else if status_lower.contains("fail") || status_lower.contains("error") {
-            PullRequestCheckBucket::Fail
-        } else if status_lower.contains("pend")
-            || status_lower.contains("progress")
-            || status_lower.contains("queued")
-        {
-            PullRequestCheckBucket::Pending
-        } else if lower.contains("skip") || lower.contains("neutral") || lower.contains("cancel") {
-            PullRequestCheckBucket::Skipped
-        } else if lower.contains("pass") || lower.contains("success") {
-            PullRequestCheckBucket::Pass
-        } else if lower.contains("fail") || lower.contains("error") {
-            PullRequestCheckBucket::Fail
-        } else {
-            PullRequestCheckBucket::Pending
-        };
-        let detail = columns
-            .get(1)
-            .map(|value| value.trim())
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned);
-        let url = columns
-            .iter()
-            .map(|value| value.trim())
-            .find(|value| value.starts_with("http://") || value.starts_with("https://"))
-            .map(ToOwned::to_owned);
-        checks.push(PullRequestCheck {
-            name: name.to_owned(),
-            bucket,
-            detail,
-            url,
-        });
-    }
-    checks
-}
-
+/// One line for the digest header: passing, pending, and failing counts in
+/// the order a reader triages them.
 pub(crate) fn summarize_checks(checks: &[tidebreak_core::PullRequestCheck]) -> Option<String> {
     use tidebreak_core::PullRequestCheckBucket;
 
@@ -1942,11 +1677,7 @@ pub(crate) async fn run_gh(
     args: &[&str],
     limit: Duration,
 ) -> Result<String, String> {
-    if args
-        .iter()
-        .any(|arg| *arg == "merge" || *arg == "--merge" || *arg == "--auto" || *arg == "graphql")
-        || args.windows(2).any(|pair| pair == ["api", "graphql"])
-    {
+    if refuse_gh_args(args) {
         return Err("refusing to run a merge or GraphQL gh command".into());
     }
     spawn_gh(cwd, binary, args, limit).await
@@ -2276,6 +2007,26 @@ async fn spawn_gh_with_login_env(
     args: &[&str],
     limit: Duration,
 ) -> Result<String, String> {
+    let output = spawn_gh_output(cwd, binary, login_env, args, limit).await?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if output.status.success() || args == ["pr", "checks"] {
+        // `gh pr checks` exits non-zero when checks are pending or failing;
+        // the table is still the digest we want.
+        if output.status.success() || !stdout.is_empty() {
+            return Ok(stdout);
+        }
+    }
+    Err(if stderr.is_empty() { stdout } else { stderr })
+}
+
+async fn spawn_gh_output(
+    cwd: &Path,
+    binary: &Path,
+    login_env: Option<&[(OsString, OsString)]>,
+    args: &[&str],
+    limit: Duration,
+) -> Result<std::process::Output, String> {
     let mut command = Command::new(binary);
     if let Some(login_env) = login_env {
         command.env_clear();
@@ -2296,20 +2047,110 @@ async fn spawn_gh_with_login_env(
     let child = command
         .spawn()
         .map_err(|err| format!("failed to spawn gh: {err}"))?;
-    let output = timeout(limit, child.wait_with_output())
+    timeout(limit, child.wait_with_output())
         .await
         .map_err(|_| format!("gh {} timed out", args.join(" ")))?
-        .map_err(|err| format!("gh {} failed: {err}", args.join(" ")))?;
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if output.status.success() || args == ["pr", "checks"] {
-        // `gh pr checks` exits non-zero when checks are pending or failing;
-        // the table is still the digest we want.
-        if output.status.success() || !stdout.is_empty() {
-            return Ok(stdout);
+        .map_err(|err| format!("gh {} failed: {err}", args.join(" ")))
+}
+
+/// One `gh api --include` answer: the status line, the caching and pacing
+/// headers the fetcher acts on, and the body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RawHttpResponse {
+    pub status: u16,
+    pub etag: Option<String>,
+    pub retry_after_secs: Option<u64>,
+    pub ratelimit_remaining: Option<u64>,
+    pub ratelimit_reset_epoch: Option<u64>,
+    pub body: String,
+}
+
+/// Run `gh api --include` and keep the HTTP answer whatever the exit code.
+///
+/// `gh api` exits non-zero for a 304 or a 4xx that is still a real answer
+/// this process must read — a 304 is the conditional fetcher's cheapest
+/// success, and a 403's headers say how long to park. Only a run that
+/// produced no HTTP status line at all is an error here.
+pub(crate) async fn run_gh_http(
+    cwd: &Path,
+    binary: &Path,
+    args: &[&str],
+    limit: Duration,
+) -> Result<RawHttpResponse, String> {
+    if refuse_gh_args(args) {
+        return Err("refusing to run a merge or GraphQL gh command".into());
+    }
+    let login_env = GH_LAUNCH
+        .get()
+        .filter(|launch| launch.binary == binary)
+        .and_then(|launch| launch.login_env.as_deref().map(Vec::as_slice));
+    let output = spawn_gh_output(cwd, binary, login_env, args, limit).await?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    match parse_raw_http(&stdout) {
+        Some(response) => Ok(response),
+        None => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            Err(if stderr.is_empty() {
+                format!("gh {} answered no HTTP status", args.join(" "))
+            } else {
+                stderr
+            })
         }
     }
-    Err(if stderr.is_empty() { stdout } else { stderr })
+}
+
+fn refuse_gh_args(args: &[&str]) -> bool {
+    args.iter()
+        .any(|arg| *arg == "merge" || *arg == "--merge" || *arg == "--auto" || *arg == "graphql")
+        || args.windows(2).any(|pair| pair == ["api", "graphql"])
+}
+
+/// Parse a `gh api --include` answer: status line, headers, blank line, body.
+fn parse_raw_http(stdout: &str) -> Option<RawHttpResponse> {
+    fn take_line<'a>(rest: &mut &'a str) -> &'a str {
+        let end = rest.find('\n').map_or(rest.len(), |index| index + 1);
+        let line = rest[..end].trim_end_matches(['\r', '\n']);
+        *rest = &rest[end..];
+        line
+    }
+    let mut rest = stdout;
+    let status_line = take_line(&mut rest);
+    let mut parts = status_line.split_whitespace();
+    if !parts.next()?.starts_with("HTTP/") {
+        return None;
+    }
+    let status: u16 = parts.next()?.parse().ok()?;
+    let mut etag = None;
+    let mut retry_after_secs = None;
+    let mut ratelimit_remaining = None;
+    let mut ratelimit_reset_epoch = None;
+    while !rest.is_empty() {
+        let line = take_line(&mut rest);
+        if line.is_empty() {
+            break;
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        if name.eq_ignore_ascii_case("etag") {
+            etag = Some(value.to_owned());
+        } else if name.eq_ignore_ascii_case("retry-after") {
+            retry_after_secs = value.parse().ok();
+        } else if name.eq_ignore_ascii_case("x-ratelimit-remaining") {
+            ratelimit_remaining = value.parse().ok();
+        } else if name.eq_ignore_ascii_case("x-ratelimit-reset") {
+            ratelimit_reset_epoch = value.parse().ok();
+        }
+    }
+    Some(RawHttpResponse {
+        status,
+        etag,
+        retry_after_secs,
+        ratelimit_remaining,
+        ratelimit_reset_epoch,
+        body: rest.trim().to_owned(),
+    })
 }
 
 #[cfg(all(test, unix))]
@@ -2451,11 +2292,47 @@ mod tests {
     }
 
     #[test]
+    fn raw_http_answers_parse_status_headers_and_body() {
+        let ok = parse_raw_http(
+            "HTTP/2.0 200 OK\r\nEtag: W/\"abc\"\r\nX-Ratelimit-Remaining: 4200\r\n\r\n{\"number\":12}\n",
+        )
+        .unwrap();
+        assert_eq!(ok.status, 200);
+        assert_eq!(ok.etag.as_deref(), Some("W/\"abc\""));
+        assert_eq!(ok.ratelimit_remaining, Some(4200));
+        assert_eq!(ok.body, "{\"number\":12}");
+
+        let not_modified =
+            parse_raw_http("HTTP/2.0 304 Not Modified\r\nEtag: W/\"abc\"\r\n\r\n").unwrap();
+        assert_eq!(not_modified.status, 304);
+        assert!(not_modified.body.is_empty());
+
+        let parked = parse_raw_http(
+            "HTTP/1.1 403 Forbidden\nRetry-After: 90\n\n{\"message\":\"You have exceeded a secondary rate limit\"}",
+        )
+        .unwrap();
+        assert_eq!(parked.status, 403);
+        assert_eq!(parked.retry_after_secs, Some(90));
+
+        assert!(parse_raw_http("gh: command not found").is_none());
+        assert!(parse_raw_http("").is_none());
+    }
+
+    #[test]
     fn checks_summary_counts_buckets() {
-        let table = "lint\tpass\t1s\thttps://example.test/lint\ntest\tpending\t0\thttps://example.test/test\nfmt\tfail\t2s\thttps://example.test/fmt\nrelease\tskipping\t0\thttps://example.test/release\n";
-        let checks = parse_pr_checks(table);
-        assert_eq!(checks.len(), 4);
-        assert_eq!(checks[0].name, "lint");
+        use tidebreak_core::{PullRequestCheck, PullRequestCheckBucket};
+        let check = |name: &str, bucket: PullRequestCheckBucket| PullRequestCheck {
+            name: name.into(),
+            bucket,
+            detail: None,
+            url: None,
+        };
+        let checks = vec![
+            check("lint", PullRequestCheckBucket::Pass),
+            check("test", PullRequestCheckBucket::Pending),
+            check("fmt", PullRequestCheckBucket::Fail),
+            check("release", PullRequestCheckBucket::Skipped),
+        ];
         assert_eq!(
             summarize_checks(&checks).as_deref(),
             Some("1 passing, 1 pending, 1 failing, 1 skipped")
@@ -2729,7 +2606,7 @@ exit 3
     }
 
     #[tokio::test]
-    async fn create_pr_uses_view_and_checks_and_never_merges() {
+    async fn create_pr_returns_the_creation_stub_and_never_merges() {
         let (_dir, work, _bare) = init_paired_repos();
         run(&work, &["git", "checkout", "-b", "tidebreak/first-change"]);
         std::fs::write(work.join("extra.txt"), "line\n").unwrap();
@@ -2788,10 +2665,10 @@ exit 3
             Some("https://github.com/example/demo/pull/12")
         );
         assert_eq!(digest.state, "open");
-        assert_eq!(
-            digest.checks_summary.as_deref(),
-            Some("1 passing, 0 pending, 0 failing")
-        );
+        // The creation answer is a stub: the conditional fetcher (decision
+        // 66) enriches it on the caller's next status read, so creation
+        // itself pays no view, checks, or timeline read.
+        assert_eq!(digest.checks_summary, None);
         let logged = std::fs::read_to_string(&log).unwrap();
         assert!(logged.contains("pr create"), "{logged}");
         assert!(
@@ -2799,10 +2676,8 @@ exit 3
             "gh pr create must target the workspace base, not the host default: {logged}"
         );
         assert!(!logged.contains("--base origin/main"), "{logged}");
-        assert!(logged.contains("pr view"), "{logged}");
-        assert!(logged.contains("pr checks"), "{logged}");
-        // The view field list legitimately names mergeable/autoMergeRequest;
-        // what may never appear is a merge invocation or flag.
+        assert!(!logged.contains("pr view"), "{logged}");
+        assert!(!logged.contains("pr checks"), "{logged}");
         assert!(!logged.contains("pr merge"), "{logged}");
         assert!(!logged.contains("--merge"), "{logged}");
         assert!(!logged.contains("--auto"), "{logged}");
@@ -3036,225 +2911,6 @@ exit 3
             classify_merge_error("something else entirely".into()),
             GhError::User(_)
         ));
-    }
-
-    #[test]
-    fn rich_pr_view_json_maps_to_digest() {
-        let json = r#"{
-            "number": 12,
-            "url": "https://github.com/example/demo/pull/12",
-            "state": "OPEN",
-            "title": "feat: first change",
-            "isDraft": true,
-            "reviewDecision": "CHANGES_REQUESTED",
-            "mergeable": "MERGEABLE",
-            "mergeStateStatus": "BLOCKED",
-            "autoMergeRequest": {"enabledAt": "2026-08-17T00:00:00Z"},
-            "headRefName": "tidebreak/first-change",
-            "headRefOid": "aaaaaaaa",
-            "baseRefName": "main"
-        }"#;
-        let digest = digest_from_view_json(json, "lint\tpass\t1s\n").unwrap();
-        assert_eq!(digest.number, 12);
-        assert_eq!(digest.state, "open");
-        assert_eq!(digest.draft, Some(true));
-        assert_eq!(digest.merged, Some(false));
-        assert_eq!(digest.review_decision.as_deref(), Some("changes_requested"));
-        assert_eq!(digest.mergeable.as_deref(), Some("mergeable"));
-        assert_eq!(digest.merge_state_status.as_deref(), Some("blocked"));
-        assert_eq!(
-            digest.head_branch.as_deref(),
-            Some("tidebreak/first-change")
-        );
-        assert_eq!(digest.base_branch.as_deref(), Some("main"));
-        assert_eq!(digest.auto_merge_enabled, Some(true));
-        assert_eq!(digest.in_merge_queue, None);
-        assert_eq!(
-            digest.checks_summary.as_deref(),
-            Some("1 passing, 0 pending, 0 failing")
-        );
-
-        // Older gh output without the extra fields still yields a digest, and
-        // a merged state is reflected in both `state` and `merged`.
-        let sparse = digest_from_view_json(
-            r#"{"number": 7, "state": "MERGED", "autoMergeRequest": null}"#,
-            "",
-        )
-        .unwrap();
-        assert_eq!(sparse.state, "merged");
-        assert_eq!(sparse.merged, Some(true));
-        assert_eq!(sparse.draft, None);
-        assert_eq!(sparse.review_decision, None);
-        assert_eq!(sparse.auto_merge_enabled, Some(false));
-        assert_eq!(sparse.in_merge_queue, None);
-        assert!(digest_from_view_json("not json", "").is_none());
-    }
-
-    #[test]
-    fn pr_view_snapshot_retains_head_oid_for_consistency_checks() {
-        let snapshot = pr_view_snapshot_from_json(
-            r#"{
-                "number": 12,
-                "state": "OPEN",
-                "mergeable": "MERGEABLE",
-                "mergeStateStatus": "CLEAN",
-                "headRefOid": "abcdef123456"
-            }"#,
-            "lint\tpass\t1s\n",
-        )
-        .unwrap();
-
-        assert_eq!(snapshot.head_oid.as_deref(), Some("abcdef123456"));
-        assert_eq!(snapshot.digest.mergeable.as_deref(), Some("mergeable"));
-        assert_eq!(
-            snapshot.digest.checks_summary.as_deref(),
-            Some("1 passing, 0 pending, 0 failing")
-        );
-    }
-
-    #[tokio::test]
-    async fn pr_digest_retries_when_the_head_changes_during_auxiliary_reads() {
-        let work = TempDir::new().unwrap();
-        let shim_dir = TempDir::new().unwrap();
-        let view_count = shim_dir.path().join("view-count");
-        let checks_count = shim_dir.path().join("checks-count");
-        write_executable(
-            &shim_dir.path().join("gh"),
-            &format!(
-                r#"#!/bin/sh
-if [ "$1" = pr ] && [ "$2" = view ]; then
-  count=0
-  if [ -f {view_count} ]; then count=$(sed -n '1p' {view_count}); fi
-  count=$((count + 1))
-  printf '%s\n' "$count" > {view_count}
-  if [ "$count" -eq 1 ]; then
-    echo '{{"number":12,"state":"OPEN","title":"old head","mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","headRefOid":"aaaaaaaa"}}'
-  else
-    echo '{{"number":12,"state":"OPEN","title":"new head","mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","headRefOid":"bbbbbbbb"}}'
-  fi
-  exit 0
-fi
-if [ "$1" = pr ] && [ "$2" = checks ]; then
-  count=0
-  if [ -f {checks_count} ]; then count=$(sed -n '1p' {checks_count}); fi
-  count=$((count + 1))
-  printf '%s\n' "$count" > {checks_count}
-  if [ "$count" -eq 1 ]; then
-    printf 'old-head-check\tpass\t1s\thttps://example.test/old\n'
-  else
-    printf 'new-head-check\tfail\t1s\thttps://example.test/new\n'
-  fi
-  exit 0
-fi
-if [ "$1" = api ]; then
-  echo added_to_merge_queue
-  exit 0
-fi
-echo unexpected "$@" >&2
-exit 3
-"#,
-                view_count = shell_single_quote(&view_count.to_string_lossy()),
-                checks_count = shell_single_quote(&checks_count.to_string_lossy()),
-            ),
-        );
-        let gh = GhObservation {
-            found: true,
-            authenticated: Some(true),
-            viewer_login: None,
-            binary: Some(shim_dir.path().join("gh")),
-            remediation: String::new(),
-        };
-
-        let digest = load_pr_digest(work.path(), &gh, None)
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(digest.title.as_deref(), Some("new head"));
-        assert_eq!(digest.mergeable.as_deref(), Some("conflicting"));
-        assert_eq!(digest.merge_state_status.as_deref(), Some("dirty"));
-        assert_eq!(
-            digest.checks_summary.as_deref(),
-            Some("0 passing, 0 pending, 1 failing")
-        );
-        assert_eq!(
-            digest
-                .checks
-                .as_deref()
-                .and_then(|checks| checks.first())
-                .map(|check| check.name.as_str()),
-            Some("new-head-check")
-        );
-        assert_eq!(digest.in_merge_queue, Some(true));
-        assert_eq!(std::fs::read_to_string(view_count).unwrap().trim(), "3");
-        assert_eq!(std::fs::read_to_string(checks_count).unwrap().trim(), "2");
-    }
-
-    #[tokio::test]
-    async fn pr_digest_stays_conservative_when_the_head_keeps_changing() {
-        let work = TempDir::new().unwrap();
-        let shim_dir = TempDir::new().unwrap();
-        let view_count = shim_dir.path().join("view-count");
-        write_executable(
-            &shim_dir.path().join("gh"),
-            &format!(
-                r#"#!/bin/sh
-if [ "$1" = pr ] && [ "$2" = view ]; then
-  count=0
-  if [ -f {view_count} ]; then count=$(sed -n '1p' {view_count}); fi
-  count=$((count + 1))
-  printf '%s\n' "$count" > {view_count}
-  echo "{{\"number\":12,\"state\":\"OPEN\",\"title\":\"head $count\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"head-$count\"}}"
-  exit 0
-fi
-if [ "$1" = pr ] && [ "$2" = checks ]; then
-  printf 'lint\tpass\t1s\thttps://example.test/lint\n'
-  exit 0
-fi
-if [ "$1" = api ]; then
-  echo added_to_merge_queue
-  exit 0
-fi
-echo unexpected "$@" >&2
-exit 3
-"#,
-                view_count = shell_single_quote(&view_count.to_string_lossy()),
-            ),
-        );
-        let gh = GhObservation {
-            found: true,
-            authenticated: Some(true),
-            viewer_login: None,
-            binary: Some(shim_dir.path().join("gh")),
-            remediation: String::new(),
-        };
-
-        let digest = load_pr_digest(work.path(), &gh, None)
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(digest.title.as_deref(), Some("head 3"));
-        assert_eq!(digest.mergeable, None);
-        assert_eq!(digest.merge_state_status, None);
-        assert_eq!(digest.checks_summary, None);
-        assert_eq!(digest.checks, None);
-        assert_eq!(digest.in_merge_queue, None);
-        assert_eq!(std::fs::read_to_string(view_count).unwrap().trim(), "3");
-    }
-
-    #[test]
-    fn merge_queue_timeline_uses_the_latest_transition() {
-        assert!(in_merge_queue_from_timeline_events(
-            "added_to_merge_queue\n"
-        ));
-        assert!(!in_merge_queue_from_timeline_events(
-            "added_to_merge_queue\nremoved_from_merge_queue\n"
-        ));
-        assert!(in_merge_queue_from_timeline_events(
-            "removed_from_merge_queue\nadded_to_merge_queue\n"
-        ));
-        assert!(!in_merge_queue_from_timeline_events(""));
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod fork;
 pub(crate) mod gh;
 pub(crate) mod harness_install;
 pub(crate) mod pr_facts;
+pub(crate) mod pr_fetch;
 pub(crate) mod recap;
 pub(crate) mod reconcile;
 pub(crate) mod recovery;

--- a/crates/tidebreak-server/src/code/pr_fetch.rs
+++ b/crates/tidebreak-server/src/code/pr_fetch.rs
@@ -1,0 +1,918 @@
+//! One conditional REST fetcher for pull-request state (decision 66).
+//!
+//! Every background pull-request read runs through here: one `gh api` read
+//! of the pull request, one of its head's check runs, one of its reviews,
+//! and — only for base branches observed to run a merge queue — one
+//! timeline read for queue membership. Each read sends the stored ETag, so
+//! an unchanged answer is a 304 that GitHub does not count against the
+//! primary rate limit: sustained cost tracks how often pull requests
+//! change, not how often Tidebreak asks.
+//!
+//! One [`HostGate`] paces every call. It holds a small global concurrency,
+//! spaces requests per host, and treats a secondary-rate-limit answer or a
+//! `Retry-After` header as an order: the host parks for the stated window
+//! and every caller respects the park rather than retrying hot.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::Value;
+
+use tidebreak_core::{
+    CodePullRequestFact, CodePullRequestState, PullRequestCheck, PullRequestCheckBucket,
+    PullRequestDigest,
+};
+
+use super::gh::{run_gh, run_gh_http, summarize_checks, RawHttpResponse};
+
+/// Ceiling on concurrent GitHub reads through the gate, across every host.
+const GATE_PERMITS: usize = 4;
+/// Minimum spacing between two gated reads of the same host.
+const HOST_SPACING: Duration = Duration::from_millis(250);
+/// Park applied when a limit answer names no `Retry-After`.
+const DEFAULT_PARK: Duration = Duration::from_secs(60);
+/// Ceiling on any park, so one hostile header cannot silence a host for
+/// hours.
+const MAX_PARK: Duration = Duration::from_secs(15 * 60);
+/// Bound on one `gh api` call — the same bound the general runner uses.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Pace and park GitHub reads, one state per host (decision 66).
+#[derive(Debug)]
+pub(crate) struct HostGate {
+    permits: Arc<tokio::sync::Semaphore>,
+    hosts: Mutex<HashMap<String, HostState>>,
+}
+
+#[derive(Debug, Default)]
+struct HostState {
+    parked_until: Option<tokio::time::Instant>,
+    next_slot: Option<tokio::time::Instant>,
+}
+
+impl Default for HostGate {
+    fn default() -> Self {
+        Self {
+            permits: Arc::new(tokio::sync::Semaphore::new(GATE_PERMITS)),
+            hosts: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl HostGate {
+    /// Admission to speak to `host`: waits out the per-host spacing, then
+    /// takes a global permit. `Err` carries how much park remains — the
+    /// caller skips its read and keeps whatever state it already holds.
+    pub(crate) async fn admit(&self, host: &str) -> Result<GatePermit, Duration> {
+        let slot = {
+            let mut hosts = self.hosts.lock().expect("host gate");
+            let state = hosts.entry(host.to_ascii_lowercase()).or_default();
+            let now = tokio::time::Instant::now();
+            if let Some(until) = state.parked_until {
+                if until > now {
+                    return Err(until - now);
+                }
+                state.parked_until = None;
+            }
+            let slot = state.next_slot.map_or(now, |next| next.max(now));
+            state.next_slot = Some(slot + HOST_SPACING);
+            slot
+        };
+        tokio::time::sleep_until(slot).await;
+        {
+            let hosts = self.hosts.lock().expect("host gate");
+            if let Some(state) = hosts.get(&host.to_ascii_lowercase()) {
+                if let Some(until) = state.parked_until {
+                    let now = tokio::time::Instant::now();
+                    if until > now {
+                        return Err(until - now);
+                    }
+                }
+            }
+        }
+        let permit = Arc::clone(&self.permits)
+            .acquire_owned()
+            .await
+            .map_err(|_| Duration::ZERO)?;
+        Ok(GatePermit { _permit: permit })
+    }
+
+    /// Park every read of `host` for `duration`, capped at [`MAX_PARK`].
+    pub(crate) fn park(&self, host: &str, duration: Duration) {
+        let duration = duration.min(MAX_PARK);
+        let until = tokio::time::Instant::now() + duration;
+        let mut hosts = self.hosts.lock().expect("host gate");
+        let state = hosts.entry(host.to_ascii_lowercase()).or_default();
+        if state.parked_until.is_none_or(|current| current < until) {
+            state.parked_until = Some(until);
+        }
+    }
+}
+
+/// Held for the duration of one gated read.
+#[derive(Debug)]
+pub(crate) struct GatePermit {
+    _permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+/// Why a gated read produced nothing.
+#[derive(Debug)]
+pub(crate) enum FetchFailure {
+    /// The host is parked; retry after the carried duration.
+    Parked(Duration),
+    /// The host answered with a status the caller cannot act on.
+    Refused(u16, String),
+    /// The subprocess itself failed: spawn, timeout, or no HTTP answer.
+    Transport(String),
+}
+
+impl std::fmt::Display for FetchFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parked(remaining) => {
+                write!(f, "the host is parked for {}s", remaining.as_secs())
+            }
+            Self::Refused(status, message) => write!(f, "the host answered {status}: {message}"),
+            Self::Transport(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+/// One conditional endpoint read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EndpointRead<T> {
+    /// A 200 with new state and the ETag to send next time.
+    Fresh { value: T, etag: Option<String> },
+    /// A 304: whatever the caller stored still stands.
+    NotModified,
+    /// A 404: the resource is gone or never existed.
+    Missing,
+}
+
+/// The digest-relevant fields of one REST pull request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RestPull {
+    pub number: u64,
+    pub url: Option<String>,
+    pub state: String,
+    pub title: Option<String>,
+    pub draft: Option<bool>,
+    pub mergeable: Option<String>,
+    pub merge_state_status: Option<String>,
+    pub head_branch: Option<String>,
+    pub base_branch: Option<String>,
+    pub head_sha: Option<String>,
+    pub auto_merge_enabled: Option<bool>,
+}
+
+/// What one review aggregation says, in the lowercased vocabulary
+/// `gh pr view --json reviewDecision` used to supply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReviewTally {
+    pub approvals: u64,
+    pub changes_requested: u64,
+}
+
+/// What the base branch's rules say about merging (decision 66): whether
+/// reviews are required, and whether a merge queue runs — the one signal
+/// that decides if the timeline read is worth paying.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BranchRules {
+    pub required_approvals: u64,
+    pub has_merge_queue: bool,
+}
+
+/// GET `repos/{owner}/{name}/pulls/{number}`, conditionally.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn read_pull_request(
+    gate: &HostGate,
+    cwd: &Path,
+    binary: &Path,
+    host: &str,
+    owner: &str,
+    name: &str,
+    number: u64,
+    etag: Option<&str>,
+) -> Result<EndpointRead<RestPull>, FetchFailure> {
+    let path = format!("repos/{owner}/{name}/pulls/{number}");
+    let response = gated_read(gate, cwd, binary, host, &path, etag).await?;
+    match response.status {
+        200 => match rest_pull_from_value(&parse_body(&response)?) {
+            Some(pull) => Ok(EndpointRead::Fresh {
+                value: pull,
+                etag: response.etag,
+            }),
+            None => Err(FetchFailure::Transport(
+                "the pull request answer carried no number".into(),
+            )),
+        },
+        304 => Ok(EndpointRead::NotModified),
+        404 => Ok(EndpointRead::Missing),
+        status => Err(FetchFailure::Refused(status, bounded_body(&response))),
+    }
+}
+
+/// GET `repos/{owner}/{name}/pulls?head=...`: the branch's current pull
+/// request, when the workspace does not know one yet. The open one wins;
+/// the newest closed one answers otherwise — the same resolution
+/// `gh pr view` applied to a branch.
+pub(crate) async fn read_pull_request_for_head(
+    gate: &HostGate,
+    cwd: &Path,
+    binary: &Path,
+    host: &str,
+    owner: &str,
+    name: &str,
+    branch: &str,
+) -> Result<Option<RestPull>, FetchFailure> {
+    let path = format!("repos/{owner}/{name}/pulls?head={owner}:{branch}&state=all&per_page=10");
+    let response = gated_read(gate, cwd, binary, host, &path, None).await?;
+    match response.status {
+        200 => {
+            let listed = parse_body(&response)?;
+            let empty = Vec::new();
+            let listed = listed.as_array().unwrap_or(&empty);
+            let current = listed
+                .iter()
+                .find(|value| value.get("state").and_then(Value::as_str) == Some("open"))
+                .or_else(|| listed.first());
+            Ok(current.and_then(rest_pull_from_value))
+        }
+        404 => Ok(None),
+        status => Err(FetchFailure::Refused(status, bounded_body(&response))),
+    }
+}
+
+/// GET `repos/{owner}/{name}/commits/{sha}/check-runs`, conditionally.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn read_check_runs(
+    gate: &HostGate,
+    cwd: &Path,
+    binary: &Path,
+    host: &str,
+    owner: &str,
+    name: &str,
+    sha: &str,
+    etag: Option<&str>,
+) -> Result<EndpointRead<Vec<PullRequestCheck>>, FetchFailure> {
+    let path = format!("repos/{owner}/{name}/commits/{sha}/check-runs?per_page=100");
+    let response = gated_read(gate, cwd, binary, host, &path, etag).await?;
+    match response.status {
+        200 => {
+            let value = parse_body(&response)?;
+            Ok(EndpointRead::Fresh {
+                value: checks_from_value(&value),
+                etag: response.etag,
+            })
+        }
+        304 => Ok(EndpointRead::NotModified),
+        404 => Ok(EndpointRead::Missing),
+        status => Err(FetchFailure::Refused(status, bounded_body(&response))),
+    }
+}
+
+/// GET `repos/{owner}/{name}/pulls/{number}/reviews`, conditionally.
+///
+/// One page of one hundred: a pull request with more reviews than that has
+/// long since answered the only question this read asks.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn read_reviews(
+    gate: &HostGate,
+    cwd: &Path,
+    binary: &Path,
+    host: &str,
+    owner: &str,
+    name: &str,
+    number: u64,
+    etag: Option<&str>,
+) -> Result<EndpointRead<ReviewTally>, FetchFailure> {
+    let path = format!("repos/{owner}/{name}/pulls/{number}/reviews?per_page=100");
+    let response = gated_read(gate, cwd, binary, host, &path, etag).await?;
+    match response.status {
+        200 => {
+            let value = parse_body(&response)?;
+            Ok(EndpointRead::Fresh {
+                value: tally_reviews(&value),
+                etag: response.etag,
+            })
+        }
+        304 => Ok(EndpointRead::NotModified),
+        404 => Ok(EndpointRead::Missing),
+        status => Err(FetchFailure::Refused(status, bounded_body(&response))),
+    }
+}
+
+/// GET `repos/{owner}/{name}/rules/branches/{branch}`: what merging into
+/// this branch requires. `Missing` on hosts that predate rulesets.
+pub(crate) async fn read_branch_rules(
+    gate: &HostGate,
+    cwd: &Path,
+    binary: &Path,
+    host: &str,
+    owner: &str,
+    name: &str,
+    branch: &str,
+) -> Result<EndpointRead<BranchRules>, FetchFailure> {
+    let path = format!("repos/{owner}/{name}/rules/branches/{branch}");
+    let response = gated_read(gate, cwd, binary, host, &path, None).await?;
+    match response.status {
+        200 => {
+            let value = parse_body(&response)?;
+            Ok(EndpointRead::Fresh {
+                value: rules_from_value(&value),
+                etag: response.etag,
+            })
+        }
+        304 => Ok(EndpointRead::NotModified),
+        404 => Ok(EndpointRead::Missing),
+        status => Err(FetchFailure::Refused(status, bounded_body(&response))),
+    }
+}
+
+/// Whether the pull request sits in a merge queue, from the same timeline
+/// events the retired `gh` loader read. Paid only for base branches whose
+/// rules run a queue. `None` when the read fails: the digest states
+/// nothing rather than guessing.
+pub(crate) async fn read_merge_queue_membership(
+    gate: &HostGate,
+    cwd: &Path,
+    binary: &Path,
+    host: &str,
+    owner: &str,
+    name: &str,
+    number: u64,
+) -> Option<bool> {
+    let _permit = gate.admit(host).await.ok()?;
+    let path = format!("repos/{owner}/{name}/issues/{number}/timeline?per_page=100");
+    let mut args = vec!["api"];
+    let hostname = host_argument(host);
+    if let Some(hostname) = &hostname {
+        args.extend(["--hostname", hostname.as_str()]);
+    }
+    args.extend([
+        path.as_str(),
+        "--paginate",
+        "--jq",
+        ".[] | select(.event == \"added_to_merge_queue\" or .event == \"removed_from_merge_queue\") | .event",
+    ]);
+    let events = run_gh(cwd, binary, &args, FETCH_TIMEOUT).await.ok()?;
+    Some(queue_membership_from_events(&events))
+}
+
+/// The latest queue transition wins: a pull request added and then removed
+/// is out, whatever order history reports the rest in.
+fn queue_membership_from_events(events: &str) -> bool {
+    events
+        .lines()
+        .map(str::trim)
+        .rfind(|event| matches!(*event, "added_to_merge_queue" | "removed_from_merge_queue"))
+        == Some("added_to_merge_queue")
+}
+
+/// The `reviewDecision` word the classifier already reads, derived from the
+/// branch rules and the review tally. `review_required` needs the rules to
+/// actually require approvals; without rules, approvals and objections
+/// still speak, and silence stays `None`.
+pub(crate) fn derive_review_decision(
+    rules: Option<BranchRules>,
+    tally: &ReviewTally,
+) -> Option<String> {
+    if tally.changes_requested > 0 {
+        return Some("changes_requested".to_owned());
+    }
+    match rules {
+        Some(rules) if rules.required_approvals > 0 => {
+            if tally.approvals >= rules.required_approvals {
+                Some("approved".to_owned())
+            } else {
+                Some("review_required".to_owned())
+            }
+        }
+        _ => (tally.approvals > 0).then(|| "approved".to_owned()),
+    }
+}
+
+/// Assemble the digest one refresh produced: the pull request's own fields,
+/// the checks read for its exact head, the derived review decision, and
+/// queue membership when it was worth reading.
+pub(crate) fn digest_from_parts(
+    pull: &RestPull,
+    checks: &[PullRequestCheck],
+    review_decision: Option<String>,
+    in_merge_queue: Option<bool>,
+) -> PullRequestDigest {
+    PullRequestDigest {
+        number: pull.number,
+        url: pull.url.clone(),
+        state: pull.state.clone(),
+        title: pull.title.clone(),
+        checks_summary: summarize_checks(checks),
+        checks: (!checks.is_empty()).then(|| checks.to_vec()),
+        draft: pull.draft,
+        merged: Some(pull.state == "merged"),
+        review_decision,
+        mergeable: pull.mergeable.clone(),
+        merge_state_status: pull.merge_state_status.clone(),
+        head_branch: pull.head_branch.clone(),
+        base_branch: pull.base_branch.clone(),
+        head_sha: pull.head_sha.clone(),
+        auto_merge_enabled: pull.auto_merge_enabled,
+        in_merge_queue: if pull.state == "open" {
+            in_merge_queue
+        } else {
+            Some(false)
+        },
+    }
+}
+
+/// One gated conditional GET of `path` on `host`.
+async fn gated_read(
+    gate: &HostGate,
+    cwd: &Path,
+    binary: &Path,
+    host: &str,
+    path: &str,
+    etag: Option<&str>,
+) -> Result<RawHttpResponse, FetchFailure> {
+    let _permit = gate.admit(host).await.map_err(FetchFailure::Parked)?;
+    let mut args = vec!["api", "--include"];
+    let hostname = host_argument(host);
+    if let Some(hostname) = &hostname {
+        args.extend(["--hostname", hostname.as_str()]);
+    }
+    let conditional = etag.map(|etag| format!("If-None-Match: {etag}"));
+    if let Some(conditional) = &conditional {
+        args.extend(["-H", conditional.as_str()]);
+    }
+    args.push(path);
+    let response = run_gh_http(cwd, binary, &args, FETCH_TIMEOUT)
+        .await
+        .map_err(FetchFailure::Transport)?;
+    apply_limit_answer(gate, host, &response);
+    Ok(response)
+}
+
+/// Park the host when the answer orders it: a `Retry-After`, a secondary
+/// rate limit, or an exhausted primary window.
+fn apply_limit_answer(gate: &HostGate, host: &str, response: &RawHttpResponse) {
+    if response.status != 403 && response.status != 429 {
+        return;
+    }
+    if let Some(seconds) = response.retry_after_secs {
+        gate.park(host, Duration::from_secs(seconds.max(1)));
+        return;
+    }
+    if response.ratelimit_remaining == Some(0) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let wait = response
+            .ratelimit_reset_epoch
+            .and_then(|reset| reset.checked_sub(now))
+            .unwrap_or(DEFAULT_PARK.as_secs());
+        gate.park(host, Duration::from_secs(wait.max(1)));
+        return;
+    }
+    if response.body.to_ascii_lowercase().contains("rate limit") {
+        gate.park(host, DEFAULT_PARK);
+    }
+}
+
+/// `gh api --hostname` argument for a non-default forge host.
+fn host_argument(host: &str) -> Option<String> {
+    let lowered = host.to_ascii_lowercase();
+    (lowered != "github.com" && lowered != "www.github.com" && !lowered.is_empty())
+        .then_some(lowered)
+}
+
+fn parse_body(response: &RawHttpResponse) -> Result<Value, FetchFailure> {
+    serde_json::from_str(&response.body)
+        .map_err(|err| FetchFailure::Transport(format!("the answer was not JSON: {err}")))
+}
+
+fn bounded_body(response: &RawHttpResponse) -> String {
+    let message = serde_json::from_str::<Value>(&response.body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("message")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_else(|| response.body.clone());
+    let mut bounded: String = message.chars().take(200).collect();
+    if bounded.len() < message.len() {
+        bounded.push('…');
+    }
+    bounded
+}
+
+/// The same digest-relevant fields, projected from a stored fact row when a
+/// 304 says nothing moved since the row was written.
+pub(crate) fn rest_pull_from_fact(fact: &CodePullRequestFact) -> RestPull {
+    let live = fact.live.as_ref();
+    RestPull {
+        number: fact.number,
+        url: Some(fact.url.clone()),
+        state: match fact.state {
+            CodePullRequestState::Open => "open",
+            CodePullRequestState::Merged => "merged",
+            CodePullRequestState::Closed => "closed",
+        }
+        .to_owned(),
+        title: Some(fact.title.clone()),
+        draft: Some(fact.draft),
+        mergeable: live.and_then(|live| live.mergeable.clone()),
+        merge_state_status: live.and_then(|live| live.merge_state_status.clone()),
+        head_branch: (!fact.head_branch.is_empty()).then(|| fact.head_branch.clone()),
+        base_branch: (!fact.base_branch.is_empty()).then(|| fact.base_branch.clone()),
+        head_sha: fact.head_sha.clone(),
+        auto_merge_enabled: live.and_then(|live| live.auto_merge_enabled),
+    }
+}
+
+/// The digest-relevant fields of one REST pull request value, in the same
+/// mapping the hosted forge reader applies (`forge_rest`).
+pub(crate) fn rest_pull_from_value(value: &Value) -> Option<RestPull> {
+    let number = value.get("number").and_then(Value::as_u64)?;
+    let text = |pointer: &str| {
+        value
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(ToOwned::to_owned)
+    };
+    let state = if value.get("merged").and_then(Value::as_bool) == Some(true)
+        || value
+            .get("merged_at")
+            .is_some_and(|merged| !merged.is_null())
+    {
+        "merged".to_owned()
+    } else {
+        value
+            .get("state")
+            .and_then(Value::as_str)
+            .unwrap_or("open")
+            .to_ascii_lowercase()
+    };
+    Some(RestPull {
+        number,
+        url: text("/html_url"),
+        state,
+        title: text("/title"),
+        draft: value.get("draft").and_then(Value::as_bool),
+        mergeable: match value.get("mergeable") {
+            Some(Value::Bool(true)) => Some("mergeable".to_owned()),
+            Some(Value::Bool(false)) => Some("conflicting".to_owned()),
+            _ => None,
+        },
+        merge_state_status: text("/mergeable_state").map(|status| status.to_ascii_lowercase()),
+        head_branch: text("/head/ref"),
+        base_branch: text("/base/ref"),
+        head_sha: text("/head/sha"),
+        auto_merge_enabled: Some(
+            value
+                .get("auto_merge")
+                .is_some_and(|armed| !armed.is_null()),
+        ),
+    })
+}
+
+/// One head's check runs, bucketed exactly as the hosted forge reader
+/// buckets them.
+fn checks_from_value(value: &Value) -> Vec<PullRequestCheck> {
+    let empty = Vec::new();
+    let runs = value
+        .get("check_runs")
+        .and_then(Value::as_array)
+        .unwrap_or(&empty);
+    runs.iter()
+        .filter_map(|run| {
+            let name = run.get("name").and_then(Value::as_str)?.to_owned();
+            let conclusion = run.get("conclusion").and_then(Value::as_str);
+            let bucket = match conclusion {
+                Some("success") => PullRequestCheckBucket::Pass,
+                Some("neutral" | "cancelled" | "skipped") => PullRequestCheckBucket::Skipped,
+                Some(_) => PullRequestCheckBucket::Fail,
+                None => PullRequestCheckBucket::Pending,
+            };
+            let detail = conclusion
+                .or_else(|| run.get("status").and_then(Value::as_str))
+                .map(ToOwned::to_owned);
+            let url = run
+                .get("html_url")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            Some(PullRequestCheck {
+                name,
+                bucket,
+                detail,
+                url,
+            })
+        })
+        .collect()
+}
+
+/// Each reviewer's newest standing review, tallied. `COMMENTED` never moves
+/// a reviewer's standing, and a dismissal clears it.
+fn tally_reviews(value: &Value) -> ReviewTally {
+    let empty = Vec::new();
+    let reviews = value.as_array().unwrap_or(&empty);
+    let mut standing: HashMap<String, &str> = HashMap::new();
+    for review in reviews {
+        let Some(user) = review.pointer("/user/login").and_then(Value::as_str) else {
+            continue;
+        };
+        match review.get("state").and_then(Value::as_str) {
+            Some(state @ ("APPROVED" | "CHANGES_REQUESTED")) => {
+                standing.insert(user.to_owned(), state);
+            }
+            Some("DISMISSED") => {
+                standing.remove(user);
+            }
+            _ => {}
+        }
+    }
+    let approvals = standing
+        .values()
+        .filter(|state| **state == "APPROVED")
+        .count() as u64;
+    let changes_requested = standing
+        .values()
+        .filter(|state| **state == "CHANGES_REQUESTED")
+        .count() as u64;
+    ReviewTally {
+        approvals,
+        changes_requested,
+    }
+}
+
+/// What the branch's rules require, from the rules array the endpoint
+/// answers with.
+fn rules_from_value(value: &Value) -> BranchRules {
+    let empty = Vec::new();
+    let rules = value.as_array().unwrap_or(&empty);
+    let mut required_approvals = 0;
+    let mut has_merge_queue = false;
+    for rule in rules {
+        match rule.get("type").and_then(Value::as_str) {
+            Some("pull_request") => {
+                required_approvals = required_approvals.max(
+                    rule.pointer("/parameters/required_approving_review_count")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0),
+                );
+            }
+            Some("merge_queue") => {
+                has_merge_queue = true;
+            }
+            _ => {}
+        }
+    }
+    BranchRules {
+        required_approvals,
+        has_merge_queue,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_rest_pull_request_maps_to_digest_fields() {
+        let pull = rest_pull_from_value(&serde_json::json!({
+            "number": 12,
+            "html_url": "https://github.com/acme/demo/pull/12",
+            "state": "open",
+            "title": "Add the thing",
+            "draft": false,
+            "mergeable": true,
+            "mergeable_state": "BLOCKED",
+            "head": { "ref": "feature", "sha": "abc123" },
+            "base": { "ref": "main" },
+            "auto_merge": { "merge_method": "squash" },
+        }))
+        .unwrap();
+        assert_eq!(pull.number, 12);
+        assert_eq!(pull.state, "open");
+        assert_eq!(pull.mergeable.as_deref(), Some("mergeable"));
+        assert_eq!(pull.merge_state_status.as_deref(), Some("blocked"));
+        assert_eq!(pull.head_sha.as_deref(), Some("abc123"));
+        assert_eq!(pull.auto_merge_enabled, Some(true));
+
+        let merged = rest_pull_from_value(&serde_json::json!({
+            "number": 12,
+            "state": "closed",
+            "merged_at": "2026-08-24T11:00:00Z",
+        }))
+        .unwrap();
+        assert_eq!(merged.state, "merged");
+    }
+
+    #[test]
+    fn review_standing_keeps_each_reviewers_newest_word() {
+        let tally = tally_reviews(&serde_json::json!([
+            { "user": { "login": "ada" }, "state": "CHANGES_REQUESTED" },
+            { "user": { "login": "ada" }, "state": "APPROVED" },
+            { "user": { "login": "brin" }, "state": "APPROVED" },
+            { "user": { "login": "brin" }, "state": "DISMISSED" },
+            { "user": { "login": "cody" }, "state": "COMMENTED" },
+        ]));
+        assert_eq!(
+            tally,
+            ReviewTally {
+                approvals: 1,
+                changes_requested: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn review_decision_speaks_the_classifier_vocabulary() {
+        let rules = Some(BranchRules {
+            required_approvals: 1,
+            has_merge_queue: false,
+        });
+        let none = ReviewTally {
+            approvals: 0,
+            changes_requested: 0,
+        };
+        let approved = ReviewTally {
+            approvals: 1,
+            changes_requested: 0,
+        };
+        let objected = ReviewTally {
+            approvals: 2,
+            changes_requested: 1,
+        };
+        assert_eq!(
+            derive_review_decision(rules, &none).as_deref(),
+            Some("review_required")
+        );
+        assert_eq!(
+            derive_review_decision(rules, &approved).as_deref(),
+            Some("approved")
+        );
+        assert_eq!(
+            derive_review_decision(rules, &objected).as_deref(),
+            Some("changes_requested")
+        );
+        assert_eq!(derive_review_decision(None, &none), None);
+        assert_eq!(
+            derive_review_decision(None, &approved).as_deref(),
+            Some("approved")
+        );
+    }
+
+    #[test]
+    fn queue_membership_follows_the_latest_transition() {
+        assert!(queue_membership_from_events("added_to_merge_queue\n"));
+        assert!(!queue_membership_from_events(
+            "added_to_merge_queue\nremoved_from_merge_queue\n"
+        ));
+        assert!(queue_membership_from_events(
+            "removed_from_merge_queue\nadded_to_merge_queue\n"
+        ));
+        assert!(!queue_membership_from_events(""));
+    }
+
+    #[test]
+    fn branch_rules_read_reviews_and_queue() {
+        let rules = rules_from_value(&serde_json::json!([
+            { "type": "pull_request", "parameters": { "required_approving_review_count": 2 } },
+            { "type": "merge_queue", "parameters": {} },
+            { "type": "deletion" },
+        ]));
+        assert_eq!(rules.required_approvals, 2);
+        assert!(rules.has_merge_queue);
+        let bare = rules_from_value(&serde_json::json!([]));
+        assert_eq!(bare.required_approvals, 0);
+        assert!(!bare.has_merge_queue);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_park_refuses_reads_until_it_lapses() {
+        let gate = HostGate::default();
+        gate.park("github.com", Duration::from_secs(30));
+        let refused = gate.admit("github.com").await;
+        assert!(matches!(refused, Err(remaining) if remaining.as_secs() > 0));
+        tokio::time::advance(Duration::from_secs(31)).await;
+        assert!(gate.admit("github.com").await.is_ok());
+        // Another host never shared the park.
+        assert!(gate.admit("ghe.acme.test").await.is_ok());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn spacing_reserves_one_slot_per_read() {
+        let gate = HostGate::default();
+        let first = tokio::time::Instant::now();
+        drop(gate.admit("github.com").await.unwrap());
+        drop(gate.admit("github.com").await.unwrap());
+        assert!(tokio::time::Instant::now() - first >= HOST_SPACING);
+    }
+
+    #[cfg(unix)]
+    mod shim {
+        use super::*;
+        use std::os::unix::fs::PermissionsExt;
+
+        fn write_executable(path: &std::path::Path, body: &str) {
+            std::fs::write(path, body).unwrap();
+            let mut perms = std::fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).unwrap();
+        }
+
+        #[tokio::test]
+        async fn a_stored_etag_turns_an_unchanged_answer_into_a_304() {
+            let dir = tempfile::TempDir::new().unwrap();
+            let gh = dir.path().join("gh");
+            write_executable(
+                &gh,
+                r#"#!/bin/sh
+case "$*" in
+  *If-None-Match*)
+    printf 'HTTP/2.0 304 Not Modified\r\nEtag: W/"pull-1"\r\n\r\n'
+    exit 1;;
+  *)
+    printf 'HTTP/2.0 200 OK\r\nEtag: W/"pull-1"\r\n\r\n'
+    echo '{"number":12,"html_url":"https://github.com/acme/demo/pull/12","state":"open","head":{"ref":"f","sha":"aaa"},"base":{"ref":"main"}}'
+    exit 0;;
+esac
+"#,
+            );
+            let gate = HostGate::default();
+            let first = read_pull_request(
+                &gate,
+                dir.path(),
+                &gh,
+                "github.com",
+                "acme",
+                "demo",
+                12,
+                None,
+            )
+            .await
+            .unwrap();
+            let EndpointRead::Fresh { value, etag } = first else {
+                panic!("expected fresh: {first:?}");
+            };
+            assert_eq!(value.number, 12);
+            assert_eq!(value.head_sha.as_deref(), Some("aaa"));
+            let etag = etag.expect("a 200 carries the etag to send next time");
+            let second = read_pull_request(
+                &gate,
+                dir.path(),
+                &gh,
+                "github.com",
+                "acme",
+                "demo",
+                12,
+                Some(&etag),
+            )
+            .await
+            .unwrap();
+            assert_eq!(second, EndpointRead::NotModified);
+        }
+
+        #[tokio::test]
+        async fn a_secondary_limit_answer_parks_the_host() {
+            let dir = tempfile::TempDir::new().unwrap();
+            let gh = dir.path().join("gh");
+            write_executable(
+                &gh,
+                "#!/bin/sh\nprintf 'HTTP/2.0 403 Forbidden\\r\\nRetry-After: 120\\r\\n\\r\\n'\necho '{\"message\":\"You have exceeded a secondary rate limit. Please wait.\"}'\nexit 1\n",
+            );
+            let gate = HostGate::default();
+            let refused = read_pull_request(
+                &gate,
+                dir.path(),
+                &gh,
+                "github.com",
+                "acme",
+                "demo",
+                12,
+                None,
+            )
+            .await;
+            assert!(
+                matches!(refused, Err(FetchFailure::Refused(403, _))),
+                "{refused:?}"
+            );
+            // The next read waits out the stated window rather than going
+            // out hot.
+            let parked = gate.admit("github.com").await;
+            assert!(
+                matches!(parked, Err(remaining) if remaining.as_secs() > 100),
+                "{parked:?}"
+            );
+            // Another host never shared the park.
+            assert!(gate.admit("ghe.acme.test").await.is_ok());
+        }
+    }
+}

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -177,6 +177,12 @@ pub(crate) struct CodeRuntime {
     /// sibling's turn starts after this one ends. See record 55.
     worktree_turns: Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
     pr_cache: PrDigestCache,
+    /// Paces and parks every conditional GitHub read (decision 66).
+    host_gate: super::pr_fetch::HostGate,
+    /// Base-branch rules, cached per branch: whether a merge queue runs
+    /// decides if the timeline read is worth paying, and the required
+    /// approval count anchors the review-decision word (decision 66).
+    branch_rules: Mutex<HashMap<String, CachedBranchRules>>,
     pub(crate) delivery_cache: DeliveryCache,
     pub(crate) clone_jobs: CloneJobs,
     /// Warm harness installs started ahead of a session create.
@@ -207,6 +213,17 @@ pub(crate) struct CodeRuntime {
     /// reads the model handles the app state owns and this runtime is built
     /// first. `None` until then, and in deployments that install none.
     recap: Mutex<Option<Arc<dyn super::recap::TurnRecap>>>,
+}
+
+/// How long one base branch's rules answer stands before the next read.
+/// Rules change on the order of releases, not pushes.
+const BRANCH_RULES_TTL: Duration = Duration::from_secs(3600);
+
+/// One cached branch-rules answer. `rules: None` records a host that has no
+/// rules endpoint, so a known 404 is not re-read every refresh.
+struct CachedBranchRules {
+    fetched_at: Instant,
+    rules: Option<super::pr_fetch::BranchRules>,
 }
 
 /// What a new session starts on, beyond the engine it is bound to.
@@ -265,6 +282,8 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
+            host_gate: super::pr_fetch::HostGate::default(),
+            branch_rules: Mutex::new(HashMap::new()),
             delivery_cache: DeliveryCache::default(),
             clone_jobs: CloneJobs::default(),
             harness_installs: HarnessInstallJobs::default(),
@@ -380,6 +399,8 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             pr_cache: PrDigestCache::default(),
+            host_gate: super::pr_fetch::HostGate::default(),
+            branch_rules: Mutex::new(HashMap::new()),
             delivery_cache: DeliveryCache::default(),
             clone_jobs: CloneJobs::default(),
             harness_installs: HarnessInstallJobs::default(),
@@ -1469,16 +1490,31 @@ impl CodeRuntime {
         let gh_path = self.gh_search_path_owned();
         let mut status = gh::workspace_git_status(
             std::path::Path::new(&workspace.worktree_path),
-            workspace.id,
             &workspace.title,
             &workspace.branch_name,
             &workspace.base_ref,
             workspace.pr.clone(),
-            &self.pr_cache,
             gh_path.as_deref(),
         )
         .await
         .map_err(map_gh)?;
+        // The digest comes through the conditional fetcher (decision 66):
+        // the fact row's ETags ride along, an unchanged answer is a free 304
+        // served from the row, and a changed one writes through to every
+        // holder. A failed fetch leaves the persisted digest standing.
+        if status.gh_found && status.gh_authenticated == Some(true) {
+            if let Some(cached) = self.pr_cache.get(workspace.id) {
+                status.pr = Some(cached);
+            } else if let Some(binary) = gh::authenticated_gh_binary(gh_path.as_deref()).await {
+                if let Some(digest) = self
+                    .fetched_workspace_digest(owner, &workspace, &binary)
+                    .await
+                {
+                    self.pr_cache.put(workspace.id, digest.clone());
+                    status.pr = Some(digest);
+                }
+            }
+        }
         // On a hosted machine the digest comes from the forge REST API with
         // a borrowed credential (decision 65) — there is no `gh` here to
         // refresh it. Cache-aware exactly like the `gh` path, borrowing only
@@ -1549,6 +1585,308 @@ impl CodeRuntime {
     ) -> Result<WorkspaceGitStatus, ServerError> {
         self.pr_cache.invalidate(id);
         self.workspace_pr(owner, id).await
+    }
+
+    /// The repository identity a workspace's pull request lives on: the
+    /// registered origin when the reconcile sweep has confirmed one, the
+    /// worktree's own remote otherwise.
+    async fn workspace_repository_target(
+        &self,
+        owner: &OwnerId,
+        workspace: &CodeWorkspace,
+    ) -> Option<crate::routes::code::types::CodeGitHubRepositoryTarget> {
+        let repo = self.get_repo(owner, workspace.repo_id).await.ok()?;
+        if let (Some(host), Some(repo_owner), Some(name)) = (
+            repo.origin_host.clone(),
+            repo.origin_owner.clone(),
+            repo.origin_name.clone(),
+        ) {
+            return Some(crate::routes::code::types::CodeGitHubRepositoryTarget {
+                host,
+                owner: repo_owner,
+                name,
+            });
+        }
+        super::delivery::repository_target_from_local(&repo)
+            .await
+            .ok()
+    }
+
+    /// The workspace's digest through the conditional fetcher (decision 66).
+    ///
+    /// Identity comes from the stored digest's URL, or a head lookup when
+    /// the workspace knows no pull request yet. Each endpoint sends the
+    /// row's stored ETag: a 304 answers from the row for free, and a 200
+    /// carries new state. The result lands on the row — live tier, fanout,
+    /// and the ETags for next time. `None` leaves the caller's persisted
+    /// digest standing: no pull request, a parked host, or a failed read.
+    async fn fetched_workspace_digest(
+        &self,
+        owner: &OwnerId,
+        workspace: &CodeWorkspace,
+        binary: &Path,
+    ) -> Option<PullRequestDigest> {
+        use super::pr_fetch::{self, EndpointRead};
+
+        let cwd = std::path::Path::new(&workspace.worktree_path);
+        let gate = &self.host_gate;
+        let stored_identity = workspace
+            .pr
+            .as_ref()
+            .and_then(|pr| pr.url.as_deref())
+            .and_then(super::pr_facts::pull_request_identity_from_url);
+        let (host, repo_owner, repo_name, number) = match stored_identity {
+            Some(identity) => identity,
+            None => {
+                let target = self.workspace_repository_target(owner, workspace).await?;
+                let found = match pr_fetch::read_pull_request_for_head(
+                    gate,
+                    cwd,
+                    binary,
+                    &target.host,
+                    &target.owner,
+                    &target.name,
+                    &workspace.branch_name,
+                )
+                .await
+                {
+                    Ok(found) => found?,
+                    Err(failure) => {
+                        tracing::debug!(error = %failure, "code-mode: pull-request lookup skipped");
+                        return None;
+                    }
+                };
+                (target.host, target.owner, target.name, found.number)
+            }
+        };
+        let stored = tidebreak_core::db::code::get_pull_request_fetch_state(
+            &self.db,
+            owner,
+            &host,
+            &repo_owner,
+            &repo_name,
+            number,
+        )
+        .await
+        .ok()
+        .flatten();
+        let (stored_fact, mut pull_etag, mut checks_etag, mut reviews_etag) = match stored {
+            Some(state) => (
+                Some(state.fact),
+                state.pull_etag,
+                state.checks_etag,
+                state.reviews_etag,
+            ),
+            None => (None, None, None, None),
+        };
+        let pull = match pr_fetch::read_pull_request(
+            gate,
+            cwd,
+            binary,
+            &host,
+            &repo_owner,
+            &repo_name,
+            number,
+            pull_etag.as_deref(),
+        )
+        .await
+        {
+            Ok(EndpointRead::Fresh { value, etag }) => {
+                pull_etag = etag;
+                value
+            }
+            Ok(EndpointRead::NotModified) => pr_fetch::rest_pull_from_fact(stored_fact.as_ref()?),
+            Ok(EndpointRead::Missing) => return None,
+            Err(failure) => {
+                tracing::debug!(error = %failure, "code-mode: pull-request read skipped");
+                return None;
+            }
+        };
+        let stored_live = stored_fact.as_ref().and_then(|fact| fact.live.as_ref());
+        let checks = match pull.head_sha.as_deref() {
+            Some(sha) => {
+                // A checks ETag names one head's answer; a moved head sends
+                // an unconditional read.
+                let same_head = stored_fact
+                    .as_ref()
+                    .and_then(|fact| fact.head_sha.as_deref())
+                    == Some(sha);
+                let conditional = if same_head {
+                    checks_etag.as_deref()
+                } else {
+                    None
+                };
+                match pr_fetch::read_check_runs(
+                    gate,
+                    cwd,
+                    binary,
+                    &host,
+                    &repo_owner,
+                    &repo_name,
+                    sha,
+                    conditional,
+                )
+                .await
+                {
+                    Ok(EndpointRead::Fresh { value, etag }) => {
+                        checks_etag = etag;
+                        value
+                    }
+                    Ok(EndpointRead::NotModified) => stored_live
+                        .and_then(|live| live.checks.clone())
+                        .unwrap_or_default(),
+                    Ok(EndpointRead::Missing) => Vec::new(),
+                    Err(failure) => {
+                        tracing::debug!(error = %failure, "code-mode: check-runs read skipped");
+                        checks_etag = None;
+                        stored_live
+                            .and_then(|live| live.checks.clone())
+                            .unwrap_or_default()
+                    }
+                }
+            }
+            None => Vec::new(),
+        };
+        let open = pull.state == "open";
+        let rules = if open {
+            self.branch_rules_for(
+                cwd,
+                binary,
+                &host,
+                &repo_owner,
+                &repo_name,
+                pull.base_branch.as_deref(),
+            )
+            .await
+        } else {
+            None
+        };
+        let review_decision = if open {
+            match pr_fetch::read_reviews(
+                gate,
+                cwd,
+                binary,
+                &host,
+                &repo_owner,
+                &repo_name,
+                number,
+                reviews_etag.as_deref(),
+            )
+            .await
+            {
+                Ok(EndpointRead::Fresh { value, etag }) => {
+                    reviews_etag = etag;
+                    pr_fetch::derive_review_decision(rules, &value)
+                }
+                Ok(EndpointRead::NotModified) => {
+                    stored_live.and_then(|live| live.review_decision.clone())
+                }
+                Ok(EndpointRead::Missing) => None,
+                Err(failure) => {
+                    tracing::debug!(error = %failure, "code-mode: reviews read skipped");
+                    reviews_etag = None;
+                    stored_live.and_then(|live| live.review_decision.clone())
+                }
+            }
+        } else {
+            None
+        };
+        let in_merge_queue = if open {
+            match rules {
+                // Rules that name no queue spare the timeline read; a queue
+                // — or a host that cannot answer the rules endpoint — pays
+                // it.
+                Some(rules) if !rules.has_merge_queue => Some(false),
+                _ => {
+                    pr_fetch::read_merge_queue_membership(
+                        gate,
+                        cwd,
+                        binary,
+                        &host,
+                        &repo_owner,
+                        &repo_name,
+                        number,
+                    )
+                    .await
+                }
+            }
+        } else {
+            Some(false)
+        };
+        let digest = pr_fetch::digest_from_parts(&pull, &checks, review_decision, in_merge_queue);
+        self.record_pull_request_live_state(owner, Some(workspace.id), &digest)
+            .await;
+        if let Err(err) = tidebreak_core::db::code::set_pull_request_etags(
+            &self.db,
+            owner,
+            &host,
+            &repo_owner,
+            &repo_name,
+            number,
+            pull_etag.as_deref(),
+            checks_etag.as_deref(),
+            reviews_etag.as_deref(),
+        )
+        .await
+        {
+            tracing::debug!(error = %err, "code-mode: etag write failed");
+        }
+        Some(digest)
+    }
+
+    /// The base branch's rules, cached per branch for [`BRANCH_RULES_TTL`].
+    async fn branch_rules_for(
+        &self,
+        cwd: &Path,
+        binary: &Path,
+        host: &str,
+        repo_owner: &str,
+        repo_name: &str,
+        branch: Option<&str>,
+    ) -> Option<super::pr_fetch::BranchRules> {
+        let branch = branch?;
+        let key = format!(
+            "{}/{}/{}/{}",
+            host.to_ascii_lowercase(),
+            repo_owner.to_ascii_lowercase(),
+            repo_name.to_ascii_lowercase(),
+            branch
+        );
+        {
+            let cache = self.branch_rules.lock().expect("branch rules");
+            if let Some(entry) = cache.get(&key) {
+                if entry.fetched_at.elapsed() <= BRANCH_RULES_TTL {
+                    return entry.rules;
+                }
+            }
+        }
+        let rules = match super::pr_fetch::read_branch_rules(
+            &self.host_gate,
+            cwd,
+            binary,
+            host,
+            repo_owner,
+            repo_name,
+            branch,
+        )
+        .await
+        {
+            Ok(super::pr_fetch::EndpointRead::Fresh { value, .. }) => Some(value),
+            // A host with no rules endpoint answers for the cache period
+            // too: hammering a known 404 helps nobody.
+            Ok(_) => None,
+            // A park or a transport failure states nothing; ask again next
+            // time.
+            Err(_) => return None,
+        };
+        self.branch_rules.lock().expect("branch rules").insert(
+            key,
+            CachedBranchRules {
+                fetched_at: Instant::now(),
+                rules,
+            },
+        );
+        rules
     }
 
     /// After a pull-request state change on the delivery surface, make every

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -115,6 +115,34 @@ fn json_id(value: &serde_json::Value) -> &str {
     value["id"].as_str().expect("id is a string")
 }
 
+/// Store a minimal pull-request digest on the workspace row, as the create
+/// path does the moment a pull request exists: the URL is the identity the
+/// conditional fetcher (decision 66) resolves everything else from.
+async fn seed_workspace_pull_request(runtime: &CodeRuntime, id: &str, url: &str, number: u64) {
+    let owner = tidebreak_core::OwnerId::local();
+    let id: tidebreak_core::WorkspaceId = id.parse().unwrap();
+    let mut workspace = runtime.get_workspace(&owner, id).await.unwrap();
+    workspace.pr = Some(tidebreak_core::PullRequestDigest {
+        number,
+        url: Some(url.to_owned()),
+        state: "open".into(),
+        title: None,
+        checks_summary: None,
+        checks: None,
+        draft: None,
+        merged: None,
+        review_decision: None,
+        mergeable: None,
+        merge_state_status: None,
+        head_branch: None,
+        base_branch: None,
+        head_sha: None,
+        auto_merge_enabled: None,
+        in_merge_queue: None,
+    });
+    runtime.save_workspace(&workspace).await.unwrap();
+}
+
 async fn register_and_workspace(
     client: &reqwest::Client,
     addr: std::net::SocketAddr,
@@ -308,9 +336,21 @@ if [ "$1" = pr ] && [ "$2" = view ]; then
   echo '{{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN","headRefOid":"aaaaaaaa"}}'
   exit 0
 fi
-if [ "$1" = pr ] && [ "$2" = checks ]; then
-  printf 'lint\tpass\t1s\thttps://example.test/lint\n'
-  exit 0
+if [ "$1" = api ]; then
+  case "$*" in
+    *pulls/12/reviews*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'; echo '[]'; exit 0;;
+    *rules/branches/main*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'; echo '[]'; exit 0;;
+    *check-runs*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'
+      echo '{{"check_runs":[{{"name":"lint","conclusion":"success","html_url":"https://example.test/lint"}}]}}'
+      exit 0;;
+    *pulls/12*)
+      printf 'HTTP/2.0 200 OK\r\nEtag: W/"pull-1"\r\n\r\n'
+      echo '{{"number":12,"html_url":"https://github.com/example/demo/pull/12","state":"open","head":{{"ref":"feature","sha":"aaaaaaaa"}},"base":{{"ref":"main"}}}}'
+      exit 0;;
+  esac
 fi
 exit 3
 "#,
@@ -351,10 +391,12 @@ exit 3
         logged.contains("--base main"),
         "gh pr create must pass the workspace base: {logged}"
     );
-    assert!(logged.contains("pr view"), "{logged}");
-    assert!(logged.contains("pr checks"), "{logged}");
-    // The view field list legitimately names mergeable/autoMergeRequest; a
-    // merge invocation or flag may never appear on the create/status path.
+    // The status read is the conditional REST fetcher (decision 66): the
+    // pull request, its head's check runs, and its reviews — never a
+    // `pr checks` table read or a merge/GraphQL invocation.
+    assert!(logged.contains("repos/example/demo/pulls/12"), "{logged}");
+    assert!(logged.contains("check-runs"), "{logged}");
+    assert!(!logged.contains("pr checks"), "{logged}");
     assert!(!logged.contains("pr merge"), "{logged}");
     assert!(!logged.contains("--merge"), "{logged}");
     assert!(!logged.contains("--auto"), "{logged}");
@@ -947,13 +989,17 @@ async fn a_push_drops_the_cached_pull_request_digest() {
     let id = json_id(&workspace);
     let path = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
 
-    // A gh shim that answers `pr view` from a file, so the test moves
+    // The workspace already knows its pull request by URL, as it does the
+    // moment one exists; the fetcher resolves identity from that URL.
+    seed_workspace_pull_request(&runtime, id, "https://github.com/example/demo/pull/12", 12).await;
+
+    // A gh shim that answers the REST reads from a file, so the test moves
     // GitHub's state without waiting out any cache.
     let shim_dir = tempfile::TempDir::new().unwrap();
-    let answer = shim_dir.path().join("view.json");
+    let answer = shim_dir.path().join("pull.json");
     std::fs::write(
         &answer,
-        r#"{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN","headRefOid":"aaaaaaaa"}"#,
+        r#"{"number":12,"html_url":"https://github.com/example/demo/pull/12","state":"open","head":{"ref":"feature","sha":"aaaaaaaa"},"base":{"ref":"main"}}"#,
     )
     .unwrap();
     write_executable(
@@ -964,13 +1010,21 @@ if [ "$1" = auth ]; then
   echo '{{"hosts":{{"github.com":[{{"active":true,"state":"success","login":"tester"}}]}}}}'
   exit 0
 fi
-if [ "$1" = pr ] && [ "$2" = view ]; then
-  cat {answer}
-  exit 0
-fi
-if [ "$1" = pr ] && [ "$2" = checks ]; then
-  printf 'lint\tpass\t1s\thttps://example.test/lint\n'
-  exit 0
+if [ "$1" = api ]; then
+  case "$*" in
+    *pulls/12/reviews*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'; echo '[]'; exit 0;;
+    *rules/branches/main*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'; echo '[]'; exit 0;;
+    *check-runs*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'
+      echo '{{"check_runs":[{{"name":"lint","conclusion":"success","html_url":"https://example.test/lint"}}]}}'
+      exit 0;;
+    *pulls/12*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'
+      cat {answer}
+      exit 0;;
+  esac
 fi
 exit 3
 "#,
@@ -1010,7 +1064,7 @@ exit 3
     // GitHub's answer moves, as it does when new commits land on the head.
     std::fs::write(
         &answer,
-        r#"{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN","headRefOid":"bbbbbbbb"}"#,
+        r#"{"number":12,"html_url":"https://github.com/example/demo/pull/12","state":"open","head":{"ref":"feature","sha":"bbbbbbbb"},"base":{"ref":"main"}}"#,
     )
     .unwrap();
 
@@ -1118,11 +1172,18 @@ async fn a_digest_change_writes_through_to_every_holder_of_the_pull_request() {
     .await
     .unwrap();
 
+    // Both workspaces hold the pull request by URL, as they do the moment
+    // one exists; the fetcher resolves identity from that URL.
+    for id in [&a, &b] {
+        seed_workspace_pull_request(&runtime, id, "https://github.com/example/demo/pull/12", 12)
+            .await;
+    }
+
     let shim_dir = tempfile::TempDir::new().unwrap();
-    let answer = shim_dir.path().join("view.json");
+    let answer = shim_dir.path().join("pull.json");
     std::fs::write(
         &answer,
-        r#"{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN","headRefOid":"aaaaaaaa"}"#,
+        r#"{"number":12,"html_url":"https://github.com/example/demo/pull/12","state":"open","head":{"ref":"feature","sha":"aaaaaaaa"},"base":{"ref":"main"}}"#,
     )
     .unwrap();
     write_executable(
@@ -1133,13 +1194,21 @@ if [ "$1" = auth ]; then
   echo '{{"hosts":{{"github.com":[{{"active":true,"state":"success","login":"tester"}}]}}}}'
   exit 0
 fi
-if [ "$1" = pr ] && [ "$2" = view ]; then
-  cat {answer}
-  exit 0
-fi
-if [ "$1" = pr ] && [ "$2" = checks ]; then
-  printf 'lint\tpass\t1s\thttps://example.test/lint\n'
-  exit 0
+if [ "$1" = api ]; then
+  case "$*" in
+    *pulls/12/reviews*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'; echo '[]'; exit 0;;
+    *rules/branches/main*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'; echo '[]'; exit 0;;
+    *check-runs*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'
+      echo '{{"check_runs":[{{"name":"lint","conclusion":"success","html_url":"https://example.test/lint"}}]}}'
+      exit 0;;
+    *pulls/12*)
+      printf 'HTTP/2.0 200 OK\r\n\r\n'
+      cat {answer}
+      exit 0;;
+  esac
 fi
 exit 3
 "#,
@@ -1165,7 +1234,7 @@ exit 3
     // GitHub moves, and only workspace A reads it.
     std::fs::write(
         &answer,
-        r#"{"number":12,"url":"https://github.com/example/demo/pull/12","state":"OPEN","headRefOid":"bbbbbbbb","mergeStateStatus":"BLOCKED"}"#,
+        r#"{"number":12,"html_url":"https://github.com/example/demo/pull/12","state":"open","mergeable_state":"blocked","head":{"ref":"feature","sha":"bbbbbbbb"},"base":{"ref":"main"}}"#,
     )
     .unwrap();
     let refreshed = client


### PR DESCRIPTION
Slice 4 of [decision 66](docs/decisions/0066-pull-request-state-is-one-store.md), first half: the conditional REST fetcher behind one gate. The scheduler tiers and the digest-cache deletion follow in the next slice.

## What changes

- `pr_fetch` is the one reader for pull-request state: `gh api` reads of the pull request, its head's check runs, and its reviews. Each read sends the fact row's stored ETag (`If-None-Match`); a 304 answers from the row and does not count against GitHub's primary rate limit, so sustained cost tracks how often pull requests change rather than how often Tidebreak asks. The row stores each endpoint's ETag in three new guarded columns.
- One `HostGate` paces every read: a small global concurrency, per-host spacing, and parking — a `Retry-After`, a secondary-limit answer, or an exhausted primary window parks the host for the stated time, and every caller respects the park rather than retrying hot.
- The review decision derives from the base branch's rules plus each reviewer's newest standing review, in the same lowercased vocabulary the classifier already reads, so `needs_approval` (slice 1) keeps firing without GraphQL's `reviewDecision`.
- The merge-queue timeline read runs only where the base branch's rules run a queue (one rules read per branch, cached for an hour). Repositories without a queue stop paying the pagination entirely.
- The old digest loader is deleted: the double `gh pr view` head dance and its retry loop, the `gh pr checks` table read, and the unconditional timeline pagination. Consistency now holds by construction — check runs are read for the exact head SHA the pull request answer named.
- `gh api` transport keeps the HTTP answer whatever the exit code (`gh` exits non-zero on 304), parses status, `Etag`, `Retry-After`, and rate-limit headers, and still refuses merge and GraphQL invocations.

## What does not change here

- `PrDigestCache` and its 20-second TTL stay; the tiered scheduler, mutation-dirty refreshes, and `GET …/pr` leaving the request path are the next slice.
- The hosted-machine path (decision 65) keeps its own credentialed REST reader.

## Testing

- Unit tests cover the raw HTTP parse, the REST field mapping, review standing (dismissals, `COMMENTED`), decision derivation, branch-rules parsing, queue-transition semantics, gate parking, and per-host spacing.
- Scripted-`gh` tests prove the 304 flow (a stored ETag turns an unchanged answer into `NotModified`) and that a 403 with `Retry-After` parks the host so the next read waits — the decision's validation case.
- The end-to-end tests (create flow, push-drops-cache, write-through to every holder) now run against `gh api` shims and assert the fetch path issues no `pr checks` read and no merge or GraphQL invocation.
