### PR TITLE
refactor(desktop): share document viewer states

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChangeSummaryCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChangeSummaryCard.tsx
@@ -133,15 +133,17 @@ export function ChangeSummaryCard({ client, chatId, turnId, files }: Props) {
             </p>
           )}
         </div>
-        <button
+        <Button
           type="button"
-          className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
           disabled={available.length === 0 || undoingAll}
           onClick={() => void undoAll()}
         >
           <RotateCcw size={13} aria-hidden="true" />
           {undoingAll ? "Undoing…" : "Undo all"}
-        </button>
+        </Button>
       </header>
 
       <div className="divide-y divide-border">
@@ -202,9 +204,11 @@ function FileChangeRow({
           </p>
         </div>
         {!rejected && (
-          <button
+          <Button
             type="button"
-            className="shrink-0 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            variant="ghost"
+            size="xs"
+            className="shrink-0 text-muted-foreground"
             disabled={file.undo !== "available" || working}
             onClick={onUndo}
           >
@@ -213,7 +217,7 @@ function FileChangeRow({
               : file.undo === "already_undone"
                 ? "Undone"
                 : "Undo"}
-          </button>
+          </Button>
         )}
       </div>
       {file.diff && <TextDiff diff={file.diff} />}

--- a/crates/tidebreak-desktop/ui/src/components/document/document-details.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/document/document-details.tsx
@@ -8,7 +8,6 @@
  * which is code-split so opening one format does not fetch the others. The
  * download itself is shared — both sides use `@/document/useFileDownload`.
  */
-import { Loader2Icon } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useRef } from "react";
 
 import type { DocumentDetail } from "@/api";
@@ -16,6 +15,7 @@ import { useApp } from "@/AppContext";
 import { DocumentViewer, hasOriginalViewer } from "@/document/DocumentViewer";
 import type { SheetHighlightRange } from "@/document/UniverSpreadsheetViewer";
 import { documentFileSource } from "@/document/useFileDownload";
+import { DocumentViewerState } from "@/document/ViewerPrimitives";
 import { cn } from "@/lib/utils";
 import {
   CITATION_MARK_CLASS,
@@ -131,7 +131,16 @@ export function DocumentDetails({
           ) : type.startsWith("image/") ? (
             <ImageViewer source={source} className="bg-page-background grow" />
           ) : structured !== null ? (
-            <Suspense fallback={<ViewerLoading />}>
+            <Suspense
+              fallback={
+                <DocumentViewerState
+                  variant="loading"
+                  className="bg-page-background"
+                >
+                  Loading viewer…
+                </DocumentViewerState>
+              }
+            >
               {structured === "json" ? (
                 <JsonViewer source={source} className="grow" />
               ) : (
@@ -153,14 +162,6 @@ export function DocumentDetails({
       ) : (
         <ExtractedText info={info} targetLines={targetLines} />
       )}
-    </div>
-  );
-}
-
-function ViewerLoading() {
-  return (
-    <div className="flex grow items-center justify-center bg-page-background">
-      <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/components/document/image-viewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/document/image-viewer.dom.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import {
+  clearFileDownloadCache,
+  type FileBytesSource,
+} from "@/document/useFileDownload";
+import { ImageViewer } from "./image-viewer";
+
+function source(id: string): FileBytesSource {
+  return {
+    id,
+    cacheKey: `image/${id}`,
+    fetch: async () => ({
+      bytes: new Uint8Array([id.length]),
+      contentType: "image/png",
+    }),
+  };
+}
+
+beforeEach(() => {
+  clearFileDownloadCache();
+  let nextUrl = 0;
+  URL.createObjectURL = vi.fn(() => `blob:image-${++nextUrl}`);
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(cleanup);
+
+it("reuses the shared URL lifecycle and resets render failures for a new source", async () => {
+  const { rerender } = render(<ImageViewer source={source("one")} />);
+  const firstImage = await screen.findByRole("img", {
+    name: "Document image",
+  });
+  expect(firstImage).toHaveAttribute("src", "blob:image-1");
+
+  fireEvent.error(firstImage);
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    "This image could not be loaded.",
+  );
+
+  rerender(<ImageViewer source={source("two")} />);
+
+  await waitFor(() =>
+    expect(screen.getByRole("img", { name: "Document image" })).toHaveAttribute(
+      "src",
+      "blob:image-2",
+    ),
+  );
+  expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:image-1");
+});

--- a/crates/tidebreak-desktop/ui/src/components/document/image-viewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/document/image-viewer.tsx
@@ -1,11 +1,9 @@
-import { Loader2Icon } from "lucide-react";
 import type { HTMLAttributes } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
-import {
-  useFileDownload,
-  type FileBytesSource,
-} from "@/document/useFileDownload";
+import { useLocalDocumentUrl } from "@/document/useLocalDocumentUrl";
+import type { FileBytesSource } from "@/document/useFileDownload";
+import { DocumentViewerState } from "@/document/ViewerPrimitives";
 import { cn } from "@/lib/utils";
 import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 
@@ -14,50 +12,44 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 }
 
 export function ImageViewer({ source, className, ...restProps }: Props) {
+  return (
+    <ImageViewerSource
+      key={source.cacheKey}
+      source={source}
+      className={className}
+      {...restProps}
+    />
+  );
+}
+
+function ImageViewerSource({ source, className, ...restProps }: Props) {
   const [imageError, setImageError] = useState(false);
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const fileId = source.id;
-  const fileDownload = useFileDownload(source, {
-    parseAs: "blob",
-  });
+  const file = useLocalDocumentUrl(source);
 
-  useEffect(() => {
-    if (!fileDownload.data) return;
-    const url = URL.createObjectURL(fileDownload.data);
-    setImageUrl(url);
-    // An object URL outlives its blob, so a panel left open through a session
-    // of clicking around would otherwise leak every image it drew.
-    return () => URL.revokeObjectURL(url);
-  }, [fileDownload.data]);
-
-  // Reset error state on document change
-  useEffect(() => {
-    setImageError(false);
-  }, [fileId]);
-
-  if (fileDownload.isLoading) {
+  if (!file.objectUrl) {
     return (
       <div className={cn("relative overflow-auto", className)} {...restProps}>
-        {fileDownload.progress ? (
-          <FileDownloadProgressIndicator progress={fileDownload.progress} />
+        {file.error ? (
+          <DocumentViewerState variant="error">
+            This image could not be loaded.
+          </DocumentViewerState>
+        ) : file.progress ? (
+          <FileDownloadProgressIndicator progress={file.progress} />
         ) : (
-          <div className="flex h-64 items-center justify-center text-muted-foreground">
-            <div className="flex flex-col items-center gap-2">
-              <Loader2Icon className="size-6 animate-spin" />
-              <p>Loading image…</p>
-            </div>
-          </div>
+          <DocumentViewerState variant="loading">
+            Loading image…
+          </DocumentViewerState>
         )}
       </div>
     );
   }
 
-  if (fileDownload.error || imageError) {
+  if (imageError) {
     return (
       <div className={cn("relative overflow-auto", className)} {...restProps}>
-        <div className="flex h-64 items-center justify-center text-muted-foreground">
-          <p>Failed to load image</p>
-        </div>
+        <DocumentViewerState variant="error">
+          This image could not be loaded.
+        </DocumentViewerState>
       </div>
     );
   }
@@ -65,14 +57,12 @@ export function ImageViewer({ source, className, ...restProps }: Props) {
   return (
     <div className={cn("relative overflow-auto", className)} {...restProps}>
       <div className="flex justify-center p-4">
-        {imageUrl && (
-          <img
-            src={imageUrl}
-            alt="Document image"
-            className="max-w-full shadow-lg"
-            onError={() => setImageError(true)}
-          />
-        )}
+        <img
+          src={file.objectUrl}
+          alt="Document image"
+          className="max-w-full shadow-lg"
+          onError={() => setImageError(true)}
+        />
       </div>
     </div>
   );

--- a/crates/tidebreak-desktop/ui/src/components/document/json-viewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/document/json-viewer.tsx
@@ -3,7 +3,6 @@ import {
   ChevronDown,
   ChevronRight,
   ChevronRightIcon,
-  Loader2Icon,
 } from "lucide-react";
 import {
   createContext,
@@ -27,6 +26,7 @@ import {
   useFileDownload,
   type FileBytesSource,
 } from "@/document/useFileDownload";
+import { DocumentViewerState } from "@/document/ViewerPrimitives";
 import { cn } from "@/lib/utils";
 import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 
@@ -195,9 +195,9 @@ export function JsonViewer({
   if (fileDownload.error) {
     return (
       <div className={cn("relative overflow-auto", className)} {...props}>
-        <div className="text-muted-foreground flex h-64 items-center justify-center">
-          <p>Failed to download document</p>
-        </div>
+        <DocumentViewerState variant="error">
+          This document could not be loaded.
+        </DocumentViewerState>
       </div>
     );
   }
@@ -211,7 +211,9 @@ export function JsonViewer({
         {fileDownload.progress ? (
           <FileDownloadProgressIndicator progress={fileDownload.progress} />
         ) : (
-          <Loader2Icon className="text-muted-foreground size-6 animate-spin" />
+          <DocumentViewerState variant="loading">
+            Loading document…
+          </DocumentViewerState>
         )}
       </div>
     );
@@ -220,9 +222,9 @@ export function JsonViewer({
   if (parsed === undefined) {
     return (
       <div className={cn("relative overflow-auto", className)} {...props}>
-        <div className="text-muted-foreground flex h-64 items-center justify-center">
-          <p>Unable to parse JSON</p>
-        </div>
+        <DocumentViewerState variant="error">
+          Unable to parse JSON.
+        </DocumentViewerState>
       </div>
     );
   }
@@ -233,6 +235,7 @@ export function JsonViewer({
       {...props}
     >
       <JsonBreadcrumbBar
+        key={source.cacheKey}
         data={parsed}
         onCollapseAll={collapseAll}
         onNavigate={navigateToPath}
@@ -271,9 +274,6 @@ function JsonBreadcrumbBar({
   onNavigate: (path: string) => void;
 }) {
   const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
-
-  // Reset breadcrumb when the underlying JSON data changes
-  useEffect(() => setBreadcrumb([]), [data]);
 
   const handleSelect = useCallback(
     (depth: number, key: string) => {

--- a/crates/tidebreak-desktop/ui/src/components/document/markdown-viewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/document/markdown-viewer.tsx
@@ -6,6 +6,7 @@ import {
   useFileDownload,
   type FileBytesSource,
 } from "@/document/useFileDownload";
+import { DocumentViewerState } from "@/document/ViewerPrimitives";
 import { cn } from "@/lib/utils";
 import { extractHeadings } from "@/markdownHeadings";
 import { MessageMarkdown } from "@/MessageMarkdown";
@@ -174,9 +175,9 @@ export function MarkdownViewer({
   if (fileDownload.error) {
     return (
       <div className={cn("relative overflow-auto", className)} {...props}>
-        <div className="flex h-64 items-center justify-center text-muted-foreground">
-          <p>Failed to download document</p>
-        </div>
+        <DocumentViewerState variant="error">
+          This document could not be loaded.
+        </DocumentViewerState>
       </div>
     );
   }
@@ -190,7 +191,9 @@ export function MarkdownViewer({
         {fileDownload.progress ? (
           <FileDownloadProgressIndicator progress={fileDownload.progress} />
         ) : (
-          <Loader2Icon className="size-6 animate-spin" />
+          <DocumentViewerState variant="loading">
+            Loading document…
+          </DocumentViewerState>
         )}
       </div>
     );

--- a/crates/tidebreak-desktop/ui/src/components/document/xml-viewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/document/xml-viewer.tsx
@@ -3,7 +3,6 @@ import {
   ChevronDown,
   ChevronRight,
   ChevronRightIcon,
-  Loader2Icon,
 } from "lucide-react";
 import {
   createContext,
@@ -26,6 +25,7 @@ import {
   useFileDownload,
   type FileBytesSource,
 } from "@/document/useFileDownload";
+import { DocumentViewerState } from "@/document/ViewerPrimitives";
 import { cn } from "@/lib/utils";
 import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 
@@ -281,9 +281,9 @@ export function XmlViewer({
   if (fileDownload.error) {
     return (
       <div className={cn("relative overflow-auto", className)} {...props}>
-        <div className="text-muted-foreground flex h-64 items-center justify-center">
-          <p>Failed to download document</p>
-        </div>
+        <DocumentViewerState variant="error">
+          This document could not be loaded.
+        </DocumentViewerState>
       </div>
     );
   }
@@ -297,7 +297,9 @@ export function XmlViewer({
         {fileDownload.progress ? (
           <FileDownloadProgressIndicator progress={fileDownload.progress} />
         ) : (
-          <Loader2Icon className="text-muted-foreground size-6 animate-spin" />
+          <DocumentViewerState variant="loading">
+            Loading document…
+          </DocumentViewerState>
         )}
       </div>
     );
@@ -306,9 +308,9 @@ export function XmlViewer({
   if (!xmlDoc || !xmlDoc.documentElement) {
     return (
       <div className={cn("relative overflow-auto", className)} {...props}>
-        <div className="text-muted-foreground flex h-64 items-center justify-center">
-          <p>Unable to parse XML</p>
-        </div>
+        <DocumentViewerState variant="error">
+          Unable to parse XML.
+        </DocumentViewerState>
       </div>
     );
   }
@@ -319,6 +321,7 @@ export function XmlViewer({
       {...props}
     >
       <XmlBreadcrumbBar
+        key={source.cacheKey}
         root={xmlDoc.documentElement}
         onCollapseAll={collapseAll}
         onNavigate={navigateToPath}
@@ -359,8 +362,6 @@ function XmlBreadcrumbBar({
   const [breadcrumb, setBreadcrumb] = useState<
     { element: Element; path: string }[]
   >([]);
-
-  useEffect(() => setBreadcrumb([]), [root]);
 
   const handleSelect = useCallback(
     (depth: number, element: Element, path: string) => {

--- a/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -626,7 +626,7 @@ describe("DocumentDetailRoot", () => {
       '{"invoice": ',
     );
 
-    expect(await screen.findByText("Unable to parse JSON")).toBeVisible();
+    expect(await screen.findByText("Unable to parse JSON.")).toBeVisible();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/DocxViewer.tsx
@@ -1,15 +1,15 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import type { HTMLAttributes } from "react";
 import { useRef } from "react";
 
 import { DocxViewerPreview } from "@/components/extend/docx-viewer";
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
-import {
-  DOCUMENT_VIEWER_SURFACE,
-  useSecureViewerLinks,
-} from "@/document/extendViewerSurface";
+import { useSecureViewerLinks } from "@/document/extendViewerSurface";
 import { useLocalDocumentUrl } from "@/document/useLocalDocumentUrl";
 import type { FileBytesSource } from "@/document/useFileDownload";
-import { cn } from "@/lib/utils";
+import {
+  DocumentViewerShell,
+  DocumentViewerState,
+} from "@/document/ViewerPrimitives";
 import { useTheme } from "@/theme";
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
@@ -28,22 +28,22 @@ export default function DocxViewer({ source, className, ...restProps }: Props) {
   useSecureViewerLinks(containerRef);
 
   return (
-    <div
+    <DocumentViewerShell
       ref={containerRef}
-      className={cn(
-        "relative flex min-h-0 flex-col overflow-hidden",
-        className,
-        DOCUMENT_VIEWER_SURFACE,
-      )}
+      className={className}
       {...restProps}
     >
       {file.error ? (
-        <ViewerMessage>This document could not be loaded.</ViewerMessage>
+        <DocumentViewerState variant="error">
+          This document could not be loaded.
+        </DocumentViewerState>
       ) : !file.objectUrl ? (
         file.progress ? (
           <FileDownloadProgressIndicator progress={file.progress} />
         ) : (
-          <ViewerMessage>Loading document…</ViewerMessage>
+          <DocumentViewerState variant="loading">
+            Loading document…
+          </DocumentViewerState>
         )
       ) : (
         <div className="min-h-0 grow overflow-hidden rounded-md border bg-background shadow-xs">
@@ -60,14 +60,6 @@ export default function DocxViewer({ source, className, ...restProps }: Props) {
           />
         </div>
       )}
-    </div>
-  );
-}
-
-function ViewerMessage({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex min-h-64 grow items-center justify-center text-sm text-muted-foreground">
-      {children}
-    </div>
+    </DocumentViewerShell>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/NativeSpreadsheetViewer.tsx
@@ -13,14 +13,12 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   FunctionSquareIcon,
-  Loader2Icon,
   MinusIcon,
   PlusIcon,
 } from "lucide-react";
 import {
   type HTMLAttributes,
   type MutableRefObject,
-  type ReactNode,
   type Ref,
   useCallback,
   useEffect,
@@ -41,6 +39,7 @@ import {
   useFileDownload,
   type FileBytesSource,
 } from "@/document/useFileDownload";
+import { DocumentViewerState } from "@/document/ViewerPrimitives";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/theme";
 
@@ -86,7 +85,9 @@ export default function NativeSpreadsheetViewer({
         {fileDownload.progress ? (
           <FileDownloadProgressIndicator progress={fileDownload.progress} />
         ) : (
-          <ViewerMessage spinner>Loading workbook…</ViewerMessage>
+          <DocumentViewerState variant="loading" className="h-full">
+            Loading workbook…
+          </DocumentViewerState>
         )}
       </div>
     );
@@ -98,7 +99,9 @@ export default function NativeSpreadsheetViewer({
         className={cn(WORKBOOK_SURFACE, "relative min-h-0", className)}
         {...restProps}
       >
-        <ViewerMessage>This workbook could not be loaded.</ViewerMessage>
+        <DocumentViewerState variant="error" className="h-full">
+          This workbook could not be loaded.
+        </DocumentViewerState>
       </div>
     );
   }
@@ -139,7 +142,9 @@ function LoadedWorkbook({
         className={cn(WORKBOOK_SURFACE, "relative min-h-0", className)}
         {...restProps}
       >
-        <ViewerMessage>This workbook could not be prepared.</ViewerMessage>
+        <DocumentViewerState variant="error" className="h-full">
+          This workbook could not be prepared.
+        </DocumentViewerState>
       </div>
     );
   }
@@ -150,7 +155,9 @@ function LoadedWorkbook({
         className={cn(WORKBOOK_SURFACE, "relative min-h-0", className)}
         {...restProps}
       >
-        <ViewerMessage spinner>Preparing workbook…</ViewerMessage>
+        <DocumentViewerState variant="loading" className="h-full">
+          Preparing workbook…
+        </DocumentViewerState>
       </div>
     );
   }
@@ -244,15 +251,19 @@ function RenderedWorkbook({
         enableCanvasSelectionAnimation
         enableGestureZoom
         errorState={(error) => (
-          <ViewerMessage>
+          <DocumentViewerState variant="error" className="h-full">
             <span className="block">This workbook could not be read.</span>
             <span className="mt-1 block text-xs">{error.message}</span>
-          </ViewerMessage>
+          </DocumentViewerState>
         )}
         experimentalCanvas
         getCellStyle={getCellStyle}
         isDark={dark}
-        loadingState={<ViewerMessage spinner>Reading workbook…</ViewerMessage>}
+        loadingState={
+          <DocumentViewerState variant="loading" className="h-full">
+            Reading workbook…
+          </DocumentViewerState>
+        }
         readOnly
         renderScroller={renderScroller}
         renderTableHeaderMenu={() => null}
@@ -677,21 +688,4 @@ function workbookFileName(mediaType: string): string {
     "application/vnd.ms-excel"
     ? "workbook.xls"
     : "workbook.xlsx";
-}
-
-function ViewerMessage({
-  spinner,
-  children,
-}: {
-  spinner?: boolean;
-  children: ReactNode;
-}) {
-  return (
-    <div className="flex h-full min-h-64 items-center justify-center p-6 text-center text-sm text-muted-foreground">
-      <div className="flex flex-col items-center gap-2">
-        {spinner ? <Loader2Icon className="size-6 animate-spin" /> : null}
-        <p>{children}</p>
-      </div>
-    </div>
-  );
 }

--- a/crates/tidebreak-desktop/ui/src/document/PdfViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/PdfViewer.tsx
@@ -1,5 +1,5 @@
-import type { HTMLAttributes, ReactNode } from "react";
-import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import type { HTMLAttributes } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   PDFViewer as ExtendPdfViewer,
@@ -7,14 +7,14 @@ import {
 } from "@/components/extend/pdf-viewer";
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
 import { useRegisterPdfControls } from "@/document/PdfControlsContext";
-import {
-  DOCUMENT_VIEWER_SURFACE,
-  useSecureViewerLinks,
-} from "@/document/extendViewerSurface";
+import { useSecureViewerLinks } from "@/document/extendViewerSurface";
 import { useLocalDocumentUrl } from "@/document/useLocalDocumentUrl";
 import { usePdfPageState } from "@/document/usePdfPageState";
 import type { FileBytesSource } from "@/document/useFileDownload";
-import { cn } from "@/lib/utils";
+import {
+  DocumentViewerShell,
+  DocumentViewerState,
+} from "@/document/ViewerPrimitives";
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   source: FileBytesSource;
@@ -23,7 +23,11 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 }
 
 /** A local, continuous, searchable PDF surface using Extend's viewer chrome. */
-export function PdfViewer({
+export function PdfViewer(props: Props) {
+  return <PdfViewerSource key={props.source.cacheKey} {...props} />;
+}
+
+function PdfViewerSource({
   source,
   targetPage,
   className,
@@ -79,26 +83,34 @@ export function PdfViewer({
 
   if (file.error) {
     return (
-      <ViewerShell className={className} {...restProps}>
-        <ViewerMessage>This document could not be loaded.</ViewerMessage>
-      </ViewerShell>
+      <DocumentViewerShell className={className} {...restProps}>
+        <DocumentViewerState variant="error">
+          This document could not be loaded.
+        </DocumentViewerState>
+      </DocumentViewerShell>
     );
   }
 
   if (!file.objectUrl) {
     return (
-      <ViewerShell className={className} {...restProps}>
+      <DocumentViewerShell className={className} {...restProps}>
         {file.progress ? (
           <FileDownloadProgressIndicator progress={file.progress} />
         ) : (
-          <ViewerMessage>Loading document…</ViewerMessage>
+          <DocumentViewerState variant="loading">
+            Loading document…
+          </DocumentViewerState>
         )}
-      </ViewerShell>
+      </DocumentViewerShell>
     );
   }
 
   return (
-    <ViewerShell ref={containerRef} className={className} {...restProps}>
+    <DocumentViewerShell
+      ref={containerRef}
+      className={className}
+      {...restProps}
+    >
       <div className="min-h-0 grow overflow-hidden rounded-md border bg-background shadow-xs">
         <ExtendPdfViewer
           ref={viewerRef}
@@ -114,29 +126,6 @@ export function PdfViewer({
           src={file.objectUrl}
         />
       </div>
-    </ViewerShell>
-  );
-}
-
-const ViewerShell = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn(
-        "relative flex min-h-0 flex-col overflow-hidden",
-        className,
-        DOCUMENT_VIEWER_SURFACE,
-      )}
-      {...props}
-    />
-  ),
-);
-ViewerShell.displayName = "PdfViewerShell";
-
-function ViewerMessage({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex min-h-64 grow items-center justify-center text-sm text-muted-foreground">
-      {children}
-    </div>
+    </DocumentViewerShell>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/document/PresentationViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/PresentationViewer.tsx
@@ -3,21 +3,14 @@
  * plus PPTX files the native parser rejects, retain the existing LibreOffice
  * conversion path. Source bytes stay immutable in either path.
  */
-import {
-  FileSpreadsheetIcon,
-  Loader2Icon,
-  PresentationIcon,
-} from "lucide-react";
+import { FileSpreadsheetIcon, PresentationIcon } from "lucide-react";
 import { lazy, useEffect, useMemo, useRef, useState } from "react";
 
 import { PptxViewerPreview } from "@/components/extend/pptx-viewer";
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import {
-  DOCUMENT_VIEWER_SURFACE,
-  useSecureViewerLinks,
-} from "@/document/extendViewerSurface";
+import { useSecureViewerLinks } from "@/document/extendViewerSurface";
 import {
   cancelPresentationConverterInstall,
   ConverterMissingError,
@@ -31,6 +24,10 @@ import {
   useFileDownload,
   type FileBytesSource,
 } from "@/document/useFileDownload";
+import {
+  DocumentViewerShell,
+  DocumentViewerState,
+} from "@/document/ViewerPrimitives";
 import { cn } from "@/lib/utils";
 
 // The PDF engine is fetched on first use, same as the direct PDF branch.
@@ -52,6 +49,7 @@ export function PresentationViewer({ source, mediaType, className }: Props) {
   if (mediaType === PPTX_MEDIA_TYPE) {
     return (
       <DirectPresentationViewer
+        key={source.cacheKey}
         source={source}
         mediaType={mediaType}
         className={className}
@@ -71,8 +69,6 @@ export function PresentationViewer({ source, mediaType, className }: Props) {
 
 function DirectPresentationViewer({ source, mediaType, className }: Props) {
   const [renderFailed, setRenderFailed] = useState(false);
-
-  useEffect(() => setRenderFailed(false), [source.cacheKey]);
 
   if (renderFailed) {
     return (
@@ -104,28 +100,20 @@ function DirectPresentationSurface({
   useSecureViewerLinks(containerRef);
 
   return (
-    <div
-      ref={containerRef}
-      className={cn(
-        "relative flex min-h-0 flex-col overflow-hidden",
-        className,
-        DOCUMENT_VIEWER_SURFACE,
-      )}
-    >
+    <DocumentViewerShell ref={containerRef} className={className}>
       {file.error ? (
-        <div className="flex min-h-64 grow items-center justify-center text-sm text-muted-foreground">
+        <DocumentViewerState variant="error">
           This presentation could not be loaded.
-        </div>
+        </DocumentViewerState>
       ) : !file.objectUrl ? (
         file.progress ? (
           <div className="relative min-h-0 grow">
             <FileDownloadProgressIndicator progress={file.progress} />
           </div>
         ) : (
-          <div className="flex min-h-64 grow items-center justify-center gap-2 text-sm text-muted-foreground">
-            <Loader2Icon className="size-4 animate-spin" />
+          <DocumentViewerState variant="loading">
             Loading presentation…
-          </div>
+          </DocumentViewerState>
         )
       ) : (
         <div className="min-h-0 grow overflow-hidden rounded-md border bg-background shadow-xs">
@@ -142,7 +130,7 @@ function DirectPresentationSurface({
           />
         </div>
       )}
-    </div>
+    </DocumentViewerShell>
   );
 }
 
@@ -172,12 +160,9 @@ export function ConvertedOfficeViewer({
 
   if (isLoading) {
     return (
-      <div className="flex grow flex-col items-center justify-center gap-3">
-        <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
-        <p className="text-sm text-muted-foreground" role="status">
-          Preparing preview…
-        </p>
-      </div>
+      <DocumentViewerState variant="loading">
+        Preparing preview…
+      </DocumentViewerState>
     );
   }
 

--- a/crates/tidebreak-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
@@ -9,8 +9,7 @@ import sheetsCoreEnUS from "@univerjs/preset-sheets-core/locales/en-US";
 import "@univerjs/preset-sheets-core/lib/index.css";
 import type { FUniver, IWorkbookData, Univer } from "@univerjs/presets";
 import { createUniver, LocaleType } from "@univerjs/presets";
-import { Loader2Icon } from "lucide-react";
-import type { HTMLAttributes, ReactNode } from "react";
+import type { HTMLAttributes } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -19,6 +18,7 @@ import UniverFormulaWorker from "@/workers/univer-formula.worker?worker&inline";
 import { SpreadsheetShortcutsInfoBar } from "./SpreadsheetShortcutsInfo";
 import { parseCellAddress } from "./spreadsheet";
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
+import { DocumentViewerState } from "./ViewerPrimitives";
 import { useFileDownload, type FileBytesSource } from "./useFileDownload";
 import { useUniverWorker } from "./useUniverWorker";
 
@@ -370,7 +370,9 @@ export default function UniverSpreadsheetViewer({
         {fileDownload.progress ? (
           <FileDownloadProgressIndicator progress={fileDownload.progress} />
         ) : (
-          <ViewerMessage spinner>Loading spreadsheet…</ViewerMessage>
+          <DocumentViewerState variant="loading">
+            Loading spreadsheet…
+          </DocumentViewerState>
         )}
       </div>
     );
@@ -379,11 +381,11 @@ export default function UniverSpreadsheetViewer({
   if (errorType) {
     return (
       <div className={cn("relative overflow-auto", className)} {...restProps}>
-        <ViewerMessage>
+        <DocumentViewerState variant="error">
           {errorType === "parse"
             ? "This spreadsheet could not be read."
             : "This spreadsheet could not be loaded."}
-        </ViewerMessage>
+        </DocumentViewerState>
       </div>
     );
   }
@@ -392,7 +394,9 @@ export default function UniverSpreadsheetViewer({
     <div className={cn("relative flex flex-col", className)} {...restProps}>
       {isProcessing && (
         <div className="bg-background/80 absolute inset-0 z-10 flex items-center justify-center">
-          <ViewerMessage spinner>Reading spreadsheet…</ViewerMessage>
+          <DocumentViewerState variant="loading" className="min-h-0">
+            Reading spreadsheet…
+          </DocumentViewerState>
         </div>
       )}
       <SpreadsheetShortcutsInfoBar onAutofit={handleAutofit} />
@@ -421,23 +425,6 @@ export default function UniverSpreadsheetViewer({
         className="min-h-0 grow"
         style={{ width: "100%", height: "100%" }}
       />
-    </div>
-  );
-}
-
-function ViewerMessage({
-  spinner,
-  children,
-}: {
-  spinner?: boolean;
-  children: ReactNode;
-}) {
-  return (
-    <div className="text-muted-foreground flex h-64 items-center justify-center">
-      <div className="flex flex-col items-center gap-2">
-        {spinner && <Loader2Icon className="size-6 animate-spin" />}
-        <p>{children}</p>
-      </div>
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/document/ViewerPrimitives.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/ViewerPrimitives.dom.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+
+import { DocumentViewerShell, DocumentViewerState } from "./ViewerPrimitives";
+
+afterEach(cleanup);
+
+it("gives loading and failure states the right live-region semantics", () => {
+  const { rerender } = render(
+    <DocumentViewerState variant="loading">
+      Loading document…
+    </DocumentViewerState>,
+  );
+
+  expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
+  expect(screen.getByText("Loading document…")).toBeVisible();
+
+  rerender(
+    <DocumentViewerState variant="error">
+      This document could not be loaded.
+    </DocumentViewerState>,
+  );
+
+  expect(screen.getByRole("alert")).not.toHaveAttribute("aria-busy");
+});
+
+it("composes viewer layout classes without losing the shared surface", () => {
+  render(
+    <DocumentViewerShell data-testid="viewer" className="h-full">
+      Content
+    </DocumentViewerShell>,
+  );
+
+  expect(screen.getByTestId("viewer")).toHaveClass(
+    "h-full",
+    "bg-background",
+    "text-foreground",
+    "overflow-hidden",
+  );
+});

--- a/crates/tidebreak-desktop/ui/src/document/ViewerPrimitives.tsx
+++ b/crates/tidebreak-desktop/ui/src/document/ViewerPrimitives.tsx
@@ -1,0 +1,62 @@
+import { Loader2Icon } from "lucide-react";
+import { forwardRef, type HTMLAttributes, type ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import { DOCUMENT_VIEWER_SURFACE } from "./extendViewerSurface";
+
+export const DocumentViewerShell = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "relative flex min-h-0 flex-col overflow-hidden",
+      DOCUMENT_VIEWER_SURFACE,
+      className,
+    )}
+    {...props}
+  />
+));
+DocumentViewerShell.displayName = "DocumentViewerShell";
+
+type DocumentViewerStateProps = HTMLAttributes<HTMLDivElement> & {
+  variant?: "loading" | "error" | "message";
+  children: ReactNode;
+};
+
+/** A consistent status surface for every document engine and file format. */
+export function DocumentViewerState({
+  variant = "message",
+  className,
+  children,
+  role,
+  ...props
+}: DocumentViewerStateProps) {
+  const resolvedRole =
+    role ??
+    (variant === "error"
+      ? "alert"
+      : variant === "loading"
+        ? "status"
+        : undefined);
+
+  return (
+    <div
+      className={cn(
+        "flex min-h-64 grow items-center justify-center p-6 text-center text-sm text-muted-foreground",
+        className,
+      )}
+      role={resolvedRole}
+      aria-busy={variant === "loading" || undefined}
+      {...props}
+    >
+      <div className="flex max-w-sm flex-col items-center gap-2 text-balance">
+        {variant === "loading" ? (
+          <Loader2Icon className="size-6 animate-spin" aria-hidden="true" />
+        ) : null}
+        <div>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/outputs/OutputContent.tsx
+++ b/crates/tidebreak-desktop/ui/src/outputs/OutputContent.tsx
@@ -6,11 +6,11 @@
  * on the bounded preview string. Everything else offers export only.
  */
 import { lazy, Suspense } from "react";
-import { Loader2Icon } from "lucide-react";
 
 import { ImageViewer } from "@/components/document/image-viewer";
 import { DocumentViewer, hasOriginalViewer } from "@/document/DocumentViewer";
 import { outputFileSource } from "@/document/useFileDownload";
+import { DocumentViewerState } from "@/document/ViewerPrimitives";
 import {
   isTextDeliverableMediaType,
   type DeliverablePreview,
@@ -108,8 +108,8 @@ export function OutputContent({
 
 function ViewerLoading() {
   return (
-    <div className="flex grow items-center justify-center">
-      <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
-    </div>
+    <DocumentViewerState variant="loading">
+      Loading preview…
+    </DocumentViewerState>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/stories/ChangeSummaryCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ChangeSummaryCard.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { ApiClient, ExecFileChangeSummary } from "@/api";
+import { ChangeSummaryCard } from "@/ChangeSummaryCard";
+
+const files: ExecFileChangeSummary[] = [
+  {
+    snapshot_id: "snapshot-readme",
+    folder_name: "Tidebreak",
+    relative_path: "README.md",
+    classification: "applied",
+    change: "overwritten",
+    rejection_reason: null,
+    undo: "available",
+    diff: "--- before\n+++ after\n@@ -1 +1 @@\n-Old setup\n+Updated setup\n",
+    binary_preview: null,
+  },
+  {
+    snapshot_id: "snapshot-stale",
+    folder_name: "Tidebreak",
+    relative_path: "src/session.ts",
+    classification: "rejected",
+    change: null,
+    rejection_reason: "stale",
+    undo: "not_available",
+    diff: null,
+    binary_preview: null,
+  },
+];
+
+const client = {
+  getFileChangePreview: async () => new Blob(),
+  undoFileChange: async (_chatId, _turnId, snapshotId) => ({
+    snapshot_id: snapshotId,
+    folder_name: "Tidebreak",
+    relative_path: "README.md",
+    status: "restored" as const,
+  }),
+  undoTurnFileChanges: async (chatId, turnId) => ({
+    chat_id: chatId,
+    turn_id: turnId,
+    files: [],
+  }),
+} satisfies Pick<
+  ApiClient,
+  "getFileChangePreview" | "undoFileChange" | "undoTurnFileChanges"
+>;
+
+const meta = {
+  title: "Conversation/Change summary",
+  component: ChangeSummaryCard,
+  args: {
+    client,
+    chatId: "chat-review",
+    turnId: "turn-writeback",
+    files,
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-3xl p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ChangeSummaryCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MixedResults: Story = {};
+
+export const NothingToUndo: Story = {
+  args: {
+    files: files.map((file) =>
+      file.classification === "applied"
+        ? { ...file, undo: "already_undone" as const }
+        : file,
+    ),
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/DocumentViewerStates.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DocumentViewerStates.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  DocumentViewerShell,
+  DocumentViewerState,
+} from "@/document/ViewerPrimitives";
+
+type ViewerState = "loading" | "error" | "message";
+
+function DocumentViewerStateStory({ state }: { state: ViewerState }) {
+  const copy = {
+    loading: "Loading document…",
+    error: "This document could not be loaded.",
+    message: "No preview is available for this file type.",
+  }[state];
+
+  return (
+    <DocumentViewerShell className="h-[420px] rounded-lg border bg-page-background">
+      <DocumentViewerState variant={state}>{copy}</DocumentViewerState>
+    </DocumentViewerShell>
+  );
+}
+
+const meta = {
+  title: "Documents/Viewer states",
+  component: DocumentViewerStateStory,
+  args: { state: "loading" },
+  argTypes: {
+    state: {
+      control: "select",
+      options: ["loading", "error", "message"],
+    },
+  },
+} satisfies Meta<typeof DocumentViewerStateStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {};
+
+export const Error: Story = {
+  args: { state: "error" },
+};
+
+export const NoPreview: Story = {
+  args: { state: "message" },
+};


### PR DESCRIPTION
## What changed

The frontend now shares viewer shells, loading states, and accessible errors across document and output formats. Source-specific viewer state resets when documents change, image previews reuse the shared object-URL lifecycle, standard buttons handle undo actions, and Storybook covers the affected states.

## Validation

Ran 41 focused tests, frontend lint, TypeScript, the styles contract, the application production build, and the Storybook production build; screenshot capture was unavailable because no browser instance was connected.

## Compatibility and risk

No persisted data, wire-format, platform, or security-boundary changes.