### PR TITLE
test(desktop): stabilize pairing nudge coverage

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -84,6 +84,7 @@ function HostedGatewayProbe() {
 
 afterEach(() => {
   cleanup();
+  pairingNudge.fire = null;
   vi.clearAllMocks();
   vi.useRealTimers();
   vi.unstubAllGlobals();
@@ -542,6 +543,12 @@ describe("ManagedGate", () => {
     mount(client);
     expect(await screen.findByText("the open product")).toBeInTheDocument();
     await waitFor(() => expect(pairingNudge.fire).not.toBeNull());
+
+    // The pairing listener is attached in an effect after the first
+    // resolved-policy render. Wait for it so the nudge is not a no-op.
+    await waitFor(() => {
+      expect(pairingNudge.fire).toEqual(expect.any(Function));
+    });
 
     // No timer advance: the nudge alone must refetch and lower the gate.
     await act(async () => {


### PR DESCRIPTION
## What changed

- Reset the pairing nudge test hook after each ManagedGate test.
- Wait until the pairing listener is attached before firing the nudge in the policy-refresh test.

## Backwards compatibility

This changes test synchronization only. Production code and behavior are unchanged.

## Safety and risk

The test now waits on the observable listener registration instead of racing the effect that installs it. The hook reset prevents one test from leaking a callback into the next test.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/ManagedGate.dom.test.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/ManagedGate.dom.test.tsx`
- `git diff --check`