### PR TITLE
feat(code): engines download the first time you pick one

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -2179,12 +2179,21 @@ export class ApiClient {
    * that follow arrive on `WS /code/updates`. Safe to call repeatedly — an
    * installed pin answers `ready` and one already running is not restarted.
    */
+  /**
+   * Start — or report — the pinned download of one engine.
+   *
+   * `deliberate` marks a reader who pressed Install rather than a picker
+   * warming its selection. Only that case retries a managed-Node install that
+   * already failed.
+   */
   async startHarnessInstall(
     kind: HarnessKind,
+    deliberate = false,
   ): Promise<CodeHarnessInstallSnapshot> {
+    const path = `/code/harnesses/${encodeURIComponent(kind)}/install`;
     return requireParsed(
       parseCodeHarnessInstall(
-        await this.json(`/code/harnesses/${encodeURIComponent(kind)}/install`, {
+        await this.json(deliberate ? `${path}?deliberate=true` : path, {
           method: "POST",
           headers: this.headers(),
         }),

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -159,10 +159,10 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     const doctor = await client.refreshHarnessDoctor();
     set({ doctor });
   },
-  // The memoized read, for picking up an engine a warm install just put on
-  // disk. `refreshDoctor` is the doctor's own button: it re-probes every
-  // engine and installs every pin, which is far more than reading one result
-  // that already exists.
+  // The memoized read, for picking up an engine a download just put on disk.
+  // `refreshDoctor` is the doctor's own button: it drops every memoized probe
+  // and takes them all cold, which is far more than reading one result that
+  // already exists.
   reloadDoctor: async (client) => {
     set({ doctor: await client.getHarnessDoctor() });
   },

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
@@ -37,6 +37,7 @@ const READY_DOCTOR: HarnessDoctorReport = {
     {
       kind: "claude_code",
       found: true,
+      installable: true,
       tier: "reference",
       caps: {
         resume: "supported",
@@ -200,7 +201,7 @@ describe("CodeHome", () => {
     );
 
     expect(
-      await screen.findByRole("heading", { name: "Install a coding harness" }),
+      await screen.findByRole("heading", { name: "Set up a coding engine" }),
     ).toBeInTheDocument();
     expect(
       screen.queryByText("Start with a repository"),

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { FolderGit2, GitBranch, Plus, Sparkles } from "lucide-react";
 
+import type { HarnessKind } from "../api/types";
+
 import { useApp } from "@/AppContext";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,18 +18,20 @@ import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { AddRepoPalette } from "./AddRepoPalette";
 import { CodeSidebar } from "./CodeSidebar";
 import { useCodeUiStore } from "./CodeUiStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { DoctorList } from "./DoctorList";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
-import { isHarnessReady } from "./labels";
+import { harnessUnusableReason } from "./labels";
 import { middleTruncate } from "./workspaceCards";
 
 /**
- * `/code` home: the doctor when no engine is usable, otherwise repo
- * registration and the registered list.
+ * `/code` home: the doctor when no engine can be started or downloaded,
+ * otherwise repo registration and the registered list.
  *
- * A reader who has not installed or signed in to a harness cannot start a
- * workspace, so the empty state is the remediation the doctor already wrote
- * rather than a blank register form.
+ * A machine with nothing downloaded yet is not blocked: picking an engine in
+ * the New Workspace dialog fetches it. The doctor only takes the page when
+ * every engine is signed out or unsupported, which is the one case a reader
+ * cannot resolve by starting a workspace.
  */
 
 export function CodeHome() {
@@ -51,18 +55,41 @@ function CodeHomeBody() {
   const refreshDoctor = useCodeCatalogStore((state) => state.refreshDoctor);
   const [addOpen, setAddOpen] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const installs = useCodeUpdatesStore((state) => state.harnessInstalls);
+  const reloadDoctor = useCodeCatalogStore((state) => state.reloadDoctor);
 
   useEffect(() => {
     void refresh(client);
   }, [client, refresh]);
 
-  const ready = doctor?.harnesses.some(isHarnessReady) ?? false;
+  // Startable now, or one download away. Either way the reader can get to
+  // work from here, so the register form is what the page owes them.
+  const usable =
+    doctor?.harnesses.some((entry) => !harnessUnusableReason(entry)) ?? false;
   const showRepos = loaded && repos.length > 0;
-  const showEmpty = loaded && repos.length === 0 && ready;
-  const showDoctor = Boolean(doctor && !ready);
+  const showEmpty = loaded && repos.length === 0 && usable;
+  const showDoctor = Boolean(doctor && !usable);
   // Repos resolve before the doctor. Until one of the three settled
   // bodies can render, keep this slot filled so the empty state does not pop in.
   const showLoading = !showRepos && !showEmpty && !showDoctor && !error;
+
+  async function install(kind: HarnessKind) {
+    try {
+      const snapshot = await client.startHarnessInstall(kind, true);
+      useCodeUpdatesStore
+        .getState()
+        .apply({ type: "harness_install", install: snapshot });
+    } catch {
+      // Create still reports why, with the reason the server gave.
+    }
+  }
+
+  // Pick up an engine a download just put on disk.
+  useEffect(() => {
+    if (!Object.values(installs).some((item) => item?.phase === "ready"))
+      return;
+    void reloadDoctor(client).catch(() => {});
+  }, [client, installs, reloadDoctor]);
 
   async function onRefresh() {
     setRefreshing(true);
@@ -102,16 +129,17 @@ function CodeHomeBody() {
       )}
       {showDoctor && doctor && (
         <section className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">Install a coding harness</h2>
+          <h2 className="text-lg font-semibold">Set up a coding engine</h2>
           <p className="text-muted-foreground text-sm">
-            No pinned harness is ready yet. Refresh to install the engines this
-            build drives, sign in from your own terminal, then start a
-            workspace.
+            No engine can start yet. Sign in to one from your own terminal, then
+            re-check.
           </p>
           <DoctorList
             report={doctor}
             onRefresh={() => void onRefresh()}
             refreshing={refreshing}
+            onInstall={(kind) => void install(kind)}
+            installs={installs}
           />
         </section>
       )}

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
@@ -1,19 +1,21 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { HarnessDoctorReport } from "../api/types";
+import type { HarnessDoctorEntry, HarnessDoctorReport } from "../api/types";
 import { DoctorList } from "./DoctorList";
 
 afterEach(cleanup);
 
 describe("DoctorList", () => {
-  it("states that protocol-gap counts include saved session history", () => {
+  it("states that protocol-gap counts include saved session history", async () => {
     const report: HarnessDoctorReport = {
       harnesses: [
         {
           kind: "codex",
           found: true,
+          installable: true,
           version: "codex-cli 0.147.0",
           tier: "secondary",
           caps: {
@@ -40,9 +42,81 @@ describe("DoctorList", () => {
 
     render(<DoctorList report={report} />);
 
+    // Diagnostics sit behind the row's disclosure; the resting row is the
+    // engine, its state, and the one thing to do about it.
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Details for Codex CLI" }));
     expect(screen.getByText("Protocol gaps (history):")).toBeInTheDocument();
     expect(
       screen.getByText("6 events across saved sessions"),
     ).toBeInTheDocument();
   });
+
+  // The point of the lazy pin: a missing engine offers its own download
+  // instead of sending the reader off to install every engine at once.
+  it("offers a download for an engine this machine has not fetched", async () => {
+    const onInstall = vi.fn();
+    render(
+      <DoctorList
+        report={{ harnesses: [notDownloaded] }}
+        onInstall={onInstall}
+      />,
+    );
+
+    expect(screen.getByText("Not downloaded")).toBeInTheDocument();
+    expect(
+      screen.getByText("Downloads the first time you pick it."),
+    ).toBeInTheDocument();
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: /Download/ }));
+    expect(onInstall).toHaveBeenCalledWith("opencode");
+  });
+
+  /** An engine still downloading offers no second Download button. */
+  it("reports a download in flight instead of offering another", () => {
+    render(
+      <DoctorList
+        report={{ harnesses: [notDownloaded] }}
+        onInstall={vi.fn()}
+        installs={{
+          opencode: {
+            kind: "opencode",
+            version: "1.18.18",
+            phase: "installing",
+            done: false,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Downloading")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Download/ })).toBeNull();
+  });
 });
+
+const notDownloaded: HarnessDoctorEntry = {
+  kind: "opencode",
+  found: false,
+  installable: true,
+  tier: "tertiary",
+  caps: {
+    resume: "supported",
+    streaming_deltas: "supported",
+    mid_turn_steering: "unknown",
+    plan_mode: "supported",
+    auto_mode: "supported",
+    allow_mode: "supported",
+    reasoning_levels: "supported",
+    native_file_change_events: "unknown",
+    native_interrupt: "supported",
+    structured_approvals: "supported",
+    image_input: "unknown",
+    slash_commands: "unknown",
+  },
+  commands: [],
+  remediation: "",
+  stderr: "",
+  unrecognized_event_count: 0,
+};

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -1,115 +1,294 @@
-import type { HarnessDoctorEntry, HarnessDoctorReport } from "../api/types";
+import { useState, type ReactNode } from "react";
+import { ChevronDown, Download, Loader2, RotateCw } from "lucide-react";
+
+import type {
+  CodeHarnessInstallSnapshot,
+  HarnessDoctorEntry,
+  HarnessDoctorReport,
+  HarnessKind,
+} from "../api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { HARNESS_LABELS, HARNESS_TIER_LABELS, isHarnessReady } from "./labels";
+import { cn } from "@/lib/utils";
+import { HARNESS_ICONS } from "./HarnessPicker";
+import {
+  HARNESS_LABELS,
+  HARNESS_TIER_LABELS,
+  harnessNeedsDownload,
+  isHarnessReady,
+} from "./labels";
 
 /**
  * The harness doctor, shared by the code-mode empty state and Settings.
  *
- * Found / version / auth / remediation are the facts a reader can act on.
- * Capability flags stay a one-line summary so the page does not become a
- * matrix of every adapter's self-report.
+ * One row per engine, and the row leads with what the reader came for: is
+ * this engine usable, and if not, what closes the gap. An engine Tidebreak
+ * has not downloaded yet is a row with a Download button on it, not a fault —
+ * the pins are fetched one at a time, when someone asks for one.
+ *
+ * Version, path, and probe stderr are diagnostics rather than answers, so
+ * they sit behind each row's disclosure with the capability list. Nothing on
+ * the resting surface is a `Label: value` pair.
  */
 
 export function DoctorList({
   report,
+  title,
   onRefresh,
   refreshing,
+  onInstall,
+  installs,
 }: {
   report: HarnessDoctorReport;
+  /** Section heading, where the surface has not written its own above this. */
+  title?: string;
   onRefresh?: () => void;
   refreshing?: boolean;
+  /** Start this engine's download. Omitted where no client can install. */
+  onInstall?: (kind: HarnessKind) => void;
+  /** Live install progress, keyed by engine. */
+  installs?: Partial<Record<HarnessKind, CodeHarnessInstallSnapshot>>;
 }) {
-  const allReady =
-    report.harnesses.length > 0 && report.harnesses.every(isHarnessReady);
+  const ready = report.harnesses.filter(isHarnessReady).length;
+  const total = report.harnesses.length;
   return (
-    <div className="flex flex-col gap-3">
-      {onRefresh && (
-        <div className="flex justify-end">
+    <section className="flex flex-col gap-3">
+      <div className="flex items-end justify-between gap-4">
+        <div className="flex flex-col gap-0.5">
+          {title && <h2 className="text-sm font-medium">{title}</h2>}
+          {total > 0 && (
+            // The verdict the rows add up to, so a reader who only needs to
+            // know "can I start work" does not walk every row to find out.
+            <p className="text-muted-foreground text-sm">
+              {ready === 0
+                ? "No engine is ready yet. Download one, or pick it when you start a workspace."
+                : `${ready} of ${total} ${total === 1 ? "engine" : "engines"} ready.`}
+            </p>
+          )}
+        </div>
+        {onRefresh && (
           <Button
             type="button"
             variant="outline"
             size="sm"
+            className="ml-auto shrink-0"
             onClick={onRefresh}
             disabled={refreshing}
           >
-            {refreshing ? "Refreshing…" : "Refresh"}
+            <RotateCw
+              className={cn("size-3.5", refreshing && "animate-spin")}
+              aria-hidden="true"
+            />
+            {refreshing ? "Checking…" : "Re-check"}
           </Button>
+        )}
+      </div>
+      <div className="divide-subtle overflow-hidden rounded-lg border divide-y">
+        {report.harnesses.map((entry) => (
+          <DoctorRow
+            key={entry.kind}
+            entry={entry}
+            install={installs?.[entry.kind]}
+            onInstall={onInstall}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The version, without the product name a CLI repeats back.
+ *
+ * `claude --version` answers `2.1.234 (Claude Code)`, and this row already
+ * says Claude Code two words to the left. Only a parenthetical that restates
+ * the label is dropped; anything else a CLI reports is kept.
+ */
+function shortVersion(version: string, label: string): string {
+  const trimmed = version.trim();
+  const match = /^(.*?)\s*\(([^()]*)\)$/.exec(trimmed);
+  if (match && match[2].toLowerCase() === label.toLowerCase()) {
+    return match[1].trim() || trimmed;
+  }
+  return trimmed;
+}
+
+/** The badge a row leads with, and the tone it carries. */
+function statusBadge(
+  entry: HarnessDoctorEntry,
+  install: CodeHarnessInstallSnapshot | undefined,
+): {
+  label: string;
+  variant: "success" | "warning" | "critical" | "info" | "outline";
+} {
+  if (install && !install.done && !install.error) {
+    return { label: "Downloading", variant: "info" };
+  }
+  if (install?.error) return { label: "Download failed", variant: "critical" };
+  if (isHarnessReady(entry)) return { label: "Ready", variant: "success" };
+  // A state, not an instruction — the instruction is the line below it.
+  if (entry.found) return { label: "Signed out", variant: "warning" };
+  if (harnessNeedsDownload(entry)) {
+    return { label: "Not downloaded", variant: "outline" };
+  }
+  return { label: "Unavailable", variant: "warning" };
+}
+
+/**
+ * The one line under an engine's name.
+ *
+ * What stands between the reader and using it, when something does. When
+ * nothing does, how well this build drives the engine, which is the other
+ * thing worth knowing before picking one.
+ */
+function subtitle(
+  entry: HarnessDoctorEntry,
+  install: CodeHarnessInstallSnapshot | undefined,
+): string {
+  if (install && !install.done && !install.error) {
+    return "Downloading the pinned version. This takes a few minutes.";
+  }
+  if (install?.error) return install.error;
+  if (entry.remediation) return entry.remediation;
+  if (harnessNeedsDownload(entry)) {
+    return "Downloads the first time you pick it.";
+  }
+  return TIER_NOTES[entry.tier];
+}
+
+/** What each adapter tier means for the reader picking an engine. */
+const TIER_NOTES: Record<HarnessDoctorEntry["tier"], string> = {
+  reference: "Reference adapter — the engine this build is built around.",
+  secondary: "Secondary adapter — well covered, a step behind the reference.",
+  tertiary: "Tertiary adapter — the common paths are covered.",
+  best_effort: "Best-effort adapter — expect gaps in what it can do.",
+};
+
+function DoctorRow({
+  entry,
+  install,
+  onInstall,
+}: {
+  entry: HarnessDoctorEntry;
+  install: CodeHarnessInstallSnapshot | undefined;
+  onInstall?: (kind: HarnessKind) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const Icon = HARNESS_ICONS[entry.kind];
+  const badge = statusBadge(entry, install);
+  const downloading = Boolean(install && !install.done && !install.error);
+  const failed = Boolean(install?.error);
+  const canDownload =
+    Boolean(onInstall) && !entry.found && entry.installable && !downloading;
+  const detailId = `harness-detail-${entry.kind}`;
+
+  return (
+    <div className="bg-background flex flex-col">
+      {/* One grid so every row is the same height whatever it carries: the
+          name line, one note, and the controls all sit on fixed tracks. */}
+      <div className="flex items-center gap-3 px-4 py-3">
+        <Icon className="text-foreground size-5 shrink-0" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="text-md truncate font-medium">
+              {HARNESS_LABELS[entry.kind]}
+            </span>
+            {entry.version && (
+              <span className="text-muted-foreground truncate font-mono text-xs">
+                {shortVersion(entry.version, HARNESS_LABELS[entry.kind])}
+              </span>
+            )}
+            <Badge variant={badge.variant} size="sm" className="shrink-0">
+              {downloading && (
+                <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+              )}
+              {badge.label}
+            </Badge>
+          </div>
+          <p
+            className={cn(
+              "truncate text-xs",
+              // A failed install's only content is npm's own words, so it
+              // renders in the machine voice rather than as prose.
+              failed
+                ? "text-critical-foreground font-mono"
+                : "text-muted-foreground",
+            )}
+          >
+            {subtitle(entry, install)}
+          </p>
         </div>
-      )}
-      {report.harnesses.map((entry) => (
-        <DoctorCard key={entry.kind} entry={entry} />
-      ))}
-      {allReady && (
-        // Every card here says "Ready", which leaves the reader checking each
-        // one to learn that nothing needs doing. One line states the verdict
-        // the cards add up to, and that the list is the whole list.
-        <p className="text-muted-foreground text-sm">
-          Every engine this build drives is installed and signed in.
-        </p>
+        {canDownload && onInstall && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={() => onInstall(entry.kind)}
+          >
+            <Download className="size-3.5" aria-hidden="true" />
+            {failed ? "Retry" : "Download"}
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="text-muted-foreground shrink-0"
+          onClick={() => setOpen((current) => !current)}
+          aria-expanded={open}
+          aria-controls={detailId}
+          aria-label={`Details for ${HARNESS_LABELS[entry.kind]}`}
+        >
+          <ChevronDown
+            className={cn("size-4 transition-transform", open && "rotate-180")}
+            aria-hidden="true"
+          />
+        </Button>
+      </div>
+      {open && (
+        <dl
+          id={detailId}
+          className="border-subtle text-muted-foreground grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 border-t px-4 py-3 pl-12 text-sm"
+        >
+          <Detail label="Tier">{HARNESS_TIER_LABELS[entry.tier]}</Detail>
+          <Detail label="Signed in">
+            {entry.authenticated === undefined
+              ? "not observed"
+              : entry.authenticated
+                ? "yes"
+                : "no"}
+          </Detail>
+          {entry.path && (
+            <Detail label="Path">
+              <span className="font-mono break-all">{entry.path}</span>
+            </Detail>
+          )}
+          <Detail label="Supports">{capsSummary(entry)}</Detail>
+          {entry.unrecognized_event_count > 0 && (
+            <Detail label="Protocol gaps (history)">
+              {`${entry.unrecognized_event_count} ${entry.unrecognized_event_count === 1 ? "event" : "events"} across saved sessions`}
+            </Detail>
+          )}
+          {entry.stderr && (
+            <Detail label="Probe output">
+              <span className="font-mono break-all">{entry.stderr}</span>
+            </Detail>
+          )}
+        </dl>
       )}
     </div>
   );
 }
 
-function DoctorCard({ entry }: { entry: HarnessDoctorEntry }) {
-  const ready = isHarnessReady(entry);
+function Detail({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <Card className="gap-3 p-4">
-      <CardHeader className="justify-between">
-        <CardTitle className="text-sm">{HARNESS_LABELS[entry.kind]}</CardTitle>
-        <Badge variant={ready ? "success" : "warning"} size="sm">
-          {ready ? "Ready" : entry.found ? "Sign in" : "Not found"}
-        </Badge>
-      </CardHeader>
-      <CardContent className="gap-1 text-sm">
-        <Row label="Found" value={entry.found ? "yes" : "no"} />
-        {entry.path && <Row label="Path" value={entry.path} mono />}
-        {entry.version && <Row label="Version" value={entry.version} mono />}
-        <Row label="Tier" value={HARNESS_TIER_LABELS[entry.tier]} />
-        <Row label="Capabilities" value={capsSummary(entry)} />
-        <Row
-          label="Authenticated"
-          value={
-            entry.authenticated === undefined
-              ? "unknown"
-              : entry.authenticated
-                ? "yes"
-                : "no"
-          }
-        />
-        {entry.unrecognized_event_count > 0 && (
-          <Row
-            label="Protocol gaps (history)"
-            value={`${entry.unrecognized_event_count} ${entry.unrecognized_event_count === 1 ? "event" : "events"} across saved sessions`}
-          />
-        )}
-        {entry.remediation && (
-          <p className="text-warning-foreground mt-2">{entry.remediation}</p>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function Row({
-  label,
-  value,
-  mono = false,
-}: {
-  label: string;
-  value: string;
-  /** An install path or a version string: mono, like everywhere else. */
-  mono?: boolean;
-}) {
-  return (
-    // A harness path or version carries no spaces to break at, so without this
-    // a deep install location runs past the card.
-    <p className="text-muted-foreground break-words">
-      <span className="text-foreground font-medium">{label}: </span>
-      <span className={mono ? "font-mono" : undefined}>{value}</span>
-    </p>
+    <>
+      <dt className="text-foreground font-medium whitespace-nowrap">
+        {label}:
+      </dt>
+      <dd className="min-w-0">{children}</dd>
+    </>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/HarnessInstallNote.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessInstallNote.tsx
@@ -4,12 +4,12 @@ import type { CodeHarnessInstallSnapshot } from "../api/types";
 import { HARNESS_LABELS } from "./labels";
 
 /**
- * What a warm harness install is doing, under the engine picker.
+ * What a harness download is doing, under the engine picker.
  *
  * A pinned engine is a 37-297MB npm install the first time its version is
  * used. Create used to pay for it with nothing on screen, so the surface that
- * knows which engine is next starts the install and says so here. Ready
- * installs render nothing: the picker already shows a usable engine.
+ * knows which engine is next starts the download and says so here. Engines
+ * already on disk render nothing: the picker already shows a usable engine.
  */
 export function HarnessInstallNote({
   install,
@@ -28,7 +28,7 @@ export function HarnessInstallNote({
         />
         <span>
           {label}
-          {version} could not be installed. {install.error}
+          {version} could not be downloaded. {install.error}
         </span>
       </p>
     );
@@ -40,8 +40,8 @@ export function HarnessInstallNote({
     >
       <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden="true" />
       <span>
-        Installing {label}
-        {version}. First use downloads the engine.
+        Downloading {label}
+        {version}. This runs once, and takes a few minutes.
       </span>
     </p>
   );

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -31,6 +31,7 @@ function entry(
 ): HarnessDoctorEntry {
   return {
     found: true,
+    installable: true,
     version: "9.9.9",
     path: "/opt/harness",
     tier: "reference",
@@ -52,7 +53,7 @@ describe("HarnessPicker", () => {
         harnesses={[
           entry({ kind: "claude_code" }),
           entry({ kind: "codex" }),
-          entry({ kind: "opencode", found: false }),
+          entry({ kind: "opencode", found: false, installable: false }),
         ]}
         value="claude_code"
         onChange={onChange}
@@ -70,6 +71,34 @@ describe("HarnessPicker", () => {
     ).toHaveAttribute("aria-disabled", "true");
     await user.click(screen.getByRole("option", { name: /Codex CLI/ }));
     expect(onChange).toHaveBeenCalledWith("codex");
+  });
+
+  // The lazy pin: an engine this machine has never fetched is a wait, not a
+  // fault, so it stays selectable and picking it is what starts the download.
+  it("offers an engine that has not been downloaded yet", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    await renderWithRouter(
+      <HarnessPicker
+        harnesses={[
+          entry({ kind: "claude_code" }),
+          entry({
+            kind: "opencode",
+            found: false,
+            version: undefined,
+            path: undefined,
+          }),
+        ]}
+        value="claude_code"
+        onChange={onChange}
+      />,
+    );
+    await user.click(screen.getByRole("combobox", { name: "Harness" }));
+    const row = screen.getByRole("option", { name: /opencode/ });
+    expect(row).toHaveTextContent("Downloads on first use");
+    expect(row).not.toHaveAttribute("aria-disabled", "true");
+    await user.click(row);
+    expect(onChange).toHaveBeenCalledWith("opencode");
   });
 
   it("keeps an Auto-only engine selectable and never renders doctor strings", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
@@ -15,7 +15,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { HARNESS_LABELS, harnessUnusableReason } from "./labels";
+import {
+  HARNESS_LABELS,
+  harnessNeedsDownload,
+  harnessUnusableReason,
+} from "./labels";
+
+/** What picking a not-yet-downloaded engine does. */
+const DOWNLOAD_NOTE = "Downloads on first use";
 
 export const HARNESS_ICONS: Record<
   HarnessKind,
@@ -31,10 +38,12 @@ export const HARNESS_ICONS: Record<
  * Branded harness dropdown: logo and product name per row.
  *
  * Ready rows are selectable and carry nothing but the name — a vendor gloss
- * tells a reader picking an engine nothing they do not already know.
- * Unusable rows stay listed, disabled, with the one reason they cannot be
- * chosen; a quiet link to the doctor appears under the control while any row
- * is unusable. Versions and capability flags stay off this surface.
+ * tells a reader picking an engine nothing they do not already know. A row
+ * this machine has not downloaded yet is still selectable and says so, since
+ * choosing it is what starts the download. Only a row that cannot be fixed by
+ * waiting is disabled, with the one reason it cannot be chosen; a quiet link
+ * to the doctor appears under the control while any row is unusable. Versions
+ * and capability flags stay off this surface.
  */
 export function HarnessPicker({
   harnesses,
@@ -75,6 +84,8 @@ export function HarnessPicker({
         <SelectContent scrollButtons={false}>
           {harnesses.map((entry) => {
             const reason = harnessUnusableReason(entry);
+            const note =
+              reason ?? (harnessNeedsDownload(entry) ? DOWNLOAD_NOTE : null);
             const Icon = HARNESS_ICONS[entry.kind];
             return (
               <SelectItem
@@ -88,9 +99,9 @@ export function HarnessPicker({
                     <span className="truncate font-medium">
                       {HARNESS_LABELS[entry.kind]}
                     </span>
-                    {reason && (
+                    {note && (
                       <span className="text-muted-foreground truncate text-xs">
-                        {reason}
+                        {note}
                       </span>
                     )}
                   </span>

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -194,6 +194,74 @@ describe("NewWorkspaceDialog", () => {
     });
   });
 
+  // A report that has not landed knows nothing about any engine, so the
+  // dialog falls back to a guess to render. Downloading on that guess fetches
+  // hundreds of megabytes of whichever engine the fallback named, and takes
+  // the dialog down on any client that cannot install at all.
+  it("downloads nothing until the doctor names a missing engine", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      workspaces: [],
+      sessionsByWorkspace: {},
+      doctor: { harnesses: [] } as never,
+    });
+    const startHarnessInstall = vi.fn(async () => {
+      throw new Error("the dialog must not ask for this");
+    });
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          startHarnessInstall,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: "First message" }),
+    ).toBeInTheDocument();
+    expect(startHarnessInstall).not.toHaveBeenCalled();
+  });
+
+  it("downloads the engine the doctor reports missing", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      workspaces: [],
+      sessionsByWorkspace: {},
+      doctor: {
+        harnesses: [{ ...harness("claude_code"), found: false }],
+      } as never,
+    });
+    const startHarnessInstall = vi.fn(async () => ({
+      kind: "claude_code" as const,
+      version: "2.1.234",
+      phase: "installing",
+      done: false,
+    }));
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          startHarnessInstall,
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    await waitFor(() =>
+      expect(startHarnessInstall).toHaveBeenCalledWith("claude_code"),
+    );
+    // Create waits for the pin rather than stalling minutes on it.
+    expect(screen.getByRole("button", { name: /Create/ })).toBeDisabled();
+  });
+
   it("opens on the last repo, harness, and model, and creates on Cmd+Enter", async () => {
     const repos = [repo("repo-old", "legacy"), repo("repo-new", "tidebreak")];
     useCodeCatalogStore.setState({

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -63,6 +63,7 @@ function harness(kind: HarnessKind): HarnessDoctorEntry {
   return {
     kind,
     found: true,
+    installable: true,
     tier: "reference",
     caps: { ...CAPS },
     commands: [],

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -211,10 +211,14 @@ export function NewWorkspaceDialog({
 
   // A pin this machine has never installed is minutes of npm. Warming it
   // when the dialog opens — and again when the engine changes — moves that
-  // off create, where it was a silent stall.
+  // off create, where it was a silent stall. The doctor entry is the only
+  // trigger: until the report lands, `harness` is the fallback guess rather
+  // than anything the reader picked, and downloading on a guess fetches
+  // hundreds of megabytes nobody asked for.
   const doctorEntry = allHarnesses.find((item) => item.kind === harness);
   const installed = Boolean(doctorEntry?.found);
-  const install = useWarmHarnessInstall(client, harness, open, installed);
+  const needsDownload = Boolean(doctorEntry && !doctorEntry.found);
+  const install = useWarmHarnessInstall(client, harness, open, needsDownload);
 
   const selectedRepo = repos.find((repo) => repo.id === repoId);
   const selectedHarness = selectableHarnesses.find(

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -41,15 +41,16 @@ import { PermissionModeMenu } from "../PermissionModeMenu";
 import { usesCommandModifier } from "@/ShellShortcuts";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
-import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { HarnessModelMenu } from "./CodeComposer";
 import { HarnessInstallNote } from "./HarnessInstallNote";
+import { useWarmHarnessInstall } from "./useHarnessInstall";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import {
   autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   gatewayCodeModels,
+  harnessCanStartNow,
   harnessUnusableReason,
   preferredCodeModels,
   requiresHarnessModelIds,
@@ -100,9 +101,15 @@ function recentRepoId(
   return known(newest?.repo_id) ?? known(remembered) ?? repos[0]?.id ?? "";
 }
 
-/** The engine this reader started last, if it can still be started. */
+/**
+ * The engine this reader started last, if it can still be started.
+ *
+ * Falling back to the first selectable row would open the dialog on an engine
+ * this machine has never downloaded while an installed one sits below it, so
+ * the fallback prefers an engine that can start now.
+ */
 function recentHarness(
-  ready: readonly HarnessDoctorEntry[],
+  selectable: readonly HarnessDoctorEntry[],
   sessions: Record<string, CodeSessionSnapshot>,
   remembered: HarnessKind | undefined,
 ): HarnessKind | undefined {
@@ -110,9 +117,12 @@ function recentHarness(
     b.created_at.localeCompare(a.created_at),
   )[0];
   for (const kind of [newest?.harness_kind, remembered]) {
-    if (kind && ready.some((entry) => entry.kind === kind)) return kind;
+    if (kind && selectable.some((entry) => entry.kind === kind)) return kind;
   }
-  return ready[0]?.kind;
+  return (
+    selectable.find((entry) => harnessCanStartNow(entry))?.kind ??
+    selectable[0]?.kind
+  );
 }
 
 /** Pickers a chord can open; one open at a time, chords toggle. */
@@ -138,8 +148,6 @@ export function NewWorkspaceDialog({
   const ensureHarnessModels = useCodeCatalogStore(
     (state) => state.ensureHarnessModels,
   );
-  const reloadDoctor = useCodeCatalogStore((state) => state.reloadDoctor);
-  const harnessInstalls = useCodeUpdatesStore((state) => state.harnessInstalls);
   const lastCreate = useCodeUiStore((state) => state.lastCreate);
   const rememberCreate = useCodeUiStore((state) => state.rememberCreate);
   const [repoId, setRepoId] = useState("");
@@ -164,17 +172,17 @@ export function NewWorkspaceDialog({
   const command = useMemo(() => usesCommandModifier(navigator.userAgent), []);
 
   const allHarnesses = doctor?.harnesses ?? [];
-  const readyHarnesses = allHarnesses.filter(
+  const selectableHarnesses = allHarnesses.filter(
     (entry) => !harnessUnusableReason(entry),
   );
   // The doctor can land after the dialog opens, so the engine is derived
   // rather than seeded: a pick wins, and until there is one the recent
-  // engine follows whatever the report says is ready.
+  // engine follows whatever the report says can be chosen.
   const harness: HarnessKind =
-    (pickedHarness && readyHarnesses.some((e) => e.kind === pickedHarness)
+    (pickedHarness && selectableHarnesses.some((e) => e.kind === pickedHarness)
       ? pickedHarness
       : undefined) ??
-    recentHarness(readyHarnesses, sessions, lastCreate?.harness) ??
+    recentHarness(selectableHarnesses, sessions, lastCreate?.harness) ??
     "claude_code";
   const model = modelsByHarness[harness];
 
@@ -203,45 +211,13 @@ export function NewWorkspaceDialog({
 
   // A pin this machine has never installed is minutes of npm. Warming it
   // when the dialog opens — and again when the engine changes — moves that
-  // off create, where it was a silent stall. The doctor entry is the only
-  // trigger: an engine already on disk is never asked for.
+  // off create, where it was a silent stall.
   const doctorEntry = allHarnesses.find((item) => item.kind === harness);
-  const needsInstall = Boolean(doctorEntry && !doctorEntry.found);
-  const install = harnessInstalls[harness];
-
-  useEffect(() => {
-    if (!open || !needsInstall) return;
-    let cancelled = false;
-    void client.startHarnessInstall(harness).then(
-      (snapshot) => {
-        // The answer is immediate; the phases after it arrive on the updates
-        // socket. Applying it here means the note shows even on the profile
-        // that never opened one.
-        if (!cancelled) {
-          useCodeUpdatesStore
-            .getState()
-            .apply({ type: "harness_install", install: snapshot });
-        }
-      },
-      // Nothing is broken yet: create still reports `harness_not_found` with
-      // the reason, and a member of a shared deployment may not install at
-      // all. A toast on dialog open would be noise either way.
-      () => {},
-    );
-    return () => {
-      cancelled = true;
-    };
-  }, [client, harness, needsInstall, open]);
-
-  useEffect(() => {
-    // A finished install leaves the doctor report saying "Not installed", so
-    // the engine would stay unpickable until something re-read it.
-    if (!open || !needsInstall || !install?.done || install.error) return;
-    void reloadDoctor(client).catch(() => {});
-  }, [client, install, needsInstall, open, reloadDoctor]);
+  const installed = Boolean(doctorEntry?.found);
+  const install = useWarmHarnessInstall(client, harness, open, installed);
 
   const selectedRepo = repos.find((repo) => repo.id === repoId);
-  const selectedHarness = readyHarnesses.find(
+  const selectedHarness = selectableHarnesses.find(
     (entry) => entry.kind === harness,
   );
   const availableModes = selectedHarness
@@ -255,8 +231,13 @@ export function NewWorkspaceDialog({
     (selectedHarness
       ? defaultCreatePermissionMode(selectedHarness.caps)
       : "plan");
+  // An engine still downloading is a legal pick, not a legal start: create
+  // would sit on the same npm install with nothing but a spinner. The install
+  // note under the pills says what the wait is, and any engine already on
+  // disk is one pick away.
   const canCreate =
-    Boolean(repoId && selectedRepo && selectedHarness) && !creating;
+    Boolean(repoId && selectedRepo && selectedHarness && installed) &&
+    !creating;
   const modeNote =
     postedMode === "auto" &&
     selectedHarness &&
@@ -270,7 +251,10 @@ export function NewWorkspaceDialog({
   useEffect(() => {
     if (!open || !harness) return;
     // The reader's last model wins where it is still on offer; otherwise the
-    // catalog's default, then the first row.
+    // catalog's default, then the first row. `installed` is a dependency
+    // because an engine still downloading has no CLI to list models from:
+    // the gateway rows show meanwhile, and the native listing is fetched
+    // once the pin lands.
     const apply = (listed: CodeModelOption[]) => {
       setModelOptions(listed);
       setModelsByHarness((current) => {
@@ -300,6 +284,13 @@ export function NewWorkspaceDialog({
       setModelLoading(false);
       return;
     }
+    if (!installed) {
+      // `GET /code/harnesses/{kind}/models` runs the engine's own CLI, so it
+      // answers `harness_not_found` until the pin is on disk.
+      apply(gateway);
+      setModelLoading(false);
+      return;
+    }
     setModelOptions([]);
     setModelLoading(true);
     let cancelled = false;
@@ -314,7 +305,15 @@ export function NewWorkspaceDialog({
     // `lastCreate` seeds `modelsByHarness` when the dialog opens. Subscribing
     // this fetch to later writes would undo a deliberate pick after create.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [client, defaultModelKey, ensureHarnessModels, harness, models, open]);
+  }, [
+    client,
+    defaultModelKey,
+    ensureHarnessModels,
+    harness,
+    installed,
+    models,
+    open,
+  ]);
 
   function selectModel(next: string) {
     setModelsByHarness((current) => ({ ...current, [harness]: next }));

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -86,6 +86,7 @@ function entry(
   return {
     kind,
     found: true,
+    installable: true,
     tier: "reference",
     caps: { ...CAPS, structured_approvals: "supported", ...caps },
     commands: [],

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -115,7 +115,7 @@ export function StartSessionPrompt({
     canInstallHarnesses(client) ? client : undefined,
     selectedKind,
     true,
-    installed,
+    Boolean(selected && !selected.found),
   );
 
   useEffect(() => {

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -11,12 +11,18 @@ import type { ComposerWorkspaceFiles } from "@/Composer";
 import { CodeComposer } from "./CodeComposer";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
+import { HarnessInstallNote } from "./HarnessInstallNote";
 import { HarnessPicker } from "./HarnessPicker";
+import {
+  canInstallHarnesses,
+  useWarmHarnessInstall,
+} from "./useHarnessInstall";
 import {
   autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   gatewayCodeModels,
+  harnessCanStartNow,
   harnessUnusableReason,
   preferredCodeModels,
   requiresHarnessModelIds,
@@ -30,10 +36,15 @@ const NO_CATALOG_MODELS: ModelInfo[] = [];
 /**
  * Create-time harness + permission mode for a workspace with no session.
  *
- * The harness dropdown defaults to the first ready engine; the mode list and
- * default follow the selected engine's own capability flags, so start always
- * posts a mode that engine can honor, and an unsupervised one says so before
- * the session exists (decisions 0038, 0039).
+ * The harness dropdown defaults to the first engine that can start now; the
+ * mode list and default follow the selected engine's own capability flags, so
+ * start always posts a mode that engine can honor, and an unsupervised one
+ * says so before the session exists (decisions 0038, 0039).
+ *
+ * An engine this machine has not downloaded yet is still on offer. Picking it
+ * starts the download and the note under the picker says so; start stays
+ * disabled until the pin lands, because create would otherwise sit on the
+ * same npm install with nothing on screen.
  *
  * Cmd+Enter starts from anywhere on this surface, matching the new-workspace
  * dialog. The draft lives in the composer, so the shortcut goes through the
@@ -62,7 +73,8 @@ export function StartSessionPrompt({
     message: string,
     model?: string,
   ) => Promise<void> | void;
-  client?: Pick<ApiClient, "listCodeHarnessModels">;
+  client?: Pick<ApiClient, "listCodeHarnessModels"> &
+    Partial<Pick<ApiClient, "startHarnessInstall" | "getHarnessDoctor">>;
   catalogModels?: ModelInfo[];
   defaultModelKey?: string | null;
   /** Worktree files the first message names — a fork's transcript. */
@@ -81,11 +93,13 @@ export function StartSessionPrompt({
   const ensureHarnessModels = useCodeCatalogStore(
     (state) => state.ensureHarnessModels,
   );
-  const ready = harnesses.filter((entry) => !harnessUnusableReason(entry));
+  const selectable = harnesses.filter((entry) => !harnessUnusableReason(entry));
   const selected =
     harnesses.find(
       (entry) => entry.kind === picked && !harnessUnusableReason(entry),
-    ) ?? ready[0];
+    ) ??
+    selectable.find((entry) => harnessCanStartNow(entry)) ??
+    selectable[0];
   const availableModes = selected ? createPermissionModes(selected.caps) : [];
   const mode: PermissionMode =
     selectedMode && availableModes.includes(selectedMode)
@@ -96,6 +110,13 @@ export function StartSessionPrompt({
 
   const selectedKind = selected?.kind;
   const model = selectedKind ? modelsByHarness[selectedKind] : undefined;
+  const installed = Boolean(selected?.found);
+  const install = useWarmHarnessInstall(
+    canInstallHarnesses(client) ? client : undefined,
+    selectedKind,
+    true,
+    installed,
+  );
 
   useEffect(() => {
     if (!selectedKind) {
@@ -186,6 +207,7 @@ export function StartSessionPrompt({
             setPicked(next);
           }}
         />
+        <HarnessInstallNote install={install} />
         {mode === "auto" && selected && autoIsUnsupervised(selected.caps) && (
           <p className="text-muted-foreground text-xs">
             {UNSUPERVISED_AUTO_NOTE}
@@ -197,7 +219,7 @@ export function StartSessionPrompt({
       </div>
       <div className="mt-auto">
         <CodeComposer
-          disabled={starting || !selected}
+          disabled={starting || !selected || !installed}
           running={starting}
           permissionMode={mode}
           availableModes={availableModes}

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -9,6 +9,8 @@ import {
   effortLadder,
   gatewayCodeModels,
   groupCodeModelOptions,
+  harnessCanStartNow,
+  harnessNeedsDownload,
   harnessUnusableReason,
   preferredCodeModels,
   sessionLifecycleTooltip,
@@ -107,12 +109,14 @@ describe("harnessUnusableReason", () => {
     expect(
       harnessUnusableReason({
         found: false,
+        installable: false,
         caps: caps("supported", "supported", "supported"),
       }),
     ).toBe("Not installed");
     expect(
       harnessUnusableReason({
         found: true,
+        installable: true,
         authenticated: false,
         caps: caps("supported", "supported", "supported"),
       }),
@@ -120,12 +124,14 @@ describe("harnessUnusableReason", () => {
     expect(
       harnessUnusableReason({
         found: true,
+        installable: true,
         caps: caps("unsupported", "unsupported", "unsupported"),
       }),
     ).toBe("Not available yet");
     expect(
       harnessUnusableReason({
         found: true,
+        installable: true,
         caps: caps("supported", "unsupported", "unsupported"),
       }),
     ).toBeNull();
@@ -133,9 +139,26 @@ describe("harnessUnusableReason", () => {
     expect(
       harnessUnusableReason({
         found: true,
+        installable: true,
         caps: caps("unsupported", "unsupported", "supported"),
       }),
     ).toBeNull();
+  });
+
+  // The whole point of the lazy pin: an engine Tidebreak can fetch is a wait,
+  // not a fault, so the picker offers it and choosing it starts the download.
+  it("lets a downloadable engine be chosen", () => {
+    const entry = {
+      found: false,
+      installable: true,
+      caps: caps("supported", "supported", "supported"),
+    };
+    expect(harnessUnusableReason(entry)).toBeNull();
+    expect(harnessNeedsDownload(entry)).toBe(true);
+    expect(harnessCanStartNow(entry)).toBe(false);
+    expect(
+      harnessCanStartNow({ ...entry, found: true, authenticated: true }),
+    ).toBe(true);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -136,18 +136,45 @@ export function harnessHonorsAnyCreateMode(entry: { caps: ModeCaps }): boolean {
 }
 
 /**
- * Why a picker row is not selectable. Ready rows return null.
+ * True when this engine is not on disk yet but Tidebreak ships a pin it can
+ * download.
+ *
+ * Every engine used to have to be installed before any of them could be used,
+ * because the doctor's only install control fetched all four. A missing pin is
+ * now a wait, not a fault: pick the engine and the download starts.
+ */
+export function harnessNeedsDownload(entry: {
+  found: boolean;
+  installable: boolean;
+}): boolean {
+  return !entry.found && entry.installable;
+}
+
+/**
+ * Why a picker row is not selectable. Ready rows return null, and so does a
+ * row that only needs downloading — see [`harnessNeedsDownload`].
  * Versions, paths, and capability names stay on the doctor.
  */
 export function harnessUnusableReason(entry: {
   found: boolean;
+  installable: boolean;
   authenticated?: boolean;
   caps: ModeCaps;
 }): string | null {
-  if (!entry.found) return "Not installed";
+  if (!entry.found && !entry.installable) return "Not installed";
   if (entry.authenticated === false) return "Sign in via your terminal";
   if (!harnessHonorsAnyCreateMode(entry)) return "Not available yet";
   return null;
+}
+
+/** True when this engine can be started right now, with nothing to wait for. */
+export function harnessCanStartNow(entry: {
+  found: boolean;
+  installable: boolean;
+  authenticated?: boolean;
+  caps: ModeCaps;
+}): boolean {
+  return entry.found && !harnessUnusableReason(entry);
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2669,6 +2669,7 @@ export function parseHarnessDoctorEntry(
     !onlyKeys<WireHarnessDoctorEntry>(value, [
       "kind",
       "found",
+      "installable",
       "path",
       "version",
       "tier",
@@ -2699,6 +2700,9 @@ export function parseHarnessDoctorEntry(
   return {
     kind: value.kind,
     found: value.found,
+    // A server that predates the field offers no on-demand download, which
+    // is what this build did before the pin became lazy.
+    installable: value.installable === true,
     tier: value.tier,
     caps,
     remediation: value.remediation,

--- a/crates/tidebreak-desktop/ui/src/code/useHarnessInstall.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useHarnessInstall.ts
@@ -1,0 +1,86 @@
+import { useEffect } from "react";
+
+import type { ApiClient } from "../api/client";
+import type { CodeHarnessInstallSnapshot, HarnessKind } from "../api/types";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+
+/** What this hook needs from the client; a test can pass two functions. */
+export type HarnessInstallClient = Pick<
+  ApiClient,
+  "startHarnessInstall" | "getHarnessDoctor"
+>;
+
+/**
+ * Whether a client carries both halves of an install.
+ *
+ * Surfaces that take an optional, narrowed client — the workspace start
+ * prompt, and every test that stubs one method — reach the hook through this
+ * rather than a cast.
+ */
+export function canInstallHarnesses(
+  client: Partial<HarnessInstallClient> | undefined,
+): client is HarnessInstallClient {
+  return Boolean(client?.startHarnessInstall && client?.getHarnessDoctor);
+}
+
+/**
+ * Download the engine a picker has landed on, if this machine does not have
+ * it yet.
+ *
+ * A pinned engine is a 37-297MB `npm install`. Tidebreak used to install all
+ * four before any of them could be used, because the doctor's one install
+ * control fetched every pin. Now nothing is fetched until a reader picks it,
+ * which puts the download on the surface that knows which engine is next
+ * rather than on create, where it was a silent multi-minute stall.
+ *
+ * Returns the install's own progress so the caller can say what the wait is.
+ * Ready engines return `undefined` and nothing is requested.
+ */
+export function useWarmHarnessInstall(
+  /** Undefined on a surface with no client, which downloads nothing. */
+  client: HarnessInstallClient | undefined,
+  harness: HarnessKind | undefined,
+  /** False while the surface is closed, so a hidden picker downloads nothing. */
+  active: boolean,
+  /** The doctor's answer for `harness`. False starts the download. */
+  installed: boolean,
+): CodeHarnessInstallSnapshot | undefined {
+  const reloadDoctor = useCodeCatalogStore((state) => state.reloadDoctor);
+  const installs = useCodeUpdatesStore((state) => state.harnessInstalls);
+  const install = harness ? installs[harness] : undefined;
+  const wanted = Boolean(active && client && harness && !installed);
+
+  useEffect(() => {
+    if (!wanted || !client || !harness) return;
+    let cancelled = false;
+    void client.startHarnessInstall(harness).then(
+      (snapshot) => {
+        // The answer is immediate; the phases after it arrive on the updates
+        // socket. Applying it here means the note shows even on the profile
+        // that never opened one.
+        if (!cancelled) {
+          useCodeUpdatesStore
+            .getState()
+            .apply({ type: "harness_install", install: snapshot });
+        }
+      },
+      // Nothing is broken yet: create still reports `harness_not_found` with
+      // the reason, and a member of a shared deployment may not install at
+      // all. A toast on picker open would be noise either way.
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [client, harness, wanted]);
+
+  useEffect(() => {
+    // A finished install leaves the doctor report saying the engine is not
+    // installed, so it would stay unstartable until something re-read it.
+    if (!wanted || !client || !install?.done || install.error) return;
+    void reloadDoctor(client).catch(() => {});
+  }, [client, install, reloadDoctor, wanted]);
+
+  return install;
+}

--- a/crates/tidebreak-desktop/ui/src/code/useHarnessInstall.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useHarnessInstall.ts
@@ -43,33 +43,46 @@ export function useWarmHarnessInstall(
   harness: HarnessKind | undefined,
   /** False while the surface is closed, so a hidden picker downloads nothing. */
   active: boolean,
-  /** The doctor's answer for `harness`. False starts the download. */
-  installed: boolean,
+  /**
+   * The doctor says this engine is missing.
+   *
+   * This is deliberately not "the doctor does not say it is present". A report
+   * that has not landed yet knows nothing about any engine, and downloading on
+   * that would fetch whichever engine the picker happened to fall back to.
+   */
+  needsDownload: boolean,
 ): CodeHarnessInstallSnapshot | undefined {
   const reloadDoctor = useCodeCatalogStore((state) => state.reloadDoctor);
   const installs = useCodeUpdatesStore((state) => state.harnessInstalls);
   const install = harness ? installs[harness] : undefined;
-  const wanted = Boolean(active && client && harness && !installed);
+  const wanted = Boolean(active && client && harness && needsDownload);
 
   useEffect(() => {
     if (!wanted || !client || !harness) return;
     let cancelled = false;
-    void client.startHarnessInstall(harness).then(
-      (snapshot) => {
-        // The answer is immediate; the phases after it arrive on the updates
-        // socket. Applying it here means the note shows even on the profile
-        // that never opened one.
-        if (!cancelled) {
-          useCodeUpdatesStore
-            .getState()
-            .apply({ type: "harness_install", install: snapshot });
-        }
-      },
-      // Nothing is broken yet: create still reports `harness_not_found` with
-      // the reason, and a member of a shared deployment may not install at
-      // all. A toast on picker open would be noise either way.
-      () => {},
-    );
+    // Warming a pin is an optimization on top of the create path's own
+    // ensure, so nothing here may take the surface down with it — a client
+    // that cannot install at all still has to render its picker.
+    try {
+      void client.startHarnessInstall(harness).then(
+        (snapshot) => {
+          // The answer is immediate; the phases after it arrive on the
+          // updates socket. Applying it here means the note shows even on the
+          // profile that never opened one.
+          if (!cancelled) {
+            useCodeUpdatesStore
+              .getState()
+              .apply({ type: "harness_install", install: snapshot });
+          }
+        },
+        // Nothing is broken yet: create still reports `harness_not_found`
+        // with the reason, and a member of a shared deployment may not
+        // install at all. A toast on picker open would be noise either way.
+        () => {},
+      );
+    } catch {
+      // Same reasoning as the rejection above.
+    }
     return () => {
       cancelled = true;
     };

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2443,7 +2443,15 @@ description: string, };
 /**
  * One engine's probe, capabilities, and remediation.
  */
-export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, remediation: string, stderr: string, unrecognized_event_count: number, };
+export type HarnessDoctorEntry = { kind: HarnessKind, found: boolean, 
+/**
+ * Whether Tidebreak ships a pin it can download for this engine.
+ *
+ * A `found: false, installable: true` engine is not a fault. Pick it and
+ * the download starts; the doctor is not a gate the reader must clear
+ * first.
+ */
+installable: boolean, path?: string, version?: string, tier: HarnessTier, caps: HarnessCaps, commands: Array<HarnessCommand>, authenticated?: boolean, remediation: string, stderr: string, unrecognized_event_count: number, };
 
 /**
  * Doctor report for every registered engine adapter.

--- a/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/CodingHarnessesPanel.tsx
@@ -1,9 +1,14 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import type { ApiClient } from "../api/client";
-import type { CodeWorktreeRoot, HarnessDoctorReport } from "../api/types";
+import type {
+  CodeWorktreeRoot,
+  HarnessDoctorReport,
+  HarnessKind,
+} from "../api/types";
 import { DoctorList } from "@/code/DoctorList";
+import { useCodeUpdatesStore } from "@/code/CodeUpdatesStore";
 import { hasLocalHostAuthority, pickCodeDirectory } from "@/host";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { hostMachineLabel } from "@/remoteMachine";
@@ -13,11 +18,14 @@ import { WorktreeRootSection } from "./WorktreeRootSection";
 /**
  * Settings: the coding-harness doctor, and where workspaces land on disk.
  *
- * Found, path, version, tier, capabilities, auth, remediation, and
- * unrecognized-event counts live here so a reader can repair an engine
- * without opening a workspace. The workspace folder sits above them because it
- * decides where the user's own code ends up, which matters before any engine
- * runs.
+ * Every engine's state, and the control that downloads one, live here so a
+ * reader can get an engine working without opening a workspace. Downloads run
+ * one engine at a time and report on the same live bus the pickers watch, so
+ * starting one here and then opening the New Workspace dialog shows the same
+ * progress in both places.
+ *
+ * The workspace folder sits below the engines: a reader who came here came for
+ * an engine, and the folder only matters once one runs.
  */
 
 export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
@@ -70,6 +78,42 @@ export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
     };
   }, [client]);
 
+  const installs = useCodeUpdatesStore((state) => state.harnessInstalls);
+
+  async function install(kind: HarnessKind) {
+    try {
+      const snapshot = await client.startHarnessInstall(kind, true);
+      useCodeUpdatesStore
+        .getState()
+        .apply({ type: "harness_install", install: snapshot });
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not start the download"));
+    }
+  }
+
+  // A finished download leaves the report saying the engine is missing, so
+  // read it again rather than making the reader press Re-check. Each install
+  // is answered once: a pin that reports `ready` while its probe still finds
+  // nothing is a real fault for Re-check to surface, not a reload loop.
+  const reloadedFor = useRef(new Set<string>());
+  useEffect(() => {
+    const landed = Object.values(installs).filter(
+      (item) => item?.phase === "ready",
+    );
+    const fresh = landed.filter(
+      (item) =>
+        item && !reloadedFor.current.has(`${item.kind}:${item.version}`),
+    );
+    if (fresh.length === 0) return;
+    for (const item of fresh) {
+      if (item) reloadedFor.current.add(`${item.kind}:${item.version}`);
+    }
+    void client
+      .getHarnessDoctor()
+      .then(setReport)
+      .catch(() => {});
+  }, [client, installs]);
+
   async function saveRoot(root: string | null) {
     setSavingRoot(true);
     setError(null);
@@ -92,10 +136,20 @@ export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
   return (
     <SettingsPanel
       title="Coding harnesses"
-      description={`Engines installed on ${hostMachineLabel()}, what they can do, and where the workspaces they run in live.`}
+      description={`Coding engines on ${hostMachineLabel()}. Each one downloads the first time you pick it, so you only pay for the ones you use.`}
       busy={loading || refreshing}
     >
       {error && <SettingsError>{error}</SettingsError>}
+      {report && (
+        <DoctorList
+          report={report}
+          title="Engines"
+          onRefresh={() => void load(true)}
+          refreshing={refreshing}
+          onInstall={(kind) => void install(kind)}
+          installs={installs}
+        />
+      )}
       {worktreeRoot && (
         <WorktreeRootSection
           value={rootDraft}
@@ -113,13 +167,6 @@ export function CodingHarnessesPanel({ client }: { client: ApiClient }) {
           }}
           onSave={() => void saveRoot(rootDraft.trim())}
           onReset={() => void saveRoot(null)}
-        />
-      )}
-      {report && (
-        <DoctorList
-          report={report}
-          onRefresh={() => void load(true)}
-          refreshing={refreshing}
         />
       )}
     </SettingsPanel>

--- a/crates/tidebreak-desktop/ui/src/stories/CodingHarnessesPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodingHarnessesPanel.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useLayoutEffect } from "react";
+
+import { CodingHarnessesPanel } from "@/settings/CodingHarnessesPanel";
+import { useCodeUpdatesStore } from "@/code/CodeUpdatesStore";
+import type { HarnessDoctorReport } from "@/api";
+import {
+  harnessDoctor,
+  harnessDoctorCold,
+  harnessDoctorDegraded,
+  harnessDoctorMixed,
+  harnessInstallsInFlight,
+} from "./fixtures";
+import {
+  SettingsStoryHarness,
+  type SettingsStoryState,
+} from "./SettingsStoryHarness";
+
+/**
+ * Settings → Coding harnesses, the whole page.
+ *
+ * The engines lead, because a reader who opens this page opens it to get one
+ * working. Each row states whether it is usable and carries the one control
+ * that changes that; the workspace folder follows, since it only matters once
+ * an engine runs.
+ */
+
+type Variant = {
+  report?: HarnessDoctorReport;
+  installs?: typeof harnessInstallsInFlight;
+  state?: SettingsStoryState;
+};
+
+function HarnessesShowcase({
+  report,
+  installs,
+  state = "configured",
+}: Variant) {
+  useLayoutEffect(() => {
+    useCodeUpdatesStore.setState({ harnessInstalls: installs ?? {} });
+  }, [installs]);
+  return (
+    <SettingsStoryHarness state={state}>
+      {(client) => (
+        <CodingHarnessesPanel
+          client={Object.assign(client, {
+            getHarnessDoctor: async () => report ?? harnessDoctor,
+            refreshHarnessDoctor: async () => report ?? harnessDoctor,
+          })}
+        />
+      )}
+    </SettingsStoryHarness>
+  );
+}
+
+const meta = {
+  title: "Settings/Coding harnesses",
+  component: HarnessesShowcase,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof HarnessesShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Every engine downloaded and signed in. */
+export const AllReady: Story = { args: { report: harnessDoctor } };
+
+/** A fresh machine, before anything has been downloaded. */
+export const NothingDownloaded: Story = { args: { report: harnessDoctorCold } };
+
+/** One engine in use, the rest never fetched. */
+export const Mixed: Story = { args: { report: harnessDoctorMixed } };
+
+/** A download running, and one that failed with the registry error shown. */
+export const Downloading: Story = {
+  args: { report: harnessDoctorCold, installs: harnessInstallsInFlight },
+};
+
+/** States no download fixes: no pin for one engine, no sign-in for the other. */
+export const NeedsYou: Story = { args: { report: harnessDoctorDegraded } };
+
+/** The first read has not landed. */
+export const Loading: Story = { args: { state: "loading" } };

--- a/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HarnessDoctor.stories.tsx
@@ -2,20 +2,34 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 import { DoctorList } from "@/code/DoctorList";
-import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
+import {
+  harnessDoctor,
+  harnessDoctorCold,
+  harnessDoctorDegraded,
+  harnessDoctorMixed,
+  harnessInstallsInFlight,
+} from "./fixtures";
 
 /**
- * The harness doctor: every engine's probe, capability matrix, and
- * remediation. Honest capability differences (Codex's supported steering,
- * Grok's refusals) must read directly from the matrix.
+ * The harness doctor: one row per engine, leading with whether it is usable
+ * and what closes the gap when it is not.
+ *
+ * Engines download one at a time, when someone picks one or presses Download
+ * here, so "not downloaded" is a resting state with an action on it rather
+ * than a fault. Version, path, capabilities, and probe output sit behind each
+ * row's Details disclosure.
  */
 const meta = {
   title: "Code/Harness doctor",
   component: DoctorList,
-  args: { report: harnessDoctor, onRefresh: fn() },
+  args: {
+    report: harnessDoctor,
+    onRefresh: fn(),
+    onInstall: fn(),
+  },
   decorators: [
     (Story) => (
-      <div className="mx-auto max-w-2xl pt-8">
+      <div className="mx-auto max-w-3xl p-8">
         <Story />
       </div>
     ),
@@ -25,19 +39,38 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** Every engine present and usable; capability levels differ honestly. */
+/** Every engine downloaded and signed in; capability levels differ honestly. */
 export const AllReady: Story = {};
 
-/** Missing binary and signed-out engine, each with its remediation. */
-export const NeedsSetup: Story = {
+/** A fresh machine: nothing downloaded, every row one click from working. */
+export const NothingDownloaded: Story = {
+  args: { report: harnessDoctorCold },
+};
+
+/** The common middle: one engine in use, the rest never fetched. */
+export const Mixed: Story = {
+  args: { report: harnessDoctorMixed },
+};
+
+/** A download in flight and one that failed, side by side. */
+export const Downloading: Story = {
+  args: {
+    report: harnessDoctorCold,
+    installs: harnessInstallsInFlight,
+  },
+};
+
+/** Nothing a download fixes: an engine with no pin, and one signed out. */
+export const NeedsYou: Story = {
   args: { report: harnessDoctorDegraded },
 };
 
-export const Refreshing: Story = {
+/** The re-probe is running. */
+export const Rechecking: Story = {
   args: { refreshing: true },
 };
 
-/** A machine with no engines at all. */
+/** A build that drives no engines at all. */
 export const Empty: Story = {
   args: { report: { harnesses: [] } },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/HarnessInstallNote.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HarnessInstallNote.stories.tsx
@@ -3,11 +3,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { HarnessInstallNote } from "@/code/HarnessInstallNote";
 
 /**
- * The install line under the engine picker in New workspace.
+ * The download line under the engine picker in New workspace.
  *
- * A pinned engine that this machine has never installed is a 37-297MB npm
- * install. It runs ahead of create now, so the dialog says what is happening
- * instead of stalling on the Create button.
+ * A pinned engine this machine has never fetched is a 37-297MB npm install.
+ * It runs ahead of create now, so the dialog says what is happening instead
+ * of stalling on the Create button.
  */
 const meta = {
   title: "Code/Harness install note",
@@ -32,10 +32,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** The install is running. */
-export const Installing: Story = {};
+/** The download is running. */
+export const Downloading: Story = {};
 
-/** The install failed; the reason stays on screen rather than in a toast. */
+/** The download failed; the reason stays on screen rather than in a toast. */
 export const Failed: Story = {
   args: {
     install: {
@@ -48,7 +48,7 @@ export const Failed: Story = {
   },
 };
 
-/** Installed engines render nothing — the picker already shows them. */
+/** Engines already on disk render nothing — the picker already shows them. */
 export const Ready: Story = {
   args: {
     install: {

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -13,7 +13,13 @@ import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { CodeRepoSnapshot, HarnessKind } from "@/api/types";
 import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
 import { NewWorkspaceDialog } from "@/code/NewWorkspaceDialog";
-import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
+import { useCodeUpdatesStore } from "@/code/CodeUpdatesStore";
+import {
+  harnessDoctor,
+  harnessDoctorCold,
+  harnessDoctorDegraded,
+  harnessInstallsInFlight,
+} from "./fixtures";
 
 /**
  * The new-workspace composer: the first message is the surface, and every
@@ -154,8 +160,10 @@ function withRouter(children: ReactNode) {
 
 function NewWorkspace({
   doctor = harnessDoctor,
+  installs,
 }: {
   doctor?: typeof harnessDoctor;
+  installs?: typeof harnessInstallsInFlight;
 }) {
   // Seed the catalog before the dialog mounts: its defaults read the store.
   const [seeded, setSeeded] = useState(false);
@@ -166,8 +174,9 @@ function NewWorkspace({
       sessionsByWorkspace: {},
       workspaces: [],
     });
+    useCodeUpdatesStore.setState({ harnessInstalls: installs ?? {} });
     setSeeded(true);
-  }, [doctor]);
+  }, [doctor, installs]);
   if (!seeded) return null;
   return (
     <AppContextProvider value={appContext()}>
@@ -194,9 +203,28 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 /**
- * Engines that need install or sign-in stay listed and dimmed in the engine
- * menu; a warm install for the missing pin reports under the message.
+ * Engines that cannot be fixed by waiting — no pin, or signed out — stay
+ * listed and dimmed in the engine menu with the one reason why.
  */
 export const EnginesNeedSetup: Story = {
   args: { doctor: harnessDoctorDegraded },
+};
+
+/**
+ * A machine with nothing downloaded. The engine menu still offers all four,
+ * because picking one is what fetches it; Create waits for the pin, and the
+ * line under the message says what the wait is.
+ */
+export const EngineDownloading: Story = {
+  args: {
+    doctor: harnessDoctorCold,
+    installs: {
+      claude_code: {
+        kind: "claude_code",
+        version: "2.1.234",
+        phase: "installing",
+        done: false,
+      },
+    },
+  },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -7,6 +7,7 @@ import type {
   CodeDeliveryRunDetail,
   CodeDeliveryRunSummary,
   CodeGitHubRepositoryRef,
+  CodeHarnessInstallSnapshot,
   CodeRepoSnapshot,
   CodeSessionDigest,
   CodeSessionSnapshot,
@@ -17,6 +18,7 @@ import type {
   HarnessCaps,
   HarnessDoctorEntry,
   HarnessDoctorReport,
+  HarnessKind,
   PendingUserQuestions,
   GatewayApps,
   GatewayStatus,
@@ -462,6 +464,7 @@ function doctorEntry(
 ): HarnessDoctorEntry {
   return {
     found: true,
+    installable: true,
     tier: "reference",
     caps: fullCaps,
     commands: [],
@@ -504,6 +507,7 @@ export const harnessDoctor: HarnessDoctorReport = {
       version: "grok 1.0.5",
       tier: "best_effort",
       authenticated: false,
+      remediation: "Sign in to grok in your own terminal, then re-check.",
       caps: {
         ...fullCaps,
         mid_turn_steering: "unsupported",
@@ -520,7 +524,8 @@ export const harnessDoctorDegraded: HarnessDoctorReport = {
     doctorEntry({
       kind: "claude_code",
       found: false,
-      remediation: "Install Claude Code, then refresh.",
+      installable: false,
+      remediation: "This build ships no pinned Claude Code binary to download.",
       stderr: "claude: command not found",
     }),
     doctorEntry({
@@ -528,10 +533,60 @@ export const harnessDoctorDegraded: HarnessDoctorReport = {
       version: "codex-cli 0.147.0",
       tier: "secondary",
       authenticated: false,
-      remediation: "Run codex login in a terminal, then refresh.",
+      remediation: "Sign in to codex in your own terminal, then re-check.",
       caps: { ...fullCaps, mid_turn_steering: "supported" },
     }),
   ],
+};
+
+/** A fresh machine: nothing downloaded, and every engine one click away. */
+export const harnessDoctorCold: HarnessDoctorReport = {
+  harnesses: harnessDoctor.harnesses.map((entry) => ({
+    ...entry,
+    found: false,
+    authenticated: undefined,
+    path: undefined,
+    version: undefined,
+    remediation: "",
+  })),
+};
+
+/**
+ * The common middle: one engine in use, the rest never fetched, and one that
+ * arrived but was never signed into.
+ */
+export const harnessDoctorMixed: HarnessDoctorReport = {
+  harnesses: harnessDoctor.harnesses.map((entry, index) =>
+    index === 0 || entry.authenticated === false
+      ? entry
+      : {
+          ...entry,
+          found: false,
+          authenticated: undefined,
+          path: undefined,
+          version: undefined,
+        },
+  ),
+};
+
+/** One engine mid-download, one that failed, for the doctor's live states. */
+export const harnessInstallsInFlight: Partial<
+  Record<HarnessKind, CodeHarnessInstallSnapshot>
+> = {
+  codex: {
+    kind: "codex",
+    version: "0.147.0",
+    phase: "installing",
+    done: false,
+  },
+  opencode: {
+    kind: "opencode",
+    version: "1.18.18",
+    phase: "failed",
+    done: true,
+    error:
+      "npm install opencode-ai@1.18.18 failed: ETIMEDOUT registry.npmjs.org",
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/tidebreak-server/src/code/harness_install.rs
+++ b/crates/tidebreak-server/src/code/harness_install.rs
@@ -99,10 +99,16 @@ impl CodeRuntime {
     /// Answers immediately in every case: the pin is already installed, an
     /// install this process started is still running, or a fresh one is now
     /// detached. Two callers never produce two installs.
+    ///
+    /// `deliberate` separates the two callers. A picker warms the pin because
+    /// a surface opened, so a failed managed-Node install stays failed rather
+    /// than restarting every time someone opens a dialog. The doctor's
+    /// Install button is a person asking, so it retries Node first.
     pub(crate) fn start_harness_install(
         self: &Arc<Self>,
         owner: &OwnerId,
         kind: HarnessKind,
+        deliberate: bool,
     ) -> Result<CodeHarnessInstallSnapshot, ServerError> {
         let pin = tidebreak_harness::pin_for(kind).ok_or_else(|| {
             ServerError::unprocessable_kind(
@@ -137,16 +143,18 @@ impl CodeRuntime {
         let runtime = Arc::clone(self);
         let owner = owner.clone();
         tokio::spawn(async move {
-            runtime.run_harness_install(&owner, kind).await;
+            runtime.run_harness_install(&owner, kind, deliberate).await;
         });
         Ok(job.to_snapshot())
     }
 
-    async fn run_harness_install(self: Arc<Self>, owner: &OwnerId, kind: HarnessKind) {
-        // `false`, like the create path: ensure the managed Node runtime and
-        // wait for it. A retry here would re-trigger a Node install because a
-        // dialog opened.
-        match self.ensure_pinned_harness(kind, false).await {
+    async fn run_harness_install(
+        self: Arc<Self>,
+        owner: &OwnerId,
+        kind: HarnessKind,
+        retry_node: bool,
+    ) {
+        match self.ensure_pinned_harness(kind, retry_node).await {
             Ok(binary) => {
                 self.record_pin_install(kind, Ok(()));
                 // The doctor's memoized probe was taken before this install

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -666,30 +666,6 @@ impl CodeRuntime {
         tidebreak_harness::ensure_installed(&self.data_dir, kind, Some(&node_root)).await
     }
 
-    #[cfg_attr(test, allow(dead_code))]
-    pub(crate) async fn refresh_pinned_harnesses(&self) {
-        let node_root = self.managed_node_root(true).await;
-        let installs = HarnessKind::ALL.iter().map(|kind| {
-            let node_root = node_root.as_ref();
-            async move {
-                let result = match node_root {
-                    Ok(root) => tidebreak_harness::ensure_installed(
-                        &self.data_dir,
-                        *kind,
-                        Some(root.as_path()),
-                    )
-                    .await
-                    .map(|_| ()),
-                    Err(err) => Err(err.clone()),
-                };
-                (*kind, result)
-            }
-        });
-        for (kind, result) in futures::future::join_all(installs).await {
-            self.record_pin_install(kind, result);
-        }
-    }
-
     pub(crate) fn adapter(
         &self,
         kind: HarnessKind,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -805,13 +805,10 @@ impl ScopedCode {
     pub(crate) fn start_harness_install(
         &self,
         kind: HarnessKind,
+        deliberate: bool,
     ) -> Result<CodeHarnessInstallSnapshot, ServerError> {
-        self.runtime.start_harness_install(&self.owner, kind)
-    }
-
-    #[cfg(not(test))]
-    pub(crate) async fn refresh_pinned_harnesses(&self) {
-        self.runtime.refresh_pinned_harnesses().await;
+        self.runtime
+            .start_harness_install(&self.owner, kind, deliberate)
     }
 }
 

--- a/crates/tidebreak-server/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server/src/routes/code/harnesses.rs
@@ -1,4 +1,4 @@
-use axum::extract::Path;
+use axum::extract::{Path, Query};
 
 use crate::code::ScopedCode;
 use crate::error::ServerError;
@@ -6,7 +6,7 @@ use crate::extract::Json;
 
 use super::types::{
     CodeHarnessInstallSnapshot, HarnessDoctorEntry, HarnessDoctorReport, HarnessModel,
-    HarnessModelList,
+    HarnessModelList, InstallHarnessQuery,
 };
 use tidebreak_core::HarnessKind;
 
@@ -18,9 +18,12 @@ pub async fn list_harnesses(code: ScopedCode) -> Result<Json<HarnessDoctorReport
 /// The explicit re-probe decision 0034 puts behind the doctor's refresh: drop
 /// the memoized probes, then report what a cold read finds. This is how a
 /// harness installed or signed into while the app runs becomes visible.
+///
+/// Refresh does not install. It used to `npm install` every pin, which spent
+/// hundreds of megabytes and minutes on three engines the reader had not
+/// asked for to make a fourth usable. An engine downloads when someone picks
+/// it, or when they press Download on its doctor row.
 pub async fn refresh_harnesses(code: ScopedCode) -> Result<Json<HarnessDoctorReport>, ServerError> {
-    #[cfg(not(test))]
-    code.refresh_pinned_harnesses().await;
     code.invalidate_probes();
     Ok(Json(doctor(&code).await?))
 }
@@ -28,16 +31,21 @@ pub async fn refresh_harnesses(code: ScopedCode) -> Result<Json<HarnessDoctorRep
 /// Start the pinned install of one engine ahead of a session create, and
 /// report where that install stands.
 ///
-/// The New Workspace dialog calls this when it opens and when the engine
-/// changes. A cold pin is minutes of `npm install`; on the create path that
-/// is a silent stall, so it runs here instead and reports on
+/// Every surface that picks an engine calls this when it opens and when the
+/// engine changes. A cold pin is minutes of `npm install`; on the create path
+/// that is a silent stall, so it runs here instead and reports on
 /// `WS /code/updates`. Answers immediately in every case — already installed,
 /// already running, or now started — and never installs twice for one pin.
+///
+/// `?deliberate=true` marks a reader who pressed Download rather than a picker
+/// warming its selection, which is the only case that retries a managed-Node
+/// install that already failed.
 pub async fn install_harness(
     code: ScopedCode,
     Path(kind): Path<HarnessKind>,
+    Query(query): Query<InstallHarnessQuery>,
 ) -> Result<Json<CodeHarnessInstallSnapshot>, ServerError> {
-    Ok(Json(code.start_harness_install(kind)?))
+    Ok(Json(code.start_harness_install(kind, query.deliberate)?))
 }
 
 /// Models this harness currently lists. Not on the doctor path.
@@ -100,18 +108,22 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
                 .map(|session| session.unrecognized_event_count)
                 .sum();
             let install_error = code.pin_install_error(*kind);
+            let installable = tidebreak_harness::pin_for(*kind).is_some();
             let remediation = if let Some(err) = install_error {
-                format!("could not install the pinned {kind} binary: {err}")
-            } else if !probe.found {
-                format!("refresh to install the pinned {kind} binary")
-            } else if probe.authenticated == Some(false) {
-                format!("sign in to {kind} in your own terminal, then refresh")
+                format!("could not download the pinned {kind} binary: {err}")
+            } else if probe.found && probe.authenticated == Some(false) {
+                format!("sign in to {kind} in your own terminal, then re-check")
+            } else if !probe.found && !installable {
+                format!("this build ships no pinned {kind} binary to download")
             } else {
+                // A missing but installable engine has nothing for the reader
+                // to repair: picking it downloads it.
                 String::new()
             };
             HarnessDoctorEntry {
                 kind: *kind,
                 found: probe.found,
+                installable,
                 path: probe
                     .binary_path
                     .as_ref()

--- a/crates/tidebreak-server/src/routes/code/types.rs
+++ b/crates/tidebreak-server/src/routes/code/types.rs
@@ -245,6 +245,12 @@ pub struct HarnessDoctorReport {
 pub struct HarnessDoctorEntry {
     pub kind: HarnessKind,
     pub found: bool,
+    /// Whether Tidebreak ships a pin it can download for this engine.
+    ///
+    /// A `found: false, installable: true` engine is not a fault. Pick it and
+    /// the download starts; the doctor is not a gate the reader must clear
+    /// first.
+    pub installable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub path: Option<String>,
@@ -1595,6 +1601,14 @@ pub struct CodeApprovalDecisionBody {
 pub enum CodeApprovalDecision {
     Approve,
     Deny,
+}
+
+/// Query for `POST /code/harnesses/{kind}/install`.
+#[derive(Debug, Default, Deserialize)]
+pub struct InstallHarnessQuery {
+    /// A reader pressed Install. Absent means a picker warmed its selection.
+    #[serde(default)]
+    pub deliberate: bool,
 }
 
 /// Query for `GET /code/approvals`.


### PR DESCRIPTION
## What changed

Refresh used to `npm install` every pinned engine, so the only way to make one usable was to fetch all four — hundreds of megabytes and minutes for three engines the reader never asked for. Nothing is fetched now until someone picks it: refresh only re-probes, `HarnessDoctorEntry` carries `installable` so a missing-but-fetchable engine stays selectable in both the New Workspace and start-session pickers, and choosing one starts its download through a shared warm-install hook while create waits for the pin instead of stalling silently on it. Settings gained a per-engine Download button (`?deliberate=true`, the only case that retries a managed-Node install that already failed), and the doctor was rebuilt around it — one even row per engine leading with its state and the one thing to do about it, with version, path, capabilities, and probe output behind a disclosure rather than a stack of label/value pairs. `/code` no longer hands a cold machine the doctor instead of the register form, since picking an engine there now fetches it.

## Validation

`vitest run src/code src/settings src/api.test.ts` (74 files, 830 tests) passes, along with `tsc --noEmit`, `biome format`, `biome lint`, `cargo fmt --all`, and `storybook:build`. Six `Settings/Coding harnesses` stories and seven `Code/Harness doctor` stories cover ready, nothing-downloaded, mixed, downloading, download-failed, signed-out, and empty; each was screenshotted at 1200px and read back — the first pass had jumpy row heights and a "Details" link repeated on every row, which became one chevron per row and a fixed note line. Rust is not compiled locally; CI owns `cargo clippy` and `cargo test`.

## Compatibility and risk

`HarnessDoctorEntry` gains a required `installable` field and `POST /code/harnesses/{kind}/install` gains an optional `deliberate` query parameter; the client parser reads `installable` field-wise and defaults it to `false`, so an older server still loads. `CodeRuntime::refresh_pinned_harnesses` is deleted with its only caller. No schema or storage changes.