### PR TITLE
feat(code): a hot tier refreshes viewed pull requests and reads leave the request path

### DIFF
--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -5,7 +5,6 @@
 //! a hosted machine instead lends each git operation a dying, gateway-minted
 //! credential through the environment (decision 63).
 
-use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -16,7 +15,7 @@ use tokio::process::Command;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
 
-use tidebreak_core::{Diffstat, PullRequestDigest, QuickAction, WorkspaceId};
+use tidebreak_core::{Diffstat, PullRequestDigest, QuickAction};
 use tidebreak_harness::{filter_child_env, probe_shell, HostEnv};
 
 use super::setup_script::spawn_workspace_script;
@@ -27,7 +26,6 @@ const GIT_PUSH_TIMEOUT: Duration = Duration::from_secs(120);
 const GH_TIMEOUT: Duration = Duration::from_secs(30);
 const ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_OUTPUT_CHARS: usize = 4_096;
-const PR_CACHE_TTL: Duration = Duration::from_secs(20);
 const GH_OBSERVATION_TTL: Duration = Duration::from_secs(30);
 pub(crate) const GH_UNAVAILABLE_PREFIX: &str = "gh_unavailable: ";
 pub(crate) const PR_HEAD_CHANGED_PREFIX: &str = "pr_head_changed: ";
@@ -93,43 +91,6 @@ impl CachedGhObservation {
             self.observed_at.elapsed() <= GH_OBSERVATION_TTL
         };
         fresh.then(|| self.observation.clone())
-    }
-}
-
-/// Brief in-memory cache of a workspace PR digest.
-#[derive(Debug, Default)]
-pub(crate) struct PrDigestCache {
-    entries: std::sync::Mutex<HashMap<WorkspaceId, CachedPr>>,
-}
-
-#[derive(Debug, Clone)]
-struct CachedPr {
-    fetched_at: Instant,
-    digest: PullRequestDigest,
-}
-
-impl PrDigestCache {
-    pub(crate) fn get(&self, id: WorkspaceId) -> Option<PullRequestDigest> {
-        let guard = self.entries.lock().expect("pr cache");
-        let entry = guard.get(&id)?;
-        if entry.fetched_at.elapsed() > PR_CACHE_TTL {
-            return None;
-        }
-        Some(entry.digest.clone())
-    }
-
-    pub(crate) fn put(&self, id: WorkspaceId, digest: PullRequestDigest) {
-        self.entries.lock().expect("pr cache").insert(
-            id,
-            CachedPr {
-                fetched_at: Instant::now(),
-                digest,
-            },
-        );
-    }
-
-    pub(crate) fn invalidate(&self, id: WorkspaceId) {
-        self.entries.lock().expect("pr cache").remove(&id);
     }
 }
 
@@ -407,13 +368,11 @@ pub(crate) async fn authenticated_gh_binary(search_path: Option<&str>) -> Option
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn create_pull_request(
     worktree: &Path,
-    workspace_id: WorkspaceId,
     title: &str,
     branch: &str,
     base_ref: &str,
     requested_title: Option<&str>,
     requested_body: Option<&str>,
-    cache: &PrDigestCache,
     gh_search_path: Option<&str>,
 ) -> Result<PullRequestDigest, GhError> {
     let inspect = inspect_git(worktree, base_ref, title).await?;
@@ -460,7 +419,6 @@ pub(crate) async fn create_pull_request(
             &inspect.diffstat,
         )
     })?;
-    cache.invalidate(workspace_id);
     // A light digest from the creation answer. The caller's next status
     // read enriches it through the conditional fetcher (decision 66), which
     // needs exactly this URL to name the pull request.
@@ -504,13 +462,11 @@ pub(crate) async fn create_pull_request(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn create_pull_request_rest(
     worktree: &Path,
-    workspace_id: WorkspaceId,
     title: &str,
     branch: &str,
     base_ref: &str,
     requested_title: Option<&str>,
     requested_body: Option<&str>,
-    cache: &PrDigestCache,
     api_base: &str,
     target: &crate::routes::code::types::CodeGitHubRepositoryTarget,
     credential: &GitCredential,
@@ -532,11 +488,9 @@ pub(crate) async fn create_pull_request_rest(
     )
     .await
     .map_err(|reason| GhError::user(format!("the pull request was not created: {reason}")))?;
-    cache.invalidate(workspace_id);
     if let Ok(Some(digest)) =
         super::forge_rest::pull_request_digest(api_base, target, credential, branch).await
     {
-        cache.put(workspace_id, digest.clone());
         return Ok((digest, fact));
     }
     let number = fact.get("number").and_then(serde_json::Value::as_u64);
@@ -573,7 +527,6 @@ pub(crate) async fn create_pull_request_rest(
         auto_merge_enabled: None,
         in_merge_queue: None,
     };
-    cache.put(workspace_id, digest.clone());
     Ok((digest, fact))
 }
 
@@ -601,10 +554,8 @@ impl MergeMethod {
 /// refuses merge argv outright.
 pub(crate) async fn merge_pull_request(
     worktree: &Path,
-    workspace_id: WorkspaceId,
     method: MergeMethod,
     auto: bool,
-    cache: &PrDigestCache,
     gh_search_path: Option<&str>,
 ) -> Result<(), GhError> {
     let gh = observe_gh(gh_search_path).await;
@@ -616,7 +567,6 @@ pub(crate) async fn merge_pull_request(
     run_gh_user_merge(worktree, &binary, &args, GH_TIMEOUT)
         .await
         .map_err(classify_merge_error)?;
-    cache.invalidate(workspace_id);
     Ok(())
 }
 
@@ -632,8 +582,6 @@ pub(crate) async fn merge_pull_request(
 /// point of having two runners (decision 42).
 pub(crate) async fn mark_workspace_pull_request_ready(
     worktree: &Path,
-    workspace_id: WorkspaceId,
-    cache: &PrDigestCache,
     gh_search_path: Option<&str>,
 ) -> Result<(), GhError> {
     let observation = observe_gh(gh_search_path).await;
@@ -641,7 +589,6 @@ pub(crate) async fn mark_workspace_pull_request_ready(
     run_gh(worktree, &binary, &["pr", "ready"], GH_TIMEOUT)
         .await
         .map_err(|error| classify_observed_gh(error, &observation))?;
-    cache.invalidate(workspace_id);
     Ok(())
 }
 
@@ -2645,16 +2592,13 @@ exit 3
                 log = log.display()
             ),
         );
-        let cache = PrDigestCache::default();
         let digest = create_pull_request(
             &work,
-            WorkspaceId::new(),
             "first change",
             "tidebreak/first-change",
             "origin/main",
             None,
             None,
-            &cache,
             Some(shim_dir.path().to_str().unwrap()),
         )
         .await
@@ -2722,16 +2666,9 @@ exit 3
             ),
         );
         let work = TempDir::new().unwrap();
-        let cache = PrDigestCache::default();
-        let workspace = WorkspaceId::new();
-        mark_workspace_pull_request_ready(
-            work.path(),
-            workspace,
-            &cache,
-            Some(shim_dir.path().to_str().unwrap()),
-        )
-        .await
-        .expect("gh pr ready should run");
+        mark_workspace_pull_request_ready(work.path(), Some(shim_dir.path().to_str().unwrap()))
+            .await
+            .expect("gh pr ready should run");
         let logged = std::fs::read_to_string(&log).unwrap();
         assert!(logged.contains("pr ready"), "{logged}");
         assert!(!logged.contains("merge"), "{logged}");
@@ -2786,23 +2723,18 @@ exit 3
         assert!(!log.exists(), "a refused argv must never spawn gh");
 
         // The dedicated merge operation is the one path that runs it.
-        let cache = PrDigestCache::default();
         merge_pull_request(
             dir.path(),
-            WorkspaceId::new(),
             MergeMethod::Squash,
             false,
-            &cache,
             Some(shim_dir.path().to_str().unwrap()),
         )
         .await
         .unwrap();
         merge_pull_request(
             dir.path(),
-            WorkspaceId::new(),
             MergeMethod::Merge,
             true,
-            &cache,
             Some(shim_dir.path().to_str().unwrap()),
         )
         .await

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod gh;
 pub(crate) mod harness_install;
 pub(crate) mod pr_facts;
 pub(crate) mod pr_fetch;
+pub(crate) mod pr_refresh;
 pub(crate) mod recap;
 pub(crate) mod reconcile;
 pub(crate) mod recovery;

--- a/crates/tidebreak-server/src/code/pr_fetch.rs
+++ b/crates/tidebreak-server/src/code/pr_fetch.rs
@@ -357,7 +357,17 @@ pub(crate) async fn read_merge_queue_membership(
         "--jq",
         ".[] | select(.event == \"added_to_merge_queue\" or .event == \"removed_from_merge_queue\") | .event",
     ]);
-    let events = run_gh(cwd, binary, &args, FETCH_TIMEOUT).await.ok()?;
+    let events = match run_gh(cwd, binary, &args, FETCH_TIMEOUT).await {
+        Ok(events) => events,
+        Err(error) => {
+            // The paginated read cannot carry headers, so a limit answer
+            // parks the host by its text rather than by `Retry-After`.
+            if error.to_ascii_lowercase().contains("rate limit") {
+                gate.park(host, DEFAULT_PARK);
+            }
+            return None;
+        }
+    };
     Some(queue_membership_from_events(&events))
 }
 

--- a/crates/tidebreak-server/src/code/pr_refresh.rs
+++ b/crates/tidebreak-server/src/code/pr_refresh.rs
@@ -1,0 +1,67 @@
+//! Hot-tier pull-request refresher (decision 66).
+//!
+//! The pull requests someone is looking at — a workspace whose digest the
+//! UI just requested, or one with an active watch — refresh every
+//! [`HOT_REFRESH_INTERVAL`] through the conditional fetcher, where an
+//! unchanged answer is a free 304. Everything else rides the reconcile
+//! sweep's slower list read. No view owns a fetch, and no view triggers an
+//! unconditional one: the request path reads the stored row, and this
+//! sweep is what keeps the row current while anyone watches.
+
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use tidebreak_core::db::code::list_active_watches_all_owners;
+
+use super::runtime::CodeRuntime;
+
+/// Coprime with the 47s watch, 53s trigger, and 61s reconcile sweeps, so
+/// the four background readers never land on the same tick.
+pub(crate) const HOT_REFRESH_INTERVAL: Duration = Duration::from_secs(17);
+
+/// Abort the hot refresher when the runtime is dropped. The loop holds a
+/// [`Weak`] handle for the same reason every sweep does: an `Arc` would
+/// keep the runtime alive from its own field.
+pub(crate) struct PrRefreshGuard(Option<tokio::task::JoinHandle<()>>);
+
+impl PrRefreshGuard {
+    pub(crate) fn spawn(runtime: Weak<CodeRuntime>) -> Self {
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(HOT_REFRESH_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let Some(runtime) = runtime.upgrade() else {
+                    return;
+                };
+                sweep_hot(&runtime).await;
+            }
+        });
+        Self(Some(handle))
+    }
+}
+
+impl Drop for PrRefreshGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// One hot pass: every workspace with recent digest attention or an active
+/// watch takes one conditional refresh. Sequential on purpose — the gate
+/// spaces the host anyway, and the hot set is small by construction.
+async fn sweep_hot(runtime: &Arc<CodeRuntime>) {
+    let mut targets = runtime.hot_pull_request_workspaces();
+    if let Ok(watches) = list_active_watches_all_owners(&runtime.db).await {
+        for watch in watches {
+            if !targets.iter().any(|(_, id)| *id == watch.workspace_id) {
+                targets.push((watch.owner.clone(), watch.workspace_id));
+            }
+        }
+    }
+    for (owner, id) in targets {
+        runtime.refresh_workspace_pr_row(&owner, id).await;
+    }
+}

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -41,9 +41,7 @@ use super::ci_logs;
 use super::clone::CloneJobs;
 use super::delivery::DeliveryCache;
 use super::fork;
-use super::gh::{
-    self, ActionOutcome, CommitOutcome, GhError, PrDigestCache, PushOutcome, WorkspaceGitStatus,
-};
+use super::gh::{self, ActionOutcome, CommitOutcome, GhError, PushOutcome, WorkspaceGitStatus};
 use super::harness_install::HarnessInstallJobs;
 use super::recovery::{self, RecoveryAction};
 use super::session_worker::{
@@ -176,7 +174,9 @@ pub(crate) struct CodeRuntime {
     /// A worker takes the workspace's lock for the length of a turn, so a
     /// sibling's turn starts after this one ends. See record 55.
     worktree_turns: Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
-    pr_cache: PrDigestCache,
+    /// Workspaces whose digest was requested recently, with the owner each
+    /// belongs to: the hot tier the refresher walks (decision 66).
+    hot_prs: Mutex<HashMap<WorkspaceId, (OwnerId, Instant)>>,
     /// Paces and parks every conditional GitHub read (decision 66).
     host_gate: super::pr_fetch::HostGate,
     /// Base-branch rules, cached per branch: whether a merge queue runs
@@ -201,6 +201,8 @@ pub(crate) struct CodeRuntime {
     trigger_started: AtomicBool,
     reconcile_sweep: Mutex<Option<super::reconcile::ReconcileSweepGuard>>,
     reconcile_started: AtomicBool,
+    pr_refresh_sweep: Mutex<Option<super::pr_refresh::PrRefreshGuard>>,
+    pr_refresh_started: AtomicBool,
     /// Workspaces with a background naming call in flight.
     ///
     /// One call per workspace at a time; a second trigger is dropped rather
@@ -218,6 +220,11 @@ pub(crate) struct CodeRuntime {
 /// How long one base branch's rules answer stands before the next read.
 /// Rules change on the order of releases, not pushes.
 const BRANCH_RULES_TTL: Duration = Duration::from_secs(3600);
+
+/// How long one digest request keeps a workspace on the hot refresh tier
+/// (decision 66). The UI asks again while a workspace stays open, so the
+/// window only needs to outlive its poll spacing with room to spare.
+const HOT_WINDOW: Duration = Duration::from_secs(120);
 
 /// One cached branch-rules answer. `rules: None` records a host that has no
 /// rules endpoint, so a known 404 is not re-read every refresh.
@@ -281,7 +288,7 @@ impl CodeRuntime {
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
-            pr_cache: PrDigestCache::default(),
+            hot_prs: Mutex::new(HashMap::new()),
             host_gate: super::pr_fetch::HostGate::default(),
             branch_rules: Mutex::new(HashMap::new()),
             delivery_cache: DeliveryCache::default(),
@@ -299,6 +306,8 @@ impl CodeRuntime {
             trigger_started: AtomicBool::new(false),
             reconcile_sweep: Mutex::new(None),
             reconcile_started: AtomicBool::new(false),
+            pr_refresh_sweep: Mutex::new(None),
+            pr_refresh_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
             recap: Mutex::new(None),
         }
@@ -350,6 +359,7 @@ impl CodeRuntime {
             runtime.ensure_watch_sweep();
             runtime.ensure_trigger_sweep();
             runtime.ensure_reconcile_sweep();
+            runtime.ensure_pr_refresh_sweep();
             actions
         })
     }
@@ -398,7 +408,7 @@ impl CodeRuntime {
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
             worktree_turns: Mutex::new(HashMap::new()),
-            pr_cache: PrDigestCache::default(),
+            hot_prs: Mutex::new(HashMap::new()),
             host_gate: super::pr_fetch::HostGate::default(),
             branch_rules: Mutex::new(HashMap::new()),
             delivery_cache: DeliveryCache::default(),
@@ -416,6 +426,8 @@ impl CodeRuntime {
             trigger_started: AtomicBool::new(false),
             reconcile_sweep: Mutex::new(None),
             reconcile_started: AtomicBool::new(false),
+            pr_refresh_sweep: Mutex::new(None),
+            pr_refresh_started: AtomicBool::new(false),
             titling_in_flight: Mutex::new(std::collections::HashSet::new()),
             recap: Mutex::new(None),
         }
@@ -1330,10 +1342,7 @@ impl CodeRuntime {
         let outcome = gh::push_branch(&worktree, &workspace.branch_name, credential.as_ref())
             .await
             .map_err(map_gh)?;
-        // The digest cached before the push describes the old head. Drop it
-        // and the delivery lists so the next reader sees checks pending on
-        // the new head rather than the pre-push snapshot (decision 66).
-        self.pr_cache.invalidate(id);
+        // The delivery lists hold the pre-push row.
         self.delivery_cache.invalidate();
         // Best-effort contributed fact (decision 62): a user push to a branch
         // that is a pull request's head is the same act the detector mints
@@ -1378,6 +1387,11 @@ impl CodeRuntime {
                 .await;
             }
         }
+        // A push dirties the row: refresh it now (decision 66), so the next
+        // reader sees checks pending on the new head rather than the
+        // pre-push snapshot. The fetcher's checks read is keyed to the new
+        // head by construction.
+        self.refresh_workspace_pr_row(owner, id).await;
         Ok(outcome)
     }
 
@@ -1487,6 +1501,10 @@ impl CodeRuntime {
         id: WorkspaceId,
     ) -> Result<WorkspaceGitStatus, ServerError> {
         let mut workspace = self.get_workspace(owner, id).await?;
+        // Being asked is the attention signal (decision 66): the request
+        // path reads local git plus the stored row, and the hot refresher
+        // this mark feeds is what keeps the row current while anyone reads.
+        self.mark_workspace_pr_hot(owner, workspace.id);
         let gh_path = self.gh_search_path_owned();
         let mut status = gh::workspace_git_status(
             std::path::Path::new(&workspace.worktree_path),
@@ -1498,35 +1516,14 @@ impl CodeRuntime {
         )
         .await
         .map_err(map_gh)?;
-        // The digest comes through the conditional fetcher (decision 66):
-        // the fact row's ETags ride along, an unchanged answer is a free 304
-        // served from the row, and a changed one writes through to every
-        // holder. A failed fetch leaves the persisted digest standing.
-        if status.gh_found && status.gh_authenticated == Some(true) {
-            if let Some(cached) = self.pr_cache.get(workspace.id) {
-                status.pr = Some(cached);
-            } else if let Some(binary) = gh::authenticated_gh_binary(gh_path.as_deref()).await {
-                if let Some(digest) = self
-                    .fetched_workspace_digest(owner, &workspace, &binary)
-                    .await
-                {
-                    self.pr_cache.put(workspace.id, digest.clone());
-                    status.pr = Some(digest);
-                }
-            }
-        }
         // On a hosted machine the digest comes from the forge REST API with
-        // a borrowed credential (decision 65) — there is no `gh` here to
-        // refresh it. Cache-aware exactly like the `gh` path, borrowing only
-        // on a miss; failures leave the persisted digest and the next read
-        // asks again.
+        // a borrowed credential (decision 65) — there is no `gh` here for
+        // the hot refresher to drive, so this read stays in the request
+        // path. Failures leave the persisted digest and the next read asks
+        // again.
         if self.git_credentials().is_some() {
             let worktree = std::path::Path::new(&workspace.worktree_path);
-            if let Some(cached) = self.pr_cache.get(workspace.id) {
-                status.pr = Some(cached);
-            } else if let Ok(Some((target, credential))) =
-                self.forge_rest_context(owner, worktree).await
-            {
+            if let Ok(Some((target, credential))) = self.forge_rest_context(owner, worktree).await {
                 let api_base = self.forge_api_base_for(&target.host);
                 if let Ok(Some(digest)) = super::forge_rest::pull_request_digest(
                     &api_base,
@@ -1536,7 +1533,6 @@ impl CodeRuntime {
                 )
                 .await
                 {
-                    self.pr_cache.put(workspace.id, digest.clone());
                     status.pr = Some(digest);
                 }
             }
@@ -1576,15 +1572,68 @@ impl CodeRuntime {
         Ok(status)
     }
 
-    /// Force a fresh host read: drop the digest cache entry, then take the
-    /// normal status path.
+    /// Force a fresh host read now — the user asked, or a mutation just
+    /// moved the pull request — then answer with the refreshed row.
     pub(crate) async fn refresh_workspace_pr(
         &self,
         owner: &OwnerId,
         id: WorkspaceId,
     ) -> Result<WorkspaceGitStatus, ServerError> {
-        self.pr_cache.invalidate(id);
+        self.refresh_workspace_pr_row(owner, id).await;
         self.workspace_pr(owner, id).await
+    }
+
+    /// One conditional refresh of the workspace's pull-request row: fetch,
+    /// write the row (which fans real change out to every other holder),
+    /// and take the new digest as this workspace's column. Quiet on every
+    /// failure — the caller's row keeps whatever it had, and the next tick
+    /// or sweep corrects.
+    pub(crate) async fn refresh_workspace_pr_row(&self, owner: &OwnerId, id: WorkspaceId) {
+        let Ok(mut workspace) = self.get_workspace(owner, id).await else {
+            return;
+        };
+        if workspace.status != CodeWorkspaceStatus::Active {
+            return;
+        }
+        let gh_path = self.gh_search_path_owned();
+        let Some(binary) = gh::authenticated_gh_binary(gh_path.as_deref()).await else {
+            return;
+        };
+        let Some(digest) = self
+            .fetched_workspace_digest(owner, &workspace, &binary)
+            .await
+        else {
+            return;
+        };
+        if workspace.pr.as_ref() != Some(&digest) {
+            workspace.pr = Some(digest);
+            let _ = self.save_workspace(&workspace).await;
+        }
+    }
+
+    /// Keep this workspace on the hot refresh tier for [`HOT_WINDOW`].
+    fn mark_workspace_pr_hot(&self, owner: &OwnerId, id: WorkspaceId) {
+        let mut hot = self.hot_prs.lock().expect("hot prs");
+        hot.retain(|_, (_, marked)| marked.elapsed() <= HOT_WINDOW);
+        hot.insert(id, (owner.clone(), Instant::now()));
+    }
+
+    /// The workspaces the hot refresher walks this tick.
+    pub(super) fn hot_pull_request_workspaces(&self) -> Vec<(OwnerId, WorkspaceId)> {
+        let mut hot = self.hot_prs.lock().expect("hot prs");
+        hot.retain(|_, (_, marked)| marked.elapsed() <= HOT_WINDOW);
+        hot.iter()
+            .map(|(id, (owner, _))| (owner.clone(), *id))
+            .collect()
+    }
+
+    /// Start the hot pull-request refresher once (decision 66).
+    pub(super) fn ensure_pr_refresh_sweep(self: &Arc<Self>) {
+        if self.pr_refresh_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let guard = super::pr_refresh::PrRefreshGuard::spawn(Arc::downgrade(self));
+        *self.pr_refresh_sweep.lock().expect("pr refresh sweep") = Some(guard);
     }
 
     /// The repository identity a workspace's pull request lives on: the
@@ -2002,10 +2051,6 @@ impl CodeRuntime {
             if !holds || workspace.pr.as_ref() == Some(digest) {
                 continue;
             }
-            // The cache takes the same snapshot the column does, so this
-            // workspace's next read serves it rather than a stale entry that
-            // would write the old digest back.
-            self.pr_cache.put(workspace.id, digest.clone());
             workspace.pr = Some(digest.clone());
             if let Err(err) = self.save_workspace(&workspace).await {
                 tracing::warn!(
@@ -2075,18 +2120,16 @@ impl CodeRuntime {
         let gh_path = self.gh_search_path_owned();
         gh::merge_pull_request(
             std::path::Path::new(&workspace.worktree_path),
-            workspace.id,
             method,
             auto,
-            &self.pr_cache,
             gh_path.as_deref(),
         )
         .await
         .map_err(map_gh)?;
-        // The merge helper already dropped this workspace's digest cache
-        // entry; the delivery lists hold the pre-merge row (decision 66).
+        // A merge dirties the row (decision 66); the delivery lists hold the
+        // pre-merge row.
         self.delivery_cache.invalidate();
-        self.workspace_pr(owner, id).await
+        self.refresh_workspace_pr(owner, id).await
     }
 
     /// Take the workspace's pull request out of draft and return a fresh
@@ -2102,14 +2145,12 @@ impl CodeRuntime {
         let gh_path = self.gh_search_path_owned();
         gh::mark_workspace_pull_request_ready(
             std::path::Path::new(&workspace.worktree_path),
-            workspace.id,
-            &self.pr_cache,
             gh_path.as_deref(),
         )
         .await
         .map_err(map_gh)?;
         self.delivery_cache.invalidate();
-        self.workspace_pr(owner, id).await
+        self.refresh_workspace_pr(owner, id).await
     }
 
     pub(crate) async fn create_workspace_pr(
@@ -2131,13 +2172,11 @@ impl CodeRuntime {
                 let api_base = self.forge_api_base_for(&target.host);
                 let (digest, fact) = gh::create_pull_request_rest(
                     &worktree,
-                    workspace.id,
                     &workspace.title,
                     &workspace.branch_name,
                     &workspace.base_ref,
                     title.as_deref(),
                     body.as_deref(),
-                    &self.pr_cache,
                     &api_base,
                     &target,
                     &credential,
@@ -2150,13 +2189,11 @@ impl CodeRuntime {
                 let gh_path = self.gh_search_path_owned();
                 let digest = gh::create_pull_request(
                     &worktree,
-                    workspace.id,
                     &workspace.title,
                     &workspace.branch_name,
                     &workspace.base_ref,
                     title.as_deref(),
                     body.as_deref(),
-                    &self.pr_cache,
                     gh_path.as_deref(),
                 )
                 .await
@@ -2210,7 +2247,10 @@ impl CodeRuntime {
                 .await;
             }
         }
-        self.workspace_pr(owner, id).await
+        // Creation dirties the row (decision 66): the response carries the
+        // fetched digest — checks pending on the fresh pull request — not
+        // the light creation stub.
+        self.refresh_workspace_pr(owner, id).await
     }
 
     pub(crate) async fn run_workspace_action(

--- a/crates/tidebreak-server/src/tests/code_git.rs
+++ b/crates/tidebreak-server/src/tests/code_git.rs
@@ -976,10 +976,10 @@ async fn a_hosted_pull_request_create_fails_closed_with_the_gateway_refusal() {
 }
 
 /// The moments after a push are when the reader most wants "checks pending
-/// on the new head", and the digest cache used to keep serving the pre-push
-/// snapshot for its whole TTL (decision 66).
+/// on the new head" (decision 66): the push refreshes the row before it
+/// answers, and a plain read never serves anything but that row.
 #[tokio::test]
-async fn a_push_drops_the_cached_pull_request_digest() {
+async fn a_push_refreshes_the_pull_request_row_immediately() {
     let (router, token, runtime, dir) = code_app().await;
     let addr = serve(router).await;
     let client = reqwest::Client::new();
@@ -1068,7 +1068,7 @@ exit 3
     )
     .unwrap();
 
-    // Within the TTL the cache still serves the old head...
+    // A plain read serves the stored row without a fetch of its own...
     let cached = client
         .get(format!("http://{addr}/code/workspaces/{id}/pr"))
         .bearer_auth(&token)
@@ -1080,7 +1080,8 @@ exit 3
         .unwrap();
     assert_eq!(cached["pr"]["head_sha"], "aaaaaaaa");
 
-    // ...and a push drops it, so the next read carries the new head.
+    // ...and a push refreshes the row immediately, so the next read carries
+    // the new head.
     std::fs::write(path.join("extra.txt"), "two\n").unwrap();
     let committed = client
         .post(format!("http://{addr}/code/workspaces/{id}/git/commit"))
@@ -1217,19 +1218,29 @@ exit 3
     );
     runtime.set_gh_search_path(Some(shim_dir.path().display().to_string()));
 
-    // Both workspaces observe the first snapshot.
-    for id in [&a, &b] {
-        let status = client
-            .get(format!("http://{addr}/code/workspaces/{id}/pr"))
-            .bearer_auth(&token)
-            .send()
-            .await
-            .unwrap()
-            .json::<serde_json::Value>()
-            .await
-            .unwrap();
-        assert_eq!(status["pr"]["head_sha"], "aaaaaaaa");
-    }
+    // Workspace A fetches the first snapshot; the write-through hands it to
+    // B's column, and B's own read serves that column with no host read of
+    // its own (decision 66: the request path reads the stored row).
+    let refreshed = client
+        .post(format!("http://{addr}/code/workspaces/{a}/pr/refresh"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(refreshed["pr"]["head_sha"], "aaaaaaaa");
+    let status_b = client
+        .get(format!("http://{addr}/code/workspaces/{b}/pr"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(status_b["pr"]["head_sha"], "aaaaaaaa");
 
     // GitHub moves, and only workspace A reads it.
     std::fs::write(
@@ -1260,8 +1271,8 @@ exit 3
         .unwrap();
     assert_eq!(listed["pr"]["head_sha"], "bbbbbbbb");
 
-    // ...its next digest read serves that copy rather than a stale cache
-    // entry that would write the old head back...
+    // ...its next digest read serves that column with no fetch of its
+    // own...
     let status_b = client
         .get(format!("http://{addr}/code/workspaces/{b}/pr"))
         .bearer_auth(&token)


### PR DESCRIPTION
Follows #2565 (the conditional fetcher, merged). Supersedes #2568, which GitHub closed when the merged parent branch was deleted out from under the stack.

Slice 4 of [decision 66](docs/decisions/0066-pull-request-state-is-one-store.md), second half: the tiered refresh schedule, and the request path off GitHub.

## What changes

- `GET …/pr` stops calling GitHub. The read marks the workspace hot and answers from local git plus the stored row, so opening a workspace stops paying the one-to-three-second digest fetch. `POST …/pr/refresh` stays a forced host read.
- A 17-second refresher (coprime with the 47s watch, 53s trigger, and 61s reconcile sweeps) walks the hot set — workspaces whose digest was requested in the last two minutes, plus active watches — through the conditional fetcher. An unchanged pull request costs two 304s; freshness while anyone watches is bounded by the tier, not by which component happens to poll.
- Mutations dirty the row and refresh it before answering: push, create, merge, and mark-ready responses carry the fetched state of the new head. The pre-push staleness window is gone rather than shortened.
- `PrDigestCache` and its 20-second TTL are deleted. The workspace column — written by the refresher, by mutations, and by the write-through fanout — is the one copy a read serves, so there is no second store to disagree with it.
- The merge-queue timeline read parks the host when a limit answer names it, closing the follow-up from the fetcher review.
- The hosted-machine read (decision 65, borrowed credential, no `gh`) stays in the request path; it has no refresher to ride yet.

## Why

Decision 66's freshness goal: "no view owns a timer, and no view triggers an unconditional fetch." After this slice the server side is done — one fetcher, one gate, one schedule, one store — and slice 5 can drop the UI's own poll timers onto the broadcast channel.

## Testing

- The push test proves the row refreshes inside the push and that a plain read never fetches.
- The write-through test now proves one refresh feeds every holder's read: workspace B's `GET …/pr` serves the column workspace A's refresh wrote, with no host read of its own.
- The create test keeps asserting the response carries the fresh pull request's checks, now via the mutation-refresh path.
