### PR TITLE
fix(code): apply reasoning effort changes to the next turn

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -368,6 +368,12 @@ function makeClient() {
         user_input: message,
       },
     })),
+    setCodeSessionReasoningEffort: vi.fn(
+      async (_sessionId: string, reasoningEffort: "low" | "high" | null) => ({
+        ...SESSION,
+        reasoning_effort: reasoningEffort ?? undefined,
+      }),
+    ),
     getCodeWorkspaceDiff: vi.fn(async () => ({
       diff: "",
       truncated: false,
@@ -622,6 +628,65 @@ describe("CodeWorkspacePage", () => {
       expect(within(status).getByText("Monitoring")).toBeInTheDocument(),
     );
     expect(within(status).queryByText("Running")).not.toBeInTheDocument();
+  });
+
+  it("applies a mid-turn reasoning change to the next submission", async () => {
+    const client = makeClient();
+    client.listCodeWorkspaceSessions.mockResolvedValue([
+      {
+        ...SESSION,
+        lifecycle: "running",
+        reasoning_effort: "low",
+      },
+    ]);
+    client.listCodeSessionTurns.mockResolvedValue([
+      {
+        ...TURN,
+        status: "running",
+        ended_at: undefined,
+      },
+    ] as never);
+    client.listCodeHarnessModels.mockResolvedValue({
+      kind: "claude_code",
+      models: [],
+      reasoning_efforts: ["low", "high"],
+    } as never);
+    client.submitCodeTurn.mockResolvedValue({
+      kind: "queued",
+      queued: {
+        session_id: SESSION.id,
+        message: "use more reasoning",
+        position: 1,
+      },
+    } as never);
+    const user = userEvent.setup();
+    await mountWorkspace(client);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Reasoning: Low" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "High" }));
+
+    expect(client.setCodeSessionReasoningEffort).not.toHaveBeenCalled();
+
+    const message = screen.getByRole("textbox", { name: "Message" });
+    await user.type(message, "use more reasoning");
+    await user.click(
+      screen.getByRole("button", {
+        name: "Queue message for after this response",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(client.submitCodeTurn).toHaveBeenCalledWith(
+        SESSION.id,
+        "use more reasoning",
+        undefined,
+        undefined,
+        "high",
+      ),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("keeps the Codex session model selectable before its catalog loads", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -630,15 +630,14 @@ describe("CodeWorkspacePage", () => {
     expect(within(status).queryByText("Running")).not.toBeInTheDocument();
   });
 
-  it("applies a mid-turn reasoning change to the next submission", async () => {
+  it("keeps a mid-turn reasoning change until the next idle submission", async () => {
     const client = makeClient();
-    client.listCodeWorkspaceSessions.mockResolvedValue([
-      {
-        ...SESSION,
-        lifecycle: "running",
-        reasoning_effort: "low",
-      },
-    ]);
+    const runningSession: CodeSessionSnapshot = {
+      ...SESSION,
+      lifecycle: "running",
+      reasoning_effort: "low",
+    };
+    client.listCodeWorkspaceSessions.mockResolvedValue([runningSession]);
     client.listCodeSessionTurns.mockResolvedValue([
       {
         ...TURN,
@@ -651,14 +650,11 @@ describe("CodeWorkspacePage", () => {
       models: [],
       reasoning_efforts: ["low", "high"],
     } as never);
-    client.submitCodeTurn.mockResolvedValue({
-      kind: "queued",
-      queued: {
-        session_id: SESSION.id,
-        message: "use more reasoning",
-        position: 1,
-      },
-    } as never);
+    let emitFrame: ((frame: SequencedCodeEventFrame) => void) | undefined;
+    client.openCodeEvents.mockImplementation((_sessionId, _after, onFrame) => {
+      emitFrame = onFrame;
+      return codeEventSocket(onFrame);
+    });
     const user = userEvent.setup();
     await mountWorkspace(client);
 
@@ -669,13 +665,25 @@ describe("CodeWorkspacePage", () => {
 
     expect(client.setCodeSessionReasoningEffort).not.toHaveBeenCalled();
 
+    // The completed-turn refresh still carries the stored low effort. The
+    // pending high choice must win when the settings effect syncs that row.
+    runningSession.lifecycle = "idle";
+    runningSession.fast_mode = true;
+    act(() => {
+      emitFrame?.({
+        seq: 1,
+        replayed: false,
+        event: { type: "turn_completed", usage: TURN.usage },
+      });
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "Reasoning: High" }),
+    ).toBeInTheDocument();
+
     const message = screen.getByRole("textbox", { name: "Message" });
     await user.type(message, "use more reasoning");
-    await user.click(
-      screen.getByRole("button", {
-        name: "Queue message for after this response",
-      }),
-    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
 
     await waitFor(() =>
       expect(client.submitCodeTurn).toHaveBeenCalledWith(

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1842,10 +1842,15 @@ function CodeSessionPane({
   }, [inferred, session.model]);
 
   useEffect(() => {
-    pendingReasoningEffortRef.current = null;
+    // A refreshed row can still carry the stored effort while a mid-turn
+    // choice waits for its first submission. Keep that choice until an
+    // accepted submission clears it; changing sessions remounts this pane.
+    const pendingReasoningEffort = pendingReasoningEffortRef.current;
     setSettings({
       permissionMode: session.permission_mode,
-      reasoningEffort: session.reasoning_effort ?? null,
+      reasoningEffort: pendingReasoningEffort
+        ? pendingReasoningEffort.value
+        : (session.reasoning_effort ?? null),
       fastMode: session.fast_mode,
     });
   }, [
@@ -2004,9 +2009,12 @@ function CodeSessionPane({
         session.id,
         mode,
       );
+      const pendingReasoningEffort = pendingReasoningEffortRef.current;
       setSettings({
         permissionMode: updated.permission_mode,
-        reasoningEffort: updated.reasoning_effort ?? null,
+        reasoningEffort: pendingReasoningEffort
+          ? pendingReasoningEffort.value
+          : (updated.reasoning_effort ?? null),
         fastMode: updated.fast_mode,
       });
     } catch (err) {
@@ -2046,9 +2054,12 @@ function CodeSessionPane({
     setSettings((current) => ({ ...current, fastMode }));
     try {
       const updated = await client.setCodeSessionFastMode(session.id, fastMode);
+      const pendingReasoningEffort = pendingReasoningEffortRef.current;
       setSettings({
         permissionMode: updated.permission_mode,
-        reasoningEffort: updated.reasoning_effort ?? null,
+        reasoningEffort: pendingReasoningEffort
+          ? pendingReasoningEffort.value
+          : (updated.reasoning_effort ?? null),
         fastMode: updated.fast_mode,
       });
     } catch (err) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -1833,12 +1833,16 @@ function CodeSessionPane({
     reasoningEffort: session.reasoning_effort ?? null,
     fastMode: session.fast_mode,
   });
+  const pendingReasoningEffortRef = useRef<{
+    value: ReasoningEffort | null;
+  } | null>(null);
 
   useEffect(() => {
     setModel(session.model ?? inferred);
   }, [inferred, session.model]);
 
   useEffect(() => {
+    pendingReasoningEffortRef.current = null;
     setSettings({
       permissionMode: session.permission_mode,
       reasoningEffort: session.reasoning_effort ?? null,
@@ -1887,6 +1891,7 @@ function CodeSessionPane({
     ? createPermissionModes(doctorEntry.caps)
     : ["plan", "ask", "auto", "allow"];
   const steeringSupported = doctorEntry?.caps.mid_turn_steering === "supported";
+  const turnRunning = busy || lifecycle === "running";
   const composerHistory = useMemo(
     () =>
       items
@@ -1959,6 +1964,7 @@ function CodeSessionPane({
     message: string,
     attachments?: readonly { blob_id: string; media_type: string }[],
   ) {
+    const pendingReasoningEffort = pendingReasoningEffortRef.current;
     // Sending is a deliberate return to the tail: whatever the reader was
     // reading, they now want to watch their own turn run.
     follow.armFollow();
@@ -1968,13 +1974,26 @@ function CodeSessionPane({
     // A queued outcome needs no state here — the tray polls the durable queue
     // and shows the row.
     return submitAcceptedTurn(store.getState().update, () =>
-      client.submitCodeTurn(
-        session.id,
-        message,
-        model ?? undefined,
-        attachments,
-      ),
-    );
+      pendingReasoningEffort
+        ? client.submitCodeTurn(
+            session.id,
+            message,
+            model ?? undefined,
+            attachments,
+            pendingReasoningEffort.value,
+          )
+        : client.submitCodeTurn(
+            session.id,
+            message,
+            model ?? undefined,
+            attachments,
+          ),
+    ).then((outcome) => {
+      if (pendingReasoningEffortRef.current === pendingReasoningEffort) {
+        pendingReasoningEffortRef.current = null;
+      }
+      return outcome;
+    });
   }
 
   async function changePermissionMode(mode: PermissionMode) {
@@ -1999,6 +2018,13 @@ function CodeSessionPane({
   async function changeReasoningEffort(effort: ReasoningEffort | null) {
     const previous = settings.reasoningEffort;
     setSettings((current) => ({ ...current, reasoningEffort: effort }));
+    // A running turn keeps the effort it started with. The selected level
+    // rides on the next submission, where the server also makes it sticky.
+    if (turnRunning) {
+      pendingReasoningEffortRef.current = { value: effort };
+      return;
+    }
+    pendingReasoningEffortRef.current = null;
     try {
       const updated = await client.setCodeSessionReasoningEffort(
         session.id,
@@ -2110,12 +2136,12 @@ function CodeSessionPane({
           <div className="shrink-0 px-[clamp(0.5rem,4%,5rem)]">
             <QueueTray
               queue={sessionQueue}
-              active={busy || lifecycle === "running"}
+              active={turnRunning}
               onStop={interrupt}
             />
           </div>
           <CodeComposer
-            running={busy || lifecycle === "running"}
+            running={turnRunning}
             disabled={disabled}
             permissionMode={settings.permissionMode}
             availableModes={availableModes}


### PR DESCRIPTION
## What changed

When you change reasoning effort during a running turn, the UI now keeps that choice pending instead of calling the session setting endpoint. Same-session refreshes preserve the choice until the next submitted or queued turn carries it and makes it sticky. Idle changes still update the session immediately.

A page-level regression test covers changing effort during a run, waiting for that turn to finish, and then sending.

## Validation

- `pnpm exec vitest run src/code/CodeWorkspacePage.dom.test.tsx` (48 passed)
- `pnpm exec biome lint src/code/CodeWorkspacePage.tsx src/code/CodeWorkspacePage.dom.test.tsx`
- `pnpm exec tsc --noEmit`
- `git diff --check origin/main...HEAD`

## Compatibility and risk

Low. The change reuses the existing optional `reasoning_effort` submission field and does not change persisted data or wire formats.