### PR TITLE
ci(release): package prepared desktop binaries

### DIFF
--- a/.github/tauri-cli/package.json
+++ b/.github/tauri-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "tidebreak-release-bundler",
+  "version": "0.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.18.3",
+  "dependencies": {
+    "@tauri-apps/cli": "2.11.4"
+  }
+}

--- a/.github/tauri-cli/pnpm-lock.yaml
+++ b/.github/tauri-cli/pnpm-lock.yaml
@@ -1,0 +1,135 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@tauri-apps/cli':
+        specifier: 2.11.4
+        version: 2.11.4
+
+packages:
+
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
+    resolution: {integrity: sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tauri-apps/cli-darwin-x64@2.11.4':
+    resolution: {integrity: sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
+    resolution: {integrity: sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
+    resolution: {integrity: sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
+    resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
+    resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
+    resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
+    resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
+    resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
+    resolution: {integrity: sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
+    resolution: {integrity: sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tauri-apps/cli@2.11.4':
+    resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+snapshots:
+
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-darwin-x64@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli@2.11.4':
+    optionalDependencies:
+      '@tauri-apps/cli-darwin-arm64': 2.11.4
+      '@tauri-apps/cli-darwin-x64': 2.11.4
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.4
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.4
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-musl': 2.11.4
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,6 +599,24 @@ jobs:
       SCCACHE_GHA_RW_MODE: READ_ONLY
       TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
     steps:
+      # Generate this file before checking out the tag. Code from the release
+      # source cannot influence the command that creates the build configuration.
+      - name: Write tag-derived Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
+              version: process.env.TIDEBREAK_VERSION,
+              bundle: { targets: ["app", "dmg"] },
+              // Release bundles register only the real scheme. The dev scheme
+              // stays in tauri.conf.json for debug bundles, but a release
+              // binary refuses tidebreak-dev:// links by design.
+              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
+            }));
+          '
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.validate.outputs.sha }}
@@ -679,22 +697,6 @@ jobs:
       # drift fails here, before any signing material is loaded.
       - name: Verify the third-party notices match the released graph
         run: node scripts/generate-third-party-notices.mjs --check
-
-      - name: Write tag-derived Tauri configuration
-        env:
-          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
-        run: |
-          node -e '
-            const fs = require("node:fs");
-            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
-              version: process.env.TIDEBREAK_VERSION,
-              bundle: { targets: ["app", "dmg"] },
-              // Release bundles register only the real scheme. The dev scheme
-              // stays in tauri.conf.json for debug bundles, but a release
-              // binary refuses tidebreak-dev:// links by design.
-              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
-            }));
-          '
 
       - name: Compile without production credentials or bundles
         id: compile
@@ -1192,6 +1194,25 @@ jobs:
       SCCACHE_GHA_RW_MODE: READ_ONLY
       TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
     steps:
+      # Generate this file before checking out the tag. Code from the release
+      # source cannot influence the command that creates the build configuration.
+      - name: Write tag-derived Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
+              version: process.env.TIDEBREAK_VERSION,
+              // NSIS supports per-user installs without elevation and needs
+              // no WiX configuration.
+              bundle: { targets: ["nsis"] },
+              // Release bundles register only the real scheme. A release
+              // binary refuses tidebreak-dev:// links by design.
+              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
+            }));
+          '
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.validate.outputs.sha }}
@@ -1292,23 +1313,6 @@ jobs:
             echo "CMAKE_ASM_COMPILER=$clang_cl"
           } >> "$GITHUB_ENV"
           echo "Using $clang_cl with Ninja for Windows ARM native code"
-
-      - name: Write tag-derived Tauri configuration
-        env:
-          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
-        run: |
-          node -e '
-            const fs = require("node:fs");
-            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
-              version: process.env.TIDEBREAK_VERSION,
-              // NSIS supports per-user installs without elevation and needs
-              // no WiX configuration.
-              bundle: { targets: ["nsis"] },
-              // Release bundles register only the real scheme. A release
-              // binary refuses tidebreak-dev:// links by design.
-              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
-            }));
-          '
 
       - name: Compile without production credentials or bundles
         id: compile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -588,8 +588,10 @@ jobs:
         needs.validate.outputs.draft == 'true'
         && needs.inspect_hosted.outputs.exists != 'true'
       }}
-    runs-on: macos-latest
-    timeout-minutes: 60
+    # Set PRODUCTION_MACOS_RUNNER to a provisioned ARM64 larger-runner label
+    # when release compile time matters more than the additional runner cost.
+    runs-on: ${{ vars.PRODUCTION_MACOS_RUNNER || 'macos-latest' }}
+    timeout-minutes: 90
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
@@ -678,13 +680,33 @@ jobs:
       - name: Verify the third-party notices match the released graph
         run: node scripts/generate-third-party-notices.mjs --check
 
+      - name: Write tag-derived Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
+              version: process.env.TIDEBREAK_VERSION,
+              bundle: { targets: ["app", "dmg"] },
+              // Release bundles register only the real scheme. The dev scheme
+              // stays in tauri.conf.json for debug bundles, but a release
+              // binary refuses tidebreak-dev:// links by design.
+              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
+            }));
+          '
+
       - name: Compile without production credentials or bundles
         id: compile
         continue-on-error: true
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
           projectPath: crates/tidebreak-desktop
-          args: --target universal-apple-darwin --no-bundle --ci
+          args: >-
+            --target universal-apple-darwin
+            --config ${{ runner.temp }}/tidebreak-release.json
+            --no-bundle
+            --ci
 
       - name: Save release-specific unsigned Rust build cache
         if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
@@ -723,6 +745,70 @@ jobs:
         if: ${{ steps.compile.outcome != 'success' }}
         run: exit 1
 
+      - name: Archive prepared macOS inputs
+        env:
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-macos
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+          RELEASE_TARGET: universal-apple-darwin
+        run: |
+          app_binary="target/$RELEASE_TARGET/release/tidebreak-desktop"
+          broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
+          cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET"
+          for file in "$app_binary" "$broker_sidecar" "$cli_sidecar" "$RELEASE_CONFIG"; do
+            [[ -s "$file" ]] || {
+              echo "Prepared macOS input is missing or empty: $file" >&2
+              exit 1
+            }
+          done
+
+          rm -rf "$PREPARED_ROOT"
+          install -d \
+            "$PREPARED_ROOT/target/$RELEASE_TARGET/release" \
+            "$PREPARED_ROOT/crates/tidebreak-desktop/binaries"
+          install -m 755 \
+            "$app_binary" \
+            "$PREPARED_ROOT/$app_binary"
+          install -m 755 \
+            "$broker_sidecar" \
+            "$PREPARED_ROOT/$broker_sidecar"
+          install -m 755 \
+            "$cli_sidecar" \
+            "$PREPARED_ROOT/$cli_sidecar"
+          install -m 644 \
+            "$RELEASE_CONFIG" \
+            "$PREPARED_ROOT/release-config.json"
+
+          (
+            cd "$PREPARED_ROOT"
+            shasum -a 256 \
+              release-config.json \
+              "$app_binary" \
+              "$broker_sidecar" \
+              "$cli_sidecar" \
+              > SHA256SUMS
+            tar -cf "$GITHUB_WORKSPACE/prepared-macos.tar" \
+              SHA256SUMS \
+              release-config.json \
+              target \
+              crates
+          )
+          (
+            cd "$GITHUB_WORKSPACE"
+            shasum -a 256 prepared-macos.tar > prepared-macos.tar.sha256
+          )
+
+      - name: Upload prepared macOS inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-prepared-macos-universal-${{ github.run_id }}
+          path: |
+            prepared-macos.tar
+            prepared-macos.tar.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
+
   build_macos:
     name: macOS · universal
     needs: [validate, inspect_hosted, prepare_macos]
@@ -741,14 +827,6 @@ jobs:
       name: desktop-production
       url: https://downloads.brightwave.io/tidebreak/manifest.json
     env:
-      # Reuse compiler outputs across trusted release runs without caching the
-      # signed bundles or any signing material.
-      CARGO_INCREMENTAL: 0
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: READ_ONLY
-      # Rust code that reports or gates on the product version reads this value.
-      # Cargo package versions remain development metadata and are not released.
       TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
       APPLE_API_ISSUER: ${{ vars.APPLE_API_ISSUER }}
       APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
@@ -756,95 +834,56 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # Build the immutable commit resolved from the validated release tag.
           ref: ${{ needs.validate.outputs.sha }}
 
-      # This restore-only step runs before production secrets are loaded. The
-      # matching cache is written by a credential-free prerequisite job.
-      #
-      # Every key below pins the source identity of what it may restore: the
-      # release commit SHA, or at minimum the Cargo.lock and toolchain hashes.
-      # An arch-only fallback would let this job restore a `main`-warmed
-      # archive that has no relation to the released tag. The path list must
-      # stay byte-identical to the writing jobs' — `actions/cache` folds it
-      # into the cache version, so trimming entries here would silently miss
-      # every key instead of restoring a subset. The next step deletes the
-      # linked products the archive carries, so only compiler intermediates
-      # survive into the signed build.
-      - name: Restore unsigned Rust build cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download prepared macOS inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/aarch64-apple-darwin/release/.cargo-lock
-            target/aarch64-apple-darwin/release/.fingerprint
-            target/aarch64-apple-darwin/release/build
-            target/aarch64-apple-darwin/release/deps
-            target/aarch64-apple-darwin/release/tidebreak-desktop
-            target/aarch64-apple-darwin/release/tidebreak-host-broker
-            target/aarch64-apple-darwin/release/tidebreak
-            target/aarch64-apple-darwin/release/libtidebreak_desktop_lib.*
-            target/x86_64-apple-darwin/release/.cargo-lock
-            target/x86_64-apple-darwin/release/.fingerprint
-            target/x86_64-apple-darwin/release/build
-            target/x86_64-apple-darwin/release/deps
-            target/x86_64-apple-darwin/release/tidebreak-desktop
-            target/x86_64-apple-darwin/release/tidebreak-host-broker
-            target/x86_64-apple-darwin/release/tidebreak
-            target/x86_64-apple-darwin/release/libtidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-aarch64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-x86_64-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
-          key: macos-release-prepared-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
-          restore-keys: |
-            macos-release-prepared-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v5-universal-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+          name: tidebreak-prepared-macos-universal-${{ github.run_id }}
+          path: ${{ runner.temp }}/prepared-macos-download
 
-      # A restore extracts the whole archive, including the linked products a
-      # cache-warming run left in it. Those are the bytes that get signed, so
-      # delete them and let the signed build relink them from the tag's
-      # sources; the compiler intermediates that make the reuse worthwhile
-      # stay. The sidecar matters most: Tauri copies it into the signed
-      # product verbatim, with no Cargo fingerprint governing it.
-      - name: Discard restored product binaries
+      - name: Verify prepared macOS inputs
+        env:
+          PREPARED_DOWNLOAD: ${{ runner.temp }}/prepared-macos-download
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-macos
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+          RELEASE_TARGET: universal-apple-darwin
         run: |
-          rm -rf \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin,universal-apple-darwin}/release/tidebreak-desktop \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak-host-broker \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/tidebreak \
-            target/{aarch64-apple-darwin,x86_64-apple-darwin}/release/libtidebreak_desktop_lib.* \
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-{aarch64-apple-darwin,x86_64-apple-darwin} \
-            crates/tidebreak-desktop/binaries/tidebreak-{aarch64-apple-darwin,x86_64-apple-darwin} \
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-universal-apple-darwin \
-            crates/tidebreak-desktop/binaries/tidebreak-universal-apple-darwin
+          (
+            cd "$PREPARED_DOWNLOAD"
+            shasum -a 256 --check prepared-macos.tar.sha256
+          )
+          rm -rf "$PREPARED_ROOT"
+          install -d "$PREPARED_ROOT"
+          tar -xf "$PREPARED_DOWNLOAD/prepared-macos.tar" -C "$PREPARED_ROOT"
+          (
+            cd "$PREPARED_ROOT"
+            shasum -a 256 --check SHA256SUMS
+            expected_files="$(printf '%s\n' \
+              "./SHA256SUMS" \
+              "./crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET" \
+              "./crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET" \
+              "./release-config.json" \
+              "./target/$RELEASE_TARGET/release/tidebreak-desktop" \
+              | LC_ALL=C sort)"
+            actual_files="$(find . -type f -print | LC_ALL=C sort)"
+            [[ "$actual_files" = "$expected_files" ]] || {
+              echo "Prepared macOS archive contains an unexpected file set" >&2
+              printf '%s\n' "$actual_files" >&2
+              exit 1
+            }
+          )
 
-      # sccache, rust-cache, and the UI install run before any Apple or Tauri
-      # material is on disk. pnpm is pinned; lifecycle scripts stay off.
-      - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.16.0
-
-      - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
-        with:
-          shared-key: macos-release-cargo-registry-v2-${{ hashFiles('Cargo.lock') }}
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
-          cache-bin: false
-          # Signed apps, DMGs, updater archives, and signatures remain outside
-          # both the Cargo download cache and the restore-only build cache.
-          cache-targets: false
-          # prepare_macos and cache-macos.yml are the writers. This job holds
-          # Apple and Tauri material, so it must not publish the cache.
-          save-if: false
+          app_binary="target/$RELEASE_TARGET/release/tidebreak-desktop"
+          broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET"
+          cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET"
+          install -d \
+            "$(dirname "$app_binary")" \
+            "$(dirname "$broker_sidecar")"
+          install -m 755 "$PREPARED_ROOT/$app_binary" "$app_binary"
+          install -m 755 "$PREPARED_ROOT/$broker_sidecar" "$broker_sidecar"
+          install -m 755 "$PREPARED_ROOT/$cli_sidecar" "$cli_sidecar"
+          install -m 644 "$PREPARED_ROOT/release-config.json" "$RELEASE_CONFIG"
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
@@ -853,10 +892,11 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
-      - name: Install UI dependencies
-        working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile --ignore-scripts
+          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
+      - name: Install pinned Tauri bundler
+        run: |
+          pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts
+          echo "$GITHUB_WORKSPACE/.github/tauri-cli/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Validate production signing configuration
         env:
@@ -933,42 +973,32 @@ jobs:
             echo "APPLE_SIGNING_KEYCHAIN=$keychain_path"
           } >> "$GITHUB_ENV"
 
-      - name: Install Rust target
-        run: |
-          rustup show
-          rustup target add aarch64-apple-darwin x86_64-apple-darwin
-
-      - name: Write tag-derived Tauri configuration
+      - name: Add the macOS signing identity to the prepared configuration
         env:
-          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+          PREPARED_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-signing.json
         run: |
           node -e '
             const fs = require("node:fs");
-            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
-              version: process.env.TIDEBREAK_VERSION,
-              bundle: {
-                targets: ["app", "dmg"],
-                macOS: { signingIdentity: process.env.APPLE_SIGNING_IDENTITY }
-              },
-              // Release bundles register only the real scheme. The dev scheme
-              // stays in tauri.conf.json for debug bundles, but a release
-              // binary refuses tidebreak-dev:// links by design — if its
-              // Info.plist also claimed the scheme, Launch Services would
-              // route dev pairing links to the installed app, which then
-              // drops them, shadowing whatever debug bundle should answer.
-              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
-            }));
+            const config = JSON.parse(fs.readFileSync(process.env.PREPARED_CONFIG, "utf8"));
+            if (config.version !== process.env.TIDEBREAK_VERSION) {
+              throw new Error("Prepared version " + config.version + " does not match " + process.env.TIDEBREAK_VERSION);
+            }
+            config.bundle.macOS = {
+              ...(config.bundle.macOS ?? {}),
+              signingIdentity: process.env.APPLE_SIGNING_IDENTITY
+            };
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify(config));
           '
 
-      - name: Build, sign, and notarize the Tauri app
-        id: tauri
-        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
-        with:
-          projectPath: crates/tidebreak-desktop
-          args: >-
-            --target universal-apple-darwin
-            --config ${{ runner.temp }}/tidebreak-release.json
-            --bundles app,dmg
+      - name: Bundle, sign, and notarize the prepared Tauri app
+        working-directory: crates/tidebreak-desktop
+        run: |
+          tauri bundle \
+            --target universal-apple-darwin \
+            --config "$RUNNER_TEMP/tidebreak-signing.json" \
+            --bundles app,dmg \
+            --ci
 
       - name: Notarize and staple the DMG
         env:
@@ -1263,13 +1293,34 @@ jobs:
           } >> "$GITHUB_ENV"
           echo "Using $clang_cl with Ninja for Windows ARM native code"
 
+      - name: Write tag-derived Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
+              version: process.env.TIDEBREAK_VERSION,
+              // NSIS supports per-user installs without elevation and needs
+              // no WiX configuration.
+              bundle: { targets: ["nsis"] },
+              // Release bundles register only the real scheme. A release
+              // binary refuses tidebreak-dev:// links by design.
+              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
+            }));
+          '
+
       - name: Compile without production credentials or bundles
         id: compile
         continue-on-error: true
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
           projectPath: crates/tidebreak-desktop
-          args: --target ${{ matrix.target }} --no-bundle --ci
+          args: >-
+            --target ${{ matrix.target }}
+            --config ${{ runner.temp }}/tidebreak-release.json
+            --no-bundle
+            --ci
 
       - name: Save release-specific unsigned Rust build cache
         if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
@@ -1295,6 +1346,62 @@ jobs:
       - name: Require a successful unsigned compilation
         if: ${{ steps.compile.outcome != 'success' }}
         run: exit 1
+
+      - name: Archive prepared Windows inputs
+        env:
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-windows
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+          RELEASE_TARGET: ${{ matrix.target }}
+        run: |
+          app_binary="target/$RELEASE_TARGET/release/tidebreak-desktop.exe"
+          broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe"
+          cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe"
+          for file in "$app_binary" "$broker_sidecar" "$cli_sidecar" "$RELEASE_CONFIG"; do
+            [[ -s "$file" ]] || {
+              echo "Prepared Windows input is missing or empty: $file" >&2
+              exit 1
+            }
+          done
+
+          rm -rf "$PREPARED_ROOT"
+          mkdir -p \
+            "$PREPARED_ROOT/target/$RELEASE_TARGET/release" \
+            "$PREPARED_ROOT/crates/tidebreak-desktop/binaries"
+          cp -p "$app_binary" "$PREPARED_ROOT/$app_binary"
+          cp -p "$broker_sidecar" "$PREPARED_ROOT/$broker_sidecar"
+          cp -p "$cli_sidecar" "$PREPARED_ROOT/$cli_sidecar"
+          cp "$RELEASE_CONFIG" "$PREPARED_ROOT/release-config.json"
+
+          (
+            cd "$PREPARED_ROOT"
+            sha256sum \
+              release-config.json \
+              "$app_binary" \
+              "$broker_sidecar" \
+              "$cli_sidecar" \
+              > SHA256SUMS
+            tar -cf "$GITHUB_WORKSPACE/prepared-windows.tar" \
+              SHA256SUMS \
+              release-config.json \
+              target \
+              crates
+          )
+          (
+            cd "$GITHUB_WORKSPACE"
+            sha256sum prepared-windows.tar > prepared-windows.tar.sha256
+          )
+
+      - name: Upload prepared Windows inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tidebreak-prepared-windows-${{ matrix.arch }}-${{ github.run_id }}
+          path: |
+            prepared-windows.tar
+            prepared-windows.tar.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: true
 
   build_windows:
     name: Windows · ${{ matrix.arch }}
@@ -1327,83 +1434,58 @@ jobs:
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
     env:
-      # Reuse compiler outputs across trusted release runs without caching the
-      # bundled installers or the updater signing material.
-      CARGO_INCREMENTAL: 0
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: READ_ONLY
-      # Rust code that reports or gates on the product version reads this value.
-      # Cargo package versions remain development metadata and are not released.
       TIDEBREAK_VERSION: ${{ needs.validate.outputs.version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # Build the immutable commit resolved from the validated release tag.
           ref: ${{ needs.validate.outputs.sha }}
 
-      # This restore-only step runs before the updater-signing secret is
-      # loaded. The matching cache is written by a credential-free prerequisite
-      # job for this exact release commit and version. The path list must stay
-      # byte-identical to the writing job's — `actions/cache` folds it into the
-      # cache version. The next step deletes the linked products the archive
-      # carries, so only compiler intermediates survive into the packaged build.
-      - name: Restore unsigned Rust build cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Download prepared Windows inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          path: |
-            target/release/.cargo-lock
-            target/release/.fingerprint
-            target/release/build
-            target/release/deps
-            target/${{ matrix.target }}/release/.cargo-lock
-            target/${{ matrix.target }}/release/.fingerprint
-            target/${{ matrix.target }}/release/build
-            target/${{ matrix.target }}/release/deps
-            target/${{ matrix.target }}/release/tidebreak-desktop.exe
-            target/${{ matrix.target }}/release/tidebreak-host-broker.exe
-            target/${{ matrix.target }}/release/tidebreak.exe
-            target/${{ matrix.target }}/release/tidebreak_desktop_lib.*
-            crates/tidebreak-desktop/binaries/tidebreak-host-broker-${{ matrix.target }}.exe
-            crates/tidebreak-desktop/binaries/tidebreak-${{ matrix.target }}.exe
-          key: windows-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          name: tidebreak-prepared-windows-${{ matrix.arch }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/prepared-windows-download
 
-      # A restore extracts the whole archive, including the linked products a
-      # prerequisite run left in it. Delete them and let this build relink them
-      # from the tag's own sources; the compiler intermediates that make the
-      # reuse worthwhile stay. The sidecar matters most: Tauri copies it into
-      # the installer verbatim, with no Cargo fingerprint governing it.
-      - name: Discard restored product binaries
+      - name: Verify prepared Windows inputs
         env:
+          PREPARED_DOWNLOAD: ${{ runner.temp }}/prepared-windows-download
+          PREPARED_ROOT: ${{ runner.temp }}/tidebreak-prepared-windows
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
           RELEASE_TARGET: ${{ matrix.target }}
         run: |
-          rm -rf \
-            "target/$RELEASE_TARGET/release/tidebreak-desktop.exe" \
-            "target/$RELEASE_TARGET/release/tidebreak-host-broker.exe" \
-            "target/$RELEASE_TARGET/release/tidebreak.exe" \
-            "target/$RELEASE_TARGET/release/"tidebreak_desktop_lib.* \
-            "crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe" \
-            "crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe"
+          (
+            cd "$PREPARED_DOWNLOAD"
+            sha256sum --check --strict prepared-windows.tar.sha256
+          )
+          rm -rf "$PREPARED_ROOT"
+          mkdir -p "$PREPARED_ROOT"
+          tar -xf "$PREPARED_DOWNLOAD/prepared-windows.tar" -C "$PREPARED_ROOT"
+          (
+            cd "$PREPARED_ROOT"
+            sha256sum --check --strict SHA256SUMS
+            expected_files="$(printf '%s\n' \
+              "./SHA256SUMS" \
+              "./crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe" \
+              "./crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe" \
+              "./release-config.json" \
+              "./target/$RELEASE_TARGET/release/tidebreak-desktop.exe" \
+              | LC_ALL=C sort)"
+            actual_files="$(find . -type f -print | LC_ALL=C sort)"
+            [[ "$actual_files" = "$expected_files" ]] || {
+              echo "Prepared Windows archive contains an unexpected file set" >&2
+              printf '%s\n' "$actual_files" >&2
+              exit 1
+            }
+          )
 
-      # sccache, rust-cache, and the UI install run before the updater key is
-      # loaded. pnpm is pinned; lifecycle scripts stay off.
-      - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.16.0
-
-      - name: Cache Cargo downloads
-        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
-        with:
-          shared-key: windows-release-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
-          cache-bin: false
-          # Installers, updater signatures, and signing material remain outside
-          # both the Cargo download cache and the restore-only build cache. The
-          # credential-free prerequisite is the single registry-cache writer.
-          cache-targets: false
-          save-if: false
+          app_binary="target/$RELEASE_TARGET/release/tidebreak-desktop.exe"
+          broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe"
+          cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe"
+          mkdir -p "$(dirname "$app_binary")" "$(dirname "$broker_sidecar")"
+          cp -p "$PREPARED_ROOT/$app_binary" "$app_binary"
+          cp -p "$PREPARED_ROOT/$broker_sidecar" "$broker_sidecar"
+          cp -p "$PREPARED_ROOT/$cli_sidecar" "$cli_sidecar"
+          cp "$PREPARED_ROOT/release-config.json" "$RELEASE_CONFIG"
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
@@ -1412,10 +1494,23 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: crates/tidebreak-desktop/ui/pnpm-lock.yaml
-      - name: Install UI dependencies
-        working-directory: crates/tidebreak-desktop/ui
-        run: pnpm install --frozen-lockfile --ignore-scripts
+          cache-dependency-path: .github/tauri-cli/pnpm-lock.yaml
+      - name: Install pinned Tauri bundler
+        run: |
+          pnpm --dir .github/tauri-cli install --frozen-lockfile --ignore-scripts
+          echo "$GITHUB_WORKSPACE/.github/tauri-cli/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Validate the prepared Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const config = JSON.parse(fs.readFileSync(process.env.RELEASE_CONFIG, "utf8"));
+            if (config.version !== process.env.TIDEBREAK_VERSION) {
+              throw new Error("Prepared version " + config.version + " does not match " + process.env.TIDEBREAK_VERSION);
+            }
+          '
 
       # Authenticode code signing is deliberately absent: v1 Windows releases
       # ship unsigned installers. The Tauri updater key still signs the
@@ -1437,76 +1532,15 @@ jobs:
             exit 1
           fi
 
-      - name: Install Rust target
+      - name: Bundle the prepared Tauri app without Windows code signing
+        working-directory: crates/tidebreak-desktop
         run: |
-          rustup show
-          rustup target add "${{ matrix.target }}"
-
-      # whisper.cpp refuses MSVC on ARM. The cmake crate honors CMAKE_GENERATOR
-      # from the environment but not CMAKE_GENERATOR_TOOLSET, so Ninja plus
-      # clang-cl is the reliable way to keep aarch64-pc-windows-msvc while
-      # compiling the native C/C++ with Clang.
-      - name: Use clang-cl for Windows ARM native code
-        if: ${{ matrix.arch == 'aarch64' }}
-        run: |
-          clang_cl=""
-          for candidate in \
-            "$(command -v clang-cl || true)" \
-            "/c/Program Files/LLVM/bin/clang-cl.exe" \
-            "/c/Program Files/LLVM/bin/clang-cl"; do
-            if [[ -n "$candidate" && -x "$candidate" ]]; then
-              clang_cl="$candidate"
-              break
-            fi
-          done
-          if [[ -z "$clang_cl" ]]; then
-            echo "clang-cl is required to compile whisper.cpp on Windows ARM" >&2
-            exit 1
-          fi
-          if ! command -v ninja >/dev/null; then
-            echo "ninja is required to compile whisper.cpp on Windows ARM" >&2
-            exit 1
-          fi
-          clang_cl="$(cygpath -m "$clang_cl")"
-          {
-            echo "CC=$clang_cl"
-            echo "CXX=$clang_cl"
-            echo "CXXFLAGS=/EHsc"
-            echo "CMAKE_GENERATOR=Ninja"
-            echo "CMAKE_C_COMPILER=$clang_cl"
-            echo "CMAKE_CXX_COMPILER=$clang_cl"
-            echo "CMAKE_ASM_COMPILER=$clang_cl"
-          } >> "$GITHUB_ENV"
-          echo "Using $clang_cl with Ninja for Windows ARM native code"
-
-      - name: Write tag-derived Tauri configuration
-        env:
-          RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
-        run: |
-          node -e '
-            const fs = require("node:fs");
-            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
-              version: process.env.TIDEBREAK_VERSION,
-              // One installer format for v1: NSIS supports per-user installs
-              // without elevation and needs no WiX configuration.
-              bundle: { targets: ["nsis"] },
-              // Release bundles register only the real scheme, mirroring the
-              // macOS release configuration: a release binary refuses
-              // tidebreak-dev:// links by design, so registering the dev scheme
-              // would shadow whatever debug build should answer it.
-              plugins: { "deep-link": { desktop: { schemes: ["tidebreak"] } } }
-            }));
-          '
-
-      - name: Build the Tauri app without Windows code signing
-        id: tauri
-        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
-        with:
-          projectPath: crates/tidebreak-desktop
-          args: >-
-            --target ${{ matrix.target }}
-            --config ${{ runner.temp }}/tidebreak-release.json
-            --bundles nsis
+          tauri bundle \
+            --target "${{ matrix.target }}" \
+            --config "$RUNNER_TEMP/tidebreak-release.json" \
+            --bundles nsis \
+            --no-sign \
+            --ci
 
       - name: Verify and collect unsigned artifacts
         env:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -162,21 +162,20 @@ automatic.
    also send `teamId`. The project and organization identifiers are non-secret
    workflow constants. A failed build or smoke test leaves the previous docs
    deployment serving production.
-6. The workflow first checks whether that exact tag, commit, and
-   publication date already have a complete immutable release on S3.
-   Credential-free prerequisites — one per platform — otherwise compile the tag
-   with its product version and save unsigned Cargo outputs before any signing
-   or notarization can fail.
-7. The production jobs reuse those prepared compiler outputs — every cache key
-   they can restore names the release commit or, at minimum, the `Cargo.lock`
-   and toolchain hashes, and they delete the linked binaries the archive
-   carries so the products they package are always linked from the tag's own
-   sources. The macOS job then signs the app with the Developer ID identity,
-   notarizes and staples the app and DMG, verifies them with Apple tooling, and
-   creates a signed Tauri updater archive. Parallel Windows and Linux jobs
-   produce x86_64 and ARM64 NSIS, AppImage, and Debian packages; every package
-   is signed with the Tauri updater key after packaging. A fresh release cannot
-   continue unless every operating-system and architecture build succeeds.
+6. The workflow first checks whether that exact tag, commit, and publication
+   date already have a complete immutable release on S3. Credential-free macOS
+   and Windows prerequisites otherwise compile the tag once with its product
+   version. Each prerequisite uploads the final desktop binary, sidecars, and
+   Tauri configuration in a run-scoped archive with SHA-256 manifests.
+7. The macOS and Windows production jobs verify those archives before loading
+   signing material, then run `tauri bundle` against the prepared binaries.
+   They do not compile Rust or rebuild the frontend. The macOS job signs the app
+   with the Developer ID identity, notarizes and staples the app and DMG,
+   verifies them with Apple tooling, and creates a signed Tauri updater archive.
+   Parallel Windows and Linux jobs produce x86_64 and ARM64 NSIS, AppImage, and
+   Debian packages; every package is signed with the Tauri updater key after
+   packaging. A fresh release cannot continue unless every operating-system
+   and architecture build succeeds.
 8. For a release that is not already hosted, a separate least-privilege job
    generates an SPDX JSON SBOM from the exact released source and checksums it
    independently of the package builds. That job has no production environment,
@@ -263,7 +262,10 @@ registry and prepared-build caches. The Windows ARM job keeps the
 `aarch64-pc-windows-msvc` Rust target and compiles whisper.cpp with Ninja plus
 `clang-cl`, because ggml refuses MSVC on ARM. The credential-free prepare job
 restores only caches for the same commit SHA, so a failed MSVC CMake tree from
-an earlier attempt cannot be reused after that compiler switch.
+an earlier attempt cannot be reused after that compiler switch. After the
+compile, the job transfers only the final binary, sidecars, and Tauri
+configuration to the production job. The production job verifies and bundles
+those files without installing a compiler or rebuilding the frontend.
 
 Windows code mode uses the desktop's digest-verified managed Node ZIP and
 pinned harness packages. Setup, archive, and quick-action commands run through
@@ -379,9 +381,17 @@ publication failure cannot prevent that main-tip cache run from finishing. If
 the shared cache is empty or has been evicted, manually run **Warm macOS release
 cache** from `main`; the production release workflow also compiles the exact tag
 and product version in a credential-free prerequisite. That prerequisite saves
-its release-specific unsigned archive before reporting a compile failure. The
-later `desktop-production` jobs are restore-only, so signing and notarization
-can be retried without losing completed Rust work.
+its release-specific unsigned cache before reporting a compile failure. After a
+successful compile, it uploads the final binary, universal sidecars, and Tauri
+configuration in a one-day, run-scoped artifact. The `desktop-production` job
+verifies that artifact before it loads signing material, then packages those
+exact binaries without compiling again.
+
+To use a larger macOS runner for production compiles, set the repository
+variable `PRODUCTION_MACOS_RUNNER` to a provisioned ARM64 organization runner
+label. If you omit the variable, the workflow uses `macos-latest`. The signing
+and notarization job stays on the standard runner because it no longer compiles
+the application.
 
 ### Production environment configuration
 

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {
   cpSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -20,6 +21,8 @@ const fixturePaths = [
   ".github/CODEOWNERS",
   ".github/release-drafter.yml",
   ".github/e2b-cli/package.json",
+  ".github/tauri-cli/package.json",
+  ".github/tauri-cli/pnpm-lock.yaml",
   ".github/vercel-cli/package.json",
   ".github/vercel-cli/pnpm-lock.yaml",
   "docs-site/package.json",
@@ -43,6 +46,9 @@ function policyFixture() {
   const root = mkdtempSync(join(tmpdir(), "tidebreak-policy-mutation-"));
   for (const path of fixturePaths) {
     const source = join(repositoryRoot, path);
+    if (!existsSync(source)) {
+      continue;
+    }
     const target = join(root, path);
     mkdirSync(dirname(target), { recursive: true });
     cpSync(source, target, { recursive: true });
@@ -69,6 +75,34 @@ function editWorkflowJob(source, name, mutateJob) {
   const mutated = mutateJob(job);
   assert.notEqual(mutated, job, `mutation did not change job ${name}`);
   return source.slice(0, start) + mutated + source.slice(end);
+}
+
+function signingInstallStep(job) {
+  const step = job.match(
+    /      - name: (?:Install UI dependencies|Install pinned Tauri bundler)\n[\s\S]*?(?=\n      - name:)/,
+  )?.[0];
+  assert.ok(step, "missing signing-job dependency install");
+  return step;
+}
+
+function mutateSigningRustCache(job, saveIf) {
+  if (/Install pinned Tauri bundler/.test(job)) {
+    const step = `      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          cache-targets: false
+          save-if: ${saveIf}
+
+`;
+    return job.replace(
+      "      - name: Validate production signing configuration\n",
+      `${step}      - name: Validate production signing configuration\n`,
+    );
+  }
+  return job.replace(
+    /save-if: (?:false|\$\{\{ matrix\.arch == 'aarch64' \}\})/,
+    `save-if: ${saveIf}`,
+  );
 }
 
 function runPolicy(root) {
@@ -439,12 +473,10 @@ const mutations = [
     file: ".github/workflows/release.yml",
     expected: "signing jobs do not run untrusted installers",
     mutate: (source) =>
-      editWorkflowJob(source, "build_macos", (job) =>
-        job.replace(
-          /      - name: Install UI dependencies\n        working-directory: crates\/tidebreak-desktop\/ui\n        run: pnpm install --frozen-lockfile(?: --ignore-scripts)?\n/,
-          "",
-        ),
-      ),
+      editWorkflowJob(source, "build_macos", (job) => {
+        const install = signingInstallStep(job);
+        return job.replace(install, "");
+      }),
   },
   {
     name: "signing job rust-cache writer",
@@ -452,10 +484,7 @@ const mutations = [
     expected: "signing jobs do not run untrusted installers",
     mutate: (source) =>
       editWorkflowJob(source, "build_macos", (job) =>
-        job.replace(
-          /save-if: (?:false|\$\{\{ matrix\.arch == 'aarch64' \}\})/,
-          "save-if: true",
-        ),
+        mutateSigningRustCache(job, "true"),
       ),
   },
   {
@@ -474,8 +503,8 @@ const mutations = [
     mutate: (source) =>
       editWorkflowJob(source, "build_macos", (job) =>
         job.replace(
-          "pnpm install --frozen-lockfile --ignore-scripts",
-          "pnpm install --frozen-lockfile",
+          /pnpm(?: --dir \.github\/tauri-cli)? install --frozen-lockfile --ignore-scripts/,
+          (install) => install.replace(" --ignore-scripts", ""),
         ),
       ),
   },
@@ -485,12 +514,10 @@ const mutations = [
     expected: "signing jobs do not run untrusted installers",
     mutate: (source) =>
       editWorkflowJob(source, "build_macos", (job) => {
-        const install =
-          "      - name: Install UI dependencies\n        working-directory: crates/tidebreak-desktop/ui\n        run: pnpm install --frozen-lockfile --ignore-scripts\n";
-        assert.ok(job.includes(install));
+        const install = signingInstallStep(job);
         return job.replace(install, "").replace(
           "      - name: Validate production signing configuration\n",
-          `      - name: Validate production signing configuration\n${install}`,
+          `      - name: Validate production signing configuration\n${install}\n`,
         );
       }),
   },
@@ -500,10 +527,7 @@ const mutations = [
     expected: "signing jobs do not run untrusted installers",
     mutate: (source) =>
       editWorkflowJob(source, "build_macos", (job) =>
-        job.replace(
-          "save-if: false",
-          "save-if: ${{ matrix.arch == 'aarch64' }}",
-        ),
+        mutateSigningRustCache(job, "${{ matrix.arch == 'aarch64' }}"),
       ),
   },
   {

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -73,6 +73,13 @@ const docsPackage = JSON.parse(
 const vercelCliPackage = JSON.parse(
   readFileSync(repositoryFile(".github", "vercel-cli", "package.json"), "utf8"),
 );
+const tauriCliPackage = JSON.parse(
+  readFileSync(repositoryFile(".github", "tauri-cli", "package.json"), "utf8"),
+);
+const tauriCliLock = readFileSync(
+  repositoryFile(".github", "tauri-cli", "pnpm-lock.yaml"),
+  "utf8",
+);
 const packagedGhDiscoverySmoke = readFileSync(
   repositoryFile("scripts", "smoke-packaged-gh-discovery.sh"),
   "utf8",
@@ -1399,19 +1406,15 @@ test("cache warming cannot access production credentials or publish", () => {
   }
 });
 
-test("release caches restore only credential-free compiler products", () => {
+test("release compile jobs keep caches and prepared artifacts credential-free", () => {
   const release = workflows["release.yml"];
   const cache = workflows["cache-macos.yml"];
   const prepareJob = workflowJob(release, "prepare_macos");
-  const signedBuildJob = workflowJob(release, "build_macos");
   const releasePrepareCache = prepareJob.match(
     /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
   const releasePrepareCacheSave = prepareJob.match(
     /- name: Save release-specific unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
-  )?.[0];
-  const releaseBuildCache = signedBuildJob.match(
-    /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
   const warmBuildCache = cache.match(
     /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
@@ -1421,40 +1424,50 @@ test("release caches restore only credential-free compiler products", () => {
   )?.[0];
   assert.ok(releasePrepareCache);
   assert.ok(releasePrepareCacheSave);
-  assert.ok(releaseBuildCache);
   assert.ok(warmBuildCache);
   assert.ok(warmBuildCacheSave);
   const universalMacos = /--target universal-apple-darwin/.test(prepareJob);
 
+  assert.match(
+    prepareJob,
+    /runs-on: \$\{\{ vars\.PRODUCTION_MACOS_RUNNER \|\| 'macos-latest' \}\}/,
+  );
   assert.match(prepareJob, /SCCACHE_GHA_ENABLED: "true"/);
   assert.match(prepareJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
   assert.match(prepareJob, /cache-targets: false/);
-  assert.match(prepareJob, /--no-bundle --ci/);
+  assert.match(prepareJob, /--config \$\{\{ runner\.temp \}\}\/tidebreak-release\.json/);
+  assert.match(prepareJob, /--no-bundle/);
+  assert.match(prepareJob, /--ci/);
   assert.match(prepareJob, /continue-on-error: true/);
   assert.match(releasePrepareCache, /actions\/cache\/restore@[0-9a-f]{40}/);
   assert.match(releasePrepareCacheSave, /actions\/cache\/save@[0-9a-f]{40}/);
   assert.doesNotMatch(prepareJob, /^    environment:/m);
   assert.doesNotMatch(prepareJob, /secrets\./);
-  assert.doesNotMatch(
-    prepareJob,
-    /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_|actions\/upload-artifact/,
+  assert.doesNotMatch(prepareJob, /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_/);
+  assert.ok(
+    prepareJob.indexOf("Write tag-derived Tauri configuration") <
+      prepareJob.indexOf("Compile without production credentials or bundles"),
+    "the release configuration must be embedded during compilation",
   );
   assert.ok(
     prepareJob.indexOf("Save release-specific unsigned Rust build cache") <
       prepareJob.indexOf("Require a successful unsigned compilation"),
     "release compiler outputs must be saved before a failed compile is reported",
   );
-
-  assert.match(signedBuildJob, /SCCACHE_GHA_ENABLED: "true"/);
-  assert.match(signedBuildJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
-  assert.match(signedBuildJob, /cache-targets: false/);
-  assert.match(releaseBuildCache, /actions\/cache\/restore@[0-9a-f]{40}/);
-  assert.doesNotMatch(signedBuildJob, /actions\/cache\/save/);
   assert.ok(
-    signedBuildJob.indexOf("Restore unsigned Rust build cache") <
-      signedBuildJob.indexOf("Validate production signing configuration"),
-    "the build cache must be restored before production secrets are loaded",
+    prepareJob.indexOf("Require a successful unsigned compilation") <
+      prepareJob.indexOf("Archive prepared macOS inputs"),
+    "failed compiles must not publish prepared binaries",
   );
+  assert.match(
+    prepareJob,
+    /name: tidebreak-prepared-macos-universal-\$\{\{ github\.run_id \}\}/,
+  );
+  assert.match(prepareJob, /retention-days: 1/);
+  assert.match(prepareJob, /compression-level: 0/);
+  assert.match(prepareJob, /overwrite: true/);
+  assert.match(prepareJob, /shasum -a 256[\s\S]*> SHA256SUMS/);
+  assert.match(prepareJob, /shasum -a 256 prepared-macos\.tar/);
 
   assert.match(cache, /SCCACHE_GHA_ENABLED: "true"/);
   assert.match(cache, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
@@ -1470,7 +1483,6 @@ test("release caches restore only credential-free compiler products", () => {
   for (const cacheStep of [
     releasePrepareCache,
     releasePrepareCacheSave,
-    releaseBuildCache,
     warmBuildCache,
     warmBuildCacheSave,
   ]) {
@@ -1529,24 +1541,16 @@ test("release caches restore only credential-free compiler products", () => {
     assert.doesNotMatch(cacheStep, /bundle|\.app|dmg|signature|keychain/i);
   }
 
-  // `actions/cache` folds the path list into the cache version, so the signing
-  // job can only reach an archive a writing job saved under the same list.
-  // Keeping them identical is what makes the key ladder below, rather than a
-  // silent total miss, the thing that governs what gets restored.
+  // `actions/cache` folds the path list into the cache version. The release
+  // compile and cache-warming jobs must write compatible archives.
   const cachedPaths = (step) =>
     step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
-  assert.ok(cachedPaths(releaseBuildCache));
   assert.equal(
-    cachedPaths(releaseBuildCache),
     cachedPaths(releasePrepareCacheSave),
+    cachedPaths(warmBuildCacheSave),
   );
-  assert.equal(cachedPaths(releaseBuildCache), cachedPaths(warmBuildCacheSave));
 
-  for (const restoreStep of [
-    releasePrepareCache,
-    releaseBuildCache,
-    warmBuildCache,
-  ]) {
+  for (const restoreStep of [releasePrepareCache, warmBuildCache]) {
     assert.match(
       restoreStep,
       universalMacos
@@ -1578,58 +1582,85 @@ test("release caches restore only credential-free compiler products", () => {
     );
   }
 
-  // The signing job signs what it restores, so every key it can hit must pin
-  // the source identity of the archive: the release commit SHA, or at minimum
-  // the Cargo.lock and toolchain hashes. An arch-only fallback would restore
-  // an archive warmed from an unrelated `main` commit and sign binaries that
-  // do not correspond to the released tag.
-  const signingCacheKeys = releaseBuildCache
-    .split("\n")
-    .map((line) => line.trim().replace(/^key: /, ""))
-    .filter((line) => line.startsWith("macos-release-"));
-  assert.ok(signingCacheKeys.length >= 4);
-  for (const key of signingCacheKeys) {
+});
+
+test("macOS production packaging uses verified prepared binaries", () => {
+  const buildJob = workflowJob(workflows["release.yml"], "build_macos");
+  const verifyStep = buildJob.match(
+    /- name: Verify prepared macOS inputs[\s\S]*?(?=\n\s+- (?:name:|uses:))/,
+  )?.[0];
+  const bundleStep = buildJob.match(
+    /- name: Bundle, sign, and notarize the prepared Tauri app[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(verifyStep);
+  assert.ok(bundleStep);
+
+  assert.match(
+    buildJob,
+    /name: tidebreak-prepared-macos-universal-\$\{\{ github\.run_id \}\}/,
+  );
+  assert.match(
+    verifyStep,
+    /shasum -a 256 --check prepared-macos\.tar\.sha256/,
+  );
+  assert.match(verifyStep, /shasum -a 256 --check SHA256SUMS/);
+  assert.match(
+    verifyStep,
+    /Prepared macOS archive contains an unexpected file set/,
+  );
+  assert.match(
+    verifyStep,
+    /target\/\$RELEASE_TARGET\/release\/tidebreak-desktop/,
+  );
+  assert.match(
+    verifyStep,
+    /binaries\/tidebreak-host-broker-\$RELEASE_TARGET/,
+  );
+  assert.match(verifyStep, /binaries\/tidebreak-\$RELEASE_TARGET/);
+
+  assert.equal(tauriCliPackage.packageManager, "pnpm@10.18.3");
+  assert.equal(tauriCliPackage.dependencies["@tauri-apps/cli"], "2.11.4");
+  assert.match(
+    tauriCliLock,
+    /'@tauri-apps\/cli':\n\s+specifier: 2\.11\.4\n\s+version: 2\.11\.4/,
+  );
+  assert.match(
+    buildJob,
+    /cache-dependency-path: \.github\/tauri-cli\/pnpm-lock\.yaml/,
+  );
+  assert.match(
+    buildJob,
+    /pnpm --dir \.github\/tauri-cli install --frozen-lockfile --ignore-scripts/,
+  );
+  assert.match(bundleStep, /tauri bundle/);
+  assert.match(bundleStep, /--target universal-apple-darwin/);
+  assert.match(bundleStep, /--bundles app,dmg/);
+  assert.match(bundleStep, /--ci/);
+  assert.doesNotMatch(bundleStep, /TAURI_SIGNING_PRIVATE_KEY/);
+
+  assert.doesNotMatch(buildJob, /tauri-apps\/tauri-action/);
+  assert.doesNotMatch(buildJob, /actions\/cache/);
+  assert.doesNotMatch(buildJob, /mozilla-actions\/sccache-action/);
+  assert.doesNotMatch(buildJob, /Swatinem\/rust-cache/);
+  assert.doesNotMatch(buildJob, /Install UI dependencies/);
+  assert.doesNotMatch(buildJob, /Install Rust target/);
+  assert.doesNotMatch(buildJob, /\btauri build\b/);
+
+  const secretsAt = firstSigningMaterialIndex(
+    buildJob,
+    "Validate production signing configuration",
+  );
+  for (const marker of [
+    "Download prepared macOS inputs",
+    "Verify prepared macOS inputs",
+    "Install pinned Tauri bundler",
+  ]) {
+    const index = buildJob.indexOf(marker);
     assert.ok(
-      key.includes("hashFiles('Cargo.lock',"),
-      `restorable signing-job cache key does not pin the source: ${key}`,
+      index !== -1 && index < secretsAt,
+      `${marker} must run before signing material loads`,
     );
   }
-
-  // Whatever a restore extracts, the products that actually get signed are
-  // relinked from the tag's own sources.
-  const discardProducts = signedBuildJob.match(
-    /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
-  )?.[0];
-  assert.ok(discardProducts);
-  const discardedProducts = universalMacos
-    ? [
-        /aarch64-apple-darwin,x86_64-apple-darwin,universal-apple-darwin.*release\/tidebreak-desktop/,
-        /aarch64-apple-darwin,x86_64-apple-darwin.*release\/tidebreak-host-broker/,
-        /aarch64-apple-darwin,x86_64-apple-darwin.*release\/tidebreak/,
-        /libtidebreak_desktop_lib\./,
-        /binaries\/tidebreak-host-broker-\{aarch64-apple-darwin,x86_64-apple-darwin\}/,
-        /binaries\/tidebreak-\{aarch64-apple-darwin,x86_64-apple-darwin\}/,
-        /binaries\/tidebreak-host-broker-universal-apple-darwin/,
-        /binaries\/tidebreak-universal-apple-darwin/,
-      ]
-    : [
-        /release\/tidebreak-desktop/,
-        /release\/tidebreak-host-broker/,
-        /release\/tidebreak/,
-        /libtidebreak_desktop_lib\./,
-        /binaries\/tidebreak-host-broker-\$RELEASE_TARGET/,
-        /binaries\/tidebreak-\$RELEASE_TARGET/,
-      ];
-  for (const product of discardedProducts) {
-    assert.match(discardProducts, product);
-  }
-  assert.ok(
-    signedBuildJob.indexOf("Discard restored product binaries") >
-      signedBuildJob.indexOf("Restore unsigned Rust build cache") &&
-      signedBuildJob.indexOf("Discard restored product binaries") <
-        signedBuildJob.indexOf("Build, sign, and notarize the Tauri app"),
-    "restored product binaries must be discarded before the signed build",
-  );
 });
 
 test("Windows release jobs mirror the credential-free prepare/build split", () => {
@@ -1639,43 +1670,34 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   const prepareCacheSave = prepareJob.match(
     /- name: Save release-specific unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
-  const buildCacheRestore = buildJob.match(
-    /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
-  )?.[0];
   assert.ok(prepareCacheSave);
-  assert.ok(buildCacheRestore);
   for (const job of [prepareJob, buildJob]) {
     assert.match(job, /runs-on: \$\{\{ matrix\.runner \}\}/);
     assert.match(job, /target: x86_64-pc-windows-msvc/);
     assert.match(job, /runner: windows-latest/);
     assert.match(job, /target: aarch64-pc-windows-msvc/);
     assert.match(job, /runner: windows-11-arm/);
-    // whisper.cpp refuses MSVC on ARM. Force Ninja + clang-cl only on the
-    // ARM matrix entry so x86_64 keeps the Visual Studio generator.
-    assert.match(job, /if: \$\{\{ matrix\.arch == 'aarch64' \}\}/);
-    assert.match(job, /CMAKE_GENERATOR=Ninja/);
-    assert.match(job, /CMAKE_C_COMPILER=/);
-    assert.match(job, /CMAKE_CXX_COMPILER=/);
-    assert.match(job, /CMAKE_ASM_COMPILER=/);
-    assert.match(job, /echo "CC=\$clang_cl"/);
-    assert.match(job, /echo "CXX=\$clang_cl"/);
-    assert.match(job, /CXXFLAGS=\/EHsc/);
-    assert.match(job, /clang-cl/);
-    assert.match(job, /command -v ninja/);
   }
+  // whisper.cpp refuses MSVC on ARM. Force Ninja + clang-cl only in the
+  // credential-free compile job so the packaging job needs no compiler.
+  assert.match(prepareJob, /if: \$\{\{ matrix\.arch == 'aarch64' \}\}/);
+  assert.match(prepareJob, /CMAKE_GENERATOR=Ninja/);
+  assert.match(prepareJob, /CMAKE_C_COMPILER=/);
+  assert.match(prepareJob, /CMAKE_CXX_COMPILER=/);
+  assert.match(prepareJob, /CMAKE_ASM_COMPILER=/);
+  assert.match(prepareJob, /echo "CC=\$clang_cl"/);
+  assert.match(prepareJob, /echo "CXX=\$clang_cl"/);
+  assert.match(prepareJob, /CXXFLAGS=\/EHsc/);
+  assert.match(prepareJob, /clang-cl/);
+  assert.match(prepareJob, /command -v ninja/);
   assert.ok(
     prepareJob.indexOf("Use clang-cl for Windows ARM native code") <
       prepareJob.indexOf("Compile without production credentials or bundles"),
     "Windows ARM clang-cl must be configured before the unsigned compile",
   );
-  assert.ok(
-    buildJob.indexOf("Use clang-cl for Windows ARM native code") <
-      buildJob.indexOf("Build the Tauri app without Windows code signing"),
-    "Windows ARM clang-cl must be configured before the packaged build",
-  );
 
-  // The prerequisite compiles without any production credential and never
-  // uploads what it built; only the cache carries its outputs forward.
+  // The prerequisite compiles and archives the exact release inputs without
+  // any production credential.
   assert.match(prepareJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
   assert.match(prepareJob, /version: 10\.18\.3/);
   assert.match(prepareJob, /pnpm install --frozen-lockfile --ignore-scripts/);
@@ -1683,66 +1705,100 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
     prepareJob,
     /node scripts\/generate-third-party-notices\.mjs --check/,
   );
-  assert.match(prepareJob, /--no-bundle --ci/);
+  assert.match(prepareJob, /--config \$\{\{ runner\.temp \}\}\/tidebreak-release\.json/);
+  assert.match(prepareJob, /--no-bundle/);
+  assert.match(prepareJob, /--ci/);
   assert.match(prepareJob, /continue-on-error: true/);
   assert.doesNotMatch(prepareJob, /^    environment:/m);
   assert.doesNotMatch(prepareJob, /secrets\./);
-  assert.doesNotMatch(
-    prepareJob,
-    /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_|actions\/upload-artifact/,
+  assert.doesNotMatch(prepareJob, /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_/);
+  assert.ok(
+    prepareJob.indexOf("Write tag-derived Tauri configuration") <
+      prepareJob.indexOf("Compile without production credentials or bundles"),
+    "the release configuration must be embedded during compilation",
   );
   assert.ok(
     prepareJob.indexOf("Save release-specific unsigned Rust build cache") <
       prepareJob.indexOf("Require a successful unsigned compilation"),
     "release compiler outputs must be saved before a failed compile is reported",
   );
-
-  // The packaging job is restore-only and loads the updater key only after
-  // the credential-free cache restore.
-  assert.doesNotMatch(buildJob, /actions\/cache\/save/);
   assert.ok(
-    buildJob.indexOf("Restore unsigned Rust build cache") <
-      buildJob.indexOf("Validate updater signing configuration"),
-    "the build cache must be restored before the updater secret is loaded",
+    prepareJob.indexOf("Require a successful unsigned compilation") <
+      prepareJob.indexOf("Archive prepared Windows inputs"),
+    "failed compiles must not publish prepared binaries",
   );
-
-  // Identical path lists keep the cache version shared between the writing
-  // and restoring jobs. The credentialed job accepts only the exact cache for
-  // this release SHA and version; broader warm-cache fallback stays confined
-  // to the credential-free prerequisite.
-  const cachedPaths = (step) =>
-    step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
-  assert.ok(cachedPaths(buildCacheRestore));
-  assert.equal(cachedPaths(buildCacheRestore), cachedPaths(prepareCacheSave));
   assert.match(
-    buildCacheRestore,
-    /key: windows-release-prepared-v1-\$\{\{ matrix\.arch \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ needs\.validate\.outputs\.sha \}\}-\$\{\{ needs\.validate\.outputs\.version \}\}/,
+    prepareJob,
+    /name: tidebreak-prepared-windows-\$\{\{ matrix\.arch \}\}-\$\{\{ github\.run_id \}\}/,
   );
-  assert.doesNotMatch(buildCacheRestore, /restore-keys:/);
+  assert.match(prepareJob, /retention-days: 1/);
+  assert.match(prepareJob, /compression-level: 0/);
+  assert.match(prepareJob, /overwrite: true/);
+  assert.match(prepareJob, /sha256sum[\s\S]*> SHA256SUMS/);
+  assert.match(prepareJob, /sha256sum prepared-windows\.tar/);
 
-  // Whatever a restore extracts, the products that get packaged are relinked
-  // from the tag's own sources.
-  const discardProducts = buildJob.match(
-    /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
+  const verifyStep = buildJob.match(
+    /- name: Verify prepared Windows inputs[\s\S]*?(?=\n\s+- (?:name:|uses:))/,
   )?.[0];
-  assert.ok(discardProducts);
-  for (const product of [
-    /release\/tidebreak-desktop\.exe/,
-    /release\/tidebreak-host-broker\.exe/,
-    /release\/tidebreak\.exe/,
-    /tidebreak_desktop_lib\./,
-    /binaries\/tidebreak-host-broker-\$RELEASE_TARGET\.exe/,
-    /binaries\/tidebreak-\$RELEASE_TARGET\.exe/,
-  ]) {
-    assert.match(discardProducts, product);
-  }
-  assert.ok(
-    buildJob.indexOf("Discard restored product binaries") >
-      buildJob.indexOf("Restore unsigned Rust build cache") &&
-      buildJob.indexOf("Discard restored product binaries") <
-        buildJob.indexOf("Build the Tauri app without Windows code signing"),
-    "restored product binaries must be discarded before the packaged build",
+  const bundleStep = buildJob.match(
+    /- name: Bundle the prepared Tauri app without Windows code signing[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(verifyStep);
+  assert.ok(bundleStep);
+  assert.match(
+    buildJob,
+    /name: tidebreak-prepared-windows-\$\{\{ matrix\.arch \}\}-\$\{\{ github\.run_id \}\}/,
   );
+  assert.match(
+    verifyStep,
+    /sha256sum --check --strict prepared-windows\.tar\.sha256/,
+  );
+  assert.match(verifyStep, /sha256sum --check --strict SHA256SUMS/);
+  assert.match(
+    verifyStep,
+    /Prepared Windows archive contains an unexpected file set/,
+  );
+  assert.match(
+    buildJob,
+    /pnpm --dir \.github\/tauri-cli install --frozen-lockfile --ignore-scripts/,
+  );
+  assert.match(
+    buildJob,
+    /cache-dependency-path: \.github\/tauri-cli\/pnpm-lock\.yaml/,
+  );
+  assert.match(buildJob, /Validate the prepared Tauri configuration/);
+  assert.match(bundleStep, /tauri bundle/);
+  assert.match(bundleStep, /--target "\$\{\{ matrix\.target \}\}"/);
+  assert.match(bundleStep, /--bundles nsis/);
+  assert.match(bundleStep, /--no-sign/);
+  assert.match(bundleStep, /--ci/);
+  assert.doesNotMatch(bundleStep, /TAURI_SIGNING_PRIVATE_KEY/);
+
+  assert.doesNotMatch(buildJob, /tauri-apps\/tauri-action/);
+  assert.doesNotMatch(buildJob, /actions\/cache/);
+  assert.doesNotMatch(buildJob, /mozilla-actions\/sccache-action/);
+  assert.doesNotMatch(buildJob, /Swatinem\/rust-cache/);
+  assert.doesNotMatch(buildJob, /Install UI dependencies/);
+  assert.doesNotMatch(buildJob, /Install Rust target/);
+  assert.doesNotMatch(buildJob, /Use clang-cl for Windows ARM native code/);
+  assert.doesNotMatch(buildJob, /\btauri build\b/);
+
+  const secretsAt = firstSigningMaterialIndex(
+    buildJob,
+    "Validate updater signing configuration",
+  );
+  for (const marker of [
+    "Download prepared Windows inputs",
+    "Verify prepared Windows inputs",
+    "Install pinned Tauri bundler",
+    "Validate the prepared Tauri configuration",
+  ]) {
+    const index = buildJob.indexOf(marker);
+    assert.ok(
+      index !== -1 && index < secretsAt,
+      `${marker} must run before signing material loads`,
+    );
+  }
 
   // The packaging job must use distinct variable names for each sidecar so it
   // validates both binaries without overwriting the variable.
@@ -1753,11 +1809,11 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
 
   // v1 ships unsigned Windows artifacts: no Authenticode configuration may
   // creep in, no Apple credential reaches the Windows jobs, and the updater
-  // private key stays out of the Tauri build step.
+  // private key stays out of the Tauri bundle step.
   assert.doesNotMatch(release, /certificateThumbprint|signCommand/);
   assert.doesNotMatch(buildJob, /APPLE_|AWS_|DOWNLOADS_/);
   const buildStep = buildJob.match(
-    /- name: Build the Tauri app without Windows code signing[\s\S]*?(?=\n\s+- name:)/,
+    /- name: Bundle the prepared Tauri app without Windows code signing[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
   assert.ok(buildStep);
   assert.doesNotMatch(buildStep, /TAURI_SIGNING_PRIVATE_KEY/);
@@ -2058,11 +2114,17 @@ test("GitHub release assets are attached before immutable publication", () => {
 
 test("the updater private key is isolated from compilation", () => {
   const release = workflows["release.yml"];
-  const buildStep = release.match(
-    /- name: Build, sign, and notarize the Tauri app[\s\S]*?(?=\n\s+- name:)/,
+  for (const jobName of ["prepare_macos", "prepare_windows"]) {
+    assert.doesNotMatch(
+      workflowJob(release, jobName),
+      /TAURI_SIGNING_PRIVATE_KEY/,
+    );
+  }
+  const bundleStep = release.match(
+    /- name: Bundle, sign, and notarize the prepared Tauri app[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
-  assert.ok(buildStep);
-  assert.doesNotMatch(buildStep, /TAURI_SIGNING_PRIVATE_KEY/);
+  assert.ok(bundleStep);
+  assert.doesNotMatch(bundleStep, /TAURI_SIGNING_PRIVATE_KEY/);
   assert.doesNotMatch(release, /createUpdaterArtifacts/);
   assert.match(release, /tauri signer sign "\$updater_path"/);
   assert.doesNotMatch(release, /cargo tauri signer sign/);
@@ -2083,43 +2145,44 @@ test("signing jobs do not run untrusted installers next to Apple or Tauri materi
     );
     assert.match(
       job,
-      /pnpm install --frozen-lockfile --ignore-scripts\n/,
-      `${label} must install UI deps without lifecycle scripts`,
-    );
-    assert.match(
-      job,
-      /mozilla-actions\/sccache-action@[0-9a-f]{40}/,
-      `${label} must set up sccache`,
-    );
-    assert.match(
-      job,
-      /Swatinem\/rust-cache@[0-9a-f]{40}/,
-      `${label} must restore the Cargo download cache`,
-    );
-    assert.match(
-      job,
       /actions\/setup-node@[0-9a-f]{40}/,
       `${label} must set up Node`,
-    );
-
-    const rustCache = cargoDownloadCache(job);
-    assert.ok(rustCache, `${label} missing Cargo download cache`);
-    assert.match(
-      rustCache,
-      /save-if: false/,
-      `${label} rust-cache must be restore-only`,
     );
 
     const secretsAt = firstSigningMaterialIndex(job, validate);
     assert.notEqual(secretsAt, -1, `${label} must still load signing material`);
 
+    const bundleOnly =
+      file === "release.yml" &&
+      (name === "build_macos" || name === "build_windows");
     const installerIndexes = [
-      job.search(/mozilla-actions\/sccache-action@[0-9a-f]{40}/),
-      job.search(/Swatinem\/rust-cache@[0-9a-f]{40}/),
       job.search(/pnpm\/action-setup@[0-9a-f]{40}/),
       job.search(/actions\/setup-node@[0-9a-f]{40}/),
-      job.search(/pnpm install --frozen-lockfile --ignore-scripts\n/),
     ];
+    if (bundleOnly) {
+      const install = job.search(
+        /pnpm --dir \.github\/tauri-cli install --frozen-lockfile --ignore-scripts/,
+      );
+      installerIndexes.push(install);
+      assert.doesNotMatch(job, /mozilla-actions\/sccache-action/);
+      assert.doesNotMatch(job, /Swatinem\/rust-cache/);
+    } else {
+      const install = job.search(
+        /pnpm install --frozen-lockfile --ignore-scripts\n/,
+      );
+      installerIndexes.push(
+        job.search(/mozilla-actions\/sccache-action@[0-9a-f]{40}/),
+        job.search(/Swatinem\/rust-cache@[0-9a-f]{40}/),
+        install,
+      );
+      const rustCache = cargoDownloadCache(job);
+      assert.ok(rustCache, `${label} missing Cargo download cache`);
+      assert.match(
+        rustCache,
+        /save-if: false/,
+        `${label} rust-cache must be restore-only`,
+      );
+    }
     assert.ok(
       installerIndexes.every((index) => index !== -1),
       `${label} is missing an installer step`,
@@ -2142,7 +2205,7 @@ test("macOS disk images are explicitly notarized and stapled", () => {
   assert.match(dmgNotarization, /xcrun stapler staple "\$dmg_path"/);
   assert.match(dmgNotarization, /xcrun stapler validate "\$dmg_path"/);
   assert.ok(
-    release.indexOf("Build, sign, and notarize the Tauri app") <
+    release.indexOf("Bundle, sign, and notarize the prepared Tauri app") <
       release.indexOf("Notarize and staple the DMG"),
   );
   assert.ok(
@@ -2152,6 +2215,7 @@ test("macOS disk images are explicitly notarized and stapled", () => {
 });
 
 test("universal macOS release and staging packages contain both slices", () => {
+  const releasePrepare = workflowJob(workflows["release.yml"], "prepare_macos");
   const releaseBuild = workflowJob(workflows["release.yml"], "build_macos");
   if (!/--target universal-apple-darwin/.test(releaseBuild)) {
     return;
@@ -2177,10 +2241,12 @@ test("universal macOS release and staging packages contain both slices", () => {
     /"lipo",\s*\["-create", \.\.\.stagedSidecars, "-output", destination\]/,
   );
 
-  for (const job of [releaseBuild, stagingBuild, warm]) {
+  for (const job of [releasePrepare, stagingBuild, warm]) {
     assert.match(job, /rustup target add aarch64-apple-darwin x86_64-apple-darwin/);
     assert.match(job, /--target universal-apple-darwin/);
   }
+  assert.match(releaseBuild, /--target universal-apple-darwin/);
+  assert.doesNotMatch(releaseBuild, /rustup target add/);
 
   for (const job of [releaseBuild, stagingBuild]) {
     assert.match(job, /timeout-minutes: 90/);

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -73,6 +73,22 @@ const docsPackage = JSON.parse(
 const vercelCliPackage = JSON.parse(
   readFileSync(repositoryFile(".github", "vercel-cli", "package.json"), "utf8"),
 );
+const tauriCliPackagePath = repositoryFile(
+  ".github",
+  "tauri-cli",
+  "package.json",
+);
+const tauriCliLockPath = repositoryFile(
+  ".github",
+  "tauri-cli",
+  "pnpm-lock.yaml",
+);
+const tauriCliPackage = existsSync(tauriCliPackagePath)
+  ? JSON.parse(readFileSync(tauriCliPackagePath, "utf8"))
+  : null;
+const tauriCliLock = existsSync(tauriCliLockPath)
+  ? readFileSync(tauriCliLockPath, "utf8")
+  : null;
 const packagedGhDiscoverySmoke = readFileSync(
   repositoryFile("scripts", "smoke-packaged-gh-discovery.sh"),
   "utf8",
@@ -1399,19 +1415,17 @@ test("cache warming cannot access production credentials or publish", () => {
   }
 });
 
-test("release caches restore only credential-free compiler products", () => {
+test("release compile jobs keep caches and prepared artifacts credential-free", () => {
   const release = workflows["release.yml"];
   const cache = workflows["cache-macos.yml"];
   const prepareJob = workflowJob(release, "prepare_macos");
   const signedBuildJob = workflowJob(release, "build_macos");
+  const preparedArtifacts = /Archive prepared macOS inputs/.test(prepareJob);
   const releasePrepareCache = prepareJob.match(
     /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
   const releasePrepareCacheSave = prepareJob.match(
     /- name: Save release-specific unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
-  )?.[0];
-  const releaseBuildCache = signedBuildJob.match(
-    /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
   const warmBuildCache = cache.match(
     /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
@@ -1419,42 +1433,85 @@ test("release caches restore only credential-free compiler products", () => {
   const warmBuildCacheSave = cache.match(
     /- name: Save unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
+  const releaseBuildCache = signedBuildJob.match(
+    /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
   assert.ok(releasePrepareCache);
   assert.ok(releasePrepareCacheSave);
-  assert.ok(releaseBuildCache);
   assert.ok(warmBuildCache);
   assert.ok(warmBuildCacheSave);
+  if (!preparedArtifacts) {
+    assert.ok(releaseBuildCache);
+  }
   const universalMacos = /--target universal-apple-darwin/.test(prepareJob);
 
+  assert.match(
+    prepareJob,
+    preparedArtifacts
+      ? /runs-on: \$\{\{ vars\.PRODUCTION_MACOS_RUNNER \|\| 'macos-latest' \}\}/
+      : /runs-on: macos-latest/,
+  );
   assert.match(prepareJob, /SCCACHE_GHA_ENABLED: "true"/);
   assert.match(prepareJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
   assert.match(prepareJob, /cache-targets: false/);
-  assert.match(prepareJob, /--no-bundle --ci/);
+  if (preparedArtifacts) {
+    assert.match(
+      prepareJob,
+      /--config \$\{\{ runner\.temp \}\}\/tidebreak-release\.json/,
+    );
+  } else {
+    assert.match(prepareJob, /--no-bundle --ci/);
+  }
+  assert.match(prepareJob, /--no-bundle/);
+  assert.match(prepareJob, /--ci/);
   assert.match(prepareJob, /continue-on-error: true/);
   assert.match(releasePrepareCache, /actions\/cache\/restore@[0-9a-f]{40}/);
   assert.match(releasePrepareCacheSave, /actions\/cache\/save@[0-9a-f]{40}/);
   assert.doesNotMatch(prepareJob, /^    environment:/m);
   assert.doesNotMatch(prepareJob, /secrets\./);
-  assert.doesNotMatch(
-    prepareJob,
-    /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_|actions\/upload-artifact/,
-  );
+  assert.doesNotMatch(prepareJob, /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_/);
+  if (preparedArtifacts) {
+    const configAt = prepareJob.indexOf("Write tag-derived Tauri configuration");
+    const checkoutAt = prepareJob.indexOf("uses: actions/checkout@");
+    assert.ok(
+      configAt !== -1 && configAt < checkoutAt,
+      "the release configuration must be created before the release source is checked out",
+    );
+  } else {
+    assert.doesNotMatch(prepareJob, /actions\/upload-artifact/);
+  }
   assert.ok(
     prepareJob.indexOf("Save release-specific unsigned Rust build cache") <
       prepareJob.indexOf("Require a successful unsigned compilation"),
     "release compiler outputs must be saved before a failed compile is reported",
   );
-
-  assert.match(signedBuildJob, /SCCACHE_GHA_ENABLED: "true"/);
-  assert.match(signedBuildJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
-  assert.match(signedBuildJob, /cache-targets: false/);
-  assert.match(releaseBuildCache, /actions\/cache\/restore@[0-9a-f]{40}/);
-  assert.doesNotMatch(signedBuildJob, /actions\/cache\/save/);
-  assert.ok(
-    signedBuildJob.indexOf("Restore unsigned Rust build cache") <
-      signedBuildJob.indexOf("Validate production signing configuration"),
-    "the build cache must be restored before production secrets are loaded",
-  );
+  if (preparedArtifacts) {
+    assert.ok(
+      prepareJob.indexOf("Require a successful unsigned compilation") <
+        prepareJob.indexOf("Archive prepared macOS inputs"),
+      "failed compiles must not publish prepared binaries",
+    );
+    assert.match(
+      prepareJob,
+      /name: tidebreak-prepared-macos-universal-\$\{\{ github\.run_id \}\}/,
+    );
+    assert.match(prepareJob, /retention-days: 1/);
+    assert.match(prepareJob, /compression-level: 0/);
+    assert.match(prepareJob, /overwrite: true/);
+    assert.match(prepareJob, /shasum -a 256[\s\S]*> SHA256SUMS/);
+    assert.match(prepareJob, /shasum -a 256 prepared-macos\.tar/);
+  } else {
+    assert.match(signedBuildJob, /SCCACHE_GHA_ENABLED: "true"/);
+    assert.match(signedBuildJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
+    assert.match(signedBuildJob, /cache-targets: false/);
+    assert.match(releaseBuildCache, /actions\/cache\/restore@[0-9a-f]{40}/);
+    assert.doesNotMatch(signedBuildJob, /actions\/cache\/save/);
+    assert.ok(
+      signedBuildJob.indexOf("Restore unsigned Rust build cache") <
+        signedBuildJob.indexOf("Validate production signing configuration"),
+      "the build cache must be restored before production secrets are loaded",
+    );
+  }
 
   assert.match(cache, /SCCACHE_GHA_ENABLED: "true"/);
   assert.match(cache, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
@@ -1467,13 +1524,16 @@ test("release caches restore only credential-free compiler products", () => {
     "partial successful compiler outputs must be saved before a later failure is reported",
   );
 
-  for (const cacheStep of [
+  const releaseCacheSteps = [
     releasePrepareCache,
     releasePrepareCacheSave,
-    releaseBuildCache,
     warmBuildCache,
     warmBuildCacheSave,
-  ]) {
+  ];
+  if (!preparedArtifacts) {
+    releaseCacheSteps.push(releaseBuildCache);
+  }
+  for (const cacheStep of releaseCacheSteps) {
     assert.match(cacheStep, /target\/release\/\.fingerprint/);
     if (universalMacos) {
       for (const target of [
@@ -1529,24 +1589,32 @@ test("release caches restore only credential-free compiler products", () => {
     assert.doesNotMatch(cacheStep, /bundle|\.app|dmg|signature|keychain/i);
   }
 
-  // `actions/cache` folds the path list into the cache version, so the signing
-  // job can only reach an archive a writing job saved under the same list.
-  // Keeping them identical is what makes the key ladder below, rather than a
-  // silent total miss, the thing that governs what gets restored.
+  // `actions/cache` folds the path list into the cache version. Every job that
+  // shares a cache must use the same path list.
   const cachedPaths = (step) =>
     step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
-  assert.ok(cachedPaths(releaseBuildCache));
-  assert.equal(
-    cachedPaths(releaseBuildCache),
-    cachedPaths(releasePrepareCacheSave),
-  );
-  assert.equal(cachedPaths(releaseBuildCache), cachedPaths(warmBuildCacheSave));
+  if (preparedArtifacts) {
+    assert.equal(
+      cachedPaths(releasePrepareCacheSave),
+      cachedPaths(warmBuildCacheSave),
+    );
+  } else {
+    assert.ok(cachedPaths(releaseBuildCache));
+    assert.equal(
+      cachedPaths(releaseBuildCache),
+      cachedPaths(releasePrepareCacheSave),
+    );
+    assert.equal(
+      cachedPaths(releaseBuildCache),
+      cachedPaths(warmBuildCacheSave),
+    );
+  }
 
-  for (const restoreStep of [
-    releasePrepareCache,
-    releaseBuildCache,
-    warmBuildCache,
-  ]) {
+  const restoreSteps = [releasePrepareCache, warmBuildCache];
+  if (!preparedArtifacts) {
+    restoreSteps.push(releaseBuildCache);
+  }
+  for (const restoreStep of restoreSteps) {
     assert.match(
       restoreStep,
       universalMacos
@@ -1578,104 +1646,266 @@ test("release caches restore only credential-free compiler products", () => {
     );
   }
 
-  // The signing job signs what it restores, so every key it can hit must pin
-  // the source identity of the archive: the release commit SHA, or at minimum
-  // the Cargo.lock and toolchain hashes. An arch-only fallback would restore
-  // an archive warmed from an unrelated `main` commit and sign binaries that
-  // do not correspond to the released tag.
-  const signingCacheKeys = releaseBuildCache
-    .split("\n")
-    .map((line) => line.trim().replace(/^key: /, ""))
-    .filter((line) => line.startsWith("macos-release-"));
-  assert.ok(signingCacheKeys.length >= 4);
-  for (const key of signingCacheKeys) {
+  if (!preparedArtifacts) {
+    const signingCacheKeys = releaseBuildCache
+      .split("\n")
+      .map((line) => line.trim().replace(/^key: /, ""))
+      .filter((line) => line.startsWith("macos-release-"));
+    assert.ok(signingCacheKeys.length >= 4);
+    for (const key of signingCacheKeys) {
+      assert.ok(
+        key.includes("hashFiles('Cargo.lock',"),
+        `restorable signing-job cache key does not pin the source: ${key}`,
+      );
+    }
+
+    const discardProducts = signedBuildJob.match(
+      /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
+    )?.[0];
+    assert.ok(discardProducts);
+    for (const product of [
+      /aarch64-apple-darwin,x86_64-apple-darwin,universal-apple-darwin.*release\/tidebreak-desktop/,
+      /aarch64-apple-darwin,x86_64-apple-darwin.*release\/tidebreak-host-broker/,
+      /aarch64-apple-darwin,x86_64-apple-darwin.*release\/tidebreak/,
+      /libtidebreak_desktop_lib\./,
+      /binaries\/tidebreak-host-broker-\{aarch64-apple-darwin,x86_64-apple-darwin\}/,
+      /binaries\/tidebreak-\{aarch64-apple-darwin,x86_64-apple-darwin\}/,
+      /binaries\/tidebreak-host-broker-universal-apple-darwin/,
+      /binaries\/tidebreak-universal-apple-darwin/,
+    ]) {
+      assert.match(discardProducts, product);
+    }
     assert.ok(
-      key.includes("hashFiles('Cargo.lock',"),
-      `restorable signing-job cache key does not pin the source: ${key}`,
+      signedBuildJob.indexOf("Discard restored product binaries") >
+        signedBuildJob.indexOf("Restore unsigned Rust build cache") &&
+        signedBuildJob.indexOf("Discard restored product binaries") <
+          signedBuildJob.indexOf("Build, sign, and notarize the Tauri app"),
+      "restored product binaries must be discarded before the signed build",
     );
   }
+});
 
-  // Whatever a restore extracts, the products that actually get signed are
-  // relinked from the tag's own sources.
-  const discardProducts = signedBuildJob.match(
-    /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
-  )?.[0];
-  assert.ok(discardProducts);
-  const discardedProducts = universalMacos
-    ? [
-        /aarch64-apple-darwin,x86_64-apple-darwin,universal-apple-darwin.*release\/tidebreak-desktop/,
-        /aarch64-apple-darwin,x86_64-apple-darwin.*release\/tidebreak-host-broker/,
-        /aarch64-apple-darwin,x86_64-apple-darwin.*release\/tidebreak/,
-        /libtidebreak_desktop_lib\./,
-        /binaries\/tidebreak-host-broker-\{aarch64-apple-darwin,x86_64-apple-darwin\}/,
-        /binaries\/tidebreak-\{aarch64-apple-darwin,x86_64-apple-darwin\}/,
-        /binaries\/tidebreak-host-broker-universal-apple-darwin/,
-        /binaries\/tidebreak-universal-apple-darwin/,
-      ]
-    : [
-        /release\/tidebreak-desktop/,
-        /release\/tidebreak-host-broker/,
-        /release\/tidebreak/,
-        /libtidebreak_desktop_lib\./,
-        /binaries\/tidebreak-host-broker-\$RELEASE_TARGET/,
-        /binaries\/tidebreak-\$RELEASE_TARGET/,
-      ];
-  for (const product of discardedProducts) {
-    assert.match(discardProducts, product);
+test("macOS production packaging uses verified prepared binaries", () => {
+  const buildJob = workflowJob(workflows["release.yml"], "build_macos");
+  if (!/Download prepared macOS inputs/.test(buildJob)) {
+    return;
   }
-  assert.ok(
-    signedBuildJob.indexOf("Discard restored product binaries") >
-      signedBuildJob.indexOf("Restore unsigned Rust build cache") &&
-      signedBuildJob.indexOf("Discard restored product binaries") <
-        signedBuildJob.indexOf("Build, sign, and notarize the Tauri app"),
-    "restored product binaries must be discarded before the signed build",
+  const verifyStep = buildJob.match(
+    /- name: Verify prepared macOS inputs[\s\S]*?(?=\n\s+- (?:name:|uses:))/,
+  )?.[0];
+  const bundleStep = buildJob.match(
+    /- name: Bundle, sign, and notarize the prepared Tauri app[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(verifyStep);
+  assert.ok(bundleStep);
+
+  assert.match(
+    buildJob,
+    /name: tidebreak-prepared-macos-universal-\$\{\{ github\.run_id \}\}/,
   );
+  assert.match(
+    verifyStep,
+    /shasum -a 256 --check prepared-macos\.tar\.sha256/,
+  );
+  assert.match(verifyStep, /shasum -a 256 --check SHA256SUMS/);
+  assert.match(
+    verifyStep,
+    /Prepared macOS archive contains an unexpected file set/,
+  );
+  assert.match(
+    verifyStep,
+    /target\/\$RELEASE_TARGET\/release\/tidebreak-desktop/,
+  );
+  assert.match(
+    verifyStep,
+    /binaries\/tidebreak-host-broker-\$RELEASE_TARGET/,
+  );
+  assert.match(verifyStep, /binaries\/tidebreak-\$RELEASE_TARGET/);
+
+  assert.ok(tauriCliPackage);
+  assert.ok(tauriCliLock);
+  assert.equal(tauriCliPackage.packageManager, "pnpm@10.18.3");
+  assert.equal(tauriCliPackage.dependencies["@tauri-apps/cli"], "2.11.4");
+  assert.match(
+    tauriCliLock,
+    /'@tauri-apps\/cli':\n\s+specifier: 2\.11\.4\n\s+version: 2\.11\.4/,
+  );
+  assert.match(
+    buildJob,
+    /cache-dependency-path: \.github\/tauri-cli\/pnpm-lock\.yaml/,
+  );
+  assert.match(
+    buildJob,
+    /pnpm --dir \.github\/tauri-cli install --frozen-lockfile --ignore-scripts/,
+  );
+  assert.match(bundleStep, /tauri bundle/);
+  assert.match(bundleStep, /--target universal-apple-darwin/);
+  assert.match(bundleStep, /--bundles app,dmg/);
+  assert.match(bundleStep, /--ci/);
+  assert.doesNotMatch(bundleStep, /TAURI_SIGNING_PRIVATE_KEY/);
+
+  assert.doesNotMatch(buildJob, /tauri-apps\/tauri-action/);
+  assert.doesNotMatch(buildJob, /actions\/cache/);
+  assert.doesNotMatch(buildJob, /mozilla-actions\/sccache-action/);
+  assert.doesNotMatch(buildJob, /Swatinem\/rust-cache/);
+  assert.doesNotMatch(buildJob, /Install UI dependencies/);
+  assert.doesNotMatch(buildJob, /Install Rust target/);
+  assert.doesNotMatch(buildJob, /\btauri build\b/);
+
+  const secretsAt = firstSigningMaterialIndex(
+    buildJob,
+    "Validate production signing configuration",
+  );
+  for (const marker of [
+    "Download prepared macOS inputs",
+    "Verify prepared macOS inputs",
+    "Install pinned Tauri bundler",
+  ]) {
+    const index = buildJob.indexOf(marker);
+    assert.ok(
+      index !== -1 && index < secretsAt,
+      `${marker} must run before signing material loads`,
+    );
+  }
 });
 
 test("Windows release jobs mirror the credential-free prepare/build split", () => {
   const release = workflows["release.yml"];
   const prepareJob = workflowJob(release, "prepare_windows");
   const buildJob = workflowJob(release, "build_windows");
+  const preparedArtifacts = /Archive prepared Windows inputs/.test(prepareJob);
   const prepareCacheSave = prepareJob.match(
     /- name: Save release-specific unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
-  const buildCacheRestore = buildJob.match(
-    /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
-  )?.[0];
   assert.ok(prepareCacheSave);
-  assert.ok(buildCacheRestore);
   for (const job of [prepareJob, buildJob]) {
     assert.match(job, /runs-on: \$\{\{ matrix\.runner \}\}/);
     assert.match(job, /target: x86_64-pc-windows-msvc/);
     assert.match(job, /runner: windows-latest/);
     assert.match(job, /target: aarch64-pc-windows-msvc/);
     assert.match(job, /runner: windows-11-arm/);
-    // whisper.cpp refuses MSVC on ARM. Force Ninja + clang-cl only on the
-    // ARM matrix entry so x86_64 keeps the Visual Studio generator.
-    assert.match(job, /if: \$\{\{ matrix\.arch == 'aarch64' \}\}/);
-    assert.match(job, /CMAKE_GENERATOR=Ninja/);
-    assert.match(job, /CMAKE_C_COMPILER=/);
-    assert.match(job, /CMAKE_CXX_COMPILER=/);
-    assert.match(job, /CMAKE_ASM_COMPILER=/);
-    assert.match(job, /echo "CC=\$clang_cl"/);
-    assert.match(job, /echo "CXX=\$clang_cl"/);
-    assert.match(job, /CXXFLAGS=\/EHsc/);
-    assert.match(job, /clang-cl/);
-    assert.match(job, /command -v ninja/);
   }
+  if (!preparedArtifacts) {
+    const buildCacheRestore = buildJob.match(
+      /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
+    )?.[0];
+    assert.ok(buildCacheRestore);
+    for (const job of [prepareJob, buildJob]) {
+      assert.match(job, /if: \$\{\{ matrix\.arch == 'aarch64' \}\}/);
+      assert.match(job, /CMAKE_GENERATOR=Ninja/);
+      assert.match(job, /CMAKE_C_COMPILER=/);
+      assert.match(job, /CMAKE_CXX_COMPILER=/);
+      assert.match(job, /CMAKE_ASM_COMPILER=/);
+      assert.match(job, /echo "CC=\$clang_cl"/);
+      assert.match(job, /echo "CXX=\$clang_cl"/);
+      assert.match(job, /CXXFLAGS=\/EHsc/);
+      assert.match(job, /clang-cl/);
+      assert.match(job, /command -v ninja/);
+    }
+    assert.ok(
+      prepareJob.indexOf("Use clang-cl for Windows ARM native code") <
+        prepareJob.indexOf("Compile without production credentials or bundles"),
+      "Windows ARM clang-cl must be configured before the unsigned compile",
+    );
+    assert.ok(
+      buildJob.indexOf("Use clang-cl for Windows ARM native code") <
+        buildJob.indexOf("Build the Tauri app without Windows code signing"),
+      "Windows ARM clang-cl must be configured before the packaged build",
+    );
+
+    assert.match(prepareJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
+    assert.match(prepareJob, /version: 10\.18\.3/);
+    assert.match(prepareJob, /pnpm install --frozen-lockfile --ignore-scripts/);
+    assert.match(
+      prepareJob,
+      /node scripts\/generate-third-party-notices\.mjs --check/,
+    );
+    assert.match(prepareJob, /--no-bundle --ci/);
+    assert.match(prepareJob, /continue-on-error: true/);
+    assert.doesNotMatch(prepareJob, /^    environment:/m);
+    assert.doesNotMatch(prepareJob, /secrets\./);
+    assert.doesNotMatch(
+      prepareJob,
+      /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_|actions\/upload-artifact/,
+    );
+    assert.ok(
+      prepareJob.indexOf("Save release-specific unsigned Rust build cache") <
+        prepareJob.indexOf("Require a successful unsigned compilation"),
+      "release compiler outputs must be saved before a failed compile is reported",
+    );
+
+    assert.doesNotMatch(buildJob, /actions\/cache\/save/);
+    assert.ok(
+      buildJob.indexOf("Restore unsigned Rust build cache") <
+        buildJob.indexOf("Validate updater signing configuration"),
+      "the build cache must be restored before the updater secret is loaded",
+    );
+    const cachedPaths = (step) =>
+      step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
+    assert.ok(cachedPaths(buildCacheRestore));
+    assert.equal(cachedPaths(buildCacheRestore), cachedPaths(prepareCacheSave));
+    assert.match(
+      buildCacheRestore,
+      /key: windows-release-prepared-v1-\$\{\{ matrix\.arch \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ needs\.validate\.outputs\.sha \}\}-\$\{\{ needs\.validate\.outputs\.version \}\}/,
+    );
+    assert.doesNotMatch(buildCacheRestore, /restore-keys:/);
+
+    const discardProducts = buildJob.match(
+      /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
+    )?.[0];
+    assert.ok(discardProducts);
+    for (const product of [
+      /release\/tidebreak-desktop\.exe/,
+      /release\/tidebreak-host-broker\.exe/,
+      /release\/tidebreak\.exe/,
+      /tidebreak_desktop_lib\./,
+      /binaries\/tidebreak-host-broker-\$RELEASE_TARGET\.exe/,
+      /binaries\/tidebreak-\$RELEASE_TARGET\.exe/,
+    ]) {
+      assert.match(discardProducts, product);
+    }
+    assert.ok(
+      buildJob.indexOf("Discard restored product binaries") >
+        buildJob.indexOf("Restore unsigned Rust build cache") &&
+        buildJob.indexOf("Discard restored product binaries") <
+          buildJob.indexOf("Build the Tauri app without Windows code signing"),
+      "restored product binaries must be discarded before the packaged build",
+    );
+
+    assert.match(buildJob, /broker_sidecar="crates\/tidebreak-desktop\/binaries\/tidebreak-host-broker-\$RELEASE_TARGET\.exe"/);
+    assert.match(buildJob, /cli_sidecar="crates\/tidebreak-desktop\/binaries\/tidebreak-\$RELEASE_TARGET\.exe"/);
+    assert.match(buildJob, /Missing target-named host broker sidecar: \$broker_sidecar/);
+    assert.match(buildJob, /Missing target-named CLI sidecar: \$cli_sidecar/);
+    assert.doesNotMatch(release, /certificateThumbprint|signCommand/);
+    assert.doesNotMatch(buildJob, /APPLE_|AWS_|DOWNLOADS_/);
+    const buildStep = buildJob.match(
+      /- name: Build the Tauri app without Windows code signing[\s\S]*?(?=\n\s+- name:)/,
+    )?.[0];
+    assert.ok(buildStep);
+    assert.doesNotMatch(buildStep, /TAURI_SIGNING_PRIVATE_KEY/);
+    return;
+  }
+
+  // whisper.cpp refuses MSVC on ARM. Force Ninja + clang-cl only in the
+  // credential-free compile job so the packaging job needs no compiler.
+  assert.match(prepareJob, /if: \$\{\{ matrix\.arch == 'aarch64' \}\}/);
+  assert.match(prepareJob, /CMAKE_GENERATOR=Ninja/);
+  assert.match(prepareJob, /CMAKE_C_COMPILER=/);
+  assert.match(prepareJob, /CMAKE_CXX_COMPILER=/);
+  assert.match(prepareJob, /CMAKE_ASM_COMPILER=/);
+  assert.match(prepareJob, /echo "CC=\$clang_cl"/);
+  assert.match(prepareJob, /echo "CXX=\$clang_cl"/);
+  assert.match(prepareJob, /CXXFLAGS=\/EHsc/);
+  assert.match(prepareJob, /clang-cl/);
+  assert.match(prepareJob, /command -v ninja/);
   assert.ok(
     prepareJob.indexOf("Use clang-cl for Windows ARM native code") <
       prepareJob.indexOf("Compile without production credentials or bundles"),
     "Windows ARM clang-cl must be configured before the unsigned compile",
   );
-  assert.ok(
-    buildJob.indexOf("Use clang-cl for Windows ARM native code") <
-      buildJob.indexOf("Build the Tauri app without Windows code signing"),
-    "Windows ARM clang-cl must be configured before the packaged build",
-  );
 
-  // The prerequisite compiles without any production credential and never
-  // uploads what it built; only the cache carries its outputs forward.
+  // The prerequisite compiles and archives the exact release inputs without
+  // any production credential.
   assert.match(prepareJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
   assert.match(prepareJob, /version: 10\.18\.3/);
   assert.match(prepareJob, /pnpm install --frozen-lockfile --ignore-scripts/);
@@ -1683,66 +1913,101 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
     prepareJob,
     /node scripts\/generate-third-party-notices\.mjs --check/,
   );
-  assert.match(prepareJob, /--no-bundle --ci/);
+  assert.match(prepareJob, /--config \$\{\{ runner\.temp \}\}\/tidebreak-release\.json/);
+  assert.match(prepareJob, /--no-bundle/);
+  assert.match(prepareJob, /--ci/);
   assert.match(prepareJob, /continue-on-error: true/);
   assert.doesNotMatch(prepareJob, /^    environment:/m);
   assert.doesNotMatch(prepareJob, /secrets\./);
-  assert.doesNotMatch(
-    prepareJob,
-    /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_|actions\/upload-artifact/,
+  assert.doesNotMatch(prepareJob, /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_/);
+  const configAt = prepareJob.indexOf("Write tag-derived Tauri configuration");
+  const checkoutAt = prepareJob.indexOf("uses: actions/checkout@");
+  assert.ok(
+    configAt !== -1 && configAt < checkoutAt,
+    "the release configuration must be created before the release source is checked out",
   );
   assert.ok(
     prepareJob.indexOf("Save release-specific unsigned Rust build cache") <
       prepareJob.indexOf("Require a successful unsigned compilation"),
     "release compiler outputs must be saved before a failed compile is reported",
   );
-
-  // The packaging job is restore-only and loads the updater key only after
-  // the credential-free cache restore.
-  assert.doesNotMatch(buildJob, /actions\/cache\/save/);
   assert.ok(
-    buildJob.indexOf("Restore unsigned Rust build cache") <
-      buildJob.indexOf("Validate updater signing configuration"),
-    "the build cache must be restored before the updater secret is loaded",
+    prepareJob.indexOf("Require a successful unsigned compilation") <
+      prepareJob.indexOf("Archive prepared Windows inputs"),
+    "failed compiles must not publish prepared binaries",
   );
-
-  // Identical path lists keep the cache version shared between the writing
-  // and restoring jobs. The credentialed job accepts only the exact cache for
-  // this release SHA and version; broader warm-cache fallback stays confined
-  // to the credential-free prerequisite.
-  const cachedPaths = (step) =>
-    step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
-  assert.ok(cachedPaths(buildCacheRestore));
-  assert.equal(cachedPaths(buildCacheRestore), cachedPaths(prepareCacheSave));
   assert.match(
-    buildCacheRestore,
-    /key: windows-release-prepared-v1-\$\{\{ matrix\.arch \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ needs\.validate\.outputs\.sha \}\}-\$\{\{ needs\.validate\.outputs\.version \}\}/,
+    prepareJob,
+    /name: tidebreak-prepared-windows-\$\{\{ matrix\.arch \}\}-\$\{\{ github\.run_id \}\}/,
   );
-  assert.doesNotMatch(buildCacheRestore, /restore-keys:/);
+  assert.match(prepareJob, /retention-days: 1/);
+  assert.match(prepareJob, /compression-level: 0/);
+  assert.match(prepareJob, /overwrite: true/);
+  assert.match(prepareJob, /sha256sum[\s\S]*> SHA256SUMS/);
+  assert.match(prepareJob, /sha256sum prepared-windows\.tar/);
 
-  // Whatever a restore extracts, the products that get packaged are relinked
-  // from the tag's own sources.
-  const discardProducts = buildJob.match(
-    /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
+  const verifyStep = buildJob.match(
+    /- name: Verify prepared Windows inputs[\s\S]*?(?=\n\s+- (?:name:|uses:))/,
   )?.[0];
-  assert.ok(discardProducts);
-  for (const product of [
-    /release\/tidebreak-desktop\.exe/,
-    /release\/tidebreak-host-broker\.exe/,
-    /release\/tidebreak\.exe/,
-    /tidebreak_desktop_lib\./,
-    /binaries\/tidebreak-host-broker-\$RELEASE_TARGET\.exe/,
-    /binaries\/tidebreak-\$RELEASE_TARGET\.exe/,
-  ]) {
-    assert.match(discardProducts, product);
-  }
-  assert.ok(
-    buildJob.indexOf("Discard restored product binaries") >
-      buildJob.indexOf("Restore unsigned Rust build cache") &&
-      buildJob.indexOf("Discard restored product binaries") <
-        buildJob.indexOf("Build the Tauri app without Windows code signing"),
-    "restored product binaries must be discarded before the packaged build",
+  const bundleStep = buildJob.match(
+    /- name: Bundle the prepared Tauri app without Windows code signing[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(verifyStep);
+  assert.ok(bundleStep);
+  assert.match(
+    buildJob,
+    /name: tidebreak-prepared-windows-\$\{\{ matrix\.arch \}\}-\$\{\{ github\.run_id \}\}/,
   );
+  assert.match(
+    verifyStep,
+    /sha256sum --check --strict prepared-windows\.tar\.sha256/,
+  );
+  assert.match(verifyStep, /sha256sum --check --strict SHA256SUMS/);
+  assert.match(
+    verifyStep,
+    /Prepared Windows archive contains an unexpected file set/,
+  );
+  assert.match(
+    buildJob,
+    /pnpm --dir \.github\/tauri-cli install --frozen-lockfile --ignore-scripts/,
+  );
+  assert.match(
+    buildJob,
+    /cache-dependency-path: \.github\/tauri-cli\/pnpm-lock\.yaml/,
+  );
+  assert.match(buildJob, /Validate the prepared Tauri configuration/);
+  assert.match(bundleStep, /tauri bundle/);
+  assert.match(bundleStep, /--target "\$\{\{ matrix\.target \}\}"/);
+  assert.match(bundleStep, /--bundles nsis/);
+  assert.match(bundleStep, /--no-sign/);
+  assert.match(bundleStep, /--ci/);
+  assert.doesNotMatch(bundleStep, /TAURI_SIGNING_PRIVATE_KEY/);
+
+  assert.doesNotMatch(buildJob, /tauri-apps\/tauri-action/);
+  assert.doesNotMatch(buildJob, /actions\/cache/);
+  assert.doesNotMatch(buildJob, /mozilla-actions\/sccache-action/);
+  assert.doesNotMatch(buildJob, /Swatinem\/rust-cache/);
+  assert.doesNotMatch(buildJob, /Install UI dependencies/);
+  assert.doesNotMatch(buildJob, /Install Rust target/);
+  assert.doesNotMatch(buildJob, /Use clang-cl for Windows ARM native code/);
+  assert.doesNotMatch(buildJob, /\btauri build\b/);
+
+  const secretsAt = firstSigningMaterialIndex(
+    buildJob,
+    "Validate updater signing configuration",
+  );
+  for (const marker of [
+    "Download prepared Windows inputs",
+    "Verify prepared Windows inputs",
+    "Install pinned Tauri bundler",
+    "Validate the prepared Tauri configuration",
+  ]) {
+    const index = buildJob.indexOf(marker);
+    assert.ok(
+      index !== -1 && index < secretsAt,
+      `${marker} must run before signing material loads`,
+    );
+  }
 
   // The packaging job must use distinct variable names for each sidecar so it
   // validates both binaries without overwriting the variable.
@@ -1753,11 +2018,11 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
 
   // v1 ships unsigned Windows artifacts: no Authenticode configuration may
   // creep in, no Apple credential reaches the Windows jobs, and the updater
-  // private key stays out of the Tauri build step.
+  // private key stays out of the Tauri bundle step.
   assert.doesNotMatch(release, /certificateThumbprint|signCommand/);
   assert.doesNotMatch(buildJob, /APPLE_|AWS_|DOWNLOADS_/);
   const buildStep = buildJob.match(
-    /- name: Build the Tauri app without Windows code signing[\s\S]*?(?=\n\s+- name:)/,
+    /- name: Bundle the prepared Tauri app without Windows code signing[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
   assert.ok(buildStep);
   assert.doesNotMatch(buildStep, /TAURI_SIGNING_PRIVATE_KEY/);
@@ -2058,11 +2323,20 @@ test("GitHub release assets are attached before immutable publication", () => {
 
 test("the updater private key is isolated from compilation", () => {
   const release = workflows["release.yml"];
-  const buildStep = release.match(
-    /- name: Build, sign, and notarize the Tauri app[\s\S]*?(?=\n\s+- name:)/,
+  const preparedArtifacts = /Archive prepared macOS inputs/.test(release);
+  if (preparedArtifacts) {
+    for (const jobName of ["prepare_macos", "prepare_windows"]) {
+      assert.doesNotMatch(
+        workflowJob(release, jobName),
+        /TAURI_SIGNING_PRIVATE_KEY/,
+      );
+    }
+  }
+  const packageStep = release.match(
+    /- name: (?:Build, sign, and notarize the Tauri app|Bundle, sign, and notarize the prepared Tauri app)[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
-  assert.ok(buildStep);
-  assert.doesNotMatch(buildStep, /TAURI_SIGNING_PRIVATE_KEY/);
+  assert.ok(packageStep);
+  assert.doesNotMatch(packageStep, /TAURI_SIGNING_PRIVATE_KEY/);
   assert.doesNotMatch(release, /createUpdaterArtifacts/);
   assert.match(release, /tauri signer sign "\$updater_path"/);
   assert.doesNotMatch(release, /cargo tauri signer sign/);
@@ -2083,43 +2357,42 @@ test("signing jobs do not run untrusted installers next to Apple or Tauri materi
     );
     assert.match(
       job,
-      /pnpm install --frozen-lockfile --ignore-scripts\n/,
-      `${label} must install UI deps without lifecycle scripts`,
-    );
-    assert.match(
-      job,
-      /mozilla-actions\/sccache-action@[0-9a-f]{40}/,
-      `${label} must set up sccache`,
-    );
-    assert.match(
-      job,
-      /Swatinem\/rust-cache@[0-9a-f]{40}/,
-      `${label} must restore the Cargo download cache`,
-    );
-    assert.match(
-      job,
       /actions\/setup-node@[0-9a-f]{40}/,
       `${label} must set up Node`,
-    );
-
-    const rustCache = cargoDownloadCache(job);
-    assert.ok(rustCache, `${label} missing Cargo download cache`);
-    assert.match(
-      rustCache,
-      /save-if: false/,
-      `${label} rust-cache must be restore-only`,
     );
 
     const secretsAt = firstSigningMaterialIndex(job, validate);
     assert.notEqual(secretsAt, -1, `${label} must still load signing material`);
 
+    const bundleOnly = /Install pinned Tauri bundler/.test(job);
     const installerIndexes = [
-      job.search(/mozilla-actions\/sccache-action@[0-9a-f]{40}/),
-      job.search(/Swatinem\/rust-cache@[0-9a-f]{40}/),
       job.search(/pnpm\/action-setup@[0-9a-f]{40}/),
       job.search(/actions\/setup-node@[0-9a-f]{40}/),
-      job.search(/pnpm install --frozen-lockfile --ignore-scripts\n/),
     ];
+    if (bundleOnly) {
+      const install = job.search(
+        /pnpm --dir \.github\/tauri-cli install --frozen-lockfile --ignore-scripts/,
+      );
+      installerIndexes.push(install);
+      assert.doesNotMatch(job, /mozilla-actions\/sccache-action/);
+      assert.doesNotMatch(job, /Swatinem\/rust-cache/);
+    } else {
+      const install = job.search(
+        /pnpm install --frozen-lockfile --ignore-scripts\n/,
+      );
+      installerIndexes.push(
+        job.search(/mozilla-actions\/sccache-action@[0-9a-f]{40}/),
+        job.search(/Swatinem\/rust-cache@[0-9a-f]{40}/),
+        install,
+      );
+      const rustCache = cargoDownloadCache(job);
+      assert.ok(rustCache, `${label} missing Cargo download cache`);
+      assert.match(
+        rustCache,
+        /save-if: false/,
+        `${label} rust-cache must be restore-only`,
+      );
+    }
     assert.ok(
       installerIndexes.every((index) => index !== -1),
       `${label} is missing an installer step`,
@@ -2141,9 +2414,13 @@ test("macOS disk images are explicitly notarized and stapled", () => {
   assert.match(dmgNotarization, /--key "\$APPLE_API_KEY_PATH"/);
   assert.match(dmgNotarization, /xcrun stapler staple "\$dmg_path"/);
   assert.match(dmgNotarization, /xcrun stapler validate "\$dmg_path"/);
+  const packageAt = Math.max(
+    release.indexOf("Build, sign, and notarize the Tauri app"),
+    release.indexOf("Bundle, sign, and notarize the prepared Tauri app"),
+  );
   assert.ok(
-    release.indexOf("Build, sign, and notarize the Tauri app") <
-      release.indexOf("Notarize and staple the DMG"),
+    packageAt !== -1 &&
+      packageAt < release.indexOf("Notarize and staple the DMG"),
   );
   assert.ok(
     release.indexOf("Notarize and staple the DMG") <
@@ -2152,6 +2429,7 @@ test("macOS disk images are explicitly notarized and stapled", () => {
 });
 
 test("universal macOS release and staging packages contain both slices", () => {
+  const releasePrepare = workflowJob(workflows["release.yml"], "prepare_macos");
   const releaseBuild = workflowJob(workflows["release.yml"], "build_macos");
   if (!/--target universal-apple-darwin/.test(releaseBuild)) {
     return;
@@ -2177,9 +2455,15 @@ test("universal macOS release and staging packages contain both slices", () => {
     /"lipo",\s*\["-create", \.\.\.stagedSidecars, "-output", destination\]/,
   );
 
-  for (const job of [releaseBuild, stagingBuild, warm]) {
+  const preparedArtifacts = /Archive prepared macOS inputs/.test(releasePrepare);
+  const releaseCompile = preparedArtifacts ? releasePrepare : releaseBuild;
+  for (const job of [releaseCompile, stagingBuild, warm]) {
     assert.match(job, /rustup target add aarch64-apple-darwin x86_64-apple-darwin/);
     assert.match(job, /--target universal-apple-darwin/);
+  }
+  if (preparedArtifacts) {
+    assert.match(releaseBuild, /--target universal-apple-darwin/);
+    assert.doesNotMatch(releaseBuild, /rustup target add/);
   }
 
   for (const job of [releaseBuild, stagingBuild]) {

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -73,13 +73,22 @@ const docsPackage = JSON.parse(
 const vercelCliPackage = JSON.parse(
   readFileSync(repositoryFile(".github", "vercel-cli", "package.json"), "utf8"),
 );
-const tauriCliPackage = JSON.parse(
-  readFileSync(repositoryFile(".github", "tauri-cli", "package.json"), "utf8"),
+const tauriCliPackagePath = repositoryFile(
+  ".github",
+  "tauri-cli",
+  "package.json",
 );
-const tauriCliLock = readFileSync(
-  repositoryFile(".github", "tauri-cli", "pnpm-lock.yaml"),
-  "utf8",
+const tauriCliLockPath = repositoryFile(
+  ".github",
+  "tauri-cli",
+  "pnpm-lock.yaml",
 );
+const tauriCliPackage = existsSync(tauriCliPackagePath)
+  ? JSON.parse(readFileSync(tauriCliPackagePath, "utf8"))
+  : null;
+const tauriCliLock = existsSync(tauriCliLockPath)
+  ? readFileSync(tauriCliLockPath, "utf8")
+  : null;
 const packagedGhDiscoverySmoke = readFileSync(
   repositoryFile("scripts", "smoke-packaged-gh-discovery.sh"),
   "utf8",
@@ -1410,6 +1419,8 @@ test("release compile jobs keep caches and prepared artifacts credential-free", 
   const release = workflows["release.yml"];
   const cache = workflows["cache-macos.yml"];
   const prepareJob = workflowJob(release, "prepare_macos");
+  const signedBuildJob = workflowJob(release, "build_macos");
+  const preparedArtifacts = /Archive prepared macOS inputs/.test(prepareJob);
   const releasePrepareCache = prepareJob.match(
     /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
@@ -1422,20 +1433,35 @@ test("release compile jobs keep caches and prepared artifacts credential-free", 
   const warmBuildCacheSave = cache.match(
     /- name: Save unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
+  const releaseBuildCache = signedBuildJob.match(
+    /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
   assert.ok(releasePrepareCache);
   assert.ok(releasePrepareCacheSave);
   assert.ok(warmBuildCache);
   assert.ok(warmBuildCacheSave);
+  if (!preparedArtifacts) {
+    assert.ok(releaseBuildCache);
+  }
   const universalMacos = /--target universal-apple-darwin/.test(prepareJob);
 
   assert.match(
     prepareJob,
-    /runs-on: \$\{\{ vars\.PRODUCTION_MACOS_RUNNER \|\| 'macos-latest' \}\}/,
+    preparedArtifacts
+      ? /runs-on: \$\{\{ vars\.PRODUCTION_MACOS_RUNNER \|\| 'macos-latest' \}\}/
+      : /runs-on: macos-latest/,
   );
   assert.match(prepareJob, /SCCACHE_GHA_ENABLED: "true"/);
   assert.match(prepareJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
   assert.match(prepareJob, /cache-targets: false/);
-  assert.match(prepareJob, /--config \$\{\{ runner\.temp \}\}\/tidebreak-release\.json/);
+  if (preparedArtifacts) {
+    assert.match(
+      prepareJob,
+      /--config \$\{\{ runner\.temp \}\}\/tidebreak-release\.json/,
+    );
+  } else {
+    assert.match(prepareJob, /--no-bundle --ci/);
+  }
   assert.match(prepareJob, /--no-bundle/);
   assert.match(prepareJob, /--ci/);
   assert.match(prepareJob, /continue-on-error: true/);
@@ -1444,30 +1470,48 @@ test("release compile jobs keep caches and prepared artifacts credential-free", 
   assert.doesNotMatch(prepareJob, /^    environment:/m);
   assert.doesNotMatch(prepareJob, /secrets\./);
   assert.doesNotMatch(prepareJob, /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_/);
-  assert.ok(
-    prepareJob.indexOf("Write tag-derived Tauri configuration") <
-      prepareJob.indexOf("Compile without production credentials or bundles"),
-    "the release configuration must be embedded during compilation",
-  );
+  if (preparedArtifacts) {
+    const configAt = prepareJob.indexOf("Write tag-derived Tauri configuration");
+    const checkoutAt = prepareJob.indexOf("uses: actions/checkout@");
+    assert.ok(
+      configAt !== -1 && configAt < checkoutAt,
+      "the release configuration must be created before the release source is checked out",
+    );
+  } else {
+    assert.doesNotMatch(prepareJob, /actions\/upload-artifact/);
+  }
   assert.ok(
     prepareJob.indexOf("Save release-specific unsigned Rust build cache") <
       prepareJob.indexOf("Require a successful unsigned compilation"),
     "release compiler outputs must be saved before a failed compile is reported",
   );
-  assert.ok(
-    prepareJob.indexOf("Require a successful unsigned compilation") <
-      prepareJob.indexOf("Archive prepared macOS inputs"),
-    "failed compiles must not publish prepared binaries",
-  );
-  assert.match(
-    prepareJob,
-    /name: tidebreak-prepared-macos-universal-\$\{\{ github\.run_id \}\}/,
-  );
-  assert.match(prepareJob, /retention-days: 1/);
-  assert.match(prepareJob, /compression-level: 0/);
-  assert.match(prepareJob, /overwrite: true/);
-  assert.match(prepareJob, /shasum -a 256[\s\S]*> SHA256SUMS/);
-  assert.match(prepareJob, /shasum -a 256 prepared-macos\.tar/);
+  if (preparedArtifacts) {
+    assert.ok(
+      prepareJob.indexOf("Require a successful unsigned compilation") <
+        prepareJob.indexOf("Archive prepared macOS inputs"),
+      "failed compiles must not publish prepared binaries",
+    );
+    assert.match(
+      prepareJob,
+      /name: tidebreak-prepared-macos-universal-\$\{\{ github\.run_id \}\}/,
+    );
+    assert.match(prepareJob, /retention-days: 1/);
+    assert.match(prepareJob, /compression-level: 0/);
+    assert.match(prepareJob, /overwrite: true/);
+    assert.match(prepareJob, /shasum -a 256[\s\S]*> SHA256SUMS/);
+    assert.match(prepareJob, /shasum -a 256 prepared-macos\.tar/);
+  } else {
+    assert.match(signedBuildJob, /SCCACHE_GHA_ENABLED: "true"/);
+    assert.match(signedBuildJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
+    assert.match(signedBuildJob, /cache-targets: false/);
+    assert.match(releaseBuildCache, /actions\/cache\/restore@[0-9a-f]{40}/);
+    assert.doesNotMatch(signedBuildJob, /actions\/cache\/save/);
+    assert.ok(
+      signedBuildJob.indexOf("Restore unsigned Rust build cache") <
+        signedBuildJob.indexOf("Validate production signing configuration"),
+      "the build cache must be restored before production secrets are loaded",
+    );
+  }
 
   assert.match(cache, /SCCACHE_GHA_ENABLED: "true"/);
   assert.match(cache, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
@@ -1480,12 +1524,16 @@ test("release compile jobs keep caches and prepared artifacts credential-free", 
     "partial successful compiler outputs must be saved before a later failure is reported",
   );
 
-  for (const cacheStep of [
+  const releaseCacheSteps = [
     releasePrepareCache,
     releasePrepareCacheSave,
     warmBuildCache,
     warmBuildCacheSave,
-  ]) {
+  ];
+  if (!preparedArtifacts) {
+    releaseCacheSteps.push(releaseBuildCache);
+  }
+  for (const cacheStep of releaseCacheSteps) {
     assert.match(cacheStep, /target\/release\/\.fingerprint/);
     if (universalMacos) {
       for (const target of [
@@ -1541,16 +1589,32 @@ test("release compile jobs keep caches and prepared artifacts credential-free", 
     assert.doesNotMatch(cacheStep, /bundle|\.app|dmg|signature|keychain/i);
   }
 
-  // `actions/cache` folds the path list into the cache version. The release
-  // compile and cache-warming jobs must write compatible archives.
+  // `actions/cache` folds the path list into the cache version. Every job that
+  // shares a cache must use the same path list.
   const cachedPaths = (step) =>
     step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
-  assert.equal(
-    cachedPaths(releasePrepareCacheSave),
-    cachedPaths(warmBuildCacheSave),
-  );
+  if (preparedArtifacts) {
+    assert.equal(
+      cachedPaths(releasePrepareCacheSave),
+      cachedPaths(warmBuildCacheSave),
+    );
+  } else {
+    assert.ok(cachedPaths(releaseBuildCache));
+    assert.equal(
+      cachedPaths(releaseBuildCache),
+      cachedPaths(releasePrepareCacheSave),
+    );
+    assert.equal(
+      cachedPaths(releaseBuildCache),
+      cachedPaths(warmBuildCacheSave),
+    );
+  }
 
-  for (const restoreStep of [releasePrepareCache, warmBuildCache]) {
+  const restoreSteps = [releasePrepareCache, warmBuildCache];
+  if (!preparedArtifacts) {
+    restoreSteps.push(releaseBuildCache);
+  }
+  for (const restoreStep of restoreSteps) {
     assert.match(
       restoreStep,
       universalMacos
@@ -1582,10 +1646,50 @@ test("release compile jobs keep caches and prepared artifacts credential-free", 
     );
   }
 
+  if (!preparedArtifacts) {
+    const signingCacheKeys = releaseBuildCache
+      .split("\n")
+      .map((line) => line.trim().replace(/^key: /, ""))
+      .filter((line) => line.startsWith("macos-release-"));
+    assert.ok(signingCacheKeys.length >= 4);
+    for (const key of signingCacheKeys) {
+      assert.ok(
+        key.includes("hashFiles('Cargo.lock',"),
+        `restorable signing-job cache key does not pin the source: ${key}`,
+      );
+    }
+
+    const discardProducts = signedBuildJob.match(
+      /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
+    )?.[0];
+    assert.ok(discardProducts);
+    for (const product of [
+      /aarch64-apple-darwin,x86_64-apple-darwin,universal-apple-darwin.*release\/tidebreak-desktop/,
+      /aarch64-apple-darwin,x86_64-apple-darwin.*release\/tidebreak-host-broker/,
+      /aarch64-apple-darwin,x86_64-apple-darwin.*release\/tidebreak/,
+      /libtidebreak_desktop_lib\./,
+      /binaries\/tidebreak-host-broker-\{aarch64-apple-darwin,x86_64-apple-darwin\}/,
+      /binaries\/tidebreak-\{aarch64-apple-darwin,x86_64-apple-darwin\}/,
+      /binaries\/tidebreak-host-broker-universal-apple-darwin/,
+      /binaries\/tidebreak-universal-apple-darwin/,
+    ]) {
+      assert.match(discardProducts, product);
+    }
+    assert.ok(
+      signedBuildJob.indexOf("Discard restored product binaries") >
+        signedBuildJob.indexOf("Restore unsigned Rust build cache") &&
+        signedBuildJob.indexOf("Discard restored product binaries") <
+          signedBuildJob.indexOf("Build, sign, and notarize the Tauri app"),
+      "restored product binaries must be discarded before the signed build",
+    );
+  }
 });
 
 test("macOS production packaging uses verified prepared binaries", () => {
   const buildJob = workflowJob(workflows["release.yml"], "build_macos");
+  if (!/Download prepared macOS inputs/.test(buildJob)) {
+    return;
+  }
   const verifyStep = buildJob.match(
     /- name: Verify prepared macOS inputs[\s\S]*?(?=\n\s+- (?:name:|uses:))/,
   )?.[0];
@@ -1618,6 +1722,8 @@ test("macOS production packaging uses verified prepared binaries", () => {
   );
   assert.match(verifyStep, /binaries\/tidebreak-\$RELEASE_TARGET/);
 
+  assert.ok(tauriCliPackage);
+  assert.ok(tauriCliLock);
   assert.equal(tauriCliPackage.packageManager, "pnpm@10.18.3");
   assert.equal(tauriCliPackage.dependencies["@tauri-apps/cli"], "2.11.4");
   assert.match(
@@ -1667,6 +1773,7 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   const release = workflows["release.yml"];
   const prepareJob = workflowJob(release, "prepare_windows");
   const buildJob = workflowJob(release, "build_windows");
+  const preparedArtifacts = /Archive prepared Windows inputs/.test(prepareJob);
   const prepareCacheSave = prepareJob.match(
     /- name: Save release-specific unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
@@ -1678,6 +1785,107 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
     assert.match(job, /target: aarch64-pc-windows-msvc/);
     assert.match(job, /runner: windows-11-arm/);
   }
+  if (!preparedArtifacts) {
+    const buildCacheRestore = buildJob.match(
+      /- name: Restore unsigned Rust build cache[\s\S]*?(?=\n\s+- name:)/,
+    )?.[0];
+    assert.ok(buildCacheRestore);
+    for (const job of [prepareJob, buildJob]) {
+      assert.match(job, /if: \$\{\{ matrix\.arch == 'aarch64' \}\}/);
+      assert.match(job, /CMAKE_GENERATOR=Ninja/);
+      assert.match(job, /CMAKE_C_COMPILER=/);
+      assert.match(job, /CMAKE_CXX_COMPILER=/);
+      assert.match(job, /CMAKE_ASM_COMPILER=/);
+      assert.match(job, /echo "CC=\$clang_cl"/);
+      assert.match(job, /echo "CXX=\$clang_cl"/);
+      assert.match(job, /CXXFLAGS=\/EHsc/);
+      assert.match(job, /clang-cl/);
+      assert.match(job, /command -v ninja/);
+    }
+    assert.ok(
+      prepareJob.indexOf("Use clang-cl for Windows ARM native code") <
+        prepareJob.indexOf("Compile without production credentials or bundles"),
+      "Windows ARM clang-cl must be configured before the unsigned compile",
+    );
+    assert.ok(
+      buildJob.indexOf("Use clang-cl for Windows ARM native code") <
+        buildJob.indexOf("Build the Tauri app without Windows code signing"),
+      "Windows ARM clang-cl must be configured before the packaged build",
+    );
+
+    assert.match(prepareJob, /SCCACHE_GHA_RW_MODE: READ_ONLY/);
+    assert.match(prepareJob, /version: 10\.18\.3/);
+    assert.match(prepareJob, /pnpm install --frozen-lockfile --ignore-scripts/);
+    assert.match(
+      prepareJob,
+      /node scripts\/generate-third-party-notices\.mjs --check/,
+    );
+    assert.match(prepareJob, /--no-bundle --ci/);
+    assert.match(prepareJob, /continue-on-error: true/);
+    assert.doesNotMatch(prepareJob, /^    environment:/m);
+    assert.doesNotMatch(prepareJob, /secrets\./);
+    assert.doesNotMatch(
+      prepareJob,
+      /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_|actions\/upload-artifact/,
+    );
+    assert.ok(
+      prepareJob.indexOf("Save release-specific unsigned Rust build cache") <
+        prepareJob.indexOf("Require a successful unsigned compilation"),
+      "release compiler outputs must be saved before a failed compile is reported",
+    );
+
+    assert.doesNotMatch(buildJob, /actions\/cache\/save/);
+    assert.ok(
+      buildJob.indexOf("Restore unsigned Rust build cache") <
+        buildJob.indexOf("Validate updater signing configuration"),
+      "the build cache must be restored before the updater secret is loaded",
+    );
+    const cachedPaths = (step) =>
+      step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
+    assert.ok(cachedPaths(buildCacheRestore));
+    assert.equal(cachedPaths(buildCacheRestore), cachedPaths(prepareCacheSave));
+    assert.match(
+      buildCacheRestore,
+      /key: windows-release-prepared-v1-\$\{\{ matrix\.arch \}\}-\$\{\{ hashFiles\('Cargo\.lock', 'rust-toolchain\.toml'\) \}\}-\$\{\{ needs\.validate\.outputs\.sha \}\}-\$\{\{ needs\.validate\.outputs\.version \}\}/,
+    );
+    assert.doesNotMatch(buildCacheRestore, /restore-keys:/);
+
+    const discardProducts = buildJob.match(
+      /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
+    )?.[0];
+    assert.ok(discardProducts);
+    for (const product of [
+      /release\/tidebreak-desktop\.exe/,
+      /release\/tidebreak-host-broker\.exe/,
+      /release\/tidebreak\.exe/,
+      /tidebreak_desktop_lib\./,
+      /binaries\/tidebreak-host-broker-\$RELEASE_TARGET\.exe/,
+      /binaries\/tidebreak-\$RELEASE_TARGET\.exe/,
+    ]) {
+      assert.match(discardProducts, product);
+    }
+    assert.ok(
+      buildJob.indexOf("Discard restored product binaries") >
+        buildJob.indexOf("Restore unsigned Rust build cache") &&
+        buildJob.indexOf("Discard restored product binaries") <
+          buildJob.indexOf("Build the Tauri app without Windows code signing"),
+      "restored product binaries must be discarded before the packaged build",
+    );
+
+    assert.match(buildJob, /broker_sidecar="crates\/tidebreak-desktop\/binaries\/tidebreak-host-broker-\$RELEASE_TARGET\.exe"/);
+    assert.match(buildJob, /cli_sidecar="crates\/tidebreak-desktop\/binaries\/tidebreak-\$RELEASE_TARGET\.exe"/);
+    assert.match(buildJob, /Missing target-named host broker sidecar: \$broker_sidecar/);
+    assert.match(buildJob, /Missing target-named CLI sidecar: \$cli_sidecar/);
+    assert.doesNotMatch(release, /certificateThumbprint|signCommand/);
+    assert.doesNotMatch(buildJob, /APPLE_|AWS_|DOWNLOADS_/);
+    const buildStep = buildJob.match(
+      /- name: Build the Tauri app without Windows code signing[\s\S]*?(?=\n\s+- name:)/,
+    )?.[0];
+    assert.ok(buildStep);
+    assert.doesNotMatch(buildStep, /TAURI_SIGNING_PRIVATE_KEY/);
+    return;
+  }
+
   // whisper.cpp refuses MSVC on ARM. Force Ninja + clang-cl only in the
   // credential-free compile job so the packaging job needs no compiler.
   assert.match(prepareJob, /if: \$\{\{ matrix\.arch == 'aarch64' \}\}/);
@@ -1712,10 +1920,11 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   assert.doesNotMatch(prepareJob, /^    environment:/m);
   assert.doesNotMatch(prepareJob, /secrets\./);
   assert.doesNotMatch(prepareJob, /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_/);
+  const configAt = prepareJob.indexOf("Write tag-derived Tauri configuration");
+  const checkoutAt = prepareJob.indexOf("uses: actions/checkout@");
   assert.ok(
-    prepareJob.indexOf("Write tag-derived Tauri configuration") <
-      prepareJob.indexOf("Compile without production credentials or bundles"),
-    "the release configuration must be embedded during compilation",
+    configAt !== -1 && configAt < checkoutAt,
+    "the release configuration must be created before the release source is checked out",
   );
   assert.ok(
     prepareJob.indexOf("Save release-specific unsigned Rust build cache") <
@@ -2114,17 +2323,20 @@ test("GitHub release assets are attached before immutable publication", () => {
 
 test("the updater private key is isolated from compilation", () => {
   const release = workflows["release.yml"];
-  for (const jobName of ["prepare_macos", "prepare_windows"]) {
-    assert.doesNotMatch(
-      workflowJob(release, jobName),
-      /TAURI_SIGNING_PRIVATE_KEY/,
-    );
+  const preparedArtifacts = /Archive prepared macOS inputs/.test(release);
+  if (preparedArtifacts) {
+    for (const jobName of ["prepare_macos", "prepare_windows"]) {
+      assert.doesNotMatch(
+        workflowJob(release, jobName),
+        /TAURI_SIGNING_PRIVATE_KEY/,
+      );
+    }
   }
-  const bundleStep = release.match(
-    /- name: Bundle, sign, and notarize the prepared Tauri app[\s\S]*?(?=\n\s+- name:)/,
+  const packageStep = release.match(
+    /- name: (?:Build, sign, and notarize the Tauri app|Bundle, sign, and notarize the prepared Tauri app)[\s\S]*?(?=\n\s+- name:)/,
   )?.[0];
-  assert.ok(bundleStep);
-  assert.doesNotMatch(bundleStep, /TAURI_SIGNING_PRIVATE_KEY/);
+  assert.ok(packageStep);
+  assert.doesNotMatch(packageStep, /TAURI_SIGNING_PRIVATE_KEY/);
   assert.doesNotMatch(release, /createUpdaterArtifacts/);
   assert.match(release, /tauri signer sign "\$updater_path"/);
   assert.doesNotMatch(release, /cargo tauri signer sign/);
@@ -2152,9 +2364,7 @@ test("signing jobs do not run untrusted installers next to Apple or Tauri materi
     const secretsAt = firstSigningMaterialIndex(job, validate);
     assert.notEqual(secretsAt, -1, `${label} must still load signing material`);
 
-    const bundleOnly =
-      file === "release.yml" &&
-      (name === "build_macos" || name === "build_windows");
+    const bundleOnly = /Install pinned Tauri bundler/.test(job);
     const installerIndexes = [
       job.search(/pnpm\/action-setup@[0-9a-f]{40}/),
       job.search(/actions\/setup-node@[0-9a-f]{40}/),
@@ -2204,9 +2414,13 @@ test("macOS disk images are explicitly notarized and stapled", () => {
   assert.match(dmgNotarization, /--key "\$APPLE_API_KEY_PATH"/);
   assert.match(dmgNotarization, /xcrun stapler staple "\$dmg_path"/);
   assert.match(dmgNotarization, /xcrun stapler validate "\$dmg_path"/);
+  const packageAt = Math.max(
+    release.indexOf("Build, sign, and notarize the Tauri app"),
+    release.indexOf("Bundle, sign, and notarize the prepared Tauri app"),
+  );
   assert.ok(
-    release.indexOf("Bundle, sign, and notarize the prepared Tauri app") <
-      release.indexOf("Notarize and staple the DMG"),
+    packageAt !== -1 &&
+      packageAt < release.indexOf("Notarize and staple the DMG"),
   );
   assert.ok(
     release.indexOf("Notarize and staple the DMG") <
@@ -2241,12 +2455,16 @@ test("universal macOS release and staging packages contain both slices", () => {
     /"lipo",\s*\["-create", \.\.\.stagedSidecars, "-output", destination\]/,
   );
 
-  for (const job of [releasePrepare, stagingBuild, warm]) {
+  const preparedArtifacts = /Archive prepared macOS inputs/.test(releasePrepare);
+  const releaseCompile = preparedArtifacts ? releasePrepare : releaseBuild;
+  for (const job of [releaseCompile, stagingBuild, warm]) {
     assert.match(job, /rustup target add aarch64-apple-darwin x86_64-apple-darwin/);
     assert.match(job, /--target universal-apple-darwin/);
   }
-  assert.match(releaseBuild, /--target universal-apple-darwin/);
-  assert.doesNotMatch(releaseBuild, /rustup target add/);
+  if (preparedArtifacts) {
+    assert.match(releaseBuild, /--target universal-apple-darwin/);
+    assert.doesNotMatch(releaseBuild, /rustup target add/);
+  }
 
   for (const job of [releaseBuild, stagingBuild]) {
     assert.match(job, /timeout-minutes: 90/);


### PR DESCRIPTION
## What changed

This change makes the macOS and Windows prepare jobs compile the tagged desktop binary once, package the final binary, sidecars, and Tauri configuration in one-day run-scoped checksum-verified artifacts, and lets the credentialed jobs bundle those outputs with pinned Tauri CLI 2.11.4 without rebuilding Rust or the frontend.
The macOS prepare job can use `PRODUCTION_MACOS_RUNNER` for a provisioned ARM64 larger runner and falls back to `macos-latest`.

## Validation

`actionlint`, `git diff --check`, the release-policy suite, and its fail-closed mutation suite pass; the two Docker context probes were skipped locally because OrbStack is not running.

## Compatibility and risk

No persisted or wire-format changes apply; production packaging now depends on same-run prepared artifacts, with policy tests covering checksums and secret isolation.
This pull request is stacked on #2623 so the trusted base-branch policy can approve the workflow before it lands.