### PR TITLE
fix(desktop): keep sidebar mounted between workspaces

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -269,6 +269,15 @@ vi.mock("./ChatView", async () => {
   };
 });
 
+vi.mock("./code/CodeWorkspacePage", () => ({
+  CodeWorkspacePage: ({ workspaceId }: { workspaceId: string }) => (
+    <>
+      <aside data-testid="code-workspace-sidebar">Workspaces</aside>
+      <main data-testid="code-workspace-body">{workspaceId}</main>
+    </>
+  ),
+}));
+
 vi.mock("./outputs/OutputsView", () => ({
   OutputsView: () => <div data-testid="outputs">outputs</div>,
 }));
@@ -785,6 +794,23 @@ describe("app shell", () => {
     await waitFor(() =>
       expect(router.state.location.pathname).toBe("/c/chat-2"),
     );
+  });
+
+  it("keeps the code sidebar mounted when switching workspaces", async () => {
+    const { router } = await mountApp({ at: "/code/w/ws-1" });
+    const sidebar = await screen.findByTestId("code-workspace-sidebar");
+
+    await router.navigate({
+      to: "/code/w/$workspaceId",
+      params: { workspaceId: "ws-2" },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("code-workspace-body")).toHaveTextContent(
+        "ws-2",
+      ),
+    );
+    expect(screen.getByTestId("code-workspace-sidebar")).toBe(sidebar);
   });
 
   it("remembers the collapsed rail across a restart", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -190,7 +190,8 @@ export function CodeWorkspacePage({ workspaceId }: { workspaceId: string }) {
   return (
     <RouteFrame sidebar={<CodeSidebar />}>
       <div className="content-container flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
-        <CodeWorkspaceBody workspaceId={workspaceId} />
+        {/* Reset workspace-scoped state without remounting the shared rail. */}
+        <CodeWorkspaceBody key={workspaceId} workspaceId={workspaceId} />
       </div>
     </RouteFrame>
   );

--- a/crates/tidebreak-desktop/ui/src/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/router.tsx
@@ -251,7 +251,7 @@ const codeNotificationsRoute = createRoute({
 
 function CodeWorkspaceRouteComponent() {
   const { workspaceId } = codeWorkspaceRoute.useParams();
-  return <CodeWorkspacePage key={workspaceId} workspaceId={workspaceId} />;
+  return <CodeWorkspacePage workspaceId={workspaceId} />;
 }
 
 export const settingsRoute = createRoute({


### PR DESCRIPTION
## Summary

- Keep the code sidebar mounted when navigation changes the selected workspace.
- Reset workspace-scoped page state inside the content area.
- Add a route regression test that verifies the sidebar DOM node survives workspace navigation.

## Testing

- `pnpm --dir crates/tidebreak-desktop/ui test`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/router.tsx src/code/CodeWorkspacePage.tsx src/AppShell.dom.test.tsx`
- `node --max-old-space-size=6144 node_modules/storybook/dist/bin/dispatcher.js build -o storybook-static`