### PR TITLE
fix(code): bound harness temporary resources

### DIFF
--- a/crates/tidebreak-harness/Cargo.toml
+++ b/crates/tidebreak-harness/Cargo.toml
@@ -21,6 +21,7 @@ base64 = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tidebreak-code-execution = { path = "../tidebreak-code-execution" }
 tidebreak-core = { path = "../tidebreak-core", default-features = false }
@@ -34,7 +35,6 @@ libc = { workspace = true }
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }
 
 [[bin]]

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -1,10 +1,13 @@
 //! One print-mode child per turn (`--prompt-file` + `--output-format streaming-json`).
 
-use std::path::{Path, PathBuf};
+use std::io::Write;
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
 use std::process::{ExitStatus, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use tokio::io::AsyncReadExt;
@@ -35,6 +38,7 @@ pub struct GrokSession {
     permission_mode: Mutex<PermissionMode>,
     resume_ref: Mutex<Option<String>>,
     version: String,
+    prompt_directory: Mutex<Option<PromptDirectory>>,
     child: AsyncMutex<Option<ProcessTreeChild>>,
     pid: ChildPid,
     /// Exit status of a child [`HarnessSession::interrupt`] already reaped.
@@ -53,6 +57,7 @@ impl GrokSession {
             permission_mode: Mutex::new(permission_mode),
             resume_ref: Mutex::new(resume_ref),
             version,
+            prompt_directory: Mutex::new(None),
             child: AsyncMutex::new(None),
             pid: ChildPid::new(),
             reaped: Mutex::new(None),
@@ -82,6 +87,66 @@ impl GrokSession {
     /// The mode in force right now.
     fn permission_mode(&self) -> PermissionMode {
         *self.permission_mode.lock().expect("grok permission mode")
+    }
+
+    fn write_prompt_file(&self, text: &str) -> Result<PromptFile, HarnessError> {
+        let mut slot = self.prompt_directory.lock().expect("grok prompt directory");
+        if slot.is_none() {
+            *slot = Some(PromptDirectory::new()?);
+        }
+        slot.as_ref()
+            .expect("grok prompt directory initialized")
+            .write(text)
+    }
+}
+
+/// Session-private storage for prompt files passed to the Grok child.
+struct PromptDirectory {
+    directory: tempfile::TempDir,
+}
+
+impl PromptDirectory {
+    fn new() -> Result<Self, HarnessError> {
+        let mut builder = tempfile::Builder::new();
+        builder.prefix("tidebreak-grok-");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            builder.permissions(std::fs::Permissions::from_mode(0o700));
+        }
+        let directory = builder.tempdir()?;
+        Ok(Self { directory })
+    }
+
+    fn write(&self, text: &str) -> Result<PromptFile, HarnessError> {
+        let mut builder = tempfile::Builder::new();
+        builder.prefix("prompt-").suffix(".txt");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            builder.permissions(std::fs::Permissions::from_mode(0o600));
+        }
+        let mut file = builder.tempfile_in(self.directory.path())?;
+        file.as_file_mut().write_all(text.as_bytes())?;
+        file.as_file_mut().flush()?;
+        Ok(PromptFile { file })
+    }
+
+    #[cfg(test)]
+    fn path(&self) -> &Path {
+        self.directory.path()
+    }
+}
+
+/// Deletes the prompt file on every Rust exit path, including cancellation
+/// and panic unwinding.
+struct PromptFile {
+    file: tempfile::NamedTempFile,
+}
+
+impl PromptFile {
+    fn path(&self) -> &Path {
+        self.file.path()
     }
 }
 
@@ -256,17 +321,14 @@ impl HarnessSession for GrokSession {
         } else {
             input.text
         };
-        let prompt_file = write_prompt_file(&prompt_text)?;
-        let plan =
-            match self.compose_plan(&prompt_file, input.model.as_deref(), input.reasoning_effort) {
-                Ok(plan) => plan,
-                Err(err) => {
-                    let _ = std::fs::remove_file(&prompt_file);
-                    return Err(err);
-                }
-            };
+        let prompt_file = self.write_prompt_file(&prompt_text)?;
+        let plan = self.compose_plan(
+            prompt_file.path(),
+            input.model.as_deref(),
+            input.reasoning_effort,
+        )?;
         let result = self.spawn_and_read(&plan).await;
-        let _ = std::fs::remove_file(&prompt_file);
+        drop(prompt_file);
         result
     }
 
@@ -322,6 +384,10 @@ impl HarnessSession for GrokSession {
         if let Some(mut child) = self.child.lock().await.take() {
             let _ = child.terminate().await;
         }
+        self.prompt_directory
+            .lock()
+            .expect("grok prompt directory")
+            .take();
         Ok(())
     }
 }
@@ -430,16 +496,6 @@ impl GrokSession {
     }
 }
 
-fn write_prompt_file(text: &str) -> Result<PathBuf, HarnessError> {
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    let path = std::env::temp_dir().join(format!("tidebreak-grok-prompt-{stamp}.txt"));
-    std::fs::write(&path, text)?;
-    Ok(path)
-}
-
 async fn emit_parsed(
     spec: &SessionSpec,
     parser: &mut GrokStreamParser,
@@ -489,6 +545,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     fn spec(bridge: &str) -> BrowserChannelSpec {
         BrowserChannelSpec::new(
@@ -505,6 +562,123 @@ mod tests {
         // Browser-present behavior is verified by the other tests below.
         let browser: Option<&BrowserChannelSpec> = None;
         assert!(browser.is_none());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn prompt_storage_is_private_and_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = PromptDirectory::new().unwrap();
+        let prompt = directory.write("private prompt").unwrap();
+        let directory_mode = std::fs::metadata(directory.path())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let file_mode = std::fs::metadata(prompt.path())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+
+        assert_eq!(directory_mode & 0o077, 0);
+        assert_eq!(file_mode & 0o077, 0);
+    }
+
+    #[test]
+    fn prompt_paths_are_unique_under_concurrent_creation() {
+        let directory = PromptDirectory::new().unwrap();
+        let prompts = std::thread::scope(|scope| {
+            let handles = (0..64)
+                .map(|index| {
+                    let directory = &directory;
+                    scope.spawn(move || directory.write(&format!("prompt {index}")).unwrap())
+                })
+                .collect::<Vec<_>>();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+        let paths = prompts
+            .iter()
+            .map(|prompt| prompt.path().to_owned())
+            .collect::<HashSet<_>>();
+
+        assert_eq!(paths.len(), prompts.len());
+        assert!(paths
+            .iter()
+            .all(|path| path.parent() == Some(directory.path())));
+    }
+
+    #[test]
+    fn prompt_guard_removes_file_on_drop() {
+        let directory = PromptDirectory::new().unwrap();
+        let prompt = directory.write("private prompt").unwrap();
+        let path = prompt.path().to_owned();
+        assert!(path.exists());
+
+        drop(prompt);
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn prompt_guard_removes_file_during_panic_unwind() {
+        let directory = PromptDirectory::new().unwrap();
+        let path = std::sync::Mutex::new(None);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let prompt = directory.write("private prompt").unwrap();
+            *path.lock().unwrap() = Some(prompt.path().to_owned());
+            panic!("exercise prompt cleanup");
+        }));
+
+        assert!(result.is_err());
+        assert!(!path.lock().unwrap().as_ref().unwrap().exists());
+    }
+
+    #[tokio::test]
+    async fn prompt_guard_removes_file_when_task_is_cancelled() {
+        let directory = PromptDirectory::new().unwrap();
+        let prompt = directory.write("private prompt").unwrap();
+        let path = prompt.path().to_owned();
+        let task = tokio::spawn(async move {
+            let _prompt = prompt;
+            std::future::pending::<()>().await;
+        });
+
+        task.abort();
+        let _ = task.await;
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn prompt_creation_does_not_replace_guessed_paths() {
+        let directory = PromptDirectory::new().unwrap();
+        let guessed = directory.path().join("prompt-guessed.txt");
+        std::fs::write(&guessed, "sentinel").unwrap();
+
+        let prompt = directory.write("private prompt").unwrap();
+
+        assert_ne!(prompt.path(), guessed);
+        assert_eq!(std::fs::read_to_string(guessed).unwrap(), "sentinel");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn prompt_creation_does_not_follow_guessed_symlinks() {
+        let directory = PromptDirectory::new().unwrap();
+        let target = directory.path().join("target.txt");
+        let guessed = directory.path().join("prompt-guessed.txt");
+        std::fs::write(&target, "sentinel").unwrap();
+        std::os::unix::fs::symlink(&target, &guessed).unwrap();
+
+        let prompt = directory.write("private prompt").unwrap();
+
+        assert_ne!(prompt.path(), guessed);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "sentinel");
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -3,16 +3,17 @@
 use std::net::TcpListener;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
-use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
 use tokio::time::timeout;
+use tracing::warn;
 
 use crate::browser_channel::apply_child_env_tokio;
 use crate::launch::{validate_launch_plan, LaunchPlan};
@@ -26,6 +27,10 @@ use tidebreak_core::PermissionMode;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(20);
 const MAX_STDERR_BYTES: usize = 64 * 1_024;
+/// Maximum number of parsed SSE payloads waiting for the turn consumer.
+const SSE_EVENT_CAPACITY: usize = 128;
+/// Maximum payload bytes held by queued SSE events.
+const SSE_BYTE_CAPACITY: usize = 1_024 * 1_024;
 const AUTO_FLAG: &str = "--auto";
 /// Environment key for the OpenCode config JSON override.
 const OPENCODE_CONFIG_CONTENT: &str = "OPENCODE_CONFIG_CONTENT";
@@ -44,7 +49,85 @@ pub struct OpencodeSession {
     base_url: Mutex<String>,
     client: reqwest::Client,
     parser: Mutex<OpencodeStreamParser>,
-    events: AsyncMutex<Option<mpsc::UnboundedReceiver<String>>>,
+    events: AsyncMutex<Option<Arc<SseEventStream>>>,
+}
+
+type SseQueueItem = Result<BufferedSseEvent, String>;
+
+/// One queued payload and its share of the queue's byte budget.
+struct BufferedSseEvent {
+    payload: String,
+    _byte_permit: OwnedSemaphorePermit,
+}
+
+struct SseEventStream {
+    receiver: AsyncMutex<mpsc::Receiver<SseQueueItem>>,
+    failure: Arc<Mutex<Option<String>>>,
+}
+
+#[derive(Clone)]
+struct SseEventSender {
+    events: mpsc::Sender<SseQueueItem>,
+    bytes: Arc<Semaphore>,
+    byte_capacity: usize,
+    failure: Arc<Mutex<Option<String>>>,
+}
+
+impl SseEventSender {
+    async fn send(&self, payload: String) -> Result<(), ()> {
+        let bytes = payload.len().max(1);
+        if bytes > self.byte_capacity {
+            self.fail(format!(
+                "opencode event stream payload exceeded the {}-byte queue limit",
+                self.byte_capacity
+            ))
+            .await;
+            return Err(());
+        }
+        let Ok(bytes) = u32::try_from(bytes) else {
+            self.fail("opencode event stream payload size is not supported".into())
+                .await;
+            return Err(());
+        };
+        let Ok(permit) = self.bytes.clone().acquire_many_owned(bytes).await else {
+            return Err(());
+        };
+        self.events
+            .send(Ok(BufferedSseEvent {
+                payload,
+                _byte_permit: permit,
+            }))
+            .await
+            .map_err(|_| ())
+    }
+
+    async fn fail(&self, message: String) {
+        let stored = {
+            let mut failure = self.failure.lock().expect("opencode event stream failure");
+            failure.get_or_insert_with(|| message.clone()).clone()
+        };
+        let _ = self.events.send(Err(stored)).await;
+    }
+}
+
+fn sse_event_channel(
+    event_capacity: usize,
+    byte_capacity: usize,
+) -> (SseEventSender, Arc<SseEventStream>) {
+    let (events, receiver) = mpsc::channel(event_capacity);
+    let failure = Arc::new(Mutex::new(None));
+    (
+        SseEventSender {
+            events,
+            bytes: Arc::new(Semaphore::new(byte_capacity)),
+            byte_capacity,
+            failure: Arc::clone(&failure),
+        },
+        Arc::new(SseEventStream {
+            receiver: AsyncMutex::new(receiver),
+            failure,
+        }),
+    )
 }
 
 impl OpencodeSession {
@@ -394,6 +477,24 @@ impl OpencodeSession {
     /// two spawns.
     pub(super) async fn ensure_child(&self) -> Result<(), HarnessError> {
         let mut slot = self.child.lock().await;
+        let stream_failure = {
+            let events = self.events.lock().await;
+            events.as_ref().and_then(|stream| {
+                stream
+                    .failure
+                    .lock()
+                    .expect("opencode event stream failure")
+                    .clone()
+            })
+        };
+        if let Some(failure) = stream_failure {
+            *self.events.lock().await = None;
+            if let Some(mut child) = slot.take() {
+                let _ = child.terminate().await;
+            }
+            self.child_pid.store(0, Ordering::SeqCst);
+            warn!(failure = %failure, "replacing opencode child after event stream failure");
+        }
         if let Some(child) = slot.as_mut() {
             if matches!(child.try_wait(), Ok(None)) {
                 return Ok(());
@@ -502,7 +603,7 @@ impl OpencodeSession {
                 response.status()
             )));
         }
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (events, receiver) = sse_event_channel(SSE_EVENT_CAPACITY, SSE_BYTE_CAPACITY);
         tokio::spawn(async move {
             let mut response = response;
             let mut lines = StreamLineBuffer::new();
@@ -511,20 +612,49 @@ impl OpencodeSession {
                 match response.chunk().await {
                     Ok(Some(chunk)) => {
                         let tick = lines.push(&chunk, budget);
+                        if tick.overflow_chunks > 0 {
+                            events
+                                .fail(format!(
+                                    "opencode event stream exceeded the {}-byte line limit",
+                                    budget.max_partial_line
+                                ))
+                                .await;
+                            return;
+                        }
                         for line in tick.lines {
                             if let Some(event) = sse_data_line(&line) {
-                                if tx.send(event).is_err() {
+                                if events.send(event).await.is_err() {
                                     return;
                                 }
                             }
                         }
                     }
-                    Ok(None) | Err(_) => return,
+                    Ok(None) => {
+                        events
+                            .fail("engine event stream closed before the turn finished".into())
+                            .await;
+                        return;
+                    }
+                    Err(err) => {
+                        events
+                            .fail(format!("opencode event stream read failed: {err}"))
+                            .await;
+                        return;
+                    }
                 }
             }
         });
-        *self.events.lock().await = Some(rx);
+        *self.events.lock().await = Some(receiver);
         Ok(())
+    }
+
+    async fn retire_child(&self) {
+        let mut slot = self.child.lock().await;
+        self.child_pid.store(0, Ordering::SeqCst);
+        *self.events.lock().await = None;
+        if let Some(mut child) = slot.take() {
+            let _ = child.terminate().await;
+        }
     }
 
     async fn open_or_resume_session(&self) -> Result<(), HarnessError> {
@@ -665,21 +795,22 @@ impl OpencodeSession {
     }
 
     async fn read_until_terminal_turn(&self) -> Result<(), HarnessError> {
+        let stream = self
+            .events
+            .lock()
+            .await
+            .clone()
+            .ok_or_else(|| HarnessError::Other("event stream is not connected".into()))?;
         loop {
-            let event = {
-                let mut slot = self.events.lock().await;
-                let Some(rx) = slot.as_mut() else {
-                    return Err(HarnessError::Other("event stream is not connected".into()));
-                };
-                rx.recv().await
-            };
+            let event = stream.receiver.lock().await.recv().await;
             let Some(event) = event else {
                 return Err(HarnessError::Other(
                     "engine event stream closed before the turn finished".into(),
                 ));
             };
+            let event = event.map_err(HarnessError::Other)?;
             let mut terminal = false;
-            for parsed in self.emit_sse_events(&event).await {
+            for parsed in self.emit_sse_events(&event.payload).await {
                 if matches!(
                     parsed,
                     HarnessEvent::TurnCompleted { .. }
@@ -717,7 +848,10 @@ impl HarnessSession for OpencodeSession {
         }
         // Long-lived server child: its exit is a session-level failure, not a
         // turn outcome.
-        self.read_until_terminal_turn().await?;
+        if let Err(err) = self.read_until_terminal_turn().await {
+            self.retire_child().await;
+            return Err(err);
+        }
         Ok(TurnOutcome::Clean)
     }
 
@@ -913,6 +1047,168 @@ mod tests {
         session.park().await.unwrap();
         session.interrupt().await.unwrap();
         assert_eq!(session.child_pid(), None);
+    }
+
+    #[tokio::test]
+    async fn sse_queue_applies_event_count_backpressure() {
+        let (sender, stream) = sse_event_channel(2, 1_024);
+        sender.send("one".into()).await.unwrap();
+        sender.send("two".into()).await.unwrap();
+        let blocked_sender = sender.clone();
+        let mut blocked = tokio::spawn(async move { blocked_sender.send("three".into()).await });
+
+        assert!(timeout(Duration::from_millis(25), &mut blocked)
+            .await
+            .is_err());
+        assert_eq!(
+            stream
+                .receiver
+                .lock()
+                .await
+                .recv()
+                .await
+                .unwrap()
+                .unwrap()
+                .payload,
+            "one"
+        );
+        assert!(timeout(Duration::from_secs(1), blocked)
+            .await
+            .unwrap()
+            .unwrap()
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn sse_queue_applies_payload_byte_backpressure() {
+        let (sender, stream) = sse_event_channel(8, 8);
+        sender.send("12345678".into()).await.unwrap();
+        let blocked_sender = sender.clone();
+        let mut blocked = tokio::spawn(async move { blocked_sender.send("x".into()).await });
+
+        assert!(timeout(Duration::from_millis(25), &mut blocked)
+            .await
+            .is_err());
+        assert_eq!(
+            stream
+                .receiver
+                .lock()
+                .await
+                .recv()
+                .await
+                .unwrap()
+                .unwrap()
+                .payload,
+            "12345678"
+        );
+        assert!(timeout(Duration::from_secs(1), blocked)
+            .await
+            .unwrap()
+            .unwrap()
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn oversized_sse_payload_fails_without_queueing_truncated_data() {
+        let (sender, stream) = sse_event_channel(2, 4);
+
+        assert!(sender.send("12345".into()).await.is_err());
+        let error = match stream.receiver.lock().await.recv().await.unwrap() {
+            Ok(_) => panic!("oversized payload must not enter the queue"),
+            Err(error) => error,
+        };
+
+        assert!(error.contains("4-byte queue limit"));
+        assert!(stream.receiver.lock().await.try_recv().is_err());
+        assert_eq!(
+            stream
+                .failure
+                .lock()
+                .expect("opencode event stream failure")
+                .as_deref(),
+            Some("opencode event stream payload exceeded the 4-byte queue limit")
+        );
+    }
+
+    #[tokio::test]
+    async fn sse_queue_preserves_terminal_event_order() {
+        let (sender, stream) = sse_event_channel(2, 1_024);
+        let progress = r#"{"type":"message.part.updated"}"#;
+        let terminal = r#"{"type":"session.idle"}"#;
+        sender.send(progress.into()).await.unwrap();
+        sender.send(terminal.into()).await.unwrap();
+
+        assert_eq!(
+            stream
+                .receiver
+                .lock()
+                .await
+                .recv()
+                .await
+                .unwrap()
+                .unwrap()
+                .payload,
+            progress
+        );
+        assert_eq!(
+            stream
+                .receiver
+                .lock()
+                .await
+                .recv()
+                .await
+                .unwrap()
+                .unwrap()
+                .payload,
+            terminal
+        );
+    }
+
+    #[tokio::test]
+    async fn retiring_a_failed_stream_clears_reconnect_state() {
+        let session = unit_session();
+        let (_sender, stream) = sse_event_channel(2, 1_024);
+        *session.events.lock().await = Some(stream);
+        session.child_pid.store(42, Ordering::SeqCst);
+
+        session.retire_child().await;
+
+        assert_eq!(session.child_pid(), None);
+        assert!(session.events.lock().await.is_none());
+        assert!(session.child.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn retiring_a_child_does_not_wait_for_the_active_event_receiver() {
+        let session = Arc::new(unit_session());
+        let (_sender, stream) = sse_event_channel(2, 1_024);
+        *session.events.lock().await = Some(Arc::clone(&stream));
+        session.child_pid.store(42, Ordering::SeqCst);
+        let receiver = stream.receiver.lock().await;
+
+        timeout(Duration::from_secs(1), session.retire_child())
+            .await
+            .expect("retirement must not wait for the event receiver");
+        drop(receiver);
+
+        assert!(session.events.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn recorded_stream_failure_retires_the_child_before_reconnect() {
+        let mut session = unit_session();
+        session.spec.binary = std::path::PathBuf::from("__tidebreak_missing_opencode_binary__");
+        let (sender, stream) = sse_event_channel(2, 1_024);
+        sender.fail("recorded stream failure".into()).await;
+        *session.events.lock().await = Some(stream);
+        session.child_pid.store(42, Ordering::SeqCst);
+
+        let error = session.ensure_child().await.unwrap_err();
+
+        assert!(matches!(error, HarnessError::Io(_)));
+        assert_eq!(session.child_pid(), None);
+        assert!(session.events.lock().await.is_none());
+        assert!(session.child.lock().await.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Store each Grok prompt in an atomically created session-private directory.
- Keep an owner-only named temporary file alive through child exit so Rust cleanup removes it on success, error, cancellation, and panic unwinding.
- Replace OpenCode’s unbounded server-sent event channel with count and byte limits that backpressure the HTTP body.
- Treat oversized frames and stream read failures as turn failures, retire the server child, and force the next turn to reconnect.
- Add focused tests for prompt permissions, unique names, cleanup paths, queue bounds, payload limits, event order, and reconnect state.

## Validation

- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- Reviewed the exact locked `tempfile` 3.27.0 creation and permission behavior.
- Per repository policy, Cargo build, test, check, and Clippy commands were not run locally. CI provides compile and test coverage.

## Compatibility and risk

- No persisted data, wire format, or public API changes.
- Grok now depends on the already locked workspace `tempfile` package at runtime.
- OpenCode applies transport backpressure when queued events reach 128 entries or 1 MiB. A frame above the existing 256 KiB line cap fails the turn and restarts the child on the next turn.