### PR TITLE
fix(desktop): move fork harness selection into composer

### DIFF
--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -322,6 +322,8 @@ export type ComposerProps = {
   draft: string;
   /** Prior user messages, newest first, for terminal-style Up/Down recall. */
   history?: readonly string[];
+  /** Engine picker for a draft that starts a new code session. */
+  harnessMenu?: ReactNode;
   modelMenu?: ReactNode;
   /** Sits immediately to the right of `modelMenu` when the surface offers one. */
   effortMenu?: ReactNode;
@@ -372,6 +374,8 @@ export type ComposerProps = {
   steerError: string | null;
   steerPending: boolean;
   steerStatus: string | null;
+  /** Quiet status or guidance that belongs to this composer setup. */
+  footerNote?: ReactNode;
 };
 
 export function Composer({
@@ -382,6 +386,7 @@ export function Composer({
   disabled,
   draft,
   history = [],
+  harnessMenu,
   modelMenu,
   effortMenu,
   fastModeToggle,
@@ -408,6 +413,7 @@ export function Composer({
   steerError,
   steerPending,
   steerStatus,
+  footerNote,
 }: ComposerProps) {
   const contextTriggerId = useId();
   const contextLabelId = `${contextTriggerId}-label`;
@@ -1236,6 +1242,7 @@ export function Composer({
                 : undefined
             }
           />
+          {harnessMenu}
           {modelMenu}
           {fastModeToggle}
           {effortMenu}
@@ -1371,6 +1378,7 @@ export function Composer({
           {steerStatus}
         </span>
       )}
+      {footerNote}
       {steerTooLong && (
         <span className="text-xs text-destructive" role="alert">
           Guidance is too long.

--- a/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
+++ b/crates/tidebreak-desktop/ui/src/FirstTaskWalkthrough.tsx
@@ -51,7 +51,7 @@ const STEPS: readonly WalkthroughStep[] = [
     surface: "permissions",
     targets: ["permissions-ask", "permissions-menu"],
     title: "Choose a permission level",
-    body: "The permission menu is open. Plan stays read-only, Ask confirms actions, Auto handles routine workspace work, and Allow all runs without asking in this work. Ask is a balanced place to start.",
+    body: "The permission menu is open. Choose a level for this work.",
   },
   {
     id: "attachments",

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -29,6 +29,8 @@ it("applies the chosen mode and closes", async () => {
   await userEvent.click(
     screen.getByRole("button", { name: "Permissions: Ask" }),
   );
+  expect(screen.queryByText(/without asking/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/read-only/)).not.toBeInTheDocument();
   await userEvent.click(
     await screen.findByRole("menuitem", { name: /Allow all/ }),
   );

--- a/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/PermissionModeMenu.tsx
@@ -21,46 +21,32 @@ import {
 import { useGuidedMenu } from "./FirstTaskWalkthrough";
 import { cn } from "@/lib/utils";
 
-/**
- * Every mode in ascending order of autonomy, with its menu copy.
- *
- * The descriptions state the decision order the server actually applies:
- * saved allowlists run without asking in every mode, and the mode governs
- * only the calls no grant covers.
- */
+/** Every mode in ascending order of autonomy. */
 const ASK_PERMISSION_MODE_OPTION = {
   value: "ask",
   label: "Ask",
-  description:
-    "Ask before edits and actions that leave the workspace. Allowlists you've saved still run without asking.",
   icon: ShieldCheck,
 } as const;
 
 const PERMISSION_MODE_SCALE: {
   value: PermissionMode;
   label: string;
-  description: string;
   icon: typeof ShieldCheck;
 }[] = [
   {
     value: "plan",
     label: "Plan",
-    description:
-      "Read-only: the agent explores and proposes a plan. Nothing is edited or run until you switch modes.",
     icon: Eye,
   },
   ASK_PERMISSION_MODE_OPTION,
   {
     value: "auto",
     label: "Auto",
-    description:
-      "Workspace edits run on their own; anything that leaves the workspace still asks.",
     icon: Zap,
   },
   {
     value: "allow",
     label: "Allow all",
-    description: "Everything runs without asking, in this work only.",
     icon: ShieldOff,
   },
 ];
@@ -206,7 +192,7 @@ export function PermissionModeMenu({
       <DropdownMenuContent
         align="end"
         side="top"
-        className="w-72"
+        className="w-64"
         data-first-task-target="permissions-menu"
         onEscapeKeyDown={guided.onEscapeKeyDown}
       >
@@ -223,7 +209,10 @@ export function PermissionModeMenu({
                 if (selected) return;
                 void selectMode(option.value);
               }}
-              className="flex flex-col items-start gap-0.5 py-3"
+              className={cn(
+                "py-2",
+                (locked || unoffered) && "flex-col items-start gap-0.5 py-2.5",
+              )}
               data-first-task-target={
                 option.value === "ask" ? "permissions-ask" : undefined
               }
@@ -246,13 +235,13 @@ export function PermissionModeMenu({
                   selected && <Check className="size-4" />
                 )}
               </div>
-              <span className="text-muted-foreground pl-6 text-xs">
-                {locked
-                  ? "Locked by your organization's policy."
-                  : unoffered
-                    ? "This harness can't honor this mode."
-                    : option.description}
-              </span>
+              {(locked || unoffered) && (
+                <span className="text-muted-foreground pl-6 text-xs">
+                  {locked
+                    ? "Locked by your organization's policy."
+                    : "This harness can't honor this mode."}
+                </span>
+              )}
             </DropdownMenuItem>
           );
         })}

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useRef, useState, useEffect } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  useEffect,
+  type ReactNode,
+} from "react";
 import {
   Check,
   ChevronDown,
@@ -264,7 +271,7 @@ export function HarnessModelMenu({
         className={
           variant === "field"
             ? "h-10 w-full justify-between px-3 font-normal"
-            : "h-8 max-w-56 min-w-0 gap-2"
+            : "h-8 max-w-56 min-w-0 shrink gap-2"
         }
         disabled
         aria-label={loading ? "Loading models" : "Model: Default"}
@@ -311,7 +318,7 @@ export function HarnessModelMenu({
           className={
             variant === "field"
               ? "h-10 w-full justify-between px-3 font-normal"
-              : "h-8 max-w-56 min-w-0 gap-2"
+              : "h-8 max-w-56 min-w-0 shrink gap-2"
           }
           disabled={locked}
           aria-label={`Model: ${current.label}`}
@@ -614,6 +621,8 @@ export function CodeComposer({
   model,
   modelOptions,
   modelLoading = false,
+  harnessMenu,
+  footerNote,
   promptScope,
   sessionId,
   history,
@@ -641,6 +650,10 @@ export function CodeComposer({
   model?: string;
   modelOptions?: readonly CodeModelOption[];
   modelLoading?: boolean;
+  /** Engine picker shown before the model control when starting a session. */
+  harnessMenu?: ReactNode;
+  /** Setup status shown inside the composer after its controls. */
+  footerNote?: ReactNode;
   /** Workspace identity used to route header actions to the matching composer. */
   promptScope?: string;
   sessionId?: string;
@@ -940,6 +953,7 @@ export function CodeComposer({
         disabled={Boolean(disabled)}
         draft={draft}
         history={history}
+        harnessMenu={harnessMenu}
         modelMenu={
           harness && ((modelOptions?.length ?? 0) > 0 || modelLoading) ? (
             <HarnessModelMenu
@@ -1032,6 +1046,7 @@ export function CodeComposer({
         steerError={steerError}
         steerPending={steerPending}
         steerStatus={steerStatus}
+        footerNote={footerNote}
       />
       {sessionId && (
         <input

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.dom.test.tsx
@@ -130,4 +130,22 @@ describe("HarnessPicker", () => {
     await user.click(grokRow);
     expect(onChange).toHaveBeenCalledWith("grok");
   });
+
+  it("does not add a settings button beside the composer control", async () => {
+    await renderWithRouter(
+      <HarnessPicker
+        harnesses={[
+          entry({ kind: "claude_code" }),
+          entry({ kind: "opencode", found: false, installable: false }),
+        ]}
+        value="claude_code"
+        onChange={vi.fn()}
+        variant="composer"
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Coding harnesses" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessPicker.tsx
@@ -50,11 +50,14 @@ export function HarnessPicker({
   value,
   onChange,
   disabled,
+  variant = "field",
 }: {
   harnesses: HarnessDoctorEntry[];
   value: HarnessKind | null;
   onChange: (kind: HarnessKind) => void;
   disabled?: boolean;
+  /** Field fills a form row; composer sits beside model and mode controls. */
+  variant?: "field" | "composer";
 }) {
   const navigate = useNavigate();
   const harnessesPath: string = "/settings/coding-harnesses";
@@ -63,13 +66,26 @@ export function HarnessPicker({
   const anyUnusable = harnesses.some((entry) => harnessUnusableReason(entry));
 
   return (
-    <div className="flex flex-col gap-1">
+    <div
+      className={
+        variant === "composer"
+          ? "flex min-w-0 items-center gap-1"
+          : "flex flex-col gap-1"
+      }
+    >
       <Select
         value={value ?? undefined}
         onValueChange={(next) => onChange(next as HarnessKind)}
         disabled={disabled || harnesses.length === 0}
       >
-        <SelectTrigger aria-label="Harness">
+        <SelectTrigger
+          aria-label="Harness"
+          className={
+            variant === "composer"
+              ? "h-8 w-auto max-w-44 min-w-0 shrink-0 gap-2 border-transparent px-2 hover:bg-accent hover:text-accent-foreground"
+              : undefined
+          }
+        >
           <SelectValue placeholder="No harness detected">
             {selected && SelectedIcon && (
               <span className="flex items-center gap-2">
@@ -111,7 +127,7 @@ export function HarnessPicker({
           })}
         </SelectContent>
       </Select>
-      {anyUnusable && (
+      {anyUnusable && variant === "field" && (
         <button
           type="button"
           className="text-muted-foreground w-fit cursor-pointer text-xs underline-offset-2 hover:underline"

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -443,13 +443,11 @@ describe("NewWorkspaceDialog", () => {
         screen.getByRole("button", { name: "Model: GPT 5.6 Sol" }),
       ).toBeEnabled(),
     );
-    // Allow is the default where the engine honors it, and it says so.
+    // Allow is the default where the engine honors it.
     expect(
       screen.getByRole("button", { name: "Permissions: Allow all" }),
     ).toBeEnabled();
-    expect(
-      screen.getByText(/every action runs without asking/),
-    ).toBeInTheDocument();
+    expect(screen.queryByText(/runs without asking/)).toBeNull();
 
     fireEvent.keyDown(screen.getByRole("dialog"), {
       key: "Enter",

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -49,7 +49,6 @@ import { HarnessInstallNote } from "./HarnessInstallNote";
 import { useWarmHarnessInstall } from "./useHarnessInstall";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import {
-  autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   gatewayCodeModels,
@@ -58,8 +57,6 @@ import {
   preferredCodeModels,
   requiresHarnessModelIds,
   HARNESS_LABELS,
-  ALLOW_ALL_NOTE,
-  UNSUPERVISED_AUTO_NOTE,
   type CodeModelOption,
 } from "./labels";
 
@@ -84,10 +81,9 @@ import {
  * The title is optional: left blank, the server generates a two-word name and
  * later replaces it with one derived from the first turn, the same way chats
  * are named. Permission mode defaults to the most autonomous posture the
- * engine honors (decision 0039, amended); whichever posture is armed, the
- * note under the message states it. The engine menu lists every doctor entry —
- * ready rows are selectable; unusable ones stay visible, dimmed, with the
- * reason.
+ * engine honors (decision 0039, amended). The engine menu lists every doctor
+ * entry — ready rows are selectable; unusable ones stay visible, dimmed, with
+ * the reason.
  */
 
 /** The repo this reader worked on last: newest workspace, then storage. */
@@ -277,14 +273,6 @@ export function NewWorkspaceDialog({
   const canCreate = Boolean(
     repoId && selectedRepo && selectedHarness && installed,
   );
-  const modeNote =
-    postedMode === "auto" &&
-    selectedHarness &&
-    autoIsUnsupervised(selectedHarness.caps)
-      ? UNSUPERVISED_AUTO_NOTE
-      : postedMode === "allow"
-        ? ALLOW_ALL_NOTE
-        : null;
   const installNote = install && (!install.done || install.error);
 
   useEffect(() => {
@@ -752,12 +740,9 @@ export function NewWorkspaceDialog({
               void create();
             }}
           />
-          {(installNote || modeNote) && (
+          {installNote && (
             <div className="flex flex-col gap-1 px-4 pb-1.5">
               <HarnessInstallNote install={install} />
-              {modeNote && (
-                <p className="text-muted-foreground text-xs">{modeNote}</p>
-              )}
             </div>
           )}
           <div className="flex min-w-0 items-center gap-1 px-3 pb-3">

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -15,7 +15,6 @@ import type { HarnessDoctorEntry } from "../api/types";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
-import { ALLOW_ALL_NOTE, UNSUPERVISED_AUTO_NOTE } from "./labels";
 import { StartSessionPrompt } from "./StartSessionPrompt";
 import type { ReasoningEffort } from "../api/types";
 import type { ParsedHarnessModel } from "./parsers";
@@ -135,7 +134,7 @@ describe("StartSessionPrompt", () => {
     expect(document.querySelector('input[type="file"][accept]')).toBeNull();
   });
 
-  it("defaults to the widest mode the engine honors, says so, and starts on Cmd+Enter", async () => {
+  it("defaults to the widest mode the engine honors and starts on Cmd+Enter", async () => {
     const user = userEvent.setup();
     const onStart = vi.fn();
     await renderWithRouter(
@@ -153,7 +152,10 @@ describe("StartSessionPrompt", () => {
     expect(
       screen.getByRole("button", { name: "Permissions: Allow all" }),
     ).toBeInTheDocument();
-    expect(screen.getByText(ALLOW_ALL_NOTE)).toBeInTheDocument();
+    expect(screen.queryByText(/runs without asking/)).toBeNull();
+    expect(
+      screen.getByRole("combobox", { name: "Harness" }).closest("form"),
+    ).toHaveClass("chat-composer");
     const field = screen.getByRole("textbox", { name: "Message" });
     await user.type(field, "list the files");
     await user.keyboard("{Meta>}{Enter}{/Meta}");
@@ -202,7 +204,7 @@ describe("StartSessionPrompt", () => {
     );
   });
 
-  it("switches an Auto-only engine to unsupervised Auto and says so", async () => {
+  it("switches an Auto-only engine to Auto without extra permission copy", async () => {
     const user = userEvent.setup();
     const onStart = vi.fn();
     await renderWithRouter(
@@ -224,14 +226,13 @@ describe("StartSessionPrompt", () => {
         />,
       ),
     );
-    expect(screen.queryByText(UNSUPERVISED_AUTO_NOTE)).toBeNull();
     await user.click(screen.getByRole("combobox", { name: "Harness" }));
     await user.click(screen.getByRole("option", { name: /Grok CLI/ }));
     // The selected Ask is not honorable here; the mode follows the engine.
     expect(
       screen.getByRole("button", { name: "Permissions: Auto" }),
     ).toBeInTheDocument();
-    expect(screen.getByText(UNSUPERVISED_AUTO_NOTE)).toBeInTheDocument();
+    expect(screen.queryByText(/runs without asking/)).toBeNull();
     await user.type(
       screen.getByRole("textbox", { name: "Message" }),
       "list the files",

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -18,7 +18,6 @@ import {
   useWarmHarnessInstall,
 } from "./useHarnessInstall";
 import {
-  autoIsUnsupervised,
   createPermissionModes,
   defaultCreatePermissionMode,
   gatewayCodeModels,
@@ -27,8 +26,6 @@ import {
   preferredCodeModels,
   requiresHarnessModelIds,
   type CodeModelOption,
-  ALLOW_ALL_NOTE,
-  UNSUPERVISED_AUTO_NOTE,
 } from "./labels";
 
 const NO_CATALOG_MODELS: ModelInfo[] = [];
@@ -38,13 +35,13 @@ const NO_CATALOG_MODELS: ModelInfo[] = [];
  *
  * The harness dropdown defaults to the first engine that can start now; the
  * mode list and default follow the selected engine's own capability flags, so
- * start always posts a mode that engine can honor, and an unsupervised one
- * says so before the session exists (decisions 0038, 0039).
+ * start always posts a mode that engine can honor (decisions 0038, 0039).
  *
- * An engine this machine has not downloaded yet is still on offer. Picking it
- * starts the download and the note under the picker says so; start stays
- * disabled until the pin lands, because create would otherwise sit on the
- * same npm install with nothing on screen.
+ * The harness sits in the composer beside the model so it stays next to the
+ * draft it controls. An engine this machine has not downloaded yet is still
+ * on offer. Picking it starts the download and the composer says so; start
+ * stays disabled until the pin lands, because create would otherwise sit on
+ * the same npm install with nothing on screen.
  *
  * Cmd+Enter starts from anywhere on this surface, matching the new-workspace
  * dialog. The draft lives in the composer, so the shortcut goes through the
@@ -195,27 +192,8 @@ export function StartSessionPrompt({
         send.click();
       }}
     >
-      <div className="flex flex-col gap-3 px-4 py-6">
+      <div className="px-4 py-6">
         <p className="text-sm">Start a session on this workspace.</p>
-        <HarnessPicker
-          harnesses={harnesses}
-          value={selected?.kind ?? null}
-          disabled={starting}
-          onChange={(next) => {
-            setModelOptions([]);
-            setModelLoading(true);
-            setPicked(next);
-          }}
-        />
-        <HarnessInstallNote install={install} />
-        {mode === "auto" && selected && autoIsUnsupervised(selected.caps) && (
-          <p className="text-muted-foreground text-xs">
-            {UNSUPERVISED_AUTO_NOTE}
-          </p>
-        )}
-        {mode === "allow" && (
-          <p className="text-muted-foreground text-xs">{ALLOW_ALL_NOTE}</p>
-        )}
       </div>
       <div className="mt-auto">
         <CodeComposer
@@ -227,6 +205,20 @@ export function StartSessionPrompt({
           model={model}
           modelOptions={modelOptions}
           modelLoading={modelLoading}
+          harnessMenu={
+            <HarnessPicker
+              harnesses={harnesses}
+              value={selected?.kind ?? null}
+              disabled={starting}
+              variant="composer"
+              onChange={(next) => {
+                setModelOptions([]);
+                setModelLoading(true);
+                setPicked(next);
+              }}
+            />
+          }
+          footerNote={<HarnessInstallNote install={install} />}
           promptScope={workspaceId}
           workspaceFiles={workspaceFiles}
           onModelChange={(next) => {

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -99,14 +99,6 @@ export const PERMISSION_MODE_UNAVAILABLE_REASON =
 export const SESSION_PERMISSION_MODE_LOCKED =
   "Set when the session started — start a new session to change it";
 
-/** Stated wherever unsupervised Auto is offered (decision 0038). */
-export const UNSUPERVISED_AUTO_NOTE =
-  "This engine has no approval channel: in Auto, every action runs without asking.";
-
-/** Stated wherever Allow is offered (decision 0039). */
-export const ALLOW_ALL_NOTE =
-  "This engine's permission system is off: every action runs without asking.";
-
 /** The capability flags the mode policy reads. */
 export type ModeCaps = Pick<
   HarnessCaps,

--- a/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
@@ -8,9 +8,11 @@ import {
   RouterProvider,
 } from "@tanstack/react-router";
 
-import type { CodeForkTranscript } from "@/api/types";
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import type { CodeForkTranscript, HarnessKind } from "@/api/types";
 import { useCodeUiStore } from "@/code/CodeUiStore";
 import { forkFraming, forkTranscriptFile } from "@/code/fork";
+import type { ParsedHarnessModel } from "@/code/parsers";
 import { StartSessionPrompt } from "@/code/StartSessionPrompt";
 import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
 
@@ -19,6 +21,88 @@ import { harnessDoctor, harnessDoctorDegraded } from "./fixtures";
  * and the first message. Mode lists must follow each engine's declared
  * capabilities — Grok's honest refusals leave it Auto-only.
  */
+const models: Partial<Record<HarnessKind, ParsedHarnessModel[]>> = {
+  claude_code: [
+    {
+      id: "claude-fable-5",
+      label: "Claude Fable 5",
+      default: true,
+      reasoning_efforts: [],
+      fast_mode: false,
+    },
+  ],
+  codex: [
+    {
+      id: "gpt-5.6",
+      label: "GPT 5.6",
+      default: true,
+      reasoning_efforts: [],
+      fast_mode: false,
+    },
+  ],
+  opencode: [
+    {
+      id: "gpt-5.6",
+      label: "GPT 5.6",
+      default: true,
+      reasoning_efforts: [],
+      fast_mode: false,
+    },
+  ],
+  grok: [
+    {
+      id: "grok-4.6",
+      label: "Grok 4.6",
+      default: true,
+      reasoning_efforts: [],
+      fast_mode: false,
+    },
+  ],
+};
+
+const client = {
+  listCodeHarnessModels: async (kind: HarnessKind) => ({
+    kind,
+    models: models[kind] ?? [],
+    reasoning_efforts: [],
+  }),
+};
+
+function appContext(): AppContextValue {
+  return {
+    client: client as never,
+    models: [],
+    defaultModelKey: null,
+    providers: [],
+    refreshCatalog: async () => {},
+    refreshChats: async () => {},
+    status: "",
+    setStatus: () => {},
+    newChat: () => {},
+    deleteChat: () => {},
+    startRename: () => {},
+    commitRename: () => {},
+    cancelRename: () => {},
+    newProject: async () => false,
+    deleteProject: () => {},
+    startProjectRename: () => {},
+    commitProjectRename: () => {},
+    cancelProjectRename: () => {},
+    newChatInProject: () => {},
+    moveChatToProject: () => {},
+    updateState: { status: "idle", version: null, error: null, enabled: false },
+    updateUpToDate: false,
+    checkForUpdate: async () => ({
+      status: "idle",
+      version: null,
+      error: null,
+      enabled: false,
+    }),
+    attachment: "local",
+    restartForUpdate: async () => {},
+  };
+}
+
 function withRouter(children: ReactNode) {
   const rootRoute = createRootRoute({ component: () => children });
   const router = createRouter({
@@ -44,17 +128,24 @@ function StartSession({
     useCodeUiStore.getState().offerComposerPrompt("ws-1", forkFraming(fork));
   }, [fork]);
   return (
-    <StartSessionPrompt
-      workspaceId="ws-1"
-      harnesses={harnesses}
-      starting={starting}
-      selectedMode={null}
-      onSelectMode={fn()}
-      onStart={fn()}
-      workspaceFiles={
-        fork ? { items: [forkTranscriptFile(fork)], onRemove: fn() } : undefined
-      }
-    />
+    <AppContextProvider value={appContext()}>
+      <div className="flex h-full flex-col">
+        <StartSessionPrompt
+          workspaceId="ws-1"
+          harnesses={harnesses}
+          starting={starting}
+          selectedMode={null}
+          onSelectMode={fn()}
+          onStart={fn()}
+          client={client}
+          workspaceFiles={
+            fork
+              ? { items: [forkTranscriptFile(fork)], onRemove: fn() }
+              : undefined
+          }
+        />
+      </div>
+    </AppContextProvider>
   );
 }
 
@@ -62,10 +153,9 @@ const meta = {
   title: "Code/Start session",
   component: StartSession,
   args: { harnesses: harnessDoctor.harnesses },
+  parameters: { layout: "fullscreen" },
   decorators: [
-    (Story) => (
-      <div className="mx-auto max-w-xl pt-8">{withRouter(<Story />)}</div>
-    ),
+    (Story) => <div className="h-screen w-full">{withRouter(<Story />)}</div>,
   ],
 } satisfies Meta<typeof StartSession>;
 


### PR DESCRIPTION
## What changed

Move the fork and session-start harness picker into the composer beside the model and permission controls, remove the extra settings button, and trim repeated permission explanations while preserving policy and compatibility reasons.
Expand the Start session stories with model context and fork transcript states so the composer layout has representative coverage.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/stylesContract.test.ts src/PermissionModeMenu.dom.test.tsx src/FirstTaskWalkthrough.dom.test.tsx src/code/CodeComposer.dom.test.tsx src/code/StartSessionPrompt.dom.test.tsx src/code/HarnessPicker.dom.test.tsx src/code/NewWorkspaceDialog.dom.test.tsx src/code/CodeWorkspacePage.dom.test.tsx` (124 tests)
- `pnpm exec biome lint` on the changed source and test files
- `pnpm storybook:build`
- `git diff --check`

A fresh screenshot pass could not run because no controllable browser was connected.

## Compatibility and risk

None. This change affects desktop UI layout and copy without changing persisted data or wire formats.
