### PR TITLE
fix(code): make harness control results authoritative

### DIFF
--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/manifest.toml
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/manifest.toml
@@ -35,6 +35,7 @@ scenarios = [
   "resume",
   "interrupt",
   "error",
+  "posture-retry",
   "collab-agents",
 ]
 

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/posture-retry.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/posture-retry.expected.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "turn_failed",
+    "error": {
+      "message": "invalid turn options"
+    }
+  },
+  {
+    "type": "turn_started"
+  },
+  {
+    "type": "turn_completed",
+    "usage": {
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation_input_tokens": 0,
+      "context_tokens": 0
+    }
+  }
+]

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/posture-retry.ndjson
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/posture-retry.ndjson
@@ -1,0 +1,6 @@
+{"dir":"out","msg":{"id":41,"method":"turn/start","params":{"threadId":"thread-1","input":[{"type":"text","text":"first"}],"sandboxPolicy":{"type":"readOnly"},"approvalPolicy":"untrusted"}}}
+{"dir":"in","msg":{"id":41,"error":{"code":-32602,"message":"invalid turn options"}}}
+{"dir":"out","msg":{"id":42,"method":"turn/start","params":{"threadId":"thread-1","input":[{"type":"text","text":"second"}],"sandboxPolicy":{"type":"readOnly"},"approvalPolicy":"untrusted"}}}
+{"dir":"in","msg":{"id":42,"result":{"turn":{"id":"turn-2","status":"inProgress"}}}}
+{"dir":"in","msg":{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"turn-2","status":"inProgress"}}}}
+{"dir":"in","msg":{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-2","status":"completed"}}}}

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -18,7 +18,8 @@ use async_trait::async_trait;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{ChildStdin, ChildStdout, Command};
 use tokio::sync::watch;
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{oneshot, Mutex as AsyncMutex};
+use tokio::time::timeout;
 use tracing::warn;
 
 use crate::browser_channel::apply_child_env_tokio;
@@ -32,7 +33,14 @@ use crate::{
 };
 use tidebreak_core::{PermissionMode, ReasoningEffort};
 
+#[cfg(not(test))]
 const INTERRUPT_GRACE: Duration = Duration::from_secs(2);
+#[cfg(test)]
+const INTERRUPT_GRACE: Duration = Duration::from_millis(50);
+#[cfg(not(test))]
+const CONTROL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const CONTROL_RESPONSE_TIMEOUT: Duration = Duration::from_millis(250);
 const MAX_STDERR_BYTES: usize = 64 * 1_024;
 /// How long a dying child gets to finish writing its stderr before the turn
 /// reports why it died.
@@ -363,12 +371,12 @@ impl EngineChannel {
 
     /// Reap the process, recording its exit for the turn to report.
     async fn stop(&self, grace: Option<Duration>) -> Option<ExitStatus> {
+        if let Some(grace) = grace {
+            return self.interrupt_tree(grace).await.ok().flatten();
+        }
         let mut slot = self.child.lock().await;
         let status = match slot.as_mut() {
-            Some(child) => match grace {
-                Some(grace) => child.interrupt(grace).await.ok(),
-                None => child.terminate().await.ok(),
-            },
+            Some(child) => child.terminate().await.ok(),
             None => None,
         };
         *slot = None;
@@ -376,6 +384,16 @@ impl EngineChannel {
             *self.reaped.lock().expect("claude child exit") = status;
         }
         status
+    }
+
+    async fn interrupt_tree(&self, grace: Duration) -> io::Result<Option<ExitStatus>> {
+        let child = self.child.lock().await.take();
+        let Some(mut child) = child else {
+            return Ok(None);
+        };
+        let status = child.interrupt(grace).await?;
+        *self.reaped.lock().expect("claude child exit") = Some(status);
+        Ok(Some(status))
     }
 
     /// How the process ended, whoever reaped it.
@@ -419,6 +437,12 @@ pub struct ClaudeSession {
     /// Monotonic id for control requests, so a late `control_response` is
     /// never confused with the current one.
     next_control_id: AtomicU64,
+    pending_interrupt: Mutex<Option<PendingClaudeInterrupt>>,
+}
+
+struct PendingClaudeInterrupt {
+    request_id: String,
+    reply: Option<oneshot::Sender<Result<(), HarnessError>>>,
 }
 
 /// Clears the in-flight flag however `run_turn` leaves.
@@ -448,6 +472,7 @@ impl ClaudeSession {
             interrupts_this_turn: AtomicU64::new(0),
             turn_in_flight: AtomicBool::new(false),
             next_control_id: AtomicU64::new(1),
+            pending_interrupt: Mutex::new(None),
         }
     }
 
@@ -688,6 +713,130 @@ impl ClaudeSession {
         stdin.flush().await
     }
 
+    fn register_interrupt(
+        &self,
+        request_id: String,
+    ) -> oneshot::Receiver<Result<(), HarnessError>> {
+        let (reply, receiver) = oneshot::channel();
+        *self.pending_interrupt.lock().expect("claude interrupt") = Some(PendingClaudeInterrupt {
+            request_id,
+            reply: Some(reply),
+        });
+        receiver
+    }
+
+    fn cancel_interrupt(&self, request_id: &str, detail: &str) {
+        let pending = {
+            let mut slot = self.pending_interrupt.lock().expect("claude interrupt");
+            if slot
+                .as_ref()
+                .is_none_or(|pending| pending.request_id != request_id)
+            {
+                return;
+            }
+            slot.take()
+        };
+        if let Some(mut pending) = pending {
+            if let Some(reply) = pending.reply.take() {
+                let _ = reply.send(Err(HarnessError::Other(detail.into())));
+            }
+        }
+    }
+
+    fn fail_pending_interrupt(&self, detail: &str) {
+        let request_id = self
+            .pending_interrupt
+            .lock()
+            .expect("claude interrupt")
+            .as_ref()
+            .map(|pending| pending.request_id.clone());
+        if let Some(request_id) = request_id {
+            self.cancel_interrupt(&request_id, detail);
+        }
+    }
+
+    fn observe_control_response(&self, line: &str) {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            return;
+        };
+        if value.get("type").and_then(serde_json::Value::as_str) != Some("control_response") {
+            return;
+        }
+        let Some(request_id) = value
+            .pointer("/response/request_id")
+            .and_then(serde_json::Value::as_str)
+        else {
+            return;
+        };
+        let pending = {
+            let mut slot = self.pending_interrupt.lock().expect("claude interrupt");
+            if slot
+                .as_ref()
+                .is_none_or(|pending| pending.request_id != request_id)
+            {
+                return;
+            }
+            slot.take()
+        };
+        let Some(mut pending) = pending else {
+            return;
+        };
+        let result = match value
+            .pointer("/response/subtype")
+            .and_then(serde_json::Value::as_str)
+        {
+            Some("success") => Ok(()),
+            Some("error") => {
+                let detail = value
+                    .pointer("/response/error")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("the engine rejected the interrupt");
+                Err(HarnessError::Other(detail.into()))
+            }
+            _ => Err(HarnessError::Other(
+                "the engine returned a malformed interrupt response".into(),
+            )),
+        };
+        if let Some(reply) = pending.reply.take() {
+            let _ = reply.send(result);
+        }
+    }
+
+    fn resolve_interrupt_for_terminal(&self, interrupted: bool) {
+        let pending = self
+            .pending_interrupt
+            .lock()
+            .expect("claude interrupt")
+            .take();
+        if let Some(mut pending) = pending {
+            if let Some(reply) = pending.reply.take() {
+                let result = if interrupted {
+                    Ok(())
+                } else {
+                    Err(HarnessError::Other(
+                        "the turn ended before the interrupt was acknowledged".into(),
+                    ))
+                };
+                let _ = reply.send(result);
+            }
+        }
+    }
+
+    async fn interrupt_process_tree(&self) -> Result<(), HarnessError> {
+        self.fail_pending_interrupt("the native interrupt did not complete");
+        let taken = self.channel.lock().await.take();
+        self.pid.clear();
+        if let Some(channel) = taken {
+            channel
+                .interrupt_tree(INTERRUPT_GRACE)
+                .await
+                .map_err(|err| {
+                    HarnessError::Other(format!("the process-tree interrupt failed: {err}"))
+                })?;
+        }
+        Ok(())
+    }
+
     /// Read the stream until the turn's own terminal event, or until the
     /// child's stdout closes.
     async fn read_turn(&self, channel: &EngineChannel) -> Result<TurnRead, HarnessError> {
@@ -721,13 +870,9 @@ impl ClaudeSession {
                         // the child has nothing more to say until the next
                         // prompt.
                         for line in tick.lines {
-                            saw_terminal |= emit_parsed(
-                                &self.spec,
-                                &mut reader.parser,
-                                &self.resume_ref,
-                                &line,
-                            )
-                            .await;
+                            saw_terminal |=
+                                emit_parsed(self, &mut reader.parser, &self.resume_ref, &line)
+                                    .await;
                         }
                         if saw_terminal {
                             break;
@@ -750,8 +895,12 @@ impl ClaudeSession {
         }
         if eof && !reader.lines.pending().is_empty() {
             let pending = reader.lines.pending().to_owned();
-            saw_terminal |=
-                emit_parsed(&self.spec, &mut reader.parser, &self.resume_ref, &pending).await;
+            saw_terminal |= emit_parsed(self, &mut reader.parser, &self.resume_ref, &pending).await;
+        }
+        if eof {
+            self.fail_pending_interrupt(
+                "engine stdout closed before the interrupt was acknowledged",
+            );
         }
         let total = reader.parser.unrecognized();
         self.unrecognized
@@ -764,6 +913,7 @@ impl ClaudeSession {
     }
 
     async fn run_turn_inner(&self, input: TurnInput) -> Result<TurnOutcome, HarnessError> {
+        self.fail_pending_interrupt("the prior turn ended before the interrupt was acknowledged");
         self.interrupts_this_turn.store(0, Ordering::SeqCst);
         self.turn_in_flight.store(true, Ordering::SeqCst);
         let _in_flight = TurnGuard(&self.turn_in_flight);
@@ -862,33 +1012,47 @@ impl HarnessSession for ClaudeSession {
         let Some(channel) = self.channel.lock().await.clone() else {
             return Ok(());
         };
+        if !self.turn_in_flight.load(Ordering::SeqCst) {
+            return Ok(());
+        }
         let asked = self.interrupts_this_turn.fetch_add(1, Ordering::SeqCst);
-        let escalate = asked > 0 && self.turn_in_flight.load(Ordering::SeqCst);
-        if !escalate {
-            let request_id = format!(
-                "tb-interrupt-{}",
-                self.next_control_id.fetch_add(1, Ordering::SeqCst)
-            );
-            let mut line = serde_json::to_vec(&serde_json::json!({
-                "type": "control_request",
-                "request_id": request_id,
-                "request": { "subtype": "interrupt" },
-            }))
-            .map_err(|err| HarnessError::Other(format!("encode interrupt: {err}")))?;
-            line.push(b'\n');
-            match self.write_line(&channel, &line).await {
-                Ok(()) => return Ok(()),
-                Err(err) => {
-                    warn!(%err, "engine child refused a stop request; stopping the process")
-                }
+        if asked > 0 {
+            return self.interrupt_process_tree().await;
+        }
+
+        let request_id = format!(
+            "tb-interrupt-{}",
+            self.next_control_id.fetch_add(1, Ordering::SeqCst)
+        );
+        let receiver = self.register_interrupt(request_id.clone());
+        let mut line = serde_json::to_vec(&serde_json::json!({
+            "type": "control_request",
+            "request_id": request_id,
+            "request": { "subtype": "interrupt" },
+        }))
+        .map_err(|err| HarnessError::Other(format!("encode interrupt: {err}")))?;
+        line.push(b'\n');
+        if let Err(err) = self.write_line(&channel, &line).await {
+            self.cancel_interrupt(&request_id, "the engine refused the interrupt request");
+            warn!(%err, "engine child refused a stop request; stopping the process");
+            return self.interrupt_process_tree().await;
+        }
+
+        match timeout(CONTROL_RESPONSE_TIMEOUT, receiver).await {
+            Ok(Ok(Ok(()))) => Ok(()),
+            Ok(Ok(Err(err))) => {
+                warn!(%err, "engine rejected a stop request; stopping the process");
+                self.interrupt_process_tree().await
+            }
+            Ok(Err(_)) => self.interrupt_process_tree().await,
+            Err(_) => {
+                self.cancel_interrupt(
+                    &request_id,
+                    "timed out waiting for the engine to acknowledge the interrupt",
+                );
+                self.interrupt_process_tree().await
             }
         }
-        let taken = self.channel.lock().await.take();
-        if let Some(channel) = taken {
-            channel.stop(Some(INTERRUPT_GRACE)).await;
-        }
-        self.pid.clear();
-        Ok(())
     }
 
     /// Re-posture a live child with the `set_permission_mode` control request.
@@ -972,12 +1136,14 @@ impl HarnessSession for ClaudeSession {
 
 /// Emits one line's events, reporting whether any of them ended the turn.
 async fn emit_parsed(
-    spec: &SessionSpec,
+    session: &ClaudeSession,
     parser: &mut ClaudeStreamParser,
     resume_ref: &Mutex<Option<String>>,
     line: &str,
 ) -> bool {
+    session.observe_control_response(line);
     let mut terminal = false;
+    let mut interrupted = false;
     for event in parser.push_line(line) {
         if let HarnessEvent::SessionStarted {
             resume_ref: Some(resume),
@@ -992,7 +1158,11 @@ async fn emit_parsed(
                 | HarnessEvent::TurnFailed { .. }
                 | HarnessEvent::TurnInterrupted
         );
-        spec.sink.emit(event).await;
+        interrupted |= matches!(event, HarnessEvent::TurnInterrupted);
+        session.spec.sink.emit(event).await;
+    }
+    if terminal {
+        session.resolve_interrupt_for_terminal(interrupted);
     }
     terminal
 }
@@ -1206,6 +1376,85 @@ mod tests {
             .lines()
             .map(str::to_owned)
             .collect()
+    }
+
+    async fn run_interrupt_case(
+        mode: &str,
+    ) -> (
+        Result<TurnOutcome, HarnessError>,
+        Result<(), HarnessError>,
+        bool,
+        bool,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = write_engine(
+            dir.path(),
+            r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *control_request*)
+      printf '%s\n' "$line" >>"$FAKE_CLAUDE_INTERRUPTS"
+      case "$FAKE_CLAUDE_INTERRUPT_MODE" in
+        wrong_id)
+          printf '{"type":"control_response","response":{"subtype":"success","request_id":"wrong-id","response":{}}}\n'
+          ;;
+        error)
+          printf '{"type":"control_response","response":{"subtype":"error","request_id":"tb-interrupt-1","error":"turn is no longer active"}}\n'
+          ;;
+        none)
+          :
+          ;;
+        exit)
+          exit 0
+          ;;
+      esac
+      ;;
+    *)
+      printf '{"type":"system","subtype":"init","session_id":"sess-1","claude_code_version":"2.1.238"}\n'
+      touch "$FAKE_CLAUDE_STARTED"
+      ;;
+  esac
+done
+"#,
+        );
+        let mut session = session_with(binary, dir.path(), Arc::new(Discard));
+        session.spec.extra_env.extend([
+            ("FAKE_CLAUDE_INTERRUPT_MODE".into(), mode.to_owned()),
+            (
+                "FAKE_CLAUDE_INTERRUPTS".into(),
+                dir.path()
+                    .join("interrupts.ndjson")
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
+            (
+                "FAKE_CLAUDE_STARTED".into(),
+                dir.path().join("started").to_string_lossy().into_owned(),
+            ),
+        ]);
+        let session = Arc::new(session);
+        let running = tokio::spawn({
+            let session = Arc::clone(&session);
+            async move { session.run_turn(turn("keep working")).await }
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !dir.path().join("started").exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("fake turn did not start");
+
+        let stopped = session.interrupt().await;
+        let outcome = tokio::time::timeout(Duration::from_secs(2), running)
+            .await
+            .expect("fake turn did not finish")
+            .expect("turn task panicked");
+        let child_alive = session.child_pid().is_some();
+        let request_written = std::fs::read_to_string(dir.path().join("interrupts.ndjson"))
+            .is_ok_and(|input| input.lines().count() == 1);
+        session.park().await.unwrap();
+        (outcome, stopped, child_alive, request_written)
     }
 
     /// The engine takes `low..max` on `--effort`. `Ultra` is ultracode, which
@@ -1793,6 +2042,42 @@ done
             .snapshot()
             .iter()
             .any(|event| matches!(event, HarnessEvent::TurnCompleted { .. })));
+    }
+
+    #[tokio::test]
+    async fn a_wrong_claude_interrupt_id_times_out_and_stops_the_process_tree() {
+        let (outcome, stopped, child_alive, request_written) = run_interrupt_case("wrong_id").await;
+        stopped.unwrap();
+        assert!(!matches!(outcome.unwrap(), TurnOutcome::Clean));
+        assert!(!child_alive);
+        assert!(request_written);
+    }
+
+    #[tokio::test]
+    async fn a_claude_interrupt_error_stops_the_process_tree() {
+        let (outcome, stopped, child_alive, request_written) = run_interrupt_case("error").await;
+        stopped.unwrap();
+        assert!(!matches!(outcome.unwrap(), TurnOutcome::Clean));
+        assert!(!child_alive);
+        assert!(request_written);
+    }
+
+    #[tokio::test]
+    async fn a_missing_claude_interrupt_response_stops_the_process_tree() {
+        let (outcome, stopped, child_alive, request_written) = run_interrupt_case("none").await;
+        stopped.unwrap();
+        assert!(!matches!(outcome.unwrap(), TurnOutcome::Clean));
+        assert!(!child_alive);
+        assert!(request_written);
+    }
+
+    #[tokio::test]
+    async fn a_claude_child_exit_during_interrupt_runs_the_process_fallback() {
+        let (outcome, stopped, child_alive, request_written) = run_interrupt_case("exit").await;
+        stopped.unwrap();
+        assert!(!matches!(outcome.unwrap(), TurnOutcome::Clean));
+        assert!(!child_alive);
+        assert!(request_written);
     }
 
     /// A second stop for the same turn does not wait on an engine that is not

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -669,6 +669,91 @@ mod tests {
     }
 
     #[test]
+    fn posture_retry_fixture_repeats_the_same_policy_after_rejection() {
+        let (events, unrecognized) = replay("posture-retry");
+        assert_eq!(unrecognized, 0);
+        assert!(matches!(
+            events.first(),
+            Some(HarnessEvent::TurnFailed { .. })
+        ));
+        assert!(matches!(
+            events.last(),
+            Some(HarnessEvent::TurnCompleted { .. })
+        ));
+
+        let input = std::fs::read_to_string(fixture_dir().join("posture-retry.ndjson")).unwrap();
+        let requests = input
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter_map(|value| value.get("msg").cloned())
+            .filter(|message| {
+                message.get("method").and_then(serde_json::Value::as_str) == Some("turn/start")
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(requests.len(), 2);
+        for request in requests {
+            assert_eq!(request["params"]["sandboxPolicy"]["type"], "readOnly");
+            assert_eq!(request["params"]["approvalPolicy"], "untrusted");
+        }
+    }
+
+    #[test]
+    fn checked_in_terminal_values_are_allowlisted() {
+        for entry in std::fs::read_dir(fixture_dir()).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("ndjson") {
+                continue;
+            }
+            let input = std::fs::read_to_string(&path).unwrap();
+            for line in input.lines() {
+                let value: serde_json::Value = serde_json::from_str(line).unwrap();
+                let message = value.get("msg").unwrap_or(&value);
+                match message.get("method").and_then(serde_json::Value::as_str) {
+                    Some("turn/completed") => {
+                        let status = message
+                            .pointer("/params/turn/status")
+                            .and_then(serde_json::Value::as_str)
+                            .expect("captured turn terminal must name its status");
+                        assert!(
+                            ["completed", "interrupted", "failed"].contains(&status),
+                            "{} has unknown turn status {status}",
+                            path.display()
+                        );
+                    }
+                    Some("item/completed") => {
+                        let item = &message["params"]["item"];
+                        let item_type = item.get("type").and_then(serde_json::Value::as_str);
+                        if matches!(
+                            item_type,
+                            Some("commandExecution" | "fileChange" | "collabAgentToolCall")
+                        ) {
+                            let status = item
+                                .get("status")
+                                .and_then(serde_json::Value::as_str)
+                                .expect("captured tool terminal must name its status");
+                            assert!(
+                                [
+                                    "completed",
+                                    "declined",
+                                    "failed",
+                                    "interrupted",
+                                    "cancelled",
+                                    "canceled"
+                                ]
+                                .contains(&status),
+                                "{} has unknown {item_type:?} status {status}",
+                                path.display()
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    #[test]
     fn adapter_has_a_fixtures_directory_with_a_manifest() {
         assert!(fixture_dir().join("manifest.toml").is_file());
     }

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -407,9 +407,8 @@ impl CodexStreamParser {
                 }]
             }
             // The manifest records the observed set as
-            // `completed | interrupted | failed`. A fourth value still ends
-            // the turn, so it closes as completed — but counted and stated,
-            // never folded in silently (decision 0031).
+            // `completed | interrupted | failed`. Anything else is protocol
+            // drift and must fail closed.
             other => {
                 let label = if other.is_empty() { "missing" } else { other };
                 self.count_unrecognized(&format!("turn/completed/{label}"), params);
@@ -419,17 +418,18 @@ impl CodexStreamParser {
                         message: bound(
                             &format!(
                                 "the engine ended the turn with an unrecognized status \
-                                 ({label}); it was recorded as completed"
+                                 ({label}); it was recorded as failed"
                             ),
                             MAX_NOTICE_CHARS,
                         ),
                     },
-                    HarnessEvent::TurnCompleted {
-                        usage: turn_usage_since(
-                            &self.last_usage,
-                            &self.turn_usage_baseline,
-                            self.turn_first_call_context_tokens,
-                        ),
+                    HarnessEvent::TurnFailed {
+                        error: BoundedError {
+                            message: bound(
+                                &format!("Codex protocol drift: turn ended with status {label}"),
+                                MAX_NOTICE_CHARS,
+                            ),
+                        },
                     },
                 ]
             }
@@ -538,9 +538,10 @@ impl CodexStreamParser {
         match item.get("tool").and_then(Value::as_str) {
             Some("spawnAgent") => {
                 let targets = collab_targets(item);
+                let outcome = self.collab_outcome(item);
                 let mut events = self.start_spawned_subagents(item, parent_call_id.clone());
                 if targets.is_empty() {
-                    if collab_outcome(item) == ToolOutcome::Failed {
+                    if outcome != ToolOutcome::Succeeded {
                         let call_id = item
                             .get("id")
                             .and_then(Value::as_str)
@@ -555,7 +556,7 @@ impl CodexStreamParser {
                             ));
                             events.extend(self.settle_subagent(
                                 call_id,
-                                ToolOutcome::Failed,
+                                outcome,
                                 "Codex could not start the subagent".to_owned(),
                             ));
                         }
@@ -563,14 +564,16 @@ impl CodexStreamParser {
                     return events;
                 }
                 for target in targets {
-                    if let Some((outcome, preview)) = subagent_state_outcome(item, &target) {
-                        events.extend(self.settle_subagent(target, outcome, preview));
-                    } else if collab_outcome(item) == ToolOutcome::Failed {
+                    if outcome != ToolOutcome::Succeeded {
                         events.extend(self.settle_subagent(
                             target,
-                            ToolOutcome::Failed,
+                            outcome,
                             "Codex could not start the subagent".to_owned(),
                         ));
+                    } else if let Some((task_outcome, preview)) =
+                        subagent_state_outcome(item, &target)
+                    {
+                        events.extend(self.settle_subagent(target, task_outcome, preview));
                     }
                 }
                 events
@@ -578,7 +581,7 @@ impl CodexStreamParser {
             Some("sendInput" | "resumeAgent" | "wait" | "closeAgent") => {
                 let targets = collab_targets(item);
                 let mut events = self.start_collab_companions(item);
-                let outcome = collab_outcome(item);
+                let outcome = self.collab_outcome(item);
                 for target in targets {
                     let call_id = collab_call_id(item, &target);
                     if !call_id.is_empty() {
@@ -702,8 +705,14 @@ impl CodexStreamParser {
             "turn/start" => {
                 if let Some(turn_id) = result.pointer("/turn/id").and_then(Value::as_str) {
                     self.last_turn_id = Some(turn_id.to_owned());
+                    return Vec::new();
                 }
-                Vec::new()
+                self.count_unrecognized("rpc-result/turn-start/missing-turn-id", value);
+                vec![HarnessEvent::TurnFailed {
+                    error: BoundedError {
+                        message: "Codex returned a malformed turn/start result".into(),
+                    },
+                }]
             }
             "initialize" | "turn/interrupt" | "turn/steer" | "" => Vec::new(),
             other => {
@@ -726,9 +735,9 @@ impl CodexStreamParser {
                 message: bound(message, MAX_NOTICE_CHARS),
             }];
         }
-        if method == "turn/steer" {
-            // The live session routes this response back to the caller that
-            // issued the control RPC. A rejected steer is not a failed turn.
+        if matches!(method.as_str(), "turn/steer" | "turn/interrupt") {
+            // The live session routes control responses back to their callers.
+            // A rejected control request is not itself a failed turn.
             return Vec::new();
         }
         if method.is_empty() {
@@ -806,9 +815,14 @@ impl CodexStreamParser {
         let exit_code = item.get("exitCode").and_then(Value::as_i64);
         let outcome = match status {
             "declined" => ToolOutcome::Denied,
-            "failed" => ToolOutcome::Failed,
+            "failed" | "cancelled" | "canceled" => ToolOutcome::Failed,
             "completed" if exit_code.unwrap_or(0) != 0 => ToolOutcome::Failed,
-            _ => ToolOutcome::Succeeded,
+            "completed" => ToolOutcome::Succeeded,
+            other => {
+                let label = if other.is_empty() { "missing" } else { other };
+                self.count_unrecognized(&format!("commandExecution/completed/{label}"), item);
+                ToolOutcome::Failed
+            }
         };
         let preview = item
             .get("aggregatedOutput")
@@ -874,7 +888,12 @@ impl CodexStreamParser {
         let outcome = match status {
             "declined" => ToolOutcome::Denied,
             "failed" | "cancelled" | "canceled" => ToolOutcome::Failed,
-            _ => ToolOutcome::Succeeded,
+            "completed" => ToolOutcome::Succeeded,
+            other => {
+                let label = if other.is_empty() { "missing" } else { other };
+                self.count_unrecognized(&format!("fileChange/completed/{label}"), item);
+                ToolOutcome::Failed
+            }
         };
         events.push(HarnessEvent::ToolCompleted {
             call_id,
@@ -884,6 +903,22 @@ impl CodexStreamParser {
             parent_call_id,
         });
         events
+    }
+
+    fn collab_outcome(&mut self, item: &Value) -> ToolOutcome {
+        match item.get("status").and_then(Value::as_str) {
+            Some("completed") => ToolOutcome::Succeeded,
+            Some("declined") => ToolOutcome::Denied,
+            Some("failed" | "interrupted" | "cancelled" | "canceled") => ToolOutcome::Failed,
+            Some(other) => {
+                self.count_unrecognized(&format!("collab/completed/{other}"), item);
+                ToolOutcome::Failed
+            }
+            None => {
+                self.count_unrecognized("collab/completed/missing", item);
+                ToolOutcome::Failed
+            }
+        }
     }
 
     fn count_unrecognized(&mut self, label: &str, payload: impl std::fmt::Display) {
@@ -973,13 +1008,6 @@ fn collab_detail(item: &Value, target: &str) -> ToolDetail {
     };
     ToolDetail::Other {
         summary: bound(&summary, MAX_TOOL_SUMMARY_CHARS),
-    }
-}
-
-fn collab_outcome(item: &Value) -> ToolOutcome {
-    match item.get("status").and_then(Value::as_str) {
-        Some("failed") => ToolOutcome::Failed,
-        _ => ToolOutcome::Succeeded,
     }
 }
 
@@ -1389,8 +1417,6 @@ mod tests {
 
     #[test]
     fn an_unknown_turn_status_is_counted_and_stated_before_the_turn_closes() {
-        // The turn still has to end — the plausible wrong implementation folds
-        // a fourth status into a plain completion and says nothing.
         let input = r#"
 {"dir":"in","msg":{"method":"turn/completed","params":{"turn":{"status":"abandoned"}}}}
 "#;
@@ -1405,8 +1431,157 @@ mod tests {
         ));
         assert!(matches!(
             out.events.last(),
-            Some(HarnessEvent::TurnCompleted { .. })
+            Some(HarnessEvent::TurnFailed { .. })
         ));
+    }
+
+    #[test]
+    fn a_missing_turn_status_fails_closed() {
+        let out =
+            CodexStreamParser::parse_ndjson(r#"{"method":"turn/completed","params":{"turn":{}}}"#);
+
+        assert_eq!(out.unrecognized, 1);
+        assert!(matches!(
+            out.events.last(),
+            Some(HarnessEvent::TurnFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn unknown_and_missing_command_statuses_fail_closed() {
+        for status in [Some("abandoned"), None] {
+            let mut item = serde_json::json!({
+                "type": "commandExecution",
+                "id": "command-1",
+                "command": "true",
+                "cwd": "/workspace",
+                "exitCode": 0
+            });
+            if let Some(status) = status {
+                item["status"] = serde_json::json!(status);
+            }
+            let input = serde_json::json!({
+                "method": "item/completed",
+                "params": { "item": item }
+            });
+            let out = CodexStreamParser::parse_ndjson(&input.to_string());
+
+            assert_eq!(out.unrecognized, 1, "status: {status:?}");
+            assert!(out.events.iter().any(|event| matches!(
+                event,
+                HarnessEvent::ToolCompleted {
+                    outcome: ToolOutcome::Failed,
+                    ..
+                }
+            )));
+        }
+    }
+
+    #[test]
+    fn unknown_and_missing_file_change_statuses_fail_closed() {
+        for status in [Some("abandoned"), None] {
+            let mut item = serde_json::json!({
+                "type": "fileChange",
+                "id": "edit-1",
+                "changes": [{"path": "note.txt", "diff": "+text"}]
+            });
+            if let Some(status) = status {
+                item["status"] = serde_json::json!(status);
+            }
+            let input = serde_json::json!({
+                "method": "item/completed",
+                "params": { "item": item }
+            });
+            let out = CodexStreamParser::parse_ndjson(&input.to_string());
+
+            assert_eq!(out.unrecognized, 1, "status: {status:?}");
+            assert!(out.events.iter().any(|event| matches!(
+                event,
+                HarnessEvent::ToolCompleted {
+                    outcome: ToolOutcome::Failed,
+                    ..
+                }
+            )));
+        }
+    }
+
+    #[test]
+    fn unknown_and_missing_collaboration_statuses_fail_closed() {
+        for status in [Some("abandoned"), None] {
+            let mut item = serde_json::json!({
+                "type": "collabAgentToolCall",
+                "id": "wait-1",
+                "tool": "wait",
+                "receiverThreadIds": ["child"],
+                "agentsStates": {"child": {"status": "running", "message": null}}
+            });
+            if let Some(status) = status {
+                item["status"] = serde_json::json!(status);
+            }
+            let input = serde_json::json!({
+                "method": "item/completed",
+                "params": { "item": item }
+            });
+            let out = CodexStreamParser::parse_ndjson(&input.to_string());
+
+            assert_eq!(out.unrecognized, 1, "status: {status:?}");
+            assert!(out.events.iter().any(|event| matches!(
+                event,
+                HarnessEvent::ToolCompleted {
+                    outcome: ToolOutcome::Failed,
+                    ..
+                }
+            )));
+        }
+    }
+
+    #[test]
+    fn unknown_spawn_status_overrides_a_successful_child_snapshot() {
+        let input = r#"{"method":"item/completed","params":{"item":{"type":"collabAgentToolCall","id":"spawn-1","tool":"spawnAgent","status":"abandoned","receiverThreadIds":["child"],"agentsStates":{"child":{"status":"completed","message":"done"}}}}}"#;
+        let out = CodexStreamParser::parse_ndjson(input);
+
+        assert_eq!(out.unrecognized, 1);
+        assert!(out.events.iter().any(|event| matches!(
+            event,
+            HarnessEvent::ToolCompleted {
+                call_id,
+                outcome: ToolOutcome::Failed,
+                ..
+            } if call_id == "child"
+        )));
+        assert!(!out.events.iter().any(|event| matches!(
+            event,
+            HarnessEvent::ToolCompleted {
+                call_id,
+                outcome: ToolOutcome::Succeeded,
+                ..
+            } if call_id == "child"
+        )));
+    }
+
+    #[test]
+    fn captured_success_statuses_still_succeed() {
+        let input = r#"
+{"method":"item/completed","params":{"item":{"type":"commandExecution","id":"command-1","status":"completed","command":"true","cwd":"/workspace","exitCode":0}}}
+{"method":"item/completed","params":{"item":{"type":"fileChange","id":"edit-1","status":"completed","changes":[{"path":"note.txt","diff":"+text"}]}}}
+{"method":"item/completed","params":{"item":{"type":"collabAgentToolCall","id":"wait-1","tool":"wait","status":"completed","receiverThreadIds":["child"],"agentsStates":{"child":{"status":"running","message":null}}}}}
+"#;
+        let out = CodexStreamParser::parse_ndjson(input);
+
+        assert_eq!(out.unrecognized, 0);
+        assert_eq!(
+            out.events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    HarnessEvent::ToolCompleted {
+                        outcome: ToolOutcome::Succeeded,
+                        ..
+                    }
+                ))
+                .count(),
+            3
+        );
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -25,7 +25,14 @@ use crate::{
 use tidebreak_core::{PermissionMode, ReasoningEffort, MAX_NOTICE_CHARS};
 
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
+#[cfg(not(test))]
+const PROCESS_INTERRUPT_GRACE: Duration = Duration::from_secs(2);
+#[cfg(test)]
+const PROCESS_INTERRUPT_GRACE: Duration = Duration::from_millis(50);
+#[cfg(not(test))]
 const CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const CONTROL_RPC_TIMEOUT: Duration = Duration::from_millis(250);
 const MAX_STDERR_BYTES: usize = 64 * 1_024;
 
 /// The service-tier id Codex serves fast mode under.
@@ -43,11 +50,8 @@ pub struct CodexSession {
     /// thread for "this turn and subsequent turns", so a switch lands here and
     /// rides out on the next turn rather than relaunching the child.
     permission_mode: Mutex<PermissionMode>,
-    /// Whether the mode has moved since the last turn told the engine about
-    /// it. [`Self::handshake`] settles it per child: a started thread was
-    /// just told its posture, while a resumed thread carries whatever it was
-    /// last told and gets a restatement on the next turn.
-    posture_unsent: AtomicBool,
+    /// Posture generations that still need correlated engine admission.
+    posture: Mutex<PostureState>,
     resume_ref: Mutex<Option<String>>,
     /// Whether a turn has actually run on this thread. Codex only writes the
     /// thread's rollout once a turn starts, so a thread id from
@@ -62,6 +66,7 @@ pub struct CodexSession {
     stdout: Mutex<Option<Arc<AsyncMutex<StdoutReader>>>>,
     parser: Arc<Mutex<CodexStreamParser>>,
     next_id: AtomicI64,
+    interrupts_this_turn: AtomicU32,
     control_state: Arc<Mutex<ControlState>>,
     control_state_changed: Arc<Notify>,
     pending_approvals: Mutex<HashMap<String, Value>>,
@@ -75,6 +80,27 @@ struct StdoutReader {
 struct ControlState {
     turn: ControlTurn,
     pending: HashMap<i64, PendingSteer>,
+    interrupt: Option<PendingInterrupt>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PostureGeneration {
+    id: u64,
+    mode: PermissionMode,
+}
+
+struct PostureState {
+    next_generation: u64,
+    pending: Option<PostureGeneration>,
+    admission: Option<TurnAdmission>,
+}
+
+struct TurnAdmission {
+    rpc_id: i64,
+    thread_id: String,
+    posture_generation: Option<u64>,
+    turn_id: Option<String>,
+    deadline: Instant,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,6 +125,11 @@ struct PendingSteer {
     deadline: Option<Instant>,
     write_state: PendingWriteState,
     accept_response: bool,
+}
+
+struct PendingInterrupt {
+    rpc_id: i64,
+    reply: Option<oneshot::Sender<Result<(), HarnessError>>>,
 }
 
 struct ControlRegistration<'a> {
@@ -149,12 +180,18 @@ impl CodexSession {
     pub(super) fn new(spec: SessionSpec) -> Self {
         let resume_ref = spec.resume_ref.clone();
         let permission_mode = spec.permission_mode;
+        let pending_posture = resume_ref.as_ref().map(|_| PostureGeneration {
+            id: 1,
+            mode: permission_mode,
+        });
         Self {
             spec,
             permission_mode: Mutex::new(permission_mode),
-            // Settled per child by `handshake`; until one runs there is no
-            // engine to disagree with.
-            posture_unsent: AtomicBool::new(resume_ref.is_some()),
+            posture: Mutex::new(PostureState {
+                next_generation: u64::from(pending_posture.is_some()),
+                pending: pending_posture,
+                admission: None,
+            }),
             resume_ref: Mutex::new(resume_ref),
             thread_ran_a_turn: AtomicBool::new(false),
             resume_lost: Mutex::new(None),
@@ -164,9 +201,11 @@ impl CodexSession {
             stdout: Mutex::new(None),
             parser: Arc::new(Mutex::new(CodexStreamParser::new())),
             next_id: AtomicI64::new(1),
+            interrupts_this_turn: AtomicU32::new(0),
             control_state: Arc::new(Mutex::new(ControlState {
                 turn: ControlTurn::Idle,
                 pending: HashMap::new(),
+                interrupt: None,
             })),
             control_state_changed: Arc::new(Notify::new()),
             pending_approvals: Mutex::new(HashMap::new()),
@@ -198,6 +237,125 @@ impl CodexSession {
         self.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
+    fn arm_posture(&self, mode: PermissionMode) -> PostureGeneration {
+        let mut state = self.posture.lock().expect("codex posture");
+        state.next_generation = state.next_generation.saturating_add(1);
+        let generation = PostureGeneration {
+            id: state.next_generation,
+            mode,
+        };
+        state.pending = Some(generation);
+        generation
+    }
+
+    fn ensure_posture_pending(&self) -> PostureGeneration {
+        let mode = self.permission_mode();
+        let mut state = self.posture.lock().expect("codex posture");
+        if let Some(generation) = state.pending {
+            return generation;
+        }
+        state.next_generation = state.next_generation.saturating_add(1);
+        let generation = PostureGeneration {
+            id: state.next_generation,
+            mode,
+        };
+        state.pending = Some(generation);
+        generation
+    }
+
+    fn pending_posture(&self) -> Option<PostureGeneration> {
+        self.posture.lock().expect("codex posture").pending
+    }
+
+    fn register_turn_admission(
+        &self,
+        rpc_id: i64,
+        thread_id: String,
+        posture_generation: Option<u64>,
+    ) {
+        self.posture.lock().expect("codex posture").admission = Some(TurnAdmission {
+            rpc_id,
+            thread_id,
+            posture_generation,
+            turn_id: None,
+            deadline: Instant::now() + HANDSHAKE_TIMEOUT,
+        });
+    }
+
+    fn turn_admission_deadline(&self) -> Option<Instant> {
+        self.posture
+            .lock()
+            .expect("codex posture")
+            .admission
+            .as_ref()
+            .map(|admission| admission.deadline)
+    }
+
+    fn expire_turn_admission(&self) -> bool {
+        let mut state = self.posture.lock().expect("codex posture");
+        if state
+            .admission
+            .as_ref()
+            .is_some_and(|admission| admission.deadline <= Instant::now())
+        {
+            state.admission = None;
+            return true;
+        }
+        false
+    }
+
+    fn clear_turn_admission(&self) {
+        self.posture.lock().expect("codex posture").admission = None;
+    }
+
+    /// Admit only the posture generation that rode on this exact turn.
+    /// A newer mode switch leaves a newer generation pending.
+    fn observe_turn_admission(&self, value: &Value) -> Option<String> {
+        let mut state = self.posture.lock().expect("codex posture");
+        let admission = state.admission.as_mut()?;
+
+        let turn_id = if is_rpc_response(value) {
+            if value_rpc_id(value) != Some(admission.rpc_id) {
+                return None;
+            }
+            if value.get("error").is_some() {
+                state.admission = None;
+                return None;
+            }
+            let turn_id = value.pointer("/result/turn/id").and_then(Value::as_str)?;
+            admission.turn_id = Some(turn_id.to_owned());
+            turn_id.to_owned()
+        } else if value.get("method").and_then(Value::as_str) == Some("turn/started") {
+            if value.pointer("/params/threadId").and_then(Value::as_str)
+                != Some(admission.thread_id.as_str())
+            {
+                return None;
+            }
+            let turn_id = value.pointer("/params/turn/id").and_then(Value::as_str)?;
+            if admission
+                .turn_id
+                .as_deref()
+                .is_some_and(|expected| expected != turn_id)
+            {
+                return None;
+            }
+            turn_id.to_owned()
+        } else {
+            return None;
+        };
+
+        let generation = admission.posture_generation;
+        state.admission = None;
+        if generation.is_some_and(|generation| {
+            state
+                .pending
+                .is_some_and(|pending| pending.id == generation)
+        }) {
+            state.pending = None;
+        }
+        Some(turn_id)
+    }
+
     async fn write_message(&self, message: &Value) -> Result<(), HarnessError> {
         let Some(stdin) = self.stdin.lock().expect("codex stdin").clone() else {
             return Err(HarnessError::Other("engine child has no stdin".into()));
@@ -217,8 +375,16 @@ impl CodexSession {
             .lock()
             .expect("codex parser")
             .note_outbound(&json!(id), method);
-        self.write_message(&json!({ "id": id, "method": method, "params": params }))
-            .await?;
+        if let Err(err) = self
+            .write_message(&json!({ "id": id, "method": method, "params": params }))
+            .await
+        {
+            self.parser
+                .lock()
+                .expect("codex parser")
+                .forget_outbound(&json!(id));
+            return Err(err);
+        }
         Ok(id)
     }
 
@@ -313,10 +479,11 @@ impl CodexSession {
     }
 
     fn begin_control_turn(&self) {
-        let pending = {
+        self.interrupts_this_turn.store(0, Ordering::SeqCst);
+        let (pending, interrupt) = {
             let mut state = self.control_state.lock().expect("codex control state");
             state.turn = ControlTurn::Starting;
-            std::mem::take(&mut state.pending)
+            (std::mem::take(&mut state.pending), state.interrupt.take())
         };
         for (id, mut pending) in pending {
             if let Some(reply) = pending.reply.take() {
@@ -328,6 +495,17 @@ impl CodexSession {
                 .lock()
                 .expect("codex parser")
                 .forget_outbound(&json!(id));
+        }
+        if let Some(mut interrupt) = interrupt {
+            if let Some(reply) = interrupt.reply.take() {
+                let _ = reply.send(Err(HarnessError::Other(
+                    "the prior turn ended before the interrupt was acknowledged".into(),
+                )));
+            }
+            self.parser
+                .lock()
+                .expect("codex parser")
+                .forget_outbound(&json!(interrupt.rpc_id));
         }
         self.control_state_changed.notify_waiters();
     }
@@ -353,8 +531,8 @@ impl CodexSession {
     /// not started writing are removed immediately. An in-flight write becomes
     /// a bounded tombstone: its caller is rejected now, and the sole stream
     /// reader still consumes its eventual response without emitting a steer.
-    fn close_control_turn_for_terminal(&self, detail: &str) {
-        let removed = {
+    fn close_control_turn_for_terminal(&self, detail: &str, interrupted: bool) {
+        let (removed, interrupt) = {
             let mut state = self.control_state.lock().expect("codex control state");
             state.turn = ControlTurn::Closed;
             let queued_ids = state
@@ -374,7 +552,7 @@ impl CodexSession {
                     let _ = reply.send(Err(HarnessError::SteeringRejected(detail.into())));
                 }
             }
-            removed
+            (removed, state.interrupt.take())
         };
         for (id, mut pending) in removed {
             if let Some(reply) = pending.reply.take() {
@@ -385,14 +563,28 @@ impl CodexSession {
                 .expect("codex parser")
                 .forget_outbound(&json!(id));
         }
+        if let Some(mut pending) = interrupt {
+            if let Some(reply) = pending.reply.take() {
+                let result = if interrupted {
+                    Ok(())
+                } else {
+                    Err(HarnessError::Other(detail.into()))
+                };
+                let _ = reply.send(result);
+            }
+            self.parser
+                .lock()
+                .expect("codex parser")
+                .forget_outbound(&json!(pending.rpc_id));
+        }
         self.control_state_changed.notify_waiters();
     }
 
     fn abort_control_turn(&self, detail: &str) {
-        let pending = {
+        let (pending, interrupt) = {
             let mut state = self.control_state.lock().expect("codex control state");
             state.turn = ControlTurn::Closed;
-            std::mem::take(&mut state.pending)
+            (std::mem::take(&mut state.pending), state.interrupt.take())
         };
         for (id, mut pending) in pending {
             if let Some(reply) = pending.reply.take() {
@@ -402,6 +594,15 @@ impl CodexSession {
                 .lock()
                 .expect("codex parser")
                 .forget_outbound(&json!(id));
+        }
+        if let Some(mut pending) = interrupt {
+            if let Some(reply) = pending.reply.take() {
+                let _ = reply.send(Err(HarnessError::Other(detail.into())));
+            }
+            self.parser
+                .lock()
+                .expect("codex parser")
+                .forget_outbound(&json!(pending.rpc_id));
         }
         self.control_state_changed.notify_waiters();
     }
@@ -449,12 +650,8 @@ impl CodexSession {
     }
 
     fn controls_pending(&self) -> bool {
-        !self
-            .control_state
-            .lock()
-            .expect("codex control state")
-            .pending
-            .is_empty()
+        let state = self.control_state.lock().expect("codex control state");
+        !state.pending.is_empty() || state.interrupt.is_some()
     }
 
     fn active_control_turn_id(&self) -> Option<String> {
@@ -463,6 +660,104 @@ impl CodexSession {
             ControlTurn::Active(turn_id) => Some(turn_id.clone()),
             ControlTurn::Idle | ControlTurn::Starting | ControlTurn::Closed => None,
         }
+    }
+
+    fn register_interrupt(&self, rpc_id: i64) -> oneshot::Receiver<Result<(), HarnessError>> {
+        let (reply, receiver) = oneshot::channel();
+        self.parser
+            .lock()
+            .expect("codex parser")
+            .note_outbound(&json!(rpc_id), "turn/interrupt");
+        self.control_state
+            .lock()
+            .expect("codex control state")
+            .interrupt = Some(PendingInterrupt {
+            rpc_id,
+            reply: Some(reply),
+        });
+        receiver
+    }
+
+    fn resolve_interrupt_response(&self, rpc_id: i64, value: &Value) -> bool {
+        let pending = {
+            let mut state = self.control_state.lock().expect("codex control state");
+            if state
+                .interrupt
+                .as_ref()
+                .is_none_or(|pending| pending.rpc_id != rpc_id)
+            {
+                return false;
+            }
+            state.interrupt.take()
+        };
+        let Some(mut pending) = pending else {
+            return false;
+        };
+        let result = if let Some(detail) = rpc_error_detail(value) {
+            Err(HarnessError::Other(format!(
+                "the engine rejected the interrupt: {detail}"
+            )))
+        } else if value.get("result").is_some() {
+            Ok(())
+        } else {
+            Err(HarnessError::Other(
+                "the engine returned a malformed interrupt response".into(),
+            ))
+        };
+        if let Some(reply) = pending.reply.take() {
+            let _ = reply.send(result);
+        }
+        true
+    }
+
+    fn cancel_interrupt(&self, rpc_id: i64, detail: &str) {
+        let pending = {
+            let mut state = self.control_state.lock().expect("codex control state");
+            if state
+                .interrupt
+                .as_ref()
+                .is_none_or(|pending| pending.rpc_id != rpc_id)
+            {
+                return;
+            }
+            state.interrupt.take()
+        };
+        if let Some(mut pending) = pending {
+            if let Some(reply) = pending.reply.take() {
+                let _ = reply.send(Err(HarnessError::Other(detail.into())));
+            }
+        }
+        self.parser
+            .lock()
+            .expect("codex parser")
+            .forget_outbound(&json!(rpc_id));
+        self.control_state_changed.notify_waiters();
+    }
+
+    fn fail_pending_interrupt(&self, detail: &str) {
+        let rpc_id = self
+            .control_state
+            .lock()
+            .expect("codex control state")
+            .interrupt
+            .as_ref()
+            .map(|pending| pending.rpc_id);
+        if let Some(rpc_id) = rpc_id {
+            self.cancel_interrupt(rpc_id, detail);
+        }
+    }
+
+    async fn interrupt_process_tree(&self) -> Result<(), HarnessError> {
+        self.clear_turn_admission();
+        self.fail_pending_interrupt("the native interrupt did not complete");
+        let mut slot = self.child.lock().await;
+        *self.stdin.lock().expect("codex stdin") = None;
+        *self.stdout.lock().expect("codex stdout") = None;
+        self.child_pid.store(0, Ordering::SeqCst);
+        if let Some(mut child) = slot.take() {
+            child.interrupt(PROCESS_INTERRUPT_GRACE).await?;
+        }
+        Ok(())
     }
 
     async fn notify(&self, method: &str, params: Option<Value>) -> Result<(), HarnessError> {
@@ -668,8 +963,10 @@ impl CodexSession {
         }
         // A resumed thread carries whatever posture it was last told, so the
         // next turn restates the mode rather than assume it holds. A started
-        // thread was just told its posture.
-        self.posture_unsent.store(resumed, Ordering::SeqCst);
+        // thread was just created with this mode.
+        if resumed {
+            self.ensure_posture_pending();
+        }
         Ok(())
     }
 
@@ -709,7 +1006,13 @@ impl CodexSession {
         let mut terminal = false;
         loop {
             let changed = self.control_state_changed.notified();
-            let deadline = self.next_control_deadline();
+            let control_deadline = self.next_control_deadline();
+            let admission_deadline = self.turn_admission_deadline();
+            let deadline = match (control_deadline, admission_deadline) {
+                (Some(control), Some(admission)) => Some(control.min(admission)),
+                (Some(deadline), None) | (None, Some(deadline)) => Some(deadline),
+                (None, None) => None,
+            };
             if terminal && !self.controls_pending() {
                 return Ok(());
             }
@@ -721,6 +1024,11 @@ impl CodexSession {
                         lines = self.read_lines() => lines?,
                         () = changed => continue,
                         () = tokio::time::sleep_until(deadline) => {
+                            if self.expire_turn_admission() {
+                                return Err(HarnessError::Other(
+                                    "timed out waiting for the engine to admit the turn".into(),
+                                ));
+                            }
                             self.expire_control_requests();
                             continue;
                         }
@@ -735,6 +1043,10 @@ impl CodexSession {
                 }
             };
             if lines.is_empty() {
+                self.clear_turn_admission();
+                self.fail_pending_interrupt(
+                    "engine stdout closed before the interrupt was acknowledged",
+                );
                 let message = if terminal {
                     "engine stdout closed before a control response arrived"
                 } else {
@@ -785,9 +1097,13 @@ impl CodexSession {
 
     async fn emit_parsed(&self, line: &str) -> Vec<HarnessEvent> {
         let value = serde_json::from_str::<Value>(line).ok();
+        let mut admitted_turn_id = None;
         if let Some(value) = value.as_ref() {
             if is_rpc_response(value) {
                 if let Some(rpc_id) = value_rpc_id(value) {
+                    if self.resolve_interrupt_response(rpc_id, value) {
+                        self.control_state_changed.notify_waiters();
+                    }
                     let pending = self
                         .control_state
                         .lock()
@@ -809,6 +1125,7 @@ impl CodexSession {
                     }
                 }
             }
+            admitted_turn_id = self.observe_turn_admission(value);
             if let Some(detail) = lost_resume_detail(value) {
                 *self.resume_lost.lock().expect("codex resume lost") = Some(detail);
             }
@@ -823,10 +1140,15 @@ impl CodexSession {
             )
         });
         if terminal {
+            self.clear_turn_admission();
+            let interrupted = events
+                .iter()
+                .any(|event| matches!(event, HarnessEvent::TurnInterrupted));
             self.close_control_turn_for_terminal(
                 "the active turn finished before steering was accepted",
+                interrupted,
             );
-        } else if let Some(turn_id) = value.as_ref().and_then(observed_turn_id) {
+        } else if let Some(turn_id) = admitted_turn_id.as_deref() {
             self.activate_control_turn(turn_id);
             // The engine acknowledged a turn on this thread, so it has
             // written the thread's rollout: the id is resumable now.
@@ -896,9 +1218,9 @@ impl HarnessSession for CodexSession {
         if input.fast_mode {
             params["serviceTier"] = json!(FAST_SERVICE_TIER);
         }
-        let posture_unsent = self.posture_unsent.load(Ordering::SeqCst);
-        if posture_unsent {
-            let (sandbox, approval) = turn_start_policy(self.permission_mode());
+        let posture = self.pending_posture();
+        if let Some(posture) = posture {
+            let (sandbox, approval) = turn_start_policy(posture.mode);
             params["sandboxPolicy"] = sandbox;
             params["approvalPolicy"] = json!(approval);
         }
@@ -912,10 +1234,7 @@ impl HarnessSession for CodexSession {
                 return Err(err);
             }
         };
-        if posture_unsent {
-            self.posture_unsent.store(false, Ordering::SeqCst);
-        }
-        let _ = id;
+        self.register_turn_admission(id, thread_id, posture.map(|generation| generation.id));
         // Long-lived child: its exit is a session-level failure, not a turn
         // outcome, and `read_until_terminal_turn` already errors on a stream
         // that ends without one.
@@ -948,7 +1267,7 @@ impl HarnessSession for CodexSession {
             return Ok(());
         }
         *self.permission_mode.lock().expect("codex permission mode") = mode;
-        self.posture_unsent.store(true, Ordering::SeqCst);
+        self.arm_posture(mode);
         Ok(())
     }
 
@@ -1006,27 +1325,44 @@ impl HarnessSession for CodexSession {
             // session must not cost it anything (decision 0064).
             return Ok(());
         }
+        let asked = self.interrupts_this_turn.fetch_add(1, Ordering::SeqCst);
+        if asked > 0 {
+            return self.interrupt_process_tree().await;
+        }
         let thread_id = self.resume_ref.lock().expect("codex resume").clone();
         let turn_id = self.active_control_turn_id();
-        if let (Some(thread_id), Some(turn_id)) = (thread_id, turn_id) {
-            let id = self
-                .request(
-                    "turn/interrupt",
-                    json!({ "threadId": thread_id, "turnId": turn_id }),
-                )
-                .await;
-            if id.is_ok() {
-                return Ok(());
+        let (Some(thread_id), Some(turn_id)) = (thread_id, turn_id) else {
+            return self.interrupt_process_tree().await;
+        };
+
+        let rpc_id = self.next_rpc_id();
+        let receiver = self.register_interrupt(rpc_id);
+        let message = json!({
+            "id": rpc_id,
+            "method": "turn/interrupt",
+            "params": { "threadId": thread_id, "turnId": turn_id },
+        });
+        if let Err(err) = self.write_message(&message).await {
+            self.cancel_interrupt(rpc_id, "the engine refused the interrupt request");
+            warn!(%err, "engine child refused a stop request; stopping the process");
+            return self.interrupt_process_tree().await;
+        }
+
+        match timeout(CONTROL_RPC_TIMEOUT, receiver).await {
+            Ok(Ok(Ok(()))) => Ok(()),
+            Ok(Ok(Err(err))) => {
+                warn!(%err, "engine rejected a stop request; stopping the process");
+                self.interrupt_process_tree().await
+            }
+            Ok(Err(_)) => self.interrupt_process_tree().await,
+            Err(_) => {
+                self.cancel_interrupt(
+                    rpc_id,
+                    "timed out waiting for the engine to acknowledge the interrupt",
+                );
+                self.interrupt_process_tree().await
             }
         }
-        let mut slot = self.child.lock().await;
-        let Some(child) = slot.as_mut() else {
-            return Ok(());
-        };
-        child.interrupt(Duration::from_secs(2)).await?;
-        *slot = None;
-        self.child_pid.store(0, Ordering::SeqCst);
-        Ok(())
     }
 
     fn resume_ref(&self) -> Option<String> {
@@ -1113,17 +1449,6 @@ fn is_rpc_response(value: &Value) -> bool {
     object.contains_key("id")
         && !object.contains_key("method")
         && (object.contains_key("result") || object.contains_key("error"))
-}
-
-fn observed_turn_id(value: &Value) -> Option<&str> {
-    let method = value.get("method").and_then(Value::as_str);
-    if method == Some("turn/started") {
-        return value.pointer("/params/turn/id").and_then(Value::as_str);
-    }
-    if is_rpc_response(value) {
-        return value.pointer("/result/turn/id").and_then(Value::as_str);
-    }
-    None
 }
 
 fn value_rpc_id(value: &Value) -> Option<i64> {
@@ -1442,6 +1767,71 @@ done
 "#;
 
     #[cfg(unix)]
+    const FAKE_POSTURE_APP_SERVER: &str = r#"#!/bin/sh
+turns=0
+while IFS= read -r line; do
+  id=${line#*\"id\":}
+  id=${id%%,*}
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"id":%s,"result":{"userAgent":"fake/0.147.0"}}\n' "$id"
+      ;;
+    *'"method":"thread/start"'*)
+      printf '{"id":%s,"result":{"thread":{"id":"THREAD-1","cliVersion":"0.147.0","turns":[]}}}\n' "$id"
+      ;;
+    *'"method":"turn/start"'*)
+      turns=$((turns+1))
+      printf '%s\n' "$line" >>"$FAKE_CODEX_TURNS"
+      if [ "$turns" -eq 1 ]; then
+        printf '{"id":%s,"error":{"code":-32602,"message":"invalid turn options"}}\n' "$id"
+      else
+        printf '{"id":%s,"result":{"turn":{"id":"TURN-%s","status":"inProgress"}}}\n' "$id" "$turns"
+        printf '{"method":"turn/completed","params":{"threadId":"THREAD-1","turn":{"id":"TURN-%s","status":"completed"}}}\n' "$turns"
+      fi
+      ;;
+  esac
+done
+"#;
+
+    #[cfg(unix)]
+    const FAKE_INTERRUPT_APP_SERVER: &str = r#"#!/bin/sh
+while IFS= read -r line; do
+  id=${line#*\"id\":}
+  id=${id%%,*}
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"id":%s,"result":{"userAgent":"fake/0.147.0"}}\n' "$id"
+      ;;
+    *'"method":"thread/start"'*)
+      printf '{"id":%s,"result":{"thread":{"id":"THREAD-1","cliVersion":"0.147.0","turns":[]}}}\n' "$id"
+      ;;
+    *'"method":"turn/start"'*)
+      printf '{"id":%s,"result":{"turn":{"id":"TURN-1","status":"inProgress"}}}\n' "$id"
+      printf '{"method":"turn/started","params":{"threadId":"THREAD-1","turn":{"id":"TURN-1","status":"inProgress"}}}\n'
+      ;;
+    *'"method":"turn/interrupt"'*)
+      printf '%s\n' "$line" >>"$FAKE_CODEX_INTERRUPTS"
+      case "$FAKE_CODEX_INTERRUPT_MODE" in
+        success)
+          printf '{"id":%s,"result":{}}\n' "$id"
+          printf '{"method":"turn/completed","params":{"threadId":"THREAD-1","turn":{"id":"TURN-1","status":"interrupted"}}}\n'
+          ;;
+        error)
+          printf '{"id":%s,"error":{"code":-32000,"message":"turn is no longer active"}}\n' "$id"
+          ;;
+        eof)
+          exit 0
+          ;;
+        timeout)
+          :
+          ;;
+      esac
+      ;;
+  esac
+done
+"#;
+
+    #[cfg(unix)]
     fn write_fake_app_server(path: &std::path::Path) {
         write_app_server(path, FAKE_APP_SERVER);
     }
@@ -1585,6 +1975,53 @@ done
         }
     }
 
+    #[cfg(unix)]
+    async fn run_interrupt_case(
+        mode: &str,
+    ) -> (
+        Result<TurnOutcome, HarnessError>,
+        Result<(), HarnessError>,
+        bool,
+        bool,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("codex");
+        write_app_server(&binary, FAKE_INTERRUPT_APP_SERVER);
+        let mut spec = spec_for(dir.path(), &binary, None);
+        spec.extra_env
+            .push(("FAKE_CODEX_INTERRUPT_MODE".into(), mode.to_owned()));
+        spec.extra_env.push((
+            "FAKE_CODEX_INTERRUPTS".into(),
+            dir.path()
+                .join("interrupts.ndjson")
+                .to_string_lossy()
+                .into_owned(),
+        ));
+        let session = Arc::new(CodexSession::new(spec));
+        let running = tokio::spawn({
+            let session = Arc::clone(&session);
+            async move { session.run_turn(turn("keep working")).await }
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while session.active_control_turn_id().is_none() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("fake turn was never admitted");
+
+        let stopped = session.interrupt().await;
+        let outcome = tokio::time::timeout(Duration::from_secs(2), running)
+            .await
+            .expect("fake turn did not finish")
+            .expect("turn task panicked");
+        let child_alive = session.child_pid().is_some();
+        let request_written = std::fs::read_to_string(dir.path().join("interrupts.ndjson"))
+            .is_ok_and(|input| input.lines().count() == 1);
+        session.park().await.unwrap();
+        (outcome, stopped, child_alive, request_written)
+    }
+
     /// The wedge from the app-server dying before its first turn: codex
     /// never persisted the thread, so a thread id that has run no turn must
     /// not be reported as a resume ref. The next spawn then starts a clean
@@ -1710,6 +2147,180 @@ done
         let session = unit_session(Arc::new(RecordingSink::default()));
         session.interrupt().await.unwrap();
         assert_eq!(session.child_pid(), None);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejected_turn_start_keeps_posture_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let binary = dir.path().join("codex");
+        write_app_server(&binary, FAKE_POSTURE_APP_SERVER);
+        let mut spec = spec_for(dir.path(), &binary, None);
+        spec.extra_env.push((
+            "FAKE_CODEX_TURNS".into(),
+            dir.path()
+                .join("turns.ndjson")
+                .to_string_lossy()
+                .into_owned(),
+        ));
+        let session = CodexSession::new(spec);
+        session
+            .set_permission_mode(PermissionMode::Plan)
+            .await
+            .unwrap();
+
+        session.run_turn(turn("first")).await.unwrap();
+        assert!(
+            session.pending_posture().is_some(),
+            "a rejected turn must leave its posture armed"
+        );
+        session.run_turn(turn("second")).await.unwrap();
+        assert!(
+            session.pending_posture().is_none(),
+            "the matching accepted retry settles the posture"
+        );
+
+        let requests = std::fs::read_to_string(dir.path().join("turns.ndjson")).unwrap();
+        let requests = requests
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(requests.len(), 2);
+        for request in requests {
+            assert_eq!(request["params"]["sandboxPolicy"]["type"], "readOnly");
+            assert_eq!(request["params"]["approvalPolicy"], "untrusted");
+        }
+    }
+
+    #[tokio::test]
+    async fn late_success_cannot_clear_newer_posture_generation() {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        let first = session.pending_posture().expect("resume posture is armed");
+        session.register_turn_admission(41, "THREAD-1".into(), Some(first.id));
+        let newer = session.arm_posture(PermissionMode::Plan);
+
+        session
+            .emit_parsed(r#"{"id":41,"result":{"turn":{"id":"TURN-OLD"}}}"#)
+            .await;
+
+        assert_eq!(session.pending_posture(), Some(newer));
+    }
+
+    #[test]
+    fn admission_timeout_keeps_posture_pending() {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        let generation = session.pending_posture().expect("resume posture is armed");
+        session.register_turn_admission(41, "THREAD-1".into(), Some(generation.id));
+        session
+            .posture
+            .lock()
+            .expect("codex posture")
+            .admission
+            .as_mut()
+            .expect("turn admission")
+            .deadline = Instant::now();
+
+        assert!(session.expire_turn_admission());
+        assert_eq!(session.pending_posture(), Some(generation));
+    }
+
+    #[tokio::test]
+    async fn malformed_turn_start_result_keeps_posture_pending() {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        let generation = session.pending_posture().expect("resume posture is armed");
+        session
+            .parser
+            .lock()
+            .expect("codex parser")
+            .note_outbound(&json!(41), "turn/start");
+        session.register_turn_admission(41, "THREAD-1".into(), Some(generation.id));
+
+        let events = session.emit_parsed(r#"{"id":41,"result":{}}"#).await;
+
+        assert!(matches!(
+            events.last(),
+            Some(HarnessEvent::TurnFailed { .. })
+        ));
+        assert_eq!(session.pending_posture(), Some(generation));
+    }
+
+    #[tokio::test]
+    async fn terminal_before_admission_keeps_posture_pending() {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        let generation = session.pending_posture().expect("resume posture is armed");
+        session.register_turn_admission(41, "THREAD-1".into(), Some(generation.id));
+
+        session
+            .emit_parsed(
+                r#"{"method":"turn/completed","params":{"threadId":"THREAD-1","turn":{"id":"TURN-1","status":"failed"}}}"#,
+            )
+            .await;
+
+        assert_eq!(session.pending_posture(), Some(generation));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn codex_interrupt_waits_for_correlated_success() {
+        let (outcome, stopped, child_alive, request_written) = run_interrupt_case("success").await;
+        stopped.unwrap();
+        assert!(matches!(outcome.unwrap(), TurnOutcome::Clean));
+        assert!(child_alive, "a native interrupt keeps the session child");
+        assert!(request_written);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn codex_interrupt_error_falls_back_to_the_process_tree() {
+        let (outcome, stopped, child_alive, request_written) = run_interrupt_case("error").await;
+        stopped.unwrap();
+        assert!(outcome.is_err());
+        assert!(!child_alive);
+        assert!(request_written);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn codex_interrupt_timeout_falls_back_to_the_process_tree() {
+        let (outcome, stopped, child_alive, request_written) = run_interrupt_case("timeout").await;
+        stopped.unwrap();
+        assert!(outcome.is_err());
+        assert!(!child_alive);
+        assert!(request_written);
+    }
+
+    #[tokio::test]
+    async fn a_late_codex_interrupt_response_cannot_resolve_a_new_waiter() {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        let old = session.register_interrupt(52);
+        session.cancel_interrupt(52, "timed out");
+        assert!(old.await.unwrap().is_err());
+        let current = session.register_interrupt(53);
+
+        session.emit_parsed(r#"{"id":52,"result":{}}"#).await;
+        assert_eq!(
+            session
+                .control_state
+                .lock()
+                .expect("codex control state")
+                .interrupt
+                .as_ref()
+                .map(|pending| pending.rpc_id),
+            Some(53)
+        );
+
+        session.emit_parsed(r#"{"id":53,"result":{}}"#).await;
+        current.await.unwrap().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn codex_interrupt_eof_falls_back_to_the_process_tree() {
+        let (outcome, stopped, child_alive, request_written) = run_interrupt_case("eof").await;
+        stopped.unwrap();
+        assert!(outcome.is_err());
+        assert!(!child_alive);
+        assert!(request_written);
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -431,6 +431,34 @@ mod tests {
     }
 
     #[test]
+    fn checked_in_stop_reasons_are_allowlisted() {
+        for version in ["1.0.4", "1.0.5"] {
+            for entry in std::fs::read_dir(fixture_dir(version)).unwrap() {
+                let path = entry.unwrap().path();
+                if path.extension().and_then(|extension| extension.to_str()) != Some("ndjson") {
+                    continue;
+                }
+                let input = std::fs::read_to_string(&path).unwrap();
+                for line in input.lines() {
+                    let value: serde_json::Value = serde_json::from_str(line).unwrap();
+                    if value.get("type").and_then(serde_json::Value::as_str) != Some("end") {
+                        continue;
+                    }
+                    let reason = value
+                        .get("stopReason")
+                        .and_then(serde_json::Value::as_str)
+                        .expect("captured Grok terminal must name its stop reason");
+                    assert!(
+                        ["end_turn", "cancelled"].contains(&reason),
+                        "{} has unknown stop reason {reason}",
+                        path.display()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn capabilities_for_1_0_4_are_honest() {
         let caps = GrokAdapter::new().capabilities(&HarnessProbe {
             found: true,

--- a/crates/tidebreak-harness/src/grok/parse.rs
+++ b/crates/tidebreak-harness/src/grok/parse.rs
@@ -440,11 +440,8 @@ impl GrokStreamParser {
             "end_turn" => events.push(HarnessEvent::TurnCompleted {
                 usage: self.last_usage.clone(),
             }),
-            // A stop reason this build has never seen still ends the turn —
-            // the child has exited and something must close it out. Folding it
-            // into a plain completion without a word would be exactly the
-            // silent normalization decision 0031 forbids, so it is counted and
-            // stated before the turn closes.
+            // A stop reason this build has never seen is protocol drift. The
+            // child has exited, so close the turn as a visible failure.
             other => {
                 let label = if other.is_empty() { "missing" } else { other };
                 self.count_unrecognized(&format!("end/stopReason/{label}"), value);
@@ -453,13 +450,18 @@ impl GrokStreamParser {
                     message: bound(
                         &format!(
                             "the engine ended the turn with an unrecognized stop reason \
-                             ({label}); it was recorded as completed"
+                             ({label}); it was recorded as failed"
                         ),
                         MAX_NOTICE_CHARS,
                     ),
                 });
-                events.push(HarnessEvent::TurnCompleted {
-                    usage: self.last_usage.clone(),
+                events.push(HarnessEvent::TurnFailed {
+                    error: BoundedError {
+                        message: bound(
+                            &format!("Grok protocol drift: turn ended with stop reason {label}"),
+                            MAX_NOTICE_CHARS,
+                        ),
+                    },
                 });
             }
         }
@@ -799,7 +801,7 @@ mod tests {
     fn an_unknown_stop_reason_is_counted_and_stated_while_a_progress_frame_is_not() {
         // `status: null` on tool_call_update is the manifest's documented
         // progress frame: a deliberate no-op, not a drop. An unheard-of stop
-        // reason is the opposite — it still ends the turn, but it is counted.
+        // reason is the opposite: it ends the turn as a visible failure.
         let input = r#"
 {"type":"tool_call","toolCallId":"call-1","toolName":"read_file","rawInput":{}}
 {"type":"tool_call_update","toolCallId":"call-1","status":null}
@@ -816,7 +818,20 @@ mod tests {
         )));
         assert!(matches!(
             out.events.last(),
-            Some(HarnessEvent::TurnCompleted { .. })
+            Some(HarnessEvent::TurnFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn a_missing_stop_reason_fails_closed() {
+        let out = GrokStreamParser::parse_ndjson(
+            r#"{"type":"end","sessionId":"abc","usage":{"input_tokens":1}}"#,
+        );
+
+        assert_eq!(out.unrecognized, 1);
+        assert!(matches!(
+            out.events.last(),
+            Some(HarnessEvent::TurnFailed { .. })
         ));
     }
 


### PR DESCRIPTION
Fixes #2657

## Implementation

- Keep Codex posture generations pending until the matching `turn/start` result or `turn/started` notification admits the turn.
- Preserve or re-arm posture after rejection, timeout, malformed admission, end-of-file, and terminal events before admission. Older responses cannot clear a newer generation.
- Make Codex and Claude interrupts wait for the matching positive acknowledgement or `TurnInterrupted` event. Rejection, malformed responses, timeouts, end-of-file, and child exit fall back to the owned process tree.
- Map unknown or missing Codex turn, command, file-change, and collaboration terminal values to failure.
- Map unknown or missing Grok stop reasons to `TurnFailed`.
- Add focused sequence tests and a checked-in Codex posture retry fixture.

## Compatibility

- Keep the captured successful terminal values unchanged.
- Preserve native interrupt success without retiring a healthy long-lived child.
- Keep second-stop escalation and idle-stop behavior unchanged.

## Safety

- Correlate posture updates by request ID, generation, thread ID, and turn ID where the protocol exposes them.
- Register interrupt waiters before writing so fast acknowledgements cannot race the caller.
- Bound acknowledgement waits and use the existing process-tree containment for fallback.
- Keep protocol-drift notices and counters while failing closed.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Added shell fixtures pass `sh -n`.
- Added JSON and NDJSON fixtures parse with `jq`.
- Per the repository rule, Rust build, check, Clippy, and tests were not run locally. CI will compile and test the change.