### PR TITLE
docs(design-system): carry patterns, not just tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,9 @@ that list onto the board.
 ## Desktop UI workflow
 
 - Read [`crates/tidebreak-desktop/ui/DESIGN.md`](crates/tidebreak-desktop/ui/DESIGN.md)
-  before visual work. It defines the palette, type scale, and status
-  vocabulary; `src/stylesContract.test.ts` enforces the mechanical rules, so
+  before visual work. It defines the palette, type scale, status vocabulary,
+  and the canonical patterns for settings, cards, approvals, empty states, and
+  icons; `src/stylesContract.test.ts` enforces the mechanical rules, so
   arbitrary font sizes and raw Tailwind palette classes fail CI.
 - When adding or changing a reusable visual component or a meaningful UI state,
   add or update its Storybook story under
@@ -52,6 +53,31 @@ that list onto the board.
 - Run `scripts/storybook.sh` while developing UI, and run
   `pnpm --dir crates/tidebreak-desktop/ui storybook:build` before publishing
   relevant UI changes.
+
+## Design-system approach
+
+Tidebreak treats the design system as the product's memory, not just a
+component library. Tokens and primitives are necessary but not sufficient;
+the system must also carry the recurring judgment calls that make a screen
+feel like Tidebreak.
+
+- Classify every surface before building it. The four surfaces — Orienting,
+  Index, Bulk edit, Resource detail — decide density, interaction model, and
+  how much chrome is allowed. A surface is not a route; a settings page can
+  host an Index rail next to a Resource detail panel.
+- Use the canonical pattern for the surface. `SettingsPanel` owns the page
+  shape. `ToolCardShell` owns the expandable tool row. `ApprovalCard` owns
+  consent. `ChatStatusChip` owns activity summary. Do not invent a second
+  answer to a question the system already settled.
+- Keep icons subordinate. Lucide icons are lightweight recognition markers,
+  not decorative advertising. Size them to the surrounding text, align them
+  to the primary text line, and never place them in a gray container on
+  high-density surfaces. The `EmptyMedia variant="icon"` container is the
+  only allowed exception, and only on low-density surfaces.
+- Show the canonical answer in Storybook. Real product examples beat prose
+  principles. The `Foundations/Patterns` story shows the right way to
+  compose settings, cards, approvals, and empty states so the next builder
+  copies a trusted reference instead of inventing a plausible one.
 
 ## Pointers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,10 @@ feel like Tidebreak.
 - Keep icons subordinate. Lucide icons are lightweight recognition markers,
   not decorative advertising. Size them to the surrounding text, align them
   to the primary text line, and never place them in a gray container on
-  high-density surfaces. The `EmptyMedia variant="icon"` container is the
-  only allowed exception, and only on low-density surfaces.
+  high-density surfaces. `EmptyMedia variant="icon"` draws no filled
+  container at all; it is how Inbox, Folders, Outputs, Plugins, Apps, and
+  the Code empty pages render an empty index, and it is the only icon
+  treatment allowed on an empty surface.
 - Show the canonical answer in Storybook. Real product examples beat prose
   principles. The `Foundations/Patterns` story shows the right way to
   compose settings, cards, approvals, and empty states so the next builder

--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -130,3 +130,105 @@ a `Badge` variant, and a swatch row in `Foundations/Palette`. A new scale
 rung is a `--text-*` pair in `styles.css` plus its row here and in
 `Foundations/Typography`. If a rule in this file and the code disagree, fix
 one of them in the same change.
+
+## Patterns
+
+A component library gives you parts. These rules carry the decisions that
+make a screen feel like Tidebreak. When you build a surface, classify it
+first, then reach for the pattern that owns that kind of work.
+
+### Surface classification
+
+Every region is one of four surfaces. The surface decides the density,
+the interaction model, and how much chrome is allowed.
+
+| Surface | Work | Interaction model | Chrome |
+| --- | --- | --- | --- |
+| **Orienting** | "What needs my attention right now?" | Scanning, launching | Spacious, expressive |
+| **Index** | Locating or comparing many records | Sorting, filtering, opening | Dense rows, compact controls |
+| **Bulk edit** | Mass-entering or mass-editing values | Inline editing, keyboard flow | Compact, stable row rhythm |
+| **Resource detail** | Reading and editing one record | Focused editing in a sheet | Single-column, bounded width |
+
+A surface is not a route. A settings page can host an Index surface
+(the rail) next to a Resource detail surface (the panel). A chat transcript
+is an Orienting surface that embeds Approval cards (Resource detail
+interactions).
+
+### Settings pages
+
+`SettingsPanel` owns the page shape: title, description, bounded column,
+and the rhythm between sections. Do not set a different page width or
+header layout. Do not use tabs or a card per setting.
+
+`SettingsSection` groups related fields. Put identity or account details
+first. Put destructive actions last, in a section named "Danger zone" or
+equivalent.
+
+`SettingsField` is a label and its control in one `label` element. The
+control sits below the label and spans the full width, because selects,
+text inputs, and editors read badly squeezed against the right edge.
+
+Save each field when its value changes. Do not add Save or Cancel buttons.
+Use a `Switch` for binary toggles and a `Select` for short lists. Use
+`ValidatedInput` (or an async validation pattern) for text that must be
+checked, such as a workspace URL.
+
+### Cards and rows
+
+`ToolCardShell` is the canonical expandable row for a tool call or agent
+step. The collapsed state is boxless: a transcript should read as a
+conversation with occasional notes about what ran, not as a stack of
+nested panels. Keep the icon small (`size-3.5`), align it with the primary
+text line, and keep the title on one line. Expand only while work is still
+happening; a settled card collapses to a single row.
+
+`ApprovalCard` is the canonical consent surface. It leads with a short
+question, shows the exact action in a muted preview block, and lists
+choices as numbered rows ordered narrowest grant first. Destructive or
+irreversible actions open a dialog instead; do not use an approval card
+for a delete confirmation.
+
+`ChatStatusChip` is the canonical activity summary for a conversation.
+It shows live work first, outputs otherwise, and collapses to a compact
+pill when a side panel is using the canvas. Do not build a second activity
+summary that duplicates outputs, folders, permissions, or agents.
+
+### Empty states and welcome surfaces
+
+`Empty` is the canonical null-state container. Use `EmptyMedia variant="icon"`
+only for low-density surfaces: welcome screens, onboarding, and first-run
+experiences. The icon sits in a soft gray container (`size-11`, `text-muted-foreground`)
+and matches the surrounding type scale.
+
+For high-density surfaces (menus, tables, repeated rows), do not place an
+icon in a circle, square, tint, or decorative container. Keep the icon
+small, outline-weight, and aligned to the primary text line. Render static
+attributes as plain text by default; reserve badge treatment for status
+indicators.
+
+`WelcomeState` and `CodeRepoEmptyState` are the canonical first-run
+surfaces. They use the icon-in-container pattern because they are low-density
+and orienting. Do not reuse that pattern for operational surfaces.
+
+### Icons
+
+Lucide icons are the only icon set. Use them as lightweight recognition
+markers, not as decorative advertising.
+
+- Size the icon to match the surrounding text: `size-3.5` for dense rows,
+  `size-4` for controls and labels, `size-7` only for low-density empty states.
+- Keep the icon close to the label it identifies.
+- Align the icon to the primary text line, not the vertical midpoint of a
+  title and metadata stack.
+- Use `text-muted-foreground` for icon ink in operational surfaces. Use the
+  `--icon-*` family only for identity (file types, repository swatches,
+  engine badges), never for status.
+- Do not place an icon in a colored or gray container on high-density
+  surfaces. The `EmptyMedia variant="icon"` container is the only allowed
+  exception, and only on low-density surfaces.
+
+### Destructive actions
+
+A destructive action opens a dialog. Require the user to type the name of
+the thing they are deleting before enabling the final button. Use the
+`destructive` button variant, which is the only chromatic button fill.

--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -180,7 +180,8 @@ step. The collapsed state is boxless: a transcript should read as a
 conversation with occasional notes about what ran, not as a stack of
 nested panels. Keep the icon small (`size-3.5`), align it with the primary
 text line, and keep the title on one line. Expand only while work is still
-happening; a settled card collapses to a single row.
+happening (`defaultExpanded` exists for that); a settled card collapses to
+a single row.
 
 `ApprovalCard` is the canonical consent surface. It leads with a short
 question, shows the exact action in a muted preview block, and lists
@@ -195,20 +196,23 @@ summary that duplicates outputs, folders, permissions, or agents.
 
 ### Empty states and welcome surfaces
 
-`Empty` is the canonical null-state container. Use `EmptyMedia variant="icon"`
-only for low-density surfaces: welcome screens, onboarding, and first-run
-experiences. The icon sits in a soft gray container (`size-11`, `text-muted-foreground`)
-and matches the surrounding type scale.
+`Empty` is the canonical null-state container, and `EmptyMedia variant="icon"`
+is how an empty index reads across the app: Inbox, Folders, Outputs, Plugins,
+Apps, and the Code pages all use it. The variant renders the icon at `size-11`
+in muted or identity ink (`text-muted-foreground`, `text-success`,
+`text-icon-violet`, and friends); it draws no filled container behind the
+icon. Give the empty state one useful next action when one exists.
 
-For high-density surfaces (menus, tables, repeated rows), do not place an
-icon in a circle, square, tint, or decorative container. Keep the icon
-small, outline-weight, and aligned to the primary text line. Render static
-attributes as plain text by default; reserve badge treatment for status
-indicators.
+Two first-run surfaces are their own compositions, not `Empty` variants:
+`WelcomeState` (logomark plus starter prompt cards) and `CodeRepoEmptyState`
+(the split layout with onboarding steps). `Modes/Null states` shows both. Do
+not rebuild them from `Empty`.
 
-`WelcomeState` and `CodeRepoEmptyState` are the canonical first-run
-surfaces. They use the icon-in-container pattern because they are low-density
-and orienting. Do not reuse that pattern for operational surfaces.
+In high-density operational surfaces (menus, tables, repeated rows), do not
+place an icon in a circle, square, tint, or decorative container. Keep the
+icon small, outline-weight, and aligned to the primary text line. Render
+static attributes as plain text by default; reserve badge treatment for
+status indicators.
 
 ### Icons
 
@@ -224,11 +228,13 @@ markers, not as decorative advertising.
   `--icon-*` family only for identity (file types, repository swatches,
   engine badges), never for status.
 - Do not place an icon in a colored or gray container on high-density
-  surfaces. The `EmptyMedia variant="icon"` container is the only allowed
-  exception, and only on low-density surfaces.
+  surfaces. `EmptyMedia variant="icon"` draws no container at all, and it is
+  the only icon treatment allowed on an empty surface.
 
 ### Destructive actions
 
-A destructive action opens a dialog. Require the user to type the name of
-the thing they are deleting before enabling the final button. Use the
-`destructive` button variant, which is the only chromatic button fill.
+A destructive action goes through `useConfirm`, which opens the shared
+`AlertDialog`: a title that asks the question, a description that names the
+consequence, a safe Cancel default, and the `destructive` action variant on
+the confirm button. `destructive` is the only chromatic button fill. Do not
+add type-to-confirm fields or a second confirmation shape.

--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -179,9 +179,9 @@ checked, such as a workspace URL.
 step. The collapsed state is boxless: a transcript should read as a
 conversation with occasional notes about what ran, not as a stack of
 nested panels. Keep the icon small (`size-3.5`), align it with the primary
-text line, and keep the title on one line. Expand only while work is still
-happening (`defaultExpanded` exists for that); a settled card collapses to
-a single row.
+text line, and keep the title on one line. Expand while work is still
+happening, and expand a failed card so the error is one click away; a
+settled, successful card collapses to a single row.
 
 `ApprovalCard` is the canonical consent surface. It leads with a short
 question, shows the exact action in a muted preview block, and lists

--- a/crates/tidebreak-desktop/ui/src/apps/AppsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/apps/AppsView.tsx
@@ -156,12 +156,10 @@ export function AppsView({
                       className="group flex w-full items-center gap-3 px-3 py-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                       onClick={() => onOpen(app.id)}
                     >
-                      <span className="grid size-9 shrink-0 place-items-center rounded-lg border border-border-subtle bg-muted/35">
-                        <LayoutGrid
-                          className="size-4 text-icon-blue"
-                          aria-hidden="true"
-                        />
-                      </span>
+                      <LayoutGrid
+                        className="size-4 shrink-0 text-icon-blue"
+                        aria-hidden="true"
+                      />
                       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                         <span className="truncate text-sm font-medium">
                           {app.name}

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -630,7 +630,7 @@ export function PrTab({
       {open && (
         <div className="border-border-subtle flex flex-col gap-2.5 rounded-xl border bg-background/45 p-2.5">
           <div className="flex min-w-0 items-start gap-2">
-            <span className="bg-muted text-muted-foreground mt-0.5 grid size-7 shrink-0 place-items-center rounded-lg">
+            <span className="mt-0.5 grid size-7 shrink-0 place-items-center text-muted-foreground">
               <GitMerge className="size-3.5" />
             </span>
             <div className="min-w-0 flex-1">

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -2355,7 +2355,7 @@ function SubagentContextBar({
       className="border-border-subtle bg-background/85 mx-auto mt-3 flex w-[calc(100%-2rem)] max-w-3xl items-center gap-2 rounded-lg border px-3 py-2 shadow-[0_1px_2px_color-mix(in_oklch,var(--foreground)_4%,transparent)]"
       data-testid="subagent-context-bar"
     >
-      <span className="grid size-7 shrink-0 place-items-center rounded-md bg-muted text-muted-foreground">
+      <span className="grid size-7 shrink-0 place-items-center text-muted-foreground">
         <Bot className="size-3.5" aria-hidden />
       </span>
       <div className="min-w-0 flex-1">

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -469,7 +469,7 @@ export function WorkspaceWorkflowControl({
             <div className="flex items-start gap-2.5 border-b border-border-subtle px-3 py-3">
               <span
                 className={cn(
-                  "mt-0.5 grid size-6 shrink-0 place-items-center rounded-md bg-muted/60",
+                  "mt-0.5 grid size-6 shrink-0 place-items-center",
                   STATUS_MARK[model.tone],
                 )}
               >

--- a/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
@@ -8,11 +8,11 @@ import {
   FolderOpen,
   Globe,
   Shield,
-  Sparkles,
 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ConfirmDialog";
 import {
   Empty,
   EmptyContent,
@@ -24,14 +24,58 @@ import {
 import { ToolCardShell } from "@/ToolCardShell";
 import { ApprovalCard } from "@/ApprovalCard";
 import { ChatStatusChip } from "@/ChatStatusChip";
-import {
-  SettingsPanel,
-  SettingsSection,
-  SettingsField,
-} from "@/settings/primitives";
+import { SettingsSection, SettingsField } from "@/settings/primitives";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { execPreview } from "./fixtures";
+
+function SettingsComposition() {
+  const { confirm, dialog } = useConfirm();
+  return (
+    <>
+      <SettingsSection
+        title="General"
+        description="Name and behavior for this workspace."
+      >
+        <SettingsField label="Workspace name">
+          <Input defaultValue="Acme Labs" />
+        </SettingsField>
+        <SettingsField
+          label="Automatic backups"
+          hint="Nightly snapshots of every project in this workspace."
+        >
+          <Switch defaultChecked />
+        </SettingsField>
+      </SettingsSection>
+      <SettingsSection title="Danger zone" description="Irreversible actions.">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium">Delete this workspace</p>
+            <p className="text-xs text-muted-foreground">
+              Permanently removes Acme Labs and all of its projects.
+            </p>
+          </div>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() =>
+              void confirm({
+                title: "Delete this workspace?",
+                description:
+                  "Tidebreak removes Acme Labs and all of its projects. This cannot be undone.",
+                confirmLabel: "Delete workspace",
+                destructive: true,
+              })
+            }
+          >
+            Delete workspace
+          </Button>
+        </div>
+      </SettingsSection>
+      {dialog}
+    </>
+  );
+}
 
 function PatternsShowcase() {
   return (
@@ -42,47 +86,16 @@ function PatternsShowcase() {
             Settings composition
           </h2>
           <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-            A settings page is a stack of sections on a bounded column. Each
-            section groups related fields. Each field is a label and its
-            control. The page saves on change; there are no Save or Cancel
-            buttons.
+            A settings page is a stack of sections on a bounded column that
+            SettingsPanel owns. Each section groups related fields. Each field
+            is a label and its control. The page saves on change; there are no
+            Save or Cancel buttons. Destructive actions go through the shared
+            confirm dialog.
           </p>
         </div>
-        <SettingsPanel
-          title="Workspace"
-          description="Identity and defaults for this workspace."
-        >
-          <SettingsSection
-            title="General"
-            description="Name and behavior for this workspace."
-          >
-            <SettingsField label="Workspace name">
-              <Input defaultValue="Acme Labs" />
-            </SettingsField>
-            <SettingsField
-              label="Automatic backups"
-              hint="Nightly snapshots of every project in this workspace."
-            >
-              <Switch defaultChecked />
-            </SettingsField>
-          </SettingsSection>
-          <SettingsSection
-            title="Danger zone"
-            description="Irreversible actions."
-          >
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <p className="text-sm font-medium">Delete this workspace</p>
-                <p className="text-xs text-muted-foreground">
-                  Permanently removes Acme Labs and all of its projects.
-                </p>
-              </div>
-              <Button variant="destructive" size="sm">
-                Delete workspace
-              </Button>
-            </div>
-          </SettingsSection>
-        </SettingsPanel>
+        <div className="max-w-2xl">
+          <SettingsComposition />
+        </div>
       </section>
 
       <section className="grid gap-4">
@@ -93,36 +106,65 @@ function PatternsShowcase() {
           <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
             The canonical expandable row for a tool call. Collapsed it is a
             single line with a small icon; expanded it shows the command,
-            output, and metadata. The transcript stays a conversation, not a
-            stack of panels.
+            output, and metadata. Expand only while work is still happening; a
+            settled card collapses to a single row.
           </p>
         </div>
-        <div className="max-w-prose">
-          <ToolCardShell
-            icon={<FileText className="size-3.5" aria-hidden="true" />}
-            title="pnpm test -- TaskPlanCard.dom.test.tsx"
-            label="Run the focused component tests"
-            badge={
-              <>
-                <Badge variant="outline">exec</Badge>
-                <Badge variant="success">Exit 0</Badge>
-              </>
-            }
-            trailing="1.2s"
-            defaultExpanded
-          >
-            <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
-              <pre className="whitespace-pre-wrap">
-                {`$ pnpm test -- TaskPlanCard.dom.test.tsx
+        <div className="grid max-w-prose gap-3">
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">
+              Running (expanded on mount)
+            </p>
+            <ToolCardShell
+              icon={<FileText className="size-3.5" aria-hidden="true" />}
+              title="pnpm test -- TaskPlanCard.dom.test.tsx"
+              label="Run the focused component tests"
+              badge={
+                <>
+                  <Badge variant="outline">exec</Badge>
+                  <Badge variant="info">Running</Badge>
+                </>
+              }
+              defaultExpanded
+            >
+              <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
+                <pre className="whitespace-pre-wrap">
+                  {`Running the focused component tests…
+
+$ pnpm test -- TaskPlanCard.dom.test.tsx`}
+                </pre>
+              </div>
+            </ToolCardShell>
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">
+              Settled (collapsed)
+            </p>
+            <ToolCardShell
+              icon={<FileText className="size-3.5" aria-hidden="true" />}
+              title="pnpm test -- TaskPlanCard.dom.test.tsx"
+              label="Run the focused component tests"
+              badge={
+                <>
+                  <Badge variant="outline">exec</Badge>
+                  <Badge variant="success">Exit 0</Badge>
+                </>
+              }
+              trailing="1.2s"
+            >
+              <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
+                <pre className="whitespace-pre-wrap">
+                  {`$ pnpm test -- TaskPlanCard.dom.test.tsx
 
  ✓ TaskPlanCard renders the active step (12 ms)
  ✓ TaskPlanCard collapses settled steps (8 ms)
 
  Test Files  1 passed (1)
       Tests  2 passed (2)`}
-              </pre>
-            </div>
-          </ToolCardShell>
+                </pre>
+              </div>
+            </ToolCardShell>
+          </div>
         </div>
       </section>
 
@@ -225,28 +267,30 @@ function PatternsShowcase() {
             Empty states
           </h2>
           <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-            Low-density surfaces use an icon in a soft gray container.
-            High-density surfaces keep icons small and unboxed.
+            An empty index renders an icon in muted or identity ink at size-11
+            with no filled container behind it. The same variant is how Inbox,
+            Folders, Outputs, Plugins, Apps, and the Code pages read when they
+            have nothing to list. In high-density operational surfaces, icons
+            stay small and unboxed.
           </p>
         </div>
         <div className="grid gap-6 md:grid-cols-2">
           <div className="grid gap-2">
             <p className="text-xs font-medium text-muted-foreground">
-              Low density (welcome, onboarding)
+              Empty index
             </p>
             <Empty className="min-h-48 bg-background ring-1 ring-foreground/10">
               <EmptyHeader>
-                <EmptyMedia variant="icon">
-                  <Sparkles aria-hidden="true" />
+                <EmptyMedia variant="icon" className="text-icon-amber">
+                  <FolderOpen aria-hidden="true" />
                 </EmptyMedia>
-                <EmptyTitle>No review notes</EmptyTitle>
+                <EmptyTitle>No folders connected</EmptyTitle>
                 <EmptyDescription>
-                  Notes appear here when an agent finds a decision that needs
-                  your attention.
+                  Connect a folder so the agent can read and write files in it.
                 </EmptyDescription>
               </EmptyHeader>
               <EmptyContent>
-                <Button variant="outline">Review recent runs</Button>
+                <Button variant="outline">Connect a folder</Button>
               </EmptyContent>
             </Empty>
           </div>

--- a/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
@@ -233,6 +233,7 @@ $ pnpm test -- TaskPlanCard.dom.test.tsx`}
                   last_error_code: null,
                   activity: { kind: "exec", status: "running" },
                   submitted_outputs: [],
+                  terminal_text: null,
                   created_at: "2026-08-24T13:00:00Z",
                   updated_at: "2026-08-24T13:00:00Z",
                 },

--- a/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
@@ -1,0 +1,317 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import {
+  Bot,
+  CircleAlert,
+  CircleCheck,
+  FileText,
+  FolderOpen,
+  Globe,
+  Shield,
+  Sparkles,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { ToolCardShell } from "@/ToolCardShell";
+import { ApprovalCard } from "@/ApprovalCard";
+import { ChatStatusChip } from "@/ChatStatusChip";
+import { SettingsPanel, SettingsSection, SettingsField } from "@/settings/primitives";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { execPreview } from "./fixtures";
+
+function PatternsShowcase() {
+  return (
+    <div className="mx-auto grid w-full max-w-5xl gap-12 p-8">
+      <section className="grid gap-4">
+        <div className="max-w-xl">
+          <h2 className="text-base font-semibold tracking-tight">
+            Settings composition
+          </h2>
+          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+            A settings page is a stack of sections on a bounded column. Each
+            section groups related fields. Each field is a label and its
+            control. The page saves on change; there are no Save or Cancel
+            buttons.
+          </p>
+        </div>
+        <SettingsPanel
+          title="Workspace"
+          description="Identity and defaults for this workspace."
+        >
+          <SettingsSection
+            title="General"
+            description="Name and behavior for this workspace."
+          >
+            <SettingsField label="Workspace name">
+              <Input defaultValue="Acme Labs" />
+            </SettingsField>
+            <SettingsField
+              label="Automatic backups"
+              hint="Nightly snapshots of every project in this workspace."
+            >
+              <Switch defaultChecked />
+            </SettingsField>
+          </SettingsSection>
+          <SettingsSection
+            title="Danger zone"
+            description="Irreversible actions."
+          >
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Delete this workspace</p>
+                <p className="text-xs text-muted-foreground">
+                  Permanently removes Acme Labs and all of its projects.
+                </p>
+              </div>
+              <Button variant="destructive" size="sm">
+                Delete workspace
+              </Button>
+            </div>
+          </SettingsSection>
+        </SettingsPanel>
+      </section>
+
+      <section className="grid gap-4">
+        <div className="max-w-xl">
+          <h2 className="text-base font-semibold tracking-tight">
+            Tool call row
+          </h2>
+          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+            The canonical expandable row for a tool call. Collapsed it is a
+            single line with a small icon; expanded it shows the command,
+            output, and metadata. The transcript stays a conversation, not a
+            stack of panels.
+          </p>
+        </div>
+        <div className="max-w-prose">
+          <ToolCardShell
+            icon={<FileText className="size-3.5" aria-hidden="true" />}
+            title="pnpm test -- TaskPlanCard.dom.test.tsx"
+            label="Run the focused component tests"
+            badge={
+              <>
+                <Badge variant="outline">exec</Badge>
+                <Badge variant="success">Exit 0</Badge>
+              </>
+            }
+            trailing="1.2s"
+            defaultExpanded
+          >
+            <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
+              <pre className="whitespace-pre-wrap">
+                {`$ pnpm test -- TaskPlanCard.dom.test.tsx
+
+ ✓ TaskPlanCard renders the active step (12 ms)
+ ✓ TaskPlanCard collapses settled steps (8 ms)
+
+ Test Files  1 passed (1)
+      Tests  2 passed (2)`}
+              </pre>
+            </div>
+          </ToolCardShell>
+        </div>
+      </section>
+
+      <section className="grid gap-4">
+        <div className="max-w-xl">
+          <h2 className="text-base font-semibold tracking-tight">
+            Approval card
+          </h2>
+          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+            The canonical consent surface. It leads with a short question,
+            shows the exact action in a muted preview block, and lists
+            choices as numbered rows ordered narrowest grant first.
+          </p>
+        </div>
+        <div className="max-w-2xl">
+          <ApprovalCard
+            callId="pattern-storybook"
+            summary="This command can access the network and the staged files listed below."
+            preview={execPreview}
+            canApprove
+            canRemember
+            grantRungs={["exact_action", "whole_tool"]}
+            deciding={false}
+            onDecide={fn()}
+          />
+        </div>
+      </section>
+
+      <section className="grid gap-4">
+        <div className="max-w-xl">
+          <h2 className="text-base font-semibold tracking-tight">
+            Activity summary
+          </h2>
+          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+            The conversation header shows live work first, outputs otherwise.
+            The compact pill collapses when a side panel needs the canvas.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-start gap-6">
+          <div className="grid gap-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              Expanded card
+            </p>
+            <ChatStatusChip
+              outputCount={3}
+              folders={[]}
+              runs={[
+                {
+                  id: "run-1",
+                  parent_id: "parent",
+                  spawn_call_id: "spawn-1",
+                  tier: "background",
+                  execution_location: "in_process",
+                  code_execution_provider: "local",
+                  status: "running",
+                  model_steps: 3,
+                  usage: {
+                    input_tokens: 1000,
+                    output_tokens: 200,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                  },
+                  task: "Audit the conversation flow",
+                  started_at: "2026-08-24T13:00:00Z",
+                  finished_at: null,
+                  last_error_code: null,
+                  activity: { kind: "exec", status: "running" },
+                  submitted_outputs: [],
+                  created_at: "2026-08-24T13:00:00Z",
+                  updated_at: "2026-08-24T13:00:00Z",
+                },
+              ]}
+              onOpenOutputs={fn()}
+              onOpenFolders={fn()}
+              onOpenPermissions={fn()}
+              onOpenAgents={fn()}
+            />
+          </div>
+          <div className="grid gap-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              Compact pill
+            </p>
+            <ChatStatusChip
+              compact
+              outputCount={0}
+              folders={[]}
+              runs={[]}
+              onOpenOutputs={fn()}
+              onOpenFolders={fn()}
+              onOpenPermissions={fn()}
+              onOpenAgents={fn()}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4">
+        <div className="max-w-xl">
+          <h2 className="text-base font-semibold tracking-tight">
+            Empty states
+          </h2>
+          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+            Low-density surfaces use an icon in a soft gray container.
+            High-density surfaces keep icons small and unboxed.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          <div className="grid gap-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              Low density (welcome, onboarding)
+            </p>
+            <Empty className="min-h-48 bg-background ring-1 ring-foreground/10">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Sparkles aria-hidden="true" />
+                </EmptyMedia>
+                <EmptyTitle>No review notes</EmptyTitle>
+                <EmptyDescription>
+                  Notes appear here when an agent finds a decision that needs
+                  your attention.
+                </EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button variant="outline">Review recent runs</Button>
+              </EmptyContent>
+            </Empty>
+          </div>
+          <div className="grid gap-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              High density (menus, tables, rows)
+            </p>
+            <div className="rounded-lg border border-border bg-background p-2">
+              <div className="flex flex-col gap-0.5">
+                {[
+                  { icon: FileText, label: "Read a file", time: "2m ago" },
+                  { icon: Globe, label: "Search the web", time: "5m ago" },
+                  { icon: Shield, label: "Request access", time: "12m ago" },
+                ].map(({ icon: Icon, label, time }) => (
+                  <button
+                    key={label}
+                    type="button"
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50"
+                  >
+                    <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <span className="flex-1">{label}</span>
+                    <span className="text-xs text-muted-foreground">{time}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4">
+        <div className="max-w-xl">
+          <h2 className="text-base font-semibold tracking-tight">
+            Status vocabulary
+          </h2>
+          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+            Six tones cover every outcome and state. Use the Badge variants;
+            never pick raw palette classes.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="success">
+            <CircleCheck className="size-3" aria-hidden="true" /> Ready
+          </Badge>
+          <Badge variant="warning">
+            <CircleAlert className="size-3" aria-hidden="true" /> Waiting
+          </Badge>
+          <Badge variant="critical">
+            <CircleAlert className="size-3" aria-hidden="true" /> Failed
+          </Badge>
+          <Badge variant="info">
+            <Bot className="size-3" aria-hidden="true" /> Running
+          </Badge>
+          <Badge variant="merged">Merged</Badge>
+          <Badge variant="live">Working</Badge>
+          <Badge variant="outline">Neutral</Badge>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+const meta = {
+  title: "Foundations/Patterns",
+  component: PatternsShowcase,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof PatternsShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CanonicalPatterns: Story = {};

--- a/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
@@ -24,7 +24,11 @@ import {
 import { ToolCardShell } from "@/ToolCardShell";
 import { ApprovalCard } from "@/ApprovalCard";
 import { ChatStatusChip } from "@/ChatStatusChip";
-import { SettingsPanel, SettingsSection, SettingsField } from "@/settings/primitives";
+import {
+  SettingsPanel,
+  SettingsSection,
+  SettingsField,
+} from "@/settings/primitives";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { execPreview } from "./fixtures";
@@ -128,9 +132,9 @@ function PatternsShowcase() {
             Approval card
           </h2>
           <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-            The canonical consent surface. It leads with a short question,
-            shows the exact action in a muted preview block, and lists
-            choices as numbered rows ordered narrowest grant first.
+            The canonical consent surface. It leads with a short question, shows
+            the exact action in a muted preview block, and lists choices as
+            numbered rows ordered narrowest grant first.
           </p>
         </div>
         <div className="max-w-2xl">
@@ -262,9 +266,14 @@ function PatternsShowcase() {
                     type="button"
                     className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50"
                   >
-                    <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <Icon
+                      className="size-3.5 shrink-0 text-muted-foreground"
+                      aria-hidden="true"
+                    />
                     <span className="flex-1">{label}</span>
-                    <span className="text-xs text-muted-foreground">{time}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {time}
+                    </span>
                   </button>
                 ))}
               </div>


### PR DESCRIPTION
The design system now carries the recurring judgment calls, not just the tokens.

- `crates/tidebreak-desktop/ui/DESIGN.md` gains a Patterns section that classifies surfaces (Orienting, Index, Bulk edit, Resource detail) and names the canonical component for each kind of work: `SettingsPanel`, `ToolCardShell`, `ApprovalCard`, `ChatStatusChip`, and `Empty`.
- Rules for settings pages, tool cards, approvals, empty states, icons, and destructive actions are written down so the next builder does not re-decide them.
- A new `Foundations/Patterns` Storybook page shows the canonical compositions side by side, giving agents and humans a concrete reference to copy.
- `AGENTS.md` and `CLAUDE.md` both point to the pattern guidance.

Checks: `stylesContract.test.ts` passes; `storybook:build` succeeds with the new story included.