### PR TITLE
fix(code): match GitHub merge queue status

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -195,6 +195,33 @@ it("shows PR state, checks, comments, and holds merge for a draft", async () => 
   expect(client.getCodePrComments).toHaveBeenCalledWith("ws-1");
 });
 
+it("replaces open and auto-merge labels with the merge-queue state", async () => {
+  const queued = {
+    ...OPEN_PR,
+    auto_merge_enabled: true,
+    in_merge_queue: true,
+  };
+  render(
+    <CodeInspector
+      client={makeClient() as never}
+      workspaceId="ws-1"
+      workspace={{ ...WORKSPACE, pr: queued } as never}
+      contentRevision={0}
+    />,
+  );
+
+  await userEvent
+    .setup()
+    .click(screen.getByRole("tab", { name: "Pull request" }));
+
+  expect(screen.getByText("Queued")).toHaveClass("bg-warning-background");
+  expect(screen.getByText("In merge queue")).toHaveClass(
+    "text-warning-foreground",
+  );
+  expect(screen.queryByText("Auto-merge on")).not.toBeInTheDocument();
+  expect(screen.queryByText("Auto-merge is enabled")).not.toBeInTheDocument();
+});
+
 it.each([
   [
     "unknown mergeability",

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -61,7 +61,8 @@ import { useWorkspaceDigest } from "./CodeUpdatesStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import { useWorkspacePullRequests } from "./useWorkspacePullRequests";
 import { digestFromFact, factKey, WorkspacePrList } from "./WorkspacePrList";
-import { PR_ICON_TONE_CLASSES, prTone, prToneLabel } from "./workspaceCards";
+import { STATUS_MARK } from "./statusTone";
+import { prStatusLabel, prStatusTone, prTone } from "./workspaceCards";
 
 export type InspectorTab = "files" | "source" | "pr";
 
@@ -199,7 +200,7 @@ export function CodeInspector({
               <GitPullRequest
                 className={cn(
                   "size-3.5",
-                  pr ? PR_ICON_TONE_CLASSES[prTone(pr)] : undefined,
+                  pr ? STATUS_MARK[prStatusTone(pr)] : undefined,
                 )}
               />
             </InspectorTabTrigger>
@@ -574,7 +575,7 @@ export function PrTab({
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <GitPullRequest
-              className={cn("size-4 shrink-0", PR_ICON_TONE_CLASSES[tone])}
+              className={cn("size-4 shrink-0", STATUS_MARK[prStatusTone(pr)])}
             />
             {pr.url ? (
               <a
@@ -612,8 +613,11 @@ export function PrTab({
           />
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <Badge variant={prStateVariant(tone)} size="sm">
-            {prToneLabel(pr)}
+          <Badge
+            variant={pr.in_merge_queue ? "warning" : prStateVariant(tone)}
+            size="sm"
+          >
+            {prStatusLabel(pr)}
           </Badge>
           <Button
             type="button"
@@ -635,7 +639,7 @@ export function PrTab({
 
       <div className="flex flex-wrap items-center gap-1">
         {open && <ReviewDecisionBadge decision={pr.review_decision} />}
-        {open && pr.auto_merge_enabled && (
+        {open && pr.auto_merge_enabled && !pr.in_merge_queue && (
           <Badge variant="info" size="sm">
             Auto-merge on
           </Badge>
@@ -700,6 +704,11 @@ export function PrTab({
               {merging === "auto_merge" ? <Spinner aria-hidden /> : null}
               Enable auto-merge
             </Button>
+          ) : workflow.state === "queued" ? (
+            <div className="text-warning-foreground flex items-center gap-1.5 px-1 text-xs font-medium">
+              <CircleDashed className="size-3.5" />
+              In merge queue
+            </div>
           ) : pr.auto_merge_enabled ? (
             <div className="text-success-foreground flex items-center gap-1.5 px-1 text-xs font-medium">
               <CircleCheck className="size-3.5" />

--- a/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.dom.test.tsx
@@ -164,6 +164,21 @@ describe("PrCard", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
+  it("shows queued instead of open after GitHub accepts the merge queue entry", () => {
+    renderState({
+      ...BASE,
+      pr: {
+        number: 12,
+        url: "https://github.com/example/demo/pull/12",
+        state: "open",
+        in_merge_queue: true,
+      },
+    });
+
+    expect(screen.getByText("Queued")).toHaveClass("bg-warning-background");
+    expect(screen.queryByText("open")).not.toBeInTheDocument();
+  });
+
   it("keeps an existing pull request visible while changes are dirty", () => {
     renderState({
       ...BASE,

--- a/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PrCard.tsx
@@ -370,9 +370,14 @@ export function PrCardView({
 function GitStateChips({ snapshot }: { snapshot: CodeWorkspacePrSnapshot }) {
   const chips: ReactNode[] = [];
   if (snapshot.pr) {
+    const queued = snapshot.pr.in_merge_queue === true;
     chips.push(
-      <Badge key="pr" variant={prStateVariant(snapshot.pr.state)} size="sm">
-        {snapshot.pr.state}
+      <Badge
+        key="pr"
+        variant={queued ? "warning" : prStateVariant(snapshot.pr.state)}
+        size="sm"
+      >
+        {queued ? "Queued" : snapshot.pr.state}
       </Badge>,
     );
   }

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -112,6 +112,20 @@ describe("WorkspaceCard", () => {
     expect(onCommand).toHaveBeenCalledWith("toggle-terminal");
   });
 
+  it("announces a queued pull request and uses its orange chip", () => {
+    renderCard({
+      pr: { ...pr, in_merge_queue: true },
+      detailDefaultOpen: true,
+    });
+
+    expect(
+      screen.getByRole("button", { name: /Pull request #184 Queued/ }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Queued")[0]).toHaveClass(
+      "bg-warning-background",
+    );
+  });
+
   it("keeps only the PR glyph in the row and puts its action in the hover detail", async () => {
     const user = userEvent.setup();
     const { onOpen, onCommand } = renderCard({

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -65,11 +65,9 @@ import {
   isSessionRowWorthy,
   isPutAway,
   middleTruncate,
-  PR_CHIP_TONE_CLASSES,
-  PR_ICON_TONE_CLASSES,
+  prStatusLabel,
   prStatusTone,
   prTone,
-  prToneLabel,
   repoAccentClass,
   sessionRowLabel,
   watchRowLabel,
@@ -432,10 +430,10 @@ function WorkspaceDetailPanel({
             <span
               className={cn(
                 "shrink-0 rounded-md px-1.5 py-0.5 font-medium",
-                PR_CHIP_TONE_CLASSES[prTone(pr)],
+                STATUS_CHIP[prStatusTone(pr)],
               )}
             >
-              {prToneLabel(pr)}
+              {prStatusLabel(pr)}
             </span>
           ) : null}
         </div>
@@ -474,7 +472,7 @@ function WorkspaceDetailPanel({
               <GitPullRequest
                 className={cn(
                   "mt-0.5 size-3.5 shrink-0",
-                  PR_ICON_TONE_CLASSES[prTone(pr)],
+                  STATUS_MARK[prStatusTone(pr)],
                 )}
                 aria-hidden
               />
@@ -827,7 +825,7 @@ function PrGlyph({ pr }: { pr: PullRequestDigest }) {
   const tone = prTone(pr);
   return (
     <GitPullRequest
-      className={cn("size-3 shrink-0", PR_ICON_TONE_CLASSES[tone])}
+      className={cn("size-3 shrink-0", STATUS_MARK[prStatusTone(pr)])}
       data-pr-state={tone}
       aria-hidden
     />

--- a/crates/tidebreak-desktop/ui/src/code/pullRequestPresentation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/pullRequestPresentation.test.ts
@@ -168,7 +168,11 @@ describe("pullRequestListStatus", () => {
           checks: [{ name: "preview", bucket: "fail" }],
         }),
       ),
-    ).toMatchObject({ label: "In merge queue", group: "handed_off" });
+    ).toMatchObject({
+      label: "In merge queue",
+      tone: "warning",
+      group: "handed_off",
+    });
     expect(
       pullRequestListStatus(pr({ auto_merge_enabled: true })),
     ).toMatchObject({ label: "Auto-merge armed", group: "handed_off" });

--- a/crates/tidebreak-desktop/ui/src/code/pullRequestPresentation.ts
+++ b/crates/tidebreak-desktop/ui/src/code/pullRequestPresentation.ts
@@ -146,7 +146,7 @@ export function pullRequestListStatus(
   if (item.in_merge_queue === true) {
     return {
       label: "In merge queue",
-      tone: "pending",
+      tone: "warning",
       group: "handed_off",
     };
   }

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -13,6 +13,8 @@ import {
   listArchivedWorkspaces,
   middleTruncate,
   prChipTone,
+  prStatusLabel,
+  prStatusTone,
   sessionActivityLabel,
   workspaceCardLabel,
   workspacePrChipSummary,
@@ -51,6 +53,18 @@ function workspace(
 }
 
 const working: Attention = { state: { type: "working" }, source: "lifecycle" };
+
+describe("prStatusTone", () => {
+  it("uses the host merge-queue color before the open lifecycle color", () => {
+    expect(
+      prStatusTone({ state: "open", draft: false, in_merge_queue: true }),
+    ).toBe("warning");
+    expect(prStatusTone({ state: "open", draft: false })).toBe("ready");
+    expect(
+      prStatusLabel({ state: "open", draft: false, in_merge_queue: true }),
+    ).toBe("Queued");
+  });
+});
 
 function digest(
   workspaceId: string,
@@ -378,6 +392,17 @@ describe("workspaceCardLabel", () => {
         attention: { state: { type: "working" }, source: "lifecycle" },
       }),
     ).toBe("Fix login · app · tidebreak/fix-login");
+  });
+
+  it("announces queue membership instead of the open lifecycle", () => {
+    expect(
+      workspaceCardLabel({
+        title: "Fix login",
+        repoName: "app",
+        branchName: "tidebreak/fix-login",
+        pr: { number: 12, state: "open", in_merge_queue: true },
+      }),
+    ).toContain("Pull request #12 Queued");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -374,7 +374,12 @@ export function workspaceCardLabel(input: {
   branchName: string;
   attention?: Attention;
   session?: CodeSessionDigest;
-  pr?: { number: number; state: string; draft?: boolean };
+  pr?: {
+    number: number;
+    state: string;
+    draft?: boolean;
+    in_merge_queue?: boolean;
+  };
   terminalOpen?: boolean;
   workspaceStatus?: CodeWorkspaceStatus;
 }): string {
@@ -387,7 +392,7 @@ export function workspaceCardLabel(input: {
     parts.push(sessionActivityLabel(input.session));
   }
   if (input.pr) {
-    parts.push(`Pull request #${input.pr.number} ${prToneLabel(input.pr)}`);
+    parts.push(`Pull request #${input.pr.number} ${prStatusLabel(input.pr)}`);
   }
   if (input.terminalOpen) parts.push("Terminal open");
   parts.push(input.repoName);
@@ -480,6 +485,15 @@ export function prToneLabel(pr: { state: string; draft?: boolean }): string {
   }
 }
 
+/** Queue membership replaces the lifecycle word on compact status surfaces. */
+export function prStatusLabel(pr: {
+  state: string;
+  draft?: boolean;
+  in_merge_queue?: boolean;
+}): string {
+  return pr.in_merge_queue ? "Queued" : prToneLabel(pr);
+}
+
 /**
  * The PR vocabulary as a view of the shared status one. A PR chip is a status
  * chip; keeping its own color table is what let merged drift onto a hardcoded
@@ -497,7 +511,9 @@ const PR_STATUS_TONES: Record<PrChipTone, StatusTone> = {
 export function prStatusTone(pr: {
   state: string;
   draft?: boolean;
+  in_merge_queue?: boolean;
 }): StatusTone {
+  if (pr.in_merge_queue) return "warning";
   return PR_STATUS_TONES[prTone(pr)];
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.test.ts
@@ -93,6 +93,7 @@ describe("workspaceWorkflowModel", () => {
       }),
     });
     expect(queued.summary).toBe("#41 · Queued");
+    expect(queued.tone).toBe("warning");
     expect(queued.primary).toBe("open_pr");
     expect(workspaceWorkflowActionLabel(queued.primary!, queued.stage)).toBe(
       "View queue",

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -247,7 +247,7 @@ function pullRequestWorkflow(pr: PullRequestDigest): WorkspaceWorkflowModel {
       return {
         ...common,
         stage: "queued",
-        tone: "pending",
+        tone: "warning",
         summary: `#${pr.number} · Queued`,
         title: `Pull request #${pr.number} is queued`,
         detail: "GitHub will merge it when the queue requirements pass.",

--- a/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
@@ -13,6 +13,7 @@ import type { CodeWorkspacePrResource } from "@/code/useCodeWorkspacePr";
 type InspectorScenario =
   | "ready"
   | "merge-ready"
+  | "merge-queued"
   | "multi-pr"
   | "truncated"
   | "empty"
@@ -311,7 +312,13 @@ function InspectorStory({
             bucket: "pass" as const,
           })),
         }
-      : pullRequest;
+      : scenario === "merge-queued"
+        ? {
+            ...pullRequest,
+            auto_merge_enabled: true,
+            in_merge_queue: true,
+          }
+        : pullRequest;
   const storyWorkspace =
     scenario === "empty" ? workspace : { ...workspace, pr: storyPr };
   const storySnapshot = { ...prSnapshot, pr: storyPr };
@@ -374,6 +381,17 @@ export const Review: Story = {
 /** The same compact merge card when GitHub says the PR can land now. */
 export const ReviewReadyToMerge: Story = {
   args: { tab: "pr", scenario: "merge-ready" },
+};
+
+/** The review tab and detail header use GitHub's orange queue mark. */
+export const ReviewMergeQueued: Story = {
+  args: { tab: "pr", scenario: "merge-queued" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Queued")).toBeVisible();
+    await expect(canvas.getByText("In merge queue")).toBeVisible();
+    await expect(canvas.queryByText("Auto-merge is enabled")).toBeNull();
+  },
 };
 
 /**

--- a/crates/tidebreak-desktop/ui/src/stories/PrCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/PrCard.stories.tsx
@@ -10,6 +10,7 @@ import {
   hostedAppGit,
   hostedPersonGit,
   openPrGit,
+  queuedPrGit,
   readyForPrGit,
   unpushedGit,
 } from "./fixtures";
@@ -94,6 +95,10 @@ export const ReadyForPullRequest: Story = {
 
 export const PullRequestOpen: Story = {
   args: { snapshot: openPrGit },
+};
+
+export const MergeQueued: Story = {
+  args: { snapshot: queuedPrGit },
 };
 
 export const RefreshFailed: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -15,6 +15,7 @@ import {
   monitorDigest,
   needsYouDigest,
   openPrDigest,
+  queuedPrDigest,
   runningDigest,
   shellDigest,
   stalledDigest,
@@ -196,6 +197,22 @@ export const PullRequestInRail: Story = {
       archived: false,
       hasSession: true,
     }),
+    onWorkflowAction: fn(),
+  },
+};
+
+/** Queue membership replaces the open chip in the hover detail. */
+export const MergeQueued: Story = {
+  args: {
+    workspace: { ...codeWorkspace, pr: queuedPrDigest },
+    digest: { ...doneDigest, pr_state: queuedPrDigest },
+    session: codeSession,
+    commands: workspaceCommands({
+      hasPr: true,
+      archived: false,
+      hasSession: true,
+    }),
+    detailDefaultOpen: true,
     onWorkflowAction: fn(),
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -26,6 +26,7 @@ import {
   attentionWorking,
   dirtyGit,
   openPrGit,
+  queuedPrGit,
   watchingPrGit,
 } from "./fixtures";
 
@@ -158,6 +159,11 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const PullRequestOpen: Story = {};
+
+/** The workflow mark matches GitHub's orange merge-queue state. */
+export const MergeQueued: Story = {
+  args: { snapshot: queuedPrGit },
+};
 
 export const LocalChanges: Story = {
   args: { snapshot: dirtyGit },

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceWorkflow.stories.tsx
@@ -14,6 +14,7 @@ import {
   fixingPrGit,
   needsApprovalPrGit,
   openPrGit,
+  queuedPrGit,
   readyForPrGit,
   watchingPrGit,
 } from "./fixtures";
@@ -101,6 +102,11 @@ export const ReadyForPullRequest: Story = {
 };
 
 export const PullRequestOpen: Story = {};
+
+/** GitHub's merge queue uses the shared orange status treatment. */
+export const MergeQueued: Story = {
+  args: { snapshot: queuedPrGit },
+};
 
 /** Checks are green; GitHub still wants a review approval (decision 66). */
 export const NeedsApproval: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -161,6 +161,21 @@ export const openPrGit: CodeWorkspacePrSnapshot = {
   },
 };
 
+/** GitHub has accepted the pull request into its merge queue. */
+export const queuedPrGit: CodeWorkspacePrSnapshot = {
+  ...openPrGit,
+  pr: {
+    ...openPrGit.pr!,
+    auto_merge_enabled: true,
+    in_merge_queue: true,
+    checks_summary: "8 passing, 1 pending, 0 failing",
+    checks: [
+      { name: "desktop test", bucket: "pass" },
+      { name: "merge queue", bucket: "pending" },
+    ],
+  },
+};
+
 /** Failing checks with nobody watching: the Fix errors action's own state. */
 export const failingChecksPrGit: CodeWorkspacePrSnapshot = {
   ...openPrGit,
@@ -671,6 +686,12 @@ export const openPrDigest: PullRequestDigest = {
   url: "https://github.com/example/tidebreak/pull/184",
   state: "open",
   title: "Add a scoped UI workshop",
+};
+
+export const queuedPrDigest: PullRequestDigest = {
+  ...openPrDigest,
+  auto_merge_enabled: true,
+  in_merge_queue: true,
 };
 
 export const draftPrDigest: PullRequestDigest = {


### PR DESCRIPTION
## What changed

Use GitHub’s orange queue treatment for merge-queue icons, labels, badges, workflow controls, workspace cards, and Delivery Center.
Replace stale Open and auto-merge copy with Queued and In merge queue, with queued Storybook states.

## Validation

Biome checks, TypeScript, seven focused test files with 120 tests, and the Storybook production build pass.
Updated screenshots were not captured because no browser was connected.

## Compatibility and risk

None; this change only affects presentation and adds no persisted or wire-format changes.
