### PR TITLE
fix(ui): raise Storybook build heap limit

### DIFF
--- a/crates/tidebreak-desktop/ui/package.json
+++ b/crates/tidebreak-desktop/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build -o storybook-static",
+    "storybook:build": "node --max-old-space-size=6144 node_modules/storybook/dist/bin/dispatcher.js build -o storybook-static",
     "build": "tsc && node --max-old-space-size=6144 node_modules/vite/bin/vite.js build",
     "test": "vitest run",
     "format": "biome format --write src",


### PR DESCRIPTION
## What changed

Run the static Storybook build with a 6 GB Node heap so the growing UI bundle does not exhaust the default 4 GB limit.

## Validation

- `pnpm storybook:build`
- `git diff --check`

## Compatibility and risk

None. The change only affects the static Storybook build command.
