### PR TITLE
feat(desktop): streamline folder access and imports

### DIFF
--- a/crates/tidebreak-cli/src/folder.rs
+++ b/crates/tidebreak-cli/src/folder.rs
@@ -593,6 +593,7 @@ fn capability_json(capability: Capability) -> &'static str {
 fn consent_json(method: ConsentMethod) -> &'static str {
     match method {
         ConsentMethod::FolderPicker => "folder_picker",
+        ConsentMethod::TrustedFolder => "trusted_folder",
         ConsentMethod::PermissionDialog => "permission_dialog",
         ConsentMethod::OperatorConfig => "operator_config",
         ConsentMethod::CarriedForward => "carried_forward",
@@ -660,6 +661,7 @@ fn capability_label(capability: Capability) -> &'static str {
 fn consent_label(method: ConsentMethod) -> &'static str {
     match method {
         ConsentMethod::FolderPicker => "folder-picker",
+        ConsentMethod::TrustedFolder => "trusted-folder",
         ConsentMethod::PermissionDialog => "permission-dialog",
         ConsentMethod::OperatorConfig => "operator-config",
         ConsentMethod::CarriedForward => "carried-forward",

--- a/crates/tidebreak-code-execution/src/skills.rs
+++ b/crates/tidebreak-code-execution/src/skills.rs
@@ -3,13 +3,13 @@
 //! A skill is a directory whose `SKILL.md` teaches the model how to do one
 //! kind of work through `exec`: which pinned libraries to install, the
 //! conventions for saving deliverables, and the quality checks to run
-//! before declaring the work done. The directory may also carry a `scripts/`
-//! subdirectory of helper files. The host stages each skill into
-//! `<scratch>/.tidebreak/skills/<name>/` before a command runs and
+//! before declaring the work done. The directory may also carry helper files,
+//! scripts, references, and assets. The host stages the complete bounded tree
+//! into `<scratch>/.tidebreak/skills/<name>/` before a command runs and
 //! advertises only the parsed (name, description) catalog in the operating
 //! prompt; the instruction body reaches the model exclusively through
-//! `read_file`, never through prompt composition, and script bytes never
-//! reach it at all.
+//! `read_file`, never through prompt composition, and resource bytes follow
+//! the same on-demand path.
 //!
 //! Skills come from two sources: the built-in packages shipped with the
 //! application, and user-authored packages the host loads from a per-install
@@ -24,7 +24,10 @@
 //! half-understood package: the catalog line and the staged files must come
 //! from the same successfully validated manifest.
 
+use std::borrow::Cow;
 use std::path::Path;
+
+use crate::types::WorkspaceFilePath;
 
 /// Stable workspace-relative directory that staged skills are installed under.
 pub const SKILLS_DIR: &str = ".tidebreak/skills";
@@ -39,7 +42,12 @@ const MAX_NAME_BYTES: usize = 64;
 const MAX_DESCRIPTION_BYTES: usize = 200;
 const MAX_DEPS_PER_LIST: usize = 8;
 const MAX_DEP_BYTES: usize = 100;
-const MAX_SKILL_SCRIPTS: usize = 16;
+const MAX_SKILL_ENTRIES: usize = 512;
+const MAX_SKILL_RESOURCE_FILES: usize = 256;
+const MAX_SKILL_DIRECTORIES: usize = 128;
+const MAX_SKILL_DEPTH: usize = 8;
+const MAX_SKILL_BYTES: u64 = 32 * 1024 * 1024;
+const ROOT_RELATIVE_RESOURCE_PREFIX: &str = "./";
 
 /// A host-provided tool a skill depends on, from a closed vocabulary.
 ///
@@ -114,19 +122,49 @@ pub struct LoadedSkill {
     pub package: SkillPackage,
     /// The full `SKILL.md` source, staged verbatim.
     pub manifest: String,
-    /// Helper files from the package's `scripts/` directory, staged verbatim
-    /// beside the manifest. Their bytes never enter prompt composition.
+    /// Files from the package tree, staged verbatim beside the manifest with
+    /// their relative paths intact. Their bytes never enter prompt composition.
+    ///
+    /// The field name remains for compatibility with plugin installation code
+    /// that predates general skill resources.
     pub scripts: Vec<SkillScript>,
 }
 
-/// One helper file staged into a skill's `scripts/` directory.
+/// One resource staged into a skill package.
 #[derive(Debug, Clone)]
 pub struct SkillScript {
-    /// The file's own name; always a single path component.
+    /// An encoded package-relative path. Loader-created values preserve the
+    /// complete path. A legacy bare name still means `scripts/<name>`.
     pub name: String,
-    /// The file's bytes, staged verbatim. Scripts are arbitrary text or
-    /// binary payloads the sandbox may run, so they are never decoded here.
+    /// The file's bytes, staged verbatim. Resources may be text or binary, so
+    /// they are never decoded here.
     pub content: Vec<u8>,
+}
+
+impl SkillScript {
+    fn from_skill_relative_path(path: &WorkspaceFilePath, content: Vec<u8>) -> Self {
+        Self {
+            name: format!("{ROOT_RELATIVE_RESOURCE_PREFIX}{}", path.as_str()),
+            content,
+        }
+    }
+
+    /// Return the resource's normalized path relative to the skill root.
+    ///
+    /// Bare names keep the original `scripts/<name>` meaning for callers that
+    /// still construct [`SkillScript`] directly.
+    #[must_use]
+    pub fn staged_relative_path(&self) -> Option<Cow<'_, str>> {
+        if let Some(path) = self.name.strip_prefix(ROOT_RELATIVE_RESOURCE_PREFIX) {
+            WorkspaceFilePath::parse(path.to_owned()).ok()?;
+            return Some(Cow::Borrowed(path));
+        }
+        WorkspaceFilePath::parse(self.name.clone()).ok()?;
+        if self.name.contains('/') {
+            return None;
+        }
+        Some(Cow::Owned(format!("{SKILL_SCRIPTS_DIR}/{}", self.name)))
+    }
 }
 
 /// Why a skill manifest was rejected.
@@ -547,8 +585,8 @@ pub fn load_skills(source: &Path, origin: SkillOrigin) -> Vec<LoadedSkill> {
             );
             continue;
         }
-        let Some(scripts) = load_skill_scripts(&entry.path().join(SKILL_SCRIPTS_DIR)) else {
-            tracing::warn!("skipping skill '{directory_name}': its scripts/ exceeds the limits");
+        let Some(scripts) = load_skill_resources(&entry.path(), manifest.len()) else {
+            tracing::warn!("skipping skill '{directory_name}': its resources are invalid");
             continue;
         };
         skills.push(LoadedSkill {
@@ -561,64 +599,114 @@ pub fn load_skills(source: &Path, origin: SkillOrigin) -> Vec<LoadedSkill> {
     skills
 }
 
-/// Read a skill's optional `scripts/` directory: regular files one level deep,
-/// symlink-safe at every step, sorted by name.
+/// Read every resource below a skill root while preserving its relative path.
 ///
-/// Returns `None` when the directory breaks a bound — more than
-/// [`MAX_SKILL_SCRIPTS`] files, or one larger than the workspace file limit —
-/// so the caller drops the whole package. A half-staged skill whose
-/// instructions reference a script that never arrived fails in the sandbox,
-/// where the model cannot tell a missing helper from a broken one; not
-/// advertising the skill at all is the honest outcome. A missing directory is
-/// simply an empty script set.
-fn load_skill_scripts(source: &Path) -> Option<Vec<SkillScript>> {
-    let is_directory = source
-        .symlink_metadata()
-        .is_ok_and(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink());
-    if !is_directory {
-        return Some(Vec::new());
-    }
-    let entries = match std::fs::read_dir(source) {
-        Ok(entries) => entries,
+/// The loader rejects the complete package when any entry is a symlink, is not
+/// a regular file or directory, cannot be read, or breaks the import bounds.
+/// That keeps the catalog and staged package tree in sync.
+fn load_skill_resources(source: &Path, manifest_bytes: usize) -> Option<Vec<SkillScript>> {
+    let mut limits = SkillResourceLimits {
+        bytes: manifest_bytes as u64,
+        ..SkillResourceLimits::default()
+    };
+    let mut resources = Vec::new();
+    load_skill_resource_directory(source, "", 0, &mut limits, &mut resources)?;
+    resources.sort_by(|left, right| left.name.cmp(&right.name));
+    Some(resources)
+}
+
+#[derive(Default)]
+struct SkillResourceLimits {
+    entries: usize,
+    files: usize,
+    directories: usize,
+    bytes: u64,
+}
+
+fn load_skill_resource_directory(
+    source: &Path,
+    relative_directory: &str,
+    depth: usize,
+    limits: &mut SkillResourceLimits,
+    resources: &mut Vec<SkillScript>,
+) -> Option<()> {
+    let mut entries = match std::fs::read_dir(source) {
+        Ok(entries) => entries.collect::<Result<Vec<_>, _>>().ok()?,
         Err(error) => {
             tracing::warn!(
-                "skill scripts at {} are unreadable: {error}",
+                "skill resources at {} are unreadable: {error}",
                 source.display()
             );
             return None;
         }
     };
-    let mut scripts = Vec::new();
-    for entry in entries.flatten() {
-        let Ok(name) = entry.file_name().into_string() else {
-            continue;
-        };
-        let regular_file = entry
-            .path()
-            .symlink_metadata()
-            .is_ok_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink());
-        if !regular_file {
-            // A nested directory or a symlink is not staged; the package's own
-            // files still are.
-            tracing::warn!("skipping skill script '{name}': not a regular file");
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    for entry in entries {
+        let name = entry.file_name().into_string().ok()?;
+        if depth == 0 && name == SKILL_MANIFEST_FILE {
             continue;
         }
-        let Ok(content) = std::fs::read(entry.path()) else {
-            tracing::warn!("skill script '{name}' is unreadable");
+        limits.entries += 1;
+        if limits.entries > MAX_SKILL_ENTRIES {
+            tracing::warn!("a skill declares more than {MAX_SKILL_ENTRIES} files and folders");
             return None;
+        }
+
+        let metadata = entry.path().symlink_metadata().ok()?;
+        if metadata.file_type().is_symlink() {
+            tracing::warn!("skill resource '{name}' is a symbolic link");
+            return None;
+        }
+        let relative = if relative_directory.is_empty() {
+            name.clone()
+        } else {
+            format!("{relative_directory}/{name}")
         };
+        let path = WorkspaceFilePath::parse(relative.clone()).ok()?;
+
+        if metadata.is_dir() {
+            if depth >= MAX_SKILL_DEPTH {
+                tracing::warn!("skill resource directory '{relative}' exceeds the depth limit");
+                return None;
+            }
+            limits.directories += 1;
+            if limits.directories > MAX_SKILL_DIRECTORIES {
+                tracing::warn!("a skill declares more than {MAX_SKILL_DIRECTORIES} directories");
+                return None;
+            }
+            load_skill_resource_directory(
+                &entry.path(),
+                path.as_str(),
+                depth + 1,
+                limits,
+                resources,
+            )?;
+            continue;
+        }
+        if !metadata.is_file() {
+            tracing::warn!("skill resource '{relative}' is not a regular file");
+            return None;
+        }
+
+        limits.files += 1;
+        if limits.files > MAX_SKILL_RESOURCE_FILES {
+            tracing::warn!("a skill declares more than {MAX_SKILL_RESOURCE_FILES} resource files");
+            return None;
+        }
+        let content = std::fs::read(entry.path()).ok()?;
         if content.len() > crate::MAX_WORKSPACE_FILE_BYTES {
-            tracing::warn!("skill script '{name}' exceeds the workspace file limit");
+            tracing::warn!("skill resource '{relative}' exceeds the workspace file limit");
             return None;
         }
-        scripts.push(SkillScript { name, content });
-        if scripts.len() > MAX_SKILL_SCRIPTS {
-            tracing::warn!("a skill declares more than {MAX_SKILL_SCRIPTS} scripts");
+        limits.bytes = limits.bytes.checked_add(content.len() as u64)?;
+        if limits.bytes > MAX_SKILL_BYTES {
+            tracing::warn!("a skill's resources exceed the package byte limit");
             return None;
         }
+        resources.push(SkillScript::from_skill_relative_path(&path, content));
     }
-    scripts.sort_by(|a, b| a.name.cmp(&b.name));
-    Some(scripts)
+    Some(())
 }
 
 /// The built-in skills plus the user-authored packages under `user_dir`,
@@ -917,33 +1005,47 @@ Instructions.\n";
         assert!(skills[0].scripts.is_empty());
     }
 
-    /// Contract: a package's `scripts/` directory is collected verbatim beside
-    /// the manifest, and a package that breaks the staging bounds drops out
-    /// whole rather than reaching the catalog with helpers the sandbox will
-    /// not find.
+    /// Contract: the complete package tree is collected with its relative paths
+    /// intact, and a package that breaks the staging bounds drops out whole.
     #[test]
-    fn scripts_are_collected_within_bounds_or_the_skill_drops_out() {
+    fn resources_are_collected_recursively_or_the_skill_drops_out() {
         let source = tempfile::tempdir().unwrap();
         let skill = source.path().join("pdf-documents");
         let scripts = skill.join(SKILL_SCRIPTS_DIR);
-        std::fs::create_dir_all(&scripts).unwrap();
+        let references = skill.join("references").join("formats");
+        let assets = skill.join("assets").join("templates");
+        std::fs::create_dir_all(scripts.join("lib")).unwrap();
+        std::fs::create_dir_all(&references).unwrap();
+        std::fs::create_dir_all(&assets).unwrap();
         std::fs::write(skill.join(SKILL_MANIFEST_FILE), VALID).unwrap();
         std::fs::write(scripts.join("fill.py"), "print('fill')").unwrap();
-        std::fs::write(scripts.join("build.py"), "print('build')").unwrap();
-        // One level only: a nested directory is not staged, and does not cost
-        // the package its catalog entry.
-        std::fs::create_dir(scripts.join("nested")).unwrap();
+        std::fs::write(scripts.join("lib").join("layout.py"), "LAYOUT = 1").unwrap();
+        std::fs::write(references.join("pdf-a.md"), "PDF/A guidance").unwrap();
+        std::fs::write(assets.join("page.bin"), [0, 1, 2]).unwrap();
+        std::fs::write(skill.join("validate.sh"), "exit 0").unwrap();
 
         let loaded = load_skills(source.path(), SkillOrigin::Builtin);
         assert_eq!(
             loaded[0]
                 .scripts
                 .iter()
-                .map(|script| (script.name.as_str(), script.content.as_slice()))
+                .map(|resource| (
+                    resource.staged_relative_path().unwrap().into_owned(),
+                    resource.content.as_slice(),
+                ))
                 .collect::<Vec<_>>(),
             [
-                ("build.py", b"print('build')".as_slice()),
-                ("fill.py", b"print('fill')".as_slice()),
+                (
+                    "assets/templates/page.bin".to_owned(),
+                    b"\0\x01\x02".as_slice(),
+                ),
+                (
+                    "references/formats/pdf-a.md".to_owned(),
+                    b"PDF/A guidance".as_slice(),
+                ),
+                ("scripts/fill.py".to_owned(), b"print('fill')".as_slice()),
+                ("scripts/lib/layout.py".to_owned(), b"LAYOUT = 1".as_slice(),),
+                ("validate.sh".to_owned(), b"exit 0".as_slice()),
             ]
         );
 
@@ -955,7 +1057,7 @@ Instructions.\n";
         assert!(load_skills(source.path(), SkillOrigin::Builtin).is_empty());
         std::fs::remove_file(scripts.join("huge.py")).unwrap();
 
-        for index in 0..=MAX_SKILL_SCRIPTS {
+        for index in 0..=MAX_SKILL_RESOURCE_FILES {
             std::fs::write(scripts.join(format!("extra{index}.py")), "pass").unwrap();
         }
         assert!(load_skills(source.path(), SkillOrigin::Builtin).is_empty());

--- a/crates/tidebreak-desktop/native-only-commands.txt
+++ b/crates/tidebreak-desktop/native-only-commands.txt
@@ -42,10 +42,10 @@ export_library_document: writes a source document's bytes wherever the native sa
 export_deliverable: writes an output revision to a destination chosen in the native save dialog.
 save_chat_debug_bundle: writes the untruncated debug bundle to a file chosen in the native save dialog.
 copy_chat_debug_bundle: returns the clipboard-sized bundle on the same user gesture the webview requires for a clipboard write.
+import_skills: opens the native folder picker and copies validated local skill packages into this desktop profile.
 
 # Host folder consent that runs through native pickers and permission dialogs
 connect_folder: native folder picker — the host consent path for attaching a folder to a chat.
-connect_approved_folder: reattaches a previously approved folder behind the native confirmation dialog.
 grant_folder_capability: widens a folder's capability only after the native permission dialog is confirmed.
 
 # Host-side execution of client-executed tool calls
@@ -77,6 +77,9 @@ publish_chat_image: TODO(record 7) — publishes pasted image bytes from the ren
 publish_code_image: TODO(record 7) — same as publish_chat_image for a code session; desktop mounts the publish route behind the executor token.
 list_connected_folders: TODO(record 7) — broker read with no native UI; headless consumers need the same listing.
 list_approved_folders: TODO(record 7) — broker read with no native UI.
+attach_trusted_folders: TODO(record 7) — applies this desktop profile's saved folder defaults to a new chat.
+set_trusted_folder: TODO(record 7) — stores this desktop profile's automatic folder attachment defaults.
+connect_approved_folder: TODO(record 7) — attaches an already approved broker root without a native dialog.
 list_capability_consents: TODO(record 7) — broker read with no native UI; the consent projection should be a route.
 revoke_capability_consent: TODO(record 7) — broker mutation with no native dialog; revocation must be reachable headlessly.
 disconnect_folder: TODO(record 7) — broker mutation with no native dialog; record 7 item 4 gives folders a CLI path.

--- a/crates/tidebreak-desktop/src/client_execution.rs
+++ b/crates/tidebreak-desktop/src/client_execution.rs
@@ -673,6 +673,7 @@ mod tests {
             tidebreak_host_broker::RootSummary {
                 root_id: tidebreak_host_broker::RootId::new(),
                 display_name: "Documents".into(),
+                owner: None,
             },
             Some(&[
                 Capability::ReadFiles,

--- a/crates/tidebreak-desktop/src/client_execution/product_sync.rs
+++ b/crates/tidebreak-desktop/src/client_execution/product_sync.rs
@@ -90,6 +90,7 @@ pub(super) async fn resume_product_attachment(
         RootSummary {
             root_id,
             display_name: sync.display_name,
+            owner: None,
         },
     )
     .await
@@ -847,6 +848,7 @@ mod tests {
                 root: RootSummary {
                     root_id,
                     display_name: "Documents".to_owned(),
+                    owner: None,
                 },
             },
             &sync,
@@ -857,6 +859,7 @@ mod tests {
                 root: RootSummary {
                     root_id,
                     display_name: "Documents".to_owned(),
+                    owner: None,
                 },
             },
             &sync,

--- a/crates/tidebreak-desktop/src/client_execution/root_attachment_reconciliation.rs
+++ b/crates/tidebreak-desktop/src/client_execution/root_attachment_reconciliation.rs
@@ -66,7 +66,7 @@ pub(crate) async fn connect_selected_folder(
     drive_manual_connect(state, &mut receipt, ConnectMode::Interactive).await
 }
 
-/// Attach a host-approved root to one exact conversation after native consent.
+/// Attach a saved host-approved root to one exact conversation.
 ///
 /// The root summary carries no path or authority. The broker creates the
 /// conversation grant only when the durable product attachment is driven.
@@ -628,7 +628,7 @@ async fn dispatch_mutation(
         conversation_id: context.chat_id,
         root_id,
         consent_method: match action {
-            RootAttachmentChangeAction::Attach => Some(ConsentMethod::PermissionDialog),
+            RootAttachmentChangeAction::Attach => Some(ConsentMethod::TrustedFolder),
             RootAttachmentChangeAction::Detach => None,
         },
     };
@@ -867,6 +867,7 @@ fn connected_folder(root: RootSummary) -> ConnectedFolder {
         root_id: root.root_id,
         display_name: root.display_name,
         status: crate::host_access::FolderStatus::Connected,
+        available_in_future_chats: false,
     }
 }
 

--- a/crates/tidebreak-desktop/src/host_access.rs
+++ b/crates/tidebreak-desktop/src/host_access.rs
@@ -20,6 +20,7 @@ use crate::client_execution::{ControlPlaneClient, ReceiptStore};
 
 pub(crate) struct HostAccess {
     pub(super) broker: BrokerClient,
+    pub(super) trusted_folders: crate::trusted_folders::TrustedFolderStore,
     pub(super) picker: Mutex<()>,
     pub(super) output_exports: Mutex<()>,
     pub(super) debug_exports: Mutex<()>,
@@ -46,8 +47,11 @@ impl HostAccess {
     ) -> Result<Self, String> {
         let receipts = ReceiptStore::open(&data_dir)
             .map_err(|_| "could not open private client-execution receipts".to_owned())?;
+        let trusted_folders = crate::trusted_folders::TrustedFolderStore::open(&data_dir)
+            .map_err(|_| "could not open trusted folder defaults".to_owned())?;
         Ok(Self {
             broker: BrokerClient::new(app, data_dir, home_dir),
+            trusted_folders,
             picker: Mutex::const_new(()),
             output_exports: Mutex::const_new(()),
             debug_exports: Mutex::const_new(()),
@@ -554,6 +558,13 @@ pub(crate) struct ConnectApprovedFolderRequest {
     root_id: RootId,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SetTrustedFolderRequest {
+    root_id: RootId,
+    trusted: bool,
+}
+
 /// Whether the broker can currently reach a listed folder.
 ///
 /// `Unavailable` is the set-aside state: the approval and attachment stand,
@@ -573,6 +584,7 @@ pub(crate) struct ConnectedFolder {
     pub(crate) root_id: RootId,
     pub(crate) display_name: String,
     pub(crate) status: FolderStatus,
+    pub(crate) available_in_future_chats: bool,
 }
 
 #[tauri::command]
@@ -598,11 +610,19 @@ pub(crate) async fn connect_folder(
     }
 
     let _root_change = state.root_changes.lock().await;
-    crate::client_execution::root_attachment_reconciliation::connect_selected_folder(
-        &state, context, path,
-    )
-    .await
-    .map(Some)
+    let connected =
+        crate::client_execution::root_attachment_reconciliation::connect_selected_folder(
+            &state, context, path,
+        )
+        .await?;
+    state
+        .trusted_folders
+        .set(connected.root_id, true)
+        .map_err(trusted_folder_error)?;
+    Ok(Some(ConnectedFolder {
+        available_in_future_chats: true,
+        ..connected
+    }))
 }
 
 /// The folders attached to one conversation, by their safe identities.
@@ -641,6 +661,7 @@ async fn connected_folders(
     if chat.root_attachments.is_empty() {
         return Ok(Vec::new());
     }
+    let trusted = state.trusted_folders.list().map_err(trusted_folder_error)?;
     let roots = approved_roots(state).await?;
     let product_roots = chat
         .root_attachments
@@ -654,6 +675,7 @@ async fn connected_folders(
             root_id: root.root_id,
             display_name: root.display_name,
             status: FolderStatus::Connected,
+            available_in_future_chats: trusted.contains(&root.root_id),
         })
         .collect::<Vec<_>>();
     // A set-aside root — one the broker could not reopen — used to vanish
@@ -676,6 +698,7 @@ async fn connected_folders(
                 root_id: root.root_id,
                 display_name: root.display_name,
                 status: FolderStatus::Unavailable,
+                available_in_future_chats: trusted.contains(&root.root_id),
             }),
     );
     Ok(folders)
@@ -753,6 +776,7 @@ async fn capability_statement(
     };
     let method = match grant.consent_method {
         ConsentMethod::FolderPicker => ConsentMethodSnapshot::FolderPicker,
+        ConsentMethod::TrustedFolder => ConsentMethodSnapshot::TrustedFolder,
         ConsentMethod::PermissionDialog => ConsentMethodSnapshot::PermissionDialog,
         ConsentMethod::OperatorConfig => ConsentMethodSnapshot::OperatorConfig,
         ConsentMethod::CarriedForward => ConsentMethodSnapshot::CarriedForward,
@@ -853,37 +877,115 @@ pub(crate) async fn revoke_capability_consent(
 
 #[tauri::command]
 pub(crate) async fn connect_approved_folder(
-    app: AppHandle,
     state: State<'_, HostAccess>,
     request: ConnectApprovedFolderRequest,
 ) -> Result<Option<ConnectedFolder>, String> {
     state
         .require_local(crate::host_authority::Authority::FolderBroker)
         .await?;
-    state.context(request.chat_id).await?;
-    let chat_label = conversation_label(&state, request.chat_id).await?;
     let root = approved_roots(&state)
         .await?
         .into_iter()
         .find(|root| root.root_id == request.root_id)
         .ok_or_else(|| "the approved folder is no longer available".to_owned())?;
-    let _consent = state
-        .picker
-        .try_lock()
-        .map_err(|_| "a folder permission prompt is already open".to_owned())?;
-    if !confirm_folder_attachment(&app, &chat_label, &root.display_name).await? {
-        return Ok(None);
-    }
-
-    // Resolve authority again after the user responds so a deleted or changed
-    // conversation cannot reuse the earlier context.
     let _root_change = state.root_changes.lock().await;
     let context = state.context(request.chat_id).await?;
-    crate::client_execution::root_attachment_reconciliation::connect_existing_root(
+    let connected = crate::client_execution::root_attachment_reconciliation::connect_existing_root(
         &state, context, root,
     )
-    .await
-    .map(Some)
+    .await?;
+    state
+        .trusted_folders
+        .set(connected.root_id, true)
+        .map_err(trusted_folder_error)?;
+    Ok(Some(ConnectedFolder {
+        available_in_future_chats: true,
+        ..connected
+    }))
+}
+
+/// Save or clear one folder's automatic attachment default.
+#[tauri::command]
+pub(crate) async fn set_trusted_folder(
+    state: State<'_, HostAccess>,
+    request: SetTrustedFolderRequest,
+) -> Result<bool, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
+    let _root_change = state.root_changes.lock().await;
+    if request.trusted {
+        let live = approved_roots(&state)
+            .await?
+            .iter()
+            .any(|root| root.root_id == request.root_id);
+        if !live {
+            let result = state
+                .broker
+                .control(ControlRequest::ListUnavailableRoots)
+                .await
+                .map_err(|error| error.to_string())?;
+            let ControlResult::ListUnavailableRoots { roots } = result else {
+                return Err("host broker returned an unexpected response".to_owned());
+            };
+            if !roots.iter().any(|root| root.root_id == request.root_id) {
+                return Err("the approved folder is no longer available".to_owned());
+            }
+        }
+    }
+    state
+        .trusted_folders
+        .set(request.root_id, request.trusted)
+        .map_err(trusted_folder_error)
+}
+
+/// Attach every saved folder to one newly created chat without another host
+/// prompt. The saved root IDs are intersected with the broker's current live
+/// approvals before any product or broker attachment changes.
+#[tauri::command]
+pub(crate) async fn attach_trusted_folders(
+    state: State<'_, HostAccess>,
+    chat_id: Uuid,
+) -> Result<Vec<ConnectedFolder>, String> {
+    state
+        .require_local(crate::host_authority::Authority::FolderBroker)
+        .await?;
+    let trusted = state.trusted_folders.list().map_err(trusted_folder_error)?;
+    if trusted.is_empty() {
+        return Ok(Vec::new());
+    }
+    let roots = approved_roots(&state)
+        .await?
+        .into_iter()
+        .filter(|root| trusted.contains(&root.root_id))
+        .collect::<Vec<_>>();
+    if roots.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let _root_change = state.root_changes.lock().await;
+    let attached = connected_folders(&state, chat_id)
+        .await?
+        .into_iter()
+        .map(|folder| folder.root_id)
+        .collect::<std::collections::HashSet<_>>();
+    let mut connected = Vec::new();
+    for root in roots {
+        if attached.contains(&root.root_id) {
+            continue;
+        }
+        let context = state.context(chat_id).await?;
+        let folder =
+            crate::client_execution::root_attachment_reconciliation::connect_existing_root(
+                &state, context, root,
+            )
+            .await?;
+        connected.push(ConnectedFolder {
+            available_in_future_chats: true,
+            ..folder
+        });
+    }
+    Ok(connected)
 }
 
 /// The capabilities the folders and permissions surfaces may ask to add to an
@@ -996,14 +1098,7 @@ pub(crate) struct ForgetFolderRequest {
     root_id: RootId,
 }
 
-/// Withdraw the host approval for a folder the broker can no longer reach.
-///
-/// The remove half of the set-aside surface: a folder that is gone for good
-/// would otherwise keep its grants and attachments indefinitely, since the
-/// broker only ever deletes a registration on an explicit revocation and
-/// nothing sent one. Deliberately restricted to set-aside roots — a live
-/// folder's exit is the ordinary per-chat disconnect — and addressed at the
-/// registering subject the broker reports, which `RevokeRoot` requires.
+/// Withdraw one folder's approval, grants, and attachments everywhere.
 #[tauri::command]
 pub(crate) async fn forget_folder(
     state: State<'_, HostAccess>,
@@ -1013,6 +1108,11 @@ pub(crate) async fn forget_folder(
         .require_local(crate::host_authority::Authority::FolderBroker)
         .await?;
     let _root_change = state.root_changes.lock().await;
+    let live = approved_roots(&state)
+        .await?
+        .into_iter()
+        .find(|root| root.root_id == request.root_id)
+        .and_then(|root| root.owner);
     let result = state
         .broker
         .control(ControlRequest::ListUnavailableRoots)
@@ -1021,18 +1121,20 @@ pub(crate) async fn forget_folder(
     let ControlResult::ListUnavailableRoots { roots } = result else {
         return Err("host broker returned an unexpected response".to_owned());
     };
-    let root = roots
+    let unavailable = roots
         .into_iter()
         .find(|root| root.root_id == request.root_id)
-        .ok_or_else(|| {
-            "the folder is not unavailable — disconnect it from its chats instead".to_owned()
-        })?;
+        .map(|root| root.owner);
+    let owner = live
+        .or(unavailable)
+        .ok_or_else(|| "the approved folder is no longer available".to_owned())?;
+    disconnect_root_everywhere(&state, request.root_id).await?;
     let result = state
         .broker
         .control(ControlRequest::RevokeRoot(
             tidebreak_host_broker::RevokeRootRequest {
                 operation_id: tidebreak_host_broker::OperationId::new(),
-                subject: root.owner,
+                subject: owner,
                 root_id: request.root_id,
             },
         ))
@@ -1041,7 +1143,37 @@ pub(crate) async fn forget_folder(
     let ControlResult::RevokeRoot(result) = result else {
         return Err("host broker returned an unexpected response".to_owned());
     };
+    state
+        .trusted_folders
+        .set(request.root_id, false)
+        .map_err(trusted_folder_error)?;
     Ok(result.revoked)
+}
+
+async fn disconnect_root_everywhere(state: &HostAccess, root_id: RootId) -> Result<(), String> {
+    let store = state
+        .store()
+        .ok_or_else(|| "Tidebreak is still starting".to_owned())?;
+    let chat_ids = store
+        .list_chats()
+        .await
+        .map_err(|_| "could not load chats using this folder".to_owned())?
+        .into_iter()
+        .filter(|chat| {
+            chat.root_attachments
+                .iter()
+                .any(|attachment| attachment.root_id.as_uuid() == root_id.as_uuid())
+        })
+        .map(|chat| chat.id.0)
+        .collect::<Vec<_>>();
+    for chat_id in chat_ids {
+        let context = state.context(chat_id).await?;
+        crate::client_execution::root_attachment_reconciliation::disconnect_root(
+            state, context, root_id,
+        )
+        .await?;
+    }
+    Ok(())
 }
 
 /// Forget host-broker authority held by a conversation that no longer exists.
@@ -1098,6 +1230,7 @@ pub(crate) struct PurgeDeletedConversationSubjectRequest {
 }
 
 async fn approved_folders(state: &HostAccess) -> Result<Vec<ConnectedFolder>, String> {
+    let trusted = state.trusted_folders.list().map_err(trusted_folder_error)?;
     Ok(approved_roots(state)
         .await?
         .into_iter()
@@ -1105,8 +1238,13 @@ async fn approved_folders(state: &HostAccess) -> Result<Vec<ConnectedFolder>, St
             root_id: root.root_id,
             display_name: root.display_name,
             status: FolderStatus::Connected,
+            available_in_future_chats: trusted.contains(&root.root_id),
         })
         .collect())
+}
+
+fn trusted_folder_error(_error: std::io::Error) -> String {
+    "could not update trusted folder defaults".to_owned()
 }
 
 async fn approved_roots(state: &HostAccess) -> Result<Vec<RootSummary>, String> {
@@ -1153,33 +1291,6 @@ fn safe_dialog_label(value: &str) -> String {
             }
         })
         .collect()
-}
-
-async fn confirm_folder_attachment(
-    app: &AppHandle,
-    chat_label: &str,
-    display_name: &str,
-) -> Result<bool, String> {
-    let folder_label = safe_dialog_label(display_name);
-    let (tx, rx) = oneshot::channel();
-    let mut dialog = app
-        .dialog()
-        .message(format!(
-            "Allow the chat “{chat_label}” to read the previously approved folder “{folder_label}”?"
-        ))
-        .title("Connect folder")
-        .buttons(MessageDialogButtons::OkCancelCustom(
-            "Connect".to_owned(),
-            "Cancel".to_owned(),
-        ));
-    if let Some(window) = app.get_webview_window("main") {
-        dialog = dialog.parent(&window);
-    }
-    dialog.show(move |approved| {
-        let _ = tx.send(approved);
-    });
-    rx.await
-        .map_err(|_| "folder permission prompt closed unexpectedly".to_owned())
 }
 
 async fn confirm_folder_widening(

--- a/crates/tidebreak-desktop/src/host_access.rs
+++ b/crates/tidebreak-desktop/src/host_access.rs
@@ -1162,7 +1162,7 @@ async fn disconnect_root_everywhere(state: &HostAccess, root_id: RootId) -> Resu
         .filter(|chat| {
             chat.root_attachments
                 .iter()
-                .any(|attachment| attachment.root_id.as_uuid() == root_id.as_uuid())
+                .any(|attachment| *attachment.root_id.as_uuid() == root_id.as_uuid())
         })
         .map(|chat| chat.id.0)
         .collect::<Vec<_>>();

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -49,6 +49,8 @@ mod office_pdf;
 #[cfg(target_os = "macos")]
 mod office_sandbox;
 mod remote;
+mod skill_import;
+mod trusted_folders;
 mod updater;
 mod voice_transcription;
 
@@ -829,6 +831,8 @@ pub fn run() {
             host_access::pick_code_directory,
             host_access::connect_folder,
             host_access::connect_approved_folder,
+            host_access::attach_trusted_folders,
+            host_access::set_trusted_folder,
             host_access::list_approved_folders,
             host_access::list_capability_consents,
             host_access::revoke_capability_consent,
@@ -837,6 +841,7 @@ pub fn run() {
             host_access::disconnect_folder,
             host_access::forget_folder,
             host_access::purge_deleted_conversation_subject,
+            skill_import::import_skills,
             updater::desktop_update_state,
             updater::check_for_update,
             updater::restart_for_update

--- a/crates/tidebreak-desktop/src/skill_import.rs
+++ b/crates/tidebreak-desktop/src/skill_import.rs
@@ -194,7 +194,7 @@ fn import_child_skills(
             "This folder contains more than {MAX_PARENT_ENTRIES} entries. Choose a smaller folder"
         ));
     }
-    entries.sort_by(|left, right| left.file_name().cmp(&right.file_name()));
+    entries.sort_by_key(|entry| entry.file_name());
 
     let mut candidate_skills = 0_usize;
     let mut child_directories = 0_usize;
@@ -401,7 +401,7 @@ fn inspect_directory(
         .map_err(|_| "Could not read a folder in this skill".to_owned())?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|_| "Could not read a folder in this skill".to_owned())?;
-    entries.sort_by(|left, right| left.file_name().cmp(&right.file_name()));
+    entries.sort_by_key(|entry| entry.file_name());
 
     let mut files = Vec::new();
     let mut directories = Vec::new();

--- a/crates/tidebreak-desktop/src/skill_import.rs
+++ b/crates/tidebreak-desktop/src/skill_import.rs
@@ -1,0 +1,883 @@
+//! Native import for user-authored skill folders.
+//!
+//! The renderer asks for one folder picker and receives only skill names and
+//! outcomes. Source paths never cross into the webview. A selected folder can
+//! be one skill package or a parent whose direct children are skill packages.
+//! Parent discovery stays one level deep. Skill contents use a bounded
+//! recursive traversal that rejects symbolic links and holds validated bytes
+//! before publishing anything.
+
+use std::collections::HashSet;
+use std::ffi::{OsStr, OsString};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
+use serde::Serialize;
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_dialog::DialogExt;
+use tidebreak_code_execution::{
+    is_valid_skill_name, load_skills, parse_skill_manifest, SkillOrigin, WorkspaceFilePath,
+    MAX_WORKSPACE_FILE_BYTES, SKILL_MANIFEST_FILE,
+};
+use tokio::sync::oneshot;
+
+use crate::host_access::HostAccess;
+
+const MAX_PARENT_ENTRIES: usize = 256;
+const MAX_SKILLS_PER_IMPORT: usize = 64;
+const MAX_SKILL_ENTRIES: usize = 512;
+const MAX_SKILL_FILES: usize = 256;
+const MAX_SKILL_DIRECTORIES: usize = 128;
+const MAX_SKILL_DEPTH: usize = 8;
+const MAX_SKILL_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_IMPORT_BYTES: u64 = 128 * 1024 * 1024;
+
+#[derive(Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SkillImportReport {
+    imported: Vec<String>,
+    skipped: Vec<SkillImportIssue>,
+    conflicts: Vec<SkillImportIssue>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SkillImportIssue {
+    name: String,
+    reason: String,
+}
+
+impl SkillImportReport {
+    fn skip(&mut self, name: impl Into<String>, reason: impl Into<String>) {
+        self.skipped.push(SkillImportIssue {
+            name: name.into(),
+            reason: reason.into(),
+        });
+    }
+
+    fn conflict(&mut self, name: impl Into<String>, reason: impl Into<String>) {
+        self.conflicts.push(SkillImportIssue {
+            name: name.into(),
+            reason: reason.into(),
+        });
+    }
+
+    fn sort(&mut self) {
+        self.imported.sort();
+        self.skipped
+            .sort_by(|left, right| left.name.cmp(&right.name));
+        self.conflicts
+            .sort_by(|left, right| left.name.cmp(&right.name));
+    }
+}
+
+/// Pick one skill folder or a parent of skill folders and copy valid packages
+/// into this desktop profile's user-skills tree.
+#[tauri::command]
+pub(crate) async fn import_skills(
+    app: AppHandle,
+    host_access: State<'_, HostAccess>,
+) -> Result<Option<SkillImportReport>, String> {
+    host_access
+        .require_local(crate::host_authority::Authority::NativeExport)
+        .await
+        .map_err(|_| "Import skills on the Tidebreak desktop that hosts this library".to_owned())?;
+
+    let selected = {
+        let _picker = host_access
+            .picker
+            .try_lock()
+            .map_err(|_| "A file or folder picker is already open".to_owned())?;
+        pick_skill_folder(&app).await?
+    };
+    let Some(selected) = selected else {
+        return Ok(None);
+    };
+
+    let user_skills_dir = crate::data_dir(&app)?.join("skills");
+    let builtin_skills_dir = crate::exec_skills_dir(&app)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let builtin_names = load_skills(&builtin_skills_dir, SkillOrigin::Builtin)
+            .into_iter()
+            .map(|skill| skill.package.name)
+            .collect();
+        import_selected_folder(&selected, &user_skills_dir, &builtin_names)
+    })
+    .await
+    .map_err(|error| format!("Skill import stopped unexpectedly: {error}"))?
+    .map(Some)
+}
+
+async fn pick_skill_folder(app: &AppHandle) -> Result<Option<PathBuf>, String> {
+    let (sender, receiver) = oneshot::channel();
+    let mut picker = app
+        .dialog()
+        .file()
+        .set_title("Choose a skill folder or a folder of skills");
+    if let Some(window) = app.get_webview_window("main") {
+        picker = picker.set_parent(&window);
+    }
+    picker.pick_folder(move |path| {
+        let _ = sender.send(path);
+    });
+    let selected = receiver
+        .await
+        .map_err(|_| "The folder picker closed unexpectedly".to_owned())?
+        .map(tauri_plugin_dialog::FilePath::into_path)
+        .transpose()
+        .map_err(|_| "The folder picker returned an invalid path".to_owned())?;
+    if selected.as_ref().is_some_and(|path| !path.is_absolute()) {
+        return Err("The folder picker returned an invalid path".to_owned());
+    }
+    Ok(selected)
+}
+
+fn import_selected_folder(
+    selected: &Path,
+    user_skills_dir: &Path,
+    builtin_names: &HashSet<String>,
+) -> Result<SkillImportReport, String> {
+    let source = open_directory_nofollow(selected)
+        .map_err(|_| "Could not read the selected folder".to_owned())?;
+    let destination = open_or_create_absolute_directory(user_skills_dir)
+        .map_err(|_| "Could not open Tidebreak's skills folder".to_owned())?;
+    let selected_name = display_name(selected);
+    let mut report = SkillImportReport::default();
+    let mut imported_bytes = 0_u64;
+
+    match manifest_state(&source) {
+        Ok(ManifestState::Regular) => import_candidate(
+            &selected_name,
+            source,
+            &destination,
+            builtin_names,
+            &mut imported_bytes,
+            &mut report,
+        ),
+        Ok(ManifestState::Invalid) => report.skip(
+            selected_name,
+            "SKILL.md must be a regular file, not a link or folder",
+        ),
+        Ok(ManifestState::Missing) => import_child_skills(
+            selected,
+            &source,
+            &destination,
+            builtin_names,
+            &mut imported_bytes,
+            &mut report,
+        )?,
+        Err(_) => report.skip(selected_name, "Could not inspect SKILL.md"),
+    }
+
+    report.sort();
+    Ok(report)
+}
+
+fn import_child_skills(
+    selected: &Path,
+    source: &Dir,
+    destination: &Dir,
+    builtin_names: &HashSet<String>,
+    imported_bytes: &mut u64,
+    report: &mut SkillImportReport,
+) -> Result<(), String> {
+    let mut entries = source
+        .entries()
+        .map_err(|_| "Could not read the selected folder".to_owned())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| "Could not read the selected folder".to_owned())?;
+    if entries.len() > MAX_PARENT_ENTRIES {
+        return Err(format!(
+            "This folder contains more than {MAX_PARENT_ENTRIES} entries. Choose a smaller folder"
+        ));
+    }
+    entries.sort_by(|left, right| left.file_name().cmp(&right.file_name()));
+
+    let mut candidate_skills = 0_usize;
+    let mut child_directories = 0_usize;
+    for entry in entries {
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(_) => continue,
+        };
+        if file_type.is_symlink() {
+            if entry.file_name().to_str().is_some_and(is_valid_skill_name) {
+                report.skip(
+                    entry.file_name().to_string_lossy(),
+                    "Symbolic-link skill folders are not imported",
+                );
+            }
+            continue;
+        }
+        if !file_type.is_dir() {
+            continue;
+        }
+        child_directories += 1;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let child = match source.open_dir_nofollow(entry.file_name()) {
+            Ok(child) => child,
+            Err(_) => {
+                report.skip(name, "Could not read this skill folder");
+                continue;
+            }
+        };
+        match manifest_state(&child) {
+            Ok(ManifestState::Regular) => {
+                if !is_valid_skill_name(&name) {
+                    report.skip(
+                        name,
+                        "The folder name must be a lowercase kebab-case skill name",
+                    );
+                    continue;
+                }
+                candidate_skills += 1;
+                if candidate_skills > MAX_SKILLS_PER_IMPORT {
+                    report.skip(
+                        name,
+                        format!("One import is limited to {MAX_SKILLS_PER_IMPORT} skill folders"),
+                    );
+                    continue;
+                }
+                import_candidate(
+                    &name,
+                    child,
+                    destination,
+                    builtin_names,
+                    imported_bytes,
+                    report,
+                );
+            }
+            Ok(ManifestState::Missing) => report.skip(name, "No regular SKILL.md was found"),
+            Ok(ManifestState::Invalid) => report.skip(
+                name,
+                "SKILL.md must be a regular file, not a link or folder",
+            ),
+            Err(_) => report.skip(name, "Could not inspect SKILL.md"),
+        }
+    }
+
+    if child_directories == 0 && report.skipped.is_empty() {
+        report.skip(
+            display_name(selected),
+            "No skill folders were found one level inside this folder",
+        );
+    }
+    Ok(())
+}
+
+fn import_candidate(
+    directory_name: &str,
+    source: Dir,
+    destination_root: &Dir,
+    builtin_names: &HashSet<String>,
+    imported_bytes: &mut u64,
+    report: &mut SkillImportReport,
+) {
+    if !is_valid_skill_name(directory_name) {
+        report.skip(
+            directory_name,
+            "The folder name must be a lowercase kebab-case skill name",
+        );
+        return;
+    }
+    let prepared = match prepare_skill(&source) {
+        Ok(prepared) => prepared,
+        Err(reason) => {
+            report.skip(directory_name, reason);
+            return;
+        }
+    };
+    if prepared.name != directory_name {
+        report.skip(
+            directory_name,
+            format!("SKILL.md names this skill '{}'", prepared.name),
+        );
+        return;
+    }
+    if builtin_names.contains(directory_name) {
+        report.conflict(
+            directory_name,
+            "A skill included with Tidebreak already uses this name",
+        );
+        return;
+    }
+    if prepared.estimated_bytes > MAX_IMPORT_BYTES.saturating_sub(*imported_bytes) {
+        report.skip(
+            directory_name,
+            format!("One import is limited to {MAX_IMPORT_BYTES} bytes"),
+        );
+        return;
+    }
+
+    match destination_root.create_dir(directory_name) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            report.conflict(
+                directory_name,
+                "A user skill or plugin skill already uses this name",
+            );
+            return;
+        }
+        Err(_) => {
+            report.skip(directory_name, "Could not create this skill folder");
+            return;
+        }
+    }
+
+    let copied = publish_skill(destination_root, directory_name, &prepared);
+    match copied {
+        Ok(bytes) => {
+            *imported_bytes += bytes;
+            report.imported.push(directory_name.to_owned());
+        }
+        Err(reason) => {
+            let _ = destination_root.remove_dir_all(directory_name);
+            report.skip(directory_name, reason);
+        }
+    }
+}
+
+struct PreparedSkill {
+    name: String,
+    manifest: Vec<u8>,
+    contents: PreparedDirectory,
+    estimated_bytes: u64,
+}
+
+struct PreparedDirectory {
+    files: Vec<SourceFile>,
+    directories: Vec<PreparedSubdirectory>,
+}
+
+struct PreparedSubdirectory {
+    name: OsString,
+    contents: PreparedDirectory,
+}
+
+struct SourceFile {
+    name: OsString,
+    content: Vec<u8>,
+    executable: bool,
+}
+
+#[derive(Default)]
+struct InspectionLimits {
+    entries: usize,
+    files: usize,
+    directories: usize,
+}
+
+fn prepare_skill(source: &Dir) -> Result<PreparedSkill, String> {
+    let manifest = read_bounded_file(source, OsStr::new(SKILL_MANIFEST_FILE))
+        .map_err(|reason| format!("Could not read SKILL.md: {reason}"))?;
+    let manifest_text =
+        std::str::from_utf8(&manifest).map_err(|_| "SKILL.md must use UTF-8 text".to_owned())?;
+    let package = parse_skill_manifest(manifest_text, SkillOrigin::User)
+        .map_err(|error| error.to_string())?;
+    let mut estimated_bytes = manifest.len() as u64;
+    let mut limits = InspectionLimits::default();
+    let contents = inspect_directory(source, "", 0, false, &mut limits, &mut estimated_bytes)?;
+    Ok(PreparedSkill {
+        name: package.name,
+        manifest,
+        contents,
+        estimated_bytes,
+    })
+}
+
+fn inspect_directory(
+    directory: &Dir,
+    relative_directory: &str,
+    depth: usize,
+    executable_files: bool,
+    limits: &mut InspectionLimits,
+    estimated_bytes: &mut u64,
+) -> Result<PreparedDirectory, String> {
+    let mut entries = directory
+        .entries()
+        .map_err(|_| "Could not read a folder in this skill".to_owned())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| "Could not read a folder in this skill".to_owned())?;
+    entries.sort_by(|left, right| left.file_name().cmp(&right.file_name()));
+
+    let mut files = Vec::new();
+    let mut directories = Vec::new();
+    for entry in entries {
+        let name = entry.file_name();
+        if depth == 0 && name == OsStr::new(SKILL_MANIFEST_FILE) {
+            continue;
+        }
+        let component = name
+            .to_str()
+            .ok_or_else(|| "Skill paths must use UTF-8 names".to_owned())?;
+        let relative = if relative_directory.is_empty() {
+            component.to_owned()
+        } else {
+            format!("{relative_directory}/{component}")
+        };
+        WorkspaceFilePath::parse(relative.clone())
+            .map_err(|_| "A skill contains an invalid or overly long path".to_owned())?;
+        limits.entries += 1;
+        if limits.entries > MAX_SKILL_ENTRIES {
+            return Err(format!(
+                "A skill is limited to {MAX_SKILL_ENTRIES} files and folders"
+            ));
+        }
+        let file_type = entry
+            .file_type()
+            .map_err(|_| "Could not inspect a file in this skill".to_owned())?;
+        if file_type.is_symlink() {
+            return Err("Symbolic links are not imported".to_owned());
+        }
+        if file_type.is_dir() {
+            if depth >= MAX_SKILL_DEPTH {
+                return Err(format!(
+                    "Skill folders are limited to {MAX_SKILL_DEPTH} levels"
+                ));
+            }
+            limits.directories += 1;
+            if limits.directories > MAX_SKILL_DIRECTORIES {
+                return Err(format!(
+                    "A skill is limited to {MAX_SKILL_DIRECTORIES} folders"
+                ));
+            }
+            let child = directory
+                .open_dir_nofollow(&name)
+                .map_err(|_| "Could not read a folder in this skill".to_owned())?;
+            let child_executable = executable_files || name == OsStr::new("scripts");
+            directories.push(PreparedSubdirectory {
+                name,
+                contents: inspect_directory(
+                    &child,
+                    &relative,
+                    depth + 1,
+                    child_executable,
+                    limits,
+                    estimated_bytes,
+                )?,
+            });
+            continue;
+        }
+        if !file_type.is_file() {
+            return Err("Skill contents must be regular files and folders".to_owned());
+        }
+        limits.files += 1;
+        if limits.files > MAX_SKILL_FILES {
+            return Err(format!("A skill is limited to {MAX_SKILL_FILES} files"));
+        }
+        let content = read_bounded_file(directory, &name)?;
+        *estimated_bytes = checked_skill_bytes(*estimated_bytes, content.len() as u64)?;
+        files.push(SourceFile {
+            name,
+            content,
+            executable: executable_files,
+        });
+    }
+    Ok(PreparedDirectory { files, directories })
+}
+
+fn regular_file_len(directory: &Dir, name: &OsStr) -> Result<u64, String> {
+    let metadata = directory
+        .symlink_metadata(name)
+        .map_err(|_| "Could not inspect a skill file".to_owned())?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err("Skill files must be regular files".to_owned());
+    }
+    let byte_len = metadata.len();
+    if byte_len > MAX_WORKSPACE_FILE_BYTES as u64 {
+        return Err(format!(
+            "Each skill file is limited to {MAX_WORKSPACE_FILE_BYTES} bytes"
+        ));
+    }
+    Ok(byte_len)
+}
+
+fn checked_skill_bytes(current: u64, added: u64) -> Result<u64, String> {
+    let total = current
+        .checked_add(added)
+        .ok_or_else(|| "This skill is too large to import".to_owned())?;
+    if total > MAX_SKILL_BYTES {
+        return Err(format!("One skill is limited to {MAX_SKILL_BYTES} bytes"));
+    }
+    Ok(total)
+}
+
+fn publish_skill(
+    destination_root: &Dir,
+    name: &str,
+    prepared: &PreparedSkill,
+) -> Result<u64, String> {
+    let destination = destination_root
+        .open_dir_nofollow(name)
+        .map_err(|_| "Could not open the new skill folder".to_owned())?;
+    let mut copied = 0_u64;
+    publish_directory(&destination, &prepared.contents, &mut copied)?;
+    copied = checked_copied_bytes(
+        copied,
+        write_new_file(
+            &destination,
+            OsStr::new(SKILL_MANIFEST_FILE),
+            &prepared.manifest,
+        )?,
+    )?;
+    Ok(copied)
+}
+
+fn publish_directory(
+    destination: &Dir,
+    prepared: &PreparedDirectory,
+    copied: &mut u64,
+) -> Result<(), String> {
+    for file in &prepared.files {
+        *copied = checked_copied_bytes(
+            *copied,
+            write_prepared_file(destination, &file.name, &file.content, file.executable)?,
+        )?;
+    }
+    for child in &prepared.directories {
+        destination
+            .create_dir(&child.name)
+            .map_err(|_| "Could not create a skill subfolder".to_owned())?;
+        let destination_child = destination
+            .open_dir_nofollow(&child.name)
+            .map_err(|_| "Could not open a skill subfolder".to_owned())?;
+        publish_directory(&destination_child, &child.contents, copied)?;
+    }
+    Ok(())
+}
+
+fn write_prepared_file(
+    destination: &Dir,
+    name: &OsStr,
+    content: &[u8],
+    executable: bool,
+) -> Result<u64, String> {
+    let mut write_options = OpenOptions::new();
+    write_options
+        .write(true)
+        .create_new(true)
+        .follow(FollowSymlinks::No);
+    #[cfg(unix)]
+    {
+        use cap_std::fs::OpenOptionsExt as _;
+        write_options.mode(if executable { 0o700 } else { 0o600 });
+    }
+    let mut destination_file = destination
+        .open_with(name, &write_options)
+        .map_err(|_| "Could not copy a skill file".to_owned())?;
+    destination_file
+        .write_all(content)
+        .and_then(|()| destination_file.flush())
+        .and_then(|()| destination_file.sync_all())
+        .map_err(|_| "Could not finish copying a skill file".to_owned())?;
+    Ok(content.len() as u64)
+}
+
+fn write_new_file(destination: &Dir, name: &OsStr, content: &[u8]) -> Result<u64, String> {
+    let mut options = OpenOptions::new();
+    options
+        .write(true)
+        .create_new(true)
+        .follow(FollowSymlinks::No);
+    #[cfg(unix)]
+    {
+        use cap_std::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = destination
+        .open_with(name, &options)
+        .map_err(|_| "Could not write SKILL.md".to_owned())?;
+    file.write_all(content)
+        .and_then(|()| file.flush())
+        .and_then(|()| file.sync_all())
+        .map_err(|_| "Could not write SKILL.md".to_owned())?;
+    Ok(content.len() as u64)
+}
+
+fn checked_copied_bytes(current: u64, added: u64) -> Result<u64, String> {
+    let total = current
+        .checked_add(added)
+        .ok_or_else(|| "This skill is too large to import".to_owned())?;
+    if total > MAX_SKILL_BYTES {
+        return Err("A skill grew beyond the import limit while it was being copied".to_owned());
+    }
+    Ok(total)
+}
+
+fn read_bounded_file(directory: &Dir, name: &OsStr) -> Result<Vec<u8>, String> {
+    let expected_len = regular_file_len(directory, name)?;
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = directory
+        .open_with(name, &options)
+        .map_err(|_| "The file could not be opened".to_owned())?;
+    if !file.metadata().is_ok_and(|metadata| metadata.is_file()) {
+        return Err("The file is not a regular file".to_owned());
+    }
+    let mut content = Vec::with_capacity(expected_len as usize);
+    file.take(expected_len.saturating_add(1))
+        .read_to_end(&mut content)
+        .map_err(|_| "The file could not be read".to_owned())?;
+    if content.len() as u64 != expected_len {
+        return Err("The file changed while it was being read".to_owned());
+    }
+    Ok(content)
+}
+
+enum ManifestState {
+    Missing,
+    Regular,
+    Invalid,
+}
+
+fn manifest_state(directory: &Dir) -> std::io::Result<ManifestState> {
+    match directory.symlink_metadata(SKILL_MANIFEST_FILE) {
+        Ok(metadata) => {
+            if metadata.is_file() && !metadata.file_type().is_symlink() {
+                Ok(ManifestState::Regular)
+            } else {
+                Ok(ManifestState::Invalid)
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(ManifestState::Missing),
+        Err(error) => Err(error),
+    }
+}
+
+fn open_or_create_absolute_directory(path: &Path) -> std::io::Result<Dir> {
+    if let Ok(directory) = open_directory_nofollow(path) {
+        return Ok(directory);
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let parent = open_directory_nofollow(parent)?;
+    match parent.create_dir(name) {
+        Ok(()) => parent.open_dir_nofollow(name),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            parent.open_dir_nofollow(name)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn open_directory_nofollow(path: &Path) -> std::io::Result<Dir> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    Dir::open_ambient_dir(parent, ambient_authority())?.open_dir_nofollow(name)
+}
+
+fn display_name(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "Selected folder".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    const MANIFEST: &str = "---\nname: meeting-notes\ndescription: Write concise meeting notes.\n---\n\n# Meeting notes\n";
+
+    #[test]
+    fn imports_one_skill_with_nested_scripts_references_and_assets() {
+        let source = tempfile::tempdir().unwrap();
+        let skill = source.path().join("meeting-notes");
+        fs::create_dir_all(skill.join("scripts/nested")).unwrap();
+        fs::create_dir_all(skill.join("references/guides")).unwrap();
+        fs::create_dir_all(skill.join("assets")).unwrap();
+        fs::write(skill.join(SKILL_MANIFEST_FILE), MANIFEST).unwrap();
+        fs::write(skill.join("LICENSE"), "license").unwrap();
+        fs::write(skill.join("scripts/render.sh"), "echo notes").unwrap();
+        fs::write(skill.join("scripts/nested/helper.sh"), "echo helper").unwrap();
+        fs::write(skill.join("references/guides/style.md"), "Be concise").unwrap();
+        fs::write(skill.join("assets/icon.png"), [0_u8, 1, 2, 3]).unwrap();
+
+        let destination = tempfile::tempdir().unwrap();
+        let report =
+            import_selected_folder(&skill, &destination.path().join("skills"), &HashSet::new())
+                .unwrap();
+
+        assert_eq!(report.imported, vec!["meeting-notes"]);
+        assert!(report.skipped.is_empty());
+        assert!(report.conflicts.is_empty());
+        let imported = destination.path().join("skills/meeting-notes");
+        assert_eq!(
+            fs::read_to_string(imported.join("LICENSE")).unwrap(),
+            "license"
+        );
+        assert_eq!(
+            fs::read_to_string(imported.join("scripts/render.sh")).unwrap(),
+            "echo notes"
+        );
+        assert_eq!(
+            fs::read_to_string(imported.join("scripts/nested/helper.sh")).unwrap(),
+            "echo helper"
+        );
+        assert_eq!(
+            fs::read_to_string(imported.join("references/guides/style.md")).unwrap(),
+            "Be concise"
+        );
+        assert_eq!(
+            fs::read(imported.join("assets/icon.png")).unwrap(),
+            [0, 1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn publishes_the_bytes_that_were_validated() {
+        let source = tempfile::tempdir().unwrap();
+        let skill = source.path().join("meeting-notes");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join(SKILL_MANIFEST_FILE), MANIFEST).unwrap();
+        fs::write(skill.join("helper.txt"), "safe bytes").unwrap();
+
+        let source_dir = open_directory_nofollow(&skill).unwrap();
+        let prepared = prepare_skill(&source_dir).unwrap();
+        fs::write(skill.join("helper.txt"), "evil bytes").unwrap();
+
+        let destination = tempfile::tempdir().unwrap();
+        let destination_root =
+            open_or_create_absolute_directory(&destination.path().join("skills")).unwrap();
+        destination_root.create_dir("meeting-notes").unwrap();
+        publish_skill(&destination_root, "meeting-notes", &prepared).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(destination.path().join("skills/meeting-notes/helper.txt")).unwrap(),
+            "safe bytes"
+        );
+    }
+
+    #[test]
+    fn unrelated_folders_do_not_consume_the_skill_limit() {
+        let source = tempfile::tempdir().unwrap();
+        for index in 0..MAX_SKILLS_PER_IMPORT {
+            fs::create_dir(source.path().join(format!("a-{index:02}"))).unwrap();
+        }
+        let skill = source.path().join("meeting-notes");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join(SKILL_MANIFEST_FILE), MANIFEST).unwrap();
+
+        let destination = tempfile::tempdir().unwrap();
+        let report = import_selected_folder(
+            source.path(),
+            &destination.path().join("skills"),
+            &HashSet::new(),
+        )
+        .unwrap();
+
+        assert_eq!(report.imported, vec!["meeting-notes"]);
+        assert!(destination
+            .path()
+            .join("skills/meeting-notes/SKILL.md")
+            .is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_a_skill_that_contains_a_symbolic_link() {
+        let source = tempfile::tempdir().unwrap();
+        let skill = source.path().join("meeting-notes");
+        fs::create_dir_all(skill.join("references")).unwrap();
+        fs::write(skill.join(SKILL_MANIFEST_FILE), MANIFEST).unwrap();
+        fs::write(skill.join("references/style.md"), "Be concise").unwrap();
+        std::os::unix::fs::symlink(
+            skill.join("references/style.md"),
+            skill.join("references/linked.md"),
+        )
+        .unwrap();
+
+        let destination = tempfile::tempdir().unwrap();
+        let report =
+            import_selected_folder(&skill, &destination.path().join("skills"), &HashSet::new())
+                .unwrap();
+
+        assert!(report.imported.is_empty());
+        assert_eq!(report.skipped[0].reason, "Symbolic links are not imported");
+        assert!(!destination.path().join("skills/meeting-notes").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_a_path_execution_cannot_stage() {
+        let source = tempfile::tempdir().unwrap();
+        let skill = source.path().join("meeting-notes");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join(SKILL_MANIFEST_FILE), MANIFEST).unwrap();
+        fs::write(skill.join("bad\\name.txt"), "not portable").unwrap();
+
+        let destination = tempfile::tempdir().unwrap();
+        let report =
+            import_selected_folder(&skill, &destination.path().join("skills"), &HashSet::new())
+                .unwrap();
+
+        assert!(report.imported.is_empty());
+        assert_eq!(
+            report.skipped[0].reason,
+            "A skill contains an invalid or overly long path"
+        );
+    }
+
+    #[test]
+    fn a_parent_import_reports_invalid_and_conflicting_skills_without_overwriting() {
+        let source = tempfile::tempdir().unwrap();
+        let valid = source.path().join("meeting-notes");
+        fs::create_dir_all(&valid).unwrap();
+        fs::write(valid.join(SKILL_MANIFEST_FILE), MANIFEST).unwrap();
+        fs::create_dir_all(source.path().join("missing-manifest")).unwrap();
+        let mismatched = source.path().join("different-name");
+        fs::create_dir_all(&mismatched).unwrap();
+        fs::write(mismatched.join(SKILL_MANIFEST_FILE), MANIFEST).unwrap();
+
+        let destination = tempfile::tempdir().unwrap();
+        let existing = destination.path().join("skills/meeting-notes");
+        fs::create_dir_all(&existing).unwrap();
+        fs::write(existing.join(SKILL_MANIFEST_FILE), "keep me").unwrap();
+        let report = import_selected_folder(
+            source.path(),
+            &destination.path().join("skills"),
+            &HashSet::new(),
+        )
+        .unwrap();
+
+        assert!(report.imported.is_empty());
+        assert_eq!(report.conflicts[0].name, "meeting-notes");
+        assert_eq!(report.skipped.len(), 2);
+        assert_eq!(
+            fs::read_to_string(existing.join(SKILL_MANIFEST_FILE)).unwrap(),
+            "keep me"
+        );
+    }
+
+    #[test]
+    fn a_builtin_name_is_a_conflict_even_when_the_user_tree_is_empty() {
+        let source = tempfile::tempdir().unwrap();
+        let skill = source.path().join("meeting-notes");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join(SKILL_MANIFEST_FILE), MANIFEST).unwrap();
+        let destination = tempfile::tempdir().unwrap();
+
+        let report = import_selected_folder(
+            &skill,
+            &destination.path().join("skills"),
+            &HashSet::from(["meeting-notes".to_owned()]),
+        )
+        .unwrap();
+
+        assert!(report.imported.is_empty());
+        assert_eq!(report.conflicts[0].name, "meeting-notes");
+        assert!(!destination.path().join("skills/meeting-notes").exists());
+    }
+}

--- a/crates/tidebreak-desktop/src/trusted_folders.rs
+++ b/crates/tidebreak-desktop/src/trusted_folders.rs
@@ -1,0 +1,187 @@
+//! Private product defaults for folders attached to future conversations.
+
+use std::collections::HashSet;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tidebreak_host_broker::RootId;
+use uuid::Uuid;
+
+const DIRECTORY: &str = "host-access";
+const FILE: &str = "trusted-folders.json";
+const VERSION: u8 = 1;
+const MAX_BYTES: u64 = 256 * 1024;
+
+pub(crate) struct TrustedFolderStore {
+    directory: PathBuf,
+    path: PathBuf,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StoredTrustedFolders {
+    version: u8,
+    root_ids: Vec<RootId>,
+}
+
+impl TrustedFolderStore {
+    pub(crate) fn open(data_dir: &Path) -> io::Result<Self> {
+        let directory = data_dir.join(DIRECTORY);
+        fs::create_dir_all(&directory)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
+        }
+        Ok(Self {
+            path: directory.join(FILE),
+            directory,
+        })
+    }
+
+    pub(crate) fn list(&self) -> io::Result<HashSet<RootId>> {
+        let bytes = match fs::read(&self.path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(HashSet::new()),
+            Err(error) => return Err(error),
+        };
+        let metadata = fs::metadata(&self.path)?;
+        if !metadata.is_file() || metadata.len() > MAX_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "trusted folder defaults are invalid",
+            ));
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            if metadata.permissions().mode() & 0o077 != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "trusted folder defaults have broad permissions",
+                ));
+            }
+        }
+        let stored: StoredTrustedFolders = serde_json::from_slice(&bytes)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        if stored.version != VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "trusted folder defaults use an unsupported version",
+            ));
+        }
+        Ok(stored.root_ids.into_iter().collect())
+    }
+
+    pub(crate) fn set(&self, root_id: RootId, trusted: bool) -> io::Result<bool> {
+        let mut roots = self.list()?;
+        let changed = if trusted {
+            roots.insert(root_id)
+        } else {
+            roots.remove(&root_id)
+        };
+        if !changed {
+            return Ok(false);
+        }
+        let mut root_ids = roots.into_iter().collect::<Vec<_>>();
+        root_ids.sort_by_key(|root_id| root_id.to_string());
+        let bytes = serde_json::to_vec_pretty(&StoredTrustedFolders {
+            version: VERSION,
+            root_ids,
+        })
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        write_atomically(&self.directory, &self.path, &bytes)?;
+        Ok(true)
+    }
+}
+
+fn write_atomically(directory: &Path, destination: &Path, bytes: &[u8]) -> io::Result<()> {
+    let temporary = directory.join(format!(".trusted-folders-{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        replace_file(&temporary, destination)?;
+        sync_directory(directory)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(temporary, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let temporary = temporary
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let destination = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let succeeded = unsafe {
+        MoveFileExW(
+            temporary.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if succeeded == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory(directory: &Path) -> io::Result<()> {
+    std::fs::File::open(directory)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_directory(_directory: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stores_and_removes_opaque_folder_defaults() {
+        let data = tempfile::tempdir().unwrap();
+        let store = TrustedFolderStore::open(data.path()).unwrap();
+        let first = RootId::new();
+        let second = RootId::new();
+
+        assert!(store.list().unwrap().is_empty());
+        assert!(store.set(first, true).unwrap());
+        assert!(store.set(second, true).unwrap());
+        assert!(!store.set(first, true).unwrap());
+        assert_eq!(store.list().unwrap(), HashSet::from([first, second]));
+        assert!(store.set(first, false).unwrap());
+        assert_eq!(store.list().unwrap(), HashSet::from([second]));
+    }
+}

--- a/crates/tidebreak-desktop/ui/src/ChatStatusChip.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChatStatusChip.dom.test.tsx
@@ -11,6 +11,7 @@ const folder = {
   rootId: "root-1",
   displayName: "Notes",
   status: "connected",
+  availableInFutureChats: true,
   statements: [],
 } as unknown as ChatFolderAccess;
 

--- a/crates/tidebreak-desktop/ui/src/Composer.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.test.tsx
@@ -665,6 +665,7 @@ describe("composerFolderChips", () => {
         rootId: "root-1",
         displayName: "Downloads",
         status: "connected",
+        availableInFutureChats: true,
         statements: [],
       },
     ],

--- a/crates/tidebreak-desktop/ui/src/ComposerFolders.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerFolders.dom.test.tsx
@@ -25,6 +25,7 @@ it("attaches and confirms revoking a folder from the ordinary chat composer", as
             rootId: "root-1",
             displayName: "Research",
             status: "connected",
+            availableInFutureChats: true,
             statements: (["read_files", "write_files"] as const).map(
               (capability, index) => ({
                 handle: {
@@ -87,6 +88,7 @@ it("drops folder chips after send without needing a disconnect", () => {
             rootId: "root-1",
             displayName: "Downloads",
             status: "connected",
+            availableInFutureChats: true,
             statements: (
               ["read_files", "write_files", "execute_commands"] as const
             ).map((capability, index) => ({

--- a/crates/tidebreak-desktop/ui/src/ComposerMentions.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerMentions.dom.test.tsx
@@ -65,7 +65,12 @@ function composerFolders(
   return {
     items: [],
     approved: [
-      { rootId: "root-1", displayName: "Reports", status: "connected" },
+      {
+        rootId: "root-1",
+        displayName: "Reports",
+        status: "connected",
+        availableInFutureChats: true,
+      },
     ],
     working: false,
     error: null,

--- a/crates/tidebreak-desktop/ui/src/ComposerMentions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ComposerMentions.test.ts
@@ -93,11 +93,17 @@ it("offers workspace paths as insertable mention rows", () => {
 
 it("offers only approved folders this conversation has not attached", () => {
   const approved = [
-    { rootId: "root-1", displayName: "Reports", status: "connected" as const },
+    {
+      rootId: "root-1",
+      displayName: "Reports",
+      status: "connected" as const,
+      availableInFutureChats: true,
+    },
     {
       rootId: "root-2",
       displayName: "Contracts",
       status: "connected" as const,
+      availableInFutureChats: false,
     },
   ];
 

--- a/crates/tidebreak-desktop/ui/src/FoldersView.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/FoldersView.test.tsx
@@ -16,6 +16,7 @@ vi.mock("./host", () => ({
   listCapabilityConsents: vi.fn(),
   listConnectedFolders: vi.fn(),
   revokeCapabilityConsent: vi.fn(),
+  setTrustedFolder: vi.fn(),
 }));
 
 const chat = {
@@ -28,8 +29,9 @@ function folder(
   rootId: string,
   displayName: string,
   status: host.FolderStatus = "connected",
+  availableInFutureChats = false,
 ): host.ConnectedFolder {
-  return { rootId, displayName, status };
+  return { rootId, displayName, status, availableInFutureChats };
 }
 
 type FolderCapabilityVerb = Extract<
@@ -73,6 +75,7 @@ beforeEach(() => {
   vi.mocked(host.forgetFolder).mockResolvedValue(true);
   vi.mocked(host.grantFolderCapability).mockResolvedValue(null);
   vi.mocked(host.revokeCapabilityConsent).mockResolvedValue(true);
+  vi.mocked(host.setTrustedFolder).mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -258,9 +261,12 @@ describe("FoldersView", () => {
       screen.queryByText("Available on this device"),
     ).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Forget" }));
+    await user.click(screen.getAllByRole("button", { name: "Forget" })[1]);
     // Forgetting is destructive across every chat, so it confirms first.
-    await user.click(await screen.findByRole("button", { name: "Forget" }));
+    const forgetButtons = await screen.findAllByRole("button", {
+      name: "Forget",
+    });
+    await user.click(forgetButtons[forgetButtons.length - 1]);
     await waitFor(() =>
       expect(host.forgetFolder).toHaveBeenCalledWith("unplugged"),
     );
@@ -300,13 +306,20 @@ describe("FoldersView", () => {
         rootId: "connected",
         displayName: "Current project",
         status: "connected",
+        availableInFutureChats: false,
       },
-      { rootId: "available", displayName: "Research", status: "connected" },
+      {
+        rootId: "available",
+        displayName: "Research",
+        status: "connected",
+        availableInFutureChats: false,
+      },
     ]);
     vi.mocked(host.connectApprovedFolder).mockResolvedValue({
       rootId: "available",
       displayName: "Research",
       status: "connected",
+      availableInFutureChats: true,
     });
     const user = userEvent.setup();
     render(<FoldersView chat={chat} />);
@@ -329,9 +342,14 @@ describe("FoldersView", () => {
     expect(screen.getAllByText("Research")).toHaveLength(1);
   });
 
-  it("leaves an approved folder unattached when native consent is canceled", async () => {
+  it("leaves an approved folder listed when connection returns no change", async () => {
     vi.mocked(host.listApprovedFolders).mockResolvedValue([
-      { rootId: "available", displayName: "Research", status: "connected" },
+      {
+        rootId: "available",
+        displayName: "Research",
+        status: "connected",
+        availableInFutureChats: false,
+      },
     ]);
     const user = userEvent.setup();
     render(<FoldersView chat={chat} />);
@@ -341,6 +359,42 @@ describe("FoldersView", () => {
     expect(host.connectApprovedFolder).toHaveBeenCalledWith(chat, "available");
     expect(host.listConnectedFolders).toHaveBeenCalledOnce();
     expect(screen.getByText("Research")).toBeInTheDocument();
+  });
+
+  it("changes whether a folder is available in future chats", async () => {
+    vi.mocked(host.listConnectedFolders)
+      .mockResolvedValueOnce([folder("drafts", "Drafts")])
+      .mockResolvedValueOnce([folder("drafts", "Drafts", "connected", true)]);
+    const user = userEvent.setup();
+    render(<FoldersView chat={chat} />);
+
+    const toggle = await screen.findByRole("switch", {
+      name: "Available in future chats for Drafts",
+    });
+    expect(toggle).not.toBeChecked();
+    await user.click(toggle);
+
+    expect(host.setTrustedFolder).toHaveBeenCalledWith("drafts", true);
+    await waitFor(() => expect(toggle).toBeChecked());
+  });
+
+  it("forgets a live folder everywhere without using per-chat disconnect", async () => {
+    vi.mocked(host.listConnectedFolders)
+      .mockResolvedValueOnce([folder("drafts", "Drafts", "connected", true)])
+      .mockResolvedValueOnce([]);
+    const user = userEvent.setup();
+    render(<FoldersView chat={chat} />);
+
+    await user.click(await screen.findByRole("button", { name: "Forget" }));
+    const forgetButtons = await screen.findAllByRole("button", {
+      name: "Forget",
+    });
+    await user.click(forgetButtons[forgetButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(host.forgetFolder).toHaveBeenCalledWith("drafts"),
+    );
+    expect(host.disconnectFolder).not.toHaveBeenCalled();
   });
 
   it("ignores a late folder response after switching chats", async () => {

--- a/crates/tidebreak-desktop/ui/src/FoldersView.tsx
+++ b/crates/tidebreak-desktop/ui/src/FoldersView.tsx
@@ -8,6 +8,7 @@ import { useConfirm } from "@/components/ConfirmDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
 import {
   Empty,
   EmptyContent,
@@ -26,6 +27,7 @@ import {
   listCapabilityConsents,
   listConnectedFolders,
   revokeCapabilityConsent,
+  setTrustedFolder,
   type ConnectedFolder,
   type WidenedFolderCapability,
 } from "./host";
@@ -137,9 +139,29 @@ export function FoldersView({ chat }: { chat: Chat }) {
   }
 
   async function addApprovedFolder(rootId: string) {
-    await withPicker(PICKER_HOLDERS.confirmApprovedFolder, () =>
-      connectApprovedFolder(chat, rootId),
-    );
+    setWorking(true);
+    try {
+      const connected = await connectApprovedFolder(chat, rootId);
+      if (connected) useRefreshSignals.getState().signal("folderAccess");
+    } catch (err) {
+      toast.error(hostErrorMessage(err, "The folder could not be connected."));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function setFutureChats(folder: ConnectedFolder, trusted: boolean) {
+    setWorking(true);
+    try {
+      await setTrustedFolder(folder.rootId, trusted);
+      useRefreshSignals.getState().signal("folderAccess");
+    } catch (err) {
+      toast.error(
+        hostErrorMessage(err, "The future chat setting could not be changed."),
+      );
+    } finally {
+      setWorking(false);
+    }
   }
 
   /**
@@ -182,11 +204,11 @@ export function FoldersView({ chat }: { chat: Chat }) {
    * is deliberately not a button: the attachment and grants are riding out
    * the outage, so the folder comes back on its own when its directory does.
    */
-  async function forgetUnavailableFolder(folder: ConnectedFolder) {
+  async function forgetApprovedFolder(folder: ConnectedFolder) {
     const accepted = await confirm({
       title: `Forget ${folder.displayName}?`,
       description:
-        "Withdraws Tidebreak's approval for this folder everywhere, for all work. If the folder comes back, connect it again from scratch.",
+        "Tidebreak removes this folder from every chat and withdraws its access everywhere. To use it again, connect it from scratch.",
       confirmLabel: "Forget",
       destructive: true,
     });
@@ -271,9 +293,9 @@ export function FoldersView({ chat }: { chat: Chat }) {
               </EmptyMedia>
               <EmptyTitle>No folders connected</EmptyTitle>
               <EmptyDescription>
-                Connect a folder to let Tidebreak work with files on your
-                computer in this conversation. It can reach only the folders you
-                attach here, and each one shows what it allows.
+                Connect a folder once to let Tidebreak read and write it in this
+                chat and future chats. You can still disconnect it from one chat
+                or forget it everywhere.
               </EmptyDescription>
             </EmptyHeader>
             <EmptyContent>{connectButton}</EmptyContent>
@@ -304,16 +326,33 @@ export function FoldersView({ chat }: { chat: Chat }) {
                       name={folder.displayName}
                       reach={reach}
                       action={
-                        <Button
-                          variant="outline"
-                          size="xs"
-                          disabled={working}
-                          onClick={() => void removeFolder(folder)}
-                        >
-                          Disconnect
-                        </Button>
+                        <div className="flex shrink-0 gap-1">
+                          <Button
+                            variant="outline"
+                            size="xs"
+                            disabled={working}
+                            onClick={() => void removeFolder(folder)}
+                          >
+                            Disconnect
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="xs"
+                            disabled={working}
+                            onClick={() => void forgetApprovedFolder(folder)}
+                          >
+                            Forget
+                          </Button>
+                        </div>
                       }
                     >
+                      <FutureChatToggle
+                        folder={folder}
+                        disabled={working}
+                        onChange={(trusted) =>
+                          void setFutureChats(folder, trusted)
+                        }
+                      />
                       {statements.map((statement) => (
                         <div
                           key={
@@ -384,13 +423,20 @@ export function FoldersView({ chat }: { chat: Chat }) {
                           variant="outline"
                           size="xs"
                           disabled={working}
-                          onClick={() => void forgetUnavailableFolder(folder)}
+                          onClick={() => void forgetApprovedFolder(folder)}
                         >
                           Forget
                         </Button>
                       </div>
                     }
                   >
+                    <FutureChatToggle
+                      folder={folder}
+                      disabled={working}
+                      onChange={(trusted) =>
+                        void setFutureChats(folder, trusted)
+                      }
+                    />
                     <p className="text-sm text-muted-foreground">
                       Tidebreak can’t reach this folder right now. It stays
                       connected and returns on its own once the folder is back —
@@ -409,20 +455,40 @@ export function FoldersView({ chat }: { chat: Chat }) {
                     name={folder.displayName}
                     badge={
                       <Badge variant="outline" size="sm">
-                        Previously approved
+                        {folder.availableInFutureChats
+                          ? "Future chats"
+                          : "Previously approved"}
                       </Badge>
                     }
                     action={
-                      <Button
-                        variant="outline"
-                        size="xs"
-                        disabled={working}
-                        onClick={() => void addApprovedFolder(folder.rootId)}
-                      >
-                        Connect
-                      </Button>
+                      <div className="flex shrink-0 gap-1">
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          disabled={working}
+                          onClick={() => void addApprovedFolder(folder.rootId)}
+                        >
+                          Connect
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          disabled={working}
+                          onClick={() => void forgetApprovedFolder(folder)}
+                        >
+                          Forget
+                        </Button>
+                      </div>
                     }
-                  />
+                  >
+                    <FutureChatToggle
+                      folder={folder}
+                      disabled={working}
+                      onChange={(trusted) =>
+                        void setFutureChats(folder, trusted)
+                      }
+                    />
+                  </FolderCard>
                 ))}
               </FolderSection>
             )}
@@ -464,7 +530,34 @@ function FolderSection({
   );
 }
 
-function FolderCard({
+export function FutureChatToggle({
+  folder,
+  disabled = false,
+  onChange,
+}: {
+  folder: ConnectedFolder;
+  disabled?: boolean;
+  onChange: (trusted: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-subtle pb-2">
+      <div className="min-w-0">
+        <p className="text-sm font-medium">Available in future chats</p>
+        <p className="text-xs text-muted-foreground">
+          Tidebreak attaches this folder before a new chat starts.
+        </p>
+      </div>
+      <Switch
+        aria-label={`Available in future chats for ${folder.displayName}`}
+        checked={folder.availableInFutureChats}
+        disabled={disabled}
+        onCheckedChange={onChange}
+      />
+    </div>
+  );
+}
+
+export function FolderCard({
   name,
   reach,
   badge,

--- a/crates/tidebreak-desktop/ui/src/NativePickerLatch.test.ts
+++ b/crates/tidebreak-desktop/ui/src/NativePickerLatch.test.ts
@@ -54,14 +54,12 @@ describe("native picker latch", () => {
   });
 
   it("names every surface that opens a host picker", () => {
-    // Eight Tauri commands take the host picker mutex: resolving a
-    // folder-access decision (keyed by call id), connecting a folder,
-    // confirming a previously approved one, granting a capability on an
-    // attached folder, importing a source, exporting an output, saving a chat
-    // debug bundle, and attaching an image to a message.
+    // Seven Tauri commands take the host picker mutex: resolving a
+    // folder-access decision (keyed by call id), connecting a folder, granting
+    // a capability on an attached folder, importing a source, exporting an
+    // output, saving a chat debug bundle, and attaching an image to a message.
     expect(Object.values(PICKER_HOLDERS)).toEqual([
       "connect-folder",
-      "confirm-approved-folder",
       "grant-folder-capability",
       "import-source",
       "export-output",

--- a/crates/tidebreak-desktop/ui/src/NativePickerLatch.ts
+++ b/crates/tidebreak-desktop/ui/src/NativePickerLatch.ts
@@ -4,8 +4,8 @@ import { create } from "zustand";
  * The one native file-or-folder picker the host will have open at a time.
  *
  * Every surface that opens one — a folder-access decision, connecting a folder,
- * confirming a previously approved one, importing a source, exporting an output
- * — ends up at the same host mutex, and the host rejects a second call outright
+ * importing a source, or exporting an output — ends up at the same host mutex,
+ * and the host rejects a second call outright
  * rather than queueing it. So the latch that keeps a reader from starting a
  * second one has to be app-wide and shared by all of them: a latch held by only
  * one caller does not prevent the collision, it just decides which caller gets
@@ -24,7 +24,6 @@ export type NativePickerLatchStore = {
 /** Stable holders for the surfaces that are not keyed by a call id. */
 export const PICKER_HOLDERS = {
   connectFolder: "connect-folder",
-  confirmApprovedFolder: "confirm-approved-folder",
   grantFolderCapability: "grant-folder-capability",
   importSource: "import-source",
   exportOutput: "export-output",

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -1,6 +1,6 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
 
-import { attachedRemotely } from "../host";
+import { attachedRemotely, attachTrustedFolders } from "../host";
 
 import {
   APP_INVOKE_REFUSAL_KINDS,
@@ -1033,7 +1033,7 @@ export class ApiClient {
    * correcting PATCH races the first turn, which reads the chat as it was
    * created.
    */
-  createChat(
+  async createChat(
     model?: ModelSelectionKey,
     projectId?: string | null,
     settings?: {
@@ -1042,7 +1042,7 @@ export class ApiClient {
       networkPolicy?: NetworkPolicy;
     },
   ): Promise<Chat> {
-    return this.json("/chats", {
+    const chat = await this.json<Chat>("/chats", {
       method: "POST",
       headers: this.headers(true),
       body: JSON.stringify({
@@ -1053,6 +1053,14 @@ export class ApiClient {
         network_policy: settings?.networkPolicy,
       }),
     });
+    try {
+      await attachTrustedFolders(chat);
+    } catch (error) {
+      // The chat already exists. Keep it usable if the local folder broker is
+      // unavailable instead of making a retry create a second conversation.
+      console.warn("could not attach saved folders to the new chat", error);
+    }
+    return chat;
   }
 
   listChats(): Promise<Chat[]> {

--- a/crates/tidebreak-desktop/ui/src/api/createChatTrustedFolders.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api/createChatTrustedFolders.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+const attachTrustedFolders = vi.hoisted(() => vi.fn());
+
+vi.mock("../host", () => ({
+  attachedRemotely: () => false,
+  attachTrustedFolders,
+}));
+
+import { ApiClient } from "./client";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+it("attaches saved folders before returning a newly created chat", async () => {
+  const chat = {
+    id: "chat-1",
+    title: null,
+    model: null,
+    attachment_revision: 0,
+    root_attachments: [],
+    project_id: null,
+    created_at: "2026-08-25T12:00:00Z",
+  };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(chat), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+  attachTrustedFolders.mockResolvedValue([]);
+
+  const created = await new ApiClient("http://127.0.0.1", "token").createChat();
+
+  expect(attachTrustedFolders).toHaveBeenCalledWith(chat);
+  expect(created).toEqual(chat);
+});
+
+it("returns the created chat when saved-folder attachment fails", async () => {
+  const chat = {
+    id: "chat-2",
+    title: null,
+    model: null,
+    attachment_revision: 0,
+    root_attachments: [],
+    project_id: null,
+    created_at: "2026-08-25T12:00:00Z",
+  };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(chat), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+  attachTrustedFolders.mockRejectedValue(new Error("broker unavailable"));
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+  const created = await new ApiClient("http://127.0.0.1", "token").createChat();
+
+  expect(created).toEqual(chat);
+  expect(warn).toHaveBeenCalledWith(
+    "could not attach saved folders to the new chat",
+    expect.any(Error),
+  );
+  warn.mockRestore();
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.dom.test.tsx
@@ -295,6 +295,75 @@ describe("CodeTranscript", () => {
     expect(alert).toHaveTextContent("4.0s");
   });
 
+  it("attributes a revoked refresh token to Codex CLI and gives recovery steps", () => {
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "notice",
+            id: "notice-codex-auth",
+            level: "error",
+            message:
+              "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.",
+          },
+          {
+            kind: "turn_boundary",
+            id: "b-codex-auth",
+            turnId: "t-codex-auth",
+            status: "failed",
+            durationMs: 4_000,
+            usage: null,
+            error:
+              "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.",
+            diffstat: null,
+          },
+        ]}
+      />,
+    );
+
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts).toHaveLength(1);
+    const alert = alerts[0]!;
+    expect(alert).toHaveTextContent("Codex CLI rejected its saved sign-in");
+    expect(alert).toHaveTextContent(
+      "Tidebreak's account sign-in does not reset Codex CLI",
+    );
+    expect(within(alert).getByText("codex logout").tagName).toBe("CODE");
+    expect(within(alert).getByText("codex login").tagName).toBe("CODE");
+    expect(alert).toHaveTextContent(
+      "Then open Settings → Coding harnesses and select Re-check",
+    );
+    expect(alert).not.toHaveTextContent("Your access token could not");
+  });
+
+  it("keeps a revoked-token notice when the next turn failed for another reason", () => {
+    render(
+      <CodeTranscript
+        items={[
+          {
+            kind: "notice",
+            id: "notice-codex-auth",
+            level: "error",
+            message:
+              "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.",
+          },
+          {
+            kind: "turn_boundary",
+            id: "b-other-failure",
+            turnId: "t-other-failure",
+            status: "failed",
+            durationMs: 4_000,
+            usage: null,
+            error: "the engine exited before the turn completed",
+            diffstat: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByRole("alert")).toHaveLength(2);
+  });
+
   it("falls back to the tool name when the engine sends no target", () => {
     render(
       <CodeTranscript

--- a/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTranscript.tsx
@@ -43,6 +43,7 @@ import { MiddleTruncate } from "./MiddleTruncate";
 import {
   formatElapsedDuration,
   formatTurnDuration,
+  isCodexRevokedRefreshTokenError,
   TurnReviewCard,
 } from "./TurnReviewCard";
 
@@ -159,10 +160,11 @@ export function CodeTranscript({
       </div>
     );
   }
+  const presentationItems = codeTranscriptPresentationItems(items);
   // The recap belongs to the session, so only its newest boundary carries one.
   let newestBoundaryId: string | undefined;
-  for (let index = items.length - 1; index >= 0; index -= 1) {
-    const item = items[index];
+  for (let index = presentationItems.length - 1; index >= 0; index -= 1) {
+    const item = presentationItems[index];
     if (item?.kind === "turn_boundary") {
       newestBoundaryId = item.id;
       break;
@@ -171,7 +173,7 @@ export function CodeTranscript({
   return (
     <div className="messages" ref={scrollRef} onScroll={onScroll}>
       <div className="messages-column" ref={contentRef}>
-        {groupCodeTranscriptRows(items).map((row) =>
+        {groupCodeTranscriptRows(presentationItems).map((row) =>
           row.kind === "group"
             ? isolatedCard(
                 row.id,
@@ -213,13 +215,45 @@ export function CodeTranscript({
                 />,
               ),
         )}
-        {shouldShowCodeWorking(items, busy, streamStalled) && (
+        {shouldShowCodeWorking(presentationItems, busy, streamStalled) && (
           <AssistantWorkingIndicator />
         )}
-        <TurnLifecycleAnnouncer text={codeTurnAnnouncement(items, busy)} />
+        <TurnLifecycleAnnouncer
+          text={codeTurnAnnouncement(presentationItems, busy)}
+        />
       </div>
     </div>
   );
+}
+
+/**
+ * Remove a harness error when the turn boundary already presents the same
+ * Codex CLI recovery. The notice has no turn id, so transcript order is the
+ * boundary: only the next boundary before another prompt can absorb it.
+ */
+export function codeTranscriptPresentationItems(
+  items: readonly CodeTranscriptItem[],
+): CodeTranscriptItem[] {
+  return items.filter((item, index) => {
+    if (
+      item.kind !== "notice" ||
+      item.level !== "error" ||
+      !isCodexRevokedRefreshTokenError(item.message)
+    ) {
+      return true;
+    }
+
+    for (let nextIndex = index + 1; nextIndex < items.length; nextIndex += 1) {
+      const next = items[nextIndex];
+      if (!next || next.kind === "user") return true;
+      if (next.kind !== "turn_boundary") continue;
+      return !(
+        next.status === "failed" && isCodexRevokedRefreshTokenError(next.error)
+      );
+    }
+
+    return true;
+  });
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.test.ts
@@ -1,6 +1,32 @@
 import { describe, expect, it } from "vitest";
 
-import { formatElapsedDuration, formatTurnDuration } from "./TurnReviewCard";
+import {
+  formatElapsedDuration,
+  formatTurnDuration,
+  isCodexRevokedRefreshTokenError,
+} from "./TurnReviewCard";
+
+describe("isCodexRevokedRefreshTokenError", () => {
+  it("recognizes the Codex CLI diagnostic through prefixes and line wrapping", () => {
+    expect(
+      isCodexRevokedRefreshTokenError(
+        "Error: Your access token could not be refreshed because your refresh\n token was revoked. Please log out and sign in again.",
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves other engine and authentication failures unchanged", () => {
+    expect(isCodexRevokedRefreshTokenError(null)).toBe(false);
+    expect(isCodexRevokedRefreshTokenError("claude exited with status 1")).toBe(
+      false,
+    );
+    expect(
+      isCodexRevokedRefreshTokenError(
+        "Your access token expired. Please sign in again.",
+      ),
+    ).toBe(false);
+  });
+});
 
 describe("formatTurnDuration", () => {
   it("never rounds a turn that happened to zero", () => {

--- a/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TurnReviewCard.tsx
@@ -36,6 +36,22 @@ import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 
 type TurnBoundary = Extract<CodeTranscriptItem, { kind: "turn_boundary" }>;
 
+const CODEX_REVOKED_REFRESH_TOKEN_FINGERPRINT =
+  "your access token could not be refreshed because your refresh token was revoked";
+
+/**
+ * Whether Codex CLI rejected the saved refresh token for this session.
+ *
+ * The CLI can wrap the sentence with its own prefix or line breaks. Normalize
+ * whitespace and match the full diagnostic clause so other authentication and
+ * engine failures keep their original text.
+ */
+export function isCodexRevokedRefreshTokenError(error: string | null): boolean {
+  if (!error) return false;
+  const normalized = error.toLowerCase().replace(/\s+/g, " ").trim();
+  return normalized.includes(CODEX_REVOKED_REFRESH_TOKEN_FINGERPRINT);
+}
+
 export function TurnReviewCard({
   turn,
   narrative,
@@ -71,6 +87,7 @@ export function TurnReviewCard({
   );
 
   if (turn.status === "failed") {
+    const codexNeedsLogin = isCodexRevokedRefreshTokenError(turn.error);
     return (
       <div
         role="alert"
@@ -83,7 +100,11 @@ export function TurnReviewCard({
             <span className="font-normal tabular-nums">· {duration}</span>
           )}
         </p>
-        <p>{turn.error ?? "The engine stopped without saying why."}</p>
+        {codexNeedsLogin ? (
+          <CodexLoginRecovery />
+        ) : (
+          <p>{turn.error ?? "The engine stopped without saying why."}</p>
+        )}
         {narrative}
         {(diffstat || actions) && (
           <div className="flex items-center gap-2">
@@ -117,6 +138,33 @@ export function TurnReviewCard({
       {diffstat}
       {actions}
     </SeamRow>
+  );
+}
+
+/** Recovery for the revoked credential that belongs to Codex CLI. */
+function CodexLoginRecovery() {
+  return (
+    <div className="flex flex-col gap-2">
+      <p>
+        Codex CLI rejected its saved sign-in. Tidebreak&apos;s account sign-in
+        does not reset Codex CLI.
+      </p>
+      <div className="flex flex-col gap-1">
+        <p>Run these commands in your terminal:</p>
+        <ol className="list-decimal space-y-1 pl-5">
+          <li>
+            <code className="font-mono">codex logout</code>
+          </li>
+          <li>
+            <code className="font-mono">codex login</code>
+          </li>
+        </ol>
+      </div>
+      <p>
+        Then open Settings → Coding harnesses and select{" "}
+        <strong>Re-check</strong>.
+      </p>
+    </div>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1937,7 +1937,7 @@ export type ConsentHandle = { "kind": "tool_grant", call_id: CallId, } | { "kind
 /**
  * The trusted interaction that captured a consent statement.
  */
-export type ConsentMethodSnapshot = "approval_card" | "folder_picker" | "permission_dialog" | "operator_config" | "carried_forward";
+export type ConsentMethodSnapshot = "approval_card" | "folder_picker" | "trusted_folder" | "permission_dialog" | "operator_config" | "carried_forward";
 
 /**
  * What a consent statement's verb is allowed to touch.

--- a/crates/tidebreak-desktop/ui/src/host.ts
+++ b/crates/tidebreak-desktop/ui/src/host.ts
@@ -11,6 +11,7 @@ export type ConnectedFolder = {
   rootId: string;
   displayName: string;
   status: FolderStatus;
+  availableInFutureChats: boolean;
 };
 
 export type FolderAccessDecision = "allow" | "decline";
@@ -170,6 +171,24 @@ export function connectApprovedFolder(
   });
 }
 
+/** Attach every saved folder before a newly created chat can start work. */
+export function attachTrustedFolders(chat: {
+  id: string;
+}): Promise<ConnectedFolder[]> {
+  if (!hasLocalHostAuthority()) return Promise.resolve([]);
+  return invoke("attach_trusted_folders", { chatId: chat.id });
+}
+
+/** Change whether one approved folder attaches to future chats. */
+export function setTrustedFolder(
+  rootId: string,
+  trusted: boolean,
+): Promise<boolean> {
+  return invoke("set_trusted_folder", {
+    request: { rootId, trusted },
+  });
+}
+
 export function disconnectFolder(chat: Chat, rootId: string): Promise<boolean> {
   return invoke("disconnect_folder", {
     request: { chatId: chat.id, rootId },
@@ -177,10 +196,7 @@ export function disconnectFolder(chat: Chat, rootId: string): Promise<boolean> {
 }
 
 /**
- * Withdraw the host approval for a folder the broker can no longer reach —
- * the remove half of the set-aside surface, for a folder that is gone for
- * good. Refused for live folders, whose exit is the per-chat disconnect.
- * Returns whether anything was revoked.
+ * Withdraw one folder's host approval, grants, and chat attachments everywhere.
  */
 export function forgetFolder(rootId: string): Promise<boolean> {
   return invoke("forget_folder", {

--- a/crates/tidebreak-desktop/ui/src/plugins/Plugins.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/plugins/Plugins.dom.test.tsx
@@ -12,6 +12,7 @@ import type { PluginCatalog } from "@/api";
 import { PluginDetailView } from "./PluginDetailView";
 import type { PluginsApis } from "./pluginsApis";
 import { PluginsView } from "./PluginsView";
+import type { SkillImportReport } from "./skillImport";
 import { usePluginCatalog } from "./usePluginCatalog";
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
@@ -80,13 +81,20 @@ function apisWith(overrides: Partial<PluginsApis> = {}): PluginsApis {
 }
 
 /** Drives the real catalog hook so a toggle exercises the whole round trip. */
-function ListHarness({ apis }: { apis: PluginsApis }) {
+function ListHarness({
+  apis,
+  importSkills,
+}: {
+  apis: PluginsApis;
+  importSkills?: () => Promise<SkillImportReport | null>;
+}) {
   const state = usePluginCatalog(apis);
   return (
     <PluginsView
       state={state}
       loadInstructions={apis.instructions}
       onOpen={() => {}}
+      importSkills={importSkills}
     />
   );
 }
@@ -218,5 +226,59 @@ describe("Plugins library", () => {
     expect(await screen.findByText("No plugins installed")).toBeInTheDocument();
     // The user-skills section is absent rather than empty when there are none.
     expect(screen.queryByLabelText("Your skills")).not.toBeInTheDocument();
+  });
+
+  it("reports every import outcome and reloads the catalog", async () => {
+    const apis = apisWith();
+    const importedName =
+      "customer-support-incident-review-with-a-long-unbroken-skill-name";
+    const importSkills = vi.fn().mockResolvedValue({
+      imported: [importedName],
+      skipped: [
+        { name: "draft-helper", reason: "No regular SKILL.md was found" },
+      ],
+      conflicts: [
+        {
+          name: "documents",
+          reason: "A skill included with Tidebreak already uses this name",
+        },
+      ],
+    } satisfies SkillImportReport);
+    render(<ListHarness apis={apis} importSkills={importSkills} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Import skills" }),
+    );
+
+    expect(
+      await screen.findByText("Skill import complete"),
+    ).toBeInTheDocument();
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent(
+      "1 skill imported, 1 skipped, and 1 conflict",
+    );
+    expect(status).not.toHaveTextContent(importedName);
+    expect(screen.getByText(importedName)).toHaveClass("break-all");
+    expect(screen.getByText("draft-helper")).toBeInTheDocument();
+    expect(screen.getAllByText("documents").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("No regular SKILL.md was found"),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(apis.list).toHaveBeenCalledTimes(2));
+  });
+
+  it("leaves the catalog alone when the folder picker is cancelled", async () => {
+    const apis = apisWith();
+    const importSkills = vi.fn().mockResolvedValue(null);
+    render(<ListHarness apis={apis} importSkills={importSkills} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Import skills" }),
+    );
+
+    await waitFor(() => expect(importSkills).toHaveBeenCalledOnce());
+    expect(apis.list).toHaveBeenCalledOnce();
+    expect(screen.queryByText("Skill import complete")).not.toBeInTheDocument();
+    expect(screen.queryByText("No skills imported")).not.toBeInTheDocument();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/plugins/PluginsView.tsx
+++ b/crates/tidebreak-desktop/ui/src/plugins/PluginsView.tsx
@@ -1,5 +1,6 @@
-import { Puzzle } from "lucide-react";
+import { FolderInput, Puzzle } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
+import { toast } from "sonner";
 
 import type { PluginInfo, PluginSkillInfo } from "@/api";
 import { SearchInput } from "@/components/SearchInput";
@@ -15,6 +16,11 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { PluginGlyph, SkillGlyph } from "./PluginGlyph";
 import type { PluginsApis } from "./pluginsApis";
+import {
+  importSkillsFromFolder,
+  type SkillImportIssue,
+  type SkillImportReport,
+} from "./skillImport";
 import { SkillDialog } from "./SkillDialog";
 import {
   hostToolProvisioningLabel,
@@ -40,16 +46,23 @@ export function PluginsView({
   state,
   loadInstructions,
   onOpen,
+  importSkills = importSkillsFromFolder,
 }: {
   state: PluginCatalogState;
   loadInstructions: PluginsApis["instructions"];
   /** Navigate to the bundle's own page. */
   onOpen: (pluginId: string) => void;
+  /** Open a native picker and copy user skills into this installation. */
+  importSkills?: () => Promise<SkillImportReport | null>;
 }) {
   const { catalog, loading, error, reload, setEnabled } = state;
   const provisioning = useHostToolProvisioning();
   const [query, setQuery] = useState("");
   const [openSkill, setOpenSkill] = useState<PluginSkillInfo | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [importReport, setImportReport] = useState<SkillImportReport | null>(
+    null,
+  );
 
   const filtered = useMemo(
     () => filterCatalog(catalog, query),
@@ -81,6 +94,23 @@ export function PluginsView({
       openSkill)
     : null;
 
+  const runImport = async () => {
+    setImporting(true);
+    setImportReport(null);
+    try {
+      const report = await importSkills();
+      if (!report) return;
+      setImportReport(report);
+      reload();
+    } catch (caught) {
+      toast.error(
+        friendlyImportError(caught, "Could not import those skills."),
+      );
+    } finally {
+      setImporting(false);
+    }
+  };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
@@ -92,15 +122,26 @@ export function PluginsView({
                 Skills the agent can use when you turn them on.
               </p>
             </div>
-            {catalog && !isEmpty && (
-              <SearchInput
-                value={query}
-                onValueChange={setQuery}
-                placeholder="Search plugins and skills…"
-                aria-label="Search plugins and skills"
-                className="w-full max-w-md rounded-full"
-              />
-            )}
+            <div className="flex w-full max-w-xl flex-col items-stretch justify-center gap-2 sm:flex-row">
+              {catalog && !isEmpty && (
+                <SearchInput
+                  value={query}
+                  onValueChange={setQuery}
+                  placeholder="Search plugins and skills…"
+                  aria-label="Search plugins and skills"
+                  className="min-w-0 flex-1 rounded-full"
+                />
+              )}
+              <Button
+                variant="outline"
+                className="shrink-0"
+                disabled={importing}
+                onClick={() => void runImport()}
+              >
+                <FolderInput aria-hidden="true" />
+                {importing ? "Importing…" : "Import skills"}
+              </Button>
+            </div>
           </header>
 
           {provisioning && (
@@ -128,6 +169,8 @@ export function PluginsView({
               </Button>
             </div>
           )}
+
+          {importReport && <SkillImportSummary report={importReport} />}
 
           {loading && !catalog && (
             <p
@@ -231,6 +274,116 @@ export function PluginsView({
       />
     </div>
   );
+}
+
+export function SkillImportSummary({ report }: { report: SkillImportReport }) {
+  const imported = report.imported.length;
+  const heading = imported > 0 ? "Skill import complete" : "No skills imported";
+  return (
+    <section
+      className="border-border bg-background flex flex-col gap-3 rounded-xl border p-4"
+      aria-labelledby="skill-import-title"
+    >
+      <div className="flex flex-col gap-0.5" role="status" aria-atomic="true">
+        <h2 id="skill-import-title" className="text-md font-semibold">
+          {heading}
+        </h2>
+        <p className="text-muted-foreground text-xs">{importSummary(report)}</p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <ImportResultGroup
+          title="Imported"
+          empty="None"
+          names={report.imported}
+        />
+        <ImportIssueGroup
+          title="Skipped"
+          empty="None"
+          issues={report.skipped}
+        />
+        <ImportIssueGroup
+          title="Conflicts"
+          empty="None"
+          issues={report.conflicts}
+        />
+      </div>
+    </section>
+  );
+}
+
+function ImportResultGroup({
+  title,
+  empty,
+  names,
+}: {
+  title: string;
+  empty: string;
+  names: string[];
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1.5">
+      <h3 className="text-muted-foreground text-2xs font-medium tracking-wide uppercase">
+        {title} · {names.length}
+      </h3>
+      {names.length > 0 ? (
+        <ul className="flex flex-col gap-1">
+          {names.map((name) => (
+            <li key={name} className="break-all font-mono text-xs">
+              {name}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-muted-foreground text-xs">{empty}</p>
+      )}
+    </div>
+  );
+}
+
+function ImportIssueGroup({
+  title,
+  empty,
+  issues,
+}: {
+  title: string;
+  empty: string;
+  issues: SkillImportIssue[];
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1.5">
+      <h3 className="text-muted-foreground text-2xs font-medium tracking-wide uppercase">
+        {title} · {issues.length}
+      </h3>
+      {issues.length > 0 ? (
+        <ul className="flex flex-col gap-2">
+          {issues.map((issue) => (
+            <li key={`${issue.name}:${issue.reason}`} className="min-w-0">
+              <p className="break-all font-mono text-xs">{issue.name}</p>
+              <p className="text-muted-foreground break-words text-xs leading-snug">
+                {issue.reason}
+              </p>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-muted-foreground text-xs">{empty}</p>
+      )}
+    </div>
+  );
+}
+
+function importSummary(report: SkillImportReport): string {
+  const imported = `${report.imported.length} skill${report.imported.length === 1 ? "" : "s"} imported`;
+  const skipped = `${report.skipped.length} skipped`;
+  const conflicts = `${report.conflicts.length} conflict${report.conflicts.length === 1 ? "" : "s"}`;
+  return `${imported}, ${skipped}, and ${conflicts}.`;
+}
+
+function friendlyImportError(error: unknown, fallback: string): string {
+  const message = String(error)
+    .replace(/^Error:\s*/, "")
+    .trim();
+  return message && message.length <= 240 ? message : fallback;
 }
 
 function Section({

--- a/crates/tidebreak-desktop/ui/src/plugins/skillImport.ts
+++ b/crates/tidebreak-desktop/ui/src/plugins/skillImport.ts
@@ -1,0 +1,69 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
+export type SkillImportIssue = {
+  name: string;
+  reason: string;
+};
+
+export type SkillImportReport = {
+  imported: string[];
+  skipped: SkillImportIssue[];
+  conflicts: SkillImportIssue[];
+};
+
+/** Open the native folder picker and import skills into this desktop profile. */
+export async function importSkillsFromFolder(): Promise<SkillImportReport | null> {
+  if (!isTauri()) {
+    throw new Error("Skill import is available in the Tidebreak desktop app.");
+  }
+  const value = await invoke<unknown>("import_skills");
+  if (value === null) return null;
+  const report = parseSkillImportReport(value);
+  if (!report)
+    throw new Error("Tidebreak returned an invalid skill import result.");
+  return report;
+}
+
+export function parseSkillImportReport(
+  value: unknown,
+): SkillImportReport | null {
+  if (!isRecord(value)) return null;
+  const imported = parseStrings(value.imported);
+  const skipped = parseIssues(value.skipped);
+  const conflicts = parseIssues(value.conflicts);
+  if (!imported || !skipped || !conflicts) return null;
+  return { imported, skipped, conflicts };
+}
+
+function parseStrings(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length > 64) return null;
+  const strings = value.filter(
+    (entry): entry is string =>
+      typeof entry === "string" && entry.length > 0 && entry.length <= 64,
+  );
+  return strings.length === value.length ? strings : null;
+}
+
+function parseIssues(value: unknown): SkillImportIssue[] | null {
+  if (!Array.isArray(value) || value.length > 256) return null;
+  const issues: SkillImportIssue[] = [];
+  for (const entry of value) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.name !== "string" ||
+      entry.name.length === 0 ||
+      entry.name.length > 255 ||
+      typeof entry.reason !== "string" ||
+      entry.reason.length === 0 ||
+      entry.reason.length > 500
+    ) {
+      return null;
+    }
+    issues.push({ name: entry.name, reason: entry.reason });
+  }
+  return issues;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.test.tsx
@@ -140,6 +140,91 @@ describe("McpPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("imports a JSON file into the editor and reports skipped servers", async () => {
+    const client = api();
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await screen.findByText("Healthy");
+    const fileName =
+      "mcp-configuration-with-a-filename-that-must-wrap-without-overflowing.json";
+    const secretName =
+      "CALENDAR_TOKEN_WITH_A_LONG_UNBROKEN_IDENTIFIER_FOR_A_COMPACT_PANEL";
+    const file = new File(
+      [
+        JSON.stringify({
+          mcpServers: {
+            private_docs: { command: "duplicate" },
+            "bad.name": { command: "invalid-name" },
+            calendar: {
+              command: "npx",
+              args: ["-y", "@example/calendar-mcp"],
+              env: { [secretName]: "do-not-retain" },
+            },
+            remote: { url: "https://mcp.example.test/tools" },
+          },
+        }),
+      ],
+      fileName,
+      { type: "application/json" },
+    );
+    if (typeof file.text !== "function") {
+      Object.defineProperty(file, "text", {
+        value: vi
+          .fn()
+          .mockResolvedValue(
+            await file
+              .arrayBuffer()
+              .then((value) => new TextDecoder().decode(value)),
+          ),
+      });
+    }
+    await user.upload(screen.getByLabelText("Import MCP configuration"), file);
+
+    const importSection = screen
+      .getByRole("heading", { name: "Import configuration" })
+      .closest("section");
+    if (!importSection) throw new Error("import section missing");
+    const status = await within(importSection).findByRole("status");
+    expect(status).toHaveTextContent(
+      `2 servers added to the editor from ${fileName}. 2 entries were skipped.`,
+    );
+    expect(status.closest("[aria-live]")).toBeNull();
+    expect(status).not.toContainElement(
+      within(importSection).getByRole("list", {
+        name: "Environment values to enter",
+      }),
+    );
+    expect(within(status).getByText(fileName)).toHaveClass("break-all");
+    const skipped = within(
+      screen.getByRole("list", { name: "Skipped MCP servers" }),
+    )
+      .getAllByRole("listitem")
+      .map((item) => item.textContent);
+    expect(skipped).toEqual([
+      "private_docs: Namespace already exists.",
+      "bad.name: Namespace must use 1–32 ASCII letters, numbers, underscores, or hyphens.",
+    ]);
+    expect(screen.getByRole("heading", { name: "calendar" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "remote" })).toBeVisible();
+    expect(screen.getByText(secretName)).toHaveClass("break-all");
+    expect(
+      within(
+        screen.getByRole("list", { name: "Skipped MCP servers" }),
+      ).getByText("private_docs"),
+    ).toHaveClass("break-all");
+    expect(screen.queryByText("do-not-retain")).not.toBeInTheDocument();
+    expect(client.putMcpServers).not.toHaveBeenCalled();
+
+    const calendarSection = screen
+      .getByRole("heading", { name: "calendar" })
+      .closest("section");
+    if (!calendarSection) throw new Error("calendar section missing");
+    expect(
+      within(calendarSection).getByLabelText("Environment value 1"),
+    ).toHaveValue("");
+  });
+
   it("sends argv and selected environment names as typed arrays", async () => {
     const client = api({ servers: [] });
     const user = userEvent.setup();

--- a/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/McpPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
-import { Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Plus, RefreshCw, Trash2, Upload } from "lucide-react";
 import type {
   ApiClient,
   GatewayApps,
@@ -21,9 +21,15 @@ import {
   SettingsSection,
   SettingsStatus,
 } from "./primitives";
+import {
+  parseMcpImport,
+  type McpImportResult,
+  type McpImportSecret,
+} from "./mcpImport";
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 const MAX_TIMEOUT_MS = 3_600_000;
+const MAX_IMPORT_BYTES = 1024 * 1024;
 /** Mount health lives in the local MCP supervisor, so a modest refresh while
  * the section is visible keeps the health lines honest without gateway load. */
 const MOUNT_REFRESH_MS = 15_000;
@@ -31,6 +37,8 @@ const MOUNT_REFRESH_MS = 15_000;
  * to 127, so the mount name is derived, not the slug itself. Mount identity
  * is always the `gateway_endpoint` field, never the name. */
 const MAX_NAMESPACE_BYTES = 32;
+
+type McpImportSummary = McpImportResult & { fileName: string };
 
 function emptyServer(index: number): McpServerInfo {
   return {
@@ -196,9 +204,15 @@ export function McpPanel({
   const [servers, setServers] = useState<McpServerInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [importing, setImporting] = useState(false);
   const [reconnecting, setReconnecting] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importSummary, setImportSummary] = useState<McpImportSummary | null>(
+    null,
+  );
+  const importInputRef = useRef<HTMLInputElement>(null);
   // Gateway session state, held here because the gateway endpoints section
   // shares this panel's one server list instead of owning a second copy.
   const [signedIn, setSignedIn] = useState(false);
@@ -376,6 +390,34 @@ export function McpPanel({
     }
   }
 
+  async function importConfiguration(file: File) {
+    setImporting(true);
+    setImportError(null);
+    setImportSummary(null);
+    try {
+      if (file.size > MAX_IMPORT_BYTES) {
+        throw new Error("Choose a JSON file no larger than 1 MB.");
+      }
+      const text = await file.text();
+      let value: unknown;
+      try {
+        value = JSON.parse(text);
+      } catch {
+        throw new Error("The file is not valid JSON.");
+      }
+      const result = parseMcpImport(value, servers);
+      setImportSummary({ ...result, fileName: file.name });
+      if (result.servers.length > 0) {
+        markDirty(true);
+        setServers((current) => [...current, ...result.servers]);
+      }
+    } catch (err) {
+      setImportError(`Couldn't import ${file.name}: ${errorMessage(err)}`);
+    } finally {
+      setImporting(false);
+    }
+  }
+
   /** Mount or unmount one endpoint: an immediate, complete configuration
    * write, rebuilt from the live configuration rather than the draft above
    * so it never persists an unsaved edit — nor drops a server saved from
@@ -436,7 +478,7 @@ export function McpPanel({
     }
   }
 
-  const working = saving || reconnecting !== null || mounting;
+  const working = saving || importing || reconnecting !== null || mounting;
 
   const entitledSlugs = new Set(
     apps?.apps.flatMap((app) => app.mcp_endpoint_slugs) ?? [],
@@ -626,6 +668,47 @@ export function McpPanel({
         <p className="text-sm text-muted-foreground">Loading MCP servers…</p>
       ) : (
         <>
+          <SettingsSection
+            title="Import configuration"
+            description="Add servers from a Tidebreak, Claude, or Cursor JSON file. Imported servers stay unsaved until you review them and save."
+          >
+            <div className="flex flex-col items-start gap-2">
+              <input
+                ref={importInputRef}
+                type="file"
+                accept=".json,application/json"
+                className="sr-only"
+                aria-label="Import MCP configuration"
+                disabled={working}
+                onChange={(event) => {
+                  const input = event.currentTarget;
+                  const file = input.files?.[0];
+                  if (file !== undefined) void importConfiguration(file);
+                  input.value = "";
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                disabled={working}
+                onClick={() => importInputRef.current?.click()}
+              >
+                <Upload size={14} />
+                {importing ? "Importing…" : "Import JSON"}
+              </Button>
+              <p className="text-xs text-muted-foreground">
+                Tidebreak imports environment variable names but never their
+                values. Enter secret values again before you save.
+              </p>
+            </div>
+            {importSummary !== null && (
+              <ImportSummary summary={importSummary} />
+            )}
+            {importError !== null && (
+              <SettingsError>{importError}</SettingsError>
+            )}
+          </SettingsSection>
+
           {servers.length === 0 && (
             <SettingsSection>
               <p className="text-sm text-muted-foreground">
@@ -946,6 +1029,76 @@ export function McpPanel({
       {error && <SettingsError>{error}</SettingsError>}
     </McpKindSection>
   );
+}
+
+function ImportSummary({ summary }: { summary: McpImportSummary }) {
+  const imported = summary.servers.length;
+  const skipped = summary.skipped.length;
+  const secrets = secretsByServer(summary.secrets);
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <p className="min-w-0 text-sm" role="status" aria-atomic="true">
+        {imported === 0 ? (
+          <>
+            No servers imported from{" "}
+            <span className="break-all">{summary.fileName}</span>.
+          </>
+        ) : (
+          <>
+            {imported} server{imported === 1 ? "" : "s"} added to the editor
+            from <span className="break-all">{summary.fileName}</span>.
+          </>
+        )}{" "}
+        {skipped > 0 &&
+          `${skipped} entr${skipped === 1 ? "y was" : "ies were"} skipped.`}
+      </p>
+      {secrets.length > 0 && (
+        <div className="text-xs text-muted-foreground">
+          <p>Enter these environment values before saving:</p>
+          <ul
+            aria-label="Environment values to enter"
+            className="mt-1 list-disc space-y-1 pl-5"
+          >
+            {secrets.map(([server, names]) => (
+              <li key={server} className="min-w-0 break-words">
+                <code className="break-all">{server}</code>:{" "}
+                {names.map((name, index) => (
+                  <span key={name}>
+                    {index > 0 && ", "}
+                    <code className="break-all">{name}</code>
+                  </span>
+                ))}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {summary.skipped.length > 0 && (
+        <ul
+          aria-label="Skipped MCP servers"
+          className="list-disc space-y-1 pl-5 text-xs text-muted-foreground"
+        >
+          {summary.skipped.map((item, index) => (
+            <li key={`${item.name}-${index}`} className="min-w-0 break-words">
+              <code className="break-all">{item.name}</code>: {item.reason}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function secretsByServer(
+  secrets: McpImportSecret[],
+): Array<[string, string[]]> {
+  const grouped = new Map<string, string[]>();
+  for (const secret of secrets) {
+    const names = grouped.get(secret.server) ?? [];
+    if (!names.includes(secret.name)) names.push(secret.name);
+    grouped.set(secret.server, names);
+  }
+  return [...grouped.entries()];
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
@@ -181,6 +181,7 @@ describe("PermissionsPanel", () => {
         rootId: "55555555-5555-5555-5555-555555555555",
         displayName: "Documents",
         status: "connected",
+        availableInFutureChats: true,
       },
     ]);
     grantFolderCapability.mockImplementation(() => {

--- a/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -158,6 +158,7 @@ export function resourceLabel(statement: ConsentStatementSnapshot): string {
 const METHOD_PHRASES: Record<ConsentStatementSnapshot["method"], string> = {
   approval_card: "from an approval card",
   folder_picker: "with the folder picker",
+  trusted_folder: "from a saved folder",
   permission_dialog: "in a permission dialog",
   operator_config: "by operator configuration",
   carried_forward: "carried forward from an earlier approval",

--- a/crates/tidebreak-desktop/ui/src/settings/mcpImport.test.ts
+++ b/crates/tidebreak-desktop/ui/src/settings/mcpImport.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import type { McpServerInfo } from "../api";
+import { parseMcpImport } from "./mcpImport";
+
+function existing(name: string): McpServerInfo {
+  return {
+    name,
+    command: "/opt/mcp/server",
+    args: [],
+    env: [],
+    env_from: [],
+    cwd: null,
+    url: null,
+    bearer_token_env: null,
+    gateway_endpoint: null,
+    request_timeout_ms: 60_000,
+    enabled: true,
+    plugin: null,
+    health: "healthy",
+    tool_count: 1,
+    diagnostic: null,
+    curated: null,
+  };
+}
+
+describe("parseMcpImport", () => {
+  it("imports Claude and Cursor servers without retaining environment values", () => {
+    const result = parseMcpImport(
+      {
+        mcpServers: {
+          docs: {
+            command: "npx",
+            args: ["-y", "@example/docs-mcp"],
+            env: { DOCS_TOKEN: "do-not-retain", LOG_LEVEL: "debug" },
+            cwd: "/Users/alex/Code/docs",
+          },
+          remote: {
+            url: "https://mcp.example.test/tools",
+            headers: { Authorization: "Bearer ${REMOTE_TOKEN}" },
+          },
+        },
+      },
+      [],
+    );
+
+    expect(result.skipped).toEqual([]);
+    expect(result.servers).toEqual([
+      expect.objectContaining({
+        name: "docs",
+        command: "npx",
+        args: ["-y", "@example/docs-mcp"],
+        env: ["DOCS_TOKEN", "LOG_LEVEL"],
+        cwd: "/Users/alex/Code/docs",
+        url: null,
+      }),
+      expect.objectContaining({
+        name: "remote",
+        command: null,
+        args: [],
+        env: [],
+        cwd: null,
+        url: "https://mcp.example.test/tools",
+        bearer_token_env: "REMOTE_TOKEN",
+      }),
+    ]);
+    expect(result.secrets).toEqual([
+      { server: "docs", name: "DOCS_TOKEN" },
+      { server: "docs", name: "LOG_LEVEL" },
+    ]);
+    expect(JSON.stringify(result)).not.toContain("do-not-retain");
+    expect(JSON.stringify(result)).not.toContain("debug");
+  });
+
+  it("imports Tidebreak fields and drops inbound secret values", () => {
+    const result = parseMcpImport(
+      {
+        servers: [
+          {
+            name: "private_docs",
+            command: "/opt/mcp/docs",
+            args: ["--stdio"],
+            env: ["DOCS_TOKEN"],
+            env_values: {
+              DOCS_TOKEN: "do-not-retain",
+              SEARCH_TOKEN: "also-do-not-retain",
+            },
+            env_from: ["LOG_LEVEL"],
+            cwd: "/tmp/docs",
+            request_timeout_ms: 90_000,
+            enabled: false,
+          },
+        ],
+      },
+      [],
+    );
+
+    expect(result.servers).toEqual([
+      expect.objectContaining({
+        name: "private_docs",
+        command: "/opt/mcp/docs",
+        args: ["--stdio"],
+        env: ["DOCS_TOKEN", "SEARCH_TOKEN"],
+        env_from: ["LOG_LEVEL"],
+        cwd: "/tmp/docs",
+        request_timeout_ms: 90_000,
+        enabled: false,
+      }),
+    ]);
+    expect(JSON.stringify(result)).not.toContain("do-not-retain");
+    expect(JSON.stringify(result)).not.toContain("also-do-not-retain");
+  });
+
+  it("skips existing, repeated, invalid, and malformed namespaces", () => {
+    const result = parseMcpImport(
+      {
+        mcpServers: {
+          existing: { command: "existing-server" },
+          "bad.name": { command: "bad-server" },
+          valid: { command: "first-server" },
+          broken: { command: "", url: "https://mcp.example.test" },
+        },
+      },
+      [existing("existing")],
+    );
+
+    expect(result.servers.map((server) => server.name)).toEqual(["valid"]);
+    expect(result.skipped).toEqual([
+      { name: "existing", reason: "Namespace already exists." },
+      {
+        name: "bad.name",
+        reason:
+          "Namespace must use 1–32 ASCII letters, numbers, underscores, or hyphens.",
+      },
+      { name: "broken", reason: "Configure exactly one command or URL." },
+    ]);
+  });
+
+  it("imports the first Tidebreak server when a namespace repeats", () => {
+    const result = parseMcpImport(
+      {
+        servers: [
+          { name: "calendar", command: "first-server" },
+          { name: "calendar", command: "second-server" },
+        ],
+      },
+      [],
+    );
+
+    expect(result.servers).toEqual([
+      expect.objectContaining({ name: "calendar", command: "first-server" }),
+    ]);
+    expect(result.skipped).toEqual([
+      {
+        name: "calendar",
+        reason: "Namespace appears more than once in this file.",
+      },
+    ]);
+  });
+
+  it("rejects custom or literal HTTP headers without retaining their values", () => {
+    const result = parseMcpImport(
+      {
+        mcpServers: {
+          literal: {
+            url: "https://mcp.example.test/literal",
+            headers: { Authorization: "Bearer do-not-retain" },
+          },
+          custom: {
+            url: "https://mcp.example.test/custom",
+            headers: { "X-API-Key": "also-do-not-retain" },
+          },
+        },
+      },
+      [],
+    );
+
+    expect(result.servers).toEqual([]);
+    expect(result.skipped.map((item) => item.name)).toEqual([
+      "literal",
+      "custom",
+    ]);
+    expect(JSON.stringify(result)).not.toContain("do-not-retain");
+    expect(JSON.stringify(result)).not.toContain("also-do-not-retain");
+  });
+
+  it("rejects files without a supported top-level shape", () => {
+    expect(() => parseMcpImport({ tools: [] }, [])).toThrow(
+      /Tidebreak.*Claude\/Cursor/,
+    );
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/settings/mcpImport.ts
+++ b/crates/tidebreak-desktop/ui/src/settings/mcpImport.ts
@@ -1,0 +1,445 @@
+import type { McpServerInfo } from "../api";
+
+const MAX_SERVERS = 32;
+const MAX_ARGS = 128;
+const MAX_ENVIRONMENT_VARIABLES = 128;
+const MAX_ENVIRONMENT_NAME_BYTES = 256;
+const MAX_PROCESS_STRING_BYTES = 32 * 1024;
+const MAX_REQUEST_TIMEOUT_MS = 3_600_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+const MAX_NAMESPACE_BYTES = 32;
+
+type ImportShape = "tidebreak" | "common";
+
+type SourceEntry = {
+  fallbackName: string;
+  raw: unknown;
+  shape: ImportShape;
+};
+
+export type McpImportSkip = {
+  name: string;
+  reason: string;
+};
+
+export type McpImportSecret = {
+  server: string;
+  name: string;
+};
+
+export type McpImportResult = {
+  servers: McpServerInfo[];
+  skipped: McpImportSkip[];
+  secrets: McpImportSecret[];
+};
+
+type ParsedEntry = {
+  server: McpServerInfo;
+  secrets: McpImportSecret[];
+};
+
+type FieldResult<T> = { value: T } | { error: string };
+
+export function parseMcpImport(
+  value: unknown,
+  existingServers: readonly McpServerInfo[],
+): McpImportResult {
+  const entries = sourceEntries(value);
+  const taken = new Set(existingServers.map((server) => server.name));
+  const seen = new Set<string>();
+  const remaining = Math.max(
+    0,
+    MAX_SERVERS -
+      existingServers.filter((server) => server.plugin === null).length,
+  );
+  const servers: McpServerInfo[] = [];
+  const skipped: McpImportSkip[] = [];
+  const secrets: McpImportSecret[] = [];
+
+  for (const [index, entry] of entries.entries()) {
+    const rawName =
+      entry.shape === "common"
+        ? entry.fallbackName
+        : isRecord(entry.raw) && typeof entry.raw.name === "string"
+          ? entry.raw.name
+          : "";
+    const label = rawName || `Server ${index + 1}`;
+
+    if (!validNamespace(rawName)) {
+      skipped.push({
+        name: label,
+        reason:
+          "Namespace must use 1–32 ASCII letters, numbers, underscores, or hyphens.",
+      });
+      continue;
+    }
+    if (seen.has(rawName)) {
+      skipped.push({
+        name: rawName,
+        reason: "Namespace appears more than once in this file.",
+      });
+      continue;
+    }
+    seen.add(rawName);
+    if (taken.has(rawName)) {
+      skipped.push({ name: rawName, reason: "Namespace already exists." });
+      continue;
+    }
+    if (servers.length >= remaining) {
+      skipped.push({
+        name: rawName,
+        reason: `Tidebreak supports up to ${MAX_SERVERS} configured servers.`,
+      });
+      continue;
+    }
+
+    const parsed = parseEntry(rawName, entry.raw, entry.shape);
+    if ("error" in parsed) {
+      skipped.push({ name: rawName, reason: parsed.error });
+      continue;
+    }
+    servers.push(parsed.value.server);
+    secrets.push(...parsed.value.secrets);
+    taken.add(rawName);
+  }
+
+  return { servers, skipped, secrets };
+}
+
+function sourceEntries(value: unknown): SourceEntry[] {
+  if (!isRecord(value)) {
+    throw new Error("The file must contain a JSON object.");
+  }
+  if (Array.isArray(value.servers)) {
+    return value.servers.map((raw, index) => ({
+      fallbackName: `Server ${index + 1}`,
+      raw,
+      shape: "tidebreak",
+    }));
+  }
+  if (isRecord(value.mcpServers)) {
+    return Object.entries(value.mcpServers).map(([name, raw]) => ({
+      fallbackName: name,
+      raw,
+      shape: "common",
+    }));
+  }
+  throw new Error(
+    'Use a Tidebreak {"servers": [...]} file or a Claude/Cursor {"mcpServers": {...}} file.',
+  );
+}
+
+function parseEntry(
+  name: string,
+  raw: unknown,
+  shape: ImportShape,
+): FieldResult<ParsedEntry> {
+  if (!isRecord(raw)) return { error: "Server definition must be an object." };
+
+  const command = nullableString(raw, "command");
+  if ("error" in command) return command;
+  const url = nullableString(raw, "url");
+  if ("error" in url) return url;
+  const gateway =
+    shape === "tidebreak"
+      ? nullableString(raw, "gateway_endpoint")
+      : { value: null };
+  if ("error" in gateway) return gateway;
+
+  const transports = [command.value, url.value, gateway.value].filter(
+    (candidate) => candidate !== null,
+  );
+  if (transports.length !== 1) {
+    return {
+      error:
+        shape === "tidebreak"
+          ? "Configure exactly one command, URL, or gateway endpoint."
+          : "Configure exactly one command or URL.",
+    };
+  }
+
+  const args = stringArray(raw.args, "Arguments");
+  if ("error" in args) return args;
+  if (args.value.length > MAX_ARGS) {
+    return { error: `Arguments must contain at most ${MAX_ARGS} items.` };
+  }
+
+  const directEnvironment = environmentNames(raw.env, "Environment");
+  if ("error" in directEnvironment) return directEnvironment;
+  const forwardedEnvironment = stringArray(
+    raw.env_from,
+    "Forwarded environment",
+  );
+  if ("error" in forwardedEnvironment) return forwardedEnvironment;
+
+  let secretValueNames: string[] = [];
+  if (raw.env_values !== undefined && raw.env_values !== null) {
+    if (!isRecord(raw.env_values)) {
+      return { error: "Environment values must be a JSON object." };
+    }
+    secretValueNames = Object.keys(raw.env_values);
+  }
+  const env = unique([...directEnvironment.value, ...secretValueNames]);
+  const envFrom = forwardedEnvironment.value;
+  if (env.length + envFrom.length > MAX_ENVIRONMENT_VARIABLES) {
+    return {
+      error: `Environment must contain at most ${MAX_ENVIRONMENT_VARIABLES} names.`,
+    };
+  }
+  const environmentError = validateEnvironmentNames([...env, ...envFrom]);
+  if (environmentError !== null) return { error: environmentError };
+  if (new Set([...env, ...envFrom]).size !== env.length + envFrom.length) {
+    return {
+      error: "An environment variable name is configured more than once.",
+    };
+  }
+
+  const cwd = nullableString(raw, "cwd");
+  if ("error" in cwd) return cwd;
+  const bearer = nullableString(raw, "bearer_token_env");
+  if ("error" in bearer) return bearer;
+  const headerBearer =
+    shape === "common"
+      ? bearerEnvironmentFromHeaders(raw.headers)
+      : { value: null };
+  if ("error" in headerBearer) return headerBearer;
+  if (
+    bearer.value !== null &&
+    headerBearer.value !== null &&
+    bearer.value !== headerBearer.value
+  ) {
+    return { error: "Bearer token variables are configured more than once." };
+  }
+  const bearerEnvironment = bearer.value ?? headerBearer.value;
+  if (bearerEnvironment !== null) {
+    const bearerError = validateEnvironmentNames([bearerEnvironment]);
+    if (bearerError !== null) return { error: bearerError };
+  }
+
+  const enabled = booleanField(raw, "enabled", true);
+  if ("error" in enabled) return enabled;
+  const timeout = numberField(
+    raw,
+    "request_timeout_ms",
+    DEFAULT_REQUEST_TIMEOUT_MS,
+  );
+  if ("error" in timeout) return timeout;
+  if (
+    !Number.isInteger(timeout.value) ||
+    timeout.value < 1 ||
+    timeout.value > MAX_REQUEST_TIMEOUT_MS
+  ) {
+    return {
+      error: `Request timeout must be a whole number from 1 to ${MAX_REQUEST_TIMEOUT_MS.toLocaleString()}.`,
+    };
+  }
+
+  if (command.value !== null) {
+    if (command.value.length === 0) {
+      return { error: "Command must not be empty." };
+    }
+    if (bearerEnvironment !== null) {
+      return { error: "Bearer token variables apply only to URL servers." };
+    }
+  } else if (
+    args.value.length > 0 ||
+    env.length > 0 ||
+    envFrom.length > 0 ||
+    cwd.value !== null
+  ) {
+    return {
+      error:
+        "Arguments, environment, and working directory apply only to command servers.",
+    };
+  }
+
+  if (url.value !== null) {
+    const urlError = validateUrl(url.value);
+    if (urlError !== null) return { error: urlError };
+  } else if (bearerEnvironment !== null) {
+    return { error: "Bearer token variables apply only to URL servers." };
+  }
+
+  if (gateway.value !== null && !validGatewayEndpoint(gateway.value)) {
+    return {
+      error:
+        "Gateway endpoint must use 1–127 ASCII letters, numbers, underscores, or hyphens.",
+    };
+  }
+
+  const processStrings = [
+    command.value,
+    url.value,
+    cwd.value,
+    ...args.value,
+  ].filter((item): item is string => item !== null);
+  if (
+    processStrings.some(
+      (item) => item.length > MAX_PROCESS_STRING_BYTES || item.includes("\0"),
+    )
+  ) {
+    return {
+      error:
+        "Command, URL, arguments, and working directory must be valid text.",
+    };
+  }
+
+  return {
+    value: {
+      server: {
+        name,
+        command: command.value,
+        args: args.value,
+        env,
+        env_from: envFrom,
+        cwd: cwd.value,
+        url: url.value,
+        bearer_token_env: bearerEnvironment,
+        gateway_endpoint: gateway.value,
+        request_timeout_ms: timeout.value,
+        enabled: enabled.value,
+        plugin: null,
+        health: "initializing",
+        tool_count: 0,
+        diagnostic: null,
+        curated: null,
+      },
+      secrets: env.map((environmentName) => ({
+        server: name,
+        name: environmentName,
+      })),
+    },
+  };
+}
+
+function bearerEnvironmentFromHeaders(
+  value: unknown,
+): FieldResult<string | null> {
+  if (value === undefined || value === null) return { value: null };
+  if (!isRecord(value)) return { error: "HTTP headers must be a JSON object." };
+  const entries = Object.entries(value);
+  if (entries.length === 0) return { value: null };
+  if (entries.length !== 1 || entries[0]?.[0].toLowerCase() !== "authorization") {
+    return {
+      error:
+        "Custom HTTP headers are not supported. Add this server manually.",
+    };
+  }
+  const authorization = entries[0][1];
+  if (typeof authorization !== "string") {
+    return { error: "The Authorization header must be a string." };
+  }
+  const match = authorization.match(
+    /^Bearer\s+(?:\$\{(?:env:)?([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*))$/,
+  );
+  const environment = match?.[1] ?? match?.[2];
+  return environment
+    ? { value: environment }
+    : {
+        error:
+          "Authorization must use a bearer environment variable, not a saved token value.",
+      };
+}
+
+function nullableString(
+  raw: Record<string, unknown>,
+  field: string,
+): FieldResult<string | null> {
+  const value = raw[field];
+  if (value === undefined || value === null) return { value: null };
+  return typeof value === "string"
+    ? { value }
+    : { error: `${field} must be a string.` };
+}
+
+function stringArray(value: unknown, label: string): FieldResult<string[]> {
+  if (value === undefined || value === null) return { value: [] };
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string")
+  ) {
+    return { error: `${label} must be an array of strings.` };
+  }
+  return { value: value as string[] };
+}
+
+function environmentNames(
+  value: unknown,
+  label: string,
+): FieldResult<string[]> {
+  if (isRecord(value)) return { value: Object.keys(value) };
+  return stringArray(value, label);
+}
+
+function booleanField(
+  raw: Record<string, unknown>,
+  field: string,
+  fallback: boolean,
+): FieldResult<boolean> {
+  const value = raw[field];
+  if (value === undefined || value === null) return { value: fallback };
+  return typeof value === "boolean"
+    ? { value }
+    : { error: `${field} must be true or false.` };
+}
+
+function numberField(
+  raw: Record<string, unknown>,
+  field: string,
+  fallback: number,
+): FieldResult<number> {
+  const value = raw[field];
+  if (value === undefined || value === null) return { value: fallback };
+  return typeof value === "number"
+    ? { value }
+    : { error: `${field} must be a number.` };
+}
+
+function validateEnvironmentNames(names: string[]): string | null {
+  const invalid = names.find(
+    (name) =>
+      name.length === 0 ||
+      name.length > MAX_ENVIRONMENT_NAME_BYTES ||
+      name.includes("=") ||
+      name.includes("\0"),
+  );
+  return invalid === undefined
+    ? null
+    : `Environment variable name ${JSON.stringify(invalid)} is invalid.`;
+}
+
+function validateUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      return "URL must use http or https.";
+    }
+    if (parsed.username !== "" || parsed.password !== "") {
+      return "URL must not contain credentials.";
+    }
+    if (parsed.hostname === "") return "URL must name a host.";
+    return null;
+  } catch {
+    return "URL must be a valid HTTP or HTTPS URL.";
+  }
+}
+
+function validNamespace(name: string): boolean {
+  return (
+    name.length > 0 &&
+    name.length <= MAX_NAMESPACE_BYTES &&
+    /^[A-Za-z0-9_-]+$/.test(name)
+  );
+}
+
+function validGatewayEndpoint(slug: string): boolean {
+  return slug.length > 0 && slug.length <= 127 && /^[A-Za-z0-9_-]+$/.test(slug);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/crates/tidebreak-desktop/ui/src/settings/mcpImport.ts
+++ b/crates/tidebreak-desktop/ui/src/settings/mcpImport.ts
@@ -319,10 +319,12 @@ function bearerEnvironmentFromHeaders(
   if (!isRecord(value)) return { error: "HTTP headers must be a JSON object." };
   const entries = Object.entries(value);
   if (entries.length === 0) return { value: null };
-  if (entries.length !== 1 || entries[0]?.[0].toLowerCase() !== "authorization") {
+  if (
+    entries.length !== 1 ||
+    entries[0]?.[0].toLowerCase() !== "authorization"
+  ) {
     return {
-      error:
-        "Custom HTTP headers are not supported. Add this server manually.",
+      error: "Custom HTTP headers are not supported. Add this server manually.",
     };
   }
   const authorization = entries[0][1];

--- a/crates/tidebreak-desktop/ui/src/stories/ChatView.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ChatView.stories.tsx
@@ -772,6 +772,7 @@ function StoryChat({
       rootId: "folder-research",
       displayName: "Research notes",
       status: "connected",
+      availableInFutureChats: true,
       statements: [],
     },
   ];

--- a/crates/tidebreak-desktop/ui/src/stories/FoldersView.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/FoldersView.stories.tsx
@@ -1,0 +1,216 @@
+import { mockIPC } from "@tauri-apps/api/mocks";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import type { Chat, ConsentStatementSnapshot } from "@/api";
+import { FoldersView } from "@/FoldersView";
+import type { ConnectedFolder, WidenedFolderCapability } from "@/host";
+
+const chat = {
+  id: "folder-story-chat",
+  title: "Folder access story",
+  project_id: null,
+} as unknown as Chat;
+
+type FolderStoryState = {
+  connected: ConnectedFolder[];
+  approved: ConnectedFolder[];
+  consents: ConsentStatementSnapshot[];
+  nextGrant: number;
+};
+
+function consent(
+  grantId: string,
+  rootId: string,
+  capability: WidenedFolderCapability,
+  method: ConsentStatementSnapshot["method"] = "folder_picker",
+): ConsentStatementSnapshot {
+  return {
+    handle: { kind: "capability_grant", grant_id: grantId },
+    level: { level: "chat", chat_id: chat.id },
+    level_title: chat.title,
+    verb: { kind: "capability", capability },
+    resource: {
+      kind: "host_root",
+      root_id: rootId,
+      display_name: null,
+    },
+    method,
+    granted_at: "2026-08-25T16:00:00Z",
+  };
+}
+
+function createFolderStoryState(): FolderStoryState {
+  const connected: ConnectedFolder[] = [
+    {
+      rootId: "folder-product",
+      displayName: "Product workspace",
+      status: "connected",
+      availableInFutureChats: true,
+    },
+    {
+      rootId: "folder-archive",
+      displayName: "External customer archive",
+      status: "unavailable",
+      availableInFutureChats: true,
+    },
+  ];
+  return {
+    connected,
+    approved: [
+      ...connected,
+      {
+        rootId: "folder-exports",
+        displayName: "Client exports approved on this device",
+        status: "connected",
+        availableInFutureChats: false,
+      },
+    ],
+    consents: [
+      consent("grant-read", "folder-product", "read_files"),
+      consent("grant-write", "folder-product", "write_files"),
+      consent("grant-command", "folder-product", "execute_commands"),
+    ],
+    nextGrant: 1,
+  };
+}
+
+function replaceFolderTrust(
+  folders: ConnectedFolder[],
+  rootId: string,
+  trusted: boolean,
+): ConnectedFolder[] {
+  return folders.map((folder) =>
+    folder.rootId === rootId
+      ? { ...folder, availableInFutureChats: trusted }
+      : folder,
+  );
+}
+
+function installFolderStoryBackend() {
+  const state = createFolderStoryState();
+  mockIPC((command, args) => {
+    const request = (args as { request?: Record<string, unknown> } | undefined)
+      ?.request;
+    switch (command) {
+      case "list_connected_folders":
+        return state.connected.map((folder) => ({ ...folder }));
+      case "list_approved_folders":
+        return state.approved.map((folder) => ({ ...folder }));
+      case "list_capability_consents":
+        return [...state.consents];
+      case "set_trusted_folder": {
+        const rootId = String(request?.rootId);
+        const trusted = Boolean(request?.trusted);
+        state.connected = replaceFolderTrust(state.connected, rootId, trusted);
+        state.approved = replaceFolderTrust(state.approved, rootId, trusted);
+        return true;
+      }
+      case "connect_approved_folder": {
+        const rootId = String(request?.rootId);
+        const approved = state.approved.find(
+          (folder) => folder.rootId === rootId,
+        );
+        if (!approved) return null;
+        const connected = { ...approved, status: "connected" as const };
+        state.connected = [
+          ...state.connected.filter((folder) => folder.rootId !== rootId),
+          connected,
+        ];
+        return connected;
+      }
+      case "disconnect_folder": {
+        const rootId = String(request?.rootId);
+        state.connected = state.connected.filter(
+          (folder) => folder.rootId !== rootId,
+        );
+        return true;
+      }
+      case "forget_folder": {
+        const rootId = String(request?.rootId);
+        state.connected = state.connected.filter(
+          (folder) => folder.rootId !== rootId,
+        );
+        state.approved = state.approved.filter(
+          (folder) => folder.rootId !== rootId,
+        );
+        state.consents = state.consents.filter(
+          (statement) =>
+            statement.resource.kind !== "host_root" ||
+            statement.resource.root_id !== rootId,
+        );
+        return true;
+      }
+      case "grant_folder_capability": {
+        const rootId = String(request?.rootId);
+        const capability = request?.capability as WidenedFolderCapability;
+        state.consents = [
+          ...state.consents,
+          consent(
+            `grant-story-${state.nextGrant++}`,
+            rootId,
+            capability,
+            "permission_dialog",
+          ),
+        ];
+        return true;
+      }
+      case "revoke_capability_consent": {
+        const grantId = String(request?.grantId);
+        state.consents = state.consents.filter(
+          (statement) =>
+            statement.handle.kind !== "capability_grant" ||
+            statement.handle.grant_id !== grantId,
+        );
+        return true;
+      }
+      case "connect_folder":
+        return null;
+      default:
+        throw new Error(`Unexpected folder story command: ${command}`);
+    }
+  });
+}
+
+function renderFolderStory({ chat: storyChat }: { chat: Chat }) {
+  installFolderStoryBackend();
+  return <FoldersView chat={storyChat} />;
+}
+
+const verifyFolderStates = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await expect(await canvas.findByText("Product workspace")).toBeVisible();
+  await expect(canvas.getByText("External customer archive")).toBeVisible();
+  await expect(
+    canvas.getByText("Client exports approved on this device"),
+  ).toBeVisible();
+
+  const approvedToggle = canvas.getByRole("switch", {
+    name: "Available in future chats for Client exports approved on this device",
+  });
+  await expect(approvedToggle).not.toBeChecked();
+  await userEvent.click(approvedToggle);
+  await expect(approvedToggle).toBeChecked();
+  await userEvent.click(approvedToggle);
+  await expect(approvedToggle).not.toBeChecked();
+};
+
+const meta = {
+  title: "Chat/Folders",
+  component: FoldersView,
+  parameters: { layout: "fullscreen" },
+  args: { chat },
+  render: renderFolderStory,
+} satisfies Meta<typeof FoldersView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FutureChatAccess: Story = {
+  play: ({ canvasElement }) => verifyFolderStates(canvasElement),
+};
+
+export const FutureChatAccessCompact: Story = {
+  parameters: { viewport: { defaultViewport: "compact" } },
+  play: ({ canvasElement }) => verifyFolderStates(canvasElement),
+};

--- a/crates/tidebreak-desktop/ui/src/stories/Plugins.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Plugins.stories.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import type { PluginCatalog, PluginSkillInfo } from "@/api";
 import { PluginDetailView } from "@/plugins/PluginDetailView";
@@ -172,6 +173,77 @@ export const Empty: Story = {
 };
 
 export const DenseCatalog: Story = {};
+
+const importedSkillNames = [
+  "incident-review",
+  "customer-support-incident-review-with-a-long-unbroken-skill-name",
+];
+
+const importReport = {
+  imported: importedSkillNames,
+  skipped: [
+    {
+      name: "draft-helper",
+      reason: "No regular SKILL.md was found",
+    },
+  ],
+  conflicts: [
+    {
+      name: "documents",
+      reason: "A skill included with Tidebreak already uses this name",
+    },
+  ],
+};
+
+const catalogAfterImport: PluginCatalog = {
+  ...catalog,
+  skills: [
+    ...catalog.skills,
+    ...importedSkillNames.map((name) => ({
+      name,
+      description: "Imported from a local skill folder.",
+      origin: "user" as const,
+      enabled: true,
+    })),
+  ],
+};
+
+function ImportResultsStory() {
+  const [storyCatalog, setStoryCatalog] = useState(catalog);
+  return (
+    <PluginsView
+      state={state({
+        catalog: storyCatalog,
+        reload: () => setStoryCatalog(catalogAfterImport),
+      })}
+      loadInstructions={loadInstructions}
+      onOpen={fn()}
+      importSkills={async () => importReport}
+    />
+  );
+}
+
+const importResultsPlay = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(
+    await canvas.findByRole("button", { name: "Import skills" }),
+  );
+  const summary = await canvas.findByText("Skill import complete");
+  await expect(summary).toBeInTheDocument();
+  await expect(await canvas.findAllByText("incident-review")).toHaveLength(2);
+  summary.scrollIntoView({ block: "center" });
+};
+
+export const ImportResults: Story = {
+  render: () => <ImportResultsStory />,
+  play: ({ canvasElement }) => importResultsPlay(canvasElement),
+};
+
+export const ImportResultsCompact: Story = {
+  render: () => <ImportResultsStory />,
+  parameters: { viewport: { defaultViewport: "compact" } },
+  play: ({ canvasElement }) => importResultsPlay(canvasElement),
+};
 
 export const LoadFailure: Story = {
   args: {

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsAdvanced.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsAdvanced.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import { CodingHarnessesPanel } from "@/settings/CodingHarnessesPanel";
 import { ConnectedAppsPanel } from "@/settings/ConnectedAppsPanel";
@@ -208,6 +208,54 @@ export const ConnectedAppsEmpty: Story = {
       ),
     ).toBeVisible();
   },
+};
+
+const MCP_IMPORT_FILE_NAME =
+  "desktop-mcp-configuration-for-the-customer-support-workspace.json";
+
+const connectedAppsMcpImportPlay = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  const file = new File(
+    [
+      JSON.stringify({
+        mcpServers: {
+          calendar_sync_for_incident_team: {
+            command: "npx",
+            args: ["-y", "@example/calendar-mcp"],
+            env: {
+              CALENDAR_TOKEN_FOR_THE_CUSTOMER_SUPPORT_INCIDENT_WORKSPACE:
+                "not-imported",
+            },
+          },
+          "invalid.server.name.that.must.wrap": {
+            command: "invalid-server",
+          },
+        },
+      }),
+    ],
+    MCP_IMPORT_FILE_NAME,
+    { type: "application/json" },
+  );
+  await userEvent.upload(
+    await canvas.findByLabelText("Import MCP configuration"),
+    file,
+  );
+  const summary = await canvas.findByRole("status");
+  await expect(summary).toHaveTextContent(
+    `1 server added to the editor from ${MCP_IMPORT_FILE_NAME}. 1 entry was skipped.`,
+  );
+  summary.scrollIntoView({ block: "center" });
+};
+
+export const ConnectedAppsMcpImportSummary: Story = {
+  args: { panel: "connected-apps", state: "empty" },
+  play: ({ canvasElement }) => connectedAppsMcpImportPlay(canvasElement),
+};
+
+export const ConnectedAppsMcpImportSummaryCompact: Story = {
+  args: { panel: "connected-apps", state: "empty" },
+  parameters: { viewport: { defaultViewport: "compact" } },
+  play: ({ canvasElement }) => connectedAppsMcpImportPlay(canvasElement),
 };
 
 export const ConnectedAppsFailure: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 
+import { CodeTranscript } from "@/code/CodeTranscript";
+import type { CodeTranscriptItem } from "@/code/CodeSessionReducer";
 import { TurnReviewCard } from "@/code/TurnReviewCard";
+
+const CODEX_REVOKED_TOKEN_ERROR =
+  "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.";
 
 function boundary(
   overrides: Partial<Parameters<typeof TurnReviewCard>[0]["turn"]> = {},
@@ -84,6 +89,47 @@ export const Failed: Story = {
       diffstat: null,
     }),
   },
+};
+
+const codexRevokedTokenItems: CodeTranscriptItem[] = [
+  {
+    kind: "notice",
+    id: "notice-codex-auth",
+    level: "error",
+    message: CODEX_REVOKED_TOKEN_ERROR,
+  },
+  boundary({
+    status: "failed",
+    error: CODEX_REVOKED_TOKEN_ERROR,
+    diffstat: null,
+  }),
+];
+
+const renderCodexRevokedTokenTranscript = () => (
+  <div className="h-[520px] min-h-0 overflow-auto">
+    <CodeTranscript items={codexRevokedTokenItems} />
+  </div>
+);
+
+const assertOneCodexRecovery = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  const alerts = await canvas.findAllByRole("alert");
+  await expect(alerts).toHaveLength(1);
+  await expect(alerts[0]).toHaveTextContent(
+    "Codex CLI rejected its saved sign-in",
+  );
+};
+
+/** The transcript folds the duplicate harness error into one recovery card. */
+export const CodexRevokedRefreshToken: Story = {
+  render: renderCodexRevokedTokenTranscript,
+  play: ({ canvasElement }) => assertOneCodexRecovery(canvasElement),
+};
+
+export const CodexRevokedRefreshTokenCompact: Story = {
+  render: renderCodexRevokedTokenTranscript,
+  parameters: { viewport: { defaultViewport: "compact" } },
+  play: ({ canvasElement }) => assertOneCodexRecovery(canvasElement),
 };
 
 /**

--- a/crates/tidebreak-desktop/ui/src/useChatFolderAttachments.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/useChatFolderAttachments.test.tsx
@@ -67,6 +67,7 @@ it("connects and revokes a chat folder through the existing host flow", async ()
         rootId: "root-1",
         displayName: "Research",
         status: "connected",
+        availableInFutureChats: true,
       },
     ])
     .mockResolvedValueOnce([]);
@@ -74,6 +75,7 @@ it("connects and revokes a chat folder through the existing host flow", async ()
     rootId: "root-1",
     displayName: "Research",
     status: "connected",
+    availableInFutureChats: true,
   });
   vi.mocked(host.disconnectFolder).mockResolvedValue(true);
   const user = userEvent.setup();

--- a/crates/tidebreak-host-broker/src/broker.rs
+++ b/crates/tidebreak-host-broker/src/broker.rs
@@ -1250,7 +1250,7 @@ impl Controller {
         let outcome = match prepared {
             Ok(prepared) => {
                 let existing = preferred_root_alias(&next, &prepared.root);
-                if let Some((root_id, display_name)) = existing {
+                if let Some((root_id, display_name, owner)) = existing {
                     // Picking a folder this conversation already has is the
                     // same non-event as attaching one it already has: it says
                     // where the folder may be used, and the chat is already
@@ -1277,6 +1277,7 @@ impl Controller {
                         root: RootSummary {
                             root_id,
                             display_name,
+                            owner: Some(owner),
                         },
                     })
                 } else {
@@ -1284,6 +1285,7 @@ impl Controller {
                         root: RootSummary {
                             root_id: prepared.root_id,
                             display_name: prepared.root.display_name.clone(),
+                            owner: Some(prepared.root.owner),
                         },
                     };
                     next.roots.insert(prepared.root_id, prepared.root);
@@ -4246,7 +4248,10 @@ fn ensure_subject_grants(
     Ok(())
 }
 
-fn preferred_root_alias(state: &State, candidate: &RegisteredRoot) -> Option<(RootId, String)> {
+fn preferred_root_alias(
+    state: &State,
+    candidate: &RegisteredRoot,
+) -> Option<(RootId, String, GrantSubject)> {
     state
         .roots
         .iter()
@@ -4254,7 +4259,7 @@ fn preferred_root_alias(state: &State, candidate: &RegisteredRoot) -> Option<(Ro
         // Preserve an existing subject's legacy product root ID when possible,
         // then use the opaque UUID as the host-wide deterministic tie-breaker.
         .min_by_key(|(root_id, root)| (root.owner != candidate.owner, root_id.as_uuid()))
-        .map(|(root_id, root)| (*root_id, root.display_name.clone()))
+        .map(|(root_id, root)| (*root_id, root.display_name.clone(), root.owner))
 }
 
 /// Record that an approved folder went dark, without naming its host path.
@@ -4368,6 +4373,7 @@ fn list_approved_roots(state: &State) -> Result<Vec<RootSummary>, ErrorResponse>
         .map(|(root_id, root)| RootSummary {
             root_id: *root_id,
             display_name: root.display_name.clone(),
+            owner: Some(root.owner),
         })
         .collect::<Vec<_>>();
     roots.sort_by(|left, right| {

--- a/crates/tidebreak-host-broker/src/broker/tests.rs
+++ b/crates/tidebreak-host-broker/src/broker/tests.rs
@@ -369,6 +369,7 @@ fn install_legacy_alias(
                     root: RootSummary {
                         root_id: alias_root_id,
                         display_name,
+                        owner: Some(subject),
                     },
                 })),
             },
@@ -791,15 +792,19 @@ fn approved_roots_can_be_explicitly_attached_to_another_standalone_conversation(
     let second_conversation = Uuid::new_v4();
     let second_subject = GrantSubject::conversation(second_conversation).unwrap();
     let attach_id = OperationId::new();
-    mutate_attachment(
-        &broker.controller(),
-        attach_id,
-        second_subject,
-        second_conversation,
-        root_id,
-        RootAttachmentMutationKind::Attach,
-    )
+    let result = unwrap_response(broker.controller().handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::AttachRoot(RootAttachmentMutationRequest {
+            operation_id: attach_id,
+            subject: second_subject,
+            conversation_id: second_conversation,
+            root_id,
+            consent_method: Some(ConsentMethod::TrustedFolder),
+        }),
+    }))
     .unwrap();
+    assert!(matches!(result, ControlResult::AttachRoot(_)));
     assert!(broker
         .shared
         .state
@@ -811,7 +816,7 @@ fn approved_roots_can_be_explicitly_attached_to_another_standalone_conversation(
             grant.subject() == second_subject
                 && grant.capability() == Capability::ReadFiles
                 && matches!(grant.scope(), Scope::Root { root_id: granted } if *granted == root_id)
-                && grant.consent().method() == ConsentMethod::PermissionDialog
+                && grant.consent().method() == ConsentMethod::TrustedFolder
         }));
     let conflicting_consent = broker.controller().handle(ControlEnvelope {
         protocol_version: PROTOCOL_VERSION,

--- a/crates/tidebreak-host-broker/src/capability.rs
+++ b/crates/tidebreak-host-broker/src/capability.rs
@@ -103,6 +103,8 @@ pub enum Scope {
 pub enum ConsentMethod {
     /// The user chose a folder through a trusted native picker.
     FolderPicker,
+    /// The user saved an approved folder for automatic use in future chats.
+    TrustedFolder,
     /// The user approved a capability in an explicit permission dialog.
     PermissionDialog,
     /// A local operator deliberately provisioned a headless installation.

--- a/crates/tidebreak-host-broker/src/protocol.rs
+++ b/crates/tidebreak-host-broker/src/protocol.rs
@@ -853,12 +853,16 @@ pub struct HelloResult {
     pub operations: Vec<String>,
 }
 
-/// Safe agent-facing identity for a connected folder.
+/// Safe trusted-control identity for an approved folder.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RootSummary {
     pub root_id: RootId,
     pub display_name: String,
+    /// Original registering subject. Present on trusted management listings
+    /// and current registration receipts so the desktop can revoke the root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<GrantSubject>,
 }
 
 /// One capability grant with its consent provenance, for the management UI.
@@ -1182,6 +1186,7 @@ mod tests {
             root: RootSummary {
                 root_id: RootId::new(),
                 display_name: "Documents".to_owned(),
+                owner: None,
             },
         });
         let encoded = serde_json::to_string(&control).unwrap();

--- a/crates/tidebreak-server/src/code_execution/staging.rs
+++ b/crates/tidebreak-server/src/code_execution/staging.rs
@@ -273,9 +273,9 @@ pub(super) async fn prepare_execution_directories(
 }
 
 /// Stage the validated skills (built-in and user-authored) into
-/// `.tidebreak/skills/<name>/`: the manifest, plus any helper files the package
-/// carries under `scripts/`. Anything already staged under a name that is not
-/// in `skills` is removed, so the staged tree is exactly the enabled set.
+/// `.tidebreak/skills/<name>/`: the manifest, plus every bounded resource in
+/// the package tree. Anything already staged is removed before installation,
+/// so deleted resources cannot survive a later staging pass.
 ///
 /// Each destination is resolved a component at a time for the same reason the
 /// helper install is: `.tidebreak/` is writable by local exec, so a planted
@@ -288,26 +288,35 @@ pub(super) async fn install_skills(
     let root = resolve_scratch_directory(host_dir, tidebreak_code_execution::SKILLS_DIR, true)
         .await
         .ok_or_else(|| ExecError::Sandbox("the staged skills directory is unavailable".into()))?;
-    // Staging is the whole set, not an accumulation. A skill the install has
-    // switched off — or one the user deleted — must leave a workspace that
-    // staged it on an earlier turn, or the model could still `read_file`
-    // instructions the catalog no longer advertises. Removal is best effort:
-    // a leftover directory is untidy, but failing the command over it would
-    // take working execution down with it.
-    for entry in root.entries().await.unwrap_or_default() {
-        if skills.iter().any(|skill| skill.package.name == entry.name) {
-            continue;
-        }
+    // Staging is the whole set, not an accumulation. Recreate active skills so
+    // a resource removed from the stored package leaves the workspace too.
+    // Removal remains best effort only for inactive entries, matching the old
+    // cleanup behavior for a disabled or deleted skill.
+    let entries = root
+        .entries()
+        .await
+        .map_err(|_| ExecError::Sandbox("the staged skills directory is unreadable".into()))?;
+    for entry in entries {
+        let active = skills.iter().any(|skill| skill.package.name == entry.name);
         let removed = match entry.kind {
             tidebreak_code_execution::ScratchEntryKind::Directory => {
                 root.remove_dir_all(&entry.name).await
             }
             kind => root.remove(&entry.name, kind).await,
         };
-        if let Err(error) = removed {
-            tracing::warn!(
-                "a skill no longer staged could not be removed from the workspace: {error}"
-            );
+        match removed {
+            Ok(()) => {}
+            Err(_) if active => {
+                return Err(ExecError::Sandbox(format!(
+                    "skill '{}' could not be refreshed",
+                    entry.name
+                )));
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "a skill no longer staged could not be removed from the workspace: {error}"
+                );
+            }
         }
     }
     for skill in skills {
@@ -326,30 +335,34 @@ pub(super) async fn install_skills(
             )
             .await
             .map_err(|_| ExecError::Sandbox(format!("skill '{name}' could not be installed")))?;
-        if skill.scripts.is_empty() {
-            continue;
-        }
-        let scripts = resolve_scratch_directory(
-            host_dir,
-            &format!(
-                "{}/{name}/{}",
-                tidebreak_code_execution::SKILLS_DIR,
-                tidebreak_code_execution::SKILL_SCRIPTS_DIR
-            ),
-            true,
-        )
-        .await
-        .ok_or_else(|| {
-            ExecError::Sandbox(format!("skill '{name}' scripts directory is unavailable"))
-        })?;
-        for script in &skill.scripts {
-            scripts
-                .write_file(&script.name, &script.content)
+        for resource in &skill.scripts {
+            let relative = resource.staged_relative_path().ok_or_else(|| {
+                ExecError::Sandbox(format!("skill '{name}' contains an invalid resource path"))
+            })?;
+            let (parent, file_name) = relative
+                .rsplit_once('/')
+                .map_or(("", relative.as_ref()), |(parent, file_name)| {
+                    (parent, file_name)
+                });
+            let parent = if parent.is_empty() {
+                format!("{}/{name}", tidebreak_code_execution::SKILLS_DIR)
+            } else {
+                format!("{}/{name}/{parent}", tidebreak_code_execution::SKILLS_DIR)
+            };
+            let destination = resolve_scratch_directory(host_dir, &parent, true)
+                .await
+                .ok_or_else(|| {
+                    ExecError::Sandbox(format!(
+                        "skill '{name}' resource directory '{parent}' is unavailable"
+                    ))
+                })?;
+            destination
+                .write_file(file_name, &resource.content)
                 .await
                 .map_err(|_| {
                     ExecError::Sandbox(format!(
-                        "skill '{name}' script '{}' could not be installed",
-                        script.name
+                        "skill '{name}' resource '{}' could not be installed",
+                        relative
                     ))
                 })?;
         }

--- a/crates/tidebreak-server/src/code_execution/tests.rs
+++ b/crates/tidebreak-server/src/code_execution/tests.rs
@@ -551,6 +551,59 @@ async fn bundled_document_helpers_are_installed_as_one_library() {
     );
 }
 
+/// A stored user skill reaches execution with every resource at the same path
+/// that its `SKILL.md` names, including nested directories and root helpers.
+#[tokio::test]
+async fn stored_skill_resources_keep_their_paths_in_execution_staging() {
+    let source = tempfile::tempdir().unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    let skill = source.path().join("document-review");
+    std::fs::create_dir_all(skill.join("scripts").join("lib")).unwrap();
+    std::fs::create_dir_all(skill.join("references").join("formats")).unwrap();
+    std::fs::create_dir_all(skill.join("assets").join("templates")).unwrap();
+    std::fs::write(
+        skill.join(tidebreak_code_execution::SKILL_MANIFEST_FILE),
+        "---\nname: document-review\ndescription: Review documents.\n---\nBody.\n",
+    )
+    .unwrap();
+
+    let resources = [
+        ("validate.sh", b"exit 0\n".as_slice()),
+        (
+            "scripts/run.py",
+            b"from lib.layout import render\n".as_slice(),
+        ),
+        ("scripts/lib/layout.py", b"def render(): pass\n".as_slice()),
+        (
+            "references/formats/pdf-a.md",
+            b"Preserve the archive profile.\n".as_slice(),
+        ),
+        ("assets/templates/page.bin", b"\0\x01\x02".as_slice()),
+    ];
+    for (relative, content) in resources {
+        std::fs::write(skill.join(relative), content).unwrap();
+    }
+
+    let skills = tidebreak_code_execution::load_skills(
+        source.path(),
+        tidebreak_code_execution::SkillOrigin::User,
+    );
+    assert_eq!(skills.len(), 1);
+    prepare_execution_directories(workspace.path(), false, None, &skills)
+        .await
+        .unwrap();
+
+    let staged = workspace
+        .path()
+        .join(tidebreak_code_execution::SKILLS_DIR)
+        .join("document-review");
+    for (relative, content) in resources {
+        let actual = std::fs::read(staged.join(relative)).unwrap();
+        assert_eq!(actual.as_slice(), content);
+    }
+    assert!(!staged.join("scripts").join("validate.sh").exists());
+}
+
 /// Turn-start staging pins the contract the prompt catalog relies on:
 /// every advertised skill's `SKILL.md` — and the helper files it tells the
 /// model to run — is readable in the chat's private scratch, the directory

--- a/crates/tidebreak-server/src/consent.rs
+++ b/crates/tidebreak-server/src/consent.rs
@@ -117,6 +117,8 @@ pub enum ConsentMethodSnapshot {
     ApprovalCard,
     /// A folder chosen through the trusted native picker.
     FolderPicker,
+    /// An approved folder saved for automatic use in future chats.
+    TrustedFolder,
     /// An explicit permission dialog.
     PermissionDialog,
     /// A local operator deliberately provisioned a headless installation.


### PR DESCRIPTION
## What changed

Saved folders now attach automatically to new chats, remain trusted when temporarily unavailable, and support per-chat disconnect or global forget.
MCP and skill imports now preserve safe configuration and nested skill files without retaining secrets, while Codex token failures provide direct recovery steps and avoid duplicate transcript errors.

## Validation

Passed Cargo formatting, the full TypeScript check, Biome lint, all 1,845 UI tests, and the Storybook production build; Rust compilation and tests remain deferred to CI under repository policy, and browser control was unavailable for Storybook screenshot inspection.

## Compatibility and risk

This adds the persisted `host-access/trusted-folders.json` file, an optional `RootSummary.owner` wire field, the `trusted_folder` consent value, and recursive skill staging.