### PR TITLE
fix(code): make terminal input recoverable

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import type { ComponentProps } from "react";
 import {
   act,
   cleanup,
@@ -111,15 +112,9 @@ function readPage(
   };
 }
 
-function clientWith(
-  overrides: Partial<{
-    listCodeTerminals: ReturnType<typeof vi.fn>;
-    createCodeTerminal: ReturnType<typeof vi.fn>;
-    readCodeTerminal: ReturnType<typeof vi.fn>;
-    writeCodeTerminal: ReturnType<typeof vi.fn>;
-    resizeCodeTerminal: ReturnType<typeof vi.fn>;
-  }> = {},
-) {
+type TerminalClient = ComponentProps<typeof TerminalPane>["client"];
+
+function clientWith(overrides: Partial<TerminalClient> = {}): TerminalClient {
   return {
     listCodeTerminals: vi.fn().mockResolvedValue([snapshot()]),
     createCodeTerminal: vi.fn().mockResolvedValue(snapshot("term-new")),

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.dom.test.tsx
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TerminalPane } from "./TerminalPane";
@@ -7,7 +14,11 @@ import { TerminalPane } from "./TerminalPane";
 const written: string[] = [];
 const terminals: Array<{
   disposed: boolean;
-  options: { theme?: Record<string, string> };
+  options: {
+    theme?: Record<string, string>;
+    disableStdin?: boolean;
+  };
+  dataHandler: ((data: string) => void) | null;
   write: (data: string, cb?: () => void) => void;
 }> = [];
 
@@ -16,7 +27,11 @@ vi.mock("@xterm/xterm", () => ({
     cols = 80;
     rows = 24;
     disposed = false;
-    options: { theme?: Record<string, string> };
+    options: {
+      theme?: Record<string, string>;
+      disableStdin?: boolean;
+    };
+    dataHandler: ((data: string) => void) | null = null;
     write(data: string, cb?: () => void) {
       written.push(data);
       cb?.();
@@ -26,10 +41,14 @@ vi.mock("@xterm/xterm", () => ({
     dispose() {
       this.disposed = true;
     }
-    onData() {
+    onData(handler: (data: string) => void) {
+      this.dataHandler = handler;
       return { dispose() {} };
     }
-    constructor(options?: { theme?: Record<string, string> }) {
+    constructor(options?: {
+      theme?: Record<string, string>;
+      disableStdin?: boolean;
+    }) {
       this.options = { ...options };
       terminals.push(this);
     }
@@ -59,41 +78,100 @@ function encode(text: string): string {
   return btoa(binary);
 }
 
+function snapshot(id = "term-1", ended = false) {
+  return {
+    id,
+    workspace_id: "ws-1",
+    cols: 80,
+    rows: 24,
+    ended,
+    created_at: "2026-08-25T12:00:00.000Z",
+  };
+}
+
+function readPage(
+  id = "term-1",
+  overrides: Partial<{
+    bytes: string;
+    cursor: number;
+    overflow: boolean;
+    truncated: boolean;
+    ended: boolean;
+  }> = {},
+) {
+  return {
+    id,
+    workspace_id: "ws-1",
+    bytes: "",
+    cursor: 0,
+    overflow: false,
+    truncated: false,
+    ended: false,
+    ...overrides,
+  };
+}
+
+function clientWith(
+  overrides: Partial<{
+    listCodeTerminals: ReturnType<typeof vi.fn>;
+    createCodeTerminal: ReturnType<typeof vi.fn>;
+    readCodeTerminal: ReturnType<typeof vi.fn>;
+    writeCodeTerminal: ReturnType<typeof vi.fn>;
+    resizeCodeTerminal: ReturnType<typeof vi.fn>;
+  }> = {},
+) {
+  return {
+    listCodeTerminals: vi.fn().mockResolvedValue([snapshot()]),
+    createCodeTerminal: vi.fn().mockResolvedValue(snapshot("term-new")),
+    readCodeTerminal: vi.fn().mockResolvedValue(readPage()),
+    writeCodeTerminal: vi.fn().mockResolvedValue(undefined),
+    resizeCodeTerminal: vi.fn().mockResolvedValue(snapshot()),
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function expectReady() {
+  await waitFor(() =>
+    expect(screen.getByTestId("terminal-host")).toHaveAttribute(
+      "aria-disabled",
+      "false",
+    ),
+  );
+}
+
+function emitData(data: string, index = terminals.length - 1) {
+  const handler = terminals[index]?.dataHandler;
+  if (!handler) throw new Error(`Terminal ${index} has no data handler`);
+  act(() => handler(data));
+}
+
+async function rejectWrite(
+  pending: ReturnType<typeof deferred<void>>,
+  message = "Terminal write failed",
+) {
+  await act(async () => {
+    pending.reject(new Error(message));
+    await Promise.resolve();
+  });
+}
+
 describe("TerminalPane", () => {
   it("disposes the renderer when the pane unmounts", async () => {
-    const client = {
-      listCodeTerminals: vi.fn().mockResolvedValue([]),
-      createCodeTerminal: vi.fn().mockResolvedValue({
-        id: "term-1",
-        workspace_id: "ws-1",
-        cols: 80,
-        rows: 24,
-        ended: false,
-        created_at: "2026-08-15T12:00:00.000Z",
-      }),
-      readCodeTerminal: vi.fn().mockResolvedValue({
-        id: "term-1",
-        workspace_id: "ws-1",
-        bytes: "",
-        cursor: 0,
-        overflow: false,
-        truncated: false,
-        ended: false,
-      }),
-      writeCodeTerminal: vi.fn().mockResolvedValue(undefined),
-      resizeCodeTerminal: vi.fn().mockResolvedValue({
-        id: "term-1",
-        workspace_id: "ws-1",
-        cols: 80,
-        rows: 24,
-        ended: false,
-        created_at: "2026-08-15T12:00:00.000Z",
-      }),
-    };
+    const client = clientWith();
     const { unmount } = render(
       <TerminalPane client={client} workspaceId="ws-1" />,
     );
-    await waitFor(() => expect(client.createCodeTerminal).toHaveBeenCalled());
+    await waitFor(() => expect(client.readCodeTerminal).toHaveBeenCalled());
     expect(terminals).toHaveLength(1);
     expect(terminals[0]?.disposed).toBe(false);
     unmount();
@@ -101,109 +179,414 @@ describe("TerminalPane", () => {
   });
 
   it("renders a truncation notice when the ring overflowed", async () => {
-    const client = {
-      listCodeTerminals: vi.fn().mockResolvedValue([
-        {
-          id: "term-1",
-          workspace_id: "ws-1",
-          cols: 80,
-          rows: 24,
-          ended: false,
-          created_at: "2026-08-15T12:00:00.000Z",
-        },
-      ]),
-      createCodeTerminal: vi.fn(),
-      readCodeTerminal: vi.fn().mockResolvedValue({
-        id: "term-1",
-        workspace_id: "ws-1",
-        bytes: encode("\r\n[output truncated]\r\nlater"),
-        cursor: 12,
-        overflow: true,
-        truncated: false,
-        ended: false,
-      }),
-      writeCodeTerminal: vi.fn(),
-      resizeCodeTerminal: vi.fn(),
-    };
+    const client = clientWith({
+      readCodeTerminal: vi.fn().mockResolvedValue(
+        readPage("term-1", {
+          bytes: encode("\r\n[output truncated]\r\nlater"),
+          cursor: 12,
+          overflow: true,
+        }),
+      ),
+    });
     render(<TerminalPane client={client} workspaceId="ws-1" />);
     expect(await screen.findByTestId("terminal-truncated")).toHaveTextContent(
       "Output was truncated.",
     );
-    // xterm owns everything inside the host, so the host is the only place
-    // that can name the surface. A label on a bare div names nothing.
     expect(screen.getByRole("group", { name: "Terminal output" })).toBe(
       screen.getByTestId("terminal-host"),
     );
   });
 
   it("says the shell is opening until it answers, then gets out of the way", async () => {
-    let answer: (page: unknown) => void = () => {};
-    const client = {
+    const pendingRead = deferred<ReturnType<typeof readPage>>();
+    const client = clientWith({
       listCodeTerminals: vi.fn().mockResolvedValue([]),
-      createCodeTerminal: vi.fn().mockResolvedValue({
-        id: "term-1",
-        workspace_id: "ws-1",
-        cols: 80,
-        rows: 24,
-        ended: false,
-        created_at: "2026-08-15T12:00:00.000Z",
-      }),
-      readCodeTerminal: vi.fn().mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            answer = resolve;
-          }),
-      ),
-      writeCodeTerminal: vi.fn(),
-      resizeCodeTerminal: vi.fn(),
-    };
+      createCodeTerminal: vi.fn().mockResolvedValue(snapshot()),
+      readCodeTerminal: vi.fn().mockReturnValue(pendingRead.promise),
+    });
     render(<TerminalPane client={client} workspaceId="ws-1" />);
     expect(await screen.findByTestId("terminal-starting")).toHaveTextContent(
       "Opening a shell in the worktree…",
     );
 
-    // A shell that answers with nothing is a cleared screen, not a pending one.
-    answer({
-      id: "term-1",
-      workspace_id: "ws-1",
-      bytes: "",
-      cursor: 0,
-      overflow: false,
-      truncated: false,
-      ended: false,
-    });
+    await act(async () => pendingRead.resolve(readPage()));
     await waitFor(() =>
       expect(screen.queryByTestId("terminal-starting")).toBeNull(),
     );
   });
 
   it("renders the ended-shell state", async () => {
-    const client = {
+    const client = clientWith({
       listCodeTerminals: vi.fn().mockResolvedValue([]),
-      createCodeTerminal: vi.fn().mockResolvedValue({
-        id: "term-1",
-        workspace_id: "ws-1",
-        cols: 80,
-        rows: 24,
-        ended: true,
-        created_at: "2026-08-15T12:00:00.000Z",
-      }),
-      readCodeTerminal: vi.fn().mockResolvedValue({
-        id: "term-1",
-        workspace_id: "ws-1",
-        bytes: "",
-        cursor: 0,
-        overflow: false,
-        truncated: false,
-        ended: true,
-      }),
-      writeCodeTerminal: vi.fn(),
-      resizeCodeTerminal: vi.fn(),
-    };
+      createCodeTerminal: vi.fn().mockResolvedValue(snapshot("term-1", true)),
+      readCodeTerminal: vi
+        .fn()
+        .mockResolvedValue(readPage("term-1", { ended: true })),
+    });
     render(<TerminalPane client={client} workspaceId="ws-1" />);
     expect(await screen.findByTestId("terminal-ended")).toHaveTextContent(
       "Shell ended.",
     );
+    expect(screen.getByTestId("terminal-host")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("serializes writes while an earlier request is delayed", async () => {
+    const first = deferred<void>();
+    const writeCodeTerminal = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(undefined);
+    const client = clientWith({ writeCodeTerminal });
+    render(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-1" />,
+    );
+    await expectReady();
+
+    emitData("first");
+    emitData("second");
+    expect(writeCodeTerminal).toHaveBeenCalledTimes(1);
+    expect(writeCodeTerminal).toHaveBeenNthCalledWith(
+      1,
+      "ws-1",
+      "term-1",
+      "first",
+    );
+
+    await act(async () => first.resolve(undefined));
+    await waitFor(() => expect(writeCodeTerminal).toHaveBeenCalledTimes(2));
+    expect(writeCodeTerminal).toHaveBeenNthCalledWith(
+      2,
+      "ws-1",
+      "term-1",
+      "second",
+    );
+  });
+
+  it("preserves all unsent bytes and freezes input after a write failure", async () => {
+    const first = deferred<void>();
+    const writeCodeTerminal = vi.fn().mockReturnValue(first.promise);
+    const client = clientWith({ writeCodeTerminal });
+    render(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-1" />,
+    );
+    await expectReady();
+
+    emitData("echo ");
+    emitData("safe\n");
+    await rejectWrite(first);
+
+    const failure = await screen.findByTestId("terminal-write-failure");
+    expect(failure).toHaveTextContent("10 unsent bytes");
+    expect(failure).toHaveTextContent("Terminal write failed");
+    expect(screen.getByTestId("terminal-host")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(terminals.at(-1)?.options.disableStdin).toBe(true);
+
+    emitData("ignored");
+    expect(writeCodeTerminal).toHaveBeenCalledTimes(1);
+    expect(failure).toHaveTextContent("10 unsent bytes");
+  });
+
+  it("retries the failed chunk before later retained chunks", async () => {
+    const first = deferred<void>();
+    const writeCodeTerminal = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(undefined);
+    const client = clientWith({ writeCodeTerminal });
+    render(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-1" />,
+    );
+    await expectReady();
+
+    emitData("a");
+    emitData("β");
+    await rejectWrite(first);
+    expect(
+      await screen.findByTestId("terminal-write-failure"),
+    ).toHaveTextContent("3 unsent bytes");
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(writeCodeTerminal).toHaveBeenCalledTimes(3));
+    expect(writeCodeTerminal.mock.calls.map((call) => call[2])).toEqual([
+      "a",
+      "a",
+      "β",
+    ]);
+    expect(screen.queryByTestId("terminal-write-failure")).toBeNull();
+    expect(screen.getByTestId("terminal-host")).toHaveAttribute(
+      "aria-disabled",
+      "false",
+    );
+  });
+
+  it("keeps failed input retryable when the parent adopts the attached terminal id", async () => {
+    const first = deferred<void>();
+    const writeCodeTerminal = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(undefined);
+    const client = clientWith({ writeCodeTerminal });
+    const { rerender } = render(
+      <TerminalPane client={client} workspaceId="ws-1" />,
+    );
+    await expectReady();
+
+    emitData("retained");
+    await rejectWrite(first);
+    await screen.findByTestId("terminal-write-failure");
+    rerender(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-1" />,
+    );
+
+    await waitFor(() =>
+      expect(client.readCodeTerminal).toHaveBeenCalledTimes(2),
+    );
+    expect(screen.getByTestId("terminal-write-failure")).toHaveTextContent(
+      "8 unsent bytes",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(writeCodeTerminal).toHaveBeenCalledTimes(2));
+    expect(writeCodeTerminal.mock.calls.map((call) => call[2])).toEqual([
+      "retained",
+      "retained",
+    ]);
+    expect(screen.queryByTestId("terminal-write-failure")).toBeNull();
+  });
+
+  it("discards retained bytes and continues in the same shell", async () => {
+    const first = deferred<void>();
+    const writeCodeTerminal = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(undefined);
+    const client = clientWith({ writeCodeTerminal });
+    render(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-1" />,
+    );
+    await expectReady();
+
+    emitData("failed");
+    emitData("queued");
+    await rejectWrite(first);
+    await screen.findByTestId("terminal-write-failure");
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    emitData("after");
+    await waitFor(() => expect(writeCodeTerminal).toHaveBeenCalledTimes(2));
+    expect(writeCodeTerminal.mock.calls.map((call) => call[2])).toEqual([
+      "failed",
+      "after",
+    ]);
+    expect(writeCodeTerminal.mock.calls[1]?.[1]).toBe("term-1");
+  });
+
+  it("reconnects to a fresh shell after discarding retained bytes", async () => {
+    const first = deferred<void>();
+    const writeCodeTerminal = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(undefined);
+    const createCodeTerminal = vi.fn().mockResolvedValue(snapshot("term-2"));
+    const readCodeTerminal = vi.fn(
+      async (_workspaceId: string, terminalId: string) => readPage(terminalId),
+    );
+    const onAttach = vi.fn();
+    const client = clientWith({
+      createCodeTerminal,
+      readCodeTerminal,
+      writeCodeTerminal,
+    });
+    render(
+      <TerminalPane client={client} workspaceId="ws-1" onAttach={onAttach} />,
+    );
+    await expectReady();
+
+    emitData("failed");
+    emitData("queued");
+    await rejectWrite(first);
+    await screen.findByTestId("terminal-write-failure");
+    fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
+
+    await waitFor(() => expect(createCodeTerminal).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onAttach).toHaveBeenCalledWith("term-2"));
+    await expectReady();
+    emitData("new-shell");
+    await waitFor(() => expect(writeCodeTerminal).toHaveBeenCalledTimes(2));
+    expect(writeCodeTerminal.mock.calls).toEqual([
+      ["ws-1", "term-1", "failed"],
+      ["ws-1", "term-2", "new-shell"],
+    ]);
+  });
+
+  it("retries an attach failure", async () => {
+    const listCodeTerminals = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Could not list terminals"))
+      .mockResolvedValue([snapshot()]);
+    const client = clientWith({ listCodeTerminals });
+    render(<TerminalPane client={client} workspaceId="ws-1" />);
+
+    const failure = await screen.findByTestId("terminal-attach-error");
+    expect(failure).toHaveTextContent("Input stays paused");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(listCodeTerminals).toHaveBeenCalledTimes(2));
+    await expectReady();
+    expect(screen.queryByTestId("terminal-attach-error")).toBeNull();
+  });
+
+  it("retries a read failure without replacing the shell", async () => {
+    const readCodeTerminal = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Terminal output was unavailable"))
+      .mockResolvedValue(readPage());
+    const client = clientWith({ readCodeTerminal });
+    render(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-1" />,
+    );
+
+    const failure = await screen.findByTestId("terminal-read-error");
+    expect(failure).toHaveTextContent("Input is paused");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(readCodeTerminal).toHaveBeenCalledTimes(2));
+    await expectReady();
+    expect(client.listCodeTerminals).not.toHaveBeenCalled();
+    expect(client.createCodeTerminal).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("terminal-read-error")).toBeNull();
+  });
+
+  it("fences a stale data handler when the terminal identity changes", async () => {
+    const client = clientWith({
+      readCodeTerminal: vi.fn(
+        async (_workspaceId: string, terminalId: string) =>
+          readPage(terminalId),
+      ),
+    });
+    const { rerender } = render(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-a" />,
+    );
+    await expectReady();
+    const staleTerminal = terminals[0];
+
+    rerender(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-b" />,
+    );
+    act(() => staleTerminal?.dataHandler?.("stale"));
+    await waitFor(() =>
+      expect(client.readCodeTerminal).toHaveBeenCalledWith("ws-1", "term-b", 0),
+    );
+    await expectReady();
+    emitData("current");
+
+    await waitFor(() =>
+      expect(client.writeCodeTerminal).toHaveBeenCalledOnce(),
+    );
+    expect(client.writeCodeTerminal).toHaveBeenCalledWith(
+      "ws-1",
+      "term-b",
+      "current",
+    );
+  });
+
+  it("abandons queued input when the workspace changes during a delayed write", async () => {
+    const first = deferred<void>();
+    const nextWorkspaceTerminals = deferred<ReturnType<typeof snapshot>[]>();
+    const listCodeTerminals = vi.fn((workspaceId: string) =>
+      workspaceId === "ws-a"
+        ? Promise.resolve([snapshot("term-a")])
+        : nextWorkspaceTerminals.promise,
+    );
+    const writeCodeTerminal = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(undefined);
+    const client = clientWith({
+      listCodeTerminals,
+      readCodeTerminal: vi.fn(
+        async (_workspaceId: string, terminalId: string) =>
+          readPage(terminalId),
+      ),
+      writeCodeTerminal,
+    });
+    const { rerender } = render(
+      <TerminalPane client={client} workspaceId="ws-a" />,
+    );
+    await expectReady();
+
+    emitData("in-flight");
+    emitData("must-not-cross");
+    rerender(<TerminalPane client={client} workspaceId="ws-b" />);
+    await act(async () => first.resolve(undefined));
+    expect(writeCodeTerminal).toHaveBeenCalledTimes(1);
+
+    await act(async () => nextWorkspaceTerminals.resolve([snapshot("term-b")]));
+    await expectReady();
+    emitData("current");
+
+    await waitFor(() => expect(writeCodeTerminal).toHaveBeenCalledTimes(2));
+    expect(writeCodeTerminal.mock.calls).toEqual([
+      ["ws-a", "term-a", "in-flight"],
+      ["ws-b", "term-b", "current"],
+    ]);
+  });
+
+  it("ignores a delayed read from the preceding terminal identity", async () => {
+    const firstRead = deferred<ReturnType<typeof readPage>>();
+    const readCodeTerminal = vi.fn(
+      async (_workspaceId: string, terminalId: string) => {
+        if (terminalId === "term-a") return firstRead.promise;
+        return readPage("term-b", { bytes: encode("current output") });
+      },
+    );
+    const client = clientWith({ readCodeTerminal });
+    const { rerender } = render(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-a" />,
+    );
+    await waitFor(() =>
+      expect(readCodeTerminal).toHaveBeenCalledWith("ws-1", "term-a", 0),
+    );
+
+    rerender(
+      <TerminalPane client={client} workspaceId="ws-1" terminalId="term-b" />,
+    );
+    await waitFor(() => expect(written).toContain("current output"));
+    await act(async () =>
+      firstRead.resolve(
+        readPage("term-a", { bytes: encode("preceding output") }),
+      ),
+    );
+
+    expect(written).not.toContain("preceding output");
+  });
+
+  it("does not finish a pending attach retry after unmount", async () => {
+    const retryList = deferred<ReturnType<typeof snapshot>[]>();
+    const listCodeTerminals = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Could not list terminals"))
+      .mockReturnValueOnce(retryList.promise);
+    const createCodeTerminal = vi.fn().mockResolvedValue(snapshot());
+    const client = clientWith({ listCodeTerminals, createCodeTerminal });
+    const { unmount } = render(
+      <TerminalPane client={client} workspaceId="ws-1" />,
+    );
+
+    await screen.findByTestId("terminal-attach-error");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(listCodeTerminals).toHaveBeenCalledTimes(2));
+    unmount();
+    await act(async () => retryList.resolve([]));
+
+    expect(createCodeTerminal).not.toHaveBeenCalled();
+    expect(terminals.every((terminal) => terminal.disposed)).toBe(true);
   });
 
   it("builds the xterm theme from CSS tokens and reapplies it when the root class flips", async () => {
@@ -246,32 +629,10 @@ describe("TerminalPane", () => {
       return original.call(window, element);
     });
 
-    const client = {
-      listCodeTerminals: vi.fn().mockResolvedValue([]),
-      createCodeTerminal: vi.fn().mockResolvedValue({
-        id: "term-1",
-        workspace_id: "ws-1",
-        cols: 80,
-        rows: 24,
-        ended: false,
-        created_at: "2026-08-15T12:00:00.000Z",
-      }),
-      readCodeTerminal: vi.fn().mockResolvedValue({
-        id: "term-1",
-        workspace_id: "ws-1",
-        bytes: "",
-        cursor: 0,
-        overflow: false,
-        truncated: false,
-        ended: false,
-      }),
-      writeCodeTerminal: vi.fn(),
-      resizeCodeTerminal: vi.fn(),
-    };
-
+    const client = clientWith();
     document.documentElement.classList.remove("dark");
     render(<TerminalPane client={client} workspaceId="ws-1" />);
-    await waitFor(() => expect(client.createCodeTerminal).toHaveBeenCalled());
+    await waitFor(() => expect(client.readCodeTerminal).toHaveBeenCalled());
 
     expect(screen.getByTestId("terminal-host")).toHaveAttribute(
       "aria-label",
@@ -295,6 +656,5 @@ describe("TerminalPane", () => {
         green: "#4ade80",
       }),
     );
-    document.documentElement.classList.remove("dark");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/TerminalPane.tsx
@@ -155,6 +155,52 @@ function toHex(r: string, g: string, b: string): string {
   return `#${byte(r)}${byte(g)}${byte(b)}`;
 }
 
+type TerminalClient = Pick<
+  ApiClient,
+  | "listCodeTerminals"
+  | "createCodeTerminal"
+  | "readCodeTerminal"
+  | "writeCodeTerminal"
+  | "resizeCodeTerminal"
+>;
+
+type RenderTerminalIdentity = {
+  client: TerminalClient;
+  workspaceId: string;
+  requestedTerminalId: string | null;
+  epoch: number;
+};
+
+type TerminalWriter = {
+  token: number;
+  client: TerminalClient;
+  workspaceId: string;
+  terminalId: string;
+  chunks: string[];
+  running: boolean;
+  failed: boolean;
+  failureMessage?: string;
+  cancelled: boolean;
+};
+
+type ActiveTerminal = {
+  epoch: number;
+  writer: TerminalWriter;
+};
+
+type TerminalRecoveryError = {
+  kind: "attach" | "read";
+  message: string;
+};
+
+type TerminalWriteFailure = {
+  writerToken: number;
+  message: string;
+  unsentBytes: number;
+};
+
+let nextWriterToken = 1;
+
 /**
  * Ephemeral renderer over the cursor-pull terminal API.
  *
@@ -174,14 +220,7 @@ export function TerminalPane({
   onAttach,
   hideHeader = false,
 }: {
-  client: Pick<
-    ApiClient,
-    | "listCodeTerminals"
-    | "createCodeTerminal"
-    | "readCodeTerminal"
-    | "writeCodeTerminal"
-    | "resizeCodeTerminal"
-  >;
+  client: TerminalClient;
   workspaceId: string;
   /** The shell this pane draws. Absent means adopt one and report it. */
   terminalId?: string;
@@ -190,10 +229,31 @@ export function TerminalPane({
   /** The drawer already names this surface. */
   hideHeader?: boolean;
 }) {
+  const renderIdentityRef = useRef<RenderTerminalIdentity | null>(null);
+  let renderIdentity = renderIdentityRef.current;
+  const requestedTerminalId = terminalId ?? null;
+  if (
+    !renderIdentity ||
+    renderIdentity.client !== client ||
+    renderIdentity.workspaceId !== workspaceId ||
+    renderIdentity.requestedTerminalId !== requestedTerminalId
+  ) {
+    renderIdentity = {
+      client,
+      workspaceId,
+      requestedTerminalId,
+      epoch: (renderIdentity?.epoch ?? 0) + 1,
+    };
+    renderIdentityRef.current = renderIdentity;
+  }
+  const identityEpoch = renderIdentity.epoch;
+
   const hostRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const tidRef = useRef<string | null>(null);
+  const activeTerminalRef = useRef<ActiveTerminal | null>(null);
+  const writerRef = useRef<TerminalWriter | null>(null);
   /** Set by reconnect, so the next attach starts a shell instead of reusing. */
   const startFreshRef = useRef(false);
   const onAttachRef = useRef(onAttach);
@@ -202,6 +262,8 @@ export function TerminalPane({
   const pendingRef = useRef("");
   const rafRef = useRef<number | null>(null);
   const lastFlushRef = useRef(Date.now());
+  const inputPausedRef = useRef(true);
+  const stalledRef = useRef(false);
   const [generation, setGeneration] = useState(0);
   const [ended, setEnded] = useState(false);
   const [overflow, setOverflow] = useState(false);
@@ -211,7 +273,12 @@ export function TerminalPane({
    * that covers spawning a process and reading its first bytes.
    */
   const [attached, setAttached] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [inputPaused, setInputPaused] = useState(true);
+  const [terminalError, setTerminalError] =
+    useState<TerminalRecoveryError | null>(null);
+  const [writeFailure, setWriteFailure] = useState<TerminalWriteFailure | null>(
+    null,
+  );
 
   useEffect(() => {
     const host = hostRef.current;
@@ -220,6 +287,7 @@ export function TerminalPane({
       convertEol: true,
       fontSize: 13,
       cursorBlink: true,
+      disableStdin: true,
       theme: readXtermTheme(),
     });
     const fit = new FitAddon();
@@ -230,11 +298,20 @@ export function TerminalPane({
     fitRef.current = fit;
 
     const dataSub = term.onData((data) => {
-      const tid = tidRef.current;
-      if (!tid) return;
-      void client.writeCodeTerminal(workspaceId, tid, data).catch(() => {
-        // A failed keystroke is dropped; the next poll shows ended/error.
-      });
+      const active = activeTerminalRef.current;
+      if (
+        !active ||
+        active.epoch !== identityEpoch ||
+        renderIdentityRef.current?.epoch !== identityEpoch ||
+        writerRef.current !== active.writer ||
+        inputPausedRef.current ||
+        active.writer.failed ||
+        active.writer.cancelled
+      ) {
+        return;
+      }
+      active.writer.chunks.push(data);
+      drainWriter(active.writer);
     });
     const command = usesCommandModifier(navigator.userAgent);
     function onKeyDownCapture(event: KeyboardEvent) {
@@ -255,7 +332,9 @@ export function TerminalPane({
 
     const onResize = () => {
       fit.fit();
-      const tid = tidRef.current;
+      const active = activeTerminalRef.current;
+      const tid =
+        active?.epoch === identityEpoch ? active.writer.terminalId : null;
       const dims =
         term.cols && term.rows ? { cols: term.cols, rows: term.rows } : null;
       if (tid && dims) {
@@ -284,38 +363,89 @@ export function TerminalPane({
       observer?.disconnect();
       host.removeEventListener("keydown", onKeyDownCapture, true);
       dataSub.dispose();
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
       term.dispose();
       termRef.current = null;
       fitRef.current = null;
     };
-  }, [client, workspaceId, generation]);
+  }, [client, workspaceId, terminalId, generation, identityEpoch]);
 
   useEffect(() => {
     let cancelled = false;
-    let timer: ReturnType<typeof setInterval> | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
-    async function pull() {
-      const tid = tidRef.current;
-      if (!tid) return;
+    setInputPausedForCurrent(true);
+    setAttached(false);
+    setEnded(false);
+    setOverflow(false);
+    setStalled(false);
+    stalledRef.current = false;
+    setTerminalError(null);
+    pendingRef.current = "";
+    cursorRef.current = 0;
+    tidRef.current = null;
+    activeTerminalRef.current = null;
+
+    async function pull(): Promise<boolean> {
+      const active = activeTerminalRef.current;
+      if (
+        !active ||
+        active.epoch !== identityEpoch ||
+        renderIdentityRef.current?.epoch !== identityEpoch
+      ) {
+        return false;
+      }
+      const tid = active.writer.terminalId;
       try {
         const page = await client.readCodeTerminal(
           workspaceId,
           tid,
           cursorRef.current,
         );
-        if (cancelled) return;
+        if (
+          cancelled ||
+          activeTerminalRef.current !== active ||
+          renderIdentityRef.current?.epoch !== identityEpoch
+        ) {
+          return false;
+        }
         cursorRef.current = page.cursor;
         setAttached(true);
+        setTerminalError(null);
         if (page.overflow) setOverflow(true);
-        if (page.ended) setEnded(true);
+        setEnded(page.ended);
+        setInputPausedForCurrent(
+          page.ended || active.writer.failed || stalledRef.current,
+        );
         const text = decodeTerminalBytes(page.bytes);
         if (text.includes(TRUNCATION_TEXT)) setOverflow(true);
-        if (text) enqueue(text);
+        if (text) enqueue(text, identityEpoch);
+        return !page.ended;
       } catch (err) {
-        if (!cancelled) {
-          setError(friendlyErrorMessage(err, "Could not read the terminal"));
+        if (
+          !cancelled &&
+          activeTerminalRef.current === active &&
+          renderIdentityRef.current?.epoch === identityEpoch
+        ) {
+          setInputPausedForCurrent(true);
+          setTerminalError({
+            kind: "read",
+            message: friendlyErrorMessage(err, "Could not read the terminal"),
+          });
         }
+        return false;
       }
+    }
+
+    function schedulePull() {
+      timer = setTimeout(() => {
+        void pull().then((keepPolling) => {
+          if (keepPolling && !cancelled) schedulePull();
+        });
+      }, POLL_MS);
     }
 
     async function attach() {
@@ -332,37 +462,105 @@ export function TerminalPane({
           !start && terminalId
             ? { id: terminalId, ended: false }
             : await adoptOrCreate(start);
-        if (cancelled) return;
+        if (cancelled || !snap) return;
         tidRef.current = snap.id;
         cursorRef.current = 0;
+        const writer = writerFor(snap.id);
+        activeTerminalRef.current = { epoch: identityEpoch, writer };
+        if (writer.failed) {
+          surfaceWriteFailure(writer);
+        } else {
+          drainWriter(writer);
+        }
         if (snap.ended) setEnded(true);
         if (snap.id !== terminalId) onAttachRef.current?.(snap.id);
-        await pull();
-        timer = setInterval(() => {
-          void pull();
-        }, POLL_MS);
+        const keepPolling = await pull();
+        if (keepPolling && !cancelled) schedulePull();
       } catch (err) {
-        if (!cancelled) {
-          setError(friendlyErrorMessage(err, "Could not open a terminal"));
+        if (!cancelled && renderIdentityRef.current?.epoch === identityEpoch) {
+          setInputPausedForCurrent(true);
+          setTerminalError({
+            kind: "attach",
+            message: friendlyErrorMessage(err, "Could not open a terminal"),
+          });
         }
       }
 
       async function adoptOrCreate(forceNew: boolean) {
         if (!forceNew) {
           const listed = await client.listCodeTerminals(workspaceId);
+          if (cancelled || renderIdentityRef.current?.epoch !== identityEpoch) {
+            return null;
+          }
           const live = listed.find((item) => !item.ended);
           if (live) return live;
         }
+        if (cancelled || renderIdentityRef.current?.epoch !== identityEpoch) {
+          return null;
+        }
         return client.createCodeTerminal(workspaceId, size);
+      }
+
+      function writerFor(tid: string): TerminalWriter {
+        const existing = writerRef.current;
+        if (
+          existing &&
+          !existing.cancelled &&
+          existing.client === client &&
+          existing.workspaceId === workspaceId &&
+          existing.terminalId === tid
+        ) {
+          return existing;
+        }
+        abandonWriter(existing);
+        const writer: TerminalWriter = {
+          token: nextWriterToken,
+          client,
+          workspaceId,
+          terminalId: tid,
+          chunks: [],
+          running: false,
+          failed: false,
+          cancelled: false,
+        };
+        nextWriterToken += 1;
+        writerRef.current = writer;
+        setWriteFailure(null);
+        return writer;
       }
     }
 
     void attach();
     return () => {
       cancelled = true;
-      if (timer) clearInterval(timer);
+      if (timer) clearTimeout(timer);
+      const active = activeTerminalRef.current;
+      if (active?.epoch === identityEpoch) {
+        const nextIdentity = renderIdentityRef.current;
+        const keepsActiveTerminal =
+          nextIdentity?.client === client &&
+          nextIdentity.workspaceId === workspaceId &&
+          (nextIdentity.requestedTerminalId === requestedTerminalId ||
+            nextIdentity.requestedTerminalId === active.writer.terminalId);
+        if (!keepsActiveTerminal) {
+          abandonWriter(active.writer);
+          if (writerRef.current === active.writer) writerRef.current = null;
+          setWriteFailure(null);
+        }
+        activeTerminalRef.current = null;
+        tidRef.current = null;
+      }
     };
-  }, [client, workspaceId, terminalId, generation]);
+  }, [client, workspaceId, terminalId, generation, identityEpoch]);
+
+  useEffect(
+    () => () => {
+      abandonWriter(writerRef.current);
+      writerRef.current = null;
+      activeTerminalRef.current = null;
+    },
+    [],
+  );
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -370,43 +568,190 @@ export function TerminalPane({
         pendingRef.current.length > FRAME_BUDGET * 8 &&
         Date.now() - lastFlushRef.current > STALL_MS
       ) {
+        stalledRef.current = true;
         setStalled(true);
+        setInputPausedForCurrent(true);
       }
     }, 500);
     return () => clearInterval(timer);
   }, [generation]);
 
-  function enqueue(text: string) {
+  function enqueue(text: string, epoch: number) {
+    if (renderIdentityRef.current?.epoch !== epoch) return;
     pendingRef.current += text;
-    flushSoon();
+    flushSoon(epoch);
   }
 
-  function flushSoon() {
+  function flushSoon(epoch: number) {
     if (rafRef.current != null) return;
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
+      if (renderIdentityRef.current?.epoch !== epoch) return;
       const term = termRef.current;
       if (!term) return;
       const chunk = pendingRef.current.slice(0, FRAME_BUDGET);
       pendingRef.current = pendingRef.current.slice(FRAME_BUDGET);
       lastFlushRef.current = Date.now();
       term.write(chunk, () => {
-        if (pendingRef.current) flushSoon();
+        if (renderIdentityRef.current?.epoch !== epoch) return;
+        if (pendingRef.current) flushSoon(epoch);
       });
     });
   }
 
+  function drainWriter(writer: TerminalWriter) {
+    if (
+      writer.running ||
+      writer.failed ||
+      writer.cancelled ||
+      !writerIsCurrent(writer)
+    ) {
+      return;
+    }
+    writer.running = true;
+    void (async () => {
+      try {
+        while (
+          !writer.failed &&
+          !writer.cancelled &&
+          writerIsCurrent(writer) &&
+          writer.chunks.length
+        ) {
+          const chunk = writer.chunks[0];
+          if (chunk == null) break;
+          try {
+            await writer.client.writeCodeTerminal(
+              writer.workspaceId,
+              writer.terminalId,
+              chunk,
+            );
+          } catch (err) {
+            if (writer.cancelled) break;
+            writer.failed = true;
+            writer.failureMessage = friendlyErrorMessage(
+              err,
+              "Could not send terminal input",
+            );
+            if (writerIsCurrent(writer)) surfaceWriteFailure(writer);
+            break;
+          }
+          if (writer.cancelled) break;
+          if (writer.chunks[0] === chunk) writer.chunks.shift();
+        }
+      } finally {
+        writer.running = false;
+        if (
+          !writer.failed &&
+          !writer.cancelled &&
+          writerIsCurrent(writer) &&
+          writer.chunks.length
+        ) {
+          drainWriter(writer);
+        }
+      }
+    })();
+  }
+
+  function writerIsCurrent(writer: TerminalWriter) {
+    const active = activeTerminalRef.current;
+    return (
+      writerRef.current === writer &&
+      active?.writer === writer &&
+      active.epoch === renderIdentityRef.current?.epoch
+    );
+  }
+
+  function surfaceWriteFailure(writer: TerminalWriter) {
+    if (!writer.failureMessage || !writerIsCurrent(writer)) return;
+    setInputPausedForCurrent(true);
+    setWriteFailure({
+      writerToken: writer.token,
+      message: writer.failureMessage,
+      unsentBytes: unsentByteCount(writer.chunks),
+    });
+  }
+
+  function setInputPausedForCurrent(paused: boolean) {
+    inputPausedRef.current = paused;
+    setInputPaused(paused);
+    const term = termRef.current;
+    if (term?.options) term.options.disableStdin = paused;
+  }
+
+  function retryTerminal() {
+    setTerminalError(null);
+    setAttached(false);
+    setInputPausedForCurrent(true);
+    advanceIdentityEpoch();
+    setGeneration((value) => value + 1);
+  }
+
+  function retryUnsentInput() {
+    const writer = writerRef.current;
+    if (
+      !writer ||
+      writer.token !== writeFailure?.writerToken ||
+      writer.cancelled
+    ) {
+      return;
+    }
+    writer.failed = false;
+    writer.failureMessage = undefined;
+    setWriteFailure(null);
+    setInputPausedForCurrent(
+      !attached || ended || stalledRef.current || terminalError != null,
+    );
+    drainWriter(writer);
+  }
+
+  function discardUnsentInput() {
+    const writer = writerRef.current;
+    if (!writer || writer.token !== writeFailure?.writerToken) return;
+    writer.chunks.length = 0;
+    writer.failed = false;
+    writer.failureMessage = undefined;
+    setWriteFailure(null);
+    if (attached && !ended && !stalled && !terminalError) {
+      setInputPausedForCurrent(false);
+    }
+  }
+
   function reconnect() {
+    abandonWriter(writerRef.current);
+    writerRef.current = null;
+    activeTerminalRef.current = null;
     startFreshRef.current = true;
+    stalledRef.current = false;
     setStalled(false);
     setEnded(false);
     setOverflow(false);
     setAttached(false);
-    setError(null);
+    setTerminalError(null);
+    setWriteFailure(null);
+    setInputPausedForCurrent(true);
     pendingRef.current = "";
     tidRef.current = null;
+    advanceIdentityEpoch();
     setGeneration((value) => value + 1);
   }
+
+  function advanceIdentityEpoch() {
+    const current = renderIdentityRef.current;
+    if (!current) return;
+    renderIdentityRef.current = { ...current, epoch: current.epoch + 1 };
+  }
+
+  function abandonWriter(writer: TerminalWriter | null) {
+    if (!writer) return;
+    writer.cancelled = true;
+    writer.failed = false;
+    writer.failureMessage = undefined;
+    writer.chunks.length = 0;
+  }
+
+  const unsentLabel = writeFailure
+    ? `${writeFailure.unsentBytes} unsent ${writeFailure.unsentBytes === 1 ? "byte" : "bytes"}`
+    : null;
 
   return (
     <div
@@ -445,7 +790,72 @@ export function TerminalPane({
           </Button>
         </div>
       )}
-      {error && <p className="text-critical px-3 py-2 text-sm">{error}</p>}
+      {writeFailure && (
+        <div
+          className="flex shrink-0 flex-col gap-2 border-b border-critical-border bg-critical-background px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+          data-testid="terminal-write-failure"
+          role="alert"
+        >
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-critical-foreground">
+              Terminal input paused · {unsentLabel}
+            </p>
+            <p className="mt-0.5 text-xs text-critical-foreground-muted">
+              {asSentence(writeFailure.message)} Retry sends the input to this
+              shell and can repeat it if the first request arrived. Reconnect
+              discards it and opens a new shell. Discard drops it and keeps this
+              shell.
+            </p>
+          </div>
+          <div className="flex shrink-0 flex-wrap items-center gap-1.5">
+            <Button type="button" size="xs" onClick={retryUnsentInput}>
+              Retry
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              onClick={reconnect}
+            >
+              Reconnect
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost-destructive"
+              onClick={discardUnsentInput}
+            >
+              Discard
+            </Button>
+          </div>
+        </div>
+      )}
+      {terminalError && (
+        <div
+          className="flex shrink-0 flex-col gap-2 border-b border-critical-border bg-critical-background px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+          data-testid={`terminal-${terminalError.kind}-error`}
+          role="alert"
+        >
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-critical-foreground">
+              {terminalError.message}
+            </p>
+            <p className="mt-0.5 text-xs text-critical-foreground-muted">
+              {terminalError.kind === "read"
+                ? "Input is paused so you do not send commands without seeing the result."
+                : "Input stays paused until the shell opens."}
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={retryTerminal}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
       <div className="relative min-h-0 flex-1">
         <div
           ref={hostRef}
@@ -456,8 +866,9 @@ export function TerminalPane({
           // reaches anyone.
           role="group"
           aria-label="Terminal output"
+          aria-disabled={inputPaused}
         />
-        {!attached && !error && (
+        {!attached && !terminalError && (
           // Spawning a shell and reading its first bytes takes a moment, and
           // an empty black rectangle is indistinguishable from one that
           // failed. The line sits over the host rather than above it so the
@@ -475,6 +886,17 @@ export function TerminalPane({
       </div>
     </div>
   );
+}
+
+function unsentByteCount(chunks: string[]): number {
+  return chunks.reduce(
+    (total, chunk) => total + new TextEncoder().encode(chunk).byteLength,
+    0,
+  );
+}
+
+function asSentence(message: string): string {
+  return /[.!?]$/.test(message) ? message : `${message}.`;
 }
 
 export function decodeTerminalBytes(encoded: string): string {

--- a/crates/tidebreak-desktop/ui/src/stories/TerminalPane.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TerminalPane.stories.tsx
@@ -1,0 +1,128 @@
+import { useMemo } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { encodeTerminalBytes, TerminalPane } from "@/code/TerminalPane";
+
+type TerminalScenario = "write-failure" | "attach-failure" | "read-failure";
+
+const terminal = {
+  id: "terminal-story",
+  workspace_id: "workspace-story",
+  cols: 80,
+  rows: 24,
+  ended: false,
+  created_at: "2026-08-25T18:00:00.000Z",
+};
+
+function TerminalRecoveryStory({ scenario }: { scenario: TerminalScenario }) {
+  const client = useMemo(() => storyClient(scenario), [scenario]);
+
+  return (
+    <div className="grid min-h-dvh place-items-center bg-muted/45 p-4 sm:p-8">
+      <div className="flex h-[min(620px,calc(100dvh-2rem))] min-h-[360px] w-full max-w-5xl flex-col overflow-hidden rounded-xl border border-border-subtle bg-background sm:h-[min(620px,calc(100dvh-4rem))]">
+        <TerminalPane client={client} workspaceId="workspace-story" />
+      </div>
+    </div>
+  );
+}
+
+function storyClient(scenario: TerminalScenario) {
+  let reads = 0;
+  return {
+    listCodeTerminals: async () => {
+      if (scenario === "attach-failure") {
+        throw new Error("The terminal service did not answer");
+      }
+      return [terminal];
+    },
+    createCodeTerminal: async () => terminal,
+    readCodeTerminal: async () => {
+      if (scenario === "read-failure") {
+        throw new Error("Terminal output stopped updating");
+      }
+      const firstRead = reads === 0;
+      reads += 1;
+      return {
+        id: terminal.id,
+        workspace_id: terminal.workspace_id,
+        bytes: firstRead
+          ? encodeTerminalBytes(
+              "Last login: Tue Aug 25 17:58:14\r\nthet@tidebreak % pnpm test\r\n",
+            )
+          : "",
+        cursor: 62,
+        overflow: false,
+        truncated: false,
+        ended: false,
+      };
+    },
+    writeCodeTerminal: async () => {
+      if (scenario === "write-failure") {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        throw new Error(
+          "The terminal connection dropped before it confirmed the input",
+        );
+      }
+    },
+    resizeCodeTerminal: async () => terminal,
+  };
+}
+
+const meta = {
+  title: "Code/Terminal recovery",
+  component: TerminalRecoveryStory,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof TerminalRecoveryStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WriteFailure: Story = {
+  args: { scenario: "write-failure" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() =>
+      expect(canvas.getByTestId("terminal-host")).toHaveAttribute(
+        "aria-disabled",
+        "false",
+      ),
+    );
+    const input = canvasElement.querySelector<HTMLTextAreaElement>(
+      ".xterm-helper-textarea",
+    );
+    if (!input) throw new Error("xterm input did not mount");
+    input.focus();
+    await userEvent.keyboard("pnpm test{Enter}");
+    await expect(
+      await canvas.findByTestId("terminal-write-failure"),
+    ).toBeVisible();
+    await expect(canvas.getByRole("button", { name: "Retry" })).toBeVisible();
+    await expect(
+      canvas.getByRole("button", { name: "Reconnect" }),
+    ).toBeVisible();
+    await expect(canvas.getByRole("button", { name: "Discard" })).toBeVisible();
+  },
+};
+
+export const AttachFailure: Story = {
+  args: { scenario: "attach-failure" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByTestId("terminal-attach-error"),
+    ).toBeVisible();
+    await expect(canvas.getByRole("button", { name: "Retry" })).toBeVisible();
+  },
+};
+
+export const ReadFailure: Story = {
+  args: { scenario: "read-failure" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByTestId("terminal-read-error"),
+    ).toBeVisible();
+    await expect(canvas.getByRole("button", { name: "Retry" })).toBeVisible();
+  },
+};


### PR DESCRIPTION
## Implementation

- Serialize terminal writes so concurrent input cannot reorder chunks.
- Retain unsent input after a write failure and pause new input until the operator retries, reconnects, or discards it.
- Keep terminal identity changes, delayed reads, retries, and unmounts fenced from stale handlers.
- Show recovery states for write, attach, and read failures, with matching Storybook coverage.

## Compatibility

The terminal client contract and existing component props remain unchanged. Successful terminal sessions keep the same behavior.

## Safety and risk

Retrying a failed write can repeat input if the server received the request before the connection failed. The recovery message states this risk and offers reconnect and discard paths. Workspace and terminal changes abandon retained input so bytes cannot cross shell boundaries.

## Validation

- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/TerminalPane.dom.test.tsx` — 17 tests passed
- `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/code/TerminalPane.tsx src/code/TerminalPane.dom.test.tsx src/stories/TerminalPane.stories.tsx` — passed
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build` — passed
- `git diff --check origin/main...HEAD` — passed
- Captured and inspected all three changed stories in light, dark, high-contrast light, and high-contrast dark themes at desktop and narrow widths