### PR TITLE
fix: address Code and Work mode exercise findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,6 +7163,7 @@ dependencies = [
  "tidebreak-core",
  "tokio",
  "tracing",
+ "uuid",
  "windows-sys 0.61.2",
 ]
 

--- a/crates/tidebreak-cli/src/api/client.rs
+++ b/crates/tidebreak-cli/src/api/client.rs
@@ -2,10 +2,12 @@
 //! consumes.
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use tidebreak_core::{
-    AgentError, AgentRunId, CallId, ChatId, OutputId, OutputRevisionId, Result, TurnId,
+    AgentError, AgentRunId, CallId, ChatId, DocumentId, MessageId, OutputId, OutputRevisionId,
+    Result, TurnId,
 };
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
@@ -29,6 +31,7 @@ pub struct Client {
     base: String,
     token: String,
     local_import_token: Option<String>,
+    listen_data_dir: Option<PathBuf>,
 }
 
 /// The error body every route answers with on failure.
@@ -55,6 +58,45 @@ pub struct IngestedSource {
     pub readiness: tidebreak_core::DocumentReadiness,
 }
 
+/// Durable terminal state used when a print-mode event socket cannot recover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DurableTurn {
+    pub status: DurableTurnStatus,
+    pub content: String,
+    pub last_event_seq: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DurableTurnStatus {
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Deserialize)]
+struct DurableTranscript {
+    messages: Vec<DurableMessage>,
+    terminal_turns: Vec<DurableTerminalTurn>,
+    last_event_seq: i64,
+}
+
+#[derive(Deserialize)]
+struct DurableMessage {
+    id: MessageId,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct DurableTerminalTurn {
+    turn_id: TurnId,
+    #[serde(default)]
+    message_id: Option<MessageId>,
+    status: DurableTurnStatus,
+    #[serde(default)]
+    partial_content: String,
+}
+
 impl Client {
     /// A client for a server bound in this process.
     pub fn new(addr: SocketAddr, token: &str) -> Result<Self> {
@@ -78,6 +120,17 @@ impl Client {
         token: &str,
         local_import_token: Option<&str>,
     ) -> Result<Self> {
+        Self::attach_with_reconnect_source(base, token, local_import_token, None)
+    }
+
+    /// Attach to a server and remember the profile whose `listen.json` owns
+    /// its rotating endpoint credentials.
+    pub fn attach_with_reconnect_source(
+        base: String,
+        token: &str,
+        local_import_token: Option<&str>,
+        listen_data_dir: Option<PathBuf>,
+    ) -> Result<Self> {
         let mut headers = reqwest::header::HeaderMap::new();
         let mut value = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
             .map_err(|error| AgentError::msg(format!("invalid server token: {error}")))?;
@@ -94,7 +147,24 @@ impl Client {
             base,
             token: token.to_owned(),
             local_import_token: local_import_token.map(str::to_owned),
+            listen_data_dir,
         })
+    }
+
+    /// Re-read a desktop-owned attach endpoint after the desktop restarts.
+    /// Explicit `--server` clients have no rotating source and remain unchanged.
+    pub fn refresh_attach_endpoint(&mut self) -> Result<()> {
+        let Some(data_dir) = self.listen_data_dir.clone() else {
+            return Ok(());
+        };
+        let endpoint = tidebreak_server::listen_endpoint::ListenEndpoint::read(&data_dir)?;
+        *self = Self::attach_with_reconnect_source(
+            endpoint.base_url.trim_end_matches('/').to_owned(),
+            &endpoint.token,
+            Some(&endpoint.local_import_token),
+            Some(data_dir),
+        )?;
+        Ok(())
     }
 
     fn with_local_import(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
@@ -484,14 +554,16 @@ impl Client {
 
     /// Accept a user message and queue its turn (`202`).
     ///
-    /// `attachments` are image ids returned by [`Self::attach_image`]. An empty
-    /// slice is the ordinary text-only send.
+    /// `attachments` are image ids returned by [`Self::attach_image`].
+    /// `file_attachments` are document ids returned by
+    /// [`Self::attach_document`]. Empty slices are the ordinary text-only send.
     pub async fn post_message(
         &self,
         chat: ChatId,
         turn_id: TurnId,
         content: &str,
         attachments: &[uuid::Uuid],
+        file_attachments: &[DocumentId],
     ) -> Result<()> {
         let response = self
             .http
@@ -500,12 +572,21 @@ impl Client {
                 "turn_id": turn_id,
                 "content": content,
                 "attachments": attachments,
+                "file_attachments": file_attachments,
             }))
             .send()
             .await
             .map_err(request_error)?;
         Self::expect_success(response).await?;
         Ok(())
+    }
+
+    /// Read one turn's durable terminal state after live event delivery fails.
+    pub async fn durable_turn(&self, chat: ChatId, turn_id: TurnId) -> Result<Option<DurableTurn>> {
+        let transcript: DurableTranscript = self
+            .get_json(format!("{}/chats/{chat}/messages", self.base))
+            .await?;
+        Ok(durable_turn_from_transcript(transcript, turn_id))
     }
 
     /// Cancel one exact turn (`202`; `409` if it already finished).
@@ -707,12 +788,12 @@ impl Client {
         title: &str,
         media_type: &str,
         bytes: Vec<u8>,
-    ) -> Result<String> {
-        Ok(self
-            .publish_document_source(chat, Some(title), None, media_type, bytes)
-            .await?
-            .document_id
-            .to_string())
+    ) -> Result<DocumentId> {
+        Ok(DocumentId::from(
+            self.publish_document_source(chat, Some(title), None, media_type, bytes)
+                .await?
+                .document_id,
+        ))
     }
 
     /// Publish one source into a conversation through the ingest route.
@@ -1124,4 +1205,123 @@ fn urlencode(value: &str) -> String {
         }
     }
     encoded
+}
+
+fn durable_turn_from_transcript(
+    transcript: DurableTranscript,
+    turn_id: TurnId,
+) -> Option<DurableTurn> {
+    let turn = transcript
+        .terminal_turns
+        .into_iter()
+        .find(|turn| turn.turn_id == turn_id)?;
+    let content = turn
+        .message_id
+        .and_then(|message_id| {
+            transcript
+                .messages
+                .iter()
+                .find(|message| message.id == message_id)
+                .map(|message| message.content.clone())
+        })
+        .unwrap_or(turn.partial_content);
+    Some(DurableTurn {
+        status: turn.status,
+        content,
+        last_event_seq: transcript.last_event_seq,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refreshing_an_attach_client_reloads_the_rotated_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        tidebreak_server::listen_endpoint::write(
+            dir.path(),
+            "http://127.0.0.1:1001",
+            "first-token",
+            "first-import",
+        )
+        .unwrap();
+        let mut client = Client::attach_with_reconnect_source(
+            "http://127.0.0.1:1001".into(),
+            "first-token",
+            Some("first-import"),
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
+
+        tidebreak_server::listen_endpoint::write(
+            dir.path(),
+            "http://127.0.0.1:2002/",
+            "second-token",
+            "second-import",
+        )
+        .unwrap();
+        client.refresh_attach_endpoint().unwrap();
+
+        assert_eq!(client.base, "http://127.0.0.1:2002");
+        assert_eq!(client.token, "second-token");
+        assert_eq!(client.local_import_token.as_deref(), Some("second-import"));
+        assert_eq!(client.listen_data_dir.as_deref(), Some(dir.path()));
+    }
+
+    #[test]
+    fn durable_reconciliation_prefers_the_committed_message_and_keeps_partial_fallback() {
+        let completed_turn = TurnId::new();
+        let cancelled_turn = TurnId::new();
+        let message_id = MessageId::new();
+        let transcript = DurableTranscript {
+            messages: vec![DurableMessage {
+                id: message_id,
+                content: "authoritative answer".into(),
+            }],
+            terminal_turns: vec![
+                DurableTerminalTurn {
+                    turn_id: completed_turn,
+                    message_id: Some(message_id),
+                    status: DurableTurnStatus::Completed,
+                    partial_content: "partial".into(),
+                },
+                DurableTerminalTurn {
+                    turn_id: cancelled_turn,
+                    message_id: None,
+                    status: DurableTurnStatus::Cancelled,
+                    partial_content: "visible before cancellation".into(),
+                },
+            ],
+            last_event_seq: 41,
+        };
+
+        assert_eq!(
+            durable_turn_from_transcript(transcript, completed_turn),
+            Some(DurableTurn {
+                status: DurableTurnStatus::Completed,
+                content: "authoritative answer".into(),
+                last_event_seq: 41,
+            })
+        );
+
+        let transcript = DurableTranscript {
+            messages: Vec::new(),
+            terminal_turns: vec![DurableTerminalTurn {
+                turn_id: cancelled_turn,
+                message_id: None,
+                status: DurableTurnStatus::Cancelled,
+                partial_content: "visible before cancellation".into(),
+            }],
+            last_event_seq: 42,
+        };
+        assert_eq!(
+            durable_turn_from_transcript(transcript, cancelled_turn),
+            Some(DurableTurn {
+                status: DurableTurnStatus::Cancelled,
+                content: "visible before cancellation".into(),
+                last_event_seq: 42,
+            })
+        );
+    }
 }

--- a/crates/tidebreak-cli/src/connect.rs
+++ b/crates/tidebreak-cli/src/connect.rs
@@ -23,6 +23,7 @@
 //! in shell history, and a per-launch bearer token is full authority over the
 //! profile.
 
+use std::path::PathBuf;
 use tidebreak_core::{AgentError, Result};
 
 use crate::api::client::Client;
@@ -42,6 +43,10 @@ pub enum Server {
         base: String,
         token: String,
         local_import_token: Option<String>,
+        /// Data directory whose `listen.json` should be re-read after a
+        /// dropped connection. Explicit `--server` attachments leave this
+        /// unset because their endpoint is fixed by the caller.
+        listen_data_dir: Option<PathBuf>,
     },
 }
 
@@ -77,6 +82,7 @@ impl Server {
                 base,
                 token: endpoint.token,
                 local_import_token: Some(endpoint.local_import_token),
+                listen_data_dir: Some(config.data_dir),
             });
         }
         let url = match url_flag {
@@ -110,6 +116,7 @@ impl Server {
             base,
             token,
             local_import_token: None,
+            listen_data_dir: None,
         })
     }
 }
@@ -177,11 +184,13 @@ impl Session {
                 base,
                 token,
                 local_import_token,
+                listen_data_dir,
             } => Ok(Self {
-                client: Client::attach_with_local_import(
+                client: Client::attach_with_reconnect_source(
                     base.clone(),
                     token,
                     local_import_token.as_deref(),
+                    listen_data_dir.clone(),
                 )?,
                 serve: None,
                 client_executor_token: None,

--- a/crates/tidebreak-cli/src/outputs.rs
+++ b/crates/tidebreak-cli/src/outputs.rs
@@ -11,7 +11,7 @@
 use std::path::{Path, PathBuf};
 
 use tidebreak_core::{
-    AgentError, ChatId, OutputId, OutputRevisionId, Result, MAX_MESSAGE_ATTACHMENTS,
+    AgentError, ChatId, DocumentId, OutputId, OutputRevisionId, Result, MAX_MESSAGE_ATTACHMENTS,
 };
 use uuid::Uuid;
 
@@ -267,6 +267,7 @@ pub async fn attach(chat: ChatId, path: PathBuf, server: Server) -> Result<()> {
             .attach_document(chat, &title, &media_type, bytes)
             .await
             .map_err(|error| local_import_error(client, error))?;
+        record_pending_document(chat, document_id)?;
         println!("{document_id}");
         eprintln!("tidebreak: attached {title} as {media_type}");
     }
@@ -311,18 +312,50 @@ pub(crate) fn clear_pending_image_attachments(chat: ChatId) -> Result<()> {
     }
 }
 
+/// Document ids `tidebreak attach` published for `chat` that the next `-p`
+/// turn has not yet submitted.
+pub(crate) fn pending_document_attachments(chat: ChatId) -> Result<Vec<DocumentId>> {
+    read_pending_ids(&pending_documents_path(chat)?, "document", chat)
+}
+
+pub(crate) fn clear_pending_document_attachments(chat: ChatId) -> Result<()> {
+    clear_pending_ids(&pending_documents_path(chat)?, "document", chat)
+}
+
 fn record_pending_image(chat: ChatId, attachment_id: &Uuid) -> Result<()> {
     let mut ids = pending_image_attachments(chat)?;
     if ids.contains(attachment_id) {
         return Ok(());
     }
-    if ids.len() >= MAX_MESSAGE_ATTACHMENTS {
+    if ids
+        .len()
+        .saturating_add(pending_document_attachments(chat)?.len())
+        >= MAX_MESSAGE_ATTACHMENTS
+    {
         return Err(AgentError::msg(format!(
-            "a message may carry at most {MAX_MESSAGE_ATTACHMENTS} image attachments"
+            "a message may carry at most {MAX_MESSAGE_ATTACHMENTS} attachments"
         )));
     }
     ids.push(*attachment_id);
     write_pending_images(chat, &ids)
+}
+
+fn record_pending_document(chat: ChatId, document_id: DocumentId) -> Result<()> {
+    let mut ids = pending_document_attachments(chat)?;
+    if ids.contains(&document_id) {
+        return Ok(());
+    }
+    if ids
+        .len()
+        .saturating_add(pending_image_attachments(chat)?.len())
+        >= MAX_MESSAGE_ATTACHMENTS
+    {
+        return Err(AgentError::msg(format!(
+            "a message may carry at most {MAX_MESSAGE_ATTACHMENTS} attachments"
+        )));
+    }
+    ids.push(document_id);
+    write_pending_ids(&pending_documents_path(chat)?, &ids, "document", chat)
 }
 
 fn write_pending_images(chat: ChatId, ids: &[Uuid]) -> Result<()> {
@@ -357,4 +390,67 @@ fn pending_images_path(chat: ChatId) -> Result<PathBuf> {
         .data_dir
         .join("pending-image-attachments")
         .join(chat.to_string()))
+}
+
+fn pending_documents_path(chat: ChatId) -> Result<PathBuf> {
+    Ok(crate::profile_config()?
+        .data_dir
+        .join("pending-document-attachments")
+        .join(chat.to_string()))
+}
+
+fn read_pending_ids<T: serde::de::DeserializeOwned>(
+    path: &Path,
+    kind: &str,
+    chat: ChatId,
+) -> Result<Vec<T>> {
+    let Some(bytes) = std::fs::read(path).ok() else {
+        return Ok(Vec::new());
+    };
+    serde_json::from_slice(&bytes).map_err(|error| {
+        AgentError::msg(format!(
+            "could not read pending {kind} attachments for {chat}: {error}"
+        ))
+    })
+}
+
+fn clear_pending_ids(path: &Path, kind: &str, chat: ChatId) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(AgentError::msg(format!(
+            "could not clear pending {kind} attachments for {chat}: {error}"
+        ))),
+    }
+}
+
+fn write_pending_ids<T: serde::Serialize>(
+    path: &Path,
+    ids: &[T],
+    kind: &str,
+    chat: ChatId,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            AgentError::msg(format!(
+                "could not write pending {kind} attachments for {chat}: {error}"
+            ))
+        })?;
+    }
+    let encoded = serde_json::to_vec(ids).map_err(|error| {
+        AgentError::msg(format!(
+            "could not write pending {kind} attachments for {chat}: {error}"
+        ))
+    })?;
+    let temporary = path.with_extension("tmp");
+    let write =
+        std::fs::write(&temporary, encoded).and_then(|()| std::fs::rename(&temporary, path));
+    if write.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    write.map_err(|error| {
+        AgentError::msg(format!(
+            "could not write pending {kind} attachments for {chat}: {error}"
+        ))
+    })
 }

--- a/crates/tidebreak-cli/src/print.rs
+++ b/crates/tidebreak-cli/src/print.rs
@@ -11,10 +11,9 @@
 //! a proposed plan, a question. Two things answer those. A **driver** — another
 //! process holding this one's stdin, opted in with `--output-format json` — is
 //! asked over the NDJSON protocol in [`protocol`]. With no driver attached, the
-//! standing policy answers instead: approvals are rejected, so the model can
-//! choose another route rather than hang, and a plan or a question ends the run
-//! with a distinct exit status and a machine-readable reason. Nothing is ever
-//! cancelled silently.
+//! missing driver ends the run with a distinct exit status and a
+//! machine-readable reason. The parked turn is cancelled so the model cannot
+//! reinterpret an unavailable decision as a user rejection or retry it.
 //!
 //! A request for another host folder is deliberately **not** one of those.
 //! Folder access is host-machine consent, and the driving protocol has no way
@@ -46,7 +45,9 @@ use tidebreak_core::{
 };
 use tokio_tungstenite::tungstenite::Message;
 
-use crate::api::client::{Client, ClientExecutionOutcome, EventSocket};
+use crate::api::client::{
+    Client, ClientExecutionOutcome, DurableTurn, DurableTurnStatus, EventSocket,
+};
 use crate::api::wire::{ChatFrame, ClientEvent, ToolCallStatus};
 
 mod driver;
@@ -70,8 +71,16 @@ const EXIT_INTERRUPTED: i32 = 130;
 /// Attempts to re-open the event socket after it closes mid-turn before giving
 /// up. The retries cover a transient hiccup — an accept-loop stumble when the
 /// server is in-process, a dropped connection when it is not.
-const RECONNECT_ATTEMPTS: usize = 3;
-const RECONNECT_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
+const RECONNECT_DELAYS: [std::time::Duration; 8] = [
+    std::time::Duration::from_millis(250),
+    std::time::Duration::from_millis(500),
+    std::time::Duration::from_secs(1),
+    std::time::Duration::from_secs(2),
+    std::time::Duration::from_secs(4),
+    std::time::Duration::from_secs(5),
+    std::time::Duration::from_secs(6),
+    std::time::Duration::from_secs(6),
+];
 
 /// How often a folder refusal asks whether its call has become claimable, and
 /// the ceiling that interval backs off to.
@@ -121,7 +130,7 @@ pub async fn run(
     // keeps an embedded engine alive — dropping it aborts the accept loop and
     // with it the turn worker.
     let session = crate::connect::Session::open(&server).await?;
-    let client = session.client().clone();
+    let mut client = session.client().clone();
     // Present only when this process is the server. Answering a client-owned
     // tool call is the trusted surface's job, and an attached run is not it.
     let executor_token = session.client_executor_token().map(str::to_owned);
@@ -179,7 +188,7 @@ pub async fn run(
     };
 
     let outcome = one_turn(
-        &client,
+        &mut client,
         executor_token.as_deref(),
         chat,
         &prompt,
@@ -202,7 +211,7 @@ impl Drop for FolderExecutorTask {
 
 /// Post the message and follow the event stream until the turn ends.
 async fn one_turn(
-    client: &Client,
+    client: &mut Client,
     executor_token: Option<&str>,
     chat: ChatId,
     prompt: &str,
@@ -214,11 +223,15 @@ async fn one_turn(
     // socket's replay only reaches back to the cursor it was opened at.
     let mut stream = Stream::open(client, chat).await?;
     let attachments = crate::outputs::pending_image_attachments(chat)?;
+    let file_attachments = crate::outputs::pending_document_attachments(chat)?;
     client
-        .post_message(chat, turn_id, prompt, &attachments)
+        .post_message(chat, turn_id, prompt, &attachments, &file_attachments)
         .await?;
     if !attachments.is_empty() {
         let _ = crate::outputs::clear_pending_image_attachments(chat);
+    }
+    if !file_attachments.is_empty() {
+        let _ = crate::outputs::clear_pending_document_attachments(chat);
     }
     // Installed once the turn exists, and not before. Installing it earlier
     // would swallow signals over the handshake and the post — neither of which
@@ -233,7 +246,7 @@ async fn one_turn(
 
     let outcome = loop {
         let frame = tokio::select! {
-            frame = stream.next(client, chat) => frame?,
+            frame = stream.next(client, chat, turn_id) => frame?,
             () = interrupt.fired() => {
                 break halted(client, chat, turn_id, &interrupted(), &mut printer).await;
             }
@@ -253,8 +266,18 @@ async fn one_turn(
             },
         };
 
-        let Some((raw, event)) = frame else {
-            continue;
+        let (raw, event) = match frame {
+            StreamNext::Frame(raw, event) => (raw, event),
+            StreamNext::Ignore => continue,
+            StreamNext::Durable(turn) => {
+                printer.reconciled(turn_id, &turn);
+                break match turn.status {
+                    DurableTurnStatus::Completed => 0,
+                    DurableTurnStatus::Failed | DurableTurnStatus::Cancelled => {
+                        EXIT_TURN_UNSUCCESSFUL
+                    }
+                };
+            }
         };
         if !ours {
             if !matches!(&event, ClientEvent::TurnStarted { turn_id: id } if *id == turn_id) {
@@ -313,8 +336,8 @@ async fn one_turn(
                     break halted(client, chat, turn_id, &halt, &mut printer).await;
                 }
             }
-            // Neither can be answered from the standing policy, so both reach
-            // for the driver first and end the run loudly if there is none.
+            // Neither can be answered without a driver, so both end the run
+            // loudly if there is none.
             ClientEvent::PlanProposed { call_id } => {
                 match pending_plan(client, chat, call_id).await {
                     Ok(Some(interaction)) => {
@@ -381,8 +404,8 @@ async fn one_turn(
     Ok(outcome)
 }
 
-/// Settle one parked interaction: ask the driver, fall back to the standing
-/// policy, and carry the decision out. `Some(halt)` ends the run.
+/// Settle one parked interaction: ask the driver and carry the decision out.
+/// If no driver answers, the undriven policy halts the run.
 ///
 /// The interrupt is watched here too. A driven run waiting on a decision line
 /// receives no further frames — the turn is parked on this very answer — so an
@@ -405,16 +428,10 @@ async fn settle(
     };
     let decision = match answered {
         Some(decision) => decision,
-        None => match interaction.undriven() {
-            Undriven::Decide(decision) => {
-                printer.notice(&format!(
-                    "no driver attached; {} answered by standing policy",
-                    interaction.kind()
-                ));
-                decision
-            }
-            Undriven::Halt(halt) => return Some(halt),
-        },
+        None => {
+            let Undriven::Halt(halt) = interaction.undriven();
+            return Some(halt);
+        }
     };
     apply(client, chat, interaction, decision, printer).await
 }
@@ -886,6 +903,12 @@ struct Stream {
     last_seq: i64,
 }
 
+enum StreamNext {
+    Frame(String, ClientEvent),
+    Durable(DurableTurn),
+    Ignore,
+}
+
 impl Stream {
     async fn open(client: &Client, chat: ChatId) -> Result<Self> {
         Ok(Self {
@@ -894,39 +917,55 @@ impl Stream {
         })
     }
 
-    /// The next journaled frame: its raw JSON text and its decoded event.
-    /// `Ok(None)` is a frame with nothing to act on (metadata, a ping, an
-    /// undecodable payload), so the caller simply asks again.
+    /// The next journaled frame, a durable terminal fallback, or an ignorable
+    /// payload such as metadata, a ping, or undecodable text.
     async fn next(
         &mut self,
-        client: &Client,
+        client: &mut Client,
         chat: ChatId,
-    ) -> Result<Option<(String, ClientEvent)>> {
+        turn_id: TurnId,
+    ) -> Result<StreamNext> {
         match self.socket.next().await {
             Some(Ok(Message::Text(text))) => {
                 let Ok(ChatFrame::Event(frame)) = serde_json::from_str::<ChatFrame>(&text) else {
-                    return Ok(None);
+                    return Ok(StreamNext::Ignore);
                 };
                 self.last_seq = frame.seq;
-                Ok(Some((text.to_string(), frame.event)))
+                Ok(StreamNext::Frame(text.to_string(), frame.event))
             }
-            Some(Ok(_)) => Ok(None),
-            Some(Err(_)) | None => {
-                self.reconnect(client, chat).await?;
-                Ok(None)
-            }
+            Some(Ok(_)) => Ok(StreamNext::Ignore),
+            Some(Err(_)) | None => match self.reconnect(client, chat, turn_id).await? {
+                Some(turn) => Ok(StreamNext::Durable(turn)),
+                None => Ok(StreamNext::Ignore),
+            },
         }
     }
 
-    async fn reconnect(&mut self, client: &Client, chat: ChatId) -> Result<()> {
+    async fn reconnect(
+        &mut self,
+        client: &mut Client,
+        chat: ChatId,
+        turn_id: TurnId,
+    ) -> Result<Option<DurableTurn>> {
         let mut last = None;
-        for _ in 0..RECONNECT_ATTEMPTS {
-            tokio::time::sleep(RECONNECT_DELAY).await;
+        for delay in RECONNECT_DELAYS {
+            tokio::time::sleep(delay).await;
+            if let Err(error) = client.refresh_attach_endpoint() {
+                last = Some(error);
+                continue;
+            }
             match client.open_events(chat, self.last_seq).await {
                 Ok(socket) => {
                     self.socket = socket;
-                    return Ok(());
+                    return Ok(None);
                 }
+                Err(error) => last = Some(error),
+            }
+        }
+        if client.refresh_attach_endpoint().is_ok() {
+            match client.durable_turn(chat, turn_id).await {
+                Ok(Some(turn)) => return Ok(Some(turn)),
+                Ok(None) => {}
                 Err(error) => last = Some(error),
             }
         }
@@ -944,6 +983,7 @@ struct Printer {
     /// Whether stdout's last text ended without a newline, so the final flush
     /// can leave the shell prompt on its own line.
     dangling_line: bool,
+    assistant_text: String,
 }
 
 impl Printer {
@@ -952,6 +992,7 @@ impl Printer {
             format,
             tools: HashMap::new(),
             dangling_line: false,
+            assistant_text: String::new(),
         }
     }
 
@@ -969,7 +1010,11 @@ impl Printer {
     }
 
     fn text(&mut self, text: &str) {
-        if self.format != OutputFormat::Text || text.is_empty() {
+        if text.is_empty() {
+            return;
+        }
+        self.assistant_text.push_str(text);
+        if self.format != OutputFormat::Text {
             return;
         }
         let mut stdout = std::io::stdout().lock();
@@ -977,6 +1022,33 @@ impl Printer {
         // Unbuffered: a caller reading the pipe should see the answer form.
         let _ = stdout.flush();
         self.dangling_line = !text.ends_with('\n');
+    }
+
+    fn reconciled(&mut self, turn_id: TurnId, turn: &DurableTurn) {
+        self.notice("the live event stream was unavailable; recovered the terminal turn from the durable transcript");
+        if self.format == OutputFormat::Text {
+            if let Some(suffix) = turn.content.strip_prefix(&self.assistant_text) {
+                self.text(suffix);
+            } else if !turn.content.is_empty() {
+                if !self.assistant_text.is_empty() && !self.assistant_text.ends_with('\n') {
+                    self.text("\n");
+                }
+                self.text(&turn.content);
+            }
+            return;
+        }
+        self.control(serde_json::json!({
+            "tidebreak": protocol::PROTOCOL_VERSION,
+            "type": "turn_reconciled",
+            "turn_id": turn_id,
+            "status": match turn.status {
+                DurableTurnStatus::Completed => "completed",
+                DurableTurnStatus::Failed => "failed",
+                DurableTurnStatus::Cancelled => "cancelled",
+            },
+            "content": turn.content,
+            "last_event_seq": turn.last_event_seq,
+        }));
     }
 
     fn tool_started(&mut self, call_id: CallId, name: String) {

--- a/crates/tidebreak-cli/src/print/driver.rs
+++ b/crates/tidebreak-cli/src/print/driver.rs
@@ -3,7 +3,7 @@
 //! A driver is attached when the caller asked for NDJSON output *and* stdin is
 //! something other than a terminal — a pipe, a socket, a file. Reading a
 //! decision from an unattached driver, or from one whose input has ended,
-//! yields nothing, and the caller falls back to the standing policy in
+//! yields nothing, and the caller applies the undriven policy in
 //! [`super::protocol::Interaction::undriven`]. That is what keeps
 //! `tidebreak -p … --output-format json < /dev/null` from blocking forever on
 //! an answer nobody is going to write.
@@ -40,7 +40,7 @@ impl<R: AsyncBufRead + Unpin> Driver<R> {
     ///
     /// Emits the request event, then reads lines until one decides it.
     /// `None` means no driver answered — unattached, or the input ended — and
-    /// the standing policy applies. Lines that cannot decide the pending
+    /// the undriven policy applies. Lines that cannot decide the pending
     /// request produce an `error` event and are skipped, so one malformed line
     /// does not lose the session.
     pub async fn decide(
@@ -152,9 +152,7 @@ mod tests {
                 .await;
             assert_eq!(decision, None);
 
-            let Undriven::Halt(halt) = interaction.undriven() else {
-                panic!("an unanswered question must halt");
-            };
+            let Undriven::Halt(halt) = interaction.undriven();
             assert_eq!(halt.reason, HaltReason::QuestionsUndriven);
             let event = halt.event();
             assert_eq!(event["type"], "halted");

--- a/crates/tidebreak-cli/src/print/protocol.rs
+++ b/crates/tidebreak-cli/src/print/protocol.rs
@@ -19,11 +19,6 @@ use crate::api::wire::{GrantRung, PendingPlan, PendingQuestions};
 /// Version tag stamped on every event this module emits.
 pub const PROTOCOL_VERSION: &str = "v1";
 
-/// The reason recorded against an approval rejected by standing policy — no
-/// driver was attached to answer it. It reaches the model, which is what lets
-/// it choose another route rather than retry.
-pub const REJECTION_REASON: &str = "non-interactive print mode";
-
 /// Something the turn parked on, waiting for an answer.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Interaction {
@@ -155,15 +150,14 @@ impl Interaction {
         event
     }
 
-    /// What happens when no driver answers: the standing, documented policy.
+    /// What happens when no driver answers.
     pub fn undriven(&self) -> Undriven {
         match self {
-            // Rejecting keeps the turn moving: the model can pick another
-            // route instead of waiting for a human who is not there.
-            Self::Approval { .. } => Undriven::Decide(Decision::Approval {
-                approve: false,
-                reason: REJECTION_REASON.to_owned(),
-                grant: None,
+            Self::Approval { call_id, .. } => Undriven::Halt(Halt {
+                reason: HaltReason::ApprovalDriverUnavailable,
+                call_id: Some(*call_id),
+                message: "the turn requested approval and no driver is attached to decide it"
+                    .to_owned(),
             }),
             Self::Plan { call_id, .. } => Undriven::Halt(Halt {
                 reason: HaltReason::PlanUndriven,
@@ -182,12 +176,10 @@ impl Interaction {
     }
 }
 
-/// The standing answer to an interaction nobody is driving.
+/// The outcome for an interaction nobody is driving.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Undriven {
-    /// Policy can answer this one on its own.
-    Decide(Decision),
-    /// Policy has no answer; the turn ends, loudly.
+    /// The turn ends because no caller can answer the interaction.
     Halt(Halt),
 }
 
@@ -213,6 +205,7 @@ pub enum Decision {
 /// Why an unattended run gave up, in a form a caller can branch on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HaltReason {
+    ApprovalDriverUnavailable,
     PlanUndriven,
     QuestionsUndriven,
     DecisionFailed,
@@ -231,6 +224,7 @@ pub enum HaltReason {
 impl HaltReason {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::ApprovalDriverUnavailable => "approval_driver_unavailable",
             Self::PlanUndriven => "plan_undriven",
             Self::QuestionsUndriven => "questions_undriven",
             Self::DecisionFailed => "decision_failed",
@@ -240,14 +234,16 @@ impl HaltReason {
         }
     }
 
-    /// The process exit status this halt produces. Both undriven reasons share
+    /// The process exit status this halt produces. The undriven reasons share
     /// one code — they are the same fact ("nobody was there to answer") and the
     /// `reason` field separates them. The three failure reasons share one for
     /// the same reason: the run reached something it had to settle and could
     /// not carry it through.
     pub fn exit_code(self) -> i32 {
         match self {
-            Self::PlanUndriven | Self::QuestionsUndriven => super::EXIT_INTERACTION_UNDRIVEN,
+            Self::ApprovalDriverUnavailable | Self::PlanUndriven | Self::QuestionsUndriven => {
+                super::EXIT_INTERACTION_UNDRIVEN
+            }
             Self::DecisionFailed | Self::PendingLookupFailed | Self::FolderDeclineFailed => {
                 super::EXIT_DECISION_FAILED
             }

--- a/crates/tidebreak-cli/tests/serve.rs
+++ b/crates/tidebreak-cli/tests/serve.rs
@@ -3,7 +3,7 @@
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
 use std::path::Path;
-use std::process::{Child, Command, Output, Stdio};
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::str::FromStr;
 use std::time::{Duration, Instant};
 
@@ -17,18 +17,22 @@ const TURN_EXIT_TIMEOUT: Duration = Duration::from_secs(60);
 struct Reaper(Child);
 
 impl Reaper {
-    fn wait_with_output(&mut self, timeout: Duration) -> Output {
+    fn wait_status(&mut self, timeout: Duration) -> ExitStatus {
         let deadline = Instant::now() + timeout;
-        let status = loop {
+        loop {
             if let Some(status) = self.0.try_wait().unwrap() {
-                break status;
+                return status;
             }
             assert!(
                 Instant::now() < deadline,
                 "child did not exit within {timeout:?}"
             );
             std::thread::sleep(Duration::from_millis(10));
-        };
+        }
+    }
+
+    fn wait_with_output(&mut self, timeout: Duration) -> Output {
+        let status = self.wait_status(timeout);
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         if let Some(mut pipe) = self.0.stdout.take() {
@@ -810,6 +814,31 @@ fn get_json(url: &str, token: &str, path: &str) -> serde_json::Value {
         })
 }
 
+fn json_lines(bytes: &[u8]) -> Vec<serde_json::Value> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("every stdout line is JSON"))
+        .collect()
+}
+
+fn wait_for_terminal_status(url: &str, token: &str, chat: &str, status: &str) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let transcript = get_json(url, token, &format!("/chats/{chat}/messages"));
+        if transcript["terminal_turns"]
+            .as_array()
+            .is_some_and(|turns| turns.iter().any(|turn| turn["status"] == status))
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "turn did not reach {status}: {transcript}"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
 /// #2115: `tidebreak attach` of an image must land on the next `-p` user
 /// message. Publishing the blob is not enough — `GET /chats/{id}/messages`
 /// has to show it.
@@ -884,5 +913,292 @@ fn attaching_an_image_lands_on_the_next_print_turn() {
             "height": 1,
         }]),
         "transcript: {transcript}"
+    );
+}
+
+/// A document published through `tidebreak attach` is pending for exactly the
+/// next successfully submitted message. The message binds the document to the
+/// transcript. On macOS, where the local executor is available, exec also sees
+/// the same bytes under `documents/`.
+#[test]
+fn attaching_a_document_lands_on_the_next_turn_and_local_exec_can_read_it() {
+    let served = tempfile::tempdir().unwrap();
+    let elsewhere = tempfile::tempdir().unwrap();
+    let script = if cfg!(target_os = "macos") {
+        serde_json::json!([
+            {
+                "tool": "exec",
+                "input": {
+                    "summary": "Read the attached CSV",
+                    "command": "sh",
+                    "args": ["-c", "cat documents/*"],
+                    "files": ["documents"]
+                }
+            },
+            {"text": "read the CSV"}
+        ])
+    } else {
+        serde_json::json!([{"text": "read the CSV"}])
+    }
+    .to_string();
+    let (_server, url, token) =
+        spawn_serve_with_env(served.path(), &[("TIDEBREAK_SCRIPTED_PROVIDER", &script)]);
+    let chat = create_chat(&url, &token);
+
+    let source = elsewhere.path().join("sales.csv");
+    std::fs::write(&source, "region,total\nwest,42\n").unwrap();
+    let attached = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+        .args(["attach", &chat])
+        .arg(&source)
+        .arg("--server")
+        .arg(&url)
+        .env("TIDEBREAK_SERVER_TOKEN", &token)
+        .env("TIDEBREAK_DATA_DIR", elsewhere.path())
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("attach the CSV");
+    let stderr = String::from_utf8_lossy(&attached.stderr).into_owned();
+    assert!(attached.status.success(), "stderr: {stderr}");
+    let document_id = String::from_utf8_lossy(&attached.stdout).trim().to_owned();
+    assert!(
+        tidebreak_core::DocumentId::from_str(&document_id).is_ok(),
+        "document id: {document_id:?}"
+    );
+
+    let pending = elsewhere
+        .path()
+        .join("pending-document-attachments")
+        .join(&chat);
+    let pending_ids: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&pending).unwrap()).unwrap();
+    assert_eq!(pending_ids, serde_json::json!([document_id]));
+
+    let printed = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+        .args([
+            "-p",
+            "read the attached sales CSV",
+            "--chat",
+            &chat,
+            "--permission-mode",
+            "allow",
+            "--output-format",
+            "json",
+            "--server",
+        ])
+        .arg(&url)
+        .env("TIDEBREAK_SERVER_TOKEN", &token)
+        .env("TIDEBREAK_DATA_DIR", elsewhere.path())
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run -p after attaching the CSV");
+    let stdout = String::from_utf8_lossy(&printed.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&printed.stderr).into_owned();
+    assert!(
+        printed.status.success(),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !pending.exists(),
+        "a successful submission clears the pending id"
+    );
+
+    #[cfg(target_os = "macos")]
+    {
+        let events = json_lines(&printed.stdout);
+        let completed = events
+            .iter()
+            .filter_map(|line| line.get("event"))
+            .find(|event| event["type"] == "tool_call_completed")
+            .unwrap_or_else(|| panic!("exec did not complete: {stdout}"));
+        assert_eq!(completed["status"], "completed", "stdout: {stdout}");
+        assert_eq!(
+            completed["result"]["stdout"], "region,total\nwest,42\n",
+            "stdout: {stdout}"
+        );
+    }
+
+    let transcript = get_json(&url, &token, &format!("/chats/{chat}/messages"));
+    assert_eq!(
+        transcript["messages"][0]["file_attachments"],
+        serde_json::json!([{
+            "document_id": document_id,
+            "name": "sales.csv",
+            "media_type": "text/csv",
+        }]),
+        "transcript: {transcript}"
+    );
+}
+
+/// An approval with no stdin driver is an unavailable interaction, not a user
+/// rejection. Print mode reports one halt, cancels the parked turn, and exits
+/// with the interaction status instead of letting the model retry.
+#[test]
+fn an_undriven_approval_halts_once_and_cancels_the_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = serde_json::json!([{
+        "tool": "exec",
+        "input": {"summary": "Run a command", "command": "true"}
+    }])
+    .to_string();
+    let (_server, url, token) =
+        spawn_serve_with_env(dir.path(), &[("TIDEBREAK_SCRIPTED_PROVIDER", &script)]);
+    let chat = create_chat(&url, &token);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+        .args([
+            "-p",
+            "run the command",
+            "--chat",
+            &chat,
+            "--permission-mode",
+            "ask",
+            "--output-format",
+            "json",
+            "--server",
+        ])
+        .arg(&url)
+        .env("TIDEBREAK_SERVER_TOKEN", &token)
+        .env("TIDEBREAK_DATA_DIR", dir.path())
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run an undriven approval turn");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let lines = json_lines(&output.stdout);
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|line| {
+                line.pointer("/event/type")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("approval_required")
+            })
+            .count(),
+        1,
+        "stdout: {stdout}"
+    );
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|line| line["type"] == "approval_request")
+            .count(),
+        1,
+        "stdout: {stdout}"
+    );
+    let halts = lines
+        .iter()
+        .filter(|line| line["type"] == "halted")
+        .collect::<Vec<_>>();
+    assert_eq!(halts.len(), 1, "stdout: {stdout}");
+    assert_eq!(halts[0]["reason"], "approval_driver_unavailable");
+    assert!(!stdout.contains("approval_decided"), "stdout: {stdout}");
+
+    wait_for_terminal_status(&url, &token, &chat, "cancelled");
+}
+
+/// `--attach` follows the profile's new `listen.json` after a server restart.
+/// The turn starts on the first endpoint and finishes through the second one.
+#[test]
+fn an_attached_print_turn_refreshes_listen_json_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = serde_json::json!([
+        {
+            "tool": "exec",
+            "input": {
+                "summary": "Pause during restart",
+                "command": "sh",
+                "args": ["-c", "sleep 3"]
+            }
+        },
+        {"text": "recovered after restart"}
+    ])
+    .to_string();
+    let (mut first_server, url, first_token) =
+        spawn_serve_with_env(dir.path(), &[("TIDEBREAK_SCRIPTED_PROVIDER", &script)]);
+    let chat = create_chat(&url, &first_token);
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_tidebreak"));
+    command
+        .args([
+            "-p",
+            "survive the restart",
+            "--chat",
+            &chat,
+            "--permission-mode",
+            "allow",
+            "--output-format",
+            "json",
+            "--attach",
+        ])
+        .env("TIDEBREAK_DATA_DIR", dir.path())
+        .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_SERVER_URL")
+        .env_remove("TIDEBREAK_SERVER_TOKEN")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = Reaper(command.spawn().expect("spawn an attached print turn"));
+    let stdout = child.0.stdout.take().unwrap();
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        let mut captured = String::new();
+        for line in BufReader::new(stdout).lines() {
+            let line = line.unwrap();
+            if serde_json::from_str::<serde_json::Value>(&line)
+                .ok()
+                .is_some_and(|value| {
+                    value
+                        .pointer("/event/type")
+                        .and_then(serde_json::Value::as_str)
+                        == Some("tool_call_started")
+                })
+            {
+                let _ = started_tx.send(());
+            }
+            captured.push_str(&line);
+            captured.push('\n');
+        }
+        captured
+    });
+
+    started_rx
+        .recv_timeout(TURN_EXIT_TIMEOUT)
+        .expect("the turn reaches exec before the restart");
+    first_server.0.kill().unwrap();
+    first_server.0.wait().unwrap();
+
+    let (_second_server, _second_url, second_token) =
+        spawn_serve_with_env(dir.path(), &[("TIDEBREAK_SCRIPTED_PROVIDER", &script)]);
+    assert_ne!(
+        first_token, second_token,
+        "a restart rotates attach credentials"
+    );
+
+    let status = child.wait_status(Duration::from_secs(90));
+    let stdout = reader.join().unwrap();
+    let mut stderr = String::new();
+    child
+        .0
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+    assert_eq!(status.code(), Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        stdout.contains("\"type\":\"turn_completed\""),
+        "stdout: {stdout}"
     );
 }

--- a/crates/tidebreak-code-execution/src/preview.rs
+++ b/crates/tidebreak-code-execution/src/preview.rs
@@ -70,6 +70,7 @@ pub fn scan_preview_directory(preview_dir: &Path) -> PreviewScan {
         }
     };
     let mut candidates = Vec::new();
+    let mut unsupported = Vec::new();
     for entry in entries.flatten() {
         let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
             continue;
@@ -84,6 +85,7 @@ pub fn scan_preview_directory(preview_dir: &Path) -> PreviewScan {
             continue;
         }
         if preview_media_type_from_extension(&name).is_none() {
+            unsupported.push(name);
             continue;
         }
         candidates.push(Candidate { name });
@@ -93,6 +95,14 @@ pub fn scan_preview_directory(preview_dir: &Path) -> PreviewScan {
             .cmp(&preview_priority(&right.name))
             .then_with(|| alphabetical(&left.name, &right.name))
     });
+    unsupported.sort_by(|left, right| alphabetical(left, right));
+
+    if !unsupported.is_empty() {
+        scan.notes.push(format!(
+            "unsupported preview file(s): {}. preview/ accepts PNG, JPEG, or WebP images. Keep SVG and other source files in output/, and write a raster copy to preview/ for visual review.",
+            unsupported.join(", ")
+        ));
+    }
 
     let mut rejected = Vec::new();
     let mut omitted = Vec::new();
@@ -339,5 +349,23 @@ mod tests {
         write_png(dir.path(), "actually-png.jpg", 24, 12);
         let scan = scan_preview_directory(dir.path());
         assert_eq!(scan.images[0].0.media_type, ImageMediaType::Png);
+    }
+
+    #[test]
+    fn unsupported_preview_files_produce_an_actionable_note() {
+        let preview = tempfile::tempdir().unwrap();
+        std::fs::write(
+            preview.path().join("palette.svg"),
+            r#"<svg xmlns="http://www.w3.org/2000/svg"></svg>"#,
+        )
+        .unwrap();
+
+        let scan = scan_preview_directory(preview.path());
+
+        assert!(scan.images.is_empty());
+        assert_eq!(scan.notes.len(), 1);
+        assert!(scan.notes[0].contains("palette.svg"));
+        assert!(scan.notes[0].contains("PNG, JPEG, or WebP"));
+        assert!(scan.notes[0].contains("output/"));
     }
 }

--- a/crates/tidebreak-core/fixtures/code-journal-events.json
+++ b/crates/tidebreak-core/fixtures/code-journal-events.json
@@ -74,7 +74,8 @@
       "output_tokens": 22,
       "cache_read_input_tokens": 33,
       "cache_creation_input_tokens": 44,
-      "context_tokens": 88
+      "context_tokens": 88,
+      "first_call_context_tokens": 55
     },
     "checkpoint": {
       "checkpoint_ref": "refs/tidebreak/checkpoints/ws/1",

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -176,6 +176,12 @@ pub struct CodeUsage {
     /// Zero when the engine does not publish enough to compute it.
     #[serde(default)]
     pub context_tokens: u64,
+    /// Prompt tokens resident on the turn's first model call, when the engine
+    /// publishes per-call usage. This exposes startup context separately from
+    /// context that grows while the turn runs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub first_call_context_tokens: Option<u64>,
 }
 
 /// Hint that a turn recorded a checkpoint. The diff body is loaded separately.
@@ -496,6 +502,7 @@ mod tests {
                     cache_read_input_tokens: 33,
                     cache_creation_input_tokens: 44,
                     context_tokens: 88,
+                    first_call_context_tokens: Some(55),
                 },
                 checkpoint: Some(CheckpointHint {
                     checkpoint_ref: Some("refs/tidebreak/checkpoints/ws/1".into()),

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -410,6 +410,16 @@ describe("parseCodeTurnList", () => {
     expect(parsed?.usage).toEqual({ ...older, context_tokens: 0 });
   });
 
+  it("keeps optional first-call context and accepts older usage without it", () => {
+    expect(
+      parseCodeTurn({
+        ...TURN,
+        usage: { ...USAGE, first_call_context_tokens: 9_500 },
+      })?.usage,
+    ).toEqual({ ...USAGE, first_call_context_tokens: 9_500 });
+    expect(parseCodeTurn({ ...TURN, usage: USAGE })?.usage).toEqual(USAGE);
+  });
+
   it("rejects a non-array or a row the turn parser would drop", () => {
     expect(parseCodeTurnList({ turns: [TURN] })).toBeNull();
     expect(parseCodeTurnList([{ ...TURN, status: "paused" }])).toBeNull();

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -3458,12 +3458,22 @@ function parseUsage(value: unknown): CodeUsage | null {
   if (contextTokens !== undefined && !isFiniteNumber(contextTokens)) {
     return null;
   }
+  const firstCallContextTokens = value.first_call_context_tokens;
+  if (
+    firstCallContextTokens !== undefined &&
+    !isFiniteNumber(firstCallContextTokens)
+  ) {
+    return null;
+  }
   return {
     input_tokens: value.input_tokens,
     output_tokens: value.output_tokens,
     cache_read_input_tokens: value.cache_read_input_tokens,
     cache_creation_input_tokens: value.cache_creation_input_tokens,
     context_tokens: contextTokens ?? 0,
+    ...(firstCallContextTokens === undefined
+      ? {}
+      : { first_call_context_tokens: firstCallContextTokens }),
   };
 }
 

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1686,7 +1686,13 @@ cache_creation_input_tokens: number,
  *
  * Zero when the engine does not publish enough to compute it.
  */
-context_tokens: number, };
+context_tokens: number, 
+/**
+ * Prompt tokens resident on the turn's first model call, when the engine
+ * publishes per-call usage. This exposes startup context separately from
+ * context that grows while the turn runs.
+ */
+first_call_context_tokens?: number, };
 
 /**
  * Identifies one durable watch task on a workspace's pull request.

--- a/crates/tidebreak-harness/Cargo.toml
+++ b/crates/tidebreak-harness/Cargo.toml
@@ -26,6 +26,7 @@ tidebreak-code-execution = { path = "../tidebreak-code-execution" }
 tidebreak-core = { path = "../tidebreak-core", default-features = false }
 tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "sync", "time"] }
 tracing = { workspace = true }
+uuid = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
@@ -47,7 +47,8 @@
       "output_tokens": 107,
       "cache_read_input_tokens": 103012,
       "cache_creation_input_tokens": 186,
-      "context_tokens": 51694
+      "context_tokens": 51694,
+      "first_call_context_tokens": 51694
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
@@ -35,7 +35,8 @@
       "output_tokens": 140,
       "cache_read_input_tokens": 99470,
       "cache_creation_input_tokens": 3728,
-      "context_tokens": 51679
+      "context_tokens": 51679,
+      "first_call_context_tokens": 51679
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
@@ -44,7 +44,8 @@
       "output_tokens": 123,
       "cache_read_input_tokens": 91858,
       "cache_creation_input_tokens": 3759,
-      "context_tokens": 47883
+      "context_tokens": 47883,
+      "first_call_context_tokens": 47883
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/plain-text.expected.json
@@ -20,7 +20,8 @@
       "output_tokens": 574,
       "cache_read_input_tokens": 44122,
       "cache_creation_input_tokens": 5211,
-      "context_tokens": 49335
+      "context_tokens": 49335,
+      "first_call_context_tokens": 49335
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/resume.expected.json
@@ -24,7 +24,8 @@
       "output_tokens": 14,
       "cache_read_input_tokens": 49333,
       "cache_creation_input_tokens": 596,
-      "context_tokens": 49931
+      "context_tokens": 49931,
+      "first_call_context_tokens": 49931
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
@@ -82,7 +82,8 @@
       "output_tokens": 196,
       "cache_read_input_tokens": 142916,
       "cache_creation_input_tokens": 5479,
-      "context_tokens": 49603
+      "context_tokens": 49603,
+      "first_call_context_tokens": 49603
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/two-turn.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/two-turn.expected.json
@@ -20,7 +20,8 @@
       "output_tokens": 2,
       "cache_read_input_tokens": 0,
       "cache_creation_input_tokens": 29585,
-      "context_tokens": 49335
+      "context_tokens": 49335,
+      "first_call_context_tokens": 49335
     }
   },
   {
@@ -38,7 +39,8 @@
       "output_tokens": 2,
       "cache_read_input_tokens": 37451,
       "cache_creation_input_tokens": 29,
-      "context_tokens": 49335
+      "context_tokens": 49335,
+      "first_call_context_tokens": 49335
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
@@ -120,7 +120,8 @@
       "output_tokens": 118,
       "cache_read_input_tokens": 23040,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 14466
+      "context_tokens": 14466,
+      "first_call_context_tokens": 14328
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
@@ -116,7 +116,8 @@
       "output_tokens": 132,
       "cache_read_input_tokens": 23040,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 14499
+      "context_tokens": 14499,
+      "first_call_context_tokens": 14326
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/collab-agents.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/collab-agents.expected.json
@@ -196,7 +196,8 @@
       "output_tokens": 285,
       "cache_read_input_tokens": 89856,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 23449
+      "context_tokens": 23449,
+      "first_call_context_tokens": 14407
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/plain-text.expected.json
@@ -31,7 +31,8 @@
       "output_tokens": 7,
       "cache_read_input_tokens": 8960,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 13959
+      "context_tokens": 13959,
+      "first_call_context_tokens": 13959
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
@@ -27,7 +27,8 @@
       "output_tokens": 6,
       "cache_read_input_tokens": 14080,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 15352
+      "context_tokens": 15352,
+      "first_call_context_tokens": 15352
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
@@ -44,7 +44,8 @@
       "output_tokens": 114,
       "cache_read_input_tokens": 22016,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 14109
+      "context_tokens": 14109,
+      "first_call_context_tokens": 13975
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/permission-denied.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/permission-denied.expected.json
@@ -379,7 +379,8 @@
       "output_tokens": 161,
       "cache_read_input_tokens": 36608,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 18311
+      "context_tokens": 18311,
+      "first_call_context_tokens": 18163
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/plain-text.expected.json
@@ -356,7 +356,8 @@
       "output_tokens": 17,
       "cache_read_input_tokens": 18048,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 18150
+      "context_tokens": 18150,
+      "first_call_context_tokens": 18150
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/resume.expected.json
@@ -84,7 +84,8 @@
       "output_tokens": 17,
       "cache_read_input_tokens": 384,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 18674
+      "context_tokens": 18674,
+      "first_call_context_tokens": 18674
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.4/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.4/tool-use.expected.json
@@ -291,7 +291,8 @@
       "output_tokens": 84,
       "cache_read_input_tokens": 9728,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 9483
+      "context_tokens": 9483,
+      "first_call_context_tokens": 9434
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/grok/1.0.5/subagent-task.expected.json
+++ b/crates/tidebreak-harness/fixtures/grok/1.0.5/subagent-task.expected.json
@@ -74,7 +74,8 @@
       "output_tokens": 18,
       "cache_read_input_tokens": 0,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 40
+      "context_tokens": 40,
+      "first_call_context_tokens": 40
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/approval-approve.expected.json
@@ -145,7 +145,8 @@
       "output_tokens": 3,
       "cache_read_input_tokens": 7552,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 7675
+      "context_tokens": 7675,
+      "first_call_context_tokens": 7571
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/plain-text.expected.json
@@ -87,7 +87,8 @@
       "output_tokens": 4,
       "cache_read_input_tokens": 0,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 8281
+      "context_tokens": 8281,
+      "first_call_context_tokens": 8281
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/resume.expected.json
@@ -31,7 +31,8 @@
       "output_tokens": 4,
       "cache_read_input_tokens": 8192,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 8308
+      "context_tokens": 8308,
+      "first_call_context_tokens": 8308
     }
   }
 ]

--- a/crates/tidebreak-harness/fixtures/opencode/1.18.18/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/opencode/1.18.18/tool-use.expected.json
@@ -126,7 +126,8 @@
       "output_tokens": 2,
       "cache_read_input_tokens": 6272,
       "cache_creation_input_tokens": 0,
-      "context_tokens": 6397
+      "context_tokens": 6397,
+      "first_call_context_tokens": 6256
     }
   }
 ]

--- a/crates/tidebreak-harness/src/claude/parse.rs
+++ b/crates/tidebreak-harness/src/claude/parse.rs
@@ -252,7 +252,7 @@ impl ClaudeStreamParser {
                 Some(key) => self.close_tool_block(&key),
                 None => Vec::new(),
             },
-            "message_start" | "message_delta" | "message_stop" => Vec::new(),
+            "message_start" | "message_delta" | "message_stop" | "ping" => Vec::new(),
             other => {
                 self.count_unrecognized(&format!("stream_event/{other}"), event);
                 Vec::new()
@@ -672,6 +672,7 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
             .and_then(Value::as_u64)
             .unwrap_or(0),
         context_tokens: context_tokens_from(value),
+        first_call_context_tokens: first_call_context_tokens_from(value),
     }
 }
 
@@ -694,6 +695,28 @@ fn context_tokens_from(usage: &Value) -> u64 {
     field("input_tokens")
         .saturating_add(field("cache_read_input_tokens"))
         .saturating_add(field("cache_creation_input_tokens"))
+}
+
+fn first_call_context_tokens_from(usage: &Value) -> Option<u64> {
+    let call = usage
+        .get("iterations")
+        .and_then(Value::as_array)
+        .and_then(|iterations| iterations.first())?;
+    let tokens = call
+        .get("input_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        .saturating_add(
+            call.get("cache_read_input_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+        )
+        .saturating_add(
+            call.get("cache_creation_input_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+        );
+    (tokens > 0).then_some(tokens)
 }
 
 fn bound(text: &str, max: usize) -> String {
@@ -730,6 +753,7 @@ mod tests {
         let parsed = usage_from(Some(&usage));
 
         assert_eq!(parsed.context_tokens, 49_603);
+        assert_eq!(parsed.first_call_context_tokens, Some(49_335));
         // The four spend counts keep the turn totals they already carried.
         assert_eq!(parsed.cache_read_input_tokens, 142_916);
         assert_eq!(parsed.output_tokens, 196);
@@ -770,6 +794,14 @@ mod tests {
             Some(HarnessEvent::TurnCompleted { .. })
         ));
         assert_eq!(out.resume_ref.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn stream_ping_is_a_known_noop() {
+        let out =
+            ClaudeStreamParser::parse_ndjson(r#"{"type":"stream_event","event":{"type":"ping"}}"#);
+        assert_eq!(out.unrecognized, 0);
+        assert!(out.events.is_empty());
     }
 
     /// The captured streams repeat a finished block on an `assistant` line

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -5,7 +5,10 @@
 //! stream's own `result` line ends the turn; the child stays up for the next
 //! one. Record 57 has the measurements that forced this.
 
-use std::io;
+use std::collections::{BTreeMap, BTreeSet};
+use std::hash::Hasher;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -84,14 +87,11 @@ pub(crate) fn effort_flags(effort: Option<ReasoningEffort>) -> Vec<String> {
     vec!["--effort".into(), token.to_owned()]
 }
 
-/// The `--settings` flag that arms fast mode, or nothing when it is off or the
-/// model cannot serve it.
+/// The single `--settings` flag for Tidebreak-owned Claude settings.
 ///
-/// `fastMode` is a settings key rather than a flag of its own, and `--settings`
-/// takes inline JSON as well as a path. Off is the engine's own default, so an
-/// off session composes no flag at all rather than an explicit `false` — that
-/// keeps argv identical to what a session without the feature would produce,
-/// and leaves a user's own settings file to speak for itself.
+/// `plansDirectory` keeps Claude's Plan-mode notes outside both the worktree
+/// and the user's default `~/.claude/plans` directory. `fastMode` shares this
+/// object because Claude accepts one inline JSON settings value.
 ///
 /// The model check is here rather than at the route that stores the bit,
 /// because this is the first point that knows which model the turn actually
@@ -100,12 +100,147 @@ pub(crate) fn effort_flags(effort: Option<ReasoningEffort>) -> Vec<String> {
 /// Dropping the flag degrades that turn to standard speed, which is the same
 /// degrade-don't-refuse rule effort follows — and it is the honest direction,
 /// since the alternative claims a premium the model would never run.
-#[must_use]
-pub(crate) fn fast_mode_flags(fast_mode: bool, model: Option<&str>) -> Vec<String> {
-    if !fast_mode || !model.is_some_and(crate::claude::model_serves_fast_mode) {
-        return Vec::new();
+pub(crate) fn settings_flags(
+    plans_directory: &Path,
+    fast_mode: bool,
+    model: Option<&str>,
+) -> Result<Vec<String>, HarnessError> {
+    let plans_directory = plans_directory
+        .to_str()
+        .ok_or_else(|| HarnessError::Other("Claude plans directory must be valid UTF-8".into()))?;
+    let mut settings = serde_json::Map::from_iter([(
+        "plansDirectory".to_owned(),
+        serde_json::Value::String(plans_directory.to_owned()),
+    )]);
+    if fast_mode && model.is_some_and(crate::claude::model_serves_fast_mode) {
+        settings.insert("fastMode".to_owned(), serde_json::Value::Bool(true));
     }
-    vec!["--settings".into(), r#"{"fastMode":true}"#.to_owned()]
+    Ok(vec![
+        "--settings".into(),
+        serde_json::Value::Object(settings).to_string(),
+    ])
+}
+
+/// One file-system entry under Claude's default plan directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlanEntry {
+    kind: u8,
+    len: u64,
+    modified_nanos: u128,
+    content_hash: u64,
+}
+
+/// Snapshot of the default plan directory before a Plan-mode turn.
+struct PlanWriteGuard {
+    root: PathBuf,
+    before: BTreeMap<PathBuf, PlanEntry>,
+}
+
+impl PlanWriteGuard {
+    fn capture(root: PathBuf) -> io::Result<Self> {
+        let before = snapshot_directory(&root)?;
+        Ok(Self { root, before })
+    }
+
+    fn changed_path(&self) -> io::Result<Option<PathBuf>> {
+        let after = snapshot_directory(&self.root)?;
+        let paths = self
+            .before
+            .keys()
+            .chain(after.keys())
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let changed = |path: &PathBuf| self.before.get(path) != after.get(path);
+        Ok(paths
+            .iter()
+            .find(|path| !path.as_os_str().is_empty() && changed(path))
+            .cloned()
+            .or_else(|| paths.into_iter().find(changed))
+            .map(|path| self.root.join(path)))
+    }
+}
+
+fn snapshot_directory(root: &Path) -> io::Result<BTreeMap<PathBuf, PlanEntry>> {
+    let mut entries = BTreeMap::new();
+    if !root.exists() {
+        return Ok(entries);
+    }
+    snapshot_directory_at(root, root, &mut entries)?;
+    Ok(entries)
+}
+
+fn snapshot_directory_at(
+    root: &Path,
+    path: &Path,
+    entries: &mut BTreeMap<PathBuf, PlanEntry>,
+) -> io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    let relative = path.strip_prefix(root).unwrap_or(path).to_path_buf();
+    let file_type = metadata.file_type();
+    let kind = if file_type.is_dir() {
+        1
+    } else if file_type.is_file() {
+        2
+    } else if file_type.is_symlink() {
+        3
+    } else {
+        4
+    };
+    let modified_nanos = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |duration| duration.as_nanos());
+    let content_hash = if file_type.is_file() {
+        hash_file(path)?
+    } else if file_type.is_symlink() {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        hasher.write(std::fs::read_link(path)?.as_os_str().as_encoded_bytes());
+        hasher.finish()
+    } else {
+        0
+    };
+    entries.insert(
+        relative,
+        PlanEntry {
+            kind,
+            len: metadata.len(),
+            modified_nanos,
+            content_hash,
+        },
+    );
+    if file_type.is_dir() {
+        let mut children = std::fs::read_dir(path)?.collect::<io::Result<Vec<_>>>()?;
+        children.sort_by_key(std::fs::DirEntry::file_name);
+        for child in children {
+            snapshot_directory_at(root, &child.path(), entries)?;
+        }
+    }
+    Ok(())
+}
+
+fn hash_file(path: &Path) -> io::Result<u64> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.write(&buffer[..read]);
+    }
+    Ok(hasher.finish())
+}
+
+fn ensure_private_directory(path: &Path) -> io::Result<()> {
+    std::fs::create_dir_all(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
 }
 
 /// The prompt as the engine receives it: the user's text, plus the ultracode
@@ -264,6 +399,8 @@ struct TurnRead {
 /// Live Claude Code session: one child for the session lifetime.
 pub struct ClaudeSession {
     spec: SessionSpec,
+    /// Tidebreak-owned destination for Claude's Plan-mode files.
+    plans_directory: PathBuf,
     /// The session's current permission mode, which a live switch moves.
     /// `spec.permission_mode` is only what it started on.
     permission_mode: Mutex<PermissionMode>,
@@ -297,8 +434,12 @@ impl ClaudeSession {
     pub(super) fn new(spec: SessionSpec) -> Self {
         let resume_ref = spec.resume_ref.clone();
         let permission_mode = spec.permission_mode;
+        let plans_directory = std::env::temp_dir()
+            .join("tidebreak-claude-plans")
+            .join(uuid::Uuid::new_v4().to_string());
         Self {
             spec,
+            plans_directory,
             permission_mode: Mutex::new(permission_mode),
             resume_ref: Mutex::new(resume_ref),
             channel: AsyncMutex::new(None),
@@ -339,6 +480,36 @@ impl ClaudeSession {
         *self.permission_mode.lock().expect("claude permission mode")
     }
 
+    fn default_plans_directory(&self) -> Option<PathBuf> {
+        let extra_home = self
+            .spec
+            .extra_env
+            .iter()
+            .rev()
+            .find(|(key, _)| key.eq_ignore_ascii_case("HOME"))
+            .map(|(_, value)| PathBuf::from(value.as_str()));
+        let probed_home = self
+            .spec
+            .env
+            .iter()
+            .rev()
+            .find(|(key, _)| key.eq_ignore_ascii_case("HOME"))
+            .map(|(_, value)| PathBuf::from(value.as_os_str()));
+        extra_home
+            .or(probed_home)
+            .map(|home| home.join(".claude").join("plans"))
+    }
+
+    fn plan_write_guard(&self) -> Result<Option<PlanWriteGuard>, HarnessError> {
+        if self.permission_mode() != PermissionMode::Plan {
+            return Ok(None);
+        }
+        self.default_plans_directory()
+            .map(PlanWriteGuard::capture)
+            .transpose()
+            .map_err(HarnessError::from)
+    }
+
     fn compose_plan_for(
         &self,
         turn_model: Option<&str>,
@@ -365,10 +536,12 @@ impl ClaudeSession {
             argv.push(model);
         }
         argv.extend(effort_flags(self.resolved_effort(turn_effort)));
-        argv.extend(fast_mode_flags(
+        ensure_private_directory(&self.plans_directory)?;
+        argv.extend(settings_flags(
+            &self.plans_directory,
             self.spec.fast_mode,
             self.resolved_model(turn_model).as_deref(),
-        ));
+        )?);
         if let Some(flags) = crate::claude::browser::launch_args_for_mcp_channels(
             self.spec.approval.as_ref(),
             self.spec.browser.as_ref(),
@@ -589,11 +762,8 @@ impl ClaudeSession {
             None => Ok(TurnRead { saw_terminal, eof }),
         }
     }
-}
 
-#[async_trait]
-impl HarnessSession for ClaudeSession {
-    async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
+    async fn run_turn_inner(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
         self.interrupts_this_turn.store(0, Ordering::SeqCst);
         self.turn_in_flight.store(true, Ordering::SeqCst);
         let _in_flight = TurnGuard(&self.turn_in_flight);
@@ -605,11 +775,6 @@ impl HarnessSession for ClaudeSession {
                 .await?;
             match self.write_line(&channel, &prompt).await {
                 Ok(()) => break channel,
-                // A child that died between turns leaves a pipe that only
-                // answers on write. Respawning resumes the session, so the
-                // user's message is delivered rather than lost. A child that
-                // was just spawned and already refuses stdin is a real
-                // failure, not a stale handle.
                 Err(err) if !fresh && !retried => {
                     retried = true;
                     warn!(%err, "engine child refused the turn; respawning");
@@ -625,8 +790,6 @@ impl HarnessSession for ClaudeSession {
         let read = match self.read_turn(&channel).await {
             Ok(read) => read,
             Err(err) => {
-                // The stream is unusable. Retire the child so the next turn
-                // starts a fresh one and resumes.
                 self.retire_channel().await;
                 return Err(err);
             }
@@ -637,12 +800,9 @@ impl HarnessSession for ClaudeSession {
             if !stderr.is_empty() {
                 warn!(bytes = stderr.len(), "engine stderr (capped)");
             }
-            // The child is still up and the stream closed the turn itself.
             return Ok(turn_outcome(None, read.saw_terminal, &stderr));
         }
 
-        // Stdout closed: the process is gone. Report how it ended and drop it,
-        // so the next turn respawns and resumes from the session's ref.
         let status = channel.exit_status().await;
         let stderr = channel.take_final_stderr().await;
         if !stderr.is_empty() {
@@ -650,6 +810,26 @@ impl HarnessSession for ClaudeSession {
         }
         self.retire_channel().await;
         Ok(turn_outcome(status, read.saw_terminal, &stderr))
+    }
+}
+
+#[async_trait]
+impl HarnessSession for ClaudeSession {
+    async fn run_turn(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
+        let guard = self.plan_write_guard()?;
+        let outcome = self.run_turn_inner(input).await;
+        if let Some(path) = guard
+            .as_ref()
+            .map(PlanWriteGuard::changed_path)
+            .transpose()?
+            .flatten()
+        {
+            self.retire_channel().await;
+            return Err(HarnessError::PlanWriteOutsideWorktree(
+                path.to_string_lossy().into_owned(),
+            ));
+        }
+        outcome
     }
 
     async fn decide(
@@ -788,6 +968,7 @@ impl HarnessSession for ClaudeSession {
         if let Some(channel) = taken {
             channel.stop(None).await;
         }
+        let _ = std::fs::remove_dir_all(&self.plans_directory);
         Ok(())
     }
 }
@@ -1104,6 +1285,36 @@ mod tests {
         assert_eq!(plan.argv[index + 1], "low");
     }
 
+    #[test]
+    fn tidebreak_settings_redirect_plans_and_merge_fast_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut session = session_with_mode(
+            PathBuf::from("/usr/bin/claude"),
+            dir.path(),
+            Arc::new(Discard),
+            PermissionMode::Plan,
+        );
+        session.spec.model = Some("claude-opus-5".into());
+        session.spec.fast_mode = true;
+
+        let plan = session.compose_plan_for(None, None).unwrap();
+        let settings_indexes = plan
+            .argv
+            .iter()
+            .enumerate()
+            .filter_map(|(index, arg)| (arg == "--settings").then_some(index))
+            .collect::<Vec<_>>();
+        assert_eq!(settings_indexes.len(), 1);
+        let settings: serde_json::Value =
+            serde_json::from_str(&plan.argv[settings_indexes[0] + 1]).unwrap();
+        assert_eq!(settings["fastMode"], true);
+        assert_eq!(
+            settings["plansDirectory"],
+            session.plans_directory.to_string_lossy().as_ref()
+        );
+        assert!(!session.plans_directory.starts_with(dir.path()));
+    }
+
     /// The control request reaches `plan`, `manual`, and `acceptEdits`.
     /// `Allow` is the bypass flag, which only a fresh child can carry.
     #[test]
@@ -1411,6 +1622,36 @@ done
             other => panic!("a child that exited 3 must not look clean: {other:?}"),
         }
         assert_eq!(session.child_pid(), None, "the pid is cleared on exit");
+    }
+
+    #[tokio::test]
+    async fn plan_mode_fails_if_the_engine_writes_to_the_default_home_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let worktree = dir.path().join("worktree");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&worktree).unwrap();
+        let binary = write_engine(
+            dir.path(),
+            r#"#!/bin/sh
+while IFS= read -r line; do
+  mkdir -p "$HOME/.claude/plans"
+  printf 'escaped\n' > "$HOME/.claude/plans/escaped.md"
+  printf '{"type":"system","subtype":"init","session_id":"sess-plan","claude_code_version":"2.1.245"}\n'
+  printf '{"type":"result","subtype":"success","is_error":false,"terminal_reason":"completed","session_id":"sess-plan","usage":{"input_tokens":1,"output_tokens":1}}\n'
+done
+"#,
+        );
+        let mut session = session_with(binary, &worktree, Arc::new(Discard));
+        session.spec.env = vec![("HOME".into(), home.as_os_str().to_owned())];
+
+        let error = session.run_turn(turn("plan this")).await.unwrap_err();
+        assert!(matches!(
+            error,
+            HarnessError::PlanWriteOutsideWorktree(path)
+                if path.ends_with(".claude/plans/escaped.md")
+        ));
+        assert_eq!(session.child_pid(), None, "the violating child is retired");
     }
 
     /// The whole point of record 57: two turns, one process, and a turn that

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -646,6 +646,7 @@ mod tests {
                 cache_read_input_tokens: 14_080,
                 cache_creation_input_tokens: 0,
                 context_tokens: 15_352,
+                first_call_context_tokens: Some(15_352),
             },
             "the resumed turn must not inherit the first turn's spend"
         );

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -42,6 +42,8 @@ pub struct CodexStreamParser {
     parent_turn_active: bool,
     /// Thread-wide counters at the start of the active turn.
     turn_usage_baseline: CodeUsage,
+    /// Prompt resident on the first usage update after `turn/started`.
+    turn_first_call_context_tokens: Option<u64>,
     /// Latest thread-wide counters plus the final call's context occupancy.
     last_usage: CodeUsage,
     last_turn_id: Option<String>,
@@ -232,6 +234,7 @@ impl CodexStreamParser {
                 }
                 self.parent_turn_active = true;
                 self.turn_usage_baseline = self.last_usage.clone();
+                self.turn_first_call_context_tokens = None;
                 vec![HarnessEvent::TurnStarted]
             }
             "turn/completed" if parent_thread => self.parse_turn_completed(&params),
@@ -255,7 +258,12 @@ impl CodexStreamParser {
                 // The app server multiplexes child threads over the parent's
                 // connection. Their counters must not replace the parent's.
                 if parent_thread {
-                    self.last_usage = usage_from(params.get("tokenUsage"));
+                    let usage = usage_from(params.get("tokenUsage"));
+                    if self.parent_turn_active && self.turn_first_call_context_tokens.is_none() {
+                        self.turn_first_call_context_tokens =
+                            (usage.context_tokens > 0).then_some(usage.context_tokens);
+                    }
+                    self.last_usage = usage;
                 }
                 Vec::new()
             }
@@ -302,6 +310,7 @@ impl CodexStreamParser {
         }
         match item.get("type").and_then(Value::as_str) {
             Some("commandExecution") => self.emit_tool_started(&item, parent_call_id),
+            Some("fileChange") => self.emit_file_change_started(&item, parent_call_id),
             Some("collabAgentToolCall") => self.emit_collab_started(&item, parent_call_id),
             Some("subAgentActivity" | "userMessage" | "agentMessage" | "reasoning") => Vec::new(),
             Some(other) => {
@@ -323,6 +332,7 @@ impl CodexStreamParser {
         }
         match item.get("type").and_then(Value::as_str) {
             Some("commandExecution") => self.emit_tool_completed(&item, parent_call_id),
+            Some("fileChange") => self.emit_file_change_completed(&item, parent_call_id),
             Some("collabAgentToolCall") => self.emit_collab_completed(&item, parent_call_id),
             Some("agentMessage") => {
                 let text = item.get("text").and_then(Value::as_str).unwrap_or("");
@@ -378,7 +388,11 @@ impl CodexStreamParser {
         self.parent_turn_active = false;
         match status {
             "completed" => vec![HarnessEvent::TurnCompleted {
-                usage: turn_usage_since(&self.last_usage, &self.turn_usage_baseline),
+                usage: turn_usage_since(
+                    &self.last_usage,
+                    &self.turn_usage_baseline,
+                    self.turn_first_call_context_tokens,
+                ),
             }],
             "interrupted" => vec![HarnessEvent::TurnInterrupted],
             "failed" => {
@@ -411,7 +425,11 @@ impl CodexStreamParser {
                         ),
                     },
                     HarnessEvent::TurnCompleted {
-                        usage: turn_usage_since(&self.last_usage, &self.turn_usage_baseline),
+                        usage: turn_usage_since(
+                            &self.last_usage,
+                            &self.turn_usage_baseline,
+                            self.turn_first_call_context_tokens,
+                        ),
                     },
                 ]
             }
@@ -808,6 +826,66 @@ impl CodexStreamParser {
         }]
     }
 
+    fn emit_file_change_started(
+        &mut self,
+        item: &Value,
+        parent_call_id: Option<String>,
+    ) -> Vec<HarnessEvent> {
+        let call_id = item
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned();
+        if call_id.is_empty() || !self.started_tools.insert(call_id.clone()) {
+            return Vec::new();
+        }
+        vec![HarnessEvent::ToolStarted {
+            call_id,
+            name: "fileChange".into(),
+            detail: file_change_detail(item),
+            parent_call_id,
+        }]
+    }
+
+    fn emit_file_change_completed(
+        &mut self,
+        item: &Value,
+        parent_call_id: Option<String>,
+    ) -> Vec<HarnessEvent> {
+        let call_id = item
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned();
+        if call_id.is_empty() {
+            return Vec::new();
+        }
+        let detail = file_change_detail(item);
+        let mut events = Vec::new();
+        if self.started_tools.insert(call_id.clone()) {
+            events.push(HarnessEvent::ToolStarted {
+                call_id: call_id.clone(),
+                name: "fileChange".into(),
+                detail: detail.clone(),
+                parent_call_id: parent_call_id.clone(),
+            });
+        }
+        let status = item.get("status").and_then(Value::as_str).unwrap_or("");
+        let outcome = match status {
+            "declined" => ToolOutcome::Denied,
+            "failed" | "cancelled" | "canceled" => ToolOutcome::Failed,
+            _ => ToolOutcome::Succeeded,
+        };
+        events.push(HarnessEvent::ToolCompleted {
+            call_id,
+            outcome,
+            preview: file_change_preview(item),
+            detail: (detail.specificity() > 0).then_some(detail),
+            parent_call_id,
+        });
+        events
+    }
+
     fn count_unrecognized(&mut self, label: &str, payload: impl std::fmt::Display) {
         self.unrecognized += 1;
         let mut rendered = payload.to_string();
@@ -944,6 +1022,30 @@ fn command_detail(item: &Value) -> ToolDetail {
     }
 }
 
+fn file_change_detail(item: &Value) -> ToolDetail {
+    let path = item
+        .get("changes")
+        .and_then(Value::as_array)
+        .and_then(|changes| changes.first())
+        .and_then(|change| change.get("path"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_owned();
+    ToolDetail::FileEdit { path }
+}
+
+fn file_change_preview(item: &Value) -> String {
+    let preview = item
+        .get("changes")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|change| change.get("diff").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
+    bound(&preview, MAX_PREVIEW_CHARS)
+}
+
 /// Normalize `thread/tokenUsage` into disjoint cumulative counters.
 ///
 /// Two corrections over reading the payload verbatim.
@@ -976,6 +1078,7 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
         cache_read_input_tokens,
         cache_creation_input_tokens,
         context_tokens: context_tokens_from(value),
+        first_call_context_tokens: None,
     }
 }
 
@@ -985,7 +1088,11 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
 /// before `turn/started`. Subtracting that snapshot keeps later turns from
 /// inheriting every earlier turn's spend. If the engine resets a counter,
 /// treat the latest value as a fresh total instead of subtracting past zero.
-fn turn_usage_since(total: &CodeUsage, baseline: &CodeUsage) -> CodeUsage {
+fn turn_usage_since(
+    total: &CodeUsage,
+    baseline: &CodeUsage,
+    first_call_context_tokens: Option<u64>,
+) -> CodeUsage {
     let counters_reset = total.input_tokens < baseline.input_tokens
         || total.output_tokens < baseline.output_tokens
         || total.cache_read_input_tokens < baseline.cache_read_input_tokens
@@ -1005,6 +1112,7 @@ fn turn_usage_since(total: &CodeUsage, baseline: &CodeUsage) -> CodeUsage {
             .cache_creation_input_tokens
             .saturating_sub(baseline.cache_creation_input_tokens),
         context_tokens: total.context_tokens,
+        first_call_context_tokens,
     }
 }
 
@@ -1089,6 +1197,7 @@ mod tests {
             cache_read_input_tokens: 9_984,
             cache_creation_input_tokens: 0,
             context_tokens: 14_531,
+            first_call_context_tokens: None,
         };
         let total = CodeUsage {
             input_tokens: 5_819,
@@ -1096,16 +1205,18 @@ mod tests {
             cache_read_input_tokens: 24_064,
             cache_creation_input_tokens: 0,
             context_tokens: 15_352,
+            first_call_context_tokens: None,
         };
 
         assert_eq!(
-            turn_usage_since(&total, &baseline),
+            turn_usage_since(&total, &baseline, Some(15_352)),
             CodeUsage {
                 input_tokens: 1_272,
                 output_tokens: 6,
                 cache_read_input_tokens: 14_080,
                 cache_creation_input_tokens: 0,
                 context_tokens: 15_352,
+                first_call_context_tokens: Some(15_352),
             }
         );
     }
@@ -1203,6 +1314,77 @@ mod tests {
 
         assert_eq!(out.unrecognized, 0);
         assert!(out.events.is_empty());
+    }
+
+    #[test]
+    fn file_change_items_emit_a_matched_bounded_edit_span() {
+        let long_diff = format!("+{}", "x".repeat(MAX_PREVIEW_CHARS + 20));
+        let started = serde_json::json!({
+            "method": "item/started",
+            "params": {
+                "item": {
+                    "type": "fileChange",
+                    "id": "edit-1",
+                    "changes": [{"path": "docs/exercise.md"}]
+                }
+            }
+        });
+        let completed = serde_json::json!({
+            "method": "item/completed",
+            "params": {
+                "item": {
+                    "type": "fileChange",
+                    "id": "edit-1",
+                    "status": "completed",
+                    "changes": [{"path": "docs/exercise.md", "diff": long_diff}]
+                }
+            }
+        });
+        let mut parser = CodexStreamParser::new();
+        let mut events = parser.push_line(&started.to_string());
+        events.extend(parser.push_line(&completed.to_string()));
+
+        assert_eq!(parser.unrecognized(), 0);
+        assert!(matches!(
+            events.first(),
+            Some(HarnessEvent::ToolStarted {
+                call_id,
+                detail: ToolDetail::FileEdit { path },
+                ..
+            }) if call_id == "edit-1" && path == "docs/exercise.md"
+        ));
+        assert!(matches!(
+            events.last(),
+            Some(HarnessEvent::ToolCompleted {
+                call_id,
+                outcome: ToolOutcome::Succeeded,
+                preview,
+                detail: Some(ToolDetail::FileEdit { path }),
+                ..
+            }) if call_id == "edit-1"
+                && path == "docs/exercise.md"
+                && preview.chars().count() == MAX_PREVIEW_CHARS
+        ));
+    }
+
+    #[test]
+    fn first_usage_update_records_starting_context() {
+        let input = r#"
+{"method":"turn/started","params":{"turn":{"status":"inProgress"}}}
+{"method":"thread/tokenUsage/updated","params":{"tokenUsage":{"total":{"inputTokens":15000,"cachedInputTokens":5000,"outputTokens":1},"last":{"inputTokens":15000}}}}
+{"method":"thread/tokenUsage/updated","params":{"tokenUsage":{"total":{"inputTokens":31000,"cachedInputTokens":13000,"outputTokens":2},"last":{"inputTokens":16000}}}}
+{"method":"turn/completed","params":{"turn":{"status":"completed"}}}
+"#;
+        let out = CodexStreamParser::parse_ndjson(input);
+        let usage = out.events.iter().find_map(|event| match event {
+            HarnessEvent::TurnCompleted { usage } => Some(usage),
+            _ => None,
+        });
+        assert_eq!(
+            usage.and_then(|usage| usage.first_call_context_tokens),
+            Some(15_000)
+        );
+        assert_eq!(usage.map(|usage| usage.context_tokens), Some(16_000));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/grok/parse.rs
+++ b/crates/tidebreak-harness/src/grok/parse.rs
@@ -35,6 +35,8 @@ pub struct GrokStreamParser {
     /// call. Kept apart from `last_usage` because the closing `end` event
     /// overwrites that with the turn's cumulative total.
     last_call_context_tokens: Option<u64>,
+    /// Prompt tokens on the first per-call usage event in this turn.
+    first_call_context_tokens: Option<u64>,
     pending_text: String,
 }
 
@@ -52,6 +54,7 @@ impl Default for GrokStreamParser {
             emitted_session: false,
             last_usage: CodeUsage::default(),
             last_call_context_tokens: None,
+            first_call_context_tokens: None,
             pending_text: String::new(),
         }
     }
@@ -265,6 +268,14 @@ impl GrokStreamParser {
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_owned();
+        if matches!(status, "in_progress" | "inProgress" | "running") {
+            if let Some(spawn) = self.pending_spawns.get_mut(&call_id) {
+                if let Some(input) = value.get("rawInput") {
+                    spawn.detail = subagent_detail(input);
+                }
+            }
+            return Vec::new();
+        }
         if call_id.is_empty() || !self.completed_tools.insert(call_id.clone()) {
             return Vec::new();
         }
@@ -395,6 +406,9 @@ impl GrokStreamParser {
         // reports their 9189 sum. So this call's prompt-side sum is an
         // occupancy reading; the `end` event's is spend.
         self.last_call_context_tokens = Some(usage.context_tokens);
+        if self.first_call_context_tokens.is_none() && usage.context_tokens > 0 {
+            self.first_call_context_tokens = Some(usage.context_tokens);
+        }
         self.last_usage = usage;
         self.flush_assistant()
     }
@@ -414,6 +428,7 @@ impl GrokStreamParser {
         if let Some(context_tokens) = self.last_call_context_tokens {
             self.last_usage.context_tokens = context_tokens;
         }
+        self.last_usage.first_call_context_tokens = self.first_call_context_tokens;
         let mut events = self.emit_session();
         events.extend(self.flush_assistant());
         let stop = value
@@ -448,6 +463,8 @@ impl GrokStreamParser {
                 });
             }
         }
+        self.last_call_context_tokens = None;
+        self.first_call_context_tokens = None;
         events
     }
 
@@ -742,6 +759,7 @@ fn usage_from(value: Option<&Value>) -> CodeUsage {
         context_tokens: field("input_tokens")
             .saturating_add(field("cache_read_input_tokens"))
             .saturating_add(field("cache_creation_input_tokens")),
+        first_call_context_tokens: None,
     }
 }
 
@@ -800,6 +818,40 @@ mod tests {
             out.events.last(),
             Some(HarnessEvent::TurnCompleted { .. })
         ));
+    }
+
+    #[test]
+    fn progress_status_synonyms_do_not_complete_or_count_a_tool() {
+        for status in ["in_progress", "inProgress", "running"] {
+            let input = format!(
+                "{{\"type\":\"tool_call\",\"toolCallId\":\"call-1\",\"toolName\":\"read_file\",\"rawInput\":{{}}}}\n{{\"type\":\"tool_call_update\",\"toolCallId\":\"call-1\",\"status\":\"{status}\"}}"
+            );
+            let out = GrokStreamParser::parse_ndjson(&input);
+            assert_eq!(out.unrecognized, 0, "status: {status}");
+            assert!(!out
+                .events
+                .iter()
+                .any(|event| matches!(event, HarnessEvent::ToolCompleted { .. })));
+        }
+    }
+
+    #[test]
+    fn usage_keeps_the_first_and_last_call_contexts() {
+        let input = r#"
+{"type":"usage","usage":{"input_tokens":9000,"cache_read_input_tokens":1000}}
+{"type":"usage","usage":{"input_tokens":100,"cache_read_input_tokens":12000}}
+{"type":"end","stopReason":"end_turn","sessionId":"abc","usage":{"input_tokens":9100,"cache_read_input_tokens":13000}}
+"#;
+        let out = GrokStreamParser::parse_ndjson(input);
+        let usage = out.events.iter().find_map(|event| match event {
+            HarnessEvent::TurnCompleted { usage } => Some(usage),
+            _ => None,
+        });
+        assert_eq!(
+            usage.and_then(|usage| usage.first_call_context_tokens),
+            Some(10_000)
+        );
+        assert_eq!(usage.map(|usage| usage.context_tokens), Some(12_100));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -635,6 +635,10 @@ pub enum HarnessError {
     /// against the new mode instead of giving up.
     #[error("this engine sets its permission mode at launch")]
     PermissionModeSwitchUnsupported,
+    /// A Plan-mode engine changed its default plan storage outside the
+    /// worktree after Tidebreak redirected plan files to private storage.
+    #[error("plan mode wrote outside the worktree: {0}")]
+    PlanWriteOutsideWorktree(String),
     /// The adapter has no verified same-turn steering channel.
     #[error("mid-turn steering is not available on this engine")]
     SteeringUnsupported,

--- a/crates/tidebreak-harness/src/opencode/parse.rs
+++ b/crates/tidebreak-harness/src/opencode/parse.rs
@@ -17,8 +17,8 @@ use std::collections::HashSet;
 
 use serde_json::Value;
 use tidebreak_core::{
-    BoundedError, CodeUsage, HarnessKind, ToolDetail, ToolOutcome, MAX_EVENT_TEXT_CHARS,
-    MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS,
+    BoundedError, CodeUsage, Diffstat, FileChangeKind, HarnessKind, ToolDetail, ToolOutcome,
+    MAX_EVENT_TEXT_CHARS, MAX_NOTICE_CHARS, MAX_PREVIEW_CHARS,
 };
 
 use crate::{ApprovalDecision, HarnessApprovalRef, HarnessEvent};
@@ -38,7 +38,9 @@ pub struct OpencodeStreamParser {
     started_tools: HashSet<String>,
     completed_tools: HashSet<String>,
     resolved_approvals: HashSet<String>,
+    changed_files: HashSet<String>,
     last_usage: CodeUsage,
+    first_call_context_tokens: Option<u64>,
 }
 
 /// Result of parsing a whole fixture or a finished stream.
@@ -125,6 +127,9 @@ impl OpencodeStreamParser {
         let path = value.get("path").and_then(Value::as_str).unwrap_or("");
         if method == "POST" && path.contains("/prompt_async") {
             self.turn_terminal = false;
+            self.changed_files.clear();
+            self.last_usage = CodeUsage::default();
+            self.first_call_context_tokens = None;
             return Vec::new();
         }
         if method == "POST" && path.contains("/permission/") && path.ends_with("/reply") {
@@ -218,12 +223,15 @@ impl OpencodeStreamParser {
             }
             "permission.asked" => self.parse_permission_asked(&props),
             "permission.replied" => self.parse_permission_replied(&props),
+            "file.edited" => self.parse_file_edited(&props),
             "server.connected"
             | "server.heartbeat"
             | "catalog.updated"
             | "integration.updated"
             | "plugin.added"
             | "reference.updated"
+            | "project.directories.updated"
+            | "file.watcher.updated"
             | "session.diff"
             | "session.updated" => {
                 // Known catalog/session broadcasts with no normalized
@@ -249,6 +257,9 @@ impl OpencodeStreamParser {
                 }
                 self.turn_open = true;
                 self.turn_terminal = false;
+                self.changed_files.clear();
+                self.last_usage = CodeUsage::default();
+                self.first_call_context_tokens = None;
                 vec![HarnessEvent::TurnStarted]
             }
             "idle" => self.emit_turn_completed(),
@@ -347,6 +358,7 @@ impl OpencodeStreamParser {
                 Vec::new()
             }
             Some("step-start") => Vec::new(),
+            Some("patch") => self.parse_patch_part(&part),
             Some(other) => {
                 self.count_unrecognized(&format!("message.part.updated/{other}"), &part);
                 Vec::new()
@@ -356,6 +368,61 @@ impl OpencodeStreamParser {
                 Vec::new()
             }
         }
+    }
+
+    fn parse_file_edited(&mut self, props: &Value) -> Vec<HarnessEvent> {
+        let path = first_path(props);
+        self.emit_file_changed(path, FileChangeKind::Modified, None)
+    }
+
+    fn parse_patch_part(&mut self, part: &Value) -> Vec<HarnessEvent> {
+        let paths = part
+            .get("files")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|value| {
+                value
+                    .as_str()
+                    .map(str::to_owned)
+                    .or_else(|| first_path(value))
+            })
+            .chain(first_path(part))
+            .collect::<Vec<_>>();
+        let diff = part
+            .get("patch")
+            .or_else(|| part.get("diff"))
+            .and_then(Value::as_str);
+        let mut events = Vec::new();
+        for path in paths {
+            events.extend(self.emit_file_changed(Some(path), file_kind_from_diff(diff), diff));
+        }
+        events
+    }
+
+    fn emit_file_changed(
+        &mut self,
+        path: Option<String>,
+        kind: FileChangeKind,
+        diff: Option<&str>,
+    ) -> Vec<HarnessEvent> {
+        let Some(path) = path.filter(|path| !path.trim().is_empty()) else {
+            return Vec::new();
+        };
+        if !self.changed_files.insert(path.clone()) {
+            return Vec::new();
+        }
+        let (insertions, deletions) = diff.map(diff_counts).unwrap_or((0, 0));
+        vec![HarnessEvent::FileChanged {
+            path,
+            kind,
+            diffstat: Diffstat {
+                files: 1,
+                insertions,
+                deletions,
+                truncated: false,
+            },
+        }]
     }
 
     fn parse_tool_part(&mut self, part: &Value) -> Vec<HarnessEvent> {
@@ -567,6 +634,12 @@ impl OpencodeStreamParser {
             .pointer("/cache/write")
             .and_then(Value::as_u64)
             .unwrap_or(0);
+        let context_tokens = input_tokens
+            .saturating_add(cache_read_input_tokens)
+            .saturating_add(cache_creation_input_tokens);
+        if self.first_call_context_tokens.is_none() && context_tokens > 0 {
+            self.first_call_context_tokens = Some(context_tokens);
+        }
         self.last_usage = CodeUsage {
             input_tokens,
             output_tokens: tokens.get("output").and_then(Value::as_u64).unwrap_or(0),
@@ -577,9 +650,8 @@ impl OpencodeStreamParser {
             // and the session-level `session.updated` row carries their 5390
             // sum, which this parser does not read. So the snapshot standing
             // when the turn ends is the last call's prompt.
-            context_tokens: input_tokens
-                .saturating_add(cache_read_input_tokens)
-                .saturating_add(cache_creation_input_tokens),
+            context_tokens,
+            first_call_context_tokens: self.first_call_context_tokens,
         };
     }
 
@@ -635,6 +707,41 @@ fn permission_id_from_path(path: &str) -> Option<String> {
 /// Whether a view of a call still says nothing about its arguments.
 fn arguments_pending(input: &Value) -> bool {
     input.as_object().is_none_or(serde_json::Map::is_empty)
+}
+
+fn first_path(value: &Value) -> Option<String> {
+    value
+        .get("path")
+        .or_else(|| value.get("file"))
+        .or_else(|| value.get("filePath"))
+        .or_else(|| value.pointer("/info/path"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+fn file_kind_from_diff(diff: Option<&str>) -> FileChangeKind {
+    let Some(diff) = diff else {
+        return FileChangeKind::Modified;
+    };
+    if diff.contains("--- /dev/null") {
+        FileChangeKind::Added
+    } else if diff.contains("+++ /dev/null") {
+        FileChangeKind::Deleted
+    } else {
+        FileChangeKind::Modified
+    }
+}
+
+fn diff_counts(diff: &str) -> (u32, u32) {
+    diff.lines().fold((0, 0), |(insertions, deletions), line| {
+        if line.starts_with('+') && !line.starts_with("+++") {
+            (insertions.saturating_add(1), deletions)
+        } else if line.starts_with('-') && !line.starts_with("---") {
+            (insertions, deletions.saturating_add(1))
+        } else {
+            (insertions, deletions)
+        }
+    })
 }
 
 fn tool_detail(name: &str, input: &Value) -> ToolDetail {
@@ -734,5 +841,97 @@ mod tests {
             })
             .collect();
         assert_eq!(kinds, ["started", "completed"]);
+    }
+
+    #[test]
+    fn watcher_broadcasts_are_known_noops() {
+        let input = r#"
+{"type":"project.directories.updated","properties":{}}
+{"type":"file.watcher.updated","properties":{}}
+"#;
+        let out = OpencodeStreamParser::parse_ndjson(input);
+        assert_eq!(out.unrecognized, 0);
+        assert!(out.events.is_empty());
+    }
+
+    #[test]
+    fn file_events_normalize_once_per_path_with_patch_counts() {
+        let input = r#"
+{"dir":"out","msg":{"kind":"http","method":"POST","path":"/session/ses_abc/prompt_async","body":{}}}
+{"type":"file.edited","properties":{"file":"docs/exercise.md"}}
+{"type":"message.part.updated","properties":{"part":{"type":"patch","files":[{"path":"docs/exercise.md"},{"path":"src/lib.rs"}],"diff":"--- a/file\n+++ b/file\n-old\n+new\n+more"}}}
+"#;
+        let out = OpencodeStreamParser::parse_ndjson(input);
+        assert_eq!(out.unrecognized, 0);
+        let changes = out
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                HarnessEvent::FileChanged {
+                    path,
+                    kind,
+                    diffstat,
+                } => Some((
+                    path.as_str(),
+                    *kind,
+                    diffstat.insertions,
+                    diffstat.deletions,
+                )),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            changes,
+            vec![
+                ("docs/exercise.md", FileChangeKind::Modified, 0, 0),
+                ("src/lib.rs", FileChangeKind::Modified, 2, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn usage_keeps_the_first_and_last_call_contexts() {
+        let input = r#"
+{"dir":"out","msg":{"kind":"http","method":"POST","path":"/session/ses_abc/prompt_async","body":{}}}
+{"type":"session.status","properties":{"status":{"type":"busy"}}}
+{"type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":4000,"output":1,"cache":{"read":2000,"write":0}}}}}
+{"type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":100,"output":1,"cache":{"read":7000,"write":0}}}}}
+{"type":"session.idle","properties":{"sessionID":"ses_abc"}}
+"#;
+        let out = OpencodeStreamParser::parse_ndjson(input);
+        let usage = out.events.iter().find_map(|event| match event {
+            HarnessEvent::TurnCompleted { usage } => Some(usage),
+            _ => None,
+        });
+        assert_eq!(
+            usage.and_then(|usage| usage.first_call_context_tokens),
+            Some(6_000)
+        );
+        assert_eq!(usage.map(|usage| usage.context_tokens), Some(7_100));
+    }
+
+    #[test]
+    fn a_new_turn_does_not_inherit_the_previous_turns_usage() {
+        let input = r#"
+{"type":"session.status","properties":{"status":{"type":"busy"}}}
+{"type":"message.part.updated","properties":{"part":{"type":"step-finish","tokens":{"input":4000,"output":1,"cache":{"read":2000,"write":0}}}}}
+{"type":"session.idle","properties":{"sessionID":"ses_abc"}}
+{"dir":"out","msg":{"kind":"http","method":"POST","path":"/session/ses_abc/prompt_async","body":{}}}
+{"type":"session.status","properties":{"status":{"type":"busy"}}}
+{"type":"session.idle","properties":{"sessionID":"ses_abc"}}
+"#;
+        let out = OpencodeStreamParser::parse_ndjson(input);
+        let completed = out
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                HarnessEvent::TurnCompleted { usage } => Some(usage),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(completed.len(), 2);
+        assert_eq!(completed[0].context_tokens, 6_000);
+        assert_eq!(completed[1], &CodeUsage::default());
     }
 }

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -34,8 +34,8 @@ use tidebreak_core::{
     bound_subagents, Attention, AttentionSource, BlobStore, BoundedError, CodeApproval,
     CodeApprovalId, CodeApprovalKind, CodeApprovalState, CodeEvent, CodeQueuedTurn, CodeSession,
     CodeSessionId, CodeSessionLifecycle, CodeSubagentStatus, CodeSubagentSummary, CodeTurn,
-    CodeTurnId, CodeTurnStatus, DbStore, FenceReason, HarnessNoticeLevel, OwnerId, PermissionMode,
-    ReasoningEffort, ToolOutcome,
+    CodeTurnId, CodeTurnStatus, CodeUsage, DbStore, FenceReason, HarnessNoticeLevel, OwnerId,
+    PermissionMode, ReasoningEffort, ToolOutcome,
 };
 use tidebreak_harness::{
     ApprovalDecision, HarnessApprovalRef, HarnessError, HarnessEvent, HarnessEventSink,
@@ -43,6 +43,9 @@ use tidebreak_harness::{
 };
 
 use super::bus::CodeEventBus;
+
+const HIGH_FIRST_CALL_CONTEXT_TOKENS: u64 = 20_000;
+const SHORT_FIRST_TURN_INPUT_CHARS: usize = 2_000;
 
 pub(crate) enum WorkerCommand {
     RunTurn {
@@ -483,6 +486,26 @@ impl HarnessEventSink for LiveSink {
             return;
         }
         let turn_id = *self.turn_id.lock().unwrap();
+        if let (Some(turn_id), HarnessEvent::TurnCompleted { usage }) = (turn_id, &event) {
+            if let Ok(Some(turn)) =
+                tidebreak_core::db::code::get_turn(&self.db, &self.owner, turn_id).await
+            {
+                if let Some(message) = high_first_call_context_warning(&turn, usage) {
+                    let _ = persist_and_publish(
+                        &self.db,
+                        &self.bus,
+                        &self.owner,
+                        self.session_id,
+                        self.spawn_epoch,
+                        CodeEvent::HarnessNotice {
+                            level: HarnessNoticeLevel::Warning,
+                            message,
+                        },
+                    )
+                    .await;
+                }
+            }
+        }
         let Some(code_event) = map_event(event, turn_id) else {
             return;
         };
@@ -550,6 +573,20 @@ impl HarnessEventSink for LiveSink {
             recap.spawn(self.owner.clone(), self.session_id, turn_id);
         }
     }
+}
+
+fn high_first_call_context_warning(turn: &CodeTurn, usage: &CodeUsage) -> Option<String> {
+    let context_tokens = usage.first_call_context_tokens?;
+    let input_chars = turn.user_input.chars().count();
+    if turn.ordinal != 1
+        || input_chars > SHORT_FIRST_TURN_INPUT_CHARS
+        || context_tokens < HIGH_FIRST_CALL_CONTEXT_TOKENS
+    {
+        return None;
+    }
+    Some(format!(
+        "The first model call used {context_tokens} context tokens for a {input_chars}-character first-turn prompt. Check harness startup instructions and injected context for duplication."
+    ))
 }
 
 /// Start the worker for a session.
@@ -2124,16 +2161,12 @@ fn kind_from_raw(raw: &serde_json::Value) -> CodeApprovalKind {
         .and_then(serde_json::Value::as_str)
         .or_else(|| raw.get("permission").and_then(serde_json::Value::as_str))
         .unwrap_or("");
-    let path = input
-        .get("file_path")
-        .or_else(|| input.get("path"))
-        .or_else(|| raw.get("path"))
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("");
+    let paths = approval_file_paths(raw, &input);
+    let path = paths.first().map(String::as_str).unwrap_or("");
     match tool {
-        "Write" | "Edit" | "NotebookEdit" | "write" | "edit" => CodeApprovalKind::FileWrite {
-            paths: vec![path.to_owned()],
-        },
+        "Write" | "Edit" | "NotebookEdit" | "write" | "edit" => {
+            CodeApprovalKind::FileWrite { paths }
+        }
         "Bash" | "bash" => CodeApprovalKind::Command {
             cmd: String::new(),
             cwd: input
@@ -2160,6 +2193,64 @@ fn kind_from_raw(raw: &serde_json::Value) -> CodeApprovalKind {
             summary: other.to_owned(),
         },
     }
+}
+
+fn approval_file_paths(raw: &serde_json::Value, input: &serde_json::Value) -> Vec<String> {
+    let metadata = raw.get("metadata").unwrap_or(&serde_json::Value::Null);
+    let cwd = metadata
+        .get("cwd")
+        .or_else(|| input.get("cwd"))
+        .or_else(|| raw.get("cwd"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|path| !path.trim().is_empty());
+    let direct = metadata
+        .get("filepath")
+        .or_else(|| metadata.get("file_path"))
+        .or_else(|| input.get("file_path"))
+        .or_else(|| input.get("path"))
+        .or_else(|| raw.get("path"))
+        .and_then(serde_json::Value::as_str);
+    let candidates = direct.into_iter().chain(
+        raw.get("patterns")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(serde_json::Value::as_str)
+            .filter(|path| !path.chars().any(|ch| "*?[]{}".contains(ch))),
+    );
+    let mut paths = Vec::new();
+    for candidate in candidates {
+        let candidate = candidate.trim();
+        if candidate.is_empty() {
+            continue;
+        }
+        let normalized = normalize_approval_path(candidate, cwd);
+        if !normalized.is_empty() && !paths.contains(&normalized) {
+            paths.push(normalized);
+        }
+    }
+    paths
+}
+
+fn normalize_approval_path(path: &str, cwd: Option<&str>) -> String {
+    let path = std::path::Path::new(path);
+    if let Ok(relative) = path.strip_prefix("/workspace") {
+        if let Some(cwd) = cwd.filter(|cwd| !cwd.trim().is_empty()) {
+            return std::path::Path::new(cwd)
+                .join(relative)
+                .to_string_lossy()
+                .into_owned();
+        }
+    }
+    if path.is_relative() {
+        if let Some(cwd) = cwd.filter(|cwd| !cwd.trim().is_empty()) {
+            return std::path::Path::new(cwd)
+                .join(path)
+                .to_string_lossy()
+                .into_owned();
+        }
+    }
+    path.to_string_lossy().into_owned()
 }
 
 fn map_event(event: HarnessEvent, turn_id: Option<CodeTurnId>) -> Option<CodeEvent> {
@@ -2292,6 +2383,47 @@ mod tests {
             CodeSubagentStatus::Failed
         ));
         assert_eq!(failed[0].status, CodeSubagentStatus::Failed);
+    }
+
+    #[test]
+    fn high_first_call_context_warns_only_for_short_first_turns() {
+        let mut turn = CodeTurn {
+            id: CodeTurnId::new(),
+            session_id: CodeSessionId::new(),
+            ordinal: 1,
+            status: CodeTurnStatus::Completed,
+            model: None,
+            fast_mode: false,
+            user_input: "fix the parser".into(),
+            user_input_blob_id: None,
+            attachments: Vec::new(),
+            checkpoint_ref: None,
+            diffstat: None,
+            usage: None,
+            narrative: None,
+            started_at: Utc::now(),
+            ended_at: Some(Utc::now()),
+        };
+        let usage = CodeUsage {
+            first_call_context_tokens: Some(HIGH_FIRST_CALL_CONTEXT_TOKENS),
+            ..CodeUsage::default()
+        };
+
+        assert!(high_first_call_context_warning(&turn, &usage).is_some());
+        turn.ordinal = 2;
+        assert!(high_first_call_context_warning(&turn, &usage).is_none());
+        turn.ordinal = 1;
+        turn.user_input = "x".repeat(SHORT_FIRST_TURN_INPUT_CHARS + 1);
+        assert!(high_first_call_context_warning(&turn, &usage).is_none());
+        turn.user_input = "short".into();
+        assert!(high_first_call_context_warning(
+            &turn,
+            &CodeUsage {
+                first_call_context_tokens: Some(HIGH_FIRST_CALL_CONTEXT_TOKENS - 1),
+                ..CodeUsage::default()
+            }
+        )
+        .is_none());
     }
 
     async fn seeded_sink() -> (
@@ -2633,6 +2765,36 @@ mod tests {
                 cmd: "rg foo".into(),
                 cwd: None,
             }
+        );
+        assert_eq!(
+            kind_from_raw(&serde_json::json!({
+                "permission": "edit",
+                "metadata": {
+                    "filepath": "/workspace/docs/approval.md",
+                    "cwd": "/worktree"
+                },
+                "patterns": ["docs/approval.md", "*.md"]
+            })),
+            CodeApprovalKind::FileWrite {
+                paths: vec!["/worktree/docs/approval.md".into()],
+            }
+        );
+        assert_eq!(
+            kind_from_raw(&serde_json::json!({
+                "permission": "edit",
+                "cwd": "/worktree",
+                "patterns": ["docs/fallback.md", "*"]
+            })),
+            CodeApprovalKind::FileWrite {
+                paths: vec!["/worktree/docs/fallback.md".into()],
+            }
+        );
+        assert_eq!(
+            kind_from_raw(&serde_json::json!({
+                "permission": "edit",
+                "patterns": ["*"]
+            })),
+            CodeApprovalKind::FileWrite { paths: Vec::new() }
         );
         assert_eq!(
             kind_from_raw(&serde_json::json!({

--- a/crates/tidebreak-server/src/foreground_prompt.rs
+++ b/crates/tidebreak-server/src/foreground_prompt.rs
@@ -28,6 +28,7 @@ You are Tidebreak, an assistant working with the user inside one conversation.
 - Proceed with reasonable, reversible assumptions when ambiguity is minor. If a missing choice would materially change the result or authorize a broader action, ask one concise question instead of guessing.
 - Use tools when they materially improve correctness or complete requested work. Never claim to have accessed, changed, or verified something unless the available tools or conversation actually support that claim.
 - When the user explicitly asks you to run, reproduce, or test something, do not substitute reasoning for execution or imply that it ran. Make an execution claim only after an `exec` result supports it; if `exec` is unavailable this turn, say plainly that you cannot execute it.
+- Images from earlier conversation turns remain available inline unless the conversation contains an explicit `[image omitted from context: ...]` marker. `list_documents` does not list image attachments, and the absence of an image file in scratch or `documents/` does not mean that you lost its pixels.
 - Stay within the current conversation. Do not invent projects, organization context, shared memory, or access outside the capabilities provided for this turn.
 
 ## Trust and safety
@@ -44,6 +45,7 @@ You are Tidebreak, an assistant working with the user inside one conversation.
 - Proceed with reasonable, reversible assumptions when ambiguity is minor. If a missing choice would materially change the result or authorize a broader action, ask one concise question instead of guessing.
 - Answer from the conversation and your own knowledge. Never claim to have accessed, changed, or verified anything outside the conversation.
 - When the user explicitly asks you to run, reproduce, or test something, say plainly that execution is unavailable in this reply. Do not substitute reasoning for execution or imply that anything ran.
+- Images from earlier conversation turns remain available inline unless the conversation contains an explicit `[image omitted from context: ...]` marker.
 - Stay within the current conversation. Do not invent projects, organization context, shared memory, or access outside this reply.
 
 ## Trust and safety
@@ -469,6 +471,7 @@ pub(crate) fn compose_for_surface(
             OUTPUTS_HEADING,
             &[
                 "- Files you save in `output/` during `exec` are published to the user automatically as durable outputs; use them when the user explicitly wants a report, plan, table, data file, web page, or another file to preview or save.",
+                "- For visual review, write PNG, JPEG, or WebP images to `preview/`. SVG remains a durable source file in `output/`, but it needs a raster copy in `preview/` before you can inspect its pixels.",
                 "- Prefer a normal conversational answer when a separate file would add no value.",
                 "- Make each output self-contained and use a clear portable filename. Saving to the same filename updates that output in place as a new version, so preserve useful content intentionally.",
             ],
@@ -917,6 +920,19 @@ mod tests {
         assert!(chat_only.contains("execution is unavailable in this reply"));
         assert!(chat_only.contains("Do not substitute reasoning for execution"));
         assert!(chat_only.contains("or imply that anything ran"));
+    }
+
+    #[test]
+    fn image_and_preview_contracts_are_explicit() {
+        let prompt = compose(&[spec("list_documents"), spec("exec")]);
+        let chat_only = compose(&[]);
+
+        assert!(prompt.contains("remain available inline"));
+        assert!(chat_only.contains("remain available inline"));
+        assert!(prompt.contains("[image omitted from context:"));
+        assert!(prompt.contains("`list_documents` does not list image attachments"));
+        assert!(prompt.contains("SVG remains a durable source file in `output/`"));
+        assert!(prompt.contains("raster copy in `preview/`"));
     }
 
     #[test]
@@ -1646,7 +1662,7 @@ mod tests {
         // Re-pinned for the Tidebreak product identity carried by the prompt.
         assert_eq!(
             identity(&prompt),
-            "foreground-v2:sha256:9f937d96870bc18021864e08981d1fe8baca851a37508b07f1f674ba5743b8d0"
+            "foreground-v2:sha256:8c5ddcc6e2a85de35dadca1b282791a44e0202e67225d2a26aa3b91bbf65a9e6"
         );
     }
 }

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -596,6 +596,7 @@ pub(crate) fn plain_text_script() -> Vec<HarnessEvent> {
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
                 context_tokens: 4,
+                first_call_context_tokens: Some(4),
             },
         },
     ]


### PR DESCRIPTION
## What changed

Fixes the Code and Work mode exercise findings across print attachments and recovery, Claude plan isolation, image and preview guidance, usage diagnostics, approval paths, and Claude, Codex, Grok, and OpenCode event normalization.

## Validation

`cargo fmt --all -- --check`, `cargo metadata --locked --no-deps --format-version 1`, `git diff --check origin/main...`, and `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/parsers.test.ts` pass with 68 tests.

## Compatibility and risk

Adds an optional wire field for first-call context and changes undriven print approvals to cancel the turn and exit with code 3; older clients continue to parse usage without the new field.