### PR TITLE
ci: give Windows release tar POSIX paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1357,6 +1357,11 @@ jobs:
           RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
           RELEASE_TARGET: ${{ matrix.target }}
         run: |
+          # GNU tar treats C:\path as a remote host and \ as escapes. Stay on
+          # POSIX paths for every tar argument.
+          PREPARED_ROOT="$(cygpath -u "$PREPARED_ROOT")"
+          RELEASE_CONFIG="$(cygpath -u "$RELEASE_CONFIG")"
+          workspace="$(cygpath -u "$GITHUB_WORKSPACE")"
           app_binary="target/$RELEASE_TARGET/release/tidebreak-desktop.exe"
           broker_sidecar="crates/tidebreak-desktop/binaries/tidebreak-host-broker-$RELEASE_TARGET.exe"
           cli_sidecar="crates/tidebreak-desktop/binaries/tidebreak-$RELEASE_TARGET.exe"
@@ -1385,9 +1390,8 @@ jobs:
               "$cli_sidecar" \
               > SHA256SUMS
           )
-          # GNU tar treats C:\path as host C. Keep the archive name relative.
           (
-            cd "$GITHUB_WORKSPACE"
+            cd "$workspace"
             tar -cf prepared-windows.tar -C "$PREPARED_ROOT" \
               SHA256SUMS \
               release-config.json \
@@ -1458,12 +1462,14 @@ jobs:
           RELEASE_CONFIG: ${{ runner.temp }}/tidebreak-release.json
           RELEASE_TARGET: ${{ matrix.target }}
         run: |
+          PREPARED_ROOT="$(cygpath -u "$PREPARED_ROOT")"
+          PREPARED_DOWNLOAD="$(cygpath -u "$PREPARED_DOWNLOAD")"
+          RELEASE_CONFIG="$(cygpath -u "$RELEASE_CONFIG")"
           rm -rf "$PREPARED_ROOT"
           mkdir -p "$PREPARED_ROOT"
           (
             cd "$PREPARED_DOWNLOAD"
             sha256sum --check --strict prepared-windows.tar.sha256
-            # GNU tar treats C:\path as host C. Keep the archive name relative.
             tar -xf prepared-windows.tar -C "$PREPARED_ROOT"
           )
           (

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1944,6 +1944,7 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   assert.match(prepareJob, /compression-level: 0/);
   assert.match(prepareJob, /overwrite: true/);
   assert.match(prepareJob, /sha256sum[\s\S]*> SHA256SUMS/);
+  assert.match(prepareJob, /PREPARED_ROOT="\$\(cygpath -u "\$PREPARED_ROOT"\)"/);
   assert.match(prepareJob, /tar -cf prepared-windows\.tar -C "\$PREPARED_ROOT"/);
   assert.match(prepareJob, /sha256sum prepared-windows\.tar/);
   assert.doesNotMatch(prepareJob, /tar -[cx]f "\$/);
@@ -1963,6 +1964,11 @@ test("Windows release jobs mirror the credential-free prepare/build split", () =
   assert.match(
     verifyStep,
     /sha256sum --check --strict prepared-windows\.tar\.sha256/,
+  );
+  assert.match(verifyStep, /PREPARED_ROOT="\$\(cygpath -u "\$PREPARED_ROOT"\)"/);
+  assert.match(
+    verifyStep,
+    /PREPARED_DOWNLOAD="\$\(cygpath -u "\$PREPARED_DOWNLOAD"\)"/,
   );
   assert.match(verifyStep, /tar -xf prepared-windows\.tar -C "\$PREPARED_ROOT"/);
   assert.doesNotMatch(verifyStep, /tar -[cx]f "\$/);


### PR DESCRIPTION
## What changed

#2636 stopped GNU tar from treating `C:\path` as a remote host when writing `prepared-windows.tar`. Extract still failed: `tar -C C:\a\_temp\...` treats backslashes as escapes, so the directory `mkdir` created is not the one tar opens.

Seen on https://github.com/brightwave-inc/tidebreak/actions/runs/32924321644 after a successful Windows prepare.

Archive and extract now convert `runner.temp` paths with `cygpath -u` before calling tar.

## Validation

- `node --test --test-name-pattern='Windows release jobs' scripts/workflow-security.test.mjs`
- Did not re-run the production release. Re-dispatch after this lands.

## Compatibility and risk

Windows Git Bash only. Archive members and checksums are unchanged.