### PR TITLE
fix(code): make clone onboarding recoverable

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api.test.ts
@@ -21,6 +21,46 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+describe("repository setup request cancellation", () => {
+  it("passes the caller's abort signal to every setup read", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ repositories: [] }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ sources: [], chooses_destination: false }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            parent_dir: "/tmp/src",
+            gh_found: true,
+            gh_authenticated: true,
+            gh_remediation: "",
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+    const controller = new AbortController();
+
+    await client.listCodeGithubRepositories(controller.signal);
+    await client.getCodeRepoSources(controller.signal);
+    await client.getCodeCloneDefaults(controller.signal);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    for (const call of fetchMock.mock.calls) {
+      const [, init] = call as [string, RequestInit];
+      expect(init.signal).toBe(controller.signal);
+    }
+  });
+});
+
 describe("parseFolderAccessRequest", () => {
   it("accepts only the closed renderer-safe consent projection", () => {
     expect(

--- a/crates/tidebreak-desktop/ui/src/api/client.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client.ts
@@ -2073,29 +2073,38 @@ export class ApiClient {
    * on a shared machine the person adding a repository is usually not an
    * administrator, and a dialog that cannot read its own options is no dialog.
    */
-  async listCodeGithubRepositories(): Promise<CodeGithubRepositories> {
+  async listCodeGithubRepositories(
+    signal?: AbortSignal,
+  ): Promise<CodeGithubRepositories> {
     return requireParsed(
       parseCodeGithubRepositories(
-        await this.json("/code/repos/github", { headers: this.headers() }),
+        await this.json("/code/repos/github", {
+          headers: this.headers(),
+          signal,
+        }),
       ),
       "github repositories",
     );
   }
 
-  async getCodeRepoSources(): Promise<CodeRepoSources> {
+  async getCodeRepoSources(signal?: AbortSignal): Promise<CodeRepoSources> {
     return requireParsed(
       parseCodeRepoSources(
-        await this.json("/code/repos/sources", { headers: this.headers() }),
+        await this.json("/code/repos/sources", {
+          headers: this.headers(),
+          signal,
+        }),
       ),
       "repo sources",
     );
   }
 
-  async getCodeCloneDefaults(): Promise<CodeCloneDefaults> {
+  async getCodeCloneDefaults(signal?: AbortSignal): Promise<CodeCloneDefaults> {
     return requireParsed(
       parseCodeCloneDefaults(
         await this.json("/code/repos/clone-defaults", {
           headers: this.headers(),
+          signal,
         }),
       ),
       "clone defaults",

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@testing-library/react";
 import { useState } from "react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
@@ -17,7 +18,12 @@ import { setAttachedRemotely } from "@/host";
 import { AddRepoPalette } from "./AddRepoPalette";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
-import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+import {
+  activateCodeCloneClient,
+  selectCodeClone,
+  trackCodeClone,
+  useCodeUpdatesStore,
+} from "./CodeUpdatesStore";
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -32,7 +38,9 @@ afterEach(() => {
     newWorkspaceRepoId: undefined,
     addRepoOpen: false,
   });
+  setAttachedRemotely(false);
   vi.useRealTimers();
+  vi.clearAllMocks();
 });
 
 const REPO = {
@@ -198,6 +206,33 @@ describe("AddRepoPalette", () => {
     );
   });
 
+  it("keeps a destination typed before clone defaults resolve", async () => {
+    const defaults =
+      deferred<
+        Awaited<ReturnType<AppContextValue["client"]["getCodeCloneDefaults"]>>
+      >();
+    await renderPalette(
+      app({
+        getCodeCloneDefaults: vi.fn(() => defaults.promise),
+      }),
+    );
+    fireEvent.click(await screen.findByRole("option", { name: /Git URL/ }));
+    const destination = await screen.findByLabelText("Destination folder");
+    fireEvent.change(destination, { target: { value: "/tmp/chosen" } });
+
+    await act(async () => {
+      defaults.resolve({
+        parent_dir: "/tmp/stale-default",
+        gh_found: true,
+        gh_authenticated: true,
+        gh_remediation: "",
+      });
+      await defaults.promise;
+    });
+
+    expect(destination).toHaveValue("/tmp/chosen");
+  });
+
   it("drives clone progress to done and shows an error tail with retry", async () => {
     const started = vi.fn(async () => ({
       id: "job-1",
@@ -298,6 +333,138 @@ describe("AddRepoPalette", () => {
 
     await waitFor(() => expect(getCodeRepo).not.toHaveBeenCalled());
     expect(useCodeUiStore.getState().newWorkspaceOpen).toBe(false);
+  });
+
+  it("opens the exact clone selected by a background notification", async () => {
+    const value = app();
+    const clientGeneration = activateCodeCloneClient(value.client);
+    trackCodeClone(
+      value.client,
+      { id: "job-a", phase: "Clone A", done: false },
+      { github: "acme/a", parent_dir: "/tmp/src" },
+      true,
+    );
+    trackCodeClone(
+      value.client,
+      { id: "job-b", phase: "Clone B", done: false },
+      { github: "acme/b", parent_dir: "/tmp/src" },
+      true,
+    );
+    expect(selectCodeClone({ jobId: "job-a", clientGeneration })).toBe(true);
+
+    render(<PaletteHarness value={value} />);
+
+    expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
+      "Clone A",
+    );
+    expect(screen.queryByText("Clone B")).not.toBeInTheDocument();
+  });
+
+  it("keeps the selected clone destination when pending defaults resolve", async () => {
+    const defaults =
+      deferred<
+        Awaited<ReturnType<AppContextValue["client"]["getCodeCloneDefaults"]>>
+      >();
+    const value = app({
+      getCodeCloneDefaults: vi.fn(() => defaults.promise),
+    });
+    const clientGeneration = activateCodeCloneClient(value.client);
+    render(<PaletteHarness value={value} />);
+    expect(
+      await screen.findByRole("option", { name: /Local folder/ }),
+    ).toBeVisible();
+
+    act(() => {
+      trackCodeClone(
+        value.client,
+        { id: "job-a", phase: "Clone A", done: false },
+        { github: "acme/a", parent_dir: "/tmp/selected" },
+        true,
+      );
+      selectCodeClone({ jobId: "job-a", clientGeneration });
+    });
+    expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
+      "Clone A",
+    );
+
+    await act(async () => {
+      defaults.resolve({
+        parent_dir: "/tmp/stale-default",
+        gh_found: true,
+        gh_authenticated: true,
+        gh_remediation: "",
+      });
+      await defaults.promise;
+    });
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Backspace" });
+
+    expect(await screen.findByLabelText("Destination folder")).toHaveValue(
+      "/tmp/selected",
+    );
+  });
+
+  it("aborts every setup probe when the palette closes", async () => {
+    const sources = vi.fn((_signal?: AbortSignal) => new Promise(() => {}));
+    const github = vi.fn((_signal?: AbortSignal) => new Promise(() => {}));
+    const defaults = vi.fn((_signal?: AbortSignal) => new Promise(() => {}));
+    render(
+      <PaletteHarness
+        value={app({
+          getCodeRepoSources: sources as never,
+          listCodeGithubRepositories: github as never,
+          getCodeCloneDefaults: defaults as never,
+        })}
+      />,
+    );
+    await waitFor(() => {
+      expect(sources).toHaveBeenCalledTimes(1);
+      expect(github).toHaveBeenCalledTimes(1);
+      expect(defaults).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    for (const probe of [sources, github, defaults]) {
+      const signal = probe.mock.calls[0]?.[0];
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(true);
+    }
+  });
+
+  it("keeps a successful local registration after dismissal", async () => {
+    const registration = deferred<typeof REPO>();
+    const value = app({
+      createCodeRepo: vi.fn(() => registration.promise),
+    });
+    render(<PaletteHarness value={value} />);
+    fireEvent.click(
+      await screen.findByRole("option", { name: /Local folder/ }),
+    );
+    fireEvent.change(await screen.findByLabelText("Path"), {
+      target: { value: REPO.root_path },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Register" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    await act(async () => {
+      registration.resolve(REPO);
+      await registration.promise;
+    });
+
+    expect(useCodeCatalogStore.getState().repos).toContainEqual(REPO);
+    expect(toast.success).toHaveBeenCalledWith(
+      "Repository registered",
+      expect.objectContaining({
+        description: "Create a workspace when you are ready.",
+      }),
+    );
+    expect(useCodeUiStore.getState().newWorkspaceOpen).toBe(false);
+    expect(useCodeUiStore.getState().newWorkspaceRepoId).toBeUndefined();
+    const options = vi.mocked(toast.success).mock.calls[0]?.[1] as
+      | { action?: { onClick: () => void } }
+      | undefined;
+    options?.action?.onClick();
+    expect(useCodeUiStore.getState().newWorkspaceRepoId).toBe(REPO.id);
   });
 
   it("ignores slow setup probes from a dismissed opening after reopen", async () => {
@@ -507,6 +674,88 @@ describe("AddRepoPalette", () => {
     expect(
       screen.queryByRole("option", { name: /stale\/repository/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it("clears the previous client's defaults while replacement probes wait", async () => {
+    const replacementDefaults =
+      deferred<
+        Awaited<ReturnType<AppContextValue["client"]["getCodeCloneDefaults"]>>
+      >();
+    const first = app({
+      getCodeCloneDefaults: vi.fn(async () => ({
+        parent_dir: "/first/src",
+        gh_found: false,
+        gh_authenticated: false,
+        gh_remediation: "Client A needs a GitHub credential.",
+      })),
+    });
+    const replacement = app({
+      getCodeCloneDefaults: vi.fn(() => replacementDefaults.promise),
+    });
+    const view = render(<PaletteHarness value={first} />);
+    fireEvent.click(
+      await screen.findByRole("option", { name: /GitHub repository/ }),
+    );
+    expect(await screen.findByTestId("gh-absent-hint")).toHaveTextContent(
+      "Client A needs a GitHub credential.",
+    );
+
+    view.rerender(<PaletteHarness value={replacement} />);
+    fireEvent.click(
+      await screen.findByRole("option", { name: /GitHub repository/ }),
+    );
+
+    expect(
+      screen.queryByText(/Client A needs a GitHub credential/),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      name: "completed",
+      job: {
+        id: "job-terminal",
+        phase: "Clone complete",
+        done: true,
+        repo_id: REPO.id,
+      },
+    },
+    {
+      name: "failed",
+      job: {
+        id: "job-terminal",
+        phase: "Clone failed",
+        done: true,
+        error: "fatal: repository not found",
+      },
+    },
+  ])("forgets a $name clone when Back leaves progress", async ({ job }) => {
+    const value = app();
+    activateCodeCloneClient(value.client);
+    trackCodeClone(value.client, job, {
+      url: "https://example.com/acme/app.git",
+      parent_dir: "/tmp/src",
+    });
+    render(<PaletteHarness value={value} />);
+    expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
+      job.phase,
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Backspace" });
+    expect(
+      await screen.findByPlaceholderText("https://example.com/acme/app.git"),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open add repository" }),
+    );
+
+    expect(
+      await screen.findByRole("option", { name: /Local folder/ }),
+    ).toBeVisible();
+    expect(
+      useCodeUpdatesStore.getState().cloneJobs["job-terminal"],
+    ).toBeUndefined();
   });
 
   it("recovers a clone that completes while Code UI is unmounted", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -7,12 +15,45 @@ import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import { renderWithRouter } from "@/test/router";
 import { setAttachedRemotely } from "@/host";
 import { AddRepoPalette } from "./AddRepoPalette";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { useCodeUiStore } from "./CodeUiStore";
 import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
 
 afterEach(() => {
   cleanup();
+  useCodeCatalogStore.getState().reset();
   useCodeUpdatesStore.getState().reset();
+  useCodeUiStore.setState({
+    newWorkspaceOpen: false,
+    newWorkspaceRepoId: undefined,
+    addRepoOpen: false,
+  });
+  vi.useRealTimers();
 });
+
+const REPO = {
+  id: "repo-1",
+  root_path: "/tmp/src/demo",
+  display_name: "demo",
+  default_base_ref: "main",
+  branch_prefix: "tidebreak/",
+  quick_actions: [],
+  created_at: "2026-08-17T00:00:00.000Z",
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
 
 function app(
   overrides: Partial<AppContextValue["client"]> = {},
@@ -34,6 +75,7 @@ function app(
       })),
       listCodeGithubRepositories: vi.fn(async () => ({ repositories: [] })),
       startCodeClone: vi.fn(),
+      getCodeCloneJob: vi.fn(() => new Promise(() => {})),
       getCodeRepo: vi.fn(),
       createCodeRepo: vi.fn(),
       ...overrides,
@@ -77,6 +119,36 @@ async function renderPalette(value: AppContextValue = app()) {
     </AppContextProvider>,
     { initialUrl: "/code" },
   );
+}
+
+function PaletteHarness({
+  value,
+  mounted = true,
+}: {
+  value: AppContextValue;
+  mounted?: boolean;
+}) {
+  const [open, setOpen] = useState(true);
+  return (
+    <AppContextProvider value={value}>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open add repository
+      </button>
+      {mounted && <AddRepoPalette open={open} onOpenChange={setOpen} />}
+    </AppContextProvider>
+  );
+}
+
+async function startGitClone(url = "https://example.com/acme/app.git") {
+  fireEvent.click(await screen.findByRole("option", { name: /Git URL/ }));
+  const urlInput = await screen.findByPlaceholderText(
+    "https://example.com/acme/app.git",
+  );
+  await waitFor(() =>
+    expect(screen.getByLabelText("Destination folder")).toHaveValue("/tmp/src"),
+  );
+  fireEvent.change(urlInput, { target: { value: url } });
+  fireEvent.click(screen.getByRole("button", { name: "Clone" }));
 }
 
 describe("AddRepoPalette", () => {
@@ -189,6 +261,400 @@ describe("AddRepoPalette", () => {
     expect(
       screen.getByPlaceholderText("https://example.com/acme/app.git"),
     ).toBeInTheDocument();
+  });
+
+  it("does not open New Workspace after clone progress is dismissed", async () => {
+    const getCodeRepo = vi.fn(async () => REPO);
+    const value = app({
+      startCodeClone: vi.fn(async () => ({
+        id: "job-dismissed",
+        phase: "starting",
+        done: false,
+      })),
+      getCodeRepo,
+    });
+    render(<PaletteHarness value={value} />);
+
+    await startGitClone();
+    expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
+      "starting",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+
+    act(() => {
+      useCodeUpdatesStore.getState().apply({
+        type: "clone_progress",
+        job: {
+          id: "job-dismissed",
+          phase: "complete",
+          done: true,
+          repo_id: REPO.id,
+        },
+      });
+    });
+
+    await waitFor(() => expect(getCodeRepo).not.toHaveBeenCalled());
+    expect(useCodeUiStore.getState().newWorkspaceOpen).toBe(false);
+  });
+
+  it("ignores slow setup probes from a dismissed opening after reopen", async () => {
+    const oldSources =
+      deferred<
+        Awaited<ReturnType<AppContextValue["client"]["getCodeRepoSources"]>>
+      >();
+    const oldGithub =
+      deferred<
+        Awaited<
+          ReturnType<AppContextValue["client"]["listCodeGithubRepositories"]>
+        >
+      >();
+    const oldDefaults =
+      deferred<
+        Awaited<ReturnType<AppContextValue["client"]["getCodeCloneDefaults"]>>
+      >();
+    const getCodeRepoSources = vi
+      .fn()
+      .mockImplementationOnce(() => oldSources.promise)
+      .mockResolvedValue({
+        sources: [
+          {
+            kind: "local",
+            available: false,
+            remediation: "Local folders are unavailable on this machine.",
+          },
+          { kind: "git_url", available: true },
+          { kind: "github", available: true },
+        ],
+        chooses_destination: false,
+      });
+    const listCodeGithubRepositories = vi
+      .fn()
+      .mockImplementationOnce(() => oldGithub.promise)
+      .mockResolvedValue({
+        repositories: [{ full_name: "new-owner/new-repo", private: true }],
+      });
+    const getCodeCloneDefaults = vi
+      .fn()
+      .mockImplementationOnce(() => oldDefaults.promise)
+      .mockResolvedValue({
+        parent_dir: "/new/src",
+        gh_found: true,
+        gh_authenticated: true,
+      });
+    render(
+      <PaletteHarness
+        value={app({
+          getCodeRepoSources,
+          listCodeGithubRepositories,
+          getCodeCloneDefaults,
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getCodeRepoSources).toHaveBeenCalledTimes(1);
+      expect(listCodeGithubRepositories).toHaveBeenCalledTimes(1);
+      expect(getCodeCloneDefaults).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open add repository" }),
+    );
+    await waitFor(() => {
+      expect(getCodeRepoSources).toHaveBeenCalledTimes(2);
+      expect(listCodeGithubRepositories).toHaveBeenCalledTimes(2);
+      expect(getCodeCloneDefaults).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("option", { name: /Local folder/ }),
+      ).not.toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      oldSources.resolve({
+        sources: [
+          { kind: "local", available: true },
+          { kind: "git_url", available: true },
+          { kind: "github", available: true },
+        ],
+        chooses_destination: false,
+      });
+      oldGithub.resolve({
+        repositories: [{ full_name: "old-owner/old-repo", private: true }],
+      });
+      oldDefaults.resolve({
+        parent_dir: "/old/src",
+        gh_found: true,
+        gh_authenticated: true,
+        gh_remediation: "",
+      });
+      await Promise.all([
+        oldSources.promise,
+        oldGithub.promise,
+        oldDefaults.promise,
+      ]);
+    });
+
+    expect(
+      screen.queryByRole("option", { name: /Local folder/ }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("option", { name: /GitHub repository/ }));
+    expect(await screen.findByLabelText("Destination folder")).toHaveValue(
+      "/new/src",
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox", { name: "Repository" }));
+    expect(
+      await screen.findByRole("option", { name: /new-owner\/new-repo/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /old-owner\/old-repo/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("ignores setup probes from a replaced ApiClient", async () => {
+    const oldSources =
+      deferred<
+        Awaited<ReturnType<AppContextValue["client"]["getCodeRepoSources"]>>
+      >();
+    const oldGithub =
+      deferred<
+        Awaited<
+          ReturnType<AppContextValue["client"]["listCodeGithubRepositories"]>
+        >
+      >();
+    const oldDefaults =
+      deferred<
+        Awaited<ReturnType<AppContextValue["client"]["getCodeCloneDefaults"]>>
+      >();
+    const oldValue = app({
+      getCodeRepoSources: vi.fn(() => oldSources.promise),
+      listCodeGithubRepositories: vi.fn(() => oldGithub.promise),
+      getCodeCloneDefaults: vi.fn(() => oldDefaults.promise),
+    });
+    const replacement = app({
+      getCodeRepoSources: vi.fn(async () => ({
+        sources: [
+          { kind: "local", available: true },
+          { kind: "git_url", available: true },
+          { kind: "github", available: true },
+        ],
+        chooses_destination: false,
+      })),
+      listCodeGithubRepositories: vi.fn(async () => ({
+        repositories: [{ full_name: "replacement/repository", private: true }],
+      })),
+      getCodeCloneDefaults: vi.fn(async () => ({
+        parent_dir: "/replacement/src",
+        gh_found: true,
+        gh_authenticated: true,
+        gh_remediation: "",
+      })),
+    });
+    const view = render(<PaletteHarness value={oldValue} />);
+    await waitFor(() =>
+      expect(oldValue.client.getCodeRepoSources).toHaveBeenCalled(),
+    );
+
+    view.rerender(<PaletteHarness value={replacement} />);
+    fireEvent.click(
+      await screen.findByRole("option", { name: /GitHub repository/ }),
+    );
+    expect(await screen.findByLabelText("Destination folder")).toHaveValue(
+      "/replacement/src",
+    );
+
+    await act(async () => {
+      oldSources.resolve({
+        sources: [
+          { kind: "local", available: false },
+          { kind: "git_url", available: false },
+          { kind: "github", available: true },
+        ],
+        chooses_destination: true,
+      });
+      oldGithub.resolve({
+        repositories: [{ full_name: "stale/repository", private: true }],
+      });
+      oldDefaults.resolve({
+        parent_dir: "/stale/src",
+        gh_found: false,
+        gh_authenticated: false,
+        gh_remediation: "stale credential result",
+      });
+      await Promise.all([
+        oldSources.promise,
+        oldGithub.promise,
+        oldDefaults.promise,
+      ]);
+    });
+
+    expect(screen.getByLabelText("Destination folder")).toHaveValue(
+      "/replacement/src",
+    );
+    expect(
+      screen.queryByText("stale credential result"),
+    ).not.toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox", { name: "Repository" }));
+    expect(
+      await screen.findByRole("option", { name: /replacement\/repository/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /stale\/repository/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("recovers a clone that completes while Code UI is unmounted", async () => {
+    let completed = false;
+    const getCodeCloneJob = vi.fn(async () =>
+      completed
+        ? {
+            id: "job-unmounted",
+            phase: "complete",
+            done: true,
+            repo_id: REPO.id,
+          }
+        : {
+            id: "job-unmounted",
+            phase: "receiving objects",
+            percent: 48,
+            done: false,
+          },
+    );
+    const getCodeRepo = vi.fn(async () => REPO);
+    const value = app({
+      startCodeClone: vi.fn(async () => ({
+        id: "job-unmounted",
+        phase: "starting",
+        done: false,
+      })),
+      getCodeCloneJob,
+      getCodeRepo,
+    });
+    const view = render(<PaletteHarness value={value} />);
+    await startGitClone();
+    await waitFor(() => expect(getCodeCloneJob).toHaveBeenCalled());
+
+    completed = true;
+    view.rerender(<PaletteHarness value={value} mounted={false} />);
+    act(() => useCodeUpdatesStore.getState().resetLive());
+    view.rerender(<PaletteHarness value={value} />);
+
+    expect(await screen.findByText("The repository is ready.")).toBeVisible();
+    expect(getCodeRepo).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
+    await waitFor(() => expect(getCodeRepo).toHaveBeenCalledWith(REPO.id));
+    expect(useCodeUiStore.getState().newWorkspaceRepoId).toBe(REPO.id);
+  });
+
+  it("recovers a missed completion notice from durable clone state", async () => {
+    const getCodeRepo = vi.fn(async () => REPO);
+    const value = app({
+      startCodeClone: vi.fn(async () => ({
+        id: "job-missed-notice",
+        phase: "starting",
+        done: false,
+      })),
+      getCodeCloneJob: vi.fn(async () => ({
+        id: "job-missed-notice",
+        phase: "complete",
+        done: true,
+        repo_id: REPO.id,
+      })),
+      getCodeRepo,
+    });
+    render(<PaletteHarness value={value} />);
+
+    await startGitClone();
+    await waitFor(() => expect(getCodeRepo).toHaveBeenCalledWith(REPO.id));
+    expect(useCodeUiStore.getState().newWorkspaceOpen).toBe(true);
+    expect(useCodeUiStore.getState().newWorkspaceRepoId).toBe(REPO.id);
+  });
+
+  it("retries a failed durable progress read", async () => {
+    const getCodeCloneJob = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("The progress service is unavailable."))
+      .mockResolvedValue({
+        id: "job-retry-read",
+        phase: "complete",
+        done: true,
+        repo_id: REPO.id,
+      });
+    const getCodeRepo = vi.fn(async () => REPO);
+    const value = app({
+      startCodeClone: vi.fn(async () => ({
+        id: "job-retry-read",
+        phase: "starting",
+        done: false,
+      })),
+      getCodeCloneJob,
+      getCodeRepo,
+    });
+    render(<PaletteHarness value={value} />);
+
+    await startGitClone();
+    expect(
+      await screen.findByText("The progress service is unavailable."),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Retry check" }));
+    await waitFor(() => expect(getCodeCloneJob).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(getCodeRepo).toHaveBeenCalledWith(REPO.id));
+  });
+
+  it("resumes a dismissed clone without rearming its automatic handoff", async () => {
+    const getCodeRepo = vi.fn(async () => REPO);
+    const value = app({
+      startCodeClone: vi.fn(async () => ({
+        id: "job-resume",
+        phase: "receiving objects",
+        percent: 32,
+        done: false,
+      })),
+      getCodeCloneJob: vi.fn(async () => ({
+        id: "job-resume",
+        phase: "receiving objects",
+        percent: 32,
+        done: false,
+      })),
+      getCodeRepo,
+    });
+    render(<PaletteHarness value={value} />);
+
+    await startGitClone();
+    expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
+      "receiving objects",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open add repository" }),
+    );
+    expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
+      "receiving objects",
+    );
+
+    act(() => {
+      useCodeUpdatesStore.getState().apply({
+        type: "clone_progress",
+        job: {
+          id: "job-resume",
+          phase: "complete",
+          done: true,
+          repo_id: REPO.id,
+        },
+      });
+    });
+
+    expect(await screen.findByText("The repository is ready.")).toBeVisible();
+    expect(getCodeRepo).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Create workspace" }),
+    ).toBeVisible();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import { ChevronDown, Folder, GitBranch, Link2 } from "lucide-react";
 
 import type {
@@ -42,10 +49,49 @@ import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { usesCommandModifier } from "@/ShellShortcuts";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
-import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+import { STATUS_TEXT } from "./statusTone";
+import {
+  activateCodeCloneClient,
+  codeClientGeneration,
+  forgetCodeClone,
+  latestCodeClone,
+  reconcileCodeClone,
+  setCodeCloneBackground,
+  trackCodeClone,
+  useCodeUpdatesStore,
+  type CodeCloneRequest,
+} from "./CodeUpdatesStore";
 
 type Stage = "sources" | "local" | "git_url" | "github" | "progress";
 type SourceKey = "local" | "git_url" | "github";
+
+type PaletteOpening = {
+  id: number;
+  clientGeneration: number;
+  active: boolean;
+};
+
+type CloneHandoff = {
+  openingId: number;
+  clientGeneration: number;
+  jobId: string;
+  armed: boolean;
+};
+
+const CLONE_POLL_INTERVAL_MS = 1_500;
+
+function isAuthorizationFailure(error: unknown): boolean {
+  if (
+    error &&
+    typeof error === "object" &&
+    "status" in error &&
+    ((error as { status?: unknown }).status === 401 ||
+      (error as { status?: unknown }).status === 403)
+  ) {
+    return true;
+  }
+  return error instanceof Error && /\b(?:401|403)\b/.test(error.message);
+}
 
 const SOURCES: OptionRow[] = [
   {
@@ -84,6 +130,7 @@ export function AddRepoPalette({
   const { client } = useApp();
   const upsertRepo = useCodeCatalogStore((state) => state.upsertRepo);
   const cloneJobs = useCodeUpdatesStore((state) => state.cloneJobs);
+  const cloneReadErrors = useCodeUpdatesStore((state) => state.cloneReadErrors);
   const [stage, setStage] = useState<Stage>("sources");
   const [query, setQuery] = useState("");
   const [path, setPath] = useState("");
@@ -93,16 +140,29 @@ export function AddRepoPalette({
   const [parentDir, setParentDir] = useState("");
   const [cloneName, setCloneName] = useState("");
   const [defaults, setDefaults] = useState<CodeCloneDefaults | null>(null);
+  const [defaultsProbeFailed, setDefaultsProbeFailed] = useState(false);
   const [sources, setSources] = useState<CodeRepoSources | null>(null);
+  const [sourcesProbeFailed, setSourcesProbeFailed] = useState(false);
   const [githubRepos, setGithubRepos] = useState<CodeGithubRepository[] | null>(
     null,
   );
   const [githubListFailed, setGithubListFailed] = useState(false);
+  const [probeBusy, setProbeBusy] = useState<
+    "sources" | "github" | "defaults" | null
+  >(null);
   const [jobId, setJobId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [handoffBusy, setHandoffBusy] = useState(false);
+  const [handoffError, setHandoffError] = useState<string | null>(null);
+  const openingSequence = useRef(0);
+  const openingRef = useRef<PaletteOpening | null>(null);
+  const handoffRef = useRef<CloneHandoff | null>(null);
+  const activeJobIdRef = useRef<string | null>(null);
+  const autoAttemptedJobs = useRef(new Set<string>());
 
   const job = jobId ? cloneJobs[jobId] : undefined;
+  const readError = jobId ? cloneReadErrors[jobId] : undefined;
   // Whether this window can name a path the machine would resolve. Browsing
   // is the host's, resolving is the machine's, and they are the same computer
   // only when the window is not attached elsewhere.
@@ -160,76 +220,291 @@ export function AddRepoPalette({
     return null;
   }, [sources]);
 
+  const setCurrentJob = useCallback((nextJobId: string | null) => {
+    activeJobIdRef.current = nextJobId;
+    setJobId(nextJobId);
+  }, []);
+
+  const isCurrentOpening = useCallback(
+    (opening: PaletteOpening | null): opening is PaletteOpening =>
+      Boolean(
+        opening?.active &&
+          openingRef.current === opening &&
+          opening.clientGeneration === codeClientGeneration(client) &&
+          opening.clientGeneration ===
+            useCodeUpdatesStore.getState().cloneClientGeneration,
+      ),
+    [client],
+  );
+
+  const backgroundCurrentClone = useCallback(() => {
+    const handoff = handoffRef.current;
+    if (!handoff) return;
+    handoff.armed = false;
+    setCodeCloneBackground(client, handoff.jobId, true);
+  }, [client]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        const opening = openingRef.current;
+        if (opening) opening.active = false;
+        backgroundCurrentClone();
+      }
+      onOpenChange(nextOpen);
+    },
+    [backgroundCurrentClone, onOpenChange],
+  );
+
+  const loadSources = useCallback(
+    async (opening: PaletteOpening, showBusy = false) => {
+      if (showBusy) setProbeBusy("sources");
+      try {
+        const next = await client.getCodeRepoSources();
+        if (!isCurrentOpening(opening)) return;
+        setSources(next);
+        setSourcesProbeFailed(false);
+      } catch {
+        if (!isCurrentOpening(opening)) return;
+        setSources(null);
+        setSourcesProbeFailed(true);
+      } finally {
+        if (showBusy && isCurrentOpening(opening)) setProbeBusy(null);
+      }
+    },
+    [client, isCurrentOpening],
+  );
+
+  const loadGithubRepositories = useCallback(
+    async (opening: PaletteOpening, showBusy = false) => {
+      if (showBusy) setProbeBusy("github");
+      try {
+        const next = await client.listCodeGithubRepositories();
+        if (!isCurrentOpening(opening)) return;
+        setGithubRepos(next.repositories);
+        setGithubListFailed(false);
+      } catch {
+        if (!isCurrentOpening(opening)) return;
+        setGithubRepos([]);
+        setGithubListFailed(true);
+      } finally {
+        if (showBusy && isCurrentOpening(opening)) setProbeBusy(null);
+      }
+    },
+    [client, isCurrentOpening],
+  );
+
+  const loadCloneDefaults = useCallback(
+    async (
+      opening: PaletteOpening,
+      preserveDestination: boolean,
+      showBusy = false,
+    ) => {
+      if (showBusy) setProbeBusy("defaults");
+      try {
+        const next = await client.getCodeCloneDefaults();
+        if (!isCurrentOpening(opening)) return;
+        setDefaults(next);
+        setDefaultsProbeFailed(false);
+        if (!preserveDestination) setParentDir(next.parent_dir ?? "");
+      } catch (caught) {
+        if (!isCurrentOpening(opening)) return;
+        setDefaults(null);
+        setDefaultsProbeFailed(!isAuthorizationFailure(caught));
+      } finally {
+        if (showBusy && isCurrentOpening(opening)) setProbeBusy(null);
+      }
+    },
+    [client, isCurrentOpening],
+  );
+
   useEffect(() => {
-    if (!open) return;
+    const clientGeneration = activateCodeCloneClient(client);
+    if (!open) {
+      openingRef.current = null;
+      return;
+    }
+    openingSequence.current += 1;
+    const opening: PaletteOpening = {
+      id: openingSequence.current,
+      clientGeneration,
+      active: true,
+    };
+    openingRef.current = opening;
+    handoffRef.current = null;
+    activeJobIdRef.current = null;
+    autoAttemptedJobs.current.clear();
     setStage("sources");
     setQuery("");
     setPath("");
     setDisplayName("");
     setUrl("");
     setGithub("");
+    setParentDir("");
     setCloneName("");
-    setJobId(null);
+    setCurrentJob(null);
     setBusy(false);
     setError(null);
+    setHandoffBusy(false);
+    setHandoffError(null);
     setSources(null);
+    setSourcesProbeFailed(false);
+    setDefaultsProbeFailed(false);
     setGithubRepos(null);
     setGithubListFailed(false);
-    void client
-      .getCodeRepoSources()
-      .then(setSources)
-      .catch(() => setSources(null));
-    void client
-      .listCodeGithubRepositories()
-      .then((next) => {
-        setGithubRepos(next.repositories);
-        setGithubListFailed(false);
-      })
-      .catch(() => {
-        setGithubRepos([]);
-        setGithubListFailed(true);
-      });
+    setProbeBusy(null);
+
+    const resumable = latestCodeClone(client);
+    if (resumable) {
+      const { request } = resumable.tracking;
+      const handoffWasCancelled = resumable.tracking.background;
+      setUrl(request.url ?? "");
+      setGithub(request.github ?? "");
+      setParentDir(request.parent_dir ?? "");
+      setCloneName(request.name ?? "");
+      setCurrentJob(resumable.job.id);
+      setStage("progress");
+      setCodeCloneBackground(client, resumable.job.id, false);
+      handoffRef.current = {
+        openingId: opening.id,
+        clientGeneration,
+        jobId: resumable.job.id,
+        // Closing the progress surface cancels its automatic handoff. Reopening
+        // restores progress, but only an explicit action creates the workspace.
+        armed: !handoffWasCancelled && !resumable.job.done,
+      };
+    }
+
+    void loadSources(opening);
+    void loadGithubRepositories(opening);
     // Administrator-only, and the person adding a repo on a shared machine
     // usually is not one. A refusal leaves the remembered destination unknown,
     // which the machine fills in for itself.
-    void client
-      .getCodeCloneDefaults()
-      .then((next) => {
-        setDefaults(next);
-        setParentDir(next.parent_dir ?? "");
-      })
-      .catch(() => setDefaults(null));
-  }, [open, client]);
+    void loadCloneDefaults(opening, Boolean(resumable));
+
+    return () => {
+      opening.active = false;
+      if (openingRef.current === opening) openingRef.current = null;
+      const handoff = handoffRef.current;
+      if (
+        handoff?.openingId === opening.id &&
+        handoff.clientGeneration === clientGeneration
+      ) {
+        handoff.armed = false;
+        setCodeCloneBackground(client, handoff.jobId, true);
+      }
+    };
+  }, [
+    client,
+    loadCloneDefaults,
+    loadGithubRepositories,
+    loadSources,
+    open,
+    setCurrentJob,
+  ]);
 
   useEffect(() => {
-    if (!job || stage !== "progress") return;
-    if (job.done && job.repo_id) {
-      void (async () => {
-        try {
-          const repo = await client.getCodeRepo(job.repo_id!);
-          upsertRepo(repo);
-          onOpenChange(false);
-          // A registered repo does nothing on its own. Hand the reader
-          // straight to the one thing it is for, with the new repo picked.
-          useCodeUiStore.getState().startNewWorkspace(repo.id);
-        } catch (err) {
-          setError(
-            friendlyErrorMessage(err, "Cloned, but could not open the repo"),
+    if (!open || stage !== "progress" || !jobId || job?.done || readError) {
+      return;
+    }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const poll = async () => {
+      const next = await reconcileCodeClone(client, jobId);
+      if (cancelled || !next || next.done) return;
+      timer = setTimeout(() => void poll(), CLONE_POLL_INTERVAL_MS);
+    };
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [client, job?.done, jobId, open, readError, stage]);
+
+  const completeClone = useCallback(
+    async (requireAutomaticHandoff: boolean) => {
+      const opening = openingRef.current;
+      const currentJob = activeJobIdRef.current
+        ? useCodeUpdatesStore.getState().cloneJobs[activeJobIdRef.current]
+        : undefined;
+      if (
+        !isCurrentOpening(opening) ||
+        !currentJob?.done ||
+        currentJob.error ||
+        !currentJob.repo_id
+      ) {
+        return;
+      }
+      const handoff = handoffRef.current;
+      if (
+        requireAutomaticHandoff &&
+        (!handoff?.armed ||
+          handoff.jobId !== currentJob.id ||
+          handoff.openingId !== opening.id ||
+          handoff.clientGeneration !== opening.clientGeneration)
+      ) {
+        return;
+      }
+
+      setHandoffBusy(true);
+      setHandoffError(null);
+      try {
+        const repo = await client.getCodeRepo(currentJob.repo_id);
+        if (!isCurrentOpening(opening)) return;
+        if (requireAutomaticHandoff && !handoffRef.current?.armed) return;
+        upsertRepo(repo);
+        forgetCodeClone(client, currentJob.id);
+        handoffRef.current = null;
+        opening.active = false;
+        onOpenChange(false);
+        // A registered repo does nothing on its own. Hand the reader straight
+        // to the one thing it is for, with the new repo picked.
+        useCodeUiStore.getState().startNewWorkspace(repo.id);
+      } catch (caught) {
+        if (isCurrentOpening(opening)) {
+          setHandoffError(
+            friendlyErrorMessage(
+              caught,
+              "Cloned, but could not open the repository",
+            ),
           );
         }
-      })();
+      } finally {
+        if (isCurrentOpening(opening)) setHandoffBusy(false);
+      }
+    },
+    [client, isCurrentOpening, onOpenChange, upsertRepo],
+  );
+
+  useEffect(() => {
+    if (
+      !open ||
+      stage !== "progress" ||
+      !job?.done ||
+      job.error ||
+      !job.repo_id ||
+      autoAttemptedJobs.current.has(job.id)
+    ) {
+      return;
     }
-  }, [job, stage, client, upsertRepo, onOpenChange]);
+    const handoff = handoffRef.current;
+    if (!handoff?.armed || handoff.jobId !== job.id) return;
+    autoAttemptedJobs.current.add(job.id);
+    void completeClone(true);
+  }, [completeClone, job, open, stage]);
 
   function goBack() {
     if (stage === "sources") {
-      onOpenChange(false);
+      handleOpenChange(false);
       return;
     }
     if (stage === "progress") {
+      backgroundCurrentClone();
+      handoffRef.current = null;
       setStage(github.trim() ? "github" : url.trim() ? "git_url" : "sources");
-      setJobId(null);
+      setCurrentJob(null);
       setError(null);
+      setHandoffError(null);
       return;
     }
     setStage("sources");
@@ -237,14 +512,17 @@ export function AddRepoPalette({
   }
 
   async function pickDirectory(into: "path" | "parent") {
+    const opening = openingRef.current;
     const picked = await pickCodeDirectory();
-    if (!picked) return;
+    if (!picked || !isCurrentOpening(opening)) return;
     if (into === "path") setPath(picked);
     else setParentDir(picked);
   }
 
   async function registerLocal() {
     if (!path.trim()) return;
+    const opening = openingRef.current;
+    if (!isCurrentOpening(opening)) return;
     setBusy(true);
     setError(null);
     try {
@@ -252,13 +530,19 @@ export function AddRepoPalette({
         path: path.trim(),
         display_name: displayName.trim() || undefined,
       });
+      if (!isCurrentOpening(opening)) return;
       upsertRepo(repo);
+      opening.active = false;
       onOpenChange(false);
       useCodeUiStore.getState().startNewWorkspace(repo.id);
-    } catch (err) {
-      setError(friendlyErrorMessage(err, "Could not register that repo"));
+    } catch (caught) {
+      if (isCurrentOpening(opening)) {
+        setError(
+          friendlyErrorMessage(caught, "Could not register that repository"),
+        );
+      }
     } finally {
-      setBusy(false);
+      if (isCurrentOpening(opening)) setBusy(false);
     }
   }
 
@@ -275,24 +559,38 @@ export function AddRepoPalette({
       ? undefined
       : body.parent_dir?.trim();
     if (!parent && !machineChoosesDestination) return;
+    const opening = openingRef.current;
+    if (!isCurrentOpening(opening)) return;
+    const request: CodeCloneRequest = {
+      ...body,
+      parent_dir: parent || undefined,
+      name: body.name?.trim() || undefined,
+    };
+    const replacedJobId = activeJobIdRef.current;
     setBusy(true);
     setError(null);
     try {
-      const started = await client.startCodeClone({
-        ...body,
-        parent_dir: parent || undefined,
-        name: body.name?.trim() || undefined,
-      });
-      useCodeUpdatesStore.getState().apply({
-        type: "clone_progress",
-        job: started,
-      });
-      setJobId(started.id);
+      const started = await client.startCodeClone(request);
+      const current = isCurrentOpening(opening);
+      const tracked = trackCodeClone(client, started, request, !current);
+      if (!tracked || !current) return;
+      if (replacedJobId && replacedJobId !== started.id) {
+        forgetCodeClone(client, replacedJobId);
+      }
+      setCurrentJob(started.id);
+      handoffRef.current = {
+        openingId: opening.id,
+        clientGeneration: opening.clientGeneration,
+        jobId: started.id,
+        armed: true,
+      };
       setStage("progress");
-    } catch (err) {
-      setError(friendlyErrorMessage(err, "Could not start the clone"));
+    } catch (caught) {
+      if (isCurrentOpening(opening)) {
+        setError(friendlyErrorMessage(caught, "Could not start the clone"));
+      }
     } finally {
-      setBusy(false);
+      if (isCurrentOpening(opening)) setBusy(false);
     }
   }
 
@@ -335,7 +633,7 @@ export function AddRepoPalette({
   function onKeyDown(event: KeyboardEvent) {
     if (event.key === "Escape") {
       event.preventDefault();
-      onOpenChange(false);
+      handleOpenChange(false);
       return;
     }
     if (
@@ -359,6 +657,8 @@ export function AddRepoPalette({
     }
   }
 
+  const cloneSucceeded = job?.done === true && !job.error;
+  const cloneFailed = job?.done === true && Boolean(job.error);
   const title =
     stage === "local"
       ? "Local folder"
@@ -367,15 +667,19 @@ export function AddRepoPalette({
         : stage === "github"
           ? "GitHub repository"
           : stage === "progress"
-            ? "Cloning"
+            ? cloneSucceeded
+              ? "Repository cloned"
+              : cloneFailed
+                ? "Clone failed"
+                : "Cloning"
             : "Add a repo";
 
   return (
-    <Dialog open={open} onOpenChange={busy ? undefined : onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="max-w-md gap-4 p-5"
         onKeyDown={onKeyDown}
-        aria-busy={busy}
+        aria-busy={busy || handoffBusy}
       >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
@@ -388,7 +692,11 @@ export function AddRepoPalette({
                   ? "Clone from a remote URL into a parent folder."
                   : stage === "github"
                     ? "Clone an owner/repo from GitHub."
-                    : "Cloning into the chosen folder."}
+                    : cloneSucceeded
+                      ? "Create a workspace when you are ready."
+                      : cloneFailed
+                        ? "Fix the source or destination, then try again."
+                        : "You can close this window while the clone continues."}
           </DialogDescription>
         </DialogHeader>
 
@@ -450,6 +758,17 @@ export function AddRepoPalette({
           </Command>
         )}
 
+        {stage === "sources" && sourcesProbeFailed && (
+          <ProbeFailure
+            message="Could not check which sources this machine supports."
+            busy={probeBusy === "sources"}
+            onRetry={() => {
+              const opening = openingRef.current;
+              if (isCurrentOpening(opening)) void loadSources(opening, true);
+            }}
+          />
+        )}
+
         {stage === "local" && (
           <LocalStage
             path={path}
@@ -478,7 +797,15 @@ export function AddRepoPalette({
             canBrowse={canBrowse}
             attached={attached}
             machineChoosesDestination={machineChoosesDestination}
+            defaultsProbeFailed={defaultsProbeFailed}
+            defaultsBusy={probeBusy === "defaults"}
             onBrowse={() => void pickDirectory("parent")}
+            onRetryDefaults={() => {
+              const opening = openingRef.current;
+              if (isCurrentOpening(opening)) {
+                void loadCloneDefaults(opening, false, true);
+              }
+            }}
             onSubmit={() =>
               void startClone({
                 url,
@@ -499,6 +826,7 @@ export function AddRepoPalette({
             hint={githubHint}
             repositories={githubRepos}
             listFailed={githubListFailed}
+            listBusy={probeBusy === "github"}
             busy={busy}
             error={error}
             onGithub={setGithub}
@@ -507,7 +835,21 @@ export function AddRepoPalette({
             canBrowse={canBrowse}
             attached={attached}
             machineChoosesDestination={machineChoosesDestination}
+            defaultsProbeFailed={defaultsProbeFailed}
+            defaultsBusy={probeBusy === "defaults"}
             onBrowse={() => void pickDirectory("parent")}
+            onRetryRepositories={() => {
+              const opening = openingRef.current;
+              if (isCurrentOpening(opening)) {
+                void loadGithubRepositories(opening, true);
+              }
+            }}
+            onRetryDefaults={() => {
+              const opening = openingRef.current;
+              if (isCurrentOpening(opening)) {
+                void loadCloneDefaults(opening, false, true);
+              }
+            }}
             onSubmit={() =>
               void startClone({
                 github,
@@ -522,12 +864,21 @@ export function AddRepoPalette({
         {stage === "progress" && (
           <ProgressStage
             job={job}
-            error={error ?? job?.error}
+            readError={readError}
+            handoffError={handoffError}
+            handoffBusy={handoffBusy}
             onRetry={() => {
+              if (jobId) forgetCodeClone(client, jobId);
               setStage(github.trim() ? "github" : "git_url");
-              setJobId(null);
+              setCurrentJob(null);
+              handoffRef.current = null;
               setError(null);
+              setHandoffError(null);
             }}
+            onResume={() => {
+              if (jobId) void reconcileCodeClone(client, jobId);
+            }}
+            onCreateWorkspace={() => void completeClone(false)}
           />
         )}
 
@@ -634,7 +985,10 @@ function GitUrlStage({
   canBrowse,
   attached,
   machineChoosesDestination,
+  defaultsProbeFailed,
+  defaultsBusy,
   onBrowse,
+  onRetryDefaults,
   onSubmit,
   command,
 }: {
@@ -649,7 +1003,10 @@ function GitUrlStage({
   canBrowse: boolean;
   attached: boolean;
   machineChoosesDestination: boolean;
+  defaultsProbeFailed: boolean;
+  defaultsBusy: boolean;
   onBrowse: () => void;
+  onRetryDefaults: () => void;
   onSubmit: () => void;
   command: boolean;
 }) {
@@ -678,8 +1035,11 @@ function GitUrlStage({
           busy={busy}
           canBrowse={canBrowse}
           blocked={destinationBlocked}
+          defaultsProbeFailed={defaultsProbeFailed}
+          defaultsBusy={defaultsBusy}
           onChange={onParentDir}
           onBrowse={onBrowse}
+          onRetryDefaults={onRetryDefaults}
         />
       )}
       <label className="flex flex-col gap-1 text-sm">
@@ -715,6 +1075,7 @@ function GithubStage({
   hint,
   repositories,
   listFailed,
+  listBusy,
   busy,
   error,
   onGithub,
@@ -723,7 +1084,11 @@ function GithubStage({
   canBrowse,
   attached,
   machineChoosesDestination,
+  defaultsProbeFailed,
+  defaultsBusy,
   onBrowse,
+  onRetryRepositories,
+  onRetryDefaults,
   onSubmit,
   command,
 }: {
@@ -735,6 +1100,7 @@ function GithubStage({
   hint: string | null;
   repositories: CodeGithubRepository[] | null;
   listFailed: boolean;
+  listBusy: boolean;
   busy: boolean;
   error: string | null;
   onGithub: (value: string) => void;
@@ -743,7 +1109,11 @@ function GithubStage({
   canBrowse: boolean;
   attached: boolean;
   machineChoosesDestination: boolean;
+  defaultsProbeFailed: boolean;
+  defaultsBusy: boolean;
   onBrowse: () => void;
+  onRetryRepositories: () => void;
+  onRetryDefaults: () => void;
   onSubmit: () => void;
   command: boolean;
 }) {
@@ -767,8 +1137,10 @@ function GithubStage({
         value={github}
         repositories={repositories}
         listFailed={listFailed}
+        listBusy={listBusy}
         busy={busy}
         onChange={onGithub}
+        onRetry={onRetryRepositories}
       />
       {ghHint && (
         <p
@@ -786,8 +1158,11 @@ function GithubStage({
           busy={busy}
           canBrowse={canBrowse}
           blocked={destinationBlocked}
+          defaultsProbeFailed={defaultsProbeFailed}
+          defaultsBusy={defaultsBusy}
           onChange={onParentDir}
           onBrowse={onBrowse}
+          onRetryDefaults={onRetryDefaults}
         />
       )}
       <label className="flex flex-col gap-1 text-sm">
@@ -819,14 +1194,18 @@ function GithubRepoField({
   value,
   repositories,
   listFailed,
+  listBusy,
   busy,
   onChange,
+  onRetry,
 }: {
   value: string;
   repositories: CodeGithubRepository[] | null;
   listFailed: boolean;
+  listBusy: boolean;
   busy: boolean;
   onChange: (value: string) => void;
+  onRetry: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -948,12 +1327,21 @@ function GithubRepoField({
         </Popover>
       )}
       {listFailed && (
-        <p
-          className="text-muted-foreground text-xs"
-          data-testid="github-list-failed"
-        >
-          Suggestions did not load. Type owner/repo to clone.
-        </p>
+        <div className="flex items-center justify-between gap-3 text-xs">
+          <p className="text-muted-foreground" data-testid="github-list-failed">
+            Suggestions did not load. Type owner/repo or retry.
+          </p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="shrink-0"
+            disabled={busy || listBusy}
+            onClick={onRetry}
+          >
+            {listBusy ? "Retrying…" : "Retry"}
+          </Button>
+        </div>
       )}
     </label>
   );
@@ -995,15 +1383,21 @@ function ParentDirField({
   busy,
   canBrowse,
   blocked,
+  defaultsProbeFailed,
+  defaultsBusy,
   onChange,
   onBrowse,
+  onRetryDefaults,
 }: {
   value: string;
   busy: boolean;
   canBrowse: boolean;
   blocked: boolean;
+  defaultsProbeFailed: boolean;
+  defaultsBusy: boolean;
   onChange: (value: string) => void;
   onBrowse: () => void;
+  onRetryDefaults: () => void;
 }) {
   if (blocked) {
     return (
@@ -1037,31 +1431,79 @@ function ParentDirField({
           </Button>
         )}
       </div>
+      {defaultsProbeFailed && (
+        <div className="flex items-center justify-between gap-3 text-xs">
+          <p className="text-muted-foreground">
+            The saved destination did not load. Choose one or retry.
+          </p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="shrink-0"
+            disabled={busy || defaultsBusy}
+            onClick={onRetryDefaults}
+          >
+            {defaultsBusy ? "Retrying…" : "Retry"}
+          </Button>
+        </div>
+      )}
     </label>
   );
 }
 
 function ProgressStage({
   job,
-  error,
+  readError,
+  handoffError,
+  handoffBusy,
   onRetry,
+  onResume,
+  onCreateWorkspace,
 }: {
   job: CodeCloneJobSnapshot | undefined;
-  error: string | null | undefined;
+  readError: string | undefined;
+  handoffError: string | null;
+  handoffBusy: boolean;
   onRetry: () => void;
+  onResume: () => void;
+  onCreateWorkspace: () => void;
 }) {
-  const failed = Boolean(error) || (job?.done === true && Boolean(job.error));
+  const failed = job?.done === true && Boolean(job.error);
+  const completed = job?.done === true && !job.error && Boolean(job.repo_id);
   const percent = job?.percent ?? (job?.done && !job.error ? 100 : 0);
   return (
     <div className="flex flex-col gap-3">
-      <p className="text-sm" data-testid="clone-phase">
-        {job?.phase ?? "starting"}
-      </p>
-      <Progress value={percent} />
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium" data-testid="clone-phase">
+            {job?.phase ?? "Starting"}
+          </p>
+          {!job?.done && (
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              This clone keeps running if you close this window.
+            </p>
+          )}
+        </div>
+        {job?.percent !== undefined && (
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">
+            {Math.round(job.percent)}%
+          </span>
+        )}
+      </div>
+      <Progress value={percent} style={{ forcedColorAdjust: "none" }} />
+      {readError && !job?.done && (
+        <ProbeFailure
+          message={readError}
+          busy={false}
+          action="Retry check"
+          onRetry={onResume}
+        />
+      )}
       {failed && (
         <>
           <pre className="bg-muted max-h-32 overflow-auto rounded-md p-2 text-xs whitespace-pre-wrap">
-            {error ?? job?.error}
+            {job?.error}
           </pre>
           <Button
             type="button"
@@ -1073,6 +1515,59 @@ function ProgressStage({
           </Button>
         </>
       )}
+      {completed && (
+        <div className="rounded-lg border border-success-border bg-success-background p-3">
+          <p className={cn("text-sm font-medium", STATUS_TEXT.ready)}>
+            The repository is ready.
+          </p>
+          <p className="mt-1 text-xs text-success-foreground-muted">
+            Create a workspace to start working in the new checkout.
+          </p>
+          {handoffError && (
+            <p className="mt-2 text-xs text-critical">{handoffError}</p>
+          )}
+          <Button
+            type="button"
+            className="mt-3"
+            disabled={handoffBusy}
+            onClick={onCreateWorkspace}
+          >
+            {handoffBusy
+              ? "Opening…"
+              : handoffError
+                ? "Retry"
+                : "Create workspace"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProbeFailure({
+  message,
+  busy,
+  action = "Retry",
+  onRetry,
+}: {
+  message: string;
+  busy: boolean;
+  action?: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="rounded-lg border border-warning-border bg-warning-background p-3">
+      <p className={cn("text-sm", STATUS_TEXT.warning)}>{message}</p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-2"
+        disabled={busy}
+        onClick={onRetry}
+      >
+        {busy ? "Retrying…" : action}
+      </Button>
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -7,6 +7,7 @@ import {
   type KeyboardEvent,
 } from "react";
 import { ChevronDown, Folder, GitBranch, Link2 } from "lucide-react";
+import { toast } from "sonner";
 
 import type {
   CodeCloneDefaults,
@@ -57,9 +58,11 @@ import {
   latestCodeClone,
   reconcileCodeClone,
   setCodeCloneBackground,
+  takeSelectedCodeClone,
   trackCodeClone,
   useCodeUpdatesStore,
   type CodeCloneRequest,
+  type ResumableCodeClone,
 } from "./CodeUpdatesStore";
 
 type Stage = "sources" | "local" | "git_url" | "github" | "progress";
@@ -69,6 +72,7 @@ type PaletteOpening = {
   id: number;
   clientGeneration: number;
   active: boolean;
+  controller: AbortController;
 };
 
 type CloneHandoff = {
@@ -91,6 +95,17 @@ function isAuthorizationFailure(error: unknown): boolean {
     return true;
   }
   return error instanceof Error && /\b(?:401|403)\b/.test(error.message);
+}
+
+function isAbortFailure(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : Boolean(
+        error &&
+          typeof error === "object" &&
+          "name" in error &&
+          (error as { name?: unknown }).name === "AbortError",
+      );
 }
 
 const SOURCES: OptionRow[] = [
@@ -131,6 +146,7 @@ export function AddRepoPalette({
   const upsertRepo = useCodeCatalogStore((state) => state.upsertRepo);
   const cloneJobs = useCodeUpdatesStore((state) => state.cloneJobs);
   const cloneReadErrors = useCodeUpdatesStore((state) => state.cloneReadErrors);
+  const selectedClone = useCodeUpdatesStore((state) => state.selectedClone);
   const [stage, setStage] = useState<Stage>("sources");
   const [query, setQuery] = useState("");
   const [path, setPath] = useState("");
@@ -139,7 +155,10 @@ export function AddRepoPalette({
   const [github, setGithub] = useState("");
   const [parentDir, setParentDir] = useState("");
   const [cloneName, setCloneName] = useState("");
-  const [defaults, setDefaults] = useState<CodeCloneDefaults | null>(null);
+  const [loadedDefaults, setLoadedDefaults] = useState<{
+    clientGeneration: number;
+    value: CodeCloneDefaults;
+  } | null>(null);
   const [defaultsProbeFailed, setDefaultsProbeFailed] = useState(false);
   const [sources, setSources] = useState<CodeRepoSources | null>(null);
   const [sourcesProbeFailed, setSourcesProbeFailed] = useState(false);
@@ -160,9 +179,14 @@ export function AddRepoPalette({
   const handoffRef = useRef<CloneHandoff | null>(null);
   const activeJobIdRef = useRef<string | null>(null);
   const autoAttemptedJobs = useRef(new Set<string>());
+  const destinationEditVersion = useRef(0);
 
   const job = jobId ? cloneJobs[jobId] : undefined;
   const readError = jobId ? cloneReadErrors[jobId] : undefined;
+  const defaults =
+    loadedDefaults?.clientGeneration === codeClientGeneration(client)
+      ? loadedDefaults.value
+      : null;
   // Whether this window can name a path the machine would resolve. Browsing
   // is the host's, resolving is the machine's, and they are the same computer
   // only when the window is not attached elsewhere.
@@ -225,16 +249,30 @@ export function AddRepoPalette({
     setJobId(nextJobId);
   }, []);
 
-  const isCurrentOpening = useCallback(
+  const editParentDir = useCallback((value: string) => {
+    destinationEditVersion.current += 1;
+    setParentDir(value);
+  }, []);
+
+  const isCurrentClient = useCallback(
     (opening: PaletteOpening | null): opening is PaletteOpening =>
       Boolean(
-        opening?.active &&
-          openingRef.current === opening &&
+        opening &&
           opening.clientGeneration === codeClientGeneration(client) &&
           opening.clientGeneration ===
             useCodeUpdatesStore.getState().cloneClientGeneration,
       ),
     [client],
+  );
+
+  const isCurrentOpening = useCallback(
+    (opening: PaletteOpening | null): opening is PaletteOpening =>
+      Boolean(
+        opening?.active &&
+          openingRef.current === opening &&
+          isCurrentClient(opening),
+      ),
+    [isCurrentClient],
   );
 
   const backgroundCurrentClone = useCallback(() => {
@@ -248,7 +286,10 @@ export function AddRepoPalette({
     (nextOpen: boolean) => {
       if (!nextOpen) {
         const opening = openingRef.current;
-        if (opening) opening.active = false;
+        if (opening) {
+          opening.active = false;
+          opening.controller.abort();
+        }
         backgroundCurrentClone();
       }
       onOpenChange(nextOpen);
@@ -260,11 +301,12 @@ export function AddRepoPalette({
     async (opening: PaletteOpening, showBusy = false) => {
       if (showBusy) setProbeBusy("sources");
       try {
-        const next = await client.getCodeRepoSources();
+        const next = await client.getCodeRepoSources(opening.controller.signal);
         if (!isCurrentOpening(opening)) return;
         setSources(next);
         setSourcesProbeFailed(false);
-      } catch {
+      } catch (caught) {
+        if (opening.controller.signal.aborted || isAbortFailure(caught)) return;
         if (!isCurrentOpening(opening)) return;
         setSources(null);
         setSourcesProbeFailed(true);
@@ -279,11 +321,14 @@ export function AddRepoPalette({
     async (opening: PaletteOpening, showBusy = false) => {
       if (showBusy) setProbeBusy("github");
       try {
-        const next = await client.listCodeGithubRepositories();
+        const next = await client.listCodeGithubRepositories(
+          opening.controller.signal,
+        );
         if (!isCurrentOpening(opening)) return;
         setGithubRepos(next.repositories);
         setGithubListFailed(false);
-      } catch {
+      } catch (caught) {
+        if (opening.controller.signal.aborted || isAbortFailure(caught)) return;
         if (!isCurrentOpening(opening)) return;
         setGithubRepos([]);
         setGithubListFailed(true);
@@ -297,25 +342,76 @@ export function AddRepoPalette({
   const loadCloneDefaults = useCallback(
     async (
       opening: PaletteOpening,
-      preserveDestination: boolean,
-      showBusy = false,
+      options: {
+        seedDestination: boolean;
+        replaceDestination?: boolean;
+        showBusy?: boolean;
+      },
     ) => {
+      const {
+        seedDestination,
+        replaceDestination = false,
+        showBusy = false,
+      } = options;
+      const editVersion = destinationEditVersion.current;
+      const maySeedDestination =
+        seedDestination &&
+        (replaceDestination || destinationEditVersion.current === 0);
       if (showBusy) setProbeBusy("defaults");
       try {
-        const next = await client.getCodeCloneDefaults();
+        const next = await client.getCodeCloneDefaults(
+          opening.controller.signal,
+        );
         if (!isCurrentOpening(opening)) return;
-        setDefaults(next);
+        setLoadedDefaults({
+          clientGeneration: opening.clientGeneration,
+          value: next,
+        });
         setDefaultsProbeFailed(false);
-        if (!preserveDestination) setParentDir(next.parent_dir ?? "");
+        if (
+          maySeedDestination &&
+          destinationEditVersion.current === editVersion
+        ) {
+          setParentDir(next.parent_dir ?? "");
+        }
       } catch (caught) {
+        if (opening.controller.signal.aborted || isAbortFailure(caught)) return;
         if (!isCurrentOpening(opening)) return;
-        setDefaults(null);
+        setLoadedDefaults(null);
         setDefaultsProbeFailed(!isAuthorizationFailure(caught));
       } finally {
         if (showBusy && isCurrentOpening(opening)) setProbeBusy(null);
       }
     },
     [client, isCurrentOpening],
+  );
+
+  const showClone = useCallback(
+    (
+      opening: PaletteOpening,
+      resumable: ResumableCodeClone,
+      allowAutomaticHandoff: boolean,
+    ) => {
+      const { request } = resumable.tracking;
+      setUrl(request.url ?? "");
+      setGithub(request.github ?? "");
+      destinationEditVersion.current += 1;
+      setParentDir(request.parent_dir ?? "");
+      setCloneName(request.name ?? "");
+      setCurrentJob(resumable.job.id);
+      setStage("progress");
+      setCodeCloneBackground(client, resumable.job.id, false);
+      handoffRef.current = {
+        openingId: opening.id,
+        clientGeneration: opening.clientGeneration,
+        jobId: resumable.job.id,
+        armed:
+          allowAutomaticHandoff &&
+          !resumable.tracking.background &&
+          !resumable.job.done,
+      };
+    },
+    [client, setCurrentJob],
   );
 
   useEffect(() => {
@@ -329,6 +425,7 @@ export function AddRepoPalette({
       id: openingSequence.current,
       clientGeneration,
       active: true,
+      controller: new AbortController(),
     };
     openingRef.current = opening;
     handoffRef.current = null;
@@ -341,12 +438,14 @@ export function AddRepoPalette({
     setUrl("");
     setGithub("");
     setParentDir("");
+    destinationEditVersion.current = 0;
     setCloneName("");
     setCurrentJob(null);
     setBusy(false);
     setError(null);
     setHandoffBusy(false);
     setHandoffError(null);
+    setLoadedDefaults(null);
     setSources(null);
     setSourcesProbeFailed(false);
     setDefaultsProbeFailed(false);
@@ -354,25 +453,11 @@ export function AddRepoPalette({
     setGithubListFailed(false);
     setProbeBusy(null);
 
-    const resumable = latestCodeClone(client);
+    const selected = takeSelectedCodeClone(client);
+    const resumable =
+      selected === undefined ? latestCodeClone(client) : selected;
     if (resumable) {
-      const { request } = resumable.tracking;
-      const handoffWasCancelled = resumable.tracking.background;
-      setUrl(request.url ?? "");
-      setGithub(request.github ?? "");
-      setParentDir(request.parent_dir ?? "");
-      setCloneName(request.name ?? "");
-      setCurrentJob(resumable.job.id);
-      setStage("progress");
-      setCodeCloneBackground(client, resumable.job.id, false);
-      handoffRef.current = {
-        openingId: opening.id,
-        clientGeneration,
-        jobId: resumable.job.id,
-        // Closing the progress surface cancels its automatic handoff. Reopening
-        // restores progress, but only an explicit action creates the workspace.
-        armed: !handoffWasCancelled && !resumable.job.done,
-      };
+      showClone(opening, resumable, selected === undefined);
     }
 
     void loadSources(opening);
@@ -380,10 +465,13 @@ export function AddRepoPalette({
     // Administrator-only, and the person adding a repo on a shared machine
     // usually is not one. A refusal leaves the remembered destination unknown,
     // which the machine fills in for itself.
-    void loadCloneDefaults(opening, Boolean(resumable));
+    void loadCloneDefaults(opening, {
+      seedDestination: !resumable,
+    });
 
     return () => {
       opening.active = false;
+      opening.controller.abort();
       if (openingRef.current === opening) openingRef.current = null;
       const handoff = handoffRef.current;
       if (
@@ -401,6 +489,25 @@ export function AddRepoPalette({
     loadSources,
     open,
     setCurrentJob,
+    showClone,
+  ]);
+
+  useEffect(() => {
+    if (!open || !selectedClone) return;
+    const opening = openingRef.current;
+    if (!isCurrentOpening(opening)) return;
+    const resumable = takeSelectedCodeClone(client);
+    if (!resumable) return;
+    if (activeJobIdRef.current !== resumable.job.id) backgroundCurrentClone();
+    handoffRef.current = null;
+    showClone(opening, resumable, false);
+  }, [
+    backgroundCurrentClone,
+    client,
+    isCurrentOpening,
+    open,
+    selectedClone,
+    showClone,
   ]);
 
   useEffect(() => {
@@ -499,7 +606,11 @@ export function AddRepoPalette({
       return;
     }
     if (stage === "progress") {
-      backgroundCurrentClone();
+      const currentJob = activeJobIdRef.current
+        ? useCodeUpdatesStore.getState().cloneJobs[activeJobIdRef.current]
+        : undefined;
+      if (currentJob?.done) forgetCodeClone(client, currentJob.id);
+      else backgroundCurrentClone();
       handoffRef.current = null;
       setStage(github.trim() ? "github" : url.trim() ? "git_url" : "sources");
       setCurrentJob(null);
@@ -516,7 +627,7 @@ export function AddRepoPalette({
     const picked = await pickCodeDirectory();
     if (!picked || !isCurrentOpening(opening)) return;
     if (into === "path") setPath(picked);
-    else setParentDir(picked);
+    else editParentDir(picked);
   }
 
   async function registerLocal() {
@@ -530,11 +641,21 @@ export function AddRepoPalette({
         path: path.trim(),
         display_name: displayName.trim() || undefined,
       });
-      if (!isCurrentOpening(opening)) return;
+      if (!isCurrentClient(opening)) return;
       upsertRepo(repo);
-      opening.active = false;
-      onOpenChange(false);
-      useCodeUiStore.getState().startNewWorkspace(repo.id);
+      if (isCurrentOpening(opening)) {
+        opening.active = false;
+        onOpenChange(false);
+        useCodeUiStore.getState().startNewWorkspace(repo.id);
+      } else {
+        toast.success("Repository registered", {
+          description: "Create a workspace when you are ready.",
+          action: {
+            label: "Open",
+            onClick: () => useCodeUiStore.getState().startNewWorkspace(repo.id),
+          },
+        });
+      }
     } catch (caught) {
       if (isCurrentOpening(opening)) {
         setError(
@@ -792,7 +913,7 @@ export function AddRepoPalette({
             busy={busy}
             error={error}
             onUrl={setUrl}
-            onParentDir={setParentDir}
+            onParentDir={editParentDir}
             onName={setCloneName}
             canBrowse={canBrowse}
             attached={attached}
@@ -803,7 +924,11 @@ export function AddRepoPalette({
             onRetryDefaults={() => {
               const opening = openingRef.current;
               if (isCurrentOpening(opening)) {
-                void loadCloneDefaults(opening, false, true);
+                void loadCloneDefaults(opening, {
+                  seedDestination: true,
+                  replaceDestination: true,
+                  showBusy: true,
+                });
               }
             }}
             onSubmit={() =>
@@ -830,7 +955,7 @@ export function AddRepoPalette({
             busy={busy}
             error={error}
             onGithub={setGithub}
-            onParentDir={setParentDir}
+            onParentDir={editParentDir}
             onName={setCloneName}
             canBrowse={canBrowse}
             attached={attached}
@@ -847,7 +972,11 @@ export function AddRepoPalette({
             onRetryDefaults={() => {
               const opening = openingRef.current;
               if (isCurrentOpening(opening)) {
-                void loadCloneDefaults(opening, false, true);
+                void loadCloneDefaults(opening, {
+                  seedDestination: true,
+                  replaceDestination: true,
+                  showBusy: true,
+                });
               }
             }}
             onSubmit={() =>

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -16,13 +16,16 @@ import {
   noticeToAction,
   reconcileCodeClone,
   reduceCodeUpdates,
+  selectCodeClone,
   shouldRequestOsAttention,
+  takeSelectedCodeClone,
   trackCodeClone,
   useCodeUpdatesStore,
   watchChildren,
   workspaceDigest,
   type CodeUpdatesState,
 } from "./CodeUpdatesStore";
+import { useCodeUiStore } from "./CodeUiStore";
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -58,6 +61,7 @@ const EMPTY_STATE: CodeUpdatesState = {
   cloneTracking: {},
   cloneReadErrors: {},
   cloneClientGeneration: null,
+  selectedClone: null,
   harnessInstalls: {},
   viewedWorkspaceId: null,
   deliveryRevision: 0,
@@ -66,6 +70,7 @@ const EMPTY_STATE: CodeUpdatesState = {
 afterEach(() => {
   disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
+  useCodeUiStore.setState({ addRepoOpen: false });
   vi.useRealTimers();
   vi.clearAllMocks();
   vi.restoreAllMocks();
@@ -373,6 +378,106 @@ describe("reduceCodeUpdates", () => {
 });
 
 describe("clone onboarding reconciliation", () => {
+  it("notifies once when terminal socket progress beats the start response", () => {
+    const { client } = cloneClient(async (jobId) => completeClone(jobId));
+    activateCodeCloneClient(client);
+    useCodeUpdatesStore.getState().apply({
+      type: "clone_progress",
+      job: completeClone("job-fast"),
+    });
+
+    trackCodeClone(
+      client,
+      pendingClone("job-fast"),
+      { github: "acme/fast" },
+      true,
+    );
+
+    expect(useCodeUpdatesStore.getState().cloneJobs["job-fast"]).toEqual(
+      completeClone("job-fast"),
+    );
+    expect(
+      useCodeUpdatesStore.getState().cloneTracking["job-fast"]?.notified,
+    ).toBe(true);
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("binds each background notification action to its clone", () => {
+    const { client } = cloneClient(async (jobId) => pendingClone(jobId));
+    activateCodeCloneClient(client);
+    trackCodeClone(client, pendingClone("job-a"), { github: "acme/a" }, true);
+    trackCodeClone(client, pendingClone("job-b"), { github: "acme/b" }, true);
+
+    useCodeUpdatesStore.getState().apply({
+      type: "clone_progress",
+      job: completeClone("job-a"),
+    });
+    const options = vi.mocked(toast.success).mock.calls[0]?.[1] as
+      | { action?: { onClick: () => void } }
+      | undefined;
+    options?.action?.onClick();
+
+    expect(useCodeUiStore.getState().addRepoOpen).toBe(true);
+    expect(takeSelectedCodeClone(client)?.job.id).toBe("job-a");
+    expect(useCodeUpdatesStore.getState().selectedClone).toBeNull();
+  });
+
+  it("ignores a notification from a replaced client generation", () => {
+    const first = cloneClient(async (jobId) => pendingClone(jobId)).client;
+    activateCodeCloneClient(first);
+    trackCodeClone(
+      first,
+      pendingClone("job-shared"),
+      { github: "acme/old" },
+      true,
+    );
+    useCodeUpdatesStore.getState().apply({
+      type: "clone_progress",
+      job: completeClone("job-shared"),
+    });
+    const options = vi.mocked(toast.success).mock.calls[0]?.[1] as
+      | { action?: { onClick: () => void } }
+      | undefined;
+
+    const replacement = cloneClient(async (jobId) =>
+      pendingClone(jobId),
+    ).client;
+    activateCodeCloneClient(replacement);
+    trackCodeClone(
+      replacement,
+      pendingClone("job-shared"),
+      { github: "acme/new" },
+      true,
+    );
+    options?.action?.onClick();
+
+    expect(useCodeUiStore.getState().addRepoOpen).toBe(false);
+    expect(useCodeUpdatesStore.getState().selectedClone).toBeNull();
+  });
+
+  it("does not fall back when a selected clone belongs to the old client", () => {
+    const first = cloneClient(async (jobId) => pendingClone(jobId)).client;
+    const firstGeneration = activateCodeCloneClient(first);
+    trackCodeClone(first, pendingClone("job-old"), { github: "acme/old" });
+    expect(
+      selectCodeClone({
+        jobId: "job-old",
+        clientGeneration: firstGeneration,
+      }),
+    ).toBe(true);
+
+    const replacement = cloneClient(async (jobId) =>
+      pendingClone(jobId),
+    ).client;
+    activateCodeCloneClient(replacement);
+    trackCodeClone(replacement, pendingClone("job-new"), {
+      github: "acme/new",
+    });
+
+    expect(takeSelectedCodeClone(replacement)).toBeNull();
+    expect(useCodeUpdatesStore.getState().selectedClone).toBeNull();
+  });
+
   it("keeps tracked clone state when live Code updates disconnect", () => {
     const { client } = cloneClient(async (jobId) => pendingClone(jobId));
     activateCodeCloneClient(client);

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -1,15 +1,32 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 
-import type { Attention, CodeSessionDigest } from "../api/types";
+import type { ApiClient } from "../api/client";
+import type {
+  Attention,
+  CodeCloneJobSnapshot,
+  CodeSessionDigest,
+  CodeUpdateNotice,
+} from "../api/types";
 import {
+  activateCodeCloneClient,
+  codeClientGeneration,
+  connectCodeUpdates,
+  disconnectCodeUpdates,
   noticeToAction,
+  reconcileCodeClone,
   reduceCodeUpdates,
   shouldRequestOsAttention,
+  trackCodeClone,
   useCodeUpdatesStore,
   watchChildren,
   workspaceDigest,
   type CodeUpdatesState,
 } from "./CodeUpdatesStore";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
 
 const working: Attention = { state: { type: "working" }, source: "lifecycle" };
 const need: Attention = {
@@ -38,15 +55,78 @@ const EMPTY_STATE: CodeUpdatesState = {
   conversationsByWorkspace: {},
   childrenByWorkspace: {},
   cloneJobs: {},
+  cloneTracking: {},
+  cloneReadErrors: {},
+  cloneClientGeneration: null,
   harnessInstalls: {},
   viewedWorkspaceId: null,
   deliveryRevision: 0,
 };
 
 afterEach(() => {
+  disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
+  vi.useRealTimers();
+  vi.clearAllMocks();
   vi.restoreAllMocks();
 });
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+class FakeSocket {
+  onopen: WebSocket["onopen"] = null;
+  onclose: WebSocket["onclose"] = null;
+  onerror: WebSocket["onerror"] = null;
+  closed = false;
+
+  close() {
+    this.closed = true;
+  }
+}
+
+function pendingClone(id: string): CodeCloneJobSnapshot {
+  return { id, phase: "receiving objects", percent: 40, done: false };
+}
+
+function completeClone(id: string): CodeCloneJobSnapshot {
+  return {
+    id,
+    phase: "complete",
+    done: true,
+    repo_id: `repo-${id}`,
+  };
+}
+
+function cloneClient(getCodeCloneJob: ApiClient["getCodeCloneJob"]): {
+  client: Pick<ApiClient, "getCodeCloneJob" | "openCodeUpdates">;
+  sockets: FakeSocket[];
+  send: (notice: CodeUpdateNotice, index?: number) => void;
+} {
+  const sockets: FakeSocket[] = [];
+  const listeners: Array<(notice: CodeUpdateNotice) => void> = [];
+  const client = {
+    getCodeCloneJob: vi.fn(getCodeCloneJob),
+    openCodeUpdates: vi.fn((listener: (notice: CodeUpdateNotice) => void) => {
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      listeners.push(listener);
+      return socket as unknown as WebSocket;
+    }),
+  };
+  return {
+    client,
+    sockets,
+    send: (notice, index = listeners.length - 1) => listeners[index]?.(notice),
+  };
+}
 
 describe("reduceCodeUpdates", () => {
   it("replaces the map on snapshot and upserts a digest", () => {
@@ -277,6 +357,180 @@ describe("reduceCodeUpdates", () => {
       phase: "ready",
       done: true,
     });
+  });
+
+  it("does not let late clone progress replace a terminal result", () => {
+    const completed = reduceCodeUpdates(EMPTY_STATE, {
+      type: "clone_progress",
+      job: completeClone("job-1"),
+    });
+    const stale = reduceCodeUpdates(completed, {
+      type: "clone_progress",
+      job: pendingClone("job-1"),
+    });
+    expect(stale.cloneJobs["job-1"]).toEqual(completeClone("job-1"));
+  });
+});
+
+describe("clone onboarding reconciliation", () => {
+  it("keeps tracked clone state when live Code updates disconnect", () => {
+    const { client } = cloneClient(async (jobId) => pendingClone(jobId));
+    activateCodeCloneClient(client);
+    trackCodeClone(
+      client,
+      pendingClone("job-persisted"),
+      { url: "https://example.com/acme/app.git" },
+      true,
+    );
+
+    connectCodeUpdates(client);
+    disconnectCodeUpdates();
+
+    expect(useCodeUpdatesStore.getState().cloneJobs["job-persisted"]).toEqual(
+      pendingClone("job-persisted"),
+    );
+    expect(
+      useCodeUpdatesStore.getState().cloneTracking["job-persisted"]?.background,
+    ).toBe(true);
+  });
+
+  it("reconciles every active clone when the updates socket opens", async () => {
+    const { client, sockets } = cloneClient(async (jobId) =>
+      pendingClone(jobId),
+    );
+    activateCodeCloneClient(client);
+    trackCodeClone(client, pendingClone("job-a"), { github: "acme/a" }, true);
+    trackCodeClone(client, pendingClone("job-b"), { github: "acme/b" }, true);
+
+    connectCodeUpdates(client);
+    sockets[0]?.onopen?.call(
+      sockets[0] as unknown as WebSocket,
+      new Event("open"),
+    );
+
+    await vi.waitFor(() =>
+      expect(client.getCodeCloneJob).toHaveBeenCalledTimes(2),
+    );
+    expect(client.getCodeCloneJob).toHaveBeenCalledWith("job-a");
+    expect(client.getCodeCloneJob).toHaveBeenCalledWith("job-b");
+  });
+
+  it("recovers a background completion after Code updates reconnect", async () => {
+    const { client, sockets } = cloneClient(async (jobId) =>
+      completeClone(jobId),
+    );
+    activateCodeCloneClient(client);
+    trackCodeClone(
+      client,
+      pendingClone("job-reconnect"),
+      { github: "acme/app" },
+      true,
+    );
+
+    connectCodeUpdates(client);
+    disconnectCodeUpdates();
+    connectCodeUpdates(client);
+    sockets[1]?.onopen?.call(
+      sockets[1] as unknown as WebSocket,
+      new Event("open"),
+    );
+
+    await vi.waitFor(() =>
+      expect(
+        useCodeUpdatesStore.getState().cloneJobs["job-reconnect"]?.done,
+      ).toBe(true),
+    );
+    expect(toast.success).toHaveBeenCalledWith(
+      "Repository cloned",
+      expect.objectContaining({
+        description: "Create a workspace when you are ready.",
+      }),
+    );
+  });
+
+  it("shows one terminal notice when socket and durable results overlap", async () => {
+    const durable = deferred<CodeCloneJobSnapshot>();
+    const { client, sockets, send } = cloneClient(() => durable.promise);
+    activateCodeCloneClient(client);
+    trackCodeClone(
+      client,
+      pendingClone("job-overlap"),
+      { url: "https://example.com/acme/app.git" },
+      true,
+    );
+    connectCodeUpdates(client);
+    sockets[0]?.onopen?.call(
+      sockets[0] as unknown as WebSocket,
+      new Event("open"),
+    );
+    await vi.waitFor(() =>
+      expect(client.getCodeCloneJob).toHaveBeenCalledWith("job-overlap"),
+    );
+
+    send({
+      type: "clone_progress",
+      job: "job-overlap",
+      phase: "complete",
+      done: true,
+      repo_id: "repo-job-overlap",
+    });
+    durable.resolve(pendingClone("job-overlap"));
+    await durable.promise;
+    await Promise.resolve();
+
+    expect(toast.success).toHaveBeenCalledTimes(1);
+    expect(useCodeUpdatesStore.getState().cloneJobs["job-overlap"]).toEqual(
+      completeClone("job-overlap"),
+    );
+  });
+
+  it("clears tracked clone state for a replacement ApiClient", () => {
+    const first = cloneClient(async (jobId) => pendingClone(jobId)).client;
+    const replacement = cloneClient(async (jobId) =>
+      pendingClone(jobId),
+    ).client;
+    activateCodeCloneClient(first);
+    trackCodeClone(first, pendingClone("job-old"), { github: "acme/old" });
+
+    const replacementGeneration = activateCodeCloneClient(replacement);
+
+    expect(useCodeUpdatesStore.getState().cloneJobs).toEqual({});
+    expect(useCodeUpdatesStore.getState().cloneTracking).toEqual({});
+    expect(useCodeUpdatesStore.getState().cloneClientGeneration).toBe(
+      replacementGeneration,
+    );
+    expect(replacementGeneration).not.toBe(codeClientGeneration(first));
+  });
+
+  it("ignores a durable result from an old ApiClient generation", async () => {
+    const staleRead = deferred<CodeCloneJobSnapshot>();
+    const first = cloneClient(() => staleRead.promise).client;
+    const replacement = cloneClient(async (jobId) =>
+      pendingClone(jobId),
+    ).client;
+    activateCodeCloneClient(first);
+    trackCodeClone(
+      first,
+      pendingClone("job-shared"),
+      { github: "acme/old" },
+      true,
+    );
+    const reconciliation = reconcileCodeClone(first, "job-shared");
+
+    activateCodeCloneClient(replacement);
+    trackCodeClone(
+      replacement,
+      pendingClone("job-shared"),
+      { github: "acme/new" },
+      true,
+    );
+    staleRead.resolve(completeClone("job-shared"));
+    await expect(reconciliation).resolves.toBeNull();
+
+    expect(useCodeUpdatesStore.getState().cloneJobs["job-shared"]).toEqual(
+      pendingClone("job-shared"),
+    );
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -46,6 +46,11 @@ export type CodeCloneTracking = {
   startedOrder: number;
 };
 
+export type SelectedCodeClone = {
+  jobId: string;
+  clientGeneration: number;
+};
+
 export type CodeUpdatesState = {
   /**
    * Conversation digests, keyed workspace → session. Never a watch.
@@ -72,6 +77,8 @@ export type CodeUpdatesState = {
   cloneReadErrors: Record<string, string>;
   /** The ApiClient generation that owns every clone entry in this store. */
   cloneClientGeneration: number | null;
+  /** The exact clone requested by a notification action, consumed on open. */
+  selectedClone: SelectedCodeClone | null;
   /**
    * Warm harness installs, keyed by engine. The New Workspace dialog starts
    * them and reads their phase from here; nothing else depends on them, and a
@@ -104,6 +111,7 @@ const EMPTY: CodeUpdatesState = {
   cloneTracking: {},
   cloneReadErrors: {},
   cloneClientGeneration: null,
+  selectedClone: null,
   harnessInstalls: {},
   viewedWorkspaceId: null,
   deliveryRevision: 0,
@@ -419,7 +427,12 @@ type CodeUpdatesStore = CodeUpdatesState & {
 export const useCodeUpdatesStore = create<CodeUpdatesStore>()((set, get) => ({
   ...EMPTY,
   apply: (action) => {
-    let backgroundClone: CodeCloneJobSnapshot | null = null;
+    const backgroundClone: {
+      current: {
+        job: CodeCloneJobSnapshot;
+        clientGeneration: number;
+      } | null;
+    } = { current: null };
     set((previous) => {
       let next = reduceCodeUpdates(previous, action);
       // OS attention stays keyed to the conversation: a watch child's state
@@ -434,7 +447,10 @@ export const useCodeUpdatesStore = create<CodeUpdatesStore>()((set, get) => ({
         const tracking = next.cloneTracking[action.job.id];
         const updatedJob = next.cloneJobs[action.job.id];
         if (tracking?.background && updatedJob?.done && !tracking.notified) {
-          backgroundClone = updatedJob;
+          backgroundClone.current = {
+            job: updatedJob,
+            clientGeneration: tracking.clientGeneration,
+          };
           next = {
             ...next,
             cloneTracking: {
@@ -446,7 +462,10 @@ export const useCodeUpdatesStore = create<CodeUpdatesStore>()((set, get) => ({
       }
       return next;
     });
-    if (backgroundClone) notifyBackgroundClone(backgroundClone);
+    const notification = backgroundClone.current;
+    if (notification) {
+      notifyBackgroundClone(notification.job, notification.clientGeneration);
+    }
   },
   setViewedWorkspace: (workspaceId) => {
     set(reduceCodeUpdates(get(), { type: "view", workspaceId }));
@@ -458,6 +477,7 @@ export const useCodeUpdatesStore = create<CodeUpdatesStore>()((set, get) => ({
       cloneTracking: state.cloneTracking,
       cloneReadErrors: state.cloneReadErrors,
       cloneClientGeneration: state.cloneClientGeneration,
+      selectedClone: state.selectedClone,
       viewedWorkspaceId: state.viewedWorkspaceId,
     })),
   reset: () => set({ ...EMPTY }),
@@ -503,13 +523,17 @@ export function trackCodeClone(
 ): boolean {
   const clientGeneration = codeClientGeneration(client);
   let tracked = false;
+  let terminal: CodeCloneJobSnapshot | null = null;
   useCodeUpdatesStore.setState((state) => {
     if (state.cloneClientGeneration !== clientGeneration) return state;
     tracked = true;
     const cloneReadErrors = { ...state.cloneReadErrors };
     delete cloneReadErrors[job.id];
-    nextCloneOrder += 1;
+    const existing = state.cloneTracking[job.id];
+    const startedOrder = existing?.startedOrder ?? ++nextCloneOrder;
     const trackedJob = mergeCloneJob(state.cloneJobs[job.id], job);
+    const notify = background && trackedJob.done && !existing?.notified;
+    if (notify) terminal = trackedJob;
     return {
       cloneJobs: { ...state.cloneJobs, [job.id]: trackedJob },
       cloneTracking: {
@@ -518,16 +542,14 @@ export function trackCodeClone(
           request,
           clientGeneration,
           background,
-          notified: false,
-          startedOrder: nextCloneOrder,
+          notified: existing?.notified === true || notify,
+          startedOrder,
         },
       },
       cloneReadErrors,
     };
   });
-  if (tracked && background && job.done) {
-    setCodeCloneBackground(client, job.id, true);
-  }
+  if (terminal) notifyBackgroundClone(terminal, clientGeneration);
   return tracked;
 }
 
@@ -561,7 +583,7 @@ export function setCodeCloneBackground(
       },
     };
   });
-  if (terminal) notifyBackgroundClone(terminal);
+  if (terminal) notifyBackgroundClone(terminal, clientGeneration);
 }
 
 export type ResumableCodeClone = {
@@ -569,6 +591,56 @@ export type ResumableCodeClone = {
   tracking: CodeCloneTracking;
   readError: string | null;
 };
+
+function resumableCodeClone(
+  state: CodeUpdatesState,
+  clientGeneration: number,
+  jobId: string,
+): ResumableCodeClone | null {
+  const tracking = state.cloneTracking[jobId];
+  const job = state.cloneJobs[jobId];
+  if (tracking?.clientGeneration !== clientGeneration || !job) return null;
+  return {
+    job,
+    tracking,
+    readError: state.cloneReadErrors[jobId] ?? null,
+  };
+}
+
+/** Select the exact tracked clone that a notification action represents. */
+export function selectCodeClone(selection: SelectedCodeClone): boolean {
+  let selected = false;
+  useCodeUpdatesStore.setState((state) => {
+    if (
+      state.cloneClientGeneration !== selection.clientGeneration ||
+      !resumableCodeClone(state, selection.clientGeneration, selection.jobId)
+    ) {
+      return state;
+    }
+    selected = true;
+    return { selectedClone: selection };
+  });
+  return selected;
+}
+
+/** Consume the clone selected by a notification action. */
+export function takeSelectedCodeClone(
+  client: object,
+): ResumableCodeClone | null | undefined {
+  const clientGeneration = codeClientGeneration(client);
+  let selected: ResumableCodeClone | null | undefined;
+  useCodeUpdatesStore.setState((state) => {
+    const request = state.selectedClone;
+    if (!request) return state;
+    selected =
+      state.cloneClientGeneration === clientGeneration &&
+      request.clientGeneration === clientGeneration
+        ? resumableCodeClone(state, clientGeneration, request.jobId)
+        : null;
+    return { selectedClone: null };
+  });
+  return selected;
+}
 
 /** The most recently started clone that this client can resume. */
 export function latestCodeClone(client: object): ResumableCodeClone | null {
@@ -579,14 +651,8 @@ export function latestCodeClone(client: object): ResumableCodeClone | null {
     .filter(([, entry]) => entry.clientGeneration === clientGeneration)
     .sort(([, left], [, right]) => right.startedOrder - left.startedOrder)[0];
   if (!tracking) return null;
-  const [jobId, entry] = tracking;
-  const job = state.cloneJobs[jobId];
-  if (!job) return null;
-  return {
-    job,
-    tracking: entry,
-    readError: state.cloneReadErrors[jobId] ?? null,
-  };
+  const [jobId] = tracking;
+  return resumableCodeClone(state, clientGeneration, jobId);
 }
 
 /** Remove a clone once onboarding has handed its repository off. */
@@ -685,10 +751,16 @@ export function reconcileCodeClone(
   return request;
 }
 
-function notifyBackgroundClone(job: CodeCloneJobSnapshot): void {
+function notifyBackgroundClone(
+  job: CodeCloneJobSnapshot,
+  clientGeneration: number,
+): void {
   const action = {
     label: job.error ? "Retry" : "Open",
-    onClick: () => useCodeUiStore.getState().setAddRepoOpen(true),
+    onClick: () => {
+      if (!selectCodeClone({ jobId: job.id, clientGeneration })) return;
+      useCodeUiStore.getState().setAddRepoOpen(true);
+    },
   };
   if (job.error) {
     toast.error("Repository clone failed", {

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { toast } from "sonner";
 import { create } from "zustand";
 
 import type { ApiClient } from "../api/client";
@@ -18,6 +19,8 @@ import {
   nextReconnectDelay,
 } from "../ChatSessionController";
 import { requestUserAttention } from "../host";
+import { friendlyErrorMessage } from "../lib/utils";
+import { useCodeUiStore } from "./CodeUiStore";
 
 /**
  * Install-wide digest store fed by `WS /code/updates`.
@@ -32,6 +35,16 @@ export type DigestsByWorkspace = Record<
   string,
   Record<string, CodeSessionDigest>
 >;
+
+export type CodeCloneRequest = Parameters<ApiClient["startCodeClone"]>[0];
+
+export type CodeCloneTracking = {
+  request: CodeCloneRequest;
+  clientGeneration: number;
+  background: boolean;
+  notified: boolean;
+  startedOrder: number;
+};
 
 export type CodeUpdatesState = {
   /**
@@ -50,6 +63,15 @@ export type CodeUpdatesState = {
    */
   childrenByWorkspace: DigestsByWorkspace;
   cloneJobs: Record<string, CodeCloneJobSnapshot>;
+  /**
+   * Clone jobs started by this window, including enough context to resume the
+   * onboarding flow after its dialog or the whole Code route unmounts.
+   */
+  cloneTracking: Record<string, CodeCloneTracking>;
+  /** A durable-read failure is separate from a clone failure. */
+  cloneReadErrors: Record<string, string>;
+  /** The ApiClient generation that owns every clone entry in this store. */
+  cloneClientGeneration: number | null;
   /**
    * Warm harness installs, keyed by engine. The New Workspace dialog starts
    * them and reads their phase from here; nothing else depends on them, and a
@@ -79,6 +101,9 @@ const EMPTY: CodeUpdatesState = {
   conversationsByWorkspace: {},
   childrenByWorkspace: {},
   cloneJobs: {},
+  cloneTracking: {},
+  cloneReadErrors: {},
+  cloneClientGeneration: null,
   harnessInstalls: {},
   viewedWorkspaceId: null,
   deliveryRevision: 0,
@@ -133,7 +158,10 @@ export function reduceCodeUpdates(
         ...state,
         cloneJobs: {
           ...state.cloneJobs,
-          [action.job.id]: action.job,
+          [action.job.id]: mergeCloneJob(
+            state.cloneJobs[action.job.id],
+            action.job,
+          ),
         },
       };
     case "harness_install":
@@ -151,6 +179,14 @@ export function reduceCodeUpdates(
     case "reset":
       return { ...EMPTY, viewedWorkspaceId: state.viewedWorkspaceId };
   }
+}
+
+function mergeCloneJob(
+  current: CodeCloneJobSnapshot | undefined,
+  incoming: CodeCloneJobSnapshot,
+): CodeCloneJobSnapshot {
+  if (current?.done && !incoming.done) return current;
+  return incoming;
 }
 
 function upsertDigest(
@@ -376,26 +412,296 @@ export function noticeToAction(
 type CodeUpdatesStore = CodeUpdatesState & {
   apply: (action: CodeUpdatesAction) => void;
   setViewedWorkspace: (workspaceId: string | null) => void;
+  resetLive: () => void;
   reset: () => void;
 };
 
 export const useCodeUpdatesStore = create<CodeUpdatesStore>()((set, get) => ({
   ...EMPTY,
   apply: (action) => {
-    const previous = get();
-    const next = reduceCodeUpdates(previous, action);
-    // OS attention stays keyed to the conversation: a watch child's state
-    // change would compare against the interactive digest and misfire.
-    if (action.type === "digest" && action.digest.kind !== "watch") {
-      maybeNotify(previous, action.digest);
-    }
-    set(next);
+    let backgroundClone: CodeCloneJobSnapshot | null = null;
+    set((previous) => {
+      let next = reduceCodeUpdates(previous, action);
+      // OS attention stays keyed to the conversation: a watch child's state
+      // change would compare against the interactive digest and misfire.
+      if (action.type === "digest" && action.digest.kind !== "watch") {
+        maybeNotify(previous, action.digest);
+      }
+      if (action.type === "clone_progress") {
+        const cloneReadErrors = { ...next.cloneReadErrors };
+        delete cloneReadErrors[action.job.id];
+        next = { ...next, cloneReadErrors };
+        const tracking = next.cloneTracking[action.job.id];
+        const updatedJob = next.cloneJobs[action.job.id];
+        if (tracking?.background && updatedJob?.done && !tracking.notified) {
+          backgroundClone = updatedJob;
+          next = {
+            ...next,
+            cloneTracking: {
+              ...next.cloneTracking,
+              [action.job.id]: { ...tracking, notified: true },
+            },
+          };
+        }
+      }
+      return next;
+    });
+    if (backgroundClone) notifyBackgroundClone(backgroundClone);
   },
   setViewedWorkspace: (workspaceId) => {
     set(reduceCodeUpdates(get(), { type: "view", workspaceId }));
   },
+  resetLive: () =>
+    set((state) => ({
+      ...EMPTY,
+      cloneJobs: state.cloneJobs,
+      cloneTracking: state.cloneTracking,
+      cloneReadErrors: state.cloneReadErrors,
+      cloneClientGeneration: state.cloneClientGeneration,
+      viewedWorkspaceId: state.viewedWorkspaceId,
+    })),
   reset: () => set({ ...EMPTY }),
 }));
+
+const clientGenerations = new WeakMap<object, number>();
+let nextClientGeneration = 0;
+let nextCloneOrder = 0;
+
+/** A stable identity for one ApiClient object. */
+export function codeClientGeneration(client: object): number {
+  const existing = clientGenerations.get(client);
+  if (existing !== undefined) return existing;
+  nextClientGeneration += 1;
+  clientGenerations.set(client, nextClientGeneration);
+  return nextClientGeneration;
+}
+
+/**
+ * Move clone state to one client authority. A job ID from another machine or
+ * token generation must never be read through the replacement client.
+ */
+export function activateCodeCloneClient(client: object): number {
+  const clientGeneration = codeClientGeneration(client);
+  useCodeUpdatesStore.setState((state) => {
+    if (state.cloneClientGeneration === clientGeneration) return state;
+    return {
+      cloneJobs: {},
+      cloneTracking: {},
+      cloneReadErrors: {},
+      cloneClientGeneration: clientGeneration,
+    };
+  });
+  return clientGeneration;
+}
+
+/** Record a clone before the palette can unmount. */
+export function trackCodeClone(
+  client: object,
+  job: CodeCloneJobSnapshot,
+  request: CodeCloneRequest,
+  background = false,
+): boolean {
+  const clientGeneration = codeClientGeneration(client);
+  let tracked = false;
+  useCodeUpdatesStore.setState((state) => {
+    if (state.cloneClientGeneration !== clientGeneration) return state;
+    tracked = true;
+    const cloneReadErrors = { ...state.cloneReadErrors };
+    delete cloneReadErrors[job.id];
+    nextCloneOrder += 1;
+    const trackedJob = mergeCloneJob(state.cloneJobs[job.id], job);
+    return {
+      cloneJobs: { ...state.cloneJobs, [job.id]: trackedJob },
+      cloneTracking: {
+        ...state.cloneTracking,
+        [job.id]: {
+          request,
+          clientGeneration,
+          background,
+          notified: false,
+          startedOrder: nextCloneOrder,
+        },
+      },
+      cloneReadErrors,
+    };
+  });
+  if (tracked && background && job.done) {
+    setCodeCloneBackground(client, job.id, true);
+  }
+  return tracked;
+}
+
+/** Make a clone resumable without leaving its completion handoff armed. */
+export function setCodeCloneBackground(
+  client: object,
+  jobId: string,
+  background: boolean,
+): void {
+  const clientGeneration = codeClientGeneration(client);
+  let terminal: CodeCloneJobSnapshot | null = null;
+  useCodeUpdatesStore.setState((state) => {
+    const tracking = state.cloneTracking[jobId];
+    if (
+      state.cloneClientGeneration !== clientGeneration ||
+      tracking?.clientGeneration !== clientGeneration
+    ) {
+      return state;
+    }
+    const job = state.cloneJobs[jobId];
+    const notify = background && job?.done && !tracking.notified;
+    if (notify) terminal = job;
+    return {
+      cloneTracking: {
+        ...state.cloneTracking,
+        [jobId]: {
+          ...tracking,
+          background,
+          notified: tracking.notified || Boolean(notify),
+        },
+      },
+    };
+  });
+  if (terminal) notifyBackgroundClone(terminal);
+}
+
+export type ResumableCodeClone = {
+  job: CodeCloneJobSnapshot;
+  tracking: CodeCloneTracking;
+  readError: string | null;
+};
+
+/** The most recently started clone that this client can resume. */
+export function latestCodeClone(client: object): ResumableCodeClone | null {
+  const clientGeneration = codeClientGeneration(client);
+  const state = useCodeUpdatesStore.getState();
+  if (state.cloneClientGeneration !== clientGeneration) return null;
+  const tracking = Object.entries(state.cloneTracking)
+    .filter(([, entry]) => entry.clientGeneration === clientGeneration)
+    .sort(([, left], [, right]) => right.startedOrder - left.startedOrder)[0];
+  if (!tracking) return null;
+  const [jobId, entry] = tracking;
+  const job = state.cloneJobs[jobId];
+  if (!job) return null;
+  return {
+    job,
+    tracking: entry,
+    readError: state.cloneReadErrors[jobId] ?? null,
+  };
+}
+
+/** Remove a clone once onboarding has handed its repository off. */
+export function forgetCodeClone(client: object, jobId: string): void {
+  const clientGeneration = codeClientGeneration(client);
+  useCodeUpdatesStore.setState((state) => {
+    const tracking = state.cloneTracking[jobId];
+    if (
+      state.cloneClientGeneration !== clientGeneration ||
+      tracking?.clientGeneration !== clientGeneration
+    ) {
+      return state;
+    }
+    const cloneJobs = { ...state.cloneJobs };
+    const cloneTracking = { ...state.cloneTracking };
+    const cloneReadErrors = { ...state.cloneReadErrors };
+    delete cloneJobs[jobId];
+    delete cloneTracking[jobId];
+    delete cloneReadErrors[jobId];
+    return { cloneJobs, cloneTracking, cloneReadErrors };
+  });
+}
+
+type CloneUpdatesClient = Pick<
+  ApiClient,
+  "getCodeCloneJob" | "openCodeUpdates"
+>;
+
+const cloneReconciliations = new Map<
+  string,
+  Promise<CodeCloneJobSnapshot | null>
+>();
+
+/** Read the server's durable clone state and ignore a stale client response. */
+export function reconcileCodeClone(
+  client: Pick<ApiClient, "getCodeCloneJob">,
+  jobId: string,
+): Promise<CodeCloneJobSnapshot | null> {
+  const clientGeneration = codeClientGeneration(client);
+  const key = `${clientGeneration}:${jobId}`;
+  const existing = cloneReconciliations.get(key);
+  if (existing) return existing;
+
+  const state = useCodeUpdatesStore.getState();
+  if (
+    state.cloneClientGeneration !== clientGeneration ||
+    state.cloneTracking[jobId]?.clientGeneration !== clientGeneration
+  ) {
+    return Promise.resolve(null);
+  }
+
+  useCodeUpdatesStore.setState((current) => {
+    if (!current.cloneReadErrors[jobId]) return current;
+    const cloneReadErrors = { ...current.cloneReadErrors };
+    delete cloneReadErrors[jobId];
+    return { cloneReadErrors };
+  });
+
+  const request = Promise.resolve()
+    .then(() => client.getCodeCloneJob(jobId))
+    .then((job) => {
+      const current = useCodeUpdatesStore.getState();
+      if (
+        current.cloneClientGeneration !== clientGeneration ||
+        current.cloneTracking[jobId]?.clientGeneration !== clientGeneration
+      ) {
+        return null;
+      }
+      current.apply({ type: "clone_progress", job });
+      return job;
+    })
+    .catch((error: unknown) => {
+      useCodeUpdatesStore.setState((current) => {
+        if (
+          current.cloneClientGeneration !== clientGeneration ||
+          current.cloneTracking[jobId]?.clientGeneration !== clientGeneration
+        ) {
+          return current;
+        }
+        return {
+          cloneReadErrors: {
+            ...current.cloneReadErrors,
+            [jobId]: friendlyErrorMessage(
+              error,
+              "Could not check clone progress",
+            ),
+          },
+        };
+      });
+      return null;
+    })
+    .finally(() => {
+      cloneReconciliations.delete(key);
+    });
+  cloneReconciliations.set(key, request);
+  return request;
+}
+
+function notifyBackgroundClone(job: CodeCloneJobSnapshot): void {
+  const action = {
+    label: job.error ? "Retry" : "Open",
+    onClick: () => useCodeUiStore.getState().setAddRepoOpen(true),
+  };
+  if (job.error) {
+    toast.error("Repository clone failed", {
+      description: job.error,
+      action,
+    });
+    return;
+  }
+  toast.success("Repository cloned", {
+    description: "Create a workspace when you are ready.",
+    action,
+  });
+}
 
 function maybeNotify(
   previous: CodeUpdatesState,
@@ -418,19 +724,18 @@ function maybeNotify(
   }
 }
 
-let activeClient: Pick<ApiClient, "openCodeUpdates"> | null = null;
+let activeClient: CloneUpdatesClient | null = null;
 let socket: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
 let generation = 0;
 
-export function connectCodeUpdates(
-  client: Pick<ApiClient, "openCodeUpdates">,
-): () => void {
+export function connectCodeUpdates(client: CloneUpdatesClient): () => void {
   if (activeClient === client && socket) {
     return disconnectCodeUpdates;
   }
   disconnectCodeUpdates();
+  activateCodeCloneClient(client);
   activeClient = client;
   generation += 1;
   const born = generation;
@@ -446,25 +751,34 @@ export function disconnectCodeUpdates(): void {
     reconnectTimer = null;
   }
   if (socket) {
+    socket.onopen = null;
     socket.onclose = null;
     socket.onerror = null;
     socket.close();
     socket = null;
   }
-  useCodeUpdatesStore.getState().reset();
+  useCodeUpdatesStore.getState().resetLive();
 }
 
-function open(client: Pick<ApiClient, "openCodeUpdates">, born: number): void {
+function open(client: CloneUpdatesClient, born: number): void {
   if (born !== generation) return;
   const next = client.openCodeUpdates((notice) => {
     if (born !== generation) return;
     const action = noticeToAction(notice);
+    if (
+      action?.type === "clone_progress" &&
+      useCodeUpdatesStore.getState().cloneClientGeneration !==
+        codeClientGeneration(client)
+    ) {
+      return;
+    }
     if (action) useCodeUpdatesStore.getState().apply(action);
   });
   socket = next;
   next.onopen = () => {
     if (born !== generation) return;
     reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+    reconcileTrackedClones(client, born);
   };
   next.onclose = () => {
     if (born !== generation) return;
@@ -476,16 +790,31 @@ function open(client: Pick<ApiClient, "openCodeUpdates">, born: number): void {
   };
 }
 
-function scheduleReconnect(
-  client: Pick<ApiClient, "openCodeUpdates">,
-  born: number,
-): void {
+function scheduleReconnect(client: CloneUpdatesClient, born: number): void {
   if (born !== generation) return;
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
     open(client, born);
   }, reconnectDelayMs);
   reconnectDelayMs = nextReconnectDelay(reconnectDelayMs);
+}
+
+function reconcileTrackedClones(
+  client: CloneUpdatesClient,
+  born: number,
+): void {
+  if (born !== generation) return;
+  const clientGeneration = codeClientGeneration(client);
+  const state = useCodeUpdatesStore.getState();
+  if (state.cloneClientGeneration !== clientGeneration) return;
+  for (const [jobId, tracking] of Object.entries(state.cloneTracking)) {
+    if (
+      tracking.clientGeneration === clientGeneration &&
+      !state.cloneJobs[jobId]?.done
+    ) {
+      void reconcileCodeClone(client, jobId);
+    }
+  }
 }
 
 export function digestLifecycle(

--- a/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
@@ -39,6 +39,11 @@ type SetupScenario =
   | "clone-complete"
   | "hosted-picker"
   | "hosted-list-failed"
+  | "source-probe-failure"
+  | "defaults-probe-failure"
+  | "progress-read-failure"
+  | "repository-handoff-failure"
+  | "registration-background-complete"
   | "workspace"
   | "workspace-needs-harness";
 
@@ -50,14 +55,19 @@ function setupClient(scenario: SetupScenario): ApiClient {
   const localOnly = scenario === "local-only";
   const githubHint = scenario === "github-hint";
   return {
-    getCodeCloneDefaults: async () => ({
-      parent_dir: "/Users/sam/src",
-      gh_found: !githubHint,
-      gh_authenticated: !githubHint,
-      gh_remediation: githubHint
-        ? "GitHub CLI is not signed in on this machine."
-        : "",
-    }),
+    getCodeCloneDefaults: async () => {
+      if (scenario === "defaults-probe-failure") {
+        throw new Error("The saved destination is unavailable.");
+      }
+      return {
+        parent_dir: "/Users/sam/src",
+        gh_found: !githubHint,
+        gh_authenticated: !githubHint,
+        gh_remediation: githubHint
+          ? "GitHub CLI is not signed in on this machine."
+          : "",
+      };
+    },
     listCodeGithubRepositories: async () => {
       if (scenario === "hosted-list-failed") {
         throw new Error("502: bad gateway");
@@ -79,39 +89,44 @@ function setupClient(scenario: SetupScenario): ApiClient {
           }
         : { repositories: [] };
     },
-    getCodeRepoSources: async () => ({
-      sources: localOnly
-        ? [
-            { kind: "local", available: true },
-            {
-              kind: "git_url",
-              available: false,
-              remediation: "Install git on this machine to clone a remote.",
-            },
-            {
-              kind: "github",
-              available: false,
-              remediation: "Install git on this machine to clone a remote.",
-            },
-          ]
-        : [
-            { kind: "local", available: true },
-            { kind: "git_url", available: true },
-            {
-              kind: "github",
-              available: true,
-              remediation:
-                scenario === "hosted-picker" ||
-                scenario === "hosted-list-failed"
-                  ? "Clones and pushes use your own GitHub account: work lands as mira-chen."
-                  : githubHint
-                    ? "GitHub CLI is not signed in on this machine."
-                    : undefined,
-            },
-          ],
-      chooses_destination:
-        scenario === "hosted-picker" || scenario === "hosted-list-failed",
-    }),
+    getCodeRepoSources: async () => {
+      if (scenario === "source-probe-failure") {
+        throw new Error("The machine did not answer.");
+      }
+      return {
+        sources: localOnly
+          ? [
+              { kind: "local", available: true },
+              {
+                kind: "git_url",
+                available: false,
+                remediation: "Install git on this machine to clone a remote.",
+              },
+              {
+                kind: "github",
+                available: false,
+                remediation: "Install git on this machine to clone a remote.",
+              },
+            ]
+          : [
+              { kind: "local", available: true },
+              { kind: "git_url", available: true },
+              {
+                kind: "github",
+                available: true,
+                remediation:
+                  scenario === "hosted-picker" ||
+                  scenario === "hosted-list-failed"
+                    ? "Clones and pushes use your own GitHub account: work lands as mira-chen."
+                    : githubHint
+                      ? "GitHub CLI is not signed in on this machine."
+                      : undefined,
+              },
+            ],
+        chooses_destination:
+          scenario === "hosted-picker" || scenario === "hosted-list-failed",
+      };
+    },
     startCodeClone: async () => {
       return {
         id: "clone-story",
@@ -120,15 +135,31 @@ function setupClient(scenario: SetupScenario): ApiClient {
         done: false,
       };
     },
-    getCodeCloneJob: async (jobId: string) =>
-      useCodeUpdatesStore.getState().cloneJobs[jobId] ?? {
-        id: jobId,
-        phase: "Receiving objects",
-        percent: 38,
-        done: false,
-      },
-    getCodeRepo: async () => codeRepositories[0]!,
-    createCodeRepo: async () => codeRepositories[0]!,
+    getCodeCloneJob: async (jobId: string) => {
+      if (scenario === "progress-read-failure") {
+        throw new Error("The progress service is unavailable.");
+      }
+      return (
+        useCodeUpdatesStore.getState().cloneJobs[jobId] ?? {
+          id: jobId,
+          phase: "Receiving objects",
+          percent: 38,
+          done: false,
+        }
+      );
+    },
+    getCodeRepo: async () => {
+      if (scenario === "repository-handoff-failure") {
+        throw new Error("The repository catalog is unavailable.");
+      }
+      return codeRepositories[0]!;
+    },
+    createCodeRepo: async () => {
+      if (scenario === "registration-background-complete") {
+        await new Promise((resolve) => globalThis.setTimeout(resolve, 250));
+      }
+      return codeRepositories[0]!;
+    },
     listCodeHarnessModels: async (kind: HarnessKind) => ({
       kind,
       models: [
@@ -236,7 +267,7 @@ const CLONE_REQUEST = {
 
 function seedCloneScenario(client: ApiClient, scenario: SetupScenario) {
   activateCodeCloneClient(client);
-  if (scenario === "clone-progress") {
+  if (scenario === "clone-progress" || scenario === "progress-read-failure") {
     trackCodeClone(
       client,
       {
@@ -273,7 +304,10 @@ function seedCloneScenario(client: ApiClient, scenario: SetupScenario) {
       CLONE_REQUEST,
     );
   }
-  if (scenario === "clone-complete") {
+  if (
+    scenario === "clone-complete" ||
+    scenario === "repository-handoff-failure"
+  ) {
     trackCodeClone(
       client,
       {
@@ -288,10 +322,19 @@ function seedCloneScenario(client: ApiClient, scenario: SetupScenario) {
 }
 
 function RepositorySetupStory({ scenario }: { scenario: SetupScenario }) {
+  const [paletteOpen, setPaletteOpen] = useState(
+    scenario !== "clone-background-complete",
+  );
   const [state] = useState(() => {
     useCodeCatalogStore.getState().reset();
     useCodeUpdatesStore.getState().reset();
-    useCodeUiStore.setState({ lastCreate: null, pendingComposerPrompt: null });
+    useCodeUiStore.setState({
+      addRepoOpen: false,
+      lastCreate: null,
+      newWorkspaceOpen: false,
+      newWorkspaceRepoId: undefined,
+      pendingComposerPrompt: null,
+    });
     useCodeCatalogStore.setState({
       repos: codeRepositories,
       workspaces: [],
@@ -325,7 +368,6 @@ function RepositorySetupStory({ scenario }: { scenario: SetupScenario }) {
   }, [scenario]);
 
   const workspace = scenario.startsWith("workspace");
-  const paletteOpen = scenario !== "clone-background-complete";
   return (
     <AppContextProvider value={appContext(state.client)}>
       <RouterProvider router={state.router as never} />
@@ -336,7 +378,7 @@ function RepositorySetupStory({ scenario }: { scenario: SetupScenario }) {
           repos={codeRepositories}
         />
       ) : (
-        <AddRepoPalette open={paletteOpen} onOpenChange={() => {}} />
+        <AddRepoPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
       )}
       <Toaster richColors duration={Number.POSITIVE_INFINITY} />
     </AppContextProvider>
@@ -421,11 +463,64 @@ export const HostedGitHubListFailed: Story = {
   },
 };
 
+export const SourceProbeFailure: Story = {
+  args: { scenario: "source-probe-failure" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(
+      await body.findByText(
+        "Could not check which sources this machine supports.",
+      ),
+    ).toBeVisible();
+    await userEvent.click(await body.findByRole("button", { name: "Retry" }));
+    await expect(
+      await body.findByText(
+        "Could not check which sources this machine supports.",
+      ),
+    ).toBeVisible();
+  },
+};
+
+export const DefaultsProbeFailure: Story = {
+  args: { scenario: "defaults-probe-failure" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await body.findByRole("option", { name: /Git URL/ }));
+    await expect(
+      await body.findByText(
+        "The saved destination did not load. Choose one or retry.",
+      ),
+    ).toBeVisible();
+    await userEvent.click(await body.findByRole("button", { name: "Retry" }));
+    await expect(
+      await body.findByText(
+        "The saved destination did not load. Choose one or retry.",
+      ),
+    ).toBeVisible();
+  },
+};
+
 export const CloneProgress: Story = {
   args: { scenario: "clone-progress" },
   play: async ({ canvasElement }) => {
     const body = within(canvasElement.ownerDocument.body);
     await expect(await body.findByText("Receiving objects")).toBeVisible();
+  },
+};
+
+export const DurableProgressReadFailure: Story = {
+  args: { scenario: "progress-read-failure" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(
+      await body.findByText("The progress service is unavailable."),
+    ).toBeVisible();
+    await userEvent.click(
+      await body.findByRole("button", { name: "Retry check" }),
+    );
+    await expect(
+      await body.findByText("The progress service is unavailable."),
+    ).toBeVisible();
   },
 };
 
@@ -449,6 +544,42 @@ export const CloneCompleted: Story = {
     ).toBeVisible();
     await expect(
       await body.findByRole("button", { name: "Create workspace" }),
+    ).toBeVisible();
+  },
+};
+
+export const RepositoryHandoffFailure: Story = {
+  args: { scenario: "repository-handoff-failure" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await body.findByRole("button", { name: "Create workspace" }),
+    );
+    await expect(
+      await body.findByText("The repository catalog is unavailable."),
+    ).toBeVisible();
+    await userEvent.click(await body.findByRole("button", { name: "Retry" }));
+    await expect(
+      await body.findByText("The repository catalog is unavailable."),
+    ).toBeVisible();
+  },
+};
+
+export const RegistrationCompletedInBackground: Story = {
+  args: { scenario: "registration-background-complete" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      await body.findByRole("option", { name: /Local folder/ }),
+    );
+    await userEvent.type(await body.findByLabelText("Path"), "/Users/sam/src");
+    await userEvent.click(
+      await body.findByRole("button", { name: "Register" }),
+    );
+    await userEvent.click(await body.findByRole("button", { name: "Close" }));
+    await expect(await body.findByText("Repository registered")).toBeVisible();
+    await expect(
+      await body.findByRole("button", { name: "Open" }),
     ).toBeVisible();
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/RepositorySetup.stories.tsx
@@ -12,10 +12,16 @@ import { expect, userEvent, within } from "storybook/test";
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { ApiClient } from "@/api/client";
 import type { HarnessKind } from "@/api/types";
+import { Toaster } from "@/components/ui/sonner";
 import { AddRepoPalette } from "@/code/AddRepoPalette";
 import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
+import { CodeRepoEmptyState } from "@/code/CodeHome";
 import { useCodeUiStore } from "@/code/CodeUiStore";
-import { useCodeUpdatesStore } from "@/code/CodeUpdatesStore";
+import {
+  activateCodeCloneClient,
+  trackCodeClone,
+  useCodeUpdatesStore,
+} from "@/code/CodeUpdatesStore";
 import { NewWorkspaceDialog } from "@/code/NewWorkspaceDialog";
 import {
   codeRepositories,
@@ -29,6 +35,8 @@ type SetupScenario =
   | "local-only"
   | "clone-failure"
   | "clone-progress"
+  | "clone-background-complete"
+  | "clone-complete"
   | "hosted-picker"
   | "hosted-list-failed"
   | "workspace"
@@ -105,9 +113,6 @@ function setupClient(scenario: SetupScenario): ApiClient {
         scenario === "hosted-picker" || scenario === "hosted-list-failed",
     }),
     startCodeClone: async () => {
-      if (scenario === "clone-failure") {
-        throw new Error("The remote repository could not be reached.");
-      }
       return {
         id: "clone-story",
         phase: "Receiving objects",
@@ -115,6 +120,13 @@ function setupClient(scenario: SetupScenario): ApiClient {
         done: false,
       };
     },
+    getCodeCloneJob: async (jobId: string) =>
+      useCodeUpdatesStore.getState().cloneJobs[jobId] ?? {
+        id: jobId,
+        phase: "Receiving objects",
+        percent: 38,
+        done: false,
+      },
     getCodeRepo: async () => codeRepositories[0]!,
     createCodeRepo: async () => codeRepositories[0]!,
     listCodeHarnessModels: async (kind: HarnessKind) => ({
@@ -204,7 +216,7 @@ function setupRouter() {
   const codeRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/code",
-    component: () => <p>Code</p>,
+    component: () => <CodeRepoEmptyState onAddRepo={() => {}} />,
   });
   const workspaceRoute = createRoute({
     getParentRoute: () => rootRoute,
@@ -215,6 +227,64 @@ function setupRouter() {
     routeTree: rootRoute.addChildren([codeRoute, workspaceRoute]),
     history: createMemoryHistory({ initialEntries: ["/code"] }),
   });
+}
+
+const CLONE_REQUEST = {
+  url: "https://github.com/brightwave-inc/tidebreak.git",
+  parent_dir: "/Users/sam/src",
+};
+
+function seedCloneScenario(client: ApiClient, scenario: SetupScenario) {
+  activateCodeCloneClient(client);
+  if (scenario === "clone-progress") {
+    trackCodeClone(
+      client,
+      {
+        id: "clone-story",
+        phase: "Receiving objects",
+        percent: 38,
+        done: false,
+      },
+      CLONE_REQUEST,
+    );
+  }
+  if (scenario === "clone-background-complete") {
+    trackCodeClone(
+      client,
+      {
+        id: "clone-story",
+        phase: "Receiving objects",
+        percent: 82,
+        done: false,
+      },
+      CLONE_REQUEST,
+      true,
+    );
+  }
+  if (scenario === "clone-failure") {
+    trackCodeClone(
+      client,
+      {
+        id: "clone-story",
+        phase: "Clone failed",
+        done: true,
+        error: "fatal: repository not found",
+      },
+      CLONE_REQUEST,
+    );
+  }
+  if (scenario === "clone-complete") {
+    trackCodeClone(
+      client,
+      {
+        id: "clone-story",
+        phase: "Clone complete",
+        done: true,
+        repo_id: codeRepositories[0]!.id,
+      },
+      CLONE_REQUEST,
+    );
+  }
 }
 
 function RepositorySetupStory({ scenario }: { scenario: SetupScenario }) {
@@ -231,18 +301,31 @@ function RepositorySetupStory({ scenario }: { scenario: SetupScenario }) {
           : harnessDoctor,
       loaded: true,
     });
-    return { client: setupClient(scenario), router: setupRouter() };
+    const client = setupClient(scenario);
+    seedCloneScenario(client, scenario);
+    return { client, router: setupRouter() };
   });
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    if (scenario === "clone-background-complete") {
+      useCodeUpdatesStore.getState().apply({
+        type: "clone_progress",
+        job: {
+          id: "clone-story",
+          phase: "Clone complete",
+          done: true,
+          repo_id: codeRepositories[0]!.id,
+        },
+      });
+    }
+    return () => {
       useCodeCatalogStore.getState().reset();
       useCodeUpdatesStore.getState().reset();
-    },
-    [],
-  );
+    };
+  }, [scenario]);
 
   const workspace = scenario.startsWith("workspace");
+  const paletteOpen = scenario !== "clone-background-complete";
   return (
     <AppContextProvider value={appContext(state.client)}>
       <RouterProvider router={state.router as never} />
@@ -253,8 +336,9 @@ function RepositorySetupStory({ scenario }: { scenario: SetupScenario }) {
           repos={codeRepositories}
         />
       ) : (
-        <AddRepoPalette open onOpenChange={() => {}} />
+        <AddRepoPalette open={paletteOpen} onOpenChange={() => {}} />
       )}
+      <Toaster richColors duration={Number.POSITIVE_INFINITY} />
     </AppContextProvider>
   );
 }
@@ -297,14 +381,11 @@ export const CloneFailure: Story = {
   args: { scenario: "clone-failure" },
   play: async ({ canvasElement }) => {
     const body = within(canvasElement.ownerDocument.body);
-    await userEvent.click(await body.findByRole("option", { name: /Git URL/ }));
-    await userEvent.type(
-      await body.findByPlaceholderText("https://example.com/acme/app.git"),
-      "https://github.com/brightwave-inc/missing.git",
-    );
-    await userEvent.click(await body.findByRole("button", { name: "Clone" }));
     await expect(
-      await body.findByText("The remote repository could not be reached."),
+      await body.findByText("fatal: repository not found"),
+    ).toBeVisible();
+    await expect(
+      await body.findByRole("button", { name: "Retry" }),
     ).toBeVisible();
   },
 };
@@ -344,13 +425,31 @@ export const CloneProgress: Story = {
   args: { scenario: "clone-progress" },
   play: async ({ canvasElement }) => {
     const body = within(canvasElement.ownerDocument.body);
-    await userEvent.click(await body.findByRole("option", { name: /Git URL/ }));
-    await userEvent.type(
-      await body.findByPlaceholderText("https://example.com/acme/app.git"),
-      "https://github.com/brightwave-inc/tidebreak.git",
-    );
-    await userEvent.click(await body.findByRole("button", { name: "Clone" }));
     await expect(await body.findByText("Receiving objects")).toBeVisible();
+  },
+};
+
+export const BackgroundCloneCompleted: Story = {
+  args: { scenario: "clone-background-complete" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(await body.findByText("Repository cloned")).toBeVisible();
+    await expect(
+      await body.findByText("Create a workspace when you are ready."),
+    ).toBeVisible();
+  },
+};
+
+export const CloneCompleted: Story = {
+  args: { scenario: "clone-complete" },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(
+      await body.findByText("The repository is ready."),
+    ).toBeVisible();
+    await expect(
+      await body.findByRole("button", { name: "Create workspace" }),
+    ).toBeVisible();
   },
 };
 


### PR DESCRIPTION
## Implementation

- Keep clone jobs in the Code updates store when the palette or Code route unmounts.
- Reconcile active clone jobs from durable server state after reconnects and missed WebSocket notices.
- Bind notification actions and clone handoffs to the exact API client generation so stale clients cannot open or complete another machine’s job.
- Let people retry setup probes, progress reads, clone failures, and repository handoff failures without restarting onboarding.
- Abort setup reads when the palette closes or the API client changes.
- Preserve local repository registration and clone completion when the dialog closes before the request finishes.
- Add RepositorySetup stories for probe failures, durable progress failures, background completion, completed clones, handoff failure, and background registration.

## Compatibility

The existing local folder, Git URL, GitHub picker, clone progress, and new workspace flows keep their public API shapes. The API client only adds optional abort signals to setup reads. Clone requests still omit the destination when the machine chooses it.

## Safety and risk

Clone state is scoped to one API client generation. A reconnect can restore only jobs started by that client, and late nonterminal progress cannot replace a terminal result. The main risk is lifecycle complexity across dialog close, route unmount, reconnect, and client replacement; focused tests cover those boundaries.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/api.test.ts src/code/AddRepoPalette.dom.test.tsx src/code/CodeUpdatesStore.test.ts` — 122 tests passed.
- Full UI suite — 1,913 tests passed.
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check ...` — passed for all changed files.
- `git diff --check origin/main...HEAD` — passed.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — passed.
- Captured and visually inspected all nine changed Repository setup stories on the exact PR head in light, dark, high-contrast light, and high-contrast dark at 1440×900 and 430×900. The dialogs, retry states, completion toasts, and compact layouts remain readable and unclipped.