### PR TITLE
fix(code): reconcile replay turn state

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SequencedCodeEventFrame } from "../api/types";
-import { CodeSessionController } from "./CodeSessionController";
+import {
+  CodeSessionController,
+  INITIAL_RECONNECT_DELAY_MS,
+  MAX_RECONNECT_DELAY_MS,
+} from "./CodeSessionController";
 
 class FakeSocket {
   onopen: (() => void) | null = null;
@@ -154,6 +158,103 @@ describe("CodeSessionController", () => {
       },
     ]);
 
+    controller.dispose();
+  });
+
+  it("keeps a capped-window marker while compacting adjacent replay deltas", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const batches: (readonly SequencedCodeEventFrame[])[] = [];
+    const controller = new CodeSessionController({
+      openSocket: (_after, onFrame) => {
+        const socket = new FakeSocket(onFrame);
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+      getAfter: () => 0,
+      onEvents: (events) => batches.push(events),
+      onConnectionState: () => undefined,
+    });
+    controller.start();
+
+    sockets[0]?.emit({
+      seq: 2_000,
+      replayed: true,
+      truncated: true,
+      event: { type: "reasoning_delta", text: "First " },
+    });
+    sockets[0]?.emit({
+      seq: 2_001,
+      replayed: true,
+      event: { type: "reasoning_delta", text: "retained thought" },
+    });
+
+    await vi.runAllTimersAsync();
+
+    expect(batches).toEqual([
+      [
+        {
+          seq: 2_001,
+          replayed: true,
+          truncated: true,
+          event: {
+            type: "reasoning_delta",
+            text: "First retained thought",
+          },
+        },
+      ],
+    ]);
+
+    controller.dispose();
+  });
+
+  it("retries pending turn snapshots with bounded backoff", async () => {
+    vi.useFakeTimers();
+    let pending = false;
+    let attempts = 0;
+    const refreshTurns = vi.fn(async () => {
+      attempts += 1;
+      if (attempts < 8) throw new Error("offline");
+      return [];
+    });
+    const controller = new CodeSessionController({
+      openSocket: (_after, onFrame) =>
+        new FakeSocket(onFrame) as unknown as WebSocket,
+      getAfter: () => 0,
+      onEvents: () => undefined,
+      onConnectionState: () => undefined,
+      refreshTurns,
+      onTurnRefresh: () => {
+        pending = false;
+      },
+      getPendingTurnRefreshes: () =>
+        pending ? [{ turnId: "t1", eventSeq: 1, observedSeq: 1 }] : [],
+    });
+    controller.start();
+    pending = true;
+    controller.requestTurnRefresh();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(refreshTurns).toHaveBeenCalledTimes(1);
+    const delays = [
+      INITIAL_RECONNECT_DELAY_MS,
+      500,
+      1_000,
+      2_000,
+      4_000,
+      MAX_RECONNECT_DELAY_MS,
+      MAX_RECONNECT_DELAY_MS,
+    ];
+    for (const [index, delay] of delays.entries()) {
+      await vi.advanceTimersByTimeAsync(delay - 1);
+      expect(refreshTurns).toHaveBeenCalledTimes(index + 1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(refreshTurns).toHaveBeenCalledTimes(index + 2);
+    }
+
+    expect(pending).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
     controller.dispose();
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
@@ -228,7 +228,16 @@ describe("CodeSessionController", () => {
         pending = false;
       },
       getPendingTurnRefreshes: () =>
-        pending ? [{ turnId: "t1", eventSeq: 1, observedSeq: 1 }] : [],
+        pending
+          ? [
+              {
+                turnId: "t1",
+                eventSeq: 1,
+                observedSeq: 1,
+                observedTurnActivityRevision: 0,
+              },
+            ]
+          : [],
     });
     controller.start();
     pending = true;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -7,6 +7,13 @@ import {
 
 export type CodeConnectionState = "live" | "reconnecting";
 
+export type CodeTurnRefreshRequest = {
+  turnId: string | null;
+  eventSeq: number;
+  /** Journal cursor captured when this refresh generation started. */
+  observedSeq: number;
+};
+
 /** A brief quiet window means the initial journal burst has reached its tail. */
 export const CODE_REPLAY_SETTLE_MS = 40;
 
@@ -38,6 +45,13 @@ export type CodeSessionControllerOptions = {
    */
   hydrateTurns?: () => Promise<CodeTurnSnapshot[]>;
   onHydrate?: (turns: CodeTurnSnapshot[]) => void;
+  /** Read durable turns again when replay leaves a terminal unresolved. */
+  refreshTurns?: () => Promise<CodeTurnSnapshot[]>;
+  onTurnRefresh?: (
+    turns: CodeTurnSnapshot[],
+    requested: readonly CodeTurnRefreshRequest[],
+  ) => void;
+  getPendingTurnRefreshes?: () => readonly CodeTurnRefreshRequest[];
 };
 
 /**
@@ -63,11 +77,16 @@ export class CodeSessionController {
   private socket: WebSocket | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+  private turnRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private turnRefreshInFlight = false;
+  private turnRefreshRequested = false;
+  private turnRefreshDelayMs = INITIAL_RECONNECT_DELAY_MS;
   private replayFrames: SequencedCodeEventFrame[] = [];
   private replayDelta: {
     type: "assistant_delta" | "reasoning_delta";
     seq: number;
     chunks: string[];
+    truncated: boolean;
   } | null = null;
   private replayFlush: ReturnType<typeof setTimeout> | null = null;
   private initialViewSettled = false;
@@ -90,17 +109,101 @@ export class CodeSessionController {
       }
     }
     this.connect();
+    if (this.pendingTurnRefreshes().length > 0) this.scheduleTurnRefresh();
+  }
+
+  /** Try pending terminal reconciliation now, then retry with bounded backoff. */
+  requestTurnRefresh(): void {
+    if (
+      this.disposed ||
+      !this.options.refreshTurns ||
+      this.pendingTurnRefreshes().length === 0
+    ) {
+      return;
+    }
+    this.turnRefreshDelayMs = INITIAL_RECONNECT_DELAY_MS;
+    if (this.turnRefreshInFlight) {
+      this.turnRefreshRequested = true;
+      return;
+    }
+    if (this.turnRefreshTimer !== null) {
+      clearTimeout(this.turnRefreshTimer);
+      this.turnRefreshTimer = null;
+    }
+    this.refreshTurnsNow();
+  }
+
+  private refreshTurnsNow(): void {
+    if (
+      this.disposed ||
+      this.turnRefreshInFlight ||
+      !this.options.refreshTurns ||
+      this.pendingTurnRefreshes().length === 0
+    ) {
+      return;
+    }
+    const requested = this.pendingTurnRefreshes();
+    const refreshTurns = this.options.refreshTurns;
+    this.turnRefreshInFlight = true;
+    void Promise.resolve()
+      .then(() => refreshTurns())
+      .then((turns) => {
+        if (this.disposed) return;
+        this.options.onTurnRefresh?.(turns, requested);
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        this.turnRefreshInFlight = false;
+        if (this.disposed) return;
+        if (this.pendingTurnRefreshes().length === 0) {
+          this.turnRefreshRequested = false;
+          this.turnRefreshDelayMs = INITIAL_RECONNECT_DELAY_MS;
+        } else if (this.turnRefreshRequested) {
+          this.turnRefreshRequested = false;
+          this.turnRefreshDelayMs = INITIAL_RECONNECT_DELAY_MS;
+          this.refreshTurnsNow();
+        } else {
+          this.scheduleTurnRefresh();
+        }
+      });
+  }
+
+  private pendingTurnRefreshes(): readonly CodeTurnRefreshRequest[] {
+    return this.options.getPendingTurnRefreshes?.() ?? [];
+  }
+
+  private scheduleTurnRefresh(): void {
+    if (
+      this.disposed ||
+      this.turnRefreshTimer !== null ||
+      this.turnRefreshInFlight ||
+      !this.options.refreshTurns ||
+      this.pendingTurnRefreshes().length === 0
+    ) {
+      return;
+    }
+    const delay = this.turnRefreshDelayMs;
+    this.turnRefreshDelayMs = nextReconnectDelay(this.turnRefreshDelayMs);
+    this.turnRefreshTimer = setTimeout(() => {
+      this.turnRefreshTimer = null;
+      this.refreshTurnsNow();
+    }, delay);
   }
 
   /** Close the socket and silence every callback and pending timer, forever. */
   dispose(): void {
     this.disposed = true;
+    this.turnRefreshRequested = false;
     this.cancelReplayFlush();
     this.replayFrames = [];
     this.replayDelta = null;
     if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+    if (this.turnRefreshTimer !== null) {
+      clearTimeout(this.turnRefreshTimer);
+      this.turnRefreshTimer = null;
     }
     if (this.socket) {
       this.socket.close();
@@ -129,12 +232,14 @@ export class CodeSessionController {
       ) {
         previous.seq = frame.seq;
         previous.chunks.push(frame.event.text);
+        previous.truncated ||= frame.truncated === true;
       } else {
         this.flushReplayDelta();
         this.replayDelta = {
           type: frame.event.type,
           seq: frame.seq,
           chunks: [frame.event.text],
+          truncated: frame.truncated === true,
         };
       }
     } else {
@@ -164,6 +269,7 @@ export class CodeSessionController {
     this.replayFrames.push({
       seq: delta.seq,
       replayed: true,
+      ...(delta.truncated ? { truncated: true } : {}),
       event: { type: delta.type, text: delta.chunks.join("") },
     });
     this.replayDelta = null;

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -12,6 +12,8 @@ export type CodeTurnRefreshRequest = {
   eventSeq: number;
   /** Journal cursor captured when this refresh generation started. */
   observedSeq: number;
+  /** Live activity revision captured with the journal cursor. */
+  observedTurnActivityRevision: number;
 };
 
 /** A brief quiet window means the initial journal burst has reached its tail. */

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { CodeEvent, SequencedCodeEventFrame } from "../api/types";
 import {
   applyAcceptedTurn,
+  applyCodeTurnSnapshot,
   hydrateCodeTurns,
   initialCodeSessionState,
   mainAgentTranscriptItems,
   markCodeSessionHydrated,
+  reconcileCodeTurnSnapshot,
+  reconcilePendingCodeTurns,
   reduceCodeSessionEvent,
   subagentTranscriptItems,
   userItemId,
@@ -15,6 +18,10 @@ import {
 
 const NOW = "2026-08-15T12:00:00.000Z";
 const LATER = "2026-08-15T12:00:02.500Z";
+const LONG_TURN_START = "2026-08-15T20:41:23.000Z";
+const LONG_TURN_END = "2026-08-15T20:42:28.000Z";
+const FAST_REPLAY_START = "2026-08-15T20:45:00.000Z";
+const FAST_REPLAY_END = "2026-08-15T20:45:00.040Z";
 
 const NO_USAGE = {
   input_tokens: 10,
@@ -510,6 +517,1036 @@ const SNAPSHOT_TURN = {
 };
 
 describe("hydrate then replay", () => {
+  it("does not let a stale running snapshot reopen a completed turn", () => {
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce(NOW)
+      .mockReturnValue(LATER);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+    const started = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      framed(1, { type: "turn_started", turn_id: "t1" }),
+      clock,
+    );
+    const completed = reduceCodeSessionEvent(
+      started.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }),
+      clock,
+    );
+
+    const refreshed = applyCodeTurnSnapshot(completed.state, {
+      ...SNAPSHOT_TURN,
+      status: "running",
+      ended_at: undefined,
+    });
+
+    expect(refreshed).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      turnStartedAt: null,
+      lifecycle: "idle",
+    });
+    expect(refreshed.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+  });
+
+  it("does not let an older running snapshot replace a newer active turn", () => {
+    const clock: CodeSessionDeps = {
+      nextId: deps().nextId,
+      now: vi
+        .fn<() => string>()
+        .mockReturnValueOnce(NOW)
+        .mockReturnValueOnce(LATER)
+        .mockReturnValue("2026-08-15T12:00:03.000Z"),
+    };
+    const t1Started = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      framed(1, { type: "turn_started", turn_id: "t1" }),
+      clock,
+    );
+    const t1Completed = reduceCodeSessionEvent(
+      t1Started.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }),
+      clock,
+    );
+    const t2Started = reduceCodeSessionEvent(
+      t1Completed.state,
+      framed(3, { type: "turn_started", turn_id: "t2" }),
+      clock,
+    );
+
+    const refreshed = applyCodeTurnSnapshot(t2Started.state, {
+      ...SNAPSHOT_TURN,
+      status: "running",
+      ended_at: undefined,
+    });
+
+    expect(refreshed).toMatchObject({
+      busy: true,
+      activeTurnId: "t2",
+      journalTurnId: "t2",
+      turnStartedAt: "2026-08-15T12:00:03.000Z",
+      lifecycle: "running",
+    });
+  });
+
+  it("keeps a long completed turn's durable duration during fast replay", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      {
+        ...SNAPSHOT_TURN,
+        started_at: LONG_TURN_START,
+        ended_at: LONG_TURN_END,
+      },
+    ]);
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce(FAST_REPLAY_START)
+      .mockReturnValue(FAST_REPLAY_END);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+
+    const started = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      clock,
+    );
+    const completed = reduceCodeSessionEvent(
+      started.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      clock,
+    );
+
+    expect(completed.state.items[0]).toMatchObject({
+      kind: "user",
+      createdAt: LONG_TURN_START,
+    });
+    expect(completed.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 65_000,
+    });
+    expect(now).not.toHaveBeenCalled();
+  });
+
+  it("keeps one durable boundary after duplicate replayed terminal events", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      {
+        ...SNAPSHOT_TURN,
+        started_at: LONG_TURN_START,
+        ended_at: LONG_TURN_END,
+      },
+    ]);
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce(FAST_REPLAY_START)
+      .mockReturnValue(FAST_REPLAY_END);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+    const started = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      clock,
+    );
+    const completed = reduceCodeSessionEvent(
+      started.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      clock,
+    );
+    const duplicate = reduceCodeSessionEvent(
+      completed.state,
+      framed(3, { type: "turn_completed", usage: NO_USAGE }, true),
+      clock,
+    );
+    const boundaries = duplicate.state.items.filter(
+      (item) => item.kind === "turn_boundary",
+    );
+
+    expect(boundaries).toHaveLength(1);
+    expect(boundaries[0]).toMatchObject({
+      turnId: "t1",
+      durationMs: 65_000,
+    });
+    expect(now).not.toHaveBeenCalled();
+  });
+
+  it("keeps replay duration unknown when the snapshot has no durable end", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, ended_at: undefined },
+    ]);
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce(FAST_REPLAY_START)
+      .mockReturnValue(FAST_REPLAY_END);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+    const started = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      clock,
+    );
+    const completed = reduceCodeSessionEvent(
+      started.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      clock,
+    );
+
+    expect(completed.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: null,
+    });
+    expect(now).not.toHaveBeenCalled();
+  });
+
+  it("requests and applies exact timing after a replay-only terminal", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, status: "running", ended_at: undefined },
+    ]);
+    const replayedStart = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      deps(),
+    );
+    const completed = reduceCodeSessionEvent(
+      replayedStart.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      deps(),
+    );
+
+    expect(completed.effects).toEqual([
+      { type: "turn_resolved" },
+      { type: "turn_snapshot_needed", turnId: "t1" },
+    ]);
+    expect(completed.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: null,
+    });
+
+    const reconciled = reconcileCodeTurnSnapshot(completed.state, {
+      ...SNAPSHOT_TURN,
+      started_at: LONG_TURN_START,
+      ended_at: LONG_TURN_END,
+    });
+    expect(reconciled).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      lifecycle: "idle",
+    });
+    expect(reconciled.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 65_000,
+    });
+  });
+
+  it("does not reopen an attributed terminal from a stale running hydration", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, status: "running", ended_at: undefined },
+    ]);
+    const replayedStart = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      deps(),
+    );
+    const completed = reduceCodeSessionEvent(
+      replayedStart.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      deps(),
+    );
+
+    const staleHydration = hydrateCodeTurns(completed.state, [
+      { ...SNAPSHOT_TURN, status: "running", ended_at: undefined },
+    ]);
+
+    expect(staleHydration).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      journalTurnId: null,
+      lifecycle: "idle",
+    });
+    expect(staleHydration.pendingTerminalReconciliations.get(2)).toMatchObject({
+      eventSeq: 2,
+      turnId: "t1",
+      status: "completed",
+    });
+  });
+
+  it("reconciles a capped terminal against the hydrated active turn", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      {
+        ...SNAPSHOT_TURN,
+        id: "t2",
+        ordinal: 2,
+        status: "running",
+        user_input: "run the tests",
+        ended_at: undefined,
+      },
+    ]);
+    const terminal = reduceCodeSessionEvent(
+      hydrated,
+      {
+        seq: 2_001,
+        replayed: true,
+        truncated: true,
+        event: { type: "turn_completed", usage: NO_USAGE },
+      },
+      deps(),
+    );
+
+    expect(terminal.state).toMatchObject({
+      lastSeq: 2_001,
+      busy: true,
+      activeTurnId: "t2",
+      journalTurnId: null,
+      lifecycle: "running",
+    });
+    expect(terminal.effects).toEqual([
+      { type: "turn_snapshot_needed", turnId: null },
+      { type: "turn_resolved" },
+    ]);
+
+    const reconciled = reconcilePendingCodeTurns(
+      terminal.state,
+      [
+        {
+          ...SNAPSHOT_TURN,
+          id: "t2",
+          ordinal: 2,
+          user_input: "run the tests",
+          started_at: NOW,
+          ended_at: LATER,
+        },
+      ],
+      [{ turnId: null, eventSeq: 2_001, observedSeq: 2_001 }],
+    );
+    expect(reconciled).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      journalTurnId: null,
+      turnStartedAt: null,
+      lifecycle: "idle",
+    });
+    expect(reconciled.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      durationMs: 2_500,
+    });
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(0);
+  });
+
+  it("keeps a capped failure error until the candidate snapshot confirms it", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      {
+        ...SNAPSHOT_TURN,
+        id: "t2",
+        ordinal: 2,
+        status: "running",
+        user_input: "run the tests",
+        ended_at: undefined,
+      },
+    ]);
+    const terminal = reduceCodeSessionEvent(
+      hydrated,
+      {
+        seq: 2_001,
+        replayed: true,
+        truncated: true,
+        event: {
+          type: "turn_failed",
+          error: { message: "compiler crashed: missing libssl" },
+        },
+      },
+      deps(),
+    );
+
+    expect(terminal.state.pendingTerminalReconciliations.get(2_001)).toEqual({
+      eventSeq: 2_001,
+      turnId: null,
+      candidateTurnId: "t2",
+      nextTurnId: null,
+      status: "failed",
+      usage: null,
+      error: "compiler crashed: missing libssl",
+      diffstat: null,
+      previousUsage: null,
+    });
+    expect(
+      terminal.state.items.find(
+        (item) => item.kind === "turn_boundary" && item.turnId === "t2",
+      ),
+    ).toBeUndefined();
+
+    const reconciled = hydrateCodeTurns(terminal.state, [
+      {
+        ...SNAPSHOT_TURN,
+        id: "t2",
+        ordinal: 2,
+        status: "failed",
+        user_input: "run the tests",
+        started_at: NOW,
+        ended_at: LATER,
+      },
+    ]);
+
+    expect(reconciled).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      lifecycle: "idle",
+    });
+    expect(reconciled.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      status: "failed",
+      durationMs: 2_500,
+      error: "compiler crashed: missing libssl",
+    });
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(0);
+  });
+
+  it("restores a capped failure after hydration already returned the terminal turn", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      {
+        ...SNAPSHOT_TURN,
+        id: "t2",
+        ordinal: 2,
+        status: "failed",
+        user_input: "run the tests",
+      },
+    ]);
+    const terminal = reduceCodeSessionEvent(
+      hydrated,
+      {
+        seq: 2_001,
+        replayed: true,
+        truncated: true,
+        event: {
+          type: "turn_failed",
+          error: { message: "compiler crashed: missing libssl" },
+        },
+      },
+      deps(),
+    );
+
+    const reconciled = reconcilePendingCodeTurns(
+      terminal.state,
+      [
+        {
+          ...SNAPSHOT_TURN,
+          id: "t2",
+          ordinal: 2,
+          status: "failed",
+          user_input: "run the tests",
+        },
+      ],
+      [{ turnId: null, eventSeq: 2_001, observedSeq: 2_001 }],
+    );
+
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(0);
+    expect(
+      reconciled.items.find(
+        (item) => item.kind === "turn_boundary" && item.turnId === "t2",
+      ),
+    ).toMatchObject({
+      status: "failed",
+      durationMs: 2_500,
+      error: "compiler crashed: missing libssl",
+    });
+  });
+
+  it("restores a capped failure when no initial turn snapshot was available", () => {
+    const terminal = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      {
+        seq: 2_001,
+        replayed: true,
+        truncated: true,
+        event: {
+          type: "turn_failed",
+          error: { message: "compiler crashed: missing libssl" },
+        },
+      },
+      deps(),
+    );
+
+    const reconciled = reconcilePendingCodeTurns(
+      terminal.state,
+      [
+        SNAPSHOT_TURN,
+        {
+          ...SNAPSHOT_TURN,
+          id: "t2",
+          ordinal: 2,
+          status: "failed",
+          user_input: "run the tests",
+        },
+      ],
+      [{ turnId: null, eventSeq: 2_001, observedSeq: 2_001 }],
+    );
+
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(0);
+    expect(reconciled.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      status: "failed",
+      error: "compiler crashed: missing libssl",
+    });
+  });
+
+  it("keeps a capped failure pending while its stale candidate still runs", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      {
+        ...SNAPSHOT_TURN,
+        id: "t2",
+        ordinal: 2,
+        status: "running",
+        user_input: "run the tests",
+        ended_at: undefined,
+      },
+    ]);
+    const terminal = reduceCodeSessionEvent(
+      hydrated,
+      {
+        seq: 2_001,
+        replayed: true,
+        truncated: true,
+        event: {
+          type: "turn_failed",
+          error: { message: "belongs to an older turn" },
+        },
+      },
+      deps(),
+    );
+
+    const reconciled = hydrateCodeTurns(terminal.state, [
+      {
+        ...SNAPSHOT_TURN,
+        status: "failed",
+      },
+      {
+        ...SNAPSHOT_TURN,
+        id: "t2",
+        ordinal: 2,
+        status: "running",
+        user_input: "run the tests",
+        ended_at: undefined,
+      },
+    ]);
+
+    expect(reconciled).toMatchObject({
+      busy: true,
+      activeTurnId: "t2",
+      lifecycle: "running",
+      contentRevision: 1,
+    });
+    expect(reconciled.pendingTerminalReconciliations.get(2_001)).toMatchObject({
+      turnId: null,
+      candidateTurnId: "t2",
+      status: "failed",
+      error: "belongs to an older turn",
+    });
+    expect(
+      reconciled.items.find(
+        (item) =>
+          item.kind === "turn_boundary" &&
+          item.error === "belongs to an older turn",
+      ),
+    ).toBeUndefined();
+    expect(
+      reconciled.items.find(
+        (item) => item.kind === "turn_boundary" && item.turnId === "t1",
+      ),
+    ).toMatchObject({ error: null });
+    expect(
+      reconciled.items.find(
+        (item) => item.kind === "turn_boundary" && item.turnId === "t2",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does not attribute capped replay output to a stale retained turn", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      {
+        ...SNAPSHOT_TURN,
+        id: "t1",
+        ordinal: 1,
+        status: "running",
+        user_input: "old work",
+        ended_at: undefined,
+      },
+    ]);
+    const output = reduceCodeSessionEvent(
+      hydrated,
+      {
+        seq: 2_000,
+        replayed: true,
+        truncated: true,
+        event: { type: "assistant_delta", text: "new turn output" },
+      },
+      deps(),
+    );
+    const terminal = reduceCodeSessionEvent(
+      output.state,
+      framed(
+        2_001,
+        { type: "turn_failed", error: { message: "new turn failed" } },
+        true,
+      ),
+      deps(),
+    );
+
+    const reconciled = reconcilePendingCodeTurns(
+      terminal.state,
+      [
+        {
+          ...SNAPSHOT_TURN,
+          id: "t1",
+          ordinal: 1,
+          status: "completed",
+          user_input: "old work",
+        },
+        {
+          ...SNAPSHOT_TURN,
+          id: "t2",
+          ordinal: 2,
+          status: "failed",
+          user_input: "new work",
+        },
+      ],
+      [{ turnId: null, eventSeq: 2_001, observedSeq: 2_001 }],
+    );
+
+    expect(
+      reconciled.items.find((item) => item.kind === "assistant"),
+    ).toMatchObject({ turnId: null, text: "new turn output" });
+    expect(
+      reconciled.items.find(
+        (item) => item.kind === "turn_boundary" && item.turnId === "t1",
+      ),
+    ).toMatchObject({ error: null });
+    expect(reconciled.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      error: "new turn failed",
+    });
+  });
+
+  it("inserts a recovered boundary before the following turn", () => {
+    const terminal = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      {
+        seq: 100,
+        replayed: true,
+        truncated: true,
+        event: { type: "turn_completed", usage: NO_USAGE },
+      },
+      deps(),
+    );
+    const started = reduceCodeSessionEvent(
+      terminal.state,
+      framed(101, { type: "turn_started", turn_id: "t2" }, true),
+      deps(),
+    );
+    const output = reduceCodeSessionEvent(
+      started.state,
+      framed(102, { type: "assistant_delta", text: "second turn" }, true),
+      deps(),
+    );
+
+    const reconciled = reconcilePendingCodeTurns(
+      output.state,
+      [
+        SNAPSHOT_TURN,
+        {
+          ...SNAPSHOT_TURN,
+          id: "t2",
+          ordinal: 2,
+          status: "running",
+          user_input: "run the tests",
+          ended_at: undefined,
+        },
+      ],
+      [{ turnId: null, eventSeq: 100, observedSeq: 102 }],
+    );
+
+    expect(reconciled.items.map((item) => item.id)).toEqual([
+      "notice:truncated-replay",
+      "user:t1",
+      "boundary:t1",
+      "user:t2",
+      "c1",
+    ]);
+    expect(reconciled).toMatchObject({
+      busy: true,
+      activeTurnId: "t2",
+      journalTurnId: "t2",
+    });
+  });
+
+  it("promotes confirmed replay usage when the snapshot omits usage", () => {
+    const usage = { ...NO_USAGE, input_tokens: 44, output_tokens: 12 };
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, status: "running", ended_at: undefined },
+    ]);
+    const started = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      deps(),
+    );
+    const terminal = reduceCodeSessionEvent(
+      started.state,
+      framed(2, { type: "turn_completed", usage }, true),
+      deps(),
+    );
+
+    expect(terminal.state.lastUsage).toBeNull();
+    const reconciled = reconcilePendingCodeTurns(
+      terminal.state,
+      [SNAPSHOT_TURN],
+      [{ turnId: "t1", eventSeq: 2, observedSeq: 2 }],
+    );
+
+    expect(reconciled.lastUsage).toEqual(usage);
+    expect(reconciled.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      usage,
+    });
+  });
+
+  it("uses a stale refresh for history without settling a newer live turn", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, status: "running", ended_at: undefined },
+    ]);
+    const started = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      deps(),
+    );
+    const terminal = reduceCodeSessionEvent(
+      started.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      deps(),
+    );
+    const newer = reduceCodeSessionEvent(
+      terminal.state,
+      framed(3, { type: "turn_started", turn_id: "t2" }),
+      deps(),
+    );
+
+    const reconciled = reconcilePendingCodeTurns(
+      newer.state,
+      [
+        {
+          ...SNAPSHOT_TURN,
+          started_at: LONG_TURN_START,
+          ended_at: LONG_TURN_END,
+        },
+        {
+          ...SNAPSHOT_TURN,
+          id: "t2",
+          ordinal: 2,
+          status: "running",
+          user_input: "run the tests",
+          ended_at: undefined,
+        },
+      ],
+      [{ turnId: "t1", eventSeq: 2, observedSeq: 2 }],
+    );
+
+    expect(reconciled).toMatchObject({
+      busy: true,
+      activeTurnId: "t2",
+      journalTurnId: "t2",
+      lifecycle: "running",
+    });
+    expect(
+      reconciled.items.find((item) => item.id === "boundary:t1"),
+    ).toMatchObject({ durationMs: 65_000 });
+  });
+
+  it("does not let an older terminal refresh settle a newer turn", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, status: "running", ended_at: undefined },
+    ]);
+    const replayedStart = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      deps(),
+    );
+    const completed = reduceCodeSessionEvent(
+      replayedStart.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      deps(),
+    );
+    const t2Started = reduceCodeSessionEvent(
+      completed.state,
+      framed(3, { type: "turn_started", turn_id: "t2" }),
+      deps(),
+    );
+
+    const reconciled = reconcileCodeTurnSnapshot(t2Started.state, {
+      ...SNAPSHOT_TURN,
+      started_at: LONG_TURN_START,
+      ended_at: LONG_TURN_END,
+    });
+
+    expect(reconciled).toMatchObject({
+      busy: true,
+      activeTurnId: "t2",
+      journalTurnId: "t2",
+      lifecycle: "running",
+    });
+    expect(
+      reconciled.items.find((item) => item.id === "boundary:t1"),
+    ).toMatchObject({
+      kind: "turn_boundary",
+      durationMs: 65_000,
+    });
+  });
+
+  it("clears stale activity when an authoritative snapshot has no running turn", () => {
+    const running = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, status: "running", ended_at: undefined },
+    ]);
+    const completed = hydrateCodeTurns(running, [SNAPSHOT_TURN]);
+
+    expect(completed).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      journalTurnId: null,
+      turnStartedAt: null,
+      turnStartObservedLive: false,
+      lifecycle: "idle",
+    });
+    expect(completed.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+  });
+
+  it("lets live timing replace a replay-only unknown boundary", () => {
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce(NOW)
+      .mockReturnValue(LATER);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+    const replayedStart = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      clock,
+    );
+    const replayedEnd = reduceCodeSessionEvent(
+      replayedStart.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      clock,
+    );
+    expect(replayedEnd.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: null,
+    });
+
+    const liveStart = reduceCodeSessionEvent(
+      replayedEnd.state,
+      framed(3, { type: "turn_started", turn_id: "t1" }),
+      clock,
+    );
+    const liveEnd = reduceCodeSessionEvent(
+      liveStart.state,
+      framed(4, { type: "turn_completed", usage: NO_USAGE }),
+      clock,
+    );
+
+    expect(liveEnd.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+    expect(now).toHaveBeenCalledTimes(2);
+  });
+
+  it("measures a genuinely live turn from the client clock", () => {
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce(NOW)
+      .mockReturnValue(LATER);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+    const started = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      framed(1, { type: "turn_started", turn_id: "t1" }),
+      clock,
+    );
+    const completed = reduceCodeSessionEvent(
+      started.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }),
+      clock,
+    );
+
+    expect(completed.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+    expect(now).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps live timing when completion arrives through replay", () => {
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce(NOW)
+      .mockReturnValue(LATER);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+    const started = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      framed(1, { type: "turn_started", turn_id: "t1" }),
+      clock,
+    );
+    const completed = reduceCodeSessionEvent(
+      started.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      clock,
+    );
+
+    expect(completed.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+    expect(now).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps live provenance when prompt hydration replaces the start timestamp", () => {
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("2026-08-15T12:00:00.100Z")
+      .mockReturnValue(LATER);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+    const started = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      framed(1, { type: "turn_started", turn_id: "t1" }),
+      clock,
+    );
+    const hydrated = applyAcceptedTurn(started.state, {
+      ...SNAPSHOT_TURN,
+      status: "running",
+      ended_at: undefined,
+    });
+    const completed = reduceCodeSessionEvent(
+      hydrated,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      clock,
+    );
+
+    expect(completed.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+    expect(now).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a hydrated running turn's durable start for live completion", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      {
+        ...SNAPSHOT_TURN,
+        status: "running",
+        ended_at: undefined,
+      },
+    ]);
+    const now = vi.fn<() => string>().mockReturnValue(LATER);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+    const replayedStart = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      clock,
+    );
+
+    expect(replayedStart.state.turnStartedAt).toBe(NOW);
+    expect(now).not.toHaveBeenCalled();
+
+    const completed = reduceCodeSessionEvent(
+      replayedStart.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }),
+      clock,
+    );
+    expect(completed.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+    expect(now).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not assign a truncated replay terminal to the hydrated running turn", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      {
+        ...SNAPSHOT_TURN,
+        started_at: LONG_TURN_START,
+        ended_at: LONG_TURN_END,
+      },
+      {
+        ...SNAPSHOT_TURN,
+        id: "t2",
+        ordinal: 2,
+        status: "running",
+        user_input: "run the tests",
+        started_at: NOW,
+        ended_at: undefined,
+      },
+    ]);
+    const now = vi.fn<() => string>().mockReturnValue(LATER);
+    const clock: CodeSessionDeps = { nextId: deps().nextId, now };
+    const staleTerminal = reduceCodeSessionEvent(
+      hydrated,
+      {
+        seq: 100,
+        replayed: true,
+        truncated: true,
+        event: { type: "turn_completed", usage: NO_USAGE },
+      },
+      clock,
+    );
+
+    expect(staleTerminal.effects).toEqual([
+      { type: "turn_snapshot_needed", turnId: null },
+      { type: "turn_resolved" },
+    ]);
+    expect(staleTerminal.state.busy).toBe(true);
+    expect(staleTerminal.state.activeTurnId).toBe("t2");
+    expect(staleTerminal.state.lifecycle).toBe("running");
+    expect(staleTerminal.state.lastUsage).toBeNull();
+    expect(
+      staleTerminal.state.items.find(
+        (item) => item.kind === "turn_boundary" && item.turnId === "t2",
+      ),
+    ).toBeUndefined();
+    expect(now).not.toHaveBeenCalled();
+
+    const replayedStart = reduceCodeSessionEvent(
+      staleTerminal.state,
+      framed(101, { type: "turn_started", turn_id: "t2" }, true),
+      clock,
+    );
+    const completed = reduceCodeSessionEvent(
+      replayedStart.state,
+      framed(102, {
+        type: "turn_completed",
+        usage: { ...NO_USAGE, input_tokens: 20, output_tokens: 8 },
+      }),
+      clock,
+    );
+
+    expect(completed.state.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      durationMs: 2_500,
+      usage: { input_tokens: 20, output_tokens: 8 },
+    });
+    expect(now).toHaveBeenCalledTimes(1);
+  });
+
   it("shows the user prompt after a disposed store reopens from after=0", () => {
     const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
       SNAPSHOT_TURN,
@@ -763,6 +1800,22 @@ describe("file_changed", () => {
       },
     });
     expect(state.contentRevision).toBe(3);
+  });
+});
+
+describe("unattributed terminals", () => {
+  it("invalidates worktree readers without inventing a transcript boundary", () => {
+    const terminal = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      framed(1, { type: "turn_completed", usage: NO_USAGE }),
+      deps(),
+    );
+
+    expect(terminal.effects).toEqual([{ type: "turn_resolved" }]);
+    expect(terminal.state.contentRevision).toBe(1);
+    expect(
+      terminal.state.items.some((item) => item.kind === "turn_boundary"),
+    ).toBe(false);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -772,6 +772,113 @@ describe("hydrate then replay", () => {
     });
   });
 
+  it("keeps a newly accepted turn active while buffered replay finishes an older turn", () => {
+    const accepted = applyAcceptedTurn(initialCodeSessionState(), {
+      ...SNAPSHOT_TURN,
+      id: "t2",
+      ordinal: 2,
+      status: "running",
+      user_input: "run the tests",
+      ended_at: undefined,
+    });
+
+    expect(accepted).toMatchObject({
+      lastSeq: 0,
+      activeTurnId: "t2",
+      journalTurnId: null,
+      acceptedTurnFence: { turnId: "t2", afterSeq: 0 },
+      turnActivityRevision: 1,
+    });
+
+    const replayedStart = reduceCodeSessionEvent(
+      accepted,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      deps(),
+    );
+    const replayedTerminal = reduceCodeSessionEvent(
+      replayedStart.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      deps(),
+    );
+
+    expect(replayedStart.state).toMatchObject({
+      lastSeq: 1,
+      busy: true,
+      activeTurnId: "t2",
+      journalTurnId: "t1",
+      acceptedTurnFence: { turnId: "t2", afterSeq: 0 },
+      turnActivityRevision: 1,
+    });
+    expect(replayedTerminal.state).toMatchObject({
+      lastSeq: 2,
+      busy: true,
+      activeTurnId: "t2",
+      journalTurnId: null,
+      acceptedTurnFence: { turnId: "t2", afterSeq: 0 },
+      turnActivityRevision: 1,
+      lifecycle: "running",
+    });
+    expect(
+      replayedTerminal.state.items.find(
+        (item) => item.kind === "turn_boundary" && item.turnId === "t1",
+      ),
+    ).toMatchObject({ status: "completed", usage: NO_USAGE });
+  });
+
+  it("rejects a snapshot activity update captured before an accepted turn", () => {
+    const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
+      { ...SNAPSHOT_TURN, status: "running", ended_at: undefined },
+    ]);
+    const replayedStart = reduceCodeSessionEvent(
+      hydrated,
+      framed(1, { type: "turn_started", turn_id: "t1" }, true),
+      deps(),
+    );
+    const terminal = reduceCodeSessionEvent(
+      replayedStart.state,
+      framed(2, { type: "turn_completed", usage: NO_USAGE }, true),
+      deps(),
+    );
+    const observedTurnActivityRevision = terminal.state.turnActivityRevision;
+    const accepted = applyAcceptedTurn(terminal.state, {
+      ...SNAPSHOT_TURN,
+      id: "t2",
+      ordinal: 2,
+      status: "running",
+      user_input: "run the tests",
+      ended_at: undefined,
+    });
+
+    expect(accepted.lastSeq).toBe(terminal.state.lastSeq);
+    const reconciled = reconcilePendingCodeTurns(
+      accepted,
+      [SNAPSHOT_TURN],
+      [
+        {
+          turnId: "t1",
+          eventSeq: 2,
+          observedSeq: 2,
+          observedTurnActivityRevision,
+        },
+      ],
+    );
+
+    expect(reconciled).toMatchObject({
+      lastSeq: 2,
+      busy: true,
+      activeTurnId: "t2",
+      acceptedTurnFence: { turnId: "t2", afterSeq: 2 },
+      lifecycle: "running",
+    });
+    expect(
+      reconciled.items.find((item) => item.id === "boundary:t1"),
+    ).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+  });
+
   it("reconciles a capped terminal against the hydrated active turn", () => {
     const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
       {
@@ -818,7 +925,14 @@ describe("hydrate then replay", () => {
           ended_at: LATER,
         },
       ],
-      [{ turnId: null, eventSeq: 2_001, observedSeq: 2_001 }],
+      [
+        {
+          turnId: null,
+          eventSeq: 2_001,
+          observedSeq: 2_001,
+          observedTurnActivityRevision: terminal.state.turnActivityRevision,
+        },
+      ],
     );
     expect(reconciled).toMatchObject({
       busy: false,
@@ -832,10 +946,10 @@ describe("hydrate then replay", () => {
       turnId: "t2",
       durationMs: 2_500,
     });
-    expect(reconciled.pendingTerminalReconciliations.size).toBe(0);
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(1);
   });
 
-  it("keeps a capped failure error until the candidate snapshot confirms it", () => {
+  it("keeps a capped failure unassigned when only its snapshot candidate completes", () => {
     const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
       {
         ...SNAPSHOT_TURN,
@@ -899,12 +1013,12 @@ describe("hydrate then replay", () => {
       turnId: "t2",
       status: "failed",
       durationMs: 2_500,
-      error: "compiler crashed: missing libssl",
+      error: null,
     });
-    expect(reconciled.pendingTerminalReconciliations.size).toBe(0);
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(1);
   });
 
-  it("restores a capped failure after hydration already returned the terminal turn", () => {
+  it("does not attach a capped failure after hydration already returned the terminal turn", () => {
     const hydrated = hydrateCodeTurns(initialCodeSessionState(), [
       {
         ...SNAPSHOT_TURN,
@@ -939,10 +1053,17 @@ describe("hydrate then replay", () => {
           user_input: "run the tests",
         },
       ],
-      [{ turnId: null, eventSeq: 2_001, observedSeq: 2_001 }],
+      [
+        {
+          turnId: null,
+          eventSeq: 2_001,
+          observedSeq: 2_001,
+          observedTurnActivityRevision: terminal.state.turnActivityRevision,
+        },
+      ],
     );
 
-    expect(reconciled.pendingTerminalReconciliations.size).toBe(0);
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(1);
     expect(
       reconciled.items.find(
         (item) => item.kind === "turn_boundary" && item.turnId === "t2",
@@ -950,11 +1071,11 @@ describe("hydrate then replay", () => {
     ).toMatchObject({
       status: "failed",
       durationMs: 2_500,
-      error: "compiler crashed: missing libssl",
+      error: null,
     });
   });
 
-  it("restores a capped failure when no initial turn snapshot was available", () => {
+  it("does not attach a capped failure when no initial turn snapshot was available", () => {
     const terminal = reduceCodeSessionEvent(
       initialCodeSessionState(),
       {
@@ -981,16 +1102,70 @@ describe("hydrate then replay", () => {
           user_input: "run the tests",
         },
       ],
-      [{ turnId: null, eventSeq: 2_001, observedSeq: 2_001 }],
+      [
+        {
+          turnId: null,
+          eventSeq: 2_001,
+          observedSeq: 2_001,
+          observedTurnActivityRevision: terminal.state.turnActivityRevision,
+        },
+      ],
     );
 
-    expect(reconciled.pendingTerminalReconciliations.size).toBe(0);
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(1);
     expect(reconciled.items.at(-1)).toMatchObject({
       kind: "turn_boundary",
       turnId: "t2",
       status: "failed",
-      error: "compiler crashed: missing libssl",
+      error: null,
     });
+  });
+
+  it("does not give a later completed turn an earlier unattributed terminal's usage", () => {
+    const replayUsage = {
+      ...NO_USAGE,
+      input_tokens: 91,
+      output_tokens: 37,
+    };
+    const terminal = reduceCodeSessionEvent(
+      initialCodeSessionState(),
+      {
+        seq: 2_001,
+        replayed: true,
+        truncated: true,
+        event: { type: "turn_completed", usage: replayUsage },
+      },
+      deps(),
+    );
+    const reconciled = reconcilePendingCodeTurns(
+      terminal.state,
+      [
+        {
+          ...SNAPSHOT_TURN,
+          id: "t2",
+          ordinal: 2,
+          user_input: "later completed work",
+        },
+      ],
+      [
+        {
+          turnId: null,
+          eventSeq: 2_001,
+          observedSeq: 2_001,
+          observedTurnActivityRevision: terminal.state.turnActivityRevision,
+        },
+      ],
+    );
+
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(1);
+    expect(reconciled.items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      status: "completed",
+      usage: null,
+      error: null,
+    });
+    expect(reconciled.lastUsage).toBeNull();
   });
 
   it("keeps a capped failure pending while its stale candidate still runs", () => {
@@ -1113,7 +1288,14 @@ describe("hydrate then replay", () => {
           user_input: "new work",
         },
       ],
-      [{ turnId: null, eventSeq: 2_001, observedSeq: 2_001 }],
+      [
+        {
+          turnId: null,
+          eventSeq: 2_001,
+          observedSeq: 2_001,
+          observedTurnActivityRevision: terminal.state.turnActivityRevision,
+        },
+      ],
     );
 
     expect(
@@ -1127,8 +1309,9 @@ describe("hydrate then replay", () => {
     expect(reconciled.items.at(-1)).toMatchObject({
       kind: "turn_boundary",
       turnId: "t2",
-      error: "new turn failed",
+      error: null,
     });
+    expect(reconciled.pendingTerminalReconciliations.size).toBe(1);
   });
 
   it("inserts a recovered boundary before the following turn", () => {
@@ -1166,7 +1349,14 @@ describe("hydrate then replay", () => {
           ended_at: undefined,
         },
       ],
-      [{ turnId: null, eventSeq: 100, observedSeq: 102 }],
+      [
+        {
+          turnId: null,
+          eventSeq: 100,
+          observedSeq: 102,
+          observedTurnActivityRevision: output.state.turnActivityRevision,
+        },
+      ],
     );
 
     expect(reconciled.items.map((item) => item.id)).toEqual([
@@ -1203,7 +1393,14 @@ describe("hydrate then replay", () => {
     const reconciled = reconcilePendingCodeTurns(
       terminal.state,
       [SNAPSHOT_TURN],
-      [{ turnId: "t1", eventSeq: 2, observedSeq: 2 }],
+      [
+        {
+          turnId: "t1",
+          eventSeq: 2,
+          observedSeq: 2,
+          observedTurnActivityRevision: terminal.state.turnActivityRevision,
+        },
+      ],
     );
 
     expect(reconciled.lastUsage).toEqual(usage);
@@ -1251,7 +1448,14 @@ describe("hydrate then replay", () => {
           ended_at: undefined,
         },
       ],
-      [{ turnId: "t1", eventSeq: 2, observedSeq: 2 }],
+      [
+        {
+          turnId: "t1",
+          eventSeq: 2,
+          observedSeq: 2,
+          observedTurnActivityRevision: terminal.state.turnActivityRevision,
+        },
+      ],
     );
 
     expect(reconciled).toMatchObject({

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -136,6 +136,13 @@ export type CodeSessionState = {
   activeTurnId: string | null;
   /** Turn established by a journal `turn_started` frame. */
   journalTurnId: string | null;
+  /**
+   * A submit accepted after this journal cursor still owns live activity until
+   * the journal names that turn or a newer live frame supersedes it.
+   */
+  acceptedTurnFence: { turnId: string; afterSeq: number } | null;
+  /** Changes when live activity changes without necessarily moving `lastSeq`. */
+  turnActivityRevision: number;
   turnStartedAt: string | null;
   /** Whether this store observed the active turn start as a live frame. */
   turnStartObservedLive: boolean;
@@ -215,6 +222,8 @@ export function initialCodeSessionState(): CodeSessionState {
     busy: false,
     activeTurnId: null,
     journalTurnId: null,
+    acceptedTurnFence: null,
+    turnActivityRevision: 0,
     turnStartedAt: null,
     turnStartObservedLive: false,
     durableBoundaryTurnIds: new Set(),
@@ -292,6 +301,8 @@ export function applyAcceptedTurn(
     ...next,
     busy: true,
     activeTurnId: turn.id,
+    acceptedTurnFence: { turnId: turn.id, afterSeq: state.lastSeq },
+    turnActivityRevision: state.turnActivityRevision + 1,
     turnStartedAt: turn.started_at,
     turnStartObservedLive: continuesObservedTurn,
     lifecycle: "running",
@@ -388,6 +399,11 @@ function reconcileCodeTurnSnapshotWithPending(
     busy: false,
     activeTurnId: null,
     journalTurnId: null,
+    acceptedTurnFence:
+      state.acceptedTurnFence?.turnId === turn.id
+        ? null
+        : state.acceptedTurnFence,
+    turnActivityRevision: state.turnActivityRevision + 1,
     turnStartedAt: null,
     turnStartObservedLive: false,
     assistantBuffer: "",
@@ -413,7 +429,8 @@ export function reconcilePendingCodeTurns(
   requested?: readonly {
     turnId: string | null;
     eventSeq: number;
-    observedSeq?: number;
+    observedSeq: number;
+    observedTurnActivityRevision: number;
   }[],
 ): CodeSessionState {
   const orderedTurns = [...turns].sort(
@@ -425,6 +442,8 @@ export function reconcilePendingCodeTurns(
     [...state.pendingTerminalReconciliations.values()].map((pending) => ({
       turnId: pending.turnId,
       eventSeq: pending.eventSeq,
+      observedSeq: state.lastSeq,
+      observedTurnActivityRevision: state.turnActivityRevision,
     }));
   const currentPending = requests.flatMap((request) => {
     const pending = next.pendingTerminalReconciliations.get(request.eventSeq);
@@ -459,15 +478,22 @@ export function reconcilePendingCodeTurns(
       : applyCodeTurnSnapshot(next, turn);
   }
 
-  const observedSeqs = requested
-    ?.map((request) => request.observedSeq)
-    .filter((seq): seq is number => seq !== undefined);
   const responseMatchesCurrentJournal =
     requested === undefined ||
-    (observedSeqs !== undefined &&
-      observedSeqs.length > 0 &&
-      observedSeqs.every((seq) => seq === next.lastSeq));
-  if (orderedTurns.length > 0 && responseMatchesCurrentJournal) {
+    (requested.length > 0 &&
+      requested.every((request) => request.observedSeq === state.lastSeq));
+  const responseMatchesCurrentActivity =
+    requested === undefined ||
+    (requested.length > 0 &&
+      requested.every(
+        (request) =>
+          request.observedTurnActivityRevision === state.turnActivityRevision,
+      ));
+  if (
+    orderedTurns.length > 0 &&
+    responseMatchesCurrentJournal &&
+    responseMatchesCurrentActivity
+  ) {
     next = applyAuthoritativeTurnActivity(next, orderedTurns);
   }
   return next;
@@ -562,22 +588,13 @@ function assignUnattributedTerminals(
   }
 
   for (const [nextTurnId, group] of groups) {
+    // Without either an exact `turn_started` identity or a following start as
+    // an ordinal anchor, a capped terminal could belong to any earlier turn.
+    // Do not bind it to whichever snapshot happens to be last.
+    if (nextTurnId === null) continue;
     group.sort((left, right) => left.eventSeq - right.eventSeq);
-    let anchor: number;
-    if (nextTurnId !== null) {
-      anchor = turns.findIndex((turn) => turn.id === nextTurnId);
-      if (anchor === -1) continue;
-    } else {
-      if (turns.some((turn) => turn.status === "running")) continue;
-      const candidateTurnId = group.at(-1)?.candidateTurnId;
-      if (
-        candidateTurnId &&
-        !turns.some((turn) => turn.id === candidateTurnId)
-      ) {
-        continue;
-      }
-      anchor = turns.length;
-    }
+    const anchor = turns.findIndex((turn) => turn.id === nextTurnId);
+    if (anchor === -1) continue;
     if (anchor < group.length) continue;
 
     const proposed: Array<[PendingTerminalReconciliation, CodeTurnSnapshot]> =
@@ -611,6 +628,22 @@ function applyAuthoritativeTurnActivity(
   state: CodeSessionState,
   turns: readonly CodeTurnSnapshot[],
 ): CodeSessionState {
+  const acceptedTurn = state.acceptedTurnFence
+    ? turns.find((turn) => turn.id === state.acceptedTurnFence?.turnId)
+    : undefined;
+  if (
+    state.acceptedTurnFence &&
+    (!acceptedTurn || acceptedTurn.status === "running")
+  ) {
+    return {
+      ...state,
+      lastUsage: latestTurnUsage(state, turns),
+      busy: true,
+      activeTurnId: state.acceptedTurnFence.turnId,
+      turnStartedAt: acceptedTurn?.started_at ?? state.turnStartedAt,
+      lifecycle: "running",
+    };
+  }
   const open = [...turns]
     .reverse()
     .find(
@@ -619,6 +652,7 @@ function applyAuthoritativeTurnActivity(
     );
   const lastUsage = latestTurnUsage(state, turns);
   if (open) {
+    const activityChanged = state.activeTurnId !== open.id;
     return {
       ...state,
       lastUsage,
@@ -629,15 +663,22 @@ function applyAuthoritativeTurnActivity(
       turnStartedAt: open.started_at,
       turnStartObservedLive:
         state.activeTurnId === open.id && state.turnStartObservedLive,
+      acceptedTurnFence: null,
+      turnActivityRevision:
+        state.turnActivityRevision + (activityChanged ? 1 : 0),
       lifecycle: "running",
     };
   }
+  const activityChanged = state.activeTurnId !== null || state.busy;
   return {
     ...state,
     lastUsage,
     busy: false,
     activeTurnId: null,
     journalTurnId: null,
+    acceptedTurnFence: null,
+    turnActivityRevision:
+      state.turnActivityRevision + (activityChanged ? 1 : 0),
     turnStartedAt: null,
     turnStartObservedLive: false,
     assistantBuffer: "",
@@ -763,21 +804,35 @@ export function reduceCodeSessionEvent(
         state.activeTurnId === event.turn_id ? state.turnStartedAt : null;
       const continuesObservedTurn =
         state.journalTurnId === event.turn_id && state.turnStartObservedLive;
+      const preservesAcceptedTurn =
+        replayFollowsAcceptedTurn(state, framed) &&
+        state.acceptedTurnFence.turnId !== event.turn_id;
+      const activityChanged =
+        !preservesAcceptedTurn && state.activeTurnId !== event.turn_id;
       return {
         state: {
           ...state,
           busy: true,
-          activeTurnId: event.turn_id,
+          activeTurnId: preservesAcceptedTurn
+            ? state.activeTurnId
+            : event.turn_id,
           journalTurnId: event.turn_id,
+          acceptedTurnFence: preservesAcceptedTurn
+            ? state.acceptedTurnFence
+            : null,
+          turnActivityRevision:
+            state.turnActivityRevision + (activityChanged ? 1 : 0),
           // Hydration carries the server's accepted timestamp. Keep it when
           // replay walks the same turn, and never invent a start for history
           // that the client did not observe live.
-          turnStartedAt:
-            durableStartedAt ??
-            observedStartedAt ??
-            (framed.replayed === true ? null : deps.now()),
-          turnStartObservedLive:
-            framed.replayed !== true || continuesObservedTurn,
+          turnStartedAt: preservesAcceptedTurn
+            ? state.turnStartedAt
+            : (durableStartedAt ??
+              observedStartedAt ??
+              (framed.replayed === true ? null : deps.now())),
+          turnStartObservedLive: preservesAcceptedTurn
+            ? state.turnStartObservedLive
+            : framed.replayed !== true || continuesObservedTurn,
           assistantBuffer: "",
           reasoningBuffer: "",
           lifecycle: "running",
@@ -1105,6 +1160,12 @@ export function reduceCodeSessionEvent(
         canMeasureTurn && !hasDurableBoundary
           ? durationMs(state.turnStartedAt, deps.now())
           : null;
+      const resolvesActiveTurn =
+        state.activeTurnId === turnId &&
+        !(
+          replayFollowsAcceptedTurn(state, framed) &&
+          state.acceptedTurnFence.turnId !== turnId
+        );
       const finalized = finalizeStreaming(
         finalizeStreaming(state.items, "assistant"),
         "reasoning",
@@ -1112,7 +1173,7 @@ export function reduceCodeSessionEvent(
       return {
         state: {
           ...state,
-          busy: false,
+          busy: resolvesActiveTurn ? false : state.busy,
           lastUsage: needsSnapshot
             ? state.lastUsage
             : (usage ?? state.lastUsage),
@@ -1135,11 +1196,19 @@ export function reduceCodeSessionEvent(
                 state.turnOrdinals,
               )
             : finalized,
-          activeTurnId: null,
-          journalTurnId: null,
-          turnStartedAt: null,
-          turnStartObservedLive: false,
-          lifecycle: "idle",
+          activeTurnId: resolvesActiveTurn ? null : state.activeTurnId,
+          journalTurnId:
+            state.journalTurnId === turnId ? null : state.journalTurnId,
+          acceptedTurnFence: resolvesActiveTurn
+            ? null
+            : state.acceptedTurnFence,
+          turnActivityRevision:
+            state.turnActivityRevision + (resolvesActiveTurn ? 1 : 0),
+          turnStartedAt: resolvesActiveTurn ? null : state.turnStartedAt,
+          turnStartObservedLive: resolvesActiveTurn
+            ? false
+            : state.turnStartObservedLive,
+          lifecycle: resolvesActiveTurn ? "idle" : state.lifecycle,
           // A failed or interrupted turn still leaves whatever the engine
           // wrote before it stopped, so every resolution is a content change.
           contentRevision: state.contentRevision + 1,
@@ -1151,6 +1220,19 @@ export function reduceCodeSessionEvent(
     default:
       return { state, effects };
   }
+}
+
+function replayFollowsAcceptedTurn(
+  state: CodeSessionState,
+  framed: SequencedCodeEventFrame,
+): state is CodeSessionState & {
+  acceptedTurnFence: { turnId: string; afterSeq: number };
+} {
+  return (
+    framed.replayed === true &&
+    state.acceptedTurnFence !== null &&
+    framed.seq > state.acceptedTurnFence.afterSeq
+  );
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -134,7 +134,27 @@ export type CodeSessionState = {
   items: CodeTranscriptItem[];
   busy: boolean;
   activeTurnId: string | null;
+  /** Turn established by a journal `turn_started` frame. */
+  journalTurnId: string | null;
   turnStartedAt: string | null;
+  /** Whether this store observed the active turn start as a live frame. */
+  turnStartObservedLive: boolean;
+  /** Boundaries whose timing came from durable turn snapshots. */
+  durableBoundaryTurnIds: ReadonlySet<string>;
+  /** Durable turn order, used to place boundaries recovered after later turns render. */
+  turnOrdinals: ReadonlyMap<string, number>;
+  /**
+   * Replayed terminals that still need an authoritative turn snapshot.
+   *
+   * This state lives with the retained transcript instead of one controller,
+   * so a failed read survives workspace close and reopen. The event sequence
+   * is the key because a capped replay may contain several terminals before
+   * the first retained `turn_started` frame establishes any turn identity.
+   */
+  pendingTerminalReconciliations: ReadonlyMap<
+    number,
+    PendingTerminalReconciliation
+  >;
   assistantBuffer: string;
   reasoningBuffer: string;
   harnessKind: HarnessKind | null;
@@ -158,7 +178,8 @@ export type CodeSessionState = {
 
 export type CodeSessionEffect =
   | { type: "turn_began"; turnId: string }
-  | { type: "turn_resolved" };
+  | { type: "turn_resolved" }
+  | { type: "turn_snapshot_needed"; turnId: string | null };
 
 export type CodeSessionTransition = {
   state: CodeSessionState;
@@ -170,6 +191,21 @@ export type CodeSessionDeps = {
   now: () => string;
 };
 
+export type PendingTerminalReconciliation = {
+  eventSeq: number;
+  /** Exact when a retained `turn_started` established the terminal's turn. */
+  turnId: string | null;
+  /** Snapshot activity is only an ordering hint. It is never identity proof. */
+  candidateTurnId: string | null;
+  /** The first retained start after an unassigned terminal, when one appears. */
+  nextTurnId: string | null;
+  status: Exclude<CodeTurnStatus, "running">;
+  usage: CodeUsage | null;
+  error: string | null;
+  diffstat: Diffstat | null;
+  previousUsage: CodeUsage | null;
+};
+
 export function initialCodeSessionState(): CodeSessionState {
   return {
     lastSeq: 0,
@@ -178,7 +214,12 @@ export function initialCodeSessionState(): CodeSessionState {
     items: [],
     busy: false,
     activeTurnId: null,
+    journalTurnId: null,
     turnStartedAt: null,
+    turnStartObservedLive: false,
+    durableBoundaryTurnIds: new Set(),
+    turnOrdinals: new Map(),
+    pendingTerminalReconciliations: new Map(),
     assistantBuffer: "",
     reasoningBuffer: "",
     harnessKind: null,
@@ -238,14 +279,402 @@ export function markCodeSessionHydrated(
   return state.hydrated ? state : { ...state, hydrated: true };
 }
 
-/**
- * Record a turn the server accepted. Create and hydrate share this so a
- * reopen and a live send produce the same turn-keyed user item.
- */
+/** Record a turn that a live submit received before its journal start. */
 export function applyAcceptedTurn(
   state: CodeSessionState,
   turn: CodeTurnSnapshot,
 ): CodeSessionState {
+  const next = upsertTurnPrompt(state, turn);
+  if (turn.status !== "running") return next;
+  const continuesObservedTurn =
+    state.activeTurnId === turn.id && state.turnStartObservedLive;
+  return {
+    ...next,
+    busy: true,
+    activeTurnId: turn.id,
+    turnStartedAt: turn.started_at,
+    turnStartObservedLive: continuesObservedTurn,
+    lifecycle: "running",
+  };
+}
+
+/**
+ * Apply one fetched turn without letting the snapshot choose live activity.
+ *
+ * Prompt fetches race the journal. Their durable user item and completed
+ * boundary remain useful, but a running response may already be stale by the
+ * time it arrives and must not reopen a turn or replace a newer active turn.
+ */
+export function applyCodeTurnSnapshot(
+  state: CodeSessionState,
+  turn: CodeTurnSnapshot,
+): CodeSessionState {
+  const next = upsertTurnPrompt(state, turn);
+  if (turn.status === "running") return next;
+  const durableBoundaryTurnIds = new Set(next.durableBoundaryTurnIds);
+  durableBoundaryTurnIds.add(turn.id);
+  return {
+    ...next,
+    durableBoundaryTurnIds,
+    items: upsertTurnBoundary(
+      next.items,
+      {
+        turnId: turn.id,
+        status: turn.status,
+        durationMs: durationMs(turn.started_at, turn.ended_at ?? null),
+        usage: turn.usage ?? null,
+        error: null,
+        diffstat: turn.diffstat ?? null,
+      },
+      next.turnOrdinals,
+    ),
+  };
+}
+
+/**
+ * Reconcile one requested turn after replay exposed an uncertain terminal.
+ *
+ * A completed snapshot may settle only that same active turn. If another turn
+ * started while the request was in flight, the snapshot still fills durable
+ * transcript data but leaves the newer activity untouched.
+ */
+export function reconcileCodeTurnSnapshot(
+  state: CodeSessionState,
+  turn: CodeTurnSnapshot,
+): CodeSessionState {
+  const pending = latestPendingForTurn(state, turn.id);
+  return reconcileCodeTurnSnapshotWithPending(state, turn, pending);
+}
+
+function reconcileCodeTurnSnapshotWithPending(
+  state: CodeSessionState,
+  turn: CodeTurnSnapshot,
+  pending: PendingTerminalReconciliation | undefined,
+): CodeSessionState {
+  if (turn.status === "running") {
+    return applyCodeTurnSnapshot(state, turn);
+  }
+
+  let next = applyCodeTurnSnapshot(state, turn);
+  if (pending) {
+    const terminalMatches = pending.status === turn.status;
+    next = {
+      ...next,
+      items: replaceTurnBoundary(
+        next.items,
+        {
+          turnId: turn.id,
+          status: turn.status,
+          durationMs: durationMs(turn.started_at, turn.ended_at ?? null),
+          usage: turn.usage ?? (terminalMatches ? pending.usage : null),
+          error: terminalMatches ? pending.error : null,
+          diffstat:
+            turn.diffstat ?? (terminalMatches ? pending.diffstat : null),
+        },
+        next.turnOrdinals,
+      ),
+    };
+    next = withoutPendingTerminalReconciliation(next, pending.eventSeq);
+  }
+  if (
+    state.activeTurnId !== turn.id ||
+    (state.journalTurnId !== null && state.journalTurnId !== turn.id)
+  ) {
+    return next;
+  }
+  const terminalMatches = pending?.status === turn.status;
+  return {
+    ...next,
+    busy: false,
+    activeTurnId: null,
+    journalTurnId: null,
+    turnStartedAt: null,
+    turnStartObservedLive: false,
+    assistantBuffer: "",
+    reasoningBuffer: "",
+    items: finalizeStreaming(
+      finalizeStreaming(next.items, "assistant"),
+      "reasoning",
+    ),
+    lastUsage:
+      turn.usage ??
+      (terminalMatches ? pending?.usage : null) ??
+      (pending && !terminalMatches ? pending.previousUsage : next.lastUsage),
+    lifecycle:
+      next.lifecycle === "running" ? "idle" : (next.lifecycle ?? "idle"),
+    contentRevision: next.contentRevision + 1,
+  };
+}
+
+/** Reconcile every pending terminal that appears in one authoritative read. */
+export function reconcilePendingCodeTurns(
+  state: CodeSessionState,
+  turns: readonly CodeTurnSnapshot[],
+  requested?: readonly {
+    turnId: string | null;
+    eventSeq: number;
+    observedSeq?: number;
+  }[],
+): CodeSessionState {
+  const orderedTurns = [...turns].sort(
+    (left, right) => left.ordinal - right.ordinal,
+  );
+  let next = withTurnOrdinals(state, orderedTurns);
+  const requests =
+    requested ??
+    [...state.pendingTerminalReconciliations.values()].map((pending) => ({
+      turnId: pending.turnId,
+      eventSeq: pending.eventSeq,
+    }));
+  const currentPending = requests.flatMap((request) => {
+    const pending = next.pendingTerminalReconciliations.get(request.eventSeq);
+    if (!pending || pending.turnId !== request.turnId) return [];
+    return [pending];
+  });
+  const usedTurnIds = new Set<string>();
+  const assignments = new Map<string, PendingTerminalReconciliation>();
+
+  for (const pending of currentPending) {
+    if (pending.turnId === null) continue;
+    const turn = orderedTurns.find(
+      (candidate) => candidate.id === pending.turnId,
+    );
+    if (!turn) continue;
+    usedTurnIds.add(turn.id);
+    assignments.set(turn.id, pending);
+  }
+
+  for (const [pending, turn] of assignUnattributedTerminals(
+    orderedTurns,
+    currentPending.filter((candidate) => candidate.turnId === null),
+    usedTurnIds,
+  )) {
+    assignments.set(turn.id, pending);
+  }
+
+  for (const turn of orderedTurns) {
+    const pending = assignments.get(turn.id);
+    next = pending
+      ? reconcileCodeTurnSnapshotWithPending(next, turn, pending)
+      : applyCodeTurnSnapshot(next, turn);
+  }
+
+  const observedSeqs = requested
+    ?.map((request) => request.observedSeq)
+    .filter((seq): seq is number => seq !== undefined);
+  const responseMatchesCurrentJournal =
+    requested === undefined ||
+    (observedSeqs !== undefined &&
+      observedSeqs.length > 0 &&
+      observedSeqs.every((seq) => seq === next.lastSeq));
+  if (orderedTurns.length > 0 && responseMatchesCurrentJournal) {
+    next = applyAuthoritativeTurnActivity(next, orderedTurns);
+  }
+  return next;
+}
+
+function withPendingTerminalReconciliation(
+  state: CodeSessionState,
+  pending: PendingTerminalReconciliation,
+): CodeSessionState {
+  const pendingTerminalReconciliations = new Map(
+    state.pendingTerminalReconciliations,
+  );
+  if (pending.turnId !== null) {
+    for (const [eventSeq, current] of pendingTerminalReconciliations) {
+      if (current.turnId === pending.turnId) {
+        pendingTerminalReconciliations.delete(eventSeq);
+      }
+    }
+  }
+  pendingTerminalReconciliations.set(pending.eventSeq, pending);
+  return { ...state, pendingTerminalReconciliations };
+}
+
+function withoutPendingTerminalReconciliation(
+  state: CodeSessionState,
+  eventSeq: number,
+): CodeSessionState {
+  if (!state.pendingTerminalReconciliations.has(eventSeq)) return state;
+  const pendingTerminalReconciliations = new Map(
+    state.pendingTerminalReconciliations,
+  );
+  pendingTerminalReconciliations.delete(eventSeq);
+  return { ...state, pendingTerminalReconciliations };
+}
+
+function latestPendingForTurn(
+  state: CodeSessionState,
+  turnId: string,
+): PendingTerminalReconciliation | undefined {
+  return [...state.pendingTerminalReconciliations.values()]
+    .filter((pending) => pending.turnId === turnId)
+    .sort((left, right) => right.eventSeq - left.eventSeq)[0];
+}
+
+function anchorUnattributedTerminals(
+  state: CodeSessionState,
+  nextTurnId: string,
+): CodeSessionState {
+  let changed = false;
+  const pendingTerminalReconciliations = new Map(
+    [...state.pendingTerminalReconciliations.entries()].map(
+      ([eventSeq, pending]) => {
+        if (pending.turnId !== null || pending.nextTurnId !== null) {
+          return [eventSeq, pending] as const;
+        }
+        changed = true;
+        return [eventSeq, { ...pending, nextTurnId }] as const;
+      },
+    ),
+  );
+  return changed ? { ...state, pendingTerminalReconciliations } : state;
+}
+
+function withTurnOrdinals(
+  state: CodeSessionState,
+  turns: readonly CodeTurnSnapshot[],
+): CodeSessionState {
+  if (turns.length === 0) return state;
+  const turnOrdinals = new Map(state.turnOrdinals);
+  let changed = false;
+  for (const turn of turns) {
+    if (turnOrdinals.get(turn.id) === turn.ordinal) continue;
+    turnOrdinals.set(turn.id, turn.ordinal);
+    changed = true;
+  }
+  return changed ? { ...state, turnOrdinals } : state;
+}
+
+function assignUnattributedTerminals(
+  turns: readonly CodeTurnSnapshot[],
+  pending: readonly PendingTerminalReconciliation[],
+  usedTurnIds: ReadonlySet<string>,
+): Array<[PendingTerminalReconciliation, CodeTurnSnapshot]> {
+  const assignments: Array<[PendingTerminalReconciliation, CodeTurnSnapshot]> =
+    [];
+  const claimed = new Set(usedTurnIds);
+  const groups = new Map<string | null, PendingTerminalReconciliation[]>();
+  for (const item of pending) {
+    const group = groups.get(item.nextTurnId) ?? [];
+    group.push(item);
+    groups.set(item.nextTurnId, group);
+  }
+
+  for (const [nextTurnId, group] of groups) {
+    group.sort((left, right) => left.eventSeq - right.eventSeq);
+    let anchor: number;
+    if (nextTurnId !== null) {
+      anchor = turns.findIndex((turn) => turn.id === nextTurnId);
+      if (anchor === -1) continue;
+    } else {
+      if (turns.some((turn) => turn.status === "running")) continue;
+      const candidateTurnId = group.at(-1)?.candidateTurnId;
+      if (
+        candidateTurnId &&
+        !turns.some((turn) => turn.id === candidateTurnId)
+      ) {
+        continue;
+      }
+      anchor = turns.length;
+    }
+    if (anchor < group.length) continue;
+
+    const proposed: Array<[PendingTerminalReconciliation, CodeTurnSnapshot]> =
+      [];
+    let valid = true;
+    for (let offset = 0; offset < group.length; offset += 1) {
+      const item = group[group.length - 1 - offset];
+      const turn = turns[anchor - 1 - offset];
+      if (
+        !item ||
+        !turn ||
+        turn.status === "running" ||
+        turn.status !== item.status ||
+        claimed.has(turn.id)
+      ) {
+        valid = false;
+        break;
+      }
+      proposed.push([item, turn]);
+    }
+    if (!valid) continue;
+    for (const assignment of proposed.reverse()) {
+      claimed.add(assignment[1].id);
+      assignments.push(assignment);
+    }
+  }
+  return assignments;
+}
+
+function applyAuthoritativeTurnActivity(
+  state: CodeSessionState,
+  turns: readonly CodeTurnSnapshot[],
+): CodeSessionState {
+  const open = [...turns]
+    .reverse()
+    .find(
+      (turn) =>
+        turn.status === "running" && !latestPendingForTurn(state, turn.id),
+    );
+  const lastUsage = latestTurnUsage(state, turns);
+  if (open) {
+    return {
+      ...state,
+      lastUsage,
+      busy: true,
+      activeTurnId: open.id,
+      journalTurnId:
+        state.activeTurnId === open.id ? state.journalTurnId : null,
+      turnStartedAt: open.started_at,
+      turnStartObservedLive:
+        state.activeTurnId === open.id && state.turnStartObservedLive,
+      lifecycle: "running",
+    };
+  }
+  return {
+    ...state,
+    lastUsage,
+    busy: false,
+    activeTurnId: null,
+    journalTurnId: null,
+    turnStartedAt: null,
+    turnStartObservedLive: false,
+    assistantBuffer: "",
+    reasoningBuffer: "",
+    items: finalizeStreaming(
+      finalizeStreaming(state.items, "assistant"),
+      "reasoning",
+    ),
+    lifecycle:
+      state.lifecycle === "running" ? "idle" : (state.lifecycle ?? "idle"),
+  };
+}
+
+function latestTurnUsage(
+  state: CodeSessionState,
+  turns: readonly CodeTurnSnapshot[],
+): CodeUsage | null {
+  for (const turn of [...turns].reverse()) {
+    if (turn.status === "running") continue;
+    if (turn.usage) return turn.usage;
+    if (!state.durableBoundaryTurnIds.has(turn.id)) continue;
+    const boundary = state.items.find(
+      (item) => item.kind === "turn_boundary" && item.turnId === turn.id,
+    );
+    if (boundary?.kind === "turn_boundary" && boundary.usage) {
+      return boundary.usage;
+    }
+  }
+  return state.lastUsage;
+}
+
+function upsertTurnPrompt(
+  state: CodeSessionState,
+  turn: CodeTurnSnapshot,
+): CodeSessionState {
+  const turnOrdinals = new Map(state.turnOrdinals);
+  turnOrdinals.set(turn.id, turn.ordinal);
   const user: CodeTranscriptItem = {
     kind: "user",
     id: userItemId(turn.id),
@@ -263,16 +692,8 @@ export function applyAcceptedTurn(
     ? state.items.map((item) =>
         item.kind === "user" && item.turnId === turn.id ? user : item,
       )
-    : insertUserBeforeTurn(state.items, user, turn.id);
-  const running = turn.status === "running";
-  return {
-    ...state,
-    items,
-    busy: running || state.busy,
-    activeTurnId: running ? turn.id : state.activeTurnId,
-    turnStartedAt: running ? turn.started_at : state.turnStartedAt,
-    lifecycle: running ? "running" : state.lifecycle,
-  };
+    : insertUserBeforeTurn(state.items, user, turn.id, turnOrdinals);
+  return { ...state, items, turnOrdinals };
 }
 
 /** Snapshot of durable turns, applied before the journal replays. */
@@ -280,40 +701,7 @@ export function hydrateCodeTurns(
   state: CodeSessionState,
   turns: readonly CodeTurnSnapshot[],
 ): CodeSessionState {
-  let next = state;
-  for (const turn of turns) {
-    next = applyAcceptedTurn(next, turn);
-    if (turn.status !== "running") {
-      next = {
-        ...next,
-        items: upsertTurnBoundary(next.items, {
-          turnId: turn.id,
-          status: turn.status,
-          durationMs: durationMs(turn.started_at, turn.ended_at ?? null),
-          usage: turn.usage ?? null,
-          error: null,
-          diffstat: turn.diffstat ?? null,
-        }),
-      };
-    }
-  }
-  const lastUsage =
-    [...turns].reverse().find((turn) => turn.usage)?.usage ?? next.lastUsage;
-  const open = [...turns].reverse().find((turn) => turn.status === "running");
-  if (open) {
-    return {
-      ...next,
-      lastUsage,
-      busy: true,
-      activeTurnId: open.id,
-      turnStartedAt: open.started_at,
-      lifecycle: "running",
-    };
-  }
-  if (turns.length > 0) {
-    return { ...next, lastUsage, lifecycle: next.lifecycle ?? "idle" };
-  }
-  return next;
+  return reconcilePendingCodeTurns(state, turns);
 }
 
 export function reduceCodeSessionEvent(
@@ -328,10 +716,15 @@ export function reduceCodeSessionEvent(
   // current assistant tail, so it replaces the buffer instead of appending.
   const transient = framed.transient === true;
   if (!transient && framed.seq <= state.lastSeq) return { state, effects: [] };
+  const cappedReplayStart =
+    framed.replayed === true && framed.truncated === true;
   state = {
     ...state,
     lastSeq: transient ? state.lastSeq : framed.seq,
     animateStreaming: framed.replayed !== true,
+    journalTurnId: cappedReplayStart ? null : state.journalTurnId,
+    assistantBuffer: cappedReplayStart ? "" : state.assistantBuffer,
+    reasoningBuffer: cappedReplayStart ? "" : state.reasoningBuffer,
     items:
       framed.truncated === true
         ? withTruncationNotice(state.items)
@@ -339,6 +732,10 @@ export function reduceCodeSessionEvent(
   };
   const event = framed.event;
   const effects: CodeSessionEffect[] = [];
+  // Snapshot activity can be stale across a retained close. Historical rows
+  // stay unassigned until replay itself establishes their turn.
+  const attributedTurnId =
+    framed.replayed === true ? state.journalTurnId : state.activeTurnId;
 
   switch (event.type) {
     case "session_started":
@@ -353,12 +750,34 @@ export function reduceCodeSessionEvent(
 
     case "turn_started": {
       effects.push({ type: "turn_began", turnId: event.turn_id });
+      const anchored = anchorUnattributedTerminals(state, event.turn_id);
+      if (anchored !== state) {
+        effects.push({ type: "turn_snapshot_needed", turnId: null });
+        state = anchored;
+      }
+      const durableStartedAt = acceptedTurnStartedAt(
+        state.items,
+        event.turn_id,
+      );
+      const observedStartedAt =
+        state.activeTurnId === event.turn_id ? state.turnStartedAt : null;
+      const continuesObservedTurn =
+        state.journalTurnId === event.turn_id && state.turnStartObservedLive;
       return {
         state: {
           ...state,
           busy: true,
           activeTurnId: event.turn_id,
-          turnStartedAt: state.turnStartedAt ?? deps.now(),
+          journalTurnId: event.turn_id,
+          // Hydration carries the server's accepted timestamp. Keep it when
+          // replay walks the same turn, and never invent a start for history
+          // that the client did not observe live.
+          turnStartedAt:
+            durableStartedAt ??
+            observedStartedAt ??
+            (framed.replayed === true ? null : deps.now()),
+          turnStartObservedLive:
+            framed.replayed !== true || continuesObservedTurn,
           assistantBuffer: "",
           reasoningBuffer: "",
           lifecycle: "running",
@@ -383,7 +802,7 @@ export function reduceCodeSessionEvent(
             finalizeStreaming(state.items, "reasoning"),
             "assistant",
             assistantBuffer,
-            state.activeTurnId,
+            attributedTurnId,
             null,
             deps.nextId,
           ),
@@ -407,7 +826,7 @@ export function reduceCodeSessionEvent(
               state.items,
               "assistant",
               event.text,
-              state.activeTurnId,
+              attributedTurnId,
               parentCallId,
               deps.nextId,
             ),
@@ -429,7 +848,7 @@ export function reduceCodeSessionEvent(
             state.items,
             "reasoning",
             reasoningBuffer,
-            state.activeTurnId,
+            attributedTurnId,
             null,
             deps.nextId,
           ),
@@ -453,10 +872,10 @@ export function reduceCodeSessionEvent(
           ...state,
           assistantBuffer: parentCallId === null ? "" : state.assistantBuffer,
           reasoningBuffer: parentCallId === null ? "" : state.reasoningBuffer,
-          items: insertBeforeTurnBoundary(opened, state.activeTurnId, {
+          items: insertBeforeTurnBoundary(opened, attributedTurnId, {
             kind: "tool",
             id: deps.nextId(),
-            turnId: state.activeTurnId,
+            turnId: attributedTurnId,
             callId: event.call_id,
             parentCallId,
             name: event.name,
@@ -506,7 +925,7 @@ export function reduceCodeSessionEvent(
           ...state,
           items: existing
             ? state.items
-            : insertBeforeTurnBoundary(state.items, state.activeTurnId, {
+            : insertBeforeTurnBoundary(state.items, attributedTurnId, {
                 kind: "approval",
                 id: `approval:${approvalId}`,
                 approvalId,
@@ -537,7 +956,7 @@ export function reduceCodeSessionEvent(
       return {
         state: {
           ...state,
-          items: insertBeforeTurnBoundary(state.items, state.activeTurnId, {
+          items: insertBeforeTurnBoundary(state.items, attributedTurnId, {
             kind: "notice",
             id: deps.nextId(),
             level: event.level,
@@ -563,10 +982,10 @@ export function reduceCodeSessionEvent(
       return {
         state: {
           ...state,
-          items: insertBeforeTurnBoundary(state.items, state.activeTurnId, {
+          items: insertBeforeTurnBoundary(state.items, attributedTurnId, {
             kind: "steer",
             id: deps.nextId(),
-            turnId: state.activeTurnId,
+            turnId: attributedTurnId,
             text: event.text,
           }),
         },
@@ -590,7 +1009,7 @@ export function reduceCodeSessionEvent(
           ...state,
           items: upsertFileActivity(
             state.items,
-            state.activeTurnId,
+            attributedTurnId,
             event.path,
             event.kind,
             event.diffstat,
@@ -604,7 +1023,6 @@ export function reduceCodeSessionEvent(
     case "turn_completed":
     case "turn_failed":
     case "turn_interrupted": {
-      effects.push({ type: "turn_resolved" });
       const status =
         event.type === "turn_completed"
           ? "completed"
@@ -617,7 +1035,76 @@ export function reduceCodeSessionEvent(
         event.type === "turn_completed"
           ? (event.checkpoint?.diffstat ?? null)
           : null;
-      const turnId = state.activeTurnId;
+      const turnId =
+        state.journalTurnId ??
+        (framed.replayed === true ? null : state.activeTurnId);
+      // Terminal rows carry no turn id. A replay may start after the matching
+      // `turn_started`, so snapshot activity alone cannot safely attribute it.
+      if (turnId === null) {
+        if (framed.replayed === true) {
+          state = withPendingTerminalReconciliation(state, {
+            eventSeq: framed.seq,
+            turnId: null,
+            candidateTurnId: state.activeTurnId,
+            nextTurnId: null,
+            status,
+            usage,
+            error,
+            diffstat,
+            previousUsage: state.lastUsage,
+          });
+          effects.push({
+            type: "turn_snapshot_needed",
+            turnId: null,
+          });
+          effects.push({ type: "turn_resolved" });
+          return {
+            state: {
+              ...state,
+              contentRevision: state.contentRevision + 1,
+            },
+            effects,
+          };
+        }
+        // A reader can attach after the matching start. The terminal still
+        // proves that the worktree may have changed, even when no transcript
+        // turn can be named safely.
+        effects.push({ type: "turn_resolved" });
+        return {
+          state: { ...state, contentRevision: state.contentRevision + 1 },
+          effects,
+        };
+      }
+      effects.push({ type: "turn_resolved" });
+      const hasDurableBoundary = state.durableBoundaryTurnIds.has(turnId);
+      const needsSnapshot = framed.replayed === true && !hasDurableBoundary;
+      if (needsSnapshot) {
+        state = withPendingTerminalReconciliation(state, {
+          eventSeq: framed.seq,
+          turnId,
+          candidateTurnId: turnId,
+          nextTurnId: null,
+          status,
+          usage,
+          error,
+          diffstat,
+          previousUsage: state.lastUsage,
+        });
+        effects.push({ type: "turn_snapshot_needed", turnId });
+      } else {
+        const pending = latestPendingForTurn(state, turnId);
+        if (pending) {
+          state = withoutPendingTerminalReconciliation(state, pending.eventSeq);
+        }
+      }
+      const canMeasureTurn =
+        state.activeTurnId === turnId &&
+        state.turnStartedAt !== null &&
+        (framed.replayed !== true || state.turnStartObservedLive);
+      const turnDuration =
+        canMeasureTurn && !hasDurableBoundary
+          ? durationMs(state.turnStartedAt, deps.now())
+          : null;
       const finalized = finalizeStreaming(
         finalizeStreaming(state.items, "assistant"),
         "reasoning",
@@ -626,21 +1113,32 @@ export function reduceCodeSessionEvent(
         state: {
           ...state,
           busy: false,
-          lastUsage: usage ?? state.lastUsage,
+          lastUsage: needsSnapshot
+            ? state.lastUsage
+            : (usage ?? state.lastUsage),
           assistantBuffer: "",
           reasoningBuffer: "",
           items: turnId
-            ? upsertTurnBoundary(finalized, {
-                turnId,
-                status,
-                durationMs: durationMs(state.turnStartedAt, deps.now()),
-                usage,
-                error,
-                diffstat,
-              })
+            ? upsertTurnBoundary(
+                finalized,
+                {
+                  turnId,
+                  status,
+                  // A snapshot boundary owns completed timing. Replayed or
+                  // duplicate terminal frames can enrich it, but cannot
+                  // replace its server-derived duration with client time.
+                  durationMs: turnDuration,
+                  usage,
+                  error,
+                  diffstat,
+                },
+                state.turnOrdinals,
+              )
             : finalized,
           activeTurnId: null,
+          journalTurnId: null,
           turnStartedAt: null,
+          turnStartObservedLive: false,
           lifecycle: "idle",
           // A failed or interrupted turn still leaves whatever the engine
           // wrote before it stopped, so every resolution is a content change.
@@ -813,12 +1311,33 @@ function insertUserBeforeTurn(
   items: CodeTranscriptItem[],
   user: Extract<CodeTranscriptItem, { kind: "user" }>,
   turnId: string,
+  turnOrdinals: ReadonlyMap<string, number>,
 ): CodeTranscriptItem[] {
-  const index = items.findIndex(
+  let index = items.findIndex(
     (item) => "turnId" in item && item.turnId === turnId,
   );
+  if (index === -1) {
+    const ordinal = turnOrdinals.get(turnId);
+    if (ordinal !== undefined) {
+      index = items.findIndex((item) => {
+        if (!("turnId" in item) || item.turnId === null) return false;
+        const itemOrdinal = turnOrdinals.get(item.turnId);
+        return itemOrdinal !== undefined && itemOrdinal > ordinal;
+      });
+    }
+  }
   if (index === -1) return [...items, user];
   return [...items.slice(0, index), user, ...items.slice(index)];
+}
+
+function acceptedTurnStartedAt(
+  items: readonly CodeTranscriptItem[],
+  turnId: string,
+): string | null {
+  const user = items.find(
+    (item) => item.kind === "user" && item.turnId === turnId,
+  );
+  return user?.kind === "user" ? user.createdAt : null;
 }
 
 function upsertTurnBoundary(
@@ -831,6 +1350,7 @@ function upsertTurnBoundary(
     error: string | null;
     diffstat: Diffstat | null;
   },
+  turnOrdinals: ReadonlyMap<string, number>,
 ): CodeTranscriptItem[] {
   const item: CodeTranscriptItem = {
     kind: "turn_boundary",
@@ -847,7 +1367,9 @@ function upsertTurnBoundary(
       candidate.kind === "turn_boundary" &&
       candidate.turnId === boundary.turnId,
   );
-  if (index === -1) return [...items, item];
+  if (index === -1) {
+    return insertTurnBoundary(items, item, turnOrdinals);
+  }
   const existing = items[index];
   if (existing && existing.kind === "turn_boundary") {
     return [
@@ -863,6 +1385,57 @@ function upsertTurnBoundary(
     ];
   }
   return items;
+}
+
+function replaceTurnBoundary(
+  items: CodeTranscriptItem[],
+  boundary: {
+    turnId: string;
+    status: Exclude<CodeTurnStatus, "running">;
+    durationMs: number | null;
+    usage: CodeUsage | null;
+    error: string | null;
+    diffstat: Diffstat | null;
+  },
+  turnOrdinals: ReadonlyMap<string, number>,
+): CodeTranscriptItem[] {
+  const item: CodeTranscriptItem = {
+    kind: "turn_boundary",
+    id: boundaryItemId(boundary.turnId),
+    turnId: boundary.turnId,
+    status: boundary.status,
+    durationMs: boundary.durationMs,
+    usage: boundary.usage,
+    error: boundary.error,
+    diffstat: boundary.diffstat,
+  };
+  const index = items.findIndex(
+    (candidate) =>
+      candidate.kind === "turn_boundary" &&
+      candidate.turnId === boundary.turnId,
+  );
+  if (index === -1) {
+    return insertTurnBoundary(items, item, turnOrdinals);
+  }
+  return [...items.slice(0, index), item, ...items.slice(index + 1)];
+}
+
+function insertTurnBoundary(
+  items: CodeTranscriptItem[],
+  boundary: Extract<CodeTranscriptItem, { kind: "turn_boundary" }>,
+  turnOrdinals: ReadonlyMap<string, number>,
+): CodeTranscriptItem[] {
+  const ordinal = boundary.turnId
+    ? turnOrdinals.get(boundary.turnId)
+    : undefined;
+  if (ordinal === undefined) return [...items, boundary];
+  const index = items.findIndex((item) => {
+    if (!("turnId" in item) || item.turnId === null) return false;
+    const itemOrdinal = turnOrdinals.get(item.turnId);
+    return itemOrdinal !== undefined && itemOrdinal > ordinal;
+  });
+  if (index === -1) return [...items, boundary];
+  return [...items.slice(0, index), boundary, ...items.slice(index)];
 }
 
 function applyDiffstat(

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { SequencedCodeEventFrame } from "../api/types";
+import type { CodeTurnSnapshot, SequencedCodeEventFrame } from "../api/types";
 import {
   acquireCodeSession,
   MAX_RETAINED_CODE_SESSIONS,
@@ -21,6 +21,46 @@ class FakeSocket {
   close() {
     this.closed = true;
   }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const NO_USAGE = {
+  input_tokens: 10,
+  output_tokens: 4,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+  context_tokens: 0,
+};
+
+function turnSnapshot(
+  id: string,
+  status: CodeTurnSnapshot["status"],
+  startedAt: string,
+  endedAt?: string,
+): CodeTurnSnapshot {
+  return {
+    id,
+    session_id: "s1",
+    ordinal: id === "t1" ? 1 : 2,
+    status,
+    user_input: id === "t1" ? "list the files" : "run the tests",
+    attachments: [],
+    started_at: startedAt,
+    ...(endedAt ? { ended_at: endedAt, usage: NO_USAGE } : {}),
+  };
 }
 
 afterEach(() => {
@@ -273,6 +313,573 @@ describe("CodeSessionRegistry", () => {
 
     sockets[0]?.onclose?.();
     expect(store.getState().connectionState).toBe("reconnecting");
+  });
+
+  it("keeps live turn timing when reconnect replays the terminal row", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("2026-08-15T12:00:00.000Z")
+      .mockReturnValue("2026-08-15T12:00:02.500Z");
+    const store = acquireCodeSession("s1", openSocket, {
+      nextId: () => "id",
+      now,
+    });
+
+    sockets[0]?.emit({
+      seq: 1,
+      event: { type: "turn_started", turn_id: "t1" },
+    });
+    sockets[0]?.onclose?.();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(sockets.map((socket) => socket.after)).toEqual([0, 1]);
+    sockets[1]?.emit({
+      seq: 2,
+      replayed: true,
+      event: {
+        type: "turn_completed",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 4,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          context_tokens: 0,
+        },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(40);
+
+    expect(store.getState().items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+    expect(now).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reopen a finished turn when delayed prompt hydration resolves", async () => {
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const promptRead = deferred<CodeTurnSnapshot[]>();
+    const hydrateTurns = vi
+      .fn<() => Promise<CodeTurnSnapshot[]>>()
+      .mockResolvedValueOnce([])
+      .mockImplementationOnce(() => promptRead.promise);
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("2026-08-15T12:00:00.000Z")
+      .mockReturnValue("2026-08-15T12:00:02.500Z");
+    const store = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now },
+      hydrateTurns,
+    );
+    await flushMicrotasks();
+
+    sockets[0]?.emit({
+      seq: 1,
+      event: { type: "turn_started", turn_id: "t1" },
+    });
+    expect(hydrateTurns).toHaveBeenCalledTimes(2);
+    sockets[0]?.emit({
+      seq: 2,
+      event: { type: "turn_completed", usage: NO_USAGE },
+    });
+
+    promptRead.resolve([
+      turnSnapshot("t1", "running", "2026-08-15T12:00:00.000Z"),
+    ]);
+    await flushMicrotasks();
+
+    expect(store.getState()).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      turnStartedAt: null,
+      lifecycle: "idle",
+    });
+    expect(store.getState().items).toContainEqual({
+      kind: "user",
+      id: userItemId("t1"),
+      turnId: "t1",
+      text: "list the files",
+      createdAt: "2026-08-15T12:00:00.000Z",
+      attachments: [],
+    });
+    expect(store.getState().items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 2_500,
+    });
+  });
+
+  it("does not replace a newer active turn when an older prompt read resolves", async () => {
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const t1PromptRead = deferred<CodeTurnSnapshot[]>();
+    const hydrateTurns = vi
+      .fn<() => Promise<CodeTurnSnapshot[]>>()
+      .mockResolvedValueOnce([])
+      .mockImplementationOnce(() => t1PromptRead.promise)
+      .mockResolvedValueOnce([
+        turnSnapshot("t2", "running", "2026-08-15T12:00:03.000Z"),
+      ]);
+    const now = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("2026-08-15T12:00:00.000Z")
+      .mockReturnValueOnce("2026-08-15T12:00:02.500Z")
+      .mockReturnValue("2026-08-15T12:00:03.000Z");
+    const store = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now },
+      hydrateTurns,
+    );
+    await flushMicrotasks();
+
+    sockets[0]?.emit({
+      seq: 1,
+      event: { type: "turn_started", turn_id: "t1" },
+    });
+    sockets[0]?.emit({
+      seq: 2,
+      event: { type: "turn_completed", usage: NO_USAGE },
+    });
+    sockets[0]?.emit({
+      seq: 3,
+      event: { type: "turn_started", turn_id: "t2" },
+    });
+    await flushMicrotasks();
+
+    expect(store.getState()).toMatchObject({
+      busy: true,
+      activeTurnId: "t2",
+      journalTurnId: "t2",
+      turnStartedAt: "2026-08-15T12:00:03.000Z",
+      lifecycle: "running",
+    });
+
+    t1PromptRead.resolve([
+      turnSnapshot("t1", "running", "2026-08-15T12:00:00.000Z"),
+    ]);
+    await flushMicrotasks();
+
+    expect(store.getState()).toMatchObject({
+      busy: true,
+      activeTurnId: "t2",
+      journalTurnId: "t2",
+      turnStartedAt: "2026-08-15T12:00:03.000Z",
+      lifecycle: "running",
+    });
+    expect(store.getState().items).toContainEqual({
+      kind: "user",
+      id: userItemId("t1"),
+      turnId: "t1",
+      text: "list the files",
+      createdAt: "2026-08-15T12:00:00.000Z",
+      attachments: [],
+    });
+  });
+
+  it("refreshes exact duration after a replay terminal lacks a durable boundary", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const hydrateTurns = vi
+      .fn<() => Promise<CodeTurnSnapshot[]>>()
+      .mockResolvedValueOnce([
+        turnSnapshot("t1", "running", "2026-08-15T20:41:23.000Z"),
+      ])
+      .mockResolvedValueOnce([
+        turnSnapshot(
+          "t1",
+          "completed",
+          "2026-08-15T20:41:23.000Z",
+          "2026-08-15T20:42:28.000Z",
+        ),
+      ]);
+    const now = vi.fn<() => string>();
+    const store = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now },
+      hydrateTurns,
+    );
+    await flushMicrotasks();
+
+    sockets[0]?.emit({
+      seq: 1,
+      replayed: true,
+      event: { type: "turn_started", turn_id: "t1" },
+    });
+    sockets[0]?.emit({
+      seq: 2,
+      replayed: true,
+      event: { type: "turn_completed", usage: NO_USAGE },
+    });
+    await vi.advanceTimersByTimeAsync(40);
+    await flushMicrotasks();
+
+    expect(hydrateTurns).toHaveBeenCalledTimes(2);
+    expect(store.getState()).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      lifecycle: "idle",
+    });
+    expect(store.getState().items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t1",
+      durationMs: 65_000,
+    });
+    expect(now).not.toHaveBeenCalled();
+  });
+
+  it("settles a hydrated turn when capped replay contains only its terminal", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const hydrateTurns = vi
+      .fn<() => Promise<CodeTurnSnapshot[]>>()
+      .mockResolvedValueOnce([
+        turnSnapshot("t2", "running", "2026-08-15T12:00:00.000Z"),
+      ])
+      .mockResolvedValueOnce([
+        turnSnapshot(
+          "t2",
+          "completed",
+          "2026-08-15T12:00:00.000Z",
+          "2026-08-15T12:00:02.500Z",
+        ),
+      ]);
+    const store = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now: vi.fn<() => string>() },
+      hydrateTurns,
+    );
+    await flushMicrotasks();
+
+    sockets[0]?.emit({
+      seq: 2_001,
+      replayed: true,
+      truncated: true,
+      event: { type: "turn_completed", usage: NO_USAGE },
+    });
+    await vi.advanceTimersByTimeAsync(40);
+    await flushMicrotasks();
+
+    expect(hydrateTurns).toHaveBeenCalledTimes(2);
+    expect(store.getState()).toMatchObject({
+      lastSeq: 2_001,
+      busy: false,
+      activeTurnId: null,
+      journalTurnId: null,
+      turnStartedAt: null,
+      lifecycle: "idle",
+      lastUsage: NO_USAGE,
+    });
+    expect(store.getState().items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      durationMs: 2_500,
+    });
+  });
+
+  it("restores a capped failure after initial hydration already saw it end", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const failed = turnSnapshot(
+      "t2",
+      "failed",
+      "2026-08-15T12:00:00.000Z",
+      "2026-08-15T12:00:02.500Z",
+    );
+    const hydrateTurns = vi.fn(async () => [failed]);
+    const store = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now: vi.fn<() => string>() },
+      hydrateTurns,
+    );
+    await flushMicrotasks();
+
+    expect(store.getState().items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      error: null,
+    });
+    sockets[0]?.emit({
+      seq: 2_001,
+      replayed: true,
+      truncated: true,
+      event: {
+        type: "turn_failed",
+        error: { message: "compiler crashed: missing libssl" },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(40);
+    await flushMicrotasks();
+
+    expect(hydrateTurns).toHaveBeenCalledTimes(2);
+    expect(store.getState().pendingTerminalReconciliations.size).toBe(0);
+    expect(store.getState().items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      status: "failed",
+      durationMs: 2_500,
+      error: "compiler crashed: missing libssl",
+    });
+  });
+
+  it("restores a capped failure after initial hydration was unavailable", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const hydrateTurns = vi
+      .fn<() => Promise<CodeTurnSnapshot[]>>()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce([
+        turnSnapshot(
+          "t2",
+          "failed",
+          "2026-08-15T12:00:00.000Z",
+          "2026-08-15T12:00:02.500Z",
+        ),
+      ]);
+    const store = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now: vi.fn<() => string>() },
+      hydrateTurns,
+    );
+    await flushMicrotasks();
+
+    sockets[0]?.emit({
+      seq: 2_001,
+      replayed: true,
+      truncated: true,
+      event: {
+        type: "turn_failed",
+        error: { message: "compiler crashed: missing libssl" },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(40);
+    await flushMicrotasks();
+
+    expect(hydrateTurns).toHaveBeenCalledTimes(2);
+    expect(store.getState().pendingTerminalReconciliations.size).toBe(0);
+    expect(store.getState()).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      lifecycle: "idle",
+    });
+    expect(store.getState().items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      status: "failed",
+      durationMs: 2_500,
+      error: "compiler crashed: missing libssl",
+    });
+  });
+
+  it("retries a failed terminal refresh with bounded backoff", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const hydrateTurns = vi
+      .fn<() => Promise<CodeTurnSnapshot[]>>()
+      .mockResolvedValueOnce([
+        turnSnapshot("t2", "running", "2026-08-15T12:00:00.000Z"),
+      ])
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce([
+        turnSnapshot(
+          "t2",
+          "failed",
+          "2026-08-15T12:00:00.000Z",
+          "2026-08-15T12:00:02.500Z",
+        ),
+      ]);
+    const store = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now: vi.fn<() => string>() },
+      hydrateTurns,
+    );
+    await flushMicrotasks();
+
+    sockets[0]?.emit({
+      seq: 2_001,
+      replayed: true,
+      truncated: true,
+      event: {
+        type: "turn_failed",
+        error: { message: "compiler crashed: missing libssl" },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(40);
+    await flushMicrotasks();
+
+    expect(hydrateTurns).toHaveBeenCalledTimes(2);
+    expect(store.getState().pendingTerminalReconciliations.size).toBe(1);
+    expect(store.getState()).toMatchObject({
+      busy: true,
+      activeTurnId: "t2",
+      lifecycle: "running",
+    });
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(hydrateTurns).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushMicrotasks();
+
+    expect(hydrateTurns).toHaveBeenCalledTimes(3);
+    expect(store.getState().pendingTerminalReconciliations.size).toBe(0);
+    expect(store.getState()).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      lifecycle: "idle",
+    });
+    expect(store.getState().items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      status: "failed",
+      durationMs: 2_500,
+      error: "compiler crashed: missing libssl",
+    });
+  });
+
+  it("reconciles a failed capped terminal before a retained store reconnects", async () => {
+    vi.useFakeTimers();
+    const sockets: FakeSocket[] = [];
+    const openSocket = (
+      after: number,
+      onFrame: (frame: SequencedCodeEventFrame) => void,
+    ) => {
+      const socket = new FakeSocket(after, onFrame);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    };
+    const hydrateTurns = vi
+      .fn<() => Promise<CodeTurnSnapshot[]>>()
+      .mockResolvedValueOnce([
+        turnSnapshot("t2", "running", "2026-08-15T12:00:00.000Z"),
+      ])
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce([
+        turnSnapshot(
+          "t2",
+          "failed",
+          "2026-08-15T12:00:00.000Z",
+          "2026-08-15T12:00:02.500Z",
+        ),
+      ]);
+    const first = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now: vi.fn<() => string>() },
+      hydrateTurns,
+    );
+    await flushMicrotasks();
+
+    sockets[0]?.emit({
+      seq: 2_001,
+      replayed: true,
+      truncated: true,
+      event: {
+        type: "turn_failed",
+        error: { message: "compiler crashed: missing libssl" },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(40);
+    await flushMicrotasks();
+    expect(first.getState().pendingTerminalReconciliations.size).toBe(1);
+
+    releaseCodeSession("s1");
+    const reopened = acquireCodeSession(
+      "s1",
+      openSocket,
+      { nextId: () => "id", now: vi.fn<() => string>() },
+      hydrateTurns,
+    );
+    await flushMicrotasks();
+
+    expect(reopened).toBe(first);
+    expect(hydrateTurns).toHaveBeenCalledTimes(3);
+    expect(sockets.map((socket) => socket.after)).toEqual([0, 2_001]);
+    expect(reopened.getState().pendingTerminalReconciliations.size).toBe(0);
+    expect(reopened.getState()).toMatchObject({
+      busy: false,
+      activeTurnId: null,
+      lifecycle: "idle",
+    });
+    expect(reopened.getState().items.at(-1)).toMatchObject({
+      kind: "turn_boundary",
+      turnId: "t2",
+      status: "failed",
+      durationMs: 2_500,
+      error: "compiler crashed: missing libssl",
+    });
   });
 
   it("fills in the prompt of a turn the socket announces", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -623,7 +623,7 @@ describe("CodeSessionRegistry", () => {
     });
   });
 
-  it("restores a capped failure after initial hydration already saw it end", async () => {
+  it("keeps a capped failure unassigned after initial hydration already saw it end", async () => {
     vi.useFakeTimers();
     const sockets: FakeSocket[] = [];
     const openSocket = (
@@ -667,17 +667,17 @@ describe("CodeSessionRegistry", () => {
     await flushMicrotasks();
 
     expect(hydrateTurns).toHaveBeenCalledTimes(2);
-    expect(store.getState().pendingTerminalReconciliations.size).toBe(0);
+    expect(store.getState().pendingTerminalReconciliations.size).toBe(1);
     expect(store.getState().items.at(-1)).toMatchObject({
       kind: "turn_boundary",
       turnId: "t2",
       status: "failed",
       durationMs: 2_500,
-      error: "compiler crashed: missing libssl",
+      error: null,
     });
   });
 
-  it("restores a capped failure after initial hydration was unavailable", async () => {
+  it("keeps a capped failure unassigned after initial hydration was unavailable", async () => {
     vi.useFakeTimers();
     const sockets: FakeSocket[] = [];
     const openSocket = (
@@ -720,7 +720,7 @@ describe("CodeSessionRegistry", () => {
     await flushMicrotasks();
 
     expect(hydrateTurns).toHaveBeenCalledTimes(2);
-    expect(store.getState().pendingTerminalReconciliations.size).toBe(0);
+    expect(store.getState().pendingTerminalReconciliations.size).toBe(1);
     expect(store.getState()).toMatchObject({
       busy: false,
       activeTurnId: null,
@@ -731,11 +731,11 @@ describe("CodeSessionRegistry", () => {
       turnId: "t2",
       status: "failed",
       durationMs: 2_500,
-      error: "compiler crashed: missing libssl",
+      error: null,
     });
   });
 
-  it("retries a failed terminal refresh with bounded backoff", async () => {
+  it("retries an unresolved terminal refresh with bounded backoff", async () => {
     vi.useFakeTimers();
     const sockets: FakeSocket[] = [];
     const openSocket = (
@@ -794,7 +794,7 @@ describe("CodeSessionRegistry", () => {
     await flushMicrotasks();
 
     expect(hydrateTurns).toHaveBeenCalledTimes(3);
-    expect(store.getState().pendingTerminalReconciliations.size).toBe(0);
+    expect(store.getState().pendingTerminalReconciliations.size).toBe(1);
     expect(store.getState()).toMatchObject({
       busy: false,
       activeTurnId: null,
@@ -805,11 +805,11 @@ describe("CodeSessionRegistry", () => {
       turnId: "t2",
       status: "failed",
       durationMs: 2_500,
-      error: "compiler crashed: missing libssl",
+      error: null,
     });
   });
 
-  it("reconciles a failed capped terminal before a retained store reconnects", async () => {
+  it("keeps an unattributed capped terminal pending across a retained reconnect", async () => {
     vi.useFakeTimers();
     const sockets: FakeSocket[] = [];
     const openSocket = (
@@ -867,7 +867,7 @@ describe("CodeSessionRegistry", () => {
     expect(reopened).toBe(first);
     expect(hydrateTurns).toHaveBeenCalledTimes(3);
     expect(sockets.map((socket) => socket.after)).toEqual([0, 2_001]);
-    expect(reopened.getState().pendingTerminalReconciliations.size).toBe(0);
+    expect(reopened.getState().pendingTerminalReconciliations.size).toBe(1);
     expect(reopened.getState()).toMatchObject({
       busy: false,
       activeTurnId: null,
@@ -878,7 +878,7 @@ describe("CodeSessionRegistry", () => {
       turnId: "t2",
       status: "failed",
       durationMs: 2_500,
-      error: "compiler crashed: missing libssl",
+      error: null,
     });
   });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -121,6 +121,7 @@ function createController(
           turnId: pending.turnId,
           eventSeq: pending.eventSeq,
           observedSeq: state.lastSeq,
+          observedTurnActivityRevision: state.turnActivityRevision,
         }),
       );
     },

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -6,8 +6,9 @@ import {
   type CodeSessionStore,
 } from "./CodeSessionStore";
 import {
-  applyAcceptedTurn,
+  applyCodeTurnSnapshot,
   hydrateCodeTurns,
+  reconcilePendingCodeTurns,
   type CodeSessionDeps,
 } from "./CodeSessionReducer";
 
@@ -70,13 +71,16 @@ function createController(
       .then((turns) => {
         const turn = turns.find((candidate) => candidate.id === turnId);
         if (!turn) return;
-        store.getState().update((session) => applyAcceptedTurn(session, turn));
+        store
+          .getState()
+          .update((session) => applyCodeTurnSnapshot(session, turn));
       })
       .catch(() => {
         // The prompt lands on the next open. The turn itself still streams.
       });
   };
-  return new CodeSessionController({
+  let controller: CodeSessionController;
+  controller = new CodeSessionController({
     openSocket,
     getAfter: () => store.getState().lastSeq,
     onEvents: (frames, initialViewSettled) => {
@@ -84,11 +88,15 @@ function createController(
       // only when the turn ends, and a queued follow-up is never answered
       // with a turn at all. Pull the snapshot so the transcript shows what
       // the engine is working on while it works.
-      for (const effect of store
+      const effects = store
         .getState()
-        .applyEvents(frames, deps, initialViewSettled)) {
+        .applyEvents(frames, deps, initialViewSettled);
+      let turnSnapshotNeeded = false;
+      for (const effect of effects) {
         if (effect.type === "turn_began") fillPrompt(effect.turnId);
+        if (effect.type === "turn_snapshot_needed") turnSnapshotNeeded = true;
       }
+      if (turnSnapshotNeeded) controller.requestTurnRefresh();
     },
     onConnectionState: (connectionState) => {
       store.getState().setConnectionState(connectionState);
@@ -98,7 +106,26 @@ function createController(
       store.getState().update((session) => hydrateCodeTurns(session, turns));
       onTurnsHydrated();
     },
+    refreshTurns: hydrateTurns,
+    onTurnRefresh: (turns, requested) => {
+      store
+        .getState()
+        .update((session) =>
+          reconcilePendingCodeTurns(session, turns, requested),
+        );
+    },
+    getPendingTurnRefreshes: () => {
+      const state = store.getState();
+      return [...state.pendingTerminalReconciliations.values()].map(
+        (pending) => ({
+          turnId: pending.turnId,
+          eventSeq: pending.eventSeq,
+          observedSeq: state.lastSeq,
+        }),
+      );
+    },
   });
+  return controller;
 }
 
 function retainCodeSession(sessionId: string): void {
@@ -124,12 +151,14 @@ export function acquireCodeSession(
     if (existing.refCount === 0) {
       retainedSessionIds.delete(sessionId);
       existing.refCount = 1;
+      const pendingTerminalReconciliation =
+        existing.store.getState().pendingTerminalReconciliations.size > 0;
       existing.controller = createController(
         existing.store,
         openSocket,
         deps,
         hydrateTurns,
-        !existing.turnsHydrated,
+        !existing.turnsHydrated || pendingTerminalReconciliation,
         () => {
           existing.turnsHydrated = true;
         },


### PR DESCRIPTION
## Implementation

- Preserve the capped-replay marker when the controller compacts adjacent replay deltas.
- Track journal-attributed turns and live start timing separately from durable snapshot activity.
- Retain unresolved replay terminals by event sequence, refresh turn snapshots with bounded-delay retries, and restore terminal status, duration, usage, errors, and transcript order when the durable turn appears.
- Ignore stale refresh activity when a newer live turn has started.

## Compatibility

This change does not alter the API, event protocol, or stored data. Live turns still use observed timing. Replayed turns use durable server timestamps when available, and keep duration unknown until an authoritative snapshot resolves it.

## Safety and risk

The change stays inside the in-memory code-session controller, reducer, and registry. It does not assign capped terminal rows from snapshot activity alone. The main risk is incorrect correlation across truncated replay windows, which the focused reducer and registry cases cover for stale snapshots, missing initial hydration, retries, reconnects, multiple turn order, and newer live turns.

## Validation

- `pnpm exec vitest run src/code/CodeSessionController.test.ts src/code/CodeSessionReducer.test.ts src/code/CodeSessionRegistry.test.ts src/code/CodeSessionStore.test.ts src/code/CodeSessionSend.test.ts` (84 tests)
- `pnpm exec biome check src/code/CodeSessionController.ts src/code/CodeSessionController.test.ts src/code/CodeSessionReducer.ts src/code/CodeSessionReducer.test.ts src/code/CodeSessionRegistry.ts src/code/CodeSessionRegistry.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`