### PR TITLE
feat(code): add host merge actions on delivery rows

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.dom.test.tsx
@@ -404,6 +404,77 @@ describe("delivery pull request list", () => {
     ).toBeInTheDocument();
   });
 
+  it("offers one host merge action per live row", async () => {
+    renderList();
+    expect(
+      within(await rowFor("Make workspace deep links durable")).getByRole(
+        "button",
+        { name: "Merge" },
+      ),
+    ).toBeEnabled();
+    expect(
+      within(await rowFor("Build the delivery center")).getByRole("button", {
+        name: "Enable auto-merge",
+      }),
+    ).toBeEnabled();
+    expect(
+      within(
+        await rowFor("Let the catalog say which scopes a server accepts"),
+      ).getByRole("button", { name: "Merge when ready" }),
+    ).toBeEnabled();
+    expect(
+      within(
+        await rowFor("Ask a hosted MCP server which scopes it accepts"),
+      ).queryByRole("button", {
+        name: /Merge|Enable auto-merge|Merge when ready/,
+      }),
+    ).toBeNull();
+    expect(
+      within(
+        await rowFor("Cache the workspace digest between polls"),
+      ).queryByRole("button", {
+        name: /Merge|Enable auto-merge|Merge when ready/,
+      }),
+    ).toBeNull();
+  });
+
+  it("merges a ready row through the delivery API after confirm", async () => {
+    const user = userEvent.setup();
+    const runAction = vi.fn(async (_body: unknown) => ({
+      success: true,
+      message: "Pull request #2247 merged",
+    }));
+    renderList(
+      deliveryClient({
+        runCodeDeliveryPullRequestAction: runAction,
+      }),
+    );
+
+    await user.click(
+      within(await rowFor("Make workspace deep links durable")).getByRole(
+        "button",
+        { name: "Merge" },
+      ),
+    );
+    expect(runAction).not.toHaveBeenCalled();
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "Merge",
+      }),
+    );
+    await waitFor(() => expect(runAction).toHaveBeenCalledTimes(1));
+    expect(runAction.mock.calls[0]![0]).toMatchObject({
+      target: { number: 2247 },
+      action: {
+        type: "merge",
+        auto: false,
+        admin: false,
+        expected_head_sha: "73fc201",
+      },
+    });
+    expect(toast.success).toHaveBeenCalled();
+  });
+
   it("shows comment counts without opening the pull request", async () => {
     renderList();
     expect(

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -22,6 +22,7 @@ import {
 import { toast } from "sonner";
 
 import { useApp } from "@/AppContext";
+import { useConfirm } from "@/components/ConfirmDialog";
 import { SearchInput } from "@/components/SearchInput";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -102,6 +103,11 @@ import {
   type PullRequestListGroup,
 } from "./pullRequestPresentation";
 import { arrangeStackLanes, type StackedRow } from "./pullRequestStacks";
+import {
+  deliveryPullRequestDigest,
+  deliveryRepositoryHasMergeQueue,
+  prDirectMergeAction,
+} from "./prActions";
 import {
   STATUS_DOT,
   STATUS_MARK,
@@ -805,6 +811,8 @@ function PullRequestsSurface({
 }) {
   const { client } = useApp();
   const navigate = useNavigate();
+  const { confirm, dialog } = useConfirm();
+  const [busyId, setBusyId] = useState<string | null>(null);
   const [items, setItems] = useState<CodeDeliveryPullRequestSummary[]>([]);
   const [errors, setErrors] = useState<CodeDeliverySourceError[]>([]);
   const [loading, setLoading] = useState(true);
@@ -841,6 +849,51 @@ function PullRequestsSurface({
   const targetKey = target
     ? `${codeDeliveryRepositoryKey(target.repository)}:pull-request:${target.number}`
     : null;
+
+  const refreshList = () => {
+    forceRefresh.current = true;
+    setRevision((value) => value + 1);
+  };
+
+  const runListMerge = async (item: CodeDeliveryPullRequestSummary) => {
+    const action = prDirectMergeAction(deliveryPullRequestDigest(item), {
+      hasMergeQueue: deliveryRepositoryHasMergeQueue(items, item.repository),
+    });
+    if (!action || !item.head_sha || busyId) return;
+    if (action.kind === "merge") {
+      const ok = await confirm({
+        title: `Merge #${item.number}?`,
+        description: `The pull request is squash-merged into ${item.base_branch} on GitHub.`,
+        confirmLabel: "Merge",
+      });
+      if (!ok) return;
+    }
+    setBusyId(item.id);
+    try {
+      const result = await client.runCodeDeliveryPullRequestAction({
+        target: {
+          repository: codeDeliveryRepositoryTarget(item.repository),
+          number: item.number,
+        },
+        action: {
+          type: "merge",
+          method: "squash",
+          auto: action.auto,
+          admin: false,
+          expected_head_sha: item.head_sha,
+        },
+      });
+      if (result.success) toast.success(result.message);
+      else toast.warning(result.message);
+      refreshList();
+    } catch (caught) {
+      toast.error(
+        friendlyErrorMessage(caught, "The pull request action failed."),
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
 
   useEffect(() => {
     routeSelectionFenced.current = false;
@@ -1000,6 +1053,7 @@ function PullRequestsSurface({
 
   return (
     <div className="flex min-h-0 flex-1">
+      {dialog}
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
         {error && (
           <InlineLoadError message={error} onRetry={() => void query()} />
@@ -1010,10 +1064,7 @@ function PullRequestsSurface({
           loading={loading}
           count={items.length}
           noun="pull request"
-          onRefresh={() => {
-            forceRefresh.current = true;
-            setRevision((value) => value + 1);
-          }}
+          onRefresh={refreshList}
         />
         {loading && items.length === 0 ? (
           <DeliveryListSkeleton />
@@ -1035,7 +1086,9 @@ function PullRequestsSurface({
               items={items}
               grouping={grouping}
               selectedId={selectedId}
+              busyId={busyId}
               onSelect={selectItem}
+              onMerge={runListMerge}
               scrollRef={scrollRef}
             />
             {nextCursor && (
@@ -1072,16 +1125,17 @@ function PullRequestsSurface({
           key={selected.id}
           client={client}
           summary={selected}
+          hasMergeQueue={deliveryRepositoryHasMergeQueue(
+            items,
+            selected.repository,
+          )}
           initialDetail={
             targetDetailState?.detail?.summary.id === selected.id
               ? targetDetailState.detail
               : undefined
           }
           onClose={closeDetail}
-          onChanged={() => {
-            forceRefresh.current = true;
-            setRevision((value) => value + 1);
-          }}
+          onChanged={refreshList}
           onOpenWorkspace={(workspaceId) =>
             void navigate({
               to: "/code/w/$workspaceId",
@@ -1447,7 +1501,8 @@ function PendingDetailSheet({
 const PR_ROW_HEIGHT = 62;
 const PR_GROUP_HEIGHT = 38;
 const RUN_ROW_HEIGHT = 62;
-const PR_GRID = "grid-cols-[minmax(280px,1fr)_150px_110px_105px_95px]";
+const PR_GRID =
+  "grid-cols-[minmax(280px,1fr)_150px_110px_105px_minmax(8.75rem,auto)_95px]";
 const RUN_GRID = "grid-cols-[minmax(260px,1fr)_150px_140px_110px]";
 
 /**
@@ -1613,13 +1668,17 @@ function PullRequestList({
   items,
   grouping,
   selectedId,
+  busyId,
   onSelect,
+  onMerge,
   scrollRef,
 }: {
   items: CodeDeliveryPullRequestSummary[];
   grouping: PullRequestGrouping;
   selectedId: string | null;
+  busyId: string | null;
   onSelect: (id: string) => void;
+  onMerge: (item: CodeDeliveryPullRequestSummary) => void;
   scrollRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const rows = useMemo(
@@ -1627,7 +1686,7 @@ function PullRequestList({
     [grouping, items],
   );
   return (
-    <div role="list" aria-label="Pull requests" className="min-w-[900px]">
+    <div role="list" aria-label="Pull requests" className="min-w-[1040px]">
       <div
         className={cn(
           "sticky top-0 z-10 grid gap-4 border-b border-border-subtle bg-background/95 px-5 py-2 text-xs font-medium text-muted-foreground backdrop-blur",
@@ -1638,6 +1697,7 @@ function PullRequestList({
         <span>Status</span>
         <span>Checks</span>
         <span>Comments</span>
+        <span>Action</span>
         <span className="text-right">Updated</span>
       </div>
       <VirtualRows
@@ -1657,7 +1717,13 @@ function PullRequestList({
               stackedOn={entry.row.stackedOn}
               showRepository={entry.showRepository}
               active={selectedId === entry.row.item.id}
+              busy={busyId === entry.row.item.id}
+              hasMergeQueue={deliveryRepositoryHasMergeQueue(
+                items,
+                entry.row.item.repository,
+              )}
               onSelect={() => onSelect(entry.row.item.id)}
+              onMerge={() => onMerge(entry.row.item)}
             />
           )
         }
@@ -1820,23 +1886,32 @@ function PullRequestRow({
   stackedOn,
   showRepository,
   active,
+  busy,
+  hasMergeQueue,
   onSelect,
+  onMerge,
 }: {
   item: CodeDeliveryPullRequestSummary;
   depth: number;
   stackedOn?: number;
   showRepository: boolean;
   active: boolean;
+  busy: boolean;
+  hasMergeQueue: boolean;
   onSelect: () => void;
+  onMerge: () => void;
 }) {
   const lifecycle = pullRequestLifecycle(item);
   const status = pullRequestListStatus(item);
   const checks = checkSummary(checkCounts(item.checks));
   const comments = item.comment_count;
+  const mergeAction = item.head_sha
+    ? prDirectMergeAction(deliveryPullRequestDigest(item), { hasMergeQueue })
+    : null;
   return (
-    <button
-      type="button"
+    <div
       role="listitem"
+      tabIndex={0}
       data-active={active || undefined}
       data-depth={depth}
       data-status-group={status.group}
@@ -1845,6 +1920,13 @@ function PullRequestRow({
         PR_GRID,
       )}
       onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
     >
       <span
         className="min-w-0"
@@ -1921,10 +2003,27 @@ function PullRequestRow({
               : `${comments} ${comments === 1 ? "comment" : "comments"}`}
         </span>
       </span>
+      <span className="flex items-center">
+        {mergeAction ? (
+          <Button
+            type="button"
+            size="xs"
+            variant={mergeAction.kind === "merge" ? "default" : "outline"}
+            disabled={busy}
+            onClick={(event) => {
+              event.stopPropagation();
+              onMerge();
+            }}
+          >
+            {busy && <LoaderCircle className="animate-spin" />}
+            {mergeAction.label}
+          </Button>
+        ) : null}
+      </span>
       <span className="flex items-center justify-end text-xs text-muted-foreground">
         {relativeTime(item.updated_at)}
       </span>
-    </button>
+    </div>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -362,8 +362,14 @@ it("only enables direct merge for an affirmatively ready PR", async () => {
     screen.getByRole("button", { name: "Squash and merge" }),
   ).toBeEnabled();
   expect(
-    screen.getByRole("button", { name: "Enable auto-merge instead" }),
-  ).toBeEnabled();
+    screen.queryByRole("button", { name: "Enable auto-merge" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Enable auto-merge instead" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Merge when ready" }),
+  ).not.toBeInTheDocument();
 });
 
 it("routes manual refresh through the shared serialized PR resource", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -56,7 +56,11 @@ import { FilesPanel } from "./FilesPanel";
 import { FOCUS_RING, FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
 import { MiddleTruncate } from "./MiddleTruncate";
 import { PrCommentCard } from "./PrCommentCard";
-import { prMergeControls, prWorkflowStatus } from "./prActions";
+import {
+  prDirectMergeAction,
+  prMergeControls,
+  prWorkflowStatus,
+} from "./prActions";
 import { useWorkspaceDigest } from "./CodeUpdatesStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import { useWorkspacePullRequests } from "./useWorkspacePullRequests";
@@ -508,8 +512,8 @@ export function PrTab({
 
   async function merge(auto: boolean) {
     if (!pr) return;
-    const controls = prMergeControls(prWorkflowStatus(pr).state);
-    if (auto ? !controls.canEnableAutoMerge : !controls.canMerge) return;
+    const action = prDirectMergeAction(pr);
+    if (!action || action.auto !== auto) return;
     if (!auto) {
       const ok = await confirm({
         title: `Merge #${pr.number}?`,
@@ -558,9 +562,8 @@ export function PrTab({
   const tone = prTone(pr);
   const workflow = prWorkflowStatus(pr);
   const mergeControls = prMergeControls(workflow.state);
-  const showMergeMethod =
-    mergeControls.canMerge ||
-    (mergeControls.canEnableAutoMerge && !pr.auto_merge_enabled);
+  const directMerge = prDirectMergeAction(pr);
+  const showMergeMethod = directMerge !== null;
   const counts = checkCounts(pr);
   const open = tone === "open" || tone === "draft";
   const branchLine =
@@ -681,7 +684,7 @@ export function PrTab({
               </Select>
             )}
           </div>
-          {mergeControls.canMerge ? (
+          {directMerge?.kind === "merge" ? (
             <Button
               type="button"
               size="sm"
@@ -692,7 +695,7 @@ export function PrTab({
               {merging === "merge" ? <Spinner aria-hidden /> : null}
               {mergeMethodLabel(method)}
             </Button>
-          ) : mergeControls.canEnableAutoMerge && !pr.auto_merge_enabled ? (
+          ) : directMerge ? (
             <Button
               type="button"
               size="sm"
@@ -702,7 +705,7 @@ export function PrTab({
               onClick={() => void merge(true)}
             >
               {merging === "auto_merge" ? <Spinner aria-hidden /> : null}
-              Enable auto-merge
+              {directMerge.label}
             </Button>
           ) : workflow.state === "queued" ? (
             <div className="text-warning-foreground flex items-center gap-1.5 px-1 text-xs font-medium">
@@ -715,20 +718,6 @@ export function PrTab({
               Auto-merge is enabled
             </div>
           ) : null}
-          {mergeControls.canMerge && !pr.auto_merge_enabled && (
-            <button
-              type="button"
-              className={cn(
-                "text-muted-foreground hover:text-foreground cursor-pointer self-center rounded-sm text-xs",
-                FOCUS_RING,
-                HOVER_TINT,
-              )}
-              disabled={mutationBusy || !mergeControls.canEnableAutoMerge}
-              onClick={() => void merge(true)}
-            >
-              Enable auto-merge instead
-            </button>
-          )}
           {mergeError && (
             <p className="text-critical text-xs" role="alert">
               {mergeError}

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.dom.test.tsx
@@ -1147,7 +1147,7 @@ describe("CodeWorkspacePage", () => {
     );
 
     const confirmation = await screen.findByRole("alertdialog");
-    expect(confirmation).toHaveTextContent("Auto-merge #41?");
+    expect(confirmation).toHaveTextContent("Enable auto-merge on #41?");
     expect(confirmation).toHaveTextContent(
       "once the remaining requirements pass",
     );

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.dom.test.tsx
@@ -168,7 +168,10 @@ describe("PullRequestDetailSheet", () => {
         "Resolve the conflicts with the base branch first.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Merge" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Enable auto-merge" }),
+    ).toBeNull();
   });
 
   it("shows the changed files with their diffs", async () => {
@@ -351,6 +354,17 @@ describe("PullRequestDetailSheet", () => {
    * modal: the sheet is already one, and stacked modals share a dismiss
    * layer and the body pointer-events lock.
    */
+  it("shows only the host merge action that is available", async () => {
+    await renderPanel(2247);
+    expect(screen.getByRole("button", { name: "Merge" })).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: "Enable auto-merge" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Merge when ready" }),
+    ).toBeNull();
+  });
+
   it("admin-merges only through the inline confirmation, with the bypass flag", async () => {
     const runAction = vi.fn(
       async (_body: CodeDeliveryPullRequestActionBody) => ({
@@ -363,8 +377,11 @@ describe("PullRequestDetailSheet", () => {
       client({ runCodeDeliveryPullRequestAction: runAction }),
     );
 
-    // The plain merge stays disabled while branch protection blocks it.
-    expect(screen.getByRole("button", { name: "Merge" })).toBeDisabled();
+    // Direct merge is not available; the host action is auto-merge instead.
+    expect(screen.queryByRole("button", { name: "Merge" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Enable auto-merge" }),
+    ).toBeEnabled();
     await userEvent.click(
       screen.getByRole("button", { name: "More pull request actions" }),
     );

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -67,6 +67,7 @@ import { MiddleTruncate } from "./MiddleTruncate";
 import {
   deliveryPullRequestDigest,
   prAgentQuickActions,
+  prDirectMergeAction,
   prFreshAgentPrompt,
   prWorkflowPrompt,
   type PrPromptAction,
@@ -155,6 +156,7 @@ export function PullRequestDetailSheet({
   client,
   summary,
   initialDetail,
+  hasMergeQueue = false,
   onClose,
   onChanged,
   onOpenWorkspace,
@@ -167,6 +169,8 @@ export function PullRequestDetailSheet({
     | "writeCodeCheckLogs"
   >;
   summary: CodeDeliveryPullRequestSummary;
+  /** True when this repository already uses a merge queue. */
+  hasMergeQueue?: boolean;
   initialDetail?: CodeDeliveryPullRequestDetail;
   onClose: () => void;
   onChanged: () => void;
@@ -422,6 +426,7 @@ export function PullRequestDetailSheet({
                 <PrActions
                   detail={detail}
                   summary={current}
+                  hasMergeQueue={hasMergeQueue}
                   busy={busy}
                   mergeMethod={mergeMethod}
                   onMergeMethodChange={setMergeMethod}
@@ -763,6 +768,7 @@ function freshAgentWorkspaceTitle(
 function PrActions({
   detail,
   summary,
+  hasMergeQueue,
   busy,
   mergeMethod,
   onMergeMethodChange,
@@ -775,6 +781,7 @@ function PrActions({
 }: {
   detail: CodeDeliveryPullRequestDetail;
   summary: CodeDeliveryPullRequestSummary;
+  hasMergeQueue: boolean;
   busy: string | null;
   mergeMethod: MergeMethod;
   onMergeMethodChange: (method: MergeMethod) => void;
@@ -786,11 +793,18 @@ function PrActions({
   onAdminMergeConfirm: () => void;
 }) {
   const blocked = mergeBlockedReason(summary);
+  const mergeAction =
+    detail.can_merge && summary.head_sha
+      ? prDirectMergeAction(deliveryPullRequestDigest(summary), {
+          hasMergeQueue,
+        })
+      : null;
   const canRerun = detail.can_rerun_failed && workflowRunIds.length > 0;
   const canAdminMerge = detail.can_merge && Boolean(summary.head_sha);
   const anyAction =
     detail.can_mark_ready ||
-    detail.can_merge ||
+    mergeAction !== null ||
+    canAdminMerge ||
     detail.can_close ||
     detail.can_reopen ||
     canRerun;
@@ -810,7 +824,7 @@ function PrActions({
             Mark ready
           </Button>
         )}
-        {detail.can_merge && summary.head_sha && (
+        {mergeAction && summary.head_sha && (
           <>
             <Select
               value={mergeMethod}
@@ -830,42 +844,23 @@ function PrActions({
             <Button
               type="button"
               size="sm"
-              disabled={Boolean(busy) || Boolean(blocked)}
+              variant={mergeAction.kind === "merge" ? "default" : "outline"}
+              disabled={Boolean(busy)}
               onClick={() =>
-                onRun("merge", {
+                onRun(mergeAction.kind, {
                   type: "merge",
                   method: mergeMethod,
-                  auto: false,
+                  auto: mergeAction.auto,
                   admin: false,
                   expected_head_sha: summary.head_sha!,
                 })
               }
             >
-              {busy === "merge" && <LoaderCircle className="animate-spin" />}
-              <GitMerge />
-              Merge
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              disabled={Boolean(busy) || summary.auto_merge_enabled}
-              onClick={() =>
-                onRun("auto-merge", {
-                  type: "merge",
-                  method: mergeMethod,
-                  auto: true,
-                  admin: false,
-                  expected_head_sha: summary.head_sha!,
-                })
-              }
-            >
-              {busy === "auto-merge" && (
+              {busy === mergeAction.kind && (
                 <LoaderCircle className="animate-spin" />
               )}
-              {summary.auto_merge_enabled
-                ? "Auto-merge on"
-                : "Enable auto-merge"}
+              {mergeAction.kind === "merge" ? <GitMerge /> : null}
+              {mergeAction.label}
             </Button>
           </>
         )}
@@ -972,7 +967,7 @@ function PrActions({
           </div>
         </div>
       )}
-      {blocked && detail.can_merge && (
+      {blocked && detail.can_merge && mergeAction === null && (
         <p className="mt-2.5 flex items-start gap-1.5 border-t border-border-subtle pt-2.5 text-xs text-warning-foreground">
           <CircleAlert className="mt-0.5 size-3.5 shrink-0" />
           {blocked}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -33,7 +33,11 @@ import { Spinner } from "@/components/ui/spinner";
 import { openExternal } from "@/host";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { fetchFixErrorsLogs } from "./checkLogs";
-import { prWorkflowPrompt, type PrPromptAction } from "./prActions";
+import {
+  prDirectMergeAction,
+  prWorkflowPrompt,
+  type PrPromptAction,
+} from "./prActions";
 import { useCodeUiStore } from "./CodeUiStore";
 import type { CodeWorkspacePrResource } from "./useCodeWorkspacePr";
 import {
@@ -267,12 +271,32 @@ export function WorkspaceWorkflowControl({
         : method === "rebase"
           ? ["rebased and merged", "rebases and merges"]
           : ["merged", "merges"];
+    const action = prDirectMergeAction(pr);
+    const kind = auto
+      ? action?.kind === "merge_when_ready"
+        ? "merge_when_ready"
+        : "enable_auto_merge"
+      : "merge";
+    const confirmLabel =
+      kind === "merge_when_ready"
+        ? "Merge when ready"
+        : kind === "enable_auto_merge"
+          ? "Enable auto-merge"
+          : "Merge";
     const ok = await confirm({
-      title: auto ? `Auto-merge #${pr.number}?` : `Merge #${pr.number}?`,
-      description: auto
-        ? `GitHub ${lands} the pull request into ${base} once the remaining requirements pass.`
-        : `The pull request is ${landed} into ${base} on GitHub.`,
-      confirmLabel: auto ? "Enable auto-merge" : "Merge",
+      title:
+        kind === "merge_when_ready"
+          ? `Merge #${pr.number} when ready?`
+          : kind === "enable_auto_merge"
+            ? `Enable auto-merge on #${pr.number}?`
+            : `Merge #${pr.number}?`,
+      description:
+        kind === "merge"
+          ? `The pull request is ${landed} into ${base} on GitHub.`
+          : kind === "merge_when_ready"
+            ? `GitHub adds the pull request to the merge queue and ${lands} it into ${base} once the remaining requirements pass.`
+            : `GitHub ${lands} the pull request into ${base} once the remaining requirements pass.`,
+      confirmLabel,
     });
     if (!ok) return;
     try {
@@ -282,7 +306,13 @@ export function WorkspaceWorkflowControl({
       );
       if (!next) return;
       resource.adopt(next);
-      toast.success(auto ? "Auto-merge enabled" : "Merged");
+      toast.success(
+        kind === "merge_when_ready"
+          ? "Merge when ready armed"
+          : kind === "enable_auto_merge"
+            ? "Auto-merge enabled"
+            : "Merged",
+      );
     } catch (err) {
       // The host's own refusal is the useful sentence here, so it goes to the
       // status line rather than being flattened into a generic failure.

--- a/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import type { PullRequestDigest } from "../api/types";
 import {
+  deliveryRepositoryHasMergeQueue,
   prAgentQuickActions,
+  prDirectMergeAction,
   prFreshAgentPrompt,
   prHasConflicts,
   prIsQueued,
@@ -267,6 +269,126 @@ describe("prWorkflowPrompt", () => {
     expect(() => prWorkflowPrompt("merge", pr({}))).toBeDefined();
     // @ts-expect-error readying a draft is not an agent action
     expect(() => prWorkflowPrompt("mark_ready", pr({}))).toBeDefined();
+  });
+});
+
+describe("prDirectMergeAction", () => {
+  it("offers merge only when the pull request is affirmatively ready", () => {
+    expect(
+      prDirectMergeAction(
+        pr({
+          head_sha: "abc",
+          mergeable: "mergeable",
+          merge_state_status: "clean",
+          checks: [{ name: "ci", bucket: "pass" }],
+        }),
+      ),
+    ).toEqual({ kind: "merge", label: "Merge", auto: false });
+  });
+
+  it("offers enable auto-merge when a direct merge is still blocked", () => {
+    expect(
+      prDirectMergeAction(
+        pr({
+          head_sha: "abc",
+          checks: [{ name: "ci", bucket: "pending" }],
+        }),
+      ),
+    ).toEqual({
+      kind: "enable_auto_merge",
+      label: "Enable auto-merge",
+      auto: true,
+    });
+  });
+
+  it("offers merge when ready on a merge-queue repository", () => {
+    expect(
+      prDirectMergeAction(
+        pr({
+          head_sha: "abc",
+          mergeable: "mergeable",
+          merge_state_status: "clean",
+          checks: [{ name: "ci", bucket: "pass" }],
+        }),
+        { hasMergeQueue: true },
+      ),
+    ).toEqual({
+      kind: "merge_when_ready",
+      label: "Merge when ready",
+      auto: true,
+    });
+    expect(
+      prDirectMergeAction(
+        pr({
+          head_sha: "abc",
+          checks: [{ name: "ci", bucket: "pending" }],
+        }),
+        { hasMergeQueue: true },
+      )?.kind,
+    ).toBe("merge_when_ready");
+  });
+
+  it("offers nothing once the host is already landing the pull request", () => {
+    expect(
+      prDirectMergeAction(
+        pr({
+          head_sha: "abc",
+          in_merge_queue: true,
+          auto_merge_enabled: true,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      prDirectMergeAction(
+        pr({
+          head_sha: "abc",
+          auto_merge_enabled: true,
+          mergeable: "mergeable",
+          merge_state_status: "clean",
+          checks: [{ name: "ci", bucket: "pass" }],
+        }),
+      ),
+    ).toBeNull();
+    expect(prDirectMergeAction(pr({ state: "merged", head_sha: "abc" }))).toBe(
+      null,
+    );
+  });
+});
+
+describe("deliveryRepositoryHasMergeQueue", () => {
+  it("treats a repository as queued when any of its rows is in the queue", () => {
+    const queued = {
+      repository: {
+        host: "github.com",
+        owner: "acme",
+        name: "app",
+        name_with_owner: "acme/app",
+        url: "https://github.com/acme/app",
+      },
+      in_merge_queue: true as const,
+    };
+    const other = {
+      repository: {
+        host: "github.com",
+        owner: "acme",
+        name: "docs",
+        name_with_owner: "acme/docs",
+        url: "https://github.com/acme/docs",
+      },
+      in_merge_queue: true as const,
+    };
+    expect(
+      deliveryRepositoryHasMergeQueue(
+        [queued, other] as never,
+        queued.repository,
+      ),
+    ).toBe(true);
+    expect(
+      deliveryRepositoryHasMergeQueue(
+        [{ ...queued, in_merge_queue: false }, other] as never,
+        queued.repository,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/prActions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/prActions.ts
@@ -118,6 +118,68 @@ export function prWorkflowStatus(pr: PullRequestDigest): PrWorkflowStatus {
  * the pull request is either mergeable or already resolved, and there is
  * nothing to explain.
  */
+export type PrDirectMergeKind =
+  | "merge"
+  | "enable_auto_merge"
+  | "merge_when_ready";
+
+export type PrDirectMergeAction = {
+  kind: PrDirectMergeKind;
+  label: string;
+  /** True when the API call arms auto-merge or the merge queue. */
+  auto: boolean;
+};
+
+/**
+ * The one merge button a surface may show.
+ *
+ * GitHub offers three distinct host actions: merge now, enable auto-merge, or
+ * add the pull request to a merge queue ("Merge when ready"). A ready
+ * pull request on a queue repository is the queue action, not a direct merge.
+ * Already-queued and already-armed pull requests offer nothing.
+ */
+export function prDirectMergeAction(
+  pr: PullRequestDigest,
+  options?: { hasMergeQueue?: boolean },
+): PrDirectMergeAction | null {
+  const { state } = prWorkflowStatus(pr);
+  const controls = prMergeControls(state);
+  if (state === "queued" || state === "auto_merge") return null;
+  if (options?.hasMergeQueue) {
+    if (!controls.canMerge && !controls.canEnableAutoMerge) return null;
+    return {
+      kind: "merge_when_ready",
+      label: "Merge when ready",
+      auto: true,
+    };
+  }
+  if (controls.canMerge) {
+    return { kind: "merge", label: "Merge", auto: false };
+  }
+  if (controls.canEnableAutoMerge && !pr.auto_merge_enabled) {
+    return {
+      kind: "enable_auto_merge",
+      label: "Enable auto-merge",
+      auto: true,
+    };
+  }
+  return null;
+}
+
+/** True when this repository already has a pull request in its merge queue. */
+export function deliveryRepositoryHasMergeQueue(
+  items: readonly CodeDeliveryPullRequestSummary[],
+  repository: CodeDeliveryPullRequestSummary["repository"],
+): boolean {
+  return items.some(
+    (item) =>
+      item.in_merge_queue === true &&
+      item.repository.host === repository.host &&
+      item.repository.owner === repository.owner &&
+      item.repository.name === repository.name,
+  );
+}
+
 export function prMergeControls(state: PrWorkflowState): {
   canMerge: boolean;
   canEnableAutoMerge: boolean;

--- a/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceWorkflow.ts
@@ -1,5 +1,6 @@
 import type { CodeWorkspacePrSnapshot, PullRequestDigest } from "../api/types";
 import {
+  prDirectMergeAction,
   prMergeControls,
   prWorkflowStatus,
   type PrCheckCounts,
@@ -445,9 +446,10 @@ function mergeIfGreen(
   }
   const pr = model.pr;
   if (!pr) return { blocked: "No pull request yet" };
+  const action = prDirectMergeAction(pr);
+  if (action?.kind === "merge") return { run: "merge" };
+  if (action) return { autoMerge: true };
   const controls = prMergeControls(prWorkflowStatus(pr).state);
-  if (controls.canMerge) return { run: "merge" };
-  if (controls.canEnableAutoMerge) return { autoMerge: true };
   return {
     blocked:
       controls.explanation ?? `Pull request #${pr.number} cannot merge yet`,

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -472,7 +472,7 @@ export const PullRequestRunningCheck: Story = {
   },
 };
 
-/** A running check blocks the merge without inventing a review requirement. */
+/** A running check on a merge-queue repo offers merge when ready, not a blocked Merge. */
 export const PullRequestRunningCheckDetail: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -483,11 +483,12 @@ export const PullRequestRunningCheckDetail: Story = {
       ),
     );
     await expect(
-      await body.findByText("Wait for the running check before merging."),
-    ).toBeVisible();
+      await body.findByRole("button", { name: "Merge when ready" }),
+    ).toBeEnabled();
+    await expect(body.queryByRole("button", { name: "Merge" })).toBeNull();
     await expect(
-      await body.findByRole("button", { name: "Merge" }),
-    ).toBeDisabled();
+      body.queryByRole("button", { name: "Enable auto-merge" }),
+    ).toBeNull();
     await expect(
       body.queryByText(/required review|review approval/i),
     ).not.toBeInTheDocument();
@@ -669,8 +670,9 @@ export const PullRequestAdminMerge: Story = {
     const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(await canvas.findByText("Build the delivery center"));
     await expect(
-      await body.findByRole("button", { name: "Merge" }),
-    ).toBeDisabled();
+      await body.findByRole("button", { name: "Enable auto-merge" }),
+    ).toBeEnabled();
+    await expect(body.queryByRole("button", { name: "Merge" })).toBeNull();
     await userEvent.click(
       await body.findByRole("button", { name: "More pull request actions" }),
     );
@@ -819,7 +821,7 @@ export const DraftPullRequestDetail: Story = {
   },
 };
 
-/** Conflicting: the merge button says why it is disabled. */
+/** Conflicting: no host merge action, and the card says why. */
 export const BlockedMergePullRequestDetail: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -832,9 +834,10 @@ export const BlockedMergePullRequestDetail: Story = {
         "Resolve the conflicts with the base branch first.",
       ),
     ).toBeVisible();
+    await expect(body.queryByRole("button", { name: "Merge" })).toBeNull();
     await expect(
-      await body.findByRole("button", { name: "Merge" }),
-    ).toBeDisabled();
+      body.queryByRole("button", { name: "Enable auto-merge" }),
+    ).toBeNull();
   },
 };
 


### PR DESCRIPTION
Each live pull request now shows one GitHub action: Merge when it can land, Enable auto-merge when GitHub can arm auto-merge, or Merge when ready when that repository already uses a merge queue.

The delivery list, the detail sheet, the review sidebar, and the workspace merge chord share that choice. They call the existing delivery or workspace merge API. Ready pull requests still confirm before they squash-merge.

A repository counts as a merge-queue repo when any of its listed pull requests is already in the queue.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec biome check` on the changed files
- `pnpm --dir crates/tidebreak-desktop/ui test` for delivery, inspector, workspace, and `prActions` coverage
