### PR TITLE
fix(code): match workspace diff counts to pull requests

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -243,7 +243,9 @@ describe("CodeTranscript", () => {
     render(<CodeTranscript items={items} />);
     const seam = screen.getByRole("group", { name: "Turn finished" });
     expect(within(seam).getByText("· 2m 14s")).toBeInTheDocument();
-    expect(within(seam).getByText(/2 files \+42 −7/)).toBeInTheDocument();
+    expect(
+      within(seam).getByLabelText("2 files, 42 additions, 7 deletions"),
+    ).toBeInTheDocument();
     expect(within(seam).queryByText(/in \//)).not.toBeInTheDocument();
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -545,7 +545,9 @@ describe("CodeWorkspacePage", () => {
 
     const seam = await screen.findByRole("group", { name: "Turn finished" });
     expect(seam).toHaveTextContent("2m 14s");
-    expect(seam).toHaveTextContent("2 files +42 −7");
+    expect(
+      within(seam).getByLabelText("2 files, 42 additions, 7 deletions"),
+    ).toBeInTheDocument();
     expect(seam).not.toHaveTextContent("in /");
     expect(
       screen.getByRole("button", { name: /Context: 9,500 tokens used/ }),

--- a/crates/tidebreak-desktop/ui/src/code/DiffOverview.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffOverview.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -50,6 +50,14 @@ describe("DiffOverview", () => {
     expect(screen.queryByText("src/new.ts")).not.toBeInTheDocument();
     expect(screen.getByText("Turn 4")).toBeInTheDocument();
     expect(screen.queryByText(/^@@/)).not.toBeInTheDocument();
+    const summary = screen.getByLabelText("2 files, 9 additions, 1 deletion");
+    expect(summary).toHaveClass("font-mono");
+    expect(within(summary).getByText("+9")).toHaveClass(
+      "text-success-foreground",
+    );
+    expect(within(summary).getByText("−1")).toHaveClass(
+      "text-critical-foreground",
+    );
     expect(client.listCodeWorkspaceFiles).toHaveBeenCalledWith(
       "ws-1",
       "turn-1",

--- a/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffPanel.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -73,6 +73,12 @@ describe("DiffPanel", () => {
         "This diff was truncated. Open a single file for the rest.",
       ),
     ).toBeInTheDocument();
+    const summary = screen.getByLabelText(
+      "1 file, 1 addition, 1 deletion, truncated",
+    );
+    expect(within(summary).getByText("· truncated")).toHaveClass(
+      "text-warning-foreground",
+    );
     expect(client.getCodeWorkspaceDiff).toHaveBeenCalledWith("ws-1", {
       turn: "turn-1",
       file: "src/lib.rs",

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -217,11 +217,22 @@ function TurnDiffstat({
 }
 
 export function DiffstatBadge({ stat }: { stat: Diffstat }) {
+  const fileLabel = `${stat.files} file${stat.files === 1 ? "" : "s"}`;
+  const additionLabel = `${stat.insertions} addition${stat.insertions === 1 ? "" : "s"}`;
+  const deletionLabel = `${stat.deletions} deletion${stat.deletions === 1 ? "" : "s"}`;
   return (
-    <Badge variant="outline" size="sm" className="tabular-nums">
-      {stat.files} file{stat.files === 1 ? "" : "s"} +{stat.insertions} −
-      {stat.deletions}
-      {stat.truncated ? " · truncated" : ""}
+    <Badge
+      variant="outline"
+      size="sm"
+      className="bg-muted/35 gap-1.5 font-mono tabular-nums"
+      aria-label={`${fileLabel}, ${additionLabel}, ${deletionLabel}${stat.truncated ? ", truncated" : ""}`}
+    >
+      <span className="text-muted-foreground">{fileLabel}</span>
+      <span className="text-success-foreground">+{stat.insertions}</span>
+      <span className="text-critical-foreground">−{stat.deletions}</span>
+      {stat.truncated && (
+        <span className="text-warning-foreground">· truncated</span>
+      )}
     </Badge>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
@@ -14,6 +14,7 @@ type InspectorScenario =
   | "ready"
   | "merge-ready"
   | "multi-pr"
+  | "truncated"
   | "empty"
   | "loading"
   | "failure";
@@ -161,6 +162,12 @@ const changedFiles = {
   stat: { files: 6, insertions: 351, deletions: 462, truncated: false },
 };
 
+const truncatedChangedFiles = {
+  ...changedFiles,
+  truncated: true,
+  stat: { files: 82, insertions: 1920, deletions: 341, truncated: true },
+};
+
 const avatar = (initials: string, color: string) =>
   `data:image/svg+xml,${encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" rx="32" fill="${color}"/><text x="32" y="39" text-anchor="middle" font-family="system-ui" font-size="22" font-weight="700" fill="white">${initials}</text></svg>`)}`;
 
@@ -215,7 +222,9 @@ function inspectorClient(scenario: InspectorScenario): ApiClient {
                       truncated: false,
                     },
                   }
-                : changedFiles,
+                : scenario === "truncated"
+                  ? truncatedChangedFiles
+                  : changedFiles,
     getCodeWorkspacePr: async () => prSnapshot,
     getCodeWorkspacePullRequests: async () => ({
       items:
@@ -382,6 +391,10 @@ export const ChangesEmpty: Story = {
 
 export const ChangesFailure: Story = {
   args: { tab: "source", scenario: "failure" },
+};
+
+export const ChangesTruncated: Story = {
+  args: { tab: "source", scenario: "truncated" },
 };
 
 export const Empty: Story = {

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -524,6 +524,60 @@ pub(crate) async fn merge_base(worktree: &Path, base_ref: &str) -> Result<String
     }
 }
 
+/// Resolve the base shown by the workspace diff.
+///
+/// A pull request can rebase onto `origin/main` while the local `main` ref
+/// stays behind. When a pull request exists, follow its remote base so the
+/// workspace pane matches the host. The read path never fetches. If the remote
+/// ref is absent, keep the workspace's configured base.
+async fn workspace_merge_base(
+    worktree: &Path,
+    configured_base: &str,
+    pull_request_base: Option<&str>,
+) -> Result<String, CheckpointError> {
+    if let Some(remote_ref) = pull_request_base.and_then(remote_tracking_ref) {
+        let commit_ref = format!("{remote_ref}^{{commit}}");
+        if git_text(
+            worktree,
+            &["rev-parse", "--verify", "--quiet", &commit_ref],
+            GIT_TIMEOUT,
+        )
+        .await
+        .is_ok()
+        {
+            return merge_base(worktree, &remote_ref).await;
+        }
+    }
+    merge_base(worktree, configured_base).await
+}
+
+fn remote_tracking_ref(base_branch: &str) -> Option<String> {
+    let base_branch = base_branch.trim();
+    if base_branch.is_empty() {
+        return None;
+    }
+    if base_branch.starts_with("refs/remotes/") {
+        return Some(base_branch.to_owned());
+    }
+    let branch = base_branch
+        .strip_prefix("refs/heads/")
+        .or_else(|| base_branch.strip_prefix("origin/"))
+        .unwrap_or(base_branch);
+    if branch.starts_with("refs/") {
+        return None;
+    }
+    Some(format!("refs/remotes/origin/{branch}"))
+}
+
+fn workspace_pull_request_base(workspace: &CodeWorkspace) -> Option<&str> {
+    workspace.pr.as_ref().map(|pull_request| {
+        pull_request
+            .base_branch
+            .as_deref()
+            .unwrap_or(&workspace.base_ref)
+    })
+}
+
 /// Delete every checkpoint ref belonging to one workspace.
 ///
 /// The workspace stays first in the ref path, so one prefix covers every
@@ -597,7 +651,12 @@ pub(crate) async fn resolve_diff_range(
     }
     match turn_id {
         None => {
-            let from = merge_base(&worktree, &workspace.base_ref).await?;
+            let from = workspace_merge_base(
+                &worktree,
+                &workspace.base_ref,
+                workspace_pull_request_base(workspace),
+            )
+            .await?;
             let to = snapshot_tree(&worktree).await?;
             Ok((worktree, from, to, None))
         }
@@ -621,7 +680,14 @@ pub(crate) async fn resolve_diff_range(
                 .ok_or_else(|| CheckpointError::user("this turn has no checkpoint"))?;
             let from = previous_checkpoint_oid(&worktree, workspace, db, &turn)
                 .await?
-                .unwrap_or(merge_base(&worktree, &workspace.base_ref).await?);
+                .unwrap_or(
+                    workspace_merge_base(
+                        &worktree,
+                        &workspace.base_ref,
+                        workspace_pull_request_base(workspace),
+                    )
+                    .await?,
+                );
             Ok((worktree, from, to, Some(id)))
         }
     }
@@ -1256,6 +1322,44 @@ mod tests {
             .unwrap();
         assert!(diff.truncated);
         assert!(diff.diff.len() <= 80, "{}", diff.diff.len());
+    }
+
+    #[tokio::test]
+    async fn workspace_diff_follows_the_pull_requests_remote_base() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "remote-base");
+
+        std::fs::write(tree.join("base-change.txt"), "landed on main\n").unwrap();
+        run(&tree, &["git", "add", "base-change.txt"]);
+        run(&tree, &["git", "commit", "-m", "advance remote main"]);
+        let remote_base = git_text(&tree, &["rev-parse", "HEAD"], GIT_TIMEOUT)
+            .await
+            .unwrap();
+        run(
+            &tree,
+            &[
+                "git",
+                "update-ref",
+                "refs/remotes/origin/main",
+                &remote_base,
+            ],
+        );
+
+        std::fs::write(tree.join("workspace-change.txt"), "pull request change\n").unwrap();
+        run(&tree, &["git", "add", "workspace-change.txt"]);
+        run(&tree, &["git", "commit", "-m", "change the workspace"]);
+
+        let from = workspace_merge_base(&tree, "main", Some("main"))
+            .await
+            .unwrap();
+        let to = snapshot_tree(&tree).await.unwrap();
+        let files = list_changed_files(&tree, &from, &to, DiffBounds::default())
+            .await
+            .unwrap();
+        let paths: Vec<_> = files.files.iter().map(|file| file.path.as_str()).collect();
+
+        assert_eq!(paths, vec!["workspace-change.txt"]);
+        assert_eq!(files.stat.files, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

The workspace change panel now compares against the pull request remote base when available, so a stale local base branch no longer inflates file and line counts.
The diff summary now uses mono data text with semantic colors for additions, deletions, and truncation, and Storybook covers the truncated state.

## Validation

- `cargo fmt --all -- --check`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome format src/code/DiffOverview.dom.test.tsx src/code/DiffPanel.dom.test.tsx src/code/TurnReviewCard.tsx src/stories/CodeInspector.stories.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui lint`
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/DiffOverview.dom.test.tsx src/code/DiffPanel.dom.test.tsx src/stylesContract.test.ts`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --dir crates/tidebreak-desktop/ui storybook:build`

The Rust regression test was not run locally because repository policy leaves Rust compilation and tests to CI.

## Compatibility and risk

No persisted or wire-format changes. The existing configured base remains the fallback when the pull request remote base is unavailable.