### PR TITLE
fix(ci): enable Tokio test utilities on Windows

### DIFF
--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -115,6 +115,7 @@ winreg = "=0.56.0"
 # so the sandbox-resident driver tests can drive the actual sandbox side over a
 # loopback socket, with only Docker and the host model mocked.
 tidebreak-sandbox-agent = { path = "../tidebreak-sandbox-agent" }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
+# `test-util` provides the paused Tokio clock used by the HostGate tests.
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync", "test-util"] }
 tower = { version = "=0.5.3", features = ["util"] }
 tokio-tungstenite = { workspace = true }


### PR DESCRIPTION
## What changed

Enables Tokio’s `test-util` feature for `tidebreak-server` development tests, so the Windows `HostGate` tests can compile their paused-clock helpers.

## Validation

Validated the manifest with `cargo metadata --locked --format-version 1 --no-deps`; this repository does not run local Rust compilation, so GitHub Actions must verify the Windows lane.

## Compatibility and risk

None; this only enables a development dependency feature.