### PR TITLE
fix(code): protect browser verification fields

### DIFF
--- a/crates/tidebreak-desktop/src/browser_control.rs
+++ b/crates/tidebreak-desktop/src/browser_control.rs
@@ -62,7 +62,9 @@ fn platform_default_engine() -> BrowserEngineDescriptor {
             // not advertise acting until the adapter sends trusted native
             // input to the freshly resolved target.
             semantic_actions: false,
-            screenshot: cfg!(target_os = "macos"),
+            // WKWebView can consume parser-created closed shadow roots before
+            // Tidebreak can prove that their rendered content is safe.
+            screenshot: false,
             cross_origin_frames: false,
             profile_reset: false,
         },
@@ -2553,9 +2555,10 @@ mod tests {
     }
 
     #[test]
-    fn macos_does_not_claim_trusted_semantic_input_before_it_exists() {
+    fn platform_does_not_claim_unverified_agent_capabilities() {
         let descriptor = platform_default_engine();
         assert!(!descriptor.capabilities.semantic_actions);
+        assert!(!descriptor.capabilities.screenshot);
     }
 
     #[tokio::test]

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -151,6 +151,14 @@ struct RawActionResult {
     title: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawScreenshotPrivacyScan {
+    sensitive_fields: usize,
+    uninspectable_regions: usize,
+    changed: bool,
+}
+
 pub(crate) async fn browser_semantic_snapshot(
     app: &AppHandle,
     registry: &BrowserRegistry,
@@ -372,7 +380,7 @@ pub(crate) async fn browser_semantic_action(
         return Ok(action_result(
             &request,
             BrowserSemanticActionStatus::HumanTakeoverRequired,
-            "Password and one-time-code fields require human takeover.",
+            "Password, file, and verification-code fields require human takeover.",
         ));
     }
 
@@ -466,7 +474,7 @@ async fn execute_semantic_action(
         return Ok(action_result(
             &request,
             BrowserSemanticActionStatus::HumanTakeoverRequired,
-            "Password and one-time-code fields require human takeover.",
+            "Password, file, and verification-code fields require human takeover.",
         ));
     }
     let webview = app
@@ -911,8 +919,37 @@ async fn capture_screenshot(
         .get_webview(&label)
         .ok_or_else(|| "browser session is not open".to_owned())?;
 
-    let image_base64 =
-        capture_browser_image(&webview, arguments.max_width, arguments.max_height).await?;
+    let privacy_watch = format!("__tidebreak_screenshot_privacy_{}", Uuid::new_v4().simple());
+    let initial_privacy: RawScreenshotPrivacyScan =
+        evaluate_json(&webview, &screenshot_privacy_script(&privacy_watch, false)?).await?;
+    if initial_privacy.sensitive_fields > 0 || initial_privacy.uninspectable_regions > 0 {
+        let _ = evaluate_json::<RawScreenshotPrivacyScan>(
+            &webview,
+            &screenshot_privacy_script(&privacy_watch, true)?,
+        )
+        .await;
+        return Err(screenshot_human_takeover_message(&initial_privacy));
+    }
+
+    let image_result =
+        capture_browser_image(&webview, arguments.max_width, arguments.max_height).await;
+    let final_privacy: RawScreenshotPrivacyScan = evaluate_json(
+        &webview,
+        &screenshot_privacy_script(&privacy_watch, true)?,
+    )
+    .await
+    .map_err(|error| {
+        format!(
+            "browser screenshot requires human takeover because the privacy scan could not be completed: {error}"
+        )
+    })?;
+    if final_privacy.sensitive_fields > 0
+        || final_privacy.uninspectable_regions > 0
+        || final_privacy.changed
+    {
+        return Err(screenshot_human_takeover_message(&final_privacy));
+    }
+    let image_base64 = image_result?;
 
     // One atomic completion: recheck capability, workspace, visibility,
     // halt, controller, grant, instance, document epoch, and stored
@@ -936,6 +973,17 @@ async fn capture_screenshot(
         image_base64,
         mime_type: "image/png".to_owned(),
     })
+}
+
+fn screenshot_human_takeover_message(scan: &RawScreenshotPrivacyScan) -> String {
+    if scan.uninspectable_regions > 0 {
+        return "browser screenshot requires human takeover because cross-origin or closed-shadow content cannot be checked for sensitive fields".to_owned();
+    }
+    if scan.sensitive_fields > 0 {
+        return "browser screenshot requires human takeover because the page contains a password, file, or verification-code field".to_owned();
+    }
+    "browser screenshot requires human takeover because the page changed during privacy-safe capture"
+        .to_owned()
 }
 
 #[cfg(target_os = "macos")]
@@ -1232,6 +1280,7 @@ fn snapshot_script(max_nodes: usize, marker: &str) -> String {
     SNAPSHOT_SCRIPT
         .replace("__MAX_NODES__", &max_nodes.to_string())
         .replace("__MARKER__", marker)
+        .replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY)
 }
 
 fn action_script(
@@ -1272,7 +1321,21 @@ fn action_script(
         },
     });
     let payload = serde_json::to_string(&payload).map_err(|error| error.to_string())?;
-    Ok(ACTION_SCRIPT.replace("__PAYLOAD__", &payload))
+    Ok(ACTION_SCRIPT
+        .replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY)
+        .replace("__PAYLOAD__", &payload))
+}
+
+fn inspect_overlay_script() -> String {
+    INSPECT_OVERLAY_SCRIPT.replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY)
+}
+
+fn screenshot_privacy_script(watch_key: &str, finish: bool) -> Result<String, String> {
+    let watch_key = serde_json::to_string(watch_key).map_err(|error| error.to_string())?;
+    Ok(SCREENSHOT_PRIVACY_SCRIPT
+        .replace("__WATCH_KEY__", &watch_key)
+        .replace("__FINISH__", if finish { "true" } else { "false" })
+        .replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY))
 }
 
 #[cfg(target_os = "macos")]
@@ -1283,7 +1346,10 @@ async fn evaluate_json<T: serde::de::DeserializeOwned>(
     use std::sync::Mutex;
 
     use block2::RcBlock;
-    use objc2::runtime::AnyObject;
+    use objc2::{
+        msg_send,
+        runtime::{AnyClass, AnyObject},
+    };
     use objc2_foundation::{NSError, NSString};
     use objc2_web_kit::WKWebView;
     use tokio::{sync::oneshot, time::timeout};
@@ -1294,6 +1360,25 @@ async fn evaluate_json<T: serde::de::DeserializeOwned>(
     webview
         .with_webview(move |platform| unsafe {
             let view: &WKWebView = &*platform.inner().cast();
+            let Some(content_world_class) = AnyClass::get(c"WKContentWorld") else {
+                if let Some(sender) = sender.lock().ok().and_then(|mut sender| sender.take()) {
+                    let _ = sender.send(Err(
+                        "browser JavaScript isolation is unavailable on this platform".to_owned(),
+                    ));
+                }
+                return;
+            };
+            let world_name = NSString::from_str("TidebreakBrowserSemantics");
+            let content_world: *mut AnyObject =
+                msg_send![content_world_class, worldWithName: &*world_name];
+            if content_world.is_null() {
+                if let Some(sender) = sender.lock().ok().and_then(|mut sender| sender.take()) {
+                    let _ = sender.send(Err(
+                        "browser JavaScript isolation could not be created".to_owned()
+                    ));
+                }
+                return;
+            }
             let handler = RcBlock::new(move |value: *mut AnyObject, error: *mut NSError| {
                 let Some(sender) = sender.lock().ok().and_then(|mut sender| sender.take()) else {
                     return;
@@ -1310,7 +1395,14 @@ async fn evaluate_json<T: serde::de::DeserializeOwned>(
                 let value: &NSString = &*value.cast();
                 let _ = sender.send(Ok(value.to_string()));
             });
-            view.evaluateJavaScript_completionHandler(&NSString::from_str(&script), Some(&handler));
+            let script = NSString::from_str(&script);
+            let _: () = msg_send![
+                view,
+                evaluateJavaScript: &*script,
+                inFrame: std::ptr::null_mut::<AnyObject>(),
+                inContentWorld: content_world,
+                completionHandler: &*handler
+            ];
         })
         .map_err(|error| format!("browser host: {error}"))?;
 
@@ -1332,6 +1424,150 @@ async fn evaluate_json<T: serde::de::DeserializeOwned>(
     Err("semantic browser control is not available on this platform yet".to_owned())
 }
 
+const SENSITIVE_FIELD_POLICY: &str = r##"
+  const tidebreakFieldSelector = "input, textarea, [contenteditable]:not([contenteditable='false']), [role='textbox']";
+  const tidebreakTextWithoutFieldDescendants = (element) => {
+    let text = clean(element?.innerText || element?.textContent);
+    for (const field of element?.querySelectorAll?.(tidebreakFieldSelector) || []) {
+      const fieldText = clean(field.innerText || field.textContent);
+      if (fieldText) text = clean(text.split(fieldText).join(" "));
+    }
+    return text;
+  };
+  const tidebreakReferencedText = (element) => {
+    if (!element || element.matches?.(tidebreakFieldSelector)) return "";
+    return tidebreakTextWithoutFieldDescendants(element);
+  };
+  const tidebreakAriaName = (element, doc) => {
+    const labelledBy = clean(element.getAttribute("aria-labelledby"), 200);
+    if (labelledBy) {
+      const root = element.getRootNode?.();
+      const value = labelledBy.split(/\s+/)
+        .map((id) => clean(
+          tidebreakReferencedText(
+            root?.getElementById?.(id) || doc.getElementById(id),
+          ),
+        ))
+        .filter(Boolean)
+        .join(" ");
+      if (value) return clean(value);
+    }
+    return clean(element.getAttribute("aria-label"));
+  };
+  const tidebreakAccessibleName = (element, doc) => {
+    const direct = tidebreakAriaName(element, doc)
+      || clean(element.labels && Array.from(element.labels).map(tidebreakReferencedText).join(" "))
+      || clean(element.getAttribute("alt"))
+      || clean(element.getAttribute("title"))
+      || clean(element.getAttribute("placeholder"));
+    if (direct) return direct;
+    return tidebreakTextWithoutFieldDescendants(element);
+  };
+  const tidebreakDescribedText = (element, doc) => clean(
+    clean(element.getAttribute("aria-describedby"), 200)
+      .split(/\s+/)
+      .map((id) => clean(
+        tidebreakReferencedText(
+          element.getRootNode?.()?.getElementById?.(id) || doc.getElementById(id),
+        ),
+      ))
+      .filter(Boolean)
+      .join(" "),
+    240,
+  );
+  const tidebreakSensitiveSignal = (value) => clean(value, 500)
+    .normalize("NFKC")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+  const tidebreakIsSensitiveField = (element, doc) => {
+    const tag = element.localName || "";
+    const role = clean(element.getAttribute("role"), 60).toLowerCase();
+    const editable = tag === "input"
+      || tag === "textarea"
+      || element.isContentEditable
+      || role === "textbox";
+    if (!editable) return false;
+
+    const type = clean(element.getAttribute("type") || element.type, 40).toLowerCase();
+    const autocomplete = clean(element.getAttribute("autocomplete"), 160).toLowerCase();
+    if (type === "password" || type === "file") return true;
+    if (["one-time-code", "current-password", "new-password", "cc-csc"]
+      .some((token) => autocomplete.split(/\s+/).includes(token))) return true;
+
+    const form = element.form;
+    const group = element.closest("[role='group']");
+    const accessibleName = tidebreakAccessibleName(element, doc);
+    const signal = tidebreakSensitiveSignal([
+      element.getAttribute("name"),
+      element.id,
+      accessibleName,
+      element.getAttribute("placeholder"),
+      element.getAttribute("aria-label"),
+      element.getAttribute("title"),
+      tidebreakDescribedText(element, doc),
+      element.closest("fieldset")?.querySelector("legend")?.textContent,
+      group && tidebreakAriaName(group, doc),
+      form?.getAttribute("name"),
+      form?.id,
+      form && tidebreakAriaName(form, doc),
+      form?.querySelector("legend, h1, h2, h3")?.textContent,
+    ].filter(Boolean).join(" "));
+    const benignNumeric = /\b(quantity|qty|count|amount|price|year|age|zip|postal|search|phone|mobile|page|size|score|rating|percent|percentage|width|height|distance|duration)\b/.test(signal);
+    const explicitSensitive = /\b(one time|otp|totp|verification|verify|auth|authentication|authenticator|security|recovery|backup|two factor|2fa|mfa|passcode|password|passphrase|secret|pin|cvv|cvc|cid)\b/.test(signal);
+    const codeOrToken = /\b(code|token)\b/.test(signal);
+    if (explicitSensitive || (!benignNumeric && codeOrToken)) return true;
+
+    const inputMode = clean(element.getAttribute("inputmode") || element.inputMode, 40).toLowerCase();
+    const pattern = clean(element.getAttribute("pattern"), 120);
+    const maxLength = Number(element.getAttribute("maxlength") || element.maxLength || 0);
+    const size = Number(element.getAttribute("size") || element.size || 0);
+    const numeric = ["numeric", "decimal", "tel"].includes(inputMode)
+      || ["number", "tel"].includes(type)
+      || /\\d|\[0-9\]|digit/i.test(pattern);
+    const shortConstraint = (maxLength >= 3 && maxLength <= 12)
+      || (size >= 3 && size <= 12);
+    const patternBounds = pattern.match(/\{\s*(\d{1,2})\s*(?:,\s*(\d{1,2})?\s*)?\}/);
+    const patternMin = Number(patternBounds?.[1]);
+    const patternMax = patternBounds?.[0].includes(",")
+      ? Number(patternBounds?.[2] || Number.POSITIVE_INFINITY)
+      : patternMin;
+    const shortDigitPattern = /\\d|\[0-9\]|digit/i.test(pattern)
+      && patternMin >= 3
+      && patternMax <= 12;
+    const looksLikeShortDigits = (value) => {
+      const example = clean(value, 80).normalize("NFKC").trim();
+      return /^(?:\d[\s\-–—]*){3,12}$/.test(example);
+    };
+    const digitExample = [
+      element.getAttribute("placeholder"),
+      element.getAttribute("aria-label"),
+      accessibleName,
+    ].some(looksLikeShortDigits);
+    if (numeric && !benignNumeric && (shortConstraint || shortDigitPattern || digitExample)) {
+      return true;
+    }
+
+    if (numeric && !benignNumeric && maxLength === 1) {
+      const container = element.closest("fieldset, [role='group'], form, div");
+      const peers = container
+        ? Array.from(container.querySelectorAll("input")).filter((candidate) => {
+          const candidateMode = clean(candidate.getAttribute("inputmode") || candidate.inputMode, 40).toLowerCase();
+          const candidateType = clean(candidate.getAttribute("type") || candidate.type, 40).toLowerCase();
+          const candidateLength = Number(candidate.getAttribute("maxlength") || candidate.maxLength || 0);
+          return candidateLength === 1
+            && (["numeric", "decimal", "tel"].includes(candidateMode)
+              || ["number", "tel"].includes(candidateType));
+        })
+        : [];
+      if (peers.length >= 4 && peers.length <= 12) return true;
+    }
+    return false;
+  };
+"##;
+
 const SNAPSHOT_SCRIPT: &str = r#"
 (() => {
   const MAX_NODES = __MAX_NODES__;
@@ -1344,7 +1580,8 @@ const SNAPSHOT_SCRIPT: &str = r#"
 
   const INTERACTIVE_SELECTOR = [
     "a[href]", "button", "input:not([type='hidden'])", "textarea", "select",
-    "[contenteditable='true']", "[role='button']", "[role='link']",
+    "[contenteditable]:not([contenteditable='false'])", "[role='textbox']",
+    "[role='button']", "[role='link']",
     "[role='checkbox']", "[role='radio']", "[role='tab']",
     "[tabindex]:not([tabindex='-1'])"
   ].join(",");
@@ -1358,6 +1595,7 @@ const SNAPSHOT_SCRIPT: &str = r#"
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, limit);
+  __SENSITIVE_FIELD_POLICY__
   const escapeCss = (value) => globalThis.CSS?.escape
     ? globalThis.CSS.escape(value)
     : String(value).replace(/[^a-zA-Z0-9_-]/g, (character) => `\\${character}`);
@@ -1409,33 +1647,6 @@ const SNAPSHOT_SCRIPT: &str = r#"
     if (element.isContentEditable) return "textbox";
     return tag || "element";
   };
-  const accessibleName = (element, doc) => {
-    const labelledBy = clean(element.getAttribute("aria-labelledby"), 200);
-    if (labelledBy) {
-      const value = labelledBy.split(/\s+/)
-        .map((id) => clean(doc.getElementById(id)?.textContent))
-        .filter(Boolean)
-        .join(" ");
-      if (value) return clean(value);
-    }
-    const direct = clean(element.getAttribute("aria-label"))
-      || clean(element.labels && Array.from(element.labels).map((label) => label.textContent).join(" "))
-      || clean(element.getAttribute("alt"))
-      || clean(element.getAttribute("title"))
-      || clean(element.getAttribute("placeholder"));
-    if (direct) return direct;
-    return clean(element.innerText || element.textContent);
-  };
-  const isSensitive = (element) => {
-    if (element.localName !== "input") return false;
-    const type = clean(element.getAttribute("type"), 40).toLowerCase();
-    const autocomplete = clean(element.getAttribute("autocomplete"), 100).toLowerCase();
-    return type === "password"
-      || type === "file"
-      || autocomplete.includes("one-time-code")
-      || autocomplete.includes("current-password")
-      || autocomplete.includes("new-password");
-  };
   const isConsequential = (element) => {
     const tag = element.localName;
     const type = clean(element.getAttribute("type") || element.type, 40).toLowerCase();
@@ -1464,7 +1675,7 @@ const SNAPSHOT_SCRIPT: &str = r#"
   };
   const contentText = (element) => element.localName === "img"
     ? clean(element.getAttribute("alt"))
-    : clean(element.innerText || element.textContent);
+    : tidebreakTextWithoutFieldDescendants(element);
 
   const visit = (doc, win, framePath, frameName, offsetX, offsetY) => {
     const candidates = doc.querySelectorAll(`${INTERACTIVE_SELECTOR},${CONTENT_SELECTOR}`);
@@ -1476,11 +1687,11 @@ const SNAPSHOT_SCRIPT: &str = r#"
       if (!isVisible(element, win)) continue;
       const interactive = element.matches(INTERACTIVE_SELECTOR);
       if (!interactive && element.closest(INTERACTIVE_SELECTOR)) continue;
-      const text = contentText(element);
-      if (!interactive && !text) continue;
       const rect = element.getBoundingClientRect();
       const role = inferredRole(element);
-      const sensitive = interactive && isSensitive(element);
+      const sensitive = interactive && tidebreakIsSensitiveField(element, doc);
+      const text = sensitive ? "" : contentText(element);
+      if (!interactive && !text) continue;
       const consequential = interactive && isConsequential(element);
       const targetRef = interactive ? `@e${nextTargetRef++}` : null;
       if (interactive) {
@@ -1501,11 +1712,13 @@ const SNAPSHOT_SCRIPT: &str = r#"
         ref: targetRef,
         tag: element.localName || "element",
         role,
-        name: interactive ? accessibleName(element, doc) : text,
+        name: interactive
+          ? (sensitive ? "Sensitive field" : tidebreakAccessibleName(element, doc))
+          : text,
         frame: frameName,
-        text: text || null,
+        text: sensitive ? null : (text || null),
         value: value || null,
-        href: interactive && element.href ? clean(element.href, 2048) : null,
+        href: interactive && !sensitive && element.href ? clean(element.href, 2048) : null,
         inputType,
         disabled: interactive && Boolean(element.disabled || element.getAttribute("aria-disabled") === "true"),
         checked: interactive && "checked" in element ? Boolean(element.checked) : null,
@@ -1568,99 +1781,356 @@ const SNAPSHOT_SCRIPT: &str = r#"
 
 const INSPECT_OVERLAY_SCRIPT: &str = r##"
 (() => {
-  const existing = document.getElementById("__tidebreak_inspect_overlay__");
-  if (existing) return "already_injected";
-  const style = document.createElement("style");
-  style.id = "__tidebreak_inspect_style__";
-  style.textContent = `
-    .__tidebreak_inspect_overlay__ {
-      all: initial;
-      position: fixed;
-      pointer-events: none;
-      z-index: 2147483647;
-      border: 1.5px solid rgba(20, 130, 240, 0.72);
-      background: rgba(20, 130, 240, 0.09);
-      border-radius: 3px;
-      box-sizing: border-box;
-      transition: opacity 0.12s ease;
-    }
-    .__tidebreak_inspect_label__ {
-      all: initial;
-      position: fixed;
-      z-index: 2147483647;
-      pointer-events: none;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      font-size: 9px;
-      font-weight: 600;
-      line-height: 1;
-      color: rgb(20, 130, 240);
-      background: rgba(255, 255, 255, 0.92);
-      padding: 1.5px 4px;
-      border-radius: 2px;
-      border: 1px solid rgba(20, 130, 240, 0.38);
-      white-space: nowrap;
-      max-width: 160px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-  `;
-  document.head.appendChild(style);
+  const STATE_KEY = "__tidebreak_inspect_state__";
+  const active = window[STATE_KEY];
+  if (active && !active.cancelled) return "already_injected";
 
-  const INTERACTIVE_SELECTOR = "a[href], button, input:not([type='hidden']), textarea, select, [contenteditable='true'], [role='button'], [role='link'], [role='checkbox'], [role='radio'], [role='tab'], [tabindex]:not([tabindex='-1'])";
+  const INTERACTIVE_SELECTOR = "a[href], button, input:not([type='hidden']), textarea, select, [contenteditable]:not([contenteditable='false']), [role='textbox'], [role='button'], [role='link'], [role='checkbox'], [role='radio'], [role='tab'], [tabindex]:not([tabindex='-1'])";
+  const FIELD_SELECTOR = "input, textarea, [contenteditable]:not([contenteditable='false']), [role='textbox']";
+  const clean = (value, limit = 240) => String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+  __SENSITIVE_FIELD_POLICY__
 
-  const isVisible = (element) => {
-    const style = window.getComputedStyle(element);
+  const state = { cancelled: false, frame: null, host: null, observers: [], schedule: null };
+  window[STATE_KEY] = state;
+
+  const isVisible = (element, win) => {
+    const style = win.getComputedStyle(element);
     const rect = element.getBoundingClientRect();
     return style.display !== "none"
       && style.visibility !== "hidden"
       && Number(style.opacity || 1) !== 0
       && rect.width > 0
-      && rect.height > 0;
+      && rect.height > 0
+      && rect.right > 0
+      && rect.bottom > 0
+      && rect.left < win.innerWidth
+      && rect.top < win.innerHeight;
+  };
+  const absoluteRect = (rect, offsetX, offsetY) => ({
+    left: offsetX + rect.left,
+    top: offsetY + rect.top,
+    width: rect.width,
+    height: rect.height,
+  });
+  const ordinaryLabel = (element) => (element.localName || "element")
+    + (element.id ? "#" + element.id : "")
+    + (element.className && typeof element.className === "string"
+      ? "." + element.className.split(" ").filter(Boolean).slice(0, 2).join(".")
+      : "");
+  const addMask = (entries, rect, label = "Sensitive region · human takeover") => {
+    entries.push({ rect, sensitive: true, label });
   };
 
-  const highlight = () => {
-    const candidates = document.querySelectorAll(INTERACTIVE_SELECTOR);
-    const overlay = document.createElement("div");
-    overlay.id = "__tidebreak_inspect_overlay__";
-    candidates.forEach((element, index) => {
-      if (!isVisible(element)) return;
-      const rect = element.getBoundingClientRect();
-      const marker = document.createElement("div");
-      marker.className = "__tidebreak_inspect_overlay__";
-      marker.style.left = rect.left + "px";
-      marker.style.top = rect.top + "px";
-      marker.style.width = rect.width + "px";
-      marker.style.height = rect.height + "px";
-      overlay.appendChild(marker);
+  const scanRoot = (root, doc, win, offsetX, offsetY, entries, roots) => {
+    roots.push({ root, win });
+    let containsSensitive = false;
+    for (const element of root.querySelectorAll(FIELD_SELECTOR)) {
+      if (tidebreakIsSensitiveField(element, doc)) containsSensitive = true;
+    }
+    for (const element of root.querySelectorAll(INTERACTIVE_SELECTOR)) {
+      const sensitive = tidebreakIsSensitiveField(element, doc);
+      if (!isVisible(element, win)) continue;
+      entries.push({
+        rect: absoluteRect(element.getBoundingClientRect(), offsetX, offsetY),
+        sensitive,
+        label: sensitive ? "Sensitive field · human takeover" : ordinaryLabel(element),
+      });
+    }
 
-      const label = document.createElement("span");
-      label.className = "__tidebreak_inspect_label__";
-      label.style.left = rect.left + "px";
-      label.style.top = Math.max(0, rect.top - 11) + "px";
-      label.textContent = (element.localName || "element")
-        + (element.id ? "#" + element.id : "")
-        + (element.className && typeof element.className === "string"
-          ? "." + element.className.split(" ").filter(Boolean).slice(0, 2).join(".")
-          : "");
-      overlay.appendChild(label);
+    for (const element of root.querySelectorAll("*")) {
+      if (element.shadowRoot) {
+        const shadowEntries = [];
+        const shadowSensitive = scanRoot(
+          element.shadowRoot,
+          doc,
+          win,
+          offsetX,
+          offsetY,
+          shadowEntries,
+          roots,
+        );
+        if (shadowSensitive) {
+          addMask(entries, absoluteRect(element.getBoundingClientRect(), offsetX, offsetY));
+          containsSensitive = true;
+        } else {
+          entries.push(...shadowEntries);
+        }
+      } else if (element.localName?.includes("-")) {
+        if (isVisible(element, win)) {
+          addMask(entries, absoluteRect(element.getBoundingClientRect(), offsetX, offsetY));
+        }
+        containsSensitive = true;
+      }
+    }
+
+    for (const frame of root.querySelectorAll("iframe")) {
+      const frameRect = absoluteRect(frame.getBoundingClientRect(), offsetX, offsetY);
+      try {
+        const childDoc = frame.contentDocument;
+        const childWin = frame.contentWindow;
+        if (!childDoc || !childWin) throw new Error("frame unavailable");
+        const childEntries = [];
+        const childSensitive = scanRoot(
+          childDoc,
+          childDoc,
+          childWin,
+          frameRect.left,
+          frameRect.top,
+          childEntries,
+          roots,
+        );
+        if (childSensitive) {
+          addMask(entries, frameRect);
+          containsSensitive = true;
+        } else {
+          entries.push(...childEntries);
+        }
+      } catch (_) {
+        if (isVisible(frame, win)) {
+          addMask(entries, frameRect, "Uninspectable frame · human takeover");
+        }
+        containsSensitive = true;
+      }
+    }
+    return containsSensitive;
+  };
+
+  const setImportant = (style, name, value) => style.setProperty(name, value, "important");
+  const buildMarker = (entry, shadow) => {
+    const marker = document.createElement("div");
+    setImportant(marker.style, "all", "initial");
+    setImportant(marker.style, "position", "fixed");
+    setImportant(marker.style, "left", entry.rect.left + "px");
+    setImportant(marker.style, "top", entry.rect.top + "px");
+    setImportant(marker.style, "width", entry.rect.width + "px");
+    setImportant(marker.style, "height", entry.rect.height + "px");
+    setImportant(marker.style, "box-sizing", "border-box");
+    setImportant(marker.style, "pointer-events", "none");
+    setImportant(marker.style, "border-radius", "3px");
+    setImportant(marker.style, "border", entry.sensitive
+      ? "1.5px solid rgb(157, 64, 40)"
+      : "1.5px solid rgba(20, 130, 240, 0.72)");
+    setImportant(marker.style, "background", entry.sensitive
+      ? "rgb(247, 240, 232)"
+      : "rgba(20, 130, 240, 0.09)");
+
+    const label = document.createElement("span");
+    label.textContent = entry.label;
+    setImportant(label.style, "all", "initial");
+    setImportant(label.style, "position", "absolute");
+    setImportant(label.style, "left", "0");
+    setImportant(label.style, "top", "0");
+    setImportant(label.style, "box-sizing", "border-box");
+    setImportant(label.style, "max-width", Math.max(1, entry.rect.width) + "px");
+    setImportant(label.style, "overflow", "hidden");
+    setImportant(label.style, "text-overflow", "ellipsis");
+    setImportant(label.style, "white-space", "nowrap");
+    setImportant(label.style, "padding", "1.5px 4px");
+    setImportant(label.style, "font-family", "-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif");
+    setImportant(label.style, "font-size", "9px");
+    setImportant(label.style, "font-weight", "600");
+    setImportant(label.style, "line-height", "1");
+    setImportant(label.style, "color", entry.sensitive ? "rgb(126, 48, 29)" : "rgb(20, 130, 240)");
+    setImportant(label.style, "background", entry.sensitive ? "rgb(255, 248, 240)" : "rgba(255, 255, 255, 0.92)");
+    marker.appendChild(label);
+    shadow.appendChild(marker);
+  };
+
+  const schedule = () => {
+    if (state.cancelled || state.frame !== null) return;
+    state.frame = window.requestAnimationFrame(() => {
+      state.frame = null;
+      render();
     });
-    document.body.appendChild(overlay);
-    return "injected";
+  };
+  state.schedule = schedule;
+  const render = () => {
+    if (state.cancelled) return;
+    const entries = [];
+    const roots = [];
+    const takeoverRequired = scanRoot(document, document, window, 0, 0, entries, roots);
+    if (takeoverRequired) {
+      entries.splice(0, entries.length, {
+        rect: { left: 0, top: 0, width: window.innerWidth, height: window.innerHeight },
+        sensitive: true,
+        label: "Sensitive content · human takeover",
+      });
+    }
+
+    const host = document.createElement("div");
+    host.setAttribute("data-tidebreak-inspect", "true");
+    setImportant(host.style, "all", "initial");
+    setImportant(host.style, "position", "fixed");
+    setImportant(host.style, "inset", "0");
+    setImportant(host.style, "display", "block");
+    setImportant(host.style, "pointer-events", "none");
+    setImportant(host.style, "z-index", "2147483647");
+    const shadow = host.attachShadow({ mode: "closed" });
+    for (const entry of entries) buildMarker(entry, shadow);
+    host.addEventListener("toggle", (event) => {
+      if (event.newState === "closed" && state.host === host) schedule();
+    });
+
+    for (const observer of state.observers) observer.disconnect();
+    state.observers = [];
+    if (state.host?.isConnected) state.host.replaceWith(host);
+    else document.documentElement.appendChild(host);
+    if (typeof host.showPopover === "function") {
+      host.setAttribute("popover", "manual");
+      try { host.showPopover(); } catch (_) {}
+    }
+    state.host = host;
+
+    for (const observed of roots) {
+      const observer = new observed.win.MutationObserver(schedule);
+      observer.observe(observed.root, {
+        subtree: true,
+        childList: true,
+        characterData: true,
+        attributes: true,
+      });
+      state.observers.push(observer);
+    }
   };
 
-  window.__tidebreak_highlight_inspect__ = highlight;
-  return highlight();
+  window.addEventListener("scroll", schedule, true);
+  window.addEventListener("resize", schedule, true);
+  document.addEventListener("fullscreenchange", schedule, true);
+  render();
+  return "injected";
 })()
 "##;
 
 const REMOVE_INSPECT_OVERLAY_SCRIPT: &str = r#"
 (() => {
-  const overlay = document.getElementById("__tidebreak_inspect_overlay__");
-  if (overlay) overlay.remove();
-  const style = document.getElementById("__tidebreak_inspect_style__");
-  if (style) style.remove();
+  const state = window.__tidebreak_inspect_state__;
+  if (state) {
+    state.cancelled = true;
+    if (state.frame !== null) window.cancelAnimationFrame(state.frame);
+    for (const observer of state.observers || []) observer.disconnect();
+    window.removeEventListener("scroll", state.schedule, true);
+    window.removeEventListener("resize", state.schedule, true);
+    document.removeEventListener("fullscreenchange", state.schedule, true);
+    state.host?.remove();
+    delete window.__tidebreak_inspect_state__;
+  }
+  document.getElementById("__tidebreak_inspect_overlay__")?.remove();
+  document.getElementById("__tidebreak_inspect_style__")?.remove();
   delete window.__tidebreak_highlight_inspect__;
   return "removed";
+})()
+"#;
+
+const SCREENSHOT_PRIVACY_SCRIPT: &str = r#"
+(() => {
+  const WATCH_KEY = __WATCH_KEY__;
+  const FINISH = __FINISH__;
+  const clean = (value, limit = 240) => String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+  __SENSITIVE_FIELD_POLICY__
+
+  const hashText = (seed, value) => {
+    let hash = seed >>> 0;
+    for (const character of String(value || "")) {
+      hash ^= character.codePointAt(0);
+      hash = Math.imul(hash, 16777619) >>> 0;
+    }
+    return hash;
+  };
+
+  const scanRoot = (root, doc, win, observers, state) => {
+    if (!FINISH) {
+      const observer = new win.MutationObserver(() => { state.changed = true; });
+      observer.observe(root, {
+        subtree: true,
+        childList: true,
+        characterData: true,
+        attributes: true,
+      });
+      observers.push(observer);
+    }
+
+    let sensitiveFields = 0;
+    let uninspectableRegions = 0;
+    let signature = 2166136261;
+    for (const element of root.querySelectorAll("input, textarea, [contenteditable]:not([contenteditable='false']), [role='textbox']")) {
+      signature = hashText(signature, element.localName);
+      signature = hashText(signature, element.getAttribute("type"));
+      signature = hashText(signature, element.getAttribute("name"));
+      signature = hashText(signature, element.id);
+      signature = hashText(signature, "value" in element ? element.value : element.textContent);
+      if (tidebreakIsSensitiveField(element, doc)) sensitiveFields += 1;
+    }
+    for (const element of root.querySelectorAll("*")) {
+      if (element.shadowRoot) {
+        const child = scanRoot(element.shadowRoot, doc, win, observers, state);
+        sensitiveFields += child.sensitiveFields;
+        uninspectableRegions += child.uninspectableRegions;
+        signature = hashText(signature, child.signature);
+      } else if (element.localName?.includes("-")) {
+        uninspectableRegions += 1;
+      }
+    }
+    for (const frame of root.querySelectorAll("iframe")) {
+      if (!FINISH) {
+        const markFrameChanged = () => { state.changed = true; };
+        frame.addEventListener("load", markFrameChanged, true);
+        state.listeners.push([frame, "load", markFrameChanged]);
+      }
+      try {
+        const childDoc = frame.contentDocument;
+        const childWin = frame.contentWindow;
+        if (!childDoc || !childWin) throw new Error("frame unavailable");
+        if (!FINISH) {
+          const markFrameChanged = () => { state.changed = true; };
+          childWin.addEventListener("pagehide", markFrameChanged, true);
+          state.listeners.push([childWin, "pagehide", markFrameChanged]);
+        }
+        const child = scanRoot(childDoc, childDoc, childWin, observers, state);
+        sensitiveFields += child.sensitiveFields;
+        uninspectableRegions += child.uninspectableRegions;
+        signature = hashText(signature, child.signature);
+      } catch (_) {
+        uninspectableRegions += 1;
+      }
+    }
+    return { sensitiveFields, uninspectableRegions, signature };
+  };
+
+  let state = window[WATCH_KEY];
+  if (!FINISH) {
+    if (state) {
+      for (const observer of state.observers || []) observer.disconnect();
+    }
+    state = { changed: false, observers: [], listeners: [], signature: null };
+    window[WATCH_KEY] = state;
+  } else if (!state) {
+    return JSON.stringify({ sensitiveFields: 0, uninspectableRegions: 0, changed: true });
+  }
+
+  const result = scanRoot(document, document, window, state.observers, state);
+  if (!FINISH) {
+    state.signature = result.signature;
+  } else if (state.signature !== result.signature) {
+    state.changed = true;
+  }
+  if (FINISH) {
+    for (const observer of state.observers) observer.disconnect();
+    for (const [target, event, listener] of state.listeners || []) {
+      target.removeEventListener(event, listener, true);
+    }
+    delete window[WATCH_KEY];
+  }
+  return JSON.stringify({
+    sensitiveFields: result.sensitiveFields,
+    uninspectableRegions: result.uninspectableRegions,
+    changed: Boolean(state.changed),
+  });
 })()
 "#;
 
@@ -1671,6 +2141,7 @@ const ACTION_SCRIPT: &str = r#"
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, limit);
+  __SENSITIVE_FIELD_POLICY__
   const roleFor = (element) => {
     const explicit = clean(element.getAttribute("role"), 60);
     if (explicit) return explicit;
@@ -1688,22 +2159,6 @@ const ACTION_SCRIPT: &str = r#"
     }
     if (element.isContentEditable) return "textbox";
     return tag || "element";
-  };
-  const nameFor = (element, doc) => {
-    const labelledBy = clean(element.getAttribute("aria-labelledby"), 200);
-    if (labelledBy) {
-      const value = labelledBy.split(/\s+/)
-        .map((id) => clean(doc.getElementById(id)?.textContent))
-        .filter(Boolean)
-        .join(" ");
-      if (value) return clean(value);
-    }
-    return clean(element.getAttribute("aria-label"))
-      || clean(element.labels && Array.from(element.labels).map((label) => label.textContent).join(" "))
-      || clean(element.getAttribute("alt"))
-      || clean(element.getAttribute("title"))
-      || clean(element.getAttribute("placeholder"))
-      || clean(element.innerText || element.textContent);
   };
   const result = (status, message) => JSON.stringify({
     status,
@@ -1728,26 +2183,20 @@ const ACTION_SCRIPT: &str = r#"
   if (element[payload.marker] !== payload.markerValue) {
     return result("stale_target", "The target element was replaced.");
   }
-  const isSensitive = (() => {
-    if (element.localName !== "input") return false;
-    const type = clean(element.getAttribute("type"), 40).toLowerCase();
-    const autocomplete = clean(element.getAttribute("autocomplete"), 100).toLowerCase();
-    return type === "password"
-      || type === "file"
-      || autocomplete.includes("one-time-code")
-      || autocomplete.includes("current-password")
-      || autocomplete.includes("new-password");
-  })();
+  const isSensitive = tidebreakIsSensitiveField(element, doc);
   const fresh = {
     tag: element.localName || "element",
     role: roleFor(element),
-    name: nameFor(element, doc),
+    name: isSensitive ? "Sensitive field" : tidebreakAccessibleName(element, doc),
     inputType: element.localName === "input"
       ? clean(element.getAttribute("type") || "text", 40).toLowerCase()
       : null,
     href: element.href ? clean(element.href, 2048) : null,
     sensitive: isSensitive,
   };
+  if (isSensitive) {
+    return result("human_takeover_required", "Password, file, and verification-code fields require human takeover.");
+  }
   if (JSON.stringify(fresh) !== JSON.stringify(payload.fingerprint)) {
     return result("stale_target", "The target's identifying content changed.");
   }
@@ -1840,7 +2289,7 @@ pub(crate) async fn browser_inject_inspect_overlay(
         .get_webview(&label)
         .ok_or_else(|| "browser session is not open".to_owned())?;
 
-    let _result: String = evaluate_json(&webview, INSPECT_OVERLAY_SCRIPT).await?;
+    let _result: String = evaluate_json(&webview, &inspect_overlay_script()).await?;
     Ok(())
 }
 
@@ -1906,6 +2355,30 @@ mod tests {
     }
 
     #[test]
+    fn page_text_cannot_replace_the_shared_policy_placeholder() {
+        let target = BrowserTargetRecord {
+            frame_path: vec![],
+            selector: "input:nth-of-type(1)".to_owned(),
+            marker: "__marker".to_owned(),
+            marker_value: "@e1".to_owned(),
+            fingerprint: BrowserTargetFingerprint {
+                tag: "input".to_owned(),
+                role: "textbox".to_owned(),
+                name: "__SENSITIVE_FIELD_POLICY__".to_owned(),
+                input_type: Some("text".to_owned()),
+                href: None,
+                sensitive: false,
+            },
+            sensitive: false,
+            consequential: false,
+        };
+
+        let script = action_script(&target, &BrowserSemanticAction::Focus).unwrap();
+        assert!(script.contains(r#""name":"__SENSITIVE_FIELD_POLICY__""#));
+        assert_eq!(script.matches("const tidebreakIsSensitiveField").count(), 1);
+    }
+
+    #[test]
     fn snapshots_label_page_content_as_untrusted() {
         assert_eq!(
             serde_json::to_value(BrowserContentTrust::UntrustedPage).unwrap(),
@@ -1922,5 +2395,113 @@ mod tests {
         assert!(script.contains("if (!interactive && !text) continue"));
         assert!(script.contains("type === \"file\""));
         assert!(script.contains("const isConsequential"));
+    }
+
+    #[test]
+    fn every_browser_surface_uses_the_shared_sensitive_field_policy() {
+        let snapshot = snapshot_script(25, "__marker");
+        let inspect = inspect_overlay_script();
+        let screenshot = screenshot_privacy_script("__watch", false).unwrap();
+        let target = BrowserTargetRecord {
+            frame_path: vec![],
+            selector: "input:nth-of-type(1)".to_owned(),
+            marker: "__marker".to_owned(),
+            marker_value: "@e1".to_owned(),
+            fingerprint: BrowserTargetFingerprint {
+                tag: "input".to_owned(),
+                role: "textbox".to_owned(),
+                name: "Sensitive field".to_owned(),
+                input_type: Some("text".to_owned()),
+                href: None,
+                sensitive: true,
+            },
+            sensitive: true,
+            consequential: false,
+        };
+        let action = action_script(&target, &BrowserSemanticAction::Focus).unwrap();
+
+        for script in [snapshot, inspect, screenshot, action] {
+            assert!(script.contains("const tidebreakIsSensitiveField"));
+            assert!(script.contains("aria-describedby"));
+            assert!(script.contains("inputmode"));
+            assert!(!script.contains("__SENSITIVE_FIELD_POLICY__"));
+        }
+    }
+
+    #[test]
+    fn semantic_scripts_run_outside_the_page_javascript_world() {
+        let source = include_str!("browser_semantics.rs");
+        assert!(source.contains("TidebreakBrowserSemantics"));
+        assert!(source.contains("inContentWorld: content_world"));
+    }
+
+    #[test]
+    fn sensitive_snapshot_nodes_hide_values_labels_and_actions() {
+        let script = snapshot_script(25, "__marker");
+        assert!(script.contains("const tidebreakTextWithoutFieldDescendants"));
+        assert!(script.contains("text.split(fieldText).join(\" \")"));
+        assert!(script.contains("sensitive ? \"Sensitive field\""));
+        assert!(script.contains("const value = !interactive || sensitive"));
+        assert!(script.contains("text: sensitive ? null : (text || null)"));
+        assert!(script.contains("interactive && !sensitive && element.href"));
+        assert!(script.contains("if (sensitive) return [\"human_takeover\"]"));
+    }
+
+    #[test]
+    fn actions_and_screenshots_fail_closed_for_sensitive_or_uninspectable_fields() {
+        let inspect = inspect_overlay_script();
+        let screenshot = screenshot_privacy_script("__watch", false).unwrap();
+        assert!(inspect.contains("attachShadow({ mode: \"closed\" })"));
+        assert!(inspect.contains("window.requestAnimationFrame(() =>"));
+        assert!(inspect.contains("new observed.win.MutationObserver(schedule)"));
+        assert!(inspect.contains("addMask(entries, frameRect"));
+        assert!(inspect.contains("Sensitive content · human takeover"));
+        assert!(screenshot.contains("tidebreakIsSensitiveField(element, doc)"));
+        assert!(screenshot.contains("if (tidebreakIsSensitiveField(element, doc))"));
+        assert!(screenshot.contains("uninspectableRegions += 1"));
+        assert!(screenshot.contains("state.changed = true"));
+        assert!(!screenshot.contains("attributeFilter"));
+        assert!(screenshot.contains("state.listeners.push([frame, \"load\""));
+        assert!(screenshot.contains("state.listeners.push([childWin, \"pagehide\""));
+
+        let target = BrowserTargetRecord {
+            frame_path: vec![],
+            selector: "input:nth-of-type(1)".to_owned(),
+            marker: "__marker".to_owned(),
+            marker_value: "@e1".to_owned(),
+            fingerprint: BrowserTargetFingerprint {
+                tag: "input".to_owned(),
+                role: "textbox".to_owned(),
+                name: "Sensitive field".to_owned(),
+                input_type: Some("text".to_owned()),
+                href: None,
+                sensitive: true,
+            },
+            sensitive: true,
+            consequential: false,
+        };
+        let action = action_script(&target, &BrowserSemanticAction::Focus).unwrap();
+        assert!(action.contains("human_takeover_required"));
+    }
+
+    #[test]
+    fn browser_fixture_covers_unannotated_codes_and_ordinary_numbers() {
+        let fixture = include_str!("../tests/browser-fixture/index.html");
+        for sensitive in [
+            "name=\"code\" inputmode=\"numeric\"",
+            "id=\"verification-code\" inputmode=\"numeric\"",
+            "placeholder=\"Recovery code\"",
+            "blockquote data-sensitive-descendant",
+        ] {
+            assert!(fixture.contains(sensitive));
+        }
+        for ordinary in [
+            "name=\"quantity\" type=\"number\"",
+            "name=\"zipCode\" inputmode=\"numeric\"",
+            "name=\"year\" type=\"number\"",
+            "name=\"search\" inputmode=\"numeric\"",
+        ] {
+            assert!(fixture.contains(ordinary));
+        }
     }
 }

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -159,6 +159,13 @@ struct RawScreenshotPrivacyScan {
     changed: bool,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawTextProbe {
+    contains: bool,
+    uninspectable_regions: usize,
+}
+
 pub(crate) async fn browser_semantic_snapshot(
     app: &AppHandle,
     registry: &BrowserRegistry,
@@ -821,12 +828,14 @@ fn wait_result(
 async fn page_contains_text(webview: &Webview, text: &str) -> Result<bool, String> {
     #[cfg(target_os = "macos")]
     {
-        let safe_text = text.replace('\\', "\\\\").replace('\'', "\\'");
-        let script = format!(
-            "JSON.stringify(Boolean(document.body && document.body.innerText.indexOf('{safe_text}') !== -1))"
-        );
-        let raw: String = evaluate_json(webview, &script).await?;
-        Ok(raw == "true")
+        let raw: RawTextProbe = evaluate_json(webview, &wait_text_script(text)?).await?;
+        if raw.uninspectable_regions > 0 {
+            return Err(
+                "browser text wait requires human takeover because visible page content cannot be inspected safely"
+                    .to_owned(),
+            );
+        }
+        Ok(raw.contains)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -849,6 +858,16 @@ pub(crate) async fn browser_screenshot(
     // Observation chained from a prior snapshot: use begin_agent_observation
     // so the stored snapshot survives for validate_snapshot_id below.
     let host_snapshot = registry.begin_agent_observation(capability_id, &arguments.browser_id)?;
+    if !host_snapshot
+        .engine
+        .as_ref()
+        .is_some_and(|engine| engine.capabilities.screenshot)
+    {
+        return Err(
+            "browser screenshot requires human takeover because this engine cannot prove closed-shadow privacy"
+                .to_owned(),
+        );
+    }
     let origin = host_snapshot
         .url
         .as_deref()
@@ -1326,6 +1345,13 @@ fn action_script(
         .replace("__PAYLOAD__", &payload))
 }
 
+fn wait_text_script(text: &str) -> Result<String, String> {
+    let text = serde_json::to_string(text).map_err(|error| error.to_string())?;
+    Ok(WAIT_TEXT_SCRIPT
+        .replace("__WAIT_TEXT__", &text)
+        .replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY))
+}
+
 fn inspect_overlay_script() -> String {
     INSPECT_OVERLAY_SCRIPT.replace("__SENSITIVE_FIELD_POLICY__", SENSITIVE_FIELD_POLICY)
 }
@@ -1426,13 +1452,22 @@ async fn evaluate_json<T: serde::de::DeserializeOwned>(
 
 const SENSITIVE_FIELD_POLICY: &str = r##"
   const tidebreakFieldSelector = "input, textarea, [contenteditable]:not([contenteditable='false']), [role='textbox']";
-  const tidebreakTextWithoutFieldDescendants = (element) => {
-    let text = clean(element?.innerText || element?.textContent);
-    for (const field of element?.querySelectorAll?.(tidebreakFieldSelector) || []) {
-      const fieldText = clean(field.innerText || field.textContent);
-      if (fieldText) text = clean(text.split(fieldText).join(" "));
-    }
-    return text;
+  const tidebreakTextWithoutFieldDescendants = (element, limit = 240) => {
+    const parts = [];
+    const visit = (node, insideField) => {
+      if (!node) return;
+      if (node.nodeType === 3) {
+        if (!insideField) parts.push(node.nodeValue || "");
+        return;
+      }
+      const nextInsideField = insideField
+        || (node !== element && Boolean(node.matches?.(tidebreakFieldSelector)));
+      for (const child of Array.from(node.childNodes || [])) {
+        visit(child, nextInsideField);
+      }
+    };
+    visit(element, Boolean(element?.matches?.(tidebreakFieldSelector)));
+    return clean(parts.join(" "), limit);
   };
   const tidebreakReferencedText = (element) => {
     if (!element || element.matches?.(tidebreakFieldSelector)) return "";
@@ -1546,6 +1581,9 @@ const SENSITIVE_FIELD_POLICY: &str = r##"
       element.getAttribute("aria-label"),
       accessibleName,
     ].some(looksLikeShortDigits);
+    if (numeric && !benignNumeric && (element.isContentEditable || role === "textbox")) {
+      return true;
+    }
     if (numeric && !benignNumeric && (shortConstraint || shortDigitPattern || digitExample)) {
       return true;
     }
@@ -1567,6 +1605,78 @@ const SENSITIVE_FIELD_POLICY: &str = r##"
     return false;
   };
 "##;
+
+const WAIT_TEXT_SCRIPT: &str = r#"
+(() => {
+  const NEEDLE = __WAIT_TEXT__;
+  const TEXT_LIMIT = 1_000_000;
+  const clean = (value, limit = 240) => String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+  __SENSITIVE_FIELD_POLICY__
+
+  const isVisible = (element, win) => {
+    const style = win.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return style.display !== "none"
+      && style.visibility !== "hidden"
+      && Number(style.opacity || 1) !== 0
+      && rect.width > 0
+      && rect.height > 0;
+  };
+  const ordinaryFieldText = (element) => {
+    if ("value" in element) return clean(element.value, TEXT_LIMIT);
+    return clean(element.textContent, TEXT_LIMIT);
+  };
+  const collectRoot = (root, doc, win, seen) => {
+    if (seen.has(root)) return { parts: [], uninspectableRegions: 0 };
+    seen.add(root);
+    const parts = [];
+    let uninspectableRegions = 0;
+    if (root.body || root.nodeType === 11) {
+      const text = tidebreakTextWithoutFieldDescendants(root.body || root, TEXT_LIMIT);
+      if (text) parts.push(text);
+    }
+    for (const field of root.querySelectorAll(tidebreakFieldSelector)) {
+      if (!isVisible(field, win) || tidebreakIsSensitiveField(field, doc)) continue;
+      const text = ordinaryFieldText(field);
+      if (text) parts.push(text);
+    }
+    for (const host of root.querySelectorAll("*")) {
+      if (!host.shadowRoot) continue;
+      const child = collectRoot(host.shadowRoot, doc, win, seen);
+      parts.push(...child.parts);
+      uninspectableRegions += child.uninspectableRegions;
+    }
+    for (const frame of root.querySelectorAll("iframe, frame, object, embed")) {
+      if (!isVisible(frame, win)) continue;
+      if (frame.localName === "embed") {
+        uninspectableRegions += 1;
+        continue;
+      }
+      try {
+        const childDoc = frame.contentDocument;
+        const childWin = frame.contentWindow || childDoc?.defaultView;
+        if (!childDoc || !childWin) throw new Error("nested document unavailable");
+        const child = collectRoot(childDoc, childDoc, childWin, seen);
+        parts.push(...child.parts);
+        uninspectableRegions += child.uninspectableRegions;
+      } catch (_) {
+        uninspectableRegions += 1;
+      }
+    }
+    return { parts, uninspectableRegions };
+  };
+
+  const projection = collectRoot(document, document, window, new Set());
+  const text = clean(projection.parts.join(" "), TEXT_LIMIT);
+  return JSON.stringify({
+    contains: text.includes(NEEDLE),
+    uninspectableRegions: projection.uninspectableRegions,
+  });
+})()
+"#;
 
 const SNAPSHOT_SCRIPT: &str = r#"
 (() => {
@@ -2284,6 +2394,17 @@ pub(crate) async fn browser_inject_inspect_overlay(
     workspace_id: &str,
 ) -> Result<(), String> {
     registry.ensure_workspace(browser_id, workspace_id)?;
+    let snapshot = registry.snapshot(browser_id, workspace_id)?;
+    if !snapshot
+        .engine
+        .as_ref()
+        .is_some_and(|engine| engine.capabilities.screenshot)
+    {
+        return Err(
+            "browser inspect requires human takeover because this engine cannot prove closed-shadow privacy"
+                .to_owned(),
+        );
+    }
     let label = crate::code_browser::browser_label(browser_id)?;
     let webview = app
         .get_webview(&label)

--- a/crates/tidebreak-desktop/src/browser_semantics.rs
+++ b/crates/tidebreak-desktop/src/browser_semantics.rs
@@ -2560,7 +2560,8 @@ mod tests {
     fn sensitive_snapshot_nodes_hide_values_labels_and_actions() {
         let script = snapshot_script(25, "__marker");
         assert!(script.contains("const tidebreakTextWithoutFieldDescendants"));
-        assert!(script.contains("text.split(fieldText).join(\" \")"));
+        assert!(script.contains("node.nodeType === 3"));
+        assert!(script.contains("node.matches?.(tidebreakFieldSelector)"));
         assert!(script.contains("sensitive ? \"Sensitive field\""));
         assert!(script.contains("const value = !interactive || sensitive"));
         assert!(script.contains("text: sensitive ? null : (text || null)"));

--- a/crates/tidebreak-desktop/src/code_browser.rs
+++ b/crates/tidebreak-desktop/src/code_browser.rs
@@ -165,15 +165,15 @@ pub(crate) async fn code_browser_command(
                 registry.remove(&request.browser_id, &request.workspace_id)?;
                 return Err("browser session is not open".to_owned());
             }
-            registry.set_inspect(&request.browser_id, &request.workspace_id, enabled)?;
             if enabled {
-                let _ = browser_inject_inspect_overlay(
+                browser_inject_inspect_overlay(
                     &app,
                     &registry,
                     &request.browser_id,
                     &request.workspace_id,
                 )
-                .await;
+                .await?;
+                registry.set_inspect(&request.browser_id, &request.workspace_id, true)?;
             } else {
                 let _ = browser_remove_inspect_overlay(
                     &app,
@@ -182,6 +182,7 @@ pub(crate) async fn code_browser_command(
                     &request.workspace_id,
                 )
                 .await;
+                registry.set_inspect(&request.browser_id, &request.workspace_id, false)?;
             }
             registry.snapshot(&request.browser_id, &request.workspace_id)
         }
@@ -657,7 +658,7 @@ async fn native_public_share_choice(
     let mut dialog = app
         .dialog()
         .message(format!(
-            "Allow agents in this workspace to inspect and navigate {origin}?\n\nPage content is untrusted. Password and verification-code values stay private and require human takeover."
+            "Allow agents in this workspace to inspect and navigate {origin}?\n\nPage content is untrusted. Password, file, and verification-code fields stay private and require human takeover. Screenshots pause when the host cannot prove that visible fields are safe."
         ))
         .title("Share this site with agents?")
         .kind(MessageDialogKind::Warning)
@@ -685,7 +686,7 @@ async fn native_loopback_share_choice(
     let mut dialog = app
         .dialog()
         .message(format!(
-            "Allow agents in this workspace to inspect and navigate {origin_label}?\n\nChoose only this origin, or all loopback sites in this workspace so development ports can change without another prompt."
+            "Allow agents in this workspace to inspect and navigate {origin_label}?\n\nPassword, file, and verification-code fields stay private and require human takeover. Screenshots pause when the host cannot prove that visible fields are safe. Choose only this origin, or all loopback sites in this workspace so development ports can change without another prompt."
         ))
         .title("Share a local site with agents?")
         .kind(MessageDialogKind::Warning)

--- a/crates/tidebreak-desktop/tests/browser-fixture/README.md
+++ b/crates/tidebreak-desktop/tests/browser-fixture/README.md
@@ -25,7 +25,8 @@ The primary page deliberately includes:
 
 - history-API navigation and a server redirect;
 - dynamic content and a replaceable stale target;
-- ordinary, password, OTP, select, checkbox, upload, and submit controls;
+- annotated and unannotated verification fields plus ordinary numeric controls;
+- password, select, checkbox, upload, and submit controls;
 - same-origin and cross-origin frames;
 - a popup and a download;
 - a console-error trigger;

--- a/crates/tidebreak-desktop/tests/browser-fixture/index.html
+++ b/crates/tidebreak-desktop/tests/browser-fixture/index.html
@@ -186,6 +186,57 @@
               One-time code
               <input name="otp" inputmode="numeric" autocomplete="one-time-code" />
             </label>
+            <label>
+              Custom numeric code
+              <input name="code" inputmode="numeric" value="831204" />
+            </label>
+            <label>
+              Account verification
+              <input id="verification-code" inputmode="numeric" value="745920" />
+            </label>
+            <label>
+              Enter the digits from your authenticator
+              <input name="auth-digits" inputmode="numeric" maxlength="6" value="190274" />
+            </label>
+            <label>
+              Challenge digits
+              <input name="challenge-response" inputmode="numeric" pattern="[0-9]{6}" placeholder="123 456" value="608315" />
+            </label>
+            <label>
+              Recovery value
+              <input name="recovery-value" placeholder="Recovery code" value="RECOVERY-1882" />
+            </label>
+            <blockquote data-sensitive-descendant>
+              Enter the verification value
+              <span role="textbox" contenteditable inputmode="numeric" aria-label="Verification code">314159</span>
+            </blockquote>
+            <fieldset>
+              <legend>Device digits</legend>
+              <div class="actions" id="split-code">
+                <input aria-label="Digit 1" name="digit-1" inputmode="numeric" maxlength="1" value="8" />
+                <input aria-label="Digit 2" name="digit-2" inputmode="numeric" maxlength="1" value="3" />
+                <input aria-label="Digit 3" name="digit-3" inputmode="numeric" maxlength="1" value="1" />
+                <input aria-label="Digit 4" name="digit-4" inputmode="numeric" maxlength="1" value="2" />
+                <input aria-label="Digit 5" name="digit-5" inputmode="numeric" maxlength="1" value="0" />
+                <input aria-label="Digit 6" name="digit-6" inputmode="numeric" maxlength="1" value="4" />
+              </div>
+            </fieldset>
+            <label>
+              Quantity
+              <input name="quantity" type="number" value="3" />
+            </label>
+            <label>
+              ZIP code
+              <input name="zipCode" inputmode="numeric" maxlength="5" value="02139" />
+            </label>
+            <label>
+              Year
+              <input name="year" type="number" value="2026" />
+            </label>
+            <label>
+              Numeric search
+              <input name="search" inputmode="numeric" value="12345" />
+            </label>
           </div>
           <label class="checkbox">
             <input name="notify" type="checkbox" value="yes" />

--- a/crates/tidebreak-desktop/tests/browser-fixture/privacy-policy.test.mjs
+++ b/crates/tidebreak-desktop/tests/browser-fixture/privacy-policy.test.mjs
@@ -26,6 +26,14 @@ const buildClassifier = new Function(`
   return tidebreakIsSensitiveField;
 `);
 const classify = buildClassifier();
+const projectText = new Function(`
+  const clean = (value, limit = 240) => String(value || "")
+    .replace(/\\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+  ${policyMatch[1]}
+  return tidebreakTextWithoutFieldDescendants;
+`)();
 
 function runSensitiveSnapshot({ tag, attrs, secret }) {
   const normalized = new Map(
@@ -142,7 +150,15 @@ function field({
     isContentEditable: normalized.has("contenteditable"),
     innerText: text,
     textContent: text,
-    labels: label ? [{ textContent: label }] : [],
+    labels: label
+      ? [{
+          nodeType: 1,
+          childNodes: [{ nodeType: 3, nodeValue: label }],
+          matches() {
+            return false;
+          },
+        }]
+      : [],
     form: null,
     getAttribute(name) {
       if (name === "id") return id || null;
@@ -192,8 +208,8 @@ test("the shared policy requires human takeover for unannotated verification fie
     field({ tag: "div", text: "314159", attrs: { role: "textbox", contenteditable: "", inputmode: "numeric" } }),
   ];
 
-  for (const element of sensitive) {
-    assert.equal(classify(element, documentStub), true);
+  for (const [index, element] of sensitive.entries()) {
+    assert.equal(classify(element, documentStub), true, `sensitive fixture ${index + 1}`);
   }
 });
 
@@ -213,6 +229,7 @@ test("the shared policy preserves ordinary numeric controls", () => {
 test("every browser surface injects the shared policy", () => {
   for (const constant of [
     "SNAPSHOT_SCRIPT",
+    "WAIT_TEXT_SCRIPT",
     "INSPECT_OVERLAY_SCRIPT",
     "SCREENSHOT_PRIVACY_SCRIPT",
     "ACTION_SCRIPT",
@@ -227,8 +244,36 @@ test("every browser surface injects the shared policy", () => {
 
 test("snapshot text strips editable descendants before serialization", () => {
   assert.match(semanticsSource, /const tidebreakTextWithoutFieldDescendants/);
-  assert.match(semanticsSource, /text\.split\(fieldText\)\.join\(" "\)/);
+  assert.match(semanticsSource, /node\.nodeType === 3/);
+  assert.match(semanticsSource, /node\.matches\?\.\(tidebreakFieldSelector\)/);
   assert.match(semanticsSource, /const text = sensitive \? "" : contentText\(element\)/);
+});
+
+test("parent text never reads or serializes editable descendant values", () => {
+  let valueReads = 0;
+  const text = (value) => ({ nodeType: 3, nodeValue: value });
+  const sensitiveInput = {
+    nodeType: 1,
+    childNodes: [],
+    matches: () => true,
+    get value() {
+      valueReads += 1;
+      return "831204";
+    },
+  };
+  const sensitiveEditable = {
+    nodeType: 1,
+    childNodes: [text("314159")],
+    matches: () => true,
+  };
+  const parent = {
+    nodeType: 1,
+    childNodes: [text("Public status"), sensitiveInput, sensitiveEditable],
+    matches: () => false,
+  };
+
+  assert.equal(projectText(parent), "Public status");
+  assert.equal(valueReads, 0);
 });
 
 test("sensitive textarea and contenteditable values never reach snapshot fields", () => {

--- a/crates/tidebreak-desktop/tests/browser-fixture/privacy-policy.test.mjs
+++ b/crates/tidebreak-desktop/tests/browser-fixture/privacy-policy.test.mjs
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const fixtureRoot = dirname(fileURLToPath(import.meta.url));
+const semanticsPath = resolve(fixtureRoot, "../../src/browser_semantics.rs");
+const semanticsSource = await readFile(semanticsPath, "utf8");
+const policyMatch = semanticsSource.match(
+  /const SENSITIVE_FIELD_POLICY: &str = r##"([\s\S]*?)"##;/,
+);
+const snapshotMatch = semanticsSource.match(
+  /const SNAPSHOT_SCRIPT: &str = r#"([\s\S]*?)"#;/,
+);
+
+assert.ok(policyMatch, "the browser semantics source must expose one shared policy");
+assert.ok(snapshotMatch, "the browser semantics source must expose the snapshot script");
+
+const buildClassifier = new Function(`
+  const clean = (value, limit = 240) => String(value || "")
+    .replace(/\\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+  ${policyMatch[1]}
+  return tidebreakIsSensitiveField;
+`);
+const classify = buildClassifier();
+
+function runSensitiveSnapshot({ tag, attrs, secret }) {
+  const normalized = new Map(
+    Object.entries(attrs).map(([name, value]) => [name.toLowerCase(), String(value)]),
+  );
+  const reads = { href: 0, text: 0, value: 0 };
+  const element = {
+    id: "",
+    localName: tag,
+    nodeType: 1,
+    isContentEditable: normalized.has("contenteditable"),
+    labels: [],
+    form: null,
+    parentElement: null,
+    previousElementSibling: null,
+    disabled: false,
+    getAttribute(name) {
+      return normalized.get(name.toLowerCase()) ?? null;
+    },
+    getRootNode() {
+      return document;
+    },
+    closest() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    matches() {
+      return true;
+    },
+    getBoundingClientRect() {
+      return { x: 10, y: 20, width: 120, height: 32 };
+    },
+  };
+  Object.defineProperties(element, {
+    href: {
+      get() {
+        reads.href += 1;
+        return `https://fixture.invalid/${secret}`;
+      },
+    },
+    innerText: {
+      get() {
+        reads.text += 1;
+        return secret;
+      },
+    },
+    textContent: {
+      get() {
+        reads.text += 1;
+        return secret;
+      },
+    },
+    value: {
+      get() {
+        reads.value += 1;
+        return secret;
+      },
+    },
+  });
+
+  const document = {
+    title: "Fixture",
+    getElementById() {
+      return null;
+    },
+    querySelectorAll(selector) {
+      return selector === "iframe" || selector.startsWith("#") ? [] : [element];
+    },
+  };
+  const window = {
+    innerHeight: 768,
+    innerWidth: 1024,
+    scrollX: 0,
+    scrollY: 0,
+    getComputedStyle() {
+      return { display: "block", visibility: "visible", opacity: "1" };
+    },
+  };
+  const script = snapshotMatch[1]
+    .replace("__MAX_NODES__", "25")
+    .replace("__MARKER__", "__fixture_marker__")
+    .replace("__SENSITIVE_FIELD_POLICY__", policyMatch[1]);
+  const execute = new Function(
+    "document",
+    "window",
+    "Node",
+    "location",
+    `return (${script});`,
+  );
+  const result = JSON.parse(
+    execute(document, window, { ELEMENT_NODE: 1 }, { href: "https://fixture.invalid" }),
+  );
+  return { reads, result };
+}
+
+function field({
+  tag = "input",
+  id = "",
+  label = "",
+  legend = "",
+  groupLabel = "",
+  peerCount = 0,
+  text = "",
+  attrs = {},
+} = {}) {
+  const normalized = new Map(
+    Object.entries(attrs).map(([name, value]) => [name.toLowerCase(), String(value)]),
+  );
+  const element = {
+    id,
+    localName: tag,
+    isContentEditable: normalized.has("contenteditable"),
+    innerText: text,
+    textContent: text,
+    labels: label ? [{ textContent: label }] : [],
+    form: null,
+    getAttribute(name) {
+      if (name === "id") return id || null;
+      return normalized.get(name.toLowerCase()) ?? null;
+    },
+    closest(selector) {
+      if (selector === "fieldset" && legend) {
+        return { querySelector: () => ({ textContent: legend }) };
+      }
+      if (selector === "[role='group']" && groupLabel) {
+        return { getAttribute: () => groupLabel };
+      }
+      if (selector === "fieldset, [role='group'], form, div" && peerCount) {
+        return {
+          querySelectorAll: () =>
+            Array.from({ length: peerCount }, () =>
+              field({ attrs: { inputmode: "numeric", maxlength: "1" } }),
+            ),
+        };
+      }
+      return null;
+    },
+  };
+  element.type = normalized.get("type") ?? "text";
+  element.inputMode = normalized.get("inputmode") ?? "";
+  element.maxLength = Number(normalized.get("maxlength") ?? -1);
+  element.size = Number(normalized.get("size") ?? 20);
+  return element;
+}
+
+const documentStub = { getElementById: () => null };
+
+test("the shared policy requires human takeover for unannotated verification fields", () => {
+  const sensitive = [
+    field({ attrs: { name: "code", inputmode: "numeric" } }),
+    field({ id: "verification-code", attrs: { inputmode: "numeric" } }),
+    field({ id: "verificationCode", attrs: { inputmode: "numeric" } }),
+    field({ label: "Enter the digits from your authenticator", attrs: { inputmode: "numeric" } }),
+    field({ attrs: { placeholder: "Security code", inputmode: "numeric" } }),
+    field({ attrs: { name: "recovery-value", placeholder: "Recovery code" } }),
+    field({ legend: "Two-factor authentication", attrs: { name: "digits", inputmode: "numeric" } }),
+    field({ peerCount: 6, attrs: { name: "digit-1", inputmode: "numeric", maxlength: "1" } }),
+    field({ label: "Phone verification code", attrs: { name: "phone", inputmode: "numeric" } }),
+    field({ attrs: { name: "challenge-response", inputmode: "numeric", pattern: "[0-9]{6}" } }),
+    field({ attrs: { name: "challenge-response", inputmode: "numeric", pattern: "[0-9]{4,8}" } }),
+    field({ attrs: { inputmode: "numeric", placeholder: "123 456" } }),
+    field({ tag: "div", text: "314159", attrs: { role: "textbox", contenteditable: "", inputmode: "numeric" } }),
+  ];
+
+  for (const element of sensitive) {
+    assert.equal(classify(element, documentStub), true);
+  }
+});
+
+test("the shared policy preserves ordinary numeric controls", () => {
+  const ordinary = [
+    field({ label: "Quantity", attrs: { name: "quantity", type: "number" } }),
+    field({ label: "ZIP code", attrs: { name: "zipCode", inputmode: "numeric", maxlength: "5", pattern: "[0-9]{5}" } }),
+    field({ label: "Year", attrs: { name: "year", type: "number" } }),
+    field({ label: "Numeric search", attrs: { name: "search", inputmode: "numeric" } }),
+  ];
+
+  for (const element of ordinary) {
+    assert.equal(classify(element, documentStub), false);
+  }
+});
+
+test("every browser surface injects the shared policy", () => {
+  for (const constant of [
+    "SNAPSHOT_SCRIPT",
+    "INSPECT_OVERLAY_SCRIPT",
+    "SCREENSHOT_PRIVACY_SCRIPT",
+    "ACTION_SCRIPT",
+  ]) {
+    const start = semanticsSource.indexOf(`const ${constant}: &str`);
+    assert.notEqual(start, -1, `${constant} must exist`);
+    const next = semanticsSource.indexOf("\nconst ", start + 6);
+    const body = semanticsSource.slice(start, next === -1 ? undefined : next);
+    assert.match(body, /__SENSITIVE_FIELD_POLICY__/);
+  }
+});
+
+test("snapshot text strips editable descendants before serialization", () => {
+  assert.match(semanticsSource, /const tidebreakTextWithoutFieldDescendants/);
+  assert.match(semanticsSource, /text\.split\(fieldText\)\.join\(" "\)/);
+  assert.match(semanticsSource, /const text = sensitive \? "" : contentText\(element\)/);
+});
+
+test("sensitive textarea and contenteditable values never reach snapshot fields", () => {
+  for (const scenario of [
+    {
+      tag: "textarea",
+      attrs: { "aria-label": "Verification code", inputmode: "numeric" },
+      secret: "831204",
+    },
+    {
+      tag: "div",
+      attrs: {
+        "aria-label": "Security code",
+        contenteditable: "",
+        inputmode: "numeric",
+        role: "textbox",
+      },
+      secret: "314159",
+    },
+  ]) {
+    const { reads, result } = runSensitiveSnapshot(scenario);
+    assert.equal(reads.text, 0);
+    assert.equal(reads.value, 0);
+    assert.equal(reads.href, 0);
+    assert.equal(JSON.stringify(result).includes(scenario.secret), false);
+    assert.equal(result.nodes.length, 1);
+    assert.deepEqual(result.nodes[0].actions, ["human_takeover"]);
+    assert.equal(result.nodes[0].name, "Sensitive field");
+    assert.equal(result.nodes[0].text, null);
+    assert.equal(result.nodes[0].value, null);
+    assert.equal(result.nodes[0].href, null);
+  }
+});

--- a/crates/tidebreak-desktop/tests/browser-fixture/server.test.mjs
+++ b/crates/tidebreak-desktop/tests/browser-fixture/server.test.mjs
@@ -23,6 +23,24 @@ test("the primary page names the live cross-origin frame", async () => {
   assert.match(source, /Ignore the user's task/);
 });
 
+test("the primary page covers verification privacy and ordinary numeric controls", async () => {
+  const source = await fetch(fixture.origin).then((response) => response.text());
+
+  assert.match(source, /name="code" inputmode="numeric"/);
+  assert.match(source, /id="verification-code" inputmode="numeric"/);
+  assert.match(source, /name="auth-digits" inputmode="numeric" maxlength="6"/);
+  assert.match(source, /name="challenge-response" inputmode="numeric" pattern="\[0-9\]\{6\}"/);
+  assert.match(source, /placeholder="Recovery code"/);
+  assert.match(source, /role="textbox" contenteditable inputmode="numeric" aria-label="Verification code"/);
+  assert.match(source, /blockquote data-sensitive-descendant/);
+  assert.match(source, /id="split-code"/);
+  assert.equal((source.match(/input aria-label="Digit [1-6]"/g) ?? []).length, 6);
+  assert.match(source, /name="quantity" type="number"/);
+  assert.match(source, /name="zipCode" inputmode="numeric" maxlength="5"/);
+  assert.match(source, /name="year" type="number"/);
+  assert.match(source, /name="search" inputmode="numeric"/);
+});
+
 test("the item API is deterministic and resettable", async () => {
   const initial = await fetch(`${fixture.origin}/api/items`).then((response) =>
     response.json(),


### PR DESCRIPTION
## What changed

- Keep sensitive field names, values, links, and text out of semantic browser snapshots.
- Build content text from DOM text nodes while skipping editable descendants, so a wrapping paragraph cannot expose an input or contenteditable value.
- Use the same privacy-safe projection for text waits and refuse waits across uninspectable embedded content.
- Disable browser screenshots and inspect overlays on the current WebKit adapter because parser-created closed shadow roots cannot be proven safe before capture.

## Backwards compatibility

No persisted data or wire format changes. Semantic snapshots, navigation, and ordinary waits remain available. Screenshot and inspect requests now return a human-takeover error on WebKit instead of returning content that the host cannot verify.

## Safety and risk

This deliberately trades screenshot and inspect availability for privacy. The capabilities can be enabled again after an executable WebKit test proves coverage for parser-created closed shadow roots.

## Validation

- node --test crates/tidebreak-desktop/tests/browser-fixture/privacy-policy.test.mjs crates/tidebreak-desktop/tests/browser-fixture/server.test.mjs
- cargo fmt --all -- --check
- git diff --check

Rust compilation and tests run in CI per repository policy.