### PR TITLE
fix(code): correct Codex usage and preserve checkpoints

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/repo.rs
+++ b/crates/tidebreak-core/src/db/ops/code/repo.rs
@@ -81,9 +81,9 @@ pub async fn list_repos(store: &DbStore, owner: &OwnerId) -> Result<Vec<CodeRepo
 
 /// Every registered repository on the machine, most recently created first.
 ///
-/// A system path, not a request path: the boot-time checkpoint-ref sweep
-/// walks every repo regardless of who owns it. Nothing reachable from a
-/// route may call it.
+/// A system path, not a request path: background reconciliation reads every
+/// repository regardless of who owns it. Nothing reachable from a route may
+/// call it.
 pub async fn list_repos_all_owners(store: &DbStore) -> Result<Vec<CodeRepo>> {
     entities::code_repo::Entity::find()
         .order_by_desc(entities::code_repo::Column::CreatedAt)

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
@@ -23,9 +23,9 @@
   {
     "type": "turn_completed",
     "usage": {
-      "input_tokens": 5819,
-      "output_tokens": 12,
-      "cache_read_input_tokens": 24064,
+      "input_tokens": 1272,
+      "output_tokens": 6,
+      "cache_read_input_tokens": 14080,
       "cache_creation_input_tokens": 0,
       "context_tokens": 15352
     }

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -533,6 +533,17 @@ mod tests {
             })
             .expect("resume fixture must report a thread id");
         assert!(!started.is_empty());
+        assert_eq!(
+            completed_usage(&events),
+            tidebreak_core::CodeUsage {
+                input_tokens: 1_272,
+                output_tokens: 6,
+                cache_read_input_tokens: 14_080,
+                cache_creation_input_tokens: 0,
+                context_tokens: 15_352,
+            },
+            "the resumed turn must not inherit the first turn's spend"
+        );
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -28,6 +28,9 @@ pub struct CodexStreamParser {
     version: Option<String>,
     started_tools: HashSet<String>,
     emitted_session: bool,
+    /// Thread-wide counters at the start of the active turn.
+    turn_usage_baseline: CodeUsage,
+    /// Latest thread-wide counters plus the final call's context occupancy.
     last_usage: CodeUsage,
     last_turn_id: Option<String>,
     outbound_methods: HashMap<String, String>,
@@ -202,7 +205,10 @@ impl CodexStreamParser {
             "item/started" => self.parse_item_started(&params),
             "item/completed" => self.parse_item_completed(&params),
             "item/commandExecution/requestApproval" => self.parse_approval_request(value, &params),
-            "turn/started" => vec![HarnessEvent::TurnStarted],
+            "turn/started" => {
+                self.turn_usage_baseline = self.last_usage.clone();
+                vec![HarnessEvent::TurnStarted]
+            }
             "turn/completed" => self.parse_turn_completed(&params),
             "warning" | "error" => {
                 let message = params
@@ -226,15 +232,29 @@ impl CodexStreamParser {
             "account/rateLimits/updated"
             | "hook/completed"
             | "hook/started"
+            | "item/commandExecution/outputDelta"
+            | "item/fileChange/outputDelta"
+            | "item/fileChange/patchUpdated"
+            | "item/mcpToolCall/progress"
+            | "item/plan/delta"
+            | "item/reasoning/summaryPartAdded"
+            | "item/reasoning/summaryTextDelta"
+            | "item/reasoning/textDelta"
             | "mcpServer/startupStatus/updated"
             | "remoteControl/status/changed"
             | "serverRequest/resolved"
+            | "thread/compacted"
+            | "thread/goal/updated"
+            | "thread/queue/changed"
+            | "thread/settings/updated"
             | "thread/started"
             | "thread/status/changed"
-            | "thread/goal/cleared" => {
-                // Known app-server state notifications that do not change the
-                // normalized transcript. Treating them as unknown made every
-                // healthy turn look like protocol drift.
+            | "thread/goal/cleared"
+            | "turn/diff/updated"
+            | "turn/plan/updated" => {
+                // Known app-server state and streaming notifications that do
+                // not change the normalized transcript. Treating them as
+                // unknown makes long, healthy turns look like protocol drift.
                 Vec::new()
             }
             other => {
@@ -313,7 +333,7 @@ impl CodexStreamParser {
             .unwrap_or("");
         match status {
             "completed" => vec![HarnessEvent::TurnCompleted {
-                usage: self.last_usage.clone(),
+                usage: turn_usage_since(&self.last_usage, &self.turn_usage_baseline),
             }],
             "interrupted" => vec![HarnessEvent::TurnInterrupted],
             "failed" => {
@@ -346,7 +366,7 @@ impl CodexStreamParser {
                         ),
                     },
                     HarnessEvent::TurnCompleted {
-                        usage: self.last_usage.clone(),
+                        usage: turn_usage_since(&self.last_usage, &self.turn_usage_baseline),
                     },
                 ]
             }
@@ -516,16 +536,15 @@ fn command_detail(item: &Value) -> ToolDetail {
     }
 }
 
-/// Normalize `thread/tokenUsage` into the disjoint per-turn split
-/// [`CodeUsage`] documents.
+/// Normalize `thread/tokenUsage` into disjoint cumulative counters.
 ///
 /// Two corrections over reading the payload verbatim.
 ///
-/// The engine reports `total` (the turn so far) beside `last` (the most
-/// recent model call). A turn that makes several calls has genuinely
+/// The engine reports `total` (the thread so far) beside `last` (the most
+/// recent model call). A thread that makes several calls has genuinely
 /// different values in the two — `total.totalTokens 28912` against
-/// `last.totalTokens 14471` in `approval-approve.ndjson` — and the turn's
-/// usage is the total.
+/// `last.totalTokens 14471` in `approval-approve.ndjson`. The parser snapshots
+/// these counters at `turn/started` and subtracts them at completion.
 ///
 /// `inputTokens` is the whole prompt: `totalTokens == inputTokens +
 /// outputTokens` holds in every captured payload, and `cachedInputTokens` is
@@ -549,6 +568,35 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
         cache_read_input_tokens,
         cache_creation_input_tokens,
         context_tokens: context_tokens_from(value),
+    }
+}
+
+/// Convert Codex's thread-wide counters into the current turn's usage.
+///
+/// A resumed thread publishes its previous cumulative total immediately
+/// before `turn/started`. Subtracting that snapshot keeps later turns from
+/// inheriting every earlier turn's spend. If the engine resets a counter,
+/// treat the latest value as a fresh total instead of subtracting past zero.
+fn turn_usage_since(total: &CodeUsage, baseline: &CodeUsage) -> CodeUsage {
+    let counters_reset = total.input_tokens < baseline.input_tokens
+        || total.output_tokens < baseline.output_tokens
+        || total.cache_read_input_tokens < baseline.cache_read_input_tokens
+        || total.cache_creation_input_tokens < baseline.cache_creation_input_tokens;
+    let baseline = if counters_reset {
+        CodeUsage::default()
+    } else {
+        baseline.clone()
+    };
+    CodeUsage {
+        input_tokens: total.input_tokens.saturating_sub(baseline.input_tokens),
+        output_tokens: total.output_tokens.saturating_sub(baseline.output_tokens),
+        cache_read_input_tokens: total
+            .cache_read_input_tokens
+            .saturating_sub(baseline.cache_read_input_tokens),
+        cache_creation_input_tokens: total
+            .cache_creation_input_tokens
+            .saturating_sub(baseline.cache_creation_input_tokens),
+        context_tokens: total.context_tokens,
     }
 }
 
@@ -594,11 +642,10 @@ fn bound(text: &str, max: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    /// `thread/tokenUsage` reports the turn's running `total` beside the last
-    /// model call's `last`, and folds the cached portion into `inputTokens`.
-    /// Reading it verbatim took one call's slice and double-counted the cache.
+    /// `thread/tokenUsage` folds the cached portion into `inputTokens`.
+    /// Reading it verbatim double-counts the cache.
     #[test]
-    fn token_usage_is_a_disjoint_turn_total() {
+    fn token_usage_is_a_disjoint_thread_total() {
         let payload = serde_json::json!({
             "total": {
                 "totalTokens": 28912, "inputTokens": 28794,
@@ -613,7 +660,7 @@ mod tests {
         });
         let usage = usage_from(Some(&payload));
 
-        // The turn total, not the last call: `last` would report 5.
+        // The thread total, not the last call: `last` would report 5.
         assert_eq!(usage.output_tokens, 118);
         // Disjoint: the three prompt-side counts sum to the prompt the engine
         // actually sent, and the cached portion is not also in `input_tokens`.
@@ -623,6 +670,35 @@ mod tests {
             usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens,
             28794,
             "the split must reconstruct inputTokens"
+        );
+    }
+
+    #[test]
+    fn a_resumed_turn_excludes_the_previous_thread_usage() {
+        let baseline = CodeUsage {
+            input_tokens: 4_547,
+            output_tokens: 6,
+            cache_read_input_tokens: 9_984,
+            cache_creation_input_tokens: 0,
+            context_tokens: 14_531,
+        };
+        let total = CodeUsage {
+            input_tokens: 5_819,
+            output_tokens: 12,
+            cache_read_input_tokens: 24_064,
+            cache_creation_input_tokens: 0,
+            context_tokens: 15_352,
+        };
+
+        assert_eq!(
+            turn_usage_since(&total, &baseline),
+            CodeUsage {
+                input_tokens: 1_272,
+                output_tokens: 6,
+                cache_read_input_tokens: 14_080,
+                cache_creation_input_tokens: 0,
+                context_tokens: 15_352,
+            }
         );
     }
 
@@ -705,6 +781,20 @@ mod tests {
             Some(HarnessEvent::TurnCompleted { .. })
         ));
         assert_eq!(out.resume_ref.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn known_streaming_telemetry_does_not_count_as_protocol_drift() {
+        let input = r#"
+{"method":"item/reasoning/summaryTextDelta","params":{"delta":"thinking"}}
+{"method":"item/commandExecution/outputDelta","params":{"delta":"output"}}
+{"method":"turn/diff/updated","params":{"diff":"patch"}}
+{"method":"thread/compacted","params":{}}
+"#;
+        let out = CodexStreamParser::parse_ndjson(input);
+
+        assert_eq!(out.unrecognized, 0);
+        assert!(out.events.is_empty());
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -58,9 +58,8 @@ const REF_PREFIX: &str = "refs/tidebreak/checkpoints";
 ///
 /// Numbering the baseline keeps it in the same ref path as the session's
 /// checkpoints, so [`previous_checkpoint_oid`] resolves `ordinal - 1` for
-/// turn 1 the way it does for every later turn, and both
-/// [`delete_workspace_refs`] and [`sweep_orphaned_refs`] reap it by prefix
-/// along with the rest of the workspace's refs.
+/// turn 1 the way it does for every later turn, and
+/// [`delete_workspace_refs`] reaps it by prefix with the workspace's refs.
 const BASELINE_ORDINAL: i64 = 0;
 
 /// Byte and file-count caps for a produced diff or file list.
@@ -136,8 +135,7 @@ impl CheckpointError {
 /// Keyed on the session as well as the workspace. Ordinals come from
 /// `next_turn_ordinal`, which counts per session, so two sessions sharing a
 /// workspace both reach turn 1. The workspace stays first in the path so
-/// [`delete_workspace_refs`] and [`sweep_orphaned_refs`] keep matching by
-/// prefix.
+/// [`delete_workspace_refs`] can match every session by prefix.
 pub(crate) fn checkpoint_ref(
     workspace_id: WorkspaceId,
     session_id: CodeSessionId,
@@ -598,27 +596,6 @@ pub(crate) async fn delete_workspace_refs(
     Ok(removed)
 }
 
-/// Drop checkpoint refs whose workspace is no longer live (crash / leftover).
-pub(crate) async fn sweep_orphaned_refs(
-    repo_root: &Path,
-    live_workspace_ids: &[WorkspaceId],
-) -> Result<usize, CheckpointError> {
-    let live: std::collections::HashSet<String> =
-        live_workspace_ids.iter().map(ToString::to_string).collect();
-    let refs = list_checkpoint_refs(repo_root).await?;
-    let mut removed = 0usize;
-    for r#ref in refs {
-        let Some(workspace) = workspace_id_from_ref(&r#ref) else {
-            continue;
-        };
-        if !live.contains(&workspace) {
-            delete_ref(repo_root, &r#ref).await?;
-            removed += 1;
-        }
-    }
-    Ok(removed)
-}
-
 pub(crate) async fn list_checkpoint_refs(repo_root: &Path) -> Result<Vec<String>, CheckpointError> {
     let out = git_text(
         repo_root,
@@ -713,27 +690,34 @@ async fn previous_checkpoint_oid(
         return Ok(None);
     }
     let previous_ref = checkpoint_ref(workspace.id, turn.session_id, turn.ordinal - 1);
-    if let Ok(oid) = git_text(
-        worktree,
-        &["rev-parse", "--verify", &previous_ref],
-        GIT_TIMEOUT,
-    )
-    .await
-    {
-        if !oid.is_empty() {
-            return Ok(Some(oid));
-        }
+    if let Some(oid) = resolve_checkpoint_oid(worktree, &previous_ref).await {
+        return Ok(Some(oid));
     }
-    // The ref is gone: fall back to the last turn row that still names a
-    // checkpoint. Turn 1 has no earlier turn, so it lands on the base ref.
+    // A cleanup or older build may have removed one ref while its database row
+    // remains. Walk earlier rows, but only return a ref Git can still resolve.
     let turns = list_turns(db, &workspace.owner, turn.session_id)
         .await
         .map_err(|err| CheckpointError::internal(err.to_string()))?;
-    Ok(turns
-        .into_iter()
-        .rev()
-        .find(|candidate| candidate.ordinal < turn.ordinal && candidate.checkpoint_ref.is_some())
-        .and_then(|candidate| candidate.checkpoint_ref))
+    for candidate in turns.into_iter().rev() {
+        if candidate.ordinal >= turn.ordinal {
+            continue;
+        }
+        let Some(r#ref) = candidate.checkpoint_ref else {
+            continue;
+        };
+        if let Some(oid) = resolve_checkpoint_oid(worktree, &r#ref).await {
+            return Ok(Some(oid));
+        }
+    }
+    let baseline = session_baseline_ref(workspace.id, turn.session_id);
+    Ok(resolve_checkpoint_oid(worktree, &baseline).await)
+}
+
+async fn resolve_checkpoint_oid(worktree: &Path, r#ref: &str) -> Option<String> {
+    git_text(worktree, &["rev-parse", "--verify", r#ref], GIT_TIMEOUT)
+        .await
+        .ok()
+        .filter(|oid| !oid.is_empty())
 }
 
 async fn collect_changes(
@@ -890,16 +874,6 @@ fn truncate_bytes(raw: &[u8], max: usize) -> (String, bool) {
         end -= 1;
     }
     (text[..end].to_owned(), true)
-}
-
-fn workspace_id_from_ref(r#ref: &str) -> Option<String> {
-    let rest = r#ref.strip_prefix(&format!("{REF_PREFIX}/"))?;
-    let (workspace, _ordinal) = rest.split_once('/')?;
-    if workspace.is_empty() {
-        None
-    } else {
-        Some(workspace.to_owned())
-    }
 }
 
 async fn delete_ref(repo_root: &Path, r#ref: &str) -> Result<(), CheckpointError> {
@@ -1363,7 +1337,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn archive_removes_workspace_refs_and_sweep_drops_orphans() {
+    async fn archive_removes_only_the_target_workspaces_refs() {
         let (_dir, repo) = init_repo();
         let tree = add_worktree(&repo, "gone");
         let live = ws();
@@ -1400,9 +1374,11 @@ mod tests {
         assert_eq!(listed.len(), 1);
         assert!(listed[0].contains(&live.to_string()));
 
-        let swept = sweep_orphaned_refs(&repo, &[]).await.unwrap();
-        assert_eq!(swept, 1);
-        assert!(list_checkpoint_refs(&repo).await.unwrap().is_empty());
+        assert_eq!(
+            list_checkpoint_refs(&repo).await.unwrap().len(),
+            1,
+            "another workspace's refs must survive"
+        );
     }
 
     /// Two sessions share a workspace and both reach turn 1, because
@@ -2023,6 +1999,57 @@ mod tests {
             oid_of(&tree, &format!("{first_ref}^")).await,
             oid_of(&tree, &baseline).await,
             "turn 1 parents off the baseline"
+        );
+    }
+
+    /// A missing hidden ref must not poison every later turn. The database row
+    /// can outlive the ref after cleanup, so the next checkpoint resumes from
+    /// the session baseline and includes the edits that lost their checkpoint.
+    #[tokio::test]
+    async fn a_missing_previous_checkpoint_falls_back_to_the_session_baseline() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "missing-previous");
+        let (db, bus, session) = seed_session(&repo, &tree).await;
+        let baseline = record_session_baseline(&tree, session.workspace_id, session.id)
+            .await
+            .unwrap();
+
+        std::fs::write(tree.join("one.txt"), "one\n").unwrap();
+        let mut first = seed_turn(&db, &session, 1, CodeTurnStatus::Completed).await;
+        after_turn_ended(&db, &bus, &session, &mut first).await;
+        let first_ref = first.checkpoint_ref.clone().unwrap();
+        delete_ref(&repo, &first_ref).await.unwrap();
+
+        std::fs::write(tree.join("two.txt"), "two\n").unwrap();
+        let mut second = seed_turn(&db, &session, 2, CodeTurnStatus::Completed).await;
+        after_turn_ended(&db, &bus, &session, &mut second).await;
+        let second_ref = second
+            .checkpoint_ref
+            .clone()
+            .expect("turn 2 still records a checkpoint");
+
+        assert_eq!(
+            oid_of(&tree, &format!("{second_ref}^")).await,
+            oid_of(&tree, &baseline).await,
+            "the surviving baseline restarts the checkpoint chain"
+        );
+        assert_eq!(
+            second.diffstat.as_ref().map(|stat| stat.files),
+            Some(2),
+            "the recovered checkpoint includes both turns' live edits"
+        );
+        assert!(
+            recorded_events(&db, &session)
+                .await
+                .iter()
+                .all(|event| !matches!(
+                    event,
+                    CodeEvent::HarnessNotice {
+                        level: HarnessNoticeLevel::Warning,
+                        ..
+                    }
+                )),
+            "a stale row must not produce another checkpoint warning"
         );
     }
 

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -12,10 +12,10 @@ use tokio::sync::oneshot;
 use tidebreak_core::db::code::{
     arm_trigger, delete_trigger, delete_workspace, get_approval, get_open_turn, get_repo,
     get_repo_by_root_path, get_session, get_workspace, insert_repo, insert_session,
-    insert_workspace, list_approvals, list_events, list_repos, list_repos_all_owners,
-    list_sessions, list_sessions_all_owners, list_sessions_for_workspace, list_triggers_for_repo,
-    list_turns, list_workspaces, mark_repo_removed, save_approval, save_repo, save_session,
-    save_workspace, update_trigger_enabled, MAX_REPLAY_EVENTS,
+    insert_workspace, list_approvals, list_events, list_repos, list_sessions,
+    list_sessions_all_owners, list_sessions_for_workspace, list_triggers_for_repo, list_turns,
+    list_workspaces, mark_repo_removed, save_approval, save_repo, save_session, save_workspace,
+    update_trigger_enabled, MAX_REPLAY_EVENTS,
 };
 use tidebreak_core::{
     ApprovalDecisionKind, Attention, AttentionSource, CapLevel, CodeApproval, CodeApprovalId,
@@ -35,7 +35,7 @@ use super::browser_channel::{BrowserSubject, BrowserTokenRegistry};
 use super::bus::CodeEventBus;
 use super::checkpoint::{
     delete_workspace_refs, list_changed_files, produce_diff, record_session_baseline,
-    resolve_diff_range, sweep_orphaned_refs, ChangedFile, CheckpointError, DiffBounds,
+    resolve_diff_range, ChangedFile, CheckpointError, DiffBounds,
 };
 use super::ci_logs;
 use super::clone::CloneJobs;
@@ -526,12 +526,9 @@ impl CodeRuntime {
         let actions = recovery::recover_running_sessions(&self.db, &self.bus)
             .await
             .map_err(ServerError::from)?;
-        if let Err(error) = self.sweep_orphaned_checkpoints().await {
-            tracing::warn!(
-                "code-mode: checkpoint ref sweep failed: {}",
-                error.message()
-            );
-        }
+        // Do not sweep repository-wide checkpoint refs here. Another
+        // Tidebreak profile can manage the same repository from a separate
+        // database, so this process cannot identify global orphans safely.
         // Recovery only mutates rows. Re-attach a worker for every session
         // that is still usable so submit_turn is not stuck after a restart.
         // Concurrently: each attach launches an engine child, so a serial pass
@@ -1066,15 +1063,6 @@ impl CodeRuntime {
             tracing::warn!(
                 workspace = %workspace.id,
                 "code-mode: could not delete checkpoint refs on archive: {error}"
-            );
-        }
-        if let Err(error) = self
-            .sweep_repo_checkpoint_refs(owner, std::path::Path::new(&repo.root_path), repo.id)
-            .await
-        {
-            tracing::warn!(
-                "code-mode: checkpoint ref sweep failed: {}",
-                error.message()
             );
         }
         workspace.status = CodeWorkspaceStatus::Archived;
@@ -3727,36 +3715,6 @@ impl CodeRuntime {
             .await
             .map_err(map_checkpoint)?;
         Ok((produced.diff, produced.truncated, produced.stat, turn))
-    }
-
-    async fn sweep_orphaned_checkpoints(&self) -> Result<(), ServerError> {
-        for repo in list_repos_all_owners(&self.db).await? {
-            self.sweep_repo_checkpoint_refs(
-                &repo.owner,
-                std::path::Path::new(&repo.root_path),
-                repo.id,
-            )
-            .await?;
-        }
-        Ok(())
-    }
-
-    async fn sweep_repo_checkpoint_refs(
-        &self,
-        owner: &OwnerId,
-        repo_root: &std::path::Path,
-        repo_id: RepoId,
-    ) -> Result<(), ServerError> {
-        let live: Vec<WorkspaceId> = list_workspaces(&self.db, owner, Some(repo_id))
-            .await?
-            .into_iter()
-            .filter(|workspace| workspace.status != CodeWorkspaceStatus::Archived)
-            .map(|workspace| workspace.id)
-            .collect();
-        sweep_orphaned_refs(repo_root, &live)
-            .await
-            .map(|_| ())
-            .map_err(map_checkpoint)
     }
 
     async fn refuse_running_sessions(

--- a/docs/decisions/0032-code-workspaces-worktrees-checkpoints.md
+++ b/docs/decisions/0032-code-workspaces-worktrees-checkpoints.md
@@ -127,9 +127,10 @@ Tidebreak becomes a git citizen: it must behave well when the user's git
 config is unusual, when `git` is old, and when a repo is large. Version and
 capability checks happen at repo registration, not mid-session.
 
-Hidden refs accumulate; archive cleans a workspace's refs, and a periodic
-sweep covers refs orphaned by crashes. Checkpoint commits share the repo's
-object store, so their cost is incremental.
+Archive cleans a workspace's refs. Refs orphaned by crashes may remain because
+separate Tidebreak profiles can share one repository, and one profile cannot
+safely decide that another profile's ref is unused. Checkpoint commits share
+the repository's object store, so their cost is incremental.
 
 The data-dir worktree location makes "where is my code?" a product question;
 the workspace UI must surface the path prominently (open in editor / reveal /


### PR DESCRIPTION
## What changed

Codex usage now reports per-turn counters, and known streaming notifications no longer count as protocol drift.
Checkpoint recovery now skips missing refs and preserves refs owned by other Tidebreak profiles.

## Validation

Formatting, fixture JSON validation, and diff checks pass; Rust tests are deferred to CI under repository policy.

## Compatibility and risk

No persisted or wire-format changes.