### PR TITLE
feat(code): show changed file count on Changes tab

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";
 
@@ -575,6 +581,36 @@ it("gives the active inspector tab a selected fill idle tabs do not share", asyn
   await userEvent.setup().keyboard("{ArrowRight}");
   expect(pr).toHaveAttribute("data-state", "active");
   expect(pr).toHaveFocus();
+});
+
+it("shows the changed-file count in the Changes tab", async () => {
+  const client = makeClient();
+  vi.mocked(client.listCodeWorkspaceFiles).mockResolvedValue({
+    files: [
+      {
+        path: "src/login.rs",
+        kind: "modified",
+        insertions: 3,
+        deletions: 1,
+      },
+    ],
+    truncated: true,
+    stat: { files: 12, insertions: 30, deletions: 10, truncated: true },
+  });
+
+  render(
+    <CodeInspector
+      client={client as never}
+      workspaceId="ws-1"
+      workspace={WORKSPACE}
+      contentRevision={0}
+    />,
+  );
+
+  const source = screen.getByRole("tab", { name: "Source control" });
+  expect(
+    await within(source).findByLabelText("12 changed files"),
+  ).toHaveTextContent("12");
 });
 
 it("closes the review sidebar from its own chrome", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -51,7 +51,7 @@ import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { openExternal } from "@/host";
 import type { CodeTranscriptItem } from "./CodeSessionReducer";
 import { useCodeUiStore } from "./CodeUiStore";
-import { DiffOverview } from "./DiffOverview";
+import { DiffOverviewContent, useChangedFilesResource } from "./DiffOverview";
 import { FilesPanel } from "./FilesPanel";
 import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { MiddleTruncate } from "./MiddleTruncate";
@@ -116,6 +116,12 @@ export function CodeInspector({
   const [tab, setTab] = useState<InspectorTab>(scope ? "source" : "files");
   const [file, setFile] = useState<string | undefined>();
   const turnId = scope?.turnId;
+  const changedFiles = useChangedFilesResource({
+    client,
+    workspaceId,
+    turnId,
+    contentRevision,
+  });
 
   useEffect(() => {
     if (!scope) return;
@@ -180,6 +186,7 @@ export function CodeInspector({
               label="Source control"
               displayLabel="Changes"
               selected={tab === "source"}
+              count={changedFiles.data?.stat.files}
             >
               <GitBranch className="size-3.5" />
             </InspectorTabTrigger>
@@ -244,13 +251,11 @@ export function CodeInspector({
           className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
         >
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            <DiffOverview
-              client={client}
-              workspaceId={workspaceId}
+            <DiffOverviewContent
+              resource={changedFiles}
               turnId={turnId}
               turnLabel={scope?.label}
               selected={file}
-              contentRevision={contentRevision}
               onOpenFile={openDiff}
             />
           </div>
@@ -278,12 +283,14 @@ function InspectorTabTrigger({
   label,
   displayLabel,
   selected,
+  count,
   children,
 }: {
   value: InspectorTab;
   label: string;
   displayLabel: string;
   selected: boolean;
+  count?: number;
   children: ReactNode;
 }) {
   return (
@@ -294,6 +301,16 @@ function InspectorTabTrigger({
     >
       {children}
       <span>{displayLabel}</span>
+      {count !== undefined && (
+        <Badge
+          variant="secondary"
+          size="sm"
+          className="h-4 min-w-4 justify-center px-1 font-mono text-2xs font-medium tabular-nums"
+          aria-label={`${count} changed ${count === 1 ? "file" : "files"}`}
+        >
+          {count}
+        </Badge>
+      )}
     </TabsTrigger>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/DiffOverview.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffOverview.tsx
@@ -3,14 +3,18 @@ import { useCallback, useMemo, useState } from "react";
 import { ChevronRight, Folder, FolderOpen } from "lucide-react";
 
 import type { ApiClient } from "../api/client";
-import type { CodeFileChange, FileChangeKind } from "../api/types";
+import type {
+  CodeFileChange,
+  CodeWorkspaceFiles,
+  FileChangeKind,
+} from "../api/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { CodeFileIcon } from "./CodeFileIcon";
 import { DiffstatBadge } from "./TurnReviewCard";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
-import { useLiveResource } from "./useLiveContent";
+import { type LiveResource, useLiveResource } from "./useLiveContent";
 
 const FILE_KIND: Record<
   FileChangeKind,
@@ -61,20 +65,65 @@ export function DiffOverview({
   contentRevision?: number;
   onOpenFile: (path: string) => void;
 }) {
+  const resource = useChangedFilesResource({
+    client,
+    workspaceId,
+    turnId,
+    contentRevision,
+  });
+
+  return (
+    <DiffOverviewContent
+      resource={resource}
+      turnId={turnId}
+      turnLabel={turnLabel}
+      selected={selected}
+      onOpenFile={onOpenFile}
+    />
+  );
+}
+
+export function useChangedFilesResource({
+  client,
+  workspaceId,
+  turnId,
+  contentRevision = 0,
+}: {
+  client: Pick<ApiClient, "listCodeWorkspaceFiles">;
+  workspaceId: string;
+  turnId?: string;
+  contentRevision?: number;
+}): LiveResource<CodeWorkspaceFiles> {
   const load = useCallback(
     () => client.listCodeWorkspaceFiles(workspaceId, turnId),
     [client, workspaceId, turnId],
   );
-  const {
-    data: payload,
-    error,
-    refreshing,
-  } = useLiveResource({
+  return useLiveResource({
     key: `${workspaceId}:${turnId ?? "workspace"}`,
     revision: contentRevision,
     load,
     errorMessage: "Could not load changed files",
   });
+}
+
+export function DiffOverviewContent({
+  resource,
+  turnId,
+  turnLabel,
+  selected,
+  onOpenFile,
+}: {
+  resource: Pick<
+    LiveResource<CodeWorkspaceFiles>,
+    "data" | "error" | "refreshing"
+  >;
+  turnId?: string;
+  /** Ordinal label for the scoped turn. Never a raw id. */
+  turnLabel?: string;
+  selected?: string;
+  onOpenFile: (path: string) => void;
+}) {
+  const { data: payload, error, refreshing } = resource;
 
   const scopeCaption = turnId
     ? (turnLabel ?? "This turn")

--- a/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 
 import type { ApiClient } from "@/api/client";
 import type {
@@ -357,9 +357,13 @@ type Story = StoryObj<typeof meta>;
 /** Worktree navigation stays a compact, searchable optional pane. */
 export const Files: Story = {};
 
-/** Git state and the changed-file index share one focused surface. */
+/** The tab count and changed-file index share the same live workspace read. */
 export const Changes: Story = {
   args: { tab: "source" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByLabelText("6 changed files")).toBeVisible();
+  },
 };
 
 /** Checks, merge state, and review discussion are one readable review surface. */


### PR DESCRIPTION
## What changed

The Changes tab now shows the number of changed files before you open it. The inspector shares the live changed-file resource with the panel, so the chip refreshes with workspace and turn scope changes and shows the full total for truncated lists.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/code/DiffOverview.tsx src/code/CodeInspector.tsx src/code/CodeInspector.dom.test.tsx src/stories/CodeInspector.stories.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/CodeInspector.dom.test.tsx src/code/DiffOverview.dom.test.tsx` (25 tests)
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`

Screenshot inspection was unavailable because no browser was connected to the session.

## Compatibility and risk

None. This change does not alter persisted data or wire formats.