### PR TITLE
feat(desktop): attach long pasted text to messages

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatRoute.tsx
@@ -87,6 +87,7 @@ import { useDeliverableCatalog } from "./useDeliverableCatalog";
 import { backgroundAgentSpawnKeys, useAgentRuns } from "./useAgentRuns";
 import { appendTranscript, useVoiceComposer } from "./useVoiceComposer";
 import { useVoiceInputStore, voiceSelectionReady } from "./VoiceInputStore";
+import { messageWithPastedText, type PastedTextAttachment } from "./PastedText";
 
 const CodeBrowserTab = lazy(async () => {
   const module = await import("./code/browser/CodeBrowserTab");
@@ -141,6 +142,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const [hydrated, setHydrated] = useState(false);
   const composerAttachments = useComposerAttachments(chatId);
   const files = composerAttachments.files;
+  const pastedTexts = composerAttachments.pastedTexts;
   const pendingFolderIds = composerAttachments.folders;
   const [attaching, setAttaching] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
@@ -205,12 +207,14 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     const pending = firstMessageActions.take(chatId);
     if (pending) {
       if (pending.voiceInputUsed) voice.markInputUsed();
+      composerDraftActions.setPastedTexts(chatId, pending.pastedTexts);
       void sendMessage(
         pending.text,
         pending.images,
         pending.files,
         pending.skills,
         pending.voiceInputUsed,
+        pending.pastedTexts,
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -390,7 +394,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   }
 
   async function onSend() {
-    await sendMessage(draftRef.current.trim());
+    await sendMessage(draftRef.current);
   }
 
   /**
@@ -399,8 +403,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
    * the tray above the composer shows and manages the rows.
    */
   async function onQueue() {
-    const content = draftRef.current.trim();
+    const content = messageWithPastedText(draftRef.current, pastedTexts);
     if (!chat || !content) return;
+    const queuedPastedTextIds = new Set(pastedTexts.map((item) => item.id));
     await queueComposerMessage(
       () =>
         client.postMessage(
@@ -416,6 +421,12 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       () => {
         setComposerDraft("");
         images.clear();
+        const current =
+          useComposerDrafts.getState().attachments[chatId]?.pastedTexts ?? [];
+        composerDraftActions.setPastedTexts(
+          chatId,
+          current.filter((item) => !queuedPastedTextIds.has(item.id)),
+        );
         composerDraftActions.setFolders(chatId, []);
         voice.resetInputUsed();
       },
@@ -433,9 +444,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     fileItems: readonly ImportedDocument[] = files,
     skillNames: readonly string[] = invokedSkills(),
     voiceInputUsed = voice.inputUsed,
+    pastedTextItems: readonly PastedTextAttachment[] = pastedTexts,
   ) {
+    const message = messageWithPastedText(content, pastedTextItems);
     await postTurn({
-      content,
+      content: message,
+      composerDraft: content.trim(),
+      pastedTextIds: pastedTextItems.map((item) => item.id),
       attachments: readyImageAttachmentIds(imageItems),
       transcriptImages: readyTranscriptImageAttachments(imageItems),
       documentIds: fileItems.map((file) => file.documentId),
@@ -489,6 +504,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
    */
   async function postTurn({
     content,
+    composerDraft,
+    pastedTextIds = [],
     attachments,
     transcriptImages,
     documentIds,
@@ -498,6 +515,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     fromComposer,
   }: {
     content: string;
+    composerDraft?: string;
+    pastedTextIds?: readonly string[];
     attachments: readonly string[];
     transcriptImages: readonly TranscriptImageAttachment[];
     documentIds: readonly string[];
@@ -549,6 +568,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       // files, skills, and folders wait so a refused send can still retry.
       if (fromComposer) {
         setComposerFiles(() => []);
+        const sentPastedTextIds = new Set(pastedTextIds);
+        const current =
+          useComposerDrafts.getState().attachments[chatId]?.pastedTexts ?? [];
+        composerDraftActions.setPastedTexts(
+          chatId,
+          current.filter((item) => !sentPastedTextIds.has(item.id)),
+        );
         composerDraftActions.setSkills(chatId, []);
         composerDraftActions.setFolders(chatId, []);
         voice.resetInputUsed();
@@ -568,7 +594,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           { id: nextId(), role: "error", text: String(err) },
         ],
       }));
-      if (!draftRef.current) setComposerDraft(content);
+      if (!draftRef.current) setComposerDraft(composerDraft ?? content);
       signalTurnLifecycle("resolved");
     }
   }
@@ -798,7 +824,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           hydrated={hydrated}
           nativeHost={nativeHost}
           deletingChat={deletingChatId !== null}
-          draftRef={draftRef}
           attachError={attachError}
           files={{
             items: files,

--- a/crates/tidebreak-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.dom.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, Chat } from "./api";
 import { ChatView, type ChatViewProps } from "./ChatView";
@@ -56,12 +55,9 @@ function noFiles() {
 }
 
 /**
- * The pane with the draft wired up the way the root wires it: the store slice
- * the pane subscribes to, and a ref for reading it at the moment guidance is
- * sent.
+ * The pane with the draft wired up through the store slice it subscribes to.
  */
 function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
-  const draftRef = useRef("");
   return (
     <ChatView
       client={client}
@@ -69,7 +65,6 @@ function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
       hydrated
       nativeHost={false}
       deletingChat={false}
-      draftRef={draftRef}
       composerModelMenu={null}
       composerPermissionMenu={null}
       composerImages={noImages()}
@@ -77,10 +72,9 @@ function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
       voiceInputUsed={false}
       onVoiceInputAccepted={vi.fn()}
       attachError={null}
-      onDraftChange={(value) => {
-        draftRef.current = value;
-        useComposerDrafts.getState().setDraft(chat.id, value);
-      }}
+      onDraftChange={(value) =>
+        useComposerDrafts.getState().setDraft(chat.id, value)
+      }
       onSelectPrompt={vi.fn()}
       onSend={vi.fn(async () => {})}
       {...overrides}
@@ -95,7 +89,6 @@ function chatViewProps(overrides: Partial<ChatViewProps> = {}): ChatViewProps {
     hydrated: true,
     nativeHost: false,
     deletingChat: false,
-    draftRef: { current: "" },
     composerModelMenu: null,
     composerPermissionMenu: null,
     composerImages: noImages(),
@@ -386,6 +379,38 @@ describe("ChatView", () => {
     await waitFor(() =>
       expect(screen.queryByText("Guidance sent")).not.toBeInTheDocument(),
     );
+  });
+
+  it("sends and clears pasted text used as guidance", async () => {
+    vi.mocked(client.steer).mockResolvedValue(undefined);
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      busy: true,
+      activeTurnId: "turn-1",
+    }));
+    useComposerDrafts
+      .getState()
+      .setPastedTexts(chat.id, [
+        { id: "paste-1", text: "First source line\nSecond source line" },
+      ]);
+    await renderWithRouter(<DraftingChatView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Steer active response" }),
+    );
+
+    await waitFor(() =>
+      expect(client.steer).toHaveBeenCalledWith(
+        "chat-1",
+        "turn-1",
+        expect.any(String),
+        "<pasted_text>\nFirst source line\nSecond source line\n</pasted_text>",
+        true,
+        false,
+        [],
+      ),
+    );
+    expect(screen.queryByText("Pasted text")).toBeNull();
   });
 
   it("retires the redirect failure the reader is answering by retyping", async () => {

--- a/crates/tidebreak-desktop/ui/src/ChatView.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatView.tsx
@@ -5,7 +5,6 @@ import {
   useRef,
   useState,
   type ReactNode,
-  type RefObject,
 } from "react";
 import type { ApiClient, Chat } from "./api";
 import type { ContextUsageReading } from "./ContextUsageIndicator";
@@ -22,6 +21,7 @@ import {
   type ComposerFiles,
   type ComposerFolders,
   type ComposerImages,
+  type ComposerPastedTexts,
   type ComposerVoice,
 } from "./Composer";
 import type { SlashCommandName } from "./ComposerCommands";
@@ -56,6 +56,7 @@ import {
   TranscriptNavigation,
   transcriptNavigationEntries,
 } from "./TranscriptNavigation";
+import { messageWithPastedText } from "./PastedText";
 
 export type ChatViewProps = {
   client: ApiClient;
@@ -63,8 +64,6 @@ export type ChatViewProps = {
   hydrated: boolean;
   nativeHost: boolean;
   deletingChat: boolean;
-  /** The composer draft, readable synchronously — see [useTurnControls]. */
-  draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
   composerPermissionMenu: ReactNode;
   /** Context-window reading the composer shows beside its own controls. */
@@ -106,7 +105,6 @@ export function ChatView({
   hydrated,
   nativeHost,
   deletingChat,
-  draftRef,
   composerModelMenu,
   composerPermissionMenu,
   contextUsage,
@@ -135,7 +133,11 @@ export function ChatView({
   // reloading its engine mid-typing.
   const draft = useComposerDraft(chat.id);
   const composerPlugins = useComposerPlugins(client);
-  const invokedSkills = useComposerAttachments(chat.id).skills;
+  const composerAttachments = useComposerAttachments(chat.id);
+  const invokedSkills = composerAttachments.skills;
+  const pastedTexts = composerAttachments.pastedTexts;
+  const steerDraftRef = useRef("");
+  steerDraftRef.current = messageWithPastedText(draft, pastedTexts);
   const folderAccess = useFolderAccessRequests(client, chat.id);
   const outputWritebacks = useOutputWritebackRequests(client, chat.id);
   const userQuestions = useUserQuestions(client, chat.id);
@@ -148,7 +150,7 @@ export function ChatView({
   const turnControls = useTurnControls(
     client,
     chat.id,
-    draftRef,
+    steerDraftRef,
     () => {
       onDraftChange("");
       // Pills go with the text they were attached to: accepted guidance has
@@ -157,6 +159,7 @@ export function ChatView({
       // draft context; the grants stay on the chat.
       useComposerDrafts.getState().setSkills(chat.id, []);
       useComposerDrafts.getState().setFolders(chat.id, []);
+      useComposerDrafts.getState().setPastedTexts(chat.id, []);
       onVoiceInputAccepted();
     },
     voiceInputUsed,
@@ -201,6 +204,29 @@ export function ChatView({
     }),
     [files, messages],
   );
+  const composerPastedTexts: ComposerPastedTexts = {
+    items: pastedTexts,
+    onPaste: (text) => {
+      turnControls.clearSteerFeedback();
+      const current =
+        useComposerDrafts.getState().attachments[chat.id]?.pastedTexts ?? [];
+      useComposerDrafts
+        .getState()
+        .setPastedTexts(chat.id, [
+          ...current,
+          { id: crypto.randomUUID(), text },
+        ]);
+    },
+    onRemove: (id) => {
+      turnControls.clearSteerFeedback();
+      const current =
+        useComposerDrafts.getState().attachments[chat.id]?.pastedTexts ?? [];
+      useComposerDrafts.getState().setPastedTexts(
+        chat.id,
+        current.filter((item) => item.id !== id),
+      );
+    },
+  };
   const composerHistory = useMemo(
     () =>
       messages
@@ -632,6 +658,7 @@ export function ChatView({
               }}
               images={composerImages}
               files={composerFiles}
+              pastedTexts={composerPastedTexts}
               folders={folders}
               voice={voice}
               nativeDropTarget={nativeDropTarget}

--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -92,6 +92,13 @@ import { useUiStore } from "./UiStore";
 import type { ConnectedFolder } from "./host";
 import type { TranscriptFileAttachment } from "./TranscriptFileAttachments";
 import type { ChatFolderAccess } from "./useChatFolderAttachments";
+import {
+  messageWithPastedText,
+  pastedTextLineCount,
+  pastedTextPreview,
+  shouldAttachPastedText,
+  type PastedTextAttachment,
+} from "./PastedText";
 
 const MIN_COMPOSER_LINES = 1;
 export const MAX_COMPOSER_LINES = 6;
@@ -205,6 +212,12 @@ export type ComposerFiles = {
   /** Put one of `recent` back on the next message. */
   onReattach?: (file: TranscriptFileAttachment) => void;
   onRemove: (documentId: string) => void;
+};
+
+export type ComposerPastedTexts = {
+  items: readonly PastedTextAttachment[];
+  onPaste: (text: string) => void;
+  onRemove: (id: string) => void;
 };
 
 /**
@@ -344,6 +357,7 @@ export type ComposerProps = {
   slash?: ComposerSlash;
   images?: ComposerImages;
   files?: ComposerFiles;
+  pastedTexts?: ComposerPastedTexts;
   /** Paths the agent can already read, shown as chips and named on send. */
   workspaceFiles?: ComposerWorkspaceFiles;
   folders?: ComposerFolders;
@@ -393,6 +407,7 @@ export function Composer({
   slash,
   images,
   files,
+  pastedTexts,
   workspaceFiles,
   folders,
   pathMentions,
@@ -452,10 +467,11 @@ export function Composer({
   const active = busy && activeTurnId !== null;
   const sendMode = useUiStore((state) => state.activeTurnSendMode);
   const queueAvailable = onQueue !== undefined;
-  const hasDraft = Boolean(draft.trim());
-  const steerHasUnsupportedCharacter = active && draft.includes("\0");
+  const submissionText = messageWithPastedText(draft, pastedTexts?.items ?? []);
+  const hasDraft = Boolean(submissionText.trim());
+  const steerHasUnsupportedCharacter = active && submissionText.includes("\0");
   const steerTooLong =
-    active && [...draft.trim()].length > MAX_STEER_CHARACTERS;
+    active && [...submissionText.trim()].length > MAX_STEER_CHARACTERS;
   const imageBlocker = imageSendBlocker(images);
   const voiceWorking = voice?.state !== undefined && voice.state !== "idle";
   const canSubmit =
@@ -488,12 +504,14 @@ export function Composer({
   const contextItemCount =
     (images?.items.length ?? 0) +
     (files?.items.length ?? 0) +
+    (pastedTexts?.items.length ?? 0) +
     (workspaceFiles?.items.length ?? 0) +
     folderChips.length +
     invokedSkills.length;
   const contextSummary = [
     contextCountLabel(images?.items.length ?? 0, "image"),
     contextCountLabel(files?.items.length ?? 0, "file"),
+    contextCountLabel(pastedTexts?.items.length ?? 0, "pasted text"),
     contextCountLabel(workspaceFiles?.items.length ?? 0, "workspace file"),
     contextCountLabel(folderChips.length, "folder"),
     contextCountLabel(invokedSkills.length, "skill"),
@@ -881,7 +899,25 @@ export function Composer({
   }
 
   function onPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
-    if (acceptTransfer(event.clipboardData)) event.preventDefault();
+    if (acceptTransfer(event.clipboardData)) {
+      event.preventDefault();
+      return;
+    }
+    const text =
+      typeof event.clipboardData.getData === "function"
+        ? event.clipboardData.getData("text/plain")
+        : "";
+    if (!pastedTexts || !shouldAttachPastedText(text)) return;
+    event.preventDefault();
+    const field = event.currentTarget;
+    if (field.selectionStart !== field.selectionEnd) {
+      const start = field.selectionStart;
+      moveCaret(
+        `${draft.slice(0, start)}${draft.slice(field.selectionEnd)}`,
+        start,
+      );
+    }
+    pastedTexts.onPaste(text);
   }
 
   /** Terminal-style recall, claimed only at the start/end of the textarea. */
@@ -1046,6 +1082,20 @@ export function Composer({
                       key={file.documentId}
                       file={file}
                       onRemove={() => files.onRemove(file.documentId)}
+                    />
+                  ))}
+                </ul>
+              )}
+              {pastedTexts && pastedTexts.items.length > 0 && (
+                <ul
+                  className="m-0 flex list-none flex-wrap gap-2 p-0"
+                  aria-label="Pasted text"
+                >
+                  {pastedTexts.items.map((item) => (
+                    <PastedTextChip
+                      key={item.id}
+                      item={item}
+                      onRemove={() => pastedTexts.onRemove(item.id)}
                     />
                   ))}
                 </ul>
@@ -1581,6 +1631,42 @@ function WorkspaceFileChip({
         type="button"
         className="absolute right-0.5 top-0.5 inline-flex items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground"
         aria-label={`Remove ${name}`}
+        onClick={onRemove}
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    </li>
+  );
+}
+
+function PastedTextChip({
+  item,
+  onRemove,
+}: {
+  item: PastedTextAttachment;
+  onRemove: () => void;
+}) {
+  const lines = pastedTextLineCount(item.text);
+  const characters = [...item.text].length;
+  const detail = `${lines.toLocaleString()} ${lines === 1 ? "line" : "lines"} · ${characters.toLocaleString()} characters`;
+  const preview = pastedTextPreview(item.text);
+  return (
+    <li className="relative flex min-w-0 max-w-full items-center gap-2 rounded-lg border border-border bg-muted/50 py-1.5 pl-2 pr-7 text-muted-foreground">
+      <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-md bg-background">
+        <FileText className="size-4" aria-hidden="true" />
+      </span>
+      <span className="grid min-w-0 gap-px">
+        <strong className="text-xs font-semibold text-foreground">
+          Pasted text
+        </strong>
+        <small className="max-w-[18rem] truncate text-2xs" title={preview}>
+          {preview} · {detail}
+        </small>
+      </span>
+      <button
+        type="button"
+        className="absolute right-0.5 top-0.5 inline-flex items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground"
+        aria-label="Remove pasted text"
         onClick={onRemove}
       >
         <X size={14} aria-hidden="true" />

--- a/crates/tidebreak-desktop/ui/src/ComposerDrafts.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ComposerDrafts.test.ts
@@ -42,12 +42,18 @@ describe("composer draft attachments", () => {
     const store = useComposerDrafts.getState();
     store.setImages("chat-1", [READY_IMAGE, QUEUED_IMAGE]);
     store.setFiles("chat-1", [IMPORTED_FILE]);
+    store.setPastedTexts("chat-1", [
+      { id: "paste-1", text: "A long pasted source" },
+    ]);
     store.setFolders("chat-1", ["root-1"]);
 
     // A fresh store is what the next load of the page gets.
     const restored =
       createComposerDraftStore().getState().attachments["chat-1"];
     expect(restored.files).toEqual([IMPORTED_FILE]);
+    expect(restored.pastedTexts).toEqual([
+      { id: "paste-1", text: "A long pasted source" },
+    ]);
     expect(restored.folders).toEqual(["root-1"]);
     // The published image re-sends as-is; the queued one was a promise to
     // move bytes no storage can hold, so no chip comes back for it.

--- a/crates/tidebreak-desktop/ui/src/ComposerDrafts.ts
+++ b/crates/tidebreak-desktop/ui/src/ComposerDrafts.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import type { ImportedDocument } from "./documents";
 import type { ImageAttachment } from "./ImageAttachments";
+import type { PastedTextAttachment } from "./PastedText";
 
 const KEY_PREFIX = "composer_";
 const ATTACHMENTS_PREFIX = "composer_attachments_";
@@ -58,6 +59,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export type ComposerAttachmentDraft = {
   images: ImageAttachment[];
   files: ImportedDocument[];
+  pastedTexts: PastedTextAttachment[];
   /** Skills the next message will invoke, by catalog name, in pick order. */
   skills: string[];
   /**
@@ -71,6 +73,7 @@ export type ComposerAttachmentDraft = {
 export const EMPTY_ATTACHMENT_DRAFT: ComposerAttachmentDraft = {
   images: [],
   files: [],
+  pastedTexts: [],
   skills: [],
   folders: [],
   pendingChatId: null,
@@ -80,6 +83,7 @@ function isEmptyAttachmentDraft(draft: ComposerAttachmentDraft): boolean {
   return (
     draft.images.length === 0 &&
     draft.files.length === 0 &&
+    draft.pastedTexts.length === 0 &&
     draft.skills.length === 0 &&
     draft.folders.length === 0 &&
     draft.pendingChatId === null
@@ -104,6 +108,7 @@ function storableDraft(
       )
       .map((image) => ({ ...image, previewUrl: null })),
     files: draft.files,
+    pastedTexts: draft.pastedTexts,
     skills: draft.skills,
     folders: draft.folders,
     pendingChatId: draft.pendingChatId,
@@ -130,9 +135,18 @@ function parseStoredAttachmentDraft(
         typeof file.documentId === "string" &&
         typeof file.displayName === "string",
     );
+    const pastedTexts = (
+      Array.isArray(parsed.pastedTexts) ? parsed.pastedTexts : []
+    ).filter(
+      (item): item is PastedTextAttachment =>
+        isRecord(item) &&
+        typeof item.id === "string" &&
+        typeof item.text === "string",
+    );
     return {
       images,
       files,
+      pastedTexts,
       skills: (Array.isArray(parsed.skills) ? parsed.skills : []).filter(
         (skill): skill is string => typeof skill === "string",
       ),
@@ -210,6 +224,7 @@ export type ComposerDraftStore = {
   clearDraft: (key: string) => void;
   setImages: (key: string, images: ImageAttachment[]) => void;
   setFiles: (key: string, files: ImportedDocument[]) => void;
+  setPastedTexts: (key: string, items: PastedTextAttachment[]) => void;
   setSkills: (key: string, skills: string[]) => void;
   setFolders: (key: string, folders: string[]) => void;
   setPendingChatId: (key: string, chatId: string | null) => void;
@@ -253,6 +268,8 @@ export function createComposerDraftStore() {
         updateAttachments(key, (current) => ({ ...current, images })),
       setFiles: (key, files) =>
         updateAttachments(key, (current) => ({ ...current, files })),
+      setPastedTexts: (key, pastedTexts) =>
+        updateAttachments(key, (current) => ({ ...current, pastedTexts })),
       setSkills: (key, skills) =>
         updateAttachments(key, (current) => ({ ...current, skills })),
       setFolders: (key, folders) =>

--- a/crates/tidebreak-desktop/ui/src/ComposerPastedText.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerPastedText.dom.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { useState } from "react";
+import {
+  cleanup,
+  createEvent,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { Composer } from "./Composer";
+import type { PastedTextAttachment } from "./PastedText";
+
+afterEach(cleanup);
+
+function pasteText(target: Element, text: string) {
+  const event = createEvent.paste(target, {
+    clipboardData: {
+      files: [],
+      getData: (type: string) => (type === "text/plain" ? text : ""),
+    },
+  });
+  fireEvent(target, event);
+  return event;
+}
+
+function ComposerHarness({ onSend = vi.fn() }: { onSend?: () => void }) {
+  const [draft, setDraft] = useState("");
+  const [pastedTexts, setPastedTexts] = useState<PastedTextAttachment[]>([]);
+  return (
+    <Composer
+      activeTurnId={null}
+      busy={false}
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft={draft}
+      pastedTexts={{
+        items: pastedTexts,
+        onPaste: (text) =>
+          setPastedTexts((current) => [
+            ...current,
+            { id: `paste-${current.length + 1}`, text },
+          ]),
+        onRemove: (id) =>
+          setPastedTexts((current) => current.filter((item) => item.id !== id)),
+      }}
+      onDraftChange={setDraft}
+      onSend={async () => onSend()}
+      onSteer={vi.fn(async () => {})}
+      onStop={vi.fn(async () => {})}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />
+  );
+}
+
+it("holds a long paste outside the textarea and lets it send", async () => {
+  const user = userEvent.setup();
+  const onSend = vi.fn();
+  render(<ComposerHarness onSend={onSend} />);
+  const field = screen.getByRole("textbox", { name: "Message" });
+  const text = `First source line\n${"x".repeat(1_000)}`;
+
+  const event = pasteText(field, text);
+
+  expect(event.defaultPrevented).toBe(true);
+  expect(field).toHaveValue("");
+  expect(screen.getByText("Pasted text")).toBeInTheDocument();
+  expect(screen.getByText(/First source line/)).toBeInTheDocument();
+  await user.click(screen.getByRole("button", { name: "Send message" }));
+  expect(onSend).toHaveBeenCalledTimes(1);
+});
+
+it("removes held paste context without changing the draft", async () => {
+  const user = userEvent.setup();
+  render(<ComposerHarness />);
+  const field = screen.getByRole("textbox", { name: "Message" });
+  await user.type(field, "Keep this instruction");
+  pasteText(field, "x".repeat(1_000));
+
+  await user.click(screen.getByRole("button", { name: "Remove pasted text" }));
+
+  expect(field).toHaveValue("Keep this instruction");
+  expect(screen.queryByText("Pasted text")).toBeNull();
+});

--- a/crates/tidebreak-desktop/ui/src/FirstMessage.test.ts
+++ b/crates/tidebreak-desktop/ui/src/FirstMessage.test.ts
@@ -7,6 +7,7 @@ describe("first message handover", () => {
     text: "summarise the filing",
     images: [],
     files: [],
+    pastedTexts: [],
     skills: [],
     voiceInputUsed: false,
   };
@@ -41,5 +42,17 @@ describe("first message handover", () => {
     const store = createFirstMessageStore();
 
     expect(store.getState().take("chat-1")).toBeNull();
+  });
+
+  it("hands over pasted text without requiring typed text", () => {
+    const store = createFirstMessageStore();
+    const pastedOnly = {
+      ...pending,
+      text: "",
+      pastedTexts: [{ id: "paste-1", text: "source material" }],
+    };
+    store.getState().hold("chat-1", pastedOnly);
+
+    expect(store.getState().take("chat-1")).toEqual(pastedOnly);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/FirstMessage.ts
+++ b/crates/tidebreak-desktop/ui/src/FirstMessage.ts
@@ -1,11 +1,13 @@
 import { create } from "zustand";
 import type { ImageAttachment } from "./ImageAttachments";
 import type { ImportedDocument } from "./documents";
+import type { PastedTextAttachment } from "./PastedText";
 
 export type PendingFirstMessage = {
   text: string;
   images: ImageAttachment[];
   files: ImportedDocument[];
+  pastedTexts: PastedTextAttachment[];
   /** Skills picked on home, which only the chat route can actually post. */
   skills: string[];
   /** Whether voice transcription contributed to this message's text. */
@@ -37,7 +39,13 @@ export function createFirstMessageStore() {
     hold: (chatId, pending) => set({ chatId, pending }),
     take: (chatId) => {
       const { chatId: heldFor, pending } = get();
-      if (heldFor !== chatId || !pending?.text) return null;
+      if (
+        heldFor !== chatId ||
+        !pending ||
+        (!pending.text && pending.pastedTexts.length === 0)
+      ) {
+        return null;
+      }
       set({ chatId: null, pending: null });
       return pending;
     },

--- a/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/HomeRoute.tsx
@@ -36,6 +36,7 @@ import { MAX_IMAGE_ATTACHMENTS } from "./ImageAttachments";
 import { useImageAttachments } from "./useImageAttachments";
 import { appendTranscript, useVoiceComposer } from "./useVoiceComposer";
 import { useVoiceInputStore, voiceSelectionReady } from "./VoiceInputStore";
+import { messageWithPastedText } from "./PastedText";
 import {
   FirstTaskWalkthrough,
   shouldOfferFirstTaskWalkthrough,
@@ -173,6 +174,7 @@ export function HomeRoute() {
   const pendingChatId = attachments.pendingChatId;
   const pendingImages = attachments.images;
   const pendingFiles = attachments.files;
+  const pendingPastedTexts = attachments.pastedTexts;
   const pendingSkills = attachments.skills;
   const [attaching, setAttaching] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
@@ -348,7 +350,7 @@ export function HomeRoute() {
   }
 
   async function startChat() {
-    const content = draft.trim();
+    const content = messageWithPastedText(draft, pendingPastedTexts);
     if (!content || creatingChat) return;
     chatListActions.setCreatingChat(true);
     setError(null);
@@ -378,9 +380,10 @@ export function HomeRoute() {
         });
       }
       firstMessageActions.hold(chatId, {
-        text: content,
+        text: draft.trim(),
         images: pendingImages,
         files: pendingFiles,
+        pastedTexts: pendingPastedTexts,
         skills: pendingSkills,
         voiceInputUsed: voice.inputUsed,
       });
@@ -506,6 +509,27 @@ export function HomeRoute() {
                   setPendingFiles((current) =>
                     current.filter((file) => file.documentId !== documentId),
                   ),
+              }}
+              pastedTexts={{
+                items: pendingPastedTexts,
+                onPaste: (text) => {
+                  const current =
+                    useComposerDrafts.getState().attachments[HOME_DRAFT_KEY]
+                      ?.pastedTexts ?? [];
+                  composerDraftActions.setPastedTexts(HOME_DRAFT_KEY, [
+                    ...current,
+                    { id: crypto.randomUUID(), text },
+                  ]);
+                },
+                onRemove: (id) => {
+                  const current =
+                    useComposerDrafts.getState().attachments[HOME_DRAFT_KEY]
+                      ?.pastedTexts ?? [];
+                  composerDraftActions.setPastedTexts(
+                    HOME_DRAFT_KEY,
+                    current.filter((item) => item.id !== id),
+                  );
+                },
               }}
               nativeDropTarget={
                 <DocumentDropTarget

--- a/crates/tidebreak-desktop/ui/src/PastedText.test.ts
+++ b/crates/tidebreak-desktop/ui/src/PastedText.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LONG_PASTE_MIN_CHARACTERS,
+  messageWithPastedText,
+  pastedTextLineCount,
+  pastedTextPreview,
+  shouldAttachPastedText,
+} from "./PastedText";
+
+describe("PastedText", () => {
+  it("keeps short paste editable and attaches long paste", () => {
+    expect(shouldAttachPastedText("short note")).toBe(false);
+    expect(shouldAttachPastedText("x".repeat(LONG_PASTE_MIN_CHARACTERS))).toBe(
+      true,
+    );
+  });
+
+  it("adds held paste context after the typed instruction", () => {
+    expect(
+      messageWithPastedText("Summarize this", [
+        { id: "paste-1", text: "First line\nSecond line" },
+      ]),
+    ).toBe(
+      "Summarize this\n\n<pasted_text>\nFirst line\nSecond line\n</pasted_text>",
+    );
+  });
+
+  it("describes multiline paste content", () => {
+    expect(pastedTextLineCount("one\r\ntwo\nthree")).toBe(3);
+    expect(pastedTextPreview("\n  First useful line  \nSecond")).toBe(
+      "First useful line",
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/PastedText.ts
+++ b/crates/tidebreak-desktop/ui/src/PastedText.ts
@@ -1,0 +1,36 @@
+export const LONG_PASTE_MIN_CHARACTERS = 1_000;
+
+/** One long clipboard paste held outside the editable composer text. */
+export type PastedTextAttachment = {
+  id: string;
+  text: string;
+};
+
+/** Short clipboard text stays editable. Long text becomes message context. */
+export function shouldAttachPastedText(text: string): boolean {
+  return [...text.trim()].length >= LONG_PASTE_MIN_CHARACTERS;
+}
+
+/** Put held paste context back into the plain-text message sent to the model. */
+export function messageWithPastedText(
+  draft: string,
+  items: readonly PastedTextAttachment[],
+): string {
+  const parts = items.map(
+    (item) => `<pasted_text>\n${item.text}\n</pasted_text>`,
+  );
+  return [draft.trim(), ...parts].filter(Boolean).join("\n\n");
+}
+
+export function pastedTextLineCount(text: string): number {
+  return text.split(/\r\n|\r|\n/).length;
+}
+
+export function pastedTextPreview(text: string): string {
+  return (
+    text
+      .split(/\r\n|\r|\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? "Pasted text"
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -89,6 +89,38 @@ const QUEUED = {
 };
 
 describe("CodeComposer", () => {
+  it("sends a long paste as held message context", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        sessionId="sess-1"
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+      />,
+    );
+    const box = screen.getByRole("textbox", { name: "Message" });
+    const pasted = `First source line\n${"x".repeat(1_000)}`;
+    const event = createEvent.paste(box, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => (type === "text/plain" ? pasted : ""),
+      },
+    });
+
+    fireEvent(box, event);
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(event.defaultPrevented).toBe(true);
+    await waitFor(() =>
+      expect(onSend).toHaveBeenCalledWith(
+        `<pasted_text>\n${pasted}\n</pasted_text>`,
+      ),
+    );
+    expect(screen.queryByText("Pasted text")).toBeNull();
+  });
+
   it("inserts a pending inspector prompt into the draft", async () => {
     useCodeUiStore
       .getState()

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -23,6 +23,10 @@ import {
   readyImageAttachmentIds,
 } from "../ImageAttachments";
 import { useImageAttachments } from "../useImageAttachments";
+import {
+  messageWithPastedText,
+  type PastedTextAttachment,
+} from "../PastedText";
 import { reasoningEffortOptions } from "../ModelMenu";
 import { familyForModelId } from "../modelFamilies";
 import { PermissionModeMenu } from "../PermissionModeMenu";
@@ -690,6 +694,7 @@ export function CodeComposer({
   const { client } = useApp();
   const composerPromptScope = promptScope ?? sessionId ?? "code";
   const [draft, setDraft] = useState("");
+  const [pastedTexts, setPastedTexts] = useState<PastedTextAttachment[]>([]);
   const [selectedModel, setSelectedModel] = useState(model ?? "");
   // Optimistic: the picker moves on click and the session row catches up when
   // the route answers. A refusal is surfaced by the caller, which owns the
@@ -703,6 +708,7 @@ export function CodeComposer({
   const [steerError, setSteerError] = useState<string | null>(null);
   const [steerStatus, setSteerStatus] = useState<string | null>(null);
   const draftRef = useRef("");
+  const pastedTextsRef = useRef<PastedTextAttachment[]>([]);
   const steerRequestRef = useRef(0);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const images = useImageAttachments(
@@ -759,6 +765,16 @@ export function CodeComposer({
     draftRef.current = draft;
   }, [draft]);
 
+  function updatePastedTexts(
+    update: (
+      current: readonly PastedTextAttachment[],
+    ) => PastedTextAttachment[],
+  ) {
+    const next = update(pastedTextsRef.current);
+    pastedTextsRef.current = next;
+    setPastedTexts(next);
+  }
+
   useEffect(() => {
     steerRequestRef.current += 1;
     setSteerPending(false);
@@ -801,7 +817,9 @@ export function CodeComposer({
   }, [fastMode, sessionId]);
 
   async function submit() {
-    const typed = draft.trim();
+    const submittedDraft = draft;
+    const submittedPastedTexts = pastedTextsRef.current;
+    const typed = messageWithPastedText(submittedDraft, submittedPastedTexts);
     if (!typed || disabled) return;
     // The chips ride out with the message: the engine reads the paths from
     // its own working directory, so nothing is uploaded.
@@ -832,7 +850,10 @@ export function CodeComposer({
       },
     );
     const held = images.attachments;
+    draftRef.current = "";
     setDraft("");
+    pastedTextsRef.current = [];
+    setPastedTexts([]);
     setNotice(null);
     // Chips leave with the draft, not after the server answers. Waiting made
     // a sent turn look like it had failed to take the images.
@@ -847,6 +868,13 @@ export function CodeComposer({
       }
     } catch (err) {
       images.restore(held);
+      updatePastedTexts((current) => [
+        ...submittedPastedTexts,
+        ...current.filter(
+          (item) =>
+            !submittedPastedTexts.some((submitted) => submitted.id === item.id),
+        ),
+      ]);
       setNotice({
         text:
           err instanceof HttpError && err.kind === "queue_full"
@@ -855,7 +883,11 @@ export function CodeComposer({
               ? err.message
               : "Could not send that turn",
       });
-      setDraft((current) => (current.length === 0 ? message : current));
+      setDraft((current) => {
+        if (current.length > 0) return current;
+        draftRef.current = submittedDraft;
+        return submittedDraft;
+      });
     }
   }
 
@@ -899,7 +931,8 @@ export function CodeComposer({
 
   async function steer() {
     const submittedDraft = draftRef.current;
-    const message = submittedDraft.trim();
+    const submittedPastedTexts = pastedTextsRef.current;
+    const message = messageWithPastedText(submittedDraft, submittedPastedTexts);
     if (!message || disabled) return;
     if (!onSteer) {
       setSteerStatus(null);
@@ -916,9 +949,14 @@ export function CodeComposer({
     try {
       await onSteer(message);
       if (steerRequestRef.current !== request) return;
-      if (draftRef.current === submittedDraft) {
+      if (
+        draftRef.current === submittedDraft &&
+        pastedTextsRef.current === submittedPastedTexts
+      ) {
         draftRef.current = "";
         setDraft("");
+        pastedTextsRef.current = [];
+        setPastedTexts([]);
       }
       setSteerStatus("Guidance sent");
     } catch (err) {
@@ -1012,6 +1050,22 @@ export function CodeComposer({
                 attaching: false,
                 onAttach: () => imageInputRef.current?.click(),
                 onRemove: () => undefined,
+              }
+            : undefined
+        }
+        pastedTexts={
+          sessionId
+            ? {
+                items: pastedTexts,
+                onPaste: (text) =>
+                  updatePastedTexts((current) => [
+                    ...current,
+                    { id: crypto.randomUUID(), text },
+                  ]),
+                onRemove: (id) =>
+                  updatePastedTexts((current) =>
+                    current.filter((item) => item.id !== id),
+                  ),
               }
             : undefined
         }

--- a/crates/tidebreak-desktop/ui/src/stories/ChatView.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ChatView.stories.tsx
@@ -41,6 +41,7 @@ import {
   useComposerDrafts,
   type ComposerAttachmentDraft,
 } from "@/ComposerDrafts";
+import { messageWithPastedText } from "@/PastedText";
 import type {
   ComposerFiles,
   ComposerFolders,
@@ -692,6 +693,9 @@ function seedScenario(scenario: StoryScenario): void {
     .setFiles(CHAT_ID, scenario.attachments?.files ?? []);
   useComposerDrafts
     .getState()
+    .setPastedTexts(CHAT_ID, scenario.attachments?.pastedTexts ?? []);
+  useComposerDrafts
+    .getState()
     .setSkills(CHAT_ID, scenario.attachments?.skills ?? []);
   useComposerDrafts
     .getState()
@@ -789,7 +793,9 @@ function StoryChat({
     useComposerDrafts.getState().setDraft(CHAT_ID, value);
   };
   const submitDraft = async () => {
-    const text = draftRef.current.trim();
+    const pastedTexts =
+      useComposerDrafts.getState().attachments[CHAT_ID]?.pastedTexts ?? [];
+    const text = messageWithPastedText(draftRef.current, pastedTexts);
     if (!text) return;
     useChatSessionStore.getState().update((session) => ({
       ...session,
@@ -804,12 +810,16 @@ function StoryChat({
       ],
     }));
     updateDraft("");
+    useComposerDrafts.getState().setPastedTexts(CHAT_ID, []);
   };
   const queueDraft = async () => {
-    const text = draftRef.current.trim();
+    const pastedTexts =
+      useComposerDrafts.getState().attachments[CHAT_ID]?.pastedTexts ?? [];
+    const text = messageWithPastedText(draftRef.current, pastedTexts);
     if (!text) return;
     client.enqueue(text);
     updateDraft("");
+    useComposerDrafts.getState().setPastedTexts(CHAT_ID, []);
   };
   const retryTurn = (turn: RetryableTurn) => updateDraft(turn.text);
 
@@ -824,7 +834,6 @@ function StoryChat({
             hydrated
             nativeHost={scenario.nativeHost ?? false}
             deletingChat={false}
-            draftRef={draftRef}
             composerModelMenu={
               <ModelMenu
                 models={storyModels}
@@ -947,6 +956,32 @@ export const AttachmentsAndDraft: Story = {
     const composer = await canvas.findByRole("textbox", { name: "Message" });
     await userEvent.click(composer);
     await expect(composer).toHaveFocus();
+  },
+};
+
+export const PastedTextAndDraft: Story = {
+  args: {
+    scenario: {
+      id: "pasted-text-and-draft",
+      messages: baseMessages,
+      draft:
+        "Summarize the pasted release notes and call out breaking changes.",
+      attachments: {
+        pastedTexts: [
+          {
+            id: "paste-storybook",
+            text: "Release notes for desktop synchronization\n\nThe client now restores unfinished uploads after restart. Existing sessions keep their original attachment identifiers.",
+          },
+        ],
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Pasted text")).toBeVisible();
+    await expect(
+      canvas.getByRole("button", { name: "Remove pasted text" }),
+    ).toBeVisible();
   },
 };
 


### PR DESCRIPTION
## Summary

- Turn clipboard text with at least 1,000 trimmed characters into removable Pasted text chips.
- Send held text in `<pasted_text>` blocks from chat, home, queued turns, active-turn guidance, and code sessions.
- Persist pasted text with composer drafts and preserve it after failed or overlapping submissions.
- Add unit, DOM, and Storybook coverage for the new composer state.

## Why

Long pastes can overwhelm the editable composer and make the typed instruction difficult to find. A chip keeps the instruction editable while preserving the full pasted source in the message sent to the model.

## Validation

- `pnpm exec biome check` on all changed UI files
- 66 focused Vitest tests
- `pnpm exec tsc --noEmit`
- `pnpm storybook:build`
- `git diff --check`