### PR TITLE
fix(desktop): keep collapsed pages below macOS stoplights

### DIFF
--- a/crates/tidebreak-desktop/ui/src/sidebar/SidebarExpandStrip.tsx
+++ b/crates/tidebreak-desktop/ui/src/sidebar/SidebarExpandStrip.tsx
@@ -7,9 +7,9 @@ import { useUiStore } from "@/UiStore";
  * The way back when the rail is collapsed away.
  *
  * Collapsed means the sidebar is gone from the layout entirely, so the shell
- * owes the reader a control to return it. This strip pins one expand button
+ * owes the reader a control to return it. This row pins one expand button
  * beside the macOS traffic lights (at the plain left edge everywhere else),
- * and doubles as the window's drag region where the overlay titlebar sits.
+ * reserves their titlebar space, and keeps that space draggable.
  */
 export function SidebarExpandStrip({ macOverlay }: { macOverlay: boolean }) {
   const collapsed = useUiStore((state) => state.sidebarCollapsed);

--- a/crates/tidebreak-desktop/ui/src/stories/CodeAnalytics.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeAnalytics.stories.tsx
@@ -7,6 +7,7 @@ import {
   createRouter,
   RouterProvider,
 } from "@tanstack/react-router";
+import { expect, within } from "storybook/test";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { ApiClient } from "@/api/client";
@@ -25,6 +26,7 @@ import {
   useCodeUpdatesStore,
 } from "@/code/CodeUpdatesStore";
 import { resetCodeSubscriptionUsageStore } from "@/code/useCodeSubscriptionUsage";
+import { SidebarExpandStrip } from "@/sidebar/SidebarExpandStrip";
 import { useUiStore } from "@/UiStore";
 import {
   deliveryCodeRepo,
@@ -362,7 +364,7 @@ function storyRouter() {
   });
 }
 
-function resetStoryState() {
+function resetStoryState(sidebarCollapsed: boolean) {
   disconnectCodeUpdates();
   useCodeCatalogStore.getState().reset();
   useCodeUpdatesStore.getState().reset();
@@ -375,12 +377,18 @@ function resetStoryState() {
     pendingComposerPrompt: null,
     composerActionScope: null,
   });
-  useUiStore.setState({ sidebarCollapsed: false, sidebarWidth: 280 });
+  useUiStore.setState({ sidebarCollapsed, sidebarWidth: 280 });
 }
 
-function CodeAnalyticsStory({ scenario }: { scenario: AnalyticsScenario }) {
+function CodeAnalyticsStory({
+  scenario,
+  sidebarCollapsed = false,
+}: {
+  scenario: AnalyticsScenario;
+  sidebarCollapsed?: boolean;
+}) {
   const [state] = useState(() => {
-    resetStoryState();
+    resetStoryState(sidebarCollapsed);
     const client = storyClient(scenario);
     return { client, router: storyRouter() };
   });
@@ -396,7 +404,10 @@ function CodeAnalyticsStory({ scenario }: { scenario: AnalyticsScenario }) {
   return (
     <AppContextProvider value={appContext(state.client)}>
       <div className="app-shell h-full min-h-0 w-full overflow-hidden">
-        <RouterProvider router={state.router as never} />
+        <SidebarExpandStrip macOverlay />
+        <div className="app-body">
+          <RouterProvider router={state.router as never} />
+        </div>
       </div>
     </AppContextProvider>
   );
@@ -405,9 +416,14 @@ function CodeAnalyticsStory({ scenario }: { scenario: AnalyticsScenario }) {
 const meta = {
   title: "Code/Analytics",
   component: CodeAnalyticsStory,
-  args: { scenario: "gateway" },
+  args: { scenario: "gateway", sidebarCollapsed: false },
   parameters: { layout: "fullscreen" },
-  render: (args) => <CodeAnalyticsStory key={args.scenario} {...args} />,
+  render: (args) => (
+    <CodeAnalyticsStory
+      key={`${args.scenario}:${args.sidebarCollapsed}`}
+      {...args}
+    />
+  ),
 } satisfies Meta<typeof CodeAnalyticsStory>;
 
 export default meta;
@@ -433,6 +449,24 @@ export const Failure: Story = {
 
 export const LongContent: Story = {
   args: { scenario: "long" },
+};
+
+export const CollapsedMacRail: Story = {
+  args: { scenario: "gateway", sidebarCollapsed: true },
+  globals: { viewport: { value: "minimumWindow", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const strip = canvasElement.querySelector<HTMLElement>(
+      ".sidebar-expand-strip",
+    );
+    const heading = await canvas.findByRole("heading", { name: "Analytics" });
+    const header = heading.closest("header");
+    await expect(strip).toBeVisible();
+    await expect(header).toBeTruthy();
+    await expect(
+      header?.getBoundingClientRect().top ?? 0,
+    ).toBeGreaterThanOrEqual((strip?.getBoundingClientRect().bottom ?? 0) - 1);
+  },
 };
 
 export const NarrowWidth: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeWorkspacePage.stories.tsx
@@ -36,6 +36,7 @@ import {
   searchFromLayout,
   type PanelSearch,
 } from "@/panel/panelUrl";
+import { SidebarExpandStrip } from "@/sidebar/SidebarExpandStrip";
 import { useUiStore } from "@/UiStore";
 import {
   attentionNeedsYou,
@@ -816,6 +817,7 @@ function WorkspacePageStory({
 
   return (
     <div className="app-shell h-full min-h-0 w-full overflow-hidden">
+      <SidebarExpandStrip macOverlay />
       <div className="app-body">
         <RouterProvider router={state.router as never} />
       </div>
@@ -1120,6 +1122,17 @@ export const MinimumWindowBusy: Story = {
 export const CompactConversation: Story = {
   args: { sidebarCollapsed: true, reviewOpen: false },
   globals: { viewport: { value: "compact", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const strip = canvasElement.querySelector<HTMLElement>(
+      ".sidebar-expand-strip",
+    );
+    const header = await canvas.findByTestId("workspace-header");
+    await expect(strip).toBeVisible();
+    await expect(header.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      (strip?.getBoundingClientRect().bottom ?? 0) - 1,
+    );
+  },
 };
 
 /** The filtered context and transcript remain legible in the compact desktop pane. */

--- a/crates/tidebreak-desktop/ui/src/stories/Navigation.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Navigation.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tanstack/react-router";
 import { expect, fn, userEvent, within } from "storybook/test";
 
+import { ChatHeaderTitle } from "@/ChatHeaderTitle";
 import { RouteFrame } from "@/RouteFrame";
 import { AppSidebar } from "@/sidebar/AppSidebar";
 import { NewProjectDialog } from "@/sidebar/NewProjectDialog";
@@ -29,21 +30,32 @@ type NavigationScenario =
   | "dense"
   | "failure"
   | "narrow"
-  | "collapsed";
+  | "collapsed"
+  | "collapsed-mac";
 
 function NavigationSurface({ activeChatId }: { activeChatId?: string }) {
   const activeChat = routeChats.find((chat) => chat.id === activeChatId);
   return (
     <RouteFrame sidebar={<AppSidebar chat={activeChat} />}>
-      <div className="content-container grid h-full min-h-0 place-items-center p-8">
-        <div className="max-w-md text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">
-            Navigation review surface
-          </h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            This canvas keeps the production rail in context while you inspect
-            active routes, list density, loading, and failure states.
-          </p>
+      <div className="content-container flex h-full min-h-0 flex-col">
+        {activeChat && (
+          <header
+            className="window-chrome-row flex h-12 shrink-0 items-center border-b border-border-subtle pr-3"
+            data-testid="work-window-chrome"
+          >
+            <ChatHeaderTitle chat={activeChat} />
+          </header>
+        )}
+        <div className="grid min-h-0 flex-1 place-items-center p-8">
+          <div className="max-w-md text-center">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Navigation review surface
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              This canvas keeps the production rail in context while you inspect
+              active routes, list density, loading, and failure states.
+            </p>
+          </div>
         </div>
       </div>
     </RouteFrame>
@@ -135,7 +147,8 @@ function NavigationStory({ scenario }: { scenario: NavigationScenario }) {
       inboxLoaded: scenario !== "loading",
       attentionChatIds: dense ? ["chat-2", "dense-chat-2"] : ["chat-2"],
       sidebarWidth: scenario === "narrow" ? 220 : 280,
-      sidebarCollapsed: scenario === "collapsed",
+      sidebarCollapsed:
+        scenario === "collapsed" || scenario === "collapsed-mac",
     });
 
     const initialPath =
@@ -147,7 +160,9 @@ function NavigationStory({ scenario }: { scenario: NavigationScenario }) {
             ? "/apps"
             : scenario === "collapsed"
               ? "/apps"
-              : "/";
+              : scenario === "collapsed-mac"
+                ? "/c/chat-1"
+                : "/";
     return {
       client: storyClient(),
       router: createNavigationRouter(initialPath),
@@ -157,7 +172,7 @@ function NavigationStory({ scenario }: { scenario: NavigationScenario }) {
   return (
     <RouteStoryProviders client={state.client}>
       <div className="app-shell h-full min-h-0 w-full overflow-hidden">
-        <SidebarExpandStrip macOverlay={false} />
+        <SidebarExpandStrip macOverlay={scenario === "collapsed-mac"} />
         <div className="app-body">
           <RouterProvider router={state.router as never} />
         </div>
@@ -209,6 +224,22 @@ export const NarrowRail: Story = {
 
 export const CollapsedRail: Story = {
   args: { scenario: "collapsed" },
+};
+
+export const CollapsedMacWork: Story = {
+  args: { scenario: "collapsed-mac" },
+  globals: { viewport: { value: "minimumWindow", isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const strip = canvasElement.querySelector<HTMLElement>(
+      ".sidebar-expand-strip",
+    );
+    const header = await canvas.findByTestId("work-window-chrome");
+    await expect(strip).toBeVisible();
+    await expect(header.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      (strip?.getBoundingClientRect().bottom ?? 0) - 1,
+    );
+  },
 };
 
 export const CollapseAndRestoreActiveRoute: Story = {

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -148,6 +148,7 @@
   --sidebar-expanded-min: 200px;
   --sidebar-expanded-max: 480px;
   --sidebar-expanded-width: 280px;
+  --window-chrome-height: 40px;
   /* macOS overlay traffic lights at trafficLightPosition (16, 20), plus a
      gap before the history buttons. */
   --mac-traffic-light-inset: 84px;
@@ -2200,7 +2201,7 @@ body {
   z-index: 40;
   display: flex;
   width: var(--sidebar-expanded-width);
-  height: 40px;
+  height: var(--window-chrome-height);
   align-items: center;
   gap: 0.5rem;
   padding-left: 1rem;
@@ -2224,7 +2225,7 @@ body {
    the key distinction from a normal titlebar row: the conversation and its
    panels no longer get pushed down by 40px. */
 .app-shell.with-titlebar [data-sidebar] {
-  padding-top: 40px;
+  padding-top: var(--window-chrome-height);
 }
 
 /* Chrome that shares the traffic-light row (the chat breadcrumb) starts after
@@ -2241,22 +2242,21 @@ body {
   top: 0;
   left: 0;
   right: 0;
-  height: 40px;
+  height: var(--window-chrome-height);
   z-index: 50;
 }
 
-/* A collapsed sidebar leaves no rail, so the shell pins a single expand
-   button beside the traffic lights instead (at the plain left edge
-   elsewhere). It is the window's drag region where the overlay titlebar
-   would be. */
+/* A collapsed sidebar leaves no rail, so this full-width row takes over the
+   titlebar space. It keeps every routed surface below the traffic lights and
+   the expand button instead of asking each page header to avoid them. */
 .sidebar-expand-strip {
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
   z-index: 40;
   display: flex;
-  height: 40px;
-  width: 120px;
+  height: var(--window-chrome-height);
   align-items: center;
   gap: 0.5rem;
   padding-left: 1rem;
@@ -2265,6 +2265,10 @@ body {
 
 .sidebar-expand-strip.is-mac-overlay {
   padding-left: var(--mac-traffic-light-inset);
+}
+
+.app-shell:has(> .sidebar-expand-strip) .app-body {
+  padding-top: var(--window-chrome-height);
 }
 
 .app-body {


### PR DESCRIPTION
## What changed

Reserve a 40 px titlebar row whenever the sidebar is collapsed so Code and Work tabs stay below the macOS traffic lights and the sidebar expand button.

## Validation

Biome lint, TypeScript `--noEmit`, the full UI test suite (236 files and 1,865 tests), and the Storybook build pass. Visual screenshot inspection could not run because browser control was unavailable.

## Compatibility and risk

None; UI layout only.