### PR TITLE
fix(code): qualify pull request stack identity

### DIFF
--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -22,12 +22,16 @@ use tidebreak_core::db::code::{
 };
 use tidebreak_core::{
     CodePullRequestAttribution, CodePullRequestDiscovery, CodePullRequestId,
-    CodePullRequestRelation, CodeRepo, CodeWorkspace, CodeWorkspaceStatus, OwnerId,
-    PullRequestCheck, PullRequestCheckBucket, PullRequestComment, PullRequestCommentKind,
+    CodePullRequestRelation, CodePullRequestState, CodeRepo, CodeWorkspace, CodeWorkspaceStatus,
+    OwnerId, PullRequestCheck, PullRequestCheckBucket, PullRequestComment, PullRequestCommentKind,
     PullRequestDigest, RepoId, WorkspaceId,
 };
 
 use super::gh::{self, GhObservation};
+use super::reconcile::{
+    StackParentCandidate, StackParentEdge, StackParentIndex, StackParentResolution,
+    StackPullRequestIdentity, StackRepositoryIdentity,
+};
 use super::runtime::CodeRuntime;
 use crate::error::ServerError;
 use crate::routes::code::types::{
@@ -60,8 +64,8 @@ const GITHUB_DETAIL_PAGE_SIZE: usize = 100;
 /// unlucky repository would otherwise blank a whole column.
 const TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(700);
 
-const PR_LIST_FIELDS: &str = "number,url,state,title,isDraft,author,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRefName,headRefOid,baseRefName,updatedAt,createdAt,mergedAt,closedAt,labels,comments";
-const PR_LIST_FIELDS_WITH_CHECKS: &str = "number,url,state,title,isDraft,author,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRefName,headRefOid,baseRefName,updatedAt,createdAt,mergedAt,closedAt,labels,comments,statusCheckRollup";
+const PR_LIST_FIELDS: &str = "number,url,state,title,isDraft,author,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRepository,headRepositoryOwner,headRefName,headRefOid,baseRefName,updatedAt,createdAt,mergedAt,closedAt,labels,comments";
+const PR_LIST_FIELDS_WITH_CHECKS: &str = "number,url,state,title,isDraft,author,reviewDecision,mergeable,mergeStateStatus,autoMergeRequest,headRepository,headRepositoryOwner,headRefName,headRefOid,baseRefName,updatedAt,createdAt,mergedAt,closedAt,labels,comments,statusCheckRollup";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PullRequestRemotePlan {
@@ -90,6 +94,36 @@ impl PullRequestRemotePlan {
             },
             self.author.as_deref().unwrap_or("*")
         )
+    }
+}
+
+/// One host pull-request observation plus identity kept off the public wire.
+///
+/// `stack_parent_number` stays wire-compatible. The fork-qualified head
+/// repository remains available until stack resolution has selected one
+/// immutable base-repository-and-number identity.
+#[derive(Debug, Clone)]
+struct PullRequestObservation {
+    summary: CodeDeliveryPullRequestSummary,
+    head_repository: Option<StackRepositoryIdentity>,
+}
+
+impl PullRequestObservation {
+    fn pull_request_identity(&self) -> StackPullRequestIdentity {
+        StackPullRequestIdentity {
+            base_repository: stack_repository_identity(&self.summary.repository),
+            number: self.summary.number,
+        }
+    }
+
+    fn stack_parent_candidate(&self) -> StackParentCandidate {
+        StackParentCandidate {
+            pull_request: self.pull_request_identity(),
+            open: self.summary.state == "open",
+            head_repository: self.head_repository.clone(),
+            head_branch: (!self.summary.head_branch.is_empty())
+                .then(|| self.summary.head_branch.clone()),
+        }
     }
 }
 
@@ -473,9 +507,10 @@ pub(crate) async fn query_pull_requests_by_number(
     }
     items.sort_by(|left, right| {
         right
+            .summary
             .updated_at
-            .cmp(&left.updated_at)
-            .then_with(|| left.id.cmp(&right.id))
+            .cmp(&left.summary.updated_at)
+            .then_with(|| left.summary.id.cmp(&right.summary.id))
     });
     // The trigger sweep reads through here, and its stacked-child suppression
     // keys on `stack_parent_number` (decision 62) — so this path persists and
@@ -486,6 +521,7 @@ pub(crate) async fn query_pull_requests_by_number(
         super::attention::emit_workspace_digests(&runtime.db, &runtime.bus, owner, workspace_id)
             .await;
     }
+    let items = items.into_iter().map(|item| item.summary).collect();
     Ok(CodeDeliveryPullRequestsPage {
         capability,
         items,
@@ -723,9 +759,10 @@ pub(crate) async fn query_pull_requests(
             }
             items.sort_by(|left, right| {
                 right
+                    .summary
                     .updated_at
-                    .cmp(&left.updated_at)
-                    .then_with(|| left.id.cmp(&right.id))
+                    .cmp(&left.summary.updated_at)
+                    .then_with(|| left.summary.id.cmp(&right.summary.id))
             });
             let workspaces_gaining_links = persist_and_augment_pull_request_facts(
                 runtime,
@@ -734,6 +771,10 @@ pub(crate) async fn query_pull_requests(
                 &mut items,
             )
             .await;
+            let items = items
+                .into_iter()
+                .map(|item| item.summary)
+                .collect::<Vec<_>>();
             runtime.delivery_cache.put_pull_requests(
                 cache_key.clone(),
                 items.clone(),
@@ -800,21 +841,21 @@ pub(crate) async fn pull_request_detail(
         .await
         .map_err(|message| ServerError::bad_request_kind("github", message))?;
     let workspace_index = workspace_index(runtime, owner, false).await?;
-    let mut summary = fetch_pull_request(binary, &repository, target.number, &workspace_index)
+    let mut observation = fetch_pull_request(binary, &repository, target.number, &workspace_index)
         .await
         .map_err(|message| ServerError::bad_request_kind("github", message))?;
     let minted = persist_and_augment_pull_request_facts(
         runtime,
         owner,
         &workspace_index,
-        std::slice::from_mut(&mut summary),
+        std::slice::from_mut(&mut observation),
     )
     .await;
     for workspace_id in minted {
         super::attention::emit_workspace_digests(&runtime.db, &runtime.bus, owner, workspace_id)
             .await;
     }
-    let summary = summary;
+    let summary = observation.summary;
 
     let pull_endpoint = api_endpoint(&target.repository, &format!("pulls/{}", target.number));
     let issue_comments_endpoint = api_endpoint(
@@ -1943,7 +1984,7 @@ async fn fetch_pull_requests(
     workspaces: &[WorkspaceIndexEntry],
     plan: &PullRequestRemotePlan,
     force_refresh: bool,
-) -> Result<Vec<CodeDeliveryPullRequestSummary>, String> {
+) -> Result<Vec<PullRequestObservation>, String> {
     let repository =
         resolve_repository_cached(runtime, binary, target, None, force_refresh).await?;
     let cli_repository = gh::cli_repository(&target.host, &target.owner, &target.name);
@@ -2014,7 +2055,7 @@ async fn fetch_pull_request(
     repository: &CodeGitHubRepositoryRef,
     number: u64,
     workspaces: &[WorkspaceIndexEntry],
-) -> Result<CodeDeliveryPullRequestSummary, String> {
+) -> Result<PullRequestObservation, String> {
     let cli_repository = gh::cli_repository(&repository.host, &repository.owner, &repository.name);
     let number = number.to_string();
     let raw = gh::run_gh(
@@ -2042,7 +2083,7 @@ fn parse_pull_request(
     repository: &CodeGitHubRepositoryRef,
     value: &Value,
     workspaces: &[WorkspaceIndexEntry],
-) -> Option<CodeDeliveryPullRequestSummary> {
+) -> Option<PullRequestObservation> {
     let number = u64_field(value, "number")?;
     let title = text_field(value, "title")?;
     let state = text_field(value, "state")?.to_ascii_lowercase();
@@ -2114,36 +2155,87 @@ fn parse_pull_request(
         &head_branch,
         workspaces,
     );
-    Some(CodeDeliveryPullRequestSummary {
-        id: format!("{}#{number}", repository_key_ref(repository)),
-        repository: repository.clone(),
-        number,
-        url,
-        title,
-        state,
-        draft,
-        author,
-        author_avatar_url,
-        head_branch,
-        base_branch,
-        head_sha,
-        review_decision,
-        mergeable,
-        merge_state_status,
-        auto_merge_enabled,
-        in_merge_queue,
-        comment_count,
-        checks,
-        attention_reasons,
-        ready_to_merge,
-        workspace_links,
-        stack_parent_number: None,
-        labels,
-        created_at: datetime_field(value, "createdAt").unwrap_or_else(Utc::now),
-        updated_at: datetime_field(value, "updatedAt").unwrap_or_else(Utc::now),
-        merged_at,
-        closed_at,
+    Some(PullRequestObservation {
+        summary: CodeDeliveryPullRequestSummary {
+            id: format!("{}#{number}", repository_key_ref(repository)),
+            repository: repository.clone(),
+            number,
+            url,
+            title,
+            state,
+            draft,
+            author,
+            author_avatar_url,
+            head_branch,
+            base_branch,
+            head_sha,
+            review_decision,
+            mergeable,
+            merge_state_status,
+            auto_merge_enabled,
+            in_merge_queue,
+            comment_count,
+            checks,
+            attention_reasons,
+            ready_to_merge,
+            workspace_links,
+            stack_parent_number: None,
+            labels,
+            created_at: datetime_field(value, "createdAt").unwrap_or_else(Utc::now),
+            updated_at: datetime_field(value, "updatedAt").unwrap_or_else(Utc::now),
+            merged_at,
+            closed_at,
+        },
+        head_repository: parse_head_repository(repository, value),
     })
+}
+
+fn parse_head_repository(
+    base_repository: &CodeGitHubRepositoryRef,
+    value: &Value,
+) -> Option<StackRepositoryIdentity> {
+    let repository = value.get("headRepository")?;
+    if repository.is_null() {
+        return None;
+    }
+    let name_with_owner = repository.get("nameWithOwner").and_then(Value::as_str);
+    let from_name_with_owner = name_with_owner.and_then(|name_with_owner| {
+        let (owner, name) = name_with_owner.split_once('/')?;
+        if name.contains('/') {
+            return None;
+        }
+        StackRepositoryIdentity::new(&base_repository.host, owner, name)
+    });
+    if name_with_owner.is_some() && from_name_with_owner.is_none() {
+        return None;
+    }
+    let owner = value
+        .get("headRepositoryOwner")
+        .and_then(|owner| owner.get("login"))
+        .and_then(Value::as_str);
+    let name = repository.get("name").and_then(Value::as_str);
+    let from_parts = owner
+        .zip(name)
+        .and_then(|(owner, name)| StackRepositoryIdentity::new(&base_repository.host, owner, name));
+    let identity = match (from_name_with_owner, from_parts) {
+        (Some(name_with_owner), Some(parts)) if name_with_owner == parts => parts,
+        (Some(_), Some(_)) => return None,
+        (Some(identity), None) | (None, Some(identity)) => identity,
+        (None, None) => return None,
+    };
+    if owner.is_some_and(|owner| {
+        StackRepositoryIdentity::new(&base_repository.host, owner, &identity.name)
+            .map_or(true, |candidate| candidate.owner != identity.owner)
+    }) {
+        return None;
+    }
+    if name.is_some_and(|name| {
+        StackRepositoryIdentity::new(&base_repository.host, &identity.owner, name)
+            .map_or(true, |candidate| candidate.name != identity.name)
+    }) {
+        return None;
+    }
+    Some(identity)
 }
 
 fn parse_check(value: &Value) -> Option<CodeDeliveryCheck> {
@@ -2581,23 +2673,30 @@ async fn persist_and_augment_pull_request_facts(
     runtime: &CodeRuntime,
     owner: &OwnerId,
     workspaces: &[WorkspaceIndexEntry],
-    items: &mut [CodeDeliveryPullRequestSummary],
+    items: &mut [PullRequestObservation],
 ) -> Vec<WorkspaceId> {
     let db = &runtime.db;
     let mut minted = Vec::new();
     let now = Utc::now();
+    let mut stack_candidates: HashMap<StackPullRequestIdentity, StackParentCandidate> = items
+        .iter()
+        .map(|item| {
+            let candidate = item.stack_parent_candidate();
+            (candidate.pull_request.clone(), candidate)
+        })
+        .collect();
 
     // One fact read per repository identity on the page.
     let mut groups: HashMap<String, Vec<usize>> = HashMap::new();
     for (index, item) in items.iter().enumerate() {
         groups
-            .entry(repository_key_ref(&item.repository))
+            .entry(repository_key_ref(&item.summary.repository))
             .or_default()
             .push(index);
     }
     let mut fact_ids: HashMap<usize, CodePullRequestId> = HashMap::new();
     for indices in groups.values() {
-        let repository = &items[indices[0]].repository;
+        let repository = &items[indices[0]].summary.repository;
         let mut repo_facts = match list_pull_request_facts_for_repo(
             db,
             owner,
@@ -2613,6 +2712,24 @@ async fn persist_and_augment_pull_request_facts(
                 continue;
             }
         };
+        let base_repository = stack_repository_identity(repository);
+        for fact in &repo_facts {
+            let pull_request = StackPullRequestIdentity {
+                base_repository: base_repository.clone(),
+                number: fact.number,
+            };
+            stack_candidates
+                .entry(pull_request.clone())
+                .or_insert_with(|| StackParentCandidate {
+                    pull_request,
+                    open: fact.state == CodePullRequestState::Open,
+                    // Durable facts predate fork-qualified identity. They can
+                    // prove that a same-named candidate exists, but they must
+                    // not select one fork by branch name alone.
+                    head_repository: None,
+                    head_branch: (!fact.head_branch.is_empty()).then(|| fact.head_branch.clone()),
+                });
+        }
         let known: HashMap<u64, CodePullRequestId> = repo_facts
             .iter()
             .map(|fact| (fact.number, fact.id))
@@ -2627,7 +2744,7 @@ async fn persist_and_augment_pull_request_facts(
             })
             .collect();
         for &index in indices {
-            let item = &mut items[index];
+            let item = &mut items[index].summary;
             if item.in_merge_queue.is_none() {
                 item.in_merge_queue = known_queue.get(&item.number).copied();
             }
@@ -2663,8 +2780,7 @@ async fn persist_and_augment_pull_request_facts(
             runtime
                 .record_pull_request_live_state(owner, None, &digest_from_summary(item))
                 .await;
-            // Keep the local fact set current with what was just written, so
-            // stack derivation below sees this pass's own observations.
+            // Keep this pass's fact set current for later durable reads.
             match repo_facts
                 .iter_mut()
                 .find(|known| known.number == fact.number)
@@ -2695,15 +2811,42 @@ async fn persist_and_augment_pull_request_facts(
                 }
             }
         }
-        // Stack annotation rides the durable set, not the page: a parent
-        // outside the current page or filter still resolves (decision 62).
-        let parents = super::reconcile::stack_parents_by_head(&repo_facts);
-        for &index in indices {
-            let item = &mut items[index];
-            item.stack_parent_number = parents
-                .get(&item.base_branch)
-                .copied()
-                .filter(|parent| *parent != item.number);
+    }
+
+    let stack_index = StackParentIndex::new(stack_candidates.into_values());
+    for item in items.iter_mut() {
+        let child = item.pull_request_identity();
+        let head_repository = item.head_repository.clone();
+        let summary = &mut item.summary;
+        summary.stack_parent_number = None;
+        if summary.base_branch.is_empty()
+            || summary
+                .repository
+                .default_branch
+                .as_deref()
+                .is_some_and(|default| default == summary.base_branch)
+        {
+            continue;
+        }
+        let Some(edge) = StackParentEdge::new(
+            stack_repository_identity(&summary.repository),
+            head_repository,
+            &summary.base_branch,
+        ) else {
+            continue;
+        };
+        match stack_index.resolve(&edge, Some(&child)) {
+            StackParentResolution::Resolved(parent) => {
+                summary.stack_parent_number = Some(parent.number);
+            }
+            StackParentResolution::Unresolved { reason, .. } => {
+                tracing::debug!(
+                    pull_request = summary.number,
+                    base_branch = %summary.base_branch,
+                    ?reason,
+                    "stack edge stayed unresolved"
+                );
+            }
         }
     }
 
@@ -2746,7 +2889,7 @@ async fn persist_and_augment_pull_request_facts(
         let Some(attributions) = by_fact.get(&fact_id) else {
             continue;
         };
-        let item = &mut items[index];
+        let item = &mut items[index].summary;
         for attribution in attributions {
             if let Some(link) = item
                 .workspace_links
@@ -3200,6 +3343,11 @@ fn repository_key_ref(repository: &CodeGitHubRepositoryRef) -> String {
     )
 }
 
+fn stack_repository_identity(repository: &CodeGitHubRepositoryRef) -> StackRepositoryIdentity {
+    StackRepositoryIdentity::new(&repository.host, &repository.owner, &repository.name)
+        .expect("a resolved GitHub repository has a complete identity")
+}
+
 fn api_endpoint(target: &CodeGitHubRepositoryTarget, tail: &str) -> String {
     format!("repos/{}/{}/{}", target.owner, target.name, tail)
 }
@@ -3532,6 +3680,8 @@ mod tests {
         assert_eq!(settled.state, "all");
         assert!(!settled.checks_loaded);
         assert!(!settled.fields.contains("statusCheckRollup"));
+        assert!(settled.fields.contains("headRepository"));
+        assert!(settled.fields.contains("headRepositoryOwner"));
 
         pull_requests.states = vec!["merged".into()];
         assert_eq!(pull_request_remote_plan(&pull_requests).state, "merged");
@@ -3695,13 +3845,13 @@ mod tests {
         )
         .unwrap();
         let parsed = parse_pull_request(&repository_ref(), &value, &[]).unwrap();
-        assert_eq!(parsed.state, "merged");
-        assert!(parsed.merged_at.is_some());
-        assert!(parsed.closed_at.is_some());
-        assert_eq!(parsed.labels, vec!["performance", "desktop"]);
+        assert_eq!(parsed.summary.state, "merged");
+        assert!(parsed.summary.merged_at.is_some());
+        assert!(parsed.summary.closed_at.is_some());
+        assert_eq!(parsed.summary.labels, vec!["performance", "desktop"]);
         // A settled pull request never asks for attention and is never ready.
-        assert!(parsed.attention_reasons.is_empty());
-        assert!(!parsed.ready_to_merge);
+        assert!(parsed.summary.attention_reasons.is_empty());
+        assert!(!parsed.summary.ready_to_merge);
     }
 
     #[test]
@@ -3720,7 +3870,7 @@ mod tests {
         )
         .unwrap();
         let parsed = parse_pull_request(&repository_ref(), &value, &[]).unwrap();
-        assert_eq!(parsed.state, "merged");
+        assert_eq!(parsed.summary.state, "merged");
     }
 
     #[test]
@@ -3740,9 +3890,49 @@ mod tests {
         )
         .unwrap();
         let parsed = parse_pull_request(&repository_ref(), &value, &[]).unwrap();
-        assert_eq!(parsed.state, "open");
-        assert!(parsed.merged_at.is_none());
-        assert!(parsed.closed_at.is_none());
+        assert_eq!(parsed.summary.state, "open");
+        assert!(parsed.summary.merged_at.is_none());
+        assert!(parsed.summary.closed_at.is_none());
+    }
+
+    #[test]
+    fn pull_request_head_repository_requires_consistent_host_identity() {
+        let value = serde_json::json!({
+            "number": 2252,
+            "title": "Qualify stack identity",
+            "state": "OPEN",
+            "url": "https://github.com/brightwave-inc/tidebreak/pull/2252",
+            "headRepository": {
+                "name": "tidebreak",
+                "nameWithOwner": "Thet/Tidebreak"
+            },
+            "headRepositoryOwner": {"login": "thet"},
+            "headRefName": "thet/stack-child",
+            "baseRefName": "thet/stack-parent"
+        });
+        let parsed = parse_pull_request(&repository_ref(), &value, &[]).unwrap();
+        assert_eq!(
+            parsed.head_repository,
+            StackRepositoryIdentity::new("github.com", "thet", "tidebreak")
+        );
+
+        let conflicting = serde_json::json!({
+            "number": 2253,
+            "title": "Reject conflicting identity",
+            "state": "OPEN",
+            "url": "https://github.com/brightwave-inc/tidebreak/pull/2253",
+            "headRepository": {
+                "name": "tidebreak",
+                "nameWithOwner": "alice/tidebreak"
+            },
+            "headRepositoryOwner": {"login": "bob"},
+            "headRefName": "stack-child",
+            "baseRefName": "stack-parent"
+        });
+        assert!(parse_pull_request(&repository_ref(), &conflicting, &[])
+            .unwrap()
+            .head_repository
+            .is_none());
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/delivery.rs
+++ b/crates/tidebreak-server/src/code/delivery.rs
@@ -2225,13 +2225,13 @@ fn parse_head_repository(
     };
     if owner.is_some_and(|owner| {
         StackRepositoryIdentity::new(&base_repository.host, owner, &identity.name)
-            .map_or(true, |candidate| candidate.owner != identity.owner)
+            .is_none_or(|candidate| candidate.owner != identity.owner)
     }) {
         return None;
     }
     if name.is_some_and(|name| {
         StackRepositoryIdentity::new(&base_repository.host, &identity.owner, name)
-            .map_or(true, |candidate| candidate.name != identity.name)
+            .is_none_or(|candidate| candidate.name != identity.name)
     }) {
         return None;
     }

--- a/crates/tidebreak-server/src/code/reconcile.rs
+++ b/crates/tidebreak-server/src/code/reconcile.rs
@@ -412,7 +412,6 @@ impl StackParentIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tidebreak_core::CodePullRequestId;
 
     fn repository(owner: &str, name: &str) -> StackRepositoryIdentity {
         StackRepositoryIdentity::new("github.com", owner, name).unwrap()
@@ -446,32 +445,6 @@ mod tests {
             head_branch,
         )
         .unwrap()
-    }
-
-    fn fact(number: u64, head: &str, state: CodePullRequestState) -> CodePullRequestFact {
-        CodePullRequestFact {
-            id: CodePullRequestId::new(),
-            owner: OwnerId::local(),
-            host: "github.com".into(),
-            repo_owner: "acme".into(),
-            repo_name: "tools".into(),
-            number,
-            url: format!("https://github.com/acme/tools/pull/{number}"),
-            title: format!("PR {number}"),
-            state,
-            draft: false,
-            author: None,
-            head_branch: head.into(),
-            base_branch: "main".into(),
-            head_sha: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            merged_at: None,
-            closed_at: None,
-            first_seen_at: chrono::Utc::now(),
-            last_seen_at: chrono::Utc::now(),
-            live: None,
-        }
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/reconcile.rs
+++ b/crates/tidebreak-server/src/code/reconcile.rs
@@ -235,15 +235,200 @@ pub(crate) fn fact_from_summary(
     })
 }
 
-/// Open head branches → pull request numbers, for stack derivation
-/// (decision 62). A pull request is stacked on another when its base branch
-/// is that pull request's head branch in the same repository; only open
-/// parents count, since a merged parent's branch is history, not a base.
+/// Case-insensitive repository identity used while resolving stack edges.
+///
+/// GitHub repository owner and name tokens are case-insensitive. Branch names
+/// remain case-sensitive and live on [`StackParentEdge`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct StackRepositoryIdentity {
+    pub(crate) host: String,
+    pub(crate) owner: String,
+    pub(crate) name: String,
+}
+
+impl StackRepositoryIdentity {
+    pub(crate) fn new(host: &str, owner: &str, name: &str) -> Option<Self> {
+        let host = host.trim().trim_end_matches('.').to_ascii_lowercase();
+        let owner = owner.trim().to_ascii_lowercase();
+        let name = name.trim().to_ascii_lowercase();
+        let name = name.strip_suffix(".git").unwrap_or(&name).to_owned();
+        if host.is_empty() || owner.is_empty() || name.is_empty() {
+            return None;
+        }
+        Some(Self { host, owner, name })
+    }
+}
+
+/// Immutable pull-request identity after a stack edge resolves.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct StackPullRequestIdentity {
+    pub(crate) base_repository: StackRepositoryIdentity,
+    pub(crate) number: u64,
+}
+
+/// The mutable branch edge that may resolve to an immutable pull request.
+///
+/// The base repository scopes the pull-request number. The head repository
+/// distinguishes same-named branches in forks of that base repository.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct StackParentEdge {
+    pub(crate) base_repository: StackRepositoryIdentity,
+    pub(crate) head_repository: Option<StackRepositoryIdentity>,
+    pub(crate) head_branch: String,
+}
+
+impl StackParentEdge {
+    pub(crate) fn new(
+        base_repository: StackRepositoryIdentity,
+        head_repository: Option<StackRepositoryIdentity>,
+        head_branch: &str,
+    ) -> Option<Self> {
+        if head_branch.is_empty() {
+            return None;
+        }
+        Some(Self {
+            base_repository,
+            head_repository,
+            head_branch: head_branch.to_owned(),
+        })
+    }
+}
+
+/// One possible open stack parent from a host observation or durable fact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StackParentCandidate {
+    pub(crate) pull_request: StackPullRequestIdentity,
+    pub(crate) open: bool,
+    pub(crate) head_repository: Option<StackRepositoryIdentity>,
+    pub(crate) head_branch: Option<String>,
+}
+
+/// Why a branch edge could not safely resolve to one pull request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StackParentUnresolvedReason {
+    MissingParent,
+    IncompleteHostIdentity,
+    Ambiguous {
+        candidates: Vec<StackPullRequestIdentity>,
+    },
+}
+
+/// A stack edge resolves to one immutable pull request or stays explicit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StackParentResolution {
+    Resolved(StackPullRequestIdentity),
+    Unresolved {
+        edge: StackParentEdge,
+        reason: StackParentUnresolvedReason,
+    },
+}
+
+/// Open pull-request heads indexed by full fork-qualified branch identity.
+#[derive(Debug, Default)]
+pub(crate) struct StackParentIndex {
+    exact: HashMap<StackParentEdge, Vec<StackPullRequestIdentity>>,
+    incomplete_branches: HashSet<(StackRepositoryIdentity, String)>,
+    incomplete_repositories: HashSet<StackRepositoryIdentity>,
+}
+
+impl StackParentIndex {
+    pub(crate) fn new(candidates: impl IntoIterator<Item = StackParentCandidate>) -> Self {
+        let mut index = Self::default();
+        for candidate in candidates {
+            if !candidate.open {
+                continue;
+            }
+            match (candidate.head_repository, candidate.head_branch) {
+                (Some(head_repository), Some(head_branch)) if !head_branch.is_empty() => {
+                    let edge = StackParentEdge {
+                        base_repository: candidate.pull_request.base_repository.clone(),
+                        head_repository: Some(head_repository),
+                        head_branch,
+                    };
+                    index
+                        .exact
+                        .entry(edge)
+                        .or_default()
+                        .push(candidate.pull_request);
+                }
+                (None, Some(head_branch)) if !head_branch.is_empty() => {
+                    index
+                        .incomplete_branches
+                        .insert((candidate.pull_request.base_repository, head_branch));
+                }
+                _ => {
+                    index
+                        .incomplete_repositories
+                        .insert(candidate.pull_request.base_repository);
+                }
+            }
+        }
+        for candidates in index.exact.values_mut() {
+            candidates.sort();
+            candidates.dedup();
+        }
+        index
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        edge: &StackParentEdge,
+        child: Option<&StackPullRequestIdentity>,
+    ) -> StackParentResolution {
+        if edge.head_repository.is_none() {
+            return StackParentResolution::Unresolved {
+                edge: edge.clone(),
+                reason: StackParentUnresolvedReason::IncompleteHostIdentity,
+            };
+        }
+        let mut candidates = self.exact.get(edge).cloned().unwrap_or_default();
+        if let Some(child) = child {
+            candidates.retain(|candidate| candidate != child);
+        }
+        let incomplete = self.incomplete_repositories.contains(&edge.base_repository)
+            || self
+                .incomplete_branches
+                .contains(&(edge.base_repository.clone(), edge.head_branch.clone()));
+        let reason = if incomplete {
+            StackParentUnresolvedReason::IncompleteHostIdentity
+        } else if candidates.is_empty() {
+            StackParentUnresolvedReason::MissingParent
+        } else if candidates.len() == 1 {
+            return StackParentResolution::Resolved(
+                candidates
+                    .pop()
+                    .expect("a one-candidate stack edge has a parent"),
+            );
+        } else {
+            StackParentUnresolvedReason::Ambiguous { candidates }
+        };
+        StackParentResolution::Unresolved {
+            edge: edge.clone(),
+            reason,
+        }
+    }
+}
+
+/// Compatibility view for durable-only watch and trigger lookups.
+///
+/// Durable facts do not carry the head repository, so they cannot form a
+/// fork-qualified [`StackParentEdge`]. Keep the established unique-branch
+/// lookup for those callers, but refuse duplicate branch candidates instead
+/// of letting iteration order choose one.
 pub(crate) fn stack_parents_by_head(facts: &[CodePullRequestFact]) -> HashMap<String, u64> {
-    facts
+    let mut candidates: HashMap<String, Option<u64>> = HashMap::new();
+    for fact in facts
         .iter()
         .filter(|fact| fact.state == CodePullRequestState::Open && !fact.head_branch.is_empty())
-        .map(|fact| (fact.head_branch.clone(), fact.number))
+    {
+        candidates
+            .entry(fact.head_branch.clone())
+            .and_modify(|number| *number = None)
+            .or_insert(Some(fact.number));
+    }
+    candidates
+        .into_iter()
+        .filter_map(|(branch, number)| number.map(|number| (branch, number)))
         .collect()
 }
 
@@ -251,6 +436,40 @@ pub(crate) fn stack_parents_by_head(facts: &[CodePullRequestFact]) -> HashMap<St
 mod tests {
     use super::*;
     use tidebreak_core::CodePullRequestId;
+
+    fn repository(owner: &str, name: &str) -> StackRepositoryIdentity {
+        StackRepositoryIdentity::new("github.com", owner, name).unwrap()
+    }
+
+    fn parent(
+        number: u64,
+        base_repository: &StackRepositoryIdentity,
+        head_repository: Option<&StackRepositoryIdentity>,
+        head_branch: Option<&str>,
+    ) -> StackParentCandidate {
+        StackParentCandidate {
+            pull_request: StackPullRequestIdentity {
+                base_repository: base_repository.clone(),
+                number,
+            },
+            open: true,
+            head_repository: head_repository.cloned(),
+            head_branch: head_branch.map(str::to_owned),
+        }
+    }
+
+    fn edge(
+        base_repository: &StackRepositoryIdentity,
+        head_repository: &StackRepositoryIdentity,
+        head_branch: &str,
+    ) -> StackParentEdge {
+        StackParentEdge::new(
+            base_repository.clone(),
+            Some(head_repository.clone()),
+            head_branch,
+        )
+        .unwrap()
+    }
 
     fn fact(number: u64, head: &str, state: CodePullRequestState) -> CodePullRequestFact {
         CodePullRequestFact {
@@ -279,14 +498,143 @@ mod tests {
     }
 
     #[test]
-    fn only_open_heads_parent_a_stack() {
-        let parents = stack_parents_by_head(&[
-            fact(1, "feat/base", CodePullRequestState::Open),
-            fact(2, "feat/merged-away", CodePullRequestState::Merged),
-            fact(3, "", CodePullRequestState::Open),
+    fn same_named_fork_heads_resolve_to_the_requested_fork() {
+        let base = repository("acme", "tools");
+        let alice = repository("alice", "tools");
+        let bob = repository("bob", "tools");
+        let index = StackParentIndex::new([
+            parent(41, &base, Some(&alice), Some("stack/base")),
+            parent(42, &base, Some(&bob), Some("stack/base")),
         ]);
-        assert_eq!(parents.get("feat/base"), Some(&1));
-        assert!(!parents.contains_key("feat/merged-away"));
-        assert!(!parents.contains_key(""));
+
+        assert_eq!(
+            index.resolve(&edge(&base, &bob, "stack/base"), None),
+            StackParentResolution::Resolved(StackPullRequestIdentity {
+                base_repository: base,
+                number: 42,
+            })
+        );
+    }
+
+    #[test]
+    fn same_named_heads_in_different_base_repositories_stay_isolated() {
+        let tools = repository("acme", "tools");
+        let web = repository("acme", "web");
+        let index = StackParentIndex::new([
+            parent(51, &tools, Some(&tools), Some("stack/base")),
+            parent(61, &web, Some(&web), Some("stack/base")),
+        ]);
+
+        assert_eq!(
+            index.resolve(&edge(&web, &web, "stack/base"), None),
+            StackParentResolution::Resolved(StackPullRequestIdentity {
+                base_repository: web,
+                number: 61,
+            })
+        );
+    }
+
+    #[test]
+    fn renamed_and_deleted_parent_branches_stay_unresolved() {
+        let base = repository("acme", "tools");
+        let other_fork = repository("other", "tools");
+        let renamed = StackParentIndex::new([
+            parent(71, &base, Some(&base), Some("stack/renamed")),
+            parent(72, &base, Some(&other_fork), Some("stack/base")),
+        ]);
+        assert_eq!(
+            renamed.resolve(&edge(&base, &base, "stack/base"), None),
+            StackParentResolution::Unresolved {
+                edge: edge(&base, &base, "stack/base"),
+                reason: StackParentUnresolvedReason::MissingParent,
+            }
+        );
+
+        let deleted = StackParentIndex::new([parent(73, &base, None, Some("stack/base"))]);
+        assert_eq!(
+            deleted.resolve(&edge(&base, &base, "stack/base"), None),
+            StackParentResolution::Unresolved {
+                edge: edge(&base, &base, "stack/base"),
+                reason: StackParentUnresolvedReason::IncompleteHostIdentity,
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_parent_candidates_are_explicit_and_deterministic() {
+        let base = repository("acme", "tools");
+        let index = StackParentIndex::new([
+            parent(82, &base, Some(&base), Some("stack/base")),
+            parent(81, &base, Some(&base), Some("stack/base")),
+        ]);
+
+        assert_eq!(
+            index.resolve(&edge(&base, &base, "stack/base"), None),
+            StackParentResolution::Unresolved {
+                edge: edge(&base, &base, "stack/base"),
+                reason: StackParentUnresolvedReason::Ambiguous {
+                    candidates: vec![
+                        StackPullRequestIdentity {
+                            base_repository: base.clone(),
+                            number: 81,
+                        },
+                        StackPullRequestIdentity {
+                            base_repository: base,
+                            number: 82,
+                        },
+                    ],
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn an_incomplete_edge_stays_explicitly_unresolved() {
+        let base = repository("acme", "tools");
+        let index = StackParentIndex::new([parent(83, &base, Some(&base), Some("stack/base"))]);
+        let incomplete = StackParentEdge::new(base, None, "stack/base").unwrap();
+
+        assert_eq!(
+            index.resolve(&incomplete, None),
+            StackParentResolution::Unresolved {
+                edge: incomplete,
+                reason: StackParentUnresolvedReason::IncompleteHostIdentity,
+            }
+        );
+    }
+
+    #[test]
+    fn durable_branch_compatibility_drops_ambiguous_heads() {
+        let parents = stack_parents_by_head(&[
+            fact(1, "stack/base", CodePullRequestState::Open),
+            fact(2, "stack/base", CodePullRequestState::Open),
+            fact(3, "stack/unique", CodePullRequestState::Open),
+            fact(4, "stack/closed", CodePullRequestState::Closed),
+        ]);
+
+        assert!(!parents.contains_key("stack/base"));
+        assert_eq!(parents.get("stack/unique"), Some(&3));
+        assert!(!parents.contains_key("stack/closed"));
+    }
+
+    #[test]
+    fn closed_heads_and_self_edges_do_not_parent_a_stack() {
+        let base = repository("acme", "tools");
+        let mut closed = parent(91, &base, Some(&base), Some("stack/base"));
+        closed.open = false;
+        let child = StackPullRequestIdentity {
+            base_repository: base.clone(),
+            number: 92,
+        };
+        let index =
+            StackParentIndex::new([closed, parent(92, &base, Some(&base), Some("stack/base"))]);
+
+        assert_eq!(
+            index.resolve(&edge(&base, &base, "stack/base"), Some(&child)),
+            StackParentResolution::Unresolved {
+                edge: edge(&base, &base, "stack/base"),
+                reason: StackParentUnresolvedReason::MissingParent,
+            }
+        );
     }
 }

--- a/crates/tidebreak-server/src/code/reconcile.rs
+++ b/crates/tidebreak-server/src/code/reconcile.rs
@@ -409,29 +409,6 @@ impl StackParentIndex {
     }
 }
 
-/// Compatibility view for durable-only watch and trigger lookups.
-///
-/// Durable facts do not carry the head repository, so they cannot form a
-/// fork-qualified [`StackParentEdge`]. Keep the established unique-branch
-/// lookup for those callers, but refuse duplicate branch candidates instead
-/// of letting iteration order choose one.
-pub(crate) fn stack_parents_by_head(facts: &[CodePullRequestFact]) -> HashMap<String, u64> {
-    let mut candidates: HashMap<String, Option<u64>> = HashMap::new();
-    for fact in facts
-        .iter()
-        .filter(|fact| fact.state == CodePullRequestState::Open && !fact.head_branch.is_empty())
-    {
-        candidates
-            .entry(fact.head_branch.clone())
-            .and_modify(|number| *number = None)
-            .or_insert(Some(fact.number));
-    }
-    candidates
-        .into_iter()
-        .filter_map(|(branch, number)| number.map(|number| (branch, number)))
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -601,20 +578,6 @@ mod tests {
                 reason: StackParentUnresolvedReason::IncompleteHostIdentity,
             }
         );
-    }
-
-    #[test]
-    fn durable_branch_compatibility_drops_ambiguous_heads() {
-        let parents = stack_parents_by_head(&[
-            fact(1, "stack/base", CodePullRequestState::Open),
-            fact(2, "stack/base", CodePullRequestState::Open),
-            fact(3, "stack/unique", CodePullRequestState::Open),
-            fact(4, "stack/closed", CodePullRequestState::Closed),
-        ]);
-
-        assert!(!parents.contains_key("stack/base"));
-        assert_eq!(parents.get("stack/unique"), Some(&3));
-        assert!(!parents.contains_key("stack/closed"));
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/trigger.rs
+++ b/crates/tidebreak-server/src/code/trigger.rs
@@ -525,7 +525,6 @@ async fn sweep_pull_requests(
                 continue;
             }
         };
-        let parents = super::reconcile::stack_parents_by_head(&repo_facts);
         let mut stale = Vec::new();
         for number in numbers {
             let fresh = repo_facts.iter().find(|fact| {
@@ -540,12 +539,8 @@ async fn sweep_pull_requests(
                 continue;
             };
             let digest = super::pr_facts::digest_from_fact(fact);
-            let stack_parent = parents
-                .get(&fact.base_branch)
-                .copied()
-                .filter(|parent| *parent != fact.number);
             for work in repository_work {
-                claim_fires_from_row(runtime, owner, work, &digest, stack_parent).await;
+                claim_fires_from_row(runtime, owner, work, &digest).await;
             }
         }
         if !stale.is_empty() {
@@ -617,7 +612,6 @@ async fn claim_fires_from_row(
     owner: &OwnerId,
     work: &RepositoryWork,
     digest: &PullRequestDigest,
-    stack_parent: Option<u64>,
 ) {
     // Without a head SHA the fire cannot be fingerprinted, and a fire that
     // cannot be bounded would repeat every tick.
@@ -627,22 +621,6 @@ async fn claim_fires_from_row(
     let Some(condition) = classify_trigger_condition(digest) else {
         return;
     };
-    // A stacked child is behind or blocked *because of its parent*
-    // (decision 62). Firing Behind or ReviewRequired at it would send an
-    // agent to rebase onto a branch that moves with every parent push.
-    if stack_parent.is_some()
-        && matches!(
-            condition,
-            CodeTriggerCondition::Behind | CodeTriggerCondition::ReviewRequired
-        )
-    {
-        debug!(
-            number = digest.number,
-            parent = stack_parent,
-            "code-mode trigger held a stacked child's fire"
-        );
-        return;
-    }
     let Some(workspaces) = work.workspaces_by_number.get(&digest.number) else {
         return;
     };

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -22,7 +22,7 @@ use tracing::warn;
 
 use tidebreak_core::db::code::{
     get_session, insert_watch, latest_watch_for_workspace, list_active_watches_all_owners,
-    list_pull_request_facts_for_repo, list_sessions_for_workspace, save_watch,
+    list_sessions_for_workspace, save_watch,
 };
 use tidebreak_core::{
     Attention, AttentionSource, AttentionState, CodeSessionKind, CodeSessionLifecycle, CodeWatch,
@@ -533,21 +533,6 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
             Ok(())
         }
         WatchAssessment::Actionable(reason) => {
-            if reason == WatchReason::Behind {
-                // A stacked child is behind *because of its parent*: rebasing
-                // onto a branch that moves with every parent push never
-                // settles (decision 62). Park until the parent lands.
-                if let Some(parent) =
-                    stacked_parent_number(runtime.as_ref(), &owner, watch.workspace_id, &pr).await
-                {
-                    return park_watch(
-                        runtime.as_ref(),
-                        watch,
-                        &format!("waiting on its parent pull request #{parent}"),
-                    )
-                    .await;
-                }
-            }
             let same_head = watch.last_fix_head.is_some()
                 && watch.last_fix_head.as_deref() == pr.head_sha.as_deref();
             if same_head {
@@ -660,42 +645,6 @@ fn settled_watch_block_attention(watch: &CodeWatch, current: &Attention) -> Opti
         )),
         _ => None,
     }
-}
-
-/// The open pull request this workspace's pull request is stacked on, when
-/// the durable fact set knows one (decision 62). `None` on any missing link
-/// — no base branch, unresolved origin, or a store failure — so the watch
-/// behaves exactly as before when the answer is unknown.
-pub(crate) async fn stacked_parent_number(
-    runtime: &CodeRuntime,
-    owner: &OwnerId,
-    workspace_id: WorkspaceId,
-    pr: &PullRequestDigest,
-) -> Option<u64> {
-    let base_branch = pr.base_branch.as_deref()?;
-    let workspace = runtime.get_workspace(owner, workspace_id).await.ok()?;
-    let repo = runtime.get_repo(owner, workspace.repo_id).await.ok()?;
-    let (host, repo_owner, repo_name) =
-        match (&repo.origin_host, &repo.origin_owner, &repo.origin_name) {
-            (Some(host), Some(repo_owner), Some(repo_name)) => {
-                (host.clone(), repo_owner.clone(), repo_name.clone())
-            }
-            _ => {
-                let target = super::delivery::repository_target_from_local(&repo)
-                    .await
-                    .ok()?;
-                (target.host, target.owner, target.name)
-            }
-        };
-    let facts =
-        list_pull_request_facts_for_repo(&runtime.db, owner, &host, &repo_owner, &repo_name)
-            .await
-            .ok()?;
-    let parents = super::reconcile::stack_parents_by_head(&facts);
-    parents
-        .get(base_branch)
-        .copied()
-        .filter(|parent| *parent != pr.number)
 }
 
 /// Park a watch as blocked with a reason, surfacing `NeedsYou` once.

--- a/crates/tidebreak-server/src/tests/code_reconcile.rs
+++ b/crates/tidebreak-server/src/tests/code_reconcile.rs
@@ -22,7 +22,96 @@ use tidebreak_core::{
 };
 use tidebreak_harness::AdapterRegistry;
 
-const LIST_JSON: &str = r#"[{"number":412,"url":"https://github.com/acme/tools/pull/412","state":"OPEN","title":"Tracked work","isDraft":false,"author":{"login":"octocat"},"reviewDecision":null,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","autoMergeRequest":null,"headRefName":"tidebreak/tracked","headRefOid":"aaa111","baseRefName":"main","updatedAt":"2026-08-22T12:00:00Z","createdAt":"2026-08-22T10:00:00Z","mergedAt":null,"closedAt":null,"labels":[]},{"number":500,"url":"https://github.com/acme/tools/pull/500","state":"OPEN","title":"Somebody else","isDraft":false,"author":{"login":"stranger"},"reviewDecision":null,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","autoMergeRequest":null,"headRefName":"tidebreak/fuzzy","headRefOid":"bbb222","baseRefName":"main","updatedAt":"2026-08-22T12:00:00Z","createdAt":"2026-08-22T11:00:00Z","mergedAt":null,"closedAt":null,"labels":[]},{"number":413,"url":"https://github.com/acme/tools/pull/413","state":"OPEN","title":"Stacked child","isDraft":false,"author":{"login":"octocat"},"reviewDecision":null,"mergeable":"MERGEABLE","mergeStateStatus":"BEHIND","autoMergeRequest":null,"headRefName":"tidebreak/tracked-child","headRefOid":"ccc333","baseRefName":"tidebreak/tracked","updatedAt":"2026-08-22T12:30:00Z","createdAt":"2026-08-22T12:00:00Z","mergedAt":null,"closedAt":null,"labels":[]}]"#;
+const LIST_JSON: &str = r#"[
+  {
+    "number": 412,
+    "url": "https://github.com/acme/tools/pull/412",
+    "state": "OPEN",
+    "title": "Tracked work",
+    "isDraft": false,
+    "author": {"login": "octocat"},
+    "reviewDecision": null,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "autoMergeRequest": null,
+    "headRepository": {"name": "tools", "nameWithOwner": "acme/tools"},
+    "headRepositoryOwner": {"login": "acme"},
+    "headRefName": "tidebreak/tracked",
+    "headRefOid": "aaa111",
+    "baseRefName": "main",
+    "updatedAt": "2026-08-22T12:00:00Z",
+    "createdAt": "2026-08-22T10:00:00Z",
+    "mergedAt": null,
+    "closedAt": null,
+    "labels": []
+  },
+  {
+    "number": 414,
+    "url": "https://github.com/acme/tools/pull/414",
+    "state": "OPEN",
+    "title": "Same branch from another fork",
+    "isDraft": false,
+    "author": {"login": "other"},
+    "reviewDecision": null,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "autoMergeRequest": null,
+    "headRepository": {"name": "tools", "nameWithOwner": "other/tools"},
+    "headRepositoryOwner": {"login": "other"},
+    "headRefName": "tidebreak/tracked",
+    "headRefOid": "ddd444",
+    "baseRefName": "main",
+    "updatedAt": "2026-08-22T12:15:00Z",
+    "createdAt": "2026-08-22T11:30:00Z",
+    "mergedAt": null,
+    "closedAt": null,
+    "labels": []
+  },
+  {
+    "number": 500,
+    "url": "https://github.com/acme/tools/pull/500",
+    "state": "OPEN",
+    "title": "Somebody else",
+    "isDraft": false,
+    "author": {"login": "stranger"},
+    "reviewDecision": null,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "autoMergeRequest": null,
+    "headRepository": {"name": "tools", "nameWithOwner": "acme/tools"},
+    "headRepositoryOwner": {"login": "acme"},
+    "headRefName": "tidebreak/fuzzy",
+    "headRefOid": "bbb222",
+    "baseRefName": "main",
+    "updatedAt": "2026-08-22T12:00:00Z",
+    "createdAt": "2026-08-22T11:00:00Z",
+    "mergedAt": null,
+    "closedAt": null,
+    "labels": []
+  },
+  {
+    "number": 413,
+    "url": "https://github.com/acme/tools/pull/413",
+    "state": "OPEN",
+    "title": "Stacked child",
+    "isDraft": false,
+    "author": {"login": "octocat"},
+    "reviewDecision": null,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "BEHIND",
+    "autoMergeRequest": null,
+    "headRepository": {"name": "tools", "nameWithOwner": "acme/tools"},
+    "headRepositoryOwner": {"login": "acme"},
+    "headRefName": "tidebreak/tracked-child",
+    "headRefOid": "ccc333",
+    "baseRefName": "tidebreak/tracked",
+    "updatedAt": "2026-08-22T12:30:00Z",
+    "createdAt": "2026-08-22T12:00:00Z",
+    "mergedAt": null,
+    "closedAt": null,
+    "labels": []
+  }
+]"#;
 
 fn write_executable(path: &std::path::Path, body: &str) {
     std::fs::write(path, body).unwrap();
@@ -208,7 +297,7 @@ async fn the_sweep_persists_facts_and_mints_exact_attribution_only() {
 
     crate::code::reconcile::sweep_reconcile(&runtime).await;
 
-    // Both listed pull requests were read, but only the tracked one — the
+    // All listed pull requests were read, but only the tracked one — the
     // exact number tier — persisted and minted.
     let fact = get_pull_request_fact(&db, &owner, "github.com", "acme", "tools", 412)
         .await
@@ -305,10 +394,9 @@ async fn a_delivery_read_serves_durable_links_with_the_relation() {
     assert!(link.exact);
     assert_eq!(link.relation, Some(CodePullRequestRelation::Contributed));
 
-    // Stack annotation rides the durable fact set: the child's base branch is
-    // the tracked pull request's head, so it points at its parent even though
-    // the child itself holds no fact row; the parent, based on main, points
-    // at nothing.
+    // Stack annotation uses the host's fork-qualified head identity. PR 414
+    // has the same branch from another fork, so the child still selects 412;
+    // the parent, based on the default branch, points at nothing.
     let child = page
         .items
         .iter()

--- a/crates/tidebreak-server/src/tests/code_trigger_facts.rs
+++ b/crates/tidebreak-server/src/tests/code_trigger_facts.rs
@@ -2,9 +2,9 @@
 //!
 //! These drive the real sweeps against a shimmed `gh`: the reconcile sweep
 //! seeds durable facts, then the trigger sweep fires `pr_opened` and
-//! `pr_updated` from the local store — no host read — and holds a stacked
-//! child's `behind` fire. Deliveries stay pending throughout because the
-//! fixture runs no sessions; the rows are the assertions.
+//! `pr_updated` from the local store with no host read. Durable facts do not
+//! guess stack parents because they do not record the head repository.
+//! Deliveries stay pending because the fixture runs no sessions.
 
 use super::*;
 
@@ -329,7 +329,7 @@ async fn pr_updated_baselines_then_fires_on_a_new_head() {
 }
 
 #[tokio::test]
-async fn a_stacked_child_holds_behind_fires_and_parks_the_watch_lookup() {
+async fn durable_facts_do_not_guess_stack_parents_from_branch_names() {
     let (_dir, runtime, db, repo_id, _tracked, child) = seeded_runtime().await;
     let owner = OwnerId::local();
     let trigger = armed(&db, &owner, repo_id, CodeTriggerCondition::Behind).await;
@@ -337,27 +337,10 @@ async fn a_stacked_child_holds_behind_fires_and_parks_the_watch_lookup() {
     crate::code::reconcile::sweep_reconcile(&runtime).await;
     crate::code::trigger::sweep_triggers(&runtime).await;
 
-    // PR 413 is BEHIND, but its base is PR 412's head: the fire is held.
+    // PR 413 uses PR 412's branch as its base. The durable rows do not record
+    // either head repository, so the sweep must not infer that relationship.
     let heads = trigger_fire_heads_for_pr(&db, &owner, trigger, child, 413)
         .await
         .unwrap();
-    assert!(heads.is_empty(), "a stacked child must not fire behind");
-
-    // The watch-side lookup resolves the same parent from the fact set.
-    let digest = PullRequestDigest {
-        base_branch: Some("tidebreak/tracked".into()),
-        ..open_pr_digest(413)
-    };
-    assert_eq!(
-        crate::code::watch::stacked_parent_number(&runtime, &owner, child, &digest).await,
-        Some(412)
-    );
-    let rooted = PullRequestDigest {
-        base_branch: Some("main".into()),
-        ..open_pr_digest(413)
-    };
-    assert_eq!(
-        crate::code::watch::stacked_parent_number(&runtime, &owner, child, &rooted).await,
-        None
-    );
+    assert_eq!(heads, vec!["ccc333".to_owned()]);
 }


### PR DESCRIPTION
## Implementation

- Fetch each pull request head repository and owner with the existing delivery query.
- Resolve stack parents by base repository, head repository, and branch instead of branch name alone.
- Keep incomplete, missing, and ambiguous parent identities unresolved.
- Preserve the durable-fact compatibility path while refusing ambiguous branch matches.
- Cover same-named fork branches, repository isolation, renamed or deleted branches, duplicate candidates, incomplete host data, closed parents, and self-edges.

## Compatibility

The public delivery response keeps the existing `stack_parent_number` field. Existing durable facts remain readable and do not require a migration. Pull requests with complete host identity keep resolving to the same parent when the branch match is unique.

## Safety and risk

The change fails closed when GitHub omits fork identity or when more than one parent can match. This can leave a stack edge unresolved instead of attaching it to the wrong pull request. The main risk is reduced stack annotation for incomplete legacy observations; the durable compatibility lookup still handles unique branch names.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Per repository guidance, Rust compilation and tests are left to continuous integration.