### PR TITLE
fix(code): relay hosted engine inference through the caller's grant

### DIFF
--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -1,0 +1,563 @@
+//! Session-scoped inference relay for engine children (decision 71).
+//!
+//! A gateway-authenticated hosted machine holds no provider credentials an
+//! engine child could use: the image carries no `ANTHROPIC_API_KEY`, no
+//! Codex login, and decision 51's on-behalf-of exchange lives in this
+//! process, never in the child. Left alone, a child falls back to its
+//! vendor endpoint and fails the first turn with a 401.
+//!
+//! This module gives each session a private inference path instead. At
+//! spawn, the runtime mints an opaque relay key and points the child's own
+//! HTTP client at `{loopback_base}/code/llm/...` on this server's listener
+//! ([`spawn_wiring`]). Each relayed request presents that key; the relay
+//! maps it back to the owning caller, exchanges the caller's live
+//! machine-bound token for a fresh inference token, and streams the request
+//! through to the gateway's compat endpoint with that token in place of the
+//! key. Because the exchange runs per upstream request, a session outlives
+//! any single short-lived token.
+//!
+//! Security properties mirror the browser channel
+//! ([`super::browser_channel`]):
+//!
+//! * Keys are random v4 UUIDs, never derived from owner or session ids.
+//! * A key authorizes exactly the relay routes — it is not the app token
+//!   and opens nothing else on the listener.
+//! * Reissue for the same session replaces the prior key, and revocation
+//!   follows the browser channel's lifecycle.
+//! * The caller's gateway tokens never reach the child. The relay key is
+//!   the only secret in the child's environment, and it is useless off
+//!   this machine.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::http::header::AUTHORIZATION;
+use axum::http::{HeaderMap, HeaderName, StatusCode};
+use axum::response::Response;
+
+use tidebreak_core::{AgentError, CodeSessionId, HarnessKind, OwnerId};
+
+use crate::obo_gateway::OboGateway;
+
+/// Whose inference a relay key spends.
+#[derive(Clone)]
+pub(crate) struct HarnessLlmSubject {
+    pub(crate) owner: OwnerId,
+    pub(crate) session: CodeSessionId,
+}
+
+/// The gateway compat endpoint one relay route forwards to.
+#[derive(Clone, Copy)]
+pub(crate) enum RelayEndpoint {
+    /// Anthropic Messages, spoken by Claude Code.
+    AnthropicMessages,
+    /// OpenAI Responses, spoken by Codex.
+    OpenAiResponses,
+}
+
+impl RelayEndpoint {
+    fn upstream_path(self) -> &'static str {
+        match self {
+            Self::AnthropicMessages => "/compat/anthropic/v1/messages",
+            Self::OpenAiResponses => "/compat/openai/v1/responses",
+        }
+    }
+
+    /// A vendor-shaped error the engine's own client reports legibly,
+    /// instead of a server shape it would print as opaque JSON.
+    pub(crate) fn error_response(self, status: StatusCode, kind: &str, message: &str) -> Response {
+        let body = match self {
+            Self::AnthropicMessages => serde_json::json!({
+                "type": "error",
+                "error": { "type": kind, "message": message },
+            }),
+            Self::OpenAiResponses => serde_json::json!({
+                "error": { "type": kind, "message": message, "param": null, "code": null },
+            }),
+        };
+        Response::builder()
+            .status(status)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::from(body.to_string()))
+            .expect("a constant error response builds")
+    }
+}
+
+/// In-memory key registry plus the forwarding client.
+pub(crate) struct HarnessLlmRelay {
+    obo: Arc<OboGateway>,
+    client: reqwest::Client,
+    state: Mutex<RelayState>,
+}
+
+#[derive(Default)]
+struct RelayState {
+    by_session: HashMap<CodeSessionId, String>,
+    keys: HashMap<String, HarnessLlmSubject>,
+}
+
+impl HarnessLlmRelay {
+    pub(crate) fn new(obo: Arc<OboGateway>) -> Self {
+        let client = reqwest::Client::builder()
+            // Only the dial is bounded. An inference stream legitimately
+            // runs for minutes, so a total request timeout would kill long
+            // turns mid-stream.
+            .connect_timeout(Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("the relay HTTP client builds from constant configuration");
+        Self {
+            obo,
+            client,
+            state: Mutex::new(RelayState::default()),
+        }
+    }
+
+    /// Mint the relay key for `subject`, replacing any prior key the same
+    /// session held. Reissue-on-attach is what keeps a reaped or relaunched
+    /// worker from extending the life of a key an old child still knows.
+    pub(crate) fn issue(&self, subject: HarnessLlmSubject) -> String {
+        let key = generate_key();
+        let mut state = self.state.lock().expect("harness llm registry");
+        if let Some(old) = state.by_session.insert(subject.session, key.clone()) {
+            state.keys.remove(&old);
+        }
+        state.keys.insert(key.clone(), subject);
+        key
+    }
+
+    /// Revoke the key for `session_id`. Idempotent.
+    pub(crate) fn revoke(&self, session_id: CodeSessionId) {
+        let mut state = self.state.lock().expect("harness llm registry");
+        if let Some(key) = state.by_session.remove(&session_id) {
+            state.keys.remove(&key);
+        }
+    }
+
+    fn subject_for_key(&self, key: &str) -> Option<HarnessLlmSubject> {
+        self.state
+            .lock()
+            .expect("harness llm registry")
+            .keys
+            .get(key)
+            .cloned()
+    }
+
+    /// Authenticate one relayed request and stream it through to the
+    /// gateway's compat endpoint with a fresh on-behalf-of token.
+    ///
+    /// Refusals are 401 with the vendor's authentication shape so the
+    /// engine fails the turn fast instead of retrying; a gateway that does
+    /// not answer is 502 so the engine's own retry policy applies.
+    pub(crate) async fn forward(
+        &self,
+        endpoint: RelayEndpoint,
+        headers: &HeaderMap,
+        query: Option<String>,
+        body: axum::body::Body,
+    ) -> Response {
+        let Some(key) = relay_key(headers) else {
+            return endpoint.error_response(
+                StatusCode::UNAUTHORIZED,
+                "authentication_error",
+                "missing harness relay key",
+            );
+        };
+        let Some(subject) = self.subject_for_key(key) else {
+            return endpoint.error_response(
+                StatusCode::UNAUTHORIZED,
+                "authentication_error",
+                "unknown or revoked harness relay key",
+            );
+        };
+        let token = match self.obo.bearer_for(&subject.owner).await {
+            Ok(token) => token,
+            Err(error @ (AgentError::SignInRequired(_) | AgentError::InvalidTarget(_))) => {
+                return endpoint.error_response(
+                    StatusCode::UNAUTHORIZED,
+                    "authentication_error",
+                    &error.to_string(),
+                );
+            }
+            Err(error) => {
+                return endpoint.error_response(
+                    StatusCode::BAD_GATEWAY,
+                    "api_error",
+                    &format!("the Model Gateway did not answer the token exchange: {error}"),
+                );
+            }
+        };
+
+        let mut url = format!(
+            "{}{}",
+            self.obo.gateway_base_url(),
+            endpoint.upstream_path()
+        );
+        if let Some(query) = query.filter(|query| !query.is_empty()) {
+            url.push('?');
+            url.push_str(&query);
+        }
+        let mut request = self
+            .client
+            .post(&url)
+            .body(reqwest::Body::wrap_stream(body.into_data_stream()));
+        for (name, value) in headers {
+            if forwardable_request_header(name) {
+                request = request.header(name, value);
+            }
+        }
+        request = request.header(AUTHORIZATION, format!("Bearer {token}"));
+
+        let upstream = match request.send().await {
+            Ok(upstream) => upstream,
+            Err(error) => {
+                return endpoint.error_response(
+                    StatusCode::BAD_GATEWAY,
+                    "api_error",
+                    &format!("the Model Gateway is unreachable: {error}"),
+                );
+            }
+        };
+        let mut response = Response::builder().status(upstream.status());
+        if let Some(headers_mut) = response.headers_mut() {
+            for (name, value) in upstream.headers() {
+                if forwardable_response_header(name) {
+                    headers_mut.append(name.clone(), value.clone());
+                }
+            }
+        }
+        response
+            .body(axum::body::Body::from_stream(upstream.bytes_stream()))
+            .unwrap_or_else(|error| {
+                endpoint.error_response(
+                    StatusCode::BAD_GATEWAY,
+                    "api_error",
+                    &format!("could not stream the gateway response: {error}"),
+                )
+            })
+    }
+}
+
+/// The argv and environment that point one engine child at the relay.
+///
+/// Claude Code takes a base URL and bearer through its standard variables.
+/// Codex takes a custom model provider on the command line; the custom
+/// provider also keeps it off its websocket transport, whose vendor-only
+/// endpoint produced the reconnect noise hosted sessions logged. Opencode
+/// and Grok have no relay wiring yet and launch unchanged.
+pub(crate) fn spawn_wiring(
+    kind: HarnessKind,
+    loopback_base: &str,
+    key: &str,
+) -> (Vec<String>, Vec<(String, String)>) {
+    let base = loopback_base.trim_end_matches('/');
+    match kind {
+        HarnessKind::ClaudeCode => (
+            Vec::new(),
+            vec![
+                (
+                    "ANTHROPIC_BASE_URL".into(),
+                    format!("{base}/code/llm/anthropic"),
+                ),
+                ("ANTHROPIC_AUTH_TOKEN".into(), key.to_owned()),
+            ],
+        ),
+        HarnessKind::Codex => (
+            vec![
+                "-c".into(),
+                "model_provider=tidebreak".into(),
+                "-c".into(),
+                "model_providers.tidebreak.name=Tidebreak".into(),
+                "-c".into(),
+                format!("model_providers.tidebreak.base_url={base}/code/llm/openai/v1"),
+                "-c".into(),
+                "model_providers.tidebreak.env_key=TIDEBREAK_LLM_KEY".into(),
+                "-c".into(),
+                "model_providers.tidebreak.wire_api=responses".into(),
+            ],
+            vec![("TIDEBREAK_LLM_KEY".into(), key.to_owned())],
+        ),
+        HarnessKind::Opencode | HarnessKind::Grok => (Vec::new(), Vec::new()),
+    }
+}
+
+fn generate_key() -> String {
+    format!("tbreak_hl_{}", uuid::Uuid::new_v4())
+}
+
+/// The relay key on an inbound request. Claude Code presents its auth token
+/// as a bearer; a client configured with an API key instead presents
+/// `x-api-key`.
+fn relay_key(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .or_else(|| {
+            headers
+                .get("x-api-key")
+                .and_then(|value| value.to_str().ok())
+        })
+}
+
+/// Request headers the relay forwards upstream: everything except the
+/// credentials it replaces and the framing headers its own client re-derives.
+fn forwardable_request_header(name: &HeaderName) -> bool {
+    !matches!(
+        name.as_str(),
+        "authorization"
+            | "x-api-key"
+            | "cookie"
+            | "host"
+            | "content-length"
+            | "connection"
+            | "transfer-encoding"
+            | "upgrade"
+            | "expect"
+            | "keep-alive"
+            | "te"
+            | "trailer"
+            | "proxy-authorization"
+            | "proxy-connection"
+    )
+}
+
+/// Response headers passed back to the child: everything except framing,
+/// which this server's own stack re-derives for the streamed body.
+fn forwardable_response_header(name: &HeaderName) -> bool {
+    !matches!(
+        name.as_str(),
+        "content-length"
+            | "transfer-encoding"
+            | "connection"
+            | "keep-alive"
+            | "upgrade"
+            | "trailer"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::extract::RawQuery;
+    use axum::response::IntoResponse as _;
+    use axum::routing::post;
+    use axum::Json;
+
+    use super::*;
+
+    /// The machine resource the fake exchange is asked for.
+    const TEST_RESOURCE: &str =
+        "tidebreak:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed";
+
+    fn owner(name: &str) -> OwnerId {
+        OwnerId::new(name).unwrap()
+    }
+
+    fn subject_for(name: &str) -> HarnessLlmSubject {
+        HarnessLlmSubject {
+            owner: owner(name),
+            session: CodeSessionId::new(),
+        }
+    }
+
+    async fn read_text(response: Response) -> (StatusCode, String) {
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, String::from_utf8(bytes.to_vec()).unwrap())
+    }
+
+    /// A gateway that mints one constant inference token and echoes what the
+    /// compat endpoint received, so a test can assert on the relayed request
+    /// through the relayed response.
+    async fn fake_gateway() -> Arc<OboGateway> {
+        async fn seen(headers: HeaderMap, RawQuery(query): RawQuery, body: String) -> Response {
+            (
+                [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                format!(
+                    "auth={} query={} body={body}",
+                    headers
+                        .get(AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default(),
+                    query.unwrap_or_default(),
+                ),
+            )
+                .into_response()
+        }
+        let app = axum::Router::new()
+            .route(
+                "/oauth/token",
+                post(|| async {
+                    Json(serde_json::json!({
+                        "access_token": "mg_it_fresh",
+                        "expires_in": 3600,
+                        "token_type": "Bearer",
+                    }))
+                }),
+            )
+            .route("/compat/anthropic/v1/messages", post(seen))
+            .route("/compat/openai/v1/responses", post(seen));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        Arc::new(OboGateway::new(&format!("http://{address}"), TEST_RESOURCE.to_owned()).unwrap())
+    }
+
+    fn bearer_headers(key: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, format!("Bearer {key}").parse().unwrap());
+        headers.insert("x-api-key", "should-never-forward".parse().unwrap());
+        headers.insert("anthropic-version", "2023-06-01".parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn spawn_wiring_points_each_engine_at_the_relay() {
+        let (argv, env) = spawn_wiring(HarnessKind::ClaudeCode, "http://0.0.0.0:8080/", "k1");
+        assert!(argv.is_empty());
+        assert_eq!(
+            env,
+            vec![
+                (
+                    "ANTHROPIC_BASE_URL".to_owned(),
+                    "http://0.0.0.0:8080/code/llm/anthropic".to_owned()
+                ),
+                ("ANTHROPIC_AUTH_TOKEN".to_owned(), "k1".to_owned()),
+            ]
+        );
+
+        let (argv, env) = spawn_wiring(HarnessKind::Codex, "http://0.0.0.0:8080", "k2");
+        assert_eq!(env, vec![("TIDEBREAK_LLM_KEY".to_owned(), "k2".to_owned())]);
+        assert_eq!(argv.len(), 10, "five -c pairs: {argv:?}");
+        assert!(argv.contains(
+            &"model_providers.tidebreak.base_url=http://0.0.0.0:8080/code/llm/openai/v1".to_owned()
+        ));
+        assert!(argv.contains(&"model_providers.tidebreak.wire_api=responses".to_owned()));
+        assert!(argv.contains(&"model_provider=tidebreak".to_owned()));
+
+        for kind in [HarnessKind::Opencode, HarnessKind::Grok] {
+            let (argv, env) = spawn_wiring(kind, "http://0.0.0.0:8080", "k3");
+            assert!(argv.is_empty() && env.is_empty(), "{kind:?} is unchanged");
+        }
+    }
+
+    #[tokio::test]
+    async fn issue_replaces_the_prior_key_and_revoke_forgets() {
+        let relay = HarnessLlmRelay::new(fake_gateway().await);
+        let subject = subject_for("thet");
+        let first = relay.issue(subject.clone());
+        assert!(first.starts_with("tbreak_hl_"));
+        assert!(relay.subject_for_key(&first).is_some());
+
+        let second = relay.issue(subject.clone());
+        assert_ne!(first, second);
+        assert!(
+            relay.subject_for_key(&first).is_none(),
+            "reissue revokes the key an old child still knows"
+        );
+        assert!(relay.subject_for_key(&second).is_some());
+
+        relay.revoke(subject.session);
+        assert!(relay.subject_for_key(&second).is_none());
+        relay.revoke(subject.session);
+    }
+
+    #[tokio::test]
+    async fn forward_exchanges_and_streams_for_a_live_caller() {
+        let obo = fake_gateway().await;
+        obo.record_caller(&owner("thet"), Arc::from("mg_at_live"));
+        let relay = HarnessLlmRelay::new(obo);
+        let key = relay.issue(subject_for("thet"));
+
+        let response = relay
+            .forward(
+                RelayEndpoint::OpenAiResponses,
+                &bearer_headers(&key),
+                Some("beta=true".to_owned()),
+                axum::body::Body::from(r#"{"model":"gpt-5.6-sol"}"#),
+            )
+            .await;
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream"),
+            "upstream headers pass through"
+        );
+        let (status, text) = read_text(response).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            text.contains("auth=Bearer mg_it_fresh"),
+            "the exchanged token replaces the relay key: {text}"
+        );
+        assert!(text.contains("query=beta=true"), "{text}");
+        assert!(text.contains(r#"body={"model":"gpt-5.6-sol"}"#), "{text}");
+        assert!(
+            !text.contains(&key) && !text.contains("should-never-forward"),
+            "child credentials never reach the gateway: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_refuses_an_unknown_key() {
+        let relay = HarnessLlmRelay::new(fake_gateway().await);
+        let response = relay
+            .forward(
+                RelayEndpoint::AnthropicMessages,
+                &bearer_headers("tbreak_hl_not-issued"),
+                None,
+                axum::body::Body::empty(),
+            )
+            .await;
+        let (status, text) = read_text(response).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert!(
+            text.contains("authentication_error") && text.contains("\"type\":\"error\""),
+            "Claude Code needs the Anthropic error shape: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_fails_closed_without_a_caller_token() {
+        let relay = HarnessLlmRelay::new(fake_gateway().await);
+        let key = relay.issue(subject_for("thet"));
+        let response = relay
+            .forward(
+                RelayEndpoint::OpenAiResponses,
+                &bearer_headers(&key),
+                None,
+                axum::body::Body::empty(),
+            )
+            .await;
+        let (status, text) = read_text(response).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "no recorded subject means sign in again, not someone else's token: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_reports_an_unreachable_gateway_as_502() {
+        let obo =
+            Arc::new(OboGateway::new("http://127.0.0.1:1", TEST_RESOURCE.to_owned()).unwrap());
+        obo.record_caller(&owner("thet"), Arc::from("mg_at_live"));
+        let relay = HarnessLlmRelay::new(obo);
+        let key = relay.issue(subject_for("thet"));
+        let response = relay
+            .forward(
+                RelayEndpoint::OpenAiResponses,
+                &bearer_headers(&key),
+                None,
+                axum::body::Body::empty(),
+            )
+            .await;
+        let (status, text) = read_text(response).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert!(text.contains("api_error"), "{text}");
+    }
+}

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod forge_rest;
 pub(crate) mod fork;
 pub(crate) mod gh;
 pub(crate) mod harness_install;
+pub(crate) mod harness_llm;
 pub(crate) mod pr_facts;
 pub(crate) mod pr_fetch;
 pub(crate) mod pr_refresh;

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -167,6 +167,10 @@ pub(crate) struct CodeRuntime {
     /// machine (decision 63). `None` everywhere else: a machine with its own
     /// `git`/`gh` configuration authenticates however the operator says.
     git_credentials: Option<Arc<dyn crate::obo_gateway::GitCredentialLender>>,
+    /// Per-session engine inference relay on a gateway-authenticated hosted
+    /// machine (decision 71). `None` everywhere else: a machine whose engines
+    /// carry their own provider credentials keeps using them.
+    harness_llm: Option<Arc<super::harness_llm::HarnessLlmRelay>>,
     loopback_base: Mutex<Option<String>>,
     /// Memoized harness probes, one per kind. See [`CodeRuntime::probe`].
     probes: Mutex<HashMap<HarnessKind, HarnessProbe>>,
@@ -344,6 +348,7 @@ impl CodeRuntime {
         browser_runtime: Option<Arc<dyn crate::code::browser_runtime::BrowserRuntime>>,
         browser_bridge_command: Option<PathBuf>,
         git_credentials: Option<Arc<dyn crate::obo_gateway::GitCredentialLender>>,
+        harness_llm: Option<Arc<super::harness_llm::HarnessLlmRelay>>,
     ) -> Self {
         let browser_tokens = BrowserTokenRegistry::new(&data_dir)
             // Panic on construction failure: the data dir is trusted/absolute
@@ -371,6 +376,7 @@ impl CodeRuntime {
             },
             host_tool_broker,
             git_credentials,
+            harness_llm,
             loopback_base: Mutex::new(None),
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
@@ -414,6 +420,11 @@ impl CodeRuntime {
         &self,
     ) -> Option<&Arc<dyn crate::obo_gateway::GitCredentialLender>> {
         self.git_credentials.as_ref()
+    }
+
+    /// The engine inference relay, on a machine that has one.
+    pub(crate) fn harness_llm(&self) -> Option<Arc<super::harness_llm::HarnessLlmRelay>> {
+        self.harness_llm.clone()
     }
 
     /// Boot: publish the bound loopback base now, and hand back the recovery
@@ -589,6 +600,9 @@ impl CodeRuntime {
     fn revoke_browser_session(&self, session: &CodeSession) {
         self.browser_tokens.revoke(session.id);
         self.approvals.revoke_session(session.id);
+        if let Some(relay) = &self.harness_llm {
+            relay.revoke(session.id);
+        }
         if let Some(runtime) = &self.browser_runtime {
             let scope = crate::code::browser_runtime::BrowserRuntimeScope {
                 owner: session.owner.clone(),
@@ -609,6 +623,9 @@ impl CodeRuntime {
     fn revoke_worker_channels(&self, session_id: CodeSessionId) {
         self.browser_tokens.revoke(session_id);
         self.approvals.revoke_session(session_id);
+        if let Some(relay) = &self.harness_llm {
+            relay.revoke(session_id);
+        }
     }
 
     pub(crate) async fn recover(&self) -> Result<Vec<RecoveryAction>, ServerError> {
@@ -4089,6 +4106,29 @@ impl CodeRuntime {
             super::scratch::workspace_root(&self.data_dir, workspace.id).map_err(|err| {
                 ServerError::internal(format!("could not open private storage: {err}"))
             })?;
+
+        // On a gateway-authenticated machine, point the engine's own
+        // inference at this server's relay (decision 71): a per-session key
+        // stands in for provider credentials the hosted image does not have.
+        let (extra_argv, extra_env) = match self.harness_llm.as_ref() {
+            Some(relay) => {
+                let base = self
+                    .loopback_base
+                    .lock()
+                    .expect("loopback base")
+                    .clone()
+                    .ok_or_else(|| {
+                        ServerError::internal("harness LLM relay: loopback base not set")
+                    })?;
+                let key = relay.issue(super::harness_llm::HarnessLlmSubject {
+                    owner: session.owner.clone(),
+                    session: session.id,
+                });
+                super::harness_llm::spawn_wiring(session.harness_kind, &base, &key)
+            }
+            None => (Vec::new(), Vec::new()),
+        };
+
         let spec = SessionSpec {
             worktree: PathBuf::from(&workspace.worktree_path),
             allowed_read_roots: vec![private_root.clone()],
@@ -4097,8 +4137,8 @@ impl CodeRuntime {
             reasoning_effort: session.reasoning_effort,
             fast_mode: session.fast_mode,
             resume_ref: session.harness_resume_ref.clone(),
-            extra_argv: Vec::new(),
-            extra_env: Vec::new(),
+            extra_argv,
+            extra_env,
             env: probe.env.clone(),
             approval,
             binary,
@@ -5039,6 +5079,7 @@ mod managed_node_wait_tests {
         let runtime = CodeRuntime::new(
             Arc::new(db),
             data_dir.path().to_path_buf(),
+            None,
             None,
             None,
             None,

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -504,6 +504,7 @@ impl CodeRuntime {
             host: HostEnv::from_process(),
             host_tool_broker: None,
             git_credentials: None,
+            harness_llm: None,
             loopback_base: Mutex::new(None),
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),

--- a/crates/tidebreak-server/src/code/runtime.rs
+++ b/crates/tidebreak-server/src/code/runtime.rs
@@ -340,6 +340,7 @@ pub(crate) struct NewSessionSettings {
 }
 
 impl CodeRuntime {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         db: Arc<DbStore>,
         data_dir: PathBuf,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -558,6 +558,23 @@ pub fn app(state: AppState) -> Router {
         )
         .with_state(state.clone());
 
+    // The engine-facing inference relay (decision 71). Authenticated per
+    // request by the session-scoped relay key, so it stays outside
+    // `require_token` like the browser channel above.
+    let harness_llm_api = Router::new()
+        .route(
+            "/code/llm/anthropic/v1/messages",
+            post(routes::code::harness_llm_anthropic_messages),
+        )
+        .route(
+            "/code/llm/openai/v1/responses",
+            post(routes::code::harness_llm_openai_responses),
+        )
+        .layer(DefaultBodyLimit::max(
+            routes::code::MAX_HARNESS_LLM_BODY_BYTES,
+        ))
+        .with_state(state.clone());
+
     let api = Router::new()
         .route("/settings", get(routes::get_settings))
         .route(
@@ -1056,7 +1073,10 @@ pub fn app(state: AppState) -> Router {
         // launch token, so its routes merge after `route_layer` wrapped the
         // routes above and stay outside `require_token`. They still sit
         // inside `require_app_origin` and CORS with the rest of the API.
-        .merge(browser_api);
+        // The inference relay authenticates the same way with its own
+        // per-session key.
+        .merge(browser_api)
+        .merge(harness_llm_api);
     let frame_state = state.clone();
     let auth_discovery = Router::new()
         .route("/auth/discovery", get(auth::discovery))
@@ -1864,6 +1884,13 @@ async fn bind_inner(
             .on_behalf_of_gateway
             .clone()
             .map(|gateway| gateway as Arc<dyn obo_gateway::GitCredentialLender>),
+        // And engine inference rides the caller's gateway grant through the
+        // relay, since the hosted image has no provider credentials of its
+        // own (decision 71).
+        state
+            .on_behalf_of_gateway
+            .clone()
+            .map(|gateway| Arc::new(code::harness_llm::HarnessLlmRelay::new(gateway))),
     );
     // A self-host machine owns its filesystem. Clones land under the data
     // directory unless an operator set a destination (decision 70).

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -427,7 +427,7 @@ impl OboGateway {
     /// # Errors
     /// Fails when this process holds no subject token for `owner`, or when
     /// the gateway refuses the exchange.
-    async fn bearer_for(&self, owner: &OwnerId) -> Result<String> {
+    pub(crate) async fn bearer_for(&self, owner: &OwnerId) -> Result<String> {
         let slot = {
             let users = self.users.lock().map_err(|_| {
                 AgentError::msg("on-behalf-of inference state is unavailable in this process")

--- a/crates/tidebreak-server/src/routes/code/llm.rs
+++ b/crates/tidebreak-server/src/routes/code/llm.rs
@@ -1,0 +1,64 @@
+//! `/code/llm/*` routes: the engine-facing inference relay.
+//!
+//! These routes authenticate with the per-session relay key minted by
+//! [`crate::code::harness_llm::HarnessLlmRelay`] — never the per-launch app
+//! token. They are registered outside `require_token` (see `crate::app`),
+//! and the relay resolves the key from each request's own headers.
+
+use axum::body::Body;
+use axum::extract::{RawQuery, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::Response;
+
+use crate::code::harness_llm::RelayEndpoint;
+use crate::state::AppState;
+
+/// Body cap for one relayed inference request. A long session's request
+/// carries its whole context, so this is far above the default limit and
+/// still bounded: the gateway enforces its own ceiling behind it.
+pub(crate) const MAX_HARNESS_LLM_BODY_BYTES: usize = 64 * 1024 * 1024;
+
+pub async fn harness_llm_anthropic_messages(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    RawQuery(query): RawQuery,
+    body: Body,
+) -> Response {
+    relay(
+        state,
+        RelayEndpoint::AnthropicMessages,
+        headers,
+        query,
+        body,
+    )
+    .await
+}
+
+pub async fn harness_llm_openai_responses(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    RawQuery(query): RawQuery,
+    body: Body,
+) -> Response {
+    relay(state, RelayEndpoint::OpenAiResponses, headers, query, body).await
+}
+
+async fn relay(
+    state: AppState,
+    endpoint: RelayEndpoint,
+    headers: HeaderMap,
+    query: Option<String>,
+    body: Body,
+) -> Response {
+    match state.code.as_ref().and_then(|code| code.harness_llm()) {
+        Some(relay) => relay.forward(endpoint, &headers, query, body).await,
+        // The desktop and static-token self-host profiles run engines on the
+        // machine's own provider configuration; they mint no relay keys, so
+        // nothing legitimate calls this.
+        None => endpoint.error_response(
+            StatusCode::NOT_FOUND,
+            "not_found_error",
+            "this machine has no harness inference relay",
+        ),
+    }
+}

--- a/crates/tidebreak-server/src/routes/code/mod.rs
+++ b/crates/tidebreak-server/src/routes/code/mod.rs
@@ -5,10 +5,10 @@
 //! pinned harness binaries, and the clone-parent and worktree-root
 //! directories every principal shares — are registered on the
 //! deployment-plane router in `crate::lib` instead, behind `require_admin`.
-//! And the `/code/browser/*` routes in [`browser`] authenticate with the
-//! per-session capability bearer rather than the launch token, so they are
-//! registered outside `require_token` and derive their owner from the
-//! browser token registry.
+//! And the `/code/browser/*` routes in [`browser`] and the `/code/llm/*`
+//! routes in [`llm`] authenticate with a per-session capability bearer
+//! rather than the launch token, so they are registered outside
+//! `require_token` and derive their owner from the session-key registry.
 
 pub(crate) use super::settings::double_option;
 
@@ -18,6 +18,7 @@ mod browser;
 mod delivery;
 mod git;
 mod harnesses;
+mod llm;
 mod repos;
 mod session_events;
 mod sessions;
@@ -49,6 +50,9 @@ pub(crate) use git::{
 };
 pub(crate) use harnesses::{
     install_harness, list_harness_models, list_harnesses, refresh_harnesses,
+};
+pub(crate) use llm::{
+    harness_llm_anthropic_messages, harness_llm_openai_responses, MAX_HARNESS_LLM_BODY_BYTES,
 };
 pub(crate) use repos::{
     clone_defaults, create_repo, delete_repo, get_clone_job, get_repo, list_github_repositories,

--- a/crates/tidebreak-server/src/tests/code.rs
+++ b/crates/tidebreak-server/src/tests/code.rs
@@ -7440,11 +7440,10 @@ fn code_routes_go_through_the_owner_scoped_view() {
         // `types.rs` declare and shape, and serve nothing.
         let serves_data = text.contains("pub async fn") && name != "mod.rs";
         if serves_data && !text.contains("ScopedCode") {
-            // The browser channel is the sole capability-bearer route: it
-            // authenticates with a session-private browser capability token
-            // (resolved into a `BrowserSubject` owner/workspace/session scope)
-            // rather than the app-token `ScopedCode` extractor. Require its
-            // own authorization path instead of the scoped extractor.
+            // Browser and harness inference are capability-bearer routes.
+            // Each resolves a session-private token to the owning session
+            // instead of accepting the app-token `ScopedCode` extractor.
+            // Require each route's own authorization path here.
             if name == "browser.rs" {
                 if !text.contains("fn authorize(")
                     || !text.contains("BrowserSubject")
@@ -7453,7 +7452,18 @@ fn code_routes_go_through_the_owner_scoped_view() {
                     findings.push(format!(
                         "{name} is the capability-bearer browser route but is \
                          missing its `authorize` / `BrowserSubject` / \
-                         `bearer_token` authorization path"
+                        `bearer_token` authorization path"
+                    ));
+                }
+            } else if name == "llm.rs" {
+                if !text.contains("HarnessLlmRelay")
+                    || !text.contains("HeaderMap")
+                    || !text.contains("relay.forward(")
+                {
+                    findings.push(format!(
+                        "{name} is the capability-bearer harness inference \
+                         route but is missing its `HarnessLlmRelay` / \
+                         `HeaderMap` / `relay.forward` authorization path"
                     ));
                 }
             } else {

--- a/docs/decisions/0071-hosted-engines-ride-the-callers-inference.md
+++ b/docs/decisions/0071-hosted-engines-ride-the-callers-inference.md
@@ -1,0 +1,108 @@
+# 71. Hosted engines ride the caller's inference
+
+- Status: Proposed
+- Date: 2026-08-26
+- Owners: server
+- Related: [`0051-on-behalf-of-inference-for-hosted-machines.md`](0051-on-behalf-of-inference-for-hosted-machines.md),
+  [`0062-per-caller-gateway-entitlements.md`](0062-per-caller-gateway-entitlements.md),
+  [`0063-hosted-machines-borrow-forge-credentials.md`](0063-hosted-machines-borrow-forge-credentials.md),
+  [`0064-idle-engine-children-are-parked.md`](0064-idle-engine-children-are-parked.md)
+
+## Context
+
+A code session runs a real engine child — Claude Code, Codex — and that
+child makes its own inference requests with its own HTTP client. On a
+desktop or self-host machine the child finds the operator's provider
+credentials the way it always has: a login the operator ran, or a key in
+the environment.
+
+A gateway-authenticated hosted machine has neither. The image carries no
+provider keys, nobody has run a harness login inside the container, and
+decision 51's on-behalf-of exchange lives in the server process, never in
+the child. The server spawned engine children with empty `extra_argv` and
+`extra_env`, so a hosted Codex session fell back to `api.openai.com`, first
+over its websocket transport (logging a reconnect notice per attempt) and
+then over HTTPS, and failed the first turn with a 401.
+
+Handing the child a credential directly does not fit the tokens we have.
+The caller's machine-bound token must never leave the server process, and
+an exchanged inference token expires in minutes while a session lives for
+days. Whatever the child holds has to be durable for the session and
+worthless anywhere else.
+
+## Decision
+
+1. **The server relays engine inference through the caller's grant.** Two
+   routes on the main listener, `/code/llm/anthropic/v1/messages` and
+   `/code/llm/openai/v1/responses`, stream requests through to the Model
+   Gateway's compat endpoints. Per request, the relay exchanges the owning
+   caller's live machine-bound token for a fresh inference token (the same
+   single-flight cache decision 51 uses for chat) and sends that upstream
+   in place of what the child presented. The session outlives any single
+   token because the exchange runs on every request.
+
+2. **The child authenticates with a session-scoped relay key.** At spawn on
+   a machine that has an on-behalf-of gateway, the runtime mints an opaque
+   `tbreak_hl_` key mapped to (owner, session) and wires the child to the
+   relay: Claude Code through `ANTHROPIC_BASE_URL` and
+   `ANTHROPIC_AUTH_TOKEN`, Codex through a `tidebreak` model provider on
+   the command line (`base_url`, `env_key`, `wire_api=responses`). The key
+   follows the browser channel's lifecycle exactly — reissue on attach
+   replaces the prior key, and every path that revokes the browser channel
+   revokes the relay key. The routes live outside `require_token`, and the
+   key opens nothing but the relay.
+
+3. **Everywhere else, nothing changes.** A machine without an on-behalf-of
+   gateway spawns children with empty `extra_argv` and `extra_env`, exactly
+   as before. The custom Codex provider also keeps hosted sessions off the
+   vendor-only websocket transport, which removes the reconnect noise.
+
+Refusals are vendor-shaped so the engine reports them legibly: 401
+`authentication_error` for a missing or revoked key and for a caller whose
+gateway session is gone (fail fast, no retry); 502 `api_error` when the
+gateway does not answer (the engine's own retry policy applies).
+
+## Alternatives considered
+
+- **Inject an exchanged inference token at spawn.** Dies when the token
+  expires, minutes into a session that lives for days, and a reap or
+  relaunch would hand the new child a stale credential.
+- **Run harness logins in the hosted image.** Provider accounts per
+  machine, not per caller: every member's sessions would spend one shared
+  account, against the whole thrust of decisions 51/62/63/65.
+- **Point the child at the gateway's compat endpoint directly.** The child
+  would need a durable gateway credential, which is exactly the thing the
+  machine-bound token model refuses to mint; the relay keeps the only
+  durable secret local and session-scoped.
+
+## Consequences
+
+- Hosted Claude Code and Codex sessions run turns as the caller, with the
+  caller's entitlements and metering, matching chat.
+- Opencode and Grok sessions on hosted machines still launch without
+  credentials and fail their first turn; they need equivalent wiring.
+- A Codex thread started before this decision recorded the default
+  provider in its rollout; resuming it may still fail. A new session is
+  the path.
+- The relay streams request and response bodies without buffering, with a
+  raised body limit on its routes, so long turns and large contexts pass
+  through unchanged.
+
+## Validation
+
+- `spawn_wiring_points_each_engine_at_the_relay` pins the per-engine argv
+  and environment.
+- `forward_exchanges_and_streams_for_a_live_caller` drives a request
+  through a fake gateway and asserts the exchanged token replaces the
+  relay key, the query string and body pass through, and the child's
+  credentials never reach upstream.
+- `issue_replaces_the_prior_key_and_revoke_forgets`,
+  `forward_refuses_an_unknown_key`,
+  `forward_fails_closed_without_a_caller_token`, and
+  `forward_reports_an_unreachable_gateway_as_502` pin the lifecycle and
+  the refusal shapes.
+- Both wirings were exercised against real engine binaries before this
+  was written: Codex 0.147.0 with the custom provider makes a single
+  `POST .../responses` with the key as bearer and never touches its
+  websocket transport; Claude Code with the base-URL override posts
+  `/v1/messages?beta=true` with the bearer and no `x-api-key`.


### PR DESCRIPTION
## What

Hosted code sessions failed their first turn with a 401: the engine child (Claude Code, Codex) makes its own inference requests, and a gateway-authenticated hosted machine has no provider credentials to give it — no keys in the image, no harness logins, and the on-behalf-of exchange lives in the server process. A hosted Codex session fell back to `api.openai.com`, logged a reconnect notice per websocket attempt, and died with `Missing bearer or basic authentication in header`.

This PR gives each session a private inference path (decision 71, included):

- Two routes on the main listener, `/code/llm/anthropic/v1/messages` and `/code/llm/openai/v1/responses`, stream requests through to the Model Gateway's compat endpoints. Per request, the relay exchanges the owning caller's live machine-bound token for a fresh inference token (the same single-flight cache chat uses) and sends that upstream. The session outlives any single short-lived token.
- At spawn on a machine with an on-behalf-of gateway, the runtime mints an opaque `tbreak_hl_` key mapped to (owner, session) and wires the child at the relay: Claude Code through `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`, Codex through a custom `tidebreak` model provider on the command line. The custom provider also keeps Codex off its vendor-only websocket transport, which removes the reconnect noise.
- Keys follow the browser channel's lifecycle exactly: routes registered outside `require_token` with per-request bearer auth, reissue-on-attach replaces the prior key, and every path that revokes the browser channel revokes the relay key.
- Machines without an on-behalf-of gateway (desktop, static-token self-host) spawn children with empty extra argv/env exactly as before.

Refusals are vendor-shaped so engines report them legibly: 401 `authentication_error` for a missing/revoked key or a caller whose gateway session is gone; 502 `api_error` when the gateway does not answer, so the engine's own retry policy applies.

## Validation

- Unit tests pin the per-engine spawn wiring, the key lifecycle, and forwarding through a fake gateway (exchanged token replaces the relay key; query and body pass through; the child's credentials never reach upstream; unknown key / missing caller token / unreachable gateway map to 401/401/502).
- Both wirings were exercised against the real engine binaries before writing the server code: Codex 0.147.0 with the custom provider makes a single `POST .../responses` with the key as bearer and never touches its websocket transport; Claude Code with the base-URL override posts `/v1/messages?beta=true` with the bearer and no `x-api-key`.

## Notes

- A Codex thread started before this change recorded the default provider in its rollout, so resuming it may still fail; a new session is the path.
- Opencode and Grok sessions on hosted machines still launch without credentials; they need equivalent wiring (follow-up issue to be filed).

Fixes #2651.
