### PR TITLE
fix(code): clarify workspace state indicators

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
@@ -63,18 +63,18 @@ describe("AttentionBadge", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  // A compact dot is often a row's only state. Working drawing as nothing here
+  // A compact mark is often a row's only state. Working drawing as nothing here
   // made a busy agent look idle, which is the one confusion worth a test.
-  it("renders a moving dot for Working when compact", () => {
+  it("renders a spinner for Working when compact", () => {
     render(
       <AttentionBadge
         compact
         attention={{ state: { type: "working" }, source: "lifecycle" }}
       />,
     );
-    const dot = screen.getByLabelText("Working");
-    expect(dot).toHaveAttribute("data-attention", "working");
-    expect(dot).toHaveClass("animate-pulse");
+    const mark = screen.getByLabelText("Working");
+    expect(mark).toHaveAttribute("data-attention", "working");
+    expect(mark.querySelector(".animate-spin")).not.toBeNull();
   });
 
   it.each(cases)(
@@ -86,7 +86,7 @@ describe("AttentionBadge", () => {
     },
   );
 
-  it("uses a compact mark with the same label", () => {
+  it("uses a compact icon with the same label", () => {
     render(
       <AttentionBadge
         compact

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
@@ -1,12 +1,14 @@
+import { Ban, CircleAlert, CircleCheck, Clock, Pin } from "lucide-react";
+
 import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 
 import type { Attention } from "../api/types";
 import { attentionLabel, attentionTooltip } from "./labels";
 import {
   attentionStatusTone,
-  STATUS_DOT,
-  STATUS_MOTION,
+  STATUS_MARK,
   type StatusTone,
 } from "./statusTone";
 
@@ -16,11 +18,10 @@ import {
  * NeedsYou is strongest. Stalled and Fenced are distinct warnings.
  * DoneUnreviewed is a quiet mark.
  *
- * Working is a dot but not a pill. The compact dot is often the only state a
- * row carries, and an agent mid-turn used to draw there as nothing at all —
- * indistinguishable from an idle one, for the state a reader most wants to
- * see. The full badge always sits beside text that names the state already, so
- * a "Working" pill there would only repeat it.
+ * Working is a spinner but not a pill. Compact surfaces use a distinct glyph
+ * for each state, so the shape still carries the meaning when color is subtle
+ * or unavailable. The full badge always sits beside text that names the state
+ * already, so a "Working" pill there would only repeat it.
  */
 
 const BADGE_VARIANTS: Record<
@@ -53,20 +54,17 @@ export function AttentionBadge({
   if (compact) {
     return (
       <span
-        className={cn(
-          "inline-block size-2 shrink-0 rounded-full",
-          STATUS_DOT[tone],
-          STATUS_MOTION[tone],
-          className,
-        )}
-        // A dot with no text is only a state if something says which one. On a
-        // bare `span` the label would be dropped; `img` is the role that takes
-        // a name and has no children to read.
+        className={cn("inline-flex size-3 shrink-0 items-center", className)}
+        // A glyph with no text is only a state if something says which one.
+        // `img` is the role that gives the wrapper an accessible name while
+        // the inner icon stays decorative.
         role="img"
         aria-label={label}
         title={tooltip}
         data-attention={attention.state.type}
-      />
+      >
+        <CompactAttentionMark attention={attention} tone={tone} />
+      </span>
     );
   }
   return (
@@ -81,4 +79,28 @@ export function AttentionBadge({
       {label}
     </Badge>
   );
+}
+
+function CompactAttentionMark({
+  attention,
+  tone,
+}: {
+  attention: Attention;
+  tone: StatusTone;
+}) {
+  const className = cn("size-3", STATUS_MARK[tone]);
+  switch (attention.state.type) {
+    case "working":
+      return <Spinner className={className} aria-hidden="true" />;
+    case "needs_you":
+      return <CircleAlert className={className} aria-hidden="true" />;
+    case "stalled":
+      return <Clock className={className} aria-hidden="true" />;
+    case "fenced":
+      return <Ban className={className} aria-hidden="true" />;
+    case "done_unreviewed":
+      return <CircleCheck className={className} aria-hidden="true" />;
+    case "manual":
+      return <Pin className={className} aria-hidden="true" />;
+  }
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -599,7 +599,7 @@ describe("CodeWorkspacePage", () => {
     expect(screen.queryByText("repo-1")).not.toBeInTheDocument();
   });
 
-  it("marks recorded unrecognized engine events with a warning dot", async () => {
+  it("marks recorded unrecognized engine events with a warning icon", async () => {
     const client = makeClient();
     client.listCodeWorkspaceSessions.mockResolvedValue([
       { ...SESSION, unrecognized_event_count: 3 },
@@ -609,7 +609,7 @@ describe("CodeWorkspacePage", () => {
     expect(
       await screen.findByRole("heading", { name: /Fix login/ }),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("unrecognized-event-dot")).toHaveAttribute(
+    expect(screen.getByTestId("unrecognized-event-indicator")).toHaveAttribute(
       "aria-label",
       "3 unrecognized engine events recorded in this session",
     );

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -54,7 +54,6 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { Skeleton } from "@/components/ui/skeleton";
-import { WithTooltip } from "@/components/ui/tooltip";
 import { PanelLayout } from "@/panel/PanelLayout";
 import type { LayoutState, PanelContent } from "@/panel/panelTypes";
 import { useLayoutState, usePanelNav } from "@/panel/usePanelNav";
@@ -160,6 +159,7 @@ import { StartSessionPrompt } from "./StartSessionPrompt";
 import { TerminalPane } from "./TerminalPane";
 import { useCodeWorkspacePr } from "./useCodeWorkspacePr";
 import { useCodeContentRevision } from "./useLiveContent";
+import { SessionLifecycleIndicator } from "./SessionLifecycleIndicator";
 import { WorkspaceHeader } from "./WorkspaceHeader";
 import {
   WorkspaceOverflowMenu,
@@ -173,10 +173,8 @@ import {
   gatewayCodeModels,
   harnessCodeModels,
   HARNESS_LABELS,
-  LIFECYCLE_LABELS,
   preferredCodeModels,
   requiresHarnessModelIds,
-  sessionLifecycleTooltip,
 } from "./labels";
 
 /**
@@ -1345,7 +1343,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                 fallback={digest?.attention ?? session.attention}
               />
               <PendingApprovalBadge sessionId={session.id} client={client} />
-              <SessionLifecycleMark
+              <SessionLifecycleIndicator
                 lifecycle={digest?.lifecycle ?? session.lifecycle}
                 harness={session.harness_kind}
                 version={session.harness_version}
@@ -1600,66 +1598,11 @@ function SessionAttentionBadge({
 }) {
   const store = useRegisteredCodeSession(sessionId, client);
   const live = store((state) => state.attention);
-  return <AttentionBadge compact attention={live ?? fallback} />;
-}
-
-/**
- * The adapter could not classify part of the engine stream. Saying so where
- * the session is read is the point of counting it at all — a silently
- * degraded transcript looks exactly like a complete one (decision 0031). The
- * count comes from the session row, so it settles at the end of a turn rather
- * than mid-stream and remains historical after the adapter is updated.
- */
-function SessionLifecycleMark({
-  lifecycle,
-  harness,
-  version,
-  unrecognizedEventCount,
-  runningLabel,
-}: {
-  lifecycle: CodeSessionSnapshot["lifecycle"];
-  harness: CodeSessionSnapshot["harness_kind"];
-  version?: string;
-  unrecognizedEventCount: number;
-  runningLabel?: string;
-}) {
-  const tooltip = sessionLifecycleTooltip({
-    lifecycle,
-    harness,
-    version,
-    unrecognizedEventCount,
-    runningLabel,
-  });
-  const label =
-    lifecycle === "running" && runningLabel
-      ? runningLabel
-      : LIFECYCLE_LABELS[lifecycle];
-  return (
-    <WithTooltip label={tooltip}>
-      {/*
-        The tooltip carries the engine version and the dropped-event warning,
-        and neither is anywhere else on the page. A span cannot be tabbed to,
-        so without a tab stop the whole explanation is hover-only.
-      */}
-      <span
-        tabIndex={0}
-        className={cn(
-          "text-muted-foreground inline-flex items-center gap-1.5 rounded-sm text-xs",
-          FOCUS_RING,
-        )}
-      >
-        {unrecognizedEventCount > 0 && (
-          <span
-            data-testid="unrecognized-event-dot"
-            className="bg-warning-foreground-muted inline-block size-2 shrink-0 rounded-full"
-            role="img"
-            aria-label={`${unrecognizedEventCount} unrecognized engine ${unrecognizedEventCount === 1 ? "event" : "events"} recorded in this session`}
-          />
-        )}
-        <span>{label}</span>
-      </span>
-    </WithTooltip>
-  );
+  const attention = live ?? fallback;
+  // The lifecycle indicator owns live motion in this header. Keep the
+  // attention mark for states that carry separate information.
+  if (attention?.state.type === "working") return null;
+  return <AttentionBadge compact attention={attention} />;
 }
 
 function PendingApprovalBadge({

--- a/crates/tidebreak-desktop/ui/src/code/SessionLifecycleIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionLifecycleIndicator.tsx
@@ -1,0 +1,78 @@
+import { CircleAlert } from "lucide-react";
+
+import { Spinner } from "@/components/ui/spinner";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+import type { CodeSessionSnapshot } from "../api/types";
+import { FOCUS_RING } from "./interactive";
+import { LIFECYCLE_LABELS, sessionLifecycleTooltip } from "./labels";
+import { STATUS_MARK } from "./statusTone";
+
+/**
+ * The lifecycle text shown in the code workspace header.
+ *
+ * Motion marks work that is happening now. A trailing warning icon marks
+ * engine events that the adapter could not classify. The warning stays
+ * separate from the lifecycle mark because it describes transcript fidelity,
+ * not whether the session is running or stopped.
+ */
+export function SessionLifecycleIndicator({
+  lifecycle,
+  harness,
+  version,
+  unrecognizedEventCount,
+  runningLabel,
+}: {
+  lifecycle: CodeSessionSnapshot["lifecycle"];
+  harness: CodeSessionSnapshot["harness_kind"];
+  version?: string;
+  unrecognizedEventCount: number;
+  runningLabel?: string;
+}) {
+  const tooltip = sessionLifecycleTooltip({
+    lifecycle,
+    harness,
+    version,
+    unrecognizedEventCount,
+    runningLabel,
+  });
+  const label =
+    lifecycle === "running" && runningLabel
+      ? runningLabel
+      : LIFECYCLE_LABELS[lifecycle];
+  const unrecognizedLabel = `${unrecognizedEventCount} unrecognized engine ${unrecognizedEventCount === 1 ? "event" : "events"} recorded in this session`;
+
+  return (
+    <WithTooltip label={tooltip}>
+      {/*
+       * The tooltip carries the engine version and the dropped-event warning,
+       * and neither is anywhere else on the page. A span cannot be tabbed to,
+       * so the tab stop keeps the explanation available without a pointer.
+       */}
+      <span
+        tabIndex={0}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-sm text-xs text-muted-foreground",
+          FOCUS_RING,
+        )}
+      >
+        {lifecycle === "running" && (
+          <Spinner
+            className={cn("size-3", STATUS_MARK.running)}
+            aria-hidden="true"
+          />
+        )}
+        <span>{label}</span>
+        {unrecognizedEventCount > 0 && (
+          <CircleAlert
+            data-testid="unrecognized-event-indicator"
+            className={cn("size-3 shrink-0", STATUS_MARK.warning)}
+            role="img"
+            aria-label={unrecognizedLabel}
+          />
+        )}
+      </span>
+    </WithTooltip>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/AttentionBadge.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/AttentionBadge.stories.tsx
@@ -12,8 +12,8 @@ import {
 
 /**
  * The server-computed attention vocabulary, as list surfaces wear it. Working
- * deliberately renders nothing; every other state must stay tellable at a
- * glance in both the labeled badge and the rail's compact dot.
+ * deliberately renders no full pill; every state stays tellable at a glance
+ * in the rail's compact mark without relying on color alone.
  */
 const meta = {
   title: "Code/Attention badge",
@@ -55,11 +55,12 @@ export const ManualPin: Story = {
   args: { attention: attentionManual },
 };
 
-/** The rail's dot form for every visible state, side by side. */
-export const CompactDots: Story = {
+/** The rail, tab, and card marks for every state, side by side. */
+export const CompactMarks: Story = {
   args: { attention: attentionNeedsYou, compact: true },
   render: () => (
     <>
+      <AttentionBadge attention={attentionWorking} compact />
       <AttentionBadge attention={attentionNeedsYou} compact />
       <AttentionBadge attention={attentionStalled} compact />
       <AttentionBadge attention={attentionDoneUnreviewed} compact />

--- a/crates/tidebreak-desktop/ui/src/stories/StateIndicators.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StateIndicators.stories.tsx
@@ -1,0 +1,205 @@
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { Attention, CodeSessionSnapshot } from "@/api";
+import { AttentionBadge } from "@/code/AttentionBadge";
+import { SessionLifecycleIndicator } from "@/code/SessionLifecycleIndicator";
+
+import {
+  attentionDoneUnreviewed,
+  attentionFenced,
+  attentionManual,
+  attentionNeedsYou,
+  attentionStalled,
+  attentionWorking,
+} from "./fixtures";
+
+const attentionStates: Array<{
+  label: string;
+  description: string;
+  attention: Attention;
+}> = [
+  {
+    label: "Working",
+    description: "The agent is doing work now.",
+    attention: attentionWorking,
+  },
+  {
+    label: "Needs you",
+    description: "Only you can answer or approve the next step.",
+    attention: attentionNeedsYou,
+  },
+  {
+    label: "Stalled",
+    description: "The session stopped making progress.",
+    attention: attentionStalled,
+  },
+  {
+    label: "Fenced",
+    description: "The session cannot continue safely.",
+    attention: attentionFenced,
+  },
+  {
+    label: "Done",
+    description: "The run ended and still needs review.",
+    attention: attentionDoneUnreviewed,
+  },
+  {
+    label: "Pinned",
+    description: "You marked the session for a later look.",
+    attention: attentionManual,
+  },
+];
+
+const headerStates: Array<{
+  label: string;
+  description: string;
+  lifecycle: CodeSessionSnapshot["lifecycle"];
+  attention?: Attention;
+  runningLabel?: string;
+  unrecognizedEventCount?: number;
+}> = [
+  {
+    label: "Live shell",
+    description: "Motion means that the session is active now.",
+    lifecycle: "running",
+    runningLabel: "Shell running",
+  },
+  {
+    label: "Needs you while running",
+    description: "The alert outranks the live state without hiding it.",
+    lifecycle: "running",
+    attention: attentionNeedsYou,
+    runningLabel: "Agent working",
+  },
+  {
+    label: "Stalled",
+    description: "The clock names a delay that needs a look.",
+    lifecycle: "idle",
+    attention: attentionStalled,
+  },
+  {
+    label: "Fenced",
+    description: "The blocked mark stays distinct from a temporary stall.",
+    lifecycle: "fenced",
+    attention: attentionFenced,
+  },
+  {
+    label: "Transcript warning",
+    description: "The trailing alert means that the adapter missed events.",
+    lifecycle: "running",
+    runningLabel: "Monitoring",
+    unrecognizedEventCount: 3,
+  },
+  {
+    label: "Ended",
+    description: "A settled session uses quiet text and no motion.",
+    lifecycle: "ended",
+  },
+];
+
+function StatusRow({
+  mark,
+  label,
+  description,
+}: {
+  mark: ReactNode;
+  label: string;
+  description: string;
+}) {
+  return (
+    <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-center gap-4 border-t border-border-subtle px-4 py-3 first:border-t-0">
+      <div className="flex min-h-7 items-center gap-2">{mark}</div>
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{label}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+function StateIndicators() {
+  return (
+    <main className="min-h-screen bg-page-background px-6 py-10 text-foreground">
+      <div className="mx-auto grid max-w-4xl gap-8">
+        <header className="max-w-2xl">
+          <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+            Code mode
+          </p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight">
+            State indicators
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            Shape carries the state. Color reinforces it. Motion appears only
+            while work is happening now.
+          </p>
+        </header>
+
+        <section className="grid gap-3">
+          <div>
+            <h2 className="text-base font-semibold">Compact attention marks</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Workspace cards, tabs, and rails use these marks at high density.
+            </p>
+          </div>
+          <div className="overflow-hidden rounded-xl border border-border-subtle bg-background">
+            {attentionStates.map((state) => (
+              <StatusRow
+                key={state.label}
+                mark={<AttentionBadge attention={state.attention} compact />}
+                label={state.label}
+                description={state.description}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-3">
+          <div>
+            <h2 className="text-base font-semibold">
+              Workspace header combinations
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              The header combines live work, attention, and transcript fidelity
+              without turning each fact into a pill.
+            </p>
+          </div>
+          <div className="overflow-hidden rounded-xl border border-border-subtle bg-background">
+            {headerStates.map((state) => (
+              <StatusRow
+                key={state.label}
+                mark={
+                  <>
+                    {state.attention && (
+                      <AttentionBadge attention={state.attention} compact />
+                    )}
+                    <SessionLifecycleIndicator
+                      lifecycle={state.lifecycle}
+                      harness="codex"
+                      version="0.84.0"
+                      unrecognizedEventCount={state.unrecognizedEventCount ?? 0}
+                      runningLabel={state.runningLabel}
+                    />
+                  </>
+                }
+                label={state.label}
+                description={state.description}
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+const meta = {
+  title: "Code/State indicators",
+  component: StateIndicators,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof StateIndicators>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Catalog: Story = {};

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -3,16 +3,31 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { MoreHorizontal } from "lucide-react";
 import { fn } from "storybook/test";
 
-import type { CodeWorkspacePrSnapshot } from "@/api";
+import type {
+  Attention,
+  CodeSessionSnapshot,
+  CodeWorkspacePrSnapshot,
+} from "@/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { AttentionBadge } from "@/code/AttentionBadge";
+import { SessionLifecycleIndicator } from "@/code/SessionLifecycleIndicator";
 import { WorkspaceHeader } from "@/code/WorkspaceHeader";
 import { WorkspaceWorkflowControl } from "@/code/WorkspaceWorkflowControl";
 import type {
   CodeWorkspacePrMutation,
   CodeWorkspacePrResource,
 } from "@/code/useCodeWorkspacePr";
-import { dirtyGit, openPrGit, watchingPrGit } from "./fixtures";
+import {
+  attentionDoneUnreviewed,
+  attentionFenced,
+  attentionNeedsYou,
+  attentionStalled,
+  attentionWorking,
+  dirtyGit,
+  openPrGit,
+  watchingPrGit,
+} from "./fixtures";
 
 function resourceFor(
   snapshot: CodeWorkspacePrSnapshot | null,
@@ -37,11 +52,19 @@ function HeaderState({
   loading = false,
   initialReviewOpen = true,
   activityLabel = "Agent working",
+  attention = attentionWorking,
+  lifecycle = "running",
+  pendingApprovals = 0,
+  unrecognizedEventCount = 0,
 }: {
   snapshot: CodeWorkspacePrSnapshot | null;
   loading?: boolean;
   initialReviewOpen?: boolean;
   activityLabel?: string;
+  attention?: Attention;
+  lifecycle?: CodeSessionSnapshot["lifecycle"];
+  pendingApprovals?: number;
+  unrecognizedEventCount?: number;
 }) {
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [reviewOpen, setReviewOpen] = useState(initialReviewOpen);
@@ -76,9 +99,24 @@ function HeaderState({
       }
       sessionStatus={
         loading ? undefined : (
-          <Badge variant="outline" size="sm">
-            {activityLabel}
-          </Badge>
+          <>
+            {attention?.state.type !== "working" && (
+              <AttentionBadge attention={attention} compact />
+            )}
+            {pendingApprovals > 0 && (
+              <Badge variant="warning" size="sm">
+                {pendingApprovals}{" "}
+                {pendingApprovals === 1 ? "approval" : "approvals"}
+              </Badge>
+            )}
+            <SessionLifecycleIndicator
+              lifecycle={lifecycle}
+              harness="codex"
+              version="0.84.0"
+              unrecognizedEventCount={unrecognizedEventCount}
+              runningLabel={lifecycle === "running" ? activityLabel : undefined}
+            />
+          </>
         )
       }
       terminalOpen={terminalOpen}
@@ -139,6 +177,46 @@ export const Monitoring: Story = {
 
 export const SubagentsWorking: Story = {
   args: { snapshot: openPrGit, activityLabel: "2 subagents working" },
+};
+
+export const NeedsYou: Story = {
+  args: { snapshot: openPrGit, attention: attentionNeedsYou },
+};
+
+export const ApprovalPending: Story = {
+  args: { snapshot: openPrGit, pendingApprovals: 1 },
+};
+
+export const Stalled: Story = {
+  args: {
+    snapshot: openPrGit,
+    attention: attentionStalled,
+    lifecycle: "idle",
+  },
+};
+
+export const Fenced: Story = {
+  args: {
+    snapshot: openPrGit,
+    attention: attentionFenced,
+    lifecycle: "fenced",
+  },
+};
+
+export const DoneUnreviewed: Story = {
+  args: {
+    snapshot: openPrGit,
+    attention: attentionDoneUnreviewed,
+    lifecycle: "ended",
+  },
+};
+
+export const UnrecognizedEngineEvents: Story = {
+  args: {
+    snapshot: openPrGit,
+    activityLabel: "Shell running",
+    unrecognizedEventCount: 3,
+  },
 };
 
 export const Loading: Story = {


### PR DESCRIPTION
## What changed

Replace compact code-mode status dots with distinct spinner, alert, clock, blocked, completed, and pinned marks, so state does not depend on color alone.
Extract the workspace lifecycle indicator, show unrecognized engine events as a trailing warning icon, and add Storybook coverage for the shared states and header combinations.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui test` — 1,828 tests passed.
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- Visual screenshot review could not run because this session had no connected browser instance.

## Compatibility and risk

None. This change affects desktop UI presentation only and does not change persisted data or wire formats.
