### PR TITLE
ci: keep Windows prepared archives on local tar paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1384,14 +1384,15 @@ jobs:
               "$broker_sidecar" \
               "$cli_sidecar" \
               > SHA256SUMS
-            tar -cf "$GITHUB_WORKSPACE/prepared-windows.tar" \
+          )
+          # GNU tar treats C:\path as host C. Keep the archive name relative.
+          (
+            cd "$GITHUB_WORKSPACE"
+            tar -cf prepared-windows.tar -C "$PREPARED_ROOT" \
               SHA256SUMS \
               release-config.json \
               target \
               crates
-          )
-          (
-            cd "$GITHUB_WORKSPACE"
             sha256sum prepared-windows.tar > prepared-windows.tar.sha256
           )
 
@@ -1457,13 +1458,14 @@ jobs:
           RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
           RELEASE_TARGET: ${{ matrix.target }}
         run: |
+          rm -rf "$PREPARED_ROOT"
+          mkdir -p "$PREPARED_ROOT"
           (
             cd "$PREPARED_DOWNLOAD"
             sha256sum --check --strict prepared-windows.tar.sha256
+            # GNU tar treats C:\path as host C. Keep the archive name relative.
+            tar -xf prepared-windows.tar -C "$PREPARED_ROOT"
           )
-          rm -rf "$PREPARED_ROOT"
-          mkdir -p "$PREPARED_ROOT"
-          tar -xf "$PREPARED_DOWNLOAD/prepared-windows.tar" -C "$PREPARED_ROOT"
           (
             cd "$PREPARED_ROOT"
             sha256sum --check --strict SHA256SUMS

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1944,7 +1944,9 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   assert.match(prepareJob, /compression-level: 0/);
   assert.match(prepareJob, /overwrite: true/);
   assert.match(prepareJob, /sha256sum[\s\S]*> SHA256SUMS/);
+  assert.match(prepareJob, /tar -cf prepared-windows\.tar -C "\$PREPARED_ROOT"/);
   assert.match(prepareJob, /sha256sum prepared-windows\.tar/);
+  assert.doesNotMatch(prepareJob, /tar -[cx]f "\$/);
 
   const verifyStep = buildJob.match(
     /- name: Verify prepared Windows inputs[\s\S]*?(?=\n\s+- (?:name:|uses:))/,
@@ -1962,6 +1964,8 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
     verifyStep,
     /sha256sum --check --strict prepared-windows\.tar\.sha256/,
   );
+  assert.match(verifyStep, /tar -xf prepared-windows\.tar -C "\$PREPARED_ROOT"/);
+  assert.doesNotMatch(verifyStep, /tar -[cx]f "\$/);
   assert.match(verifyStep, /sha256sum --check --strict SHA256SUMS/);
   assert.match(
     verifyStep,


### PR DESCRIPTION
## What changed

Windows release prepare jobs compiled successfully, then failed in Archive prepared Windows inputs with `tar: Cannot connect to C: resolve failed` (and `D:` on x86_64). GNU tar treats a drive letter in `-f C:\...\prepared-windows.tar` as a remote host.

The archive and extract steps now operate on `prepared-windows.tar` from the current directory and pass the prepared tree with `-C`.

Seen on https://github.com/brightwave-inc/tidebreak/actions/runs/32916482746.

## Validation

- `node --test scripts/workflow-security.test.mjs scripts/workflow-security-mutations.test.mjs`
- Windows release job assertions passed.
- Docker context cases in the same file failed locally because the Docker daemon was not running.
- Did not re-run the production release workflow.

## Compatibility and risk

Windows Git Bash only. Archive contents and checksum contract are unchanged. Re-dispatch the desktop release after this lands.