### PR TITLE
fix(code): retire images after publication races

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/session_image.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session_image.rs
@@ -10,9 +10,7 @@
 //! resolution can check the bytes still match what was reserved rather than
 //! trusting a client to restate it.
 
-use sea_orm::{
-    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set, TransactionTrait, TryInsertResult,
-};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set, TransactionTrait};
 
 use crate::code::{CodeSessionId, CodeSessionLifecycle};
 use crate::error::Result;
@@ -29,8 +27,9 @@ use super::acquire_code_session_write_lock;
 /// same `(session_id, blob_id)` is refused rather than silently replacing what
 /// an earlier turn may already reference. The session fence serializes this
 /// reservation with session ending. The reservation and retirement
-/// cancellation commit together, including on exact retries. Returns whether a
-/// new row was written.
+/// cancellation commit together, including on exact retries. Returns `true`
+/// when the image is published, including an exact retry, and `false` when the
+/// session lifecycle fence refuses publication.
 pub async fn publish_session_image(
     store: &DbStore,
     owner: &OwnerId,
@@ -58,21 +57,20 @@ pub async fn publish_session_image(
         return Ok(false);
     }
 
-    let inserted =
-        entities::code_session_image::Entity::insert(entities::code_session_image::ActiveModel {
-            session_id: Set(session_id.0),
-            blob_id: Set(image.blob_id),
-            owner: Set(owner.as_str().to_owned()),
-            media_type: Set(image.media_type.as_str().to_owned()),
-            width: Set(i32::try_from(image.width).unwrap_or(i32::MAX)),
-            height: Set(i32::try_from(image.height).unwrap_or(i32::MAX)),
-            byte_len: Set(i64::try_from(image.byte_len).unwrap_or(i64::MAX)),
-            created_at: Set(created_at),
-        })
-        .on_conflict_do_nothing()
-        .exec_without_returning(&transaction)
-        .await
-        .map_err(store_err)?;
+    entities::code_session_image::Entity::insert(entities::code_session_image::ActiveModel {
+        session_id: Set(session_id.0),
+        blob_id: Set(image.blob_id),
+        owner: Set(owner.as_str().to_owned()),
+        media_type: Set(image.media_type.as_str().to_owned()),
+        width: Set(i32::try_from(image.width).unwrap_or(i32::MAX)),
+        height: Set(i32::try_from(image.height).unwrap_or(i32::MAX)),
+        byte_len: Set(i64::try_from(image.byte_len).unwrap_or(i64::MAX)),
+        created_at: Set(created_at),
+    })
+    .on_conflict_do_nothing()
+    .exec_without_returning(&transaction)
+    .await
+    .map_err(store_err)?;
     if let Some(existing) =
         get_published_session_image_on(&transaction, owner, session_id, image.blob_id).await?
     {
@@ -92,7 +90,7 @@ pub async fn publish_session_image(
     }
     blob_ops::cancel_on(&transaction, image.blob_id).await?;
     transaction.commit().await.map_err(store_err)?;
-    Ok(matches!(inserted, TryInsertResult::Inserted(1)))
+    Ok(true)
 }
 
 /// Resolve one image only when it was explicitly published to this session by

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -592,7 +592,7 @@ async fn an_exact_publication_retry_cancels_a_new_retirement_episode() {
         BlobRetirementStatus::Queued
     );
 
-    assert!(!store
+    assert!(store
         .publish_code_session_image(&OwnerId::local(), session_id, &image, now())
         .await
         .unwrap());

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -780,16 +780,15 @@ impl ScopedCode {
         &self,
         session_id: CodeSessionId,
         image: &tidebreak_core::ImageRef,
-    ) -> Result<(), ServerError> {
-        tidebreak_core::db::code::publish_session_image(
+    ) -> Result<bool, ServerError> {
+        Ok(tidebreak_core::db::code::publish_session_image(
             &self.runtime.db,
             &self.owner,
             session_id,
             image,
             chrono::Utc::now(),
         )
-        .await?;
-        Ok(())
+        .await?)
     }
 
     pub(crate) async fn list_sessions(&self) -> Result<Vec<CodeSession>, ServerError> {

--- a/crates/tidebreak-server/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server/src/routes/code/sessions.rs
@@ -345,7 +345,17 @@ pub async fn publish_session_image(
     // Storing the bytes is not enough: the blob store is content-addressed and
     // owner-blind, so without this row any known id could be bound into any
     // session and read back through this session's own image route.
-    code.publish_session_image(id, &image).await?;
+    if !code.publish_session_image(id, &image).await? {
+        state
+            .store
+            .ensure_orphan_blob_retirement(image.blob_id)
+            .await?;
+        state.blob_retirement_wake.notify_one();
+        return Err(ServerError::conflict_kind(
+            "session_ended",
+            format!("session {id} ended before the image could be published"),
+        ));
+    }
     Ok((
         StatusCode::CREATED,
         crate::extract::Json(PublishedImageAttachment::from(image)),

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -18,13 +18,40 @@ use crate::code::browser_runtime::{BrowserRuntime, BrowserRuntimeError, BrowserR
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
 use tidebreak_core::{
-    Attention, AttentionSource, AttentionState, BrowserListResult, BrowserNavigateArgs,
+    Attention, AttentionSource, AttentionState, BlobStore, BrowserListResult, BrowserNavigateArgs,
     BrowserNavigateResult, BrowserPageSnapshot, BrowserScreenshotArgs, BrowserScreenshotResult,
     BrowserSnapshotArgs, BrowserWaitArgs, BrowserWaitResult, CapLevel, CodeEvent, CodeSessionId,
     CodeSessionLifecycle, CodeTurnId, CodeTurnStatus, CodeWorkspaceStatus, DbStore, FenceReason,
-    HarnessKind, PermissionMode, ReasoningEffort, WorkspaceId,
+    HarnessKind, PermissionMode, ReasoningEffort, Store, WorkspaceId,
 };
 use tidebreak_harness::{AdapterRegistry, ApprovalDecision, HarnessApprovalRef, HarnessEvent};
+
+struct PutGate {
+    started: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+struct GatedPutBlobStore {
+    inner: Arc<dyn BlobStore>,
+    gate: Arc<PutGate>,
+}
+
+#[async_trait]
+impl BlobStore for GatedPutBlobStore {
+    async fn put(&self, id: uuid::Uuid, bytes: Vec<u8>) -> tidebreak_core::Result<()> {
+        self.gate.started.notify_one();
+        self.gate.release.notified().await;
+        self.inner.put(id, bytes).await
+    }
+
+    async fn get(&self, id: uuid::Uuid) -> tidebreak_core::Result<Option<Vec<u8>>> {
+        self.inner.get(id).await
+    }
+
+    fn delete(&self, id: uuid::Uuid) -> tidebreak_core::Result<()> {
+        self.inner.delete(id)
+    }
+}
 
 #[derive(Default)]
 struct RecordingBrowserRuntime {
@@ -102,6 +129,21 @@ async fn code_app_with_optional_browser(
     adapter: ScriptedAdapter,
     browser_runtime: Option<Arc<RecordingBrowserRuntime>>,
 ) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    code_app_with_options(adapter, browser_runtime, None).await
+}
+
+async fn code_app_with_put_gate(
+    adapter: ScriptedAdapter,
+    gate: Arc<PutGate>,
+) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
+    code_app_with_options(adapter, None, Some(gate)).await
+}
+
+async fn code_app_with_options(
+    adapter: ScriptedAdapter,
+    browser_runtime: Option<Arc<RecordingBrowserRuntime>>,
+    put_gate: Option<Arc<PutGate>>,
+) -> (Router, Arc<str>, Arc<CodeRuntime>, tempfile::TempDir) {
     let (dir, store) = temp_db_store("code.db").await;
     let db = Arc::new(store);
     let store_trait: Arc<dyn Store> = db.clone();
@@ -130,6 +172,12 @@ async fn code_app_with_optional_browser(
             ..AgentConfig::default()
         },
     );
+    if let Some(gate) = put_gate {
+        state.blobs = Arc::new(GatedPutBlobStore {
+            inner: runtime.blobs.clone(),
+            gate,
+        });
+    }
     state.code = Some(runtime.clone());
     let token = state.token.clone();
     (app(state), token, runtime, dir)
@@ -7190,6 +7238,132 @@ async fn reclaim_refuses_a_checkout_tidebreak_did_not_clone() {
 /// `chat_image_publication` since it shipped; this is the code-mode
 /// equivalent, and the assertion is that publishing to one session does not
 /// authorize another.
+#[tokio::test]
+async fn a_live_session_image_upload_is_idempotently_published() {
+    let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = create_sibling_sessions(&client, addr, &token, &workspace, 1)
+        .await
+        .remove(0);
+    let pixels = one_pixel_png();
+    let expected = crate::routes::image_attachment::inspect_image_bytes(&pixels).unwrap();
+
+    for _ in 0..2 {
+        let response = client
+            .post(format!(
+                "http://{addr}/code/sessions/{session}/attachments/images"
+            ))
+            .bearer_auth(&token)
+            .header(reqwest::header::CONTENT_TYPE, "image/png")
+            .body(pixels.clone())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            reqwest::StatusCode::CREATED,
+            "an exact upload retry must keep its successful publication"
+        );
+        let body: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(body["attachment_id"], expected.blob_id.to_string());
+    }
+
+    let session_id: CodeSessionId = session.parse().unwrap();
+    assert_eq!(
+        runtime
+            .db
+            .get_published_code_session_image(
+                &tidebreak_core::OwnerId::local(),
+                session_id,
+                expected.blob_id,
+            )
+            .await
+            .unwrap(),
+        Some(expected)
+    );
+}
+
+#[tokio::test]
+async fn an_image_upload_losing_the_session_end_race_conflicts_and_queues_retirement() {
+    let gate = Arc::new(PutGate {
+        started: tokio::sync::Notify::new(),
+        release: tokio::sync::Notify::new(),
+    });
+    let (router, token, runtime, dir) =
+        code_app_with_put_gate(ScriptedAdapter::new(plain_text_script()), gate.clone()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let session = create_sibling_sessions(&client, addr, &token, &workspace, 1)
+        .await
+        .remove(0);
+    let session_id: CodeSessionId = session.parse().unwrap();
+    let pixels = one_pixel_png();
+    let image = crate::routes::image_attachment::inspect_image_bytes(&pixels).unwrap();
+    let upload = tokio::spawn({
+        let client = client.clone();
+        let token = token.clone();
+        let session = session.clone();
+        async move {
+            client
+                .post(format!(
+                    "http://{addr}/code/sessions/{session}/attachments/images"
+                ))
+                .bearer_auth(&token)
+                .header(reqwest::header::CONTENT_TYPE, "image/png")
+                .body(pixels)
+                .send()
+                .await
+                .unwrap()
+        }
+    });
+    gate.started.notified().await;
+
+    let mut row = tidebreak_core::db::code::get_session(
+        &runtime.db,
+        &tidebreak_core::OwnerId::local(),
+        session_id,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    row.lifecycle = CodeSessionLifecycle::Ended;
+    row.child_pid = None;
+    assert!(tidebreak_core::db::code::save_session(&runtime.db, &row)
+        .await
+        .unwrap());
+    gate.release.notify_one();
+
+    let response = upload.await.unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(body["kind"], "session_ended");
+    assert!(runtime
+        .db
+        .get_published_code_session_image(
+            &tidebreak_core::OwnerId::local(),
+            session_id,
+            image.blob_id,
+        )
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        runtime
+            .db
+            .get_blob_retirement(image.blob_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        tidebreak_core::BlobRetirementStatus::Queued
+    );
+}
+
 #[tokio::test]
 async fn a_session_cannot_attach_an_image_published_to_another_session() {
     // The capability gate refuses attachments before authority is consulted,


### PR DESCRIPTION
## What changed

Code image publication now reports success for both a new reservation and an exact retry. The scoped server layer preserves that result.

If a session ends after blob storage but before publication, the upload returns `409 session_ended`. The route queues the unreferenced blob through the reference-aware retirement system and wakes the retirement worker.

Focused tests cover successful idempotent publication, the lifecycle race, the typed conflict, the missing authority row, and queued blob retirement.

## Validation

- `rustfmt --edition 2021 --check` on the changed Rust files.
- `git diff --check`.
- Verified that the diff contains only the owned Code image publication paths and focused adjacent tests.
- Per repository guidance, no Cargo build, test, check, or Clippy command ran locally. CI provides compile and test coverage.

## Compatibility and risk

Successful uploads keep the existing `201 Created` response, including exact retries. Only uploads that lose the session lifecycle race change from a false success to a typed conflict.

Retirement remains asynchronous and reference-aware. If identical content still has another live reference, the retirement system keeps the shared blob.