### PR TITLE
fix(code): preserve session context across restarts

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -398,6 +398,36 @@ pub async fn set_session_subagents(
     Ok(result.rows_affected == 1)
 }
 
+/// Record the engine-native resume ref once a running turn proves it is safe.
+///
+/// The event sink learns this value while the turn is still running. A
+/// targeted, epoch-fenced write makes it survive a hard restart without
+/// letting an outgoing worker restore a stale ref after a reap or relaunch.
+pub async fn set_session_harness_resume_ref(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+    resume_ref: &str,
+) -> Result<bool> {
+    let result = entities::code_session::Entity::update_many()
+        .col_expr(
+            entities::code_session::Column::HarnessResumeRef,
+            sea_orm::sea_query::Expr::value(Some(resume_ref.to_owned())),
+        )
+        .filter(entities::code_session::Column::Id.eq(session_id.0))
+        .filter(entities::code_session::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session::Column::SpawnEpoch.eq(spawn_epoch))
+        .filter(
+            entities::code_session::Column::Lifecycle
+                .eq(CodeSessionLifecycle::Running.as_str().to_owned()),
+        )
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
 pub(super) fn session_from_row(row: entities::code_session::Model) -> Result<CodeSession> {
     let harness_kind = HarnessKind::from_str(&row.harness_kind).ok_or_else(|| {
         AgentError::Store(format!(

--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -209,9 +209,9 @@ pub async fn list_sessions_by_lifecycle_all_owners(
 }
 
 /// Persist mutable session fields. `id`, `workspace_id`, `created_at`,
-/// `attention`, and `subagents` stay as stored. Attention and subagents have
-/// targeted writes so a full-row save from a stale worker cannot clobber a
-/// concurrent structured update.
+/// `attention`, `subagents`, and a missing resume ref stay as stored. Attention,
+/// subagents, and resume-ref clearing have targeted writes so a full-row save
+/// from a stale worker cannot clobber a concurrent structured update.
 ///
 /// `spawn_epoch` must be non-decreasing, and `Ended` is terminal: a caller
 /// that is not `Ended` cannot overwrite that lifecycle. Returns `false` when
@@ -227,7 +227,7 @@ pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool
                 .ne(CodeSessionLifecycle::Ended.as_str().to_owned()),
         );
     }
-    let result = entities::code_session::Entity::update_many()
+    let mut update = entities::code_session::Entity::update_many()
         .col_expr(
             entities::code_session::Column::HarnessKind,
             sea_orm::sea_query::Expr::value(session.harness_kind.as_str().to_owned()),
@@ -235,10 +235,6 @@ pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool
         .col_expr(
             entities::code_session::Column::HarnessVersion,
             sea_orm::sea_query::Expr::value(session.harness_version.clone()),
-        )
-        .col_expr(
-            entities::code_session::Column::HarnessResumeRef,
-            sea_orm::sea_query::Expr::value(session.harness_resume_ref.clone()),
         )
         .col_expr(
             entities::code_session::Column::PermissionMode,
@@ -282,7 +278,14 @@ pub async fn save_session(store: &DbStore, session: &CodeSession) -> Result<bool
         .col_expr(
             entities::code_session::Column::UnrecognizedEventCount,
             sea_orm::sea_query::Expr::value(session.unrecognized_event_count),
-        )
+        );
+    if let Some(resume_ref) = &session.harness_resume_ref {
+        update = update.col_expr(
+            entities::code_session::Column::HarnessResumeRef,
+            sea_orm::sea_query::Expr::value(Some(resume_ref.clone())),
+        );
+    }
+    let result = update
         .filter(predicate)
         .exec(&store.conn)
         .await
@@ -421,6 +424,34 @@ pub async fn set_session_harness_resume_ref(
         .filter(
             entities::code_session::Column::Lifecycle
                 .eq(CodeSessionLifecycle::Running.as_str().to_owned()),
+        )
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
+/// Clear a resume ref that the engine has explicitly rejected.
+///
+/// A missing ref on [`save_session`] means that the caller holds a stale copy,
+/// so only this epoch-fenced write may turn a stored ref back into `NULL`.
+pub async fn clear_session_harness_resume_ref(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: CodeSessionId,
+    spawn_epoch: i64,
+) -> Result<bool> {
+    let result = entities::code_session::Entity::update_many()
+        .col_expr(
+            entities::code_session::Column::HarnessResumeRef,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .filter(entities::code_session::Column::Id.eq(session_id.0))
+        .filter(entities::code_session::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_session::Column::SpawnEpoch.eq(spawn_epoch))
+        .filter(
+            entities::code_session::Column::Lifecycle
+                .ne(CodeSessionLifecycle::Ended.as_str().to_owned()),
         )
         .exec(&store.conn)
         .await

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -7,12 +7,13 @@ use crate::code::{
     CodeWorkspaceStatus, HarnessKind, RepoId, WorkspaceId,
 };
 use crate::db::code::{
-    append_event, bump_spawn_epoch, delete_queued_turn, delete_session_queued_turns,
-    enqueue_queued_turn, get_approval, get_repo, get_repo_by_root_path, get_session, get_turn,
-    get_workspace, insert_approval, insert_repo, insert_session, insert_turn, insert_workspace,
-    list_approvals, list_events, list_queued_turns, list_repos, list_sessions, list_turn_metrics,
-    list_turns, mark_repo_removed, promote_queued_turn, queue_paused, queued_turn_head,
-    replace_session_attention, save_session, save_turn, set_queue_paused, set_session_subagents,
+    append_event, bump_spawn_epoch, clear_session_harness_resume_ref, delete_queued_turn,
+    delete_session_queued_turns, enqueue_queued_turn, get_approval, get_repo,
+    get_repo_by_root_path, get_session, get_turn, get_workspace, insert_approval, insert_repo,
+    insert_session, insert_turn, insert_workspace, list_approvals, list_events, list_queued_turns,
+    list_repos, list_sessions, list_turn_metrics, list_turns, mark_repo_removed,
+    promote_queued_turn, queue_paused, queued_turn_head, replace_session_attention, save_session,
+    save_turn, set_queue_paused, set_session_harness_resume_ref, set_session_subagents,
     set_turn_narrative, set_workspace_title_if, update_queued_turn, CodeJournalError,
     MAX_REPLAY_EVENTS,
 };
@@ -268,6 +269,52 @@ async fn session_subagents_round_trip_through_the_targeted_write() {
     )
     .await
     .unwrap());
+}
+
+/// A worker can learn its resume ref after it snapshots the session row. A
+/// later pid save from that stale copy must preserve the targeted write, while
+/// an engine rejection still needs an explicit way to clear the ref.
+#[tokio::test]
+async fn stale_session_saves_preserve_resume_refs_until_an_explicit_clear() {
+    let (_dir, store, session_id, _turn) = seeded_session().await;
+    let owner = OwnerId::local();
+    let mut stale = get_session(&store, &owner, session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    stale.lifecycle = CodeSessionLifecycle::Running;
+    assert!(save_session(&store, &stale).await.unwrap());
+    assert!(
+        set_session_harness_resume_ref(&store, &owner, session_id, 0, "session-ref")
+            .await
+            .unwrap()
+    );
+
+    stale.child_pid = Some(4242);
+    assert!(save_session(&store, &stale).await.unwrap());
+    assert_eq!(
+        get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .harness_resume_ref
+            .as_deref(),
+        Some("session-ref")
+    );
+
+    assert!(
+        clear_session_harness_resume_ref(&store, &owner, session_id, 0)
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .harness_resume_ref,
+        None
+    );
 }
 
 /// A full session save may carry attention read before a trigger notification.

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -10,8 +10,9 @@ use std::io::ErrorKind;
 
 use chrono::Utc;
 use tidebreak_core::db::code::{
-    append_event, get_open_turn, list_sessions_by_lifecycle_all_owners, replace_session_attention,
-    save_session, save_turn, set_session_subagents,
+    append_event, clear_session_harness_resume_ref, get_open_turn,
+    list_sessions_by_lifecycle_all_owners, replace_session_attention, save_session, save_turn,
+    set_session_subagents,
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeEvent, CodeSession, CodeSessionLifecycle,
@@ -73,6 +74,14 @@ pub(crate) async fn fence_session(
 ) -> Result<(), tidebreak_core::AgentError> {
     if matches!(reason, FenceReason::ResumeLost { .. }) {
         session.harness_resume_ref = None;
+        if !clear_session_harness_resume_ref(store, &session.owner, session.id, session.spawn_epoch)
+            .await?
+        {
+            return Err(tidebreak_core::AgentError::Store(format!(
+                "code session {} disappeared while clearing its rejected resume ref",
+                session.id
+            )));
+        }
     }
     session.lifecycle = CodeSessionLifecycle::Fenced;
     settle_running_subagents(&mut session.subagents, CodeSubagentStatus::Failed);
@@ -595,6 +604,8 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
+        session.harness_resume_ref = Some("rejected-ref".into());
+        assert!(save_session(&store, &session).await.unwrap());
         let bus = crate::code::bus::CodeEventBus::default();
         fence_session(
             &store,
@@ -606,6 +617,14 @@ mod tests {
         )
         .await
         .unwrap();
+        assert_eq!(
+            get_session(&store, &tidebreak_core::OwnerId::local(), session_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .harness_resume_ref,
+            None
+        );
         assert_subagent_failed(&store, session_id).await;
     }
 

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -198,6 +198,12 @@ pub(crate) struct QueuedFollowUp {
     pub queued_row: Option<Box<CodeQueuedTurn>>,
 }
 
+#[derive(Default)]
+struct ResumeRefState {
+    pending: Option<String>,
+    persisted: Option<String>,
+}
+
 pub(crate) struct LiveSink {
     db: Arc<DbStore>,
     bus: Arc<CodeEventBus>,
@@ -207,18 +213,14 @@ pub(crate) struct LiveSink {
     session_id: CodeSessionId,
     spawn_epoch: i64,
     turn_id: std::sync::Mutex<Option<CodeTurnId>>,
-    /// Resume ref reported during engine startup but not yet proven durable.
+    /// Resume ref reported during engine startup and its durable promotion.
     ///
     /// Codex creates a thread before it writes that thread to disk. The first
     /// turn event promotes this candidate into the session row, so a restart
-    /// keeps real context without trying to resume an unused thread.
-    pending_resume_ref: std::sync::Mutex<Option<String>>,
-    /// Resume ref already written to the session row by this sink.
-    ///
-    /// The worker owns a separate `CodeSession` value. Before that value makes
-    /// a full-row save, it adopts this ref so a child-pid update cannot restore
-    /// the stale value that preceded the turn.
-    persisted_resume_ref: std::sync::Mutex<Option<String>>,
+    /// keeps real context without trying to resume an unused thread. The same
+    /// lock covers mid-turn full-row saves, so no save can land between the
+    /// targeted write and the worker adopting its result.
+    resume_ref: tokio::sync::Mutex<ResumeRefState>,
     /// Where tests point `gh`; `None` outside tests. Snapshotted at attach so
     /// the post-turn fact detector confirms against the same binary every
     /// other gh call in the process resolves (decision 62).
@@ -251,25 +253,33 @@ impl LiveSink {
         total.saturating_sub(flushed)
     }
 
+    async fn note_resume_ref(&self, resume_ref: String) {
+        self.resume_ref.lock().await.pending = Some(resume_ref);
+    }
+
     /// Copy the resume ref this sink persisted onto the worker's session copy.
-    fn adopt_persisted_resume_ref(&self, session: &mut CodeSession) {
-        if let Some(resume_ref) = self
-            .persisted_resume_ref
-            .lock()
-            .expect("code sink persisted resume ref")
-            .clone()
-        {
+    async fn adopt_persisted_resume_ref(&self, session: &mut CodeSession) {
+        if let Some(resume_ref) = self.resume_ref.lock().await.persisted.clone() {
             session.harness_resume_ref = Some(resume_ref);
         }
     }
 
+    /// Persist a full session row without racing the targeted resume-ref write.
+    async fn save_session_with_resume_ref(
+        &self,
+        session: &mut CodeSession,
+    ) -> Result<bool, tidebreak_core::AgentError> {
+        let resume_ref = self.resume_ref.lock().await;
+        if let Some(persisted) = resume_ref.persisted.clone() {
+            session.harness_resume_ref = Some(persisted);
+        }
+        save_session(&self.db, session).await
+    }
+
     /// Persist a reported resume ref after the engine proves a turn started.
     async fn persist_pending_resume_ref(&self) {
-        let candidate = self
-            .pending_resume_ref
-            .lock()
-            .expect("code sink resume ref")
-            .clone();
+        let mut resume_ref = self.resume_ref.lock().await;
+        let candidate = resume_ref.pending.clone();
         let Some(candidate) = candidate else {
             return;
         };
@@ -283,25 +293,15 @@ impl LiveSink {
         .await
         {
             Ok(true) => {
-                *self
-                    .persisted_resume_ref
-                    .lock()
-                    .expect("code sink persisted resume ref") = Some(candidate.clone());
-                let mut pending = self
-                    .pending_resume_ref
-                    .lock()
-                    .expect("code sink resume ref");
-                if pending.as_deref() == Some(candidate.as_str()) {
-                    *pending = None;
+                resume_ref.persisted = Some(candidate.clone());
+                if resume_ref.pending.as_deref() == Some(candidate.as_str()) {
+                    resume_ref.pending = None;
                 }
             }
             Ok(false) => {
                 // This worker no longer owns a running session. Do not retry
                 // the stale write on every later event.
-                *self
-                    .pending_resume_ref
-                    .lock()
-                    .expect("code sink resume ref") = None;
+                resume_ref.pending = None;
             }
             Err(error) => warn!(
                 session = %self.session_id,
@@ -470,10 +470,7 @@ impl HarnessEventSink for LiveSink {
             ..
         } = &event
         {
-            *self
-                .pending_resume_ref
-                .lock()
-                .expect("code sink resume ref") = Some(resume_ref.clone());
+            self.note_resume_ref(resume_ref.clone()).await;
         }
         if matches!(
             &event,
@@ -1357,8 +1354,7 @@ async fn drive_turn_inner(
             pid = next_child_pid(pid_changes.as_mut()) => {
                 if session.child_pid != pid {
                     session.child_pid = pid;
-                    sink.adopt_persisted_resume_ref(session);
-                    let _ = save_session(db, session).await;
+                    let _ = sink.save_session_with_resume_ref(session).await;
                 }
             }
         }
@@ -1391,7 +1387,7 @@ async fn drive_turn_inner(
         None
     };
 
-    sink.adopt_persisted_resume_ref(session);
+    sink.adopt_persisted_resume_ref(session).await;
     if let Some(pid) = engine.child_pid() {
         session.child_pid = Some(pid);
     } else {
@@ -1904,8 +1900,7 @@ pub(crate) fn sink_for(
         session_id,
         spawn_epoch,
         turn_id: std::sync::Mutex::new(turn_id),
-        pending_resume_ref: std::sync::Mutex::new(None),
-        persisted_resume_ref: std::sync::Mutex::new(None),
+        resume_ref: tokio::sync::Mutex::new(ResumeRefState::default()),
         gh_search_path,
         flushed_unrecognized: AtomicU64::new(0),
         subagents: std::sync::Mutex::new(subagents),
@@ -2532,8 +2527,10 @@ mod tests {
         // the real worker path and prove that its stale session copy keeps the
         // ref instead of replacing it with NULL during the full-row save.
         worker_session.child_pid = Some(4242);
-        sink.adopt_persisted_resume_ref(&mut worker_session);
-        assert!(save_session(&store, &worker_session).await.unwrap());
+        assert!(sink
+            .save_session_with_resume_ref(&mut worker_session)
+            .await
+            .unwrap());
         assert_eq!(
             get_session(&store, &owner, session_id)
                 .await

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -213,6 +213,12 @@ pub(crate) struct LiveSink {
     /// turn event promotes this candidate into the session row, so a restart
     /// keeps real context without trying to resume an unused thread.
     pending_resume_ref: std::sync::Mutex<Option<String>>,
+    /// Resume ref already written to the session row by this sink.
+    ///
+    /// The worker owns a separate `CodeSession` value. Before that value makes
+    /// a full-row save, it adopts this ref so a child-pid update cannot restore
+    /// the stale value that preceded the turn.
+    persisted_resume_ref: std::sync::Mutex<Option<String>>,
     /// Where tests point `gh`; `None` outside tests. Snapshotted at attach so
     /// the post-turn fact detector confirms against the same binary every
     /// other gh call in the process resolves (decision 62).
@@ -245,6 +251,18 @@ impl LiveSink {
         total.saturating_sub(flushed)
     }
 
+    /// Copy the resume ref this sink persisted onto the worker's session copy.
+    fn adopt_persisted_resume_ref(&self, session: &mut CodeSession) {
+        if let Some(resume_ref) = self
+            .persisted_resume_ref
+            .lock()
+            .expect("code sink persisted resume ref")
+            .clone()
+        {
+            session.harness_resume_ref = Some(resume_ref);
+        }
+    }
+
     /// Persist a reported resume ref after the engine proves a turn started.
     async fn persist_pending_resume_ref(&self) {
         let candidate = self
@@ -265,6 +283,10 @@ impl LiveSink {
         .await
         {
             Ok(true) => {
+                *self
+                    .persisted_resume_ref
+                    .lock()
+                    .expect("code sink persisted resume ref") = Some(candidate.clone());
                 let mut pending = self
                     .pending_resume_ref
                     .lock()
@@ -1335,6 +1357,7 @@ async fn drive_turn_inner(
             pid = next_child_pid(pid_changes.as_mut()) => {
                 if session.child_pid != pid {
                     session.child_pid = pid;
+                    sink.adopt_persisted_resume_ref(session);
                     let _ = save_session(db, session).await;
                 }
             }
@@ -1368,6 +1391,7 @@ async fn drive_turn_inner(
         None
     };
 
+    sink.adopt_persisted_resume_ref(session);
     if let Some(pid) = engine.child_pid() {
         session.child_pid = Some(pid);
     } else {
@@ -1881,6 +1905,7 @@ pub(crate) fn sink_for(
         spawn_epoch,
         turn_id: std::sync::Mutex::new(turn_id),
         pending_resume_ref: std::sync::Mutex::new(None),
+        persisted_resume_ref: std::sync::Mutex::new(None),
         gh_search_path,
         flushed_unrecognized: AtomicU64::new(0),
         subagents: std::sync::Mutex::new(subagents),
@@ -2486,6 +2511,11 @@ mod tests {
     async fn assistant_activity_persists_resume_refs_for_harnesses_without_turn_started() {
         let (_directory, store, sink, session_id) = seeded_sink().await;
         let owner = OwnerId::local();
+        let mut worker_session = get_session(&store, &owner, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(worker_session.harness_resume_ref, None);
 
         sink.emit(HarnessEvent::SessionStarted {
             harness_kind: HarnessKind::ClaudeCode,
@@ -2498,6 +2528,12 @@ mod tests {
         })
         .await;
 
+        // A child pid may arrive after the sink writes the resume ref. Mirror
+        // the real worker path and prove that its stale session copy keeps the
+        // ref instead of replacing it with NULL during the full-row save.
+        worker_session.child_pid = Some(4242);
+        sink.adopt_persisted_resume_ref(&mut worker_session);
+        assert!(save_session(&store, &worker_session).await.unwrap());
         assert_eq!(
             get_session(&store, &owner, session_id)
                 .await

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -27,7 +27,8 @@ use tidebreak_core::db::code::{
     accept_trigger_turn_delivery, append_event, bump_spawn_epoch, delete_queued_turn,
     get_open_turn, get_session, get_session_all_owners, insert_approval, insert_turn,
     next_turn_ordinal, promote_queued_turn, queue_paused, queued_turn_head, save_session,
-    save_turn, set_queue_paused, set_session_subagents, CodeJournalError,
+    save_turn, set_queue_paused, set_session_harness_resume_ref, set_session_subagents,
+    CodeJournalError,
 };
 use tidebreak_core::{
     bound_subagents, Attention, AttentionSource, BlobStore, BoundedError, CodeApproval,
@@ -206,6 +207,12 @@ pub(crate) struct LiveSink {
     session_id: CodeSessionId,
     spawn_epoch: i64,
     turn_id: std::sync::Mutex<Option<CodeTurnId>>,
+    /// Resume ref reported during engine startup but not yet proven durable.
+    ///
+    /// Codex creates a thread before it writes that thread to disk. The first
+    /// turn event promotes this candidate into the session row, so a restart
+    /// keeps real context without trying to resume an unused thread.
+    pending_resume_ref: std::sync::Mutex<Option<String>>,
     /// Where tests point `gh`; `None` outside tests. Snapshotted at attach so
     /// the post-turn fact detector confirms against the same binary every
     /// other gh call in the process resolves (decision 62).
@@ -236,6 +243,50 @@ impl LiveSink {
     fn take_unrecognized_delta(&self, total: u64) -> u64 {
         let flushed = self.flushed_unrecognized.swap(total, Ordering::SeqCst);
         total.saturating_sub(flushed)
+    }
+
+    /// Persist a reported resume ref after the engine proves a turn started.
+    async fn persist_pending_resume_ref(&self) {
+        let candidate = self
+            .pending_resume_ref
+            .lock()
+            .expect("code sink resume ref")
+            .clone();
+        let Some(candidate) = candidate else {
+            return;
+        };
+        match set_session_harness_resume_ref(
+            &self.db,
+            &self.owner,
+            self.session_id,
+            self.spawn_epoch,
+            &candidate,
+        )
+        .await
+        {
+            Ok(true) => {
+                let mut pending = self
+                    .pending_resume_ref
+                    .lock()
+                    .expect("code sink resume ref");
+                if pending.as_deref() == Some(candidate.as_str()) {
+                    *pending = None;
+                }
+            }
+            Ok(false) => {
+                // This worker no longer owns a running session. Do not retry
+                // the stale write on every later event.
+                *self
+                    .pending_resume_ref
+                    .lock()
+                    .expect("code sink resume ref") = None;
+            }
+            Err(error) => warn!(
+                session = %self.session_id,
+                error = %error,
+                "could not persist the code-session resume ref"
+            ),
+        }
     }
 
     /// Track subagent spans (decision 52): a top-level `Task` call opens one,
@@ -392,6 +443,32 @@ pub(crate) fn settle_running_subagents(
 #[async_trait]
 impl HarnessEventSink for LiveSink {
     async fn emit(&self, event: HarnessEvent) {
+        if let HarnessEvent::SessionStarted {
+            resume_ref: Some(resume_ref),
+            ..
+        } = &event
+        {
+            *self
+                .pending_resume_ref
+                .lock()
+                .expect("code sink resume ref") = Some(resume_ref.clone());
+        }
+        if matches!(
+            &event,
+            HarnessEvent::TurnStarted
+                | HarnessEvent::AssistantDelta { .. }
+                | HarnessEvent::AssistantMessage { .. }
+                | HarnessEvent::ReasoningDelta { .. }
+                | HarnessEvent::ToolStarted { .. }
+                | HarnessEvent::ToolCompleted { .. }
+                | HarnessEvent::FileChanged { .. }
+                | HarnessEvent::ApprovalRequested { .. }
+                | HarnessEvent::UserSteered { .. }
+                | HarnessEvent::TurnCompleted { .. }
+                | HarnessEvent::TurnInterrupted
+        ) {
+            self.persist_pending_resume_ref().await;
+        }
         if let HarnessEvent::ApprovalRequested { harness_ref, raw } = &event {
             self.record_approval(harness_ref, raw).await;
             return;
@@ -1803,6 +1880,7 @@ pub(crate) fn sink_for(
         session_id,
         spawn_epoch,
         turn_id: std::sync::Mutex::new(turn_id),
+        pending_resume_ref: std::sync::Mutex::new(None),
         gh_search_path,
         flushed_unrecognized: AtomicU64::new(0),
         subagents: std::sync::Mutex::new(subagents),
@@ -2369,6 +2447,66 @@ mod tests {
                 Some(expected)
             );
         }
+    }
+
+    #[tokio::test]
+    async fn sink_persists_a_resume_ref_only_after_turn_activity_starts() {
+        let (_directory, store, sink, session_id) = seeded_sink().await;
+        let owner = OwnerId::local();
+
+        sink.emit(HarnessEvent::SessionStarted {
+            harness_kind: HarnessKind::Codex,
+            harness_version: "0.147.0".into(),
+            resume_ref: Some("thread-1".into()),
+        })
+        .await;
+        assert_eq!(
+            get_session(&store, &owner, session_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .harness_resume_ref,
+            None,
+            "an unused Codex thread is not a safe resume target"
+        );
+
+        sink.emit(HarnessEvent::TurnStarted).await;
+        assert_eq!(
+            get_session(&store, &owner, session_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .harness_resume_ref
+                .as_deref(),
+            Some("thread-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn assistant_activity_persists_resume_refs_for_harnesses_without_turn_started() {
+        let (_directory, store, sink, session_id) = seeded_sink().await;
+        let owner = OwnerId::local();
+
+        sink.emit(HarnessEvent::SessionStarted {
+            harness_kind: HarnessKind::ClaudeCode,
+            harness_version: "2.1.237".into(),
+            resume_ref: Some("session-1".into()),
+        })
+        .await;
+        sink.emit(HarnessEvent::AssistantDelta {
+            text: "Working".into(),
+        })
+        .await;
+
+        assert_eq!(
+            get_session(&store, &owner, session_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .harness_resume_ref
+                .as_deref(),
+            Some("session-1")
+        );
     }
 
     #[cfg(unix)]

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -198,12 +198,6 @@ pub(crate) struct QueuedFollowUp {
     pub queued_row: Option<Box<CodeQueuedTurn>>,
 }
 
-#[derive(Default)]
-struct ResumeRefState {
-    pending: Option<String>,
-    persisted: Option<String>,
-}
-
 pub(crate) struct LiveSink {
     db: Arc<DbStore>,
     bus: Arc<CodeEventBus>,
@@ -213,14 +207,12 @@ pub(crate) struct LiveSink {
     session_id: CodeSessionId,
     spawn_epoch: i64,
     turn_id: std::sync::Mutex<Option<CodeTurnId>>,
-    /// Resume ref reported during engine startup and its durable promotion.
+    /// Resume ref reported during engine startup but not yet proven durable.
     ///
     /// Codex creates a thread before it writes that thread to disk. The first
     /// turn event promotes this candidate into the session row, so a restart
-    /// keeps real context without trying to resume an unused thread. The same
-    /// lock covers mid-turn full-row saves, so no save can land between the
-    /// targeted write and the worker adopting its result.
-    resume_ref: tokio::sync::Mutex<ResumeRefState>,
+    /// keeps real context without trying to resume an unused thread.
+    pending_resume_ref: std::sync::Mutex<Option<String>>,
     /// Where tests point `gh`; `None` outside tests. Snapshotted at attach so
     /// the post-turn fact detector confirms against the same binary every
     /// other gh call in the process resolves (decision 62).
@@ -253,33 +245,13 @@ impl LiveSink {
         total.saturating_sub(flushed)
     }
 
-    async fn note_resume_ref(&self, resume_ref: String) {
-        self.resume_ref.lock().await.pending = Some(resume_ref);
-    }
-
-    /// Copy the resume ref this sink persisted onto the worker's session copy.
-    async fn adopt_persisted_resume_ref(&self, session: &mut CodeSession) {
-        if let Some(resume_ref) = self.resume_ref.lock().await.persisted.clone() {
-            session.harness_resume_ref = Some(resume_ref);
-        }
-    }
-
-    /// Persist a full session row without racing the targeted resume-ref write.
-    async fn save_session_with_resume_ref(
-        &self,
-        session: &mut CodeSession,
-    ) -> Result<bool, tidebreak_core::AgentError> {
-        let resume_ref = self.resume_ref.lock().await;
-        if let Some(persisted) = resume_ref.persisted.clone() {
-            session.harness_resume_ref = Some(persisted);
-        }
-        save_session(&self.db, session).await
-    }
-
     /// Persist a reported resume ref after the engine proves a turn started.
     async fn persist_pending_resume_ref(&self) {
-        let mut resume_ref = self.resume_ref.lock().await;
-        let candidate = resume_ref.pending.clone();
+        let candidate = self
+            .pending_resume_ref
+            .lock()
+            .expect("code sink resume ref")
+            .clone();
         let Some(candidate) = candidate else {
             return;
         };
@@ -293,15 +265,21 @@ impl LiveSink {
         .await
         {
             Ok(true) => {
-                resume_ref.persisted = Some(candidate.clone());
-                if resume_ref.pending.as_deref() == Some(candidate.as_str()) {
-                    resume_ref.pending = None;
+                let mut pending = self
+                    .pending_resume_ref
+                    .lock()
+                    .expect("code sink resume ref");
+                if pending.as_deref() == Some(candidate.as_str()) {
+                    *pending = None;
                 }
             }
             Ok(false) => {
                 // This worker no longer owns a running session. Do not retry
                 // the stale write on every later event.
-                resume_ref.pending = None;
+                *self
+                    .pending_resume_ref
+                    .lock()
+                    .expect("code sink resume ref") = None;
             }
             Err(error) => warn!(
                 session = %self.session_id,
@@ -470,7 +448,10 @@ impl HarnessEventSink for LiveSink {
             ..
         } = &event
         {
-            self.note_resume_ref(resume_ref.clone()).await;
+            *self
+                .pending_resume_ref
+                .lock()
+                .expect("code sink resume ref") = Some(resume_ref.clone());
         }
         if matches!(
             &event,
@@ -1354,7 +1335,7 @@ async fn drive_turn_inner(
             pid = next_child_pid(pid_changes.as_mut()) => {
                 if session.child_pid != pid {
                     session.child_pid = pid;
-                    let _ = sink.save_session_with_resume_ref(session).await;
+                    let _ = save_session(db, session).await;
                 }
             }
         }
@@ -1387,7 +1368,6 @@ async fn drive_turn_inner(
         None
     };
 
-    sink.adopt_persisted_resume_ref(session).await;
     if let Some(pid) = engine.child_pid() {
         session.child_pid = Some(pid);
     } else {
@@ -1900,7 +1880,7 @@ pub(crate) fn sink_for(
         session_id,
         spawn_epoch,
         turn_id: std::sync::Mutex::new(turn_id),
-        resume_ref: tokio::sync::Mutex::new(ResumeRefState::default()),
+        pending_resume_ref: std::sync::Mutex::new(None),
         gh_search_path,
         flushed_unrecognized: AtomicU64::new(0),
         subagents: std::sync::Mutex::new(subagents),
@@ -2527,10 +2507,7 @@ mod tests {
         // the real worker path and prove that its stale session copy keeps the
         // ref instead of replacing it with NULL during the full-row save.
         worker_session.child_pid = Some(4242);
-        assert!(sink
-            .save_session_with_resume_ref(&mut worker_session)
-            .await
-            .unwrap());
+        assert!(save_session(&store, &worker_session).await.unwrap());
         assert_eq!(
             get_session(&store, &owner, session_id)
                 .await


### PR DESCRIPTION
## What changed

Persist the engine resume reference as soon as turn activity proves the session can resume, so an app restart keeps the interrupted agent context without treating an unused Codex thread as durable.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Rust compilation and tests were not run locally under the repository policy; CI provides that coverage.

## Compatibility and risk

This change adds no schema or wire-format changes, and the write remains owner-scoped, lifecycle-scoped, and spawn-epoch-fenced.