### PR TITLE
feat(code): start a workspace from a prompt-first composer

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -1009,9 +1009,7 @@ describe("app shell", () => {
 
     const dialog = await screen.findByRole("dialog");
     expect(
-      within(dialog).getByText(
-        "One worktree and one session on the selected repo.",
-      ),
+      within(dialog).getByRole("textbox", { name: "First message" }),
     ).toBeInTheDocument();
     expect(createChat).not.toHaveBeenCalled();
     expect(router.state.location.pathname).toBe("/code");

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
@@ -103,12 +103,24 @@ export function PermissionModeMenu({
   value,
   disabled,
   onChange,
+  availableModes,
+  open: controlledOpen,
+  onOpenChange,
 }: {
   /** Identity of the chat or draft whose setting is being changed. */
   scopeKey: string;
   value: PermissionMode | null;
   disabled?: boolean;
   onChange: (mode: PermissionMode) => void | Promise<void>;
+  /**
+   * Modes the engine behind this surface honors. Absent means all of them —
+   * chat's server runs every mode. Rows outside the list stay visible and
+   * disabled, so what an engine cannot do is stated rather than missing.
+   */
+  availableModes?: readonly PermissionMode[];
+  /** Open the menu from outside — a surface's keyboard shortcut. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const [saving, setSaving] = useState(false);
   const savingRef = useRef(false);
@@ -162,24 +174,33 @@ export function PermissionModeMenu({
   const current = permissionModeOption(effective);
   const CurrentIcon = current.icon;
   const controlsDisabled = disabled || saving;
+  const unavailable = (mode: PermissionMode) =>
+    availableModes !== undefined && !availableModes.includes(mode);
   const guided = useGuidedMenu("permissions");
   return (
     <DropdownMenu
-      open={guided.open}
+      open={
+        controlledOpen !== undefined
+          ? controlledOpen || guided.open
+          : guided.open
+      }
       modal={guided.modal}
-      onOpenChange={guided.onOpenChange}
+      onOpenChange={(next) => {
+        guided.onOpenChange(next);
+        onOpenChange?.(next);
+      }}
     >
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          className="h-8 gap-1.5"
+          className="h-8 min-w-0 gap-1.5"
           disabled={controlsDisabled}
           aria-label={`Permissions: ${current.label}`}
           aria-busy={saving}
         >
-          <CurrentIcon className="size-4 text-foreground" />
-          {current.label}
-          <ChevronDown className="size-4 opacity-50" />
+          <CurrentIcon className="size-4 shrink-0 text-foreground" />
+          <span className="truncate">{current.label}</span>
+          <ChevronDown className="size-4 shrink-0 opacity-50" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -192,11 +213,12 @@ export function PermissionModeMenu({
         {PERMISSION_MODE_SCALE.map((option) => {
           const selected = current.value === option.value;
           const locked = overCeiling(option.value);
+          const unoffered = unavailable(option.value);
           const OptionIcon = option.icon;
           return (
             <DropdownMenuItem
               key={option.value}
-              disabled={controlsDisabled || locked}
+              disabled={controlsDisabled || locked || unoffered}
               onSelect={() => {
                 if (selected) return;
                 void selectMode(option.value);
@@ -227,7 +249,9 @@ export function PermissionModeMenu({
               <span className="text-muted-foreground pl-6 text-xs">
                 {locked
                   ? "Locked by your organization's policy."
-                  : option.description}
+                  : unoffered
+                    ? "This harness can't honor this mode."
+                    : option.description}
               </span>
             </DropdownMenuItem>
           );

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -102,6 +102,7 @@ export function PermissionModePicker({
       scopeKey={scopeKey}
       value={value}
       disabled={locked}
+      availableModes={availableModes}
       onChange={async (mode: PermissionMode) => {
         if (!availableModes.includes(mode)) {
           throw new Error(PERMISSION_MODE_UNAVAILABLE_REASON);
@@ -170,6 +171,8 @@ export function HarnessModelMenu({
   disabled,
   loading = false,
   variant = "composer",
+  open: controlledOpen,
+  onOpenChange,
 }: {
   harness: HarnessKind;
   options: readonly CodeModelOption[];
@@ -179,12 +182,20 @@ export function HarnessModelMenu({
   loading?: boolean;
   /** Composer sits above the draft; field fills a form row. */
   variant?: "composer" | "field";
+  /** Open the menu from outside — a surface's keyboard shortcut. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const current =
     options.find((option) => option.id === value) ??
     options.find((option) => option.default) ??
     options[0];
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const open = controlledOpen ?? uncontrolledOpen;
+  const setOpen = (next: boolean) => {
+    if (controlledOpen === undefined) setUncontrolledOpen(next);
+    onOpenChange?.(next);
+  };
   const [query, setQuery] = useState("");
   const searchInput = useRef<HTMLInputElement>(null);
   const currentRow = useRef<HTMLDivElement>(null);
@@ -229,13 +240,19 @@ export function HarnessModelMenu({
       : (activeGroup?.options ?? []);
   const locked = disabled || !onChange;
   useEffect(() => {
-    // A mixed catalog opens on the whole list, which runs past the fold. The
-    // row the session is on is put on screen rather than left to be found.
+    // Opening resets the search and rail — whether the trigger or a caller's
+    // keyboard chord opened it — and puts the session's row on screen: a
+    // mixed catalog opens on the whole list, which runs past the fold.
     if (!open) return;
+    setQuery("");
+    setActiveGroupId(openingGroupId);
     const frame = requestAnimationFrame(() =>
       currentRow.current?.scrollIntoView({ block: "nearest" }),
     );
     return () => cancelAnimationFrame(frame);
+    // `openingGroupId` moving mid-open (a catalog answer landing) must not
+    // yank the rail out from under the reader.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
   if (!current) {
     if (variant !== "field" && !loading) return null;
@@ -247,7 +264,7 @@ export function HarnessModelMenu({
         className={
           variant === "field"
             ? "h-10 w-full justify-between px-3 font-normal"
-            : "h-8 max-w-56 gap-2"
+            : "h-8 max-w-56 min-w-0 gap-2"
         }
         disabled
         aria-label={loading ? "Loading models" : "Model: Default"}
@@ -286,16 +303,7 @@ export function HarnessModelMenu({
   }
 
   return (
-    <DropdownMenu
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (next) {
-          setQuery("");
-          setActiveGroupId(openingGroupId);
-        }
-      }}
-    >
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <Button
           type="button"
@@ -303,7 +311,7 @@ export function HarnessModelMenu({
           className={
             variant === "field"
               ? "h-10 w-full justify-between px-3 font-normal"
-              : "h-8 max-w-56 gap-2"
+              : "h-8 max-w-56 min-w-0 gap-2"
           }
           disabled={locked}
           aria-label={`Model: ${current.label}`}
@@ -328,10 +336,9 @@ export function HarnessModelMenu({
         align="start"
         side={variant === "field" ? "bottom" : "top"}
         collisionPadding={12}
-        className={cn(
-          "model-menu-content w-80 p-0",
-          variant === "field" && "z-[60]",
-        )}
+        // z-[60] matches the select primitive: this menu also opens inside
+        // dialogs, whose overlay sits at z-50.
+        className="model-menu-content z-[60] w-80 p-0"
         onKeyDownCapture={(event) => {
           if (
             (event.metaKey || event.ctrlKey) &&

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-import type { HarnessKind } from "../api/types";
+import type { HarnessKind, PermissionMode } from "../api/types";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import type { StatusTone } from "./statusTone";
 import type { WorkflowShortcut } from "./workspaceWorkflow";
@@ -47,6 +47,7 @@ export type CodeCreateDefaults = {
   repoId?: string;
   harness?: HarnessKind;
   modelsByHarness: Partial<Record<HarnessKind, string>>;
+  permissionMode?: PermissionMode;
 };
 
 /** What one successful create adds to the remembered defaults. */
@@ -56,6 +57,7 @@ export type CodeCreateSelection = {
   model?: string;
   /** Picks made before the final harness, kept for the next switch back. */
   modelsByHarness?: Partial<Record<HarnessKind, string>>;
+  permissionMode?: PermissionMode;
 };
 
 /** Inspector filter for one turn's files and diff. `label` is the ordinal, never the id. */
@@ -79,6 +81,13 @@ function readStoredCreateDefaults(): CodeCreateDefaults | null {
     const record = parsed as Record<string, unknown>;
     const text = (value: unknown) =>
       typeof value === "string" && value.length > 0 ? value : undefined;
+    const mode = (value: unknown): PermissionMode | undefined =>
+      value === "plan" ||
+      value === "ask" ||
+      value === "auto" ||
+      value === "allow"
+        ? value
+        : undefined;
     const harness = text(record.harness);
     const rememberedHarness = HARNESS_KINDS.includes(harness as HarnessKind)
       ? (harness as HarnessKind)
@@ -105,6 +114,7 @@ function readStoredCreateDefaults(): CodeCreateDefaults | null {
       repoId: text(record.repoId),
       harness: rememberedHarness,
       modelsByHarness,
+      permissionMode: mode(record.permissionMode),
     };
   } catch {
     return null;
@@ -459,6 +469,7 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
       repoId: selection.repoId,
       harness: selection.harness,
       modelsByHarness,
+      permissionMode: selection.permissionMode,
     };
     storeCreateDefaults(defaults);
     set({ lastCreate: defaults });

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -22,12 +22,14 @@ import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import type { ReasoningEffort } from "../api/types";
-import type { ParsedHarnessModel } from "./parsers";
+import type { CodeTurnSubmission, ParsedHarnessModel } from "./parsers";
 
 const toastError = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
 vi.mock("sonner", () => ({
   toast: {
     error: toastError,
+    success: toastSuccess,
   },
 }));
 
@@ -39,6 +41,7 @@ afterEach(() => {
     pendingComposerPrompt: null,
   });
   toastError.mockReset();
+  toastSuccess.mockReset();
 });
 
 const CAPS = {
@@ -105,6 +108,23 @@ function session(workspaceId: string, kind: HarnessKind, createdAt: string) {
     unrecognized_event_count: 0,
     created_at: createdAt,
   } as unknown as CodeSessionSnapshot;
+}
+
+function claudeModels() {
+  return vi.fn(async () => ({
+    kind: "claude_code" as const,
+    models: [
+      {
+        id: "sonnet",
+        label: "Sonnet",
+        default: true,
+        reasoning_efforts: [],
+        fast_mode: false,
+      },
+    ],
+    reasoning_efforts: [],
+    fast_mode: false,
+  }));
 }
 
 function app(client: Partial<AppContextValue["client"]>): AppContextValue {
@@ -222,13 +242,16 @@ describe("NewWorkspaceDialog", () => {
       { initialUrl: "/code" },
     );
 
-    const repoField = screen.getByRole("combobox", { name: "Repo" });
-    expect(repoField).toHaveTextContent("tidebreak");
-    expect(repoField).toHaveFocus();
-    expect(repoField).toBeEnabled();
-    expect(screen.getByRole("combobox", { name: "Harness" })).toHaveTextContent(
-      "Codex CLI",
+    // Prompt-centric: the message is where focus lands, not a settings field.
+    expect(
+      screen.getByRole("textbox", { name: "First message" }),
+    ).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Repo" })).toHaveTextContent(
+      "tidebreak",
     );
+    expect(
+      screen.getByRole("button", { name: "Harness: Codex CLI" }),
+    ).toBeEnabled();
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: "Model: GPT 5.6 Sol" }),
@@ -236,8 +259,8 @@ describe("NewWorkspaceDialog", () => {
     );
     // Allow is the default where the engine honors it, and it says so.
     expect(
-      screen.getByRole("combobox", { name: "Permission mode" }),
-    ).toHaveTextContent("Allow all");
+      screen.getByRole("button", { name: "Permissions: Allow all" }),
+    ).toBeEnabled();
     expect(
       screen.getByText(/every action runs without asking/),
     ).toBeInTheDocument();
@@ -263,12 +286,13 @@ describe("NewWorkspaceDialog", () => {
         repoId: "repo-new",
         harness: "codex",
         modelsByHarness: { codex: "gpt-5.6-sol" },
+        permissionMode: "allow",
       }),
     );
     expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
   });
 
-  it("lists repo, harness, model, then starting prompt, then the rest", async () => {
+  it("creates on Enter in the message; Shift+Enter stays a newline", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({
       repos,
@@ -277,23 +301,20 @@ describe("NewWorkspaceDialog", () => {
         notices: [],
       } as never,
     });
+    const createCodeWorkspace = vi.fn(async () =>
+      workspace("ws-enter", "repo-new", "2026-08-20T00:00:00.000Z"),
+    );
     await renderWithRouter(
       <AppContextProvider
         value={app({
-          listCodeHarnessModels: vi.fn(async () => ({
-            kind: "claude_code" as const,
-            models: [
-              {
-                id: "sonnet",
-                label: "Sonnet",
-                default: true,
-                reasoning_efforts: [],
-                fast_mode: false,
-              },
-            ],
-            reasoning_efforts: [],
-            fast_mode: false,
-          })),
+          createCodeWorkspace,
+          createCodeSession: vi.fn(async () =>
+            session("ws-enter", "claude_code", "2026-08-20T00:00:00.000Z"),
+          ),
+          submitCodeTurn: vi.fn(
+            async () => ({ kind: "turn" }) as unknown as CodeTurnSubmission,
+          ),
+          listCodeHarnessModels: claudeModels(),
         })}
       >
         <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
@@ -301,25 +322,15 @@ describe("NewWorkspaceDialog", () => {
       { initialUrl: "/code" },
     );
 
-    const labels = [
-      ...screen
-        .getByRole("dialog")
-        .querySelectorAll(
-          "form > div > span.font-medium, form > label > span.font-medium",
-        ),
-    ].map((el) => el.textContent);
-    expect(labels).toEqual([
-      "Repo",
-      "Harness",
-      "Model",
-      "Starting prompt",
-      "Title",
-      "Base ref",
-      "Permission mode",
-    ]);
+    const message = screen.getByRole("textbox", { name: "First message" });
+    fireEvent.change(message, { target: { value: "ship the fix" } });
+    fireEvent.keyDown(message, { key: "Enter", shiftKey: true });
+    expect(createCodeWorkspace).not.toHaveBeenCalled();
+    fireEvent.keyDown(message, { key: "Enter" });
+    await waitFor(() => expect(createCodeWorkspace).toHaveBeenCalled());
   });
 
-  it("inserts a starting prompt into the workspace composer after create", async () => {
+  it("sends the first message as the session's first turn", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({
       repos,
@@ -334,25 +345,16 @@ describe("NewWorkspaceDialog", () => {
     const createCodeSession = vi.fn(async () =>
       session("ws-prompt", "claude_code", "2026-08-20T00:00:00.000Z"),
     );
-    await renderWithRouter(
+    const submitCodeTurn = vi.fn(
+      async () => ({ kind: "turn" }) as unknown as CodeTurnSubmission,
+    );
+    const { router } = await renderWithRouter(
       <AppContextProvider
         value={app({
           createCodeWorkspace,
           createCodeSession,
-          listCodeHarnessModels: vi.fn(async () => ({
-            kind: "claude_code" as const,
-            models: [
-              {
-                id: "sonnet",
-                label: "Sonnet",
-                default: true,
-                reasoning_efforts: [],
-                fast_mode: false,
-              },
-            ],
-            reasoning_efforts: [],
-            fast_mode: false,
-          })),
+          submitCodeTurn,
+          listCodeHarnessModels: claudeModels(),
         })}
       >
         <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
@@ -360,7 +362,7 @@ describe("NewWorkspaceDialog", () => {
       { initialUrl: "/code" },
     );
 
-    fireEvent.change(screen.getByRole("textbox", { name: "Starting prompt" }), {
+    fireEvent.change(screen.getByRole("textbox", { name: "First message" }), {
       target: { value: "  list the files  " },
     });
     fireEvent.keyDown(screen.getByRole("dialog"), {
@@ -368,12 +370,66 @@ describe("NewWorkspaceDialog", () => {
       metaKey: true,
     });
 
-    await waitFor(() => expect(createCodeWorkspace).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-prompt"),
+    );
+    expect(submitCodeTurn).toHaveBeenCalledWith(
+      "sess-ws-prompt",
+      "list the files",
+    );
+    // Sent, not parked: nothing left for the workspace composer to take.
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toBeNull();
+  });
+
+  it("hands the message to the workspace composer when the turn cannot be sent", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const submitCodeTurn = vi.fn(async () => {
+      throw new Error("engine crashed on spawn");
+    });
+    const { router } = await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace: vi.fn(async () =>
+            workspace("ws-held", "repo-new", "2026-08-20T00:00:00.000Z"),
+          ),
+          createCodeSession: vi.fn(async () =>
+            session("ws-held", "claude_code", "2026-08-20T00:00:00.000Z"),
+          ),
+          submitCodeTurn,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "First message" }), {
+      target: { value: "list the files" },
+    });
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-held"),
+    );
     expect(useCodeUiStore.getState().pendingComposerPrompt).toEqual({
-      scope: "ws-prompt",
+      scope: "ws-held",
       text: "list the files",
       submit: false,
     });
+    expect(toastError).toHaveBeenCalledWith(
+      "Session started, but the first message could not be sent. engine crashed on spawn",
+    );
   });
 
   it("drops the previous harness model while the next catalog loads", async () => {
@@ -419,8 +475,10 @@ describe("NewWorkspaceDialog", () => {
     expect(
       await screen.findByRole("button", { name: "Model: Sonnet" }),
     ).toBeInTheDocument();
-    await user.click(screen.getByRole("combobox", { name: "Harness" }));
-    await user.click(screen.getByRole("option", { name: /Codex CLI/ }));
+    await user.click(
+      screen.getByRole("button", { name: "Harness: Claude Code" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /Codex CLI/ }));
 
     expect(
       screen.queryByRole("button", { name: "Model: Sonnet" }),
@@ -509,21 +567,25 @@ describe("NewWorkspaceDialog", () => {
     );
     await user.click(screen.getByRole("menuitem", { name: /Claude Opus 5/ }));
 
-    await user.click(screen.getByRole("combobox", { name: "Harness" }));
-    await user.click(screen.getByRole("option", { name: /opencode/ }));
+    await user.click(
+      screen.getByRole("button", { name: "Harness: Claude Code" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /opencode/ }));
     await user.click(
       await screen.findByRole("button", { name: "Model: Kimi K3" }),
     );
     await user.click(screen.getByRole("menuitem", { name: /DeepSeek V4 Pro/ }));
 
-    await user.click(screen.getByRole("combobox", { name: "Harness" }));
-    await user.click(screen.getByRole("option", { name: /Claude Code/ }));
+    await user.click(screen.getByRole("button", { name: "Harness: opencode" }));
+    await user.click(screen.getByRole("menuitem", { name: /Claude Code/ }));
     expect(
       await screen.findByRole("button", { name: "Model: Claude Opus 5" }),
     ).toBeEnabled();
 
-    await user.click(screen.getByRole("combobox", { name: "Harness" }));
-    await user.click(screen.getByRole("option", { name: /opencode/ }));
+    await user.click(
+      screen.getByRole("button", { name: "Harness: Claude Code" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /opencode/ }));
     expect(
       await screen.findByRole("button", { name: "Model: DeepSeek V4 Pro" }),
     ).toBeEnabled();
@@ -541,20 +603,7 @@ describe("NewWorkspaceDialog", () => {
     await renderWithRouter(
       <AppContextProvider
         value={app({
-          listCodeHarnessModels: vi.fn(async () => ({
-            kind: "claude_code" as const,
-            models: [
-              {
-                id: "sonnet",
-                label: "Sonnet",
-                default: true,
-                reasoning_efforts: [],
-                fast_mode: false,
-              },
-            ],
-            reasoning_efforts: [],
-            fast_mode: false,
-          })),
+          listCodeHarnessModels: claudeModels(),
         })}
       >
         <NewWorkspaceDialog
@@ -567,7 +616,7 @@ describe("NewWorkspaceDialog", () => {
       { initialUrl: "/code" },
     );
 
-    const repoField = screen.getByRole("combobox", { name: "Repo" });
+    const repoField = screen.getByRole("button", { name: "Repo" });
     expect(repoField).toHaveTextContent("legacy");
     expect(repoField).toBeEnabled();
   });
@@ -616,6 +665,9 @@ describe("NewWorkspaceDialog", () => {
       { initialUrl: "/code" },
     );
 
+    fireEvent.change(screen.getByRole("textbox", { name: "First message" }), {
+      target: { value: "list the files" },
+    });
     fireEvent.keyDown(screen.getByRole("dialog"), {
       key: "Enter",
       metaKey: true,
@@ -629,12 +681,18 @@ describe("NewWorkspaceDialog", () => {
     expect(
       useCodeCatalogStore.getState().sessionsByWorkspace[created.id],
     ).toBeUndefined();
+    // No session to send to, so the message waits in the workspace composer.
+    expect(useCodeUiStore.getState().pendingComposerPrompt).toEqual({
+      scope: "ws-recover",
+      text: "list the files",
+      submit: false,
+    });
     expect(toastError).toHaveBeenCalledWith(
       "Workspace created, but the session could not start. Codex sign-in expired",
     );
   });
 
-  it("keeps plain Enter in a text field out of create", async () => {
+  it("keeps Enter in the name and base popovers out of create", async () => {
     const repos = [repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({
       repos,
@@ -653,20 +711,7 @@ describe("NewWorkspaceDialog", () => {
           createCodeSession: vi.fn(async () =>
             session("ws-typed", "claude_code", "2026-08-21T00:00:00.000Z"),
           ),
-          listCodeHarnessModels: vi.fn(async () => ({
-            kind: "claude_code" as const,
-            models: [
-              {
-                id: "sonnet",
-                label: "Sonnet",
-                default: true,
-                reasoning_efforts: [],
-                fast_mode: false,
-              },
-            ],
-            reasoning_efforts: [],
-            fast_mode: false,
-          })),
+          listCodeHarnessModels: claudeModels(),
         })}
       >
         <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
@@ -675,15 +720,26 @@ describe("NewWorkspaceDialog", () => {
     );
 
     const user = userEvent.setup();
-    // Enter on a single-line field would submit the form around it, cutting a
-    // worktree from a keystroke that only meant "done typing".
-    await user.click(screen.getByRole("textbox", { name: "Title" }));
-    await user.keyboard("rail polish{Enter}");
-    await user.click(screen.getByRole("textbox", { name: "Base ref" }));
-    await user.keyboard("{Enter}");
+    // Enter in a popover field means "done typing", never "cut a worktree".
+    await user.click(screen.getByRole("button", { name: "Workspace name" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Name" }),
+      "rail polish{Enter}",
+    );
+    expect(
+      screen.queryByRole("textbox", { name: "Name" }),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Base ref" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Base ref" }),
+      "{Enter}",
+    );
     expect(createCodeWorkspace).not.toHaveBeenCalled();
 
-    await user.keyboard("{Meta>}{Enter}{/Meta}");
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
     await waitFor(() =>
       expect(createCodeWorkspace).toHaveBeenCalledWith({
         repo_id: "repo-new",
@@ -691,6 +747,154 @@ describe("NewWorkspaceDialog", () => {
         base_ref: "main",
       }),
     );
+  });
+
+  it("stays open and clears the message when Create more is on", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    let creates = 0;
+    const createCodeWorkspace = vi.fn(async () => {
+      creates += 1;
+      return workspace(
+        `ws-more-${creates}`,
+        "repo-new",
+        "2026-08-21T00:00:00.000Z",
+      );
+    });
+    const createCodeSession = vi.fn(async () =>
+      session("ws-more", "claude_code", "2026-08-21T00:00:00.000Z"),
+    );
+    const submitCodeTurn = vi.fn(
+      async () => ({ kind: "turn" }) as unknown as CodeTurnSubmission,
+    );
+    const onOpenChange = vi.fn();
+    const { router } = await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace,
+          createCodeSession,
+          submitCodeTurn,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={onOpenChange} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("switch", { name: "Create more" }));
+    const message = screen.getByRole("textbox", { name: "First message" });
+    fireEvent.change(message, { target: { value: "first task" } });
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+    await waitFor(() => expect(submitCodeTurn).toHaveBeenCalledTimes(1));
+
+    // Still here, message cleared, settings kept — ready to fire the next one.
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(router.state.location.pathname).toBe("/code");
+    expect(message).toHaveValue("");
+    expect(toastSuccess).toHaveBeenCalled();
+
+    fireEvent.change(message, { target: { value: "second task" } });
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+    await waitFor(() => expect(createCodeWorkspace).toHaveBeenCalledTimes(2));
+    expect(submitCodeTurn).toHaveBeenLastCalledWith(
+      "sess-ws-more",
+      "second task",
+    );
+  });
+
+  it("toggles the pickers from their chords", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    await screen.findByRole("button", { name: "Model: Sonnet" });
+
+    const dialog = screen.getByRole("dialog");
+    // Cmd+N again: the repo menu, matching the shell chord that opened this.
+    fireEvent.keyDown(dialog, { code: "KeyN", metaKey: true });
+    expect(
+      await screen.findByRole("menuitem", { name: /tidebreak/ }),
+    ).toBeInTheDocument();
+    fireEvent.keyDown(dialog, { code: "KeyN", metaKey: true });
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menuitem", { name: /tidebreak/ }),
+      ).not.toBeInTheDocument(),
+    );
+
+    // Alt+M: the model menu, search and all.
+    fireEvent.keyDown(dialog, { code: "KeyM", altKey: true });
+    expect(
+      await screen.findByRole("searchbox", { name: "Search models" }),
+    ).toBeInTheDocument();
+
+    // Alt+B swaps straight over to the base popover.
+    fireEvent.keyDown(dialog, { code: "KeyB", altKey: true });
+    expect(
+      await screen.findByRole("textbox", { name: "Base ref" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("searchbox", { name: "Search models" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("opens on the remembered permission mode when the engine honors it", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    useCodeUiStore.setState({
+      lastCreate: { modelsByHarness: {}, permissionMode: "plan" },
+    });
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    // The engine's default would be Allow; the reader's last pick wins.
+    expect(
+      screen.getByRole("button", { name: "Permissions: Plan" }),
+    ).toBeEnabled();
   });
 
   it("opens a mixed model catalog on every vendor at once", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
+import {
+  Check,
+  ChevronDown,
+  Ellipsis,
+  FolderGit2,
+  GitBranch,
+} from "lucide-react";
 
 import type {
   PermissionMode,
@@ -12,31 +19,32 @@ import type {
 } from "../api/types";
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
-import { friendlyErrorMessage } from "@/lib/utils";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn, friendlyErrorMessage } from "@/lib/utils";
+import { shouldSubmitComposerKey } from "../Composer";
+import { PermissionModeMenu } from "../PermissionModeMenu";
 import { usesCommandModifier } from "@/ShellShortcuts";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { HarnessModelMenu } from "./CodeComposer";
 import { HarnessInstallNote } from "./HarnessInstallNote";
-import { HarnessPicker } from "./HarnessPicker";
+import { HARNESS_ICONS } from "./HarnessPicker";
 import {
   autoIsUnsupervised,
   createPermissionModes,
@@ -45,27 +53,37 @@ import {
   harnessUnusableReason,
   preferredCodeModels,
   requiresHarnessModelIds,
-  PERMISSION_MODE_LABELS,
+  HARNESS_LABELS,
   ALLOW_ALL_NOTE,
   UNSUPERVISED_AUTO_NOTE,
   type CodeModelOption,
 } from "./labels";
 
 /**
- * Create a workspace and its first session, then open it.
+ * Create a workspace, its first session, and — when a first message is typed —
+ * its first turn, then open it.
  *
- * Every field arrives answered, so the dialog is one keystroke deep: Cmd+Enter
- * from anywhere in it creates with what is on screen. Repo, harness, and model
- * open on what this reader used last — the catalog knows, and `lastCreate`
- * covers a fresh window. The starting prompt is optional: filled in, it lands
- * in the workspace composer after create. The title is optional too: left
- * blank, the server generates a two-word name and later replaces it with one
- * derived from the first turn, the same way chats are named.
+ * The dialog is a composer, not a form: the message is the surface, and every
+ * setting is a pill that opens on what this reader used last (repo, engine,
+ * model, and permission mode stick via `lastCreate`; the catalog covers a
+ * fresh window). Enter creates, Shift+Enter breaks a line, and Cmd+Enter
+ * creates from anywhere in the dialog, pickers included. Each pill has its own
+ * chord — Cmd+N again for the repo, and Alt+E / M / P / B / N for engine,
+ * model, permissions, base ref, and name — so a create never needs the mouse.
  *
- * Permission mode defaults to the most autonomous posture the harness honors
- * (decision 0039, amended). Whichever posture that is, the row states it.
- * The harness picker lists every doctor entry. Ready rows are selectable;
- * unusable ones stay visible and dimmed.
+ * A typed message is posted as the session's first turn once the session
+ * exists. If the session or the turn fails, the text is handed to the
+ * workspace composer as a draft instead — never dropped. "Create more" keeps
+ * the dialog open after a create, clearing only the message and name, for
+ * firing off several tasks on the same sticky settings.
+ *
+ * The title is optional: left blank, the server generates a two-word name and
+ * later replaces it with one derived from the first turn, the same way chats
+ * are named. Permission mode defaults to the most autonomous posture the
+ * engine honors (decision 0039, amended); whichever posture is armed, the
+ * note under the message states it. The engine menu lists every doctor entry —
+ * ready rows are selectable; unusable ones stay visible, dimmed, with the
+ * reason.
  */
 
 /** The repo this reader worked on last: newest workspace, then storage. */
@@ -96,6 +114,9 @@ function recentHarness(
   }
   return ready[0]?.kind;
 }
+
+/** Pickers a chord can open; one open at a time, chords toggle. */
+type PickerId = "repo" | "engine" | "model" | "mode" | "base" | "name";
 
 export function NewWorkspaceDialog({
   open,
@@ -130,12 +151,16 @@ export function NewWorkspaceDialog({
     null,
   );
   const [creating, setCreating] = useState(false);
+  const [createMore, setCreateMore] = useState(false);
   const [modelsByHarness, setModelsByHarness] = useState<
     Partial<Record<HarnessKind, string>>
   >({});
   const [modelOptions, setModelOptions] = useState<CodeModelOption[]>([]);
   const [modelLoading, setModelLoading] = useState(false);
-  const repoTrigger = useRef<HTMLButtonElement>(null);
+  const [openPicker, setOpenPicker] = useState<PickerId | null>(null);
+  const openPickerNow = useRef<PickerId | null>(null);
+  openPickerNow.current = openPicker;
+  const promptInput = useRef<HTMLTextAreaElement>(null);
   const command = useMemo(() => usesCommandModifier(navigator.userAgent), []);
 
   const allHarnesses = doctor?.harnesses ?? [];
@@ -166,9 +191,11 @@ export function NewWorkspaceDialog({
     );
     setPickedHarness(null);
     setPermissionMode(null);
+    setCreateMore(false);
     setModelsByHarness({ ...lastCreate?.modelsByHarness });
     setModelOptions([]);
     setModelLoading(false);
+    setOpenPicker(null);
     // Reset against the dialog opening, not against catalog refreshes
     // mid-open — a workspace created elsewhere must not move this form.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -220,14 +247,25 @@ export function NewWorkspaceDialog({
   const availableModes = selectedHarness
     ? createPermissionModes(selectedHarness.caps)
     : [];
+  const honors = (mode: PermissionMode | null | undefined) =>
+    mode && availableModes.includes(mode) ? mode : undefined;
   const postedMode =
-    permissionMode && availableModes.includes(permissionMode)
-      ? permissionMode
-      : selectedHarness
-        ? defaultCreatePermissionMode(selectedHarness.caps)
-        : "plan";
+    honors(permissionMode) ??
+    honors(lastCreate?.permissionMode) ??
+    (selectedHarness
+      ? defaultCreatePermissionMode(selectedHarness.caps)
+      : "plan");
   const canCreate =
     Boolean(repoId && selectedRepo && selectedHarness) && !creating;
+  const modeNote =
+    postedMode === "auto" &&
+    selectedHarness &&
+    autoIsUnsupervised(selectedHarness.caps)
+      ? UNSUPERVISED_AUTO_NOTE
+      : postedMode === "allow"
+        ? ALLOW_ALL_NOTE
+        : null;
+  const installNote = install && (!install.done || install.error);
 
   useEffect(() => {
     if (!open || !harness) return;
@@ -282,6 +320,37 @@ export function NewWorkspaceDialog({
     setModelsByHarness((current) => ({ ...current, [harness]: next }));
   }
 
+  function focusPrompt() {
+    window.requestAnimationFrame(() => {
+      // Clicking from one pill straight to another closes the first and opens
+      // the second in one gesture; the freshly opened menu keeps focus.
+      if (openPickerNow.current !== null) return;
+      promptInput.current?.focus();
+    });
+  }
+
+  /** One picker open at a time; closing by chord puts focus back on the message. */
+  function pickerProps(id: PickerId) {
+    return {
+      open: openPicker === id,
+      onOpenChange: (next: boolean) => {
+        setOpenPicker((current) =>
+          next ? id : current === id ? null : current,
+        );
+        if (!next) focusPrompt();
+      },
+    };
+  }
+
+  function togglePicker(id: PickerId) {
+    if (openPicker === id) {
+      setOpenPicker(null);
+      focusPrompt();
+      return;
+    }
+    setOpenPicker(id);
+  }
+
   async function create() {
     if (!canCreate) return;
     setCreating(true);
@@ -301,9 +370,6 @@ export function NewWorkspaceDialog({
       }
       upsertWorkspace(workspace);
       const prompt = startingPrompt.trim();
-      if (prompt) {
-        useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
-      }
       try {
         const gateway = gatewayCodeModels(models, harness, defaultModelKey);
         const native =
@@ -324,11 +390,46 @@ export function NewWorkspaceDialog({
           harness,
           model: posted,
           modelsByHarness,
+          permissionMode: postedMode,
         });
+        if (prompt) {
+          try {
+            await client.submitCodeTurn(session.id, prompt);
+          } catch (error) {
+            // Never drop typed words: the workspace composer holds them.
+            useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
+            toast.error(
+              `Session started, but the first message could not be sent. ${friendlyErrorMessage(error, "Send it from the workspace composer.")}`,
+            );
+          }
+        }
       } catch (error) {
+        // No session to send to; the workspace composer holds the text and
+        // start-session on the workspace page picks it up.
+        if (prompt) {
+          useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
+        }
         toast.error(
           `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
         );
+      }
+      if (createMore) {
+        // Stay here on the same settings; only what named this task clears.
+        setStartingPrompt("");
+        setTitle("");
+        focusPrompt();
+        const workspaceId = workspace.id;
+        toast.success(`Started ${workspace.title}`, {
+          action: {
+            label: "Open",
+            onClick: () =>
+              void navigate({
+                to: "/code/w/$workspaceId",
+                params: { workspaceId },
+              }),
+          },
+        });
+        return;
       }
       onOpenChange(false);
       await navigate({
@@ -345,180 +446,347 @@ export function NewWorkspaceDialog({
     void create();
   }
 
+  const HarnessIcon = HARNESS_ICONS[harness];
+  const anyUnusable = allHarnesses.some((entry) =>
+    harnessUnusableReason(entry),
+  );
+  // Typed as a plain string: the settings child route is not in the
+  // registered route union, the same escape HarnessPicker uses.
+  const harnessesPath: string = "/settings/coding-harnesses";
+  const shownBaseRef =
+    baseRef.trim() || selectedRepo?.default_base_ref || "base";
+  const alt = (key: string) => (command ? `⌥${key}` : `Alt+${key}`);
+
   return (
     <Dialog open={open} onOpenChange={creating ? undefined : onOpenChange}>
       <DialogContent
-        className="max-w-md gap-5 p-5"
+        className="max-w-3xl gap-0 overflow-hidden p-0 sm:rounded-xl"
+        withCloseButton={false}
         aria-busy={creating}
+        aria-describedby={undefined}
         onOpenAutoFocus={(event) => {
-          const trigger = repoTrigger.current;
-          if (!trigger || trigger.hasAttribute("disabled")) return;
+          // Prompt-centric: the message is where a create starts, so it is
+          // where focus lands. Settings are pills a chord away.
           event.preventDefault();
-          trigger.focus();
+          promptInput.current?.focus();
         }}
         onKeyDownCapture={(event) => {
-          if (event.key !== "Enter") return;
-          // Cmd+Enter (Ctrl+Enter off macOS) creates with what is on screen,
-          // whichever field has focus. An open picker portals its list out of
-          // this element, but React still routes the key through here, so the
-          // chord works with a dropdown up as well.
-          if (event.metaKey || event.ctrlKey) {
-            event.preventDefault();
-            void create();
+          // Cmd reads as Ctrl off macOS, and either chord is accepted on
+          // both: the dialog is one surface, not worth a per-platform miss.
+          const mod = event.metaKey || event.ctrlKey;
+          if (event.key === "Enter") {
+            // Cmd+Enter creates with what is on screen, whichever element has
+            // focus. An open picker portals its list out of this element, but
+            // React still routes the key through here, so the chord works
+            // with a dropdown up as well.
+            if (mod && !event.altKey && !event.shiftKey) {
+              event.preventDefault();
+              void create();
+            }
             return;
           }
-          // Plain Enter stays field-local. A single-line input inside a form
-          // submits it, so Enter on Title or Base ref used to cut a worktree
-          // from a keystroke that only meant "done typing" — and the create
-          // it started left the chord looking broken for the rest of the
-          // dialog's life. The check is on this element rather than on each
-          // field so a picker's own search box, which lives in a portal, is
-          // left to handle its own Enter.
+          if (creating) return;
+          // Every pill has a chord, so a create never needs the mouse. These
+          // ride on `event.code`: on macOS an Option chord types an accented
+          // character, and `key` would carry that instead of the letter.
           if (
-            event.target instanceof HTMLInputElement &&
-            event.currentTarget.contains(event.target)
+            mod &&
+            !event.altKey &&
+            !event.shiftKey &&
+            event.code === "KeyN"
           ) {
             event.preventDefault();
+            togglePicker("repo");
+            return;
           }
+          if (!event.altKey || mod || event.shiftKey) return;
+          const chord: Partial<Record<string, PickerId>> = {
+            KeyE: "engine",
+            KeyM: "model",
+            KeyP: "mode",
+            KeyB: "base",
+            KeyN: "name",
+          };
+          const picker = chord[event.code];
+          if (!picker) return;
+          event.preventDefault();
+          togglePicker(picker);
         }}
       >
-        <DialogHeader>
-          <DialogTitle>New workspace</DialogTitle>
-          <DialogDescription>
-            One worktree and one session on the selected repo.
-          </DialogDescription>
-        </DialogHeader>
-        <form className="flex flex-col gap-3" onSubmit={submit}>
-          <div className="flex flex-col gap-1 text-sm">
-            <span className="font-medium">Repo</span>
-            <Select
-              value={repoId || undefined}
-              onValueChange={(value) => {
-                setRepoId(value);
-                const next = repos.find((repo) => repo.id === value);
-                if (next) setBaseRef(next.default_base_ref);
-              }}
-              disabled={creating || repos.length === 0}
-            >
-              <SelectTrigger aria-label="Repo" ref={repoTrigger}>
-                <SelectValue placeholder="No repos" />
-              </SelectTrigger>
-              <SelectContent scrollButtons={false}>
+        <DialogTitle className="sr-only">New workspace</DialogTitle>
+        <form className="flex min-w-0 flex-col" onSubmit={submit}>
+          <div className="flex min-w-0 items-center gap-1 px-3 pt-3">
+            <DropdownMenu {...pickerProps("repo")}>
+              <WithTooltip label={`Repo · ${command ? "⌘N" : "Ctrl+N"}`}>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="h-8 max-w-64 gap-2 px-2.5"
+                    disabled={creating || repos.length === 0}
+                    aria-label="Repo"
+                  >
+                    <FolderGit2 className="size-4 shrink-0 opacity-70" />
+                    <span className="truncate">
+                      {selectedRepo?.display_name ?? "No repos"}
+                    </span>
+                    <ChevronDown className="size-4 shrink-0 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </WithTooltip>
+              <DropdownMenuContent align="start" className="z-[60] w-64">
                 {repos.map((repo) => (
-                  <SelectItem key={repo.id} value={repo.id}>
-                    {repo.display_name}
-                  </SelectItem>
+                  <DropdownMenuItem
+                    key={repo.id}
+                    onSelect={() => {
+                      setRepoId(repo.id);
+                      setBaseRef(repo.default_base_ref);
+                    }}
+                    className="flex items-center gap-2"
+                  >
+                    <FolderGit2 className="text-muted-foreground size-4 shrink-0" />
+                    <span className="min-w-0 flex-1 truncate">
+                      {repo.display_name}
+                    </span>
+                    {repo.id === repoId && (
+                      <Check className="size-4 shrink-0" />
+                    )}
+                  </DropdownMenuItem>
                 ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex flex-col gap-1 text-sm">
-            <span className="font-medium">Harness</span>
-            <HarnessPicker
-              harnesses={allHarnesses}
-              value={harness}
-              onChange={(next) => {
-                setModelOptions([]);
-                setModelLoading(true);
-                setPickedHarness(next);
-              }}
-              disabled={creating}
-            />
-            <HarnessInstallNote install={install} />
-          </div>
-          <div className="flex flex-col gap-1 text-sm">
-            <span className="font-medium">Model</span>
-            <HarnessModelMenu
-              harness={harness}
-              options={modelOptions}
-              value={model}
-              onChange={selectModel}
-              loading={modelLoading}
-              disabled={creating}
-              variant="field"
-            />
-          </div>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="font-medium">Starting prompt</span>
-            <Textarea
-              value={startingPrompt}
-              onChange={(event) => setStartingPrompt(event.target.value)}
-              disabled={creating}
-              placeholder="Optional"
-              rows={3}
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="font-medium">Title</span>
-            <Input
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              disabled={creating}
-              placeholder="Named automatically"
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="font-medium">Base ref</span>
-            <Input
-              value={baseRef}
-              onChange={(event) => setBaseRef(event.target.value)}
-              disabled={creating}
-              placeholder={selectedRepo?.default_base_ref}
-            />
-          </label>
-          <div className="flex flex-col gap-1 text-sm">
-            <span className="font-medium">Permission mode</span>
-            <Select
-              value={postedMode}
-              onValueChange={(next) =>
-                setPermissionMode(next as PermissionMode)
-              }
-              disabled={creating || availableModes.length === 0}
-            >
-              <SelectTrigger aria-label="Permission mode">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent scrollButtons={false}>
-                {availableModes.map((mode) => (
-                  <SelectItem key={mode} value={mode}>
-                    {PERMISSION_MODE_LABELS[mode]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {postedMode === "auto" &&
-              selectedHarness &&
-              autoIsUnsupervised(selectedHarness.caps) && (
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <Popover {...pickerProps("name")}>
+              <WithTooltip label={`Name · ${alt("N")}`}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="text-muted-foreground h-8 max-w-48 gap-1.5 px-2"
+                    disabled={creating}
+                    aria-label="Workspace name"
+                  >
+                    <Ellipsis className="size-4 shrink-0" />
+                    {title.trim() && (
+                      <span className="text-foreground truncate text-xs">
+                        {title.trim()}
+                      </span>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+              </WithTooltip>
+              <PopoverContent
+                align="start"
+                className="z-[60] flex w-72 flex-col gap-1.5 p-3"
+              >
+                <span className="text-xs font-medium">Name</span>
+                <Input
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  placeholder="Named automatically"
+                  aria-label="Name"
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" || event.metaKey || event.ctrlKey)
+                      return;
+                    event.preventDefault();
+                    togglePicker("name");
+                  }}
+                />
                 <p className="text-muted-foreground text-xs">
-                  {UNSUPERVISED_AUTO_NOTE}
+                  Left blank, the first turn names it.
                 </p>
-              )}
-            {postedMode === "allow" && (
-              <p className="text-muted-foreground text-xs">{ALLOW_ALL_NOTE}</p>
-            )}
+              </PopoverContent>
+            </Popover>
+            <div className="min-w-4 flex-1" />
+            <Popover {...pickerProps("base")}>
+              <WithTooltip label={`Base ref · ${alt("B")}`}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="text-muted-foreground h-8 max-w-56 gap-1.5 px-2"
+                    disabled={creating || !selectedRepo}
+                    aria-label="Base ref"
+                  >
+                    <GitBranch className="size-4 shrink-0" />
+                    <span className="truncate">From {shownBaseRef}</span>
+                    <ChevronDown className="size-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+              </WithTooltip>
+              <PopoverContent
+                align="end"
+                className="z-[60] flex w-72 flex-col gap-1.5 p-3"
+              >
+                <span className="text-xs font-medium">Base ref</span>
+                <Input
+                  value={baseRef}
+                  onChange={(event) => setBaseRef(event.target.value)}
+                  placeholder={selectedRepo?.default_base_ref}
+                  aria-label="Base ref"
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" || event.metaKey || event.ctrlKey)
+                      return;
+                    event.preventDefault();
+                    togglePicker("base");
+                  }}
+                />
+                <p className="text-muted-foreground text-xs">
+                  The branch, tag, or commit the worktree is cut from.
+                </p>
+              </PopoverContent>
+            </Popover>
           </div>
-          <DialogFooter>
+          <textarea
+            ref={promptInput}
+            value={startingPrompt}
+            onChange={(event) => setStartingPrompt(event.target.value)}
+            disabled={creating}
+            aria-label="First message"
+            placeholder="Describe the first task (optional)"
+            className="placeholder:text-muted-foreground max-h-[45vh] min-h-36 w-full resize-none bg-transparent px-4 py-3 text-base outline-none"
+            onKeyDown={(event) => {
+              if (!shouldSubmitComposerKey(event.nativeEvent)) return;
+              event.preventDefault();
+              void create();
+            }}
+          />
+          {(installNote || modeNote) && (
+            <div className="flex flex-col gap-1 px-4 pb-1.5">
+              <HarnessInstallNote install={install} />
+              {modeNote && (
+                <p className="text-muted-foreground text-xs">{modeNote}</p>
+              )}
+            </div>
+          )}
+          <div className="flex min-w-0 items-center gap-1 px-3 pb-3">
+            <DropdownMenu {...pickerProps("engine")}>
+              <WithTooltip label={`Engine · ${alt("E")}`}>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-8 min-w-0 max-w-48 gap-2 px-2"
+                    disabled={creating || allHarnesses.length === 0}
+                    aria-label={`Harness: ${HARNESS_LABELS[harness]}`}
+                  >
+                    <HarnessIcon className="size-4 shrink-0" />
+                    <span className="truncate">{HARNESS_LABELS[harness]}</span>
+                    <ChevronDown className="size-4 shrink-0 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </WithTooltip>
+              <DropdownMenuContent
+                align="start"
+                side="top"
+                className="z-[60] w-64"
+              >
+                {allHarnesses.map((entry) => {
+                  const reason = harnessUnusableReason(entry);
+                  const Icon = HARNESS_ICONS[entry.kind];
+                  return (
+                    <DropdownMenuItem
+                      key={entry.kind}
+                      disabled={Boolean(reason)}
+                      onSelect={() => {
+                        setModelOptions([]);
+                        setModelLoading(true);
+                        setPickedHarness(entry.kind);
+                      }}
+                      className="flex items-start gap-2.5"
+                    >
+                      <Icon className="mt-0.5 size-4 shrink-0" />
+                      <span className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate font-medium">
+                          {HARNESS_LABELS[entry.kind]}
+                        </span>
+                        {reason && (
+                          <span className="text-muted-foreground text-xs">
+                            {reason}
+                          </span>
+                        )}
+                      </span>
+                      {entry.kind === harness && (
+                        <Check className="size-4 shrink-0" />
+                      )}
+                    </DropdownMenuItem>
+                  );
+                })}
+                {anyUnusable && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onSelect={() => void navigate({ to: harnessesPath })}
+                      className="text-muted-foreground text-sm"
+                    >
+                      Coding harnesses…
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            {(modelOptions.length > 0 || modelLoading) && (
+              <WithTooltip label={`Model · ${alt("M")}`}>
+                <span className="inline-flex min-w-0">
+                  <HarnessModelMenu
+                    harness={harness}
+                    options={modelOptions}
+                    value={model}
+                    onChange={selectModel}
+                    loading={modelLoading}
+                    disabled={creating}
+                    {...pickerProps("model")}
+                  />
+                </span>
+              </WithTooltip>
+            )}
+            <WithTooltip label={`Permissions · ${alt("P")}`}>
+              <span className="inline-flex min-w-0">
+                <PermissionModeMenu
+                  scopeKey="code-create"
+                  value={postedMode}
+                  disabled={creating || availableModes.length === 0}
+                  availableModes={availableModes}
+                  onChange={(mode) => setPermissionMode(mode)}
+                  {...pickerProps("mode")}
+                />
+              </span>
+            </WithTooltip>
+            <div className="min-w-4 flex-1" />
+            <WithTooltip label="Stay here after create to fire off another">
+              <label
+                className={cn(
+                  "flex h-8 shrink-0 cursor-pointer items-center gap-2 px-2 text-sm",
+                  createMore ? "text-foreground" : "text-muted-foreground",
+                  creating && "cursor-not-allowed opacity-50",
+                )}
+              >
+                <Switch
+                  checked={createMore}
+                  onCheckedChange={setCreateMore}
+                  disabled={creating}
+                  aria-label="Create more"
+                  className="h-5 w-9"
+                  thumbClassName="size-4 data-[state=checked]:translate-x-4"
+                />
+                <span className="truncate">Create more</span>
+              </label>
+            </WithTooltip>
             <Button
-              type="button"
-              variant="ghost"
-              onClick={() => onOpenChange(false)}
-              disabled={creating}
+              type="submit"
+              disabled={!canCreate}
+              className="h-8 shrink-0"
             >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={!canCreate}>
               {creating ? "Creating…" : "Create"}
               {!creating && (
-                <span
-                  className="ml-1 inline-flex items-center gap-0.5 text-2xs font-medium opacity-60"
+                <kbd
+                  className="font-sans text-2xs font-medium opacity-60"
                   aria-hidden="true"
                 >
-                  <kbd className="font-sans">{command ? "⌘" : "Ctrl"}</kbd>
-                  <kbd className="font-sans">↩</kbd>
-                </span>
+                  ↩
+                </kbd>
               )}
             </Button>
-          </DialogFooter>
+          </div>
         </form>
       </DialogContent>
     </Dialog>

--- a/crates/tidebreak-desktop/ui/src/components/ui/switch.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/ui/switch.tsx
@@ -4,8 +4,10 @@ import { cn } from "@/lib/utils";
 
 const Switch = React.forwardRef<
   React.ComponentRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
+    thumbClassName?: string;
+  }
+>(({ className, thumbClassName, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
       "peer focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
@@ -17,6 +19,7 @@ const Switch = React.forwardRef<
     <SwitchPrimitives.Thumb
       className={cn(
         "bg-background pointer-events-none block h-5 w-5 rounded-full ring-0 shadow-lg transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+        thumbClassName,
       )}
     />
   </SwitchPrimitives.Root>

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useState, type ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import type { CodeRepoSnapshot, HarnessKind } from "@/api/types";
+import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
+import { NewWorkspaceDialog } from "@/code/NewWorkspaceDialog";
+import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
+
+/**
+ * The new-workspace composer: the first message is the surface, and every
+ * setting — repo, name, base ref, engine, model, permissions — is a pill with
+ * its own chord. Enter creates; "Create more" keeps it open for the next one.
+ */
+
+const repos: CodeRepoSnapshot[] = [
+  {
+    id: "repo-tidebreak",
+    root_path: "/Users/sam/tidebreak",
+    display_name: "tidebreak",
+    default_base_ref: "main",
+    branch_prefix: "sam/",
+    quick_actions: [],
+    created_at: "2026-08-10T12:00:00.000Z",
+  },
+  {
+    id: "repo-toronto",
+    root_path: "/Users/sam/toronto",
+    display_name: "toronto",
+    default_base_ref: "main",
+    branch_prefix: "sam/",
+    quick_actions: [],
+    created_at: "2026-08-12T12:00:00.000Z",
+  },
+  {
+    id: "repo-georgetown",
+    root_path: "/Users/sam/georgetown",
+    display_name: "georgetown",
+    default_base_ref: "develop",
+    branch_prefix: "sam/",
+    quick_actions: [],
+    created_at: "2026-08-14T12:00:00.000Z",
+  },
+];
+
+const MODELS: Partial<
+  Record<HarnessKind, { id: string; label: string; default?: boolean }[]>
+> = {
+  claude_code: [
+    { id: "claude-opus-5", label: "Claude Opus 5", default: true },
+    { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
+  ],
+  codex: [
+    { id: "gpt-5.6-sol", label: "GPT 5.6 Sol", default: true },
+    { id: "gpt-5.6-luna", label: "GPT 5.6 Luna" },
+  ],
+  opencode: [
+    { id: "gpt-5.6-sol", label: "GPT 5.6 Sol", default: true },
+    { id: "claude-opus-5", label: "Claude Opus 5" },
+    { id: "grok-4.5", label: "Grok 4.5" },
+  ],
+};
+
+function appContext(): AppContextValue {
+  const client = {
+    listCodeHarnessModels: async (kind: HarnessKind) => ({
+      kind,
+      models: MODELS[kind] ?? [],
+    }),
+    startHarnessInstall: async (kind: HarnessKind) => ({
+      kind,
+      version: "2.1.240",
+      phase: "download",
+      done: false,
+    }),
+    getHarnessDoctor: async () => harnessDoctor,
+    // The story has no server: create reports itself as stubbed rather than
+    // handing the dialog an empty snapshot.
+    createCodeWorkspace: async () => {
+      throw new Error("Storybook stub: creates are not wired here.");
+    },
+    createCodeSession: fn(),
+    submitCodeTurn: fn(),
+  };
+  return {
+    client: client as never,
+    models: [],
+    defaultModelKey: null,
+    providers: [],
+    refreshCatalog: async () => {},
+    refreshChats: async () => {},
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: { status: "idle", version: null, error: null, enabled: false },
+    updateUpToDate: false,
+    checkForUpdate: async () => ({
+      status: "idle",
+      version: null,
+      error: null,
+      enabled: false,
+    }),
+    attachment: "local",
+    restartForUpdate: async () => {},
+  } as AppContextValue;
+}
+
+function withRouter(children: ReactNode) {
+  const rootRoute = createRootRoute();
+  const index = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => <>{children}</>,
+  });
+  const workspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/code/w/$workspaceId",
+    component: () => <>{children}</>,
+  });
+  const harnessSettingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings/coding-harnesses",
+    component: () => <>{children}</>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      index,
+      workspaceRoute,
+      harnessSettingsRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+  return <RouterProvider router={router as never} />;
+}
+
+function NewWorkspace({
+  doctor = harnessDoctor,
+}: {
+  doctor?: typeof harnessDoctor;
+}) {
+  // Seed the catalog before the dialog mounts: its defaults read the store.
+  const [seeded, setSeeded] = useState(false);
+  useEffect(() => {
+    useCodeCatalogStore.setState({
+      repos,
+      doctor,
+      sessionsByWorkspace: {},
+      workspaces: [],
+    });
+    setSeeded(true);
+  }, [doctor]);
+  if (!seeded) return null;
+  return (
+    <AppContextProvider value={appContext()}>
+      <NewWorkspaceDialog open onOpenChange={fn()} repos={repos} />
+    </AppContextProvider>
+  );
+}
+
+const meta = {
+  title: "Code/New workspace",
+  component: NewWorkspace,
+  parameters: { layout: "fullscreen" },
+  decorators: [(Story) => withRouter(<Story />)],
+} satisfies Meta<typeof NewWorkspace>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Sticky defaults answered, message focused, one Enter from a running task.
+ * Every pill has a chord: Cmd+N repo, Alt+E engine, Alt+M model, Alt+P
+ * permissions, Alt+B base ref, Alt+N name.
+ */
+export const Default: Story = {};
+
+/**
+ * Engines that need install or sign-in stay listed and dimmed in the engine
+ * menu; a warm install for the missing pin reports under the message.
+ */
+export const EnginesNeedSetup: Story = {
+  args: { doctor: harnessDoctorDegraded },
+};


### PR DESCRIPTION
## What changed

The new-workspace dialog was a stack of labelled fields with the starting prompt fourth in the tab order, and the prompt it collected only landed in the workspace composer as a draft the reader still had to send; it is now a composer, where the message is the surface, focus lands there on open, and repo, engine, model, permission mode, base ref, and name are pills on the chrome that reopen on what was used last, each with its own chord (Cmd+N repo, Alt+E/M/P/B/N). The typed prompt now runs as the session's first turn, falling back to the workspace draft only when that turn cannot be sent, and a `Create more` toggle keeps the dialog open to fire off another task. Enter sends, Shift+Enter is a newline, and Cmd+Enter still creates from anywhere in the dialog including an open picker. `HarnessModelMenu` and `PermissionModeMenu` gained optional controlled-open props so the chords can drive them, `PermissionModeMenu` now takes `availableModes` so modes an engine cannot honor render disabled rather than missing, and `Switch` gained an optional `thumbClassName` so a caller can size the thumb with the track.

## Validation

`vitest run src/code src/Composer.test.ts src/PermissionModeMenu` (63 files, 662 tests) passes, along with `tsc --noEmit`, `biome format`, and `biome lint`. Both new Storybook stories were screenshotted at 1200px and at the 720px app minimum window width; an earlier revision leaked the footer 28px past the card's rounded edge, which DevTools traced to `DialogContent` being a grid whose item defaulted to `min-width: auto`, so the form's 615px min-content sized the column past the 588px card — fixed with `min-w-0` on the form and rows, `overflow-hidden` on the card, and truncation on the model and permission pills.

## Compatibility and risk

No wire or schema changes. `tidebreak.code-last-create` gains an optional `permissionMode` key, read field-wise and validated against the four known modes, so an older or newer blob still loads. `PermissionModeMenu` and `Switch` are shared with chat; both changes are additive and the defaults are unchanged.