### PR TITLE
perf(code): reuse recent workspace transcripts

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SequencedCodeEventFrame } from "../api/types";
 import {
   acquireCodeSession,
+  MAX_RETAINED_CODE_SESSIONS,
   peekCodeSession,
   releaseCodeSession,
   resetCodeSessionRegistry,
@@ -56,7 +57,7 @@ describe("CodeSessionRegistry", () => {
     expect(store.getState().hydrated).toBe(true);
   });
 
-  it("shares one store across two acquires and closes the socket on last release", () => {
+  it("shares one store and parks it after the last release", () => {
     const sockets: FakeSocket[] = [];
     const openSocket = (
       after: number,
@@ -87,7 +88,103 @@ describe("CodeSessionRegistry", () => {
 
     releaseCodeSession("s1");
     expect(sockets[0]?.closed).toBe(true);
-    expect(peekCodeSession("s1")).toBeUndefined();
+    expect(peekCodeSession("s1")).toMatchObject({
+      controller: null,
+      refCount: 0,
+    });
+    expect(first.getState().connectionState).toBe("reconnecting");
+  });
+
+  it("reopens a parked store from its last sequence without hydrating again", async () => {
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const hydrateTurns = vi.fn(async () => [
+      {
+        id: "t1",
+        session_id: "s1",
+        ordinal: 1,
+        status: "completed" as const,
+        user_input: "list the files",
+        attachments: [],
+        started_at: "2026-08-15T12:00:00.000Z",
+        ended_at: "2026-08-15T12:00:02.500Z",
+      },
+    ]);
+    const first = acquireCodeSession("s1", openSocket, undefined, hydrateTurns);
+    await Promise.resolve();
+    await Promise.resolve();
+    first
+      .getState()
+      .applyEvent(
+        { seq: 7, event: { type: "turn_started", turn_id: "t2" } },
+        { nextId: () => "id", now: () => "2026-08-15T12:00:03.000Z" },
+      );
+
+    releaseCodeSession("s1");
+    const reopened = acquireCodeSession(
+      "s1",
+      openSocket,
+      undefined,
+      hydrateTurns,
+    );
+
+    expect(reopened).toBe(first);
+    expect(reopened.getState().items).toContainEqual({
+      kind: "user",
+      id: userItemId("t1"),
+      turnId: "t1",
+      text: "list the files",
+      createdAt: "2026-08-15T12:00:00.000Z",
+      attachments: [],
+    });
+    expect(hydrateTurns).toHaveBeenCalledTimes(1);
+    expect(sockets.map((socket) => socket.after)).toEqual([0, 7]);
+  });
+
+  it("retries initial turn hydration when the first open could not read it", async () => {
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => new FakeSocket(after, onFrame) as unknown as WebSocket;
+    const hydrateTurns = vi
+      .fn<() => Promise<[]>>()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce([]);
+
+    acquireCodeSession("s1", openSocket, undefined, hydrateTurns);
+    await Promise.resolve();
+    await Promise.resolve();
+    releaseCodeSession("s1");
+
+    acquireCodeSession("s1", openSocket, undefined, hydrateTurns);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(hydrateTurns).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least recently parked store when the cache is full", () => {
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => new FakeSocket(after, onFrame) as unknown as WebSocket;
+
+    for (let index = 0; index <= MAX_RETAINED_CODE_SESSIONS; index += 1) {
+      const sessionId = `s${index}`;
+      acquireCodeSession(sessionId, openSocket);
+      releaseCodeSession(sessionId);
+    }
+
+    expect(peekCodeSession("s0")).toBeUndefined();
+    expect(peekCodeSession("s1")?.refCount).toBe(0);
+    expect(peekCodeSession(`s${MAX_RETAINED_CODE_SESSIONS}`)?.refCount).toBe(0);
   });
 
   it("reopen hydrates user prompts before the journal replays from after=0", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -15,9 +15,9 @@ import {
  * Per-session stores and the sockets that feed them.
  *
  * Chat pins one session at a time. Code mode keeps several open: two views of
- * the same session must share one store and one socket, and unmounting the
- * last view must close that socket. The map is ref-counted so that contract
- * is mechanical rather than something each page has to remember.
+ * the same session must share one store and one socket. When the last view
+ * unmounts, the registry closes the socket but retains a few recent stores so
+ * returning to a workspace can paint its transcript before reconnecting.
  */
 
 export type CodeSessionOpenSocket = (
@@ -27,11 +27,16 @@ export type CodeSessionOpenSocket = (
 
 export type CodeSessionEntry = {
   store: ReturnType<typeof createCodeSessionStore>;
-  controller: CodeSessionController;
+  controller: CodeSessionController | null;
   refCount: number;
+  turnsHydrated: boolean;
 };
 
 const registry = new Map<string, CodeSessionEntry>();
+const retainedSessionIds = new Set<string>();
+
+/** Bound transcript memory while keeping normal workspace switching instant. */
+export const MAX_RETAINED_CODE_SESSIONS = 4;
 
 const defaultDeps: CodeSessionDeps = {
   nextId: () => {
@@ -43,18 +48,14 @@ const defaultDeps: CodeSessionDeps = {
 
 let nextItem = 0;
 
-export function acquireCodeSession(
-  sessionId: string,
+function createController(
+  store: ReturnType<typeof createCodeSessionStore>,
   openSocket: CodeSessionOpenSocket,
-  deps: CodeSessionDeps = defaultDeps,
-  hydrateTurns?: () => Promise<CodeTurnSnapshot[]>,
-): ReturnType<typeof createCodeSessionStore> {
-  const existing = registry.get(sessionId);
-  if (existing) {
-    existing.refCount += 1;
-    return existing.store;
-  }
-  const store = createCodeSessionStore();
+  deps: CodeSessionDeps,
+  hydrateTurns: (() => Promise<CodeTurnSnapshot[]>) | undefined,
+  hydrateBeforeConnect: boolean,
+  onTurnsHydrated: () => void,
+): CodeSessionController {
   const fetchedPrompts = new Set<string>();
   const fillPrompt = (turnId: string) => {
     if (!hydrateTurns || fetchedPrompts.has(turnId)) return;
@@ -75,7 +76,7 @@ export function acquireCodeSession(
         // The prompt lands on the next open. The turn itself still streams.
       });
   };
-  const controller = new CodeSessionController({
+  return new CodeSessionController({
     openSocket,
     getAfter: () => store.getState().lastSeq,
     onEvents: (frames, initialViewSettled) => {
@@ -92,13 +93,72 @@ export function acquireCodeSession(
     onConnectionState: (connectionState) => {
       store.getState().setConnectionState(connectionState);
     },
-    hydrateTurns,
+    hydrateTurns: hydrateBeforeConnect ? hydrateTurns : undefined,
     onHydrate: (turns) => {
       store.getState().update((session) => hydrateCodeTurns(session, turns));
+      onTurnsHydrated();
     },
   });
-  registry.set(sessionId, { store, controller, refCount: 1 });
-  controller.start();
+}
+
+function retainCodeSession(sessionId: string): void {
+  retainedSessionIds.delete(sessionId);
+  retainedSessionIds.add(sessionId);
+  while (retainedSessionIds.size > MAX_RETAINED_CODE_SESSIONS) {
+    const oldest = retainedSessionIds.values().next().value;
+    if (oldest === undefined) return;
+    retainedSessionIds.delete(oldest);
+    registry.get(oldest)?.controller?.dispose();
+    registry.delete(oldest);
+  }
+}
+
+export function acquireCodeSession(
+  sessionId: string,
+  openSocket: CodeSessionOpenSocket,
+  deps: CodeSessionDeps = defaultDeps,
+  hydrateTurns?: () => Promise<CodeTurnSnapshot[]>,
+): ReturnType<typeof createCodeSessionStore> {
+  const existing = registry.get(sessionId);
+  if (existing) {
+    if (existing.refCount === 0) {
+      retainedSessionIds.delete(sessionId);
+      existing.refCount = 1;
+      existing.controller = createController(
+        existing.store,
+        openSocket,
+        deps,
+        hydrateTurns,
+        !existing.turnsHydrated,
+        () => {
+          existing.turnsHydrated = true;
+        },
+      );
+      existing.controller.start();
+    } else {
+      existing.refCount += 1;
+    }
+    return existing.store;
+  }
+  const store = createCodeSessionStore();
+  const entry: CodeSessionEntry = {
+    store,
+    controller: null,
+    refCount: 1,
+    turnsHydrated: hydrateTurns === undefined,
+  };
+  registry.set(sessionId, entry);
+  entry.controller = createController(
+    store,
+    openSocket,
+    deps,
+    hydrateTurns,
+    !entry.turnsHydrated,
+    () => {
+      entry.turnsHydrated = true;
+    },
+  );
+  entry.controller.start();
   return store;
 }
 
@@ -117,11 +177,13 @@ export function acquireCodeSessionFromClient(
 
 export function releaseCodeSession(sessionId: string): void {
   const existing = registry.get(sessionId);
-  if (!existing) return;
+  if (!existing || existing.refCount === 0) return;
   existing.refCount -= 1;
   if (existing.refCount > 0) return;
-  existing.controller.dispose();
-  registry.delete(sessionId);
+  existing.controller?.dispose();
+  existing.controller = null;
+  existing.store.getState().setConnectionState("reconnecting");
+  retainCodeSession(sessionId);
 }
 
 export function peekCodeSession(
@@ -133,9 +195,10 @@ export function peekCodeSession(
 /** Test-only: drop every live entry without waiting for unmounts. */
 export function resetCodeSessionRegistry(): void {
   for (const entry of registry.values()) {
-    entry.controller.dispose();
+    entry.controller?.dispose();
   }
   registry.clear();
+  retainedSessionIds.clear();
   nextItem = 0;
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -599,6 +599,29 @@ describe("CodeWorkspacePage", () => {
     expect(screen.queryByText("repo-1")).not.toBeInTheDocument();
   });
 
+  it("shows catalog workspace metadata while the route refreshes", async () => {
+    const client = makeClient();
+    client.getCodeWorkspace.mockImplementation(() => new Promise(() => {}));
+    useCodeCatalogStore.setState({
+      repos: [REPO],
+      workspaces: [WORKSPACE],
+    });
+
+    await mountWorkspace(client);
+
+    expect(
+      screen.getByRole("heading", { name: WORKSPACE.title }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("workspace-header")).getByText(
+        REPO.display_name,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("workspace-header-skeleton"),
+    ).not.toBeInTheDocument();
+  });
+
   it("marks recorded unrecognized engine events with a warning icon", async () => {
     const client = makeClient();
     client.listCodeWorkspaceSessions.mockResolvedValue([

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -239,13 +239,20 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
   const archivePending = useCodeUiStore((state) => state.archivePending);
   const terminalPending = useCodeUiStore((state) => state.terminalPending);
   const shortcutHints = useCodeShortcutHints();
-  const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(
-    null,
-  );
   const catalogWorkspace = catalog.workspaces.find(
     (candidate) => candidate.id === workspaceId,
   );
-  const [repo, setRepo] = useState<CodeRepoSnapshot | null>(null);
+  const [workspace, setWorkspace] = useState<CodeWorkspaceSnapshot | null>(
+    () => catalogWorkspace ?? null,
+  );
+  const catalogRepo = catalogWorkspace
+    ? catalog.repos.find(
+        (candidate) => candidate.id === catalogWorkspace.repo_id,
+      )
+    : undefined;
+  const [repo, setRepo] = useState<CodeRepoSnapshot | null>(
+    () => catalogRepo ?? null,
+  );
   /**
    * Every session the server knows about here, conversations and watches alike.
    *
@@ -270,6 +277,13 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       current?.id === catalogWorkspace.id ? catalogWorkspace : current,
     );
   }, [catalogWorkspace]);
+
+  useEffect(() => {
+    if (!catalogRepo) return;
+    setRepo((current) =>
+      current?.id === catalogRepo.id ? catalogRepo : current,
+    );
+  }, [catalogRepo]);
   /** True while the reader is filling in a new agent that has no session yet. */
   const [draftAgent, setDraftAgent] = useState(false);
   /**


### PR DESCRIPTION
## Summary

- Keep the four most recent code-session transcript stores in memory while their views are closed.
- Close off-screen event sockets, then resume from the stored sequence when the workspace opens again.
- Render workspace and repository metadata from the existing catalog while the route refreshes in the background.

## Why

Returning to a workspace discarded its session store and forced the desktop to fetch turns and replay the full event journal again. Keeping a bounded recent-session cache lets the conversation render immediately without leaving unused sockets open.

## Testing

- `pnpm exec biome format src/code/CodeSessionRegistry.ts src/code/CodeSessionRegistry.test.ts src/code/CodeWorkspacePage.tsx src/code/CodeWorkspacePage.dom.test.tsx`
- `pnpm exec biome lint src/code/CodeSessionRegistry.ts src/code/CodeSessionRegistry.test.ts src/code/CodeWorkspacePage.tsx src/code/CodeWorkspacePage.dom.test.tsx`
- `pnpm exec vitest run src/code/CodeSessionRegistry.test.ts src/code/CodeWorkspacePage.dom.test.tsx` (60 tests)
- `pnpm exec tsc --noEmit`