### PR TITLE
fix(code): keep session state indicators consistent

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
@@ -77,6 +77,16 @@ describe("AttentionBadge", () => {
     expect(mark.querySelector(".animate-spin")).not.toBeNull();
   });
 
+  it("renders no mark for Idle", () => {
+    const { container } = render(
+      <AttentionBadge
+        compact
+        attention={{ state: { type: "idle" }, source: "lifecycle" }}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it.each(cases)(
     "renders $type with its label",
     ({ attention, label, type }) => {

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
@@ -47,6 +47,7 @@ export function AttentionBadge({
   className?: string;
 }) {
   if (!attention) return null;
+  if (attention.state.type === "idle") return null;
   if (attention.state.type === "working" && !compact) return null;
   const label = attentionLabel(attention);
   const tooltip = attentionTooltip(attention);
@@ -100,6 +101,8 @@ function CompactAttentionMark({
       return <Ban className={className} aria-hidden="true" />;
     case "done_unreviewed":
       return <CircleCheck className={className} aria-hidden="true" />;
+    case "idle":
+      return null;
     case "manual":
       return <Pin className={className} aria-hidden="true" />;
   }

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -276,7 +276,7 @@ export function CodeCenterTabs({
                   <span className="max-w-40 truncate">
                     {conversation.label}
                   </span>
-                  {/* The dot is the agent's own state, not the tab's, so it
+                  {/* The mark is the agent's own state, not the tab's, so it
                       shows on the tabs the reader is not looking at too. */}
                   <AttentionBadge attention={conversation.attention} compact />
                 </button>

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -71,7 +71,7 @@ import {
   type ShellShortcutAction,
 } from "@/ShellShortcuts";
 import { AttentionBadge } from "./AttentionBadge";
-import { STATUS_MARK } from "./statusTone";
+import { attentionMarkForDigest, STATUS_MARK } from "./statusTone";
 import {
   codeBrowserIds,
   codeTerminalIds,
@@ -884,12 +884,15 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
       conversations[0]?.id ??
       null);
   const conversationTabs = useMemo<CodeConversationTab[]>(() => {
-    const tabs: CodeConversationTab[] = conversations.map((entry, index) => ({
-      id: entry.id,
-      label: conversationTabLabel(entry, index, conversations),
-      harness: entry.harness_kind,
-      attention: conversationDigests[entry.id]?.attention,
-    }));
+    const tabs: CodeConversationTab[] = conversations.map((entry, index) => {
+      const digest = conversationDigests[entry.id];
+      return {
+        id: entry.id,
+        label: conversationTabLabel(entry, index, conversations),
+        harness: entry.harness_kind,
+        attention: attentionMarkForDigest(digest),
+      };
+    });
     // A draft has no engine yet, so it wears the generic agent glyph. It is
     // also the one closable tab: nothing is running behind it. A workspace
     // with no agents at all still gets one, so the strip always names the

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -265,6 +265,46 @@ describe("WorkspaceCard", () => {
     expect(screen.queryByTitle("Claude Code")).not.toBeInTheDocument();
   });
 
+  it("does not show live motion when an older idle digest still says Working", () => {
+    const digest: CodeSessionDigest = {
+      workspace: workspace.id,
+      session: "sess-1",
+      kind: "interactive",
+      lifecycle: "idle",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      title: workspace.title,
+      turn_count: 1,
+    };
+    render(
+      <WorkspaceCard
+        workspace={workspace}
+        digest={digest}
+        session={undefined}
+        repoName="app"
+        active
+        terminalOpen={false}
+        density="detailed"
+        visibleMeta={{ repoChip: true, branch: true }}
+        commands={workspaceCommands({
+          hasPr: false,
+          archived: false,
+          hasSession: true,
+        })}
+        detailDefaultOpen
+        onOpen={vi.fn()}
+        onCommand={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText("Working")).not.toBeInTheDocument();
+    expect(screen.getByText("Idle · 1 turn")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Fix login · Idle · app · tidebreak/fix-login",
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("compact keeps the one-line read and the complete label", () => {
     renderCard({ density: "compact" });
 

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -52,6 +52,7 @@ import {
 } from "./workspaceWorkflow";
 import { pullRequestReviewSummary } from "./pullRequestPresentation";
 import {
+  attentionMarkForDigest,
   digestStatusTone,
   STATUS_CHIP,
   STATUS_DOT,
@@ -128,6 +129,7 @@ export function WorkspaceCard({
   const pr = digest?.pr_state ?? workspace.pr;
   const archived = isPutAway(workspace);
   const creating = workspace.status === "creating";
+  const attentionMark = attentionMarkForDigest(digest);
   const [detailOpen, setDetailOpen] = useState(detailDefaultOpen);
   const watchActive = childSessions.some(
     (child) =>
@@ -184,7 +186,7 @@ export function WorkspaceCard({
                 onClick={onOpen}
               >
                 <span className="flex min-w-0 items-center gap-2">
-                  <AttentionBadge attention={digest?.attention} compact />
+                  <AttentionBadge attention={attentionMark} compact />
                   <span className="min-w-0 flex-1 truncate text-md font-medium leading-5">
                     {title}
                   </span>
@@ -204,12 +206,6 @@ export function WorkspaceCard({
                         )}
                       />
                     )}
-                    {digest?.attention.state.type === "needs_you" &&
-                      digest.attention.state.source === "structured" && (
-                        <CircleAlert
-                          className={cn("size-3", STATUS_MARK.critical)}
-                        />
-                      )}
                   </span>
                 </span>
                 {density === "detailed" &&
@@ -299,7 +295,7 @@ export function WorkspaceCard({
                 label={`Watch - ${watchRowLabel(child)}`}
                 ariaLabel={`Watch task for ${title}: ${watchRowLabel(child)}`}
                 icon={<Eye />}
-                attention={child.attention}
+                attention={attentionMarkForDigest(child)}
                 onClick={() => onOpenChildSession?.(child.session)}
               />
             ))}

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Attention, CodeSessionDigest } from "../api/types";
 import {
+  attentionMarkForDigest,
   attentionStatusTone,
   digestStatusTone,
   STATUS_MOTION,
@@ -68,5 +69,30 @@ describe("digestStatusTone", () => {
       "neutral",
     );
     expect(digestStatusTone(undefined)).toBe("neutral");
+  });
+});
+
+describe("attentionMarkForDigest", () => {
+  it("shows motion only while lifecycle also says the session is running", () => {
+    expect(
+      attentionMarkForDigest(digest({ type: "working" }, "running")),
+    ).toEqual({ state: { type: "working" }, source: "lifecycle" });
+    expect(
+      attentionMarkForDigest(digest({ type: "working" }, "idle")),
+    ).toBeUndefined();
+    expect(
+      attentionMarkForDigest(digest({ type: "working" }, "ended")),
+    ).toBeUndefined();
+  });
+
+  it("keeps attention that outranks lifecycle and leaves idle unmarked", () => {
+    const needsYou = digest(
+      { type: "needs_you", prompt: "Approve this?", source: "structured" },
+      "idle",
+    );
+    expect(attentionMarkForDigest(needsYou)).toEqual(needsYou.attention);
+    expect(
+      attentionMarkForDigest(digest({ type: "idle" }, "idle")),
+    ).toBeUndefined();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.ts
@@ -137,3 +137,23 @@ export function digestStatusTone(
   }
   return digest.lifecycle === "running" ? "running" : "neutral";
 }
+
+/**
+ * The attention state that deserves a compact mark for one session digest.
+ *
+ * Older rows can still carry `Working` after their lifecycle settles. Motion
+ * must agree with lifecycle, or the same workspace reads as live in one place
+ * and idle in another. Idle itself has no mark because it asks for nothing.
+ */
+export function attentionMarkForDigest(
+  digest: Pick<CodeSessionDigest, "attention" | "lifecycle"> | undefined,
+): Attention | undefined {
+  if (!digest || digest.attention.state.type === "idle") return undefined;
+  if (
+    digest.attention.state.type === "working" &&
+    digest.lifecycle !== "running"
+  ) {
+    return undefined;
+  }
+  return digest.attention;
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -394,6 +394,22 @@ describe("workspaceCardLabel", () => {
     ).toBe("Fix login · app · tidebreak/fix-login");
   });
 
+  it("announces lifecycle when an older resting row still says Working", () => {
+    const session = digest("ws-a", {
+      lifecycle: "idle",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+    });
+    expect(
+      workspaceCardLabel({
+        title: "Fix login",
+        repoName: "app",
+        branchName: "tidebreak/fix-login",
+        attention: session.attention,
+        session,
+      }),
+    ).toBe("Fix login · Idle · app · tidebreak/fix-login");
+  });
+
   it("announces queue membership instead of the open lifecycle", () => {
     expect(
       workspaceCardLabel({

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -390,6 +390,8 @@ export function workspaceCardLabel(input: {
   }
   if (input.session?.lifecycle === "running") {
     parts.push(sessionActivityLabel(input.session));
+  } else if (input.session && input.attention?.state.type === "working") {
+    parts.push(LIFECYCLE_LABELS[input.session.lifecycle]);
   }
   if (input.pr) {
     parts.push(`Pull request #${input.pr.number} ${prStatusLabel(input.pr)}`);

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -309,6 +309,35 @@ export const Active: Story = {
   args: { active: true },
 };
 
+/** An older resting digest cannot make the rail look live beside an Idle panel. */
+export const HoverIdleSession: Story = {
+  args: {
+    workspace: {
+      ...codeWorkspace,
+      title: "Idle workspace",
+      branch_name: "tidebreak/idle-workspace",
+    },
+    digest: {
+      ...runningDigest,
+      title: "Idle workspace",
+      lifecycle: "idle",
+      turn_count: 1,
+    },
+    session: {
+      ...codeSession,
+      lifecycle: "idle",
+    },
+    active: true,
+    visibleMeta: { repoChip: true, branch: true },
+    commands: workspaceCommands({
+      hasPr: false,
+      archived: false,
+      hasSession: true,
+    }),
+    detailDefaultOpen: true,
+  },
+};
+
 /** Harness mark, live activity, and turn count on the detailed status line. */
 export const RunningSession: Story = {
   args: {


### PR DESCRIPTION
## What changed

- Gate compact `Working` motion on a running lifecycle across workspace cards, watch rows, and agent tabs.
- Remove the duplicate structured-alert glyph, align the accessible workspace label with lifecycle, and add regression tests plus the `Hover Idle Session` Storybook story.

## Validation

- Passed 63 focused tests, the full 1,875-test UI suite, Biome format and lint, TypeScript, the Storybook production build, and diff checks.
- Reviewed the regression story in the supported light and dark themes.

## Compatibility and risk

- None. This changes UI presentation only and does not change persisted data or wire formats.
