### PR TITLE
feat(code): a delivery nudge replaces the notification poll timers

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
@@ -13,9 +13,13 @@ import {
   trackedCodeDeliveryRepositories,
   useCodeDeliveryStore,
 } from "./CodeDeliveryStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 
-const ACTIVE_POLL_MS = 30_000;
-const VISIBLE_POLL_MS = 2 * 60_000;
+// Freshness rides the `delivery` nudge on the updates socket (decision 66):
+// the server says when the pull-request store changed, and this monitor
+// re-reads then. The remaining timers are a safety net — run summaries have
+// no store yet, and a dropped socket must not silence notifications.
+const SAFETY_POLL_MS = 5 * 60_000;
 const HIDDEN_POLL_MS = 10 * 60_000;
 const FIRST_RUN_LOOKBACK_MS = 24 * 60 * 60 * 1_000;
 const MAX_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1_000;
@@ -36,10 +40,16 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
   const pathnameRef = useRef(pathname);
   pathnameRef.current = pathname;
   const wakeRef = useRef<(() => void) | null>(null);
+  const deliveryRevision = useCodeUpdatesStore(
+    (state) => state.deliveryRevision,
+  );
 
   useEffect(() => {
+    // A nudge while hidden waits for the hidden-window poll; visibility
+    // returning schedules its own immediate pass.
+    if (document.hidden) return;
     wakeRef.current?.();
-  }, [pathname]);
+  }, [pathname, deliveryRevision]);
 
   useEffect(() => {
     let cancelled = false;
@@ -50,13 +60,7 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
 
     const interval = () => {
       if (document.hidden) return HIDDEN_POLL_MS;
-      if (
-        pathnameRef.current.startsWith("/code/delivery/") ||
-        pathnameRef.current === "/code/notifications"
-      ) {
-        return ACTIVE_POLL_MS;
-      }
-      return VISIBLE_POLL_MS;
+      return SAFETY_POLL_MS;
     };
 
     const schedule = (delay = interval()) => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -40,6 +40,7 @@ const EMPTY_STATE: CodeUpdatesState = {
   cloneJobs: {},
   harnessInstalls: {},
   viewedWorkspaceId: null,
+  deliveryRevision: 0,
 };
 
 afterEach(() => {
@@ -249,6 +250,14 @@ describe("reduceCodeUpdates", () => {
         done: false,
       },
     });
+    expect(noticeToAction({ type: "delivery" })).toEqual({ type: "delivery" });
+  });
+
+  it("bumps the delivery revision on each nudge (decision 66)", () => {
+    const first = reduceCodeUpdates(EMPTY_STATE, { type: "delivery" });
+    expect(first.deliveryRevision).toBe(1);
+    const second = reduceCodeUpdates(first, { type: "delivery" });
+    expect(second.deliveryRevision).toBe(2);
   });
 
   it("keeps one install state per engine", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -58,6 +58,12 @@ export type CodeUpdatesState = {
    */
   harnessInstalls: Partial<Record<HarnessKind, CodeHarnessInstallSnapshot>>;
   viewedWorkspaceId: string | null;
+  /**
+   * Bumped on each `delivery` notice: the pull-request store changed
+   * (decision 66). Delivery surfaces re-read their queries when this moves
+   * instead of running their own poll timers.
+   */
+  deliveryRevision: number;
 };
 
 export type CodeUpdatesAction =
@@ -65,6 +71,7 @@ export type CodeUpdatesAction =
   | { type: "digest"; digest: CodeSessionDigest }
   | { type: "clone_progress"; job: CodeCloneJobSnapshot }
   | { type: "harness_install"; install: CodeHarnessInstallSnapshot }
+  | { type: "delivery" }
   | { type: "view"; workspaceId: string | null }
   | { type: "reset" };
 
@@ -74,6 +81,7 @@ const EMPTY: CodeUpdatesState = {
   cloneJobs: {},
   harnessInstalls: {},
   viewedWorkspaceId: null,
+  deliveryRevision: 0,
 };
 
 export function reduceCodeUpdates(
@@ -136,6 +144,8 @@ export function reduceCodeUpdates(
           [action.install.kind]: action.install,
         },
       };
+    case "delivery":
+      return { ...state, deliveryRevision: state.deliveryRevision + 1 };
     case "view":
       return { ...state, viewedWorkspaceId: action.workspaceId };
     case "reset":
@@ -353,6 +363,9 @@ export function noticeToAction(
         ...(notice.error !== undefined ? { error: notice.error } : {}),
       },
     };
+  }
+  if (notice.type === "delivery") {
+    return { type: "delivery" };
   }
   return null;
 }

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1561,7 +1561,7 @@ subagents?: Array<CodeSubagentSummary>,
  * Where this session stands, in a sentence, derived from the newest
  * turn that carries one.
  */
-recap?: string, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, } | { "type": "harness_install", kind: HarnessKind, version?: string, phase: string, done: boolean, error?: string, };
+recap?: string, } | { "type": "terminal_activity", workspace_id: WorkspaceId, terminal_id: CodeTerminalId, } | { "type": "clone_progress", job: string, phase: string, percent?: number, done: boolean, error?: string, repo_id?: RepoId, } | { "type": "harness_install", kind: HarnessKind, version?: string, phase: string, done: boolean, error?: string, } | { "type": "delivery" };
 
 /**
  * Token accounting for one turn.

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -101,6 +101,9 @@ pub(crate) enum CodeLiveUpdate {
     /// Warm harness install progress. Not restated on connect; the doctor
     /// report is the durable answer for what is installed.
     HarnessInstall(HarnessInstallProgress),
+    /// The pull-request store changed (decision 66). No payload: delivery
+    /// surfaces re-read their queries on receipt.
+    Delivery,
 }
 
 /// Per-session broadcast channels for live journal events, plus one digest

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -177,6 +177,8 @@ pub(crate) struct CodeRuntime {
     /// Workspaces whose digest was requested recently, with the owner each
     /// belongs to: the hot tier the refresher walks (decision 66).
     hot_prs: Mutex<HashMap<WorkspaceId, (OwnerId, Instant)>>,
+    /// When each owner last took a delivery nudge, for the debounce.
+    delivery_nudges: Mutex<HashMap<OwnerId, Instant>>,
     /// Paces and parks every conditional GitHub read (decision 66).
     host_gate: super::pr_fetch::HostGate,
     /// Base-branch rules, cached per branch: whether a merge queue runs
@@ -225,6 +227,10 @@ const BRANCH_RULES_TTL: Duration = Duration::from_secs(3600);
 /// (decision 66). The UI asks again while a workspace stays open, so the
 /// window only needs to outlive its poll spacing with room to spare.
 const HOT_WINDOW: Duration = Duration::from_secs(120);
+
+/// Floor between two delivery nudges to one owner (decision 66): a sweep
+/// updating many rows collapses to one re-read on the other side.
+const DELIVERY_NUDGE_DEBOUNCE: Duration = Duration::from_secs(3);
 
 /// One cached branch-rules answer. `rules: None` records a host that has no
 /// rules endpoint, so a known 404 is not re-read every refresh.
@@ -289,6 +295,7 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: Mutex::new(HashMap::new()),
+            delivery_nudges: Mutex::new(HashMap::new()),
             host_gate: super::pr_fetch::HostGate::default(),
             branch_rules: Mutex::new(HashMap::new()),
             delivery_cache: DeliveryCache::default(),
@@ -409,6 +416,7 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
             hot_prs: Mutex::new(HashMap::new()),
+            delivery_nudges: Mutex::new(HashMap::new()),
             host_gate: super::pr_fetch::HostGate::default(),
             branch_rules: Mutex::new(HashMap::new()),
             delivery_cache: DeliveryCache::default(),
@@ -1618,6 +1626,23 @@ impl CodeRuntime {
         hot.insert(id, (owner.clone(), Instant::now()));
     }
 
+    /// One delivery nudge on the updates channel, debounced per owner
+    /// (decision 66): a sweep that moves several rows costs one re-read,
+    /// not one per row.
+    fn nudge_delivery_update(&self, owner: &OwnerId) {
+        {
+            let mut nudged = self.delivery_nudges.lock().expect("delivery nudges");
+            if let Some(last) = nudged.get(owner) {
+                if last.elapsed() < DELIVERY_NUDGE_DEBOUNCE {
+                    return;
+                }
+            }
+            nudged.insert(owner.clone(), Instant::now());
+        }
+        self.bus
+            .publish_update(owner, super::bus::CodeLiveUpdate::Delivery);
+    }
+
     /// The workspaces the hot refresher walks this tick.
     pub(super) fn hot_pull_request_workspaces(&self) -> Vec<(OwnerId, WorkspaceId)> {
         let mut hot = self.hot_prs.lock().expect("hot prs");
@@ -2035,6 +2060,10 @@ impl CodeRuntime {
         if !changed {
             return;
         }
+        // One delivery nudge per real change (decision 66): the delivery
+        // page and notification monitor re-read on receipt instead of on
+        // their own timers.
+        self.nudge_delivery_update(owner);
         let workspaces = match list_workspaces(&self.db, owner, None).await {
             Ok(workspaces) => workspaces,
             Err(_) => return,

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -1804,6 +1804,10 @@ pub enum CodeUpdateNotice {
         #[ts(optional)]
         error: Option<String>,
     },
+    /// The pull-request store changed (decision 66). No payload: a delivery
+    /// surface re-reads its query, which the server answers from its own
+    /// store and caches. Not restated on connect.
+    Delivery,
 }
 
 impl CodeUpdateNotice {

--- a/crates/tidebreak-server/src/routes/code/updates.rs
+++ b/crates/tidebreak-server/src/routes/code/updates.rs
@@ -107,6 +107,14 @@ async fn stream_updates(
                         break;
                     }
                 }
+                Ok(CodeLiveUpdate::Delivery) => {
+                    if send_notice(&mut socket, &CodeUpdateNotice::Delivery)
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
                 Err(RecvError::Lagged(_)) => {
                     match list_digests(&runtime.db, &owner).await {
                         Ok(sessions) => {


### PR DESCRIPTION
Stacked on #2568 (the hot tier); the diff here is against that branch, and GitHub retargets this pull request when it merges.

Slice 5 of [decision 66](docs/decisions/0066-pull-request-state-is-one-store.md): the delivery surfaces stop polling on their own clocks.

## What changes

- `WS /code/updates` gains a `delivery` notice. When the pull-request store takes a real change — from the hot refresher, a mutation, or the reconcile sweep's delivery reads — the server nudges each owner's channel once, debounced to three seconds so a sweep that moves many rows costs one re-read on the other side.
- The delivery monitor drops its 30-second and 2-minute poll tiers. It re-reads its queries when the nudge arrives; the queries stay server-cached, so a nudge costs one local round trip. Two slow safety passes remain: 5 minutes visible and 10 minutes hidden, because run summaries have no store yet and a dropped socket must not silence notifications. A nudge while the window is hidden waits for the hidden pass.
- The workspace pane needed nothing: it already rides the session digests on the same socket, and the previous slice took its `GET …/pr` reads off GitHub.

## Why

This closes decision 66's freshness loop: the store diffs on write, a change broadcasts once, and every surface reacts to the broadcast instead of asking on a timer. With the conditional fetcher and the hot tier from slice 4, steady-state GitHub traffic now scales with how often pull requests change, not with how many views are open.

## Testing

- Store tests cover the notice mapping and the revision bump per nudge.
- `tsc`, focused vitest, and biome pass; the wire binding is hand-matched to the generator's output and the staleness test verifies it in CI.
