### PR TITLE
fix(core): repair pre-pin postgres schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -784,6 +784,10 @@ jobs:
         run: >-
           cargo test -p tidebreak-core --no-default-features --features postgres
           --test postgres_code_owner --locked
+      - name: Exercise released schema upgrades on PostgreSQL
+        run: >-
+          cargo test -p tidebreak-core --no-default-features --features postgres
+          --test postgres_release_upgrade --locked
 
   self-host-build:
     name: self-host server build

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -52,8 +52,243 @@ impl MigratorTrait for Migrator {
             Box::new(CodePullRequestLiveTier),
             Box::new(CodePullRequestEtags),
             Box::new(CodeTurnModelSnapshot),
+            Box::new(PrePinCodeLifecycleRepair),
         ]
     }
+}
+
+/// Close the known self-host gap left by the last mutable baseline.
+///
+/// Tidebreak v0.60.0 added repository removal and clone provenance, workspace
+/// release state, session reasoning effort, and wider state vocabularies by
+/// editing the baseline in place. A PostgreSQL database created by v0.58.0 or
+/// v0.59.0 had already recorded that baseline name, so SeaORM never ran those
+/// statements. Later migrations repaired added tables, but not changed tables.
+///
+/// The baseline is frozen now, so this is the one historical repair. Every
+/// later schema change already has to append its own migration.
+struct PrePinCodeLifecycleRepair;
+
+impl MigrationName for PrePinCodeLifecycleRepair {
+    fn name(&self) -> &str {
+        "m20260825_000015_pre_pin_code_lifecycle_repair"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for PrePinCodeLifecycleRepair {
+    fn use_transaction(&self) -> Option<bool> {
+        Some(true)
+    }
+
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        add_pre_pin_code_columns(manager).await?;
+        replace_code_repo_registration_index(manager).await?;
+
+        if manager.get_database_backend() == DbBackend::Postgres {
+            widen_pre_pin_postgres_checks(manager).await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // The frozen baseline declares this schema. Removing any part of it
+        // would leave both fresh and upgraded databases below that contract.
+        Ok(())
+    }
+}
+
+async fn add_pre_pin_code_columns(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    if !manager.has_column("code_repo", "removed_at").await? {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(idens::CodeRepo::Table)
+                    .add_column(
+                        ColumnDef::new(idens::CodeRepo::RemovedAt).timestamp_with_time_zone(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+    }
+    if !manager.has_column("code_repo", "cloned_from").await? {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(idens::CodeRepo::Table)
+                    .add_column(ColumnDef::new(idens::CodeRepo::ClonedFrom).text())
+                    .to_owned(),
+            )
+            .await?;
+    }
+    if !manager.has_column("code_workspace", "released_at").await? {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(idens::CodeWorkspace::Table)
+                    .add_column(
+                        ColumnDef::new(idens::CodeWorkspace::ReleasedAt).timestamp_with_time_zone(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+    }
+    if !manager.has_column("code_workspace", "released_tip").await? {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(idens::CodeWorkspace::Table)
+                    .add_column(ColumnDef::new(idens::CodeWorkspace::ReleasedTip).text())
+                    .to_owned(),
+            )
+            .await?;
+    }
+    if !manager.has_column("code_workspace", "bundle_bytes").await? {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(idens::CodeWorkspace::Table)
+                    .add_column(ColumnDef::new(idens::CodeWorkspace::BundleBytes).big_integer())
+                    .to_owned(),
+            )
+            .await?;
+    }
+    if !manager
+        .has_column("code_session", "reasoning_effort")
+        .await?
+    {
+        let mut column = ColumnDef::new(idens::CodeSession::ReasoningEffort);
+        column.text();
+        if manager.get_database_backend() == DbBackend::Sqlite {
+            column.check(
+                Expr::col(idens::CodeSession::ReasoningEffort)
+                    .is_null()
+                    .or(Expr::col(idens::CodeSession::ReasoningEffort)
+                        .is_in(["none", "low", "medium", "high", "xhigh", "max", "ultra"])),
+            );
+        }
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(idens::CodeSession::Table)
+                    .add_column(column)
+                    .to_owned(),
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+async fn replace_code_repo_registration_index(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .drop_index(
+            Index::drop()
+                .name("idx_code_repo_owner_root_path")
+                .table(idens::CodeRepo::Table)
+                .if_exists()
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_code_repo_owner_root_path")
+                .table(idens::CodeRepo::Table)
+                .col(idens::CodeRepo::Owner)
+                .col(idens::CodeRepo::RootPath)
+                .unique()
+                .and_where(Expr::col(idens::CodeRepo::RemovedAt).is_null())
+                .to_owned(),
+        )
+        .await
+}
+
+async fn widen_pre_pin_postgres_checks(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute_unprepared(
+            r#"
+DO $repair$
+DECLARE
+    old_constraint text;
+BEGIN
+    FOR old_constraint IN
+        SELECT constraint_row.conname
+        FROM pg_constraint AS constraint_row
+        JOIN pg_attribute AS attribute_row
+          ON attribute_row.attrelid = constraint_row.conrelid
+         AND attribute_row.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'code_workspace'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute_row.attname = 'status'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE "code_workspace" DROP CONSTRAINT %I',
+            old_constraint
+        );
+    END LOOP;
+END
+$repair$;
+ALTER TABLE "code_workspace"
+    ADD CONSTRAINT "code_workspace_status_check"
+    CHECK ("status" IN ('creating', 'setup_failed', 'active', 'archived', 'released'));
+
+DO $repair$
+DECLARE
+    old_constraint text;
+BEGIN
+    FOR old_constraint IN
+        SELECT constraint_row.conname
+        FROM pg_constraint AS constraint_row
+        JOIN pg_attribute AS attribute_row
+          ON attribute_row.attrelid = constraint_row.conrelid
+         AND attribute_row.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'code_session'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute_row.attname = 'reasoning_effort'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE "code_session" DROP CONSTRAINT %I',
+            old_constraint
+        );
+    END LOOP;
+END
+$repair$;
+ALTER TABLE "code_session"
+    ADD CONSTRAINT "code_session_reasoning_effort_check"
+    CHECK (
+        "reasoning_effort" IS NULL
+        OR "reasoning_effort" IN ('none', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra')
+    );
+
+DO $repair$
+DECLARE
+    old_constraint text;
+BEGIN
+    FOR old_constraint IN
+        SELECT constraint_row.conname
+        FROM pg_constraint AS constraint_row
+        JOIN pg_attribute AS attribute_row
+          ON attribute_row.attrelid = constraint_row.conrelid
+         AND attribute_row.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'code_approval'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute_row.attname = 'state'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE "code_approval" DROP CONSTRAINT %I',
+            old_constraint
+        );
+    END LOOP;
+END
+$repair$;
+ALTER TABLE "code_approval"
+    ADD CONSTRAINT "code_approval_state_check"
+    CHECK ("state" IN ('pending', 'approved', 'denied', 'abandoned'));
+"#,
+        )
+        .await?;
+    Ok(())
 }
 
 /// Model and service-tier identity captured when a code turn starts.
@@ -1706,6 +1941,7 @@ mod tests {
                 "m20260824_000012_code_pull_request_live_tier",
                 "m20260824_000013_code_pull_request_etags",
                 "m20260824_000014_code_turn_model_snapshot",
+                "m20260825_000015_pre_pin_code_lifecycle_repair",
             ]
         );
         assert!(db
@@ -1809,6 +2045,82 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(row.try_get::<String>("", "owner").unwrap(), "local");
+    }
+
+    /// The first hosted machine ran v0.58.0, whose recorded baseline lacked
+    /// repository lifecycle columns. The repair keeps its row and replaces
+    /// the old all-rows uniqueness with the soft-removal contract.
+    #[tokio::test]
+    async fn a_v058_code_repo_gains_the_pre_pin_lifecycle_schema() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        db.execute_unprepared(
+            "CREATE TABLE app (
+                id TEXT PRIMARY KEY NOT NULL,
+                owner TEXT NOT NULL DEFAULT 'local',
+                name TEXT NOT NULL,
+                current_revision_id TEXT NOT NULL,
+                revision_count INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT
+            );
+            CREATE TABLE code_repo (
+                id TEXT PRIMARY KEY NOT NULL,
+                owner TEXT NOT NULL DEFAULT 'local',
+                root_path TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                default_base_ref TEXT NOT NULL,
+                branch_prefix TEXT NOT NULL,
+                setup_script TEXT,
+                archive_script TEXT,
+                quick_actions TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX idx_code_repo_owner_root_path
+                ON code_repo (owner, root_path);
+            INSERT INTO code_repo (
+                id, owner, root_path, display_name, default_base_ref,
+                branch_prefix, quick_actions, created_at
+            ) VALUES (
+                '00000000-0000-0000-0000-000000000011', 'local', '/srv/pre-pin',
+                'pre-pin', 'main', 'tidebreak/', '[]', '2026-08-20T12:00:00Z'
+            )",
+        )
+        .await
+        .unwrap();
+
+        Migrator::up(&db, None).await.unwrap();
+
+        db.execute_unprepared(
+            "UPDATE code_repo
+             SET removed_at = '2026-08-25T12:00:00Z'
+             WHERE id = '00000000-0000-0000-0000-000000000011';
+             INSERT INTO code_repo (
+                 id, owner, root_path, display_name, default_base_ref,
+                 branch_prefix, quick_actions, created_at
+             ) VALUES (
+                 '00000000-0000-0000-0000-000000000012', 'local', '/srv/pre-pin',
+                 'pre-pin-again', 'main', 'tidebreak/', '[]',
+                 '2026-08-25T12:00:00Z'
+             )",
+        )
+        .await
+        .unwrap();
+
+        let rows = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT count(*) AS repo_count,
+                        sum(cloned_from IS NULL) AS null_clone_count
+                 FROM code_repo
+                 WHERE owner = 'local' AND root_path = '/srv/pre-pin'"
+                    .to_owned(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(rows.try_get::<i64>("", "repo_count").unwrap(), 2);
+        assert_eq!(rows.try_get::<i64>("", "null_clone_count").unwrap(), 2);
     }
 
     #[tokio::test]

--- a/crates/tidebreak-core/tests/postgres_release_upgrade.rs
+++ b/crates/tidebreak-core/tests/postgres_release_upgrade.rs
@@ -25,6 +25,59 @@ struct UpgradeSnapshot {
     migration_count: i64,
 }
 
+#[derive(Debug)]
+struct PrePinUpgradeSnapshot {
+    columns: Vec<(String, String)>,
+    repo_count: i64,
+    workspace_status: String,
+    workspace_released_tip: Option<String>,
+    session_reasoning_effort: Option<String>,
+    approval_state: String,
+    invalid_workspace_status_rejected: bool,
+    invalid_reasoning_effort_rejected: bool,
+    invalid_approval_state_rejected: bool,
+    repair_migration_count: i64,
+}
+
+#[tokio::test]
+async fn postgres_v058_upgrade_repairs_the_pre_pin_code_schema() {
+    let source_url = match std::env::var("TIDEBREAK_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("TIDEBREAK_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("TIDEBREAK_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let suffix = format!("v058_{}", uuid::Uuid::new_v4().simple());
+    let (database_name, database_url) =
+        create_sibling_database(&source_url, &suffix).await.unwrap();
+
+    let result = exercise_pre_pin_upgrade(&database_url).await;
+    drop_sibling_database(&source_url, &database_name).await;
+    let snapshot = result.unwrap();
+
+    assert_eq!(
+        snapshot.columns,
+        [
+            ("code_repo".to_owned(), "cloned_from".to_owned()),
+            ("code_repo".to_owned(), "removed_at".to_owned()),
+            ("code_session".to_owned(), "reasoning_effort".to_owned()),
+            ("code_workspace".to_owned(), "bundle_bytes".to_owned()),
+            ("code_workspace".to_owned(), "released_at".to_owned()),
+            ("code_workspace".to_owned(), "released_tip".to_owned()),
+        ]
+    );
+    assert_eq!(snapshot.repo_count, 2);
+    assert_eq!(snapshot.workspace_status, "released");
+    assert_eq!(snapshot.workspace_released_tip.as_deref(), Some("deadbeef"));
+    assert_eq!(snapshot.session_reasoning_effort.as_deref(), Some("high"));
+    assert_eq!(snapshot.approval_state, "abandoned");
+    assert!(snapshot.invalid_workspace_status_rejected);
+    assert!(snapshot.invalid_reasoning_effort_rejected);
+    assert!(snapshot.invalid_approval_state_rejected);
+    assert_eq!(snapshot.repair_migration_count, 1);
+}
+
 #[tokio::test]
 async fn postgres_v060_upgrade_keeps_release_rows() {
     let source_url = match std::env::var("TIDEBREAK_POSTGRES_TEST_URL") {
@@ -77,6 +130,306 @@ async fn postgres_v060_upgrade_keeps_release_rows() {
     );
     assert!(snapshot.pending_without_next_attempt_rejected);
     assert_eq!(snapshot.migration_count, 3);
+}
+
+async fn exercise_pre_pin_upgrade(url: &str) -> Result<PrePinUpgradeSnapshot, String> {
+    let setup = Database::connect(url)
+        .await
+        .map_err(|error| error.to_string())?;
+    setup
+        .execute_unprepared(include_str!("../fixtures/schema-v0.60.0.postgres.sql"))
+        .await
+        .map_err(|error| error.to_string())?;
+    // v0.60.0 made these changes by editing the recorded baseline. Undo that
+    // delta to reproduce the v0.58.0 schema that the first hosted machine
+    // kept until it upgraded directly to v0.65.0.
+    setup
+        .execute_unprepared(
+            r#"
+DROP TABLE "code_trigger_fire";
+DROP TABLE "code_trigger";
+
+DROP INDEX "idx_code_repo_owner_root_path";
+ALTER TABLE "code_repo" DROP COLUMN "removed_at";
+ALTER TABLE "code_repo" DROP COLUMN "cloned_from";
+CREATE UNIQUE INDEX "idx_code_repo_owner_root_path"
+    ON "code_repo" ("owner", "root_path");
+
+ALTER TABLE "code_workspace" DROP COLUMN "released_at";
+ALTER TABLE "code_workspace" DROP COLUMN "released_tip";
+ALTER TABLE "code_workspace" DROP COLUMN "bundle_bytes";
+DO $downgrade$
+DECLARE
+    old_constraint text;
+BEGIN
+    FOR old_constraint IN
+        SELECT constraint_row.conname
+        FROM pg_constraint AS constraint_row
+        JOIN pg_attribute AS attribute_row
+          ON attribute_row.attrelid = constraint_row.conrelid
+         AND attribute_row.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'code_workspace'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute_row.attname = 'status'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE "code_workspace" DROP CONSTRAINT %I',
+            old_constraint
+        );
+    END LOOP;
+END
+$downgrade$;
+ALTER TABLE "code_workspace"
+    ADD CONSTRAINT "code_workspace_status_check"
+    CHECK ("status" IN ('creating', 'setup_failed', 'active', 'archived'));
+
+ALTER TABLE "code_session" DROP COLUMN "reasoning_effort";
+
+DO $downgrade$
+DECLARE
+    old_constraint text;
+BEGIN
+    FOR old_constraint IN
+        SELECT constraint_row.conname
+        FROM pg_constraint AS constraint_row
+        JOIN pg_attribute AS attribute_row
+          ON attribute_row.attrelid = constraint_row.conrelid
+         AND attribute_row.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'code_approval'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute_row.attname = 'state'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE "code_approval" DROP CONSTRAINT %I',
+            old_constraint
+        );
+    END LOOP;
+END
+$downgrade$;
+ALTER TABLE "code_approval"
+    ADD CONSTRAINT "code_approval_state_check"
+    CHECK ("state" IN ('pending', 'approved', 'denied'));
+
+CREATE TABLE seaql_migrations (
+    version varchar NOT NULL PRIMARY KEY,
+    applied_at bigint NOT NULL
+);
+INSERT INTO seaql_migrations (version, applied_at)
+VALUES ('m20260814_000001_baseline', 0);
+
+INSERT INTO code_repo (
+    id, owner, root_path, display_name, default_base_ref,
+    branch_prefix, quick_actions, created_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000301', 'local', '/srv/pre-pin',
+    'pre-pin', 'main', 'tidebreak/', '[]', '2026-08-20T12:00:00Z'
+);
+INSERT INTO code_workspace (
+    id, owner, repo_id, title, worktree_path, branch_name, base_ref,
+    status, created_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000302', 'local',
+    '00000000-0000-0000-0000-000000000301', 'pre-pin',
+    '/srv/pre-pin-worktree', 'tidebreak/pre-pin', 'main', 'active',
+    '2026-08-20T12:00:00Z'
+);
+INSERT INTO code_session (
+    id, owner, workspace_id, kind, harness_kind, permission_mode,
+    lifecycle, attention_state, attention_source, created_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000303', 'local',
+    '00000000-0000-0000-0000-000000000302', 'interactive',
+    'claude_code', 'ask', 'idle', '{}', 'lifecycle',
+    '2026-08-20T12:00:00Z'
+);
+INSERT INTO code_turn (
+    id, owner, session_id, ordinal, status, user_input, started_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000304', 'local',
+    '00000000-0000-0000-0000-000000000303', 1, 'completed',
+    'keep this turn', '2026-08-20T12:00:00Z'
+);
+INSERT INTO code_approval (
+    id, owner, session_id, turn_id, kind, harness_raw, state, requested_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000305', 'local',
+    '00000000-0000-0000-0000-000000000303',
+    '00000000-0000-0000-0000-000000000304', '{}', '{}', 'pending',
+    '2026-08-20T12:00:00Z'
+);
+"#,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+    setup.close().await.map_err(|error| error.to_string())?;
+
+    let store = DbStore::connect(url)
+        .await
+        .map_err(|error| error.to_string())?;
+    let verifier = Database::connect(url)
+        .await
+        .map_err(|error| error.to_string())?;
+
+    let columns = verifier
+        .query_all_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "SELECT table_name, column_name
+             FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND (table_name, column_name) IN (
+                   ('code_repo', 'removed_at'),
+                   ('code_repo', 'cloned_from'),
+                   ('code_workspace', 'released_at'),
+                   ('code_workspace', 'released_tip'),
+                   ('code_workspace', 'bundle_bytes'),
+                   ('code_session', 'reasoning_effort')
+               )
+             ORDER BY table_name, column_name"
+                .to_owned(),
+        ))
+        .await
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .map(|row| {
+            Ok((
+                row.try_get::<String>("", "table_name")?,
+                row.try_get::<String>("", "column_name")?,
+            ))
+        })
+        .collect::<Result<Vec<_>, sea_orm::DbErr>>()
+        .map_err(|error| error.to_string())?;
+
+    verifier
+        .execute_unprepared(
+            "UPDATE code_repo
+             SET removed_at = '2026-08-25T12:00:00Z'
+             WHERE id = '00000000-0000-0000-0000-000000000301';
+             INSERT INTO code_repo (
+                 id, owner, root_path, display_name, default_base_ref,
+                 branch_prefix, quick_actions, created_at
+             ) VALUES (
+                 '00000000-0000-0000-0000-000000000306', 'local', '/srv/pre-pin',
+                 'pre-pin-again', 'main', 'tidebreak/', '[]',
+                 '2026-08-25T12:00:00Z'
+             );
+             UPDATE code_workspace
+             SET status = 'released', released_tip = 'deadbeef', bundle_bytes = 42
+             WHERE id = '00000000-0000-0000-0000-000000000302';
+             UPDATE code_session
+             SET reasoning_effort = 'high'
+             WHERE id = '00000000-0000-0000-0000-000000000303';
+             UPDATE code_approval
+             SET state = 'abandoned'
+             WHERE id = '00000000-0000-0000-0000-000000000305';",
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+
+    let repo_count = verifier
+        .query_one_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "SELECT count(*)::bigint AS repo_count
+             FROM code_repo
+             WHERE owner = 'local' AND root_path = '/srv/pre-pin'"
+                .to_owned(),
+        ))
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "the repository count query returned no row".to_owned())?
+        .try_get("", "repo_count")
+        .map_err(|error| error.to_string())?;
+    let workspace = verifier
+        .query_one_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "SELECT status, released_tip
+             FROM code_workspace
+             WHERE id = '00000000-0000-0000-0000-000000000302'"
+                .to_owned(),
+        ))
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "the pre-pin workspace disappeared".to_owned())?;
+    let session = verifier
+        .query_one_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "SELECT reasoning_effort
+             FROM code_session
+             WHERE id = '00000000-0000-0000-0000-000000000303'"
+                .to_owned(),
+        ))
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "the pre-pin session disappeared".to_owned())?;
+    let approval = verifier
+        .query_one_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "SELECT state
+             FROM code_approval
+             WHERE id = '00000000-0000-0000-0000-000000000305'"
+                .to_owned(),
+        ))
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "the pre-pin approval disappeared".to_owned())?;
+
+    let invalid_workspace_status_rejected = verifier
+        .execute_unprepared(
+            "UPDATE code_workspace SET status = 'garbage'
+             WHERE id = '00000000-0000-0000-0000-000000000302'",
+        )
+        .await
+        .is_err();
+    let invalid_reasoning_effort_rejected = verifier
+        .execute_unprepared(
+            "UPDATE code_session SET reasoning_effort = 'garbage'
+             WHERE id = '00000000-0000-0000-0000-000000000303'",
+        )
+        .await
+        .is_err();
+    let invalid_approval_state_rejected = verifier
+        .execute_unprepared(
+            "UPDATE code_approval SET state = 'garbage'
+             WHERE id = '00000000-0000-0000-0000-000000000305'",
+        )
+        .await
+        .is_err();
+    let repair_migration_count = verifier
+        .query_one_raw(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "SELECT count(*)::bigint AS migration_count
+             FROM seaql_migrations
+             WHERE version = 'm20260825_000015_pre_pin_code_lifecycle_repair'"
+                .to_owned(),
+        ))
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "the repair migration query returned no row".to_owned())?
+        .try_get("", "migration_count")
+        .map_err(|error| error.to_string())?;
+
+    let snapshot = PrePinUpgradeSnapshot {
+        columns,
+        repo_count,
+        workspace_status: workspace
+            .try_get("", "status")
+            .map_err(|error| error.to_string())?,
+        workspace_released_tip: workspace
+            .try_get("", "released_tip")
+            .map_err(|error| error.to_string())?,
+        session_reasoning_effort: session
+            .try_get("", "reasoning_effort")
+            .map_err(|error| error.to_string())?,
+        approval_state: approval
+            .try_get("", "state")
+            .map_err(|error| error.to_string())?,
+        invalid_workspace_status_rejected,
+        invalid_reasoning_effort_rejected,
+        invalid_approval_state_rejected,
+        repair_migration_count,
+    };
+    verifier.close().await.map_err(|error| error.to_string())?;
+    store.close().await.map_err(|error| error.to_string())?;
+    Ok(snapshot)
 }
 
 async fn exercise_release_upgrade(url: &str) -> Result<UpgradeSnapshot, String> {

--- a/docs/decisions/0061-schema-changes-are-migrations.md
+++ b/docs/decisions/0061-schema-changes-are-migrations.md
@@ -84,12 +84,12 @@ the epoch deleted the rows. It no longer does. A journal payload change now
 either stays readable from the shape already on disk, or migrates the rows that
 hold it. The two journal fixtures' failure messages say so.
 
-**Self-host keeps the gap it already has, and it is now bounded.** Nothing here
-repairs a PostgreSQL database created before the pin — the tables it is missing
-depend on the day it first ran, which nothing recorded. What changes is that
-every schema change from here reaches it. Closing the pre-pin gap is tracked
-separately (#2490); it needs a schema pin inside the database, which SQLite got
-as a sidecar file and PostgreSQL never got at all.
+**Self-host repairs the known pre-pin shapes.** The ordered chain creates tables
+that older PostgreSQL databases lack. The historical lifecycle repair also adds
+columns and widens checks that `v0.60.0` put into the recorded baseline. Each
+repair checks the live catalog, preserves existing rows, and records its own
+migration name. Versioned PostgreSQL upgrade tests keep the released shapes on
+this path.
 
 Deliberately excluded: the product-major guard stays. A `1.0.0` binary still
 refuses to open a local profile until the rest of the 1.0 checklist is done,
@@ -138,9 +138,9 @@ into `Result<Vec<_>>`, so a single unreadable row fails a whole chat's history
 rather than one message. The fixtures make the change visible; they cannot make
 it compatible.
 
-The pre-pin self-host gap is unchanged and now stated. Anyone running a
-PostgreSQL deployment created before this lands should recreate it; #2490 is
-what removes the "should".
+An existing PostgreSQL deployment upgrades in place. The repair covers the
+released pre-pin schemas, including the `v0.58.0` shape that first ran on the
+hosted machine. Operators do not need to recreate the database.
 
 `reset_pre_v1_state` stays reachable, for profiles below the pin and for a
 database with no marker at all. It stops being reachable when those profiles
@@ -169,6 +169,11 @@ stopped at the baseline and later took the rest of the chain describes the same
 schema as one built in a single pass. Without it the chain and the baseline can
 disagree with nothing to notice, because each database is internally
 consistent.
+
+`postgres_v058_upgrade_repairs_the_pre_pin_code_schema` starts from the exact
+released lifecycle shape, keeps seeded rows, verifies every repaired column and
+check, and confirms that SeaORM records the repair once. The required
+PostgreSQL CI lane runs this test on every workspace change.
 
 `the_schema_baseline_is_pinned` fails on any baseline edit, on both backends,
 and its message says to append a migration instead of regenerating the fixture.


### PR DESCRIPTION
## What changed

Add an idempotent migration that repairs PostgreSQL databases created by Tidebreak v0.58.0 or v0.59.0. It adds the lifecycle columns, replaces repository registration uniqueness with the soft-removal index, and widens the affected checks without deleting rows.

Add SQLite and PostgreSQL upgrade regressions. Run the released-schema PostgreSQL test in the required PostgreSQL CI lane. Update decision 61 so operators upgrade in place instead of recreating the database.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Live repair applied and catalog-verified against the hosted development PostgreSQL database
- Rust compilation and tests left to GitHub CI per repository policy

## Compatibility and risk

The migration runs in one transaction and checks the live catalog before adding columns. It preserves existing rows. Fresh databases run the same migration as an idempotent no-op plus constraint normalization.

## Tracking

Follow-up to #2490.