### PR TITLE
perf(code): update workspace lifecycle optimistically

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { CodeWorkspaceSnapshot } from "../api/types";
-import { useCodeCatalogStore } from "./CodeCatalogStore";
+import {
+  OPTIMISTIC_WORKSPACE_ID_PREFIX,
+  useCodeCatalogStore,
+} from "./CodeCatalogStore";
 import type { ReasoningEffort } from "../api/types";
 import type { ParsedHarnessModel } from "./parsers";
 
@@ -41,6 +44,19 @@ describe("CodeCatalogStore.upsertWorkspace", () => {
       useCodeCatalogStore.getState().workspaces.map((item) => item.id),
     ).toEqual(["ws-a", "ws-b"]);
     expect(useCodeCatalogStore.getState().workspaces[1]?.title).toBe("viewed");
+  });
+
+  it("replaces a temporary workspace in place", () => {
+    const pending = workspace(
+      `${OPTIMISTIC_WORKSPACE_ID_PREFIX}one`,
+      "2026-08-24T12:00:00.000Z",
+    );
+    const created = workspace("ws-created", pending.created_at, "Created");
+    useCodeCatalogStore.setState({ workspaces: [pending] });
+
+    useCodeCatalogStore.getState().replaceWorkspace(pending.id, created);
+
+    expect(useCodeCatalogStore.getState().workspaces).toEqual([created]);
   });
 });
 
@@ -185,5 +201,55 @@ describe("CodeCatalogStore.refresh", () => {
     expect(client.listCodeWorkspaces).toHaveBeenCalledOnce();
     expect(client.getHarnessDoctor).toHaveBeenCalledOnce();
     expect(client.listCodeHarnessModels).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps temporary workspaces while the server list catches up", async () => {
+    const pending = workspace(
+      `${OPTIMISTIC_WORKSPACE_ID_PREFIX}one`,
+      "2026-08-24T12:00:00.000Z",
+    );
+    useCodeCatalogStore.setState({ workspaces: [pending] });
+    const client = {
+      listCodeRepos: vi.fn(async () => []),
+      listCodeWorkspaces: vi.fn(async () => []),
+      getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+      listCodeHarnessModels: vi.fn(async (kind: string) => ({
+        kind,
+        models: [],
+      })),
+    };
+
+    await useCodeCatalogStore.getState().refresh(client as never);
+
+    expect(useCodeCatalogStore.getState().workspaces).toEqual([pending]);
+  });
+
+  it("keeps a completed local create when an older refresh finishes", async () => {
+    const pending = workspace(
+      `${OPTIMISTIC_WORKSPACE_ID_PREFIX}one`,
+      "2026-08-24T12:00:00.000Z",
+    );
+    const created = workspace("ws-created", pending.created_at, "Created");
+    useCodeCatalogStore.setState({ workspaces: [pending] });
+    let resolveWorkspaces!: (workspaces: CodeWorkspaceSnapshot[]) => void;
+    const listed = new Promise<CodeWorkspaceSnapshot[]>((resolve) => {
+      resolveWorkspaces = resolve;
+    });
+    const client = {
+      listCodeRepos: vi.fn(async () => []),
+      listCodeWorkspaces: vi.fn(() => listed),
+      getHarnessDoctor: vi.fn(async () => ({ harnesses: [] })),
+      listCodeHarnessModels: vi.fn(async (kind: string) => ({
+        kind,
+        models: [],
+      })),
+    };
+
+    const refresh = useCodeCatalogStore.getState().refresh(client as never);
+    useCodeCatalogStore.getState().replaceWorkspace(pending.id, created);
+    resolveWorkspaces([]);
+    await refresh;
+
+    expect(useCodeCatalogStore.getState().workspaces).toEqual([created]);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -74,8 +74,19 @@ type CodeCatalogStore = CodeCatalogState & {
   forgetWorkspaceSession: (workspaceId: string) => void;
   upsertRepo: (repo: CodeRepoSnapshot) => void;
   upsertWorkspace: (workspace: CodeWorkspaceSnapshot) => void;
+  replaceWorkspace: (
+    workspaceId: string,
+    workspace: CodeWorkspaceSnapshot,
+  ) => void;
+  removeWorkspace: (workspaceId: string) => void;
   reset: () => void;
 };
+
+export const OPTIMISTIC_WORKSPACE_ID_PREFIX = "optimistic-workspace:";
+
+export function isOptimisticWorkspace(workspace: CodeWorkspaceSnapshot) {
+  return workspace.id.startsWith(OPTIMISTIC_WORKSPACE_ID_PREFIX);
+}
 
 function loadHarnessModels(
   client: Pick<ApiClient, "listCodeHarnessModels">,
@@ -116,6 +127,9 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
   error: null,
   refresh: (client) => {
     if (catalogRefresh) return catalogRefresh;
+    const workspaceIdsAtStart = new Set(
+      get().workspaces.map((workspace) => workspace.id),
+    );
     let request: Promise<void>;
     request = (async () => {
       try {
@@ -123,7 +137,25 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
           client.listCodeRepos(),
           client.listCodeWorkspaces(),
         ]);
-        set({ repos, workspaces, loaded: true, error: null });
+        const localCreates = get().workspaces.filter(
+          (workspace) =>
+            isOptimisticWorkspace(workspace) ||
+            !workspaceIdsAtStart.has(workspace.id),
+        );
+        const localCreateIds = new Set(
+          localCreates.map((workspace) => workspace.id),
+        );
+        set({
+          repos,
+          workspaces: [
+            ...workspaces.filter(
+              (workspace) => !localCreateIds.has(workspace.id),
+            ),
+            ...localCreates,
+          ],
+          loaded: true,
+          error: null,
+        });
       } catch (error) {
         set({
           loaded: true,
@@ -209,6 +241,32 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     const workspaces = current.slice();
     workspaces[index] = workspace;
     set({ workspaces });
+  },
+  replaceWorkspace: (workspaceId, workspace) => {
+    const current = get().workspaces;
+    const index = current.findIndex((item) => item.id === workspaceId);
+    if (index === -1) {
+      set({
+        workspaces: [
+          ...current.filter((item) => item.id !== workspace.id),
+          workspace,
+        ],
+      });
+      return;
+    }
+    const workspaces = current.filter(
+      (item) => item.id !== workspace.id || item.id === workspaceId,
+    );
+    const replacementIndex = workspaces.findIndex(
+      (item) => item.id === workspaceId,
+    );
+    workspaces[replacementIndex] = workspace;
+    set({ workspaces });
+  },
+  removeWorkspace: (workspaceId) => {
+    set({
+      workspaces: get().workspaces.filter((item) => item.id !== workspaceId),
+    });
   },
   reset: () => {
     catalogRefresh = null;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -166,6 +166,7 @@ export function CodeSidebar() {
             {group.workspaces.map((workspace) => {
               const digest = digests[workspace.id];
               const pr = digest?.pr_state ?? workspace.pr;
+              const creating = workspace.status === "creating";
               return (
                 <WorkspaceCard
                   key={workspace.id}
@@ -186,16 +187,22 @@ export function CodeSidebar() {
                     // order; the chip would say it twice on every row.
                     repoChip:
                       prefs.showRepoChip && prefs.sortMode !== "by-repo",
-                    branch: prefs.showBranch,
+                    branch: prefs.showBranch && !creating,
                   }}
-                  commands={workspaceCommands({
-                    hasPr: Boolean(pr),
-                    archived: isPutAway(workspace),
-                    hasSession: Boolean(sessions[workspace.id]),
-                    attentionPinned:
-                      (digest?.attention ?? sessions[workspace.id]?.attention)
-                        ?.state.type === "manual",
-                  })}
+                  commands={
+                    creating
+                      ? []
+                      : workspaceCommands({
+                          hasPr: Boolean(pr),
+                          archived: isPutAway(workspace),
+                          hasSession: Boolean(sessions[workspace.id]),
+                          attentionPinned:
+                            (
+                              digest?.attention ??
+                              sessions[workspace.id]?.attention
+                            )?.state.type === "manual",
+                        })
+                  }
                   childSessions={watchChildren(
                     { childrenByWorkspace },
                     workspace.id,
@@ -207,12 +214,13 @@ export function CodeSidebar() {
                       params: { workspaceId },
                     })
                   }
-                  onOpen={() =>
+                  onOpen={() => {
+                    if (creating) return;
                     void navigate({
                       to: "/code/w/$workspaceId",
                       params: { workspaceId: workspace.id },
-                    })
-                  }
+                    });
+                  }}
                   onOpenChildSession={(sessionId) =>
                     void navigate({
                       to: "/code/w/$workspaceId",

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -213,6 +213,16 @@ function codeEventSocket(
   return socket;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
 function makeClient() {
   return {
     getCodeWorkspace: vi.fn(async () => WORKSPACE),
@@ -1141,6 +1151,34 @@ describe("CodeWorkspacePage", () => {
     await waitFor(() => expect(router.state.location.pathname).toBe("/code"));
     expect(client.archiveCodeWorkspace).toHaveBeenCalledWith("ws-1", false);
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("hides the workspace before archive finishes and rolls back a failure", async () => {
+    const client = makeClient();
+    const archive =
+      deferred<Awaited<ReturnType<typeof client.archiveCodeWorkspace>>>();
+    client.archiveCodeWorkspace.mockImplementation(() => archive.promise);
+    const { router } = await mountWorkspace(client);
+    await screen.findByRole("heading", { name: /Fix login/ });
+
+    act(() => useCodeUiStore.getState().requestArchiveWorkspace());
+
+    expect(router.state.location.pathname).toBe("/code/w/ws-1");
+    expect(
+      useCodeCatalogStore
+        .getState()
+        .workspaces.find((workspace) => workspace.id === "ws-1")?.status,
+    ).toBe("archived");
+
+    archive.reject(new Error("worktree is busy"));
+    await waitFor(() =>
+      expect(
+        useCodeCatalogStore
+          .getState()
+          .workspaces.find((workspace) => workspace.id === "ws-1")?.status,
+      ).toBe("active"),
+    );
+    expect(toast.error).toHaveBeenCalledWith("worktree is busy");
   });
 
   it("drafts the Create PR request into the composer for local changes", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -244,6 +244,9 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(
     null,
   );
+  const catalogWorkspace = catalog.workspaces.find(
+    (candidate) => candidate.id === workspaceId,
+  );
   const [repo, setRepo] = useState<CodeRepoSnapshot | null>(null);
   /**
    * Every session the server knows about here, conversations and watches alike.
@@ -258,6 +261,17 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const [activeSessionId, setActiveSessionId] = useState<string | null>(
     catalog.sessionsByWorkspace[workspaceId]?.id ?? null,
   );
+
+  // Optimistic catalog mutations also govern the open page. Archive can hide
+  // the rail card before filesystem cleanup finishes; reflecting that same
+  // snapshot here stops the composer from offering work against a checkout
+  // that is being removed. A failed request puts the original snapshot back.
+  useEffect(() => {
+    if (!catalogWorkspace) return;
+    setWorkspace((current) =>
+      current?.id === catalogWorkspace.id ? catalogWorkspace : current,
+    );
+  }, [catalogWorkspace]);
   /** True while the reader is filling in a new agent that has no session yet. */
   const [draftAgent, setDraftAgent] = useState(false);
   /**

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -18,7 +18,10 @@ import type {
   HarnessDoctorEntry,
   HarnessKind,
 } from "../api/types";
-import { useCodeCatalogStore } from "./CodeCatalogStore";
+import {
+  OPTIMISTIC_WORKSPACE_ID_PREFIX,
+  useCodeCatalogStore,
+} from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import type { ReasoningEffort } from "../api/types";
@@ -165,13 +168,127 @@ function app(client: Partial<AppContextValue["client"]>): AppContextValue {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 describe("NewWorkspaceDialog", () => {
+  it("closes and lists the workspace before creation finishes", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const creation = deferred<CodeWorkspaceSnapshot>();
+    const created = workspace(
+      "ws-created",
+      "repo-new",
+      "2026-08-24T12:00:00.000Z",
+    );
+    const onOpenChange = vi.fn();
+    const { router } = await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace: vi.fn(() => creation.promise),
+          createCodeSession: vi.fn(async () =>
+            session("ws-created", "claude_code", "2026-08-24T12:00:00.000Z"),
+          ),
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={onOpenChange} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(router.state.location.pathname).toBe("/code");
+    expect(useCodeCatalogStore.getState().workspaces).toEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(`^${OPTIMISTIC_WORKSPACE_ID_PREFIX}`),
+        status: "creating",
+        title: "New workspace",
+      }),
+    ]);
+
+    creation.resolve(created);
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/w/ws-created"),
+    );
+    expect(useCodeCatalogStore.getState().workspaces).toEqual([created]);
+  });
+
+  it("removes a failed create and retries the captured request", async () => {
+    const repos = [repo("repo-new", "tidebreak")];
+    useCodeCatalogStore.setState({
+      repos,
+      doctor: {
+        harnesses: [harness("claude_code")],
+        notices: [],
+      } as never,
+    });
+    const created = workspace(
+      "ws-retried",
+      "repo-new",
+      "2026-08-24T12:00:00.000Z",
+    );
+    const createCodeWorkspace = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("base ref moved"))
+      .mockResolvedValueOnce(created);
+    await renderWithRouter(
+      <AppContextProvider
+        value={app({
+          createCodeWorkspace,
+          createCodeSession: vi.fn(async () =>
+            session("ws-retried", "claude_code", "2026-08-24T12:00:00.000Z"),
+          ),
+          listCodeHarnessModels: claudeModels(),
+        })}
+      >
+        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "First message" }), {
+      target: { value: "keep this request" },
+    });
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledOnce());
+    expect(useCodeCatalogStore.getState().workspaces).toEqual([]);
+    const toastOptions = toastError.mock.calls[0]?.[1] as {
+      action: { onClick: () => void };
+    };
+    toastOptions.action.onClick();
+
+    await waitFor(() => expect(createCodeWorkspace).toHaveBeenCalledTimes(2));
+    expect(createCodeWorkspace).toHaveBeenLastCalledWith({
+      repo_id: "repo-new",
+      title: undefined,
+      base_ref: "main",
+    });
+    await waitFor(() =>
+      expect(useCodeCatalogStore.getState().workspaces).toEqual([created]),
+    );
+  });
+
   it("keeps remembered models keyed by harness", () => {
     useCodeUiStore.getState().rememberCreate({
       repoId: "repo-new",

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { toast } from "sonner";
 import {
   Check,
@@ -39,7 +39,10 @@ import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { shouldSubmitComposerKey } from "../Composer";
 import { PermissionModeMenu } from "../PermissionModeMenu";
 import { usesCommandModifier } from "@/ShellShortcuts";
-import { useCodeCatalogStore } from "./CodeCatalogStore";
+import {
+  OPTIMISTIC_WORKSPACE_ID_PREFIX,
+  useCodeCatalogStore,
+} from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
 import { HarnessModelMenu } from "./CodeComposer";
 import { HarnessInstallNote } from "./HarnessInstallNote";
@@ -128,6 +131,19 @@ function recentHarness(
 /** Pickers a chord can open; one open at a time, chords toggle. */
 type PickerId = "repo" | "engine" | "model" | "mode" | "base" | "name";
 
+type CreateAttempt = {
+  repoId: string;
+  title: string;
+  baseRef: string;
+  startingPrompt: string;
+  harness: HarnessKind;
+  permissionMode: PermissionMode;
+  model: string | undefined;
+  modelsByHarness: Partial<Record<HarnessKind, string>>;
+  createMore: boolean;
+  originPath: string;
+};
+
 export function NewWorkspaceDialog({
   open,
   onOpenChange,
@@ -140,10 +156,19 @@ export function NewWorkspaceDialog({
   defaultRepoId?: string;
 }) {
   const navigate = useNavigate();
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const pathnameRef = useRef(pathname);
+  pathnameRef.current = pathname;
   const { client, models, defaultModelKey } = useApp();
   const doctor = useCodeCatalogStore((state) => state.doctor);
   const sessions = useCodeCatalogStore((state) => state.sessionsByWorkspace);
   const upsertWorkspace = useCodeCatalogStore((state) => state.upsertWorkspace);
+  const replaceWorkspace = useCodeCatalogStore(
+    (state) => state.replaceWorkspace,
+  );
+  const removeWorkspace = useCodeCatalogStore((state) => state.removeWorkspace);
   const rememberSession = useCodeCatalogStore((state) => state.rememberSession);
   const ensureHarnessModels = useCodeCatalogStore(
     (state) => state.ensureHarnessModels,
@@ -158,7 +183,6 @@ export function NewWorkspaceDialog({
   const [permissionMode, setPermissionMode] = useState<PermissionMode | null>(
     null,
   );
-  const [creating, setCreating] = useState(false);
   const [createMore, setCreateMore] = useState(false);
   const [modelsByHarness, setModelsByHarness] = useState<
     Partial<Record<HarnessKind, string>>
@@ -169,6 +193,8 @@ export function NewWorkspaceDialog({
   const openPickerNow = useRef<PickerId | null>(null);
   openPickerNow.current = openPicker;
   const promptInput = useRef<HTMLTextAreaElement>(null);
+  const createLocked = useRef(false);
+  const retryAttempt = useRef<CreateAttempt | null>(null);
   const command = useMemo(() => usesCommandModifier(navigator.userAgent), []);
 
   const allHarnesses = doctor?.harnesses ?? [];
@@ -188,19 +214,28 @@ export function NewWorkspaceDialog({
 
   useEffect(() => {
     if (!open) return;
+    createLocked.current = false;
+    const retry = retryAttempt.current;
+    retryAttempt.current = null;
     const { workspaces: known } = useCodeCatalogStore.getState();
     const nextRepo =
-      defaultRepoId ?? recentRepoId(repos, known, lastCreate?.repoId);
+      retry?.repoId ??
+      defaultRepoId ??
+      recentRepoId(repos, known, lastCreate?.repoId);
     setRepoId(nextRepo);
-    setStartingPrompt("");
-    setTitle("");
+    setStartingPrompt(retry?.startingPrompt ?? "");
+    setTitle(retry?.title ?? "");
     setBaseRef(
-      repos.find((repo) => repo.id === nextRepo)?.default_base_ref ?? "",
+      retry?.baseRef ??
+        repos.find((repo) => repo.id === nextRepo)?.default_base_ref ??
+        "",
     );
-    setPickedHarness(null);
-    setPermissionMode(null);
-    setCreateMore(false);
-    setModelsByHarness({ ...lastCreate?.modelsByHarness });
+    setPickedHarness(retry?.harness ?? null);
+    setPermissionMode(retry?.permissionMode ?? null);
+    setCreateMore(retry?.createMore ?? false);
+    setModelsByHarness(
+      retry?.modelsByHarness ?? { ...lastCreate?.modelsByHarness },
+    );
     setModelOptions([]);
     setModelLoading(false);
     setOpenPicker(null);
@@ -239,9 +274,9 @@ export function NewWorkspaceDialog({
   // would sit on the same npm install with nothing but a spinner. The install
   // note under the pills says what the wait is, and any engine already on
   // disk is one pick away.
-  const canCreate =
-    Boolean(repoId && selectedRepo && selectedHarness && installed) &&
-    !creating;
+  const canCreate = Boolean(
+    repoId && selectedRepo && selectedHarness && installed,
+  );
   const modeNote =
     postedMode === "auto" &&
     selectedHarness &&
@@ -354,94 +389,162 @@ export function NewWorkspaceDialog({
     setOpenPicker(id);
   }
 
-  async function create() {
-    if (!canCreate) return;
-    setCreating(true);
-    try {
-      let workspace: CodeWorkspaceSnapshot;
-      try {
-        workspace = await client.createCodeWorkspace({
-          repo_id: repoId,
-          title: title.trim() || undefined,
-          base_ref: baseRef.trim() || undefined,
-        });
-      } catch (error) {
-        toast.error(
-          friendlyErrorMessage(error, "Could not create the workspace"),
-        );
-        return;
-      }
-      upsertWorkspace(workspace);
-      const prompt = startingPrompt.trim();
-      try {
-        const gateway = gatewayCodeModels(models, harness, defaultModelKey);
-        const native =
-          requiresHarnessModelIds(harness) || gateway.length === 0
-            ? await ensureHarnessModels(client, harness)
-            : [];
-        const listed = preferredCodeModels(harness, native, gateway);
-        const posted =
-          model ?? listed.find((option) => option.default)?.id ?? listed[0]?.id;
-        const session = await client.createCodeSession(workspace.id, {
-          harness,
-          permission_mode: postedMode,
-          model: posted,
-        });
-        rememberSession(session);
-        rememberCreate({
-          repoId,
-          harness,
-          model: posted,
-          modelsByHarness,
-          permissionMode: postedMode,
-        });
-        if (prompt) {
-          try {
-            await client.submitCodeTurn(session.id, prompt);
-          } catch (error) {
-            // Never drop typed words: the workspace composer holds them.
-            useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
-            toast.error(
-              `Session started, but the first message could not be sent. ${friendlyErrorMessage(error, "Send it from the workspace composer.")}`,
-            );
-          }
-        }
-      } catch (error) {
-        // No session to send to; the workspace composer holds the text and
-        // start-session on the workspace page picks it up.
-        if (prompt) {
-          useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
-        }
-        toast.error(
-          `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
-        );
-      }
-      if (createMore) {
-        // Stay here on the same settings; only what named this task clears.
-        setStartingPrompt("");
-        setTitle("");
-        focusPrompt();
-        const workspaceId = workspace.id;
-        toast.success(`Started ${workspace.title}`, {
-          action: {
-            label: "Open",
-            onClick: () =>
-              void navigate({
-                to: "/code/w/$workspaceId",
-                params: { workspaceId },
-              }),
-          },
-        });
-        return;
-      }
-      onOpenChange(false);
-      await navigate({
-        to: "/code/w/$workspaceId",
-        params: { workspaceId: workspace.id },
+  function create() {
+    if (!canCreate || !selectedRepo || createLocked.current) return;
+    createLocked.current = true;
+    const attempt: CreateAttempt = {
+      repoId,
+      title,
+      baseRef,
+      startingPrompt,
+      harness,
+      permissionMode: postedMode,
+      model,
+      modelsByHarness: { ...modelsByHarness },
+      createMore,
+      originPath: pathnameRef.current,
+    };
+    if (createMore) {
+      setStartingPrompt("");
+      setTitle("");
+      focusPrompt();
+      queueMicrotask(() => {
+        createLocked.current = false;
       });
-    } finally {
-      setCreating(false);
+    } else {
+      onOpenChange(false);
     }
+    startCreateAttempt(attempt, selectedRepo);
+  }
+
+  function startCreateAttempt(
+    attempt: CreateAttempt,
+    selectedRepo?: CodeRepoSnapshot,
+  ) {
+    const repo =
+      selectedRepo ??
+      repos.find((candidate) => candidate.id === attempt.repoId);
+    if (!repo) {
+      toast.error("Could not create the workspace because its repo is gone");
+      return;
+    }
+    const pending: CodeWorkspaceSnapshot = {
+      id: `${OPTIMISTIC_WORKSPACE_ID_PREFIX}${crypto.randomUUID()}`,
+      repo_id: attempt.repoId,
+      title: attempt.title.trim() || "New workspace",
+      worktree_path: "",
+      branch_name: "",
+      base_ref: attempt.baseRef.trim() || repo.default_base_ref,
+      status: "creating",
+      created_at: new Date().toISOString(),
+    };
+    upsertWorkspace(pending);
+    void finishCreate(attempt, pending);
+  }
+
+  async function finishCreate(
+    attempt: CreateAttempt,
+    pending: CodeWorkspaceSnapshot,
+  ) {
+    let workspace: CodeWorkspaceSnapshot;
+    try {
+      workspace = await client.createCodeWorkspace({
+        repo_id: attempt.repoId,
+        title: attempt.title.trim() || undefined,
+        base_ref: attempt.baseRef.trim() || undefined,
+      });
+    } catch (error) {
+      removeWorkspace(pending.id);
+      retryAttempt.current = attempt;
+      toast.error(
+        friendlyErrorMessage(error, "Could not create the workspace"),
+        {
+          action: {
+            label: "Try again",
+            onClick: () => {
+              if (retryAttempt.current === attempt) retryAttempt.current = null;
+              startCreateAttempt(attempt);
+            },
+          },
+        },
+      );
+      return;
+    }
+    replaceWorkspace(pending.id, workspace);
+    const prompt = attempt.startingPrompt.trim();
+    try {
+      const gateway = gatewayCodeModels(
+        models,
+        attempt.harness,
+        defaultModelKey,
+      );
+      const native =
+        requiresHarnessModelIds(attempt.harness) || gateway.length === 0
+          ? await ensureHarnessModels(client, attempt.harness)
+          : [];
+      const listed = preferredCodeModels(attempt.harness, native, gateway);
+      const posted =
+        attempt.model ??
+        listed.find((option) => option.default)?.id ??
+        listed[0]?.id;
+      const session = await client.createCodeSession(workspace.id, {
+        harness: attempt.harness,
+        permission_mode: attempt.permissionMode,
+        model: posted,
+      });
+      rememberSession(session);
+      rememberCreate({
+        repoId: attempt.repoId,
+        harness: attempt.harness,
+        model: posted,
+        modelsByHarness: attempt.modelsByHarness,
+        permissionMode: attempt.permissionMode,
+      });
+      if (prompt) {
+        try {
+          await client.submitCodeTurn(session.id, prompt);
+        } catch (error) {
+          // Never drop typed words: the workspace composer holds them.
+          useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
+          toast.error(
+            `Session started, but the first message could not be sent. ${friendlyErrorMessage(error, "Send it from the workspace composer.")}`,
+          );
+        }
+      }
+    } catch (error) {
+      // No session to send to; the workspace composer holds the text and
+      // start-session on the workspace page picks it up.
+      if (prompt) {
+        useCodeUiStore.getState().offerComposerPrompt(workspace.id, prompt);
+      }
+      toast.error(
+        `Workspace created, but the session could not start. ${friendlyErrorMessage(error, "Try again from the workspace.")}`,
+      );
+    }
+    const workspaceId = workspace.id;
+    const workspacePath = `/code/w/${workspaceId}`;
+    if (
+      attempt.createMore ||
+      (pathnameRef.current !== attempt.originPath &&
+        pathnameRef.current !== workspacePath)
+    ) {
+      toast.success(`Started ${workspace.title}`, {
+        action: {
+          label: "Open",
+          onClick: () =>
+            void navigate({
+              to: "/code/w/$workspaceId",
+              params: { workspaceId },
+            }),
+        },
+      });
+      return;
+    }
+    if (pathnameRef.current === workspacePath) return;
+    await navigate({
+      to: "/code/w/$workspaceId",
+      params: { workspaceId: workspace.id },
+    });
   }
 
   function submit(event: FormEvent) {
@@ -461,11 +564,10 @@ export function NewWorkspaceDialog({
   const alt = (key: string) => (command ? `⌥${key}` : `Alt+${key}`);
 
   return (
-    <Dialog open={open} onOpenChange={creating ? undefined : onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className="max-w-3xl gap-0 overflow-hidden p-0 sm:rounded-xl"
         withCloseButton={false}
-        aria-busy={creating}
         aria-describedby={undefined}
         onOpenAutoFocus={(event) => {
           // Prompt-centric: the message is where a create starts, so it is
@@ -488,7 +590,6 @@ export function NewWorkspaceDialog({
             }
             return;
           }
-          if (creating) return;
           // Every pill has a chord, so a create never needs the mouse. These
           // ride on `event.code`: on macOS an Option chord types an accented
           // character, and `key` would carry that instead of the letter.
@@ -526,7 +627,7 @@ export function NewWorkspaceDialog({
                     type="button"
                     variant="secondary"
                     className="h-8 max-w-64 gap-2 px-2.5"
-                    disabled={creating || repos.length === 0}
+                    disabled={repos.length === 0}
                     aria-label="Repo"
                   >
                     <FolderGit2 className="size-4 shrink-0 opacity-70" />
@@ -565,7 +666,6 @@ export function NewWorkspaceDialog({
                     type="button"
                     variant="ghost"
                     className="text-muted-foreground h-8 max-w-48 gap-1.5 px-2"
-                    disabled={creating}
                     aria-label="Workspace name"
                   >
                     <Ellipsis className="size-4 shrink-0" />
@@ -607,7 +707,7 @@ export function NewWorkspaceDialog({
                     type="button"
                     variant="ghost"
                     className="text-muted-foreground h-8 max-w-56 gap-1.5 px-2"
-                    disabled={creating || !selectedRepo}
+                    disabled={!selectedRepo}
                     aria-label="Base ref"
                   >
                     <GitBranch className="size-4 shrink-0" />
@@ -643,7 +743,6 @@ export function NewWorkspaceDialog({
             ref={promptInput}
             value={startingPrompt}
             onChange={(event) => setStartingPrompt(event.target.value)}
-            disabled={creating}
             aria-label="First message"
             placeholder="Describe the first task (optional)"
             className="placeholder:text-muted-foreground max-h-[45vh] min-h-36 w-full resize-none bg-transparent px-4 py-3 text-base outline-none"
@@ -669,7 +768,7 @@ export function NewWorkspaceDialog({
                     type="button"
                     variant="ghost"
                     className="h-8 min-w-0 max-w-48 gap-2 px-2"
-                    disabled={creating || allHarnesses.length === 0}
+                    disabled={allHarnesses.length === 0}
                     aria-label={`Harness: ${HARNESS_LABELS[harness]}`}
                   >
                     <HarnessIcon className="size-4 shrink-0" />
@@ -736,7 +835,6 @@ export function NewWorkspaceDialog({
                     value={model}
                     onChange={selectModel}
                     loading={modelLoading}
-                    disabled={creating}
                     {...pickerProps("model")}
                   />
                 </span>
@@ -747,7 +845,7 @@ export function NewWorkspaceDialog({
                 <PermissionModeMenu
                   scopeKey="code-create"
                   value={postedMode}
-                  disabled={creating || availableModes.length === 0}
+                  disabled={availableModes.length === 0}
                   availableModes={availableModes}
                   onChange={(mode) => setPermissionMode(mode)}
                   {...pickerProps("mode")}
@@ -760,13 +858,11 @@ export function NewWorkspaceDialog({
                 className={cn(
                   "flex h-8 shrink-0 cursor-pointer items-center gap-2 px-2 text-sm",
                   createMore ? "text-foreground" : "text-muted-foreground",
-                  creating && "cursor-not-allowed opacity-50",
                 )}
               >
                 <Switch
                   checked={createMore}
                   onCheckedChange={setCreateMore}
-                  disabled={creating}
                   aria-label="Create more"
                   className="h-5 w-9"
                   thumbClassName="size-4 data-[state=checked]:translate-x-4"
@@ -779,15 +875,13 @@ export function NewWorkspaceDialog({
               disabled={!canCreate}
               className="h-8 shrink-0"
             >
-              {creating ? "Creating…" : "Create"}
-              {!creating && (
-                <kbd
-                  className="font-sans text-2xs font-medium opacity-60"
-                  aria-hidden="true"
-                >
-                  ↩
-                </kbd>
-              )}
+              Create
+              <kbd
+                className="font-sans text-2xs font-medium opacity-60"
+                aria-hidden="true"
+              >
+                ↩
+              </kbd>
             </Button>
           </div>
         </form>

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -81,6 +81,25 @@ describe("WorkspaceCard", () => {
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
+  it("shows a non-interactive creating state", async () => {
+    const user = userEvent.setup();
+    const { onOpen } = renderCard({
+      workspace: {
+        status: "creating",
+        branch_name: "",
+        worktree_path: "",
+      },
+    });
+
+    const row = screen.getByRole("button", {
+      name: "Fix login · Creating workspace · app",
+    });
+    expect(row).toBeDisabled();
+    expect(screen.getByText("Creating workspace")).toBeInTheDocument();
+    await user.click(row);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
   it("keeps one menu: right-click carries every command", async () => {
     const user = userEvent.setup();
     const { onCommand } = renderCard({ pr });

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -10,6 +10,7 @@ import {
   FileCode2,
   GitBranch,
   GitPullRequest,
+  LoaderCircle,
   Radar,
   RotateCcw,
   Search,
@@ -128,6 +129,7 @@ export function WorkspaceCard({
   const title = digest?.title ?? workspace.title;
   const pr = digest?.pr_state ?? workspace.pr;
   const archived = isPutAway(workspace);
+  const creating = workspace.status === "creating";
   const [detailOpen, setDetailOpen] = useState(detailDefaultOpen);
   const watchActive = childSessions.some(
     (child) =>
@@ -171,12 +173,15 @@ export function WorkspaceCard({
                   session: digest,
                   pr,
                   terminalOpen,
+                  workspaceStatus: workspace.status,
                 })}
                 aria-current={active ? "page" : undefined}
+                disabled={creating}
                 className={cn(
                   "flex w-full cursor-pointer flex-col gap-0.5 rounded-xl px-2.5 py-2 text-left",
                   FOCUS_RING_INSET,
                   HOVER_TINT,
+                  creating && "cursor-wait",
                 )}
                 onClick={onOpen}
               >
@@ -192,6 +197,14 @@ export function WorkspaceCard({
                     {pr && <PrGlyph pr={pr} />}
                     {terminalOpen && (
                       <SquareTerminal className="size-3 text-muted-foreground" />
+                    )}
+                    {creating && (
+                      <LoaderCircle
+                        className={cn(
+                          "size-3 animate-spin",
+                          STATUS_MARK.pending,
+                        )}
+                      />
                     )}
                     {digest?.attention.state.type === "needs_you" &&
                       digest.attention.state.source === "structured" && (
@@ -604,6 +617,19 @@ function WorkspaceActivityLine({
   digest: CodeSessionDigest | undefined;
   session: CodeSessionSnapshot | undefined;
 }) {
+  if (workspace.status === "creating") {
+    return (
+      <div
+        className={cn(
+          "flex min-w-0 items-center gap-1.5 px-2.5 pb-2 pl-7 text-xs",
+          STATUS_TEXT.pending,
+        )}
+      >
+        <LoaderCircle className="size-3 shrink-0 animate-spin" aria-hidden />
+        <span className="min-w-0 flex-1 truncate">Creating workspace</span>
+      </div>
+    );
+  }
   const railDigest = digest && isSessionRowWorthy(digest) ? digest : undefined;
   if (!railDigest) return null;
 

--- a/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
+++ b/crates/tidebreak-desktop/ui/src/code/codePaletteRows.ts
@@ -129,6 +129,9 @@ export function workspacePaletteRows(input: {
   );
   return (
     input.workspaces
+      // A temporary create has no server route yet. The rail shows its
+      // progress, but the palette must not offer a jump to a local-only id.
+      .filter((workspace) => workspace.status !== "creating")
       // The one already on screen is not somewhere to go.
       .filter((workspace) => workspace.id !== input.activeWorkspaceId)
       .map((workspace) => {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -253,22 +253,38 @@ export async function archiveWorkspaceWithConfirm(options: {
   client: Pick<ApiClient, "archiveCodeWorkspace">;
   workspaceId: string;
   confirm: (options: ConfirmOptions) => Promise<boolean>;
+  onOptimisticChange?: (archived: boolean) => void;
 }): Promise<CodeWorkspaceSnapshot | null> {
+  options.onOptimisticChange?.(true);
   try {
     return await options.client.archiveCodeWorkspace(
       options.workspaceId,
       false,
     );
   } catch (error) {
-    if (!archiveForceKind(error)) throw error;
+    if (!archiveForceKind(error)) {
+      options.onOptimisticChange?.(false);
+      throw error;
+    }
     const forced = await options.confirm({
       title: "Discard leftover work?",
       description: `${error instanceof Error ? error.message : String(error)} Commit and push from the review sidebar, or discard.`,
       confirmLabel: "Discard and archive",
       destructive: true,
     });
-    if (!forced) return null;
-    return await options.client.archiveCodeWorkspace(options.workspaceId, true);
+    if (!forced) {
+      options.onOptimisticChange?.(false);
+      return null;
+    }
+    try {
+      return await options.client.archiveCodeWorkspace(
+        options.workspaceId,
+        true,
+      );
+    } catch (forceError) {
+      options.onOptimisticChange?.(false);
+      throw forceError;
+    }
   }
 }
 
@@ -313,11 +329,23 @@ export function useWorkspaceCardCommands(): {
   }
 
   async function runArchive(workspace: CodeWorkspaceSnapshot) {
+    const onOptimisticChange = (archived: boolean) => {
+      upsertWorkspace(
+        archived
+          ? {
+              ...workspace,
+              status: "archived",
+              archived_at: new Date().toISOString(),
+            }
+          : workspace,
+      );
+    };
     try {
       const archived = await archiveWorkspaceWithConfirm({
         client,
         workspaceId: workspace.id,
         confirm,
+        onOptimisticChange,
       });
       if (!archived) return;
       await afterArchive(archived);
@@ -341,9 +369,16 @@ export function useWorkspaceCardCommands(): {
       destructive: true,
     });
     if (!ok) return;
+    const optimistic = {
+      ...workspace,
+      status: "archived" as const,
+      archived_at: new Date().toISOString(),
+    };
+    upsertWorkspace(optimistic);
     try {
       await afterArchive(await client.archiveCodeWorkspace(workspace.id, true));
     } catch (error) {
+      upsertWorkspace(workspace);
       toast.error(friendlyErrorMessage(error, "Could not archive"));
     }
   }

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -3,6 +3,7 @@ import type {
   CodeRepoSnapshot,
   CodeSessionDigest,
   CodeWorkspaceSnapshot,
+  CodeWorkspaceStatus,
 } from "../api/types";
 import { attentionLabel, LIFECYCLE_LABELS } from "./labels";
 import { STATUS_CHIP, STATUS_MARK, type StatusTone } from "./statusTone";
@@ -375,8 +376,10 @@ export function workspaceCardLabel(input: {
   session?: CodeSessionDigest;
   pr?: { number: number; state: string; draft?: boolean };
   terminalOpen?: boolean;
+  workspaceStatus?: CodeWorkspaceStatus;
 }): string {
   const parts = [input.title];
+  if (input.workspaceStatus === "creating") parts.push("Creating workspace");
   if (input.attention && input.attention.state.type !== "working") {
     parts.push(attentionLabel(input.attention));
   }
@@ -387,7 +390,8 @@ export function workspaceCardLabel(input: {
     parts.push(`Pull request #${input.pr.number} ${prToneLabel(input.pr)}`);
   }
   if (input.terminalOpen) parts.push("Terminal open");
-  parts.push(input.repoName, input.branchName);
+  parts.push(input.repoName);
+  if (input.branchName) parts.push(input.branchName);
   return parts.join(" · ");
 }
 

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -57,6 +57,23 @@ type Story = StoryObj<typeof meta>;
 
 export const Idle: Story = {};
 
+/** A create appears in the rail while the worktree and first session start. */
+export const Creating: Story = {
+  args: {
+    workspace: {
+      ...codeWorkspace,
+      id: "optimistic-workspace:storybook",
+      title: "New workspace",
+      branch_name: "",
+      worktree_path: "",
+      status: "creating",
+      created_at: "2026-08-24T12:00:00.000Z",
+    },
+    visibleMeta: { repoChip: true, branch: false },
+    commands: [],
+  },
+};
+
 /** A green pull request with the hover detail held open for visual review. */
 export const HoverPullRequestReady: Story = {
   args: {


### PR DESCRIPTION
## What changed

Workspace creation now closes the dialog immediately, shows a temporary progress card, supports concurrent Create more requests, survives catalog refreshes, and offers retry when creation fails.

Archive actions now hide the workspace immediately, disable the open workspace while cleanup runs, and restore the original state when the request fails or the discard confirmation is cancelled.

## Validation

Ran TypeScript checking, Biome linting, 92 focused tests, the full 1,813-test UI suite, the Storybook production build, and `git diff --check`; no browser session was available to capture the Storybook screenshot.

## Compatibility and risk

This change does not alter persisted data, wire formats, platform behavior, or security boundaries; risk is limited to client-side workspace catalog and navigation state during create and archive requests.
