### PR TITLE
fix(desktop): remember the selected app mode

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.dom.test.tsx
@@ -9,6 +9,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { APP_MODE_STORAGE_KEY, restoreStoredAppMode } from "./appMode";
 import { useChatListStore } from "./ChatListStore";
 import { useCodeCatalogStore } from "./code/CodeCatalogStore";
 import { useCodeUiStore } from "./code/CodeUiStore";
@@ -329,6 +330,7 @@ vi.mock("react-resizable-panels", () => ({
 
 async function mountApp({ at }: { at?: string } = {}) {
   if (at) window.location.hash = `#${at}`;
+  restoreStoredAppMode();
   const { createHashHistory, createRouter, RouterProvider } = await import(
     "@tanstack/react-router"
   );
@@ -477,6 +479,30 @@ describe("app shell", () => {
     // Home used to create a chat on every cold start, leaving an empty one
     // behind whenever the reader did not use it.
     expect(createChat).not.toHaveBeenCalled();
+  });
+
+  it("opens in the last selected app mode", {
+    timeout: 15000,
+  }, async () => {
+    window.localStorage.setItem(APP_MODE_STORAGE_KEY, "code");
+
+    const { router } = await mountApp();
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/code"));
+    expect(await screen.findByRole("radio", { name: "Code" })).toBeChecked();
+  });
+
+  it("remembers each app mode selection", async () => {
+    const user = userEvent.setup();
+    const { router } = await mountApp({ at: "/code" });
+
+    await user.click(await screen.findByRole("radio", { name: "Work" }));
+    await waitFor(() => expect(router.state.location.pathname).toBe("/"));
+    expect(window.localStorage.getItem(APP_MODE_STORAGE_KEY)).toBe("work");
+
+    await user.click(screen.getByRole("radio", { name: "Code" }));
+    await waitFor(() => expect(router.state.location.pathname).toBe("/code"));
+    expect(window.localStorage.getItem(APP_MODE_STORAGE_KEY)).toBe("code");
   });
 
   it("lists recent conversations to pick up again", async () => {

--- a/crates/tidebreak-desktop/ui/src/appMode.ts
+++ b/crates/tidebreak-desktop/ui/src/appMode.ts
@@ -1,0 +1,38 @@
+export type AppMode = "work" | "code";
+
+export const APP_MODE_STORAGE_KEY = "tidebreak.app-mode";
+
+/** Read the last mode the reader used. Work remains the safe first-run default. */
+export function readStoredAppMode(): AppMode {
+  try {
+    return window.localStorage.getItem(APP_MODE_STORAGE_KEY) === "code"
+      ? "code"
+      : "work";
+  } catch {
+    return "work";
+  }
+}
+
+/** Remember the selected product surface across app launches. */
+export function storeAppMode(mode: AppMode): void {
+  try {
+    window.localStorage.setItem(APP_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
+/**
+ * Restore Code on a normal launch without overriding a deep link.
+ *
+ * The desktop host opens the renderer at the bare root. Replace that root
+ * before the router reads it so Code does not flash Work on the way in.
+ */
+export function restoreStoredAppMode(): void {
+  const root =
+    window.location.hash === "" ||
+    window.location.hash === "#" ||
+    window.location.hash === "#/";
+  if (!root || readStoredAppMode() !== "code") return;
+  window.history.replaceState(window.history.state, "", "#/code");
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeModeSwitch.tsx
@@ -1,6 +1,8 @@
 import { FolderGit2, MessageSquare } from "lucide-react";
+import { useEffect } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 
+import { storeAppMode } from "@/appMode";
 import { SegmentedControl } from "@/components/ui/segmented";
 import { isCodeRoute } from "./routes";
 
@@ -19,6 +21,10 @@ export function CodeModeSwitch() {
   });
   const value: Mode = isCodeRoute(pathname) ? "code" : "chat";
 
+  useEffect(() => {
+    storeAppMode(value === "code" ? "code" : "work");
+  }, [value]);
+
   return (
     <div className="px-2">
       <SegmentedControl
@@ -26,6 +32,7 @@ export function CodeModeSwitch() {
         value={value}
         onValueChange={(next) => {
           if (next === value) return;
+          storeAppMode(next === "code" ? "code" : "work");
           void navigate({ to: next === "code" ? "/code" : "/" });
         }}
         options={[

--- a/crates/tidebreak-desktop/ui/src/main.tsx
+++ b/crates/tidebreak-desktop/ui/src/main.tsx
@@ -2,15 +2,18 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "@tanstack/react-router";
 import { Toaster } from "@/components/ui/sonner";
+import { restoreStoredAppMode } from "./appMode";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { refuseStrayFileDrops } from "./ImageAttachments";
-import { router } from "./router";
+import { createAppRouter } from "./router";
 import { initTheme } from "./theme";
 import "katex/dist/katex.min.css";
 import "./styles.css";
 
 initTheme();
+restoreStoredAppMode();
 refuseStrayFileDrops(window);
+const router = createAppRouter();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/crates/tidebreak-desktop/ui/src/router.tsx
+++ b/crates/tidebreak-desktop/ui/src/router.tsx
@@ -374,14 +374,18 @@ export const routeTree = rootRoute.addChildren([
  * server behind it to rewrite unknown paths onto the document. A path history
  * would work until the first reload of a deep link.
  */
-export const router = createRouter({
-  routeTree,
-  history: createHashHistory(),
-  defaultPreload: false,
-});
+export function createAppRouter() {
+  return createRouter({
+    routeTree,
+    history: createHashHistory(),
+    defaultPreload: false,
+  });
+}
+
+export type AppRouter = ReturnType<typeof createAppRouter>;
 
 declare module "@tanstack/react-router" {
   interface Register {
-    router: typeof router;
+    router: AppRouter;
   }
 }


### PR DESCRIPTION
## What changed

Tidebreak now stores the selected Work or Code mode and restores it before router startup, so reopening the app returns to the last product surface without flashing Work. Explicit deep links still take priority.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome lint src/appMode.ts src/code/CodeModeSwitch.tsx src/router.tsx src/main.tsx src/AppShell.dom.test.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/AppShell.dom.test.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui build`

## Compatibility and risk

This adds the best-effort `tidebreak.app-mode` local-storage preference; missing, invalid, or unavailable storage falls back to Work, and no wire formats change.
