### PR TITLE
fix(code): show one copy action per completed turn

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -134,6 +134,117 @@ describe("CodeTranscript", () => {
     expect(screen.getByText("unrecognized event dropped")).toBeInTheDocument();
   });
 
+  it("puts one copy action on the turn's closing assistant message", () => {
+    const progressTurn: CodeTranscriptItem[] = [
+      items[0],
+      {
+        kind: "assistant",
+        id: "progress-1",
+        turnId: "t1",
+        parentCallId: null,
+        text: "I’m checking the transcript reducer.",
+        streaming: false,
+      },
+      {
+        ...run("succeeded")[0],
+        id: "progress-tool-1",
+        callId: "progress-call-1",
+      },
+      {
+        kind: "assistant",
+        id: "progress-2",
+        turnId: "t1",
+        parentCallId: null,
+        text: "The reducer preserves each completed progress update.",
+        streaming: false,
+      },
+      {
+        ...run("succeeded")[1],
+        id: "progress-tool-2",
+        callId: "progress-call-2",
+      },
+      {
+        kind: "assistant",
+        id: "answer",
+        turnId: "t1",
+        parentCallId: null,
+        text: "Only this final answer should offer Copy.",
+        streaming: false,
+      },
+      items[4],
+    ];
+
+    render(<CodeTranscript items={progressTurn} />);
+
+    const assistants = screen.getAllByRole("article", { name: "Assistant" });
+    expect(assistants).toHaveLength(3);
+    expect(
+      within(assistants[0]).queryByRole("button", { name: "Copy" }),
+    ).toBeNull();
+    expect(
+      within(assistants[1]).queryByRole("button", { name: "Copy" }),
+    ).toBeNull();
+    expect(
+      within(assistants[2]).getByRole("button", { name: "Copy" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Copy" })).toHaveLength(1);
+  });
+
+  it("withholds the copy action until an active turn ends", () => {
+    render(
+      <CodeTranscript
+        busy
+        items={[
+          items[0],
+          {
+            kind: "assistant",
+            id: "progress",
+            turnId: "t1",
+            parentCallId: null,
+            text: "I’m still working.",
+            streaming: false,
+          },
+          run("running")[0],
+        ]}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+  });
+
+  it("keeps one copy action on a settled subagent transcript", () => {
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "assistant",
+            id: "child-progress",
+            turnId: "t1",
+            parentCallId: "task-1",
+            text: "I found the relevant parser.",
+            streaming: false,
+          },
+          {
+            ...run("succeeded")[0],
+            id: "child-tool",
+            callId: "child-call",
+            parentCallId: "task-1",
+          },
+          {
+            kind: "assistant",
+            id: "child-answer",
+            turnId: "t1",
+            parentCallId: "task-1",
+            text: "The parser is sound.",
+            streaming: false,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByRole("button", { name: "Copy" })).toHaveLength(1);
+  });
+
   it("shows the command beside the verb, without its worktree cd prefix", () => {
     const item: CodeTranscriptItem = {
       kind: "tool",

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -168,6 +168,7 @@ export function CodeTranscript({
       break;
     }
   }
+  const copyOwnerIds = assistantCopyOwnerIds(items, busy);
   return (
     <div className="messages" ref={scrollRef} onScroll={onScroll}>
       <div className="messages-column" ref={contentRef}>
@@ -184,10 +185,16 @@ export function CodeTranscript({
               )
             : isolatedCard(
                 row.item.id,
-                itemSignature(row.item, decidingId, approvalError),
+                itemSignature(
+                  row.item,
+                  decidingId,
+                  approvalError,
+                  copyOwnerIds.has(row.item.id),
+                ),
                 <TranscriptItem
                   item={row.item}
                   animateStreaming={animateStreaming}
+                  ownsCopyAction={copyOwnerIds.has(row.item.id)}
                   approval={
                     row.item.kind === "approval"
                       ? approvals[row.item.approvalId]
@@ -297,6 +304,51 @@ export function shouldShowCodeWorking(
   if (last.kind === "tool") return last.status !== "running";
   if (last.kind === "approval") return last.state !== "pending";
   return true;
+}
+
+/**
+ * The assistant rows that own a copy action.
+ *
+ * Harnesses emit a complete assistant message before each tool phase. Those
+ * messages remain useful progress in the transcript, but the copy action
+ * belongs to the turn, so each terminal boundary claims only the last
+ * assistant row that preceded it. A settled filtered transcript, such as one
+ * subagent's view, has no boundary of its own and falls back to its last row.
+ */
+export function assistantCopyOwnerIds(
+  items: readonly CodeTranscriptItem[],
+  busy: boolean,
+): ReadonlySet<string> {
+  const owners = new Set<string>();
+  const latestByTurn = new Map<string | null, string>();
+  let trailingAssistant: { id: string; turnId: string | null } | null = null;
+
+  for (const item of items) {
+    if (item.kind === "user") {
+      trailingAssistant = null;
+      continue;
+    }
+    if (item.kind === "assistant") {
+      latestByTurn.set(item.turnId, item.id);
+      trailingAssistant = { id: item.id, turnId: item.turnId };
+      continue;
+    }
+    if (item.kind !== "turn_boundary") continue;
+
+    const owner = latestByTurn.get(item.turnId) ?? trailingAssistant?.id;
+    if (owner) owners.add(owner);
+    latestByTurn.delete(item.turnId);
+    if (
+      trailingAssistant &&
+      (trailingAssistant.id === owner ||
+        trailingAssistant.turnId === item.turnId)
+    ) {
+      trailingAssistant = null;
+    }
+  }
+
+  if (!busy && trailingAssistant) owners.add(trailingAssistant.id);
+  return owners;
 }
 
 /**
@@ -410,6 +462,7 @@ function itemSignature(
   item: CodeTranscriptItem,
   decidingId?: string | null,
   approvalError?: string,
+  ownsCopyAction = false,
 ): string {
   switch (item.kind) {
     case "tool":
@@ -419,6 +472,7 @@ function itemSignature(
     case "turn_boundary":
       return `${item.status}:${item.diffstat?.files ?? -1}`;
     case "assistant":
+      return `${item.streaming}:${ownsCopyAction}`;
     case "reasoning":
       return String(item.streaming);
     case "file_activity":
@@ -442,6 +496,7 @@ function itemSignature(
 const TranscriptItem = memo(function TranscriptItem({
   item,
   animateStreaming,
+  ownsCopyAction = false,
   approval,
   attached = false,
   deciding,
@@ -455,6 +510,8 @@ const TranscriptItem = memo(function TranscriptItem({
 }: {
   item: CodeTranscriptItem;
   animateStreaming: boolean;
+  /** This is the final assistant row in a settled turn or filtered run. */
+  ownsCopyAction?: boolean;
   approval?: CodeApprovalSnapshot;
   /** This approval parks the tool line directly above it. */
   attached?: boolean;
@@ -520,6 +577,7 @@ const TranscriptItem = memo(function TranscriptItem({
             role="assistant"
             text={item.text}
             settled={!item.streaming}
+            sequenceEnd={ownsCopyAction}
           />
         </article>
       );

--- a/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeTranscript.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+
+import { CodeTranscript } from "@/code/CodeTranscript";
+import type { CodeTranscriptItem } from "@/code/CodeSessionReducer";
+
+const items: CodeTranscriptItem[] = [
+  {
+    kind: "user",
+    id: "user-turn-1",
+    turnId: "turn-1",
+    text: "Keep recent transcript stores in memory when I switch workspaces.",
+    createdAt: "2026-08-25T16:45:00.000Z",
+  },
+  {
+    kind: "assistant",
+    id: "assistant-progress-1",
+    turnId: "turn-1",
+    parentCallId: null,
+    text: "I’m tracing where the workspace registry releases transcript stores.",
+    streaming: false,
+  },
+  {
+    kind: "tool",
+    id: "tool-read-registry",
+    turnId: "turn-1",
+    callId: "call-read-registry",
+    parentCallId: null,
+    name: "Read",
+    detail: {
+      kind: "file_read",
+      path: "crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts",
+    },
+    status: "succeeded",
+    preview: "",
+    startedAt: null,
+    durationMs: 400,
+  },
+  {
+    kind: "assistant",
+    id: "assistant-progress-2",
+    turnId: "turn-1",
+    parentCallId: null,
+    text: "The registry drops the store on the last unmount, so a quick return has to hydrate from disk.",
+    streaming: false,
+  },
+  {
+    kind: "tool",
+    id: "tool-test-registry",
+    turnId: "turn-1",
+    callId: "call-test-registry",
+    parentCallId: null,
+    name: "Bash",
+    detail: {
+      kind: "command",
+      cmd: "pnpm vitest run src/code/CodeSessionRegistry.test.ts",
+      cwd: "/repo/crates/tidebreak-desktop/ui",
+    },
+    status: "succeeded",
+    preview: "60 tests passed",
+    startedAt: null,
+    durationMs: 2_300,
+  },
+  {
+    kind: "assistant",
+    id: "assistant-final",
+    turnId: "turn-1",
+    parentCallId: null,
+    text: "Workspace switching now reuses recent transcript stores and reconnects from the last event sequence.",
+    streaming: false,
+  },
+  {
+    kind: "turn_boundary",
+    id: "boundary-turn-1",
+    turnId: "turn-1",
+    status: "completed",
+    durationMs: 58_000,
+    usage: null,
+    error: null,
+    diffstat: { files: 4, insertions: 226, deletions: 29, truncated: false },
+  },
+];
+
+/**
+ * A code turn keeps its progress messages around tool phases, but only the
+ * final assistant message owns the turn-level copy action.
+ */
+const meta = {
+  title: "Code/Transcript",
+  component: CodeTranscript,
+  parameters: { layout: "fullscreen" },
+  args: { items },
+  decorators: [
+    (Story) => (
+      <div className="bg-page-background h-screen">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CodeTranscript>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ProgressUpdates: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole("button", { name: "Copy" })).toHaveLength(
+      1,
+    );
+  },
+};


### PR DESCRIPTION
## What changed

Show one copy action on the final assistant message in each completed turn, instead of showing it on every progress update. Keep active turns copy-free and preserve one copy action for settled subagent transcripts, with DOM coverage and a Storybook example.

## Validation

- 27 focused `CodeTranscript` DOM tests passed; Biome, TypeScript, the Storybook production build, and `git diff --check` passed.
- Storybook screenshots could not run because no browser connection was available.

## Compatibility and risk

None. This change does not alter persisted data or wire formats.
