### PR TITLE
fix(code): use Grok gateway model ids

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -175,6 +175,7 @@ import {
   HARNESS_LABELS,
   LIFECYCLE_LABELS,
   preferredCodeModels,
+  requiresHarnessModelIds,
   sessionLifecycleTooltip,
 } from "./labels";
 
@@ -500,7 +501,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     try {
       const gateway = gatewayCodeModels(models, harness, defaultModelKey);
       const native =
-        harness === "opencode" || gateway.length === 0
+        requiresHarnessModelIds(harness) || gateway.length === 0
           ? await catalog.ensureHarnessModels(client, harness)
           : [];
       const listed = preferredCodeModels(harness, native, gateway);
@@ -1787,7 +1788,8 @@ function CodeSessionPane({
       defaultModelKey,
     );
     const listed =
-      session.harness_kind === "opencode" && cachedModels === undefined
+      requiresHarnessModelIds(session.harness_kind) &&
+      cachedModels === undefined
         ? []
         : preferredCodeModels(
             session.harness_kind,
@@ -2123,7 +2125,8 @@ function CodeSessionPane({
             model={model ?? undefined}
             modelOptions={modelOptions}
             modelLoading={
-              session.harness_kind === "opencode" && cachedModels === undefined
+              requiresHarnessModelIds(session.harness_kind) &&
+              cachedModels === undefined
             }
             promptScope={workspaceId}
             sessionId={session.id}

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -44,6 +44,7 @@ import {
   gatewayCodeModels,
   harnessUnusableReason,
   preferredCodeModels,
+  requiresHarnessModelIds,
   PERMISSION_MODE_LABELS,
   ALLOW_ALL_NOTE,
   UNSUPERVISED_AUTO_NOTE,
@@ -249,7 +250,8 @@ export function NewWorkspaceDialog({
     };
     const gateway = gatewayCodeModels(models, harness, defaultModelKey);
     const native = useCodeCatalogStore.getState().modelsByHarness[harness];
-    const needsNative = harness === "opencode" || gateway.length === 0;
+    const needsNative =
+      requiresHarnessModelIds(harness) || gateway.length === 0;
     if (!needsNative) {
       apply(gateway);
       setModelLoading(false);
@@ -305,7 +307,7 @@ export function NewWorkspaceDialog({
       try {
         const gateway = gatewayCodeModels(models, harness, defaultModelKey);
         const native =
-          harness === "opencode" || gateway.length === 0
+          requiresHarnessModelIds(harness) || gateway.length === 0
             ? await ensureHarnessModels(client, harness)
             : [];
         const listed = preferredCodeModels(harness, native, gateway);

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -292,6 +292,74 @@ describe("StartSessionPrompt", () => {
     );
   });
 
+  it("posts Grok's gateway-qualified model id", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn();
+    const efforts: ReasoningEffort[] = ["low", "medium", "high", "xhigh"];
+    const client = {
+      listCodeHarnessModels: vi.fn(async () => ({
+        kind: "grok" as const,
+        models: [
+          {
+            id: "model-gateway-model-gateway/grok-4.6",
+            label: "Grok 4.6",
+            default: true,
+            reasoning_efforts: efforts,
+            fast_mode: false,
+          },
+        ],
+        reasoning_efforts: efforts,
+      })),
+    };
+    await renderWithRouter(
+      wrap(
+        <StartSessionPrompt
+          workspaceId="workspace-1"
+          harnesses={[
+            entry("grok", {
+              plan_mode: "unsupported",
+              structured_approvals: "unsupported",
+              auto_mode: "supported",
+              allow_mode: "supported",
+            }),
+          ]}
+          starting={false}
+          selectedMode={null}
+          onSelectMode={vi.fn()}
+          onStart={onStart}
+          client={client}
+          catalogModels={[
+            {
+              key: "model_gateway::grok-4.6",
+              id: "grok-4.6",
+              display_name: "Grok 4.6",
+              provider: "model_gateway",
+              vendor: "xai",
+              available: true,
+            } as never,
+          ]}
+          defaultModelKey="model_gateway::grok-4.6"
+        />,
+      ),
+    );
+
+    expect(client.listCodeHarnessModels).toHaveBeenCalledWith("grok");
+    expect(
+      await screen.findByRole("button", { name: "Model: Grok 4.6" }),
+    ).toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox", { name: "Message" }),
+      "list the files",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(onStart).toHaveBeenCalledWith(
+      "grok",
+      "allow",
+      "list the files",
+      "model-gateway-model-gateway/grok-4.6",
+    );
+  });
+
   it("keeps each harness model separate across switches", async () => {
     const user = userEvent.setup();
     const codex = deferred<{

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -19,6 +19,7 @@ import {
   gatewayCodeModels,
   harnessUnusableReason,
   preferredCodeModels,
+  requiresHarnessModelIds,
   type CodeModelOption,
   ALLOW_ALL_NOTE,
   UNSUPERVISED_AUTO_NOTE,
@@ -123,7 +124,8 @@ export function StartSessionPrompt({
       defaultModelKey,
     );
     const native = useCodeCatalogStore.getState().modelsByHarness[selectedKind];
-    const needsNative = selectedKind === "opencode" || gateway.length === 0;
+    const needsNative =
+      requiresHarnessModelIds(selectedKind) || gateway.length === 0;
     if (!needsNative) {
       apply(gateway);
       setModelLoading(false);

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -256,9 +256,17 @@ describe("preferredCodeModels", () => {
     },
   ];
 
-  it("uses OpenCode's provider-qualified native ids", () => {
+  it("uses provider-qualified ids for engines that require their own listing", () => {
     expect(preferredCodeModels("opencode", native, gateway)).toEqual(native);
     expect(preferredCodeModels("opencode", [], gateway)).toEqual(gateway);
+    const grok = [
+      {
+        id: "model-gateway-model-gateway/grok-4.6",
+        label: "Grok 4.6",
+        source: "Grok CLI",
+      },
+    ];
+    expect(preferredCodeModels("grok", grok, gateway)).toEqual(grok);
   });
 
   it("keeps gateway rows for engines that accept their ids directly", () => {

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -299,20 +299,25 @@ export function harnessCodeModels(
   }));
 }
 
+/** Whether this engine requires the exact model IDs from its own listing. */
+export function requiresHarnessModelIds(kind: HarnessKind): boolean {
+  return kind === "opencode" || kind === "grok";
+}
+
 /**
  * Pick the catalog whose identifiers the engine accepts.
  *
- * OpenCode needs the provider-qualified ids from `opencode models`; chat's
- * gateway catalog often carries a bare or upstream id instead. Other engines
- * keep the gateway catalog when it exists because their adapters accept those
- * ids directly and the catalog carries the entitled display rows.
+ * OpenCode and Grok need the provider-qualified ids from their own model
+ * listings; chat's gateway catalog carries a bare upstream id instead. Other
+ * engines keep the gateway catalog when it exists because their adapters
+ * accept those ids directly and the catalog carries the entitled display rows.
  */
 export function preferredCodeModels(
   kind: HarnessKind,
   native: readonly CodeModelOption[],
   gateway: readonly CodeModelOption[],
 ): CodeModelOption[] {
-  if (kind === "opencode" && native.length > 0) return [...native];
+  if (requiresHarnessModelIds(kind) && native.length > 0) return [...native];
   return gateway.length > 0 ? [...gateway] : [...native];
 }
 


### PR DESCRIPTION
## What changed

Tidebreak now uses model IDs reported by Grok when Model Gateway is connected, so code sessions send `model-gateway-model-gateway/grok-4.6` instead of routing bare `grok-4.6` to xAI Direct.

The new regression coverage verifies the first-session path and shared model-selection policy.

## Validation

Passed the UI test suite (226 files, 1,784 tests), focused tests, `tsc --noEmit`, Biome checks, and `git diff --check`.

## Compatibility and risk

No persisted or wire-format changes; existing sessions with bare IDs keep their stored selection until the model is reselected or a new session starts.